### PR TITLE
feat(coding-agent): add ACP mode for editor integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,15 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"node_modules/@agentclientprotocol/sdk": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.13.0.tgz",
+			"integrity": "sha512-Z6/Fp4cXLbYdMXr5AK752JM5qG2VKb6ShM0Ql6FimBSckMmLyK54OA20UhPYoH4C37FSFwUTARuwQOwQUToYrw==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			}
+		},
 		"node_modules/@anthropic-ai/sandbox-runtime": {
 			"version": "0.0.16",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.16.tgz",
@@ -6409,7 +6418,6 @@
 			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -7764,7 +7772,6 @@
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
 			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/dcastil"
@@ -7793,8 +7800,7 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -7912,7 +7918,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8009,7 +8014,6 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -8089,7 +8093,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -8204,7 +8207,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8684,6 +8686,7 @@
 			"version": "0.49.1",
 			"license": "MIT",
 			"dependencies": {
+				"@agentclientprotocol/sdk": "^0.13.0",
 				"@mariozechner/clipboard": "^0.3.0",
 				"@mariozechner/jiti": "^2.6.2",
 				"@mariozechner/pi-agent-core": "^0.49.1",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [Unreleased]
 
-### Added
-
-- Added ACP (Agent Client Protocol) mode (`--mode acp`) for integration with ACP-compatible editors like Zed and JetBrains IDEs
-- Added slash commands support to ACP mode, advertising available commands to clients on session creation. Built-in commands include `/compact`, `/new`, and `/thinking`. Prompt templates, skill commands, and extension-registered commands are also exposed when available.
-
 ## [0.49.1] - 2026-01-18
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added ACP (Agent Client Protocol) mode (`--mode acp`) for integration with ACP-compatible editors like Zed and JetBrains IDEs
+- Added slash commands support to ACP mode, advertising available commands to clients on session creation. Built-in commands include `/compact`, `/new`, and `/thinking`. Prompt templates, skill commands, and extension-registered commands are also exposed when available.
 
 ## [0.49.1] - 2026-01-18
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added ACP (Agent Client Protocol) mode (`--mode acp`) for integration with ACP-compatible editors like Zed and JetBrains IDEs
+
 ## [0.49.1] - 2026-01-18
 
 ### Added

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -47,6 +47,7 @@ Works on Linux, macOS, and Windows (requires bash; see [Windows Setup](#windows-
 - [Programmatic Usage](#programmatic-usage)
   - [SDK](#sdk)
   - [RPC Mode](#rpc-mode)
+  - [ACP Mode](#acp-mode)
   - [HTML Export](#html-export)
 - [Philosophy](#philosophy)
 - [Development](#development)
@@ -1394,6 +1395,25 @@ Send JSON commands on stdin:
 ```
 
 > See [RPC Documentation](docs/rpc.md) for the full protocol.
+
+### ACP Mode
+
+For integration with ACP-compatible editors (Zed, JetBrains IDEs, etc.):
+
+```bash
+pi --mode acp
+```
+
+ACP (Agent Client Protocol) is a standardized JSON-RPC protocol for communication between code editors and AI coding agents. When running in ACP mode, pi acts as an ACP-compliant agent that can be launched by the editor as a subprocess.
+
+**Supported features:**
+- Session creation and management
+- Prompt processing with streaming responses
+- Tool call notifications (read, write, edit, bash)
+- Thinking/reasoning display
+- Cancellation via `session/cancel`
+
+> See [ACP Protocol Documentation](https://agentclientprotocol.com/) for the full specification.
 
 ### HTML Export
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -38,6 +38,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
+		"@agentclientprotocol/sdk": "^0.13.0",
 		"@mariozechner/clipboard": "^0.3.0",
 		"@mariozechner/jiti": "^2.6.2",
 		"@mariozechner/pi-agent-core": "^0.49.1",

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -7,7 +7,7 @@ import chalk from "chalk";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR } from "../config.js";
 import { allTools, type ToolName } from "../core/tools/index.js";
 
-export type Mode = "text" | "json" | "rpc";
+export type Mode = "text" | "json" | "rpc" | "acp";
 
 export interface Args {
 	provider?: string;
@@ -62,7 +62,7 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.version = true;
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
-			if (mode === "text" || mode === "json" || mode === "rpc") {
+			if (mode === "text" || mode === "json" || mode === "rpc" || mode === "acp") {
 				result.mode = mode;
 			}
 		} else if (arg === "--continue" || arg === "-c") {
@@ -168,7 +168,7 @@ ${chalk.bold("Options:")}
   --api-key <key>                API key (defaults to env vars)
   --system-prompt <text>         System prompt (default: coding assistant prompt)
   --append-system-prompt <text>  Append text or file contents to the system prompt
-  --mode <mode>                  Output mode: text (default), json, or rpc
+  --mode <mode>                  Output mode: text (default), json, rpc, or acp
   --print, -p                    Non-interactive mode: process prompt and exit
   --continue, -c                 Continue previous session
   --resume, -r                   Select a session to resume

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -384,8 +384,8 @@ export async function main(args: string[]) {
 		return;
 	}
 
-	// Read piped stdin content (if any) - skip for RPC mode which uses stdin for JSON-RPC
-	if (parsed.mode !== "rpc") {
+	// Read piped stdin content (if any) - skip for RPC/ACP modes which use stdin for JSON-RPC
+	if (parsed.mode !== "rpc" && parsed.mode !== "acp") {
 		const stdinContent = await readPipedStdin();
 		if (stdinContent !== undefined) {
 			// Force print mode since interactive mode requires a TTY for keyboard input

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -28,7 +28,7 @@ import { resolvePromptInput } from "./core/system-prompt.js";
 import { printTimings, time } from "./core/timings.js";
 import { allTools } from "./core/tools/index.js";
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
-import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.js";
+import { InteractiveMode, runAcpMode, runPrintMode, runRpcMode } from "./modes/index.js";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.js";
 
 /**
@@ -502,6 +502,8 @@ export async function main(args: string[]) {
 
 	if (mode === "rpc") {
 		await runRpcMode(session);
+	} else if (mode === "acp") {
+		await runAcpMode(session);
 	} else if (isInteractive) {
 		if (scopedModels.length > 0 && !settingsManager.getQuietStartup()) {
 			const modelList = scopedModels

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -75,6 +75,9 @@ export class PiAgent implements acp.Agent {
 		const acpSession = new AcpSession(sessionId, this._agentSession, this._connection);
 		this._sessions.set(sessionId, acpSession);
 
+		// Send available commands after session creation
+		acpSession.sendAvailableCommands();
+
 		acpDebug(`newSession: created session ${sessionId}`);
 		return {
 			sessionId,

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1,0 +1,116 @@
+/**
+ * PiAgent: ACP Agent interface implementation for pi.
+ *
+ * Implements the Agent interface from @agentclientprotocol/sdk to handle
+ * ACP protocol requests and manage sessions.
+ */
+
+import * as crypto from "node:crypto";
+import type * as acp from "@agentclientprotocol/sdk";
+import { VERSION } from "../../config.js";
+import type { AgentSession } from "../../core/agent-session.js";
+import { AcpSession } from "./acp-session.js";
+
+/** ACP protocol version supported by this implementation */
+const PROTOCOL_VERSION = 1;
+
+/**
+ * PiAgent implements the ACP Agent interface.
+ *
+ * Handles initialization, session management, and prompt processing
+ * by delegating to AcpSession instances that wrap AgentSession.
+ */
+export class PiAgent implements acp.Agent {
+	private readonly _agentSession: AgentSession;
+	private readonly _connection: acp.AgentSideConnection;
+	private readonly _sessions: Map<string, AcpSession> = new Map();
+
+	constructor(session: AgentSession, connection: acp.AgentSideConnection) {
+		this._agentSession = session;
+		this._connection = connection;
+	}
+
+	/**
+	 * Initialize the agent and negotiate capabilities.
+	 *
+	 * Returns the protocol version and agent capabilities including
+	 * support for images and embedded context.
+	 */
+	async initialize(params: acp.InitializeRequest): Promise<acp.InitializeResponse> {
+		return {
+			protocolVersion: Math.min(params.protocolVersion, PROTOCOL_VERSION),
+			agentInfo: {
+				name: "pi",
+				version: VERSION,
+			},
+			agentCapabilities: {
+				promptCapabilities: {
+					image: true,
+					embeddedContext: true,
+				},
+			},
+			// No auth required for pi
+			authMethods: [],
+		};
+	}
+
+	/**
+	 * Create a new session.
+	 *
+	 * Creates an AcpSession wrapper around the AgentSession and returns
+	 * a unique session ID for subsequent requests.
+	 *
+	 * Note: pi ignores the cwd and mcpServers parameters as it manages
+	 * its own working directory and tool system.
+	 */
+	async newSession(_params: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
+		const sessionId = crypto.randomUUID();
+
+		// Create AcpSession wrapper
+		const acpSession = new AcpSession(sessionId, this._agentSession, this._connection);
+		this._sessions.set(sessionId, acpSession);
+
+		return {
+			sessionId,
+		};
+	}
+
+	/**
+	 * Process a user prompt.
+	 *
+	 * Delegates to the AcpSession for the given session ID.
+	 * Returns the stop reason when processing completes.
+	 */
+	async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
+		const session = this._sessions.get(params.sessionId);
+		if (!session) {
+			throw new Error(`Session not found: ${params.sessionId}`);
+		}
+
+		return session.prompt(params);
+	}
+
+	/**
+	 * Cancel ongoing operations for a session.
+	 *
+	 * Delegates to the AcpSession for the given session ID.
+	 */
+	async cancel(params: acp.CancelNotification): Promise<void> {
+		const session = this._sessions.get(params.sessionId);
+		if (!session) {
+			// Session not found - nothing to cancel
+			return;
+		}
+
+		session.cancel();
+	}
+
+	/**
+	 * Authenticate the client.
+	 *
+	 * Pi doesn't require authentication, so this is a no-op.
+	 */
+	async authenticate(_params: acp.AuthenticateRequest): Promise<acp.AuthenticateResponse> {
+		return {};
+	}
+}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -46,9 +46,9 @@ export class PiAgent implements acp.Agent {
 				version: VERSION,
 			},
 			agentCapabilities: {
+				loadSession: true,
 				promptCapabilities: {
 					image: true,
-					embeddedContext: true,
 				},
 			},
 			// No auth required for pi
@@ -78,9 +78,21 @@ export class PiAgent implements acp.Agent {
 		// Send available commands after session creation
 		acpSession.sendAvailableCommands();
 
+		// Build models state
+		const availableModels = await this._agentSession.getAvailableModels();
+		const currentModel = this._agentSession.model;
+		const models: acp.SessionModelState = {
+			availableModels: availableModels.map((m) => ({
+				modelId: `${m.provider}/${m.id}`,
+				name: `${m.name} (${m.provider})`,
+			})),
+			currentModelId: currentModel ? `${currentModel.provider}/${currentModel.id}` : "",
+		};
+
 		acpDebug(`newSession: created session ${sessionId}`);
 		return {
 			sessionId,
+			models,
 		};
 	}
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -5,7 +5,6 @@
  * ACP protocol requests and manage sessions.
  */
 
-import * as crypto from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
 import { VERSION } from "../../config.js";
 import type { AgentSession } from "../../core/agent-session.js";
@@ -61,15 +60,18 @@ export class PiAgent implements acp.Agent {
 	/**
 	 * Create a new session.
 	 *
-	 * Creates an AcpSession wrapper around the AgentSession and returns
-	 * a unique session ID for subsequent requests.
+	 * Creates a new pi session via AgentSession.newSession() and wraps it
+	 * with an AcpSession. Returns the pi session ID for subsequent requests.
 	 *
 	 * Note: pi ignores the cwd and mcpServers parameters as it manages
 	 * its own working directory and tool system.
 	 */
 	async newSession(params: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
 		acpDebug(`newSession: cwd=${params.cwd}`);
-		const sessionId = crypto.randomUUID();
+
+		// Create a new pi session
+		await this._agentSession.newSession();
+		const sessionId = this._agentSession.sessionId;
 
 		// Create AcpSession wrapper
 		const acpSession = new AcpSession(sessionId, this._agentSession, this._connection);

--- a/packages/coding-agent/src/modes/acp/acp-commands.ts
+++ b/packages/coding-agent/src/modes/acp/acp-commands.ts
@@ -1,0 +1,237 @@
+/**
+ * ACP slash command handling.
+ *
+ * Provides command building and execution for ACP sessions.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { AgentSession } from "../../core/agent-session.js";
+import { acpDebug } from "./acp-mode.js";
+
+/**
+ * Context needed for command execution.
+ */
+export type CommandContext = {
+	agentSession: AgentSession;
+	sendUpdate: (update: acp.SessionUpdate) => void;
+};
+
+/**
+ * Result of handling a slash command.
+ */
+export type CommandResult = {
+	handled: boolean;
+	stopReason?: acp.StopReason;
+};
+
+/**
+ * Build the list of available slash commands.
+ */
+export function buildAvailableCommands(agentSession: AgentSession): acp.AvailableCommand[] {
+	const commands: acp.AvailableCommand[] = [
+		{
+			name: "compact",
+			description: "Manually compact the session context to free up tokens",
+		},
+		{
+			name: "new",
+			description: "Start a new session",
+		},
+		{
+			name: "thinking",
+			description: "Set thinking level (off, low, medium, high)",
+			input: { hint: "level (off, low, medium, high)" },
+		},
+	];
+
+	// Add prompt template commands
+	for (const template of agentSession.promptTemplates) {
+		commands.push({
+			name: template.name,
+			description: template.description,
+			input: { hint: "additional context" },
+		});
+	}
+
+	// Add skill commands if enabled
+	const skillsSettings = agentSession.skillsSettings;
+	if (skillsSettings?.enableSkillCommands) {
+		for (const skill of agentSession.skills) {
+			commands.push({
+				name: `skill:${skill.name}`,
+				description: skill.description,
+				input: { hint: "task description" },
+			});
+		}
+	}
+
+	// Add extension commands
+	const extensionCommands = agentSession.extensionRunner?.getRegisteredCommands() ?? [];
+	for (const cmd of extensionCommands) {
+		commands.push({
+			name: cmd.name,
+			description: cmd.description ?? "(extension command)",
+			input: { hint: "command arguments" },
+		});
+	}
+
+	return commands;
+}
+
+/**
+ * Check if text is a slash command and handle it.
+ * @returns CommandResult indicating if the command was handled
+ */
+export async function handleSlashCommand(text: string, ctx: CommandContext): Promise<CommandResult> {
+	if (!text.startsWith("/")) {
+		return { handled: false };
+	}
+
+	const spaceIndex = text.indexOf(" ");
+	const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	const commandArg = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+
+	acpDebug(`slash command: /${commandName} arg="${commandArg}"`);
+
+	switch (commandName) {
+		case "compact": {
+			await handleCompactCommand(ctx);
+			return { handled: true, stopReason: "end_turn" };
+		}
+
+		case "new": {
+			await handleNewCommand(ctx);
+			return { handled: true, stopReason: "end_turn" };
+		}
+
+		case "thinking": {
+			handleThinkingCommand(commandArg, ctx);
+			return { handled: true, stopReason: "end_turn" };
+		}
+
+		default: {
+			// Check if it's a prompt template command
+			const template = ctx.agentSession.promptTemplates.find((t) => t.name === commandName);
+			if (template) {
+				// Return false to let the prompt be processed normally with template expansion
+				return { handled: false };
+			}
+
+			// Check if it's a skill command
+			const skillsSettings = ctx.agentSession.skillsSettings;
+			if (skillsSettings?.enableSkillCommands && commandName.startsWith("skill:")) {
+				const skillName = commandName.slice(6);
+				const skill = ctx.agentSession.skills.find((s) => s.name === skillName);
+				if (skill) {
+					// Return false to let the prompt be processed normally
+					return { handled: false };
+				}
+			}
+
+			// Check if it's an extension command
+			const extensionCommand = ctx.agentSession.extensionRunner?.getCommand(commandName);
+			if (extensionCommand) {
+				// Return false to let AgentSession handle the extension command
+				return { handled: false };
+			}
+
+			// Unknown command - send as agent message
+			ctx.sendUpdate({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: `Unknown command: /${commandName}`,
+				},
+			});
+			return { handled: true, stopReason: "end_turn" };
+		}
+	}
+}
+
+/**
+ * Handle /compact command.
+ */
+async function handleCompactCommand(ctx: CommandContext): Promise<void> {
+	try {
+		ctx.sendUpdate({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text: "Compacting session context...\n",
+			},
+		});
+
+		const result = await ctx.agentSession.compact();
+
+		ctx.sendUpdate({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text: `Compaction complete. Context had ${result.tokensBefore} tokens before compaction.`,
+			},
+		});
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		ctx.sendUpdate({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text: `Compaction failed: ${errorMessage}`,
+			},
+		});
+	}
+}
+
+/**
+ * Handle /new command.
+ */
+async function handleNewCommand(ctx: CommandContext): Promise<void> {
+	const success = await ctx.agentSession.newSession();
+
+	if (success) {
+		ctx.sendUpdate({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text: "New session started.",
+			},
+		});
+	} else {
+		ctx.sendUpdate({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text: "Failed to start new session.",
+			},
+		});
+	}
+}
+
+/**
+ * Handle /thinking command.
+ */
+function handleThinkingCommand(level: string, ctx: CommandContext): void {
+	const validLevels: ThinkingLevel[] = ["off", "low", "medium", "high"];
+	const normalizedLevel = level.toLowerCase() as ThinkingLevel;
+
+	if (!validLevels.includes(normalizedLevel)) {
+		ctx.sendUpdate({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text: `Invalid thinking level: "${level}". Valid levels: ${validLevels.join(", ")}`,
+			},
+		});
+		return;
+	}
+
+	ctx.agentSession.setThinkingLevel(normalizedLevel);
+	ctx.sendUpdate({
+		sessionUpdate: "agent_message_chunk",
+		content: {
+			type: "text",
+			text: `Thinking level set to: ${normalizedLevel}`,
+		},
+	});
+}

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -1,0 +1,40 @@
+/**
+ * ACP mode: Agent Client Protocol implementation for pi.
+ *
+ * Enables pi to act as an ACP-compliant agent, allowing integration with
+ * ACP-compatible clients like Zed, JetBrains IDEs, and other editors.
+ *
+ * Uses JSON-RPC over stdio via the @agentclientprotocol/sdk package.
+ */
+
+import { Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+import type { AgentSession } from "../../core/agent-session.js";
+import { PiAgent } from "./acp-agent.js";
+
+/**
+ * Run pi in ACP mode.
+ *
+ * Sets up the ACP connection using stdin/stdout and handles all protocol
+ * communication until the connection closes.
+ *
+ * @param session - The AgentSession to use for handling requests
+ * @returns Promise that never resolves (connection stays open until closed)
+ */
+export async function runAcpMode(session: AgentSession): Promise<never> {
+	// Create ndJsonStream from stdin/stdout
+	// The SDK expects Web Streams, so we convert Node.js streams
+	const stream = acp.ndJsonStream(
+		Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+		Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
+	);
+
+	// Create the AgentSideConnection with our PiAgent implementation
+	const connection = new acp.AgentSideConnection((conn) => new PiAgent(session, conn), stream);
+
+	// Wait for connection to close (never resolves during normal operation)
+	await connection.closed;
+
+	// If connection closes, exit the process
+	process.exit(0);
+}

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -5,12 +5,21 @@
  * ACP-compatible clients like Zed, JetBrains IDEs, and other editors.
  *
  * Uses JSON-RPC over stdio via the @agentclientprotocol/sdk package.
+ *
+ * Debug logging: Set PI_ACP_DEBUG=1 to enable stderr logging.
  */
 
 import { Readable, Writable } from "node:stream";
 import * as acp from "@agentclientprotocol/sdk";
 import type { AgentSession } from "../../core/agent-session.js";
 import { PiAgent } from "./acp-agent.js";
+
+/** Debug logger for ACP mode - outputs to stderr to avoid interfering with JSON-RPC on stdout */
+export function acpDebug(msg: string): void {
+	if (process.env.PI_ACP_DEBUG) {
+		process.stderr.write(`[ACP] ${msg}\n`);
+	}
+}
 
 /**
  * Run pi in ACP mode.
@@ -29,11 +38,17 @@ export async function runAcpMode(session: AgentSession): Promise<never> {
 		Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
 	);
 
+	acpDebug("Starting ACP mode");
+
 	// Create the AgentSideConnection with our PiAgent implementation
 	const connection = new acp.AgentSideConnection((conn) => new PiAgent(session, conn), stream);
 
+	acpDebug("Connection established, waiting for requests");
+
 	// Wait for connection to close (never resolves during normal operation)
 	await connection.closed;
+
+	acpDebug("Connection closed");
 
 	// If connection closes, exit the process
 	process.exit(0);

--- a/packages/coding-agent/src/modes/acp/acp-session.ts
+++ b/packages/coding-agent/src/modes/acp/acp-session.ts
@@ -9,6 +9,7 @@ import * as crypto from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
+import { acpDebug } from "./acp-mode.js";
 
 /**
  * AcpSession wraps an AgentSession and translates events to ACP notifications.
@@ -156,6 +157,7 @@ export class AcpSession {
 				const acpToolCallId = crypto.randomUUID();
 				this._toolCallIds.set(event.toolCallId, acpToolCallId);
 
+				acpDebug(`tool_execution_start: ${event.toolName} (${acpToolCallId})`);
 				this._sendUpdate({
 					sessionUpdate: "tool_call",
 					toolCallId: acpToolCallId,
@@ -184,6 +186,7 @@ export class AcpSession {
 				const acpToolCallId = this._toolCallIds.get(event.toolCallId);
 				if (!acpToolCallId) break;
 
+				acpDebug(`tool_execution_end: ${event.toolName} (${acpToolCallId}) isError=${event.isError}`);
 				// Use the isError field from the event
 				this._sendUpdate({
 					sessionUpdate: "tool_call_update",

--- a/packages/coding-agent/src/modes/acp/acp-session.ts
+++ b/packages/coding-agent/src/modes/acp/acp-session.ts
@@ -161,7 +161,7 @@ export class AcpSession {
 				this._sendUpdate({
 					sessionUpdate: "tool_call",
 					toolCallId: acpToolCallId,
-					title: `${event.toolName}`,
+					title: this._formatToolTitle(event.toolName, event.args),
 					status: "in_progress",
 					kind: this._mapToolKind(event.toolName),
 					rawInput: event.args,
@@ -212,6 +212,45 @@ export class AcpSession {
 			sessionId: this.id,
 			update,
 		});
+	}
+
+	/**
+	 * Format a descriptive title for tool calls.
+	 */
+	private _formatToolTitle(toolName: string, args: Record<string, unknown>): string {
+		switch (toolName) {
+			case "bash": {
+				const command = args.command as string | undefined;
+				if (command) {
+					// Truncate long commands
+					const truncated = command.length > 80 ? `${command.slice(0, 77)}...` : command;
+					return `Run \`${truncated}\``;
+				}
+				return "bash";
+			}
+			case "read": {
+				const path = args.path as string | undefined;
+				return path ? `Read ${path}` : "read";
+			}
+			case "write": {
+				const path = args.path as string | undefined;
+				return path ? `Write ${path}` : "write";
+			}
+			case "edit": {
+				const path = args.path as string | undefined;
+				return path ? `Edit ${path}` : "edit";
+			}
+			case "glob": {
+				const pattern = args.pattern as string | undefined;
+				return pattern ? `Glob ${pattern}` : "glob";
+			}
+			case "grep": {
+				const pattern = args.pattern as string | undefined;
+				return pattern ? `Grep "${pattern}"` : "grep";
+			}
+			default:
+				return toolName;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/acp/acp-session.ts
+++ b/packages/coding-agent/src/modes/acp/acp-session.ts
@@ -1,0 +1,276 @@
+/**
+ * AcpSession: Wraps AgentSession with ACP event translation.
+ *
+ * Handles the translation between pi's AgentSession events and
+ * ACP session/update notifications.
+ */
+
+import * as crypto from "node:crypto";
+import type * as acp from "@agentclientprotocol/sdk";
+import type { ImageContent } from "@mariozechner/pi-ai";
+import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
+
+/**
+ * AcpSession wraps an AgentSession and translates events to ACP notifications.
+ *
+ * Each AcpSession corresponds to a unique sessionId in the ACP protocol
+ * and manages the event subscription and translation for that session.
+ */
+export class AcpSession {
+	readonly id: string;
+	private readonly _agentSession: AgentSession;
+	private readonly _connection: acp.AgentSideConnection;
+
+	/** AbortController for the current pending prompt, if any */
+	private _pendingPrompt: AbortController | null = null;
+
+	/** Map of pi tool call IDs to ACP tool call IDs */
+	private _toolCallIds: Map<string, string> = new Map();
+
+	constructor(id: string, agentSession: AgentSession, connection: acp.AgentSideConnection) {
+		this.id = id;
+		this._agentSession = agentSession;
+		this._connection = connection;
+	}
+
+	/**
+	 * Process a user prompt and stream events as ACP notifications.
+	 *
+	 * Extracts text from ContentBlocks, sends to AgentSession, subscribes
+	 * to events and translates them to session/update notifications.
+	 *
+	 * @returns PromptResponse with stop reason
+	 */
+	async prompt(params: acp.PromptRequest): Promise<acp.PromptResponse> {
+		// Create abort controller for this prompt
+		this._pendingPrompt = new AbortController();
+		this._toolCallIds.clear();
+
+		// Extract text content from ContentBlocks
+		const textParts: string[] = [];
+		const images: ImageContent[] = [];
+
+		for (const block of params.prompt) {
+			if (block.type === "text") {
+				textParts.push(block.text);
+			} else if (block.type === "image") {
+				images.push({
+					type: "image",
+					mimeType: block.mimeType,
+					data: block.data,
+				});
+			}
+			// TODO: Handle resource and resource_link types if needed
+		}
+
+		const text = textParts.join("\n");
+
+		// Track whether we were cancelled
+		let cancelled = false;
+
+		// Subscribe to events and translate to ACP notifications
+		const unsubscribe = this._agentSession.subscribe((event) => {
+			// Check if cancelled
+			if (this._pendingPrompt?.signal.aborted) {
+				cancelled = true;
+				return;
+			}
+
+			this._translateEvent(event);
+		});
+
+		try {
+			// Send the prompt to AgentSession
+			await this._agentSession.prompt(text, {
+				images: images.length > 0 ? images : undefined,
+				expandPromptTemplates: true,
+				source: "rpc", // Use rpc source since we're in a headless mode
+			});
+
+			// Wait for agent to become idle
+			await this._agentSession.agent.waitForIdle();
+
+			return {
+				stopReason: cancelled ? "cancelled" : "end_turn",
+			};
+		} catch {
+			// If aborted, return cancelled
+			if (this._pendingPrompt?.signal.aborted) {
+				return { stopReason: "cancelled" };
+			}
+
+			// Other errors - return end_turn (error details already sent via events)
+			return { stopReason: "end_turn" };
+		} finally {
+			unsubscribe();
+			this._pendingPrompt = null;
+		}
+	}
+
+	/**
+	 * Cancel the current prompt.
+	 *
+	 * Aborts the pending prompt and triggers agent abort.
+	 */
+	cancel(): void {
+		if (this._pendingPrompt) {
+			this._pendingPrompt.abort();
+			void this._agentSession.abort();
+		}
+	}
+
+	/**
+	 * Translate an AgentSessionEvent to ACP session/update notifications.
+	 */
+	private _translateEvent(event: AgentSessionEvent): void {
+		switch (event.type) {
+			case "message_update": {
+				const assistantEvent = event.assistantMessageEvent;
+
+				// Handle text delta
+				if (assistantEvent.type === "text_delta") {
+					this._sendUpdate({
+						sessionUpdate: "agent_message_chunk",
+						content: {
+							type: "text",
+							text: assistantEvent.delta,
+						},
+					});
+				}
+
+				// Handle thinking delta
+				if (assistantEvent.type === "thinking_delta") {
+					this._sendUpdate({
+						sessionUpdate: "agent_thought_chunk",
+						content: {
+							type: "text",
+							text: assistantEvent.delta,
+						},
+					});
+				}
+				break;
+			}
+
+			case "tool_execution_start": {
+				// Generate a unique ACP tool call ID and map it
+				const acpToolCallId = crypto.randomUUID();
+				this._toolCallIds.set(event.toolCallId, acpToolCallId);
+
+				this._sendUpdate({
+					sessionUpdate: "tool_call",
+					toolCallId: acpToolCallId,
+					title: `${event.toolName}`,
+					status: "in_progress",
+					kind: this._mapToolKind(event.toolName),
+					rawInput: event.args,
+				});
+				break;
+			}
+
+			case "tool_execution_update": {
+				// Stream partial results for long-running tools
+				const updateToolCallId = this._toolCallIds.get(event.toolCallId);
+				if (!updateToolCallId) break;
+
+				this._sendUpdate({
+					sessionUpdate: "tool_call_update",
+					toolCallId: updateToolCallId,
+					rawOutput: event.partialResult,
+				});
+				break;
+			}
+
+			case "tool_execution_end": {
+				const acpToolCallId = this._toolCallIds.get(event.toolCallId);
+				if (!acpToolCallId) break;
+
+				// Use the isError field from the event
+				this._sendUpdate({
+					sessionUpdate: "tool_call_update",
+					toolCallId: acpToolCallId,
+					status: event.isError ? "failed" : "completed",
+					rawOutput: event.result,
+					content: this._formatToolResultContent(event.result),
+				});
+				break;
+			}
+
+			// Ignore other event types for now
+			default:
+				break;
+		}
+	}
+
+	/**
+	 * Send a session/update notification to the client.
+	 */
+	private _sendUpdate(update: acp.SessionUpdate): void {
+		void this._connection.sessionUpdate({
+			sessionId: this.id,
+			update,
+		});
+	}
+
+	/**
+	 * Map pi tool names to ACP ToolKind.
+	 */
+	private _mapToolKind(toolName: string): acp.ToolKind {
+		switch (toolName) {
+			case "read":
+				return "read";
+			case "write":
+			case "edit":
+				return "edit";
+			case "bash":
+				return "execute";
+			case "grep":
+			case "glob":
+				return "search";
+			default:
+				return "other";
+		}
+	}
+
+	/**
+	 * Format tool result as ACP ToolCallContent.
+	 */
+	private _formatToolResultContent(result: unknown): acp.ToolCallContent[] | undefined {
+		if (result === undefined || result === null) {
+			return undefined;
+		}
+
+		// Convert result to string representation
+		let text: string;
+		if (typeof result === "string") {
+			text = result;
+		} else if (typeof result === "object" && "content" in result) {
+			// MCP-style result with content field
+			const content = (result as { content: unknown }).content;
+			if (Array.isArray(content)) {
+				// Extract text from content array
+				text = content
+					.map((item) => {
+						if (typeof item === "object" && item && "text" in item) {
+							return (item as { text: string }).text;
+						}
+						return JSON.stringify(item);
+					})
+					.join("\n");
+			} else {
+				text = JSON.stringify(content);
+			}
+		} else {
+			text = JSON.stringify(result, null, 2);
+		}
+
+		return [
+			{
+				type: "content",
+				content: {
+					type: "text",
+					text,
+				},
+			},
+		];
+	}
+}

--- a/packages/coding-agent/src/modes/acp/acp-session.ts
+++ b/packages/coding-agent/src/modes/acp/acp-session.ts
@@ -7,10 +7,11 @@
 
 import * as crypto from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
+import { buildAvailableCommands, handleSlashCommand } from "./acp-commands.js";
 import { acpDebug } from "./acp-mode.js";
+import { formatToolResultContent, formatToolTitle, mapToolKind } from "./acp-tools.js";
 
 /**
  * AcpSession wraps an AgentSession and translates events to ACP notifications.
@@ -40,222 +41,11 @@ export class AcpSession {
 	 * Called after session creation to advertise available slash commands.
 	 */
 	sendAvailableCommands(): void {
-		const commands = this._buildAvailableCommands();
+		const commands = buildAvailableCommands(this._agentSession);
 		acpDebug(`sendAvailableCommands: ${commands.length} commands`);
 		this._sendUpdate({
 			sessionUpdate: "available_commands_update",
 			availableCommands: commands,
-		});
-	}
-
-	/**
-	 * Build the list of available slash commands.
-	 */
-	private _buildAvailableCommands(): acp.AvailableCommand[] {
-		const commands: acp.AvailableCommand[] = [
-			{
-				name: "compact",
-				description: "Manually compact the session context to free up tokens",
-			},
-			{
-				name: "new",
-				description: "Start a new session",
-			},
-			{
-				name: "thinking",
-				description: "Set thinking level (off, low, medium, high)",
-				input: { hint: "level (off, low, medium, high)" },
-			},
-		];
-
-		// Add prompt template commands
-		for (const template of this._agentSession.promptTemplates) {
-			commands.push({
-				name: template.name,
-				description: template.description,
-				input: { hint: "additional context" },
-			});
-		}
-
-		// Add skill commands if enabled
-		const skillsSettings = this._agentSession.skillsSettings;
-		if (skillsSettings?.enableSkillCommands) {
-			for (const skill of this._agentSession.skills) {
-				commands.push({
-					name: `skill:${skill.name}`,
-					description: skill.description,
-					input: { hint: "task description" },
-				});
-			}
-		}
-
-		// Add extension commands
-		const extensionCommands = this._agentSession.extensionRunner?.getRegisteredCommands() ?? [];
-		for (const cmd of extensionCommands) {
-			commands.push({
-				name: cmd.name,
-				description: cmd.description ?? "(extension command)",
-				input: { hint: "command arguments" },
-			});
-		}
-
-		return commands;
-	}
-
-	/**
-	 * Check if text is a slash command and handle it.
-	 * @returns true if the text was handled as a command, false otherwise
-	 */
-	private async _handleSlashCommand(text: string): Promise<{ handled: boolean; stopReason?: acp.StopReason }> {
-		if (!text.startsWith("/")) {
-			return { handled: false };
-		}
-
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const commandArg = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-
-		acpDebug(`slash command: /${commandName} arg="${commandArg}"`);
-
-		switch (commandName) {
-			case "compact": {
-				await this._handleCompactCommand();
-				return { handled: true, stopReason: "end_turn" };
-			}
-
-			case "new": {
-				await this._handleNewCommand();
-				return { handled: true, stopReason: "end_turn" };
-			}
-
-			case "thinking": {
-				this._handleThinkingCommand(commandArg);
-				return { handled: true, stopReason: "end_turn" };
-			}
-
-			default: {
-				// Check if it's a prompt template command
-				const template = this._agentSession.promptTemplates.find((t) => t.name === commandName);
-				if (template) {
-					// Return false to let the prompt be processed normally with template expansion
-					return { handled: false };
-				}
-
-				// Check if it's a skill command
-				const skillsSettings = this._agentSession.skillsSettings;
-				if (skillsSettings?.enableSkillCommands && commandName.startsWith("skill:")) {
-					const skillName = commandName.slice(6);
-					const skill = this._agentSession.skills.find((s) => s.name === skillName);
-					if (skill) {
-						// Return false to let the prompt be processed normally
-						return { handled: false };
-					}
-				}
-
-				// Check if it's an extension command
-				const extensionCommand = this._agentSession.extensionRunner?.getCommand(commandName);
-				if (extensionCommand) {
-					// Return false to let AgentSession handle the extension command
-					return { handled: false };
-				}
-
-				// Unknown command - send as agent message
-				this._sendUpdate({
-					sessionUpdate: "agent_message_chunk",
-					content: {
-						type: "text",
-						text: `Unknown command: /${commandName}`,
-					},
-				});
-				return { handled: true, stopReason: "end_turn" };
-			}
-		}
-	}
-
-	/**
-	 * Handle /compact command.
-	 */
-	private async _handleCompactCommand(): Promise<void> {
-		try {
-			this._sendUpdate({
-				sessionUpdate: "agent_message_chunk",
-				content: {
-					type: "text",
-					text: "Compacting session context...\n",
-				},
-			});
-
-			const result = await this._agentSession.compact();
-
-			this._sendUpdate({
-				sessionUpdate: "agent_message_chunk",
-				content: {
-					type: "text",
-					text: `Compaction complete. Context had ${result.tokensBefore} tokens before compaction.`,
-				},
-			});
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			this._sendUpdate({
-				sessionUpdate: "agent_message_chunk",
-				content: {
-					type: "text",
-					text: `Compaction failed: ${errorMessage}`,
-				},
-			});
-		}
-	}
-
-	/**
-	 * Handle /new command.
-	 */
-	private async _handleNewCommand(): Promise<void> {
-		const success = await this._agentSession.newSession();
-
-		if (success) {
-			this._sendUpdate({
-				sessionUpdate: "agent_message_chunk",
-				content: {
-					type: "text",
-					text: "New session started.",
-				},
-			});
-		} else {
-			this._sendUpdate({
-				sessionUpdate: "agent_message_chunk",
-				content: {
-					type: "text",
-					text: "Failed to start new session.",
-				},
-			});
-		}
-	}
-
-	/**
-	 * Handle /thinking command.
-	 */
-	private _handleThinkingCommand(level: string): void {
-		const validLevels: ThinkingLevel[] = ["off", "low", "medium", "high"];
-		const normalizedLevel = level.toLowerCase() as ThinkingLevel;
-
-		if (!validLevels.includes(normalizedLevel)) {
-			this._sendUpdate({
-				sessionUpdate: "agent_message_chunk",
-				content: {
-					type: "text",
-					text: `Invalid thinking level: "${level}". Valid levels: ${validLevels.join(", ")}`,
-				},
-			});
-			return;
-		}
-
-		this._agentSession.setThinkingLevel(normalizedLevel);
-		this._sendUpdate({
-			sessionUpdate: "agent_message_chunk",
-			content: {
-				type: "text",
-				text: `Thinking level set to: ${normalizedLevel}`,
-			},
 		});
 	}
 
@@ -294,7 +84,10 @@ export class AcpSession {
 
 		// Check for slash commands (only for text-only prompts)
 		if (images.length === 0 && text.startsWith("/")) {
-			const result = await this._handleSlashCommand(text);
+			const result = await handleSlashCommand(text, {
+				agentSession: this._agentSession,
+				sendUpdate: (update) => this._sendUpdate(update),
+			});
 			if (result.handled) {
 				this._pendingPrompt = null;
 				return { stopReason: result.stopReason ?? "end_turn" };
@@ -406,9 +199,9 @@ export class AcpSession {
 				this._sendUpdate({
 					sessionUpdate: "tool_call",
 					toolCallId: acpToolCallId,
-					title: this._formatToolTitle(event.toolName, event.args),
+					title: formatToolTitle(event.toolName, event.args),
 					status: "in_progress",
-					kind: this._mapToolKind(event.toolName),
+					kind: mapToolKind(event.toolName),
 					rawInput: event.args,
 				});
 				break;
@@ -438,7 +231,7 @@ export class AcpSession {
 					toolCallId: acpToolCallId,
 					status: event.isError ? "failed" : "completed",
 					rawOutput: event.result,
-					content: this._formatToolResultContent(event.result),
+					content: formatToolResultContent(event.result),
 				});
 				break;
 			}
@@ -457,107 +250,5 @@ export class AcpSession {
 			sessionId: this.id,
 			update,
 		});
-	}
-
-	/**
-	 * Format a descriptive title for tool calls.
-	 */
-	private _formatToolTitle(toolName: string, args: Record<string, unknown>): string {
-		switch (toolName) {
-			case "bash": {
-				const command = args.command as string | undefined;
-				if (command) {
-					// Truncate long commands
-					const truncated = command.length > 80 ? `${command.slice(0, 77)}...` : command;
-					return `Run \`${truncated}\``;
-				}
-				return "bash";
-			}
-			case "read": {
-				const path = args.path as string | undefined;
-				return path ? `Read ${path}` : "read";
-			}
-			case "write": {
-				const path = args.path as string | undefined;
-				return path ? `Write ${path}` : "write";
-			}
-			case "edit": {
-				const path = args.path as string | undefined;
-				return path ? `Edit ${path}` : "edit";
-			}
-			case "glob": {
-				const pattern = args.pattern as string | undefined;
-				return pattern ? `Glob ${pattern}` : "glob";
-			}
-			case "grep": {
-				const pattern = args.pattern as string | undefined;
-				return pattern ? `Grep "${pattern}"` : "grep";
-			}
-			default:
-				return toolName;
-		}
-	}
-
-	/**
-	 * Map pi tool names to ACP ToolKind.
-	 */
-	private _mapToolKind(toolName: string): acp.ToolKind {
-		switch (toolName) {
-			case "read":
-				return "read";
-			case "write":
-			case "edit":
-				return "edit";
-			case "bash":
-				return "execute";
-			case "grep":
-			case "glob":
-				return "search";
-			default:
-				return "other";
-		}
-	}
-
-	/**
-	 * Format tool result as ACP ToolCallContent.
-	 */
-	private _formatToolResultContent(result: unknown): acp.ToolCallContent[] | undefined {
-		if (result === undefined || result === null) {
-			return undefined;
-		}
-
-		// Convert result to string representation
-		let text: string;
-		if (typeof result === "string") {
-			text = result;
-		} else if (typeof result === "object" && "content" in result) {
-			// MCP-style result with content field
-			const content = (result as { content: unknown }).content;
-			if (Array.isArray(content)) {
-				// Extract text from content array
-				text = content
-					.map((item) => {
-						if (typeof item === "object" && item && "text" in item) {
-							return (item as { text: string }).text;
-						}
-						return JSON.stringify(item);
-					})
-					.join("\n");
-			} else {
-				text = JSON.stringify(content);
-			}
-		} else {
-			text = JSON.stringify(result, null, 2);
-		}
-
-		return [
-			{
-				type: "content",
-				content: {
-					type: "text",
-					text,
-				},
-			},
-		];
 	}
 }

--- a/packages/coding-agent/src/modes/acp/acp-session.ts
+++ b/packages/coding-agent/src/modes/acp/acp-session.ts
@@ -2,11 +2,12 @@
  * AcpSession: Wraps AgentSession with ACP event translation.
  *
  * Handles the translation between pi's AgentSession events and
- * ACP session/update notifications.
+ * ACP session/update notifications, including slash commands support.
  */
 
 import * as crypto from "node:crypto";
 import type * as acp from "@agentclientprotocol/sdk";
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { AgentSession, AgentSessionEvent } from "../../core/agent-session.js";
 import { acpDebug } from "./acp-mode.js";
@@ -35,10 +36,235 @@ export class AcpSession {
 	}
 
 	/**
+	 * Send the available commands update to the client.
+	 * Called after session creation to advertise available slash commands.
+	 */
+	sendAvailableCommands(): void {
+		const commands = this._buildAvailableCommands();
+		acpDebug(`sendAvailableCommands: ${commands.length} commands`);
+		this._sendUpdate({
+			sessionUpdate: "available_commands_update",
+			availableCommands: commands,
+		});
+	}
+
+	/**
+	 * Build the list of available slash commands.
+	 */
+	private _buildAvailableCommands(): acp.AvailableCommand[] {
+		const commands: acp.AvailableCommand[] = [
+			{
+				name: "compact",
+				description: "Manually compact the session context to free up tokens",
+			},
+			{
+				name: "new",
+				description: "Start a new session",
+			},
+			{
+				name: "thinking",
+				description: "Set thinking level (off, low, medium, high)",
+				input: { hint: "level (off, low, medium, high)" },
+			},
+		];
+
+		// Add prompt template commands
+		for (const template of this._agentSession.promptTemplates) {
+			commands.push({
+				name: template.name,
+				description: template.description,
+				input: { hint: "additional context" },
+			});
+		}
+
+		// Add skill commands if enabled
+		const skillsSettings = this._agentSession.skillsSettings;
+		if (skillsSettings?.enableSkillCommands) {
+			for (const skill of this._agentSession.skills) {
+				commands.push({
+					name: `skill:${skill.name}`,
+					description: skill.description,
+					input: { hint: "task description" },
+				});
+			}
+		}
+
+		// Add extension commands
+		const extensionCommands = this._agentSession.extensionRunner?.getRegisteredCommands() ?? [];
+		for (const cmd of extensionCommands) {
+			commands.push({
+				name: cmd.name,
+				description: cmd.description ?? "(extension command)",
+				input: { hint: "command arguments" },
+			});
+		}
+
+		return commands;
+	}
+
+	/**
+	 * Check if text is a slash command and handle it.
+	 * @returns true if the text was handled as a command, false otherwise
+	 */
+	private async _handleSlashCommand(text: string): Promise<{ handled: boolean; stopReason?: acp.StopReason }> {
+		if (!text.startsWith("/")) {
+			return { handled: false };
+		}
+
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const commandArg = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+
+		acpDebug(`slash command: /${commandName} arg="${commandArg}"`);
+
+		switch (commandName) {
+			case "compact": {
+				await this._handleCompactCommand();
+				return { handled: true, stopReason: "end_turn" };
+			}
+
+			case "new": {
+				await this._handleNewCommand();
+				return { handled: true, stopReason: "end_turn" };
+			}
+
+			case "thinking": {
+				this._handleThinkingCommand(commandArg);
+				return { handled: true, stopReason: "end_turn" };
+			}
+
+			default: {
+				// Check if it's a prompt template command
+				const template = this._agentSession.promptTemplates.find((t) => t.name === commandName);
+				if (template) {
+					// Return false to let the prompt be processed normally with template expansion
+					return { handled: false };
+				}
+
+				// Check if it's a skill command
+				const skillsSettings = this._agentSession.skillsSettings;
+				if (skillsSettings?.enableSkillCommands && commandName.startsWith("skill:")) {
+					const skillName = commandName.slice(6);
+					const skill = this._agentSession.skills.find((s) => s.name === skillName);
+					if (skill) {
+						// Return false to let the prompt be processed normally
+						return { handled: false };
+					}
+				}
+
+				// Check if it's an extension command
+				const extensionCommand = this._agentSession.extensionRunner?.getCommand(commandName);
+				if (extensionCommand) {
+					// Return false to let AgentSession handle the extension command
+					return { handled: false };
+				}
+
+				// Unknown command - send as agent message
+				this._sendUpdate({
+					sessionUpdate: "agent_message_chunk",
+					content: {
+						type: "text",
+						text: `Unknown command: /${commandName}`,
+					},
+				});
+				return { handled: true, stopReason: "end_turn" };
+			}
+		}
+	}
+
+	/**
+	 * Handle /compact command.
+	 */
+	private async _handleCompactCommand(): Promise<void> {
+		try {
+			this._sendUpdate({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: "Compacting session context...\n",
+				},
+			});
+
+			const result = await this._agentSession.compact();
+
+			this._sendUpdate({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: `Compaction complete. Compacted ${result.tokensBefore} tokens.`,
+				},
+			});
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			this._sendUpdate({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: `Compaction failed: ${errorMessage}`,
+				},
+			});
+		}
+	}
+
+	/**
+	 * Handle /new command.
+	 */
+	private async _handleNewCommand(): Promise<void> {
+		const success = await this._agentSession.newSession();
+
+		if (success) {
+			this._sendUpdate({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: "New session started.",
+				},
+			});
+		} else {
+			this._sendUpdate({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: "Failed to start new session.",
+				},
+			});
+		}
+	}
+
+	/**
+	 * Handle /thinking command.
+	 */
+	private _handleThinkingCommand(level: string): void {
+		const validLevels: ThinkingLevel[] = ["off", "low", "medium", "high"];
+		const normalizedLevel = level.toLowerCase() as ThinkingLevel;
+
+		if (!validLevels.includes(normalizedLevel)) {
+			this._sendUpdate({
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: `Invalid thinking level: "${level}". Valid levels: ${validLevels.join(", ")}`,
+				},
+			});
+			return;
+		}
+
+		this._agentSession.setThinkingLevel(normalizedLevel);
+		this._sendUpdate({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text: `Thinking level set to: ${normalizedLevel}`,
+			},
+		});
+	}
+
+	/**
 	 * Process a user prompt and stream events as ACP notifications.
 	 *
 	 * Extracts text from ContentBlocks, sends to AgentSession, subscribes
 	 * to events and translates them to session/update notifications.
+	 * Also handles slash commands.
 	 *
 	 * @returns PromptResponse with stop reason
 	 */
@@ -65,6 +291,15 @@ export class AcpSession {
 		}
 
 		const text = textParts.join("\n");
+
+		// Check for slash commands (only for text-only prompts)
+		if (images.length === 0 && text.startsWith("/")) {
+			const result = await this._handleSlashCommand(text);
+			if (result.handled) {
+				this._pendingPrompt = null;
+				return { stopReason: result.stopReason ?? "end_turn" };
+			}
+		}
 
 		// Track whether we were cancelled
 		let cancelled = false;

--- a/packages/coding-agent/src/modes/acp/acp-tools.ts
+++ b/packages/coding-agent/src/modes/acp/acp-tools.ts
@@ -1,0 +1,109 @@
+/**
+ * ACP tool formatting utilities.
+ *
+ * Provides formatting and mapping functions for tool calls in ACP sessions.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+
+/**
+ * Format a descriptive title for tool calls.
+ */
+export function formatToolTitle(toolName: string, args: Record<string, unknown>): string {
+	switch (toolName) {
+		case "bash": {
+			const command = args.command as string | undefined;
+			if (command) {
+				// Truncate long commands
+				const truncated = command.length > 80 ? `${command.slice(0, 77)}...` : command;
+				return `Run \`${truncated}\``;
+			}
+			return "bash";
+		}
+		case "read": {
+			const path = args.path as string | undefined;
+			return path ? `Read ${path}` : "read";
+		}
+		case "write": {
+			const path = args.path as string | undefined;
+			return path ? `Write ${path}` : "write";
+		}
+		case "edit": {
+			const path = args.path as string | undefined;
+			return path ? `Edit ${path}` : "edit";
+		}
+		case "glob": {
+			const pattern = args.pattern as string | undefined;
+			return pattern ? `Glob ${pattern}` : "glob";
+		}
+		case "grep": {
+			const pattern = args.pattern as string | undefined;
+			return pattern ? `Grep "${pattern}"` : "grep";
+		}
+		default:
+			return toolName;
+	}
+}
+
+/**
+ * Map pi tool names to ACP ToolKind.
+ */
+export function mapToolKind(toolName: string): acp.ToolKind {
+	switch (toolName) {
+		case "read":
+			return "read";
+		case "write":
+		case "edit":
+			return "edit";
+		case "bash":
+			return "execute";
+		case "grep":
+		case "glob":
+			return "search";
+		default:
+			return "other";
+	}
+}
+
+/**
+ * Format tool result as ACP ToolCallContent.
+ */
+export function formatToolResultContent(result: unknown): acp.ToolCallContent[] | undefined {
+	if (result === undefined || result === null) {
+		return undefined;
+	}
+
+	// Convert result to string representation
+	let text: string;
+	if (typeof result === "string") {
+		text = result;
+	} else if (typeof result === "object" && "content" in result) {
+		// MCP-style result with content field
+		const content = (result as { content: unknown }).content;
+		if (Array.isArray(content)) {
+			// Extract text from content array
+			text = content
+				.map((item) => {
+					if (typeof item === "object" && item && "text" in item) {
+						return (item as { text: string }).text;
+					}
+					return JSON.stringify(item);
+				})
+				.join("\n");
+		} else {
+			text = JSON.stringify(content);
+		}
+	} else {
+		text = JSON.stringify(result, null, 2);
+	}
+
+	return [
+		{
+			type: "content",
+			content: {
+				type: "text",
+				text,
+			},
+		},
+	];
+}

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -2,6 +2,7 @@
  * Run modes for the coding agent.
  */
 
+export { runAcpMode } from "./acp/acp-mode.js";
 export { InteractiveMode, type InteractiveModeOptions } from "./interactive/interactive-mode.js";
 export { type PrintModeOptions, runPrintMode } from "./print-mode.js";
 export { type ModelInfo, RpcClient, type RpcClientOptions, type RpcEventListener } from "./rpc/rpc-client.js";


### PR DESCRIPTION
## Summary

Add Agent Client Protocol (ACP) support via `--mode acp` flag, enabling pi to integrate with ACP-compatible editors like Zed and JetBrains IDEs.

Tested and working in Zed.

## Changes

- Add `@agentclientprotocol/sdk` dependency
- Implement `PiAgent` class with initialize/newSession/prompt/cancel
- Implement `AcpSession` with event translation to ACP notifications
- Map AgentSession events to ACP notifications:
  - `message_update` (text_delta) → `agent_message_chunk`
  - `message_update` (thinking_delta) → `agent_thought_chunk`
  - `tool_execution_start` → `tool_call` (in_progress)
  - `tool_execution_update` → `tool_call_update` (streaming)
  - `tool_execution_end` → `tool_call_update` (completed/failed)
- Support cancellation via `session/cancel`
- Format descriptive tool call titles (e.g., `Read <path>`, `Run \`<command>\``)
- Add debug logging via `PI_ACP_DEBUG=1` environment variable
- Add documentation and changelog entry

## Known Issues

- Slash commands not working in Zed despite following the [ACP protocol spec](https://agentclientprotocol.com/protocol/slash-commands). Will fix in a follow-up PR.

## Usage

```bash
pi --mode acp
```

The agent listens on stdin for JSON-RPC messages and responds on stdout, following the [ACP protocol](https://agentclientprotocol.com/).

### Debug Mode

```bash
PI_ACP_DEBUG=1 pi --mode acp
```

Logs connection lifecycle, protocol initialization, session creation, prompt processing, and tool execution to stderr.

## New Files

- `packages/coding-agent/src/modes/acp/acp-mode.ts` - Entry point
- `packages/coding-agent/src/modes/acp/acp-agent.ts` - Agent interface implementation
- `packages/coding-agent/src/modes/acp/acp-session.ts` - Session and event translation
- `packages/coding-agent/src/modes/acp/acp-commands.ts` - Slash commands support
- `packages/coding-agent/src/modes/acp/acp-tools.ts` - Tool call formatting

## Works with [zed](https://github.com/zed-industries/zed)
<img width="1099" height="2946" alt="image" src="https://github.com/user-attachments/assets/04709fa7-da01-46a9-9852-a18ef0ea986d" />

## Works with [toad](https://github.com/batrachianai/toad)

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/bbf17f48-552a-478e-9a42-ebb05fdbae8b" />


