### PR TITLE
feat: support Cmd+V image paste via empty bracketed paste detection

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2208,6 +2208,9 @@ export class InteractiveMode {
 				if (!customEditor.onPasteImage) {
 					customEditor.onPasteImage = () => this.defaultEditor.onPasteImage?.();
 				}
+				if (!customEditor.onEmptyPaste) {
+					customEditor.onEmptyPaste = () => this.defaultEditor.onEmptyPaste?.();
+				}
 				if (!customEditor.onExtensionShortcut) {
 					customEditor.onExtensionShortcut = (data: string) => this.defaultEditor.onExtensionShortcut?.(data);
 				}
@@ -2408,6 +2411,11 @@ export class InteractiveMode {
 
 		// Handle clipboard image paste (triggered on Ctrl+V)
 		this.defaultEditor.onPasteImage = () => {
+			this.handleClipboardImagePaste();
+		};
+
+		// Handle empty bracketed paste (Cmd+V with image on clipboard)
+		this.defaultEditor.onEmptyPaste = () => {
 			this.handleClipboardImagePaste();
 		};
 	}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -257,6 +257,14 @@ export class Editor implements Component, Focusable {
 	private pasteBuffer: string = "";
 	private isInPaste: boolean = false;
 
+	/**
+	 * Called when a bracketed paste arrives with empty content.
+	 * This typically means the user pressed Cmd+V (macOS) with an image
+	 * on the clipboard — the terminal sends a paste sequence but with no
+	 * text content. Consumers can use this hook to check for clipboard images.
+	 */
+	public onEmptyPaste?: () => void;
+
 	// Prompt history for up/down navigation
 	private history: string[] = [];
 	private historyIndex: number = -1; // -1 = not browsing, 0 = most recent, 1 = older, etc.
@@ -569,6 +577,10 @@ export class Editor implements Component, Focusable {
 				const pasteContent = this.pasteBuffer.substring(0, endIndex);
 				if (pasteContent.length > 0) {
 					this.handlePaste(pasteContent);
+				} else {
+					// Empty bracketed paste — likely Cmd+V with an image on the
+					// clipboard (terminal pastes nothing when clipboard has no text).
+					this.onEmptyPaste?.();
 				}
 				this.isInPaste = false;
 				const remaining = this.pasteBuffer.substring(endIndex + 6);


### PR DESCRIPTION
## Problem

When a user presses **Cmd+V** on macOS with an image on the clipboard, the terminal emulator (Warp, iTerm2, Kitty, etc.) sends a bracketed paste sequence with **empty content** — because there's no text to paste. Pi previously ignored empty bracketed pastes silently, so Cmd+V did nothing for images.

Users expect Cmd+V to work for image pasting (this is how Claude Code handles it), and having to remember Ctrl+V is a friction point.

## Solution

1. **`packages/tui/src/components/editor.ts`** — Added a public `onEmptyPaste` hook on the Editor class. When a bracketed paste arrives with no content, it fires this hook instead of silently returning.

2. **`packages/coding-agent/src/modes/interactive/interactive-mode.ts`** — Wires `onEmptyPaste` to the existing `handleClipboardImagePaste()` handler (the same one Ctrl+V triggers). This checks the system clipboard for image data via native APIs.

## How it works

1. User presses Cmd+V with an image on clipboard
2. Terminal sends `\x1b[200~\x1b[201~` (empty bracketed paste)
3. Editor detects empty paste content → calls `onEmptyPaste()`
4. Handler reads clipboard via native API → finds image → attaches it

## Testing

- Cmd+V with image on clipboard → image is attached ✅
- Cmd+V with text on clipboard → normal text paste (non-empty, takes existing path) ✅
- Ctrl+V still works as before ✅