### PR TITLE
feat: mouse reporting + rendered-lines API for selection extensions

### DIFF
--- a/packages/coding-agent/examples/extensions/copy-on-select/index.ts
+++ b/packages/coding-agent/examples/extensions/copy-on-select/index.ts
@@ -1,0 +1,134 @@
+/**
+ * Copy-on-select extension.
+ *
+ * Replicates the Amp CLI behaviour: drag to select text in the terminal and
+ * the selection is copied to the system clipboard on mouse release. Uses
+ * SGR 1006 mouse reporting (enabled via the new `setMouseReporting`
+ * primitive) and the existing `copyToClipboard` helper for OSC 52 / native
+ * clipboard handoff.
+ *
+ * Caveat: enabling mouse reporting suppresses native terminal text selection
+ * in most terminals. Shift-drag typically passes through to the terminal's
+ * own selection in xterm/iTerm2/WezTerm/Kitty, so users retain a fallback.
+ *
+ * Setup:
+ * - `pi -e ./examples/extensions/copy-on-select`
+ * - or copy the directory into ~/.pi/agent/extensions/
+ */
+
+import { copyToClipboard, type ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+interface Point {
+	x: number; // 1-indexed column
+	y: number; // 1-indexed row
+}
+
+interface ParsedMouse {
+	button: number;
+	x: number;
+	y: number;
+	press: boolean;
+	drag: boolean;
+}
+
+const SGR_MOUSE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+
+function parseMouse(data: string): ParsedMouse | undefined {
+	const m = data.match(SGR_MOUSE);
+	if (!m) return undefined;
+	const button = Number(m[1]);
+	return {
+		button,
+		x: Number(m[2]),
+		y: Number(m[3]),
+		press: m[4] === "M",
+		drag: (button & 32) !== 0,
+	};
+}
+
+function orderPoints(a: Point, b: Point): [Point, Point] {
+	if (a.y < b.y || (a.y === b.y && a.x <= b.x)) return [a, b];
+	return [b, a];
+}
+
+function extractSelection(lines: string[], startPoint: Point, endPoint: Point): string {
+	const [s, e] = orderPoints(startPoint, endPoint);
+	const startRow = Math.max(0, s.y - 1);
+	const endRow = Math.min(lines.length - 1, e.y - 1);
+	if (startRow > endRow) return "";
+
+	const startCol = Math.max(0, s.x - 1);
+	const endCol = Math.max(0, e.x); // SGR x is the column the release landed on; slice end is exclusive
+
+	if (startRow === endRow) {
+		const line = lines[startRow] ?? "";
+		return line.slice(startCol, endCol);
+	}
+
+	const firstLine = (lines[startRow] ?? "").slice(startCol);
+	const middle = lines.slice(startRow + 1, endRow);
+	const lastLine = (lines[endRow] ?? "").slice(0, endCol);
+	return [firstLine, ...middle, lastLine].join("\n");
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerFlag("no-copy-on-select", {
+		description: "Disable the copy-on-select extension",
+		type: "boolean",
+		default: false,
+	});
+
+	let unsubscribeInput: (() => void) | undefined;
+	let active = false;
+	let pressPoint: Point | undefined;
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		if (pi.getFlag("no-copy-on-select") === true) return;
+
+		ctx.ui.setMouseReporting(true);
+		active = true;
+
+		unsubscribeInput = ctx.ui.onTerminalInput((data) => {
+			if (!active) return undefined;
+			const mouse = parseMouse(data);
+			if (!mouse) return undefined;
+
+			// Only track the left mouse button (button code 0 with optional drag bit 32).
+			const baseButton = mouse.button & 3;
+			if (baseButton !== 0) return undefined;
+
+			if (mouse.press && !mouse.drag) {
+				pressPoint = { x: mouse.x, y: mouse.y };
+			} else if (!mouse.press) {
+				// Release: use the release coordinates as the selection end.
+				const start = pressPoint;
+				const end: Point = { x: mouse.x, y: mouse.y };
+				pressPoint = undefined;
+
+				if (!start) return undefined;
+				if (start.x === end.x && start.y === end.y) return undefined;
+
+				const text = extractSelection(ctx.ui.getRenderedLines(), start, end).trim();
+				if (text.length > 0) {
+					void copyToClipboard(text).catch(() => {
+						// Clipboard write failed — silently ignore. The user has not
+						// asked for status feedback on every drag.
+					});
+				}
+			}
+
+			// Don't consume — other extensions or future TUI mouse handling can still observe these.
+			return undefined;
+		});
+	});
+
+	pi.on("session_shutdown", () => {
+		if (unsubscribeInput) {
+			unsubscribeInput();
+			unsubscribeInput = undefined;
+		}
+		active = false;
+		pressPoint = undefined;
+	});
+}

--- a/packages/coding-agent/examples/extensions/copy-on-select/package.json
+++ b/packages/coding-agent/examples/extensions/copy-on-select/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "pi-extension-copy-on-select",
+	"private": true,
+	"version": "0.1.0",
+	"type": "module",
+	"scripts": {
+		"clean": "echo 'nothing to clean'",
+		"build": "echo 'nothing to build'",
+		"check": "echo 'nothing to check'"
+	},
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		]
+	}
+}

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -219,6 +219,8 @@ const noOpUIContext: ExtensionUIContext = {
 	setTheme: (_theme: string | Theme) => ({ success: false, error: "UI not available" }),
 	getToolsExpanded: () => false,
 	setToolsExpanded: () => {},
+	setMouseReporting: () => {},
+	getRenderedLines: () => [],
 };
 
 export class ExtensionRunner {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -272,6 +272,29 @@ export interface ExtensionUIContext {
 
 	/** Set tool output expansion state. */
 	setToolsExpanded(expanded: boolean): void;
+
+	/**
+	 * Enable or disable terminal mouse reporting (SGR 1006 with drag tracking).
+	 *
+	 * When enabled, mouse events arrive through `onTerminalInput` as raw SGR
+	 * sequences (`\x1b[<B;X;YM` for press/drag, `\x1b[<B;X;Ym` for release).
+	 * Extensions parse these to implement features like copy-on-select.
+	 *
+	 * No-op outside interactive mode. Enabling mouse reporting typically
+	 * suppresses native terminal text selection — leave it off unless an
+	 * extension actually needs mouse events.
+	 */
+	setMouseReporting(enabled: boolean): void;
+
+	/**
+	 * Snapshot of the lines most recently drawn to the terminal, with ANSI
+	 * escape codes stripped. Lines are post-wrap (terminal-cell coordinates),
+	 * so a mouse event at (col, row) maps to `lines[row - 1][col - 1]`.
+	 *
+	 * Returns an empty array outside interactive mode. The returned array is
+	 * a copy; mutating it has no effect on rendering.
+	 */
+	getRenderedLines(): string[];
 }
 
 // ============================================================================

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1991,6 +1991,8 @@ export class InteractiveMode {
 			},
 			getToolsExpanded: () => this.toolOutputExpanded,
 			setToolsExpanded: (expanded) => this.setToolsExpanded(expanded),
+			setMouseReporting: (enabled) => this.ui.setMouseReporting(enabled),
+			getRenderedLines: () => this.ui.getRenderedLines(),
 		};
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -301,6 +301,15 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		setToolsExpanded(_expanded: boolean) {
 			// Tool expansion not supported in RPC mode - no TUI
 		},
+
+		setMouseReporting(_enabled: boolean) {
+			// Mouse reporting requires a local TUI; not supported in RPC mode.
+		},
+
+		getRenderedLines(): string[] {
+			// No local terminal in RPC mode.
+			return [];
+		},
 	});
 
 	runtimeHost.setRebindSession(async () => {

--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -28,6 +28,7 @@ class FakeTerminal implements Terminal {
 	clearScreen(): void {}
 	setTitle(_title: string): void {}
 	setProgress(_active: boolean): void {}
+	setMouseReporting(_enabled: boolean): void {}
 
 	get fullClearCount(): number {
 		return this.writes.filter((write) => write.includes("\x1b[2J\x1b[H\x1b[3J")).length;

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -55,6 +55,13 @@ export interface Terminal {
 
 	// Progress indicator (OSC 9;4)
 	setProgress(active: boolean): void;
+
+	// Mouse reporting (SGR 1006 with button + drag tracking).
+	// When enabled, the terminal sends mouse press/drag/release events as
+	// `\x1b[<B;X;YM` / `\x1b[<B;X;Ym` sequences. These flow through to the
+	// regular input handler (and any addInputListener), so consumers can
+	// parse them without a dedicated callback.
+	setMouseReporting(enabled: boolean): void;
 }
 
 /**
@@ -66,6 +73,7 @@ export class ProcessTerminal implements Terminal {
 	private resizeHandler?: () => void;
 	private _kittyProtocolActive = false;
 	private _modifyOtherKeysActive = false;
+	private _mouseReportingActive = false;
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string) => void;
 	private progressInterval?: ReturnType<typeof setInterval>;
@@ -276,6 +284,12 @@ export class ProcessTerminal implements Terminal {
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
 
+		// Disable mouse reporting if it was enabled
+		if (this._mouseReportingActive) {
+			process.stdout.write("\x1b[?1006l\x1b[?1002l\x1b[?1000l");
+			this._mouseReportingActive = false;
+		}
+
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this._kittyProtocolActive) {
 			process.stdout.write("\x1b[<u");
@@ -384,6 +398,17 @@ export class ProcessTerminal implements Terminal {
 			// OSC 9;4;0 - clear progress
 			process.stdout.write(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
 		}
+	}
+
+	setMouseReporting(enabled: boolean): void {
+		if (enabled === this._mouseReportingActive) return;
+		if (enabled) {
+			// ?1000 = button events, ?1002 = button + drag motion, ?1006 = SGR encoding
+			process.stdout.write("\x1b[?1000h\x1b[?1002h\x1b[?1006h");
+		} else {
+			process.stdout.write("\x1b[?1006l\x1b[?1002l\x1b[?1000l");
+		}
+		this._mouseReportingActive = enabled;
 	}
 
 	private clearProgressInterval(): boolean {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -9,7 +9,14 @@ import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.js";
 import type { Terminal } from "./terminal.js";
 import { getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
-import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
+import {
+	extractAnsiCode,
+	extractSegments,
+	normalizeTerminalOutput,
+	sliceByColumn,
+	sliceWithWidth,
+	visibleWidth,
+} from "./utils.js";
 
 /**
  * Component interface - all components must implement this
@@ -66,6 +73,26 @@ export function isFocusable(component: Component | null): component is Component
  * TUI finds and strips this marker, then positions the hardware cursor there.
  */
 export const CURSOR_MARKER = "\x1b_pi:c\x07";
+
+/**
+ * Strip ANSI/OSC/APC escape sequences from a line.
+ * Used by TUI.getRenderedLines() to expose plain text snapshots to extensions.
+ */
+function stripAnsiCodes(line: string): string {
+	if (!line.includes("\x1b")) return line;
+	let out = "";
+	let i = 0;
+	while (i < line.length) {
+		const ansi = extractAnsiCode(line, i);
+		if (ansi) {
+			i += ansi.length;
+			continue;
+		}
+		out += line[i];
+		i++;
+	}
+	return out;
+}
 
 export { visibleWidth };
 
@@ -283,6 +310,33 @@ export class TUI extends Container {
 	 */
 	setClearOnShrink(enabled: boolean): void {
 		this.clearOnShrink = enabled;
+	}
+
+	/**
+	 * Enable or disable terminal mouse reporting (SGR 1006 with drag tracking).
+	 *
+	 * When enabled, mouse press/drag/release events arrive as `\x1b[<B;X;YM`
+	 * (press/drag) or `\x1b[<B;X;Ym` (release) sequences via the normal input
+	 * pipeline. Components and addInputListener subscribers receive them as
+	 * regular `data` strings — parse with the SGR mouse format.
+	 *
+	 * Note: enabling mouse reporting suppresses native terminal text selection
+	 * in most terminals (shift-drag typically passes through to native).
+	 */
+	setMouseReporting(enabled: boolean): void {
+		this.terminal.setMouseReporting(enabled);
+	}
+
+	/**
+	 * Returns a snapshot of the lines most recently drawn to the terminal,
+	 * with ANSI escape codes stripped. Useful for extensions that need to
+	 * read what is currently displayed (e.g. extracting text under a mouse
+	 * selection range).
+	 *
+	 * The returned array is a copy; mutating it does not affect rendering.
+	 */
+	getRenderedLines(): string[] {
+		return this.previousLines.map((line) => stripAnsiCodes(line));
 	}
 
 	setFocus(component: Component | null): void {

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -102,6 +102,8 @@ export class VirtualTerminal implements Terminal {
 
 	setProgress(_active: boolean): void {}
 
+	setMouseReporting(_enabled: boolean): void {}
+
 	// Test-specific methods not in Terminal interface
 
 	/**


### PR DESCRIPTION
## Summary

- Adds `setMouseReporting(enabled)` and `getRenderedLines()` primitives on the TUI and `ExtensionUIContext`, so extensions can implement mouse-driven features (copy-on-select, click-to-action, hover, etc.) without further core changes.
- Mouse SGR 1006 sequences flow through the existing input pipeline — extensions consume them via the already-public `onTerminalInput` listener.
- Ships `examples/extensions/copy-on-select` replicating Amp's auto-copy-on-drag behaviour using `copyToClipboard` (OSC 52 + native fallbacks already in the repo).

## Why this shape

Pi already has a clipboard helper (`copyToClipboard`) and a raw terminal input listener (`onTerminalInput`). Mouse SGR sequences are already parsed cleanly by `StdinBuffer` and propagated as `data` events. The minimal missing piece was:

1. A way to ask the terminal to *send* mouse events (`setMouseReporting`).
2. A way to look up the text under a cell coordinate (`getRenderedLines`).

Putting selection state and copy policy in the extension (not TUI core) keeps the API surface tight and avoids baking a single UX decision into the renderer.

## Caveats

- Enabling mouse reporting suppresses native terminal text selection in most terminals; **shift-drag** typically passes through to native selection in iTerm2/WezTerm/Kitty/xterm. The example extension is opt-in and ships a `--no-copy-on-select` flag.
- `getRenderedLines()` returns post-wrap, ANSI-stripped lines (terminal-cell coordinates). For copy-out this is what you want; for source-level ranges a future cell→source map would be needed.
- No visual selection overlay is added — terminal-side reverse-video is gone when mouse reporting is on. Adding overlay rendering is left as a follow-up.

## Test plan

- [x] `npm run build` (full monorepo) — green.
- [x] `node --test test/stdin-buffer.test.ts` — 51/51 pass.
- [x] `biome check` + `tsgo --noEmit` (run via pre-commit hook) — green.
- [ ] **Manual:** load `pi -e ./packages/coding-agent/examples/extensions/copy-on-select`, drag-select text in the chat history, paste into another window.
- [ ] **Manual:** verify `--no-copy-on-select` disables it.
- [ ] **Manual:** verify shift-drag still triggers native terminal selection on iTerm2 / Ghostty / WezTerm.
- [ ] **Manual:** verify mouse reporting is cleanly disabled on `pi` exit (no leaked `\x1b[<…M` sequences in the parent shell).

## Follow-ups (not in this PR)

- Visual selection overlay (reverse-video on selected cells while dragging).
- Optional `selection_change` extension event if multiple extensions want to react to selections.
- Cell→source range mapping for extensions that want logical text positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)