### PR TITLE
Add retry watchdog hook for terminal provider errors

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -631,6 +631,28 @@ pi.on("after_provider_response", (event, ctx) => {
 
 Header availability depends on provider and transport. Providers that abstract HTTP responses may not expose headers.
 
+#### retry_watchdog
+
+Fired by Pi's retry heartbeat when the agent is idle and the latest assistant message is a retryable terminal provider/API error that the normal event-driven retry path did not recover. This hook lets extensions observe, cancel, or tune watchdog-triggered recovery without replacing Pi's normal retry behavior.
+
+```typescript
+pi.on("retry_watchdog", async (event, ctx) => {
+  // event.message - terminal assistant error message
+  // event.errorMessage - convenience copy of message.errorMessage
+  // event.attempt / event.maxAttempts - retry attempt about to start
+
+  ctx.ui.notify(`Retry watchdog saw: ${event.errorMessage}`, "warning");
+
+  // Optional: suppress Pi's built-in watchdog retry for this terminal error
+  // return { cancel: true };
+
+  // Optional: override delay before the watchdog retry attempt
+  // return { delayMs: 10_000 };
+});
+```
+
+Use this for custom escalation, model/provider switching, scheduled wake-ups, or extension-owned retry policies. Return `{ cancel: true }` only if your extension will handle recovery itself; Pi suppresses repeated watchdog retries for that same terminal error.
+
 ### Model Events
 
 #### model_select

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -100,6 +100,8 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 | `retry.enabled` | boolean | `true` | Enable automatic agent-level retry on transient errors |
 | `retry.maxRetries` | number | `3` | Maximum agent-level retry attempts |
 | `retry.baseDelayMs` | number | `2000` | Base delay for agent-level exponential backoff (2s, 4s, 8s) |
+| `retry.watchdogEnabled` | boolean | `true` | Enable a low-frequency heartbeat that recovers retryable terminal errors if the event-driven retry path is missed |
+| `retry.watchdogIntervalMs` | number | `2000` | Retry watchdog heartbeat interval in milliseconds |
 | `retry.provider.timeoutMs` | number | SDK default | Provider/SDK request timeout in milliseconds |
 | `retry.provider.maxRetries` | number | SDK default | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
@@ -112,6 +114,8 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
     "enabled": true,
     "maxRetries": 3,
     "baseDelayMs": 2000,
+    "watchdogEnabled": true,
+    "watchdogIntervalMs": 2000,
     "provider": {
       "timeoutMs": 3600000,
       "maxRetries": 0,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2453,7 +2453,28 @@ export class AgentSession {
 
 		this._retryWatchdogRunning = true;
 		try {
-			await this._handleRetryableError(msg);
+			const retrySettings = this.settingsManager.getRetrySettings();
+			const hookResult = this._extensionRunner.hasHandlers("retry_watchdog")
+				? await this._extensionRunner.emitRetryWatchdog({
+						type: "retry_watchdog",
+						message: msg,
+						errorMessage: msg.errorMessage ?? "Unknown error",
+						attempt: this._retryAttempt + 1,
+						maxAttempts: retrySettings.maxRetries,
+					})
+				: undefined;
+
+			if (hookResult?.cancel) {
+				this._retryExhaustedErrorKey = key;
+				return;
+			}
+
+			await this._handleRetryableError(msg, {
+				delayMs:
+					typeof hookResult?.delayMs === "number" && Number.isFinite(hookResult.delayMs) && hookResult.delayMs >= 0
+						? Math.round(hookResult.delayMs)
+						: undefined,
+			});
 		} finally {
 			this._retryWatchdogRunning = false;
 		}
@@ -2481,7 +2502,7 @@ export class AgentSession {
 	 * Handle retryable errors with exponential backoff.
 	 * @returns true if retry was initiated, false if max retries exceeded or disabled
 	 */
-	private async _handleRetryableError(message: AssistantMessage): Promise<boolean> {
+	private async _handleRetryableError(message: AssistantMessage, options?: { delayMs?: number }): Promise<boolean> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
 			this._resolveRetry();
@@ -2514,7 +2535,7 @@ export class AgentSession {
 			return false;
 		}
 
-		const delayMs = settings.baseDelayMs * 2 ** (this._retryAttempt - 1);
+		const delayMs = options?.delayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1);
 
 		this._emit({
 			type: "auto_retry_start",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -273,6 +273,9 @@ export class AgentSession {
 	private _retryAttempt = 0;
 	private _retryPromise: Promise<void> | undefined = undefined;
 	private _retryResolve: (() => void) | undefined = undefined;
+	private _retryWatchdogTimer: ReturnType<typeof setInterval> | undefined = undefined;
+	private _retryWatchdogRunning = false;
+	private _retryExhaustedErrorKey: string | undefined = undefined;
 
 	// Bash execution state
 	private _bashAbortController: AbortController | undefined = undefined;
@@ -329,6 +332,7 @@ export class AgentSession {
 		// (session persistence, extensions, auto-compaction, retry logic)
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
 		this._installAgentToolHooks();
+		this._startRetryWatchdog();
 
 		this._buildRuntime({
 			activeToolNames: this._initialActiveToolNames,
@@ -554,6 +558,7 @@ export class AgentSession {
 				const assistantMsg = event.message as AssistantMessage;
 				if (assistantMsg.stopReason !== "error") {
 					this._overflowRecoveryAttempted = false;
+					this._retryExhaustedErrorKey = undefined;
 				}
 
 				// Reset retry counter immediately on successful assistant response
@@ -751,6 +756,7 @@ export class AgentSession {
 		this._extensionRunner.invalidate(
 			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
 		);
+		this._stopRetryWatchdog();
 		this._disconnectFromAgent();
 		this._eventListeners = [];
 		cleanupSessionResources(this.sessionId);
@@ -2407,6 +2413,52 @@ export class AgentSession {
 	// Auto-Retry
 	// =========================================================================
 
+	private _startRetryWatchdog(): void {
+		const settings = this.settingsManager.getRetryWatchdogSettings();
+		if (!settings.enabled) return;
+		this._retryWatchdogTimer = setInterval(() => {
+			void this._retryWatchdogTick();
+		}, settings.intervalMs);
+		this._retryWatchdogTimer.unref?.();
+	}
+
+	private _stopRetryWatchdog(): void {
+		if (!this._retryWatchdogTimer) return;
+		clearInterval(this._retryWatchdogTimer);
+		this._retryWatchdogTimer = undefined;
+	}
+
+	private _getRetryErrorKey(message: AssistantMessage): string {
+		return [message.timestamp ?? "", message.provider ?? "", message.model ?? "", message.errorMessage ?? ""].join(
+			"\u0000",
+		);
+	}
+
+	private _findTerminalAssistantMessage(): AssistantMessage | undefined {
+		const messages = this.agent.state.messages;
+		const last = messages[messages.length - 1];
+		return last?.role === "assistant" ? (last as AssistantMessage) : undefined;
+	}
+
+	private async _retryWatchdogTick(): Promise<void> {
+		if (this._retryWatchdogRunning) return;
+		const watchdogSettings = this.settingsManager.getRetryWatchdogSettings();
+		if (!watchdogSettings.enabled || this._retryPromise || this.isStreaming) return;
+
+		const msg = this._findTerminalAssistantMessage();
+		if (!msg || !this._isRetryableError(msg)) return;
+
+		const key = this._getRetryErrorKey(msg);
+		if (key === this._retryExhaustedErrorKey) return;
+
+		this._retryWatchdogRunning = true;
+		try {
+			await this._handleRetryableError(msg);
+		} finally {
+			this._retryWatchdogRunning = false;
+		}
+	}
+
 	/**
 	 * Check if an error is retryable (overloaded, rate limit, server errors).
 	 * Context overflow errors are NOT retryable (handled by compaction instead).
@@ -2447,7 +2499,10 @@ export class AgentSession {
 		this._retryAttempt++;
 
 		if (this._retryAttempt > settings.maxRetries) {
-			// Max retries exceeded, emit final failure and reset
+			// Max retries exceeded, emit final failure and reset. Remember this
+			// terminal error so the heartbeat watchdog does not start a fresh retry
+			// cycle against the same exhausted assistant error.
+			this._retryExhaustedErrorKey = this._getRetryErrorKey(message);
 			this._emit({
 				type: "auto_retry_end",
 				success: false,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -44,6 +44,8 @@ import type {
 	ResolvedCommand,
 	ResourcesDiscoverEvent,
 	ResourcesDiscoverResult,
+	RetryWatchdogEvent,
+	RetryWatchdogEventResult,
 	SessionBeforeCompactResult,
 	SessionBeforeForkResult,
 	SessionBeforeSwitchResult,
@@ -122,6 +124,7 @@ type RunnerEmitEvent = Exclude<
 	| BeforeAgentStartEvent
 	| MessageEndEvent
 	| ResourcesDiscoverEvent
+	| RetryWatchdogEvent
 	| InputEvent
 >;
 
@@ -751,6 +754,36 @@ export class ExtensionRunner {
 		}
 
 		return modified ? currentMessage : undefined;
+	}
+
+	async emitRetryWatchdog(event: RetryWatchdogEvent): Promise<RetryWatchdogEventResult | undefined> {
+		const ctx = this.createContext();
+		let result: RetryWatchdogEventResult | undefined;
+
+		for (const ext of this.extensions) {
+			const handlers = ext.handlers.get("retry_watchdog");
+			if (!handlers || handlers.length === 0) continue;
+
+			for (const handler of handlers) {
+				try {
+					const handlerResult = (await handler(event, ctx)) as RetryWatchdogEventResult | undefined;
+					if (!handlerResult) continue;
+					result = { ...result, ...handlerResult };
+					if (handlerResult.cancel) return result;
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					const stack = err instanceof Error ? err.stack : undefined;
+					this.emitError({
+						extensionPath: ext.path,
+						event: "retry_watchdog",
+						error: message,
+						stack,
+					});
+				}
+			}
+		}
+
+		return result;
 	}
 
 	async emitToolResult(event: ToolResultEvent): Promise<ToolResultEventResult | undefined> {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -17,6 +17,7 @@ import type {
 } from "@earendil-works/pi-agent-core";
 import type {
 	Api,
+	AssistantMessage,
 	AssistantMessageEvent,
 	AssistantMessageEventStream,
 	Context,
@@ -725,6 +726,19 @@ export interface ThinkingLevelSelectEvent {
 	previousLevel: ThinkingLevel;
 }
 
+/** Fired when the retry watchdog heartbeat finds an idle terminal retryable provider error. */
+export interface RetryWatchdogEvent {
+	type: "retry_watchdog";
+	/** Terminal assistant error message that the watchdog is about to recover. */
+	message: AssistantMessage;
+	/** Convenience copy of message.errorMessage. */
+	errorMessage: string;
+	/** Retry attempt that would be started if the hook does not cancel. */
+	attempt: number;
+	/** Max retry attempts from retry.maxRetries. */
+	maxAttempts: number;
+}
+
 // ============================================================================
 // User Bash Events
 // ============================================================================
@@ -966,6 +980,7 @@ export type ExtensionEvent =
 	| ToolExecutionEndEvent
 	| ModelSelectEvent
 	| ThinkingLevelSelectEvent
+	| RetryWatchdogEvent
 	| UserBashEvent
 	| InputEvent
 	| ToolCallEvent
@@ -999,6 +1014,13 @@ export interface ToolResultEventResult {
 	content?: (TextContent | ImageContent)[];
 	details?: unknown;
 	isError?: boolean;
+}
+
+export interface RetryWatchdogEventResult {
+	/** Cancel Pi's built-in watchdog retry for this terminal error. The extension may handle recovery itself. */
+	cancel?: boolean;
+	/** Override the delay before Pi's watchdog-triggered retry attempt. */
+	delayMs?: number;
 }
 
 export interface MessageEndEventResult {
@@ -1120,6 +1142,7 @@ export interface ExtensionAPI {
 	on(event: "tool_execution_end", handler: ExtensionHandler<ToolExecutionEndEvent>): void;
 	on(event: "model_select", handler: ExtensionHandler<ModelSelectEvent>): void;
 	on(event: "thinking_level_select", handler: ExtensionHandler<ThinkingLevelSelectEvent>): void;
+	on(event: "retry_watchdog", handler: ExtensionHandler<RetryWatchdogEvent, RetryWatchdogEventResult>): void;
 	on(event: "tool_call", handler: ExtensionHandler<ToolCallEvent, ToolCallEventResult>): void;
 	on(event: "tool_result", handler: ExtensionHandler<ToolResultEvent, ToolResultEventResult>): void;
 	on(event: "user_bash", handler: ExtensionHandler<UserBashEvent, UserBashEventResult>): void;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -26,6 +26,10 @@ export interface RetrySettings {
 	enabled?: boolean; // default: true
 	maxRetries?: number; // default: 3
 	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
+	/** Enable a low-frequency watchdog that recovers retryable terminal errors if the event-driven retry path is missed. Default: true. */
+	watchdogEnabled?: boolean;
+	/** Retry watchdog heartbeat interval. Default: 2000ms. */
+	watchdogIntervalMs?: number;
 	provider?: ProviderRetrySettings;
 }
 
@@ -723,6 +727,18 @@ export class SettingsManager {
 			enabled: this.getRetryEnabled(),
 			maxRetries: this.settings.retry?.maxRetries ?? 3,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
+		};
+	}
+
+	getRetryWatchdogSettings(): { enabled: boolean; intervalMs: number } {
+		const rawIntervalMs = this.settings.retry?.watchdogIntervalMs;
+		const intervalMs =
+			typeof rawIntervalMs === "number" && Number.isFinite(rawIntervalMs) && rawIntervalMs > 0
+				? rawIntervalMs
+				: 2000;
+		return {
+			enabled: this.getRetryEnabled() && (this.settings.retry?.watchdogEnabled ?? true),
+			intervalMs: Math.max(100, Math.round(intervalMs)),
 		};
 	}
 

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -68,10 +68,16 @@ describe("AgentSession retry", () => {
 		}
 	});
 
-	function createSession(options?: { failCount?: number; maxRetries?: number; delayAssistantMessageEndMs?: number }) {
+	function createSession(options?: {
+		failCount?: number;
+		maxRetries?: number;
+		delayAssistantMessageEndMs?: number;
+		watchdogIntervalMs?: number;
+	}) {
 		const failCount = options?.failCount ?? 1;
 		const maxRetries = options?.maxRetries ?? 3;
 		const delayAssistantMessageEndMs = options?.delayAssistantMessageEndMs ?? 0;
+		const watchdogIntervalMs = options?.watchdogIntervalMs;
 		let callCount = 0;
 
 		const model = getModel("anthropic", "claude-sonnet-4-5")!;
@@ -104,7 +110,7 @@ describe("AgentSession retry", () => {
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
 		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
-		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1 } });
+		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1, watchdogIntervalMs } });
 
 		session = new AgentSession({
 			agent,
@@ -167,6 +173,31 @@ describe("AgentSession retry", () => {
 		await created.session.prompt("Test");
 
 		expect(created.getCallCount()).toBe(2);
+		expect(created.session.isRetrying).toBe(false);
+	});
+
+	it("watchdog recovers a retryable terminal error if the event-driven retry path misses it", async () => {
+		const created = createSession({ failCount: 1, watchdogIntervalMs: 5 });
+		const sessionWithPrivates = created.session as unknown as {
+			_isRetryableError: (message: AssistantMessage) => boolean;
+		};
+		const originalIsRetryableError = sessionWithPrivates._isRetryableError.bind(created.session);
+		sessionWithPrivates._isRetryableError = () => false;
+
+		await created.session.prompt("Test");
+		expect(created.getCallCount()).toBe(1);
+
+		sessionWithPrivates._isRetryableError = originalIsRetryableError;
+		await new Promise<void>((resolve, reject) => {
+			const deadline = Date.now() + 500;
+			const poll = () => {
+				if (created.getCallCount() >= 2) return resolve();
+				if (Date.now() > deadline) return reject(new Error("retry watchdog did not fire"));
+				setTimeout(poll, 10);
+			};
+			poll();
+		});
+
 		expect(created.session.isRetrying).toBe(false);
 	});
 

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -141,6 +141,51 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
 	});
 
+	it("fires retry_watchdog extension hook and honors cancellation", async () => {
+		const watchdogEvents: Array<{ errorMessage: string; attempt: number; maxAttempts: number }> = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1, watchdogIntervalMs: 5 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("retry_watchdog", (event) => {
+						watchdogEvents.push({
+							errorMessage: event.errorMessage,
+							attempt: event.attempt,
+							maxAttempts: event.maxAttempts,
+						});
+						return { cancel: true };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" })]);
+
+		const sessionWithPrivates = harness.session as unknown as {
+			_isRetryableError: (message: unknown) => boolean;
+		};
+		const originalIsRetryableError = sessionWithPrivates._isRetryableError.bind(harness.session);
+		sessionWithPrivates._isRetryableError = () => false;
+
+		await harness.session.prompt("test");
+		expect(harness.faux.state.callCount).toBe(1);
+
+		sessionWithPrivates._isRetryableError = originalIsRetryableError;
+		await new Promise<void>((resolve, reject) => {
+			const deadline = Date.now() + 500;
+			const poll = () => {
+				if (watchdogEvents.length > 0) return resolve();
+				if (Date.now() > deadline) return reject(new Error("retry_watchdog hook did not fire"));
+				setTimeout(poll, 10);
+			};
+			poll();
+		});
+
+		expect(watchdogEvents).toEqual([{ errorMessage: "overloaded_error", attempt: 1, maxAttempts: 3 }]);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+	});
+
 	it("cancels retry sleep when abortRetry is called", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } } });
 		harnesses.push(harness);


### PR DESCRIPTION
## Summary\n- add a retry watchdog heartbeat to recover idle terminal retryable provider/API errors if the normal retry path is missed\n- expose a retry_watchdog extension hook so packages can observe, cancel, or customize watchdog-triggered retry delay\n- document retry watchdog settings and extension hook\n\n## Verification\n- npm run build (passed in dependency-ready Pi clone)\n- npm test -- test/agent-session-retry.test.ts test/suite/agent-session-retry-events.test.ts test/extensions-runner.test.ts\n- npm test\n\nFull suite from dependency-ready Pi clone: 113 passed, 6 skipped; 1169 tests passed, 44 skipped.\n\nNote: this branch was prepared from /Users/mmagsuci/repo/cue-pi-extension/libs/pi; its origin fetch URL is upstream earendil-works/pi and push URL is mcdmag/pi.