### PR TITLE
feat(tui): show/hide cursor on terminal focus change

### DIFF
--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -12,6 +12,7 @@ class FakeTerminal implements Terminal {
 	columns = 80;
 	rows = 24;
 	kittyProtocolActive = true;
+	terminalFocused = true;
 	writes: string[] = [];
 
 	start(): void {}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -485,13 +485,11 @@ export class Editor implements Component, Focusable {
 					const afterGraphemes = [...this.segment(after)];
 					const firstGrapheme = afterGraphemes[0]?.segment || "";
 					const restAfter = after.slice(firstGrapheme.length);
-					const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
-					displayText = before + marker + cursor + restAfter;
+					displayText = before + marker + firstGrapheme + restAfter;
 					// lineVisibleWidth stays the same - we're replacing, not adding
 				} else {
-					// Cursor is at the end - add highlighted space
-					const cursor = "\x1b[7m \x1b[0m";
-					displayText = before + marker + cursor;
+					// Cursor is at the end - add a space; inverse video applied by TUI
+					displayText = `${before + marker} `;
 					lineVisibleWidth = lineVisibleWidth + 1;
 					// If cursor overflows content width into the padding, flag it
 					if (lineVisibleWidth > contentWidth && paddingX > 0) {

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -489,9 +489,7 @@ export class Input implements Component, Focusable {
 		// Hardware cursor marker (zero-width, emitted before fake cursor for IME positioning)
 		const marker = this.focused ? CURSOR_MARKER : "";
 
-		// Use inverse video to show cursor
-		const cursorChar = `\x1b[7m${atCursor}\x1b[27m`; // ESC[7m = reverse video, ESC[27m = normal
-		const textWithCursor = beforeCursor + marker + cursorChar + afterCursor;
+		const textWithCursor = beforeCursor + marker + atCursor + afterCursor;
 
 		// Calculate visual width
 		const visualLength = visibleWidth(textWithCursor);

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -15,7 +15,10 @@ const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
  */
 export interface Terminal {
 	// Start the terminal with input and resize handlers
-	start(onInput: (data: string) => void, onResize: () => void): void;
+	start(onInput: (data: string) => void, onResize: () => void, onFocusChange?: (focused: boolean) => void): void;
+
+	// Whether the terminal window currently has OS focus (DECSET 1004)
+	get terminalFocused(): boolean;
 
 	// Stop the terminal and restore state
 	stop(): void;
@@ -68,6 +71,8 @@ export class ProcessTerminal implements Terminal {
 	private _modifyOtherKeysActive = false;
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string) => void;
+	private focusChangeHandler?: (focused: boolean) => void;
+	private _terminalFocused = true;
 	private progressInterval?: ReturnType<typeof setInterval>;
 	private writeLogPath = (() => {
 		const env = process.env.PI_TUI_WRITE_LOG || "";
@@ -88,9 +93,15 @@ export class ProcessTerminal implements Terminal {
 		return this._kittyProtocolActive;
 	}
 
-	start(onInput: (data: string) => void, onResize: () => void): void {
+	get terminalFocused(): boolean {
+		return this._terminalFocused;
+	}
+
+	start(onInput: (data: string) => void, onResize: () => void, onFocusChange?: (focused: boolean) => void): void {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
+		this.focusChangeHandler = onFocusChange;
+		this._terminalFocused = true;
 
 		// Save previous state and enable raw mode
 		this.wasRaw = process.stdin.isRaw || false;
@@ -102,6 +113,8 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
+		// Enable focus reporting - terminal sends \x1b[I on focus gain, \x1b[O on focus loss
+		process.stdout.write("\x1b[?1004h");
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -140,6 +153,15 @@ export class ProcessTerminal implements Terminal {
 
 		// Forward individual sequences to the input handler
 		this.stdinBuffer.on("data", (sequence) => {
+			// Intercept focus reporting sequences before anything else
+			if (sequence === "\x1b[I" || sequence === "\x1b[O") {
+				const focused = sequence === "\x1b[I";
+				this._terminalFocused = focused;
+				if (!focused) this.hideCursor();
+				this.focusChangeHandler?.(focused);
+				return;
+			}
+
 			// Check for Kitty protocol response (only if not already enabled)
 			if (!this._kittyProtocolActive) {
 				const match = sequence.match(kittyResponsePattern);
@@ -273,6 +295,11 @@ export class ProcessTerminal implements Terminal {
 			process.stdout.write(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
 		}
 
+		// Restore focus state so showCursor() works during stop()
+		this._terminalFocused = true;
+		this.focusChangeHandler = undefined;
+		// Disable focus reporting
+		process.stdout.write("\x1b[?1004l");
 		// Disable bracketed paste mode
 		process.stdout.write("\x1b[?2004l");
 
@@ -350,6 +377,7 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	showCursor(): void {
+		if (!this._terminalFocused) return;
 		process.stdout.write("\x1b[?25h");
 	}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -9,7 +9,14 @@ import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.js";
 import type { Terminal } from "./terminal.js";
 import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
-import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
+import {
+	extractSegments,
+	getSegmenter,
+	normalizeTerminalOutput,
+	sliceByColumn,
+	sliceWithWidth,
+	visibleWidth,
+} from "./utils.js";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
@@ -442,6 +449,7 @@ export class TUI extends Container {
 		this.stopped = false;
 		this.terminal.start(
 			(data) => this.handleInput(data),
+			() => this.requestRender(),
 			() => this.requestRender(),
 		);
 		this.terminal.hideCursor();
@@ -942,9 +950,17 @@ export class TUI extends Container {
 				const col = visibleWidth(beforeMarker);
 
 				// Strip marker from the line
-				lines[row] = line.slice(0, markerIndex) + line.slice(markerIndex + CURSOR_MARKER.length);
-
-				return { row, col };
+				const afterMarker = line.slice(markerIndex + CURSOR_MARKER.length);
+				if (this.terminal.terminalFocused) {
+					// Apply inverse video to the cursor grapheme
+					const firstSeg = [...getSegmenter().segment(afterMarker)][0];
+					const g = firstSeg?.segment ?? "";
+					lines[row] = `${line.slice(0, markerIndex)}\x1b[7m${g}\x1b[27m${afterMarker.slice(g.length)}`;
+					return { row, col };
+				}
+				// Terminal not focused: strip marker, leave char unstyled, suppress hardware cursor
+				lines[row] = line.slice(0, markerIndex) + afterMarker;
+				return null;
 			}
 		}
 		return null;

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "node:test";
 import { stripVTControlCharacters } from "node:util";
 import { type AutocompleteProvider, CombinedAutocompleteProvider } from "../src/autocomplete.js";
 import { Editor, wordWrapLine } from "../src/components/editor.js";
-import { TUI } from "../src/tui.js";
+import { CURSOR_MARKER, TUI } from "../src/tui.js";
 import { visibleWidth } from "../src/utils.js";
 import { defaultEditorTheme } from "./test-themes.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
@@ -676,15 +676,16 @@ describe("Editor component", () => {
 
 		it("renders cursor correctly on wide characters", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			editor.focused = true;
 			const width = 20;
 
 			editor.setText("A✅B");
 			// Cursor should be at end (after B)
 			const lines = editor.render(width);
 
-			// The cursor (reverse video space) should be visible
+			// The cursor marker should be present (TUI applies reverse video during final render)
 			const contentLine = lines[1]!;
-			assert.ok(contentLine.includes("\x1b[7m"), "Should have reverse video cursor");
+			assert.ok(contentLine.includes(CURSOR_MARKER), "Should have cursor marker");
 
 			// Line should still be correct width
 			assert.strictEqual(visibleWidth(contentLine), width);
@@ -709,13 +710,14 @@ describe("Editor component", () => {
 			const width = 10;
 			for (const paddingX of [0, 1]) {
 				const editor = new Editor(createTestTUI(width + paddingX), defaultEditorTheme, { paddingX });
+				editor.focused = true;
 
 				// Type 9 chars → fills layoutWidth exactly, cursor at end on same line
 				for (const ch of "aaaaaaaaa") editor.handleInput(ch);
 				let lines = editor.render(width + paddingX);
 				let contentLines = lines.slice(1, -1);
 				assert.strictEqual(contentLines.length, 1, "Should be 1 content line before wrap");
-				assert.ok(contentLines[0]!.endsWith("\x1b[7m \x1b[0m"), "Cursor should be at end of line");
+				assert.ok(contentLines[0]!.includes(`${CURSOR_MARKER} `), "Cursor should be at end of line");
 
 				// Type 1 more → text wraps to second line
 				editor.handleInput("a");

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
+import { Input } from "../src/components/input.js";
 import { deleteKittyImage, encodeKitty } from "../src/terminal-image.js";
 import { type Component, TUI } from "../src/tui.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
@@ -52,6 +53,16 @@ async function withEnv<T>(updates: Record<string, string | undefined>, run: () =
 			}
 		}
 	}
+}
+
+function getCellInverse(terminal: VirtualTerminal, row: number, col: number): number {
+	const xterm = (terminal as unknown as { xterm: XtermTerminalType }).xterm;
+	const buffer = xterm.buffer.active;
+	const line = buffer.getLine(buffer.viewportY + row);
+	assert.ok(line, `Missing buffer line at row ${row}`);
+	const cell = line.getCell(col);
+	assert.ok(cell, `Missing cell at row ${row} col ${col}`);
+	return cell.isInverse();
 }
 
 function getCellItalic(terminal: VirtualTerminal, row: number, col: number): number {
@@ -585,6 +596,63 @@ describe("TUI differential rendering", () => {
 			"Editor 1",
 			"Editor 2",
 		]);
+
+		tui.stop();
+	});
+});
+
+describe("TUI terminal focus reporting", () => {
+	it("suppresses inverse-video cursor and hardware cursor on blur", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const input = new Input();
+		input.setValue("abc");
+		tui.addChild(input);
+		tui.setFocus(input);
+		tui.start();
+		await terminal.waitForRender();
+
+		// Components no longer embed inverse video — TUI injects it during render.
+		// Verify via the xterm viewport instead.
+		await terminal.flush();
+		assert.ok(terminal.terminalFocused, "terminal starts focused");
+		// Cursor cell should have inverse video attribute when focused
+		assert.ok(getCellInverse(terminal, 0, 2), "focused: cursor cell has inverse video");
+
+		terminal.sendInput("\x1b[O"); // blur
+		await terminal.waitForRender();
+
+		assert.ok(!terminal.terminalFocused, "terminal is not focused after blur");
+		assert.ok(!getCellInverse(terminal, 0, 2), "blurred: cursor cell has no inverse video");
+
+		terminal.sendInput("\x1b[I"); // focus
+		await terminal.waitForRender();
+
+		assert.ok(terminal.terminalFocused, "terminal is focused after focus event");
+		assert.ok(getCellInverse(terminal, 0, 2), "refocused: cursor cell has inverse video again");
+
+		tui.stop();
+	});
+
+	it("does not forward focus sequences to component handleInput", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const received: string[] = [];
+		const component: Component = {
+			render: () => [],
+			handleInput: (d) => received.push(d),
+			invalidate: () => {},
+		};
+		tui.addChild(component);
+		tui.setFocus(component);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[O");
+		terminal.sendInput("\x1b[I");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(received, [], "focus sequences must not reach components");
 
 		tui.stop();
 	});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -12,6 +12,8 @@ export class VirtualTerminal implements Terminal {
 	private xterm: XtermTerminalType;
 	private inputHandler?: (data: string) => void;
 	private resizeHandler?: () => void;
+	private focusChangeHandler?: (focused: boolean) => void;
+	private _terminalFocused = true;
 	private _columns: number;
 	private _rows: number;
 
@@ -29,11 +31,18 @@ export class VirtualTerminal implements Terminal {
 		});
 	}
 
-	start(onInput: (data: string) => void, onResize: () => void): void {
+	get terminalFocused(): boolean {
+		return this._terminalFocused;
+	}
+
+	start(onInput: (data: string) => void, onResize: () => void, onFocusChange?: (focused: boolean) => void): void {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
-		// Enable bracketed paste mode for consistency with ProcessTerminal
+		this.focusChangeHandler = onFocusChange;
+		this._terminalFocused = true;
+		// Enable bracketed paste and focus reporting for consistency with ProcessTerminal
 		this.xterm.write("\x1b[?2004h");
+		this.xterm.write("\x1b[?1004h");
 	}
 
 	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {
@@ -41,7 +50,9 @@ export class VirtualTerminal implements Terminal {
 	}
 
 	stop(): void {
-		// Disable bracketed paste mode
+		this._terminalFocused = true;
+		this.focusChangeHandler = undefined;
+		this.xterm.write("\x1b[?1004l");
 		this.xterm.write("\x1b[?2004l");
 		this.inputHandler = undefined;
 		this.resizeHandler = undefined;
@@ -76,11 +87,12 @@ export class VirtualTerminal implements Terminal {
 	}
 
 	hideCursor(): void {
-		this.xterm.write("\x1b[?25l");
+		this.write("\x1b[?25l");
 	}
 
 	showCursor(): void {
-		this.xterm.write("\x1b[?25h");
+		if (!this._terminalFocused) return;
+		this.write("\x1b[?25h");
 	}
 
 	clearLine(): void {
@@ -108,6 +120,13 @@ export class VirtualTerminal implements Terminal {
 	 * Simulate keyboard input
 	 */
 	sendInput(data: string): void {
+		if (data === "\x1b[I" || data === "\x1b[O") {
+			const focused = data === "\x1b[I";
+			this._terminalFocused = focused;
+			if (!focused) this.hideCursor();
+			this.focusChangeHandler?.(focused);
+			return;
+		}
 		if (this.inputHandler) {
 			this.inputHandler(data);
 		}


### PR DESCRIPTION
Enable DECSET 1004 focus reporting, so that pi will hide the cursor when the terminal window loses focus (and restore it when it regains focus)

https://github.com/user-attachments/assets/696be9df-c0ab-4dc9-8100-edd42100868e

ProcessTerminal intercepts `\x1b[I` and \`x1b[O`, toggles the terminalFocused state and fires an onFocusChange callback so TUI can re-render. Other terminals are considered "always focused".

I ended up concentrating the logic for inverted-video rendering of the character after the CURSOR_MARKER. This makes sense to me since Input and Editor are concerned with the data model and should not accumulate display concerns. `\u2014` cursor styling is entirely owned by TUI and Terminal.

Fixes #3896