### PR TITLE
fix(coding-agent): /model shows stale scoped models after models.json edit

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -164,6 +164,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		}
 
 		this.allModels = this.sortModels(models);
+		this.scopedModels = this.scopedModels.map((scoped) => {
+			const refreshed = this.modelRegistry.find(scoped.model.provider, scoped.model.id);
+			return refreshed ? { ...scoped, model: refreshed } : scoped;
+		});
 		this.scopedModelItems = this.sortModels(
 			this.scopedModels.map((scoped) => ({
 				provider: scoped.model.provider,


### PR DESCRIPTION
After updating models.json, the scoped model selector still shows the old values when opened. Switching to the "all" scope, however, shows updated model definitions.

Here's the video of the bug and the fix:

https://github.com/user-attachments/assets/3df43db2-a3a2-4411-87c6-a423463877b0