### PR TITLE
feat(coding-agent): add --json-no-partial to make --mode json output O(n)

### DIFF
--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -6,6 +6,21 @@ pi --mode json "Your prompt"
 
 Outputs all session events as JSON lines to stdout. Useful for integrating pi into other tools or custom UIs.
 
+## `--json-no-partial` (compact streaming)
+
+```bash
+pi --mode json --json-no-partial "Your prompt"
+```
+
+By default, every `message_update` event carries `assistantMessageEvent.partial` (the full accumulated `AssistantMessage` so far) AND `message` (the wrapping `AgentMessage`). For per-token streaming this means each NDJSON line includes every prior token of the assistant message — total log volume grows O(n²) with the number of tokens.
+
+`--json-no-partial` strips those two fields from `message_update` events whose inner type is `text_delta`, `thinking_delta`, or `toolcall_delta`. Each line becomes O(new content). Consolidated `*_end` and `message_end` events are unchanged, so consumers still get the full content at message/turn boundaries.
+
+When to use it:
+- Wrapping `pi` from another agent and persisting its NDJSON to disk.
+- Long thinking/streaming runs where the per-token partials would otherwise blow up log size.
+- Any consumer that only needs the incremental `delta` plus end-of-message content.
+
 ## Event Types
 
 Events are defined in [`AgentSessionEvent`](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/core/agent-session.ts#L102):

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -21,6 +21,7 @@ export interface Args {
 	help?: boolean;
 	version?: boolean;
 	mode?: Mode;
+	jsonNoPartial?: boolean;
 	noSession?: boolean;
 	session?: string;
 	fork?: string;
@@ -76,6 +77,8 @@ export function parseArgs(args: string[]): Args {
 			if (mode === "text" || mode === "json" || mode === "rpc") {
 				result.mode = mode;
 			}
+		} else if (arg === "--json-no-partial") {
+			result.jsonNoPartial = true;
 		} else if (arg === "--continue" || arg === "-c") {
 			result.continue = true;
 		} else if (arg === "--resume" || arg === "-r") {
@@ -220,6 +223,11 @@ ${chalk.bold("Options:")}
   --system-prompt <text>         System prompt (default: coding assistant prompt)
   --append-system-prompt <text>  Append text or file contents to the system prompt (can be used multiple times)
   --mode <mode>                  Output mode: text (default), json, or rpc
+  --json-no-partial              In --mode json, omit the redundant "partial" and "message"
+                                 accumulated-state fields from message_update delta events.
+                                 Each line shrinks from O(n) of all prior tokens to just the
+                                 incremental "delta" — turns O(n²) NDJSON growth into O(n).
+                                 Consolidated *_end / message_end events still carry full content.
   --print, -p                    Non-interactive mode: process prompt and exit
   --continue, -c                 Continue previous session
   --resume, -r                   Select a session to resume

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -716,6 +716,7 @@ export async function main(args: string[], options?: MainOptions) {
 			messages: parsed.messages,
 			initialMessage,
 			initialImages,
+			jsonNoPartial: parsed.jsonNoPartial,
 		});
 		stopThemeWatcher();
 		restoreStdout();

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -23,6 +23,59 @@ export interface PrintModeOptions {
 	initialMessage?: string;
 	/** Images to attach to the initial message */
 	initialImages?: ImageContent[];
+	/**
+	 * In JSON mode, omit the accumulated-state `partial` (and the wrapping
+	 * `message`) fields from `message_update` delta events. The default
+	 * JSON contract emits both, which makes each per-token line carry
+	 * every prior token of the assistant message — turning a streaming
+	 * NDJSON output into O(n²) growth. Setting this flag keeps only the
+	 * `type` and the per-token delta inside `assistantMessageEvent`.
+	 * Consolidated `*_end` and `message_end` events still carry full content.
+	 * Ignored when `mode` is not "json".
+	 */
+	jsonNoPartial?: boolean;
+}
+
+/**
+ * Streaming `assistantMessageEvent.type` values that carry an accumulated
+ * `partial: AssistantMessage` snapshot on every emit. Stripping this field
+ * (and the wrapping `message` on `message_update`) from JSON output for
+ * these event types is what `--json-no-partial` does.
+ */
+const PARTIAL_BEARING_DELTA_TYPES: ReadonlySet<string> = new Set(["text_delta", "thinking_delta", "toolcall_delta"]);
+
+interface MessageUpdateLikeEvent {
+	type: "message_update";
+	message?: unknown;
+	assistantMessageEvent?: { type?: unknown; partial?: unknown };
+}
+
+function isMessageUpdateEvent(event: unknown): event is MessageUpdateLikeEvent {
+	return typeof event === "object" && event !== null && (event as { type?: unknown }).type === "message_update";
+}
+
+/**
+ * Serializes a session event for `--mode json` output. When `jsonNoPartial`
+ * is true and the event is a `message_update` for an accumulated-state
+ * delta type (text_delta / thinking_delta / toolcall_delta), strip the
+ * `assistantMessageEvent.partial` field and the wrapping `message`.
+ */
+export function serializeJsonEvent(event: unknown, jsonNoPartial: boolean): string {
+	if (!jsonNoPartial || !isMessageUpdateEvent(event)) {
+		return JSON.stringify(event);
+	}
+	const inner = event.assistantMessageEvent;
+	const innerType = typeof inner?.type === "string" ? inner.type : "";
+	if (!PARTIAL_BEARING_DELTA_TYPES.has(innerType)) {
+		return JSON.stringify(event);
+	}
+	const { partial: _partial, ...innerStripped } = (inner ?? {}) as unknown as Record<string, unknown>;
+	const { message: _message, assistantMessageEvent: _ame, ...rest } = event as unknown as Record<string, unknown>;
+	return JSON.stringify({
+		...rest,
+		type: "message_update",
+		assistantMessageEvent: innerStripped,
+	});
 }
 
 /**
@@ -30,7 +83,7 @@ export interface PrintModeOptions {
  * Sends prompts to the agent and outputs the result.
  */
 export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: PrintModeOptions): Promise<number> {
-	const { mode, messages = [], initialMessage, initialImages } = options;
+	const { mode, messages = [], initialMessage, initialImages, jsonNoPartial = false } = options;
 	let exitCode = 0;
 	let session = runtimeHost.session;
 	let unsubscribe: (() => void) | undefined;
@@ -102,7 +155,7 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 		unsubscribe?.();
 		unsubscribe = session.subscribe((event) => {
 			if (mode === "json") {
-				writeRawStdout(`${JSON.stringify(event)}\n`);
+				writeRawStdout(`${serializeJsonEvent(event, jsonNoPartial)}\n`);
 			}
 		});
 	};

--- a/packages/coding-agent/test/print-mode-json-no-partial.test.ts
+++ b/packages/coding-agent/test/print-mode-json-no-partial.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { serializeJsonEvent } from "../src/modes/print-mode.js";
+
+// `serializeJsonEvent` is the per-line serializer used by `pi --mode json`.
+// When `--json-no-partial` is passed, it strips the accumulated-state
+// `partial` field (and the wrapping `message`) from `message_update` delta
+// events, turning O(n²) NDJSON growth into O(n) of new content.
+
+const fakePartial = {
+	role: "assistant",
+	content: [{ type: "text", text: "Hello world" }],
+};
+const fakeAgentMessage = { role: "assistant", id: "m1", content: [{ type: "text", text: "Hello world" }] };
+
+const deltaEvent = (innerType: string) => ({
+	type: "message_update",
+	message: fakeAgentMessage,
+	assistantMessageEvent: {
+		type: innerType,
+		contentIndex: 0,
+		delta: " world",
+		partial: fakePartial,
+	},
+});
+
+describe("serializeJsonEvent — default (jsonNoPartial=false)", () => {
+	it("emits the full event including partial and message for delta events", () => {
+		const out = JSON.parse(serializeJsonEvent(deltaEvent("text_delta"), false));
+		expect(out.type).toBe("message_update");
+		expect(out.message).toEqual(fakeAgentMessage);
+		expect(out.assistantMessageEvent.partial).toEqual(fakePartial);
+		expect(out.assistantMessageEvent.delta).toBe(" world");
+	});
+
+	it("passes non-message_update events through unchanged", () => {
+		const event = { type: "agent_end", messages: [fakeAgentMessage] };
+		const out = JSON.parse(serializeJsonEvent(event, false));
+		expect(out).toEqual(event);
+	});
+});
+
+describe("serializeJsonEvent — jsonNoPartial=true", () => {
+	it.each(["text_delta", "thinking_delta", "toolcall_delta"] as const)(
+		"strips partial + message from message_update for %s",
+		(innerType) => {
+			const out = JSON.parse(serializeJsonEvent(deltaEvent(innerType), true));
+			expect(out.type).toBe("message_update");
+			expect(out.message).toBeUndefined();
+			expect(out.assistantMessageEvent.partial).toBeUndefined();
+			expect(out.assistantMessageEvent.type).toBe(innerType);
+			expect(out.assistantMessageEvent.contentIndex).toBe(0);
+			expect(out.assistantMessageEvent.delta).toBe(" world");
+		},
+	);
+
+	it("keeps partial on *_start and *_end events (consolidated content stays)", () => {
+		const startEvent = {
+			type: "message_update",
+			message: fakeAgentMessage,
+			assistantMessageEvent: { type: "text_start", contentIndex: 0, partial: fakePartial },
+		};
+		const endEvent = {
+			type: "message_update",
+			message: fakeAgentMessage,
+			assistantMessageEvent: { type: "text_end", contentIndex: 0, content: "Hello world", partial: fakePartial },
+		};
+		const startOut = JSON.parse(serializeJsonEvent(startEvent, true));
+		const endOut = JSON.parse(serializeJsonEvent(endEvent, true));
+		expect(startOut.assistantMessageEvent.partial).toEqual(fakePartial);
+		expect(startOut.message).toEqual(fakeAgentMessage);
+		expect(endOut.assistantMessageEvent.content).toBe("Hello world");
+		expect(endOut.assistantMessageEvent.partial).toEqual(fakePartial);
+	});
+
+	it("passes non-message_update events through unchanged", () => {
+		const events = [
+			{ type: "agent_start" },
+			{ type: "turn_start" },
+			{ type: "turn_end", message: fakeAgentMessage, toolResults: [] },
+			{ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: {} },
+			{ type: "tool_execution_end", toolCallId: "t1", toolName: "read", result: "ok", isError: false },
+			{ type: "agent_end", messages: [fakeAgentMessage] },
+		];
+		for (const event of events) {
+			expect(JSON.parse(serializeJsonEvent(event, true))).toEqual(event);
+		}
+	});
+
+	it("handles malformed events safely (passes through)", () => {
+		expect(serializeJsonEvent(null, true)).toBe("null");
+		expect(serializeJsonEvent({ type: "message_update" }, true)).toBe(JSON.stringify({ type: "message_update" }));
+	});
+
+	it("turns O(n²) growth into O(n) for a 100-token simulated stream", () => {
+		// Without the flag, every line carries the full prior accumulated text.
+		// With the flag, every line carries only the new chunk.
+		const tokens = 100;
+		let accumulated = "";
+		let withPartialBytes = 0;
+		let withoutPartialBytes = 0;
+		for (let i = 0; i < tokens; i++) {
+			const chunk = `chunk-${i}-${"x".repeat(64)}`;
+			accumulated += chunk;
+			const event = {
+				type: "message_update",
+				message: { role: "assistant", content: [{ type: "text", text: accumulated }] },
+				assistantMessageEvent: {
+					type: "text_delta",
+					contentIndex: 0,
+					delta: chunk,
+					partial: { role: "assistant", content: [{ type: "text", text: accumulated }] },
+				},
+			};
+			withPartialBytes += serializeJsonEvent(event, false).length;
+			withoutPartialBytes += serializeJsonEvent(event, true).length;
+		}
+		expect(withoutPartialBytes).toBeLessThan(withPartialBytes / 5);
+	});
+});


### PR DESCRIPTION
## Problem

`pi --mode json` currently emits, on every per-token streaming update, both the wrapping `event.message` (an `AgentMessage`) and `event.assistantMessageEvent.partial` (an `AssistantMessage`) — each of which carries the **full accumulated content so far**. For long thinking / streaming runs, total NDJSON volume grows **O(n²)** in the number of tokens.

I hit this in production wrapping `pi` from another agent. A single 4-minute turn with ~8.5K thinking-token chars produced a **46MB log**, with per-line size growing from ~1.8KB at offset 0 to ~24KB at offset 46MB. The work pi did was perfectly fine — the disk log was simply quadratic in the token count.

`partial` and `message` are not consumed inside coding-agent's own modules (verified by grep across `src/`); they are pure emission-time bloat for streaming consumers that only need the incremental `delta` plus the consolidated `*_end` content.

## Fix

Adds an opt-in flag:

\`\`\`bash
pi --mode json --json-no-partial "your prompt"
\`\`\`

Behavior:
- Affects only `message_update` events whose `assistantMessageEvent.type` is `text_delta` / `thinking_delta` / `toolcall_delta` (the per-token delta types that carry `partial`).
- Strips `partial` from `assistantMessageEvent` and the wrapping `message` from the event itself.
- Keeps `type`, `contentIndex`, `delta`, and any other inner fields.
- Leaves `*_start` / `*_end` events, `message_end`, `turn_end`, `agent_end`, `tool_execution_*`, `error`, and all other event types unchanged.
- Default JSON mode behavior is unchanged — fully backwards-compatible.

## Implementation

- `src/cli/args.ts` — new `--json-no-partial` flag, plumbed through `Args.jsonNoPartial`.
- `src/main.ts` — passes the flag into `runPrintMode`.
- `src/modes/print-mode.ts` — extracts a pure `serializeJsonEvent(event, jsonNoPartial)` helper that the subscribe handler uses. The in-memory event API (`session.subscribe`, extension runner) is **untouched**.
- `docs/json.md` — adds a `--json-no-partial` section explaining the bloat and when to use the flag.

## Tests

9 new vitest cases in `test/print-mode-json-no-partial.test.ts`:
- Default (`jsonNoPartial=false`): emits full `partial` + `message` (regression guard).
- For each delta type (`text_delta`, `thinking_delta`, `toolcall_delta`): strips both fields.
- `*_start` / `*_end` events: keep `partial` (consolidated content stays).
- Structural events (`agent_start`, `turn_start`, `turn_end`, `tool_execution_*`, `agent_end`): pass through unchanged.
- Malformed input handled safely (`null`, missing `assistantMessageEvent`).
- A 100-token simulated stream asserts >5× byte reduction with the flag.

All 1176 existing coding-agent tests continue to pass. \`tsgo --noEmit\` clean.

## Why opt-in

Some external consumers may depend on `partial` for resumable streaming or debugging. Making this opt-in keeps the default JSON contract stable. If you'd accept changing the default in a follow-up PR (with a `--include-partial` opt-out for back-compat), I'm happy to do that — just say the word.

## Notes

- `coding-agent`'s own modules don't read `partial` (verified by grep for `\\.partial\\b` excluding `partialResult`, which is a different field on tool execution events). The field is purely emission-time.
- The flag is gated to `--mode json`; in `text` and `rpc` modes it's silently ignored.
- Co-authored with Claude Code (Anthropic) — see commit trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)