### PR TITLE
Track direct NVIDIA NIM request origin

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed tool output expansion while extension confirmation dialogs are focused ([#4429](https://github.com/earendil-works/pi/issues/4429)).
+- Fixed direct NVIDIA NIM request attribution to include the Pi billing-origin header when install telemetry is enabled, while preserving user-configured header overrides.
 - Fixed auto-retry for Anthropic streams that end before `message_stop` ([#4433](https://github.com/earendil-works/pi/issues/4433)).
 - Fixed theme sharing across package scopes so extensions do not crash with `Theme not initialized` ([#4333](https://github.com/earendil-works/pi/issues/4333)).
 - Fixed keybinding hints to show Option instead of Alt on macOS ([#4289](https://github.com/earendil-works/pi/issues/4289)).

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -287,7 +287,7 @@ See [docs/settings.md](docs/settings.md) for all options.
 Pi has two separate startup features:
 
 - **Update check:** fetches `https://pi.dev/api/latest-version` to check whether a newer Pi version exists. Disable it with `PI_SKIP_VERSION_CHECK=1`. Disabling update checks only turns off this check.
-- **Install/update telemetry:** after first install or a changelog-detected update, sends an anonymous version ping to `https://pi.dev/api/report-install`. Opt out by setting `enableInstallTelemetry` to `false` in `settings.json`, or by setting `PI_TELEMETRY=0`. This does not disable update checks; Pi may still contact `pi.dev` for the latest version unless update checks are disabled or offline mode is enabled.
+- **Install/update telemetry:** after first install or a changelog-detected update, sends an anonymous version ping to `https://pi.dev/api/report-install`. This setting also controls optional provider attribution headers for OpenRouter and direct NVIDIA NIM requests. Opt out by setting `enableInstallTelemetry` to `false` in `settings.json`, or by setting `PI_TELEMETRY=0`. This does not disable update checks; Pi may still contact `pi.dev` for the latest version unless update checks are disabled or offline mode is enabled.
 
 Use `--offline` or `PI_OFFLINE=1` to disable all startup network operations described here, including update checks, package update checks, and install/update telemetry.
 
@@ -630,7 +630,7 @@ pi --thinking high "Solve this complex problem"
 | `PI_PACKAGE_DIR` | Override package directory (useful for Nix/Guix where store paths tokenize poorly) |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |
-| `PI_TELEMETRY` | Override install/update telemetry. Use `1`/`true`/`yes` to enable or `0`/`false`/`no` to disable. This does not disable update checks |
+| `PI_TELEMETRY` | Override install/update telemetry and provider attribution headers. Use `1`/`true`/`yes` to enable or `0`/`false`/`no` to disable. This does not disable update checks |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache (Anthropic: 1h, OpenAI: 24h) |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -264,7 +264,7 @@ pi --tools read,grep,find,ls -p "Review the code"
 | `PI_PACKAGE_DIR` | Override package directory, useful for Nix/Guix store paths |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
 | `PI_SKIP_VERSION_CHECK` | Skip the Pi version update check at startup. This prevents the `pi.dev` latest-version request |
-| `PI_TELEMETRY` | Override install/update telemetry: `1`/`true`/`yes` or `0`/`false`/`no`. This does not disable update checks |
+| `PI_TELEMETRY` | Override install/update telemetry and provider attribution headers: `1`/`true`/`yes` or `0`/`false`/`no`. This does not disable update checks |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache where supported |
 | `VISUAL`, `EDITOR` | External editor for Ctrl+G |
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -79,6 +79,7 @@ import { emitSessionShutdownEvent } from "./extensions/runner.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import type { ModelRegistry } from "./model-registry.js";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.js";
+import { mergeProviderAttributionHeaders } from "./provider-attribution.js";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.js";
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.js";
 import { CURRENT_SESSION_VERSION, getLatestCompactionEntry, type SessionHeader } from "./session-manager.js";
@@ -353,7 +354,10 @@ export class AgentSession {
 			throw new Error(result.error);
 		}
 		if (result.apiKey) {
-			return { apiKey: result.apiKey, headers: result.headers };
+			return {
+				apiKey: result.apiKey,
+				headers: mergeProviderAttributionHeaders(model, this.settingsManager, result.headers),
+			};
 		}
 
 		const isOAuth = this._modelRegistry.isUsingOAuth(model);
@@ -1864,8 +1868,13 @@ export class AgentSession {
 				return;
 			}
 
-			const authResult = await this._modelRegistry.getApiKeyAndHeaders(this.model);
-			if (!authResult.ok || !authResult.apiKey) {
+			let apiKey: string;
+			let headers: Record<string, string> | undefined;
+			try {
+				const auth = await this._getRequiredRequestAuth(this.model);
+				apiKey = auth.apiKey;
+				headers = auth.headers;
+			} catch {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -1875,7 +1884,6 @@ export class AgentSession {
 				});
 				return;
 			}
-			const { apiKey, headers } = authResult;
 
 			const pathEntries = this.sessionManager.getBranch();
 

--- a/packages/coding-agent/src/core/provider-attribution.ts
+++ b/packages/coding-agent/src/core/provider-attribution.ts
@@ -1,0 +1,82 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { SettingsManager } from "./settings-manager.js";
+import { isInstallTelemetryEnabled } from "./telemetry.js";
+
+const OPENROUTER_HOST = "openrouter.ai";
+const NVIDIA_NIM_HOST = "integrate.api.nvidia.com";
+const CLOUDFLARE_API_HOST = "api.cloudflare.com";
+const CLOUDFLARE_AI_GATEWAY_HOST = "gateway.ai.cloudflare.com";
+
+function matchesHost(baseUrl: string, expectedHost: string): boolean {
+	try {
+		return new URL(baseUrl).hostname === expectedHost;
+	} catch {
+		return baseUrl.includes(expectedHost);
+	}
+}
+
+function isOpenRouterModel(model: Model<Api>): boolean {
+	return model.provider === "openrouter" || model.baseUrl.includes(OPENROUTER_HOST);
+}
+
+function isNvidiaNimModel(model: Model<Api>): boolean {
+	return model.provider === "nvidia-nim" || matchesHost(model.baseUrl, NVIDIA_NIM_HOST);
+}
+
+function isCloudflareModel(model: Model<Api>): boolean {
+	return (
+		model.provider === "cloudflare-workers-ai" ||
+		model.provider === "cloudflare-ai-gateway" ||
+		model.baseUrl.includes(CLOUDFLARE_API_HOST) ||
+		model.baseUrl.includes(CLOUDFLARE_AI_GATEWAY_HOST)
+	);
+}
+
+function getProviderAttributionHeaders(
+	model: Model<Api>,
+	settingsManager: SettingsManager,
+): Record<string, string> | undefined {
+	if (!isInstallTelemetryEnabled(settingsManager)) {
+		return undefined;
+	}
+
+	if (isOpenRouterModel(model)) {
+		return {
+			"HTTP-Referer": "https://pi.dev",
+			"X-OpenRouter-Title": "pi",
+			"X-OpenRouter-Categories": "cli-agent",
+		};
+	}
+
+	if (isNvidiaNimModel(model)) {
+		return {
+			"X-BILLING-INVOKE-ORIGIN": "Pi",
+		};
+	}
+
+	if (isCloudflareModel(model)) {
+		return {
+			"User-Agent": "pi-coding-agent",
+		};
+	}
+
+	return undefined;
+}
+
+export function mergeProviderAttributionHeaders(
+	model: Model<Api>,
+	settingsManager: SettingsManager,
+	...headerSources: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+	const merged = {
+		...getProviderAttributionHeaders(model, settingsManager),
+	};
+
+	for (const headers of headerSources) {
+		if (headers) {
+			Object.assign(merged, headers);
+		}
+	}
+
+	return Object.keys(merged).length > 0 ? merged : undefined;
+}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -10,11 +10,11 @@ import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefi
 import { convertToLlm } from "./messages.js";
 import { ModelRegistry } from "./model-registry.js";
 import { findInitialModel } from "./model-resolver.js";
+import { mergeProviderAttributionHeaders } from "./provider-attribution.js";
 import type { ResourceLoader } from "./resource-loader.js";
 import { DefaultResourceLoader } from "./resource-loader.js";
 import { getDefaultSessionDir, SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
-import { isInstallTelemetryEnabled } from "./telemetry.js";
 import { time } from "./timings.js";
 import {
 	createBashTool,
@@ -123,36 +123,6 @@ export {
 
 function getDefaultAgentDir(): string {
 	return getAgentDir();
-}
-
-function getAttributionHeaders(
-	model: Model<any>,
-	settingsManager: SettingsManager,
-): Record<string, string> | undefined {
-	if (!isInstallTelemetryEnabled(settingsManager)) {
-		return undefined;
-	}
-
-	if (model.provider === "openrouter" || model.baseUrl.includes("openrouter.ai")) {
-		return {
-			"HTTP-Referer": "https://pi.dev",
-			"X-OpenRouter-Title": "pi",
-			"X-OpenRouter-Categories": "cli-agent",
-		};
-	}
-
-	if (
-		model.provider === "cloudflare-workers-ai" ||
-		model.provider === "cloudflare-ai-gateway" ||
-		model.baseUrl.includes("api.cloudflare.com") ||
-		model.baseUrl.includes("gateway.ai.cloudflare.com")
-	) {
-		return {
-			"User-Agent": "pi-coding-agent",
-		};
-	}
-
-	return undefined;
 }
 
 /**
@@ -331,17 +301,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				throw new Error(auth.error);
 			}
 			const providerRetrySettings = settingsManager.getProviderRetrySettings();
-			const attributionHeaders = getAttributionHeaders(model, settingsManager);
 			return streamSimple(model, context, {
 				...options,
 				apiKey: auth.apiKey,
 				timeoutMs: options?.timeoutMs ?? providerRetrySettings.timeoutMs,
 				maxRetries: options?.maxRetries ?? providerRetrySettings.maxRetries,
 				maxRetryDelayMs: options?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,
-				headers:
-					attributionHeaders || auth.headers || options?.headers
-						? { ...attributionHeaders, ...auth.headers, ...options?.headers }
-						: undefined,
+				headers: mergeProviderAttributionHeaders(model, settingsManager, auth.headers, options?.headers),
 			});
 		},
 		onPayload: async (payload, _model) => {

--- a/packages/coding-agent/test/sdk-openrouter-attribution.test.ts
+++ b/packages/coding-agent/test/sdk-openrouter-attribution.test.ts
@@ -15,14 +15,14 @@ import { createAgentSession } from "../src/core/sdk.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 
-describe("createAgentSession OpenRouter attribution headers", () => {
+describe("createAgentSession provider attribution headers", () => {
 	let tempDir: string;
 	let cwd: string;
 	let agentDir: string;
 	let originalTelemetryEnv: string | undefined;
 
 	beforeEach(() => {
-		tempDir = join(tmpdir(), `pi-sdk-openrouter-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		tempDir = join(tmpdir(), `pi-sdk-attribution-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		cwd = join(tempDir, "project");
 		agentDir = join(tempDir, "agent");
 		mkdirSync(cwd, { recursive: true });
@@ -42,9 +42,9 @@ describe("createAgentSession OpenRouter attribution headers", () => {
 		}
 	});
 
-	function createModel(provider: string, baseUrl: string): Model<Api> {
+	function createModel(provider: string, baseUrl: string, id = `${provider}-test-model`): Model<Api> {
 		return {
-			id: `${provider}-test-model`,
+			id,
 			name: `${provider} Test Model`,
 			api: "openai-completions",
 			provider,
@@ -177,5 +177,55 @@ describe("createAgentSession OpenRouter attribution headers", () => {
 		expect(headers?.["HTTP-Referer"]).toBe("https://provider.example");
 		expect(headers?.["X-OpenRouter-Title"]).toBe("request-title");
 		expect(headers?.["X-OpenRouter-Categories"]).toBe("provider-category");
+	});
+
+	it("adds default attribution headers for direct NVIDIA NIM endpoints", async () => {
+		const headers = await captureHeaders(createModel("custom-nim", "https://integrate.api.nvidia.com/v1"));
+
+		expect(headers?.["X-BILLING-INVOKE-ORIGIN"]).toBe("Pi");
+	});
+
+	it("adds default attribution headers for the NVIDIA NIM provider", async () => {
+		const headers = await captureHeaders(createModel("nvidia-nim", "https://example.test/v1"));
+
+		expect(headers?.["X-BILLING-INVOKE-ORIGIN"]).toBe("Pi");
+	});
+
+	it("does not add NVIDIA NIM attribution headers when telemetry is disabled", async () => {
+		const headers = await captureHeaders(createModel("custom-nim", "https://integrate.api.nvidia.com/v1"), {
+			telemetryEnabled: false,
+		});
+
+		expect(headers?.["X-BILLING-INVOKE-ORIGIN"]).toBeUndefined();
+	});
+
+	it("lets provider and request headers override NVIDIA NIM defaults", async () => {
+		const headers = await captureHeaders(createModel("custom-nim", "https://integrate.api.nvidia.com/v1"), {
+			providerHeaders: {
+				"X-BILLING-INVOKE-ORIGIN": "Provider",
+			},
+			requestHeaders: {
+				"X-BILLING-INVOKE-ORIGIN": "Request",
+			},
+		});
+
+		expect(headers?.["X-BILLING-INVOKE-ORIGIN"]).toBe("Request");
+	});
+
+	it("does not add NVIDIA NIM attribution headers for NVIDIA models routed through OpenRouter", async () => {
+		const headers = await captureHeaders(
+			createModel("openrouter", "https://openrouter.ai/api/v1", "nvidia/nemotron-3-super-120b-a12b"),
+		);
+
+		expect(headers?.["HTTP-Referer"]).toBe("https://pi.dev");
+		expect(headers?.["X-BILLING-INVOKE-ORIGIN"]).toBeUndefined();
+	});
+
+	it("does not add NVIDIA NIM attribution headers for NVIDIA models routed through Vercel AI Gateway", async () => {
+		const headers = await captureHeaders(
+			createModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1", "nvidia/nemotron-3-super-120b-a12b"),
+		);
+
+		expect(headers?.["X-BILLING-INVOKE-ORIGIN"]).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,9 +22,11 @@ export default defineConfig({
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@earendil-works\/pi-tui$/, replacement: tuiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},
 });

--- a/packages/web-ui/example/tsconfig.json
+++ b/packages/web-ui/example/tsconfig.json
@@ -6,10 +6,10 @@
 		"moduleResolution": "bundler",
 		"paths": {
 			"*": ["./*"],
-			"@earendil-works/pi-agent-core": ["../../agent/dist/index.d.ts"],
-			"@earendil-works/pi-ai": ["../../ai/dist/index.d.ts"],
-			"@earendil-works/pi-tui": ["../../tui/dist/index.d.ts"],
-			"@earendil-works/pi-web-ui": ["../dist/index.d.ts"]
+			"@earendil-works/pi-agent-core": ["../../agent/src/index.ts"],
+			"@earendil-works/pi-ai": ["../../ai/src/index.ts"],
+			"@earendil-works/pi-tui": ["../../tui/src/index.ts"],
+			"@earendil-works/pi-web-ui": ["../src/index.ts"]
 		},
 		"strict": true,
 		"skipLibCheck": true,

--- a/packages/web-ui/tsconfig.json
+++ b/packages/web-ui/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "paths": {
+      "@earendil-works/pi-agent-core": ["../agent/src/index.ts"],
+      "@earendil-works/pi-ai": ["../ai/src/index.ts"],
+      "@earendil-works/pi-tui": ["../tui/src/index.ts"]
+    }
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

- Add provider attribution headers for direct NVIDIA NIM requests so NVIDIA can identify requests originating from Pi applications.
- Reuse the same install-telemetry-gated attribution path as OpenRouter while preserving provider and request header overrides.
- Cover direct NIM endpoints, a future `nvidia-nim` provider id, disabled telemetry, header overrides, and NVIDIA models routed through other gateways.
- Add source-path mappings so fresh checkouts can run the required web UI type checks without prebuilt local package `dist` output.

## Validation

- `npm run check`
- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/sdk-openrouter-attribution.test.ts` from `packages/coding-agent`
