### PR TITLE
fix(coding-agent): use ESM resolution for extension alias fallback

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -94,6 +94,6 @@
 		"directory": "packages/coding-agent"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=20.6.0"
 	}
 }

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -65,20 +65,20 @@ function getAliases(): Record<string, string> {
 	const typeboxRoot = typeboxEntry.replace(/[\\/]build[\\/]cjs[\\/]index\.js$/, "");
 
 	const packagesRoot = path.resolve(__dirname, "../../../../");
-	const resolveWorkspaceOrSpecifier = (workspaceRelativePath: string, specifier: string): string => {
+	const resolveWorkspaceOrImport = (workspaceRelativePath: string, specifier: string): string => {
 		const workspacePath = path.join(packagesRoot, workspaceRelativePath);
 		if (fs.existsSync(workspacePath)) {
 			return workspacePath;
 		}
-		return specifier;
+		return fileURLToPath(import.meta.resolve(specifier));
 	};
 
 	_aliases = {
 		"@mariozechner/pi-coding-agent": packageIndex,
-		"@mariozechner/pi-agent-core": resolveWorkspaceOrSpecifier("agent/src/index.ts", "@mariozechner/pi-agent-core"),
-		"@mariozechner/pi-tui": resolveWorkspaceOrSpecifier("tui/src/index.ts", "@mariozechner/pi-tui"),
-		"@mariozechner/pi-ai": resolveWorkspaceOrSpecifier("ai/src/index.ts", "@mariozechner/pi-ai"),
-		"@mariozechner/pi-ai/oauth": resolveWorkspaceOrSpecifier("ai/src/oauth.ts", "@mariozechner/pi-ai/oauth"),
+		"@mariozechner/pi-agent-core": resolveWorkspaceOrImport("agent/src/index.ts", "@mariozechner/pi-agent-core"),
+		"@mariozechner/pi-tui": resolveWorkspaceOrImport("tui/src/index.ts", "@mariozechner/pi-tui"),
+		"@mariozechner/pi-ai": resolveWorkspaceOrImport("ai/src/index.ts", "@mariozechner/pi-ai"),
+		"@mariozechner/pi-ai/oauth": resolveWorkspaceOrImport("ai/src/oauth.ts", "@mariozechner/pi-ai/oauth"),
 		"@sinclair/typebox": typeboxRoot,
 	};
 


### PR DESCRIPTION
Extensions that import `@mariozechner/pi-tui` (or other pi packages) fail to load in global npm installs since v0.56.0:

```
Failed to load extension: Cannot find module '@mariozechner/pi-tui'
```

Commit 83b57924 replaced `require.resolve()` with bare specifier fallbacks to avoid `ERR_PACKAGE_PATH_NOT_EXPORTED` for ESM-only packages like `pi-ai`. However, jiti aliases require file paths, not bare specifiers, so the fallback silently broke module resolution outside the monorepo workspace.

Fix: use `import.meta.resolve()` as the fallback. It respects the `import` exports condition (unlike CJS `require.resolve`) and returns a real file path (unlike bare specifiers).

Resolves #1820.