### PR TITLE
[DEPRECATED] fix(coding-agent): normalize Windows NUL redirects to /dev/null

### DIFF
--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -57,6 +57,66 @@ export interface BashOperations {
 }
 
 /**
+ * Normalize Windows-style NUL redirects to Unix-style /dev/null so they
+ * work correctly in Git Bash / MSYS2.
+ *
+ * Covers: > nul, >> nul, 1> nul, 2> nul, 2>> nul, &> nul, &>> nul,
+ * including optional whitespace between the file descriptor and >.
+ *
+ * Only replaces redirects outside of quoted strings; text inside quotes
+ * is left untouched. No-op on non-Windows platforms.
+ */
+export function normalizeNulRedirects(command: string): string {
+	if (process.platform !== "win32") {
+		return command;
+	}
+
+	let result = "";
+	let inSingleQuotes = false;
+	let inDoubleQuotes = false;
+	let i = 0;
+
+	while (i < command.length) {
+		const char = command[i];
+
+		if (char === "'" && !inDoubleQuotes) {
+			inSingleQuotes = !inSingleQuotes;
+			result += char;
+			i++;
+			continue;
+		}
+
+		if (char === '"' && !inSingleQuotes) {
+			inDoubleQuotes = !inDoubleQuotes;
+			result += char;
+			i++;
+			continue;
+		}
+
+		if (!inSingleQuotes && !inDoubleQuotes) {
+			const match = command.slice(i).match(/^([12&]?)\s*(>>?)\s*nul\b/i);
+			if (match) {
+				const fd = match[1] || "";
+				// Avoid eating the space before > when fd is omitted.
+				if (!fd && /^\s/.test(match[0])) {
+					// skip — let the next iteration handle the >
+				} else {
+					const operator = match[2];
+					result += `${fd}${operator}/dev/null`;
+					i += match[0].length;
+					continue;
+				}
+			}
+		}
+
+		result += char;
+		i++;
+	}
+
+	return result;
+}
+
+/**
  * Create bash operations using pi's built-in local shell execution backend.
  *
  * This is useful for extensions that intercept user_bash and still want pi's
@@ -71,7 +131,8 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 					reject(new Error(`Working directory does not exist: ${cwd}\nCannot execute bash commands.`));
 					return;
 				}
-				const child = spawn(shell, [...args, command], {
+				const normalizedCommand = normalizeNulRedirects(command);
+				const child = spawn(shell, [...args, normalizedCommand], {
 					cwd,
 					detached: process.platform !== "win32",
 					env: env ?? getShellEnv(),

--- a/packages/coding-agent/test/bash-nul-redirect.test.ts
+++ b/packages/coding-agent/test/bash-nul-redirect.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { normalizeNulRedirects } from "../src/core/tools/bash.js";
+
+describe("normalizeNulRedirects", () => {
+	it("leaves commands without NUL redirects unchanged", () => {
+		expect(normalizeNulRedirects("echo hello")).toBe("echo hello");
+		expect(normalizeNulRedirects("grep nul file.txt")).toBe("grep nul file.txt");
+	});
+
+	it("does not replace > nul inside quoted strings", () => {
+		if (process.platform !== "win32") return;
+
+		expect(normalizeNulRedirects('echo "foo > nul bar"')).toBe('echo "foo > nul bar"');
+		expect(normalizeNulRedirects("echo 'foo > nul bar'")).toBe("echo 'foo > nul bar'");
+	});
+
+	it("replaces all NUL redirect variants on Windows", () => {
+		if (process.platform !== "win32") {
+			return;
+		}
+
+		// stdout overwrite
+		expect(normalizeNulRedirects("echo hello > nul")).toBe("echo hello >/dev/null");
+		expect(normalizeNulRedirects("echo hello >NUL")).toBe("echo hello >/dev/null");
+		expect(normalizeNulRedirects("echo hello >  nul")).toBe("echo hello >/dev/null");
+
+		// stdout append
+		expect(normalizeNulRedirects("echo hello >> nul")).toBe("echo hello >>/dev/null");
+		expect(normalizeNulRedirects("echo hello >>  NUL")).toBe("echo hello >>/dev/null");
+
+		// stderr overwrite with and without space between fd and >
+		expect(normalizeNulRedirects("echo hello 1> nul")).toBe("echo hello 1>/dev/null");
+		expect(normalizeNulRedirects("echo hello 1 > nul")).toBe("echo hello 1>/dev/null");
+		expect(normalizeNulRedirects("echo hello 2> nul")).toBe("echo hello 2>/dev/null");
+		expect(normalizeNulRedirects("echo hello 2  >  nul")).toBe("echo hello 2>/dev/null");
+
+		// stderr append with and without space
+		expect(normalizeNulRedirects("echo hello 2>> nul")).toBe("echo hello 2>>/dev/null");
+		expect(normalizeNulRedirects("echo hello 2 >>  nul")).toBe("echo hello 2>>/dev/null");
+
+		// stdout + stderr overwrite
+		expect(normalizeNulRedirects("echo hello &> nul")).toBe("echo hello &>/dev/null");
+		expect(normalizeNulRedirects("echo hello &>  Nul")).toBe("echo hello &>/dev/null");
+
+		// stdout + stderr append
+		expect(normalizeNulRedirects("echo hello &>> nul")).toBe("echo hello &>>/dev/null");
+		expect(normalizeNulRedirects("echo hello &>>  NuL")).toBe("echo hello &>>/dev/null");
+	});
+
+	it("does not modify commands on non-Windows platforms", () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		expect(normalizeNulRedirects("echo hello > nul")).toBe("echo hello > nul");
+		expect(normalizeNulRedirects("echo hello 2>> nul")).toBe("echo hello 2>> nul");
+		expect(normalizeNulRedirects("echo hello &>> nul")).toBe("echo hello &>> nul");
+	});
+});
+
+describe.skipIf(process.platform !== "win32")("bash tool NUL redirect integration", () => {
+	it("does not create a file named nul when redirecting output", async () => {
+		const { createLocalBashOperations } = await import("../src/core/tools/bash.js");
+		const { existsSync } = await import("node:fs");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+
+		const testDir = join(tmpdir(), `pi-nul-test-${Date.now()}`);
+		await import("node:fs").then((fs) => fs.mkdirSync(testDir, { recursive: true }));
+		const ops = createLocalBashOperations();
+
+		await ops.exec("echo hello > nul", testDir, {
+			onData: () => {},
+		});
+
+		expect(existsSync(join(testDir, "nul"))).toBe(false);
+	});
+});


### PR DESCRIPTION
On Windows Terminal with PowerShell (and any other Windows terminal), pi spawns Git Bash to execute commands. AI-generated commands like `echo hello > nul` create a spurious file named `nul` because the MSYS2 runtime used by Git Bash does not treat `nul` as a null device.

This adds `normalizeNulRedirects()` which replaces NUL redirects outside of quoted strings with `/dev/null`, preserving the original operator (`>` or `>>`).

- Only runs on `process.platform === 'win32'`
- Respects quoted strings (no replacement inside `'` or `"`)
- Covers `> nul`, `>> nul`, `1> nul`, `2> nul`, `2>> nul`, `&> nul`, `&>> nul`

Fixes #4731
