### PR TITLE
fix: LM Studio reasoning blocks invisible with Responses API

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -339,6 +339,18 @@ export async function processResponsesStream<TApi extends Api>(
 					});
 				}
 			}
+		} else if (event.type === "response.reasoning_text.done") {
+			// Some OpenAI-compatible providers (e.g. LM Studio) deliver reasoning as a
+			// single completed event instead of the standard output_item.added →
+			// reasoning_summary_text.delta → output_item.done sequence.
+			const text = event.text as string | undefined;
+			if (text) {
+				const thinkingBlock = { type: "thinking" as const, thinking: text };
+				output.content.unshift(thinkingBlock);
+				stream.push({ type: "thinking_start", contentIndex: 0, partial: output });
+				stream.push({ type: "thinking_delta", contentIndex: 0, delta: text, partial: output });
+				stream.push({ type: "thinking_end", contentIndex: 0, content: text, partial: output });
+			}
 		} else if (event.type === "response.reasoning_summary_part.done") {
 			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
 				currentItem.summary = currentItem.summary || [];


### PR DESCRIPTION
## Problem

When using LM Studio (or any OpenAI-compatible provider) with the `openai-responses` API, the model's reasoning/thinking content was completely invisible — even though the model was actively producing reasoning tokens.

The root cause: LM Studio delivers reasoning content via a single `response.reasoning_text.done` event carrying the full thinking text. `processResponsesStream` had no handler for this event, so it was silently dropped on every request.

The standard OpenAI sequence the code expected:
1. `response.output_item.added` → `{ type: "reasoning" }`
2. `response.reasoning_summary_text.delta` (incremental chunks)
3. `response.output_item.done`

What LM Studio actually sends:
1. `response.reasoning_text.done` → full thinking text in one shot

No handler = no thinking block = thinking silently lost every time.

## Fix

Adds a handler for `response.reasoning_text.done` in `processResponsesStream` (`packages/ai/src/providers/openai-responses-shared.ts`):

- Reads the full reasoning text from `event.text`
- Creates a `thinking` content block and inserts it at the **front** of `output.content` (before any text blocks — preserving correct think-before-respond ordering)
- Fires the complete `thinking_start` → `thinking_delta` → `thinking_end` event sequence so all downstream consumers receive the thinking content correctly

## Why This Is Correct

`response.reasoning_text.done` is not a non-standard event — it is part of the [official OpenAI Responses API spec](https://platform.openai.com/docs/api-reference/responses/streaming) (`ResponseReasoningTextDoneEvent`). This is a gap in spec coverage that affects any provider delivering reasoning this way.

## Verification

Tested locally with LM Studio running a Qwen3 reasoning model via the `openai-responses` API:

| Scenario | Before | After |
|---|---|---|
| Model thinks and responds | No thinking block rendered | ✅ Full thinking block appears |
| Multi-turn conversation | Thinking silently dropped every turn | ✅ Thinking visible on every turn |

## Notes

A companion PR with the same fix has been submitted to `openclaw/openclaw` for their internal
`processResponsesStream` in `src/agents/openai-transport-stream.ts`,
which covers all providers using OpenClaw's built-in Responses API transport:
openclaw/openclaw#77827