### PR TITLE
Fix TUI crash on over-wide changed lines

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed over-wide changed TUI lines to truncate instead of crashing narrow terminals.
+
 ## [0.74.0] - 2026-05-07
 
 ## [0.73.1] - 2026-05-07

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed over-wide changed TUI lines to truncate instead of crashing narrow terminals.
+- Added non-crashing diagnostics for residual over-wide rendered lines.
 
 ## [0.74.0] - 2026-05-07
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1188,13 +1188,12 @@ export class TUI extends Container {
 		for (let i = firstChanged; i <= renderEnd; i++) {
 			if (i > firstChanged) buffer += "\r\n";
 			buffer += "\x1b[2K"; // Clear current line
-			const line = newLines[i];
+			let line = newLines[i];
 			const isImage = isImageLine(line);
 			if (!isImage && visibleWidth(line) > width) {
-				// Log all lines to crash file for debugging
-				const crashLogPath = path.join(os.homedir(), ".pi", "agent", "pi-crash.log");
-				const crashData = [
-					`Crash at ${new Date().toISOString()}`,
+				const warningLogPath = path.join(os.homedir(), ".pi", "agent", "pi-render-warnings.log");
+				const warningData = [
+					`Warning at ${new Date().toISOString()}`,
 					`Terminal width: ${width}`,
 					`Line ${i} visible width: ${visibleWidth(line)}`,
 					"",
@@ -1202,21 +1201,9 @@ export class TUI extends Container {
 					...newLines.map((l, idx) => `[${idx}] (w=${visibleWidth(l)}) ${l}`),
 					"",
 				].join("\n");
-				fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-				fs.writeFileSync(crashLogPath, crashData);
-
-				// Clean up terminal state before throwing
-				this.stop();
-
-				const errorMsg = [
-					`Rendered line ${i} exceeds terminal width (${visibleWidth(line)} > ${width}).`,
-					"",
-					"This is likely caused by a custom TUI component not truncating its output.",
-					"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
-					"",
-					`Debug log written to: ${crashLogPath}`,
-				].join("\n");
-				throw new Error(errorMsg);
+				fs.mkdirSync(path.dirname(warningLogPath), { recursive: true });
+				fs.appendFileSync(warningLogPath, warningData);
+				line = sliceByColumn(line, 0, width, true);
 			}
 			buffer += line;
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -9,7 +9,14 @@ import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.js";
 import type { Terminal } from "./terminal.js";
 import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
-import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
+import {
+	extractSegments,
+	normalizeTerminalOutput,
+	sliceByColumn,
+	sliceWithWidth,
+	truncateToWidth,
+	visibleWidth,
+} from "./utils.js";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
@@ -978,6 +985,12 @@ export class TUI extends Container {
 		const cursorPos = this.extractCursorPosition(newLines, height);
 
 		newLines = this.applyLineResets(newLines);
+		for (let i = 0; i < newLines.length; i++) {
+			const line = newLines[i];
+			if (!isImageLine(line) && visibleWidth(line) > width) {
+				newLines[i] = truncateToWidth(line, width, "", false);
+			}
+		}
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -589,3 +589,25 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI over-wide changed line handling", () => {
+	it("truncates over-wide changed non-image lines instead of throwing", async () => {
+		const terminal = new VirtualTerminal(20, 8);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["ok"];
+		tui.start();
+		await terminal.waitForRender();
+
+		component.lines = ["X".repeat(24)];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		assert.strictEqual(viewport[0], "X".repeat(20));
+
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## Summary

- truncate over-wide non-image lines centrally after line resets and before diffing/writing
- add a regression test for a 20-column terminal updating from a valid line to a 24-column line
- replace the residual over-wide assertion with a non-crashing diagnostic log at `~/.pi/agent/pi-render-warnings.log`

## Reproduction

This crashes reliably before the fix because the second render enters the differential renderer with a line wider than the terminal:

```js
import { TUI } from "@earendil-works/pi-tui";

class Terminal20Cols {
  start() {}
  stop() {}
  async drainInput() {}
  write() {}
  get columns() { return 20; }
  get rows() { return 8; }
  get kittyProtocolActive() { return false; }
  moveBy() {}
  hideCursor() {}
  showCursor() {}
  clearLine() {}
  clearFromCursor() {}
  clearScreen() {}
  setTitle() {}
  setProgress() {}
}

class Component {
  overwide = false;
  render(width) { return [this.overwide ? "X".repeat(width + 4) : "ok"]; }
  invalidate() {}
}

const terminal = new Terminal20Cols();
const tui = new TUI(terminal, false);
const component = new Component();
tui.addChild(component);
tui.start();
setTimeout(() => {
  component.overwide = true;
  tui.requestRender();
}, 20);
```

Before this change, the process throws:

```text
Rendered line 0 exceeds terminal width (24 > 20).
```

## Test

```bash
cd packages/tui
node --test --import tsx test/tui-render.test.ts
```

Also ran the repo pre-commit check via the commit hook for both commits.
