### PR TITLE
fix(agent): stop run after `ctx.abort()` during tool handling

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -217,6 +217,11 @@ async function runLoop(
 
 			await emit({ type: "turn_end", message, toolResults });
 
+			if (signal?.aborted) {
+				await emit({ type: "agent_end", messages: newMessages });
+				return;
+			}
+
 			const nextTurnContext = {
 				message,
 				toolResults,
@@ -414,11 +419,22 @@ async function executeToolCallsSequential(
 		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		let finalized: FinalizedToolCallOutcome;
 		if (preparation.kind === "immediate") {
-			finalized = {
-				toolCall,
-				result: preparation.result,
-				isError: preparation.isError,
-			};
+			if ("args" in preparation) {
+				finalized = await finalizeExecutedToolCall(
+					currentContext,
+					assistantMessage,
+					{ toolCall, args: preparation.args },
+					{ result: preparation.result, isError: preparation.isError },
+					config,
+					signal,
+				);
+			} else {
+				finalized = {
+					toolCall,
+					result: preparation.result,
+					isError: preparation.isError,
+				};
+			}
 		} else {
 			const executed = await executePreparedToolCall(preparation, signal, emit);
 			finalized = await finalizeExecutedToolCall(
@@ -436,11 +452,15 @@ async function executeToolCallsSequential(
 		await emitToolResultMessage(toolResultMessage, emit);
 		finalizedCalls.push(finalized);
 		messages.push(toolResultMessage);
+
+		if (signal?.aborted) {
+			break;
+		}
 	}
 
 	return {
 		messages,
-		terminate: shouldTerminateToolBatch(finalizedCalls),
+		terminate: signal?.aborted || shouldTerminateToolBatch(finalizedCalls),
 	};
 }
 
@@ -452,7 +472,7 @@ async function executeToolCallsParallel(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 ): Promise<ExecutedToolCallBatch> {
-	const finalizedCalls: FinalizedToolCallEntry[] = [];
+	const toolCallEntries: ParallelToolCallEntry[] = [];
 
 	for (const toolCall of toolCalls) {
 		await emit({
@@ -464,33 +484,75 @@ async function executeToolCallsParallel(
 
 		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		if (preparation.kind === "immediate") {
-			const finalized = {
-				toolCall,
-				result: preparation.result,
-				isError: preparation.isError,
-			} satisfies FinalizedToolCallOutcome;
+			let finalized: FinalizedToolCallOutcome;
+			if ("args" in preparation) {
+				finalized = await finalizeExecutedToolCall(
+					currentContext,
+					assistantMessage,
+					{ toolCall, args: preparation.args },
+					{ result: preparation.result, isError: preparation.isError },
+					config,
+					signal,
+				);
+			} else {
+				finalized = {
+					toolCall,
+					result: preparation.result,
+					isError: preparation.isError,
+				};
+			}
 			await emitToolExecutionEnd(finalized, emit);
-			finalizedCalls.push(finalized);
+			toolCallEntries.push(finalized);
+			if (signal?.aborted) {
+				break;
+			}
 			continue;
 		}
 
-		finalizedCalls.push(async () => {
-			const executed = await executePreparedToolCall(preparation, signal, emit);
+		toolCallEntries.push(preparation);
+
+		if (signal?.aborted) {
+			break;
+		}
+	}
+
+	const orderedFinalizedCalls = await Promise.all(
+		toolCallEntries.map(async (entry) => {
+			if (!("kind" in entry)) {
+				return entry;
+			}
+
+			if (signal?.aborted) {
+				const finalized = await finalizeExecutedToolCall(
+					currentContext,
+					assistantMessage,
+					entry,
+					{
+						result: {
+							...createErrorToolResult("Tool execution was aborted"),
+							terminate: true,
+						},
+						isError: true,
+					},
+					config,
+					signal,
+				);
+				await emitToolExecutionEnd(finalized, emit);
+				return finalized;
+			}
+
+			const executed = await executePreparedToolCall(entry, signal, emit);
 			const finalized = await finalizeExecutedToolCall(
 				currentContext,
 				assistantMessage,
-				preparation,
+				entry,
 				executed,
 				config,
 				signal,
 			);
 			await emitToolExecutionEnd(finalized, emit);
 			return finalized;
-		});
-	}
-
-	const orderedFinalizedCalls = await Promise.all(
-		finalizedCalls.map((entry) => (typeof entry === "function" ? entry() : Promise.resolve(entry))),
+		}),
 	);
 	const messages: ToolResultMessage[] = [];
 	for (const finalized of orderedFinalizedCalls) {
@@ -501,7 +563,7 @@ async function executeToolCallsParallel(
 
 	return {
 		messages,
-		terminate: shouldTerminateToolBatch(orderedFinalizedCalls),
+		terminate: signal?.aborted || shouldTerminateToolBatch(orderedFinalizedCalls),
 	};
 }
 
@@ -512,10 +574,16 @@ type PreparedToolCall = {
 	args: unknown;
 };
 
+type FinalizableToolCall = {
+	toolCall: AgentToolCall;
+	args: unknown;
+};
+
 type ImmediateToolCallOutcome = {
 	kind: "immediate";
 	result: AgentToolResult<any>;
 	isError: boolean;
+	args?: unknown;
 };
 
 type ExecutedToolCallOutcome = {
@@ -529,7 +597,7 @@ type FinalizedToolCallOutcome = {
 	isError: boolean;
 };
 
-type FinalizedToolCallEntry = FinalizedToolCallOutcome | (() => Promise<FinalizedToolCallOutcome>);
+type ParallelToolCallEntry = PreparedToolCall | FinalizedToolCallOutcome;
 
 function shouldTerminateToolBatch(finalizedCalls: FinalizedToolCallOutcome[]): boolean {
 	return finalizedCalls.length > 0 && finalizedCalls.every((finalized) => finalized.result.terminate === true);
@@ -565,9 +633,11 @@ async function prepareToolCall(
 		};
 	}
 
+	let validatedArgs: unknown;
+
 	try {
 		const preparedToolCall = prepareToolCallArguments(tool, toolCall);
-		const validatedArgs = validateToolArguments(tool, preparedToolCall);
+		validatedArgs = validateToolArguments(tool, preparedToolCall);
 		if (config.beforeToolCall) {
 			const beforeResult = await config.beforeToolCall(
 				{
@@ -585,6 +655,17 @@ async function prepareToolCall(
 					isError: true,
 				};
 			}
+		}
+		if (signal?.aborted) {
+			return {
+				kind: "immediate",
+				result: {
+					...createErrorToolResult("Tool execution was aborted"),
+					terminate: true,
+				},
+				isError: true,
+				args: validatedArgs,
+			};
 		}
 		return {
 			kind: "prepared",
@@ -641,7 +722,7 @@ async function executePreparedToolCall(
 async function finalizeExecutedToolCall(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
-	prepared: PreparedToolCall,
+	finalizable: FinalizableToolCall,
 	executed: ExecutedToolCallOutcome,
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
@@ -654,8 +735,8 @@ async function finalizeExecutedToolCall(
 			const afterResult = await config.afterToolCall(
 				{
 					assistantMessage,
-					toolCall: prepared.toolCall,
-					args: prepared.args,
+					toolCall: finalizable.toolCall,
+					args: finalizable.args,
 					result,
 					isError,
 					context: currentContext,
@@ -677,7 +758,7 @@ async function finalizeExecutedToolCall(
 	}
 
 	return {
-		toolCall: prepared.toolCall,
+		toolCall: finalizable.toolCall,
 		result,
 		isError,
 	};

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -576,9 +576,6 @@ describe("agentLoop with AgentMessage", () => {
 		};
 
 		const abortController = new AbortController();
-		let prepareNextTurnCalls = 0;
-		let shouldStopAfterTurnCalls = 0;
-		let steeringCalls = 0;
 		let followUpCalls = 0;
 		let followUpReady = false;
 		const config: AgentLoopConfig = {
@@ -588,18 +585,6 @@ describe("agentLoop with AgentMessage", () => {
 				abortController.abort();
 				followUpReady = true;
 				return undefined;
-			},
-			prepareNextTurn: async () => {
-				prepareNextTurnCalls++;
-				return undefined;
-			},
-			shouldStopAfterTurn: async () => {
-				shouldStopAfterTurnCalls++;
-				return false;
-			},
-			getSteeringMessages: async () => {
-				steeringCalls++;
-				return [];
 			},
 			getFollowUpMessages: async () => {
 				followUpCalls++;
@@ -647,9 +632,6 @@ describe("agentLoop with AgentMessage", () => {
 		});
 
 		expect(llmCalls).toBe(1);
-		expect(prepareNextTurnCalls).toBe(0);
-		expect(shouldStopAfterTurnCalls).toBe(0);
-		expect(steeringCalls).toBe(1);
 		expect(followUpCalls).toBe(0);
 		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 		expect(assistantStopReasons).toEqual(["toolUse"]);
@@ -850,7 +832,7 @@ describe("agentLoop with AgentMessage", () => {
 		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 	});
 
-	it("should stop a parallel tool batch immediately when the signal aborts during or before tool preflight", async () => {
+	it("should stop a parallel tool batch immediately when beforeToolCall aborts the first tool", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: string[] = [];
 		const tool: AgentTool<typeof toolSchema, { value: string }> = {
@@ -946,6 +928,33 @@ describe("agentLoop with AgentMessage", () => {
 		expect(toolResultIds).toEqual(["tool-1"]);
 		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 		expect(executed).toEqual([]);
+	});
+
+	it("should stop a parallel tool batch immediately when the signal aborts before tool preflight completes", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				executed.push(params.value);
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
 
 		const preflightAbortController = new AbortController();
 		const preflightConfig: AgentLoopConfig = {
@@ -1018,6 +1027,33 @@ describe("agentLoop with AgentMessage", () => {
 		expect(preflightToolResultIds).toEqual(["tool-1"]);
 		expect(preflightMessages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 		expect(executed).toEqual([]);
+	});
+
+	it("should emit already-prepared parallel abort results without starting execution", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				executed.push(params.value);
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
 
 		const preparedAbortController = new AbortController();
 		const preparedAbortConfig: AgentLoopConfig = {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -369,6 +369,739 @@ describe("agentLoop with AgentMessage", () => {
 		expect(executed).toEqual([123]);
 	});
 
+	it("should not start another assistant turn when beforeToolCall aborts the signal", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const abortController = new AbortController();
+		let prepareNextTurnCalls = 0;
+		let shouldStopAfterTurnCalls = 0;
+		let steeringCalls = 0;
+		let steeringReady = false;
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			beforeToolCall: async () => {
+				abortController.abort();
+				steeringReady = true;
+				return undefined;
+			},
+			prepareNextTurn: async () => {
+				prepareNextTurnCalls++;
+				return undefined;
+			},
+			shouldStopAfterTurn: async () => {
+				shouldStopAfterTurnCalls++;
+				return false;
+			},
+			getSteeringMessages: async () => {
+				steeringCalls++;
+				if (steeringReady) {
+					return [createUserMessage("queued steering should stay queued")];
+				}
+				return [];
+			},
+		};
+
+		let llmCalls = 0;
+		const stream = agentLoop([createUserMessage("echo something")], context, config, abortController.signal, () => {
+			llmCalls++;
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (llmCalls === 1) {
+					const message = createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+					return;
+				}
+
+				mockStream.push({
+					type: "error",
+					reason: "aborted",
+					error: createAssistantMessage([{ type: "text", text: "Aborted" }], "aborted"),
+				});
+			});
+			return mockStream;
+		});
+
+		const events: AgentEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const assistantStopReasons = messages.flatMap((message) => {
+			if (message.role !== "assistant") {
+				return [];
+			}
+			return [message.stopReason];
+		});
+
+		expect(llmCalls).toBe(1);
+		expect(prepareNextTurnCalls).toBe(0);
+		expect(shouldStopAfterTurnCalls).toBe(0);
+		expect(steeringCalls).toBe(1);
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+		expect(assistantStopReasons).toEqual(["toolUse"]);
+		expect(events.filter((event) => event.type === "turn_end")).toHaveLength(1);
+	});
+
+	it("should run afterToolCall for an aborted tool result when beforeToolCall aborts the signal", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const abortController = new AbortController();
+		const afterToolCallInputs: Array<{ toolCallId: string; value: string; isError: boolean }> = [];
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			beforeToolCall: async () => {
+				abortController.abort();
+				return undefined;
+			},
+			afterToolCall: async ({ toolCall, args, result, isError }) => {
+				afterToolCallInputs.push({
+					toolCallId: toolCall.id,
+					value: (args as { value: string }).value,
+					isError,
+				});
+				expect(result.content).toEqual([{ type: "text", text: "Tool execution was aborted" }]);
+				return {
+					content: [{ type: "text", text: "patched aborted result" }],
+					details: { patched: true },
+					isError,
+					terminate: result.terminate,
+				};
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("echo something")], context, config, abortController.signal, () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				mockStream.push({
+					type: "done",
+					reason: "toolUse",
+					message: createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+						"toolUse",
+					),
+				});
+			});
+			return mockStream;
+		});
+
+		for await (const _event of stream) {
+			// consume
+		}
+
+		const messages = await stream.result();
+		const toolResults = messages.filter(
+			(message): message is Extract<(typeof messages)[number], { role: "toolResult" }> =>
+				message.role === "toolResult",
+		);
+
+		expect(afterToolCallInputs).toEqual([{ toolCallId: "tool-1", value: "hello", isError: true }]);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]).toMatchObject({
+			content: [{ type: "text", text: "patched aborted result" }],
+			details: { patched: true },
+			isError: true,
+		});
+	});
+
+	it("should not start another assistant turn when beforeToolCall aborts the signal and follow-up messages are queued", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const abortController = new AbortController();
+		let prepareNextTurnCalls = 0;
+		let shouldStopAfterTurnCalls = 0;
+		let steeringCalls = 0;
+		let followUpCalls = 0;
+		let followUpReady = false;
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			beforeToolCall: async () => {
+				abortController.abort();
+				followUpReady = true;
+				return undefined;
+			},
+			prepareNextTurn: async () => {
+				prepareNextTurnCalls++;
+				return undefined;
+			},
+			shouldStopAfterTurn: async () => {
+				shouldStopAfterTurnCalls++;
+				return false;
+			},
+			getSteeringMessages: async () => {
+				steeringCalls++;
+				return [];
+			},
+			getFollowUpMessages: async () => {
+				followUpCalls++;
+				if (followUpReady) {
+					return [createUserMessage("queued follow-up should stay queued")];
+				}
+				return [];
+			},
+		};
+
+		let llmCalls = 0;
+		const stream = agentLoop([createUserMessage("echo something")], context, config, abortController.signal, () => {
+			llmCalls++;
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (llmCalls === 1) {
+					const message = createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+					return;
+				}
+
+				mockStream.push({
+					type: "error",
+					reason: "aborted",
+					error: createAssistantMessage([{ type: "text", text: "Aborted" }], "aborted"),
+				});
+			});
+			return mockStream;
+		});
+
+		const events: AgentEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const assistantStopReasons = messages.flatMap((message) => {
+			if (message.role !== "assistant") {
+				return [];
+			}
+			return [message.stopReason];
+		});
+
+		expect(llmCalls).toBe(1);
+		expect(prepareNextTurnCalls).toBe(0);
+		expect(shouldStopAfterTurnCalls).toBe(0);
+		expect(steeringCalls).toBe(1);
+		expect(followUpCalls).toBe(0);
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+		expect(assistantStopReasons).toEqual(["toolUse"]);
+		expect(events.filter((event) => event.type === "turn_end")).toHaveLength(1);
+	});
+
+	it("should run afterToolCall for aborted parallel tool results that are still emitted", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const abortController = new AbortController();
+		const afterToolCallInputs: Array<{ toolCallId: string; value: string; isError: boolean }> = [];
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "parallel",
+			beforeToolCall: async ({ toolCall }) => {
+				if (toolCall.id === "tool-2") {
+					abortController.abort();
+				}
+				return undefined;
+			},
+			afterToolCall: async ({ toolCall, args, result, isError }) => {
+				afterToolCallInputs.push({
+					toolCallId: toolCall.id,
+					value: (args as { value: string }).value,
+					isError,
+				});
+				expect(result.content).toEqual([{ type: "text", text: "Tool execution was aborted" }]);
+				return {
+					content: [{ type: "text", text: `patched ${toolCall.id}` }],
+					details: { patched: toolCall.id },
+					isError,
+					terminate: result.terminate,
+				};
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("echo both")], context, config, abortController.signal, () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				mockStream.push({
+					type: "done",
+					reason: "toolUse",
+					message: createAssistantMessage(
+						[
+							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+						],
+						"toolUse",
+					),
+				});
+			});
+			return mockStream;
+		});
+
+		for await (const _event of stream) {
+			// consume
+		}
+
+		const messages = await stream.result();
+		const toolResults = messages.filter(
+			(message): message is Extract<(typeof messages)[number], { role: "toolResult" }> =>
+				message.role === "toolResult",
+		);
+
+		expect(afterToolCallInputs.sort((a, b) => a.toolCallId.localeCompare(b.toolCallId))).toEqual([
+			{ toolCallId: "tool-1", value: "first", isError: true },
+			{ toolCallId: "tool-2", value: "second", isError: true },
+		]);
+		expect(toolResults).toHaveLength(2);
+		expect(toolResults[0]).toMatchObject({
+			toolCallId: "tool-1",
+			content: [{ type: "text", text: "patched tool-1" }],
+			details: { patched: "tool-1" },
+			isError: true,
+		});
+		expect(toolResults[1]).toMatchObject({
+			toolCallId: "tool-2",
+			content: [{ type: "text", text: "patched tool-2" }],
+			details: { patched: "tool-2" },
+			isError: true,
+		});
+	});
+
+	it("should stop a sequential tool batch immediately when beforeToolCall aborts the signal", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const abortController = new AbortController();
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+			beforeToolCall: async ({ toolCall }) => {
+				if (toolCall.id === "tool-1") {
+					abortController.abort();
+				}
+				return undefined;
+			},
+		};
+
+		let llmCalls = 0;
+		const stream = agentLoop([createUserMessage("echo both")], context, config, abortController.signal, () => {
+			llmCalls++;
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (llmCalls === 1) {
+					const message = createAssistantMessage(
+						[
+							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+						],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+					return;
+				}
+
+				mockStream.push({
+					type: "error",
+					reason: "aborted",
+					error: createAssistantMessage([{ type: "text", text: "Aborted" }], "aborted"),
+				});
+			});
+			return mockStream;
+		});
+
+		const events: AgentEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const toolExecutionStartIds = events.flatMap((event) => {
+			if (event.type !== "tool_execution_start") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const toolExecutionEndIds = events.flatMap((event) => {
+			if (event.type !== "tool_execution_end") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const toolResultIds = messages.flatMap((message) => {
+			if (message.role !== "toolResult") {
+				return [];
+			}
+			return [message.toolCallId];
+		});
+
+		expect(llmCalls).toBe(1);
+		expect(toolExecutionStartIds).toEqual(["tool-1"]);
+		expect(toolExecutionEndIds).toEqual(["tool-1"]);
+		expect(toolResultIds).toEqual(["tool-1"]);
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+	});
+
+	it("should stop a parallel tool batch immediately when the signal aborts during or before tool preflight", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params, signal) {
+				executed.push(params.value);
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const abortController = new AbortController();
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "parallel",
+			beforeToolCall: async ({ toolCall }) => {
+				if (toolCall.id === "tool-1") {
+					abortController.abort();
+				}
+				return undefined;
+			},
+		};
+
+		let llmCalls = 0;
+		const stream = agentLoop([createUserMessage("echo both")], context, config, abortController.signal, () => {
+			llmCalls++;
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (llmCalls === 1) {
+					const message = createAssistantMessage(
+						[
+							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+						],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+					return;
+				}
+
+				mockStream.push({
+					type: "error",
+					reason: "aborted",
+					error: createAssistantMessage([{ type: "text", text: "Aborted" }], "aborted"),
+				});
+			});
+			return mockStream;
+		});
+
+		const events: AgentEvent[] = [];
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const toolExecutionStartIds = events.flatMap((event) => {
+			if (event.type !== "tool_execution_start") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const toolExecutionEndIds = events.flatMap((event) => {
+			if (event.type !== "tool_execution_end") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const toolResultIds = messages.flatMap((message) => {
+			if (message.role !== "toolResult") {
+				return [];
+			}
+			return [message.toolCallId];
+		});
+
+		expect(llmCalls).toBe(1);
+		expect(toolExecutionStartIds).toEqual(["tool-1"]);
+		expect(toolExecutionEndIds).toEqual(["tool-1"]);
+		expect(toolResultIds).toEqual(["tool-1"]);
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+		expect(executed).toEqual([]);
+
+		const preflightAbortController = new AbortController();
+		const preflightConfig: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "parallel",
+		};
+
+		let preflightLlmCalls = 0;
+		const preflightStream = agentLoop(
+			[createUserMessage("echo both")],
+			context,
+			preflightConfig,
+			preflightAbortController.signal,
+			() => {
+				preflightLlmCalls++;
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (preflightLlmCalls === 1) {
+						const message = createAssistantMessage(
+							[
+								{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+								{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+							],
+							"toolUse",
+						);
+						mockStream.push({ type: "done", reason: "toolUse", message });
+						preflightAbortController.abort();
+						return;
+					}
+
+					mockStream.push({
+						type: "error",
+						reason: "aborted",
+						error: createAssistantMessage([{ type: "text", text: "Aborted" }], "aborted"),
+					});
+				});
+				return mockStream;
+			},
+		);
+
+		const preflightEvents: AgentEvent[] = [];
+		for await (const event of preflightStream) {
+			preflightEvents.push(event);
+		}
+
+		const preflightMessages = await preflightStream.result();
+		const preflightToolExecutionStartIds = preflightEvents.flatMap((event) => {
+			if (event.type !== "tool_execution_start") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const preflightToolExecutionEndIds = preflightEvents.flatMap((event) => {
+			if (event.type !== "tool_execution_end") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const preflightToolResultIds = preflightMessages.flatMap((message) => {
+			if (message.role !== "toolResult") {
+				return [];
+			}
+			return [message.toolCallId];
+		});
+
+		expect(preflightLlmCalls).toBe(1);
+		expect(preflightToolExecutionStartIds).toEqual(["tool-1"]);
+		expect(preflightToolExecutionEndIds).toEqual(["tool-1"]);
+		expect(preflightToolResultIds).toEqual(["tool-1"]);
+		expect(preflightMessages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+		expect(executed).toEqual([]);
+
+		const preparedAbortController = new AbortController();
+		const preparedAbortConfig: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "parallel",
+			beforeToolCall: async ({ toolCall }) => {
+				if (toolCall.id === "tool-2") {
+					preparedAbortController.abort();
+				}
+				return undefined;
+			},
+		};
+
+		let preparedAbortLlmCalls = 0;
+		const preparedAbortStream = agentLoop(
+			[createUserMessage("echo both")],
+			context,
+			preparedAbortConfig,
+			preparedAbortController.signal,
+			() => {
+				preparedAbortLlmCalls++;
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (preparedAbortLlmCalls === 1) {
+						const message = createAssistantMessage(
+							[
+								{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+								{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+							],
+							"toolUse",
+						);
+						mockStream.push({ type: "done", reason: "toolUse", message });
+						return;
+					}
+
+					mockStream.push({
+						type: "error",
+						reason: "aborted",
+						error: createAssistantMessage([{ type: "text", text: "Aborted" }], "aborted"),
+					});
+				});
+				return mockStream;
+			},
+		);
+
+		const preparedAbortEvents: AgentEvent[] = [];
+		for await (const event of preparedAbortStream) {
+			preparedAbortEvents.push(event);
+		}
+
+		const preparedAbortMessages = await preparedAbortStream.result();
+		const preparedAbortToolExecutionStartIds = preparedAbortEvents.flatMap((event) => {
+			if (event.type !== "tool_execution_start") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const preparedAbortToolExecutionEndIds = preparedAbortEvents.flatMap((event) => {
+			if (event.type !== "tool_execution_end") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const preparedAbortToolResultIds = preparedAbortMessages.flatMap((message) => {
+			if (message.role !== "toolResult") {
+				return [];
+			}
+			return [message.toolCallId];
+		});
+
+		expect(preparedAbortLlmCalls).toBe(1);
+		expect(preparedAbortToolExecutionStartIds).toEqual(["tool-1", "tool-2"]);
+		expect(preparedAbortToolExecutionEndIds.sort()).toEqual(["tool-1", "tool-2"]);
+		expect(preparedAbortToolResultIds).toEqual(["tool-1", "tool-2"]);
+		expect(preparedAbortMessages.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"toolResult",
+			"toolResult",
+		]);
+		expect(executed).toEqual([]);
+	});
+
 	it("should prepare tool arguments for validation", async () => {
 		const replaceSchema = Type.Object({ oldText: Type.String(), newText: Type.String() });
 		const toolSchema = Type.Object({ edits: Type.Array(replaceSchema) });

--- a/packages/coding-agent/test/suite/regressions/4276-ctx-abort-tool-call.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4276-ctx-abort-tool-call.test.ts
@@ -13,86 +13,7 @@ describe("issue #4276 ctx.abort during tool_call", () => {
 		}
 	});
 
-	it("stops the current tool batch without appending an extra aborted assistant turn", async () => {
-		const observedToolCallIds: string[] = [];
-
-		const echoTool: AgentTool = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo text back",
-			parameters: Type.Object({ text: Type.String() }),
-			execute: async (_toolCallId, params, signal) => {
-				if (signal?.aborted) {
-					throw new Error("aborted");
-				}
-				const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
-				return {
-					content: [{ type: "text", text }],
-					details: { text },
-				};
-			},
-		};
-
-		const harness = await createHarness({
-			tools: [echoTool],
-			extensionFactories: [
-				(pi) => {
-					pi.on("tool_call", async (event, ctx) => {
-						observedToolCallIds.push(event.toolCallId);
-						if (event.toolCallId === "tool-1") {
-							ctx.abort();
-						}
-					});
-				},
-			],
-		});
-		harnesses.push(harness);
-
-		harness.setResponses([
-			fauxAssistantMessage(
-				[
-					fauxToolCall("echo", { text: "first" }, { id: "tool-1" }),
-					fauxToolCall("echo", { text: "second" }, { id: "tool-2" }),
-				],
-				{ stopReason: "toolUse" },
-			),
-			fauxAssistantMessage("should not run"),
-		]);
-
-		await harness.session.prompt("start");
-
-		const assistantMessages = harness.session.messages.filter(
-			(message): message is Extract<(typeof harness.session.messages)[number], { role: "assistant" }> =>
-				message.role === "assistant",
-		);
-		const toolExecutionStartIds = harness.events.flatMap((event) => {
-			if (event.type !== "tool_execution_start") {
-				return [];
-			}
-			return [event.toolCallId];
-		});
-		const toolExecutionEndIds = harness.events.flatMap((event) => {
-			if (event.type !== "tool_execution_end") {
-				return [];
-			}
-			return [event.toolCallId];
-		});
-		const toolResults = harness.session.messages.filter(
-			(message): message is Extract<(typeof harness.session.messages)[number], { role: "toolResult" }> =>
-				message.role === "toolResult",
-		);
-
-		expect(observedToolCallIds).toEqual(["tool-1"]);
-		expect(toolExecutionStartIds).toEqual(["tool-1"]);
-		expect(toolExecutionEndIds).toEqual(["tool-1"]);
-		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
-		expect(assistantMessages.map((message) => message.stopReason)).toEqual(["toolUse"]);
-		expect(toolResults).toHaveLength(1);
-		expect(toolResults[0]?.isError).toBe(true);
-		expect(harness.getPendingResponseCount()).toBe(1);
-	});
-
-	it("does not consume queued follow-up messages after ctx.abort during tool_call", async () => {
+	it("stops the current tool batch without appending an extra aborted assistant turn or consuming queued follow-up", async () => {
 		const observedToolCallIds: string[] = [];
 
 		const echoTool: AgentTool = {
@@ -145,12 +66,26 @@ describe("issue #4276 ctx.abort during tool_call", () => {
 			(message): message is Extract<(typeof harness.session.messages)[number], { role: "assistant" }> =>
 				message.role === "assistant",
 		);
+		const toolExecutionStartIds = harness.events.flatMap((event) => {
+			if (event.type !== "tool_execution_start") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const toolExecutionEndIds = harness.events.flatMap((event) => {
+			if (event.type !== "tool_execution_end") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
 		const toolResults = harness.session.messages.filter(
 			(message): message is Extract<(typeof harness.session.messages)[number], { role: "toolResult" }> =>
 				message.role === "toolResult",
 		);
 
 		expect(observedToolCallIds).toEqual(["tool-1"]);
+		expect(toolExecutionStartIds).toEqual(["tool-1"]);
+		expect(toolExecutionEndIds).toEqual(["tool-1"]);
 		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 		expect(assistantMessages.map((message) => message.stopReason)).toEqual(["toolUse"]);
 		expect(toolResults).toHaveLength(1);

--- a/packages/coding-agent/test/suite/regressions/4276-ctx-abort-tool-call.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4276-ctx-abort-tool-call.test.ts
@@ -1,0 +1,234 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.js";
+
+describe("issue #4276 ctx.abort during tool_call", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("stops the current tool batch without appending an extra aborted assistant turn", async () => {
+		const observedToolCallIds: string[] = [];
+
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async (_toolCallId, params, signal) => {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+				return {
+					content: [{ type: "text", text }],
+					details: { text },
+				};
+			},
+		};
+
+		const harness = await createHarness({
+			tools: [echoTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("tool_call", async (event, ctx) => {
+						observedToolCallIds.push(event.toolCallId);
+						if (event.toolCallId === "tool-1") {
+							ctx.abort();
+						}
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage(
+				[
+					fauxToolCall("echo", { text: "first" }, { id: "tool-1" }),
+					fauxToolCall("echo", { text: "second" }, { id: "tool-2" }),
+				],
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("should not run"),
+		]);
+
+		await harness.session.prompt("start");
+
+		const assistantMessages = harness.session.messages.filter(
+			(message): message is Extract<(typeof harness.session.messages)[number], { role: "assistant" }> =>
+				message.role === "assistant",
+		);
+		const toolExecutionStartIds = harness.events.flatMap((event) => {
+			if (event.type !== "tool_execution_start") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const toolExecutionEndIds = harness.events.flatMap((event) => {
+			if (event.type !== "tool_execution_end") {
+				return [];
+			}
+			return [event.toolCallId];
+		});
+		const toolResults = harness.session.messages.filter(
+			(message): message is Extract<(typeof harness.session.messages)[number], { role: "toolResult" }> =>
+				message.role === "toolResult",
+		);
+
+		expect(observedToolCallIds).toEqual(["tool-1"]);
+		expect(toolExecutionStartIds).toEqual(["tool-1"]);
+		expect(toolExecutionEndIds).toEqual(["tool-1"]);
+		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+		expect(assistantMessages.map((message) => message.stopReason)).toEqual(["toolUse"]);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.isError).toBe(true);
+		expect(harness.getPendingResponseCount()).toBe(1);
+	});
+
+	it("does not consume queued follow-up messages after ctx.abort during tool_call", async () => {
+		const observedToolCallIds: string[] = [];
+
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async (_toolCallId, params, signal) => {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+				return {
+					content: [{ type: "text", text }],
+					details: { text },
+				};
+			},
+		};
+
+		const harness = await createHarness({
+			tools: [echoTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("tool_call", async (event, ctx) => {
+						observedToolCallIds.push(event.toolCallId);
+						if (event.toolCallId === "tool-1") {
+							pi.sendUserMessage("queued follow-up", { deliverAs: "followUp" });
+							ctx.abort();
+						}
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage(
+				[
+					fauxToolCall("echo", { text: "first" }, { id: "tool-1" }),
+					fauxToolCall("echo", { text: "second" }, { id: "tool-2" }),
+				],
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("should not run"),
+		]);
+
+		await harness.session.prompt("start");
+
+		const assistantMessages = harness.session.messages.filter(
+			(message): message is Extract<(typeof harness.session.messages)[number], { role: "assistant" }> =>
+				message.role === "assistant",
+		);
+		const toolResults = harness.session.messages.filter(
+			(message): message is Extract<(typeof harness.session.messages)[number], { role: "toolResult" }> =>
+				message.role === "toolResult",
+		);
+
+		expect(observedToolCallIds).toEqual(["tool-1"]);
+		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+		expect(assistantMessages.map((message) => message.stopReason)).toEqual(["toolUse"]);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.isError).toBe(true);
+		expect(harness.session.pendingMessageCount).toBe(1);
+		expect(harness.getPendingResponseCount()).toBe(1);
+	});
+
+	it("still emits tool_result hooks for aborted tool results", async () => {
+		const observedToolCallIds: string[] = [];
+		const observedToolResultIds: string[] = [];
+
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async (_toolCallId, params, signal) => {
+				if (signal?.aborted) {
+					throw new Error("aborted");
+				}
+				const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+				return {
+					content: [{ type: "text", text }],
+					details: { text },
+				};
+			},
+		};
+
+		const harness = await createHarness({
+			tools: [echoTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("tool_call", async (event, ctx) => {
+						observedToolCallIds.push(event.toolCallId);
+						if (event.toolCallId === "tool-1") {
+							ctx.abort();
+						}
+					});
+					pi.on("tool_result", async (event) => {
+						observedToolResultIds.push(event.toolCallId);
+						expect(event.isError).toBe(true);
+						expect(event.content).toEqual([{ type: "text", text: "Tool execution was aborted" }]);
+						return {
+							content: [{ type: "text", text: "patched aborted result" }],
+							details: { patched: true },
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage(
+				[
+					fauxToolCall("echo", { text: "first" }, { id: "tool-1" }),
+					fauxToolCall("echo", { text: "second" }, { id: "tool-2" }),
+				],
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("should not run"),
+		]);
+
+		await harness.session.prompt("start");
+
+		const toolResults = harness.session.messages.filter(
+			(message): message is Extract<(typeof harness.session.messages)[number], { role: "toolResult" }> =>
+				message.role === "toolResult",
+		);
+
+		expect(observedToolCallIds).toEqual(["tool-1"]);
+		expect(observedToolResultIds).toEqual(["tool-1"]);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]).toMatchObject({
+			content: [{ type: "text", text: "patched aborted result" }],
+			details: { patched: true },
+			isError: true,
+		});
+	});
+});


### PR DESCRIPTION
**Description**

- Per reported issue #4276 , when `ctx.abort()` was called during tool-call handling, it would stop the current tool execution, but might've continued with rest of the batch or a follow-up loop turn.
- The current fix will check for `signal?.aborted` during prep/execution and break out early, explicitly returning aborted tool results and halts the run after current turn
- In addition:
  - aborted tool results will still finalize via `afterToolCall(...)`
- fixes #4276  

**testing**

- added additional cases to `agent-loop.test`
- added a test into `/regressions`
- Exported sessions when testing locally (mocked provider responses)
  - **single tool-call:** https://pi.dev/session/#c5cb9d25676ee136fc5e10f7933979d1
  - **multi tool-call:** https://pi.dev/session/#94325edc5b2094a1151b168804c8ef9e
    - **question:** @badlogic so right now, the session will still contain the second tool-call without a matching result, is this feasible? I'm not sure if it's just confusing in the export UI or if we should indicate this in a different way. I was restrained from modifying anything that was already emitted, so e.g. in a scenario with two tool-calls where the first is aborted, I wouldn't necessarily modify/omit the second one - since that would cause a deviation from the state of truth. Or am I missing some nuances here/ not getting it?
  