### PR TITLE
feat(tui): jump to line start/end when pressing up/down at boundaries

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -646,6 +646,9 @@ export class Editor implements Component, Focusable {
 				this.navigateHistory(-1);
 			} else if (this.historyIndex > -1 && this.isOnFirstVisualLine()) {
 				this.navigateHistory(-1);
+			} else if (this.isOnFirstVisualLine()) {
+				// Already at top - jump to start of line
+				this.moveToLineStart();
 			} else {
 				this.moveCursor(-1, 0);
 			}
@@ -654,6 +657,9 @@ export class Editor implements Component, Focusable {
 		if (kb.matches(data, "cursorDown")) {
 			if (this.historyIndex > -1 && this.isOnLastVisualLine()) {
 				this.navigateHistory(1);
+			} else if (this.isOnLastVisualLine()) {
+				// Already at bottom - jump to end of line
+				this.moveToLineEnd();
 			} else {
 				this.moveCursor(1, 0);
 			}


### PR DESCRIPTION
Improves editor navigation by making cursor up/down actions jump to line boundaries when already at the edge.

Before:
- Pressing up while on the first visual line did nothing
- Pressing down while on the last visual line did nothing

After:
- Pressing up on first visual line jumps to start of line
- Pressing down on last visual line jumps to end of line

This matches standard behavior in most native text inputs.

Tested with:
- Single line input
- Multi-line wrapped input
- History navigation (preserved existing behavior)