### PR TITLE
Implement XDG Base Directory Specification with auto-migration

### DIFF
--- a/packages/coding-agent/examples/custom-tools/subagent/agents.ts
+++ b/packages/coding-agent/examples/custom-tools/subagent/agents.ts
@@ -5,6 +5,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { CONFIG_DIR_NAME, getAgentsDir } from "../../../src/config.js";
 
 export type AgentScope = "user" | "project" | "both";
 
@@ -115,7 +116,7 @@ function isDirectory(p: string): boolean {
 function findNearestProjectAgentsDir(cwd: string): string | null {
 	let currentDir = cwd;
 	while (true) {
-		const candidate = path.join(currentDir, ".pi", "agents");
+		const candidate = path.join(currentDir, CONFIG_DIR_NAME, "agents");
 		if (isDirectory(candidate)) return candidate;
 
 		const parentDir = path.dirname(currentDir);
@@ -125,7 +126,7 @@ function findNearestProjectAgentsDir(cwd: string): string | null {
 }
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
-	const userDir = path.join(os.homedir(), ".pi", "agent", "agents");
+	const userDir = getAgentsDir();
 	const projectAgentsDir = findNearestProjectAgentsDir(cwd);
 
 	const userAgents = scope === "project" ? [] : loadAgentsFromDir(userDir, "user");

--- a/packages/coding-agent/examples/custom-tools/subagent/agents.ts
+++ b/packages/coding-agent/examples/custom-tools/subagent/agents.ts
@@ -5,7 +5,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { CONFIG_DIR_NAME, getAgentsDir } from "../../../src/config.js";
+import { CONFIG_DIR_NAME, getAgentsDir } from "@mariozechner/pi-coding-agent";
 
 export type AgentScope = "user" | "project" | "both";
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -4,7 +4,7 @@
 
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import chalk from "chalk";
-import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR } from "../config.js";
+import { APP_NAME, ENV_AGENT_DIR } from "../config.js";
 import { allTools, type ToolName } from "../core/tools/index.js";
 
 export type Mode = "text" | "json" | "rpc";
@@ -196,8 +196,8 @@ ${chalk.bold("Examples:")}
   # Read-only mode (no file modifications possible)
   ${APP_NAME} --tools read,grep,find,ls -p "Review the code in src/"
 
-  # Export a session file to HTML
-  ${APP_NAME} --export ~/${CONFIG_DIR_NAME}/agent/sessions/--path--/session.jsonl
+  # Export a session file to HTML (sessions are stored in $XDG_DATA_HOME/pi/agent/sessions/)
+  ${APP_NAME} --export path/to/session.jsonl
   ${APP_NAME} --export session.jsonl output.html
 
 ${chalk.bold("Environment Variables:")}
@@ -210,7 +210,13 @@ ${chalk.bold("Environment Variables:")}
   XAI_API_KEY             - xAI Grok API key
   OPENROUTER_API_KEY      - OpenRouter API key
   ZAI_API_KEY             - ZAI API key
-  ${ENV_AGENT_DIR.padEnd(23)} - Session storage directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  ${ENV_AGENT_DIR.padEnd(23)} - Override config/data directory (bypasses XDG)
+
+${chalk.bold("XDG Base Directory Locations:")}
+  Config: $XDG_CONFIG_HOME/pi/agent/ (settings.json, models.json, oauth.json)
+  Data:   $XDG_DATA_HOME/pi/agent/   (sessions/, themes/, tools/, hooks/, skills/, agents/)
+  State:  $XDG_STATE_HOME/pi/agent/  (debug logs, crash logs)
+  Note: On macOS, uses ~/Library/Application Support and ~/Library/Logs by default
 
 ${chalk.bold("Available Tools (default: read, bash, edit, write):")}
   read   - Read file contents

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -3,13 +3,14 @@
  */
 
 import { ProcessTerminal, TUI } from "@mariozechner/pi-tui";
+import { getCrashLogPath } from "../config.js";
 import type { SessionManager } from "../core/session-manager.js";
 import { SessionSelectorComponent } from "../modes/interactive/components/session-selector.js";
 
 /** Show TUI session selector and return selected session path or null if cancelled */
 export async function selectSession(sessionManager: SessionManager): Promise<string | null> {
 	return new Promise((resolve) => {
-		const ui = new TUI(new ProcessTerminal());
+		const ui = new TUI(new ProcessTerminal(), getCrashLogPath());
 		let resolved = false;
 
 		const selector = new SessionSelectorComponent(

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "fs";
+import { homedir, platform } from "os";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -94,50 +94,318 @@ export const VERSION: string = pkg.version;
 export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
 
 // =============================================================================
-// User Config Paths (~/.pi/agent/*)
+// XDG Base Directory Specification Support
 // =============================================================================
 
-/** Get the agent config directory (e.g., ~/.pi/agent/) */
+/**
+ * Check if we're on macOS.
+ * macOS has different conventions, but we still support XDG env vars if set.
+ */
+function isMacOS(): boolean {
+	return platform() === "darwin";
+}
+
+/**
+ * Get XDG_CONFIG_HOME or platform-appropriate default.
+ * - If XDG_CONFIG_HOME is set, use it
+ * - macOS: ~/Library/Application Support
+ * - Linux/other: ~/.config
+ */
+export function getXdgConfigHome(): string {
+	if (process.env.XDG_CONFIG_HOME) {
+		return process.env.XDG_CONFIG_HOME;
+	}
+	if (isMacOS()) {
+		return join(homedir(), "Library", "Application Support");
+	}
+	return join(homedir(), ".config");
+}
+
+/**
+ * Get XDG_DATA_HOME or platform-appropriate default.
+ * - If XDG_DATA_HOME is set, use it
+ * - macOS: ~/Library/Application Support
+ * - Linux/other: ~/.local/share
+ */
+export function getXdgDataHome(): string {
+	if (process.env.XDG_DATA_HOME) {
+		return process.env.XDG_DATA_HOME;
+	}
+	if (isMacOS()) {
+		return join(homedir(), "Library", "Application Support");
+	}
+	return join(homedir(), ".local", "share");
+}
+
+/**
+ * Get XDG_STATE_HOME or platform-appropriate default.
+ * - If XDG_STATE_HOME is set, use it
+ * - macOS: ~/Library/Logs
+ * - Linux/other: ~/.local/state
+ */
+export function getXdgStateHome(): string {
+	if (process.env.XDG_STATE_HOME) {
+		return process.env.XDG_STATE_HOME;
+	}
+	if (isMacOS()) {
+		return join(homedir(), "Library", "Logs");
+	}
+	return join(homedir(), ".local", "state");
+}
+
+// =============================================================================
+// XDG-based Directory Functions
+// =============================================================================
+
+/**
+ * Get the config directory for the agent.
+ * Contains: settings.json, models.json, oauth.json
+ * Location: $XDG_CONFIG_HOME/pi/agent/
+ */
+export function getConfigDir(): string {
+	const envDir = process.env[ENV_AGENT_DIR];
+	if (envDir) {
+		return envDir;
+	}
+	return join(getXdgConfigHome(), "pi", "agent");
+}
+
+/**
+ * Get the data directory for the agent.
+ * Contains: sessions/, themes/, tools/, hooks/, commands/, skills/, agents/
+ * Location: $XDG_DATA_HOME/pi/agent/
+ */
+export function getDataDir(): string {
+	const envDir = process.env[ENV_AGENT_DIR];
+	if (envDir) {
+		return envDir;
+	}
+	return join(getXdgDataHome(), "pi", "agent");
+}
+
+/**
+ * Get the state directory for the agent.
+ * Contains: debug logs, crash logs
+ * Location: $XDG_STATE_HOME/pi/agent/
+ */
+export function getStateDir(): string {
+	const envDir = process.env[ENV_AGENT_DIR];
+	if (envDir) {
+		return envDir;
+	}
+	return join(getXdgStateHome(), "pi", "agent");
+}
+
+/**
+ * Get the legacy agent directory path (~/.pi/agent/).
+ * Used for migration detection.
+ */
+function getLegacyAgentDir(): string {
+	return join(homedir(), CONFIG_DIR_NAME, "agent");
+}
+
+// =============================================================================
+// Migration from Legacy Paths
+// =============================================================================
+
+// Config files that should be migrated to getConfigDir()
+const CONFIG_FILES = ["settings.json", "models.json", "oauth.json"];
+
+// Data directories that should be migrated to getDataDir()
+const DATA_DIRS = ["sessions", "themes", "tools", "hooks", "commands", "skills", "agents"];
+
+let migrationDone = false;
+
+/**
+ * Migrate files and directories from legacy ~/.pi/agent/ to XDG locations.
+ * This is called automatically on first access to any path function.
+ *
+ * Migration logic:
+ * 1. If ENV_AGENT_DIR is set, skip migration (user has explicit override)
+ * 2. If legacy dir doesn't exist, skip (nothing to migrate)
+ * 3. If XDG dirs already have content, skip (already migrated or fresh install)
+ * 4. Copy config files to getConfigDir()
+ * 5. Copy data dirs to getDataDir()
+ * 6. Copy log files to getStateDir()
+ * 7. Remove legacy directory after successful migration
+ */
+export function migrateFromLegacyPaths(): void {
+	if (migrationDone) {
+		return;
+	}
+
+	// Skip if user has explicit override
+	if (process.env[ENV_AGENT_DIR]) {
+		migrationDone = true;
+		return;
+	}
+
+	const legacyDir = getLegacyAgentDir();
+
+	// Skip if legacy directory doesn't exist
+	if (!existsSync(legacyDir)) {
+		migrationDone = true;
+		return;
+	}
+
+	const configDir = getConfigDir();
+	const dataDir = getDataDir();
+	const stateDir = getStateDir();
+
+	// Check if any XDG location already has content (indicates already migrated)
+	const configHasContent = existsSync(configDir) && readdirSync(configDir).length > 0;
+	const dataHasContent = existsSync(dataDir) && readdirSync(dataDir).length > 0;
+
+	if (configHasContent || dataHasContent) {
+		// Already migrated or fresh XDG install, don't overwrite
+		migrationDone = true;
+		return;
+	}
+
+	try {
+		// Ensure target directories exist
+		mkdirSync(configDir, { recursive: true });
+		mkdirSync(dataDir, { recursive: true });
+		mkdirSync(stateDir, { recursive: true });
+
+		// Migrate config files
+		for (const file of CONFIG_FILES) {
+			const src = join(legacyDir, file);
+			const dest = join(configDir, file);
+			if (existsSync(src) && statSync(src).isFile()) {
+				cpSync(src, dest);
+			}
+		}
+
+		// Migrate data directories
+		for (const dir of DATA_DIRS) {
+			const src = join(legacyDir, dir);
+			const dest = join(dataDir, dir);
+			if (existsSync(src) && statSync(src).isDirectory()) {
+				cpSync(src, dest, { recursive: true });
+			}
+		}
+
+		// Migrate log files to state directory
+		const legacyEntries = readdirSync(legacyDir);
+		for (const entry of legacyEntries) {
+			const src = join(legacyDir, entry);
+			if (entry.endsWith(".log") && statSync(src).isFile()) {
+				const dest = join(stateDir, entry);
+				cpSync(src, dest);
+			}
+		}
+
+		// Remove legacy directory after successful migration
+		rmSync(legacyDir, { recursive: true, force: true });
+
+		// Also try to remove parent ~/.pi/ if it's now empty
+		const legacyParent = dirname(legacyDir);
+		try {
+			if (existsSync(legacyParent) && readdirSync(legacyParent).length === 0) {
+				rmSync(legacyParent, { recursive: true, force: true });
+			}
+		} catch {
+			// Ignore errors when cleaning up parent
+		}
+	} catch (error) {
+		// Log warning but don't crash
+		console.warn(`Warning: Failed to migrate from legacy path ${legacyDir}:`, error);
+	} finally {
+		migrationDone = true;
+	}
+}
+
+/**
+ * Ensure migration has been performed.
+ * Call this early in startup to trigger migration if needed.
+ */
+export function ensureMigration(): void {
+	migrateFromLegacyPaths();
+}
+
+// =============================================================================
+// User Config Paths (XDG-compliant)
+// =============================================================================
+
+/**
+ * Get the agent directory.
+ * @deprecated Use getConfigDir(), getDataDir(), or getStateDir() instead.
+ * This is kept for backward API compatibility.
+ */
 export function getAgentDir(): string {
-	return process.env[ENV_AGENT_DIR] || join(homedir(), CONFIG_DIR_NAME, "agent");
+	migrateFromLegacyPaths();
+	return getConfigDir();
 }
 
 /** Get path to user's custom themes directory */
 export function getCustomThemesDir(): string {
-	return join(getAgentDir(), "themes");
+	migrateFromLegacyPaths();
+	return join(getDataDir(), "themes");
 }
 
 /** Get path to models.json */
 export function getModelsPath(): string {
-	return join(getAgentDir(), "models.json");
+	migrateFromLegacyPaths();
+	return join(getConfigDir(), "models.json");
 }
 
 /** Get path to oauth.json */
 export function getOAuthPath(): string {
-	return join(getAgentDir(), "oauth.json");
+	migrateFromLegacyPaths();
+	return join(getConfigDir(), "oauth.json");
 }
 
 /** Get path to settings.json */
 export function getSettingsPath(): string {
-	return join(getAgentDir(), "settings.json");
+	migrateFromLegacyPaths();
+	return join(getConfigDir(), "settings.json");
 }
 
 /** Get path to tools directory */
 export function getToolsDir(): string {
-	return join(getAgentDir(), "tools");
+	migrateFromLegacyPaths();
+	return join(getDataDir(), "tools");
+}
+
+/** Get path to hooks directory */
+export function getHooksDir(): string {
+	migrateFromLegacyPaths();
+	return join(getDataDir(), "hooks");
 }
 
 /** Get path to slash commands directory */
 export function getCommandsDir(): string {
-	return join(getAgentDir(), "commands");
+	migrateFromLegacyPaths();
+	return join(getDataDir(), "commands");
 }
 
 /** Get path to sessions directory */
 export function getSessionsDir(): string {
-	return join(getAgentDir(), "sessions");
+	migrateFromLegacyPaths();
+	return join(getDataDir(), "sessions");
+}
+
+/** Get path to skills directory */
+export function getSkillsDir(): string {
+	migrateFromLegacyPaths();
+	return join(getDataDir(), "skills");
+}
+
+/** Get path to agents directory */
+export function getAgentsDir(): string {
+	migrateFromLegacyPaths();
+	return join(getDataDir(), "agents");
 }
 
 /** Get path to debug log file */
 export function getDebugLogPath(): string {
-	return join(getAgentDir(), `${APP_NAME}-debug.log`);
+	migrateFromLegacyPaths();
+	return join(getStateDir(), `${APP_NAME}-debug.log`);
+}
+
+/** Get path to crash log file */
+export function getCrashLogPath(): string {
+	migrateFromLegacyPaths();
+	return join(getStateDir(), `${APP_NAME}-crash.log`);
 }

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -172,6 +172,16 @@ export function getXdgStateHome(): string {
 	return join(homedir(), ".local", "state");
 }
 
+/**
+ * Ensures a directory exists recursively.
+ */
+function ensureDir(dir: string): string {
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	return dir;
+}
+
 // =============================================================================
 // XDG-based Directory Functions
 // =============================================================================
@@ -184,9 +194,9 @@ export function getXdgStateHome(): string {
 export function getConfigDir(): string {
 	const envDir = process.env[ENV_AGENT_DIR];
 	if (envDir) {
-		return envDir;
+		return ensureDir(envDir);
 	}
-	return join(getXdgConfigHome(), "pi", "agent");
+	return ensureDir(join(getXdgConfigHome(), "pi", "agent"));
 }
 
 /**
@@ -197,9 +207,9 @@ export function getConfigDir(): string {
 export function getDataDir(): string {
 	const envDir = process.env[ENV_AGENT_DIR];
 	if (envDir) {
-		return envDir;
+		return ensureDir(envDir);
 	}
-	return join(getXdgDataHome(), "pi", "agent");
+	return ensureDir(join(getXdgDataHome(), "pi", "agent"));
 }
 
 /**
@@ -210,9 +220,9 @@ export function getDataDir(): string {
 export function getStateDir(): string {
 	const envDir = process.env[ENV_AGENT_DIR];
 	if (envDir) {
-		return envDir;
+		return ensureDir(envDir);
 	}
-	return join(getXdgStateHome(), "pi", "agent");
+	return ensureDir(join(getXdgStateHome(), "pi", "agent"));
 }
 
 /**
@@ -360,7 +370,7 @@ export function getAgentDir(): string {
 /** Get path to user's custom themes directory */
 export function getCustomThemesDir(): string {
 	migrateFromLegacyPaths();
-	return join(getDataDir(), "themes");
+	return ensureDir(join(getDataDir(), "themes"));
 }
 
 /** Get path to models.json */
@@ -384,37 +394,37 @@ export function getSettingsPath(): string {
 /** Get path to tools directory */
 export function getToolsDir(): string {
 	migrateFromLegacyPaths();
-	return join(getDataDir(), "tools");
+	return ensureDir(join(getDataDir(), "tools"));
 }
 
 /** Get path to hooks directory */
 export function getHooksDir(): string {
 	migrateFromLegacyPaths();
-	return join(getDataDir(), "hooks");
+	return ensureDir(join(getDataDir(), "hooks"));
 }
 
 /** Get path to slash commands directory */
 export function getCommandsDir(): string {
 	migrateFromLegacyPaths();
-	return join(getDataDir(), "commands");
+	return ensureDir(join(getDataDir(), "commands"));
 }
 
 /** Get path to sessions directory */
 export function getSessionsDir(): string {
 	migrateFromLegacyPaths();
-	return join(getDataDir(), "sessions");
+	return ensureDir(join(getDataDir(), "sessions"));
 }
 
 /** Get path to skills directory */
 export function getSkillsDir(): string {
 	migrateFromLegacyPaths();
-	return join(getDataDir(), "skills");
+	return ensureDir(join(getDataDir(), "skills"));
 }
 
 /** Get path to agents directory */
 export function getAgentsDir(): string {
 	migrateFromLegacyPaths();
-	return join(getDataDir(), "agents");
+	return ensureDir(join(getDataDir(), "agents"));
 }
 
 /** Get path to debug log file */

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -106,14 +106,25 @@ function isMacOS(): boolean {
 }
 
 /**
+ * Check if we're on Windows.
+ */
+function isWindows(): boolean {
+	return platform() === "win32";
+}
+
+/**
  * Get XDG_CONFIG_HOME or platform-appropriate default.
  * - If XDG_CONFIG_HOME is set, use it
+ * - Windows: %APPDATA%
  * - macOS: ~/Library/Application Support
  * - Linux/other: ~/.config
  */
 export function getXdgConfigHome(): string {
 	if (process.env.XDG_CONFIG_HOME) {
 		return process.env.XDG_CONFIG_HOME;
+	}
+	if (isWindows()) {
+		return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
 	}
 	if (isMacOS()) {
 		return join(homedir(), "Library", "Application Support");
@@ -124,12 +135,16 @@ export function getXdgConfigHome(): string {
 /**
  * Get XDG_DATA_HOME or platform-appropriate default.
  * - If XDG_DATA_HOME is set, use it
+ * - Windows: %APPDATA%
  * - macOS: ~/Library/Application Support
  * - Linux/other: ~/.local/share
  */
 export function getXdgDataHome(): string {
 	if (process.env.XDG_DATA_HOME) {
 		return process.env.XDG_DATA_HOME;
+	}
+	if (isWindows()) {
+		return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
 	}
 	if (isMacOS()) {
 		return join(homedir(), "Library", "Application Support");
@@ -140,12 +155,16 @@ export function getXdgDataHome(): string {
 /**
  * Get XDG_STATE_HOME or platform-appropriate default.
  * - If XDG_STATE_HOME is set, use it
+ * - Windows: %LOCALAPPDATA%
  * - macOS: ~/Library/Logs
  * - Linux/other: ~/.local/state
  */
 export function getXdgStateHome(): string {
 	if (process.env.XDG_STATE_HOME) {
 		return process.env.XDG_STATE_HOME;
+	}
+	if (isWindows()) {
+		return process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local");
 	}
 	if (isMacOS()) {
 		return join(homedir(), "Library", "Logs");

--- a/packages/coding-agent/src/core/custom-tools/loader.ts
+++ b/packages/coding-agent/src/core/custom-tools/loader.ts
@@ -9,7 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
-import { getAgentDir } from "../../config.js";
+import { CONFIG_DIR_NAME, getAgentDir } from "../../config.js";
 import type { HookUIContext } from "../hooks/types.js";
 import type {
 	CustomToolFactory,
@@ -336,7 +336,7 @@ export async function discoverAndLoadCustomTools(
 	addPaths(discoverToolsInDir(globalToolsDir));
 
 	// 2. Project-local tools: cwd/.pi/tools/
-	const localToolsDir = path.join(cwd, ".pi", "tools");
+	const localToolsDir = path.join(cwd, CONFIG_DIR_NAME, "tools");
 	addPaths(discoverToolsInDir(localToolsDir));
 
 	// 3. Explicitly configured paths (can override/add)

--- a/packages/coding-agent/src/core/custom-tools/loader.ts
+++ b/packages/coding-agent/src/core/custom-tools/loader.ts
@@ -35,6 +35,7 @@ function getAliases(): Record<string, string> {
 		"@mariozechner/pi-coding-agent": packageIndex,
 		"@mariozechner/pi-tui": require.resolve("@mariozechner/pi-tui"),
 		"@mariozechner/pi-ai": require.resolve("@mariozechner/pi-ai"),
+		"@sinclair/typebox/compiler": require.resolve("@sinclair/typebox/compiler"),
 		"@sinclair/typebox": require.resolve("@sinclair/typebox"),
 	};
 	return _aliases;

--- a/packages/coding-agent/src/core/hooks/loader.ts
+++ b/packages/coding-agent/src/core/hooks/loader.ts
@@ -9,7 +9,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Attachment } from "@mariozechner/pi-agent-core";
 import { createJiti } from "jiti";
-import { getAgentDir } from "../../config.js";
+import { CONFIG_DIR_NAME, getAgentDir } from "../../config.js";
 import type { HookAPI, HookFactory } from "./types.js";
 
 // Create require function to resolve module paths at runtime
@@ -245,7 +245,7 @@ export async function discoverAndLoadHooks(configuredPaths: string[], cwd: strin
 	addPaths(discoverHooksInDir(globalHooksDir));
 
 	// 2. Project-local hooks: cwd/.pi/hooks/
-	const localHooksDir = path.join(cwd, ".pi", "hooks");
+	const localHooksDir = path.join(cwd, CONFIG_DIR_NAME, "hooks");
 	addPaths(discoverHooksInDir(localHooksDir));
 
 	// 3. Explicitly configured paths (can override/add)

--- a/packages/coding-agent/src/core/hooks/loader.ts
+++ b/packages/coding-agent/src/core/hooks/loader.ts
@@ -28,6 +28,7 @@ function getAliases(): Record<string, string> {
 		"@mariozechner/pi-coding-agent/hooks": path.resolve(__dirname, "index.js"),
 		"@mariozechner/pi-tui": require.resolve("@mariozechner/pi-tui"),
 		"@mariozechner/pi-ai": require.resolve("@mariozechner/pi-ai"),
+		"@sinclair/typebox/compiler": require.resolve("@sinclair/typebox/compiler"),
 		"@sinclair/typebox": require.resolve("@sinclair/typebox"),
 	};
 	return _aliases;

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, join, resolve } from "path";
-import { CONFIG_DIR_NAME } from "../config.js";
+import { CONFIG_DIR_NAME, getSkillsDir } from "../config.js";
 
 /**
  * Standard frontmatter fields per Agent Skills spec.
@@ -347,7 +347,7 @@ export function loadSkills(): LoadSkillsResult {
 	addSkills(loadSkillsFromDirInternal(claudeProjectDir, "claude-project", "claude"));
 
 	// Pi: recursive
-	const globalSkillsDir = join(homedir(), CONFIG_DIR_NAME, "agent", "skills");
+	const globalSkillsDir = getSkillsDir();
 	addSkills(loadSkillsFromDirInternal(globalSkillsDir, "user", "recursive"));
 
 	const projectSkillsDir = resolve(process.cwd(), CONFIG_DIR_NAME, "skills");

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,4 +1,16 @@
 // Core session management
+
+// Config paths for custom tools
+export {
+	CONFIG_DIR_NAME,
+	getAgentsDir,
+	getConfigDir,
+	getDataDir,
+	getHooksDir,
+	getSkillsDir,
+	getStateDir,
+	getToolsDir,
+} from "./config.js";
 export {
 	AgentSession,
 	type AgentSessionConfig,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -24,7 +24,7 @@ import {
 	visibleWidth,
 } from "@mariozechner/pi-tui";
 import { exec } from "child_process";
-import { APP_NAME, getDebugLogPath, getOAuthPath } from "../../config.js";
+import { APP_NAME, getCrashLogPath, getDebugLogPath, getOAuthPath } from "../../config.js";
 import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
 import type { LoadedCustomTool, SessionEvent as ToolSessionEvent } from "../../core/custom-tools/index.js";
 import type { HookUIContext } from "../../core/hooks/index.js";
@@ -141,7 +141,7 @@ export class InteractiveMode {
 		this.version = version;
 		this.changelogMarkdown = changelogMarkdown;
 		this.customTools = new Map(customTools.map((ct) => [ct.tool.name, ct]));
-		this.ui = new TUI(new ProcessTerminal());
+		this.ui = new TUI(new ProcessTerminal(), getCrashLogPath());
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -44,7 +44,8 @@ export function getShellConfig(): { shell: string; args: string[] } {
 			return cachedShellConfig;
 		}
 		throw new Error(
-			`Custom shell path not found: ${customShellPath}\n` + `Please update shellPath in ~/.pi/agent/settings.json`,
+			`Custom shell path not found: ${customShellPath}\n` +
+				`Please update shellPath in settings.json in your config directory.`,
 		);
 	}
 
@@ -78,7 +79,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
 			`No bash shell found. Options:\n` +
 				`  1. Install Git for Windows: https://git-scm.com/download/win\n` +
 				`  2. Add your bash to PATH (Cygwin, MSYS2, etc.)\n` +
-				`  3. Set shellPath in ~/.pi/agent/settings.json\n\n` +
+				`  3. Set shellPath in settings.json in your config directory\n\n` +
 				`Searched Git Bash in:\n${paths.map((p) => `  ${p}`).join("\n")}`,
 		);
 	}

--- a/packages/pods/src/config.ts
+++ b/packages/pods/src/config.ts
@@ -38,6 +38,16 @@ function getXdgConfigHome(): string {
 }
 
 /**
+ * Ensures a directory exists recursively.
+ */
+function ensureDir(dir: string): string {
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	return dir;
+}
+
+/**
  * Get the legacy config path (~/.pi/pods.json).
  */
 function getLegacyConfigPath(): string {
@@ -102,10 +112,7 @@ function migrateFromLegacyPath(): void {
 const getConfigDir = (): string => {
 	migrateFromLegacyPath();
 	const configDir = process.env.PI_CONFIG_DIR || join(getXdgConfigHome(), "pi");
-	if (!existsSync(configDir)) {
-		mkdirSync(configDir, { recursive: true });
-	}
-	return configDir;
+	return ensureDir(configDir);
 };
 
 const getConfigPath = (): string => {

--- a/packages/pods/src/config.ts
+++ b/packages/pods/src/config.ts
@@ -15,11 +15,21 @@ function isMacOS(): boolean {
 }
 
 /**
+ * Check if we're on Windows.
+ */
+function isWindows(): boolean {
+	return platform() === "win32";
+}
+
+/**
  * Get XDG_CONFIG_HOME or platform-appropriate default.
  */
 function getXdgConfigHome(): string {
 	if (process.env.XDG_CONFIG_HOME) {
 		return process.env.XDG_CONFIG_HOME;
+	}
+	if (isWindows()) {
+		return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
 	}
 	if (isMacOS()) {
 		return join(homedir(), "Library", "Application Support");

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -75,6 +75,7 @@ export class Container implements Component {
  */
 export class TUI extends Container {
 	public terminal: Terminal;
+	public crashLogPath: string;
 	private previousLines: string[] = [];
 	private previousWidth = 0;
 	private focusedComponent: Component | null = null;
@@ -83,9 +84,10 @@ export class TUI extends Container {
 	private inputBuffer = ""; // Buffer for parsing terminal responses
 	private cellSizeQueryPending = false;
 
-	constructor(terminal: Terminal) {
+	constructor(terminal: Terminal, crashLogPath?: string) {
 		super();
 		this.terminal = terminal;
+		this.crashLogPath = crashLogPath ?? path.join(os.tmpdir(), "pi-crash.log");
 	}
 
 	setFocus(component: Component | null): void {
@@ -295,7 +297,7 @@ export class TUI extends Container {
 			const isImageLine = this.containsImage(line);
 			if (!isImageLine && visibleWidth(line) > width) {
 				// Log all lines to crash file for debugging
-				const crashLogPath = path.join(os.homedir(), ".pi", "agent", "pi-crash.log");
+				const crashLogPath = this.crashLogPath;
 				const crashData = [
 					`Crash at ${new Date().toISOString()}`,
 					`Terminal width: ${width}`,


### PR DESCRIPTION
## Summary

Implements XDG Base Directory Specification compliance for config, data, and state directories with automatic migration from legacy `~/.pi/` paths.

## Changes

### New XDG Path Helpers
- `getXdgConfigHome()` - Returns `$XDG_CONFIG_HOME` or platform default
- `getXdgDataHome()` - Returns `$XDG_DATA_HOME` or platform default
- `getXdgStateHome()` - Returns `$XDG_STATE_HOME` or platform default

### Category-Specific Directories
- `getConfigDir()` - Config files (settings.json, models.json, oauth.json)
- `getDataDir()` - User data (sessions/, themes/, tools/, hooks/, commands/, skills/, agents/)
- `getStateDir()` - State/logs (debug logs, crash logs)

### Platform Defaults
- **Linux**: `~/.config`, `~/.local/share`, `~/.local/state`
- **macOS**: `~/Library/Application Support`, `~/Library/Logs` (when XDG env vars not set)

### Auto-Migration
- Automatically migrates existing `~/.pi/` data to XDG paths on first run
- Copies files/directories to new locations, then removes legacy directory
- Migration runs once per process with robust error handling (finally block)
- `ENV_AGENT_DIR` override still takes highest priority

### Packages Updated
- `coding-agent` - Full XDG support with migration
- `pods` - XDG support with migration for pods.json
- `tui` - Configurable crash log path (no hardcoded legacy paths)

### Other Improvements
- Use `CONFIG_DIR_NAME` constant for project-local discovery in loaders
- Updated CLI help text to document XDG locations
- Removed hardcoded `~/.pi/` paths from error messages

## Testing
- All checks pass (`npm run check`)
- Migration logic tested for: new installs, existing installs, error conditions