### PR TITLE
feat(agent): resolve slash commands by unambiguous prefix

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -554,8 +554,16 @@ export class ExtensionRunner {
 		return this.commandDiagnostics;
 	}
 
+	/** Resolve a command by exact name, falling back to unambiguous prefix match. */
 	getCommand(name: string): ResolvedCommand | undefined {
-		return this.resolveRegisteredCommands().find((command) => command.invocationName === name);
+		const commands = this.resolveRegisteredCommands();
+		const exact = commands.find((command) => command.invocationName === name);
+		if (exact) return exact;
+		if (name.length > 0) {
+			const prefixMatches = commands.filter((command) => command.invocationName.startsWith(name));
+			if (prefixMatches.length === 1) return prefixMatches[0];
+		}
+		return undefined;
 	}
 
 	/**


### PR DESCRIPTION
I am not sure if there's an easy way to fix this via extension, but I'd like my `/commands` to match on shortest unique prefix first. E.g. I have an `/editor` command for which I'd like to be able to say `/ed foo.txt`. 

Closes #4364.