### PR TITLE
fix(coding-agent): blocked edit tool calls render with error styling

### DIFF
--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -233,14 +233,14 @@ function getEditHeaderBg(
 	settledError: boolean | undefined,
 	theme: typeof import("../../modes/interactive/theme/theme.js").theme,
 ): (text: string) => string {
+	if (settledError) {
+		return (text: string) => theme.bg("toolErrorBg", text);
+	}
 	if (preview) {
 		if ("error" in preview) {
 			return (text: string) => theme.bg("toolErrorBg", text);
 		}
 		return (text: string) => theme.bg("toolSuccessBg", text);
-	}
-	if (settledError) {
-		return (text: string) => theme.bg("toolErrorBg", text);
 	}
 	return (text: string) => theme.bg("toolPendingBg", text);
 }


### PR DESCRIPTION
Hello!

Noticed this a few days ago and I think someone opened an issue but I can't find it:

In the tui, if a edit tool is blocked by the `tool_call` event in an extension, it still displays its bg as successful despite having failed.

Screenshots: 
<details><summary>Before</summary>
<p>

<img width="1782" height="1408" alt="Screenshot 2026-05-14 at 09 19 42 AM@2x" src="https://github.com/user-attachments/assets/dace0c4b-e5d1-4cd4-9e22-21183146e355" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1782" height="1508" alt="Screenshot 2026-05-14 at 09 21 17 AM@2x" src="https://github.com/user-attachments/assets/1727063b-3ed7-4f10-832a-4d49e7c2d4ad" />


</p>
</details> 

Investigation: https://pi.dev/session/#a3551ee267c75695803792396d59f3ea
Fix: https://pi.dev/session/#90b517e0a58613fc4d7dffa2de5df81b

Let me know if you need more changes!

------

<details><summary>Summary by zai-org/GLM-5.1:</summary>
<p>

## Bug

A `tool_call` hook can block execution by returning `{ block: true, reason }`. When this happens for the `edit` tool, the runtime correctly sets `isError: true` on the tool result. However, the edit header could still render with success (green) styling instead of error (red).

## Root Cause

`edit` uses `renderShell: "self"`, so it controls its own call/header styling. The `getEditHeaderBg()` function in `packages/coding-agent/src/core/tools/edit.ts` checked the preview state before the `settledError` flag:

```
if (preview) {           // <-- checked first
  if ("error" in preview) return toolErrorBg;
  return toolSuccessBg;  // <-- successful preview wins
}
if (settledError) {      // <-- checked second, too late
  return toolErrorBg;
}
```

When an edit has a successful preview diff (computed from arguments before execution) and then gets blocked by a `tool_call` hook, `settledError` is set to `true` in `renderResult()`, but the preview check runs first and returns `toolSuccessBg`.

## Fix

Reorder `getEditHeaderBg()` so `settledError` is checked before `preview`. A blocked edit now always renders with `toolErrorBg`, regardless of preview state.

### Changed file

- `packages/coding-agent/src/core/tools/edit.ts` — moved `settledError` check before `preview` check in `getEditHeaderBg()`

## Reproducing

Use an extension that blocks every edit call:

```typescript
import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
export default function (pi: ExtensionAPI) {
  pi.on("tool_call", async (event) => {
    if (event.toolName === "edit") {
      return { block: true, reason: "Edit blocked" };
    }
  });
}
```

Before the fix: the edit header shows green/success background. After: red/error background.

</p>
</details>