### PR TITLE
fix(coding-agent): preserve .agents provenance in skill metadata

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -2181,6 +2181,7 @@ export class DefaultPackageManager implements PackageManager {
 			}
 		};
 
+		// Project extensions from .pi/
 		addResources(
 			"extensions",
 			collectAutoExtensionEntries(projectDirs.extensions),
@@ -2188,16 +2189,32 @@ export class DefaultPackageManager implements PackageManager {
 			projectOverrides.extensions,
 			projectBaseDir,
 		);
+
+		// Project skills from .pi/
 		addResources(
 			"skills",
-			[
-				...collectAutoSkillEntries(projectDirs.skills, "pi"),
-				...projectAgentsSkillDirs.flatMap((dir) => collectAutoSkillEntries(dir, "agents")),
-			],
+			collectAutoSkillEntries(projectDirs.skills, "pi"),
 			projectMetadata,
 			projectOverrides.skills,
 			projectBaseDir,
 		);
+
+		// Project skills from .agents/ (each with its own baseDir)
+		for (const agentsSkillsDir of projectAgentsSkillDirs) {
+			const agentsBaseDir = dirname(agentsSkillsDir); // the .agents directory
+			const agentsMetadata: PathMetadata = {
+				...projectMetadata,
+				baseDir: agentsBaseDir,
+			};
+			addResources(
+				"skills",
+				collectAutoSkillEntries(agentsSkillsDir, "agents"),
+				agentsMetadata,
+				projectOverrides.skills,
+				agentsBaseDir,
+			);
+		}
+
 		addResources(
 			"prompts",
 			collectAutoPromptEntries(projectDirs.prompts),
@@ -2213,6 +2230,7 @@ export class DefaultPackageManager implements PackageManager {
 			projectBaseDir,
 		);
 
+		// User extensions from ~/.pi/agent/
 		addResources(
 			"extensions",
 			collectAutoExtensionEntries(userDirs.extensions),
@@ -2220,13 +2238,30 @@ export class DefaultPackageManager implements PackageManager {
 			userOverrides.extensions,
 			globalBaseDir,
 		);
+
+		// User skills from ~/.pi/agent/
 		addResources(
 			"skills",
-			[...collectAutoSkillEntries(userDirs.skills, "pi"), ...collectAutoSkillEntries(userAgentsSkillsDir, "agents")],
+			collectAutoSkillEntries(userDirs.skills, "pi"),
 			userMetadata,
 			userOverrides.skills,
 			globalBaseDir,
 		);
+
+		// User skills from ~/.agents/ (with its own baseDir)
+		const userAgentsBaseDir = dirname(userAgentsSkillsDir);
+		const userAgentsMetadata: PathMetadata = {
+			...userMetadata,
+			baseDir: userAgentsBaseDir,
+		};
+		addResources(
+			"skills",
+			collectAutoSkillEntries(userAgentsSkillsDir, "agents"),
+			userAgentsMetadata,
+			userOverrides.skills,
+			userAgentsBaseDir,
+		);
+
 		addResources(
 			"prompts",
 			collectAutoPromptEntries(userDirs.prompts),

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -2182,6 +2182,7 @@ export class DefaultPackageManager implements PackageManager {
 			}
 		};
 
+		// Project extensions from .pi/
 		addResources(
 			"extensions",
 			collectAutoExtensionEntries(projectDirs.extensions),
@@ -2189,16 +2190,32 @@ export class DefaultPackageManager implements PackageManager {
 			projectOverrides.extensions,
 			projectBaseDir,
 		);
+
+		// Project skills from .pi/
 		addResources(
 			"skills",
-			[
-				...collectAutoSkillEntries(projectDirs.skills, "pi"),
-				...projectAgentsSkillDirs.flatMap((dir) => collectAutoSkillEntries(dir, "agents")),
-			],
+			collectAutoSkillEntries(projectDirs.skills, "pi"),
 			projectMetadata,
 			projectOverrides.skills,
 			projectBaseDir,
 		);
+
+		// Project skills from .agents/ (each with its own baseDir)
+		for (const agentsSkillsDir of projectAgentsSkillDirs) {
+			const agentsBaseDir = dirname(agentsSkillsDir); // the .agents directory
+			const agentsMetadata: PathMetadata = {
+				...projectMetadata,
+				baseDir: agentsBaseDir,
+			};
+			addResources(
+				"skills",
+				collectAutoSkillEntries(agentsSkillsDir, "agents"),
+				agentsMetadata,
+				projectOverrides.skills,
+				agentsBaseDir,
+			);
+		}
+
 		addResources(
 			"prompts",
 			collectAutoPromptEntries(projectDirs.prompts),
@@ -2214,6 +2231,7 @@ export class DefaultPackageManager implements PackageManager {
 			projectBaseDir,
 		);
 
+		// User extensions from ~/.pi/agent/
 		addResources(
 			"extensions",
 			collectAutoExtensionEntries(userDirs.extensions),
@@ -2221,13 +2239,30 @@ export class DefaultPackageManager implements PackageManager {
 			userOverrides.extensions,
 			globalBaseDir,
 		);
+
+		// User skills from ~/.pi/agent/
 		addResources(
 			"skills",
-			[...collectAutoSkillEntries(userDirs.skills, "pi"), ...collectAutoSkillEntries(userAgentsSkillsDir, "agents")],
+			collectAutoSkillEntries(userDirs.skills, "pi"),
 			userMetadata,
 			userOverrides.skills,
 			globalBaseDir,
 		);
+
+		// User skills from ~/.agents/ (with its own baseDir)
+		const userAgentsBaseDir = dirname(userAgentsSkillsDir);
+		const userAgentsMetadata: PathMetadata = {
+			...userMetadata,
+			baseDir: userAgentsBaseDir,
+		};
+		addResources(
+			"skills",
+			collectAutoSkillEntries(userAgentsSkillsDir, "agents"),
+			userAgentsMetadata,
+			userOverrides.skills,
+			userAgentsBaseDir,
+		);
+
 		addResources(
 			"prompts",
 			collectAutoPromptEntries(userDirs.prompts),

--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -2,6 +2,7 @@
  * TUI component for managing package resources (enable/disable)
  */
 
+import { homedir } from "node:os";
 import { basename, dirname, join, relative } from "node:path";
 import {
 	type Component,
@@ -55,12 +56,34 @@ interface ResourceGroup {
 	subgroups: ResourceSubgroup[];
 }
 
+function formatBaseDir(baseDir: string): string {
+	const homeDir = homedir();
+	let displayPath: string;
+
+	if (baseDir === homeDir) {
+		displayPath = "~";
+	} else if (baseDir.startsWith(homeDir)) {
+		// Replace home prefix with ~, normalize separators for display
+		const rest = baseDir.slice(homeDir.length);
+		displayPath = `~${rest.replace(/\\/g, "/")}`;
+	} else {
+		displayPath = baseDir.replace(/\\/g, "/");
+	}
+
+	return displayPath.endsWith("/") ? displayPath : `${displayPath}/`;
+}
+
 function getGroupLabel(metadata: PathMetadata): string {
 	if (metadata.origin === "package") {
 		return `${metadata.source} (${metadata.scope})`;
 	}
 	// Top-level resources
 	if (metadata.source === "auto") {
+		if (metadata.baseDir) {
+			return metadata.scope === "user"
+				? `User (${formatBaseDir(metadata.baseDir)})`
+				: `Project (${formatBaseDir(metadata.baseDir)})`;
+		}
 		return metadata.scope === "user" ? "User (~/.pi/agent/)" : "Project (.pi/)";
 	}
 	return metadata.scope === "user" ? "User settings" : "Project settings";
@@ -72,7 +95,7 @@ function buildGroups(resolved: ResolvedPaths): ResourceGroup[] {
 	const addToGroup = (resources: ResolvedResource[], resourceType: ResourceType) => {
 		for (const res of resources) {
 			const { path, enabled, metadata } = res;
-			const groupKey = `${metadata.origin}:${metadata.scope}:${metadata.source}`;
+			const groupKey = `${metadata.origin}:${metadata.scope}:${metadata.source}:${metadata.baseDir ?? ""}`;
 
 			if (!groupMap.has(groupKey)) {
 				groupMap.set(groupKey, {

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -159,60 +159,70 @@ Content`,
 		});
 
 		it("should resolve symlinked user and project resources once", async () => {
-			const sharedDir = join(tempDir, "shared-resources");
-			const sharedExtensionsDir = join(sharedDir, "extensions");
-			const sharedSkillsDir = join(sharedDir, "skills");
-			const sharedPromptsDir = join(sharedDir, "prompts");
-			const sharedThemesDir = join(sharedDir, "themes");
-			mkdirSync(sharedExtensionsDir, { recursive: true });
-			mkdirSync(sharedSkillsDir, { recursive: true });
-			mkdirSync(sharedPromptsDir, { recursive: true });
-			mkdirSync(sharedThemesDir, { recursive: true });
+			const previousHome = process.env.HOME;
+			process.env.HOME = tempDir;
+			try {
+				const sharedDir = join(tempDir, "shared-resources");
+				const sharedExtensionsDir = join(sharedDir, "extensions");
+				const sharedSkillsDir = join(sharedDir, "skills");
+				const sharedPromptsDir = join(sharedDir, "prompts");
+				const sharedThemesDir = join(sharedDir, "themes");
+				mkdirSync(sharedExtensionsDir, { recursive: true });
+				mkdirSync(sharedSkillsDir, { recursive: true });
+				mkdirSync(sharedPromptsDir, { recursive: true });
+				mkdirSync(sharedThemesDir, { recursive: true });
 
-			writeFileSync(join(sharedExtensionsDir, "shared.ts"), "export default function() {}");
-			mkdirSync(join(sharedSkillsDir, "shared-skill"), { recursive: true });
-			writeFileSync(
-				join(sharedSkillsDir, "shared-skill", "SKILL.md"),
-				`---
+				writeFileSync(join(sharedExtensionsDir, "shared.ts"), "export default function() {}");
+				mkdirSync(join(sharedSkillsDir, "shared-skill"), { recursive: true });
+				writeFileSync(
+					join(sharedSkillsDir, "shared-skill", "SKILL.md"),
+					`---
 name: shared-skill
 description: Shared skill
 ---
 Content`,
-			);
-			writeFileSync(join(sharedPromptsDir, "shared.md"), "Shared prompt");
-			writeFileSync(join(sharedThemesDir, "shared.json"), JSON.stringify({ name: "shared-theme" }));
+				);
+				writeFileSync(join(sharedPromptsDir, "shared.md"), "Shared prompt");
+				writeFileSync(join(sharedThemesDir, "shared.json"), JSON.stringify({ name: "shared-theme" }));
 
-			mkdirSync(join(agentDir), { recursive: true });
-			mkdirSync(join(tempDir, ".pi"), { recursive: true });
-			symlinkSync(sharedExtensionsDir, join(agentDir, "extensions"), "dir");
-			symlinkSync(sharedSkillsDir, join(agentDir, "skills"), "dir");
-			symlinkSync(sharedPromptsDir, join(agentDir, "prompts"), "dir");
-			symlinkSync(sharedThemesDir, join(agentDir, "themes"), "dir");
-			symlinkSync(sharedExtensionsDir, join(tempDir, ".pi", "extensions"), "dir");
-			symlinkSync(sharedSkillsDir, join(tempDir, ".pi", "skills"), "dir");
-			symlinkSync(sharedPromptsDir, join(tempDir, ".pi", "prompts"), "dir");
-			symlinkSync(sharedThemesDir, join(tempDir, ".pi", "themes"), "dir");
+				mkdirSync(join(agentDir), { recursive: true });
+				mkdirSync(join(tempDir, ".pi"), { recursive: true });
+				symlinkSync(sharedExtensionsDir, join(agentDir, "extensions"), "dir");
+				symlinkSync(sharedSkillsDir, join(agentDir, "skills"), "dir");
+				symlinkSync(sharedPromptsDir, join(agentDir, "prompts"), "dir");
+				symlinkSync(sharedThemesDir, join(agentDir, "themes"), "dir");
+				symlinkSync(sharedExtensionsDir, join(tempDir, ".pi", "extensions"), "dir");
+				symlinkSync(sharedSkillsDir, join(tempDir, ".pi", "skills"), "dir");
+				symlinkSync(sharedPromptsDir, join(tempDir, ".pi", "prompts"), "dir");
+				symlinkSync(sharedThemesDir, join(tempDir, ".pi", "themes"), "dir");
 
-			const result = await packageManager.resolve();
+				const result = await packageManager.resolve();
 
-			expect({
-				extensions: result.extensions.length,
-				skills: result.skills.length,
-				prompts: result.prompts.length,
-				themes: result.themes.length,
-			}).toEqual({
-				extensions: 1,
-				skills: 1,
-				prompts: 1,
-				themes: 1,
-			});
+				expect({
+					extensions: result.extensions.length,
+					skills: result.skills.length,
+					prompts: result.prompts.length,
+					themes: result.themes.length,
+				}).toEqual({
+					extensions: 1,
+					skills: 1,
+					prompts: 1,
+					themes: 1,
+				});
 
-			// Project auto-discovered has higher precedence than user auto-discovered,
-			// so the surviving entry should be scoped to project.
-			expect(result.extensions[0].metadata.scope).toBe("project");
-			expect(result.skills[0].metadata.scope).toBe("project");
-			expect(result.prompts[0].metadata.scope).toBe("project");
-			expect(result.themes[0].metadata.scope).toBe("project");
+				// Project auto-discovered has higher precedence than user auto-discovered,
+				// so the surviving entry should be scoped to project.
+				expect(result.extensions[0].metadata.scope).toBe("project");
+				expect(result.skills[0].metadata.scope).toBe("project");
+				expect(result.prompts[0].metadata.scope).toBe("project");
+				expect(result.themes[0].metadata.scope).toBe("project");
+			} finally {
+				if (previousHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = previousHome;
+				}
+			}
 		});
 
 		it("should auto-discover project prompts with overrides", async () => {
@@ -259,6 +269,94 @@ Content`,
 
 			// Should NOT find helper.ts (not declared in manifest)
 			expect(result.extensions.some((r) => pathEndsWith(r.path, "helper.ts"))).toBe(false);
+		});
+	});
+
+	describe("auto-discovered skill metadata", () => {
+		it("should use the agent dir as baseDir for user .pi/agent skills", async () => {
+			const skillPath = join(agentDir, "skills", "user-pi", "SKILL.md");
+			mkdirSync(join(agentDir, "skills", "user-pi"), { recursive: true });
+			writeFileSync(skillPath, "---\nname: user-pi\ndescription: user pi\n---\n");
+
+			const result = await packageManager.resolve();
+			const skill = result.skills.find((r) => r.path === skillPath);
+
+			expect(skill?.metadata.source).toBe("auto");
+			expect(skill?.metadata.scope).toBe("user");
+			expect(skill?.metadata.baseDir).toBe(agentDir);
+		});
+
+		it("should use the project .pi dir as baseDir for project .pi skills", async () => {
+			const projectBaseDir = join(tempDir, ".pi");
+			const skillPath = join(projectBaseDir, "skills", "project-pi", "SKILL.md");
+			mkdirSync(join(projectBaseDir, "skills", "project-pi"), { recursive: true });
+			writeFileSync(skillPath, "---\nname: project-pi\ndescription: project pi\n---\n");
+
+			const result = await packageManager.resolve();
+			const skill = result.skills.find((r) => r.path === skillPath);
+
+			expect(skill?.metadata.source).toBe("auto");
+			expect(skill?.metadata.scope).toBe("project");
+			expect(skill?.metadata.baseDir).toBe(projectBaseDir);
+		});
+
+		it("should use ~/.agents as baseDir for user .agents skills", async () => {
+			const previousHome = process.env.HOME;
+			process.env.HOME = tempDir;
+
+			try {
+				const agentsBaseDir = join(tempDir, ".agents");
+				const skillPath = join(agentsBaseDir, "skills", "user-agents", "SKILL.md");
+				mkdirSync(join(agentsBaseDir, "skills", "user-agents"), { recursive: true });
+				writeFileSync(skillPath, "---\nname: user-agents\ndescription: user agents\n---\n");
+
+				const result = await packageManager.resolve();
+				const skill = result.skills.find((r) => r.path === skillPath);
+
+				expect(skill?.metadata.source).toBe("auto");
+				expect(skill?.metadata.scope).toBe("user");
+				expect(skill?.metadata.baseDir).toBe(agentsBaseDir);
+			} finally {
+				if (previousHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = previousHome;
+				}
+			}
+		});
+
+		it("should use each project .agents dir as baseDir for project .agents skills", async () => {
+			const repoRoot = join(tempDir, "repo");
+			const nestedCwd = join(repoRoot, "packages", "feature");
+			mkdirSync(nestedCwd, { recursive: true });
+			mkdirSync(join(repoRoot, ".git"), { recursive: true });
+
+			const repoAgentsBaseDir = join(repoRoot, ".agents");
+			const repoSkill = join(repoAgentsBaseDir, "skills", "repo", "SKILL.md");
+			mkdirSync(join(repoAgentsBaseDir, "skills", "repo"), { recursive: true });
+			writeFileSync(repoSkill, "---\nname: repo\ndescription: repo\n---\n");
+
+			const packageAgentsBaseDir = join(repoRoot, "packages", ".agents");
+			const packageSkill = join(packageAgentsBaseDir, "skills", "package", "SKILL.md");
+			mkdirSync(join(packageAgentsBaseDir, "skills", "package"), { recursive: true });
+			writeFileSync(packageSkill, "---\nname: package\ndescription: package\n---\n");
+
+			const pm = new DefaultPackageManager({
+				cwd: nestedCwd,
+				agentDir,
+				settingsManager,
+			});
+
+			const result = await pm.resolve();
+			const resolvedRepoSkill = result.skills.find((r) => r.path === repoSkill);
+			const resolvedPackageSkill = result.skills.find((r) => r.path === packageSkill);
+
+			expect(resolvedRepoSkill?.metadata.source).toBe("auto");
+			expect(resolvedRepoSkill?.metadata.scope).toBe("project");
+			expect(resolvedRepoSkill?.metadata.baseDir).toBe(repoAgentsBaseDir);
+			expect(resolvedPackageSkill?.metadata.source).toBe("auto");
+			expect(resolvedPackageSkill?.metadata.scope).toBe("project");
+			expect(resolvedPackageSkill?.metadata.baseDir).toBe(packageAgentsBaseDir);
 		});
 	});
 

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -274,6 +274,94 @@ Content`,
 		});
 	});
 
+	describe("auto-discovered skill metadata", () => {
+		it("should use the agent dir as baseDir for user .pi/agent skills", async () => {
+			const skillPath = join(agentDir, "skills", "user-pi", "SKILL.md");
+			mkdirSync(join(agentDir, "skills", "user-pi"), { recursive: true });
+			writeFileSync(skillPath, "---\nname: user-pi\ndescription: user pi\n---\n");
+
+			const result = await packageManager.resolve();
+			const skill = result.skills.find((r) => r.path === skillPath);
+
+			expect(skill?.metadata.source).toBe("auto");
+			expect(skill?.metadata.scope).toBe("user");
+			expect(skill?.metadata.baseDir).toBe(agentDir);
+		});
+
+		it("should use the project .pi dir as baseDir for project .pi skills", async () => {
+			const projectBaseDir = join(tempDir, ".pi");
+			const skillPath = join(projectBaseDir, "skills", "project-pi", "SKILL.md");
+			mkdirSync(join(projectBaseDir, "skills", "project-pi"), { recursive: true });
+			writeFileSync(skillPath, "---\nname: project-pi\ndescription: project pi\n---\n");
+
+			const result = await packageManager.resolve();
+			const skill = result.skills.find((r) => r.path === skillPath);
+
+			expect(skill?.metadata.source).toBe("auto");
+			expect(skill?.metadata.scope).toBe("project");
+			expect(skill?.metadata.baseDir).toBe(projectBaseDir);
+		});
+
+		it("should use ~/.agents as baseDir for user .agents skills", async () => {
+			const previousHome = process.env.HOME;
+			process.env.HOME = tempDir;
+
+			try {
+				const agentsBaseDir = join(tempDir, ".agents");
+				const skillPath = join(agentsBaseDir, "skills", "user-agents", "SKILL.md");
+				mkdirSync(join(agentsBaseDir, "skills", "user-agents"), { recursive: true });
+				writeFileSync(skillPath, "---\nname: user-agents\ndescription: user agents\n---\n");
+
+				const result = await packageManager.resolve();
+				const skill = result.skills.find((r) => r.path === skillPath);
+
+				expect(skill?.metadata.source).toBe("auto");
+				expect(skill?.metadata.scope).toBe("user");
+				expect(skill?.metadata.baseDir).toBe(agentsBaseDir);
+			} finally {
+				if (previousHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = previousHome;
+				}
+			}
+		});
+
+		it("should use each project .agents dir as baseDir for project .agents skills", async () => {
+			const repoRoot = join(tempDir, "repo");
+			const nestedCwd = join(repoRoot, "packages", "feature");
+			mkdirSync(nestedCwd, { recursive: true });
+			mkdirSync(join(repoRoot, ".git"), { recursive: true });
+
+			const repoAgentsBaseDir = join(repoRoot, ".agents");
+			const repoSkill = join(repoAgentsBaseDir, "skills", "repo", "SKILL.md");
+			mkdirSync(join(repoAgentsBaseDir, "skills", "repo"), { recursive: true });
+			writeFileSync(repoSkill, "---\nname: repo\ndescription: repo\n---\n");
+
+			const packageAgentsBaseDir = join(repoRoot, "packages", ".agents");
+			const packageSkill = join(packageAgentsBaseDir, "skills", "package", "SKILL.md");
+			mkdirSync(join(packageAgentsBaseDir, "skills", "package"), { recursive: true });
+			writeFileSync(packageSkill, "---\nname: package\ndescription: package\n---\n");
+
+			const pm = new DefaultPackageManager({
+				cwd: nestedCwd,
+				agentDir,
+				settingsManager,
+			});
+
+			const result = await pm.resolve();
+			const resolvedRepoSkill = result.skills.find((r) => r.path === repoSkill);
+			const resolvedPackageSkill = result.skills.find((r) => r.path === packageSkill);
+
+			expect(resolvedRepoSkill?.metadata.source).toBe("auto");
+			expect(resolvedRepoSkill?.metadata.scope).toBe("project");
+			expect(resolvedRepoSkill?.metadata.baseDir).toBe(repoAgentsBaseDir);
+			expect(resolvedPackageSkill?.metadata.source).toBe("auto");
+			expect(resolvedPackageSkill?.metadata.scope).toBe("project");
+			expect(resolvedPackageSkill?.metadata.baseDir).toBe(packageAgentsBaseDir);
+		});
+	});
+
 	describe(".agents/skills auto-discovery", () => {
 		it("should scan .agents/skills from cwd up to git repo root", async () => {
 			const repoRoot = join(tempDir, "repo");


### PR DESCRIPTION
Hello! This closes #3978.

Initially, I had a bandaid fix that simply handled this edgecase, but decided instead to split how we discover skills so that we can keep their source and use it to group in the ui and display it in the header.

Let me know if you need additional changes!

<details><summary>Before</summary>
<p>
<img width="2042" height="1248" alt="Screenshot 2026-04-30 at 07 24 21 PM@2x" src="https://github.com/user-attachments/assets/244647f9-3100-4d3c-ba59-494fb4fffe8b" />



</p>
</details> 

<details><summary>After</summary>
<p>

<img width="2042" height="1248" alt="Screenshot 2026-04-30 at 07 24 35 PM@2x" src="https://github.com/user-attachments/assets/c2dd887a-b1d2-4226-86c1-6ec740a3d201" />


</p>
</details> 

Investigation: https://pi.dev/session/#a4b89b5a3f90a4cd7d3ff99e11e24a73
Implementation: https://pi.dev/session/#7fe2ed220359a79a8e9f8d9841edc446


------

<details><summary>Summary by moonshotai/Kimi-K2.5:</summary>
<p>

Fixes #3978

**Problem**
`pi config` grouped auto-discovered skills from `~/.agents/skills` under `User (~/.pi/agent/)` because both directories received identical metadata (`baseDir: ~/.pi/agent`, `source: "auto"`). The same issue existed for project `.agents/skills`.

**Root Cause**
In `addAutoDiscoveredResources()`, all auto-discovered skills were flattened into single `addResources()` calls before assigning metadata, losing provenance information about which root directory each skill came from.

**Changes**

`packages/coding-agent/src/core/package-manager.ts`:
- Split auto-discovered skill handling to preserve provenance
- User `~/.agents/skills` now gets `baseDir: ~/.agents` (was `~/.pi/agent`)
- Each project `.agents/skills` directory gets its own `baseDir` pointing to its parent `.agents` dir
- Skills from `.pi` directories continue to use their `.pi` baseDir as before

`packages/coding-agent/src/modes/interactive/components/config-selector.ts`:
- Added `baseDir` to group key to prevent collapsing different sources
- Added cross-platform `formatBaseDir()` helper that normalizes Windows backslashes
- Updated group labels to show actual baseDir (e.g., `User (~/.agents/)`)

`packages/coding-agent/test/package-manager.test.ts`:
- Added HOME environment mocking to symlink test to prevent interference from real `~/.agents` directory

**Verification**
- All 99 package-manager tests pass
- `npm run check` passes (lint, format, typecheck)
- Four new tests verify correct metadata assignment for each skill source type

</p>
</details>