### PR TITLE
fix: guard against non-iterable assistant.content in estimateTokens

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -241,6 +241,7 @@ export function estimateTokens(message: AgentMessage): number {
 		}
 		case "assistant": {
 			const assistant = message as AssistantMessage;
+			if (!Array.isArray(assistant.content)) return 0;
 			for (const block of assistant.content) {
 				if (block.type === "text") {
 					chars += block.text.length;


### PR DESCRIPTION
## Problem

`estimateTokens()` in `compaction.ts` crashes with `TypeError: message.content is not iterable` when an assistant message has non-array `content`:

```
TypeError: message.content is not iterable
    at estimateTokens (compaction.js:192:45)
    at estimateContextTokens (compaction.js:130:27)
    at AgentSession.getContextUsage (agent-session.js:2267:26)
    at FooterComponent.render (footer.js:76:43)
```

This happens during footer rendering when the context usage is calculated — a crash in a render path that takes the whole TUI down.

## Cause

The `user` and `toolResult` cases in `estimateTokens()` both defensively check `typeof content === "string"` and `Array.isArray()` before iterating. The `assistant` case was missing this guard and assumed `content` is always an array.

While the TypeScript type says `content: (TextContent | ThinkingContent | ToolCall)[]`, at runtime the value can be non-iterable (e.g., from a corrupted/resumed session, partial streaming state, or a provider returning unexpected formats).

## Fix

One-line guard: `if (!Array.isArray(assistant.content)) return 0;`

This matches the defensive pattern already used by the sibling cases and prevents the crash without changing behavior for well-formed messages.