### PR TITLE
Fix: Add null check before calling .startsWith() on result.error in _getRequiredRequestAuth

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -347,10 +347,10 @@ export class AgentSession {
 	}> {
 		const result = await this._modelRegistry.getApiKeyAndHeaders(model);
 		if (!result.ok) {
-			if (result.error.startsWith("No API key found")) {
+			if (result.error && result.error.startsWith("No API key found")) {
 				throw new Error(formatNoApiKeyFoundMessage(model.provider));
 			}
-			throw new Error(result.error);
+			throw new Error(result.error || "Unknown API error");
 		}
 		if (result.apiKey) {
 			return { apiKey: result.apiKey, headers: result.headers };


### PR DESCRIPTION
- Prevents 'Cannot read properties of undefined (reading startsWith)' error
- Adds defensive null check: result.error && result.error.startsWith(...)
- Provides fallback error message when result.error is undefined
- Fixes RPC mode crashes when API providers return malformed error responses

Fixes #4605
