### PR TITLE
Keep TUI scrollback on full redraws

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -985,7 +985,9 @@ export class TUI extends Container {
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
-				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
+				// Clear the visible screen and home the cursor, but keep terminal/tmux
+				// scrollback by default so copy-mode can still show the current chat transcript.
+				buffer += process.env.PI_CLEAR_SCROLLBACK === "1" ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
 			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -143,6 +143,55 @@ describe("TUI Kitty image cleanup", () => {
 
 		tui.stop();
 	});
+
+	it("keeps terminal scrollback during full redraws by default", async () => {
+		await withEnv({ PI_CLEAR_SCROLLBACK: undefined }, async () => {
+			const terminal = new LoggingVirtualTerminal(40, 10);
+			const tui = new TUI(terminal);
+			const component = new TestComponent();
+			tui.addChild(component);
+
+			component.lines = ["Line 0"];
+			tui.start();
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			component.lines = ["Line 0 after resize"];
+			terminal.resize(50, 10);
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes("\x1b[2J\x1b[H"), "full redraw should clear the visible screen and home cursor");
+			assert.ok(!writes.includes("\x1b[3J"), "full redraw should not clear scrollback by default");
+
+			tui.stop();
+		});
+	});
+
+	it("can clear terminal scrollback during full redraws when explicitly enabled", async () => {
+		await withEnv({ PI_CLEAR_SCROLLBACK: "1" }, async () => {
+			const terminal = new LoggingVirtualTerminal(40, 10);
+			const tui = new TUI(terminal);
+			const component = new TestComponent();
+			tui.addChild(component);
+
+			component.lines = ["Line 0"];
+			tui.start();
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			component.lines = ["Line 0 after resize"];
+			terminal.resize(50, 10);
+			await terminal.waitForRender();
+
+			assert.ok(
+				terminal.getWrites().includes("\x1b[3J"),
+				"PI_CLEAR_SCROLLBACK=1 should preserve old scrollback-clearing behavior",
+			);
+
+			tui.stop();
+		});
+	});
 });
 
 describe("TUI resize handling", () => {


### PR DESCRIPTION
## Summary
- Keep terminal/tmux scrollback during TUI full redraws by default
- Preserve old scrollback-clearing behavior behind PI_CLEAR_SCROLLBACK=1
- Add coverage for both default and opt-in behavior

## Tests
- node --test --import tsx packages/tui/test/tui-render.test.ts
- npm run build (packages/tui)

Note: root pre-commit check currently fails in packages/web-ui due missing @earendil-works/pi-ai/@earendil-works/pi-agent-core type resolution in this fresh clone; TUI-specific tests and build pass.