### PR TITLE
perf(coding-agent): shared jiti instance with moduleCache for extension loading

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -338,15 +338,28 @@ function createExtensionAPI(
 	return api;
 }
 
-async function loadExtensionModule(extensionPath: string) {
-	const jiti = createJiti(import.meta.url, {
-		moduleCache: false,
-		// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
-		// Also disable tryNative so jiti handles ALL imports (not just the entry point)
-		// In Node.js/dev: use aliases to resolve to node_modules paths
-		...(isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() }),
-	});
+/**
+ * Shared jiti instance (lazy singleton).
+ * Extensions share module resolution cache, which avoids re-resolving common
+ * dependencies like @mariozechner/pi-agent-core on every load.
+ */
+let _jiti: ReturnType<typeof createJiti> | null = null;
 
+function getJiti(): ReturnType<typeof createJiti> {
+	if (!_jiti) {
+		_jiti = createJiti(import.meta.url, {
+			moduleCache: true,
+			// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
+			// Also disable tryNative so jiti handles ALL imports (not just the entry point)
+			// In Node.js/dev: use aliases to resolve to node_modules paths
+			...(isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() }),
+		});
+	}
+	return _jiti;
+}
+
+async function loadExtensionModule(extensionPath: string) {
+	const jiti = getJiti();
 	const module = await jiti.import(extensionPath, { default: true });
 	const factory = module as ExtensionFactory;
 	return typeof factory !== "function" ? undefined : factory;


### PR DESCRIPTION
Use a shared jiti singleton with `moduleCache: true` instead of creating a fresh `createJiti()` per extension in `loadExtensionModule()`.

**Change:** Hoist jiti creation to a lazy module-level singleton, flip `moduleCache: false` → `true`. Extensions share module resolution cache, avoiding re-resolution of common dependencies (`@mariozechner/pi-agent-core`, `@mariozechner/pi-tui`, `@sinclair/typebox`) on every load.

**Measurements** (64 extensions, pi 0.73.0 HEAD, macOS, Node 22.21.1, 5 runs per variant):

| Variant | Median | Δ vs baseline |
|---|---|---|
| baseline (sequential, `moduleCache: false`) | 1107ms | — |
| **shared jiti (`moduleCache: true`)** | **980ms** | **-11.5% (-127ms)** |

Tight variance (977–1034ms across 5 runs). Full tradeoff analysis — including isolation considerations around the `moduleCache: true` change — posted on [#4254](https://github.com/badlogic/pi-mono/issues/4254).

Split from #4242, which proposed both this change and parallel loading. Profiling showed the two changes interact negatively (combined is worse than baseline), so they're now independent.

Fixes #4254

```
1 file changed, +21/-8
```