### PR TITLE
Harden .npmrc and pin @mistralai/mistralai==2.2.1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+ignore-scripts=true
+save-exact=true
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -6902,7 +6902,7 @@
 				"@anthropic-ai/sdk": "^0.91.1",
 				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
 				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "^2.2.0",
+				"@mistralai/mistralai": "2.2.1",
 				"http-proxy-agent": "^7.0.2",
 				"https-proxy-agent": "^7.0.6",
 				"openai": "6.26.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -72,7 +72,7 @@
 		"@anthropic-ai/sdk": "^0.91.1",
 		"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
 		"@google/genai": "^1.40.0",
-		"@mistralai/mistralai": "^2.2.0",
+		"@mistralai/mistralai": "2.2.1",
 		"http-proxy-agent": "^7.0.2",
 		"https-proxy-agent": "^7.0.6",
 		"openai": "6.26.0",


### PR DESCRIPTION
Re: https://github.com/earendil-works/pi/issues/4432 :

This PR hardens against that issue by pinning @mistralai/mistralai version and not running pre-install scripts for this repo. .npmrc applies to anyone using the repo even if they haven't set up a global config. Effectively a no-op since the lockfile is safe.

Optional: I included extra options to npmrc for hardening, but can relax if needed

Aside: `npm run check` not passing from unrelated files. Can take a look if CI fails too
```
Found 6 errors in 4 files.

Errors  Files
     1  src/ChatPanel.ts:100
     2  src/components/Messages.ts:117
     1  src/tools/artifacts/artifacts.ts:275
     2  src/tools/javascript-repl.ts:134
```