### PR TITLE
feat: background direct bash commands

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -162,7 +162,7 @@ The editor can be temporarily replaced by other UI, like built-in `/settings` or
 | Path completion | Tab to complete paths |
 | Multi-line | Shift+Enter (or Ctrl+Enter on Windows Terminal) |
 | Images | Ctrl+V to paste (Alt+V on Windows), or drag onto terminal |
-| Bash commands | `!command` runs and sends output to LLM, `!!command` runs without sending |
+| Bash commands | `!command` runs and sends output to LLM, `!!command` runs without sending, `Ctrl+B` backgrounds a running direct `!` command |
 
 Standard editing keybindings for delete word, undo, etc. See [docs/keybindings.md](docs/keybindings.md).
 
@@ -209,6 +209,7 @@ See `/hotkeys` for the full list. Customize via `~/.pi/agent/keybindings.json`. 
 | Shift+Tab | Cycle thinking level |
 | Ctrl+O | Collapse/expand tool output |
 | Ctrl+T | Collapse/expand thinking blocks |
+| Ctrl+B | Background the active direct `!` bash command |
 
 ### Message Queue
 
@@ -479,7 +480,7 @@ Pi is aggressively extensible so it doesn't have to dictate your workflow. Featu
 
 **No built-in to-dos.** They confuse models. Use a TODO.md file, or build your own with [extensions](#extensions).
 
-**No background bash.** Use tmux. Full observability, direct interaction.
+**Background direct bash.** Press `Ctrl+B` to detach a running direct `!` command and keep working while its output continues in the transcript. For agent tool calls or fully separate shells, use tmux.
 
 Read the [blog post](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/) for the full rationale.
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -86,8 +86,11 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.clear` | `ctrl+c` | Clear editor |
 | `app.exit` | `ctrl+d` | Exit (when editor empty) |
 | `app.suspend` | `ctrl+z` (none on Windows) | Suspend to background |
+| `app.bash.background` | `ctrl+b` | Background the active direct `!` bash command |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image from clipboard |
+
+When no direct `!` bash command is running, `ctrl+b` falls back to the editor's normal cursor-left behavior.
 
 ### Sessions
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -275,7 +275,8 @@ export class AgentSession {
 	private _retryResolve: (() => void) | undefined = undefined;
 
 	// Bash execution state
-	private _bashAbortController: AbortController | undefined = undefined;
+	private _bashExecutionSequence = 0;
+	private _foregroundBashExecution: { id: number; abortController: AbortController } | undefined = undefined;
 	private _pendingBashMessages: BashExecutionMessage[] = [];
 
 	// Extension system
@@ -2561,7 +2562,9 @@ export class AgentSession {
 		onChunk?: (chunk: string) => void,
 		options?: { excludeFromContext?: boolean; operations?: BashOperations },
 	): Promise<BashResult> {
-		this._bashAbortController = new AbortController();
+		const executionId = ++this._bashExecutionSequence;
+		const abortController = new AbortController();
+		this._foregroundBashExecution = { id: executionId, abortController };
 
 		// Apply command prefix if configured (e.g., "shopt -s expand_aliases" for alias support)
 		const prefix = this.settingsManager.getShellCommandPrefix();
@@ -2575,14 +2578,16 @@ export class AgentSession {
 				options?.operations ?? createLocalBashOperations({ shellPath }),
 				{
 					onChunk,
-					signal: this._bashAbortController.signal,
+					signal: abortController.signal,
 				},
 			);
 
 			this.recordBashResult(command, result, options);
 			return result;
 		} finally {
-			this._bashAbortController = undefined;
+			if (this._foregroundBashExecution?.id === executionId) {
+				this._foregroundBashExecution = undefined;
+			}
 		}
 	}
 
@@ -2617,15 +2622,27 @@ export class AgentSession {
 	}
 
 	/**
+	 * Release the foreground bash lock without cancelling the running process.
+	 * This allows the UI to continue while the command finishes in the background.
+	 */
+	backgroundBash(): boolean {
+		if (!this._foregroundBashExecution) {
+			return false;
+		}
+		this._foregroundBashExecution = undefined;
+		return true;
+	}
+
+	/**
 	 * Cancel running bash command.
 	 */
 	abortBash(): void {
-		this._bashAbortController?.abort();
+		this._foregroundBashExecution?.abortController.abort();
 	}
 
 	/** Whether a bash command is currently running */
 	get isBashRunning(): boolean {
-		return this._bashAbortController !== undefined;
+		return this._foregroundBashExecution !== undefined;
 	}
 
 	/** Whether there are pending bash messages waiting to be flushed */

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -15,6 +15,7 @@ export interface AppKeybindings {
 	"app.clear": true;
 	"app.exit": true;
 	"app.suspend": true;
+	"app.bash.background": true;
 	"app.thinking.cycle": true;
 	"app.model.cycleForward": true;
 	"app.model.cycleBackward": true;
@@ -68,6 +69,10 @@ export const KEYBINDINGS = {
 	"app.suspend": {
 		defaultKeys: process.platform === "win32" ? [] : "ctrl+z",
 		description: "Suspend to background",
+	},
+	"app.bash.background": {
+		defaultKeys: "ctrl+b",
+		description: "Background running bash command",
 	},
 	"app.thinking.cycle": {
 		defaultKeys: "shift+tab",
@@ -237,6 +242,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	clear: "app.clear",
 	exit: "app.exit",
 	suspend: "app.suspend",
+	backgroundBash: "app.bash.background",
 	cycleThinkingLevel: "app.thinking.cycle",
 	cycleModelForward: "app.model.cycleForward",
 	cycleModelBackward: "app.model.cycleBackward",

--- a/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -21,7 +21,7 @@ const PREVIEW_LINES = 20;
 export class BashExecutionComponent extends Container {
 	private command: string;
 	private outputLines: string[] = [];
-	private status: "running" | "complete" | "cancelled" | "error" = "running";
+	private status: "running" | "backgrounded" | "complete" | "cancelled" | "error" = "running";
 	private exitCode: number | undefined = undefined;
 	private loader: Loader;
 	private truncationResult?: TruncationResult;
@@ -56,7 +56,7 @@ export class BashExecutionComponent extends Container {
 			ui,
 			(spinner) => theme.fg(colorKey, spinner),
 			(text) => theme.fg("muted", text),
-			`Running... (${keyText("tui.select.cancel")} to cancel)`, // Plain text for loader
+			`Running... (${keyText("tui.select.cancel")} to cancel, ${keyText("app.bash.background")} to background)`,
 		);
 		this.contentContainer.addChild(this.loader);
 
@@ -92,6 +92,15 @@ export class BashExecutionComponent extends Container {
 			this.outputLines.push(...newLines);
 		}
 
+		this.updateDisplay();
+	}
+
+	setBackgrounded(): void {
+		if (this.status !== "running") {
+			return;
+		}
+		this.status = "backgrounded";
+		this.loader.stop();
 		this.updateDisplay();
 	}
 
@@ -186,6 +195,8 @@ export class BashExecutionComponent extends Container {
 
 			if (this.status === "cancelled") {
 				statusParts.push(theme.fg("warning", "(cancelled)"));
+			} else if (this.status === "backgrounded") {
+				statusParts.push(theme.fg("muted", "Running in background"));
 			} else if (this.status === "error") {
 				statusParts.push(theme.fg("error", `(exit ${this.exitCode})`));
 			}

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -1,12 +1,14 @@
 import { Editor, type EditorOptions, type EditorTheme, type TUI } from "@earendil-works/pi-tui";
 import type { AppKeybinding, KeybindingsManager } from "../../../core/keybindings.js";
 
+type AppActionHandler = () => unknown;
+
 /**
  * Custom editor that handles app-level keybindings for coding-agent.
  */
 export class CustomEditor extends Editor {
 	private keybindings: KeybindingsManager;
-	public actionHandlers: Map<AppKeybinding, () => void> = new Map();
+	public actionHandlers: Map<AppKeybinding, AppActionHandler> = new Map();
 
 	// Special handlers that can be dynamically replaced
 	public onEscape?: () => void;
@@ -23,7 +25,7 @@ export class CustomEditor extends Editor {
 	/**
 	 * Register a handler for an app action.
 	 */
-	onAction(action: AppKeybinding, handler: () => void): void {
+	onAction(action: AppKeybinding, handler: AppActionHandler): void {
 		this.actionHandlers.set(action, handler);
 	}
 
@@ -69,8 +71,10 @@ export class CustomEditor extends Editor {
 		// Check all other app actions
 		for (const [action, handler] of this.actionHandlers) {
 			if (action !== "app.interrupt" && action !== "app.exit" && this.keybindings.matches(data, action)) {
-				handler();
-				return;
+				const handled = handler();
+				if (handled !== false) {
+					return;
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -291,6 +291,14 @@ export class InteractiveMode {
 
 	// Track current bash execution component
 	private bashComponent: BashExecutionComponent | undefined = undefined;
+	private foregroundBashExecution:
+		| {
+				command: string;
+				component: BashExecutionComponent;
+				backgrounded: boolean;
+				resolveBackgrounded: () => void;
+		  }
+		| undefined = undefined;
 
 	// Track pending bash components (shown in pending area, moved to chat on submit)
 	private pendingBashComponents: BashExecutionComponent[] = [];
@@ -2381,6 +2389,7 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.clear", () => this.handleCtrlC());
 		this.defaultEditor.onCtrlD = () => this.handleCtrlD();
 		this.defaultEditor.onAction("app.suspend", () => this.handleCtrlZ());
+		this.defaultEditor.onAction("app.bash.background", () => this.handleBackgroundBashAction());
 		this.defaultEditor.onAction("app.thinking.cycle", () => this.cycleThinkingLevel());
 		this.defaultEditor.onAction("app.model.cycleForward", () => this.cycleModel("forward"));
 		this.defaultEditor.onAction("app.model.cycleBackward", () => this.cycleModel("backward"));
@@ -5343,6 +5352,31 @@ export class InteractiveMode {
 		}
 	}
 
+	private handleBackgroundBashAction(): boolean {
+		const execution = this.foregroundBashExecution;
+		if (!execution) {
+			return false;
+		}
+		if (!this.session.backgroundBash()) {
+			return false;
+		}
+
+		execution.backgrounded = true;
+		execution.component.setBackgrounded();
+		execution.resolveBackgrounded();
+
+		if (this.bashComponent === execution.component) {
+			this.bashComponent = undefined;
+		}
+		if (this.foregroundBashExecution === execution) {
+			this.foregroundBashExecution = undefined;
+		}
+
+		this.showStatus(`Backgrounded bash: ${execution.command}`);
+		this.ui.requestRender();
+		return true;
+	}
+
 	private async handleBashCommand(command: string, excludeFromContext = false): Promise<void> {
 		const extensionRunner = this.session.extensionRunner;
 
@@ -5387,47 +5421,72 @@ export class InteractiveMode {
 
 		// Normal execution path (possibly with custom operations)
 		const isDeferred = this.session.isStreaming;
-		this.bashComponent = new BashExecutionComponent(command, this.ui, excludeFromContext);
+		const component = new BashExecutionComponent(command, this.ui, excludeFromContext);
+		this.bashComponent = component;
 
 		if (isDeferred) {
 			// Show in pending area when agent is streaming
-			this.pendingMessagesContainer.addChild(this.bashComponent);
-			this.pendingBashComponents.push(this.bashComponent);
+			this.pendingMessagesContainer.addChild(component);
+			this.pendingBashComponents.push(component);
 		} else {
 			// Show in chat immediately when agent is idle
-			this.chatContainer.addChild(this.bashComponent);
+			this.chatContainer.addChild(component);
 		}
 		this.ui.requestRender();
 
-		try {
-			const result = await this.session.executeBash(
-				command,
-				(chunk) => {
-					if (this.bashComponent) {
-						this.bashComponent.appendOutput(chunk);
-						this.ui.requestRender();
-					}
-				},
-				{ excludeFromContext, operations: eventResult?.operations },
-			);
+		let resolveBackgrounded = () => {};
+		const backgroundedPromise = new Promise<void>((resolve) => {
+			resolveBackgrounded = resolve;
+		});
+		const execution = {
+			command,
+			component,
+			backgrounded: false,
+			resolveBackgrounded,
+		};
+		this.foregroundBashExecution = execution;
 
-			if (this.bashComponent) {
-				this.bashComponent.setComplete(
+		const completionPromise = (async () => {
+			try {
+				const result = await this.session.executeBash(
+					command,
+					(chunk) => {
+						component.appendOutput(chunk);
+						this.ui.requestRender();
+					},
+					{ excludeFromContext, operations: eventResult?.operations },
+				);
+
+				component.setComplete(
 					result.exitCode,
 					result.cancelled,
 					result.truncated ? ({ truncated: true, content: result.output } as TruncationResult) : undefined,
 					result.fullOutputPath,
 				);
-			}
-		} catch (error) {
-			if (this.bashComponent) {
-				this.bashComponent.setComplete(undefined, false);
-			}
-			this.showError(`Bash command failed: ${error instanceof Error ? error.message : "Unknown error"}`);
-		}
 
-		this.bashComponent = undefined;
-		this.ui.requestRender();
+				if (execution.backgrounded) {
+					const status = result.cancelled
+						? `Background bash cancelled: ${command}`
+						: result.exitCode && result.exitCode !== 0
+							? `Background bash exited ${result.exitCode}: ${command}`
+							: `Background bash finished: ${command}`;
+					this.showStatus(status);
+				}
+			} catch (error) {
+				component.setComplete(undefined, false);
+				this.showError(`Bash command failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+			} finally {
+				if (this.bashComponent === component) {
+					this.bashComponent = undefined;
+				}
+				if (this.foregroundBashExecution === execution) {
+					this.foregroundBashExecution = undefined;
+				}
+				this.ui.requestRender();
+			}
+		})();
+
+		await Promise.race([completionPromise, backgroundedPromise]);
 	}
 
 	private async handleCompactCommand(customInstructions?: string): Promise<void> {

--- a/packages/coding-agent/test/bash-execution-background.test.ts
+++ b/packages/coding-agent/test/bash-execution-background.test.ts
@@ -1,0 +1,39 @@
+import stripAnsi from "strip-ansi";
+import { beforeAll, describe, expect, it } from "vitest";
+import { BashExecutionComponent } from "../src/modes/interactive/components/bash-execution.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+
+function createTuiStub(): any {
+	return {
+		terminal: {
+			columns: 120,
+			rows: 24,
+		},
+		addInterval: (_cb: () => void, _ms: number) => ({ dispose: () => {} }),
+		removeInterval: () => {},
+		requestRender: () => {},
+	};
+}
+
+describe("BashExecutionComponent backgrounding", () => {
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	it("shows backgrounded state without the cancel hint and still completes later", () => {
+		const component = new BashExecutionComponent("sleep 10", createTuiStub());
+
+		component.setBackgrounded();
+
+		const backgrounded = stripAnsi(component.render(120).join("\n"));
+		expect(backgrounded).toContain("Running in background");
+		expect(backgrounded).not.toContain("to cancel");
+
+		component.appendOutput("done\n");
+		component.setComplete(0, false);
+
+		const completed = stripAnsi(component.render(120).join("\n"));
+		expect(completed).toContain("done");
+		expect(completed).not.toContain("Running in background");
+	});
+});

--- a/packages/coding-agent/test/custom-editor-action-fallback.test.ts
+++ b/packages/coding-agent/test/custom-editor-action-fallback.test.ts
@@ -1,0 +1,59 @@
+import { Editor } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CustomEditor } from "../src/modes/interactive/components/custom-editor.js";
+
+describe("CustomEditor app action fallback", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("falls through to editor handling when an app action explicitly returns false", () => {
+		const superSpy = vi.spyOn(Editor.prototype, "handleInput").mockImplementation(() => {});
+		const handler = vi.fn(() => false);
+		const fakeThis = {
+			onExtensionShortcut: undefined,
+			keybindings: {
+				matches: (_data: string, action: string) => action === "app.bash.background",
+			},
+			onPasteImage: undefined,
+			onEscape: undefined,
+			onCtrlD: undefined,
+			isShowingAutocomplete: () => false,
+			getText: () => "",
+			actionHandlers: new Map([["app.bash.background", handler]]),
+		};
+
+		(CustomEditor.prototype as unknown as { handleInput(this: unknown, data: string): void }).handleInput.call(
+			fakeThis,
+			"\u0002",
+		);
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(superSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("consumes the key when an app action handles it", () => {
+		const superSpy = vi.spyOn(Editor.prototype, "handleInput").mockImplementation(() => {});
+		const handler = vi.fn(() => true);
+		const fakeThis = {
+			onExtensionShortcut: undefined,
+			keybindings: {
+				matches: (_data: string, action: string) => action === "app.bash.background",
+			},
+			onPasteImage: undefined,
+			onEscape: undefined,
+			onCtrlD: undefined,
+			isShowingAutocomplete: () => false,
+			getText: () => "",
+			actionHandlers: new Map([["app.bash.background", handler]]),
+		};
+
+		(CustomEditor.prototype as unknown as { handleInput(this: unknown, data: string): void }).handleInput.call(
+			fakeThis,
+			"\u0002",
+		);
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(superSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -132,6 +132,59 @@ describe("AgentSession bash and persistence characterization", () => {
 		expect(harness.session.isBashRunning).toBe(false);
 	});
 
+	it("backgrounds one bash execution without clearing a newer foreground execution", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		let releaseFirst: (() => void) | undefined;
+		let releaseSecond: (() => void) | undefined;
+
+		const firstOperations: BashOperations = {
+			exec: async (_command, _cwd, options) => {
+				return await new Promise<{ exitCode: number | null }>((resolve) => {
+					releaseFirst = () => {
+						options.onData(Buffer.from("first complete"));
+						resolve({ exitCode: 0 });
+					};
+				});
+			},
+		};
+
+		const secondOperations: BashOperations = {
+			exec: async (_command, _cwd, options) => {
+				return await new Promise<{ exitCode: number | null }>((resolve) => {
+					releaseSecond = () => {
+						options.onData(Buffer.from("second complete"));
+						resolve({ exitCode: 0 });
+					};
+				});
+			},
+		};
+
+		const firstPromise = harness.session.executeBash("first", undefined, { operations: firstOperations });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(harness.session.isBashRunning).toBe(true);
+
+		expect(harness.session.backgroundBash()).toBe(true);
+		expect(harness.session.isBashRunning).toBe(false);
+
+		const secondPromise = harness.session.executeBash("second", undefined, { operations: secondOperations });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(harness.session.isBashRunning).toBe(true);
+
+		releaseFirst?.();
+		await firstPromise;
+		expect(harness.session.isBashRunning).toBe(true);
+
+		releaseSecond?.();
+		await secondPromise;
+		expect(harness.session.isBashRunning).toBe(false);
+
+		const bashMessages = harness.session.messages.filter((message) => message.role === "bashExecution");
+		expect(bashMessages).toHaveLength(2);
+		expect(bashMessages.map((message) => message.command)).toEqual(["first", "second"]);
+	});
+
 	it("persists user, assistant, toolResult, and custom messages in order", async () => {
 		const echoTool: AgentTool = {
 			name: "echo",

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,9 +22,11 @@ export default defineConfig({
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@earendil-works\/pi-tui$/, replacement: tuiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},
 });


### PR DESCRIPTION
## Summary
- add runtime support for backgrounding direct interactive `!` bash commands with `Ctrl+B`
- keep `Ctrl+B` falling back to normal cursor-left behavior when no direct bash command is running
- update the bash execution UI, session tracking, docs, and focused tests for the new flow

## Why
Direct interactive bash in pi blocked the session until completion, and the runtime had no way to detach the active command without killing it. This change adds a real background path for the direct shell lane instead of requiring tmux for every long-running command.

## Impact
- direct `!` bash commands can be backgrounded while pi stays interactive
- backgrounded commands continue streaming into the transcript and post a completion status when they finish
- the scope is intentionally limited to direct interactive bash, not agent-issued bash tool calls

## Validation
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-bash-persistence.test.ts test/bash-execution-background.test.ts test/custom-editor-action-fallback.test.ts`
- `git diff --check`
- `npm run check` still fails in the pre-existing `packages/web-ui` baseline due unresolved `@earendil-works/pi-ai` and `@earendil-works/pi-agent-core` imports there
