### PR TITLE
fix(coding-agent): dispose SDK example sessions

### DIFF
--- a/packages/coding-agent/examples/sdk/01-minimal.ts
+++ b/packages/coding-agent/examples/sdk/01-minimal.ts
@@ -9,14 +9,18 @@ import { createAgentSession } from "@earendil-works/pi-coding-agent";
 
 const { session } = await createAgentSession();
 
-session.subscribe((event) => {
-	if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-		process.stdout.write(event.assistantMessageEvent.delta);
-	}
-});
+try {
+	session.subscribe((event) => {
+		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			process.stdout.write(event.assistantMessageEvent.delta);
+		}
+	});
 
-await session.prompt("What files are in the current directory?");
-session.state.messages.forEach((msg) => {
-	console.log(msg);
-});
-console.log();
+	await session.prompt("What files are in the current directory?");
+	session.state.messages.forEach((msg) => {
+		console.log(msg);
+	});
+	console.log();
+} finally {
+	session.dispose();
+}

--- a/packages/coding-agent/examples/sdk/02-custom-model.ts
+++ b/packages/coding-agent/examples/sdk/02-custom-model.ts
@@ -38,12 +38,16 @@ if (available.length > 0) {
 		modelRegistry,
 	});
 
-	session.subscribe((event) => {
-		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-			process.stdout.write(event.assistantMessageEvent.delta);
-		}
-	});
+	try {
+		session.subscribe((event) => {
+			if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+				process.stdout.write(event.assistantMessageEvent.delta);
+			}
+		});
 
-	await session.prompt("Say hello in one sentence.");
-	console.log();
+		await session.prompt("Say hello in one sentence.");
+		console.log();
+	} finally {
+		session.dispose();
+	}
 }

--- a/packages/coding-agent/examples/sdk/03-custom-prompt.ts
+++ b/packages/coding-agent/examples/sdk/03-custom-prompt.ts
@@ -30,15 +30,19 @@ const { session: session1 } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 });
 
-session1.subscribe((event) => {
-	if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-		process.stdout.write(event.assistantMessageEvent.delta);
-	}
-});
+try {
+	session1.subscribe((event) => {
+		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			process.stdout.write(event.assistantMessageEvent.delta);
+		}
+	});
 
-console.log("=== Replace prompt ===");
-await session1.prompt("What is 2 + 2?");
-console.log("\n");
+	console.log("=== Replace prompt ===");
+	await session1.prompt("What is 2 + 2?");
+	console.log("\n");
+} finally {
+	session1.dispose();
+}
 
 // Option 2: Append instructions to the default prompt
 const loader2 = new DefaultResourceLoader({
@@ -56,12 +60,16 @@ const { session: session2 } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 });
 
-session2.subscribe((event) => {
-	if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-		process.stdout.write(event.assistantMessageEvent.delta);
-	}
-});
+try {
+	session2.subscribe((event) => {
+		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			process.stdout.write(event.assistantMessageEvent.delta);
+		}
+	});
 
-console.log("=== Modify prompt ===");
-await session2.prompt("List 3 benefits of TypeScript.");
-console.log();
+	console.log("=== Modify prompt ===");
+	await session2.prompt("List 3 benefits of TypeScript.");
+	console.log();
+} finally {
+	session2.dispose();
+}

--- a/packages/coding-agent/examples/sdk/04-skills.ts
+++ b/packages/coding-agent/examples/sdk/04-skills.ts
@@ -47,9 +47,9 @@ if (diagnostics.length > 0) {
 	console.log("Warnings:", diagnostics);
 }
 
-await createAgentSession({
+const { session } = await createAgentSession({
 	resourceLoader: loader,
 	sessionManager: SessionManager.inMemory(),
 });
-
 console.log("Session created with filtered skills");
+session.dispose();

--- a/packages/coding-agent/examples/sdk/05-tools.ts
+++ b/packages/coding-agent/examples/sdk/05-tools.ts
@@ -13,32 +13,36 @@
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 
 // Read-only mode (no edit/write)
-await createAgentSession({
+const { session: readOnlySession } = await createAgentSession({
 	tools: ["read", "grep", "find", "ls"],
 	sessionManager: SessionManager.inMemory(),
 });
 console.log("Read-only session created");
+readOnlySession.dispose();
 
 // Custom tool selection
-await createAgentSession({
+const { session: customToolsSession } = await createAgentSession({
 	tools: ["read", "bash", "grep"],
 	sessionManager: SessionManager.inMemory(),
 });
 console.log("Custom tools session created");
+customToolsSession.dispose();
 
 // With custom cwd
 const customCwd = "/path/to/project";
-await createAgentSession({
+const { session: customCwdSession } = await createAgentSession({
 	cwd: customCwd,
 	tools: ["read", "bash", "edit", "write"],
 	sessionManager: SessionManager.inMemory(customCwd),
 });
 console.log("Custom cwd session created");
+customCwdSession.dispose();
 
 // Or pick specific tools for custom cwd
-await createAgentSession({
+const { session: specificToolsSession } = await createAgentSession({
 	cwd: customCwd,
 	tools: ["read", "bash", "grep"],
 	sessionManager: SessionManager.inMemory(customCwd),
 });
 console.log("Specific tools with custom cwd session created");
+specificToolsSession.dispose();

--- a/packages/coding-agent/examples/sdk/06-extensions.ts
+++ b/packages/coding-agent/examples/sdk/06-extensions.ts
@@ -42,14 +42,18 @@ const { session } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 });
 
-session.subscribe((event) => {
-	if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-		process.stdout.write(event.assistantMessageEvent.delta);
-	}
-});
+try {
+	session.subscribe((event) => {
+		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			process.stdout.write(event.assistantMessageEvent.delta);
+		}
+	});
 
-await session.prompt("List files in the current directory.");
-console.log();
+	await session.prompt("List files in the current directory.");
+	console.log();
+} finally {
+	session.dispose();
+}
 
 // Example extension file (./my-logging-extension.ts):
 /*

--- a/packages/coding-agent/examples/sdk/07-context-files.ts
+++ b/packages/coding-agent/examples/sdk/07-context-files.ts
@@ -39,9 +39,9 @@ for (const file of discovered) {
 	console.log(`  - ${file.path} (${file.content.length} chars)`);
 }
 
-await createAgentSession({
+const { session } = await createAgentSession({
 	resourceLoader: loader,
 	sessionManager: SessionManager.inMemory(),
 });
-
 console.log(`Session created with ${discovered.length + 1} context files`);
+session.dispose();

--- a/packages/coding-agent/examples/sdk/08-prompt-templates.ts
+++ b/packages/coding-agent/examples/sdk/08-prompt-templates.ts
@@ -43,9 +43,9 @@ for (const template of discovered) {
 	console.log(`  /${template.name}: ${template.description}`);
 }
 
-await createAgentSession({
+const { session } = await createAgentSession({
 	resourceLoader: loader,
 	sessionManager: SessionManager.inMemory(),
 });
-
 console.log(`Session created with ${discovered.length + 1} prompt templates`);
+session.dispose();

--- a/packages/coding-agent/examples/sdk/09-api-keys-and-oauth.ts
+++ b/packages/coding-agent/examples/sdk/09-api-keys-and-oauth.ts
@@ -11,38 +11,42 @@ import { AuthStorage, createAgentSession, ModelRegistry, SessionManager } from "
 const authStorage = AuthStorage.create();
 const modelRegistry = ModelRegistry.create(authStorage);
 
-await createAgentSession({
+const { session: defaultAuthSession } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 	authStorage,
 	modelRegistry,
 });
 console.log("Session with default auth storage and model registry");
+defaultAuthSession.dispose();
 
 // Custom auth storage location
 const customAuthStorage = AuthStorage.create("/tmp/my-app/auth.json");
 const customModelRegistry = ModelRegistry.create(customAuthStorage, "/tmp/my-app/models.json");
 
-await createAgentSession({
+const { session: customAuthSession } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 	authStorage: customAuthStorage,
 	modelRegistry: customModelRegistry,
 });
 console.log("Session with custom auth storage location");
+customAuthSession.dispose();
 
 // Runtime API key override (not persisted to disk)
 authStorage.setRuntimeApiKey("anthropic", "sk-my-temp-key");
-await createAgentSession({
+const { session: runtimeKeySession } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 	authStorage,
 	modelRegistry,
 });
 console.log("Session with runtime API key override");
+runtimeKeySession.dispose();
 
 // No models.json - only built-in models
 const simpleRegistry = ModelRegistry.inMemory(authStorage);
-await createAgentSession({
+const { session: builtInModelsSession } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 	authStorage,
 	modelRegistry: simpleRegistry,
 });
 console.log("Session with only built-in models");
+builtInModelsSession.dispose();

--- a/packages/coding-agent/examples/sdk/10-settings.ts
+++ b/packages/coding-agent/examples/sdk/10-settings.ts
@@ -19,12 +19,12 @@ settingsManager.applyOverrides({
 	retry: { enabled: true, maxRetries: 5, baseDelayMs: 1000 },
 });
 
-await createAgentSession({
+const { session: customSettingsSession } = await createAgentSession({
 	settingsManager,
 	sessionManager: SessionManager.inMemory(),
 });
-
 console.log("Session created with custom settings");
+customSettingsSession.dispose();
 
 // Setters update memory immediately and queue persistence writes.
 // Call flush() when you need a durability boundary.
@@ -45,9 +45,9 @@ const inMemorySettings = SettingsManager.inMemory({
 	retry: { enabled: false },
 });
 
-await createAgentSession({
+const { session: testSession } = await createAgentSession({
 	settingsManager: inMemorySettings,
 	sessionManager: SessionManager.inMemory(),
 });
-
 console.log("Test session created with in-memory settings");
+testSession.dispose();

--- a/packages/coding-agent/examples/sdk/11-sessions.ts
+++ b/packages/coding-agent/examples/sdk/11-sessions.ts
@@ -11,12 +11,14 @@ const { session: inMemory } = await createAgentSession({
 	sessionManager: SessionManager.inMemory(),
 });
 console.log("In-memory session:", inMemory.sessionFile ?? "(none)");
+inMemory.dispose();
 
 // New persistent session
 const { session: newSession } = await createAgentSession({
 	sessionManager: SessionManager.create(process.cwd()),
 });
 console.log("New session file:", newSession.sessionFile);
+newSession.dispose();
 
 // Continue most recent session (or create new if none)
 const { session: continued, modelFallbackMessage } = await createAgentSession({
@@ -24,6 +26,7 @@ const { session: continued, modelFallbackMessage } = await createAgentSession({
 });
 if (modelFallbackMessage) console.log("Note:", modelFallbackMessage);
 console.log("Continued session:", continued.sessionFile);
+continued.dispose();
 
 // List and open specific session
 const sessions = await SessionManager.list(process.cwd());
@@ -37,6 +40,7 @@ if (sessions.length > 0) {
 		sessionManager: SessionManager.open(sessions[0].path),
 	});
 	console.log(`\nOpened: ${opened.sessionId}`);
+	opened.dispose();
 }
 
 // Custom session directory (no cwd encoding)

--- a/packages/coding-agent/examples/sdk/12-full-control.ts
+++ b/packages/coding-agent/examples/sdk/12-full-control.ts
@@ -63,11 +63,15 @@ const { session } = await createAgentSession({
 	settingsManager,
 });
 
-session.subscribe((event) => {
-	if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-		process.stdout.write(event.assistantMessageEvent.delta);
-	}
-});
+try {
+	session.subscribe((event) => {
+		if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
+			process.stdout.write(event.assistantMessageEvent.delta);
+		}
+	});
 
-await session.prompt("List files in the current directory.");
-console.log();
+	await session.prompt("List files in the current directory.");
+	console.log();
+} finally {
+	session.dispose();
+}


### PR DESCRIPTION
   ## Summary

   Ensure SDK examples clean up their session/runtime before exiting.

   ## Problem

   When `transport` is configured as `websocket-cached`, one-shot SDK examples complete their work but leave the Node process running.

   ## How to reproduce

   ```bash
   pi settings set transport websocket-cached
   cd packages/coding-agent
   npx tsx examples/sdk/01-minimal.ts
 ```

 01-minimal.ts prints the final response, then remains alive because the direct SDK session is not disposed. This is the SDK equivalent of the print/json mode hang fixed in #4103.

 ## Changes

 - Add `session.dispose()` to SDK examples that create sessions directly with `createAgentSession()`.

 ## Validation

 - Set transport to websocket-cached.
 - Ran each examples/sdk/*.ts file.
 - Every example process returned promptly.
