### PR TITLE
Force TUI redraw on terminal resize

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -442,7 +442,7 @@ export class TUI extends Container {
 		this.stopped = false;
 		this.terminal.start(
 			(data) => this.handleInput(data),
-			() => this.requestRender(),
+			() => this.requestRender(!isTermuxSession()),
 		);
 		this.terminal.hideCursor();
 		this.queryCellSize();


### PR DESCRIPTION
## Summary
- Force a full TUI redraw when the terminal resize handler fires
- Preserve the existing Termux soft-keyboard behavior by keeping normal resize rendering there

## Test plan
- Verified locally in pi by resizing the terminal window before/after the patch
- `npm --prefix packages/tui test`

Note: the initial commit hook full repo check failed in `packages/web-ui` due missing workspace package type resolution for `@earendil-works/pi-agent-core` / `@earendil-works/pi-ai` in this fresh clone; the TUI package tests pass.