### PR TITLE
feat: Exit alias

### DIFF
--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -53,7 +53,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/reload` | Reload keybindings, extensions, skills, prompts, and context files |
 | `/hotkeys` | Show all keyboard shortcuts |
 | `/changelog` | Display version history |
-| `/quit` | Quit pi |
+| `/quit`, `/exit` | Quit pi |
 
 ## Message Queue
 

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -37,4 +37,5 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
+	{ name: "exit", description: `Quit ${APP_NAME}` },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2557,7 +2557,7 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/quit") {
+			if (text === "/quit" || text === "/exit") {
 				this.editor.setText("");
 				await this.shutdown();
 				return;


### PR DESCRIPTION
Closes: Issue #4538  

## Summary

- Added alias `/exit` for `/quit` with exact same similarity

## Implementation

- Found where "quit" is written in codebase, and added "exit" accordingly
- Updated docs as well
- Tried to achieve simplest implementation

## Previews

> I have custom theme set up

- <img width="1137" height="261" alt="image" src="https://github.com/user-attachments/assets/0040ec24-e092-4c2e-a23f-6f95ce4af72d" />
- <img width="488" height="165" alt="image" src="https://github.com/user-attachments/assets/dd7fc182-dc82-473f-98b7-6db75d83aaa7" />
- <img width="492" height="152" alt="image" src="https://github.com/user-attachments/assets/d51f9735-fe1d-41ae-99ac-686b87fb53a9" />

## Intent

- Match environment for Claude Code users shifting to Pi and exiting
- Matching how Codex has two options for exit - `/quit` and `/exit`
- Was annoying for me to write `/exit` instead of `/quit` because of muscle memory

## Change Checklist

- [x] Change Codebase
- [x] Add Docs
- [x] Test Changes
- [x] Run Tests and Lint