### PR TITLE
docs(coding-agent): fix termux-open chooser flag

### DIFF
--- a/packages/coding-agent/docs/termux.md
+++ b/packages/coding-agent/docs/termux.md
@@ -53,7 +53,7 @@ termux-open-url "https://example.com"
 ## Opening Files
 ```bash
 termux-open file.pdf          # Opens with default app
-termux-open -c image.jpg      # Choose app
+termux-open --chooser image.jpg      # Choose app
 ```
 
 ## Clipboard


### PR DESCRIPTION
Termux docs currently use `termux-open -c`, but `-c` is not a supported flag for `termux-open`. This updates the example to use `termux-open --chooser` instead.

References for reproducibility:

* `termux-open` implementation: https://github.com/termux/termux-tools/blob/master/scripts/termux-open.in
* Termux app receiver used by the script: https://github.com/termux/termux-app
* Verified supported options in `termux-open.in`: `--send`, `--view`, `--chooser`, `--content-type`, `-h`/`--help`
* `getopt` short options in script: `-o h` only