### PR TITLE
fix(ai): DeepSeek/Kimi tool schema + Kimi auto-detection

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -971,7 +971,8 @@ function convertTools(
 		function: {
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters as any, // TypeBox already generates JSON Schema
+			// DeepSeek/Kimi reject parameters: null. Fall back to empty object schema.
+			parameters: (tool.parameters as any) ?? { type: "object", properties: {} },
 			// Only include strict if provider supports it. Some reject unknown fields.
 			...(compat.supportsStrictMode !== false && { strict: false }),
 		},
@@ -1051,6 +1052,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
 	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
+	const isKimi = baseUrl.includes("api.kimi.com");
 	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
 	const isCloudflareAiGateway = provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
 
@@ -1063,6 +1065,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		baseUrl.includes("deepseek.com") ||
 		isZai ||
 		isMoonshot ||
+		isKimi ||
 		provider === "opencode" ||
 		baseUrl.includes("opencode.ai") ||
 		isCloudflareWorkersAI ||
@@ -1071,7 +1074,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const useMaxTokens = baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway;
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
-	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
+	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com") || isKimi;
 	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
 	return {
@@ -1094,7 +1097,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		openRouterRouting: {},
 		vercelGatewayRouting: {},
 		zaiToolStream: false,
-		supportsStrictMode: !isMoonshot && !isCloudflareAiGateway,
+		supportsStrictMode: !isMoonshot && !isKimi && !isCloudflareAiGateway,
 		cacheControlFormat,
 		sendSessionAffinityHeaders: false,
 		supportsLongCacheRetention: !(isCloudflareWorkersAI || isCloudflareAiGateway),


### PR DESCRIPTION
Fixes #4311

### Changes (`openai-completions.ts` only)

**1. `convertTools()`** — null parameters fallback

```ts
// Before:
parameters: tool.parameters as any,
// After:
parameters: (tool.parameters as any) ?? { type: "object", properties: {} },
```

Tools from skills (e.g. `recall_load_rules`) can have `parameters: null`. DeepSeek and Kimi reject `null` with `400 Invalid schema`.

**2. `detectCompat()`** — Kimi Coding API auto-detection

```ts
const isKimi = baseUrl.includes("api.kimi.com");
```

- Added to `isNonStandard` (no store/developer role)
- Added to `isDeepSeek` (same `reasoning_content` streaming format)
- Added to `!supportsStrictMode` (rejects strict field)

### Testing

| Test | Result |
|------|--------|
| DeepSeek API + null-param tools | ✅ 200 (was 400) |
| Kimi Coding API + tools + stream | ✅ 200 |
| Existing providers | ✅ no regression |