### PR TITLE
fix(compaction): auto-compaction for local models with no usage data

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -43,6 +43,7 @@ import {
 	collectEntriesForBranchSummary,
 	compact,
 	estimateContextTokens,
+	estimateTokens,
 	generateBranchSummary,
 	prepareCompaction,
 	shouldCompact,
@@ -1770,7 +1771,7 @@ export class AgentSession {
 		// Skip if message was aborted (user cancelled) - unless skipAbortedCheck is false
 		if (skipAbortedCheck && assistantMessage.stopReason === "aborted") return;
 
-		const contextWindow = this.model?.contextWindow ?? 0;
+		const contextWindow = this.model?.contextWindow ?? 128000;
 
 		// Skip overflow check if the message came from a different model.
 		// This handles the case where user switched from a smaller-context model (e.g. opus)
@@ -1837,6 +1838,16 @@ export class AgentSession {
 			contextTokens = estimate.tokens;
 		} else {
 			contextTokens = calculateContextTokens(assistantMessage.usage);
+			// Local models (Ollama, LM Studio, etc.) often return zero/default usage data.
+			// Fall back to direct estimation when reported tokens are 0.
+			if (!contextTokens) {
+				const messages = this.agent.state.messages;
+				let estimated = 0;
+				for (const msg of messages) {
+					estimated += estimateTokens(msg);
+				}
+				contextTokens = estimated;
+			}
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			await this._runAutoCompaction("threshold", false);
@@ -2415,7 +2426,7 @@ export class AgentSession {
 		if (message.stopReason !== "error" || !message.errorMessage) return false;
 
 		// Context overflow is handled by compaction, not retry
-		const contextWindow = this.model?.contextWindow ?? 0;
+		const contextWindow = this.model?.contextWindow ?? 128000;
 		if (isContextOverflow(message, contextWindow)) return false;
 
 		const err = message.errorMessage;

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -896,8 +896,8 @@ export class ModelRegistry {
 					thinkingLevelMap: modelDef.thinkingLevelMap,
 					input: modelDef.input as ("text" | "image")[],
 					cost: modelDef.cost,
-					contextWindow: modelDef.contextWindow,
-					maxTokens: modelDef.maxTokens,
+					contextWindow: modelDef.contextWindow ?? 128000,
+					maxTokens: modelDef.maxTokens ?? 16384,
 					headers: undefined,
 					compat: modelDef.compat,
 				} as Model<Api>);


### PR DESCRIPTION
## Problem
Local models via OpenAI-compatible API (Ollama, LM Studio) don't report token usage. Their usage objects contain all zeros (totalTokens: 0). `calculateContextTokens` returns 0, so `shouldCompact(0, ...)` always returns false — auto-compaction never fires.

Two additional bugs found:
1. `applyProviderConfig` in model-registry.ts sets `contextWindow: modelDef.contextWindow` without default, unlike `parseModels` which uses `?? 128000`. Custom provider models get `undefined` contextWindow.
2. `_checkCompaction` and `_isRetryableError` default to `?? 0` for contextWindow — should be `?? 128000`.

## Fix
- `agent-session._checkCompaction`: when `calculateContextTokens` returns 0, fall back to direct message estimation via `estimateTokens` (char count / 4 heuristic)
- `agent-session` both contextWindow lookups: `?? 0` → `?? 128000`
- `model-registry.applyProviderConfig`: add `?? 128000` / `?? 16384` defaults matching `parseModels`

## Testing
Before: auto-compaction never triggers for local Ollama models regardless of context size.
After: auto-compaction triggers when estimated tokens exceed `contextWindow - reserveTokens` (~111k with defaults).