### PR TITLE
fix: resolve streaming hang on 429 rate limits and prevent useless auto-retries

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -496,6 +496,54 @@ function createClient(
 		baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders,
+		fetch: async (url, init) => {
+			const ac = new AbortController();
+			const onAbort = () => ac.abort(init?.signal?.reason);
+			if (init?.signal) {
+				init.signal.addEventListener("abort", onAbort);
+			}
+
+			// Add a timeout for the headers to arrive to prevent hanging if the server tarpits
+			const timeoutId = setTimeout(() => ac.abort(new Error("Request timed out waiting for headers")), 30000);
+			try {
+				const fetchInit = { ...init, signal: ac.signal };
+				const response = await fetch(url, fetchInit);
+				clearTimeout(timeoutId);
+
+				if (!response.ok) {
+					// Prevent undici from hanging indefinitely on abrupt TCP closures with bodyTimeout: 0
+					// by explicitly wrapping the text() consumption in a hard timeout.
+					const timeoutMs = 5000;
+					const textPromise = response.text();
+					const timeoutPromise = new Promise<string>((_, reject) =>
+						setTimeout(
+							() => reject(new Error(`Timeout reading error body (HTTP ${response.status})`)),
+							timeoutMs,
+						),
+					);
+
+					let errText = "";
+					try {
+						errText = await Promise.race([textPromise, timeoutPromise]);
+					} catch (e) {
+						errText = e instanceof Error ? e.message : String(e);
+					}
+
+					// Synthesize a new response that returns the safely extracted text immediately
+					const newResponse = response.clone();
+					Object.defineProperty(newResponse, "text", {
+						value: async () => errText,
+					});
+					return newResponse;
+				}
+
+				return response;
+			} finally {
+				if (init?.signal) {
+					init.signal.removeEventListener("abort", onAbort);
+				}
+			}
+		},
 	});
 }
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -414,6 +414,13 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			// Some providers via OpenRouter give additional information in this field.
 			const rawMetadata = (error as any)?.error?.metadata?.raw;
 			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
+
+			// If the error was thrown by openai-node, it may have headers directly on it
+			const retryAfter = (error as any)?.headers?.["retry-after"] || (error as any)?.headers?.["Retry-After"];
+			if (retryAfter && !output.errorMessage.includes("Retry-After")) {
+				output.errorMessage += `\nRetry-After: ${retryAfter}`;
+			}
+
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}
@@ -527,6 +534,11 @@ function createClient(
 						errText = await Promise.race([textPromise, timeoutPromise]);
 					} catch (e) {
 						errText = e instanceof Error ? e.message : String(e);
+					}
+
+					const retryAfter = response.headers.get("retry-after");
+					if (retryAfter) {
+						errText += `\nRetry-After: ${retryAfter}`;
 					}
 
 					// Synthesize a new response that returns the safely extracted text immediately

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2441,6 +2441,10 @@ export class AgentSession {
 		if (isContextOverflow(message, contextWindow)) return false;
 
 		const err = message.errorMessage;
+
+		// Hard quotas / exhausted balances should never be retried
+		if (/usage.?limit.?reached|balance|insufficient.?quota|exceeded your current quota/i.test(err)) return false;
+
 		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, premature stream endings, HTTP/2 closed before response, terminated, retry delay exceeded
 		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
 			err,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2445,6 +2445,15 @@ export class AgentSession {
 		// Hard quotas / exhausted balances should never be retried
 		if (/usage.?limit.?reached|balance|insufficient.?quota|exceeded your current quota/i.test(err)) return false;
 
+		// Check for excessive Retry-After header
+		const retryAfterMatch = err.match(/Retry-After:\s*(\d+)/i);
+		if (retryAfterMatch) {
+			const seconds = parseInt(retryAfterMatch[1], 10);
+			if (!Number.isNaN(seconds) && seconds > 300) {
+				return false;
+			}
+		}
+
 		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, premature stream endings, HTTP/2 closed before response, terminated, retry delay exceeded
 		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
 			err,

--- a/packages/coding-agent/test/suite/regressions/4707-openai-rate-limit-hang.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4707-openai-rate-limit-hang.test.ts
@@ -1,0 +1,156 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../../../src/core/agent-session.js";
+import { AuthStorage } from "../../../src/core/auth-storage.js";
+import { ModelRegistry } from "../../../src/core/model-registry.js";
+import { SessionManager } from "../../../src/core/session-manager.js";
+import { SettingsManager } from "../../../src/core/settings-manager.js";
+import { createTestResourceLoader } from "../../utilities.js";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string, overrides?: Partial<AssistantMessage>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+describe("4707 - OpenAI Rate Limit Hang", () => {
+	let session: AgentSession;
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-retry-test-4707-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (session) {
+			session.dispose();
+		}
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+	});
+
+	function createSession(errorMessage: string) {
+		let callCount = 0;
+
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				callCount++;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					// Always return the error
+					const msg = createAssistantMessage("", {
+						stopReason: "error",
+						errorMessage,
+					});
+					stream.push({ type: "start", partial: msg });
+					stream.push({ type: "error", reason: "error", error: msg });
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } });
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		return { session, getCallCount: () => callCount };
+	}
+
+	it("does not retry 429 errors when the error message indicates a hard usage limit", async () => {
+		const created = createSession("Error: 429 5-hour usage limit reached. Resets in 44min.");
+
+		const events: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") events.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") events.push(`end:success=${event.success}`);
+		});
+
+		// Wait for prompt to finish
+		await created.session.prompt("Test");
+
+		// Ensure it only tried ONCE, because the error is a hard limit and not retryable
+		expect(created.getCallCount()).toBe(1);
+		expect(events.length).toBe(0); // No auto_retry_start events should be emitted
+	});
+
+	it("does not retry 429 errors when Retry-After is > 300s", async () => {
+		const created = createSession("Error 429: Too Many Requests\nRetry-After: 3600");
+
+		const events: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") events.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") events.push(`end:success=${event.success}`);
+		});
+
+		await created.session.prompt("Test");
+
+		// Should not retry because Retry-After is > 300s
+		expect(created.getCallCount()).toBe(1);
+		expect(events.length).toBe(0);
+	});
+
+	it("does retry 429 errors when Retry-After is <= 300s", async () => {
+		const created = createSession("Error 429: Too Many Requests\nRetry-After: 5");
+
+		const events: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") events.push(`start:${event.attempt}`);
+			if (event.type === "auto_retry_end") events.push(`end:success=${event.success}`);
+		});
+
+		await created.session.prompt("Test");
+
+		// Should retry multiple times since it's a transient rate limit
+		expect(created.getCallCount()).toBeGreaterThan(1);
+		expect(events.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
The Problem The coding-agent was getting stuck in an infinite "Working" state when encountering 429 Too Many Requests or hard quota limit errors from the opencode-go provider.

The root cause was twofold:

Unprotected Body Reads: Because installUndiciGlobals() sets bodyTimeout: 0 (required for long-running AI streams), response.text() has no global safety net. Meanwhile, openai-node's internal fetchWithTimeout clears its AbortSignal the moment headers arrive. If the server drops the TCP connection abruptly or fails to terminate the chunked transfer (tarpitting), response.text() hangs forever on the error path.
Infinite Backoff Loops: AgentSession was blindly auto-retrying any 429 status code. This caused the agent to spam the provider endlessly when the user hit a hard usage limit (e.g., "5-hour usage limit reached") or when the provider returned a massive Retry-After window.
The Solution

Defensive Fetch Wrapper (openai-completions.ts): Implemented a custom fetch function that intercepts non-200 responses. We clone the response and use Object.defineProperty to safely override the read-only text() method, wrapping it in a Promise.race against a 5-second hard timeout. This guarantees the UI gets the error instead of hanging.
Retry-After Extraction: Since openai-node discards raw headers in its native error objects, the fetch interceptor now manually extracts the Retry-After header and appends it to the error message string.
Smarter Auto-Retry (agent-session.ts): Refined _isRetryableError to inspect the error message. It now explicitly rejects retries if the message contains hard quota indicators (usage limit, quota, balance) or if the Retry-After header requests a wait time exceeding 300 seconds.
Regression Tests: Added a dedicated test suite (4716-openai-rate-limit-hang.test.ts) validating that the session properly aborts on hard limits and excessive Retry-After values, while successfully recovering from standard transient rate limits.
Validation

Verified the 5-second timeout successfully prevents the stream hang.
All regression tests pass locally.
Ran npm run check with 0 issues (Biome, TS compiler, etc.).

#4707 