### PR TITLE
Fix turn-boundary compaction resume flow

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -219,6 +219,7 @@ async function runLoop(
 				await config.shouldStopAfterTurn?.({
 					message,
 					toolResults,
+					willContinueForToolResults: hasMoreToolCalls && toolResults.length > 0,
 					context: currentContext,
 					newMessages,
 				})

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -20,6 +20,7 @@ import type {
 	AgentTool,
 	BeforeToolCallContext,
 	BeforeToolCallResult,
+	ShouldStopAfterTurnContext,
 	StreamFn,
 	ToolExecutionMode,
 } from "./types.js";
@@ -101,6 +102,7 @@ export interface AgentOptions {
 	onResponse?: SimpleStreamOptions["onResponse"];
 	beforeToolCall?: (context: BeforeToolCallContext, signal?: AbortSignal) => Promise<BeforeToolCallResult | undefined>;
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
+	shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 	steeringMode?: QueueMode;
 	followUpMode?: QueueMode;
 	sessionId?: string;
@@ -175,6 +177,7 @@ export class Agent {
 		context: AfterToolCallContext,
 		signal?: AbortSignal,
 	) => Promise<AfterToolCallResult | undefined>;
+	public shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 	private activeRun?: ActiveRun;
 	/** Session identifier forwarded to providers for cache-aware backends. */
 	public sessionId?: string;
@@ -197,6 +200,7 @@ export class Agent {
 		this.onResponse = options.onResponse;
 		this.beforeToolCall = options.beforeToolCall;
 		this.afterToolCall = options.afterToolCall;
+		this.shouldStopAfterTurn = options.shouldStopAfterTurn;
 		this.steeringQueue = new PendingMessageQueue(options.steeringMode ?? "one-at-a-time");
 		this.followUpQueue = new PendingMessageQueue(options.followUpMode ?? "one-at-a-time");
 		this.sessionId = options.sessionId;
@@ -421,6 +425,7 @@ export class Agent {
 			toolExecution: this.toolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
+			shouldStopAfterTurn: this.shouldStopAfterTurn,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -106,6 +106,13 @@ export interface ShouldStopAfterTurnContext {
 	message: AssistantMessage;
 	/** Tool result messages passed to the preceding `turn_end` event. */
 	toolResults: ToolResultMessage[];
+	/**
+	 * Whether the loop would make another assistant call to consume these tool results.
+	 *
+	 * This is false when the turn has no tool results, or when every tool result requested
+	 * termination for the current tool batch.
+	 */
+	willContinueForToolResults: boolean;
 	/** Current agent context after the turn's assistant message and tool results have been appended. */
 	context: AgentContext;
 	/** Messages that this loop invocation will return if it exits at this point. Prompt runs include the initial prompt messages; continuation runs do not include pre-existing context messages. */

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -921,6 +921,7 @@ describe("agentLoop with AgentMessage", () => {
 		let followUpPolls = 0;
 		let callbackToolResultIds: string[] = [];
 		let callbackContextRoles: string[] = [];
+		let callbackWillContinueForToolResults: boolean | undefined;
 		const config: AgentLoopConfig = {
 			model: createModel(),
 			convertToLlm: identityConverter,
@@ -932,10 +933,11 @@ describe("agentLoop with AgentMessage", () => {
 				followUpPolls++;
 				return [createUserMessage("follow up should stay queued")];
 			},
-			shouldStopAfterTurn: async ({ message, toolResults, context }) => {
+			shouldStopAfterTurn: async ({ message, toolResults, willContinueForToolResults, context }) => {
 				expect(message.role).toBe("assistant");
 				callbackToolResultIds = toolResults.map((toolResult) => toolResult.toolCallId);
 				callbackContextRoles = context.messages.map((contextMessage) => contextMessage.role);
+				callbackWillContinueForToolResults = willContinueForToolResults;
 				return true;
 			},
 		};
@@ -973,6 +975,7 @@ describe("agentLoop with AgentMessage", () => {
 		expect(steeringPolls).toBe(1);
 		expect(followUpPolls).toBe(0);
 		expect(callbackToolResultIds).toEqual(["tool-1"]);
+		expect(callbackWillContinueForToolResults).toBe(true);
 		expect(callbackContextRoles).toEqual(["user", "assistant", "toolResult"]);
 		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 		expect(events.map((event) => event.type)).toEqual([
@@ -1013,9 +1016,14 @@ describe("agentLoop with AgentMessage", () => {
 			tools: [tool],
 		};
 
+		let callbackWillContinueForToolResults: boolean | undefined;
 		const config: AgentLoopConfig = {
 			model: createModel(),
 			convertToLlm: identityConverter,
+			shouldStopAfterTurn: async ({ willContinueForToolResults }) => {
+				callbackWillContinueForToolResults = willContinueForToolResults;
+				return false;
+			},
 		};
 
 		let llmCalls = 0;
@@ -1039,6 +1047,7 @@ describe("agentLoop with AgentMessage", () => {
 
 		const messages = await stream.result();
 		expect(llmCalls).toBe(1);
+		expect(callbackWillContinueForToolResults).toBe(false);
 		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 		expect(events.filter((event) => event.type === "turn_end")).toHaveLength(1);
 	});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -21,6 +21,7 @@ import type {
 	AgentMessage,
 	AgentState,
 	AgentTool,
+	ShouldStopAfterTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@earendil-works/pi-ai";
@@ -328,6 +329,7 @@ export class AgentSession {
 		// Always subscribe to agent events for internal handling
 		// (session persistence, extensions, auto-compaction, retry logic)
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
+		this._installAgentLifecycleHooks();
 		this._installAgentToolHooks();
 
 		this._buildRuntime({
@@ -424,6 +426,16 @@ export class AgentSession {
 				details: hookResult.details,
 				isError: hookResult.isError ?? isError,
 			};
+		};
+	}
+
+	private _installAgentLifecycleHooks(): void {
+		const previousShouldStopAfterTurn = this.agent.shouldStopAfterTurn;
+		this.agent.shouldStopAfterTurn = async (context) => {
+			if ((await previousShouldStopAfterTurn?.(context)) ?? false) {
+				return true;
+			}
+			return await this._checkTurnBoundaryCompaction(context);
 		};
 	}
 
@@ -1754,21 +1766,26 @@ export class AgentSession {
 
 	/**
 	 * Check if compaction is needed and run it.
-	 * Called after agent_end and before prompt submission.
+	 * Called after agent_end, before prompt submission, and at safe turn boundaries.
 	 *
 	 * Two cases:
 	 * 1. Overflow: LLM returned context overflow error, remove error message from agent state, compact, auto-retry
-	 * 2. Threshold: Context over threshold, compact, NO auto-retry (user continues manually)
+	 * 2. Threshold: Context over threshold, compact, then optionally continue if the current tool loop is waiting.
 	 *
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
+	 * @param thresholdWillRetry If true, resume after threshold compaction. Used only at a tool turn boundary.
 	 */
-	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<void> {
+	private async _checkCompaction(
+		assistantMessage: AssistantMessage,
+		skipAbortedCheck = true,
+		thresholdWillRetry = false,
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
-		if (!settings.enabled) return;
+		if (!settings.enabled) return false;
 
 		// Skip if message was aborted (user cancelled) - unless skipAbortedCheck is false
-		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return;
+		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return false;
 
 		const contextWindow = this.model?.contextWindow ?? 0;
 
@@ -1786,7 +1803,7 @@ export class AgentSession {
 		const assistantIsFromBeforeCompaction =
 			compactionEntry !== null && assistantMessage.timestamp <= new Date(compactionEntry.timestamp).getTime();
 		if (assistantIsFromBeforeCompaction) {
-			return;
+			return false;
 		}
 
 		// Case 1: Overflow - LLM returned context overflow error
@@ -1801,7 +1818,7 @@ export class AgentSession {
 					errorMessage:
 						"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
 				});
-				return;
+				return false;
 			}
 
 			this._overflowRecoveryAttempted = true;
@@ -1811,8 +1828,7 @@ export class AgentSession {
 			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
 				this.agent.state.messages = messages.slice(0, -1);
 			}
-			await this._runAutoCompaction("overflow", true);
-			return;
+			return await this._runAutoCompaction("overflow", true);
 		}
 
 		// Case 2: Threshold - context is getting large
@@ -1822,7 +1838,7 @@ export class AgentSession {
 		if (assistantMessage.stopReason === "error") {
 			const messages = this.agent.state.messages;
 			const estimate = estimateContextTokens(messages);
-			if (estimate.lastUsageIndex === null) return; // No usage data at all
+			if (estimate.lastUsageIndex === null) return false; // No usage data at all
 			// Verify the usage source is post-compaction. Kept pre-compaction messages
 			// have stale usage reflecting the old (larger) context and would falsely
 			// trigger compaction right after one just finished.
@@ -1832,21 +1848,55 @@ export class AgentSession {
 				usageMsg.role === "assistant" &&
 				(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
 			) {
-				return;
+				return false;
 			}
 			contextTokens = estimate.tokens;
 		} else {
 			contextTokens = calculateContextTokens(assistantMessage.usage);
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
-			await this._runAutoCompaction("threshold", false);
+			return await this._runAutoCompaction("threshold", thresholdWillRetry);
 		}
+		return false;
+	}
+
+	/**
+	 * Compact between tool turns before the next provider call.
+	 *
+	 * Returning true asks the core loop to stop after the already-emitted turn. The scheduled
+	 * continuation then resumes from the compacted transcript whose tail is still a tool result.
+	 */
+	private async _checkTurnBoundaryCompaction(context: ShouldStopAfterTurnContext): Promise<boolean> {
+		if (!context.willContinueForToolResults || context.toolResults.length === 0) {
+			return false;
+		}
+		await this._agentEventQueue;
+		const lastToolResult = context.toolResults[context.toolResults.length - 1];
+		const agentTail = this.agent.state.messages[this.agent.state.messages.length - 1];
+		if (
+			agentTail?.role !== "toolResult" ||
+			agentTail.toolCallId !== lastToolResult.toolCallId ||
+			agentTail.toolName !== lastToolResult.toolName
+		) {
+			return false;
+		}
+
+		const branchTail = this.sessionManager.getBranch().at(-1);
+		if (
+			branchTail?.type !== "message" ||
+			branchTail.message.role !== "toolResult" ||
+			branchTail.message.toolCallId !== lastToolResult.toolCallId ||
+			branchTail.message.toolName !== lastToolResult.toolName
+		) {
+			return false;
+		}
+		return await this._checkCompaction(context.message, true, true);
 	}
 
 	/**
 	 * Internal: Run auto-compaction with events.
 	 */
-	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<void> {
+	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 
 		this._emit({ type: "compaction_start", reason });
@@ -1861,7 +1911,7 @@ export class AgentSession {
 					aborted: false,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 
 			const authResult = await this._modelRegistry.getApiKeyAndHeaders(this.model);
@@ -1873,7 +1923,7 @@ export class AgentSession {
 					aborted: false,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 			const { apiKey, headers } = authResult;
 
@@ -1888,7 +1938,7 @@ export class AgentSession {
 					aborted: false,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 
 			let extensionCompaction: CompactionResult | undefined;
@@ -1911,7 +1961,7 @@ export class AgentSession {
 						aborted: true,
 						willRetry: false,
 					});
-					return;
+					return false;
 				}
 
 				if (extensionResult?.compaction) {
@@ -1956,7 +2006,7 @@ export class AgentSession {
 					aborted: true,
 					willRetry: false,
 				});
-				return;
+				return false;
 			}
 
 			this.sessionManager.appendCompaction(summary, firstKeptEntryId, tokensBefore, details, fromExtension);
@@ -1992,16 +2042,13 @@ export class AgentSession {
 					this.agent.state.messages = messages.slice(0, -1);
 				}
 
-				setTimeout(() => {
-					this.agent.continue().catch(() => {});
-				}, 100);
+				this._scheduleContinueAfterIdle(reason);
 			} else if (this.agent.hasQueuedMessages()) {
 				// Auto-compaction can complete while follow-up/steering/custom messages are waiting.
 				// Kick the loop so queued messages are actually delivered.
-				setTimeout(() => {
-					this.agent.continue().catch(() => {});
-				}, 100);
+				this._scheduleContinueAfterIdle(reason);
 			}
+			return true;
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
 			this._emit({
@@ -2015,8 +2062,31 @@ export class AgentSession {
 						? `Context overflow recovery failed: ${errorMessage}`
 						: `Auto-compaction failed: ${errorMessage}`,
 			});
+			return false;
 		} finally {
 			this._autoCompactionAbortController = undefined;
+		}
+	}
+
+	private _scheduleContinueAfterIdle(reason: "overflow" | "threshold"): void {
+		void this._continueAfterIdle(reason);
+	}
+
+	private async _continueAfterIdle(reason: "overflow" | "threshold"): Promise<void> {
+		try {
+			await this.agent.waitForIdle();
+			await this._agentEventQueue;
+			await this.agent.continue();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this._emit({
+				type: "compaction_end",
+				reason,
+				result: undefined,
+				aborted: false,
+				willRetry: false,
+				errorMessage: `Auto-compaction resume failed: ${message}`,
+			});
 		}
 	}
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -113,7 +113,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 		const runAutoCompaction = (
 			session as unknown as {
-				_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+				_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 			}
 		)._runAutoCompaction.bind(session);
 
@@ -147,11 +147,11 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runAutoCompactionSpy = vi
 			.spyOn(
 				session as unknown as {
-					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 				},
 				"_runAutoCompaction",
 			)
-			.mockResolvedValue();
+			.mockResolvedValue(false);
 
 		const events: Array<{ type: string; reason: string; errorMessage?: string }> = [];
 		session.subscribe((event) => {
@@ -162,7 +162,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 		const checkCompaction = (
 			session as unknown as {
-				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
+				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
 			}
 		)._checkCompaction.bind(session);
 
@@ -218,15 +218,15 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runAutoCompactionSpy = vi
 			.spyOn(
 				session as unknown as {
-					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 				},
 				"_runAutoCompaction",
 			)
-			.mockResolvedValue();
+			.mockResolvedValue(false);
 
 		const checkCompaction = (
 			session as unknown as {
-				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
+				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
 			}
 		)._checkCompaction.bind(session);
 
@@ -288,15 +288,15 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runAutoCompactionSpy = vi
 			.spyOn(
 				session as unknown as {
-					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 				},
 				"_runAutoCompaction",
 			)
-			.mockResolvedValue();
+			.mockResolvedValue(false);
 
 		const checkCompaction = (
 			session as unknown as {
-				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
+				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
 			}
 		)._checkCompaction.bind(session);
 
@@ -336,15 +336,15 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runAutoCompactionSpy = vi
 			.spyOn(
 				session as unknown as {
-					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 				},
 				"_runAutoCompaction",
 			)
-			.mockResolvedValue();
+			.mockResolvedValue(false);
 
 		const checkCompaction = (
 			session as unknown as {
-				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
+				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
 			}
 		)._checkCompaction.bind(session);
 
@@ -417,15 +417,15 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runAutoCompactionSpy = vi
 			.spyOn(
 				session as unknown as {
-					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 				},
 				"_runAutoCompaction",
 			)
-			.mockResolvedValue();
+			.mockResolvedValue(false);
 
 		const checkCompaction = (
 			session as unknown as {
-				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
+				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
 			}
 		)._checkCompaction.bind(session);
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -1,10 +1,12 @@
-import { type AssistantMessage, fauxAssistantMessage, type Model } from "@earendil-works/pi-ai";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createHarness, type Harness } from "./harness.js";
+import { createHarness, getAssistantTexts, type Harness } from "./harness.js";
 
 type SessionWithCompactionInternals = {
-	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
-	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
+	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 };
 
 function createUsage(totalTokens: number) {
@@ -39,6 +41,38 @@ function createAssistant(
 		model: model.id,
 		usage: createUsage(options.totalTokens ?? 0),
 	};
+}
+
+const echoToolSchema = Type.Object({ text: Type.String() });
+
+function createEchoTool(
+	toolRuns: string[],
+	options: { terminate?: boolean } = {},
+): AgentTool<typeof echoToolSchema, { text: string }> {
+	return {
+		name: "echo",
+		label: "Echo",
+		description: "Echo text",
+		parameters: echoToolSchema,
+		execute: async (_toolCallId, params) => {
+			toolRuns.push(params.text);
+			return {
+				content: [{ type: "text" as const, text: params.text }],
+				details: params,
+				terminate: options.terminate,
+			};
+		},
+	};
+}
+
+async function waitForCondition(condition: () => boolean, timeoutMs = 1000): Promise<void> {
+	const startedAt = Date.now();
+	while (!condition()) {
+		if (Date.now() - startedAt > timeoutMs) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
 }
 
 describe("AgentSession compaction characterization", () => {
@@ -158,6 +192,163 @@ describe("AgentSession compaction characterization", () => {
 		expect(continueSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("compacts between tool turns and resumes from the tool result", async () => {
+		const toolRuns: string[] = [];
+		const echoTool = createEchoTool(toolRuns);
+		let releaseTurnEnd: () => void = () => {};
+		let resolveTurnEndStarted: () => void = () => {};
+		const turnEndGate = new Promise<void>((resolve) => {
+			releaseTurnEnd = resolve;
+		});
+		const turnEndBlocked = new Promise<void>((resolve) => {
+			resolveTurnEndStarted = resolve;
+		});
+
+		const harness = await createHarness({
+			tools: [echoTool],
+			settings: { compaction: { reserveTokens: 128000, keepRecentTokens: 10 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("turn_end", async () => {
+						resolveTurnEndStarted();
+						await turnEndGate;
+					});
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "turn boundary compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const model = harness.getModel();
+		const oldUser = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "old seed history" }],
+			timestamp: Date.now() - 10_000,
+		};
+		const oldAssistant: AssistantMessage = {
+			...fauxAssistantMessage("old history that should be summarized away"),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(0),
+			timestamp: Date.now() - 9000,
+		};
+		harness.sessionManager.appendMessage(oldUser);
+		harness.sessionManager.appendMessage(oldAssistant);
+		harness.session.agent.state.messages = [oldUser, oldAssistant];
+
+		let compactionStarted = false;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start") {
+				compactionStarted = true;
+			}
+		});
+
+		let rolesSeenByContinuation: string[] = [];
+		let textSeenByContinuation = "";
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("echo", { text: "hello" }), { stopReason: "toolUse" }),
+			(context) => {
+				rolesSeenByContinuation = context.messages.map((message) => message.role);
+				textSeenByContinuation = JSON.stringify(context.messages);
+				return fauxAssistantMessage("continued after compaction");
+			},
+		]);
+
+		const promptPromise = harness.session.prompt("run the tool");
+		await turnEndBlocked;
+		await Promise.resolve();
+		expect(compactionStarted).toBe(false);
+		releaseTurnEnd();
+		await promptPromise;
+		expect(harness.getPendingResponseCount()).toBe(1);
+
+		await waitForCondition(() => harness.getPendingResponseCount() === 0);
+		await harness.session.agent.waitForIdle();
+
+		expect(toolRuns).toEqual(["hello"]);
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(harness.eventsOfType("compaction_end").filter((event) => event.willRetry)).toHaveLength(1);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction").length).toBeGreaterThan(
+			0,
+		);
+		expect(textSeenByContinuation).toContain("turn boundary compacted");
+		expect(rolesSeenByContinuation.at(-1)).toBe("toolResult");
+		expect(textSeenByContinuation).not.toContain("old seed history");
+		expect(textSeenByContinuation).not.toContain("old history that should be summarized away");
+		expect(getAssistantTexts(harness)).toContain("continued after compaction");
+	});
+
+	it("does not resume after turn-boundary compaction when a tool result terminates the batch", async () => {
+		const toolRuns: string[] = [];
+		const echoTool = createEchoTool(toolRuns, { terminate: true });
+		const harness = await createHarness({
+			tools: [echoTool],
+			settings: { compaction: { reserveTokens: 128000, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "terminal tool compacted after stop",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const compactionEnded = new Promise<void>((resolve) => {
+			harness.session.subscribe((event) => {
+				if (event.type === "compaction_end") {
+					resolve();
+				}
+			});
+		});
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("echo", { text: "stop" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("should remain pending"),
+		]);
+
+		await harness.session.prompt("run terminal tool");
+		await compactionEnded;
+
+		expect(toolRuns).toEqual(["stop"]);
+		expect(harness.eventsOfType("compaction_end").filter((event) => event.willRetry)).toHaveLength(0);
+		expect(harness.getPendingResponseCount()).toBe(1);
+		expect(getAssistantTexts(harness)).not.toContain("should remain pending");
+	});
+
+	it("does not compact below threshold between tool turns", async () => {
+		const toolRuns: string[] = [];
+		const echoTool = createEchoTool(toolRuns);
+		const harness = await createHarness({
+			tools: [echoTool],
+			settings: { compaction: { enabled: true, reserveTokens: 1000 } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("echo", { text: "small" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("continued without compaction"),
+		]);
+
+		await harness.session.prompt("run small tool");
+
+		expect(toolRuns).toEqual(["small"]);
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+		expect(getAssistantTexts(harness)).toContain("continued without compaction");
+	});
+
 	it("does not retry overflow recovery more than once", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -167,7 +358,7 @@ describe("AgentSession compaction characterization", () => {
 			errorMessage: "prompt is too long",
 			timestamp: Date.now(),
 		});
-		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
 		const compactionErrors: string[] = [];
 		harness.session.subscribe((event) => {
 			if (event.type === "compaction_end" && event.errorMessage) {
@@ -215,7 +406,7 @@ describe("AgentSession compaction characterization", () => {
 			timestamp: Date.now(),
 		});
 
-		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
 
 		await sessionInternals._checkCompaction(staleAssistant, false);
 
@@ -243,7 +434,7 @@ describe("AgentSession compaction characterization", () => {
 			errorAssistant,
 		];
 
-		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
 
 		await sessionInternals._checkCompaction(errorAssistant);
 
@@ -264,7 +455,7 @@ describe("AgentSession compaction characterization", () => {
 			errorAssistant,
 		];
 
-		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
 
 		await sessionInternals._checkCompaction(errorAssistant);
 
@@ -309,7 +500,7 @@ describe("AgentSession compaction characterization", () => {
 			errorAssistant,
 		];
 
-		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
 
 		await sessionInternals._checkCompaction(errorAssistant);
 
@@ -327,8 +518,8 @@ describe("AgentSession compaction characterization", () => {
 
 		const belowThresholdInternals = belowThresholdHarness.session as unknown as SessionWithCompactionInternals;
 		const disabledInternals = disabledHarness.session as unknown as SessionWithCompactionInternals;
-		const belowThresholdSpy = vi.spyOn(belowThresholdInternals, "_runAutoCompaction").mockResolvedValue();
-		const disabledSpy = vi.spyOn(disabledInternals, "_runAutoCompaction").mockResolvedValue();
+		const belowThresholdSpy = vi.spyOn(belowThresholdInternals, "_runAutoCompaction").mockResolvedValue(false);
+		const disabledSpy = vi.spyOn(disabledInternals, "_runAutoCompaction").mockResolvedValue(false);
 
 		await belowThresholdInternals._checkCompaction(
 			createAssistant(belowThresholdHarness, { stopReason: "stop", totalTokens: 1_000, timestamp: Date.now() }),


### PR DESCRIPTION
## Summary

- expose whether the agent loop will continue for tool results after a turn ends
- compact at the coding-agent turn boundary only when pending tool-result work will continue
- wait for session/event persistence before compaction, then resume after the active run becomes idle
- add coverage for turn-boundary compaction/resume, terminating tool results, and below-threshold behavior

## Tests

- `npm --prefix packages/agent test`
- `npm --prefix packages/coding-agent test -- test/suite/agent-session-compaction.test.ts test/agent-session-auto-compaction-queue.test.ts`
- commit hook: `npm run check`