### PR TITLE
feat(coding-agent): add flat screen reader mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Added
 
+- Added `-sr flat` / `--screen-reader flat` to reduce decorative TUI output for screen readers.
 - Added Together AI to built-in provider setup, `/login` API-key auth, and default model resolution ([#3624](https://github.com/earendil-works/pi-mono/pull/3624) by [@Nutlope](https://github.com/Nutlope)).
 - Added Windows ARM64 standalone binary release artifacts ([#4458](https://github.com/earendil-works/pi/pull/4458) by [@brianmichel](https://github.com/brianmichel)).
 
 ### Fixed
 
+- Fixed screen reader mode to render footer input/output token statistics with `I` and `O` labels instead of arrow glyphs.
+- Fixed screen reader mode to use `>` as the selected-item marker in interactive selectors.
+- Fixed screen reader mode to hide the prompt editor's decorative horizontal borders.
 - Fixed interactive error messages to render with trailing spacing so reload errors do not run into resource listings ([#4510](https://github.com/earendil-works/pi/issues/4510)).
 - Fixed nested code fences in the Termux setup documentation so the example AGENTS.md renders correctly ([#4503](https://github.com/earendil-works/pi/issues/4503)).
 - Fixed tool output expansion while extension confirmation dialogs are focused ([#4429](https://github.com/earendil-works/pi/issues/4429)).

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -6,6 +6,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import chalk from "chalk";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_SESSION_DIR } from "../config.js";
 import type { ExtensionFlag } from "../core/extensions/types.js";
+import type { ScreenReaderMode } from "../modes/interactive/accessibility.js";
 
 export type Mode = "text" | "json" | "rpc";
 
@@ -43,6 +44,7 @@ export interface Args {
 	listModels?: string | true;
 	offline?: boolean;
 	verbose?: boolean;
+	screenReader?: ScreenReaderMode;
 	messages: string[];
 	fileArgs: string[];
 	/** Unknown flags (potentially extension flags) - map of flag name to value */
@@ -51,6 +53,11 @@ export interface Args {
 }
 
 const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const VALID_SCREEN_READER_MODES = ["flat"] as const;
+
+function isValidScreenReaderMode(mode: string): mode is ScreenReaderMode {
+	return VALID_SCREEN_READER_MODES.includes(mode as ScreenReaderMode);
+}
 
 export function isValidThinkingLevel(level: string): level is ThinkingLevel {
 	return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
@@ -162,6 +169,24 @@ export function parseArgs(args: string[]): Args {
 			result.verbose = true;
 		} else if (arg === "--offline") {
 			result.offline = true;
+		} else if (arg === "--screen-reader" || arg === "-sr") {
+			const next = args[i + 1];
+			if (next !== undefined && isValidScreenReaderMode(next)) {
+				result.screenReader = next;
+				i++;
+			} else {
+				result.screenReader = "flat";
+			}
+		} else if (arg.startsWith("--screen-reader=")) {
+			const mode = arg.slice("--screen-reader=".length);
+			if (isValidScreenReaderMode(mode)) {
+				result.screenReader = mode;
+			} else {
+				result.diagnostics.push({
+					type: "warning",
+					message: `Invalid screen reader mode "${mode}". Valid values: ${VALID_SCREEN_READER_MODES.join(", ")}`,
+				});
+			}
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
 		} else if (arg.startsWith("--")) {
@@ -247,6 +272,7 @@ ${chalk.bold("Options:")}
   --list-models [search]         List available models (with optional fuzzy search)
   --verbose                      Force verbose startup (overrides quietStartup setting)
   --offline                      Disable startup network operations (same as PI_OFFLINE=1)
+  --screen-reader, -sr           Enable screen reader mode (removes decorative TUI art)
   --help, -h                     Show this help
   --version, -v                  Show version number
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -42,6 +42,7 @@ import { SettingsManager } from "./core/settings-manager.js";
 import { printTimings, resetTimings, time } from "./core/timings.js";
 import { runMigrations, showDeprecationWarnings } from "./migrations.js";
 import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.js";
+import { setScreenReaderMode } from "./modes/interactive/accessibility.js";
 import { ExtensionSelectorComponent } from "./modes/interactive/components/extension-selector.js";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.js";
 import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.js";
@@ -437,6 +438,7 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	const parsed = parseArgs(args);
+	setScreenReaderMode(parsed.screenReader);
 	if (parsed.diagnostics.length > 0) {
 		for (const d of parsed.diagnostics) {
 			const color = d.type === "error" ? chalk.red : chalk.yellow;
@@ -455,6 +457,9 @@ export async function main(args: string[], options?: MainOptions) {
 
 	if (parsed.version) {
 		console.log(VERSION);
+		if (parsed.screenReader) {
+			console.log("Screen reader mode");
+		}
 		process.exit(0);
 	}
 
@@ -691,6 +696,7 @@ export async function main(args: string[], options?: MainOptions) {
 			initialImages,
 			initialMessages: parsed.messages,
 			verbose: parsed.verbose,
+			screenReader: parsed.screenReader,
 		});
 		if (startupBenchmark) {
 			await interactiveMode.init();

--- a/packages/coding-agent/src/modes/interactive/accessibility.ts
+++ b/packages/coding-agent/src/modes/interactive/accessibility.ts
@@ -1,0 +1,19 @@
+export type ScreenReaderMode = "flat";
+
+let screenReaderMode: ScreenReaderMode | undefined;
+
+export function setScreenReaderMode(mode: ScreenReaderMode | undefined): void {
+	screenReaderMode = mode;
+}
+
+export function getScreenReaderMode(): ScreenReaderMode | undefined {
+	return screenReaderMode;
+}
+
+export function isFlatScreenReaderMode(): boolean {
+	return screenReaderMode === "flat";
+}
+
+export function getSelectionPrefix(): string {
+	return isFlatScreenReaderMode() ? "> " : "→ ";
+}

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
+import { isFlatScreenReaderMode } from "../accessibility.js";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -61,6 +62,27 @@ export class AssistantMessageComponent extends Container {
 
 	override render(width: number): string[] {
 		const lines = super.render(width);
+		if (isFlatScreenReaderMode()) {
+			while (lines.length > 0 && lines[0].trim() === "") {
+				lines.shift();
+			}
+			while (lines.length > 0 && lines[lines.length - 1].trim() === "") {
+				lines.pop();
+			}
+			if (lines.length > 0) {
+				const hasAssistantLabel = lines[0].trimEnd() === "Assistant:";
+				const firstResponseLine = hasAssistantLabel ? 1 : 0;
+				if (firstResponseLine < lines.length) {
+					lines[firstResponseLine] = lines[firstResponseLine].trimStart();
+					lines[lines.length - 1] = lines[lines.length - 1].trimEnd();
+					if (hasAssistantLabel) {
+						lines.splice(0, 2, `Assistant: ${lines[firstResponseLine]}`);
+					}
+				} else if (hasAssistantLabel) {
+					lines[0] = lines[0].trimEnd();
+				}
+			}
+		}
 		if (this.hasToolCalls || lines.length === 0) {
 			return lines;
 		}
@@ -80,8 +102,16 @@ export class AssistantMessageComponent extends Container {
 			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
 		);
 
+		const flatScreenReaderMode = isFlatScreenReaderMode();
+		const horizontalPadding = 1;
+
 		if (hasVisibleContent) {
-			this.contentContainer.addChild(new Spacer(1));
+			if (!flatScreenReaderMode) {
+				this.contentContainer.addChild(new Spacer(1));
+			}
+			if (flatScreenReaderMode) {
+				this.contentContainer.addChild(new Text("Assistant:", 0, 0));
+			}
 		}
 
 		// Render content in order
@@ -90,7 +120,7 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, this.markdownTheme));
+				this.contentContainer.addChild(new Markdown(content.text.trim(), horizontalPadding, 0, this.markdownTheme));
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
@@ -101,7 +131,7 @@ export class AssistantMessageComponent extends Container {
 				if (this.hideThinkingBlock) {
 					// Show static thinking label when hidden
 					this.contentContainer.addChild(
-						new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), 1, 0),
+						new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), horizontalPadding, 0),
 					);
 					if (hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
@@ -109,7 +139,7 @@ export class AssistantMessageComponent extends Container {
 				} else {
 					// Thinking traces in thinkingText color, italic
 					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
+						new Markdown(content.thinking.trim(), horizontalPadding, 0, this.markdownTheme, {
 							color: (text: string) => theme.fg("thinkingText", text),
 							italic: true,
 						}),
@@ -136,11 +166,11 @@ export class AssistantMessageComponent extends Container {
 				} else {
 					this.contentContainer.addChild(new Spacer(1));
 				}
-				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), 1, 0));
+				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), horizontalPadding, 0));
 			} else if (message.stopReason === "error") {
 				const errorMsg = message.errorMessage || "Unknown error";
 				this.contentContainer.addChild(new Spacer(1));
-				this.contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), 1, 0));
+				this.contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), horizontalPadding, 0));
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bash-execution.ts
@@ -10,6 +10,7 @@ import {
 	truncateTail,
 } from "../../../core/tools/truncate.js";
 import { stripAnsi } from "../../../utils/ansi.js";
+import { isFlatScreenReaderMode } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint, keyText } from "./keybinding-hints.js";
@@ -57,6 +58,7 @@ export class BashExecutionComponent extends Container {
 			(spinner) => theme.fg(colorKey, spinner),
 			(text) => theme.fg("muted", text),
 			`Running... (${keyText("tui.select.cancel")} to cancel)`, // Plain text for loader
+			isFlatScreenReaderMode() ? { frames: [] } : undefined,
 		);
 		this.contentContainer.addChild(this.loader);
 

--- a/packages/coding-agent/src/modes/interactive/components/bordered-loader.ts
+++ b/packages/coding-agent/src/modes/interactive/components/bordered-loader.ts
@@ -1,4 +1,5 @@
 import { CancellableLoader, Container, Loader, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+import { isFlatScreenReaderMode } from "../accessibility.js";
 import type { Theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
@@ -14,12 +15,14 @@ export class BorderedLoader extends Container {
 		this.cancellable = options?.cancellable ?? true;
 		const borderColor = (s: string) => theme.fg("border", s);
 		this.addChild(new DynamicBorder(borderColor));
+		const indicator = isFlatScreenReaderMode() ? { frames: [] } : undefined;
 		if (this.cancellable) {
 			this.loader = new CancellableLoader(
 				tui,
 				(s) => theme.fg("accent", s),
 				(s) => theme.fg("muted", s),
 				message,
+				indicator,
 			);
 		} else {
 			this.signalController = new AbortController();
@@ -28,6 +31,7 @@ export class BorderedLoader extends Container {
 				(s) => theme.fg("accent", s),
 				(s) => theme.fg("muted", s),
 				message,
+				indicator,
 			);
 		}
 		this.addChild(this.loader);

--- a/packages/coding-agent/src/modes/interactive/components/dynamic-border.ts
+++ b/packages/coding-agent/src/modes/interactive/components/dynamic-border.ts
@@ -1,4 +1,5 @@
 import type { Component } from "@earendil-works/pi-tui";
+import { isFlatScreenReaderMode } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 
 /**
@@ -20,6 +21,9 @@ export class DynamicBorder implements Component {
 	}
 
 	render(width: number): string[] {
+		if (isFlatScreenReaderMode()) {
+			return [];
+		}
 		return [this.color("─".repeat(Math.max(1, width)))];
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/earendil-announcement.ts
+++ b/packages/coding-agent/src/modes/interactive/components/earendil-announcement.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import { Container, Image, Spacer, Text } from "@earendil-works/pi-tui";
 import { getBundledInteractiveAssetPath } from "../../../config.js";
+import { isFlatScreenReaderMode } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
@@ -35,7 +36,7 @@ export class EarendilAnnouncementComponent extends Container {
 		this.addChild(new Text(theme.fg("mdLink", BLOG_URL), 1, 0));
 		this.addChild(new Spacer(1));
 
-		const imageBase64 = loadImageBase64();
+		const imageBase64 = isFlatScreenReaderMode() ? undefined : loadImageBase64();
 		if (imageBase64) {
 			this.addChild(
 				new Image(

--- a/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container, getKeybindings, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+import { getSelectionPrefix } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { CountdownTimer } from "./countdown-timer.js";
 import { DynamicBorder } from "./dynamic-border.js";
@@ -82,7 +83,7 @@ export class ExtensionSelectorComponent extends Container {
 		for (let i = 0; i < this.options.length; i++) {
 			const isSelected = i === this.selectedIndex;
 			const text = isSelected
-				? theme.fg("accent", "→ ") + theme.fg("accent", this.options[i])
+				? theme.fg("accent", getSelectionPrefix()) + theme.fg("accent", this.options[i])
 				: `  ${theme.fg("text", this.options[i])}`;
 			this.listContainer.addChild(new Text(text, 1, 0));
 		}

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -1,6 +1,7 @@
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AgentSession } from "../../../core/agent-session.js";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.js";
+import { isFlatScreenReaderMode } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 
 /**
@@ -109,11 +110,19 @@ export class FooterComponent implements Component {
 		}
 
 		// Build stats line
+		const flatScreenReaderMode = isFlatScreenReaderMode();
 		const statsParts = [];
-		if (totalInput) statsParts.push(`↑${formatTokens(totalInput)}`);
-		if (totalOutput) statsParts.push(`↓${formatTokens(totalOutput)}`);
-		if (totalCacheRead) statsParts.push(`R${formatTokens(totalCacheRead)}`);
-		if (totalCacheWrite) statsParts.push(`W${formatTokens(totalCacheWrite)}`);
+		if (flatScreenReaderMode) {
+			if (totalInput) statsParts.push(`I${formatTokens(totalInput)}`);
+			if (totalOutput) statsParts.push(`O${formatTokens(totalOutput)}`);
+			if (totalCacheRead) statsParts.push(`R${formatTokens(totalCacheRead)}`);
+			if (totalCacheWrite) statsParts.push(`W${formatTokens(totalCacheWrite)}`);
+		} else {
+			if (totalInput) statsParts.push(`↑${formatTokens(totalInput)}`);
+			if (totalOutput) statsParts.push(`↓${formatTokens(totalOutput)}`);
+			if (totalCacheRead) statsParts.push(`R${formatTokens(totalCacheRead)}`);
+			if (totalCacheWrite) statsParts.push(`W${formatTokens(totalCacheWrite)}`);
+		}
 
 		// Show cost with "(sub)" indicator if using OAuth subscription
 		const usingSubscription = state.model ? this.session.modelRegistry.isUsingOAuth(state.model) : false;

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -11,6 +11,7 @@ import {
 } from "@earendil-works/pi-tui";
 import type { ModelRegistry } from "../../../core/model-registry.js";
 import type { SettingsManager } from "../../../core/settings-manager.js";
+import { getSelectionPrefix } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
@@ -247,7 +248,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 			let line = "";
 			if (isSelected) {
-				const prefix = theme.fg("accent", "→ ");
+				const prefix = theme.fg("accent", getSelectionPrefix());
 				const modelText = `${item.id}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -8,6 +8,7 @@ import {
 	TruncatedText,
 } from "@earendil-works/pi-tui";
 import type { AuthStatus, AuthStorage } from "../../../core/auth-storage.js";
+import { getSelectionPrefix } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
@@ -120,7 +121,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 			const statusIndicator = this.formatStatusIndicator(provider);
 			let line = "";
 			if (isSelected) {
-				const prefix = theme.fg("accent", "→ ");
+				const prefix = theme.fg("accent", getSelectionPrefix());
 				const text = theme.fg("accent", provider.name);
 				line = prefix + text + statusIndicator;
 			} else {

--- a/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
@@ -10,6 +10,7 @@ import {
 	Spacer,
 	Text,
 } from "@earendil-works/pi-tui";
+import { getSelectionPrefix } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyText } from "./keybinding-hints.js";
@@ -210,7 +211,7 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 		for (let i = startIndex; i < endIndex; i++) {
 			const item = this.filteredItems[i]!;
 			const isSelected = i === this.selectedIndex;
-			const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
+			const prefix = isSelected ? theme.fg("accent", getSelectionPrefix()) : "  ";
 			const modelText = isSelected ? theme.fg("accent", item.model.id) : item.model.id;
 			const providerBadge = theme.fg("muted", ` [${item.model.provider}]`);
 			const status = allEnabled ? "" : item.enabled ? theme.fg("success", " ✓") : theme.fg("dim", " ✗");

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -16,6 +16,7 @@ import {
 import { KeybindingsManager } from "../../../core/keybindings.js";
 import type { SessionInfo, SessionListProgress } from "../../../core/session-manager.js";
 import { canonicalizePath as _canonicalizePath } from "../../../utils/paths.js";
+import { getSelectionPrefix, isFlatScreenReaderMode } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint, keyText } from "./keybinding-hints.js";
@@ -459,7 +460,7 @@ class SessionList implements Component, Focusable {
 			}
 
 			// Cursor
-			const cursor = isSelected ? theme.fg("accent", "› ") : "  ";
+			const cursor = isSelected ? theme.fg("accent", getSelectionPrefix()) : "  ";
 
 			// Calculate available width for message
 			const prefixWidth = visibleWidth(prefix);
@@ -508,6 +509,10 @@ class SessionList implements Component, Focusable {
 	private buildTreePrefix(node: FlatSessionNode): string {
 		if (node.depth === 0) {
 			return "";
+		}
+
+		if (isFlatScreenReaderMode()) {
+			return " ".repeat(node.depth * 2);
 		}
 
 		const parts = node.ancestorContinues.map((continues) => (continues ? "│  " : "   "));

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -10,6 +10,7 @@ import {
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
 import type { SessionTreeNode } from "../../../core/session-manager.js";
+import { getSelectionPrefix, isFlatScreenReaderMode } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint, keyText } from "./keybinding-hints.js";
@@ -623,56 +624,63 @@ class TreeList implements Component {
 			const isSelected = i === this.selectedIndex;
 
 			// Build line: cursor + prefix + path marker + label + content
-			const cursor = isSelected ? theme.fg("accent", "› ") : "  ";
+			const cursor = isSelected ? theme.fg("accent", getSelectionPrefix()) : "  ";
 
 			// If multiple roots, shift display (roots at 0, not 1)
 			const displayIndent = this.multipleRoots ? Math.max(0, flatNode.indent - 1) : flatNode.indent;
 
 			// Build prefix with gutters at their correct positions
 			// Each gutter has a position (displayIndent where its connector was shown)
-			const connector =
-				flatNode.showConnector && !flatNode.isVirtualRootChild ? (flatNode.isLast ? "└─ " : "├─ ") : "";
-			const connectorPosition = connector ? displayIndent - 1 : -1;
-
-			// Build prefix char by char, placing gutters and connector at their positions
-			const totalChars = displayIndent * 3;
-			const prefixChars: string[] = [];
+			let prefix: string;
+			let foldMarker: string;
+			let pathMarker: string;
 			const isFolded = this.foldedNodes.has(entry.id);
-			for (let i = 0; i < totalChars; i++) {
-				const level = Math.floor(i / 3);
-				const posInLevel = i % 3;
-
-				// Check if there's a gutter at this level
-				const gutter = flatNode.gutters.find((g) => g.position === level);
-				if (gutter) {
-					if (posInLevel === 0) {
-						prefixChars.push(gutter.show ? "│" : " ");
-					} else {
-						prefixChars.push(" ");
-					}
-				} else if (connector && level === connectorPosition) {
-					// Connector at this level, with fold indicator
-					if (posInLevel === 0) {
-						prefixChars.push(flatNode.isLast ? "└" : "├");
-					} else if (posInLevel === 1) {
-						const foldable = this.isFoldable(entry.id);
-						prefixChars.push(isFolded ? "⊞" : foldable ? "⊟" : "─");
-					} else {
-						prefixChars.push(" ");
-					}
-				} else {
-					prefixChars.push(" ");
-				}
-			}
-			const prefix = prefixChars.join("");
-
-			// Fold marker for nodes without connectors (roots)
-			const showsFoldInConnector = flatNode.showConnector && !flatNode.isVirtualRootChild;
-			const foldMarker = isFolded && !showsFoldInConnector ? theme.fg("accent", "⊞ ") : "";
-
-			// Active path marker - shown right before the entry text
 			const isOnActivePath = this.activePathIds.has(entry.id);
-			const pathMarker = isOnActivePath ? theme.fg("accent", "• ") : "";
+			if (isFlatScreenReaderMode()) {
+				prefix = " ".repeat(displayIndent * 2);
+				foldMarker = isFolded ? theme.fg("accent", "folded ") : "";
+				pathMarker = isOnActivePath ? theme.fg("accent", "active ") : "";
+			} else {
+				const connector =
+					flatNode.showConnector && !flatNode.isVirtualRootChild ? (flatNode.isLast ? "└─ " : "├─ ") : "";
+				const connectorPosition = connector ? displayIndent - 1 : -1;
+
+				// Build prefix char by char, placing gutters and connector at their positions
+				const totalChars = displayIndent * 3;
+				const prefixChars: string[] = [];
+				for (let i = 0; i < totalChars; i++) {
+					const level = Math.floor(i / 3);
+					const posInLevel = i % 3;
+
+					// Check if there's a gutter at this level
+					const gutter = flatNode.gutters.find((g) => g.position === level);
+					if (gutter) {
+						if (posInLevel === 0) {
+							prefixChars.push(gutter.show ? "│" : " ");
+						} else {
+							prefixChars.push(" ");
+						}
+					} else if (connector && level === connectorPosition) {
+						// Connector at this level, with fold indicator
+						if (posInLevel === 0) {
+							prefixChars.push(flatNode.isLast ? "└" : "├");
+						} else if (posInLevel === 1) {
+							const foldable = this.isFoldable(entry.id);
+							prefixChars.push(isFolded ? "⊞" : foldable ? "⊟" : "─");
+						} else {
+							prefixChars.push(" ");
+						}
+					} else {
+						prefixChars.push(" ");
+					}
+				}
+				prefix = prefixChars.join("");
+
+				// Fold marker for nodes without connectors (roots)
+				const showsFoldInConnector = flatNode.showConnector && !flatNode.isVirtualRootChild;
+				foldMarker = isFolded && !showsFoldInConnector ? theme.fg("accent", "⊞ ") : "";
+				pathMarker = isOnActivePath ? theme.fg("accent", "• ") : "";
+			}
 
 			const label = flatNode.node.label ? theme.fg("warning", `[${flatNode.node.label}] `) : "";
 			const labelTimestamp =

--- a/packages/coding-agent/src/modes/interactive/components/user-message-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message-selector.ts
@@ -1,4 +1,5 @@
 import { type Component, Container, getKeybindings, Spacer, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import { getSelectionPrefix } from "../accessibility.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
@@ -54,7 +55,7 @@ class UserMessageList implements Component {
 			const normalizedMessage = message.text.replace(/\n/g, " ").trim();
 
 			// First line: cursor + message
-			const cursor = isSelected ? theme.fg("accent", "› ") : "  ";
+			const cursor = isSelected ? theme.fg("accent", getSelectionPrefix()) : "  ";
 			const maxMsgWidth = width - 2; // Account for cursor (2 chars)
 			const truncatedMsg = truncateToWidth(normalizedMessage, maxMsgWidth);
 			const messageLine = cursor + (isSelected ? theme.bold(truncatedMsg) : truncatedMsg);

--- a/packages/coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message.ts
@@ -1,4 +1,5 @@
 import { Box, Container, Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
+import { isFlatScreenReaderMode } from "../accessibility.js";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -9,17 +10,20 @@ const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
  * Component that renders a user message
  */
 export class UserMessageComponent extends Container {
-	private contentBox: Box;
-
 	constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
 		super();
-		this.contentBox = new Box(1, 1, (content: string) => theme.bg("userMessageBg", content));
-		this.contentBox.addChild(
+		if (isFlatScreenReaderMode()) {
+			this.addChild(new Markdown(`User: ${text}`, 0, 0, markdownTheme));
+			return;
+		}
+
+		const contentBox = new Box(1, 1, (content: string) => theme.bg("userMessageBg", content));
+		contentBox.addChild(
 			new Markdown(text, 0, 0, markdownTheme, {
 				color: (content: string) => theme.fg("userMessageText", content),
 			}),
 		);
-		this.addChild(this.contentBox);
+		this.addChild(contentBox);
 	}
 
 	override render(width: number): string[] {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -92,6 +92,7 @@ import { getPiUserAgent } from "../../utils/pi-user-agent.js";
 import { killTrackedDetachedChildren } from "../../utils/shell.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import { checkForNewPiVersion } from "../../utils/version-check.js";
+import { isFlatScreenReaderMode, type ScreenReaderMode, setScreenReaderMode } from "./accessibility.js";
 import { ArminComponent } from "./components/armin.js";
 import { AssistantMessageComponent } from "./components/assistant-message.js";
 import { BashExecutionComponent } from "./components/bash-execution.js";
@@ -226,6 +227,8 @@ export interface InteractiveModeOptions {
 	initialMessages?: string[];
 	/** Force verbose startup (overrides quietStartup setting) */
 	verbose?: boolean;
+	/** Screen reader mode for reducing decorative TUI output */
+	screenReader?: ScreenReaderMode;
 }
 
 export class InteractiveMode {
@@ -352,6 +355,7 @@ export class InteractiveMode {
 		runtimeHost: AgentSessionRuntime,
 		private options: InteractiveModeOptions = {},
 	) {
+		setScreenReaderMode(options.screenReader);
 		this.runtimeHost = runtimeHost;
 		this.runtimeHost.setBeforeSessionInvalidate(() => {
 			this.resetExtensionUI();
@@ -375,6 +379,7 @@ export class InteractiveMode {
 		this.defaultEditor = new CustomEditor(this.ui, getEditorTheme(), this.keybindings, {
 			paddingX: editorPaddingX,
 			autocompleteMaxVisible,
+			showBorders: !isFlatScreenReaderMode(),
 		});
 		this.editor = this.defaultEditor;
 		this.editorContainer = new Container();
@@ -577,7 +582,10 @@ export class InteractiveMode {
 
 		// Add header with keybindings from config (unless silenced)
 		if (this.options.verbose || !this.settingsManager.getQuietStartup()) {
-			const logo = theme.bold(theme.fg("accent", APP_NAME)) + theme.fg("dim", ` v${this.version}`);
+			const logo =
+				theme.bold(theme.fg("accent", APP_NAME)) +
+				theme.fg("dim", ` v${this.version}`) +
+				(this.options.screenReader ? "\nScreen reader mode" : "");
 
 			// Build startup instructions using keybinding hint helpers
 			const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
@@ -622,7 +630,7 @@ export class InteractiveMode {
 				() => `${logo}\n${compactInstructions}\n${compactOnboarding}\n\n${onboarding}`,
 				() => `${logo}\n${expandedInstructions}\n\n${onboarding}`,
 				this.getStartupExpansionState(),
-				1,
+				isFlatScreenReaderMode() ? 0 : 1,
 				0,
 			);
 
@@ -1660,13 +1668,17 @@ export class InteractiveMode {
 		return this.workingMessage ?? this.defaultWorkingMessage;
 	}
 
+	private getLoaderIndicator(indicator?: LoaderIndicatorOptions): LoaderIndicatorOptions | undefined {
+		return isFlatScreenReaderMode() ? { frames: [] } : indicator;
+	}
+
 	private createWorkingLoader(): Loader {
 		return new Loader(
 			this.ui,
 			(spinner) => theme.fg("accent", spinner),
 			(text) => theme.fg("muted", text),
 			this.getWorkingLoaderMessage(),
-			this.workingIndicatorOptions,
+			this.getLoaderIndicator(this.workingIndicatorOptions),
 		);
 	}
 
@@ -1695,7 +1707,7 @@ export class InteractiveMode {
 
 	private setWorkingIndicator(options?: LoaderIndicatorOptions): void {
 		this.workingIndicatorOptions = options;
-		this.loadingAnimation?.setIndicator(options);
+		this.loadingAnimation?.setIndicator(this.getLoaderIndicator(options));
 		this.ui.requestRender();
 	}
 
@@ -2139,6 +2151,7 @@ export class InteractiveMode {
 					this.hideExtensionEditor();
 					resolve(undefined);
 				},
+				{ showBorders: !isFlatScreenReaderMode() },
 			);
 
 			this.editorContainer.clear();
@@ -2852,6 +2865,7 @@ export class InteractiveMode {
 					(spinner) => theme.fg("accent", spinner),
 					(text) => theme.fg("muted", text),
 					label,
+					this.getLoaderIndicator(),
 				);
 				this.statusContainer.addChild(this.autoCompactionLoader);
 				this.ui.requestRender();
@@ -2917,6 +2931,7 @@ export class InteractiveMode {
 					(spinner) => theme.fg("warning", spinner),
 					(text) => theme.fg("muted", text),
 					retryMessage(Math.ceil(event.delayMs / 1000)),
+					this.getLoaderIndicator(),
 				);
 				this.retryCountdown = new CountdownTimer(
 					event.delayMs,
@@ -2987,7 +3002,7 @@ export class InteractiveMode {
 		}
 
 		const spacer = new Spacer(1);
-		const text = new Text(theme.fg("dim", message), 1, 0);
+		const text = new Text(theme.fg("dim", message), isFlatScreenReaderMode() ? 0 : 1, 0);
 		this.chatContainer.addChild(spacer);
 		this.chatContainer.addChild(text);
 		this.lastStatusSpacer = spacer;
@@ -4275,6 +4290,7 @@ export class InteractiveMode {
 							(spinner) => theme.fg("accent", spinner),
 							(text) => theme.fg("muted", text),
 							`Summarizing branch... (${keyText("app.interrupt")} to cancel)`,
+							this.getLoaderIndicator(),
 						);
 						this.statusContainer.addChild(summaryLoader);
 						this.ui.requestRender();
@@ -5358,18 +5374,32 @@ export class InteractiveMode {
 	}
 
 	private handleArminSaysHi(): void {
+		if (isFlatScreenReaderMode()) {
+			this.showStatus("Armin says hi.");
+			return;
+		}
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new ArminComponent(this.ui));
 		this.ui.requestRender();
 	}
 
 	private handleDementedDelves(): void {
+		if (isFlatScreenReaderMode()) {
+			this.showStatus(
+				"pi has joined Earendil. Read the blog post: https://mariozechner.at/posts/2026-04-08-ive-sold-out/",
+			);
+			return;
+		}
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new EarendilAnnouncementComponent());
 		this.ui.requestRender();
 	}
 
 	private handleDaxnuts(): void {
+		if (isFlatScreenReaderMode()) {
+			this.showStatus("Dax says hi.");
+			return;
+		}
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new DaxnutsComponent(this.ui));
 		this.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -8,6 +8,7 @@ import { getCustomThemesDir, getThemesDir } from "../../../config.js";
 import type { SourceInfo } from "../../../core/source-info.js";
 import { closeWatcher, watchWithErrorHandler } from "../../../utils/fs-watch.js";
 import { highlight, supportsLanguage } from "../../../utils/syntax-highlight.js";
+import { getSelectionPrefix } from "../accessibility.js";
 
 // ============================================================================
 // Types & Schema
@@ -1117,7 +1118,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 
 export function getSelectListTheme(): SelectListTheme {
 	return {
-		selectedPrefix: (text: string) => theme.fg("accent", text),
+		selectedPrefix: (_text: string) => theme.fg("accent", getSelectionPrefix()),
 		selectedText: (text: string) => theme.fg("accent", text),
 		description: (text: string) => theme.fg("muted", text),
 		scrollInfo: (text: string) => theme.fg("muted", text),
@@ -1137,7 +1138,7 @@ export function getSettingsListTheme(): import("@earendil-works/pi-tui").Setting
 		label: (text: string, selected: boolean) => (selected ? theme.fg("accent", text) : text),
 		value: (text: string, selected: boolean) => (selected ? theme.fg("accent", text) : theme.fg("muted", text)),
 		description: (text: string) => theme.fg("dim", text),
-		cursor: theme.fg("accent", "→ "),
+		cursor: theme.fg("accent", getSelectionPrefix()),
 		hint: (text: string) => theme.fg("dim", text),
 	};
 }

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
+import { setScreenReaderMode } from "../src/modes/interactive/accessibility.js";
 import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
@@ -28,6 +29,10 @@ function createAssistantMessage(content: AssistantMessage["content"]): Assistant
 }
 
 describe("AssistantMessageComponent", () => {
+	afterEach(() => {
+		setScreenReaderMode(undefined);
+	});
+
 	test("adds OSC 133 zone markers to assistant messages without tool calls", () => {
 		initTheme("dark");
 
@@ -53,5 +58,31 @@ describe("AssistantMessageComponent", () => {
 		expect(rendered.includes(OSC133_ZONE_START)).toBe(false);
 		expect(rendered.includes(OSC133_ZONE_END)).toBe(false);
 		expect(rendered.includes(OSC133_ZONE_FINAL)).toBe(false);
+	});
+
+	test("trims leading and trailing whitespace in screen reader mode", () => {
+		initTheme("dark");
+		setScreenReaderMode("flat");
+
+		const lines = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: "\n  hello  \n" }]),
+		).render(20);
+
+		expect(lines).toEqual([`${OSC133_ZONE_END}${OSC133_ZONE_FINAL}${OSC133_ZONE_START}Assistant: hello`]);
+	});
+
+	test("does not trim middle response lines in screen reader mode", () => {
+		initTheme("dark");
+		setScreenReaderMode("flat");
+
+		const lines = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: "one two three four five six seven eight nine ten" }]),
+		).render(20);
+
+		expect(lines).toEqual([
+			`${OSC133_ZONE_START}Assistant: one two three four `,
+			" five six seven     ",
+			`${OSC133_ZONE_END}${OSC133_ZONE_FINAL} eight nine ten`,
+		]);
 	});
 });

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -2,6 +2,7 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it } from "vitest";
 import type { AgentSession } from "../src/core/agent-session.js";
 import type { ReadonlyFooterDataProvider } from "../src/core/footer-data-provider.js";
+import { setScreenReaderMode } from "../src/modes/interactive/accessibility.js";
 import { FooterComponent } from "../src/modes/interactive/components/footer.js";
 import { initTheme } from "../src/modes/interactive/theme/theme.js";
 
@@ -86,6 +87,54 @@ describe("FooterComponent width handling", () => {
 		const lines = footer.render(width);
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
+	});
+
+	it("keeps normal footer input and output arrow stats", () => {
+		const session = createSession({
+			sessionName: "",
+			usage: {
+				input: 266_000,
+				output: 12_000,
+				cacheRead: 5_500_000,
+				cacheWrite: 0,
+				cost: { total: 1.234 },
+			},
+		});
+		const footer = new FooterComponent(session, createFooterData(1));
+		const lines = footer.render(120);
+
+		expect(lines[1]).toContain("↑266k");
+		expect(lines[1]).toContain("↓12k");
+		expect(lines[1]).toContain("R5.5M");
+	});
+
+	it("renders footer input and output stats without arrows in screen reader mode", () => {
+		setScreenReaderMode("flat");
+		const session = createSession({
+			sessionName: "",
+			usage: {
+				input: 12_345,
+				output: 6_789,
+				cacheRead: 123,
+				cacheWrite: 456,
+				cost: { total: 1.234 },
+			},
+		});
+		const footer = new FooterComponent(session, createFooterData(1));
+
+		try {
+			const lines = footer.render(120);
+
+			expect(lines[1]).toContain("I12k");
+			expect(lines[1]).toContain("O6.8k");
+			expect(lines[1]).toContain("R123");
+			expect(lines[1]).toContain("W456");
+			expect(lines[1]).toContain("12.3%/200k");
+			expect(lines[1]).not.toContain("↑");
+			expect(lines[1]).not.toContain("↓");
+		} finally {
+			setScreenReaderMode(undefined);
 		}
 	});
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed select lists to respect the configured selected-item prefix.
+- Fixed editor rendering to support hiding decorative prompt borders.
 - Fixed inline image rendering to cap portrait images by height instead of always scaling them to the configured maximum width.
 
 ## [0.74.0] - 2026-05-07

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -205,6 +205,7 @@ export interface EditorTheme {
 export interface EditorOptions {
 	paddingX?: number;
 	autocompleteMaxVisible?: number;
+	showBorders?: boolean;
 }
 
 const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
@@ -227,6 +228,7 @@ export class Editor implements Component, Focusable {
 	protected tui: TUI;
 	private theme: EditorTheme;
 	private paddingX: number = 0;
+	private showBorders: boolean = true;
 
 	// Store last render width for cursor navigation
 	private lastWidth: number = 80;
@@ -293,6 +295,7 @@ export class Editor implements Component, Focusable {
 		this.paddingX = Number.isFinite(paddingX) ? Math.max(0, Math.floor(paddingX)) : 0;
 		const maxVisible = options.autocompleteMaxVisible ?? 5;
 		this.autocompleteMaxVisible = Number.isFinite(maxVisible) ? Math.max(3, Math.min(20, Math.floor(maxVisible))) : 5;
+		this.showBorders = options.showBorders ?? true;
 	}
 
 	/** Set of currently valid paste IDs, for marker-aware segmentation. */
@@ -418,7 +421,7 @@ export class Editor implements Component, Focusable {
 		// Store for cursor navigation (must match wrapping width)
 		this.lastWidth = layoutWidth;
 
-		const horizontal = this.borderColor("─");
+		const horizontal = this.showBorders ? this.borderColor("─") : "";
 
 		// Layout the text
 		const layoutLines = this.layoutText(layoutWidth);
@@ -451,14 +454,18 @@ export class Editor implements Component, Focusable {
 
 		// Render top border (with scroll indicator if scrolled down)
 		if (this.scrollOffset > 0) {
-			const indicator = `─── ↑ ${this.scrollOffset} more `;
-			const remaining = width - visibleWidth(indicator);
-			if (remaining >= 0) {
-				result.push(this.borderColor(indicator + "─".repeat(remaining)));
+			if (this.showBorders) {
+				const indicator = `─── ↑ ${this.scrollOffset} more `;
+				const remaining = width - visibleWidth(indicator);
+				if (remaining >= 0) {
+					result.push(this.borderColor(indicator + "─".repeat(remaining)));
+				} else {
+					result.push(this.borderColor(truncateToWidth(indicator, width)));
+				}
 			} else {
-				result.push(this.borderColor(truncateToWidth(indicator, width)));
+				result.push(`↑ ${this.scrollOffset} more`);
 			}
-		} else {
+		} else if (this.showBorders) {
 			result.push(horizontal.repeat(width));
 		}
 
@@ -511,10 +518,14 @@ export class Editor implements Component, Focusable {
 		// Render bottom border (with scroll indicator if more content below)
 		const linesBelow = layoutLines.length - (this.scrollOffset + visibleLines.length);
 		if (linesBelow > 0) {
-			const indicator = `─── ↓ ${linesBelow} more `;
-			const remaining = width - visibleWidth(indicator);
-			result.push(this.borderColor(indicator + "─".repeat(Math.max(0, remaining))));
-		} else {
+			if (this.showBorders) {
+				const indicator = `─── ↓ ${linesBelow} more `;
+				const remaining = width - visibleWidth(indicator);
+				result.push(this.borderColor(indicator + "─".repeat(Math.max(0, remaining))));
+			} else {
+				result.push(`↓ ${linesBelow} more`);
+			}
+		} else if (this.showBorders) {
 			result.push(horizontal.repeat(width));
 		}
 

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -143,7 +143,7 @@ export class SelectList implements Component {
 		descriptionSingleLine: string | undefined,
 		primaryColumnWidth: number,
 	): string {
-		const prefix = isSelected ? "→ " : "  ";
+		const prefix = isSelected ? this.theme.selectedPrefix("→ ") : "  ";
 		const prefixWidth = visibleWidth(prefix);
 
 		if (descriptionSingleLine && width > 40) {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -593,6 +593,17 @@ describe("Editor component", () => {
 		});
 	});
 
+	describe("Rendering options", () => {
+		it("omits decorative prompt borders when disabled", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme, { showBorders: false });
+			const lines = editor.render(20);
+
+			assert.strictEqual(lines.length, 1);
+			assert.ok(!lines.some((line) => line.includes("─")));
+			assert.strictEqual(visibleWidth(lines[0]!), 20);
+		});
+	});
+
 	describe("Grapheme-aware text wrapping", () => {
 		it("wraps lines correctly when text contains wide emojis", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -18,6 +18,14 @@ const visibleIndexOf = (line: string, text: string): number => {
 };
 
 describe("SelectList", () => {
+	it("uses the configured selected prefix", () => {
+		const items = [{ value: "one", label: "one" }];
+		const list = new SelectList(items, 5, { ...testTheme, selectedPrefix: () => "> " });
+		const rendered = list.render(20);
+
+		assert.equal(rendered[0], "> one");
+	});
+
 	it("normalizes multiline descriptions to single line", () => {
 		const items = [
 			{


### PR DESCRIPTION
## Summary

- Add `-sr` / `--screen-reader` flat screen reader mode for interactive sessions
- Simplify borders, selectors, editor behavior, and footer output for screen readers
- Add coverage for screen reader rendering behavior

## Checks

- `npm run check`
