### PR TITLE
fix: prevent ANTHROPIC_AUTH_TOKEN env var from leaking into non-Anthropic API key requests

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -849,6 +849,7 @@ function createClient(
 	// API key auth
 	const client = new Anthropic({
 		apiKey,
+		authToken: null,
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: mergeHeaders(


### PR DESCRIPTION
## Problem

When using the Anthropic SDK with an explicit `apiKey` (e.g. for Xiaomi MiMo or other proxy providers), the SDK automatically reads the `ANTHROPIC_AUTH_TOKEN` environment variable and sends it as an `Authorization: Bearer` header alongside the `x-api-key` header.

This causes **401 Invalid API Key** errors when both headers carry different keys:

```
x-api-key: sk-e07jt...         ← correct provider key (from XIAOMI_API_KEY)
Authorization: Bearer sk-2U6m... ← unrelated key (from ANTHROPIC_AUTH_TOKEN)
```

The Xiaomi API (and potentially other proxy providers) rejects the request because of the conflicting credentials.

## Root Cause

In `createClient()` in `packages/ai/src/providers/anthropic.ts`, the **API key auth** branch passes `apiKey` to the Anthropic SDK but does not explicitly set `authToken: null`:

- ✅ Cloudflare branch: `authToken: null` (already fixed)
- ✅ Copilot branch: `authToken: apiKey` (explicit)
- ✅ OAuth branch: `authToken: apiKey` (explicit)
- ❌ **API key auth branch**: missing `authToken: null`

## Fix

Add `authToken: null` to the API key auth branch, matching the pattern already used in the Cloudflare branch. This tells the SDK not to read `ANTHROPIC_AUTH_TOKEN` from the environment.



## Impact

- Does **not** affect Anthropic's own API calls (uses `x-api-key` header, which is the standard auth method)
- Does **not** affect OAuth or Copilot branches (already have explicit `authToken`)
- Only prevents the SDK from injecting a stale bearer token from the environment into requests that use `x-api-key` authentication