### PR TITLE
Add Windows ARM64 Binary Output

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -69,6 +69,7 @@ jobs:
             pi-linux-x64.tar.gz \
             pi-linux-arm64.tar.gz \
             pi-windows-x64.zip \
+            pi-windows-arm64.zip \
             2>/dev/null || \
           gh release upload "${RELEASE_TAG}" \
             pi-darwin-arm64.tar.gz \
@@ -76,4 +77,5 @@ jobs:
             pi-linux-x64.tar.gz \
             pi-linux-arm64.tar.gz \
             pi-windows-x64.zip \
+            pi-windows-arm64.zip \
             --clobber

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
         with:
-          bun-version: 1.2.20
+          bun-version: 1.3.10
 
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -8,7 +8,7 @@
 #
 # Options:
 #   --skip-deps         Skip installing cross-platform dependencies
-#   --platform <name>   Build only for specified platform (darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64)
+#   --platform <name>   Build only for specified platform (darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64, windows-arm64)
 #
 # Output:
 #   packages/coding-agent/binaries/
@@ -17,6 +17,7 @@
 #     pi-linux-x64.tar.gz
 #     pi-linux-arm64.tar.gz
 #     pi-windows-x64.zip
+#     pi-windows-arm64.zip
 
 set -euo pipefail
 
@@ -49,7 +50,7 @@ if [[ -n "$PLATFORM" ]]; then
             ;;
         *)
             echo "Invalid platform: $PLATFORM"
-            echo "Valid platforms: darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64"
+            echo "Valid platforms: darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64, windows-arm64"
             exit 1
             ;;
     esac
@@ -70,11 +71,13 @@ if [[ "$SKIP_DEPS" == "false" ]]; then
         @mariozechner/clipboard-linux-x64-gnu@0.3.0 \
         @mariozechner/clipboard-linux-arm64-gnu@0.3.0 \
         @mariozechner/clipboard-win32-x64-msvc@0.3.0 \
+        @mariozechner/clipboard-win32-arm64-msvc@0.3.0 \
         @img/sharp-darwin-arm64@0.34.5 \
         @img/sharp-darwin-x64@0.34.5 \
         @img/sharp-linux-x64@0.34.5 \
         @img/sharp-linux-arm64@0.34.5 \
         @img/sharp-win32-x64@0.34.5 \
+        @img/sharp-win32-arm64@0.34.5 \
         @img/sharp-libvips-darwin-arm64@1.2.4 \
         @img/sharp-libvips-darwin-x64@1.2.4 \
         @img/sharp-libvips-linux-x64@1.2.4 \
@@ -91,13 +94,13 @@ cd packages/coding-agent
 
 # Clean previous builds
 rm -rf binaries
-mkdir -p binaries/{darwin-arm64,darwin-x64,linux-x64,linux-arm64,windows-x64}
+mkdir -p binaries/{darwin-arm64,darwin-x64,linux-x64,linux-arm64,windows-x64,windows-arm64}
 
 # Determine which platforms to build
 if [[ -n "$PLATFORM" ]]; then
     PLATFORMS=("$PLATFORM")
 else
-    PLATFORMS=(darwin-arm64 darwin-x64 linux-x64 linux-arm64 windows-x64)
+    PLATFORMS=(darwin-arm64 darwin-x64 linux-x64 linux-arm64 windows-x64 windows-arm64)
 fi
 
 for platform in "${PLATFORMS[@]}"; do
@@ -106,7 +109,7 @@ for platform in "${PLATFORMS[@]}"; do
     # into every binary. Koffi is only used on Windows for VT input and the
     # call site has a try/catch fallback. For Windows builds, we copy the
     # appropriate .node file alongside the binary below.
-    if [[ "$platform" == "windows-x64" ]]; then
+    if [[ "$platform" == windows-* ]]; then
         bun build --compile --external koffi --target=bun-$platform ./dist/bun/cli.js --outfile binaries/$platform/pi.exe
     else
         bun build --compile --external koffi --target=bun-$platform ./dist/bun/cli.js --outfile binaries/$platform/pi
@@ -130,11 +133,16 @@ for platform in "${PLATFORMS[@]}"; do
     cp -r examples binaries/$platform/
 
     # Copy koffi native module for Windows (needed for VT input support)
-    if [[ "$platform" == "windows-x64" ]]; then
-        mkdir -p binaries/$platform/node_modules/koffi/build/koffi/win32_x64
+    if [[ "$platform" == windows-* ]]; then
+        if [[ "$platform" == "windows-arm64" ]]; then
+            koffi_arch_dir="win32_arm64"
+        else
+            koffi_arch_dir="win32_x64"
+        fi
+        mkdir -p binaries/$platform/node_modules/koffi/build/koffi/$koffi_arch_dir
         cp ../../node_modules/koffi/index.js binaries/$platform/node_modules/koffi/
         cp ../../node_modules/koffi/package.json binaries/$platform/node_modules/koffi/
-        cp ../../node_modules/koffi/build/koffi/win32_x64/koffi.node binaries/$platform/node_modules/koffi/build/koffi/win32_x64/
+        cp ../../node_modules/koffi/build/koffi/$koffi_arch_dir/koffi.node binaries/$platform/node_modules/koffi/build/koffi/$koffi_arch_dir/
     fi
 done
 
@@ -142,7 +150,7 @@ done
 cd binaries
 
 for platform in "${PLATFORMS[@]}"; do
-    if [[ "$platform" == "windows-x64" ]]; then
+    if [[ "$platform" == windows-* ]]; then
         # Windows (zip)
         echo "Creating pi-$platform.zip..."
         (cd $platform && zip -r ../pi-$platform.zip .)
@@ -157,7 +165,7 @@ done
 echo "==> Extracting archives for testing..."
 for platform in "${PLATFORMS[@]}"; do
     rm -rf $platform
-    if [[ "$platform" == "windows-x64" ]]; then
+    if [[ "$platform" == windows-* ]]; then
         mkdir -p $platform && (cd $platform && unzip -q ../pi-$platform.zip)
     else
         tar -xzf pi-$platform.tar.gz && mv pi $platform


### PR DESCRIPTION
Adds support for producing a native ARM64 version of the binary for the Windows platform. 

In order to have a valid build destination, Bun must be bumped to a minimum version of 1.3.10 ([Release Notes](https://bun.com/blog/bun-v1.3.10#windows-arm64-support)) which is the earliest release that supports `bun-windows-arm64` as a bun compilation target. 

Once the compilation target is available, we can allow for `windows-arm64` to be passed in as a valid build destination and ensure that all previous places where only `windows-x64` had been used now expect multiple Windows architectures and deal with them appropriately. 

This should resolve #4410.