### PR TITLE
fix(tui): no trailing spaces with no bg color

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -151,18 +151,14 @@ export class Markdown implements Component {
 			if (bgFn) {
 				contentLines.push(applyBackgroundToLine(lineWithMargins, width, bgFn));
 			} else {
-				// No background - just pad to width
-				const visibleLen = visibleWidth(lineWithMargins);
-				const paddingNeeded = Math.max(0, width - visibleLen);
-				contentLines.push(lineWithMargins + " ".repeat(paddingNeeded));
+				contentLines.push(lineWithMargins);
 			}
 		}
 
 		// Add top/bottom padding (empty lines)
-		const emptyLine = " ".repeat(width);
 		const emptyLines: string[] = [];
 		for (let i = 0; i < this.paddingY; i++) {
-			const line = bgFn ? applyBackgroundToLine(emptyLine, width, bgFn) : emptyLine;
+			const line = bgFn ? applyBackgroundToLine("", width, bgFn) : "";
 			emptyLines.push(line);
 		}
 


### PR DESCRIPTION
# Problem

Sometimes agents will give you commands to copy & paste - and when you do that, they have a bunch of trailing whitespace that can break line continuation in bash (or similar languages).

# Solution

Unless there is a background color, stop padding the width with trailing whitespace in the markdown renderer.

# Bonus

I wasn't going to make this PR until I saw https://x.com/badlogicgames/status/2043607914951082152?s=20

> - markdown.ts, tui component rendering markdown, never looked at it once

😅

It's possible that this is doing something I'm not aware of - but if not, could help me from not needing to paste commands into an editor, remove trailing whitespace, and then run them.