### PR TITLE
fix(coding-agent): strip skill wrapper XML from HTML export user messages

### DIFF
--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -204,6 +204,10 @@
       color: var(--accent);
     }
 
+    .tree-role-skill {
+      color: var(--customMessageLabel);
+    }
+
     .tree-role-assistant {
       color: var(--success);
     }
@@ -383,7 +387,8 @@
     }
 
     .user-message:hover .copy-link-btn,
-    .assistant-message:hover .copy-link-btn {
+    .assistant-message:hover .copy-link-btn,
+    .skill-user-entry:hover .copy-link-btn {
       opacity: 1;
     }
 
@@ -784,6 +789,45 @@
     .hook-type {
       color: var(--customMessageLabel);
       font-weight: bold;
+    }
+
+    /* Skill invocation - matches compaction style (clickable, collapsed by default) */
+    .skill-invocation {
+      background: var(--customMessageBg);
+      border-radius: 4px;
+      padding: var(--line-height);
+      cursor: pointer;
+    }
+
+    .skill-invocation-label {
+      color: var(--customMessageLabel);
+      font-weight: bold;
+    }
+
+    .skill-invocation-collapsed {
+      color: var(--customMessageText);
+    }
+
+    .skill-invocation-content {
+      display: none;
+      color: var(--customMessageText);
+      margin-top: var(--line-height);
+    }
+
+    .skill-invocation.expanded .skill-invocation-collapsed {
+      display: none;
+    }
+
+    .skill-invocation.expanded .skill-invocation-content {
+      display: block;
+    }
+
+    .skill-invocation + .user-message {
+      margin-top: var(--line-height);
+    }
+
+    .skill-user-entry {
+      position: relative;
     }
 
     /* Branch summary */

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -313,6 +313,22 @@
         return '';
       }
 
+      /**
+       * Parse a skill block from message text.
+       * Returns null if the text doesn't contain a skill block.
+       * Matches the format: <skill name="..." location="...">\n...\n</skill>\n\nuser message
+       */
+      function parseSkillBlock(text) {
+        const match = text.match(/^<skill name="([^"]+)" location="([^"]+)">\n([\s\S]*?)\n<\/skill>(?:\n\n([\s\S]+))?$/);
+        if (!match) return null;
+        return {
+          name: match[1],
+          location: match[2],
+          content: match[3],
+          userMessage: match[4]?.trim() || undefined,
+        };
+      }
+
       function getSearchableText(entry, label) {
         const parts = [];
         if (label) parts.push(label);
@@ -613,7 +629,16 @@
           case 'message': {
             const msg = entry.message;
             if (msg.role === 'user') {
-              const content = truncate(normalize(extractContent(msg.content)));
+              const rawContent = extractContent(msg.content);
+              const skillBlock = parseSkillBlock(rawContent);
+              if (skillBlock) {
+                let treeHtml = labelHtml + `<span class="tree-role-skill">skill:</span> ${escapeHtml(skillBlock.name)}`;
+                if (skillBlock.userMessage) {
+                  treeHtml += ` · <span class="tree-role-user">user:</span> ${escapeHtml(truncate(normalize(skillBlock.userMessage)))}`;
+                }
+                return treeHtml;
+              }
+              const content = truncate(normalize(rawContent));
               return labelHtml + `<span class="tree-role-user">user:</span> ${escapeHtml(content)}`;
             }
             if (msg.role === 'assistant') {
@@ -1140,8 +1165,46 @@
           const msg = entry.message;
 
           if (msg.role === 'user') {
-            let html = `<div class="user-message" id="${entryDomId}">${copyBtnHtml}${tsHtml}`;
             const content = msg.content;
+            const text = typeof content === 'string' ? content :
+              content.filter(c => c.type === 'text').map(c => c.text).join('\n');
+            const skillBlock = parseSkillBlock(text);
+
+            if (skillBlock) {
+              // Collect images from content array
+              const images = Array.isArray(content) ? content.filter(c => c.type === 'image') : [];
+              const hasUserContent = skillBlock.userMessage || images.length > 0;
+              let html = `<div class="skill-user-entry" id="${entryDomId}">${copyBtnHtml}${tsHtml}`;
+
+              // Skill invocation (collapsed by default, click to expand)
+              html += `<div class="skill-invocation" onclick="if(window.getSelection().toString())return;this.classList.toggle('expanded')">
+                <div class="skill-invocation-label">[skill] ${escapeHtml(skillBlock.name)}</div>
+                <div class="skill-invocation-collapsed">${escapeHtml(skillBlock.name)} (click to expand)</div>
+                <div class="skill-invocation-content markdown-content">${safeMarkedParse(skillBlock.content)}</div>
+              </div>`;
+
+              // User message (separate block if present)
+              if (hasUserContent) {
+                html += '<div class="user-message">';
+                if (images.length > 0) {
+                  html += '<div class="message-images">';
+                  for (const img of images) {
+                    html += `<img src="data:${escapeHtml(img.mimeType || 'image/png')};base64,${escapeHtml(img.data || '')}" class="message-image" />`;
+                  }
+                  html += '</div>';
+                }
+                if (skillBlock.userMessage) {
+                  html += `<div class="markdown-content">${safeMarkedParse(skillBlock.userMessage)}</div>`;
+                }
+                html += '</div>';
+              }
+
+              html += '</div>';
+              return html;
+            }
+
+            // No skill block - normal user message
+            let html = `<div class="user-message" id="${entryDomId}">${copyBtnHtml}${tsHtml}`;
 
             if (Array.isArray(content)) {
               const images = content.filter(c => c.type === 'image');
@@ -1154,8 +1217,6 @@
               }
             }
 
-            const text = typeof content === 'string' ? content :
-              content.filter(c => c.type === 'text').map(c => c.text).join('\n');
             if (text.trim()) {
               html += `<div class="markdown-content">${safeMarkedParse(text)}</div>`;
             }
@@ -1714,6 +1775,9 @@
           el.classList.toggle('expanded', toolOutputsExpanded);
         });
         document.querySelectorAll('.compaction').forEach(el => {
+          el.classList.toggle('expanded', toolOutputsExpanded);
+        });
+        document.querySelectorAll('.skill-invocation').forEach(el => {
           el.classList.toggle('expanded', toolOutputsExpanded);
         });
       };

--- a/packages/coding-agent/test/export-html-skill-block.test.ts
+++ b/packages/coding-agent/test/export-html-skill-block.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+describe("export HTML skill block rendering", () => {
+	const templateJs = readFileSync(new URL("../src/core/export-html/template.js", import.meta.url), "utf-8");
+
+	it("strips skill wrapper XML from user message rendering", () => {
+		// Skill commands store a structural wrapper in the raw user message:
+		//   <skill name="..." location="...">\n...\n</skill>\n\nactual prompt
+		// The export renderer must detect that wrapper and render only the user-visible prompt,
+		// not the Pi-generated <skill>...</skill> XML tags.
+		expect(templateJs).toMatch(/parseSkillBlock/);
+		expect(templateJs).toMatch(/skillBlock\.userMessage/);
+	});
+
+	it("renders skill invocation and user message as separate sibling blocks", () => {
+		// The skill block and user message should render as separate entry-level elements,
+		// matching the TUI layout where SkillInvocationMessageComponent and
+		// UserMessageComponent are siblings, not nested.
+		expect(templateJs).toMatch(/skill-invocation/);
+
+		// When a skill block has a userMessage, the user-message div must be emitted
+		// as a separate block after the skill-invocation div, containing the user-authored text.
+		// Verify the code checks hasUserContent so the user-message div is only omitted
+		// when the skill block has no user prompt and no images.
+		expect(templateJs).toMatch(/hasUserContent/);
+	});
+
+	it("renders skill content as markdown, not raw text", () => {
+		// The skill block body is markdown (from the SKILL.md file).
+		// It should be rendered through safeMarkedParse, not escaped as raw text.
+		expect(templateJs).toMatch(/safeMarkedParse\(skillBlock\.content\)/);
+	});
+
+	it("shows skill name and user message in the sidebar tree", () => {
+		// The sidebar tree should display both the skill name and the user prompt,
+		// not just one or the other.
+		expect(templateJs).toMatch(/tree-role-skill/);
+	});
+});


### PR DESCRIPTION
Hello!

Noticed this weird bug when exporting a session that included a skill: since v0.68.1, we render html verbatim inside of markdown messages (https://github.com/badlogic/pi-mono/issues/3484). However, this seems to break when rendering skills and shows the `<skill ...` xml fragment in the user message (see in the session below).

This PR fixes this issue by matching the ux of the TUI and extracting the skill into its own message, collapsed by default and showing the user message below.

Let me know if you need/want more changes, especially around how the skills are rendered.

Before: https://pi.dev/session/#5417c2b7c9b6f63c08a19513958f9df1
After: https://pi.dev/session/#0a100935f38e4d29aa5331969101ebd4

Investigation (gpt-5.5): https://pi.dev/session/#08bc0557ec50e22183d1a631ee63bbe5
Implementation (glm-5.1): https://pi.dev/session/#64ddc3dc9e1c29d61d69f091e87bb303

------

<details><summary>Summary by zai-org/GLM-5.1:</summary>
<p>

## Problem

Skill slash commands store a structural `<skill name="..." location="...">...\n</skill>` wrapper in raw user messages. The TUI uses `parseSkillBlock()` to split this into separate `SkillInvocationMessageComponent` and `UserMessageComponent` siblings, but the HTML export renderer passed the full raw text through markdown rendering. This caused broken/dangling XML tags (e.g. `</skill>`) to appear in exported HTML.

## Changes

**`packages/coding-agent/src/core/export-html/template.js`**

- Added `parseSkillBlock()` function matching the regex from `agent-session.ts`
- Sidebar tree (`getTreeNodeDisplayHtml`): when a user message contains a skill block, shows `skill: <name> · user: <prompt>` with separate `tree-role-skill` and `tree-role-user` spans instead of the raw XML
- Content area (`renderEntry`): when a skill block is detected, renders two sibling blocks:
  1. `skill-invocation` div — clickable, collapsed by default, shows skill content as markdown on expand
  2. `user-message` div — only emitted when the skill block has a user prompt or images
- Copy-link button preserved on the `skill-user-entry` wrapper
- Toggle tools (O key) expands/collapses skill invocations alongside compaction and tool output blocks

**`packages/coding-agent/src/core/export-html/template.css`**

- `.tree-role-skill` color style (uses `customMessageLabel`)
- `.skill-invocation` / `.skill-invocation-label` / `.skill-invocation-collapsed` / `.skill-invocation-content` — matches compaction pattern (clickable, collapsed by default)
- `.skill-invocation + .user-message` margin for spacing between blocks
- `.skill-user-entry` with `position: relative` for copy-link button positioning
- Hover rule for `.skill-user-entry .copy-link-btn`

**`packages/coding-agent/test/export-html-skill-block.test.ts`**

- Regression tests verifying the template contains `parseSkillBlock`, `skillBlock.userMessage`, `skill-invocation`, `hasUserContent`, `safeMarkedParse(skillBlock.content)`, and `tree-role-skill`

</p>
</details>