### PR TITLE
fix(agent): split browser-safe core entry from harness exports

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Fixed browser builds by keeping the root `@earendil-works/pi-agent-core` entry browser-safe and moving harness exports to `@earendil-works/pi-agent-core/harness` ([#4387](https://github.com/earendil-works/pi/issues/4387))
+
 ## [0.74.0] - 2026-05-07
 
 ## [0.73.1] - 2026-05-07

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -5,6 +5,16 @@
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./harness": {
+			"types": "./dist/harness.d.ts",
+			"import": "./dist/harness.js"
+		}
+	},
 	"files": [
 		"dist",
 		"README.md"

--- a/packages/agent/src/harness.ts
+++ b/packages/agent/src/harness.ts
@@ -1,0 +1,32 @@
+export * from "./harness/agent-harness.js";
+export {
+	collectEntriesForBranchSummary,
+	generateBranchSummary,
+	prepareBranchEntries,
+} from "./harness/compaction/branch-summarization.js";
+export {
+	calculateContextTokens,
+	compact,
+	DEFAULT_COMPACTION_SETTINGS,
+	estimateContextTokens,
+	estimateTokens,
+	findCutPoint,
+	findTurnStartIndex,
+	generateSummary,
+	getLastAssistantUsage,
+	prepareCompaction,
+	serializeConversation,
+	shouldCompact,
+} from "./harness/compaction/compaction.js";
+export * from "./harness/execution-env.js";
+export * from "./harness/messages.js";
+export * from "./harness/prompt-templates.js";
+export * from "./harness/session/repo/jsonl.js";
+export * from "./harness/session/repo/memory.js";
+export * from "./harness/session/repo/shared.js";
+export * from "./harness/session/session.js";
+export * from "./harness/skills.js";
+export * from "./harness/system-prompt.js";
+export * from "./harness/types.js";
+export * from "./harness/utils/shell-output.js";
+export * from "./harness/utils/truncate.js";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,39 +2,6 @@
 export * from "./agent.js";
 // Loop functions
 export * from "./agent-loop.js";
-export * from "./harness/agent-harness.js";
-export {
-	collectEntriesForBranchSummary,
-	generateBranchSummary,
-	prepareBranchEntries,
-} from "./harness/compaction/branch-summarization.js";
-export {
-	calculateContextTokens,
-	compact,
-	DEFAULT_COMPACTION_SETTINGS,
-	estimateContextTokens,
-	estimateTokens,
-	findCutPoint,
-	findTurnStartIndex,
-	generateSummary,
-	getLastAssistantUsage,
-	prepareCompaction,
-	serializeConversation,
-	shouldCompact,
-} from "./harness/compaction/compaction.js";
-export * from "./harness/execution-env.js";
-export * from "./harness/messages.js";
-export * from "./harness/prompt-templates.js";
-export * from "./harness/session/repo/jsonl.js";
-export * from "./harness/session/repo/memory.js";
-export * from "./harness/session/repo/shared.js";
-export * from "./harness/session/session.js";
-export * from "./harness/skills.js";
-export * from "./harness/system-prompt.js";
-// Harness
-export * from "./harness/types.js";
-export * from "./harness/utils/shell-output.js";
-export * from "./harness/utils/truncate.js";
 // Proxy utilities
 export * from "./proxy.js";
 // Types

--- a/packages/agent/test/scratch/simple.ts
+++ b/packages/agent/test/scratch/simple.ts
@@ -11,7 +11,7 @@ import {
 	type PromptTemplate,
 	Session,
 	type Skill,
-} from "../../src/index.js";
+} from "../../src/harness.js";
 
 type Source = { type: "project" | "user" | "path"; dir: string };
 type SourcedSkill = Skill & { source: Source };


### PR DESCRIPTION
## Summary

- keep the root `@earendil-works/pi-agent-core` entry browser-safe by exporting only the core agent APIs
- add a dedicated `@earendil-works/pi-agent-core/harness` entrypoint for Node-oriented harness exports
- update the scratch harness import and changelog to match the new public surface

This is intentionally breaking for consumers that imported harness APIs from the package root. Those imports should move to `@earendil-works/pi-agent-core/harness`.

Fixes #4387

## Testing

- `npm run check`
- `cd packages/agent && npm run build`
- `cd packages/web-ui/example && npm run build`
