### PR TITLE
fix(ai): update Antigravity UA to 1.107.0 to resolve 503 API errors

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -78,7 +78,7 @@ const GEMINI_CLI_HEADERS = {
 };
 
 // Headers for Antigravity (sandbox endpoint) - requires specific User-Agent
-const DEFAULT_ANTIGRAVITY_VERSION = "1.21.9";
+const DEFAULT_ANTIGRAVITY_VERSION = "1.107.0";
 
 function getAntigravityHeaders() {
 	const version = process.env.PI_AI_ANTIGRAVITY_VERSION || DEFAULT_ANTIGRAVITY_VERSION;

--- a/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
+++ b/packages/coding-agent/examples/extensions/antigravity-image-gen.ts
@@ -48,7 +48,7 @@ type SaveMode = (typeof SAVE_MODES)[number];
 
 const ANTIGRAVITY_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 
-const DEFAULT_ANTIGRAVITY_VERSION = "1.21.9";
+const DEFAULT_ANTIGRAVITY_VERSION = "1.107.0";
 
 const ANTIGRAVITY_HEADERS = {
 	"User-Agent": `antigravity/${process.env.PI_AI_ANTIGRAVITY_VERSION || DEFAULT_ANTIGRAVITY_VERSION} darwin/arm64`,


### PR DESCRIPTION
### Description
Google's Cloud Code Assist API recently began rejecting the older hardcoded Antigravity user-agent (`1.21.9`), responding with:
`503: This version of Antigravity is no longer supported. Please upgrade to receive the latest features.`

This completely breaks all model requests using the `google-gemini-cli` and `google-antigravity` providers.

### Fix
- Bumped `DEFAULT_ANTIGRAVITY_VERSION` to `1.107.0` across the codebase (AI providers, web-ui example, and example extensions).
- This successfully restores functionality for Gemini and Claude models routed through the Antigravity endpoint.
