### PR TITLE
Fix mismatch between models.dev and OpenCode Go (Qwen3.5/3.6, MiniMax M2.7)

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -724,6 +724,26 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl = `${variant.basePath}/v1`;
 				}
 
+				// Fix known mismatches between models.dev npm data and actual
+				// OpenCode Go endpoint behaviour. models.dev reports these models
+				// as @ai-sdk/anthropic, but the OpenCode Go endpoints either don't
+				// accept Anthropic SDK auth (MiniMax M2.7) or are served through
+				// the OpenAI-compatible /v1/chat/completions path (Qwen 3.5/3.6).
+				// Switch them to openai-completions so requests use Bearer auth
+				// and the standard /v1/chat/completions endpoint.
+				if (variant.provider === "opencode-go") {
+					if (modelId === "minimax-m2.7") {
+						api = "openai-completions";
+						baseUrl = `${variant.basePath}/v1`;
+					}
+					if (modelId === "qwen3.5-plus" || modelId === "qwen3.6-plus") {
+						api = "openai-completions";
+						baseUrl = `${variant.basePath}/v1`;
+						// Qwen/DashScope uses enable_thinking at the top level.
+						compat = { ...(compat ?? {}), thinkingFormat: "qwen" };
+					}
+				}
+
 				models.push({
 					id: modelId,
 					name: m.name || modelId,

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -8463,9 +8463,9 @@ export const MODELS = {
 		"minimax-m2.7": {
 			id: "minimax-m2.7",
 			name: "MiniMax M2.7",
-			api: "anthropic-messages",
+			api: "openai-completions",
 			provider: "opencode-go",
-			baseUrl: "https://opencode.ai/zen/go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
 			reasoning: true,
 			input: ["text"],
 			cost: {
@@ -8476,13 +8476,14 @@ export const MODELS = {
 			},
 			contextWindow: 204800,
 			maxTokens: 131072,
-		} satisfies Model<"anthropic-messages">,
+		} satisfies Model<"openai-completions">,
 		"qwen3.5-plus": {
 			id: "qwen3.5-plus",
 			name: "Qwen3.5 Plus",
-			api: "anthropic-messages",
+			api: "openai-completions",
 			provider: "opencode-go",
-			baseUrl: "https://opencode.ai/zen/go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			compat: {"thinkingFormat":"qwen"},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -8493,13 +8494,14 @@ export const MODELS = {
 			},
 			contextWindow: 262144,
 			maxTokens: 65536,
-		} satisfies Model<"anthropic-messages">,
+		} satisfies Model<"openai-completions">,
 		"qwen3.6-plus": {
 			id: "qwen3.6-plus",
 			name: "Qwen3.6 Plus",
-			api: "anthropic-messages",
+			api: "openai-completions",
 			provider: "opencode-go",
-			baseUrl: "https://opencode.ai/zen/go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			compat: {"thinkingFormat":"qwen"},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -8510,7 +8512,7 @@ export const MODELS = {
 			},
 			contextWindow: 262144,
 			maxTokens: 65536,
-		} satisfies Model<"anthropic-messages">,
+		} satisfies Model<"openai-completions">,
 	},
 	"openrouter": {
 		"ai21/jamba-large-1.7": {
@@ -9316,7 +9318,7 @@ export const MODELS = {
 				cacheRead: 0.024999999999999998,
 				cacheWrite: 0.08333333333333334,
 			},
-			contextWindow: 1048576,
+			contextWindow: 1000000,
 			maxTokens: 8192,
 		} satisfies Model<"openai-completions">,
 		"google/gemini-2.0-flash-lite-001": {


### PR DESCRIPTION
Fixes #4106

Adds the conditional changes for the Qwen3.5 Plus, Qwen 3.6 Plus and MiniMax M2.7 from OpenCode Go following my investigation and local overrides that are working for me (as listed in #4106). I hope this is fine. 

I've followed the `CONTRIBUTING.md` and `AGENTS.md`. I understand what this codes does.

- [x] npm run check
- [x] ./test.sh
- [x] cd packages/ai && npm run generate-models

<img width="838" height="676" alt="Screenshot 2026-05-02 at 22 32 10" src="https://github.com/user-attachments/assets/0ed94e48-c70f-4cdd-a249-bd19bd17c35e" />