### PR TITLE
feat(ai): Add retries to Google Vertex AI

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Added Together AI as a built-in OpenAI-compatible provider with generated model metadata and `TOGETHER_API_KEY` authentication ([#3624](https://github.com/earendil-works/pi-mono/pull/3624) by [@Nutlope](https://github.com/Nutlope)).
-- Google Vertex requests now support HTTP retry handling for transient 408, 429, and supported 5xx errors.
+- Google Vertex AI provider now supports `retry.provider.maxRetries`
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Together AI as a built-in OpenAI-compatible provider with generated model metadata and `TOGETHER_API_KEY` authentication ([#3624](https://github.com/earendil-works/pi-mono/pull/3624) by [@Nutlope](https://github.com/Nutlope)).
+- Google Vertex requests now support HTTP retry handling for transient 408, 429, and supported 5xx errors.
 
 ### Fixed
 

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -3,6 +3,7 @@ import {
 	type GenerateContentParameters,
 	GoogleGenAI,
 	type HttpOptions,
+	type HttpRetryOptions,
 	ResourceScope,
 	type ThinkingConfig,
 	ThinkingLevel,
@@ -444,6 +445,17 @@ function buildParams(
 		...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
 		...(context.tools && context.tools.length > 0 && { tools: convertTools(context.tools) }),
 	};
+
+	const requestHttpOptions: HttpOptions = {};
+	if (options.timeoutMs !== undefined) {
+		requestHttpOptions.timeout = options.timeoutMs;
+	}
+	if (options.maxRetries !== undefined) {
+		requestHttpOptions.retryOptions = { attempts: options.maxRetries + 1 } satisfies HttpRetryOptions;
+	}
+	if (Object.keys(requestHttpOptions).length > 0) {
+		config.httpOptions = requestHttpOptions;
+	}
 
 	if (context.tools && context.tools.length > 0 && options.toolChoice) {
 		config.toolConfig = {


### PR DESCRIPTION
Hi, 
I noticed the Vertex AI provider does not yet accept the retry.provider.maxRetries argument, so this passes it down.

As for example we are getting pretty frequently random 429s with Gemini on Vertex, even when our usage is pretty light.