### PR TITLE
feat(safe-guard): add 'remember for session' option to confirm prompts

### DIFF
--- a/packages/coding-agent/examples/extensions/safe-guard.ts
+++ b/packages/coding-agent/examples/extensions/safe-guard.ts
@@ -1,0 +1,65 @@
+/**
+ * oh-pi Safe Guard Extension
+ * 
+ * Combines destructive command confirmation + protected paths in one extension.
+ */
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+export const DANGEROUS_PATTERNS = [
+  /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*-rf\b|.*--force\b)/,
+  /\bsudo\s+rm\b/,
+  /\b(DROP|TRUNCATE|DELETE\s+FROM)\b/i,
+  /\bchmod\s+777\b/,
+  /\bmkfs\b/,
+  /\bdd\s+if=/,
+  />\s*\/dev\/sd[a-z]/,
+];
+
+export const PROTECTED_PATHS = [".env", ".git/", "node_modules/", ".pi/", "id_rsa", ".ssh/"];
+
+export default function (pi: ExtensionAPI) {
+  const allowedPatterns = new Set<string>();
+  const allowedPaths = new Set<string>();
+
+  pi.on("tool_call", async (event, ctx) => {
+    // Check bash commands for dangerous patterns
+    if (event.toolName === "bash") {
+      const cmd = (event.input as { command?: string }).command ?? "";
+      const match = DANGEROUS_PATTERNS.find((p) => p.test(cmd));
+      if (match && ctx.hasUI) {
+        if (allowedPatterns.has(match.source)) return undefined;
+        const choice = await ctx.ui.select(
+          `⚠️  Dangerous Command\n\n  ${cmd}\n\nAllow?`,
+          ["Yes", "Yes, remember for session", "No"]
+        );
+        if (choice === "Yes, remember for session") {
+          allowedPatterns.add(match.source);
+        } else if (choice !== "Yes") {
+          return { block: true, reason: "Blocked by user" };
+        }
+      }
+    }
+
+    // Check write/edit for protected paths
+    if (event.toolName === "write" || event.toolName === "edit") {
+      const path = (event.input as { path?: string }).path ?? "";
+      const hit = PROTECTED_PATHS.find((p) => path.includes(p));
+      if (hit) {
+        if (ctx.hasUI) {
+          if (allowedPaths.has(hit)) return undefined;
+          const choice = await ctx.ui.select(
+            `🛡️  Protected Path\n\n  ${path}\n\nAllow write?`,
+            ["Yes", "Yes, remember for session", "No"]
+          );
+          if (choice === "Yes, remember for session") {
+            allowedPaths.add(hit);
+          } else if (choice !== "Yes") {
+            return { block: true, reason: `Protected path: ${hit}` };
+          }
+        } else {
+          return { block: true, reason: `Protected path: ${hit}` };
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the binary `yes/no` confirm dialogs in the Safe Guard extension with a three-choice `select` prompt: **Yes**, **Yes, remember for session**, and **No**.

## Changes

### `packages/coding-agent/examples/extensions/safe-guard.ts`

1. **Two session-scoped `Set<string>` instances** are created inside the extension function:
   - `allowedPatterns` — stores `regex.source` strings for bypassed dangerous-command patterns
   - `allowedPaths` — stores protected path fragments the user has approved

2. **`ctx.ui.confirm()` → `ctx.ui.select()`** for both gates (bash & write/edit), with options `["Yes", "Yes, remember for session", "No"]`

3. **Short-circuit checks** at the top of each gate: if the pattern/path is already in the session set, the prompt is skipped entirely and the tool call is allowed immediately.

## Behaviour

| Choice | This call | Future matching calls |
|--------|-----------|----------------------|
| Yes | ✅ allowed | 🔔 prompted again |
| Yes, remember for session | ✅ allowed | ✅ silently allowed |
| No | 🚫 blocked | 🔔 prompted again |

Sets are keyed by `regex.source` (patterns) and path fragment (paths), so approval covers the whole pattern family / path prefix — not just the exact command.

No persistence across restarts — the Sets live only for the duration of the `pi` process.