### PR TITLE
fix(coding-agent): guard undici install under Bun

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bun-compiled release binaries failing to start when Bun's built-in undici shim lacks npm undici's `install` export ([#4657](https://github.com/earendil-works/pi/issues/4657)).
+
 ## [0.75.1] - 2026-05-18
 
 ### Fixed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,7 +5,7 @@
  *
  * Test with: npx tsx src/cli-new.ts [args...]
  */
-import { EnvHttpProxyAgent, install as installUndiciGlobals, setGlobalDispatcher } from "undici";
+import * as undici from "undici";
 import { APP_NAME } from "./config.js";
 import { main } from "./main.js";
 
@@ -17,11 +17,11 @@ process.emitWarning = (() => {}) as typeof process.emitWarning;
 // (e.g. vLLM buffering a large tool call) exceed that and abort the SSE stream
 // with UND_ERR_BODY_TIMEOUT. Disable both — provider SDKs enforce their own
 // AbortController-based deadlines via retry.provider.timeoutMs.
-setGlobalDispatcher(new EnvHttpProxyAgent({ bodyTimeout: 0, headersTimeout: 0 }));
+undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent({ bodyTimeout: 0, headersTimeout: 0 }));
 
 // Keep fetch and the dispatcher on the same undici implementation. Node 26.0's
 // bundled fetch can otherwise consume compressed responses through npm undici's
 // dispatcher without decompressing them, causing response.json() failures.
-installUndiciGlobals();
+undici.install?.();
 
 main(process.argv.slice(2));


### PR DESCRIPTION
## Summary

Fix the v0.75.1 Bun-compiled release binary startup crash caused by statically importing `install` from `undici`.

Bun's built-in `undici` module exposes `EnvHttpProxyAgent` and `setGlobalDispatcher`, but not `install`, so the binary fails during module loading with:

```text
SyntaxError: Export named 'install' not found in module 'undici'.
```

This changes the import to a namespace import and calls `install()` only when that export exists. That should preserve the Node 26 fix for #4650, #4652, and #4653, because npm `undici` still exports `install()` under Node, while avoiding the Bun startup crash where the export is absent.

Fixes #4657.

## Testing

- `npm run check`
- Built the patched binary in a separate local worktree and verified `pi --version` / `pi --help` work after installing through my NixOS flake
