### PR TITLE
fix(agent): split browser-safe and Node-only entries

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -5,6 +5,16 @@
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./node": {
+			"types": "./dist/node.d.ts",
+			"import": "./dist/node.js"
+		}
+	},
 	"files": [
 		"dist",
 		"README.md"

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,19 +22,13 @@ export {
 	serializeConversation,
 	shouldCompact,
 } from "./harness/compaction/compaction.js";
-export * from "./harness/execution-env.js";
 export * from "./harness/messages.js";
 export * from "./harness/prompt-templates.js";
-export * from "./harness/session/repo/jsonl.js";
-export * from "./harness/session/repo/memory.js";
-export * from "./harness/session/repo/shared.js";
 export * from "./harness/session/session.js";
-export { uuidv7 } from "./harness/session/uuid.js";
 export * from "./harness/skills.js";
 export * from "./harness/system-prompt.js";
 // Harness
 export * from "./harness/types.js";
-export * from "./harness/utils/shell-output.js";
 export * from "./harness/utils/truncate.js";
 // Proxy utilities
 export * from "./proxy.js";

--- a/packages/agent/src/node.ts
+++ b/packages/agent/src/node.ts
@@ -1,0 +1,7 @@
+// Node-only entry. Pulls in `node:*` modules — do not import from a browser bundle.
+export { NodeExecutionEnv } from "./harness/env/nodejs.js";
+export * from "./harness/session/repo/jsonl.js";
+export * from "./harness/session/repo/memory.js";
+export * from "./harness/session/repo/shared.js";
+export { uuidv7 } from "./harness/session/uuid.js";
+export * from "./harness/utils/shell-output.js";

--- a/packages/agent/test/scratch/simple.ts
+++ b/packages/agent/test/scratch/simple.ts
@@ -7,11 +7,11 @@ import {
 	formatSkillsForSystemPrompt,
 	loadSourcedPromptTemplates,
 	loadSourcedSkills,
-	NodeExecutionEnv,
 	type PromptTemplate,
 	Session,
 	type Skill,
 } from "../../src/index.js";
+import { NodeExecutionEnv } from "../../src/node.js";
 
 type Source = { type: "project" | "user" | "path"; dir: string };
 type SourcedSkill = Skill & { source: Source };

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,4 +1,5 @@
-import { type AgentMessage, uuidv7 } from "@earendil-works/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { uuidv7 } from "@earendil-works/pi-agent-core/node";
 import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import {


### PR DESCRIPTION
## Summary

The agent package's main entry pulled in Node-only modules (`node:child_process`, `node:crypto`, `node:fs`), which broke the `packages/web-ui/example` app in the browser — it rendered as a completely blank page because the module graph crashed on first load.

Root cause: commit `617d8b31 refactor(agent): tighten harness environment and resources` added `export * from "./harness/execution-env.js"` to `src/index.ts`, which transitively re-exported `NodeExecutionEnv` (and several other Node-only files) onto the package's default entry. Any browser bundler (Vite here) externalizes `node:*` specifiers, then throws on first access — preventing `main.ts` from completing init.

## Changes

- **Move all Node-only re-exports out of `src/index.ts`** into a new `src/node.ts` entry. Affected symbols: `NodeExecutionEnv`, `JsonlSessionRepo`, `InMemorySessionRepo`, `repo/shared` helpers, `uuidv7`, `shell-output` helpers.
- **Declare an `exports` map in `packages/agent/package.json`** so the new entry is reachable as `@earendil-works/pi-agent-core/node`. The default entry stays for back-compat with all type-only imports.
- **Update internal consumers** that imported these symbols as values: `packages/coding-agent/src/core/session-manager.ts` and `packages/agent/test/scratch/simple.ts` now import from `/node`. Type-only imports continue from the main entry.

## Why split rather than lazy-load

Lazy-loading inside `nodejs.ts` would still require all consumers to await an init step or guard every call site. A subpath split is mechanical, has zero runtime overhead, and matches the conventional shape for packages that span environments (e.g. `react-dom` → `react-dom/client` & `react-dom/server`).

## Impact

- **Browser bundlers** no longer see Node-only specifiers. Verified with a headless Chromium run against `packages/web-ui/example` dev server:
  - Before: `errors: [{message: "Module 'node:child_process' has been externalized..."}]`, `<div id="app">` 0 bytes.
  - After: `errors: []`, `<div id="app">` 16,820 bytes of rendered DOM, Tailwind tokens applied.
- **All in-repo consumers** of `pi-agent-core` are type-only imports (grep-confirmed); only the two value-import sites above needed changes.
- **Breaking** for external Node users that imported `NodeExecutionEnv`, `uuidv7`, or session/shell-output helpers from the main entry — they must switch to `@earendil-works/pi-agent-core/node`. Since these symbols were Node-only to begin with, no browser code is affected.

## Test plan

- [x] `npm run check` passes (biome, tsgo --noEmit, browser smoke, web-ui type check)
- [x] `npm run build` succeeds
- [x] Headless Chromium verification of `packages/web-ui/example` (page renders, no console errors)
- [x] Node smoke-test: `import('packages/agent/dist/node.js')` exposes `uuidv7`, `NodeExecutionEnv`, etc.
- [x] Node smoke-test: `coding-agent/dist/core/session-manager.js` still loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)