### PR TITLE
config selector: scale maxVisible to terminal height

### DIFF
--- a/packages/coding-agent/src/cli/config-selector.ts
+++ b/packages/coding-agent/src/cli/config-selector.ts
@@ -43,6 +43,7 @@ export async function selectConfig(options: ConfigSelectorOptions): Promise<void
 				process.exit(0);
 			},
 			() => ui.requestRender(),
+			ui.terminal.rows,
 		);
 
 		ui.addChild(selector);

--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -178,7 +178,7 @@ class ResourceList implements Component, Focusable {
 	private filteredItems: FlatEntry[] = [];
 	private selectedIndex = 0;
 	private searchInput: Input;
-	private maxVisible = 15;
+	private maxVisible: number;
 	private settingsManager: SettingsManager;
 	private cwd: string;
 	private agentDir: string;
@@ -196,12 +196,21 @@ class ResourceList implements Component, Focusable {
 		this.searchInput.focused = value;
 	}
 
-	constructor(groups: ResourceGroup[], settingsManager: SettingsManager, cwd: string, agentDir: string) {
+	constructor(
+		groups: ResourceGroup[],
+		settingsManager: SettingsManager,
+		cwd: string,
+		agentDir: string,
+		terminalHeight?: number,
+	) {
 		this.groups = groups;
 		this.settingsManager = settingsManager;
 		this.cwd = cwd;
 		this.agentDir = agentDir;
 		this.searchInput = new Input();
+		// 8 lines of chrome: top spacer + top border + spacer + header (2 lines) + spacer + bottom spacer + bottom border
+		const chrome = 8;
+		this.maxVisible = Math.max(5, (terminalHeight ?? 24) - chrome);
 		this.buildFlatList();
 		this.filteredItems = [...this.flatItems];
 	}
@@ -565,6 +574,7 @@ export class ConfigSelectorComponent extends Container implements Focusable {
 		onClose: () => void,
 		onExit: () => void,
 		requestRender: () => void,
+		terminalHeight?: number,
 	) {
 		super();
 
@@ -578,7 +588,7 @@ export class ConfigSelectorComponent extends Container implements Focusable {
 		this.addChild(new Spacer(1));
 
 		// Resource list
-		this.resourceList = new ResourceList(groups, settingsManager, cwd, agentDir);
+		this.resourceList = new ResourceList(groups, settingsManager, cwd, agentDir, terminalHeight);
 		this.resourceList.onCancel = onClose;
 		this.resourceList.onExit = onExit;
 		this.resourceList.onToggle = () => requestRender();


### PR DESCRIPTION
### What

`pi config` resource list hardcodes `maxVisible = 15` in `ResourceList`, leaving most of the screen empty on tall terminals. This passes `terminalHeight` through the constructor chain and computes `maxVisible` dynamically.

### Why

With 50+ extensions/skills, scrolling 15 items at a time in a 60-row terminal is painful. `tree-selector` already takes `terminalHeight` — the config selector should do the same.

### How

- `ResourceList` constructor accepts optional `terminalHeight`, computes `maxVisible = Math.max(5, terminalHeight - 8)` (8 = chrome lines: borders, header, search, spacers)
- `ConfigSelectorComponent` passes it through
- `selectConfig` passes `ui.terminal.rows`
- Falls back to 24 rows when not provided (matches `ProcessTerminal` default)

2 files, +14/−3 lines. `biome check` and `tsgo --noEmit` pass.

Closes #4241