### PR TITLE
feat(tui): wrap markdown links in OSC 8 hyperlink sequences

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -464,16 +464,20 @@ export class Markdown implements Component {
 
 				case "link": {
 					const linkText = this.renderInlineTokens(token.tokens || [], resolvedStyleContext);
+					// Wrap link text in OSC 8 hyperlink sequences for terminal click support.
+					// Format: ESC ] 8 ; ; URL BEL  text  ESC ] 8 ; ; BEL
+					const osc8Open = `\x1b]8;;${token.href}\x07`;
+					const osc8Close = `\x1b]8;;\x07`;
 					// If link text matches href, only show the link once
 					// Compare raw text (token.text) not styled text (linkText) since linkText has ANSI codes
 					// For mailto: links, strip the prefix before comparing (autolinked emails have
 					// text="foo@bar.com" but href="mailto:foo@bar.com")
 					const hrefForComparison = token.href.startsWith("mailto:") ? token.href.slice(7) : token.href;
 					if (token.text === token.href || token.text === hrefForComparison) {
-						result += this.theme.link(this.theme.underline(linkText)) + stylePrefix;
+						result += osc8Open + this.theme.link(this.theme.underline(linkText)) + osc8Close + stylePrefix;
 					} else {
 						result +=
-							this.theme.link(this.theme.underline(linkText)) +
+							osc8Open + this.theme.link(this.theme.underline(linkText)) + osc8Close +
 							this.theme.linkUrl(` (${token.href})`) +
 							stylePrefix;
 					}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -10,6 +10,9 @@ import { VirtualTerminal } from "./virtual-terminal.js";
 // Force full color in CI so ANSI assertions are deterministic
 const chalk = new Chalk({ level: 3 });
 
+/** Strip SGR styling codes and OSC 8 hyperlink sequences for plain text comparison */
+const stripAnsi = (s: string) => s.replace(/\x1b\][0-9]+;[^\x07]*\x07/g, "").replace(/\x1b\[[0-9;]*m/g, "");
+
 function getCellItalic(terminal: VirtualTerminal, row: number, col: number): number {
 	const xterm = (terminal as unknown as { xterm: XtermTerminalType }).xterm;
 	const buffer = xterm.buffer.active;
@@ -49,7 +52,7 @@ describe("Markdown component", () => {
 			assert.ok(lines.length > 0);
 
 			// Strip ANSI codes for checking
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			// Check structure
 			assert.ok(plainLines.some((line) => line.includes("- Item 1")));
@@ -70,7 +73,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			// Check proper indentation
 			assert.ok(plainLines.some((line) => line.includes("- Level 1")));
@@ -91,7 +94,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			assert.ok(plainLines.some((line) => line.includes("1. First")));
 			assert.ok(plainLines.some((line) => line.includes("  1. Nested first")));
@@ -112,7 +115,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			assert.ok(plainLines.some((line) => line.includes("1. Ordered item")));
 			assert.ok(plainLines.some((line) => line.includes("  - Unordered nested")));
@@ -142,7 +145,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trim());
+			const plainLines = lines.map((line) => stripAnsi(line).trim());
 
 			// Find all lines that start with a number and period
 			const numberedLines = plainLines.filter((line) => /^\d+\./.test(line));
@@ -170,7 +173,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			// Check table structure
 			assert.ok(plainLines.some((line) => line.includes("Name")));
@@ -194,7 +197,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const dividerLines = plainLines.filter((line) => line.includes("┼"));
 
 			assert.strictEqual(dividerLines.length, 2, "Expected header + row divider");
@@ -213,7 +216,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(32);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const dataLine = plainLines.find((line) => line.includes(longestWord));
 			assert.ok(dataLine, "Expected data row containing longest word");
 
@@ -240,7 +243,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			// Check headers
 			assert.ok(plainLines.some((line) => line.includes("Left")));
@@ -266,7 +269,7 @@ describe("Markdown component", () => {
 			// Should render without errors
 			assert.ok(lines.length > 0);
 
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			assert.ok(plainLines.some((line) => line.includes("Very long column header")));
 			assert.ok(plainLines.some((line) => line.includes("This is a much longer cell content")));
 		});
@@ -284,7 +287,7 @@ describe("Markdown component", () => {
 
 			// Render at narrow width that forces wrapping
 			const lines = markdown.render(50);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			// All lines should fit within width
 			for (const line of plainLines) {
@@ -311,7 +314,7 @@ describe("Markdown component", () => {
 
 			// Render at width that forces the cell to wrap
 			const lines = markdown.render(25);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			// Should have multiple data rows due to wrapping
 			const dataRows = plainLines.filter((line) => line.startsWith("│") && !line.includes("─"));
@@ -337,7 +340,7 @@ describe("Markdown component", () => {
 
 			const width = 30;
 			const lines = markdown.render(width);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			for (const line of plainLines) {
 				assert.ok(line.length <= width, `Line exceeds width ${width}: "${line}" (length: ${line.length})`);
@@ -373,7 +376,7 @@ describe("Markdown component", () => {
 			const joinedOutput = lines.join("\n");
 			assert.ok(joinedOutput.includes("\x1b[33m"), "Inline code should be styled (yellow)");
 
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 			for (const line of plainLines) {
 				assert.ok(line.length <= width, `Line exceeds width ${width}: "${line}" (length: ${line.length})`);
 			}
@@ -397,7 +400,7 @@ describe("Markdown component", () => {
 
 			// Very narrow width
 			const lines = markdown.render(15);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			// Should not crash and should produce output
 			assert.ok(lines.length > 0, "Should produce output");
@@ -420,7 +423,7 @@ describe("Markdown component", () => {
 
 			// Wide width where table fits naturally
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			// Should have proper table structure
 			const headerLine = plainLines.find((line) => line.includes("A") && line.includes("B"));
@@ -446,7 +449,7 @@ describe("Markdown component", () => {
 
 			// Width 40 with paddingX=2 means contentWidth=36
 			const lines = markdown.render(40);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			// All lines should respect width
 			for (const line of plainLines) {
@@ -469,7 +472,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			assert.notStrictEqual(
 				plainLines.at(-1),
@@ -497,7 +500,7 @@ describe("Markdown component", () => {
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			// Check heading
 			assert.ok(plainLines.some((line) => line.includes("Test Document")));
@@ -617,7 +620,7 @@ again, hello world`,
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			const closingBackticksIndex = plainLines.indexOf("```");
 			assert.ok(closingBackticksIndex !== -1, "Should have closing backticks");
@@ -652,7 +655,7 @@ more text`,
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
 				const lines = markdown.render(80);
-				const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+				const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 				assert.deepStrictEqual(
 					plainLines,
@@ -668,7 +671,7 @@ more text`,
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
 				const lines = markdown.render(80);
-				const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+				const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 				assert.notStrictEqual(
 					plainLines.at(-1),
@@ -693,7 +696,7 @@ again, hello world`,
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			const dividerIndex = plainLines.findIndex((line) => line.includes("─"));
 			assert.ok(dividerIndex !== -1, "Should have divider");
@@ -711,7 +714,7 @@ again, hello world`,
 		it("should not add a trailing blank line when divider is the last rendered block", () => {
 			const markdown = new Markdown("---", 0, 0, defaultMarkdownTheme);
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			assert.notStrictEqual(
 				plainLines.at(-1),
@@ -733,7 +736,7 @@ This is a paragraph`,
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			const headingIndex = plainLines.findIndex((line) => line.includes("Hello"));
 			assert.ok(headingIndex !== -1, "Should have heading");
@@ -751,7 +754,7 @@ This is a paragraph`,
 		it("should not add a trailing blank line when heading is the last rendered block", () => {
 			const markdown = new Markdown("# Hello", 0, 0, defaultMarkdownTheme);
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			assert.notStrictEqual(
 				plainLines.at(-1),
@@ -775,7 +778,7 @@ again, hello world`,
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			const quoteIndex = plainLines.findIndex((line) => line.includes("This is a quote"));
 			assert.ok(quoteIndex !== -1, "Should have blockquote");
@@ -793,7 +796,7 @@ again, hello world`,
 		it("should not add a trailing blank line when blockquote is the last rendered block", () => {
 			const markdown = new Markdown("> This is a quote", 0, 0, defaultMarkdownTheme);
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			assert.notStrictEqual(
 				plainLines.at(-1),
@@ -820,7 +823,7 @@ bar`,
 			const lines = markdown.render(80);
 
 			// Both lines should have the quote border
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const quotedLines = plainLines.filter((line) => line.startsWith("│ "));
 			assert.strictEqual(quotedLines.length, 2, `Expected 2 quoted lines, got: ${JSON.stringify(plainLines)}`);
 
@@ -854,7 +857,7 @@ bar`,
 			const lines = markdown.render(80);
 
 			// Both lines should have the quote border
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const quotedLines = plainLines.filter((line) => line.startsWith("│ "));
 			assert.strictEqual(quotedLines.length, 2, `Expected 2 quoted lines, got: ${JSON.stringify(plainLines)}`);
 
@@ -879,7 +882,7 @@ bar`,
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const quotedLines = plainLines.filter((line) => line.startsWith("│ "));
 
 			assert.ok(
@@ -898,7 +901,7 @@ bar`,
 
 			// Render at narrow width to force wrapping
 			const lines = markdown.render(30);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			// Filter to non-empty lines (exclude trailing blank line after blockquote)
 			const contentLines = plainLines.filter((line) => line.length > 0);
@@ -931,7 +934,7 @@ bar`,
 			);
 
 			const lines = markdown.render(25);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
 
 			// Filter to non-empty lines
 			const contentLines = plainLines.filter((line) => line.length > 0);
@@ -953,7 +956,7 @@ bar`,
 			const markdown = new Markdown("> Quote with **bold** and `code`", 0, 0, defaultMarkdownTheme);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 
 			// Should have the quote border
 			assert.ok(
@@ -1036,7 +1039,7 @@ bar`,
 
 			const renderedLine = markdown.render(80)[0];
 			assert.ok(renderedLine, "Should render heading line");
-			const contentWidth = renderedLine.replace(/\x1b\[[0-9;]*m/g, "").trimEnd().length;
+			const contentWidth = stripAnsi(renderedLine).trimEnd().length;
 			assert.ok(contentWidth > 0, "Should have visible heading content");
 
 			for (let col = contentWidth; col < 80; col++) {
@@ -1066,7 +1069,7 @@ bar`,
 			const markdown = new Markdown("Contact user@example.com for help", 0, 0, defaultMarkdownTheme);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const joinedPlain = plainLines.join(" ");
 
 			// Should contain the email once, not duplicated with mailto:
@@ -1078,7 +1081,7 @@ bar`,
 			const markdown = new Markdown("Visit https://example.com for more", 0, 0, defaultMarkdownTheme);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const joinedPlain = plainLines.join(" ");
 
 			// URL should appear only once
@@ -1090,7 +1093,7 @@ bar`,
 			const markdown = new Markdown("[click here](https://example.com)", 0, 0, defaultMarkdownTheme);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const joinedPlain = plainLines.join(" ");
 
 			// Should show both link text and URL
@@ -1102,12 +1105,43 @@ bar`,
 			const markdown = new Markdown("[Email me](mailto:test@example.com)", 0, 0, defaultMarkdownTheme);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const joinedPlain = plainLines.join(" ");
 
 			// Should show both link text and mailto URL
 			assert.ok(joinedPlain.includes("Email me"), "Should contain link text");
 			assert.ok(joinedPlain.includes("(mailto:test@example.com)"), "Should show mailto URL in parentheses");
+		});
+
+		it("should wrap links in OSC 8 hyperlink sequences", () => {
+			const markdown = new Markdown("[click here](https://example.com)", 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80);
+			const joined = lines.join("");
+
+			// Should contain OSC 8 open and close sequences
+			assert.ok(joined.includes("\x1b]8;;https://example.com\x07"), "Should contain OSC 8 open with URL");
+			assert.ok(joined.includes("\x1b]8;;\x07"), "Should contain OSC 8 close");
+		});
+
+		it("should wrap bare URLs in OSC 8 hyperlink sequences", () => {
+			const markdown = new Markdown("Visit https://example.com for more", 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80);
+			const joined = lines.join("");
+
+			assert.ok(joined.includes("\x1b]8;;https://example.com\x07"), "Should contain OSC 8 open with URL");
+			assert.ok(joined.includes("\x1b]8;;\x07"), "Should contain OSC 8 close");
+		});
+
+		it("should wrap autolinked emails in OSC 8 hyperlink sequences", () => {
+			const markdown = new Markdown("Contact user@example.com for help", 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80);
+			const joined = lines.join("");
+
+			assert.ok(joined.includes("\x1b]8;;mailto:user@example.com\x07"), "Should contain OSC 8 open with mailto URL");
+			assert.ok(joined.includes("\x1b]8;;\x07"), "Should contain OSC 8 close");
 		});
 	});
 
@@ -1123,7 +1157,7 @@ bar`,
 			);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const joinedPlain = plainLines.join(" ");
 
 			// The content inside the tags should be visible
@@ -1137,7 +1171,7 @@ bar`,
 			const markdown = new Markdown("```html\n<div>Some HTML</div>\n```", 0, 0, defaultMarkdownTheme);
 
 			const lines = markdown.render(80);
-			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
+			const plainLines = lines.map((line) => stripAnsi(line));
 			const joinedPlain = plainLines.join("\n");
 
 			// HTML in code blocks should be visible


### PR DESCRIPTION
## Summary

Wrap link text in OSC 8 terminal hyperlink sequences so that links rendered in the Markdown component are clickable (cmd-click / ctrl-click) in terminals that support OSC 8 (Kitty, iTerm2, Ghostty, WezTerm, Windows Terminal, etc.).

## Problem

The TUI already handles OSC 8 — `SEGMENT_RESET` includes `\x1b]8;;\x07` at the end of each rendered line. However, the Markdown component's `link` case never emitted the opening OSC 8 sequence with the URL. Links were styled (underlined, colored) but not clickable.

## Solution

Minimal change in the Markdown component's `link` case: wrap the styled link text in OSC 8 open/close sequences using `token.href`:

```
\x1b]8;;URL\x07  styled link text  \x1b]8;;\x07
```

This works for all link types: explicit markdown links, bare URLs, and autolinked emails.

## Changes

- `packages/tui/src/components/markdown.ts`: Wrap link text in OSC 8 open/close sequences
- `packages/tui/test/markdown.test.ts`: 
  - Add `stripAnsi` helper that strips both SGR codes and OSC 8 sequences (replaces inline regex across all tests)
  - Add 3 new tests verifying OSC 8 presence for explicit links, bare URLs, and autolinked emails

## Testing

All 25 markdown test suites pass (527/528 total TUI tests pass — the 1 failure is a pre-existing `matchesKey` issue unrelated to this change).