### PR TITLE
feat(edit): add fuzzy matching for trailing whitespace, quotes, dashes, and spaces

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Edit tool now uses fuzzy matching as fallback when exact match fails, tolerating trailing whitespace, smart quotes, Unicode dashes, and special spaces
+
 ## [0.45.7] - 2026-01-13
 
 ### Added

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -24,6 +24,97 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
 	return ending === "\r\n" ? text.replace(/\n/g, "\r\n") : text;
 }
 
+/**
+ * Normalize text for fuzzy matching. Applies progressive transformations:
+ * - Strip trailing whitespace from each line
+ * - Normalize smart quotes to ASCII equivalents
+ * - Normalize Unicode dashes/hyphens to ASCII hyphen
+ * - Normalize special Unicode spaces to regular space
+ */
+export function normalizeForFuzzyMatch(text: string): string {
+	return (
+		text
+			// Strip trailing whitespace per line
+			.split("\n")
+			.map((line) => line.trimEnd())
+			.join("\n")
+			// Smart single quotes → '
+			.replace(/[\u2018\u2019\u201A\u201B]/g, "'")
+			// Smart double quotes → "
+			.replace(/[\u201C\u201D\u201E\u201F]/g, '"')
+			// Various dashes/hyphens → -
+			// U+2010 hyphen, U+2011 non-breaking hyphen, U+2012 figure dash,
+			// U+2013 en-dash, U+2014 em-dash, U+2015 horizontal bar, U+2212 minus
+			.replace(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g, "-")
+			// Special spaces → regular space
+			// U+00A0 NBSP, U+2002-U+200A various spaces, U+202F narrow NBSP,
+			// U+205F medium math space, U+3000 ideographic space
+			.replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ")
+	);
+}
+
+export interface FuzzyMatchResult {
+	/** Whether a match was found */
+	found: boolean;
+	/** The index where the match starts (in the content that should be used for replacement) */
+	index: number;
+	/** Length of the matched text */
+	matchLength: number;
+	/** Whether fuzzy matching was used (false = exact match) */
+	usedFuzzyMatch: boolean;
+	/**
+	 * The content to use for replacement operations.
+	 * When exact match: original content. When fuzzy match: normalized content.
+	 */
+	contentForReplacement: string;
+}
+
+/**
+ * Find oldText in content, trying exact match first, then fuzzy match.
+ * When fuzzy matching is used, the returned contentForReplacement is the
+ * fuzzy-normalized version of the content (trailing whitespace stripped,
+ * Unicode quotes/dashes normalized to ASCII).
+ */
+export function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
+	// Try exact match first
+	const exactIndex = content.indexOf(oldText);
+	if (exactIndex !== -1) {
+		return {
+			found: true,
+			index: exactIndex,
+			matchLength: oldText.length,
+			usedFuzzyMatch: false,
+			contentForReplacement: content,
+		};
+	}
+
+	// Try fuzzy match - work entirely in normalized space
+	const fuzzyContent = normalizeForFuzzyMatch(content);
+	const fuzzyOldText = normalizeForFuzzyMatch(oldText);
+	const fuzzyIndex = fuzzyContent.indexOf(fuzzyOldText);
+
+	if (fuzzyIndex === -1) {
+		return {
+			found: false,
+			index: -1,
+			matchLength: 0,
+			usedFuzzyMatch: false,
+			contentForReplacement: content,
+		};
+	}
+
+	// When fuzzy matching, we work in the normalized space for replacement.
+	// This means the output will have normalized whitespace/quotes/dashes,
+	// which is acceptable since we're fixing minor formatting differences anyway.
+	return {
+		found: true,
+		index: fuzzyIndex,
+		matchLength: fuzzyOldText.length,
+		usedFuzzyMatch: true,
+		contentForReplacement: fuzzyContent,
+	};
+}
+
 /** Strip UTF-8 BOM if present, return both the BOM (if any) and the text without it */
 export function stripBom(content: string): { bom: string; text: string } {
 	return content.startsWith("\uFEFF") ? { bom: "\uFEFF", text: content.slice(1) } : { bom: "", text: content };
@@ -174,37 +265,43 @@ export async function computeEditDiff(
 		const normalizedOldText = normalizeToLF(oldText);
 		const normalizedNewText = normalizeToLF(newText);
 
-		// Check if old text exists
-		if (!normalizedContent.includes(normalizedOldText)) {
+		// Find the old text using fuzzy matching (tries exact match first, then fuzzy)
+		const matchResult = fuzzyFindText(normalizedContent, normalizedOldText);
+
+		if (!matchResult.found) {
 			return {
 				error: `Could not find the exact text in ${path}. The old text must match exactly including all whitespace and newlines.`,
 			};
 		}
 
-		// Count occurrences
-		const occurrences = normalizedContent.split(normalizedOldText).length - 1;
+		// Count occurrences using fuzzy-normalized content for consistency
+		const fuzzyContent = normalizeForFuzzyMatch(normalizedContent);
+		const fuzzyOldText = normalizeForFuzzyMatch(normalizedOldText);
+		const occurrences = fuzzyContent.split(fuzzyOldText).length - 1;
+
 		if (occurrences > 1) {
 			return {
 				error: `Found ${occurrences} occurrences of the text in ${path}. The text must be unique. Please provide more context to make it unique.`,
 			};
 		}
 
-		// Compute the new content
-		const index = normalizedContent.indexOf(normalizedOldText);
-		const normalizedNewContent =
-			normalizedContent.substring(0, index) +
+		// Compute the new content using the matched position
+		// When fuzzy matching was used, contentForReplacement is the normalized version
+		const baseContent = matchResult.contentForReplacement;
+		const newContent =
+			baseContent.substring(0, matchResult.index) +
 			normalizedNewText +
-			normalizedContent.substring(index + normalizedOldText.length);
+			baseContent.substring(matchResult.index + matchResult.matchLength);
 
 		// Check if it would actually change anything
-		if (normalizedContent === normalizedNewContent) {
+		if (baseContent === newContent) {
 			return {
 				error: `No changes would be made to ${path}. The replacement produces identical content.`,
 			};
 		}
 
 		// Generate the diff
-		return generateDiffString(normalizedContent, normalizedNewContent);
+		return generateDiffString(baseContent, newContent);
 	} catch (err) {
 		return { error: err instanceof Error ? err.message : String(err) };
 	}


### PR DESCRIPTION
Adds fuzzy matching capabilities to the edit tool, reducing failures caused by minor whitespace and Unicode character differences between the LLM's output and actual file contents.

### Problem

The edit tool frequently fails with "Could not find the exact text" errors due to:
- Trailing whitespace differences (LLM strips trailing spaces, file has them)
- Smart/curly quotes vs ASCII quotes (copy-pasted from documentation)
- Unicode dashes vs ASCII hyphens (en-dash, em-dash from formatted text)
- Non-breaking spaces vs regular spaces

### Solution

Progressive fuzzy matching that tries exact match first, then falls back to normalized matching. This mirrors approaches used by other coding agents:

| Feature | Pi (new) | Claude Code | OpenCode | OpenAI Codex |
|---------|----------|-------------|----------|--------------|
| Trailing whitespace | ✅ | ✅ | ✅ | ✅ |
| Smart quotes | ✅ | ✅ | ❌ | ✅ |
| Unicode dashes | ✅ | ❌ | ❌ | ✅ |
| Unicode spaces | ✅ | ❌ | ❌ | ✅ |
| Leading whitespace | ❌ | ❌ | ✅ | ✅ |

**Why not leading whitespace?** Indentation is semantically meaningful in Python, YAML, and other languages. OpenCode tracks "fuzz level" and rejects high-fuzz matches specifically because leading whitespace tolerance can cause wrong matches.

### Implementation

- `normalizeForFuzzyMatch()` - strips trailing whitespace, normalizes Unicode quotes/dashes/spaces to ASCII
- `fuzzyFindText()` - tries exact match first, falls back to fuzzy match
- When fuzzy matching is used, replacement happens in normalized space (acceptable since we're fixing formatting issues)
- Duplicate detection uses fuzzy normalization to prevent false negatives

### Testing

Added 8 new tests covering:
- Trailing whitespace tolerance
- Smart single/double quotes → ASCII
- Unicode dashes → ASCII hyphen
- Non-breaking space → regular space
- Exact match preferred over fuzzy
- Proper failure when no match exists
- Duplicate detection after normalization