### PR TITLE
fix(ai): correct GPT-5.5 context metadata

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -772,8 +772,12 @@ async function generateModels() {
 			candidate.contextWindow = 272000;
 			candidate.maxTokens = 128000;
 		}
-		if (candidate.provider === "openai" && (candidate.id === "gpt-5.4" || candidate.id === "gpt-5.5")) {
+		if (candidate.provider === "openai" && candidate.id === "gpt-5.4") {
 			candidate.contextWindow = 272000;
+			candidate.maxTokens = 128000;
+		}
+		if (candidate.provider === "openai" && candidate.id === "gpt-5.5") {
+			candidate.contextWindow = 1050000;
 			candidate.maxTokens = 128000;
 		}
 		// Keep selected OpenRouter model metadata stable until upstream settles.
@@ -1096,9 +1100,10 @@ async function generateModels() {
 
 	// OpenAI Codex (ChatGPT OAuth) models
 	// NOTE: These are not fetched from models.dev; we keep a small, explicit list to avoid aliases.
-	// Context window is based on observed server limits (400s above ~272k), not marketing numbers.
+	// Older Codex routes are based on observed server limits (400s above ~272k), not marketing numbers.
 	const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 	const CODEX_CONTEXT = 272000;
+	const CODEX_GPT55_CONTEXT = 400000;
 	const CODEX_MAX_TOKENS = 128000;
 	const codexModels: Model<"openai-codex-responses">[] = [
 		{
@@ -1194,7 +1199,7 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
-			contextWindow: CODEX_CONTEXT,
+			contextWindow: CODEX_GPT55_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -2539,7 +2539,7 @@ export const MODELS = {
 				cacheRead: 0.5,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 1050000,
 			maxTokens: 128000,
 		} satisfies Model<"azure-openai-responses">,
 		"o1": {
@@ -6336,7 +6336,7 @@ export const MODELS = {
 				cacheRead: 0.5,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 1050000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-responses">,
 		"o1": {
@@ -6644,7 +6644,7 @@ export const MODELS = {
 				cacheRead: 0.5,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 400000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
 	},


### PR DESCRIPTION
## Summary

- keep GPT-5.5 OpenAI/Azure `contextWindow` at the documented native window (`1,050,000`) with `maxTokens: 128000`
- set OpenAI Codex GPT-5.5 `contextWindow` to the observed total Copilot route window (`400,000`) with `maxTokens: 128000`
- leave the older Codex route default (`272,000`) unchanged for other entries

Fixes #3736

## Rationale

`contextWindow` is consumed by pi-ai/pi-coding-agent as the total context budget for context usage, overflow detection, and compaction thresholds. The previous `272000` value for GPT-5.5 matches the prompt/input limit (`max_prompt_tokens`), not the full context window.

For the Codex/Copilot route, the reported metadata is:

- `max_context_window_tokens=400000`
- `max_prompt_tokens=272000`
- `max_output_tokens=128000`

So `contextWindow` should stay aligned with `max_context_window_tokens`, while `maxTokens` remains the output cap.

## Testing

- `npm run generate-models --workspace packages/ai` completed successfully. I kept this PR limited to the GPT-5.5 metadata changes because live model catalogs drifted and regenerated additional unrelated entries.
- `npx tsgo -p packages/ai/tsconfig.build.json --noEmit` passed.
- `npm test --workspace packages/ai` was run, but existing/live-provider tests failed unrelated to this metadata change:
  - Google `gemini-2.0-flash` now returns 404 / no longer available to new users.
  - cross-provider handoff had only one available fixture in this environment.
  - two Bedrock thinking payload assertions failed independently of the changed files.
