### PR TITLE
feat: add lockDefaults option

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -18,6 +18,7 @@ Edit directly or use `/settings` for common options.
 | `defaultProvider` | string | - | Default provider (e.g., `"anthropic"`, `"openai"`) |
 | `defaultModel` | string | - | Default model ID |
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
+| `lockDefaults` | boolean | `false` | Prevent model/provider/thinking level changes from being saved to settings |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -78,6 +78,7 @@ export interface Settings {
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	lockDefaults?: boolean;
 	transport?: TransportSetting; // default: "auto"
 	steeringMode?: "all" | "one-at-a-time";
 	followUpMode?: "all" | "one-at-a-time";
@@ -595,19 +596,32 @@ export class SettingsManager {
 		return this.settings.defaultModel;
 	}
 
+	getLockDefaults(): boolean {
+		return this.settings.lockDefaults ?? false;
+	}
+
+	setLockDefaults(locked: boolean): void {
+		this.globalSettings.lockDefaults = locked;
+		this.markModified("lockDefaults");
+		this.save();
+	}
+
 	setDefaultProvider(provider: string): void {
+		if (this.getLockDefaults()) return;
 		this.globalSettings.defaultProvider = provider;
 		this.markModified("defaultProvider");
 		this.save();
 	}
 
 	setDefaultModel(modelId: string): void {
+		if (this.getLockDefaults()) return;
 		this.globalSettings.defaultModel = modelId;
 		this.markModified("defaultModel");
 		this.save();
 	}
 
 	setDefaultModelAndProvider(provider: string, modelId: string): void {
+		if (this.getLockDefaults()) return;
 		this.globalSettings.defaultProvider = provider;
 		this.globalSettings.defaultModel = modelId;
 		this.markModified("defaultProvider");
@@ -650,6 +664,7 @@ export class SettingsManager {
 	}
 
 	setDefaultThinkingLevel(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"): void {
+		if (this.getLockDefaults()) return;
 		this.globalSettings.defaultThinkingLevel = level;
 		this.markModified("defaultThinkingLevel");
 		this.save();

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -56,6 +56,7 @@ export interface SettingsConfig {
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
 	warnings: WarningSettings;
+	lockDefaults: boolean;
 }
 
 export interface SettingsCallbacks {
@@ -83,6 +84,7 @@ export interface SettingsCallbacks {
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
 	onWarningsChange: (warnings: WarningSettings) => void;
+	onLockDefaultsChange: (locked: boolean) => void;
 	onCancel: () => void;
 }
 
@@ -214,6 +216,13 @@ export class SettingsSelectorComponent extends Container {
 				label: "Auto-compact",
 				description: "Automatically compact context when it gets too large",
 				currentValue: config.autoCompact ? "true" : "false",
+				values: ["true", "false"],
+			},
+			{
+				id: "lock-defaults",
+				label: "Lock defaults",
+				description: "Prevent model/provider/thinking level changes from being saved to settings.json",
+				currentValue: config.lockDefaults ? "true" : "false",
 				values: ["true", "false"],
 			},
 			{
@@ -457,6 +466,9 @@ export class SettingsSelectorComponent extends Container {
 				switch (id) {
 					case "autocompact":
 						callbacks.onAutoCompactChange(newValue === "true");
+						break;
+					case "lock-defaults":
+						callbacks.onLockDefaultsChange(newValue === "true");
 						break;
 					case "show-images":
 						callbacks.onShowImagesChange(newValue === "true");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3822,6 +3822,7 @@ export class InteractiveMode {
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 					showTerminalProgress: this.settingsManager.getShowTerminalProgress(),
 					warnings: this.settingsManager.getWarnings(),
+					lockDefaults: this.settingsManager.getLockDefaults(),
 				},
 				{
 					onAutoCompactChange: (enabled) => {
@@ -3937,6 +3938,9 @@ export class InteractiveMode {
 					},
 					onWarningsChange: (warnings) => {
 						this.settingsManager.setWarnings(warnings);
+					},
+					onLockDefaultsChange: (locked) => {
+						this.settingsManager.setLockDefaults(locked);
 					},
 					onCancel: () => {
 						done();

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -316,4 +316,82 @@ describe("SettingsManager", () => {
 			expect(manager.getSessionDir()).toBe(join(homedir(), "sessions"));
 		});
 	});
+
+	describe("lockDefaults", () => {
+		it("should default to false", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ theme: "dark" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getLockDefaults()).toBe(false);
+		});
+
+		it("should read lockDefaults from settings file", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ lockDefaults: true }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getLockDefaults()).toBe(true);
+		});
+
+		it("should persist lockDefaults when set", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setLockDefaults(true);
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.lockDefaults).toBe(true);
+		});
+
+		it("should block setDefaultModel when locked", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ lockDefaults: true, defaultModel: "claude-sonnet" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setDefaultModel("gpt-4o");
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultModel).toBe("claude-sonnet");
+		});
+
+		it("should block setDefaultProvider when locked", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ lockDefaults: true, defaultProvider: "anthropic" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setDefaultProvider("openai");
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultProvider).toBe("anthropic");
+		});
+
+		it("should block setDefaultModelAndProvider when locked", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(
+				settingsPath,
+				JSON.stringify({ lockDefaults: true, defaultProvider: "anthropic", defaultModel: "claude-sonnet" }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setDefaultModelAndProvider("openai", "gpt-4o");
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultProvider).toBe("anthropic");
+			expect(saved.defaultModel).toBe("claude-sonnet");
+		});
+
+		it("should block setDefaultThinkingLevel when locked", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ lockDefaults: true, defaultThinkingLevel: "low" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setDefaultThinkingLevel("high");
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultThinkingLevel).toBe("low");
+		});
+
+		it("should allow setDefaultModel when not locked", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ lockDefaults: false, defaultModel: "claude-sonnet" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setDefaultModel("gpt-4o");
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(saved.defaultModel).toBe("gpt-4o");
+		});
+	});
 });


### PR DESCRIPTION
Adds a `lockDefaults` setting, so that changing your model or thinking level during a session does not persist `defaultModel`, `defaultProvider` or `defaultThinkingLevel` to settings.json.