### PR TITLE
docs(coding-agent): document overflow normalization for custom providers

### DIFF
--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -23,6 +23,7 @@ See these complete provider examples:
 - [Unregister Provider](#unregister-provider)
 - [OAuth Support](#oauth-support)
 - [Custom Streaming API](#custom-streaming-api)
+- [Context Overflow Errors](#context-overflow-errors)
 - [Testing Your Implementation](#testing-your-implementation)
 - [Config Reference](#config-reference)
 - [Model Definition Reference](#model-definition-reference)
@@ -505,6 +506,60 @@ output.usage.totalTokens = output.usage.input + output.usage.output +
                            output.usage.cacheRead + output.usage.cacheWrite;
 calculateCost(model, output.usage);
 ```
+
+### Context Overflow Errors
+
+When a request exceeds the model's context window, pi can recover automatically by compacting the conversation and retrying. This recovery only kicks in if pi recognizes the failure as an overflow.
+
+Detection runs on the finalized assistant message:
+
+- `stopReason === "error"`
+- `errorMessage` matches one of pi's known overflow patterns (see [`packages/ai/src/utils/overflow.ts`](https://github.com/earendil-works/pi-mono/blob/main/packages/ai/src/utils/overflow.ts))
+
+If your provider returns overflow errors with a message pi does not recognize, normalize the error from the same extension that registers the provider. Use a `message_end` handler to rewrite the assistant message so its `errorMessage` starts with a phrase pi recognizes. The generic fallback `context_length_exceeded` is the safest choice.
+
+```typescript
+const MY_PROVIDER_OVERFLOW_PATTERN = /your provider's overflow phrase/i;
+
+export default function (pi: ExtensionAPI) {
+  pi.registerProvider("my-provider", { /* ... */ });
+
+  pi.on("message_end", (event, ctx) => {
+    const message = event.message;
+    if (message.role !== "assistant") return;
+    if (message.stopReason !== "error") return;
+    if (
+      message.provider !== "my-provider" &&
+      ctx.model?.provider !== "my-provider"
+    )
+      return;
+
+    const errorMessage = message.errorMessage ?? "";
+    if (errorMessage.includes("context_length_exceeded")) return;
+    if (!MY_PROVIDER_OVERFLOW_PATTERN.test(errorMessage)) return;
+
+    return {
+      message: {
+        ...message,
+        errorMessage: `context_length_exceeded: ${errorMessage}`,
+      },
+    };
+  });
+}
+```
+
+`message_end` runs before pi tracks the assistant message for auto-compaction, so the rewritten `errorMessage` is what pi checks. With this in place, pi will:
+
+1. Detect the overflow from `errorMessage`.
+2. Drop the failed assistant message from live context.
+3. Run compaction.
+4. Retry the request once.
+
+Guard the rewrite carefully:
+
+- Scope it to your provider (`message.provider` and `ctx.model?.provider`) so unrelated errors from other providers are untouched.
+- Match a provider-specific pattern, not pi's generic overflow patterns. Rewriting rate-limit or throttling errors (`rate limit`, `too many requests`) would falsely trigger compaction instead of pi's normal retry-with-backoff path.
+- Skip when `errorMessage` already includes `context_length_exceeded` so the handler is idempotent.
 
 ### Registration
 


### PR DESCRIPTION
Hello!

Noticed a couple of times with a provider I was testing that auto compaction wasn't getting triggered when the despite the error message being explicit about context window being about to be reached.

Investigation: https://pi.dev/session/#8537d699d5e5870158d77eca63d4b799

In parallel, also noticed the following issue but didn't think about solutions just yet: when checking if we should compact [before sending a prompt](https://github.com/earendil-works/pi/blob/b4ee3aaeea183b793d320d71eb91ee80c6a1c583/packages/coding-agent/src/core/agent-session.ts#L1049), [we do](https://github.com/earendil-works/pi/blob/b4ee3aaeea183b793d320d71eb91ee80c6a1c583/packages/coding-agent/src/core/compaction/compaction.ts#L219-L222):

```ts
contextTokens > contextWindow - settings.reserveTokens;
```
<sub><sup>(the logic is the same in the agent harness)</sup></sub>

When the input tokens's size sent to the provider is between the current contextWindow - requested output tokens and the contextWindow - the reserved tokens, and the requested output tokens are bigger than the reserved tokens, we're in a situation where:
- pi says: "input is below my threshold, safe, no compaction"
- provider says: "input + output budget exceeds context window, reject"

In my case, the values where:

```
contextWindow = 200000
model max output / requested max_tokens = 32000
pi reserveTokens = 16384 (default)
```

The provider's input limit was of `200000 - 32000 = 168000` token while Pi's compaction threshold was `200000 - 32000 = 168000` tokens, which meant when a prompt was sent between those two values, we would get the error that should trigger a compaction.

I fixed it for the time being by increasing my `reserveTokens` for the time being, but it sometimes ended-up being an issue and eagerly triggering compaction for our beloved local / smaller models.

There's no obvious solution, but can I open an issue an investigate a bit more deeply? It shoudlnt' overlap with the harness stuff, but wanted to make sure.

Thanks!

------

<details><summary>Summary by Claude Opus 4.7:</summary>
<p>

Adds a new `Context Overflow Errors` subsection to `packages/coding-agent/docs/custom-provider.md`.

Custom providers may surface overflow errors with messages pi's built-in `isContextOverflow()` regex list does not recognize. When that happens, pi cannot trigger its compact-and-retry recovery path.

The new section explains:

- Detection rules pi uses (`stopReason === "error"` + `errorMessage` regex against `packages/ai/src/utils/overflow.ts`).
- How to normalize unrecognized overflow errors from inside the same extension that calls `pi.registerProvider`, using a `pi.on("message_end", ...)` handler that returns a rewritten message with `errorMessage` prefixed by `context_length_exceeded`.
- Resulting behavior (drop failed assistant message, compact, retry once).
- Guard rails: scope to the custom provider, avoid pi's rate-limit/throttling patterns, keep the handler idempotent.

The example mirrors the pattern used in production by the neuralwatt extension.

</p>
</details>