### PR TITLE
fix(ai): fetch GitHub Copilot context window limits at runtime

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed OpenAI Responses replay for foreign tool-call item IDs by hashing foreign `function_call.id` values into bounded `fc_<hash>` IDs instead of preserving backend-specific normalized shapes that OpenAI Codex rejects.
 - Fixed Anthropic thinking disable handling to send `thinking: { type: "disabled" }` for reasoning-capable models when thinking is explicitly off, and added payload and env-gated end-to-end coverage for the Anthropic provider ([#2022](https://github.com/badlogic/pi-mono/issues/2022))
+- Fixed GitHub Copilot context window limits: removed incorrect 1M override for Claude 4.6 models and added runtime fetch of actual model limits from the Copilot `/models` API after OAuth login, replacing stale models.dev defaults that undercount context windows (e.g., claude-opus-4.6 reported as 144K instead of 200K)
 
 ## [0.61.1] - 2026-03-20
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -669,8 +669,7 @@ async function generateModels() {
 		if (
 			(candidate.provider === "anthropic" ||
 				candidate.provider === "opencode" ||
-				candidate.provider === "opencode-go" ||
-				candidate.provider === "github-copilot") &&
+				candidate.provider === "opencode-go") &&
 			(candidate.id === "claude-opus-4-6" ||
 				candidate.id === "claude-sonnet-4-6" ||
 				candidate.id === "claude-opus-4.6" ||

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -2578,7 +2578,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 144000,
 			maxTokens: 32000,
 		} satisfies Model<"anthropic-messages">,
 		"claude-opus-4.5": {
@@ -2596,7 +2596,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 160000,
 			maxTokens: 32000,
 		} satisfies Model<"anthropic-messages">,
 		"claude-opus-4.6": {
@@ -2614,7 +2614,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 1000000,
+			contextWindow: 144000,
 			maxTokens: 64000,
 		} satisfies Model<"anthropic-messages">,
 		"claude-sonnet-4": {
@@ -2632,7 +2632,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 216000,
 			maxTokens: 16000,
 		} satisfies Model<"anthropic-messages">,
 		"claude-sonnet-4.5": {
@@ -2650,7 +2650,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 144000,
 			maxTokens: 32000,
 		} satisfies Model<"anthropic-messages">,
 		"claude-sonnet-4.6": {
@@ -2668,7 +2668,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 1000000,
+			contextWindow: 200000,
 			maxTokens: 32000,
 		} satisfies Model<"anthropic-messages">,
 		"gemini-2.5-pro": {
@@ -2763,7 +2763,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 64000,
+			contextWindow: 128000,
 			maxTokens: 16384,
 		} satisfies Model<"openai-completions">,
 		"gpt-4o": {
@@ -2782,8 +2782,8 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 64000,
-			maxTokens: 16384,
+			contextWindow: 128000,
+			maxTokens: 4096,
 		} satisfies Model<"openai-completions">,
 		"gpt-5": {
 			id: "gpt-5",
@@ -2818,7 +2818,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 264000,
 			maxTokens: 64000,
 		} satisfies Model<"openai-responses">,
 		"gpt-5.1": {
@@ -2836,7 +2836,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 264000,
 			maxTokens: 64000,
 		} satisfies Model<"openai-responses">,
 		"gpt-5.1-codex": {
@@ -2854,7 +2854,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-responses">,
 		"gpt-5.1-codex-max": {
@@ -2872,7 +2872,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-responses">,
 		"gpt-5.1-codex-mini": {
@@ -2890,7 +2890,7 @@ export const MODELS = {
 				cacheRead: 0,
 				cacheWrite: 0,
 			},
-			contextWindow: 128000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-responses">,
 		"gpt-5.2": {
@@ -7293,12 +7293,12 @@ export const MODELS = {
 			input: ["text"],
 			cost: {
 				input: 0.21,
-				output: 0.78,
-				cacheRead: 0.105,
+				output: 0.7899999999999999,
+				cacheRead: 0.1300000002,
 				cacheWrite: 0,
 			},
 			contextWindow: 163840,
-			maxTokens: 65536,
+			maxTokens: 4096,
 		} satisfies Model<"openai-completions">,
 		"deepseek/deepseek-v3.2": {
 			id: "deepseek/deepseek-v3.2",
@@ -9265,12 +9265,12 @@ export const MODELS = {
 			input: ["text"],
 			cost: {
 				input: 0.03,
-				output: 0.14,
-				cacheRead: 0,
+				output: 0.11,
+				cacheRead: 0.015,
 				cacheWrite: 0,
 			},
 			contextWindow: 131072,
-			maxTokens: 4096,
+			maxTokens: 131072,
 		} satisfies Model<"openai-completions">,
 		"openai/gpt-oss-20b:free": {
 			id: "openai/gpt-oss-20b:free",
@@ -10386,9 +10386,9 @@ export const MODELS = {
 			reasoning: true,
 			input: ["text"],
 			cost: {
-				input: 0.25,
-				output: 0.85,
-				cacheRead: 0.125,
+				input: 0.3,
+				output: 1.1,
+				cacheRead: 0.15,
 				cacheWrite: 0,
 			},
 			contextWindow: 163840,
@@ -13628,9 +13628,9 @@ export const MODELS = {
 			contextWindow: 2000000,
 			maxTokens: 30000,
 		} satisfies Model<"openai-completions">,
-		"grok-4.20-beta-latest-non-reasoning": {
-			id: "grok-4.20-beta-latest-non-reasoning",
-			name: "Grok 4.20 Beta (Non-Reasoning)",
+		"grok-4.20-0309-non-reasoning": {
+			id: "grok-4.20-0309-non-reasoning",
+			name: "Grok 4.20 (Non-Reasoning)",
 			api: "openai-completions",
 			provider: "xai",
 			baseUrl: "https://api.x.ai/v1",
@@ -13645,9 +13645,9 @@ export const MODELS = {
 			contextWindow: 2000000,
 			maxTokens: 30000,
 		} satisfies Model<"openai-completions">,
-		"grok-4.20-beta-latest-reasoning": {
-			id: "grok-4.20-beta-latest-reasoning",
-			name: "Grok 4.20 Beta (Reasoning)",
+		"grok-4.20-0309-reasoning": {
+			id: "grok-4.20-0309-reasoning",
+			name: "Grok 4.20 (Reasoning)",
 			api: "openai-completions",
 			provider: "xai",
 			baseUrl: "https://api.x.ai/v1",

--- a/packages/ai/src/utils/oauth/github-copilot.ts
+++ b/packages/ai/src/utils/oauth/github-copilot.ts
@@ -8,6 +8,8 @@ import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } fr
 
 type CopilotCredentials = OAuthCredentials & {
 	enterpriseUrl?: string;
+	/** Model limits from the /models API, keyed by model ID */
+	modelLimits?: Record<string, { contextWindow: number; maxTokens: number }>;
 };
 
 const decode = (s: string) => atob(s);
@@ -317,6 +319,50 @@ async function enableAllGitHubCopilotModels(
 }
 
 /**
+ * Fetch model limits (contextWindow, maxTokens) from the Copilot /models API.
+ * Returns a map of model ID to limits, or empty object on failure.
+ */
+async function fetchCopilotModelLimits(
+	token: string,
+	enterpriseDomain?: string,
+): Promise<Record<string, { contextWindow: number; maxTokens: number }>> {
+	const baseUrl = getGitHubCopilotBaseUrl(token, enterpriseDomain);
+	try {
+		const response = await fetch(`${baseUrl}/models`, {
+			headers: {
+				Accept: "application/json",
+				Authorization: `Bearer ${token}`,
+				"X-GitHub-Api-Version": "2025-05-01",
+				...COPILOT_HEADERS,
+			},
+		});
+		if (!response.ok) return {};
+		const data = (await response.json()) as {
+			data?: Array<{
+				id: string;
+				capabilities?: {
+					limits?: {
+						max_context_window_tokens?: number;
+						max_output_tokens?: number;
+					};
+				};
+			}>;
+		};
+		const limits: Record<string, { contextWindow: number; maxTokens: number }> = {};
+		for (const m of data.data || []) {
+			const ctx = m.capabilities?.limits?.max_context_window_tokens;
+			const out = m.capabilities?.limits?.max_output_tokens;
+			if (ctx && out) {
+				limits[m.id] = { contextWindow: ctx, maxTokens: out };
+			}
+		}
+		return limits;
+	} catch {
+		return {};
+	}
+}
+
+/**
  * Login with GitHub Copilot OAuth (device code flow)
  *
  * @param options.onAuth - Callback with URL and optional instructions (user code)
@@ -362,6 +408,14 @@ export async function loginGitHubCopilot(options: {
 	// Enable all models after successful login
 	options.onProgress?.("Enabling models...");
 	await enableAllGitHubCopilotModels(credentials.access, enterpriseDomain ?? undefined);
+
+	// Fetch actual model limits from the /models API
+	options.onProgress?.("Fetching model limits...");
+	const modelLimits = await fetchCopilotModelLimits(credentials.access, enterpriseDomain ?? undefined);
+	if (Object.keys(modelLimits).length > 0) {
+		(credentials as CopilotCredentials).modelLimits = modelLimits;
+	}
+
 	return credentials;
 }
 
@@ -380,7 +434,13 @@ export const githubCopilotOAuthProvider: OAuthProviderInterface = {
 
 	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
 		const creds = credentials as CopilotCredentials;
-		return refreshGitHubCopilotToken(creds.refresh, creds.enterpriseUrl);
+		const refreshed = await refreshGitHubCopilotToken(creds.refresh, creds.enterpriseUrl);
+		// Refresh model limits from the /models API
+		const modelLimits = await fetchCopilotModelLimits(refreshed.access, creds.enterpriseUrl);
+		if (Object.keys(modelLimits).length > 0) {
+			(refreshed as CopilotCredentials).modelLimits = modelLimits;
+		}
+		return refreshed;
 	},
 
 	getApiKey(credentials: OAuthCredentials): string {
@@ -391,6 +451,18 @@ export const githubCopilotOAuthProvider: OAuthProviderInterface = {
 		const creds = credentials as CopilotCredentials;
 		const domain = creds.enterpriseUrl ? (normalizeDomain(creds.enterpriseUrl) ?? undefined) : undefined;
 		const baseUrl = getGitHubCopilotBaseUrl(creds.access, domain);
-		return models.map((m) => (m.provider === "github-copilot" ? { ...m, baseUrl } : m));
+		const limits = creds.modelLimits;
+		return models.map((m) => {
+			if (m.provider !== "github-copilot") return m;
+			const modelLimits = limits?.[m.id];
+			return {
+				...m,
+				baseUrl,
+				...(modelLimits && {
+					contextWindow: modelLimits.contextWindow,
+					maxTokens: modelLimits.maxTokens,
+				}),
+			};
+		});
 	},
 };


### PR DESCRIPTION
Fixes #2526

## Problem

GitHub Copilot models have incorrect `contextWindow` values. Two issues:

1. **Wrong 1M override**: `generate-models.ts` applied a 1M context window to Claude 4.6 models for the `github-copilot` provider. The Copilot API enforces 200K, not 1M. Result: the coding agent never compacts, eventually hitting prompt-too-long errors.

2. **Stale models.dev data**: The `github-copilot` section of `models.dev/api.json` reports incorrect context windows for several Claude models (e.g., claude-opus-4.6 listed as 144K, actual Copilot limit is 200K). Verified by querying `GET /models` on the Copilot API.

## Changes

### `packages/ai/scripts/generate-models.ts`
- Removed `github-copilot` from the 1M context window override (only `anthropic`, `opencode`, `opencode-go` get 1M for Claude 4.6 models)

### `packages/ai/src/utils/oauth/github-copilot.ts`
- Added `fetchCopilotModelLimits(token, enterpriseDomain?)` — queries `GET /models` on the Copilot API, parses `capabilities.limits.max_context_window_tokens` and `max_output_tokens` per model
- Extended `CopilotCredentials` type with `modelLimits` field
- Called `fetchCopilotModelLimits()` during `loginGitHubCopilot()` and `refreshToken()`, storing results in credentials
- Updated `modifyModels()` to apply fetched `contextWindow`/`maxTokens` from stored limits

### `packages/ai/src/models.generated.ts`
- Regenerated with models.dev defaults (no Copilot-specific overrides). Pre-login values are conservative; runtime fetch corrects them after OAuth

### Design rationale

Static hardcoded limits would need manual updates whenever GitHub adds or changes models. Fetching at runtime after OAuth login ensures limits are always accurate without maintenance burden. The fetch runs during login and token refresh (tokens expire every ~30 min), so new models or changed limits are picked up automatically. Failure to fetch is non-fatal — models.dev defaults are conservative (lower than real), so compaction triggers early but never overflows.
