### PR TITLE
Add environment variable support for TUI renderer preview line limits

### DIFF
--- a/packages/coding-agent/docs/environment-variables-for-user-preference.md
+++ b/packages/coding-agent/docs/environment-variables-for-user-preference.md
@@ -1,0 +1,44 @@
+# TUI renderer environment variables for preview lines
+
+This document describes environment variables that control how many lines the TUI tool renderer shows when previewing tool output (bash/read/write). These variables provide convenient user-level defaults; component-level settings take precedence when available.
+
+Variables
+- `PI_BASH_PREVIEW_LINES`
+  - Description: Number of lines to show when previewing output from the `bash` tool.
+  - Default: `5` lines.
+
+- `PI_READ_PREVIEW_LINES`
+  - Description: Number of lines to show when previewing output from the `read` tool.
+  - Default: `10` lines.
+
+- `PI_WRITE_PREVIEW_LINES`
+  - Description: Number of lines to show when previewing content passed to the `write` tool.
+  - Default: `10` lines.
+
+Behavior and validation
+
+- The renderer first checks a component-level `previewLines` value (when provided by the caller). If present, that value takes precedence.
+- If no component-level value is set, the renderer looks for the tool-specific environment variable (for example `PI_BASH_PREVIEW_LINES`). If that is not set, it falls back to `PI_TOOL_PREVIEW_LINES`.
+- If an environment variable is undefined, null, or an empty string, the renderer ignores it and uses the appropriate default.
+- Only integer values strictly greater than `0` and less than `Number.MAX_SAFE_INTEGER` are accepted from environment variables. Non-numeric values, `0`, negative numbers, or values >= `Number.MAX_SAFE_INTEGER` are ignored and the default is used instead.
+
+Examples
+
+Set the bash preview lines for the current session:
+
+```bash
+export PI_BASH_PREVIEW_LINES=20
+```
+
+Set a global default (applies when tool-specific variable is not provided):
+
+```bash
+export PI_TOOL_PREVIEW_LINES=8
+```
+
+Persist these in your shell config (`~/.bashrc`, `~/.zshrc`, etc.) to keep them across sessions.
+
+Caution
+
+- These environment variables affect only the preview display count, not the underlying data. They are intended to improve readability basedcon user preference in the TUI and are safe to change.
+- Do not set values to `0` expecting an "unlimited" behavior; `0` is considered invalid and the default will be used. If a very large value is required, set an appropriately large positive integer (but keep in mind `Number.MAX_SAFE_INTEGER` is the upper bound).

--- a/packages/coding-agent/docs/environment-variables-for-user-preference.md
+++ b/packages/coding-agent/docs/environment-variables-for-user-preference.md
@@ -18,7 +18,7 @@ Variables
 Behavior and validation
 
 - The renderer first checks a component-level `previewLines` value (when provided by the caller). If present, that value takes precedence.
-- If no component-level value is set, the renderer looks for the tool-specific environment variable (for example `PI_BASH_PREVIEW_LINES`). If that is not set, it falls back to `PI_TOOL_PREVIEW_LINES`.
+- If no component-level value is set, the renderer looks for the tool-specific environment variable (for example `PI_BASH_PREVIEW_LINES`).
 - If an environment variable is undefined, null, or an empty string, the renderer ignores it and uses the appropriate default.
 - Only integer values strictly greater than `0` and less than `Number.MAX_SAFE_INTEGER` are accepted from environment variables. Non-numeric values, `0`, negative numbers, or values >= `Number.MAX_SAFE_INTEGER` are ignored and the default is used instead.
 
@@ -28,12 +28,6 @@ Set the bash preview lines for the current session:
 
 ```bash
 export PI_BASH_PREVIEW_LINES=20
-```
-
-Set a global default (applies when tool-specific variable is not provided):
-
-```bash
-export PI_TOOL_PREVIEW_LINES=8
 ```
 
 Persist these in your shell config (`~/.bashrc`, `~/.zshrc`, etc.) to keep them across sessions.

--- a/packages/coding-agent/docs/environment-variables-for-user-preference.md
+++ b/packages/coding-agent/docs/environment-variables-for-user-preference.md
@@ -15,13 +15,6 @@ Variables
   - Description: Number of lines to show when previewing content passed to the `write` tool.
   - Default: `10` lines.
 
-Behavior and validation
-
-- The renderer first checks a component-level `previewLines` value (when provided by the caller). If present, that value takes precedence.
-- If no component-level value is set, the renderer looks for the tool-specific environment variable (for example `PI_BASH_PREVIEW_LINES`).
-- If an environment variable is undefined, null, or an empty string, the renderer ignores it and uses the appropriate default.
-- Only integer values strictly greater than `0` and less than `Number.MAX_SAFE_INTEGER` are accepted from environment variables. Non-numeric values, `0`, negative numbers, or values >= `Number.MAX_SAFE_INTEGER` are ignored and the default is used instead.
-
 Examples
 
 Set the bash preview lines for the current session:

--- a/packages/coding-agent/src/tui/tool-execution.ts
+++ b/packages/coding-agent/src/tui/tool-execution.ts
@@ -144,6 +144,24 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	private getMaxLines(defaultVal: number, envVarName?: string): number {
+		if (!envVarName) {
+			return defaultVal;
+		}
+
+		const envVal = process.env[envVarName];
+		if (envVal === undefined || envVal === null || envVal.trim() === "") {
+			return defaultVal;
+		}
+
+		const parsed = parseInt(envVal, 10);
+		if (!Number.isNaN(parsed) && parsed > 0 && parsed <= Number.MAX_SAFE_INTEGER) {
+			return parsed;
+		}
+
+		return defaultVal;
+	}
+
 	updateArgs(args: any): void {
 		this.args = args;
 		this.updateDisplay();
@@ -201,7 +219,7 @@ export class ToolExecutionComponent extends Container {
 				const output = this.getTextOutput().trim();
 				if (output) {
 					const lines = output.split("\n");
-					const maxLines = 5;
+					const maxLines = this.getMaxLines(5, "PI_BASH_PREVIEW_LINES");
 					const displayLines = lines.slice(0, maxLines);
 					const remaining = lines.length - maxLines;
 
@@ -218,7 +236,7 @@ export class ToolExecutionComponent extends Container {
 			if (this.result) {
 				const output = this.getTextOutput();
 				const lines = output.split("\n");
-				const maxLines = 10;
+				const maxLines = this.getMaxLines(10, "PI_READ_PREVIEW_LINES");
 				const displayLines = lines.slice(0, maxLines);
 				const remaining = lines.length - maxLines;
 
@@ -234,13 +252,13 @@ export class ToolExecutionComponent extends Container {
 			const totalLines = lines.length;
 
 			text = chalk.bold("write") + " " + (path ? chalk.cyan(path) : chalk.dim("..."));
-			if (totalLines > 10) {
+			if (totalLines > this.getMaxLines(10, "PI_WRITE_PREVIEW_LINES")) {
 				text += ` (${totalLines} lines)`;
 			}
 
 			// Show first 10 lines of content if available
 			if (fileContent) {
-				const maxLines = 10;
+				const maxLines = this.getMaxLines(10, "PI_WRITE_PREVIEW_LINES");
 				const displayLines = lines.slice(0, maxLines);
 				const remaining = lines.length - maxLines;
 


### PR DESCRIPTION
re: #31 (expanding tools/read calls)

I like to see a lot information and I think this is an unobtrusive way to accomplish this goal.

woo - many lines!

<img width="1461" height="1537" alt="image" src="https://github.com/user-attachments/assets/3a8f6371-a27e-413d-a94f-2dc187331da9" />
