### PR TITLE
feat(coding-agent): allow comments and trailing commas in models.json

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -213,6 +213,14 @@ function formatValidationPath(error: TLocalizedValidationError): string {
 	return path || "root";
 }
 
+/** Strip `//` line comments and trailing commas from JSON, leaving string literals untouched. */
+function stripJsonComments(input: string): string {
+	return input.replace(
+		/"(?:\\.|[^"\\])*"|\/\/[^\n]*|,(\s*[}\]])/g,
+		(m, trailing) => trailing ?? (m[0] === '"' ? m : ""),
+	);
+}
+
 /** Provider override config (baseUrl, compat) without request auth/headers */
 interface ProviderOverride {
 	baseUrl?: string;
@@ -450,7 +458,7 @@ export class ModelRegistry {
 
 		try {
 			const content = readFileSync(modelsJsonPath, "utf-8");
-			const parsed = JSON.parse(content) as unknown;
+			const parsed = JSON.parse(stripJsonComments(content)) as unknown;
 
 			if (!validateModelsConfig.Check(parsed)) {
 				const errors =

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -215,10 +215,9 @@ function formatValidationPath(error: TLocalizedValidationError): string {
 
 /** Strip `//` line comments and trailing commas from JSON, leaving string literals untouched. */
 function stripJsonComments(input: string): string {
-	return input.replace(
-		/"(?:\\.|[^"\\])*"|\/\/[^\n]*|,(\s*[}\]])/g,
-		(m, trailing) => trailing ?? (m[0] === '"' ? m : ""),
-	);
+	return input
+		.replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/g, (m) => (m[0] === '"' ? m : ""))
+		.replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (m, tail) => tail ?? (m[0] === '"' ? m : ""));
 }
 
 /** Provider override config (baseUrl, compat) without request auth/headers */


### PR DESCRIPTION
## Summary

- Run user-supplied `models.json` through a tiny `stripJsonComments` helper before `JSON.parse`, so users can annotate the file with `//` line comments and leave trailing commas without breaking the loader.
- The helper is a single regex with three alternatives: a complete JSON string literal (preserved as-is, so `//` and `,` inside strings are left alone), a `//…` line comment (stripped), or a trailing `,` before `}`/`]` (dropped).

## Alternative considered

Adding [`jsonc-parser`](https://www.npmjs.com/package/jsonc-parser) (the parser VSCode uses for its own settings.json) as a dependency. It would give a more robust JSONC implementation including `/* … */` block comments and proper error positions, at the cost of a new dep. Went with the in-tree helper instead since the surface area we need is small and avoids pulling in another dependency.

## Test plan

- [x] `tsgo --noEmit` clean
- [x] Sanity-checked the regex against:
  - trailing commas in objects and arrays
  - strings containing `//` (e.g. `"http://…"`) and `,`
  - strings with escaped quotes (`"a\"b,"`)
  - line comments mixed with trailing commas
- [ ] Try a real `models.json` with comments and a trailing comma end-to-end