### PR TITLE
feat(ai): add gpt-5.5-chat-latest (OpenAI's new default Instant model)

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1237,6 +1237,30 @@ async function generateModels() {
 		});
 	}
 
+	// Add gpt-5.5-chat-latest — OpenAI announced the GPT-5.5 Instant chat alias
+	// on 2026-05-05 (https://openai.com/index/gpt-5-5-instant/) but per-token
+	// pricing isn't yet on https://openai.com/api/pricing/. Pricing here mirrors
+	// gpt-5.3-chat-latest as a placeholder; bump in a follow-up once published.
+	if (!allModels.some(m => m.provider === "openai" && m.id === "gpt-5.5-chat-latest")) {
+		allModels.push({
+			id: "gpt-5.5-chat-latest",
+			name: "GPT-5.5 Chat (latest)",
+			api: "openai-responses",
+			baseUrl: "https://api.openai.com/v1",
+			provider: "openai",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: {
+				input: 1.75,
+				output: 14,
+				cacheRead: 0.175,
+				cacheWrite: 0,
+			},
+			contextWindow: 128000,
+			maxTokens: 16384,
+		});
+	}
+
 	// Add missing GitHub Copilot GPT-5.3 models until models.dev includes them.
 	const copilotBaseModel = allModels.find(
 		(m) => m.provider === "github-copilot" && m.id === "gpt-5.2-codex",


### PR DESCRIPTION
## Summary

OpenAI announced **GPT-5.5 Instant** on 2026-05-05 as the new default model for ChatGPT, accessed via the `chat-latest` alias on the Responses API endpoint. The pi-ai catalog already has `gpt-5-chat-latest` and `gpt-5.3-chat-latest` on the OpenAI provider plus reasoning-mode `gpt-5.5` / `gpt-5.5-pro` — the chat alias was missing.

References:
- Announcement: https://openai.com/index/gpt-5-5-instant/
- TechCrunch coverage: https://techcrunch.com/2026/05/05/openai-releases-gpt-5-5-instant-a-new-default-model-for-chatgpt/
- API model docs: https://developers.openai.com/api/docs/models/gpt-5.5
- Refs #4275 (auto-closed by the bigrefactor moratorium on 2026-04 — re-attaching context here so the entry can be picked up in the next regen pass)

## Implementation

Patches `packages/ai/scripts/generate-models.ts` with the same `if (!allModels.some(...)) allModels.push(...)` pattern already used for `gpt-5-chat-latest`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.3-codex-spark`, etc. The block runs **after** the models.dev fetch, so it self-removes once models.dev includes the entry.

The committed `packages/ai/src/models.generated.ts` is intentionally left untouched per the file's auto-gen header (`Do not edit manually - run 'npm run generate-models' to update`). Regenerate it on the next pass.

## Pricing caveat ⚠️

OpenAI hasn't published per-token rates for the `gpt-5.5-instant` alias as of 2026-05-07. Confirmed via:
- https://openai.com/api/pricing/ — covers `gpt-5.5` reasoning ($5/$30) but no chat alias entry
- https://community.openai.com/t/gpt-5-5-instant-on-api-just-via-chat-latest-pricing/1380410 — community confirms there's no separate `gpt-5.5-instant` rate sheet

This PR mirrors `gpt-5.3-chat-latest`'s pricing as a placeholder ($1.75/$14/$0.175 per 1M input/output/cacheRead). **Bump in a follow-up once OpenAI publishes the rates.** Models.dev should have the canonical numbers by then and the patch block will become a no-op.

## Why this matters

Downstream consumers (e.g. ArgentOS / argent-core) treat the pi-ai catalog as the canonical model registry. Without this entry they need local overrides — see https://github.com/ArgentAIOS/argentos-core/pull/181 for the override that lands the entry locally on argent-core's pi 0.70.2 pin until this PR ships and the next pi release flows through dependabot.

## Test plan

- [x] `git diff` shows only `packages/ai/scripts/generate-models.ts` touched
- [ ] `cd packages/ai && npm run generate-models` regenerates `models.generated.ts` cleanly with the new entry under `openai`
- [ ] Existing pi-ai test suites green