### PR TITLE
feat(coding-agent): add --mode worker-loop for bus-driven task dispatch

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -7,7 +7,22 @@ import chalk from "chalk";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_SESSION_DIR } from "../config.js";
 import type { ExtensionFlag } from "../core/extensions/types.js";
 
-export type Mode = "text" | "json" | "rpc";
+export type Mode = "text" | "json" | "rpc" | "worker-loop";
+
+/**
+ * Worker-loop CLI options. Populated only when `--mode worker-loop` is
+ * active. Defaults are applied later in `validateWorkerLoopOptions` so the
+ * parser only records what the user supplied.
+ */
+export interface WorkerLoopArgs {
+	socketPath?: string;
+	agentId?: string;
+	agentType?: string;
+	projectId?: string;
+	idleTtlMs?: number;
+	heartbeatIntervalMs?: number;
+	repoPath?: string;
+}
 
 export interface Args {
 	provider?: string;
@@ -21,6 +36,7 @@ export interface Args {
 	help?: boolean;
 	version?: boolean;
 	mode?: Mode;
+	workerLoop?: WorkerLoopArgs;
 	noSession?: boolean;
 	session?: string;
 	fork?: string;
@@ -73,9 +89,32 @@ export function parseArgs(args: string[]): Args {
 			result.version = true;
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
-			if (mode === "text" || mode === "json" || mode === "rpc") {
+			if (mode === "text" || mode === "json" || mode === "rpc" || mode === "worker-loop") {
 				result.mode = mode;
 			}
+		} else if (arg === "--bus-socket" && i + 1 < args.length) {
+			result.workerLoop = result.workerLoop ?? {};
+			result.workerLoop.socketPath = args[++i];
+		} else if (arg === "--agent-id" && i + 1 < args.length) {
+			result.workerLoop = result.workerLoop ?? {};
+			result.workerLoop.agentId = args[++i];
+		} else if (arg === "--agent-type" && i + 1 < args.length) {
+			result.workerLoop = result.workerLoop ?? {};
+			result.workerLoop.agentType = args[++i];
+		} else if (arg === "--project-id" && i + 1 < args.length) {
+			result.workerLoop = result.workerLoop ?? {};
+			result.workerLoop.projectId = args[++i];
+		} else if (arg === "--idle-ttl-ms" && i + 1 < args.length) {
+			result.workerLoop = result.workerLoop ?? {};
+			const n = Number(args[++i]);
+			if (Number.isFinite(n)) result.workerLoop.idleTtlMs = n;
+		} else if (arg === "--heartbeat-interval-ms" && i + 1 < args.length) {
+			result.workerLoop = result.workerLoop ?? {};
+			const n = Number(args[++i]);
+			if (Number.isFinite(n)) result.workerLoop.heartbeatIntervalMs = n;
+		} else if (arg === "--repo-path" && i + 1 < args.length) {
+			result.workerLoop = result.workerLoop ?? {};
+			result.workerLoop.repoPath = args[++i];
 		} else if (arg === "--continue" || arg === "-c") {
 			result.continue = true;
 		} else if (arg === "--resume" || arg === "-r") {
@@ -219,7 +258,7 @@ ${chalk.bold("Options:")}
   --api-key <key>                API key (defaults to env vars)
   --system-prompt <text>         System prompt (default: coding assistant prompt)
   --append-system-prompt <text>  Append text or file contents to the system prompt (can be used multiple times)
-  --mode <mode>                  Output mode: text (default), json, or rpc
+  --mode <mode>                  Output mode: text (default), json, rpc, or worker-loop
   --print, -p                    Non-interactive mode: process prompt and exit
   --continue, -c                 Continue previous session
   --resume, -r                   Select a session to resume
@@ -247,6 +286,16 @@ ${chalk.bold("Options:")}
   --list-models [search]         List available models (with optional fuzzy search)
   --verbose                      Force verbose startup (overrides quietStartup setting)
   --offline                      Disable startup network operations (same as PI_OFFLINE=1)
+
+${chalk.bold("Worker-loop options (with --mode worker-loop):")}
+  --bus-socket <path>            Unix socket path for the host message bus (required)
+  --agent-id <id>                This worker's agent id (required)
+  --agent-type <type>            Worker role label (e.g. worker, reviewer, tester) (required)
+  --project-id <id>              Project id this worker belongs to (required)
+  --repo-path <path>             Repo path the worker operates on (required)
+  --idle-ttl-ms <ms>             Exit cleanly after this many ms with no task (default: 3600000)
+  --heartbeat-interval-ms <ms>   Heartbeat cadence (default: 10000)
+
   --help, -h                     Show this help
   --version, -v                  Show version number
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -41,7 +41,13 @@ import { SessionManager } from "./core/session-manager.js";
 import { SettingsManager } from "./core/settings-manager.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
-import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.js";
+import {
+	InteractiveMode,
+	runPrintMode,
+	runRpcMode,
+	runWorkerLoopMode,
+	validateWorkerLoopOptions,
+} from "./modes/index.js";
 import { ExtensionSelectorComponent } from "./modes/interactive/components/extension-selector.js";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.js";
 import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.js";
@@ -93,9 +99,12 @@ function isTruthyEnvFlag(value: string | undefined): boolean {
 	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
 }
 
-type AppMode = "interactive" | "print" | "json" | "rpc";
+type AppMode = "interactive" | "print" | "json" | "rpc" | "worker-loop";
 
 function resolveAppMode(parsed: Args, stdinIsTTY: boolean): AppMode {
+	if (parsed.mode === "worker-loop") {
+		return "worker-loop";
+	}
 	if (parsed.mode === "rpc") {
 		return "rpc";
 	}
@@ -108,7 +117,7 @@ function resolveAppMode(parsed: Args, stdinIsTTY: boolean): AppMode {
 	return "interactive";
 }
 
-function toPrintOutputMode(appMode: AppMode): Exclude<Mode, "rpc"> {
+function toPrintOutputMode(appMode: AppMode): Exclude<Mode, "rpc" | "worker-loop"> {
 	return appMode === "json" ? "json" : "text";
 }
 
@@ -477,6 +486,11 @@ export async function main(args: string[], options?: MainOptions) {
 		process.exit(1);
 	}
 
+	if (parsed.mode === "worker-loop" && parsed.fileArgs.length > 0) {
+		console.error(chalk.red("Error: @file arguments are not supported in worker-loop mode"));
+		process.exit(1);
+	}
+
 	validateForkFlags(parsed);
 
 	// Run migrations (pass cwd for project-local migrations)
@@ -627,9 +641,10 @@ export async function main(args: string[], options?: MainOptions) {
 		process.exit(0);
 	}
 
-	// Read piped stdin content (if any) - skip for RPC mode which uses stdin for JSON-RPC
+	// Read piped stdin content (if any) - skip for RPC mode which uses stdin for JSON-RPC,
+	// and for worker-loop mode which has no stdin protocol (the bus socket replaces it).
 	let stdinContent: string | undefined;
-	if (appMode !== "rpc") {
+	if (appMode !== "rpc" && appMode !== "worker-loop") {
 		stdinContent = await readPipedStdin();
 		if (stdinContent !== undefined && appMode === "interactive") {
 			appMode = "print";
@@ -659,7 +674,10 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 	time("createAgentSession");
 
-	if (appMode !== "interactive" && !session.model) {
+	// Worker-loop tolerates a missing model at startup — task envelopes may
+	// supply per-task models and the host typically pre-configures defaults
+	// via env vars. RPC and print modes still require one upfront.
+	if (appMode !== "interactive" && appMode !== "worker-loop" && !session.model) {
 		console.error(chalk.red(formatNoModelsAvailableMessage()));
 		process.exit(1);
 	}
@@ -670,7 +688,26 @@ export async function main(args: string[], options?: MainOptions) {
 		process.exit(1);
 	}
 
-	if (appMode === "rpc") {
+	if (appMode === "worker-loop") {
+		const validated = validateWorkerLoopOptions({
+			socketPath: parsed.workerLoop?.socketPath,
+			agentId: parsed.workerLoop?.agentId,
+			agentType: parsed.workerLoop?.agentType,
+			projectId: parsed.workerLoop?.projectId,
+			repoPath: parsed.workerLoop?.repoPath ?? cwd,
+			idleTtlMs: parsed.workerLoop?.idleTtlMs,
+			heartbeatIntervalMs: parsed.workerLoop?.heartbeatIntervalMs,
+		});
+		if (!validated.ok) {
+			reportDiagnostics(validated.diagnostics);
+			process.exit(1);
+		}
+		printTimings();
+		const result = await runWorkerLoopMode(runtime, validated.options);
+		stopThemeWatcher();
+		restoreStdout();
+		process.exit(result.exitCode);
+	} else if (appMode === "rpc") {
 		printTimings();
 		await runRpcMode(runtime);
 	} else if (appMode === "interactive") {

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -7,3 +7,15 @@ export { type PrintModeOptions, runPrintMode } from "./print-mode.js";
 export { type ModelInfo, RpcClient, type RpcClientOptions, type RpcEventListener } from "./rpc/rpc-client.js";
 export { runRpcMode } from "./rpc/rpc-mode.js";
 export type { RpcCommand, RpcResponse, RpcSessionState } from "./rpc/rpc-types.js";
+export {
+	type AgentMessage,
+	type AgentMessageRecipient,
+	SocketBus,
+	type SocketBusOptions,
+} from "./worker-loop/socket-bus.js";
+export {
+	runWorkerLoopMode,
+	validateWorkerLoopOptions,
+	type WorkerLoopOptions,
+	type WorkerLoopRunResult,
+} from "./worker-loop/worker-loop-mode.js";

--- a/packages/coding-agent/src/modes/worker-loop/git-capture.ts
+++ b/packages/coding-agent/src/modes/worker-loop/git-capture.ts
@@ -1,0 +1,81 @@
+/**
+ * Capture commits and working-tree diff after a worker-loop task. Mirrors
+ * `captureGitState` in boss-pi's PiProcess.ts so the AgentTaskResult shape
+ * stays identical across the host wrapper and pi-mono.
+ *
+ * All probes are best-effort. A missing repo, no HEAD, or oversized diff
+ * means "no new state" — the worker still publishes a result.
+ */
+import { execSync } from "node:child_process";
+
+export interface GitStateCapture {
+	commits: string[];
+	workingDiff?: string;
+	committedDiff?: string;
+}
+
+/** Resolve HEAD before the task runs. Returns undefined outside a repo. */
+export function resolveHeadSha(cwd: string): string | undefined {
+	try {
+		const out = execSync("git rev-parse HEAD", {
+			cwd,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		return out.trim() || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * After a task, list any commits made since `headSha`, capture the diff of
+ * those commits vs `headSha`, and capture any leftover working-tree diff.
+ */
+export function captureGitState(cwd: string, headSha: string | undefined): GitStateCapture {
+	if (!headSha) return { commits: [] };
+
+	let commits: string[] = [];
+	let workingDiff: string | undefined;
+	let committedDiff: string | undefined;
+
+	try {
+		const logOut = execSync(`git log ${headSha}..HEAD --format=%H --reverse`, {
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: 1024 * 1024,
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		commits = logOut.trim().split("\n").filter(Boolean);
+	} catch {
+		// Non-fatal: no commits / not a repo.
+	}
+
+	if (commits.length > 0) {
+		try {
+			const out = execSync(`git diff ${headSha}..HEAD`, {
+				cwd,
+				encoding: "utf-8",
+				maxBuffer: 4 * 1024 * 1024,
+				stdio: ["ignore", "pipe", "ignore"],
+			});
+			if (out.trim()) committedDiff = out;
+		} catch {
+			// Non-fatal.
+		}
+	}
+
+	try {
+		const diffOut = execSync("git diff", {
+			cwd,
+			encoding: "utf-8",
+			maxBuffer: 1024 * 1024,
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		if (diffOut.trim()) workingDiff = diffOut;
+	} catch {
+		// Non-fatal.
+	}
+
+	return { commits, workingDiff, committedDiff };
+}

--- a/packages/coding-agent/src/modes/worker-loop/socket-bus.ts
+++ b/packages/coding-agent/src/modes/worker-loop/socket-bus.ts
@@ -1,0 +1,184 @@
+/**
+ * Bus client used by `--mode worker-loop`. Wraps a Unix-socket bridge that
+ * the host (e.g. boss-pi's MessageSocket) exposes for envelope-based agent
+ * messaging.
+ *
+ * Wire protocol (one JSON object per line, `\n` framed):
+ *
+ *   send:    {"action":"send","agentId":"<id>","message":AgentMessage}
+ *   receive: {"action":"receive","agentId":"<id>"} -> {ok,messages:AgentMessage[]}
+ *
+ * Each request opens a fresh socket, writes one line, and reads one reply
+ * line. This matches `scripts/worker-loop.ts` in boss-pi exactly so the host
+ * MessageSocket implementation does not have to change when the worker
+ * runtime moves into pi-mono.
+ */
+import { connect, type Socket } from "node:net";
+
+/** Recipient address as understood by boss-pi's IMessageBus. */
+export type AgentMessageRecipient = "broadcast" | "leader" | "boss" | { agentId: string; agentType: string };
+
+export interface AgentMessage {
+	id: string;
+	from: { agentId: string; agentType: string };
+	to: AgentMessageRecipient;
+	type: "request" | "response" | "status" | "artifact" | "error";
+	inReplyTo?: string;
+	payload: unknown;
+	timestamp: number;
+}
+
+interface SocketReply {
+	ok: boolean;
+	messages?: AgentMessage[];
+	error?: string;
+	id?: string;
+}
+
+export interface SocketBusOptions {
+	socketPath: string;
+	agentId: string;
+	agentType: string;
+	/** Connect/timeout for a single rpc round-trip. Default 5s. */
+	rpcTimeoutMs?: number;
+}
+
+/**
+ * Minimal client for the host's Unix-socket message bridge.
+ *
+ * Each call opens its own connection — the bridge only handles one command
+ * per connection (send or receive).
+ */
+export class SocketBus {
+	readonly socketPath: string;
+	readonly agentId: string;
+	readonly agentType: string;
+	readonly rpcTimeoutMs: number;
+
+	constructor(opts: SocketBusOptions) {
+		this.socketPath = opts.socketPath;
+		this.agentId = opts.agentId;
+		this.agentType = opts.agentType;
+		this.rpcTimeoutMs = opts.rpcTimeoutMs ?? 5_000;
+	}
+
+	/** Send one envelope addressed to `to`. */
+	async publish(payload: unknown, to: AgentMessageRecipient): Promise<void> {
+		const message = this.buildMessage(payload, to);
+		await this.rpc({ action: "send", agentId: this.agentId, message });
+	}
+
+	/**
+	 * Send one envelope addressed to `to` with an explicit id and inReplyTo
+	 * (used when worker-loop needs to correlate a reply, e.g. spawn requests).
+	 */
+	async publishWithId(
+		id: string,
+		payload: unknown,
+		to: AgentMessageRecipient,
+		opts?: { type?: AgentMessage["type"]; inReplyTo?: string },
+	): Promise<void> {
+		const message: AgentMessage = {
+			id,
+			from: { agentId: this.agentId, agentType: this.agentType },
+			to,
+			type: opts?.type ?? "status",
+			inReplyTo: opts?.inReplyTo,
+			payload,
+			timestamp: Date.now(),
+		};
+		await this.rpc({ action: "send", agentId: this.agentId, message });
+	}
+
+	/** Drain queued envelopes for this worker's inbox. */
+	async drain(): Promise<AgentMessage[]> {
+		const reply = await this.rpc({ action: "receive", agentId: this.agentId });
+		return reply.messages ?? [];
+	}
+
+	buildMessage(payload: unknown, to: AgentMessageRecipient, type: AgentMessage["type"] = "status"): AgentMessage {
+		return {
+			id: cryptoRandomId(),
+			from: { agentId: this.agentId, agentType: this.agentType },
+			to,
+			type,
+			payload,
+			timestamp: Date.now(),
+		};
+	}
+
+	private rpc(payload: Record<string, unknown>): Promise<SocketReply> {
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			const finish = (fn: () => void) => {
+				if (settled) return;
+				settled = true;
+				fn();
+			};
+
+			const client: Socket = connect(this.socketPath);
+			let buffer = "";
+			const timer = setTimeout(() => {
+				finish(() => {
+					client.destroy();
+					reject(new Error(`socket rpc timed out after ${this.rpcTimeoutMs}ms`));
+				});
+			}, this.rpcTimeoutMs);
+
+			client.on("data", (chunk: Buffer) => {
+				buffer += chunk.toString();
+				const idx = buffer.indexOf("\n");
+				if (idx < 0) return;
+				const line = buffer.slice(0, idx);
+				try {
+					const parsed = JSON.parse(line) as SocketReply;
+					finish(() => {
+						clearTimeout(timer);
+						client.end();
+						resolve(parsed);
+					});
+				} catch (err) {
+					finish(() => {
+						clearTimeout(timer);
+						client.destroy();
+						reject(err instanceof Error ? err : new Error(String(err)));
+					});
+				}
+			});
+
+			client.on("error", (err) => {
+				finish(() => {
+					clearTimeout(timer);
+					reject(err);
+				});
+			});
+
+			client.on("close", () => {
+				if (!buffer.includes("\n")) {
+					finish(() => {
+						clearTimeout(timer);
+						reject(new Error("socket closed without reply"));
+					});
+				}
+			});
+
+			client.write(`${JSON.stringify(payload)}\n`);
+		});
+	}
+}
+
+function cryptoRandomId(): string {
+	// Small, dependency-free RFC4122-ish v4. Worker-loop only needs uniqueness
+	// across the lifetime of a single container, so randomUUID is overkill but
+	// available in node 20+.
+	return globalThis.crypto?.randomUUID?.() ?? fallbackUuid();
+}
+
+function fallbackUuid(): string {
+	const bytes = new Uint8Array(16);
+	for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/coding-agent/src/modes/worker-loop/worker-loop-mode.ts
+++ b/packages/coding-agent/src/modes/worker-loop/worker-loop-mode.ts
@@ -1,0 +1,468 @@
+/**
+ * Worker-loop mode: subscribe to a host-provided Unix-socket message bus and
+ * run pi against each `agent_task_request` envelope.
+ *
+ * This mode is the in-pi replacement for boss-pi's throwaway
+ * `scripts/worker-loop.ts` wrapper. It owns the socket dispatch loop,
+ * heartbeats, idle-TTL exit, and `shutdown` envelope handling that previously
+ * lived in Node glue.
+ *
+ * Bus envelope contract (from boss-pi `src/engine/SocietyMessages.ts`):
+ *
+ *   { kind: 'agent_task_request', taskId, projectId, milestoneId,
+ *     prompt, model?, timeoutMs?, worktreePath }
+ *   { kind: 'agent_task_result', inReplyTo, status, rawOutput, durationMs,
+ *     errorMessage?, tokenUsage?, commits?, workingDiff? }
+ *   { kind: 'heartbeat', agentId, projectId, inflightTaskId?, emittedAt }
+ *   { kind: 'shutdown', toAgentId, reason }
+ *
+ * Pi-mono only owns the worker side of this contract: it does not generate
+ * spawn approvals or task requests, only consumes them.
+ */
+import type { AssistantMessage, Usage } from "@earendil-works/pi-ai";
+import type { AgentSessionEvent } from "../../core/agent-session.js";
+import type { AgentSessionRuntime } from "../../core/agent-session-runtime.js";
+import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.js";
+import { killTrackedDetachedChildren } from "../../utils/shell.js";
+import { captureGitState, resolveHeadSha } from "./git-capture.js";
+import { type AgentMessage, type AgentMessageRecipient, SocketBus, type SocketBusOptions } from "./socket-bus.js";
+
+// =============================================================================
+// Envelope types — mirror boss-pi's SocietyMessages.ts.
+// =============================================================================
+
+interface AgentTaskRequestEnvelope {
+	kind: "agent_task_request";
+	taskId: string;
+	projectId: string;
+	milestoneId: string;
+	prompt: string;
+	model?: string;
+	timeoutMs?: number;
+	worktreePath: string;
+}
+
+type AgentTaskStatus = "success" | "error" | "timeout";
+
+interface AgentTaskTokenUsage {
+	input: number;
+	output: number;
+	cached?: number;
+}
+
+interface AgentTaskResultEnvelope {
+	kind: "agent_task_result";
+	inReplyTo: string;
+	status: AgentTaskStatus;
+	rawOutput: string;
+	durationMs: number;
+	errorMessage?: string;
+	tokenUsage?: AgentTaskTokenUsage;
+	commits?: string[];
+	workingDiff?: string;
+}
+
+interface HeartbeatEnvelope {
+	kind: "heartbeat";
+	agentId: string;
+	projectId: string;
+	inflightTaskId?: string;
+	emittedAt: number;
+}
+
+interface ShutdownEnvelope {
+	kind: "shutdown";
+	toAgentId: string;
+	reason: string;
+}
+
+// =============================================================================
+// Public options
+// =============================================================================
+
+export interface WorkerLoopOptions {
+	socketPath: string;
+	agentId: string;
+	agentType: string;
+	projectId: string;
+	idleTtlMs: number;
+	heartbeatIntervalMs: number;
+	repoPath: string;
+	/** Override poll interval. Default 2000ms — matches the host wrapper. */
+	pollIntervalMs?: number;
+	/** Override the bus client (test seam). */
+	bus?: SocketBus;
+	/** Override `console` write target for fatal logs (test seam). */
+	logger?: { error: (...args: unknown[]) => void };
+}
+
+export interface WorkerLoopRunResult {
+	exitCode: number;
+	exitReason: "shutdown" | "idle_ttl" | "input_error";
+	tasksHandled: number;
+}
+
+/**
+ * Validate worker-loop CLI options. Returns diagnostics; the caller decides
+ * whether any error means abort.
+ */
+export function validateWorkerLoopOptions(
+	options: Partial<WorkerLoopOptions>,
+): { ok: true; options: WorkerLoopOptions } | { ok: false; diagnostics: AgentSessionRuntimeDiagnostic[] } {
+	const diagnostics: AgentSessionRuntimeDiagnostic[] = [];
+	const required: Array<keyof WorkerLoopOptions> = ["socketPath", "agentId", "agentType", "projectId", "repoPath"];
+	for (const key of required) {
+		const v = options[key];
+		if (typeof v !== "string" || v.length === 0) {
+			diagnostics.push({ type: "error", message: `worker-loop: --${kebab(String(key))} is required` });
+		}
+	}
+	if (options.idleTtlMs !== undefined && (typeof options.idleTtlMs !== "number" || options.idleTtlMs <= 0)) {
+		diagnostics.push({ type: "error", message: "worker-loop: --idle-ttl-ms must be a positive number" });
+	}
+	if (
+		options.heartbeatIntervalMs !== undefined &&
+		(typeof options.heartbeatIntervalMs !== "number" || options.heartbeatIntervalMs <= 0)
+	) {
+		diagnostics.push({
+			type: "error",
+			message: "worker-loop: --heartbeat-interval-ms must be a positive number",
+		});
+	}
+	if (diagnostics.length > 0) return { ok: false, diagnostics };
+	return {
+		ok: true,
+		options: {
+			socketPath: options.socketPath as string,
+			agentId: options.agentId as string,
+			agentType: options.agentType as string,
+			projectId: options.projectId as string,
+			repoPath: options.repoPath as string,
+			idleTtlMs: options.idleTtlMs ?? 60 * 60_000,
+			heartbeatIntervalMs: options.heartbeatIntervalMs ?? 10_000,
+			pollIntervalMs: options.pollIntervalMs ?? 2_000,
+			bus: options.bus,
+			logger: options.logger,
+		},
+	};
+}
+
+// =============================================================================
+// Main entry
+// =============================================================================
+
+/**
+ * Run the worker loop until a `shutdown` envelope arrives or idle-TTL
+ * elapses. Returns the desired process exit code.
+ *
+ * The runtime is consumed in a loop: per task, the worker calls
+ * `session.prompt()` against the existing rpc/print-mode plumbing, then
+ * resets via `runtimeHost.newSession()` so state does not bleed between
+ * tasks (the host wrapper used a fresh `PiAdapter.runOnce` per task — this
+ * matches that contract).
+ */
+export async function runWorkerLoopMode(
+	runtimeHost: AgentSessionRuntime,
+	options: WorkerLoopOptions,
+): Promise<WorkerLoopRunResult> {
+	const logger = options.logger ?? console;
+	const bus =
+		options.bus ??
+		new SocketBus({
+			socketPath: options.socketPath,
+			agentId: options.agentId,
+			agentType: options.agentType,
+		} satisfies SocketBusOptions);
+
+	const state = {
+		shouldExit: false,
+		exitReason: "idle_ttl" as WorkerLoopRunResult["exitReason"],
+		inflightTaskId: undefined as string | undefined,
+		lastTaskRequestAt: Date.now(),
+		tasksHandled: 0,
+	};
+
+	// Heartbeat every `heartbeatIntervalMs`. Best-effort — the host watchdog
+	// also notices the gap independently.
+	const heartbeatTimer = setInterval(() => {
+		void publishHeartbeat(bus, options, state.inflightTaskId).catch((err) => {
+			logger.error?.("worker-loop heartbeat failed:", err);
+		});
+	}, options.heartbeatIntervalMs);
+	heartbeatTimer.unref?.();
+
+	// Signal-driven shutdown: SIGTERM/SIGHUP exit cleanly.
+	const signalCleanup: Array<() => void> = [];
+	const installSignal = (signal: NodeJS.Signals) => {
+		const handler = () => {
+			killTrackedDetachedChildren();
+			state.shouldExit = true;
+			state.exitReason = "shutdown";
+		};
+		process.on(signal, handler);
+		signalCleanup.push(() => process.off(signal, handler));
+	};
+	installSignal("SIGTERM");
+	if (process.platform !== "win32") installSignal("SIGHUP");
+
+	try {
+		while (!state.shouldExit) {
+			let messages: AgentMessage[] = [];
+			try {
+				messages = await bus.drain();
+			} catch (err) {
+				// A drain failure is transient — log and back off. Idle TTL still
+				// applies via the elapsed-time check below.
+				logger.error?.("worker-loop drain failed:", err);
+				await sleep(options.pollIntervalMs ?? 2_000);
+				continue;
+			}
+
+			for (const msg of messages) {
+				if (state.shouldExit) break;
+				const envelope = envelopeOf(msg);
+				if (!envelope) continue;
+
+				if (envelope.kind === "shutdown") {
+					if (isShutdownForUs(envelope, options.agentId)) {
+						state.shouldExit = true;
+						state.exitReason = "shutdown";
+						break;
+					}
+					continue;
+				}
+
+				if (envelope.kind === "agent_task_request") {
+					await handleTaskRequest(envelope as AgentTaskRequestEnvelope, runtimeHost, bus, options, state);
+				}
+			}
+
+			if (!state.shouldExit && Date.now() - state.lastTaskRequestAt >= options.idleTtlMs) {
+				state.shouldExit = true;
+				state.exitReason = "idle_ttl";
+				break;
+			}
+
+			if (!state.shouldExit) {
+				await sleep(options.pollIntervalMs ?? 2_000);
+			}
+		}
+
+		return { exitCode: 0, exitReason: state.exitReason, tasksHandled: state.tasksHandled };
+	} finally {
+		clearInterval(heartbeatTimer);
+		for (const cleanup of signalCleanup) cleanup();
+		await runtimeHost.dispose().catch(() => {
+			// Disposal can race against in-flight work; the worker exits
+			// regardless — supervisor cleans up the container.
+		});
+	}
+}
+
+// =============================================================================
+// Task dispatch
+// =============================================================================
+
+interface LoopState {
+	shouldExit: boolean;
+	exitReason: WorkerLoopRunResult["exitReason"];
+	inflightTaskId: string | undefined;
+	lastTaskRequestAt: number;
+	tasksHandled: number;
+}
+
+async function handleTaskRequest(
+	req: AgentTaskRequestEnvelope,
+	runtimeHost: AgentSessionRuntime,
+	bus: SocketBus,
+	options: WorkerLoopOptions,
+	state: LoopState,
+): Promise<void> {
+	state.lastTaskRequestAt = Date.now();
+	state.inflightTaskId = req.taskId;
+	const startedAt = Date.now();
+
+	try {
+		const result = await runOneTask(req, runtimeHost, options);
+		await bus.publish(result, "leader");
+		state.tasksHandled++;
+	} catch (err) {
+		const errorMessage = err instanceof Error ? err.message : String(err);
+		const result: AgentTaskResultEnvelope = {
+			kind: "agent_task_result",
+			inReplyTo: req.taskId,
+			status: "error",
+			rawOutput: "",
+			durationMs: Date.now() - startedAt,
+			errorMessage,
+		};
+		await bus.publish(result, "leader").catch(() => {
+			// Bus may be unreachable during shutdown — drop the result.
+		});
+	} finally {
+		state.inflightTaskId = undefined;
+	}
+}
+
+/**
+ * Run a single task end-to-end:
+ * - Resolve HEAD before running (for git-state capture).
+ * - Reset to a fresh session so prior task state does not leak.
+ * - Subscribe to events to collect raw text + usage.
+ * - Call `session.prompt()` with the task prompt; await idle.
+ * - Capture commits + working diff.
+ * - Return an AgentTaskResult envelope.
+ */
+async function runOneTask(
+	req: AgentTaskRequestEnvelope,
+	runtimeHost: AgentSessionRuntime,
+	_options: WorkerLoopOptions,
+): Promise<AgentTaskResultEnvelope> {
+	const startedAt = Date.now();
+	const cwd = req.worktreePath;
+	const headShaBefore = resolveHeadSha(cwd);
+
+	// Each task starts from a clean slate — same shape as PiAdapter one-shot.
+	await runtimeHost.newSession({});
+
+	const session = runtimeHost.session;
+	const collected: { text: string[]; usages: Usage[]; lastStopReason?: string; lastErrorMessage?: string } = {
+		text: [],
+		usages: [],
+	};
+
+	const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
+		if (event.type === "message_end" && event.message.role === "assistant") {
+			const msg = event.message as AssistantMessage;
+			collected.usages.push(msg.usage);
+			collected.lastStopReason = msg.stopReason;
+			if (msg.errorMessage) collected.lastErrorMessage = msg.errorMessage;
+			for (const part of msg.content) {
+				if (part.type === "text") collected.text.push(part.text);
+			}
+		}
+	});
+
+	let status: AgentTaskStatus = "success";
+	let errorMessage: string | undefined;
+
+	try {
+		// Honour `timeoutMs` if present: race the prompt against a wall-clock
+		// timeout; on timeout, abort the session so the loop can move on.
+		const timeoutMs = typeof req.timeoutMs === "number" && req.timeoutMs > 0 ? req.timeoutMs : undefined;
+		const promptPromise = session.prompt(req.prompt);
+		if (timeoutMs !== undefined) {
+			const timedOut = await raceTimeout(promptPromise, timeoutMs);
+			if (timedOut) {
+				try {
+					await session.abort();
+				} catch {
+					// Abort can fail mid-stream — keep going so we still publish a result.
+				}
+				status = "timeout";
+				errorMessage = `task ${req.taskId} timed out after ${timeoutMs}ms`;
+			}
+		} else {
+			await promptPromise;
+		}
+
+		if (status === "success") {
+			if (collected.lastStopReason === "error" || collected.lastStopReason === "aborted") {
+				status = "error";
+				errorMessage = collected.lastErrorMessage ?? `task ended with stopReason=${collected.lastStopReason}`;
+			}
+		}
+	} catch (err) {
+		status = "error";
+		errorMessage = err instanceof Error ? err.message : String(err);
+	} finally {
+		unsubscribe();
+	}
+
+	const tokenUsage = aggregateUsage(collected.usages);
+	const { commits, workingDiff } = captureGitState(cwd, headShaBefore);
+
+	return {
+		kind: "agent_task_result",
+		inReplyTo: req.taskId,
+		status,
+		rawOutput: collected.text.join("\n").trim(),
+		durationMs: Date.now() - startedAt,
+		errorMessage,
+		tokenUsage,
+		commits: commits.length > 0 ? commits : undefined,
+		workingDiff,
+	};
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function envelopeOf(msg: AgentMessage): { kind: string } | null {
+	const payload = msg.payload as { kind?: unknown } | null | undefined;
+	if (!payload || typeof payload.kind !== "string") return null;
+	return payload as { kind: string };
+}
+
+function isShutdownForUs(envelope: { kind: string }, agentId: string): boolean {
+	const target = (envelope as Partial<ShutdownEnvelope>).toAgentId;
+	// Defense in depth: only honour shutdown directives addressed to us.
+	// A broadcast-style shutdown without `toAgentId` is treated as not-for-us.
+	return typeof target === "string" && target === agentId;
+}
+
+async function publishHeartbeat(
+	bus: SocketBus,
+	options: WorkerLoopOptions,
+	inflightTaskId: string | undefined,
+): Promise<void> {
+	const hb: HeartbeatEnvelope = {
+		kind: "heartbeat",
+		agentId: options.agentId,
+		projectId: options.projectId,
+		inflightTaskId,
+		emittedAt: Date.now(),
+	};
+	const to: AgentMessageRecipient = "broadcast";
+	await bus.publish(hb, to);
+}
+
+function aggregateUsage(usages: Usage[]): AgentTaskTokenUsage | undefined {
+	if (usages.length === 0) return undefined;
+	let input = 0;
+	let output = 0;
+	let cached = 0;
+	let sawCache = false;
+	for (const u of usages) {
+		input += u.input ?? 0;
+		output += u.output ?? 0;
+		const c = u.cacheRead ?? 0;
+		if (c > 0) sawCache = true;
+		cached += c;
+	}
+	const result: AgentTaskTokenUsage = { input, output };
+	if (sawCache) result.cached = cached;
+	return result;
+}
+
+async function raceTimeout(p: Promise<unknown>, ms: number): Promise<boolean> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<true>((resolve) => {
+		timer = setTimeout(() => resolve(true), ms);
+	});
+	try {
+		const settled = await Promise.race([p.then(() => false as const), timeout]);
+		return settled === true;
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+function kebab(input: string): string {
+	return input.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -125,6 +125,35 @@ describe("parseArgs", () => {
 			expect(result.mode).toBe("rpc");
 		});
 
+		test("parses --mode worker-loop with all worker-loop flags", () => {
+			const result = parseArgs([
+				"--mode",
+				"worker-loop",
+				"--bus-socket",
+				"/tmp/boss-pi-message.sock",
+				"--agent-id",
+				"worker-7",
+				"--agent-type",
+				"reviewer",
+				"--project-id",
+				"proj-42",
+				"--repo-path",
+				"/workspace",
+				"--idle-ttl-ms",
+				"60000",
+				"--heartbeat-interval-ms",
+				"5000",
+			]);
+			expect(result.mode).toBe("worker-loop");
+			expect(result.workerLoop?.socketPath).toBe("/tmp/boss-pi-message.sock");
+			expect(result.workerLoop?.agentId).toBe("worker-7");
+			expect(result.workerLoop?.agentType).toBe("reviewer");
+			expect(result.workerLoop?.projectId).toBe("proj-42");
+			expect(result.workerLoop?.repoPath).toBe("/workspace");
+			expect(result.workerLoop?.idleTtlMs).toBe(60000);
+			expect(result.workerLoop?.heartbeatIntervalMs).toBe(5000);
+		});
+
 		test("parses --session", () => {
 			const result = parseArgs(["--session", "/path/to/session.jsonl"]);
 			expect(result.session).toBe("/path/to/session.jsonl");

--- a/packages/coding-agent/test/worker-loop-mode.test.ts
+++ b/packages/coding-agent/test/worker-loop-mode.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Unit tests for `--mode worker-loop`. Drives `runWorkerLoopMode` with a
+ * fake SocketBus and a fake AgentSessionRuntime so the loop's envelope
+ * dispatch, heartbeat cadence, idle-TTL exit, and shutdown handling can be
+ * asserted without spawning the real bus, network, or model.
+ *
+ * The fakes mirror only the surface area worker-loop touches:
+ *   - bus.drain() / bus.publish()
+ *   - runtimeHost.session, runtimeHost.newSession(), runtimeHost.dispose()
+ *   - session.subscribe(), session.prompt(), session.abort()
+ */
+import type { AssistantMessage, Usage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionEventListener } from "../src/core/agent-session.js";
+import type { AgentMessage, AgentMessageRecipient, SocketBus } from "../src/modes/worker-loop/socket-bus.js";
+import { runWorkerLoopMode, validateWorkerLoopOptions } from "../src/modes/worker-loop/worker-loop-mode.js";
+
+// ----------------------------------------------------------------------------
+// Fakes
+// ----------------------------------------------------------------------------
+
+interface PublishedEnvelope {
+	payload: unknown;
+	to: AgentMessageRecipient;
+}
+
+class FakeBus implements Pick<SocketBus, "publish" | "drain" | "buildMessage" | "publishWithId"> {
+	readonly socketPath = "/dev/null";
+	readonly agentId: string;
+	readonly agentType: string;
+	readonly rpcTimeoutMs = 5_000;
+	readonly published: PublishedEnvelope[] = [];
+	private inbox: AgentMessage[][] = [];
+	private resolveDrain: ((messages: AgentMessage[]) => void) | undefined;
+
+	constructor(agentId: string, agentType: string) {
+		this.agentId = agentId;
+		this.agentType = agentType;
+	}
+
+	enqueue(messages: AgentMessage[]): void {
+		if (this.resolveDrain) {
+			const r = this.resolveDrain;
+			this.resolveDrain = undefined;
+			r(messages);
+		} else {
+			this.inbox.push(messages);
+		}
+	}
+
+	async drain(): Promise<AgentMessage[]> {
+		const next = this.inbox.shift();
+		if (next !== undefined) return next;
+		return [];
+	}
+
+	async publish(payload: unknown, to: AgentMessageRecipient): Promise<void> {
+		this.published.push({ payload, to });
+	}
+
+	async publishWithId(): Promise<void> {
+		// Unused in worker-loop today.
+	}
+
+	buildMessage(payload: unknown, to: AgentMessageRecipient, type: AgentMessage["type"] = "status"): AgentMessage {
+		return {
+			id: `m-${Math.random().toString(36).slice(2)}`,
+			from: { agentId: this.agentId, agentType: this.agentType },
+			to,
+			type,
+			payload,
+			timestamp: Date.now(),
+		};
+	}
+}
+
+interface FakeSessionEvents {
+	/** Emitted as `message_end` events the moment `prompt()` runs. */
+	assistantMessages: AssistantMessage[];
+}
+
+function makeUsage(input: number, output: number, cacheRead = 0): Usage {
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite: 0,
+		totalTokens: input + output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function makeAssistantMessage(opts: {
+	text?: string;
+	stopReason?: AssistantMessage["stopReason"];
+	errorMessage?: string;
+	usage?: Usage;
+}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: opts.text ? [{ type: "text", text: opts.text }] : [],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-4o-mini",
+		usage: opts.usage ?? makeUsage(10, 5),
+		stopReason: opts.stopReason ?? "stop",
+		errorMessage: opts.errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+interface FakeRuntimeOpts {
+	/** Per-prompt response queue. shift()ed each call to `prompt()`. */
+	responses: FakeSessionEvents[];
+	/** Slow `prompt()` calls — useful for the timeout test. */
+	promptDelayMs?: number;
+	/** Fail `prompt()` with this error. */
+	throwFromPrompt?: Error;
+}
+
+function createRuntime(opts: FakeRuntimeOpts) {
+	const listeners = new Set<AgentSessionEventListener>();
+
+	const session = {
+		model: { provider: "openai", id: "gpt-4o-mini" },
+		messages: [] as AssistantMessage[],
+		subscribe(listener: AgentSessionEventListener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		prompt: vi.fn(async (_text: string) => {
+			if (opts.promptDelayMs) {
+				await new Promise((r) => setTimeout(r, opts.promptDelayMs));
+			}
+			if (opts.throwFromPrompt) throw opts.throwFromPrompt;
+			const events = opts.responses.shift();
+			if (!events) return;
+			for (const msg of events.assistantMessages) {
+				for (const l of listeners) {
+					l({ type: "message_end", message: msg });
+				}
+			}
+		}),
+		abort: vi.fn(async () => {
+			// no-op
+		}),
+	};
+
+	const runtime = {
+		session,
+		newSession: vi.fn(async () => {
+			// Fresh session — clear listeners so per-task subscriptions don't leak.
+			listeners.clear();
+			return undefined;
+		}),
+		dispose: vi.fn(async () => {}),
+	};
+
+	return { runtime, session, listeners };
+}
+
+function buildEnvelope(payload: unknown, agentId: string): AgentMessage {
+	return {
+		id: `m-${Math.random().toString(36).slice(2)}`,
+		from: { agentId: "leader", agentType: "leader" },
+		to: { agentId, agentType: "worker" },
+		type: "request",
+		payload,
+		timestamp: Date.now(),
+	};
+}
+
+const baseOptions = {
+	socketPath: "/tmp/fake.sock",
+	agentId: "worker-1",
+	agentType: "worker",
+	projectId: "proj-1",
+	repoPath: "/tmp/repo",
+	idleTtlMs: 50,
+	heartbeatIntervalMs: 20,
+	pollIntervalMs: 5,
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+describe("validateWorkerLoopOptions", () => {
+	it("returns errors for missing required fields", () => {
+		const r = validateWorkerLoopOptions({});
+		expect(r.ok).toBe(false);
+		if (!r.ok) {
+			expect(r.diagnostics.map((d) => d.message)).toEqual(
+				expect.arrayContaining([
+					expect.stringContaining("--socket-path"),
+					expect.stringContaining("--agent-id"),
+					expect.stringContaining("--agent-type"),
+					expect.stringContaining("--project-id"),
+					expect.stringContaining("--repo-path"),
+				]),
+			);
+		}
+	});
+
+	it("applies defaults when only required fields are present", () => {
+		const r = validateWorkerLoopOptions({
+			socketPath: "/s",
+			agentId: "a",
+			agentType: "worker",
+			projectId: "p",
+			repoPath: "/r",
+		});
+		expect(r.ok).toBe(true);
+		if (r.ok) {
+			expect(r.options.idleTtlMs).toBe(60 * 60_000);
+			expect(r.options.heartbeatIntervalMs).toBe(10_000);
+		}
+	});
+});
+
+describe("runWorkerLoopMode envelope dispatch", () => {
+	it("publishes AgentTaskResult on agent_task_request and exits on shutdown", async () => {
+		const bus = new FakeBus("worker-1", "worker");
+		const { runtime, session } = createRuntime({
+			responses: [{ assistantMessages: [makeAssistantMessage({ text: "all done", usage: makeUsage(100, 50) })] }],
+		});
+
+		bus.enqueue([
+			buildEnvelope(
+				{
+					kind: "agent_task_request",
+					taskId: "task-1",
+					projectId: "proj-1",
+					milestoneId: "m-1",
+					prompt: "do thing",
+					worktreePath: "/tmp/repo",
+				},
+				"worker-1",
+			),
+		]);
+		bus.enqueue([buildEnvelope({ kind: "shutdown", toAgentId: "worker-1", reason: "leader_kill" }, "worker-1")]);
+
+		const result = await runWorkerLoopMode(runtime as never, {
+			...baseOptions,
+			bus: bus as unknown as SocketBus,
+			idleTtlMs: 60_000,
+			heartbeatIntervalMs: 60_000,
+		});
+
+		expect(result.exitReason).toBe("shutdown");
+		expect(result.exitCode).toBe(0);
+		expect(result.tasksHandled).toBe(1);
+
+		expect(session.prompt).toHaveBeenCalledWith("do thing");
+
+		const taskResults = bus.published.filter((p) => (p.payload as { kind?: string }).kind === "agent_task_result");
+		expect(taskResults).toHaveLength(1);
+		const taskResult = taskResults[0].payload as Record<string, unknown>;
+		expect(taskResult.inReplyTo).toBe("task-1");
+		expect(taskResult.status).toBe("success");
+		expect(taskResult.rawOutput).toBe("all done");
+		expect(taskResult.tokenUsage).toEqual({ input: 100, output: 50 });
+		expect(taskResults[0].to).toBe("leader");
+
+		expect(runtime.dispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores shutdown envelopes addressed to a different agent", async () => {
+		const bus = new FakeBus("worker-1", "worker");
+		const { runtime } = createRuntime({ responses: [] });
+
+		bus.enqueue([buildEnvelope({ kind: "shutdown", toAgentId: "other-agent", reason: "leader_kill" }, "worker-1")]);
+		// idle ttl is short so the loop exits via TTL, not shutdown.
+
+		const result = await runWorkerLoopMode(runtime as never, {
+			...baseOptions,
+			bus: bus as unknown as SocketBus,
+			idleTtlMs: 30,
+		});
+
+		expect(result.exitReason).toBe("idle_ttl");
+		expect(result.tasksHandled).toBe(0);
+	});
+
+	it("publishes an error AgentTaskResult when the prompt throws", async () => {
+		const bus = new FakeBus("worker-1", "worker");
+		const { runtime } = createRuntime({
+			responses: [],
+			throwFromPrompt: new Error("model down"),
+		});
+
+		bus.enqueue([
+			buildEnvelope(
+				{
+					kind: "agent_task_request",
+					taskId: "task-err",
+					projectId: "proj-1",
+					milestoneId: "m-1",
+					prompt: "boom",
+					worktreePath: "/tmp/repo",
+				},
+				"worker-1",
+			),
+		]);
+		bus.enqueue([buildEnvelope({ kind: "shutdown", toAgentId: "worker-1", reason: "leader_kill" }, "worker-1")]);
+
+		await runWorkerLoopMode(runtime as never, {
+			...baseOptions,
+			bus: bus as unknown as SocketBus,
+			idleTtlMs: 60_000,
+			heartbeatIntervalMs: 60_000,
+		});
+
+		const taskResults = bus.published.filter((p) => (p.payload as { kind?: string }).kind === "agent_task_result");
+		expect(taskResults).toHaveLength(1);
+		const taskResult = taskResults[0].payload as Record<string, unknown>;
+		expect(taskResult.status).toBe("error");
+		expect(taskResult.errorMessage).toBe("model down");
+	});
+
+	it("flags timeouts when timeoutMs elapses before prompt resolves", async () => {
+		const bus = new FakeBus("worker-1", "worker");
+		const { runtime, session } = createRuntime({
+			responses: [{ assistantMessages: [makeAssistantMessage({ text: "late" })] }],
+			promptDelayMs: 200,
+		});
+
+		bus.enqueue([
+			buildEnvelope(
+				{
+					kind: "agent_task_request",
+					taskId: "task-slow",
+					projectId: "proj-1",
+					milestoneId: "m-1",
+					prompt: "slow",
+					worktreePath: "/tmp/repo",
+					timeoutMs: 30,
+				},
+				"worker-1",
+			),
+		]);
+		bus.enqueue([buildEnvelope({ kind: "shutdown", toAgentId: "worker-1", reason: "leader_kill" }, "worker-1")]);
+
+		await runWorkerLoopMode(runtime as never, {
+			...baseOptions,
+			bus: bus as unknown as SocketBus,
+			idleTtlMs: 60_000,
+			heartbeatIntervalMs: 60_000,
+		});
+
+		const taskResults = bus.published.filter((p) => (p.payload as { kind?: string }).kind === "agent_task_result");
+		expect(taskResults).toHaveLength(1);
+		expect((taskResults[0].payload as { status: string }).status).toBe("timeout");
+		expect(session.abort).toHaveBeenCalled();
+	});
+});
+
+describe("runWorkerLoopMode lifecycle", () => {
+	it("exits via idle TTL when no tasks arrive", async () => {
+		const bus = new FakeBus("worker-1", "worker");
+		const { runtime } = createRuntime({ responses: [] });
+
+		const start = Date.now();
+		const result = await runWorkerLoopMode(runtime as never, {
+			...baseOptions,
+			bus: bus as unknown as SocketBus,
+			idleTtlMs: 25,
+		});
+
+		expect(result.exitReason).toBe("idle_ttl");
+		expect(Date.now() - start).toBeGreaterThanOrEqual(25);
+	});
+
+	it("emits heartbeat envelopes on the configured cadence", async () => {
+		const bus = new FakeBus("worker-1", "worker");
+		const { runtime } = createRuntime({ responses: [] });
+
+		await runWorkerLoopMode(runtime as never, {
+			...baseOptions,
+			bus: bus as unknown as SocketBus,
+			idleTtlMs: 80,
+			heartbeatIntervalMs: 15,
+		});
+
+		const heartbeats = bus.published.filter(
+			(p) => (p.payload as { kind?: string }).kind === "heartbeat" && p.to === "broadcast",
+		);
+		// 80ms / 15ms ≈ 5 cadence ticks; allow slack for timer drift on busy CI.
+		expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+		expect(heartbeats.length).toBeLessThanOrEqual(8);
+		const sample = heartbeats[0].payload as Record<string, unknown>;
+		expect(sample.agentId).toBe("worker-1");
+		expect(sample.projectId).toBe("proj-1");
+		expect(typeof sample.emittedAt).toBe("number");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new pi-mono mode, `pi --mode worker-loop`, that subscribes to a host-provided Unix-socket message bus and runs the existing one-shot prompt path against each `agent_task_request` envelope. This is the in-pi replacement for a throwaway Node wrapper used downstream in [boss-pi](https://github.com/anthropic-experimental/boss-pi-style-orchestrator) (`scripts/worker-loop.ts`).

The reference implementation being replaced (~340 LOC of TypeScript glue):
[`scripts/worker-loop.ts`](https://github.com/anthropic-experimental/boss-pi-style-orchestrator/blob/main/scripts/worker-loop.ts) (path is local — file kept in the consumer repo).

The downstream task spec, quoted from `docs/tasks/pi-worker-loop-mode.md`:

> ### pi-mono surface
>
> ```
> pi --mode worker-loop \
>   --bus-socket /tmp/boss-pi-message.sock \
>   --agent-id <id> \
>   --agent-type worker|reviewer|tester|... \
>   --project-id <id> \
>   --idle-ttl-ms 3600000 \
>   --heartbeat-interval-ms 10000 \
>   --repo-path /workspace
> ```
>
> Behaviour: identical envelope contract as the wrapper. pi-mono subscribes,
> dispatches `AgentTaskRequest` envelopes through its existing one-shot run
> path, publishes `AgentTaskResult`, emits `Heartbeat`s, exits 0 on
> `Shutdown` or idle timeout.

## What it does

Per `agent_task_request` envelope:
1. Reset to a fresh session via `runtimeHost.newSession()`.
2. Resolve `git rev-parse HEAD` in the worker's repo path.
3. Subscribe to `message_end` events to collect assistant text and `Usage` totals.
4. Run `session.prompt(req.prompt)`. If the envelope carries `timeoutMs`, race against a wall clock and `session.abort()` on timeout.
5. Capture `git log <head>..HEAD` and `git diff` and publish an `agent_task_result` envelope to `leader`.

Other lifecycle bits:
- Heartbeats every `--heartbeat-interval-ms` (default 10s) on `broadcast`.
- Exits 0 on `shutdown` addressed to `--agent-id`, or after `--idle-ttl-ms` of no task requests.
- `--mode worker-loop` skips the no-model startup gate so envelopes can carry per-task models.
- Stdin is left to the host. `@file` args are rejected (same as rpc).

## Wire format

Same JSON-line `send`/`receive` action protocol the consumer's bridge already speaks. One JSON object per line, `\n` framed. Each call opens a fresh socket and reads one reply line.

## Test plan

- [x] `npm run check` — biome + tsgo + browser-smoke + web-ui all pass via pre-commit hook.
- [x] `test/worker-loop-mode.test.ts` (8 tests) — envelope dispatch (success/error/timeout), shutdown filtering, idle TTL exit, heartbeat cadence.
- [x] `test/args.test.ts` (existing 60 + 1 added) — parses `--mode worker-loop` and all worker-loop flags.
- [ ] Manual: `pi --mode worker-loop --help` shows the new flags.

## Notes for reviewers

- Boss-pi cannot swap its agent-image entrypoint until this lands in a release it can pin. Once a release ships, the boss-pi side replaces `node scripts/worker-loop.ts` with `pi --mode worker-loop ...`.
- `request_spawn` is **not** wired in this PR. The wrapper exposed it as an MCP tool that emitted a `SpawnRequest` envelope and awaited the reply. Pi-mono doesn't currently host MCP tools that can publish to the worker's bus, so this is left as a follow-up. The downstream task spec calls this out explicitly — the wrapper is fine to keep around for that one feature until pi-mono grows the seam.
- New contributor here (no `lgtm` yet). Happy to close and shape this further per `CONTRIBUTING.md` if the maintainer team is interested in the surface.
