### PR TITLE
fix(tui): replace spread operator in push() to prevent stack overflow on large content

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -88,6 +88,18 @@ export class Markdown implements Component {
 	private cachedWidth?: number;
 	private cachedLines?: string[];
 
+	/**
+	 * Push all items from source into target without exceeding the call stack.
+	 * Using the spread operator (`push(...array)`) as function arguments has a
+	 * hard limit on argument count (~65k), which causes "Maximum call stack size
+	 * exceeded" when rendering large code blocks or prompts.
+	 */
+	private _pushAll(target: string[], source: string[]): void {
+		for (let i = 0; i < source.length; i++) {
+			target.push(source[i]);
+		}
+	}
+
 	constructor(
 		text: string,
 		paddingX: number,
@@ -145,7 +157,7 @@ export class Markdown implements Component {
 			const token = tokens[i];
 			const nextToken = tokens[i + 1];
 			const tokenLines = this.renderToken(token, contentWidth, nextToken?.type);
-			renderedLines.push(...tokenLines);
+			this._pushAll(renderedLines, tokenLines);
 		}
 
 		// Wrap lines (NO padding, NO background yet)
@@ -154,7 +166,7 @@ export class Markdown implements Component {
 			if (isImageLine(line)) {
 				wrappedLines.push(line);
 			} else {
-				wrappedLines.push(...wrapTextWithAnsi(line, contentWidth));
+				this._pushAll(wrappedLines, wrapTextWithAnsi(line, contentWidth));
 			}
 		}
 
@@ -191,7 +203,7 @@ export class Markdown implements Component {
 		}
 
 		// Combine top padding, content, and bottom padding
-		const result = [...emptyLines, ...contentLines, ...emptyLines];
+		const result = emptyLines.concat(contentLines, emptyLines);
 
 		// Update cache
 		this.cachedText = this.text;
@@ -355,7 +367,7 @@ export class Markdown implements Component {
 
 			case "list": {
 				const listLines = this.renderList(token as any, 0, styleContext);
-				lines.push(...listLines);
+				this._pushAll(lines, listLines);
 				// Don't add spacing after lists if a space token follows
 				// (the space token will handle it)
 				break;
@@ -363,7 +375,7 @@ export class Markdown implements Component {
 
 			case "table": {
 				const tableLines = this.renderTable(token as any, width, nextTokenType, styleContext);
-				lines.push(...tableLines);
+				this._pushAll(lines, tableLines);
 				break;
 			}
 
@@ -393,8 +405,8 @@ export class Markdown implements Component {
 				for (let i = 0; i < quoteTokens.length; i++) {
 					const quoteToken = quoteTokens[i];
 					const nextQuoteToken = quoteTokens[i + 1];
-					renderedQuoteLines.push(
-						...this.renderToken(quoteToken, quoteContentWidth, nextQuoteToken?.type, quoteInlineStyleContext),
+					this._pushAll(renderedQuoteLines,
+						this.renderToken(quoteToken, quoteContentWidth, nextQuoteToken?.type, quoteInlineStyleContext),
 					);
 				}
 
@@ -607,7 +619,7 @@ export class Markdown implements Component {
 				// Nested list - render with one additional indent level
 				// These lines will have their own indent, so we just add them as-is
 				const nestedLines = this.renderList(token as any, parentDepth + 1, styleContext);
-				lines.push(...nestedLines);
+				this._pushAll(lines, nestedLines);
 			} else if (token.type === "text") {
 				// Text content (may have inline tokens)
 				const text =


### PR DESCRIPTION
## Problem

When rendering large markdown content (e.g., benchmark prompts with big source files), the TUI crashes with:

```
RangeError: Maximum call stack size exceeded
    at Markdown.render (.../pi-tui/dist/components/markdown.js:77:27)
```

This is caused by using the spread operator in `Array.push(...items)`. JavaScript engines have a hard limit on function argument count (~65k), so large arrays exceed the call stack.

## Fix

- Added a `_pushAll(target, source)` helper that uses a simple `for` loop instead of spread
- Replaced all 6 `push(...array)\n patterns: `renderedLines`, `wrappedLines`, `listLines`, `tableLines`, `renderedQuoteLines`, `nestedLines`
- Replaced `[...a, ...b, ...a]\n with `a.concat(b, a)\n for the result array combination

## Testing

- Built successfully with `tsgo -p tsconfig.build.json\n (no errors)
- Patched the compiled `dist/\n in the installed `pi-tui\n package — benchmark runs without stack overflow