### PR TITLE
fix(web-ui): refresh agent interface after run settles

### DIFF
--- a/packages/web-ui/src/components/AgentInterface.ts
+++ b/packages/web-ui/src/components/AgentInterface.ts
@@ -1,19 +1,19 @@
+import type { Agent, AgentEvent } from "@earendil-works/pi-agent-core";
 import { streamSimple, type ToolResultMessage, type Usage } from "@earendil-works/pi-ai";
 import { html, LitElement } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { ModelSelector } from "../dialogs/ModelSelector.js";
-import type { MessageEditor } from "./MessageEditor.js";
-import "./MessageEditor.js";
-import "./MessageList.js";
-import "./Messages.js"; // Import for side effects to register the custom elements
 import { getAppStorage } from "../storage/app-storage.js";
-import "./StreamingMessageContainer.js";
-import type { Agent, AgentEvent } from "@earendil-works/pi-agent-core";
 import type { Attachment } from "../utils/attachment-utils.js";
 import { formatUsage } from "../utils/format.js";
 import { i18n } from "../utils/i18n.js";
 import { createStreamFn } from "../utils/proxy-utils.js";
+import "./MessageEditor.js";
+import type { MessageEditor } from "./MessageEditor.js";
+import "./MessageList.js";
+import "./Messages.js"; // Import for side effects to register the custom elements
 import type { UserMessageWithAttachments } from "./Messages.js";
+import "./StreamingMessageContainer.js";
 import type { StreamingMessageContainer } from "./StreamingMessageContainer.js";
 
 @customElement("agent-interface")
@@ -172,7 +172,7 @@ export class AgentInterface extends LitElement {
 						this._streamingContainer.isStreaming = false;
 						this._streamingContainer.setMessage(null, true);
 					}
-					this.requestUpdate();
+					this.session?.waitForIdle().then(() => this.requestUpdate());
 					break;
 				case "message_update":
 					if (this._streamingContainer) {


### PR DESCRIPTION
Schedule a final AgentInterface update after waitForIdle() resolves so the UI
reads runtime state after Agent.finishRun() clears isStreaming and pending tool
calls. This fixes the case where agent_end triggers a render before cleanup has
completed, leaving the input area in a stale streaming state.

<img width="1126" height="370" alt="image" src="https://github.com/user-attachments/assets/b79050b2-2bdc-4a57-a208-09496bd75bab" />
