### PR TITLE
fix(tui): Hide cursor when tmux pane is not focused

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -471,8 +471,8 @@ export class Editor implements Component, Focusable {
 			let lineVisibleWidth = visibleWidth(layoutLine.text);
 			let cursorInPadding = false;
 
-			// Add cursor if this line has it
-			if (layoutLine.hasCursor && layoutLine.cursorPos !== undefined) {
+			// Add cursor if this line has it and the editor is focused
+			if (this.focused && layoutLine.hasCursor && layoutLine.cursorPos !== undefined) {
 				const before = displayText.slice(0, layoutLine.cursorPos);
 				const after = displayText.slice(layoutLine.cursorPos);
 

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -489,9 +489,9 @@ export class Input implements Component, Focusable {
 		// Hardware cursor marker (zero-width, emitted before fake cursor for IME positioning)
 		const marker = this.focused ? CURSOR_MARKER : "";
 
-		// Use inverse video to show cursor
-		const cursorChar = `\x1b[7m${atCursor}\x1b[27m`; // ESC[7m = reverse video, ESC[27m = normal
-		const textWithCursor = beforeCursor + marker + cursorChar + afterCursor;
+		// Use inverse video to show cursor only while focused
+		const cursorChar = this.focused ? `\x1b[7m${atCursor}\x1b[27m` : atCursor; // ESC[7m = reverse video, ESC[27m = normal
+		const textWithCursor = this.focused ? beforeCursor + marker + cursorChar + afterCursor : visibleText;
 
 		// Calculate visual width
 		const visualLength = visibleWidth(textWithCursor);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -12,6 +12,10 @@ import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } fro
 import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
+const FOCUS_REPORTING_ENABLE = "\x1b[?1004h";
+const FOCUS_REPORTING_DISABLE = "\x1b[?1004l";
+const FOCUS_IN = "\x1b[I";
+const FOCUS_OUT = "\x1b[O";
 
 function extractKittyImageIds(line: string): number[] {
 	const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
@@ -243,6 +247,7 @@ export class TUI extends Container {
 	private previousWidth = 0;
 	private previousHeight = 0;
 	private focusedComponent: Component | null = null;
+	private terminalFocused = true;
 	private inputListeners = new Set<InputListener>();
 
 	/** Global callback for debug key (Shift+Ctrl+D). Called before input is forwarded to focused component. */
@@ -316,9 +321,9 @@ export class TUI extends Container {
 
 		this.focusedComponent = component;
 
-		// Set focused flag on new component
+		// Set focused flag on new component only while the terminal/pane is focused.
 		if (isFocusable(component)) {
-			component.focused = true;
+			component.focused = this.terminalFocused;
 		}
 	}
 
@@ -444,6 +449,9 @@ export class TUI extends Container {
 			(data) => this.handleInput(data),
 			() => this.requestRender(),
 		);
+		// Request terminal focus-in/focus-out events (CSI I / CSI O). Multiplexers such as tmux
+		// forward these when configured with focus-events enabled.
+		this.terminal.write(FOCUS_REPORTING_ENABLE);
 		this.terminal.hideCursor();
 		this.queryCellSize();
 		this.requestRender();
@@ -488,6 +496,7 @@ export class TUI extends Container {
 			this.terminal.write("\r\n");
 		}
 
+		this.terminal.write(FOCUS_REPORTING_DISABLE);
 		this.terminal.showCursor();
 		this.terminal.stop();
 	}
@@ -542,6 +551,10 @@ export class TUI extends Container {
 	}
 
 	private handleInput(data: string): void {
+		if (this.handleFocusEvent(data)) {
+			return;
+		}
+
 		if (this.inputListeners.size > 0) {
 			let current = data;
 			for (const listener of this.inputListeners) {
@@ -594,6 +607,22 @@ export class TUI extends Container {
 			this.focusedComponent.handleInput(data);
 			this.requestRender();
 		}
+	}
+
+	private handleFocusEvent(data: string): boolean {
+		if (data !== FOCUS_IN && data !== FOCUS_OUT) {
+			return false;
+		}
+
+		this.terminalFocused = data === FOCUS_IN;
+		if (isFocusable(this.focusedComponent)) {
+			this.focusedComponent.focused = this.terminalFocused;
+		}
+		if (!this.terminalFocused) {
+			this.terminal.hideCursor();
+		}
+		this.requestRender();
+		return true;
 	}
 
 	private consumeCellSizeResponse(data: string): boolean {
@@ -1310,7 +1339,7 @@ export class TUI extends Container {
 		}
 
 		this.hardwareCursorRow = targetRow;
-		if (this.showHardwareCursor) {
+		if (this.showHardwareCursor && this.terminalFocused) {
 			this.terminal.showCursor();
 		} else {
 			this.terminal.hideCursor();

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import { deleteKittyImage, encodeKitty } from "../src/terminal-image.js";
-import { type Component, TUI } from "../src/tui.js";
+import { type Component, type Focusable, TUI } from "../src/tui.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
 
 class TestComponent implements Component {
@@ -10,6 +10,21 @@ class TestComponent implements Component {
 	render(_width: number): string[] {
 		return this.lines;
 	}
+	invalidate(): void {}
+}
+
+class FocusableTestComponent implements Component, Focusable {
+	focused = false;
+	inputs: string[] = [];
+
+	render(_width: number): string[] {
+		return [this.focused ? "focused" : "unfocused"];
+	}
+
+	handleInput(data: string): void {
+		this.inputs.push(data);
+	}
+
 	invalidate(): void {}
 }
 
@@ -140,6 +155,62 @@ describe("TUI Kitty image cleanup", () => {
 		assert.ok(deleteIndex >= 0, "previous image should be deleted during full redraw");
 		assert.ok(clearIndex >= 0, "full redraw should clear the screen");
 		assert.ok(deleteIndex < clearIndex, "old image should be deleted before the screen is cleared");
+
+		tui.stop();
+	});
+});
+
+describe("TUI focus reporting", () => {
+	it("toggles focusable components on terminal focus events", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const component = new FocusableTestComponent();
+		tui.addChild(component);
+		tui.setFocus(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		assert.strictEqual(component.focused, true);
+		assert.ok(terminal.getWrites().includes("\x1b[?1004h"), "focus reporting should be enabled on start");
+
+		terminal.sendInput("\x1b[O");
+		await terminal.waitForRender();
+		assert.strictEqual(component.focused, false);
+		assert.deepStrictEqual(component.inputs, [], "focus event should not reach the focused component");
+
+		terminal.sendInput("a");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(component.inputs, ["a"], "regular input should still reach the focused component");
+
+		terminal.sendInput("\x1b[I");
+		await terminal.waitForRender();
+		assert.strictEqual(component.focused, true);
+
+		tui.stop();
+		assert.ok(terminal.getWrites().includes("\x1b[?1004l"), "focus reporting should be disabled on stop");
+	});
+
+	it("keeps newly focused components visually unfocused while the terminal is unfocused", async () => {
+		const terminal = new VirtualTerminal(40, 10);
+		const tui = new TUI(terminal);
+		const first = new FocusableTestComponent();
+		const second = new FocusableTestComponent();
+		tui.addChild(first);
+		tui.addChild(second);
+		tui.setFocus(first);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[O");
+		await terminal.waitForRender();
+		tui.setFocus(second);
+
+		assert.strictEqual(first.focused, false);
+		assert.strictEqual(second.focused, false);
+
+		terminal.sendInput("\x1b[I");
+		await terminal.waitForRender();
+		assert.strictEqual(second.focused, true);
 
 		tui.stop();
 	});


### PR DESCRIPTION
When we have a split in tmux panes, cursor was still shown in the not active pi tui pane. With this change we will have cursor only if the pane is active.

PS: used AI to fix the issue.