### PR TITLE
fix(ai): openai-completions - throw error on missing finish-reason

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed GitHub Copilot model availability to ignore generic `GH_TOKEN` and `GITHUB_TOKEN` environment variables, requiring OAuth login or `COPILOT_GITHUB_TOKEN` instead ([#4485](https://github.com/earendil-works/pi/issues/4485)).
+- Fixed `openai-completions` streams to surface an error when the stream ends before any terminal `finish_reason`, so truncated responses can retry instead of being accepted as success ([#4345](https://github.com/earendil-works/pi/issues/4345)).
 - Fixed Bedrock proxy handling to preserve `NO_PROXY` exclusions while using HTTP(S)-only proxy agents.
 - Fixed GitHub Copilot Claude test coverage to use the current Claude Sonnet 4.6 model ID.
 - Fixed OpenAI Responses requests for models that support disabling reasoning to send `reasoning.effort: "none"` when thinking is off.

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -165,6 +165,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 
 			let textBlock: TextContent | null = null;
 			let thinkingBlock: ThinkingContent | null = null;
+			let hasFinishReason = false;
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
 			const blocks = output.content as StreamingBlock[];
@@ -288,6 +289,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 					if (finishReasonResult.errorMessage) {
 						output.errorMessage = finishReasonResult.errorMessage;
 					}
+					hasFinishReason = true;
 				}
 
 				if (choice.delta) {
@@ -389,6 +391,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			}
 			if (output.stopReason === "error") {
 				throw new Error(output.errorMessage || "Provider returned an error stop reason");
+			}
+			if (!hasFinishReason) {
+				throw new Error("Stream ended without finish_reason");
 			}
 
 			stream.push({ type: "done", reason: output.stopReason, message: output });

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -441,6 +441,38 @@ describe("openai-completions tool_choice", () => {
 		expect(response.content).toEqual([{ type: "text", text: "OK" }]);
 	});
 
+	it("errors when a stream ends after only null finish_reason chunks", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-truncated",
+				choices: [{ delta: { content: "partial answer" }, finish_reason: null }],
+			},
+			{
+				id: "chatcmpl-truncated",
+				choices: [{ delta: { content: "partial answer" }, finish_reason: null }],
+			},
+		];
+
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = { ...baseModel, api: "openai-completions" } as const;
+		const response = await streamSimple(
+			model,
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Reply with a longer sentence",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		expect(response.stopReason).toBe("error");
+		expect(response.errorMessage).toBe("Stream ended without finish_reason");
+	});
+
 	it("coalesces tool call deltas by stable index when provider mutates ids mid-stream", async () => {
 		mockState.chunks = [
 			{


### PR DESCRIPTION
**Description**

- Track `finish_reason` setting via `hasFinishReason`
- Throw an error if `hasFinishReason` is falsy **before** emitting `done`.
- The OG issue mentions compatibility options for providers which don't adhere to the API schema (see `compat.requiresFinishReason` suggestion in the issue description), but I don't think that this is a sustainable option here. So either the `finish_reason` is provided and matches the type, or an error is thrown. Let me know if that assumption on my end is correct.
- closes #4345

**Testing**

- I added an additional test-case where all the mock-chunks have `null` as `finish_reason`

In addition, asked AI to put some mock-server together that would emit / simulate this stream of events for me (see video below, server code in the details below as well)

<details>

```js
import { createServer } from "node:http";

const host = process.env.HOST ?? "127.0.0.1";
const port = Number.parseInt(process.env.PORT ?? "8787", 10);
const delayMs = Number.parseInt(process.env.DELAY_MS ?? "150", 10);
const chunkCount = Math.max(1, Number.parseInt(process.env.CHUNKS ?? "3", 10));
const text = process.env.PARTIAL_TEXT ?? "partial answer from the mock server";

function sleep(ms) {
	return new Promise((resolve) => setTimeout(resolve, ms));
}

function splitText(input, parts) {
	if (parts <= 1 || input.length <= 1) {
		return [input];
	}

	const segments = [];
	const size = Math.ceil(input.length / parts);
	for (let i = 0; i < input.length; i += size) {
		segments.push(input.slice(i, i + size));
	}
	return segments;
}

async function readJsonBody(request) {
	let body = "";
	request.setEncoding("utf8");
	for await (const chunk of request) {
		body += chunk;
	}
	return body.length > 0 ? JSON.parse(body) : null;
}

function writeChunk(response, model, content) {
	const chunk = {
		id: "chatcmpl-incomplete",
		object: "chat.completion.chunk",
		created: Math.floor(Date.now() / 1000),
		model,
		choices: [{ index: 0, delta: { content }, finish_reason: null }],
	};
	response.write(`data: ${JSON.stringify(chunk)}\n\n`);
	return chunk;
}

const server = createServer(async (request, response) => {
	if (
		request.method !== "POST" ||
		(request.url !== "/v1/chat/completions" && request.url !== "/chat/completions")
	) {
		response.writeHead(404).end();
		return;
	}

	const body = await readJsonBody(request);
	const model = typeof body?.model === "string" && body.model.length > 0 ? body.model : "incomplete-repro";
	const chunks = splitText(text, chunkCount);

	console.log(`[request] ${request.method} ${request.url} model=${model}`);
	console.log(`[request] sending ${chunks.length} partial chunk(s), all with finish_reason=null`);

	response.writeHead(200, {
		"content-type": "text/event-stream",
		"cache-control": "no-cache",
		connection: "keep-alive",
	});
	response.flushHeaders();
	response.socket?.setNoDelay(true);

	for (const [index, content] of chunks.entries()) {
		const chunk = writeChunk(response, model, content);
		console.log(
			`[chunk ${index + 1}/${chunks.length}] content=${JSON.stringify(content)} finish_reason=${chunk.choices[0].finish_reason}`,
		);
		if (delayMs > 0) {
			await sleep(delayMs);
		}
	}

	console.log("[close] ending stream early without any terminal finish_reason");
	response.end();
});

server.listen(port, host, () => {
	console.log(`Mock OpenAI incomplete-stream server listening on http://${host}:${port}`);
	console.log(`Configured with CHUNKS=${chunkCount} DELAY_MS=${delayMs} PARTIAL_TEXT=${JSON.stringify(text)}`);
});

process.on("SIGINT", () => {
	console.log("[signal] SIGINT");
	server.close(() => process.exit(0));
});

process.on("SIGTERM", () => {
	console.log("[signal] SIGTERM");
	server.close(() => process.exit(0));
});
```

</details>

| Video |
| ------------- |
| <video src="https://github.com/user-attachments/assets/d2da0887-ae50-4f2b-a571-b5b5cc13dfe6" /> |