### PR TITLE
fix(coding-agent): reject re-entry into AgentSession.compact()

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1605,9 +1605,18 @@ export class AgentSession {
 	/**
 	 * Manually compact the session context.
 	 * Aborts current agent operation first.
+	 * Throws if a compaction (manual, auto, or branch summary) is already
+	 * running — `abort()` only cancels agent work, not compaction, so a
+	 * concurrent re-entry would orphan the prior `_compactionAbortController`
+	 * and race on `sessionManager.appendCompaction()` / agent state writes.
+	 * Callers should check `isCompacting` first or be prepared to handle
+	 * the rejection.
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
+		if (this.isCompacting) {
+			throw new Error("Compaction already in progress");
+		}
 		this._disconnectFromAgent();
 		await this.abort();
 		this._compactionAbortController = new AbortController();

--- a/packages/coding-agent/test/agent-session-compact-reentrancy.test.ts
+++ b/packages/coding-agent/test/agent-session-compact-reentrancy.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Manual-compaction re-entry guard.
+ *
+ * `AgentSession.compact()` overwrites `_compactionAbortController` and
+ * runs an LLM summary call against `sessionManager.appendCompaction()`.
+ * `await this.abort()` only cancels agent work, not compaction, so a
+ * concurrent re-entry would orphan the prior controller and race two
+ * writers on session state. Guard rejects re-entry up front.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@mariozechner/pi-agent-core";
+import { getModel } from "@mariozechner/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.js";
+import { AuthStorage } from "../src/core/auth-storage.js";
+import { ModelRegistry } from "../src/core/model-registry.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { SettingsManager } from "../src/core/settings-manager.js";
+import { createTestResourceLoader } from "./utilities.js";
+
+// Hold the LLM-summary step open so the reentry test can race a second
+// compact() against the first while it's still in flight.
+let resolveCompact:
+	| ((value: { summary: string; firstKeptEntryId: string; tokensBefore: number; details: unknown }) => void)
+	| null = null;
+
+vi.mock("../src/core/compaction/index.js", () => ({
+	calculateContextTokens: () => 0,
+	collectEntriesForBranchSummary: () => ({ entries: [], commonAncestorId: null }),
+	compact: () =>
+		new Promise((resolve) => {
+			resolveCompact = resolve as typeof resolveCompact;
+		}),
+	estimateContextTokens: () => ({ tokens: 0, usageTokens: 0, trailingTokens: 0, lastUsageIndex: null }),
+	generateBranchSummary: async () => ({ summary: "", aborted: false, readFiles: [], modifiedFiles: [] }),
+	prepareCompaction: () => ({ dummy: true }),
+	shouldCompact: () => false,
+}));
+
+describe("AgentSession.compact() re-entry", () => {
+	let session: AgentSession;
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-compact-reentry-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: "Test",
+				tools: [],
+			},
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		resolveCompact = null;
+	});
+
+	afterEach(() => {
+		// Release the in-flight compaction so vitest doesn't hang on the
+		// dangling promise from the first compact() call in each test.
+		resolveCompact?.({
+			summary: "released",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 0,
+			details: {},
+		});
+		session.dispose();
+		vi.restoreAllMocks();
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+	});
+
+	it("rejects a second compact() while the first is in flight", async () => {
+		const first = session.compact();
+		// compact() awaits abort() before assigning _compactionAbortController,
+		// so isCompacting flips a few microtasks in. Poll until it does.
+		await vi.waitFor(() => expect(session.isCompacting).toBe(true), { timeout: 1000, interval: 5 });
+
+		await expect(session.compact()).rejects.toThrow(/Compaction already in progress/);
+
+		// First call still holds the controller; afterEach releases it.
+		void first;
+	});
+});


### PR DESCRIPTION
## Problem

`AgentSession.compact()` overwrites `_compactionAbortController` and runs an LLM summary call followed by `sessionManager.appendCompaction()` and `agent.state.messages` mutation. The `await this.abort()` at the top only cancels agent work — `abortCompaction()` is the separate method that targets the compaction controller, and it isn't called here. So calling `compact()` while a prior compaction is still in flight orphans the previous controller (no caller can signal it anymore) and races two writers on session + agent state.

Symptom for callers: on the second `compact()` call, the first compaction's promise still resolves with a `CompactionResult` while the second runs in parallel; both append a compaction entry, so the session ends up with two back-to-back compactions, and the `compaction_end` event fires twice with results from races on shared state. Auto-compactions and branch summaries hit the same race because they share the same `_compactionAbortController` slot.

## Fix

Guard `compact()` with `isCompacting`. Throw `Compaction already in progress` instead of starting a second concurrent run. Callers that want a concurrent compaction to abort the prior one should call `abortCompaction()` first.

## Alternatives considered

- **Auto-abort the prior compaction and restart with the new call.** Mechanically possible (call `abortCompaction()`, await the prior to unwind via its catch/finally, then proceed). Rejected for two reasons: (1) doesn't match pi's existing convention — `abortCompaction()` is exposed as an *explicit* method, signaling that cancelling compaction should be a deliberate caller action, not an implicit side effect of re-entry; and (2) wastes tokens — every re-entry would discard partial LLM output from the prior run, and callers mashing the action (e.g., a user retriggering a `/compact` command) would multiply the cost.

- **Idempotent: return the prior compaction's promise.** Token-efficient but silently drops `customInstructions` from later calls, which is a real UX bug if a caller passes different instructions to the second invocation.

Reject-on-reentry keeps cancellation explicit (matching `abort()` / `abortCompaction()` / `abortBranchSummary()`), preserves the prior compaction's tokens, and makes the failure mode loud enough for callers to add their own coalescing or abort-first logic if they want it.

## Test

`packages/coding-agent/test/agent-session-compact-reentrancy.test.ts` mocks the compaction module, holds the first compaction's LLM call open via a deferred Promise, asserts the second call rejects with the expected error.