### PR TITLE
fix(ai): Google thinking detection + remove unsupported id fields

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -511,6 +511,12 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 										});
 									} else {
 										currentBlock.text += part.text;
+										if (part.thoughtSignature) {
+											currentBlock.textSignature = retainThoughtSignature(
+												currentBlock.textSignature,
+												part.thoughtSignature,
+											);
+										}
 										stream.push({
 											type: "text_delta",
 											contentIndex: blockIndex(),

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -511,12 +511,10 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 										});
 									} else {
 										currentBlock.text += part.text;
-										if (part.thoughtSignature) {
-											currentBlock.textSignature = retainThoughtSignature(
-												currentBlock.textSignature,
-												part.thoughtSignature,
-											);
-										}
+										currentBlock.textSignature = retainThoughtSignature(
+											currentBlock.textSignature,
+											part.thoughtSignature,
+										);
 										stream.push({
 											type: "text_delta",
 											contentIndex: blockIndex(),

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -85,7 +85,10 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 				if (block.type === "text") {
 					// Skip empty text blocks - they can cause issues with some models (e.g. Claude via Antigravity)
 					if (!block.text || block.text.trim() === "") continue;
-					parts.push({ text: sanitizeSurrogates(block.text) });
+					parts.push({
+						text: sanitizeSurrogates(block.text),
+						...(block.textSignature && { thoughtSignature: block.textSignature }),
+					});
 				} else if (block.type === "thinking") {
 					// Skip empty thinking blocks
 					if (!block.thinking || block.thinking.trim() === "") continue;

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -142,6 +142,12 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 								});
 							} else {
 								currentBlock.text += part.text;
+								if (part.thoughtSignature) {
+									currentBlock.textSignature = retainThoughtSignature(
+										currentBlock.textSignature,
+										part.thoughtSignature,
+									);
+								}
 								stream.push({
 									type: "text_delta",
 									contentIndex: blockIndex(),

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -142,12 +142,10 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 								});
 							} else {
 								currentBlock.text += part.text;
-								if (part.thoughtSignature) {
-									currentBlock.textSignature = retainThoughtSignature(
-										currentBlock.textSignature,
-										part.thoughtSignature,
-									);
-								}
+								currentBlock.textSignature = retainThoughtSignature(
+									currentBlock.textSignature,
+									part.thoughtSignature,
+								);
 								stream.push({
 									type: "text_delta",
 									contentIndex: blockIndex(),

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -129,12 +129,10 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 								});
 							} else {
 								currentBlock.text += part.text;
-								if (part.thoughtSignature) {
-									currentBlock.textSignature = retainThoughtSignature(
-										currentBlock.textSignature,
-										part.thoughtSignature,
-									);
-								}
+								currentBlock.textSignature = retainThoughtSignature(
+									currentBlock.textSignature,
+									part.thoughtSignature,
+								);
 								stream.push({
 									type: "text_delta",
 									contentIndex: blockIndex(),

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -129,6 +129,12 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 								});
 							} else {
 								currentBlock.text += part.text;
+								if (part.thoughtSignature) {
+									currentBlock.textSignature = retainThoughtSignature(
+										currentBlock.textSignature,
+										part.thoughtSignature,
+									);
+								}
 								stream.push({
 									type: "text_delta",
 									contentIndex: blockIndex(),

--- a/packages/ai/test/google-thinking-signature.test.ts
+++ b/packages/ai/test/google-thinking-signature.test.ts
@@ -4,12 +4,15 @@ import { isThinkingPart, retainThoughtSignature } from "../src/providers/google-
 describe("Google thinking detection (thoughtSignature)", () => {
 	it("treats part.thought === true as thinking", () => {
 		expect(isThinkingPart({ thought: true, thoughtSignature: undefined })).toBe(true);
+		expect(isThinkingPart({ thought: true, thoughtSignature: "opaque-signature" })).toBe(true);
 	});
 
-	it("treats a non-empty thoughtSignature as thinking even if thought is missing", () => {
-		// This is the bug: some backends omit `thought: true` but still include `thoughtSignature`
-		expect(isThinkingPart({ thought: undefined, thoughtSignature: "opaque-signature" })).toBe(true);
-		expect(isThinkingPart({ thought: false, thoughtSignature: "opaque-signature" })).toBe(true);
+	it("does not treat thoughtSignature alone as thinking", () => {
+		// Per Google docs, thoughtSignature is for context replay and can appear on any part type.
+		// Only thought === true indicates thinking content.
+		// See: https://ai.google.dev/gemini-api/docs/thought-signatures
+		expect(isThinkingPart({ thought: undefined, thoughtSignature: "opaque-signature" })).toBe(false);
+		expect(isThinkingPart({ thought: false, thoughtSignature: "opaque-signature" })).toBe(false);
 	});
 
 	it("does not treat empty/missing signatures as thinking if thought is not set", () => {
@@ -32,6 +35,4 @@ describe("Google thinking detection (thoughtSignature)", () => {
 		const updated = retainThoughtSignature("sig-1", "sig-2");
 		expect(updated).toBe("sig-2");
 	});
-
-	// Note: signature-only parts (empty text + thoughtSignature) are handled by isThinkingPart via thoughtSignature presence.
 });


### PR DESCRIPTION
Found a couple issues with the google provider while testing & getting tortured by google api schema.

**1. thinking content incorrectly detected**

`isThinkingPart()` was treating any part with a `thoughtSignature` as thinking content. but per [google's docs](https://ai.google.dev/gemini-api/docs/thought-signatures), `thoughtSignature` is just for context replay and can show up on any part type (text, function calls, etc). only `thought: true` means it's actual thinking.

this was causing normal text responses to render as thinking blocks in the tui.

**2. `id` field rejected by some backends**

`functionCall` and `functionResponse` were including an `id` field. some google backends (vertex, cloud code assist) reject it with a 400 error. since `id` is optional for all google apis, just removed it entirely.