### PR TITLE
feat(coding-agent): add --new-session-id flag for embedded callers

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -25,6 +25,7 @@ export interface Args {
 	session?: string;
 	fork?: string;
 	sessionDir?: string;
+	newSessionId?: string;
 	models?: string[];
 	tools?: string[];
 	noTools?: boolean;
@@ -99,6 +100,8 @@ export function parseArgs(args: string[]): Args {
 			result.fork = args[++i];
 		} else if (arg === "--session-dir" && i + 1 < args.length) {
 			result.sessionDir = args[++i];
+		} else if (arg === "--new-session-id" && i + 1 < args.length) {
+			result.newSessionId = args[++i];
 		} else if (arg === "--models" && i + 1 < args.length) {
 			result.models = args[++i].split(",").map((s) => s.trim());
 		} else if (arg === "--no-tools" || arg === "-nt") {
@@ -227,6 +230,7 @@ ${chalk.bold("Options:")}
   --fork <path|id>               Fork specific session file or partial UUID into a new session
   --session-dir <dir>            Directory for session storage and lookup
   --no-session                   Don't save session (ephemeral)
+  --new-session-id <uuid>        Use this UUID for a new session (any RFC-4122 UUID; rejects if combined with --session/--continue/--fork/--resume/--no-session)
   --models <patterns>            Comma-separated model patterns for Ctrl+P cycling
                                  Supports globs (anthropic/*, *sonnet*) and fuzzy matching
   --no-tools, -nt                Disable all tools by default (built-in and extension)

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1302,10 +1302,15 @@ export class SessionManager {
 	 * Create a new session.
 	 * @param cwd Working directory (stored in session header)
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.pi/agent/sessions/<encoded-cwd>/).
+	 * @param options Optional. Pass `{ id: "<uuid>" }` to use a caller-supplied UUID instead of a generated one.
 	 */
-	static create(cwd: string, sessionDir?: string): SessionManager {
+	static create(cwd: string, sessionDir?: string, options?: { id?: string }): SessionManager {
 		const dir = sessionDir ?? getDefaultSessionDir(cwd);
-		return new SessionManager(cwd, dir, undefined, true);
+		const sm = new SessionManager(cwd, dir, undefined, true);
+		if (options?.id) {
+			sm.newSession({ id: options.id });
+		}
+		return sm;
 	}
 
 	/**

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -201,6 +201,28 @@ function validateForkFlags(parsed: Args): void {
 	}
 }
 
+export function validateNewSessionIdFlags(parsed: Args): void {
+	if (!parsed.newSessionId) return;
+
+	const conflictingFlags = [
+		parsed.session ? "--session" : undefined,
+		parsed.continue ? "--continue" : undefined,
+		parsed.resume ? "--resume" : undefined,
+		parsed.fork ? "--fork" : undefined,
+		parsed.noSession ? "--no-session" : undefined,
+	].filter((flag): flag is string => flag !== undefined);
+
+	if (conflictingFlags.length > 0) {
+		console.error(chalk.red(`Error: --new-session-id cannot be combined with ${conflictingFlags.join(", ")}`));
+		process.exit(1);
+	}
+
+	if (!/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(parsed.newSessionId)) {
+		console.error(chalk.red(`Error: --new-session-id must be a UUID (got "${parsed.newSessionId}")`));
+		process.exit(1);
+	}
+}
+
 function forkSessionOrExit(sourcePath: string, cwd: string, sessionDir?: string): SessionManager {
 	try {
 		return SessionManager.forkFrom(sourcePath, cwd, sessionDir);
@@ -281,7 +303,7 @@ async function createSessionManager(
 		return SessionManager.continueRecent(cwd, sessionDir);
 	}
 
-	return SessionManager.create(cwd, sessionDir);
+	return SessionManager.create(cwd, sessionDir, parsed.newSessionId ? { id: parsed.newSessionId } : undefined);
 }
 
 function buildSessionOptions(
@@ -478,6 +500,7 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	validateForkFlags(parsed);
+	validateNewSessionIdFlags(parsed);
 
 	// Run migrations (pass cwd for project-local migrations)
 	const { migratedAuthProviders: migratedProviders, deprecationWarnings } = runMigrations(process.cwd());

--- a/packages/coding-agent/test/new-session-id.test.ts
+++ b/packages/coding-agent/test/new-session-id.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, readdirSync, rmdirSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Args } from "../src/cli/args.js";
+import { validateNewSessionIdFlags } from "../src/main.js";
+import { SessionManager } from "../src/core/session-manager.js";
+
+const VALID_UUID = "12345678-1234-1234-1234-123456789abc";
+
+function makeArgs(overrides: Partial<Args> = {}): Args {
+	return {
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		diagnostics: [],
+		...overrides,
+	};
+}
+
+describe("validateNewSessionIdFlags", () => {
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		exitSpy.mockRestore();
+		errorSpy.mockRestore();
+	});
+
+	it("accepts a valid UUID with no conflicting flags", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID }));
+		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-UUID value", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: "not-a-uuid" }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("must be a UUID"));
+	});
+
+	it("passes through when newSessionId is absent", () => {
+		validateNewSessionIdFlags(makeArgs());
+		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
+	it("rejects --new-session-id combined with --session", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, session: "some-session" }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--session"));
+	});
+
+	it("rejects --new-session-id combined with --continue", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, continue: true }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--continue"));
+	});
+
+	it("rejects --new-session-id combined with --resume", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, resume: true }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--resume"));
+	});
+
+	it("rejects --new-session-id combined with --fork", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, fork: "some-fork" }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--fork"));
+	});
+
+	it("rejects --new-session-id combined with --no-session", () => {
+		validateNewSessionIdFlags(makeArgs({ newSessionId: VALID_UUID, noSession: true }));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--no-session"));
+	});
+});
+
+describe("SessionManager.create with options.id", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-session-test-"));
+	});
+
+	afterEach(() => {
+		try {
+			const files = readdirSync(tempDir);
+			for (const file of files) {
+				unlinkSync(join(tempDir, file));
+			}
+			rmdirSync(tempDir);
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	it("uses the supplied UUID as sessionId", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir, { id: VALID_UUID });
+		expect(sm.getSessionId()).toBe(VALID_UUID);
+	});
+
+	it("includes the supplied UUID in the session file path", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir, { id: VALID_UUID });
+		expect(sm.getSessionFile()).toContain(VALID_UUID);
+	});
+
+	it("falls back to a generated UUID when options is omitted", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir);
+		expect(sm.getSessionId()).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+		expect(sm.getSessionId()).not.toBe(VALID_UUID);
+	});
+
+	it("falls back to a generated UUID when options.id is undefined", () => {
+		const sm = SessionManager.create(process.cwd(), tempDir, {});
+		expect(sm.getSessionId()).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
+	});
+});


### PR DESCRIPTION
## Problem

Embedding harnesses (CI runners, IDE integrations, multi-agent orchestrators) need to control the session UUID in order to correlate Pi's session file with their own logical session ID. Pi names session files `<timestamp>_<uuid>.jsonl`, so the embedder must know the UUID to find the file — but there is no way to supply it from the CLI. The only workaround is scanning `~/.pi/agent/sessions/` after the fact and matching by timestamp, which is fragile under concurrent sessions.

## Proposed solution

Add a `--new-session-id <uuid>` flag that pipes a caller-supplied UUID through the existing `SessionManager.newSession({ id })` pathway (`this.sessionId = options?.id ?? createSessionId()` already supports it — only the CLI and `SessionManager.create()` factory are missing the wire-up).

**Behaviour:**
- `--new-session-id <uuid>` — session file becomes `<timestamp>_<uuid>.jsonl`; JSONL header `id` field equals `<uuid>`
- Invalid UUID → `Error: --new-session-id must be a UUID (got "<value>")`; exits 1
- Combined with `--session`/`--continue`/`--fork`/`--resume`/`--no-session` → mutex error; exits 1

**Changes (~30 LOC):**
- `src/cli/args.ts` — `newSessionId?: string` field, flag parsing, help line
- `src/main.ts` — `validateNewSessionIdFlags()` following the `validateForkFlags` pattern
- `src/core/session-manager.ts` — `static create()` optional third parameter `options?: { id?: string }`

The implementation is already written, tested (12 new vitest tests), and verified working.

> **Re: `--session <file>`** — `--session` continues an *existing* session from a file path. `--new-session-id` sets the UUID for a *new* session at creation time. These are complementary, not overlapping: an embedder starting a fresh session has no file to point `--session` at yet.

## Real-world adopter

This feature is in active use at one downstream embedder via `patch-package` against v0.74.0. Happy to switch to the published version once it lands.

Closes https://github.com/earendil-works/pi/issues/4640