### PR TITLE
docs(coding-agent): fix invalid notify type in extensions example

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -162,7 +162,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("event_name", async (event, ctx) => {
     // ctx.ui for user interaction
     const ok = await ctx.ui.confirm("Title", "Are you sure?");
-    ctx.ui.notify("Done!", "success");
+    ctx.ui.notify("Done!", "info");
     ctx.ui.setStatus("my-ext", "Processing...");  // Footer status
     ctx.ui.setWidget("my-ext", ["Line 1", "Line 2"]);  // Widget above editor (default)
   });


### PR DESCRIPTION
## Summary
- The extensions docs example calls `ctx.ui.notify("Done!", "success")`, but the `notify` API only accepts `"info" | "warning" | "error"` (see [types.ts:135](packages/coding-agent/src/core/extensions/types.ts#L135)).
- Change the example to use `"info"` so it matches the actual API.

## Test plan
- [x] Docs-only change, no runtime impact.