### PR TITLE
feat(coding-agent): add --new-session-id flag for embedded callers

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -25,6 +25,7 @@ export interface Args {
 	session?: string;
 	fork?: string;
 	sessionDir?: string;
+	newSessionId?: string;
 	models?: string[];
 	tools?: string[];
 	noTools?: boolean;
@@ -99,6 +100,8 @@ export function parseArgs(args: string[]): Args {
 			result.fork = args[++i];
 		} else if (arg === "--session-dir" && i + 1 < args.length) {
 			result.sessionDir = args[++i];
+		} else if (arg === "--new-session-id" && i + 1 < args.length) {
+			result.newSessionId = args[++i];
 		} else if (arg === "--models" && i + 1 < args.length) {
 			result.models = args[++i].split(",").map((s) => s.trim());
 		} else if (arg === "--no-tools" || arg === "-nt") {
@@ -227,6 +230,7 @@ ${chalk.bold("Options:")}
   --fork <path|id>               Fork specific session file or partial UUID into a new session
   --session-dir <dir>            Directory for session storage and lookup
   --no-session                   Don't save session (ephemeral)
+  --new-session-id <uuid>        Use this UUID for a new session (any RFC-4122 UUID; rejects if combined with --session/--continue/--fork/--resume/--no-session)
   --models <patterns>            Comma-separated model patterns for Ctrl+P cycling
                                  Supports globs (anthropic/*, *sonnet*) and fuzzy matching
   --no-tools, -nt                Disable all tools by default (built-in and extension)

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1302,10 +1302,15 @@ export class SessionManager {
 	 * Create a new session.
 	 * @param cwd Working directory (stored in session header)
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.pi/agent/sessions/<encoded-cwd>/).
+	 * @param options Optional. Pass `{ id: "<uuid>" }` to use a caller-supplied UUID instead of a generated one.
 	 */
-	static create(cwd: string, sessionDir?: string): SessionManager {
+	static create(cwd: string, sessionDir?: string, options?: { id?: string }): SessionManager {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
-		return new SessionManager(cwd, dir, undefined, true);
+		const sm = new SessionManager(cwd, dir, undefined, true);
+		if (options?.id) {
+			sm.newSession({ id: options.id });
+		}
+		return sm;
 	}
 
 	/**

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -201,6 +201,28 @@ function validateForkFlags(parsed: Args): void {
 	}
 }
 
+export function validateNewSessionIdFlags(parsed: Args): void {
+	if (!parsed.newSessionId) return;
+
+	const conflictingFlags = [
+		parsed.session ? "--session" : undefined,
+		parsed.continue ? "--continue" : undefined,
+		parsed.resume ? "--resume" : undefined,
+		parsed.fork ? "--fork" : undefined,
+		parsed.noSession ? "--no-session" : undefined,
+	].filter((flag): flag is string => flag !== undefined);
+
+	if (conflictingFlags.length > 0) {
+		console.error(chalk.red(`Error: --new-session-id cannot be combined with ${conflictingFlags.join(", ")}`));
+		process.exit(1);
+	}
+
+	if (!/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(parsed.newSessionId)) {
+		console.error(chalk.red(`Error: --new-session-id must be a UUID (got "${parsed.newSessionId}")`));
+		process.exit(1);
+	}
+}
+
 function forkSessionOrExit(sourcePath: string, cwd: string, sessionDir?: string): SessionManager {
 	try {
 		return SessionManager.forkFrom(sourcePath, cwd, sessionDir);
@@ -281,7 +303,7 @@ async function createSessionManager(
 		return SessionManager.continueRecent(cwd, sessionDir);
 	}
 
-	return SessionManager.create(cwd, sessionDir);
+	return SessionManager.create(cwd, sessionDir, parsed.newSessionId ? { id: parsed.newSessionId } : undefined);
 }
 
 function buildSessionOptions(
@@ -478,6 +500,7 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	validateForkFlags(parsed);
+	validateNewSessionIdFlags(parsed);
 
 	// Run migrations (pass cwd for project-local migrations)
 	const { migratedAuthProviders: migratedProviders, deprecationWarnings } = runMigrations(process.cwd());

--- a/packages/coding-agent/test/new-session-id.test.ts
+++ b/packages/coding-agent/test/new-session-id.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, readdirSync, rmdirSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Args } from "../src/cli/args.js";
+import { validateNewSessionIdFlags } from "../src/main.js";
+import { SessionManager } from "../src/core/session-manager.js";
+
+const VALID_UUID = "12345678-1234-1234-1234-123456789abc";
+
+function makeArgs(overrides: Partial<Args> = {}): Args {
+	return {
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		diagnostics: [],
+		...overrides,
+	};
+}
+
+describe("validateNewSessionIdFlags", () => {
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		exitSpy.mockRestore();
+		errorSpy.mockRestore();
+	});
+
+	it("accepts a valid UUID with no conflicting flags", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID }));
+		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-UUID value", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: "not-a-uuid" }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("must be a UUID"));
+	});
+
+	it("passes through when newSessionId is absent", () => {
+		validateNewSessionIdFlags(makeArgs());
+		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects --new-session-id combined with --session", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, session: "some-session" }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--session"));
+	});
+
+	it("rejects --new-session-id combined with --continue", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, continue: true }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--continue"));
+	});
+
+	it("rejects --new-session-id combined with --resume", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, resume: true }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--resume"));
+	});
+
+	it("rejects --new-session-id combined with --fork", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, fork: "some-fork" }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--fork"));
+	});
+
+	it("rejects --new-session-id combined with --no-session", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, noSession: true }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--no-session"));
+	});
+});
+
+describe("SessionManager.create with options.id", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-session-test-"));
+	});
+
+	afterEach(() => {
+		try {
+			const files = readdirSync(tempDir);
+			for (const file of files) {
+				unlinkSync(join(tempDir, file));
+			}
+			rmdirSync(tempDir);
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	it("uses the supplied UUID as sessionId", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir, { id: VALID_UUID });
+		expect(sm.getSessionId()).toBe(VALID_UUID);
+	});
+
+	it("includes the supplied UUID in the session file path", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir, { id: VALID_UUID });
+		expect(sm.getSessionFile()).toContain(VALID_UUID);
+	});
+
+	it("falls back to a generated UUID when options is omitted", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir);
+		expect(sm.getSessionId()).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+		expect(sm.getSessionId()).not.toBe(VALID_UUID);
+	});
+
+	it("falls back to a generated UUID when options.id is undefined", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir, {});
+		expect(sm.getSessionId()).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+	});
+});


### PR DESCRIPTION
## Motivation

Embedding harnesses (CI runners, IDE integrations, multi-agent orchestrators) need to control the session UUID in order to correlate Pi's session file with their own logical session ID. Pi names session files `<timestamp>_<uuid>.jsonl`, so the embedder must already know the UUID to find the file — but today there is no way to supply it from the CLI. The only workaround is to scan `~/.pi/agent/sessions/` after the fact and match by timestamp, which is fragile and racy under concurrent sessions.

## Design

`SessionManager.newSession({ id })` already accepts a caller-supplied UUID (`this.sessionId = options?.id ?? createSessionId()`). Only the CLI surface and the `SessionManager.create()` factory were missing the plumbing.

**Changes:**

- **`src/cli/args.ts`** — adds `newSessionId?: string` to the `Args` interface, parses `--new-session-id <uuid>`, and adds a help line.
- **`src/main.ts`** — adds `validateNewSessionIdFlags()` (exported for testing) following the same pattern as `validateForkFlags()`; calls it right after `validateForkFlags()`; passes `{ id }` through `createSessionManager` → `SessionManager.create()`.
- **`src/core/session-manager.ts`** — extends `static create()` with an optional third parameter `options?: { id?: string }` and calls `sm.newSession({ id })` when present.

**Mutex:** `--new-session-id` is rejected when combined with `--session`, `--continue`, `--resume`, `--fork`, or `--no-session` — these flags either use an existing session or create no file at all, so a caller-supplied UUID has no meaningful effect in those cases.

**UUID validation:** accepts any RFC-4122 UUID (v1/v4/v7 — only blocks malformed input). Uppercase hex digits are accepted; the value is stored verbatim.

## Behaviour

```
# Sets the session file UUID to the supplied value
pi --new-session-id 12345678-1234-1234-1234-123456789abc -p "hello"
# → session file: <timestamp>_12345678-1234-1234-1234-123456789abc.jsonl

# UUID validation
pi --new-session-id not-a-uuid "x"
# Error: --new-session-id must be a UUID (got "not-a-uuid")

# Mutex check
pi --new-session-id 12345678-1234-1234-1234-123456789abc --continue "x"
# Error: --new-session-id cannot be combined with --continue
```

## Tests

`test/new-session-id.test.ts` (12 tests):
- `validateNewSessionIdFlags`: valid UUID accepted; invalid UUID rejected; no-op when absent; mutex with each of the 5 conflicting flags
- `SessionManager.create({ id })`: `getSessionId()` returns the supplied UUID; `getSessionFile()` path contains it; omitting `options` or `options.id` falls back to a generated UUID

Existing test suite: the 2 pre-existing failures in `test/edit-tool-no-full-redraw.test.ts` are present on `main` before this change.

## Real-world adopter

This feature is in active use at one downstream embedder via `patch-package` against v0.74.0 and will switch to the published version once it lands.

---

*Reviewed with Design CR before implementation. Risk: MED (multi-file TypeScript feature, no auth/infra/cross-system impact). All hard checks: PASS.*