### PR TITLE
Fix(coding-agent) Updated default prompt to also use xml boundaries instead of ## for clearer file seperation. 

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -153,11 +153,12 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 
 	// Append project context files
 	if (contextFiles.length > 0) {
-		prompt += "\n\n# Project Context\n\n";
+		prompt += "\n\n<project_context>\n\n";
 		prompt += "Project-specific instructions and guidelines:\n\n";
 		for (const { path: filePath, content } of contextFiles) {
-			prompt += `## ${filePath}\n\n${content}\n\n`;
+			prompt += `<project_instructions path="${filePath}">\n${content}\n</project_instructions>\n\n`;
 		}
+		prompt += "</project_context>\n";
 	}
 
 	// Append skills section (only if read tool is available)


### PR DESCRIPTION
**Context:** 
This fix was originally made in this #4541 however it was only applied to custom prompts. This PR aims to make these changes consistent for custom and default prompts. 

**Solution:**
System prompt's (System.md) and context files (AGENT.md, CLAUDE.md) are merged together using `##` headers as a way to create file boundaries. Currently, context file boundaries can become unclear for agents when a user uses `##` headers or worse `#` in their context files. A good solution is to use the less commonly used  xml tags as file context boundaries instead of `##` which are more commonly used. 

Fix: 
- Replaced `# Project Context` with `<project_context></project_context`
- Replaced `## fake/file/path/AGENTS.md` with
	- `<project_instruction path="fake/file/path/AGENTS.md"></project_instruction>`

Example:
```
<project_context>

Project-specific instructions and guidelines:

<project_instructions path="fake/file/path/SYSTEM.md">  
content  
</project_instructions> 

<project_instructions path="fake/file/path/AGENTS.md">  
content  
</project_instructions> 

<project_instructions path="fake/file/path/AGENTS.md">  
content  
</project_instructions> 
 
</project_context>
```

Fixes: #4691