### PR TITLE
Normalize Copilot API base URL by removing business subdomain

### DIFF
--- a/packages/ai/src/utils/oauth/github-copilot.ts
+++ b/packages/ai/src/utils/oauth/github-copilot.ts
@@ -74,9 +74,16 @@ function getUrls(domain: string): {
 function getBaseUrlFromToken(token: string): string | null {
 	const match = token.match(/proxy-ep=([^;]+)/);
 	if (!match) return null;
+
 	const proxyHost = match[1];
-	// Convert proxy.xxx to api.xxx
-	const apiHost = proxyHost.replace(/^proxy\./, "api.");
+
+	// Convert:
+	// proxy.business.githubcopilot.com
+	// -> api.githubcopilot.com
+	const apiHost = proxyHost
+		.replace(/^proxy\./, "api.")
+		.replace(/^api\.business\./, "api.");
+
 	return `https://${apiHost}`;
 }
 


### PR DESCRIPTION
Update getBaseUrlFromToken() to normalize GitHub Copilot proxy endpoints by removing the `business` subdomain.

Changes:
- Convert `proxy.` → `api.`
- Normalize: `proxy.business.githubcopilot.com` → `api.githubcopilot.com`

This ensures all Copilot tokens resolve to the standard API endpoint instead of business-specific proxy hosts.

Without this change, when using github-copilot enterprise, we will get 421 Misdirected Request