### PR TITLE
fix read tool failing on macOS screenshot filenames

### DIFF
--- a/packages/coding-agent/src/core/hooks/loader.ts
+++ b/packages/coding-agent/src/core/hooks/loader.ts
@@ -44,17 +44,21 @@ export interface LoadHooksResult {
 	errors: Array<{ path: string; error: string }>;
 }
 
-/**
- * Expand path with ~ support.
- */
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+
+function normalizeUnicodeSpaces(str: string): string {
+	return str.replace(UNICODE_SPACES, " ");
+}
+
 function expandPath(p: string): string {
-	if (p.startsWith("~/")) {
-		return path.join(os.homedir(), p.slice(2));
+	const normalized = normalizeUnicodeSpaces(p);
+	if (normalized.startsWith("~/")) {
+		return path.join(os.homedir(), normalized.slice(2));
 	}
-	if (p.startsWith("~")) {
-		return path.join(os.homedir(), p.slice(1));
+	if (normalized.startsWith("~")) {
+		return path.join(os.homedir(), normalized.slice(1));
 	}
-	return p;
+	return normalized;
 }
 
 /**

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -1,23 +1,10 @@
-import * as os from "node:os";
 import type { AgentTool } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import * as Diff from "diff";
 import { constants } from "fs";
 import { access, readFile, writeFile } from "fs/promises";
 import { resolve as resolvePath } from "path";
-
-/**
- * Expand ~ to home directory
- */
-function expandPath(filePath: string): string {
-	if (filePath === "~") {
-		return os.homedir();
-	}
-	if (filePath.startsWith("~/")) {
-		return os.homedir() + filePath.slice(1);
-	}
-	return filePath;
-}
+import { expandPath } from "./path-utils.js";
 
 /**
  * Generate a unified diff string with line numbers and context

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -3,23 +3,10 @@ import { Type } from "@sinclair/typebox";
 import { spawnSync } from "child_process";
 import { existsSync } from "fs";
 import { globSync } from "glob";
-import { homedir } from "os";
 import path from "path";
 import { ensureTool } from "../../utils/tools-manager.js";
+import { expandPath } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
-
-/**
- * Expand ~ to home directory
- */
-function expandPath(filePath: string): string {
-	if (filePath === "~") {
-		return homedir();
-	}
-	if (filePath.startsWith("~/")) {
-		return homedir() + filePath.slice(1);
-	}
-	return filePath;
-}
 
 const findSchema = Type.Object({
 	pattern: Type.String({

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -3,9 +3,9 @@ import type { AgentTool } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { spawn } from "child_process";
 import { readFileSync, type Stats, statSync } from "fs";
-import { homedir } from "os";
 import path from "path";
 import { ensureTool } from "../../utils/tools-manager.js";
+import { expandPath } from "./path-utils.js";
 import {
 	DEFAULT_MAX_BYTES,
 	formatSize,
@@ -14,19 +14,6 @@ import {
 	truncateHead,
 	truncateLine,
 } from "./truncate.js";
-
-/**
- * Expand ~ to home directory
- */
-function expandPath(filePath: string): string {
-	if (filePath === "~") {
-		return homedir();
-	}
-	if (filePath.startsWith("~/")) {
-		return homedir() + filePath.slice(1);
-	}
-	return filePath;
-}
 
 const grepSchema = Type.Object({
 	pattern: Type.String({ description: "Search pattern (regex or literal string)" }),

--- a/packages/coding-agent/src/core/tools/ls.ts
+++ b/packages/coding-agent/src/core/tools/ls.ts
@@ -1,22 +1,9 @@
 import type { AgentTool } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { existsSync, readdirSync, statSync } from "fs";
-import { homedir } from "os";
 import nodePath from "path";
+import { expandPath } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
-
-/**
- * Expand ~ to home directory
- */
-function expandPath(filePath: string): string {
-	if (filePath === "~") {
-		return homedir();
-	}
-	if (filePath.startsWith("~/")) {
-		return homedir() + filePath.slice(1);
-	}
-	return filePath;
-}
 
 const lsSchema = Type.Object({
 	path: Type.Optional(Type.String({ description: "Directory to list (default: current directory)" })),

--- a/packages/coding-agent/src/core/tools/path-utils.ts
+++ b/packages/coding-agent/src/core/tools/path-utils.ts
@@ -1,0 +1,48 @@
+import { accessSync, constants } from "node:fs";
+import * as os from "node:os";
+
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+const NARROW_NO_BREAK_SPACE = "\u202F";
+
+function normalizeUnicodeSpaces(str: string): string {
+	return str.replace(UNICODE_SPACES, " ");
+}
+
+function tryMacOSScreenshotPath(filePath: string): string {
+	return filePath.replace(/ (AM|PM)\./g, `${NARROW_NO_BREAK_SPACE}$1.`);
+}
+
+function fileExists(filePath: string): boolean {
+	try {
+		accessSync(filePath, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function expandPath(filePath: string): string {
+	const normalized = normalizeUnicodeSpaces(filePath);
+	if (normalized === "~") {
+		return os.homedir();
+	}
+	if (normalized.startsWith("~/")) {
+		return os.homedir() + normalized.slice(1);
+	}
+	return normalized;
+}
+
+export function resolveReadPath(filePath: string): string {
+	const expanded = expandPath(filePath);
+
+	if (fileExists(expanded)) {
+		return expanded;
+	}
+
+	const macOSVariant = tryMacOSScreenshotPath(expanded);
+	if (macOSVariant !== expanded && fileExists(macOSVariant)) {
+		return macOSVariant;
+	}
+
+	return expanded;
+}

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -1,23 +1,10 @@
-import * as os from "node:os";
 import type { AgentTool, ImageContent, TextContent } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { constants } from "fs";
 import { access, readFile } from "fs/promises";
 import { extname, resolve as resolvePath } from "path";
+import { resolveReadPath } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
-
-/**
- * Expand ~ to home directory
- */
-function expandPath(filePath: string): string {
-	if (filePath === "~") {
-		return os.homedir();
-	}
-	if (filePath.startsWith("~/")) {
-		return os.homedir() + filePath.slice(1);
-	}
-	return filePath;
-}
 
 /**
  * Map of file extensions to MIME types for common image formats
@@ -58,7 +45,7 @@ export const readTool: AgentTool<typeof readSchema> = {
 		{ path, offset, limit }: { path: string; offset?: number; limit?: number },
 		signal?: AbortSignal,
 	) => {
-		const absolutePath = resolvePath(expandPath(path));
+		const absolutePath = resolvePath(resolveReadPath(path));
 		const mimeType = isImageFile(absolutePath);
 
 		return new Promise<{ content: (TextContent | ImageContent)[]; details: ReadToolDetails | undefined }>(

--- a/packages/coding-agent/src/core/tools/write.ts
+++ b/packages/coding-agent/src/core/tools/write.ts
@@ -1,21 +1,8 @@
-import * as os from "node:os";
 import type { AgentTool } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { mkdir, writeFile } from "fs/promises";
 import { dirname, resolve as resolvePath } from "path";
-
-/**
- * Expand ~ to home directory
- */
-function expandPath(filePath: string): string {
-	if (filePath === "~") {
-		return os.homedir();
-	}
-	if (filePath.startsWith("~/")) {
-		return os.homedir() + filePath.slice(1);
-	}
-	return filePath;
-}
+import { expandPath } from "./path-utils.js";
 
 const writeSchema = Type.Object({
 	path: Type.String({ description: "Path to the file to write (relative or absolute)" }),


### PR DESCRIPTION
Been dealing with this annoyance on my Mac for a while. My workflow is usually to screenshot something and drag the preview directly into pi's input, but reading the file would fail with ENOENT even though the file clearly existed. 

<img width="1669" height="495" alt="Screenshot 2025-12-13 at 6 46 56 AM" src="https://github.com/user-attachments/assets/e3ee67fe-3d23-49c2-9bd7-798fb5b8c3b1" />

Finally tracked it down: macOS screenshots have a sneaky Unicode Narrow No-Break Space (U+202F) before "AM" or "PM" in the filename instead of a regular space. When you type the path or the LLM outputs it, you get a normal space, so the file isn't found.

<img width="1239" height="573" alt="Screenshot 2025-12-13 at 6 47 46 AM" src="https://github.com/user-attachments/assets/519f35db-f41d-40e8-b395-8e89e1a0d1ae" />

This fix adds a fallback in the read tool (and @file CLI arguments) that tries the macOS variant if the original path doesn't exist. Also consolidated the duplicated expandPath functions that were scattered across 6+ files into a shared path-utils.ts.

 Only affects read operations - writes still use the exact path you specify.