### PR TITLE
feat(agent):  keyless providers

### DIFF
--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -550,8 +550,11 @@ interface ProviderConfig {
   /** API endpoint URL. Required when defining models. */
   baseUrl?: string;
 
-  /** API key or environment variable name. Required when defining models (unless oauth). */
+  /** API key or environment variable name. Required when defining models (unless `oauth` or `keyless`). */
   apiKey?: string;
+
+  /** Declare the provider keyless (e.g., local inference). */
+  keyless?: true;
 
   /** API type for streaming. Required at provider or model level when defining models. */
   api?: Api;

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1598,7 +1598,8 @@ pi.registerProvider("corporate-ai", {
 **Config options:**
 - `name` - Display name for the provider in UI such as `/login`.
 - `baseUrl` - API endpoint URL. Required when defining models.
-- `apiKey` - API key or environment variable name. Required when defining models (unless `oauth` provided).
+- `apiKey` - API key or environment variable name. Required when defining models (unless `oauth` or `keyless` set).
+- `keyless` - Set to `true` to declare a keyless provider (e.g., local inference).
 - `api` - API type: `"anthropic-messages"`, `"openai-completions"`, `"openai-responses"`, etc.
 - `headers` - Custom headers to include in requests.
 - `authHeader` - If true, adds `Authorization: Bearer` header automatically.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -352,6 +352,9 @@ export class AgentSession {
 			}
 			throw new Error(result.error);
 		}
+		if (result.keyless) {
+			return { apiKey: "", headers: result.headers };
+		}
 		if (result.apiKey) {
 			return { apiKey: result.apiKey, headers: result.headers };
 		}
@@ -1865,7 +1868,7 @@ export class AgentSession {
 			}
 
 			const authResult = await this._modelRegistry.getApiKeyAndHeaders(this.model);
-			if (!authResult.ok || !authResult.apiKey) {
+			if (!authResult.ok || (!authResult.apiKey && !authResult.keyless)) {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -1875,7 +1878,7 @@ export class AgentSession {
 				});
 				return;
 			}
-			const { apiKey, headers } = authResult;
+			const { apiKey = "", headers } = authResult;
 
 			const pathEntries = this.sessionManager.getBranch();
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1320,8 +1320,10 @@ export interface ProviderConfig {
 	name?: string;
 	/** Base URL for the API endpoint. Required when defining models. */
 	baseUrl?: string;
-	/** API key or environment variable name. Required when defining models (unless oauth provided). */
+	/** API key or environment variable name. Required when defining models (unless `oauth` or `keyless` set). */
 	apiKey?: string;
+	/** Declare the provider keyless (e.g., local inference). */
+	keyless?: true;
 	/** API type. Required at provider or model level when defining models. */
 	api?: Api;
 	/** Optional streamSimple handler for custom APIs. */

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -185,6 +185,7 @@ const ProviderConfigSchema = Type.Object({
 	name: Type.Optional(Type.String({ minLength: 1 })),
 	baseUrl: Type.Optional(Type.String({ minLength: 1 })),
 	apiKey: Type.Optional(Type.String({ minLength: 1 })),
+	keyless: Type.Optional(Type.Literal(true)),
 	api: Type.Optional(Type.String({ minLength: 1 })),
 	headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 	compat: Type.Optional(ProviderCompatSchema),
@@ -229,6 +230,7 @@ interface ProviderOverride {
 
 interface ProviderRequestConfig {
 	apiKey?: string;
+	keyless?: true;
 	headers?: Record<string, string>;
 	authHeader?: boolean;
 }
@@ -237,6 +239,7 @@ export type ResolvedRequestAuth =
 	| {
 			ok: true;
 			apiKey?: string;
+			keyless?: true;
 			headers?: Record<string, string>;
 	  }
 	| {
@@ -528,8 +531,15 @@ export class ModelRegistry {
 				if (!providerConfig.baseUrl) {
 					throw new Error(`Provider ${providerName}: "baseUrl" is required when defining custom models.`);
 				}
-				if (!providerConfig.apiKey) {
-					throw new Error(`Provider ${providerName}: "apiKey" is required when defining custom models.`);
+				if (providerConfig.apiKey === undefined && !providerConfig.keyless) {
+					throw new Error(
+						`Provider ${providerName}: "apiKey" or "keyless" is required when defining custom models`,
+					);
+				}
+				if (providerConfig.apiKey !== undefined && providerConfig.keyless) {
+					throw new Error(
+						`Provider ${providerName}: "apiKey" and "keyless" are mutually exclusive.`,
+					);
 				}
 			}
 			// Built-in providers with custom models: baseUrl/apiKey/api are optional,
@@ -636,9 +646,11 @@ export class ModelRegistry {
 	 * Get API key for a model.
 	 */
 	hasConfiguredAuth(model: Model<Api>): boolean {
+		const config = this.providerRequestConfigs.get(model.provider);
 		return (
 			this.authStorage.hasAuth(model.provider) ||
-			this.providerRequestConfigs.get(model.provider)?.apiKey !== undefined
+			config?.apiKey !== undefined ||
+			config?.keyless === true
 		);
 	}
 
@@ -650,16 +662,18 @@ export class ModelRegistry {
 		providerName: string,
 		config: {
 			apiKey?: string;
+			keyless?: true;
 			headers?: Record<string, string>;
 			authHeader?: boolean;
 		},
 	): void {
-		if (!config.apiKey && !config.headers && !config.authHeader) {
+		if (!config.keyless && !config.apiKey && !config.headers && !config.authHeader) {
 			return;
 		}
 
 		this.providerRequestConfigs.set(providerName, {
 			apiKey: config.apiKey,
+			keyless: config.keyless,
 			headers: config.headers,
 			authHeader: config.authHeader,
 		});
@@ -674,12 +688,35 @@ export class ModelRegistry {
 		this.modelRequestHeaders.set(key, headers);
 	}
 
+	private resolveAllHeaders(
+		model: Model<Api>,
+		providerConfig: ProviderRequestConfig | undefined,
+	): Record<string, string> | undefined {
+		const providerHeaders = resolveHeadersOrThrow(providerConfig?.headers, `provider "${model.provider}"`);
+		const modelHeaders = resolveHeadersOrThrow(
+			this.modelRequestHeaders.get(this.getModelRequestKey(model.provider, model.id)),
+			`model "${model.provider}/${model.id}"`,
+		);
+		return model.headers || providerHeaders || modelHeaders
+			? { ...model.headers, ...providerHeaders, ...modelHeaders }
+			: undefined;
+	}
+
 	/**
 	 * Get API key and request headers for a model.
 	 */
 	async getApiKeyAndHeaders(model: Model<Api>): Promise<ResolvedRequestAuth> {
 		try {
 			const providerConfig = this.providerRequestConfigs.get(model.provider);
+
+			if (providerConfig?.keyless) {
+				return {
+					ok: true,
+					keyless: true,
+					headers: this.resolveAllHeaders(model, providerConfig),
+				};
+			}
+
 			const apiKeyFromAuthStorage = await this.authStorage.getApiKey(model.provider, { includeFallback: false });
 			const apiKey =
 				apiKeyFromAuthStorage ??
@@ -687,16 +724,7 @@ export class ModelRegistry {
 					? resolveConfigValueOrThrow(providerConfig.apiKey, `API key for provider "${model.provider}"`)
 					: undefined);
 
-			const providerHeaders = resolveHeadersOrThrow(providerConfig?.headers, `provider "${model.provider}"`);
-			const modelHeaders = resolveHeadersOrThrow(
-				this.modelRequestHeaders.get(this.getModelRequestKey(model.provider, model.id)),
-				`model "${model.provider}/${model.id}"`,
-			);
-
-			let headers =
-				model.headers || providerHeaders || modelHeaders
-					? { ...model.headers, ...providerHeaders, ...modelHeaders }
-					: undefined;
+			let headers = this.resolveAllHeaders(model, providerConfig);
 
 			if (providerConfig?.authHeader) {
 				if (!apiKey) {
@@ -840,8 +868,23 @@ export class ModelRegistry {
 		if (!config.baseUrl) {
 			throw new Error(`Provider ${providerName}: "baseUrl" is required when defining models.`);
 		}
-		if (!config.apiKey && !config.oauth) {
-			throw new Error(`Provider ${providerName}: "apiKey" or "oauth" is required when defining models.`);
+		const authModes = [config.apiKey !== undefined, config.oauth !== undefined, config.keyless === true].filter(
+			Boolean,
+		).length;
+		if (authModes === 0) {
+			throw new Error(
+				`Provider ${providerName}: one of "apiKey", "oauth", or "keyless" is required when defining models.`,
+			);
+		}
+		if (authModes > 1) {
+			throw new Error(
+				`Provider ${providerName}: "apiKey", "oauth", and "keyless" are mutually exclusive.`,
+			);
+		}
+		if (typeof config.apiKey === "string" && config.apiKey.length === 0) {
+			throw new Error(
+				`Provider ${providerName}: "apiKey" cannot be an empty string.`,
+			);
 		}
 
 		for (const modelDef of config.models) {
@@ -930,6 +973,7 @@ export interface ProviderConfigInput {
 	name?: string;
 	baseUrl?: string;
 	apiKey?: string;
+	keyless?: true;
 	api?: Api;
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	headers?: Record<string, string>;


### PR DESCRIPTION
Allow providers to register as keyless in order to make writing local providers easier. This achieved with a new `keyless` boolean attribute, which is mutually exclusive towards `apiKey` and `oauth`.

In addition, consolidate the shared header resolution code to `resolveAllHeaders`.

In order to test this I developed an experimental plugin for OONX community models: https://github.com/jarkkojs/pi-provider-onnx-community. It's working but has pretty bad user response for downloading models (just stalls) :-) Anyhow, good enough for PoC and to show the usefulness of the feature.

Without the change:

```
❯ pi
Error: Extension "/home/jarkko/.pi/agent/git/github.com/jarkkojs/pi-provider-onnx-community/src/index.ts" error: Provider onnx-community: "apiKey" or "oauth" is required when defining models.
```

With the change I can have this nice discussion with Qwen2.5-Code-0.5B-Instinct:

```
hello                                                                                                                                                                                          
                                                                                                                                                                                                
Thinking...                                    

Hello! How can I assist you today?             

TPS 0.1 tok/s. out 9, in 0, cache r/w 0/0, total 9, 62.9s            z
```

The motivation in this quest is to extend Pi's possibilities to be playground for so called distilled models, for instance when you are choosing a model for embedded applications.