### PR TITLE
fix(ai): restore Vertex AI ADC URL routing for native endpoints

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -382,7 +382,23 @@ function resolveCustomBaseUrl(baseUrl: string): string | undefined {
 	if (!trimmed || trimmed.includes("{location}")) {
 		return undefined;
 	}
+	if (isNativeVertexEndpoint(trimmed)) {
+		return undefined;
+	}
 	return trimmed;
+}
+
+function isNativeVertexEndpoint(baseUrl: string): boolean {
+	try {
+		const { hostname } = new URL(baseUrl);
+		return (
+			hostname === "aiplatform.googleapis.com" ||
+			hostname.endsWith("-aiplatform.googleapis.com") ||
+			/^aiplatform\.[^.]+\.rep\.googleapis\.com$/.test(hostname)
+		);
+	} catch {
+		return false;
+	}
 }
 
 function baseUrlIncludesApiVersion(baseUrl: string): boolean {

--- a/packages/ai/test/google-vertex-api-key-resolution.test.ts
+++ b/packages/ai/test/google-vertex-api-key-resolution.test.ts
@@ -157,6 +157,47 @@ describe("google-vertex api key resolution", () => {
 		expect(googleGenAiMock.constructorCalls[0]?.httpOptions).toBeUndefined();
 	});
 
+	it("treats global Vertex endpoint as native, not a custom proxy", async () => {
+		const globalModel: Model<"google-vertex"> = { ...model, baseUrl: "https://aiplatform.googleapis.com" };
+		const stream = streamGoogleVertex(globalModel, context, {
+			project: "test-project",
+			location: "global",
+		});
+
+		await stream.result();
+
+		expect(googleGenAiMock.constructorCalls).toHaveLength(1);
+		expect(googleGenAiMock.constructorCalls[0]).toMatchObject({
+			vertexai: true,
+			project: "test-project",
+			location: "global",
+			apiVersion: "v1",
+		});
+		expect(googleGenAiMock.constructorCalls[0]?.httpOptions).toBeUndefined();
+	});
+
+	it("treats hardcoded regional Vertex endpoint as native, not a custom proxy", async () => {
+		const regionalModel: Model<"google-vertex"> = {
+			...model,
+			baseUrl: "https://us-central1-aiplatform.googleapis.com",
+		};
+		const stream = streamGoogleVertex(regionalModel, context, {
+			project: "test-project",
+			location: "us-central1",
+		});
+
+		await stream.result();
+
+		expect(googleGenAiMock.constructorCalls).toHaveLength(1);
+		expect(googleGenAiMock.constructorCalls[0]).toMatchObject({
+			vertexai: true,
+			project: "test-project",
+			location: "us-central1",
+			apiVersion: "v1",
+		});
+		expect(googleGenAiMock.constructorCalls[0]?.httpOptions).toBeUndefined();
+	});
+
 	it("forwards custom baseUrl to the ADC client", async () => {
 		const customModel: Model<"google-vertex"> = { ...model, baseUrl: "https://proxy.example.com" };
 		const stream = streamGoogleVertex(customModel, context, {


### PR DESCRIPTION
fixes #3699