### PR TITLE
Copilot/fix auto compact functionality

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -21,6 +21,7 @@ import type {
 	AgentTool,
 	BeforeToolCallContext,
 	BeforeToolCallResult,
+	ShouldStopAfterTurnContext,
 	StreamFn,
 	ToolExecutionMode,
 } from "./types.js";
@@ -105,6 +106,7 @@ export interface AgentOptions {
 	prepareNextTurn?: (
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
+	shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 	steeringMode?: QueueMode;
 	followUpMode?: QueueMode;
 	sessionId?: string;
@@ -182,6 +184,7 @@ export class Agent {
 	public prepareNextTurn?: (
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
+	public shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 	private activeRun?: ActiveRun;
 	/** Session identifier forwarded to providers for cache-aware backends. */
 	public sessionId?: string;
@@ -205,6 +208,7 @@ export class Agent {
 		this.beforeToolCall = options.beforeToolCall;
 		this.afterToolCall = options.afterToolCall;
 		this.prepareNextTurn = options.prepareNextTurn;
+		this.shouldStopAfterTurn = options.shouldStopAfterTurn;
 		this.steeringQueue = new PendingMessageQueue(options.steeringMode ?? "one-at-a-time");
 		this.followUpQueue = new PendingMessageQueue(options.followUpMode ?? "one-at-a-time");
 		this.sessionId = options.sessionId;
@@ -430,6 +434,9 @@ export class Agent {
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
 			prepareNextTurn: this.prepareNextTurn ? async () => await this.prepareNextTurn?.(this.signal) : undefined,
+			shouldStopAfterTurn: this.shouldStopAfterTurn
+				? async (ctx) => (await this.shouldStopAfterTurn?.(ctx)) ?? false
+				: undefined,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -425,6 +425,18 @@ export class AgentSession {
 				isError: hookResult.isError ?? isError,
 			};
 		};
+
+		this.agent.shouldStopAfterTurn = (ctx) => {
+			const settings = this.settingsManager.getCompactionSettings();
+			if (!settings.enabled) return false;
+			const contextWindow = this.model?.contextWindow ?? 0;
+			const contextTokens = calculateContextTokens(ctx.message.usage);
+			if (!shouldCompact(contextTokens, contextWindow, settings)) return false;
+			// Only set willRetry flag when there are pending tool results — the agent
+			// is mid-task and must resume after compaction.
+			this._stoppedForCompaction = ctx.toolResults.length > 0;
+			return true;
+		};
 	}
 
 	// =========================================================================
@@ -448,6 +460,11 @@ export class AgentSession {
 
 	// Track last assistant message for auto-compaction check
 	private _lastAssistantMessage: AssistantMessage | undefined = undefined;
+	// Set to true when shouldStopAfterTurn halted the run because context hit the threshold.
+	// Causes _checkCompaction to pass willRetry=true so the agent resumes after compaction.
+	// Safe from concurrent access: Agent enforces a single activeRun at a time and turns
+	// execute sequentially within a run.
+	private _stoppedForCompaction = false;
 
 	/** Internal handler for agent events - shared by subscribe and reconnect */
 	private _handleAgentEvent = (event: AgentEvent): void => {
@@ -1839,7 +1856,9 @@ export class AgentSession {
 			contextTokens = calculateContextTokens(assistantMessage.usage);
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
-			await this._runAutoCompaction("threshold", false);
+			const willRetry = this._stoppedForCompaction;
+			this._stoppedForCompaction = false;
+			await this._runAutoCompaction("threshold", willRetry);
 		}
 	}
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -340,4 +340,130 @@ describe("AgentSession compaction characterization", () => {
 		expect(belowThresholdSpy).not.toHaveBeenCalled();
 		expect(disabledSpy).not.toHaveBeenCalled();
 	});
+
+	it("shouldStopAfterTurn stops mid-run and sets willRetry when context hits threshold with tool results", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, reserveTokens: 1000 } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "auto compacted mid-run",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+
+		// Simulate shouldStopAfterTurn being called with context over threshold and tool results present
+		const aboveThresholdMessage = createAssistant(harness, {
+			stopReason: "toolUse",
+			totalTokens: 199_500,
+			timestamp: Date.now(),
+		});
+		const fakeToolResult = {
+			role: "toolResult" as const,
+			content: [],
+			toolCallId: "t1",
+			timestamp: Date.now(),
+		};
+		const ctx = {
+			message: aboveThresholdMessage,
+			toolResults: [fakeToolResult],
+			context: { systemPrompt: "", messages: [], tools: [] },
+			newMessages: [],
+		};
+
+		const stopped = await harness.session.agent.shouldStopAfterTurn!(ctx);
+		expect(stopped).toBe(true);
+
+		// After shouldStopAfterTurn returns true, _checkCompaction is called at agent_end
+		await sessionInternals._checkCompaction(aboveThresholdMessage);
+
+		expect(runAutoCompactionSpy).toHaveBeenCalledWith("threshold", true);
+	});
+
+	it("shouldStopAfterTurn does not set willRetry when no tool results (natural turn end)", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, reserveTokens: 1000 } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+		});
+		harnesses.push(harness);
+
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue();
+
+		const aboveThresholdMessage = createAssistant(harness, {
+			stopReason: "stop",
+			totalTokens: 199_500,
+			timestamp: Date.now(),
+		});
+		const ctx = {
+			message: aboveThresholdMessage,
+			toolResults: [], // no tool results — turn completed naturally
+			context: { systemPrompt: "", messages: [], tools: [] },
+			newMessages: [],
+		};
+
+		const stopped = await harness.session.agent.shouldStopAfterTurn!(ctx);
+		expect(stopped).toBe(true);
+
+		// _stoppedForCompaction should be false (no tool results), so willRetry=false
+		await sessionInternals._checkCompaction(aboveThresholdMessage);
+		expect(runAutoCompactionSpy).toHaveBeenCalledWith("threshold", false);
+	});
+
+	it("shouldStopAfterTurn returns false when disabled", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: false } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+		});
+		harnesses.push(harness);
+
+		const aboveThresholdMessage = createAssistant(harness, {
+			stopReason: "stop",
+			totalTokens: 199_500,
+			timestamp: Date.now(),
+		});
+		const ctx = {
+			message: aboveThresholdMessage,
+			toolResults: [],
+			context: { systemPrompt: "", messages: [], tools: [] },
+			newMessages: [],
+		};
+
+		const stopped = await harness.session.agent.shouldStopAfterTurn!(ctx);
+		expect(stopped).toBe(false);
+	});
+
+	it("shouldStopAfterTurn returns false when context is below threshold", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, reserveTokens: 1000 } },
+			models: [{ id: "faux-1", contextWindow: 200_000 }],
+		});
+		harnesses.push(harness);
+
+		const belowThresholdMessage = createAssistant(harness, {
+			stopReason: "stop",
+			totalTokens: 100_000,
+			timestamp: Date.now(),
+		});
+		const ctx = {
+			message: belowThresholdMessage,
+			toolResults: [],
+			context: { systemPrompt: "", messages: [], tools: [] },
+			newMessages: [],
+		};
+
+		const stopped = await harness.session.agent.shouldStopAfterTurn!(ctx);
+		expect(stopped).toBe(false);
+	});
 });

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,6 +22,7 @@ export default defineConfig({
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@earendil-works\/pi-tui$/, replacement: tuiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },


### PR DESCRIPTION
This pull request introduces a new agent lifecycle hook, `shouldStopAfterTurn`, to support more flexible and robust context window management, specifically for auto-compaction in long-running agent sessions. The changes add the new hook to the agent core, implement it in the coding agent to trigger compaction mid-run when needed, and provide thorough tests for the new behavior. Additionally, a minor update to the test configuration improves module aliasing.

**Agent core enhancements:**

- Added a new optional hook, `shouldStopAfterTurn`, to the `AgentOptions` interface and the `Agent` class, allowing custom logic to determine if the agent should halt after a turn (e.g., for compaction or other maintenance). (`packages/agent/src/agent.ts`) [[1]](diffhunk://#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143R24) [[2]](diffhunk://#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143R109) [[3]](diffhunk://#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143R187) [[4]](diffhunk://#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143R211) [[5]](diffhunk://#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143R437-R439)

**Coding agent compaction logic:**

- Implemented `shouldStopAfterTurn` in `AgentSession` to trigger auto-compaction when the context window exceeds the threshold, setting a flag (`_stoppedForCompaction`) if the agent is mid-task (has pending tool results), ensuring the agent resumes after compaction if needed. (`packages/coding-agent/src/core/agent-session.ts`) [[1]](diffhunk://#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448aeR428-R439) [[2]](diffhunk://#diff-a72e8a0b5f514ca1def756ee863a6e8a556df115e7167a50ca4f5e66b14448aeR463-R467)
- Updated the compaction check logic to use the `willRetry` flag, which is set based on whether the agent was stopped mid-task, to control agent resumption after compaction. (`packages/coding-agent/src/core/agent-session.ts`)

**Testing improvements:**

- Added comprehensive tests to verify `shouldStopAfterTurn` behavior, including scenarios where the agent stops mid-run for compaction, does not set `willRetry` on natural turn end, and correctly handles disabled or below-threshold cases. (`packages/coding-agent/test/suite/agent-session-compaction.test.ts`)

**Build/test configuration:**

- Added a module alias for `@earendil-works/pi-tui` in the Vitest configuration to improve test reliability and maintainability. (`packages/coding-agent/vitest.config.ts`) [[1]](diffhunk://#diff-bde9d899eecf81df61ac3e23b7661d244fa4c650c879157d49d0577ad9063862R7) [[2]](diffhunk://#diff-bde9d899eecf81df61ac3e23b7661d244fa4c650c879157d49d0577ad9063862R25)