### PR TITLE
fix(ai): drop unsigned thinking blocks on Anthropic replay instead of leaking as text

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed OpenAI Responses requests for models that support disabling reasoning to send `reasoning.effort: "none"` when thinking is off.
 - Fixed Inception Mercury 2 tool calling on OpenRouter by marking `off` as unsupported in `thinkingLevelMap`, so the openai-completions provider omits the reasoning param instead of defaulting to `{reasoning:{effort:"none"}}` (which puts Mercury 2 in instant mode, disabling tool calls).
 - Fixed OpenAI Codex SSE retries to honor `retry-after-ms` and `retry-after` headers before falling back to exponential backoff.
+- Fixed Anthropic provider sending unsigned thinking blocks (from aborted streams or Anthropic-compatible providers that do not return signatures) back to the API as visible text, leaking internal reasoning into the conversation context. Unsigned thinking blocks are now dropped on replay ([#4464](https://github.com/earendil-works/pi/issues/4464)).
 
 ## [0.74.0] - 2026-05-07
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1063,21 +1063,17 @@ function convertMessages(
 						continue;
 					}
 					if (block.thinking.trim().length === 0) continue;
-					// If thinking signature is missing/empty (e.g., from aborted stream),
-					// convert to plain text block without <thinking> tags to avoid API rejection
-					// and prevent Claude from mimicking the tags in responses
+					// Drop unsigned thinking blocks: they cannot be replayed as Anthropic thinking
+					// (a valid signature is required) and converting them to visible text leaks
+					// internal reasoning into the conversation context.
 					if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
-						blocks.push({
-							type: "text",
-							text: sanitizeSurrogates(block.thinking),
-						});
-					} else {
-						blocks.push({
-							type: "thinking",
-							thinking: sanitizeSurrogates(block.thinking),
-							signature: block.thinkingSignature,
-						});
+						continue;
 					}
+					blocks.push({
+						type: "thinking",
+						thinking: sanitizeSurrogates(block.thinking),
+						signature: block.thinkingSignature,
+					});
 				} else if (block.type === "toolCall") {
 					blocks.push({
 						type: "tool_use",

--- a/packages/ai/test/anthropic-unsigned-thinking-drop.test.ts
+++ b/packages/ai/test/anthropic-unsigned-thinking-drop.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.js";
+import { streamAnthropic } from "../src/providers/anthropic.js";
+import type { AssistantMessage, Context, Usage } from "../src/types.js";
+
+function makeUsage(): Usage {
+	return {
+		input: 10,
+		output: 5,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 15,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function makeAnthropicSseStream(text = "OK"): Response {
+	const encoder = new TextEncoder();
+	const events = [
+		`event: message_start\ndata: ${JSON.stringify({
+			type: "message_start",
+			message: {
+				id: "msg_test",
+				type: "message",
+				role: "assistant",
+				content: [],
+				model: "claude-sonnet-4-5-20251001",
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: 10, output_tokens: 0 },
+			},
+		})}\n\n`,
+		`event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+		`event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text } })}\n\n`,
+		`event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+		`event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 5 } })}\n\n`,
+		`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+	];
+	const stream = new ReadableStream({
+		start(controller) {
+			for (const e of events) controller.enqueue(encoder.encode(e));
+			controller.close();
+		},
+	});
+	return new Response(stream, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+describe("Anthropic unsigned thinking blocks", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("drops unsigned thinking block from outgoing API request (not sent as text)", async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			capturedBody = JSON.parse(init?.body as string);
+			return makeAnthropicSseStream();
+		});
+
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Let me reason through this step by step...",
+					thinkingSignature: "", // no signature — aborted stream or compat provider
+				},
+				{
+					type: "text",
+					text: "The answer is 4.",
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: makeUsage(),
+			stopReason: "stop",
+			timestamp: Date.now() - 2000,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "What is 2+2?", timestamp: Date.now() - 3000 },
+				assistantMessage,
+				{ role: "user", content: "Explain your reasoning.", timestamp: Date.now() },
+			],
+		};
+
+		const s = streamAnthropic(model, context, { apiKey: "test-key" });
+		await s.result();
+
+		expect(capturedBody).toBeDefined();
+
+		type Block = { type: string; text?: string };
+		type Msg = { role: string; content: Block[] };
+		const outgoing = capturedBody as { messages: Msg[] };
+		const assistantMsgs = outgoing.messages.filter((m) => m.role === "assistant");
+		expect(assistantMsgs).toHaveLength(1);
+
+		const content = assistantMsgs[0].content;
+
+		// Unsigned thinking must not appear as a visible text block
+		expect(content.find((b) => b.type === "text" && b.text?.includes("Let me reason"))).toBeUndefined();
+		// Unsigned thinking must not appear as a thinking block either
+		expect(content.find((b) => b.type === "thinking")).toBeUndefined();
+		// The legitimate text block must still be present
+		expect(content.find((b) => b.type === "text" && b.text === "The answer is 4.")).toBeDefined();
+	});
+
+	it("keeps signed thinking blocks in outgoing API request", async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			capturedBody = JSON.parse(init?.body as string);
+			return makeAnthropicSseStream();
+		});
+
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "I should calculate carefully.",
+					thinkingSignature: "valid-opaque-signature-abc123",
+				},
+				{
+					type: "text",
+					text: "The answer is 42.",
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: makeUsage(),
+			stopReason: "stop",
+			timestamp: Date.now() - 2000,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "What is 6*7?", timestamp: Date.now() - 3000 },
+				assistantMessage,
+				{ role: "user", content: "Are you sure?", timestamp: Date.now() },
+			],
+		};
+
+		const s = streamAnthropic(model, context, { apiKey: "test-key" });
+		await s.result();
+
+		expect(capturedBody).toBeDefined();
+
+		type Block = { type: string; text?: string; thinking?: string; signature?: string };
+		type Msg = { role: string; content: Block[] };
+		const outgoing = capturedBody as { messages: Msg[] };
+		const assistantMsgs = outgoing.messages.filter((m) => m.role === "assistant");
+		expect(assistantMsgs).toHaveLength(1);
+
+		const content = assistantMsgs[0].content;
+
+		// Signed thinking block must be replayed as a thinking block with its signature
+		const thinkingBlock = content.find((b) => b.type === "thinking");
+		expect(thinkingBlock).toBeDefined();
+		expect(thinkingBlock?.thinking).toBe("I should calculate carefully.");
+		expect(thinkingBlock?.signature).toBe("valid-opaque-signature-abc123");
+	});
+});


### PR DESCRIPTION
## What

Fixes #4464. Drop unsigned thinking blocks in `convertMessages` instead of converting them to visible text.

## Why

Anthropic-compatible providers that don't implement extended thinking (Alibaba Cloud, Fireworks) return thinking blocks with an empty `thinkingSignature`. On the next turn, `convertMessages` was converting those to `{ type: "text" }` blocks and sending them back. Internal reasoning leaked into the visible conversation context. Some endpoints also 400 on this because they get a text block where they expect thinking.

There is nothing replayable without a valid signature, so dropping is the right call.

## How

Replace the `blocks.push({ type: "text", ... })` fallback with `continue`:

```typescript
if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
    continue;
}
```

Signed blocks are unaffected.

## Test plan

- [x] New unit test verifies unsigned thinking is dropped, signed thinking is preserved
- [x] Biome lint and `tsgo --noEmit` pass on `packages/ai`