### PR TITLE
fix(coding-agent): restore terminal on uncaught exception

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3245,6 +3245,36 @@ export class InteractiveMode {
 	}
 
 	/**
+	 * Last-resort handler for uncaught exceptions. The TUI puts stdin into raw
+	 * mode and hides the cursor; without this handler, an uncaught throw from
+	 * anywhere (e.g. an extension's async `ChildProcess.on("exit")` callback)
+	 * tears down the process while leaving the terminal in raw mode with no
+	 * cursor, requiring `stty sane && reset` to recover.
+	 *
+	 * Unlike emergencyTerminalExit, the terminal is still alive here, so we
+	 * call ui.stop() to restore cooked mode, the cursor, and disable bracketed
+	 * paste / Kitty / modifyOtherKeys sequences.
+	 */
+	private uncaughtCrash(error: Error): never {
+		if (this.isShuttingDown) {
+			process.exit(1);
+		}
+		this.isShuttingDown = true;
+		try {
+			this.unregisterSignalHandlers();
+		} catch {}
+		try {
+			killTrackedDetachedChildren();
+		} catch {}
+		try {
+			this.ui.stop();
+		} catch {}
+		console.error("pi exiting due to uncaughtException:");
+		console.error(error);
+		process.exit(1);
+	}
+
+	/**
 	 * Check if shutdown was requested and perform shutdown if so.
 	 */
 	private async checkShutdownRequested(): Promise<void> {
@@ -3282,6 +3312,13 @@ export class InteractiveMode {
 		process.stderr.on("error", terminalErrorHandler);
 		this.signalCleanupHandlers.push(() => process.stdout.off("error", terminalErrorHandler));
 		this.signalCleanupHandlers.push(() => process.stderr.off("error", terminalErrorHandler));
+
+		// Restore the terminal before the process dies on any uncaught throw.
+		// Without this, an unhandled exception from extension code (or anywhere
+		// in pi) leaves the terminal in raw mode with no cursor.
+		const uncaughtExceptionHandler = (error: Error) => this.uncaughtCrash(error);
+		process.prependListener("uncaughtException", uncaughtExceptionHandler);
+		this.signalCleanupHandlers.push(() => process.off("uncaughtException", uncaughtExceptionHandler));
 	}
 
 	private unregisterSignalHandlers(): void {


### PR DESCRIPTION
## What

Add a `process.on("uncaughtException", ...)` handler in `InteractiveMode.registerSignalHandlers` that calls `ui.stop()` before exiting.

## Why

The TUI puts stdin into raw mode and hides the cursor. When an uncaught exception fires, Node's default behavior is to print the stack and exit — but it does not restore the terminal first. The user is left with a dead pi process and a terminal that no longer echoes input or shows a cursor, requiring `stty sane && reset` to recover.

The most common trigger I've hit is an extension that throws from a `ChildProcess.on("exit")` callback — for example, an extension that captured a `ctx` reference before a session boundary and tries to use it from an async event handler. Pi 0.73 made stale-ctx access throw, so any extension that does this now reliably crashes pi with a borked terminal. But the underlying issue is broader: any uncaught throw from anywhere in pi or any extension produces the same outcome.

A related, still-open report: #2716 (unhandled `AbortError` from escape during a long bash) describes the same class of crash.

## How

`registerSignalHandlers` already owns `SIGTERM`, `SIGHUP`, and stdout/stderr error handlers, with cleanup tracked in `signalCleanupHandlers`. The new `uncaughtException` handler follows the same pattern:

- `prependListener` so we run before any other handler
- `signalCleanupHandlers.push(off)` so it gets removed on graceful shutdown
- delegates to a new `uncaughtCrash(error)` method that mirrors `emergencyTerminalExit` but calls `this.ui.stop()` instead of skipping it (the terminal is alive on uncaughtException, unlike the SIGHUP / dead-terminal EIO case)
- reentrancy-guarded by `isShuttingDown`

`ui.stop()` is wrapped in `try/catch` so a throw inside it can't recurse into the handler. The error is logged with `console.error` because by replacing the default uncaughtException handler we suppress Node's own crash trace.

Scope is intentionally narrow — `unhandledRejection` is not handled here. Happy to follow up with that if it's wanted.

## Test plan

Manual repro before the fix: drop an extension that throws from a `ChildProcess.exit` handler, fire it, observe the crash leaves the terminal in raw mode (input not echoed, cursor invisible).

After the fix: same setup, pi exits cleanly with the error logged and the terminal restored.

I do not have a non-flaky way to assert "terminal raw mode was restored" inside the existing test harness — open to suggestions if a regression test is wanted.
