### PR TITLE
fix(coding-agent): make docs/examples path absolute on system prompt

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -142,7 +142,17 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 - Main documentation: ${readmePath}
 - Additional docs: ${docsPath}
 - Examples: ${examplesPath} (extensions, custom tools, SDK)
-- When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), pi packages (docs/packages.md)
+- When asked about:
+  - extensions (${docsPath}/extensions.md, ${examplesPath}/extensions/)
+  - themes (${docsPath}/themes.md)
+  - skills (${docsPath}/skills.md)
+  - prompt templates (${docsPath}/prompt-templates.md)
+  - TUI components (${docsPath}/tui.md)
+  - keybindings (${docsPath}/keybindings.md)
+  - SDK integrations (${docsPath}/sdk.md)
+  - custom providers (${docsPath}/custom-provider.md)
+  - adding models (${docsPath}/models.md)
+  - pi packages (${docsPath}/packages.md)
 - When working on pi topics, read the docs and examples, and follow .md cross-references before implementing
 - Always read pi .md files completely and follow links to related docs (e.g., tui.md for TUI API details)`;
 


### PR DESCRIPTION
### Issue
Coding Agent could not find its own documentation to extend himself due to system prompt referencing documentation and examples in a relative path.

When agent is asked for documentation, it refers to current working directory (`<cwd>/docs/extensions`) instead of the **pi** package directory (`<pi-package-dir>/docs/extensions`).

### Replication steps
model used: `google/gemma-4-26b-a4b`

1. Run `./pi-test.sh`
2. Prompt: `read about pi extensions` (fails to find initially `docs/extensions` in the current working dir)

<img width="2274" height="896" alt="image" src="https://github.com/user-attachments/assets/96b14f28-3135-4fdb-9b95-105b12780d5b" />


### Solution
Updated system prompt section about "when asked about" related to **pi** documentation from **relative** to **absolute** path to prevent confusion for the agent.

### Test steps
1. Run `./pi-test.sh`
3. Prompt: `read about pi extensions` (100% of the time it refers to correct documentation path where **pi** is installed)

<img width="2268" height="780" alt="image" src="https://github.com/user-attachments/assets/78f7e561-a493-440c-9103-463e8b8870f1" />


### Other changes
- Changed "when asked about" section item separator, from `,` for each item into nested list items for better structure.