### PR TITLE
chore(coding-agent): switch back from fork to upstream jiti 2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
 				"packages/coding-agent/examples/extensions/sandbox"
 			],
 			"dependencies": {
-				"@mariozechner/jiti": "^2.6.5",
 				"@mariozechner/pi-coding-agent": "^0.30.2",
 				"get-east-asian-width": "^1.4.0"
 			},
@@ -27,6 +26,7 @@
 				"@typescript/native-preview": "7.0.0-dev.20260120.1",
 				"concurrently": "^9.2.1",
 				"husky": "^9.1.7",
+				"jiti": "^2.7.0",
 				"shx": "^0.4.0",
 				"tsx": "^4.20.3",
 				"typescript": "^5.9.2"
@@ -1781,19 +1781,6 @@
 			],
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/@mariozechner/jiti": {
-			"version": "2.6.5",
-			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-			"license": "MIT",
-			"dependencies": {
-				"std-env": "^3.10.0",
-				"yoctocolors": "^2.1.2"
-			},
-			"bin": {
-				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
 		"node_modules/@mariozechner/mini-lit": {
@@ -5772,9 +5759,9 @@
 			"license": "ISC"
 		},
 		"node_modules/jiti": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
@@ -7370,6 +7357,7 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string_decoder": {
@@ -8266,18 +8254,6 @@
 				"fd-slicer": "~1.1.0"
 			}
 		},
-		"node_modules/yoctocolors": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/zod": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -8381,7 +8357,6 @@
 			"version": "0.73.0",
 			"license": "MIT",
 			"dependencies": {
-				"@mariozechner/jiti": "^2.6.2",
 				"@mariozechner/pi-agent-core": "^0.73.0",
 				"@mariozechner/pi-ai": "^0.73.0",
 				"@mariozechner/pi-tui": "^0.73.0",
@@ -8394,6 +8369,7 @@
 				"glob": "^13.0.1",
 				"hosted-git-info": "^9.0.2",
 				"ignore": "^7.0.5",
+				"jiti": "^2.7.0",
 				"marked": "^15.0.12",
 				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"@typescript/native-preview": "7.0.0-dev.20260120.1",
 		"concurrently": "^9.2.1",
 		"husky": "^9.1.7",
+		"jiti": "^2.7.0",
 		"tsx": "^4.20.3",
 		"typescript": "^5.9.2",
 		"shx": "^0.4.0"
@@ -48,7 +49,6 @@
 	},
 	"version": "0.0.3",
 	"dependencies": {
-		"@mariozechner/jiti": "^2.6.5",
 		"@mariozechner/pi-coding-agent": "^0.30.2",
 		"get-east-asian-width": "^1.4.0"
 	},

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -38,7 +38,6 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@mariozechner/jiti": "^2.6.2",
 		"@mariozechner/pi-agent-core": "^0.73.0",
 		"@mariozechner/pi-ai": "^0.73.0",
 		"@mariozechner/pi-tui": "^0.73.0",
@@ -51,6 +50,7 @@
 		"glob": "^13.0.1",
 		"hosted-git-info": "^9.0.2",
 		"ignore": "^7.0.5",
+		"jiti": "^2.7.0",
 		"marked": "^15.0.12",
 		"minimatch": "^10.2.3",
 		"proper-lockfile": "^4.1.2",

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -1,7 +1,7 @@
 /**
  * Extension loader - loads TypeScript extension modules using jiti.
  *
- * Uses @mariozechner/jiti fork with virtualModules support for compiled Bun binaries.
+ * Uses jiti with virtualModules support for compiled Bun binaries.
  */
 
 import * as fs from "node:fs";
@@ -9,12 +9,12 @@ import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createJiti } from "@mariozechner/jiti";
 import * as _bundledPiAgentCore from "@mariozechner/pi-agent-core";
 import * as _bundledPiAi from "@mariozechner/pi-ai";
 import * as _bundledPiAiOauth from "@mariozechner/pi-ai/oauth";
 import type { KeyId } from "@mariozechner/pi-tui";
 import * as _bundledPiTui from "@mariozechner/pi-tui";
+import { createJiti } from "jiti/static";
 // Static imports of packages that extensions may use.
 // These MUST be static so Bun bundles them into the compiled binary.
 // The virtualModules option then makes them available to extensions.

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -1,7 +1,6 @@
 /**
  * Extension loader - loads TypeScript extension modules using jiti.
  *
- * Uses jiti with virtualModules support for compiled Bun binaries.
  */
 
 import * as fs from "node:fs";


### PR DESCRIPTION
This PR updates jiti to [2.7](https://github.com/unjs/jiti/releases/tag/v2.7.0) from upstream.

Relavant fixes/backports:

- virtual modules: https://github.com/badlogic/jiti/commit/ad402d33c4739da658751c391e680297c28662af => https://github.com/unjs/jiti/pull/428
- static bundling: https://github.com/badlogic/jiti/commit/800a4fc547273afa40a9c7ca1d7e0166542f8ce8 => https://github.com/unjs/jiti/pull/430
- file based fallback for ESM eval: https://github.com/badlogic/jiti/commit/7b7cdf4c198a19de07c757da8aaefc7b223321f4 > https://github.com/badlogic/jiti/commit/b882e7b3d1741e2c65bebe097fb1e2a71f8f3c55 => https://github.com/unjs/jiti/pull/429