### PR TITLE
fix(ai): mark inception/mercury-2 thinkingLevelMap.off as null

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed GitHub Copilot Claude test coverage to use the current Claude Sonnet 4.6 model ID.
 - Fixed OpenAI Responses requests for models that support disabling reasoning to send `reasoning.effort: "none"` when thinking is off.
+- Fixed Inception Mercury 2 tool calling on OpenRouter by marking `off` as unsupported in `thinkingLevelMap`, so the openai-completions provider omits the reasoning param instead of defaulting to `{reasoning:{effort:"none"}}` (which puts Mercury 2 in instant mode, disabling tool calls).
 
 ## [0.74.0] - 2026-05-07
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -240,6 +240,13 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	if (model.provider === "openai-codex" && model.id === "gpt-5.1-codex-mini") {
 		mergeThinkingLevelMap(model, { minimal: "medium", low: "medium", medium: "medium", high: "high" });
 	}
+	if (model.provider === "openrouter" && model.id.startsWith("inception/mercury-2")) {
+		// Mercury 2 in instant mode (reasoning_effort: "none") disables tool calling.
+		// Mark "off" unsupported so the openai-completions provider omits the reasoning param
+		// instead of defaulting to {reasoning:{effort:"none"}} (see openai-completions.ts:575).
+		// Pi's low/medium/high pass through verbatim; OpenRouter normalizes to Mercury's vocabulary.
+		mergeThinkingLevelMap(model, { off: null });
+	}
 }
 
 function getAnthropicMessagesCompat(provider: string, modelId: string): AnthropicMessagesCompat | undefined {

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -9731,6 +9731,7 @@ export const MODELS = {
 			provider: "openrouter",
 			baseUrl: "https://openrouter.ai/api/v1",
 			reasoning: true,
+			thinkingLevelMap: {"off":null},
 			input: ["text"],
 			cost: {
 				input: 0.25,


### PR DESCRIPTION
## Summary

Mark `thinkingLevelMap.off = null` on `inception/mercury-2` (OpenRouter) so the openai-completions provider omits the `reasoning` param instead of defaulting to `{reasoning: {effort: "none"}}`.

## Why

`packages/ai/src/providers/openai-completions.ts:575` currently hardcodes `effort: "none"` for any OpenRouter-routed reasoning model when (a) the caller doesn't pass a reasoning level, and (b) the model's `thinkingLevelMap.off` is not `null`. Today `inception/mercury-2` matches both: it has `reasoning: true` (auto-derived from OpenRouter's `supported_parameters`) but no `thinkingLevelMap`. The result is that every pi-ai consumer who calls Mercury 2 without explicitly setting a level — silently — gets `{reasoning: {effort: "none"}}` on the wire.

For Mercury 2, `reasoning_effort: "none"` selects instant mode, which does not support tool calling. Agentic workloads (anything passing tools) consistently break via this route, while the same workload against Mercury 2's direct API works fine (no `reasoning_effort` sent → Mercury's own default takes over → tools work). That's the observable OpenRouter-vs-direct discrepancy.

## What this PR does

- Adds an entry in `applyThinkingLevelMetadata` (generate-models.ts:243-249) that sets `thinkingLevelMap: { off: null }` for any `inception/mercury-2*` model on OpenRouter.
- With `off: null`, line 575's `model.thinkingLevelMap?.off !== null` check evaluates to false, so the provider no longer writes a `reasoning` param when no level is passed; Mercury 2 then uses its own default and tools work.
- pi's `low` / `medium` / `high` continue to pass through verbatim — OpenRouter normalizes them into Mercury's vocabulary. Pi's `off` clamps up to `minimal` per `clampThinkingLevel`, preserving user intent rather than silently overriding to a non-tool mode.
- Prefix-matched (`startsWith("inception/mercury-2")`) so future Mercury 2 variants on OpenRouter inherit the fix.

## Notes for reviewers

- Only the OpenRouter entry needs this. The `vercel-ai-gateway` entry for `inception/mercury-2` uses `api: "anthropic-messages"`, which goes through a different code path that doesn't hit the `effort: "none"` default; not touched here.
- Whether the default at openai-completions.ts:575 should change globally (omit param vs. hardcode `"none"` for unconfigured OpenRouter reasoning models) is a broader policy question — out of scope for this PR.

## Test plan

- [x] `npm run generate-models` produces `thinkingLevelMap: {"off":null}` on the OpenRouter Mercury 2 entry.
- [x] `tsc --noEmit` on `packages/ai` is clean.
- [x] Pre-commit `npm run check` passes.
- [ ] End-to-end: agentic call to `inception/mercury-2` via OpenRouter without an explicit reasoning level — tools should now fire.
