### PR TITLE
fix(openai-responses): multi-turn reasoning fails under store:false on Azure

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,105 @@
+# Analysis: Azure OpenAI Responses multi-turn reasoning failure under `store: false`
+
+## Symptom
+
+Multi-turn conversations against Azure OpenAI Responses (reasoning-capable models)
+fail on turn 2 with:
+
+```
+400 Item with id 'rs_...' not found. Items are not persisted when `store`
+is set to false. Try again with `store` set to true, or remove this
+item from your input.
+```
+
+Reported via `@flue/sdk`, but the root cause is in `pi-ai`.
+
+## What I confirmed
+
+- `packages/ai/src/providers/openai-responses.ts` hardcodes `store: false`.
+- `packages/ai/src/providers/azure-openai-responses.ts` does not set `store`;
+  it delegates to the Azure deployment default. When `reasoning` is configured
+  it already requests `include: ["reasoning.encrypted_content"]`, which is the
+  correct handshake for stateless replay.
+- `packages/ai/src/providers/openai-responses-shared.ts` captures the reasoning
+  item on `response.output_item.done` via `JSON.stringify(item)` and replays
+  it verbatim on the next turn. The round-trip is complete **only when the
+  stream event's `item` actually carries `encrypted_content`**.
+- The `openai` SDK's `ResponseReasoningItem` declares
+  `encrypted_content?: string | null`, so the field is optional even inside
+  `response.output_item.done`. In practice, Azure OpenAI reasoning models
+  populate `encrypted_content` reliably on the final `response.completed`
+  event's `response.output[]`, but may leave it unset on intermediate
+  `response.output_item.done` events. When that happens, `pi-ai` stores a
+  reasoning signature with only the `id` and the summary. On replay under
+  `store: false`, the server has no stored item and no encrypted payload to
+  verify, so it returns the 400 above.
+- Codex WebSocket flow in `openai-codex-responses.ts` is independent: it
+  already hardcodes `store: false` because ChatGPT Codex rejects `store: true`
+  and uses connection-scoped `previous_response_id` continuity. I did not
+  touch it.
+
+## What I changed
+
+Minimal, non-breaking:
+
+1. `packages/ai/src/providers/openai-responses-shared.ts`
+   In the `response.completed` handler, walk `response.output[]` and, for
+   each reasoning item that carries `encrypted_content`, merge it into the
+   matching stored `thinkingSignature` by `id` when the stored copy is
+   missing `encrypted_content`. This makes capture robust against deployments
+   that only finalize `encrypted_content` on `response.completed`.
+
+2. `packages/ai/src/types.ts`
+   Added `SimpleStreamOptions.store?: boolean` as an opt-in pass-through.
+
+3. `packages/ai/src/providers/openai-responses.ts`
+   Added `OpenAIResponsesOptions.store?: boolean`. `buildParams` now uses
+   `options?.store ?? false`; the default is unchanged.
+   `streamSimpleOpenAIResponses` forwards `store`.
+
+4. `packages/ai/src/providers/azure-openai-responses.ts`
+   Added `AzureOpenAIResponsesOptions.store?: boolean`. `buildParams` sets
+   `params.store = options.store` only when the caller provided a value,
+   preserving today's "let the server decide" default.
+   `streamSimpleAzureOpenAIResponses` forwards `store`.
+
+`openai-codex-responses.ts` is untouched.
+
+## Tests
+
+`packages/ai/test/azure-openai-responses-reasoning-replay.test.ts` adds four
+tests that mock the `AzureOpenAI` client and queue stream events per turn:
+
+1. Happy path: `encrypted_content` present on `response.output_item.done`
+   round-trips through replay. (passed before the fix, still passes)
+2. Regression repro: `encrypted_content` present only on `response.completed`;
+   without the fix, turn 2 replay loses it. (failed before, passes now)
+3. `store: true` option is forwarded to the Azure request body.
+4. When `store` is not provided, the Azure payload still omits the field.
+
+`npm run check` passes. Full `vitest --run` skips networked suites and
+leaves only Ollama-hook timeouts that are unrelated to these changes.
+
+## Rationale for picking this combination over other options
+
+- Option (a) semantic capture fix is the one that makes real user traffic
+  succeed without any caller change; it is the primary fix.
+- Option (b) `store` flag gives downstream consumers (e.g. Flue) a clean
+  opt-in when they want server-side persistence, without flipping defaults
+  for everyone else.
+- Option (c) stripping reasoning-item ids is not viable: the SDK types the
+  `id` field as required, and without `encrypted_content` the server cannot
+  validate the item regardless of whether the id is present.
+
+## Backport note for downstream consumers
+
+- If you are on `@flue/sdk` and ran into this bug, you have two clean paths
+  once this patch lands:
+  - Upgrade `@mariozechner/pi-ai` and rely on the default behavior. The
+    `encrypted_content` backfill alone resolves the replay failure on
+    deployments that return the field on `response.completed`.
+  - Or pass `store: true` through `streamSimple` / provider options if your
+    Azure deployment stores responses and you want `previous_response_id`-
+    style lookups.
+- No code change is required for consumers that were already working under
+  OpenAI (non-Azure) Responses.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1215,6 +1215,8 @@ const response = await complete(model, {
 
 **Azure OpenAI (Responses)**: Uses the Responses API only. Set `AZURE_OPENAI_API_KEY` and either `AZURE_OPENAI_BASE_URL` or `AZURE_OPENAI_RESOURCE_NAME`. `AZURE_OPENAI_BASE_URL` supports both `https://<resource>.openai.azure.com` and `https://<resource>.cognitiveservices.azure.com`; root endpoints are normalized to `.../openai/v1` automatically. Use `AZURE_OPENAI_API_VERSION` (defaults to `v1`) to override the API version if needed. Deployment names are treated as model IDs by default, override with `azureDeploymentName` or `AZURE_OPENAI_DEPLOYMENT_NAME_MAP` using comma-separated `model-id=deployment` pairs (for example `gpt-4o-mini=my-deployment,gpt-4o=prod`). Legacy deployment-based URLs are intentionally unsupported.
 
+Multi-turn reasoning contract: When a reasoning model is used, pi-ai sends `include: ["reasoning.encrypted_content"]` and captures each reasoning item (including its `encrypted_content`) from the stream so the next turn can replay it. If a deployment finalizes `encrypted_content` only on the `response.completed` event (rather than on intermediate `response.output_item.done` events), pi-ai backfills it automatically. You do not need to set `store: true` for multi-turn reasoning to work. If your deployment requires server-side persistence, pass `store: true` on `streamSimple` options or on `AzureOpenAIResponsesOptions`; pi-ai only sets the `store` field when you provide it explicitly.
+
 **GitHub Copilot**: If you get "The requested model is not supported" error, enable the model manually in VS Code: open Copilot Chat, click the model selector, select the model (warning icon), and click "Enable".
 
 ## Development

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -48,6 +48,14 @@ export interface AzureOpenAIResponsesOptions extends StreamOptions {
 	azureResourceName?: string;
 	azureBaseUrl?: string;
 	azureDeploymentName?: string;
+	/**
+	 * Opt-in server-side persistence. When set, forwarded to Azure as the
+	 * `store` field. When unset (default), pi-ai does not send `store` and
+	 * lets the Azure deployment decide. Set to `true` if your deployment
+	 * requires server-stored state for multi-turn reasoning, or `false` to
+	 * match the OpenAI Responses provider default.
+	 */
+	store?: boolean;
 }
 
 /**
@@ -145,6 +153,7 @@ export const streamSimpleAzureOpenAIResponses: StreamFunction<"azure-openai-resp
 	return streamAzureOpenAIResponses(model, context, {
 		...base,
 		reasoningEffort,
+		store: options?.store,
 	} satisfies AzureOpenAIResponsesOptions);
 };
 
@@ -247,6 +256,10 @@ function buildParams(
 		stream: true,
 		prompt_cache_key: options?.sessionId,
 	};
+
+	if (options?.store !== undefined) {
+		params.store = options.store;
+	}
 
 	if (options?.maxTokens) {
 		params.max_output_tokens = options?.maxTokens;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -490,6 +490,33 @@ export async function processResponsesStream<TApi extends Api>(
 			if (response?.id) {
 				output.responseId = response.id;
 			}
+			// Backfill reasoning item fields (notably `encrypted_content`) from the
+			// final response.output[]. Some deployments - e.g. Azure OpenAI - only
+			// populate `encrypted_content` on the final item here rather than on the
+			// intermediate `response.output_item.done` event. Without this backfill,
+			// multi-turn replay under `store: false` fails with
+			// "Item with id 'rs_...' not found. Items are not persisted when
+			// `store` is set to false."
+			if (response?.output) {
+				for (const responseItem of response.output) {
+					if (responseItem.type !== "reasoning") continue;
+					const finalItem = responseItem as ResponseReasoningItem;
+					if (!finalItem.encrypted_content) continue;
+					for (const block of output.content) {
+						if (block.type !== "thinking" || !block.thinkingSignature) continue;
+						let stored: ResponseReasoningItem;
+						try {
+							stored = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
+						} catch {
+							continue;
+						}
+						if (stored.id !== finalItem.id) continue;
+						if (stored.encrypted_content) continue;
+						stored.encrypted_content = finalItem.encrypted_content;
+						block.thinkingSignature = JSON.stringify(stored);
+					}
+				}
+			}
 			if (response?.usage) {
 				const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
 				output.usage = {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -56,6 +56,12 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
+	/**
+	 * Opt-in server-side persistence. Default: `false` (pi-ai uses
+	 * `include: ["reasoning.encrypted_content"]` for multi-turn reasoning).
+	 * Set to `true` if you need `previous_response_id`-style lookups.
+	 */
+	store?: boolean;
 }
 
 /**
@@ -156,6 +162,7 @@ export const streamSimpleOpenAIResponses: StreamFunction<"openai-responses", Sim
 	return streamOpenAIResponses(model, context, {
 		...base,
 		reasoningEffort,
+		store: options?.store,
 	} satisfies OpenAIResponsesOptions);
 };
 
@@ -226,7 +233,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
 		prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
-		store: false,
+		store: options?.store ?? false,
 	};
 
 	if (options?.maxTokens) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -142,6 +142,18 @@ export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ThinkingLevel;
 	/** Custom token budgets for thinking levels (token-based providers only) */
 	thinkingBudgets?: ThinkingBudgets;
+	/**
+	 * Opt-in server-side persistence for providers that expose a `store` flag
+	 * (OpenAI Responses and Azure OpenAI Responses). When `true`, the provider
+	 * sends `store: true` so reasoning items remain retrievable by id on
+	 * subsequent turns. When `false`, the provider sends `store: false` and
+	 * pi-ai relies on `reasoning.encrypted_content` for multi-turn continuity.
+	 * When unset, the provider keeps its current default (OpenAI Responses
+	 * defaults to `store: false`; Azure OpenAI Responses leaves the field
+	 * unset and lets the server decide).
+	 * Providers that do not support `store` ignore this option.
+	 */
+	store?: boolean;
 }
 
 // Generic StreamFunction with typed options.

--- a/packages/ai/test/azure-openai-responses-reasoning-replay.test.ts
+++ b/packages/ai/test/azure-openai-responses-reasoning-replay.test.ts
@@ -1,0 +1,390 @@
+import type {
+	ResponseCreateParamsStreaming,
+	ResponseReasoningItem,
+	ResponseStreamEvent,
+} from "openai/resources/responses/responses.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import { streamAzureOpenAIResponses } from "../src/providers/azure-openai-responses.js";
+import type { AssistantMessage, Context, Message, ThinkingContent } from "../src/types.js";
+
+// -----------------------------------------------------------------------------
+// Mock AzureOpenAI client
+// -----------------------------------------------------------------------------
+
+interface CapturedCreateCall {
+	params: ResponseCreateParamsStreaming;
+	response: unknown;
+}
+
+const azureMock = vi.hoisted(() => ({
+	createCalls: [] as CapturedCreateCall[],
+	queuedStreams: [] as AsyncIterable<ResponseStreamEvent>[],
+}));
+
+vi.mock("openai", () => {
+	class AzureOpenAI {
+		responses = {
+			create: (params: ResponseCreateParamsStreaming) => {
+				const nextStream = azureMock.queuedStreams.shift();
+				if (!nextStream) {
+					throw new Error("No mock stream queued for AzureOpenAI.responses.create call");
+				}
+				azureMock.createCalls.push({ params, response: nextStream });
+				const promise = Promise.resolve(nextStream) as Promise<AsyncIterable<ResponseStreamEvent>> & {
+					withResponse: () => Promise<{
+						data: AsyncIterable<ResponseStreamEvent>;
+						response: { status: number; headers: Headers };
+					}>;
+				};
+				promise.withResponse = async () => ({
+					data: nextStream,
+					response: { status: 200, headers: new Headers() },
+				});
+				return promise;
+			},
+		};
+	}
+
+	return { AzureOpenAI };
+});
+
+function makeStream(events: ResponseStreamEvent[]): AsyncIterable<ResponseStreamEvent> {
+	return {
+		[Symbol.asyncIterator]: async function* () {
+			for (const event of events) {
+				yield event;
+			}
+		},
+	};
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]> } : T;
+
+function reasoningEvents({
+	reasoningItem,
+	finalReasoningItem,
+	messageText = "hello",
+}: {
+	reasoningItem: ResponseReasoningItem;
+	finalReasoningItem?: ResponseReasoningItem;
+	messageText?: string;
+}): ResponseStreamEvent[] {
+	const responseId = "resp_test_1";
+	const messageId = "msg_test_1";
+	const messageItem = {
+		type: "message" as const,
+		id: messageId,
+		role: "assistant" as const,
+		status: "completed" as const,
+		content: [{ type: "output_text" as const, text: messageText, annotations: [] }],
+	};
+
+	// ResponseStreamEvent is a massive union. Type assertions avoid reproducing
+	// the full shape of every event when all we need is a realistic sequence.
+	const events: DeepPartial<ResponseStreamEvent>[] = [
+		{
+			type: "response.created",
+			response: { id: responseId },
+		},
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: reasoningItem,
+		},
+		...((reasoningItem.summary ?? []).flatMap((part, idx) => [
+			{
+				type: "response.reasoning_summary_part.added",
+				item_id: reasoningItem.id,
+				output_index: 0,
+				summary_index: idx,
+				part: { type: "summary_text", text: "" },
+			},
+			{
+				type: "response.reasoning_summary_text.delta",
+				item_id: reasoningItem.id,
+				output_index: 0,
+				summary_index: idx,
+				delta: part.text,
+			},
+			{
+				type: "response.reasoning_summary_part.done",
+				item_id: reasoningItem.id,
+				output_index: 0,
+				summary_index: idx,
+				part,
+			},
+		]) as DeepPartial<ResponseStreamEvent>[]),
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: reasoningItem,
+		},
+		{
+			type: "response.output_item.added",
+			output_index: 1,
+			item: messageItem,
+		},
+		{
+			type: "response.content_part.added",
+			item_id: messageId,
+			output_index: 1,
+			content_index: 0,
+			part: { type: "output_text", text: "", annotations: [] },
+		},
+		{
+			type: "response.output_text.delta",
+			item_id: messageId,
+			output_index: 1,
+			content_index: 0,
+			delta: messageText,
+		},
+		{
+			type: "response.output_item.done",
+			output_index: 1,
+			item: messageItem,
+		},
+		{
+			type: "response.completed",
+			response: {
+				id: responseId,
+				status: "completed",
+				usage: {
+					input_tokens: 10,
+					input_tokens_details: { cached_tokens: 0 },
+					output_tokens: 20,
+					output_tokens_details: { reasoning_tokens: 15 },
+					total_tokens: 30,
+				},
+				output: [finalReasoningItem ?? reasoningItem, messageItem],
+			},
+		},
+	];
+
+	return events as ResponseStreamEvent[];
+}
+
+const originalAzureBaseUrl = process.env.AZURE_OPENAI_BASE_URL;
+const originalAzureApiKey = process.env.AZURE_OPENAI_API_KEY;
+
+beforeEach(() => {
+	azureMock.createCalls.length = 0;
+	azureMock.queuedStreams.length = 0;
+	process.env.AZURE_OPENAI_BASE_URL = "https://test.openai.azure.com/openai/v1";
+	process.env.AZURE_OPENAI_API_KEY = "test-api-key";
+});
+
+afterEach(() => {
+	if (originalAzureBaseUrl === undefined) {
+		delete process.env.AZURE_OPENAI_BASE_URL;
+	} else {
+		process.env.AZURE_OPENAI_BASE_URL = originalAzureBaseUrl;
+	}
+	if (originalAzureApiKey === undefined) {
+		delete process.env.AZURE_OPENAI_API_KEY;
+	} else {
+		process.env.AZURE_OPENAI_API_KEY = originalAzureApiKey;
+	}
+});
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe("Azure OpenAI Responses multi-turn reasoning replay", () => {
+	it("replays reasoning item with encrypted_content when present in response.output_item.done", async () => {
+		const model = getModel("azure-openai-responses", "gpt-5-mini");
+
+		const reasoningItem: ResponseReasoningItem = {
+			id: "rs_happy_path",
+			type: "reasoning",
+			status: "completed",
+			summary: [{ type: "summary_text", text: "Think about hello." }],
+			encrypted_content: "ENCRYPTED_IN_OUTPUT_ITEM_DONE",
+		};
+		azureMock.queuedStreams.push(makeStream(reasoningEvents({ reasoningItem })));
+
+		const turn1Context: Context = {
+			systemPrompt: "You are concise.",
+			messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }],
+		};
+		const assistantMessage = await streamAzureOpenAIResponses(model, turn1Context, {
+			reasoningEffort: "medium",
+		}).result();
+
+		expect(assistantMessage.stopReason).toBe("stop");
+		const thinkingBlock = assistantMessage.content.find((b): b is ThinkingContent => b.type === "thinking");
+		expect(thinkingBlock?.thinkingSignature).toBeTruthy();
+		const parsed = JSON.parse(thinkingBlock!.thinkingSignature!) as ResponseReasoningItem;
+		expect(parsed.encrypted_content).toBe("ENCRYPTED_IN_OUTPUT_ITEM_DONE");
+
+		// Turn 2: replay the assistant message and verify encrypted_content is forwarded.
+		azureMock.queuedStreams.push(
+			makeStream([
+				{
+					type: "response.completed",
+					response: {
+						id: "resp_test_2",
+						status: "completed",
+						usage: {
+							input_tokens: 10,
+							input_tokens_details: { cached_tokens: 0 },
+							output_tokens: 1,
+							output_tokens_details: { reasoning_tokens: 0 },
+							total_tokens: 11,
+						},
+						output: [],
+					},
+				} as unknown as ResponseStreamEvent,
+			]),
+		);
+
+		const followUp: Message = { role: "user", content: "Now say goodbye.", timestamp: Date.now() };
+		const turn2Context: Context = {
+			systemPrompt: "You are concise.",
+			messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }, assistantMessage, followUp],
+		};
+		await streamAzureOpenAIResponses(model, turn2Context, { reasoningEffort: "medium" }).result();
+
+		expect(azureMock.createCalls).toHaveLength(2);
+		const turn2Input = azureMock.createCalls[1].params.input as unknown as Array<Record<string, unknown>>;
+		const replayedReasoning = turn2Input.find((item) => item.type === "reasoning") as
+			| ResponseReasoningItem
+			| undefined;
+		expect(replayedReasoning).toBeDefined();
+		expect(replayedReasoning?.id).toBe("rs_happy_path");
+		expect(replayedReasoning?.encrypted_content).toBe("ENCRYPTED_IN_OUTPUT_ITEM_DONE");
+	});
+
+	it("backfills encrypted_content from response.completed when output_item.done omits it", async () => {
+		// This is the real-world bug: Azure does NOT include encrypted_content on the
+		// intermediate response.output_item.done event, only on the final
+		// response.completed event's response.output[] array. Without the fix,
+		// the thinking signature captured at output_item.done time is missing
+		// encrypted_content, and turn 2 fails with
+		// "Item with id 'rs_...' not found. Items are not persisted when `store`
+		// is set to false."
+		const model = getModel("azure-openai-responses", "gpt-5-mini");
+
+		const reasoningItemIntermediate: ResponseReasoningItem = {
+			id: "rs_late_encryption",
+			type: "reasoning",
+			status: "completed",
+			summary: [{ type: "summary_text", text: "Consider a friendly goodbye." }],
+			// encrypted_content intentionally missing here.
+		};
+		const reasoningItemFinal: ResponseReasoningItem = {
+			...reasoningItemIntermediate,
+			encrypted_content: "ENCRYPTED_IN_RESPONSE_COMPLETED",
+		};
+		azureMock.queuedStreams.push(
+			makeStream(
+				reasoningEvents({
+					reasoningItem: reasoningItemIntermediate,
+					finalReasoningItem: reasoningItemFinal,
+				}),
+			),
+		);
+
+		const turn1Context: Context = {
+			systemPrompt: "You are concise.",
+			messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }],
+		};
+		const assistantMessage: AssistantMessage = await streamAzureOpenAIResponses(model, turn1Context, {
+			reasoningEffort: "medium",
+		}).result();
+
+		expect(assistantMessage.stopReason).toBe("stop");
+		const thinkingBlock = assistantMessage.content.find((b): b is ThinkingContent => b.type === "thinking");
+		expect(thinkingBlock?.thinkingSignature).toBeTruthy();
+		const parsed = JSON.parse(thinkingBlock!.thinkingSignature!) as ResponseReasoningItem;
+		expect(parsed.encrypted_content).toBe("ENCRYPTED_IN_RESPONSE_COMPLETED");
+
+		// Turn 2: replay. The replayed reasoning item must carry encrypted_content
+		// so the Azure API can verify the item without a server-side lookup.
+		azureMock.queuedStreams.push(
+			makeStream([
+				{
+					type: "response.completed",
+					response: {
+						id: "resp_test_2",
+						status: "completed",
+						usage: {
+							input_tokens: 10,
+							input_tokens_details: { cached_tokens: 0 },
+							output_tokens: 1,
+							output_tokens_details: { reasoning_tokens: 0 },
+							total_tokens: 11,
+						},
+						output: [],
+					},
+				} as unknown as ResponseStreamEvent,
+			]),
+		);
+
+		const followUp: Message = { role: "user", content: "Now say goodbye.", timestamp: Date.now() };
+		const turn2Context: Context = {
+			systemPrompt: "You are concise.",
+			messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }, assistantMessage, followUp],
+		};
+		await streamAzureOpenAIResponses(model, turn2Context, { reasoningEffort: "medium" }).result();
+
+		expect(azureMock.createCalls).toHaveLength(2);
+		const turn2Input = azureMock.createCalls[1].params.input as unknown as Array<Record<string, unknown>>;
+		const replayedReasoning = turn2Input.find((item) => item.type === "reasoning") as
+			| ResponseReasoningItem
+			| undefined;
+		expect(replayedReasoning).toBeDefined();
+		expect(replayedReasoning?.id).toBe("rs_late_encryption");
+		expect(replayedReasoning?.encrypted_content).toBe("ENCRYPTED_IN_RESPONSE_COMPLETED");
+	});
+
+	it("forwards explicit store:true to the Azure request body", async () => {
+		const model = getModel("azure-openai-responses", "gpt-5-mini");
+
+		const reasoningItem: ResponseReasoningItem = {
+			id: "rs_store_true",
+			type: "reasoning",
+			status: "completed",
+			summary: [{ type: "summary_text", text: "Ok." }],
+		};
+		azureMock.queuedStreams.push(makeStream(reasoningEvents({ reasoningItem })));
+
+		const context: Context = {
+			systemPrompt: "You are concise.",
+			messages: [{ role: "user", content: "Hi.", timestamp: Date.now() }],
+		};
+		await streamAzureOpenAIResponses(model, context, {
+			reasoningEffort: "medium",
+			store: true,
+		}).result();
+
+		expect(azureMock.createCalls).toHaveLength(1);
+		expect(azureMock.createCalls[0].params.store).toBe(true);
+	});
+
+	it("does not set store by default on Azure Responses (preserves server default)", async () => {
+		const model = getModel("azure-openai-responses", "gpt-5-mini");
+
+		const reasoningItem: ResponseReasoningItem = {
+			id: "rs_default_store",
+			type: "reasoning",
+			status: "completed",
+			summary: [{ type: "summary_text", text: "Ok." }],
+		};
+		azureMock.queuedStreams.push(makeStream(reasoningEvents({ reasoningItem })));
+
+		const context: Context = {
+			systemPrompt: "You are concise.",
+			messages: [{ role: "user", content: "Hi.", timestamp: Date.now() }],
+		};
+		await streamAzureOpenAIResponses(model, context, { reasoningEffort: "medium" }).result();
+
+		expect(azureMock.createCalls).toHaveLength(1);
+		expect(azureMock.createCalls[0].params.store).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Multi-turn conversations against Azure OpenAI Responses (reasoning-capable models)
fail on turn 2 with:

```
400 Item with id 'rs_...' not found. Items are not persisted when `store`
is set to false. Try again with `store` set to true, or remove this
item from your input.
```

`pi-ai` requests `include: ["reasoning.encrypted_content"]` and captures the
reasoning item on `response.output_item.done` so it can be replayed next
turn. Some deployments (notably Azure OpenAI) do not populate
`encrypted_content` on the intermediate event; it is only emitted on the
final `response.completed.response.output[]`. Without the backfill, the
turn-2 payload sends just `id: rs_...` and the server cannot validate it
under `store: false`.

Full analysis: [`ANALYSIS.md`](../blob/fix/azure-openai-responses-reasoning-store-false/ANALYSIS.md)

## Changes

- `packages/ai/src/providers/openai-responses-shared.ts`
  On `response.completed`, walk `response.output[]` and merge
  `encrypted_content` from reasoning items into the matching stored
  `thinkingSignature` by `id` when the stored copy is missing it.
- `packages/ai/src/types.ts`
  Add `SimpleStreamOptions.store?: boolean` (opt-in pass-through).
- `packages/ai/src/providers/openai-responses.ts`
  Add `OpenAIResponsesOptions.store?: boolean`; `buildParams` uses
  `options?.store ?? false` (default unchanged).
- `packages/ai/src/providers/azure-openai-responses.ts`
  Add `AzureOpenAIResponsesOptions.store?: boolean`; `buildParams` sets
  `params.store` only when the caller provided a value (default unchanged,
  server decides).
- `packages/ai/README.md`
  Document the Azure multi-turn reasoning contract.
- `packages/ai/test/azure-openai-responses-reasoning-replay.test.ts`
  New unit test file mocks the `AzureOpenAI` client with queued streams:
  1. Happy path: `encrypted_content` on `response.output_item.done`
     round-trips through replay.
  2. Regression repro: `encrypted_content` only on `response.completed`;
     fails before the fix, passes after.
  3. `store: true` option forwards to the Azure request body.
  4. Default omits the `store` field on Azure.

`openai-codex-responses.ts` and ChatGPT Codex WebSocket behavior are
untouched; that path keeps `store: false` by design.

## Tests

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/azure-openai-responses-reasoning-replay.test.ts` — 4 passing.
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/azure-openai-base-url.test.ts` — 9 passing (no regression).
- `npm run check` — clean.

Downstream consumers (e.g. `@flue/sdk`) get the fix automatically on
upgrade. `store: true` is available as an opt-in for deployments that
want server-side persistence.

## Notes

- No breaking changes, no new runtime dependencies.
- Not touching `CHANGELOG.md` per CONTRIBUTING.md.
- Opened as draft. Happy to iterate on the approach, naming, or test
  coverage before review.
