### PR TITLE
[DEPRECATED] fix(coding-agent): Windows NUL redirect creates spurious 'nul' files

### DIFF
--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -57,6 +57,74 @@ export interface BashOperations {
 }
 
 /**
+ * Normalize Windows NUL redirects (> nul, 2> nul, etc.) to /dev/null.
+ * No-op on non-Windows. Skips text inside quotes and after backslash escapes.
+ */
+export function normalizeNulRedirects(command: string): string {
+	if (process.platform !== "win32") return command;
+
+	let result = "";
+	let inSingleQuotes = false;
+	let inDoubleQuotes = false;
+	let i = 0;
+
+	// Track consecutive backslashes as we walk the string.
+	// When we hit a non-backslash char, an odd count means it's escaped
+	// (e.g. \> ) and an even count means it's not (e.g. \\> ).
+	let trailingBackslashes = 0;
+
+	// Sticky regex (y flag) anchors the match to lastIndex so we don't need
+	// command.slice(i). Captures optional fd (1, 2, &) + operator (>, >>).
+	const redirectRe = /([12&]?)(>>?)\s*nul(?=\s|$|[|&;()<>])/iy;
+
+	while (i < command.length) {
+		const char = command[i];
+
+		// Accumulate backslashes; they only affect the *next* character.
+		if (char === "\\") {
+			trailingBackslashes++;
+			result += char;
+			i++;
+			continue;
+		}
+
+		const isEscaped = trailingBackslashes % 2 === 1;
+		trailingBackslashes = 0;
+
+		// Toggle quote state for unescaped quotes.
+		if (char === "'" && !inDoubleQuotes && !isEscaped) {
+			inSingleQuotes = !inSingleQuotes;
+			result += char;
+			i++;
+			continue;
+		}
+
+		if (char === '"' && !inSingleQuotes && !isEscaped) {
+			inDoubleQuotes = !inDoubleQuotes;
+			result += char;
+			i++;
+			continue;
+		}
+
+		// Outside quotes and unescaped: try to match a NUL redirect.
+		if (!inSingleQuotes && !inDoubleQuotes && !isEscaped) {
+			redirectRe.lastIndex = i;
+			const match = redirectRe.exec(command);
+			if (match) {
+				result += `${match[1]}${match[2]}/dev/null`;
+				i += match[0].length;
+				continue;
+			}
+		}
+
+		result += char;
+		i++;
+	}
+
+	return result;
+}
+
+/**
  * Create bash operations using pi's built-in local shell execution backend.
  *
  * This is useful for extensions that intercept user_bash and still want pi's
@@ -71,7 +139,8 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
 					reject(new Error(`Working directory does not exist: ${cwd}\nCannot execute bash commands.`));
 					return;
 				}
-				const child = spawn(shell, [...args, command], {
+				const normalizedCommand = normalizeNulRedirects(command);
+				const child = spawn(shell, [...args, normalizedCommand], {
 					cwd,
 					detached: process.platform !== "win32",
 					env: env ?? getShellEnv(),

--- a/packages/coding-agent/test/bash-nul-redirect.test.ts
+++ b/packages/coding-agent/test/bash-nul-redirect.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { normalizeNulRedirects } from "../src/core/tools/bash.js";
+
+describe("normalizeNulRedirects", () => {
+	it("returns empty string as-is", () => {
+		expect(normalizeNulRedirects("")).toBe("");
+	});
+
+	it("leaves commands without NUL redirects unchanged", () => {
+		expect(normalizeNulRedirects("echo hello")).toBe("echo hello");
+		expect(normalizeNulRedirects("grep nul file.txt")).toBe("grep nul file.txt");
+	});
+
+	it("does not replace > nul inside quoted strings", () => {
+		if (process.platform !== "win32") return;
+
+		expect(normalizeNulRedirects('echo "foo > nul bar"')).toBe('echo "foo > nul bar"');
+		expect(normalizeNulRedirects("echo 'foo > nul bar'")).toBe("echo 'foo > nul bar'");
+		expect(normalizeNulRedirects("echo \"foo 'bar > nul baz'\"")).toBe("echo \"foo 'bar > nul baz'\"");
+	});
+
+	it("does not replace > nul inside escaped quotes", () => {
+		if (process.platform !== "win32") return;
+
+		// Escaped double quotes outside quotes: > nul is outside quotes, so it IS replaced
+		expect(normalizeNulRedirects('echo \\"foo > nul bar\\"')).toBe('echo \\"foo >/dev/null bar\\"');
+
+		// Escaped double quote inside double quotes: string stays quoted, > nul stays
+		expect(normalizeNulRedirects('echo "foo \\"bar > nul baz"')).toBe('echo "foo \\"bar > nul baz"');
+
+		// Escaped single quote outside quotes: > nul is outside quotes, so it IS replaced
+		expect(normalizeNulRedirects("echo \\'foo > nul bar\\'")).toBe("echo \\'foo >/dev/null bar\\'");
+
+		// Escaped single quote inside double quotes: double quotes stay active, > nul stays
+		expect(normalizeNulRedirects('echo "foo \\\'bar > nul baz"')).toBe('echo "foo \\\'bar > nul baz"');
+	});
+
+	it("replaces all NUL redirect variants on Windows", () => {
+		if (process.platform !== "win32") {
+			return;
+		}
+
+		// stdout overwrite
+		expect(normalizeNulRedirects("echo hello >nul")).toBe("echo hello >/dev/null");
+		expect(normalizeNulRedirects("echo hello > nul")).toBe("echo hello >/dev/null");
+		expect(normalizeNulRedirects("echo hello >NUL")).toBe("echo hello >/dev/null");
+		expect(normalizeNulRedirects("echo hello >  nul")).toBe("echo hello >/dev/null");
+
+		// stdout append
+		expect(normalizeNulRedirects("echo hello >> nul")).toBe("echo hello >>/dev/null");
+		expect(normalizeNulRedirects("echo hello >>  NUL")).toBe("echo hello >>/dev/null");
+
+		// stderr overwrite with fd adjacent to operator
+		expect(normalizeNulRedirects("echo hello 1> nul")).toBe("echo hello 1>/dev/null");
+		expect(normalizeNulRedirects("echo hello 2> nul")).toBe("echo hello 2>/dev/null");
+
+		// stderr append with fd adjacent to operator
+		expect(normalizeNulRedirects("echo hello 1>> nul")).toBe("echo hello 1>>/dev/null");
+		expect(normalizeNulRedirects("echo hello 2>> nul")).toBe("echo hello 2>>/dev/null");
+
+		// stdout + stderr overwrite
+		expect(normalizeNulRedirects("echo hello &> nul")).toBe("echo hello &>/dev/null");
+		expect(normalizeNulRedirects("echo hello &>  Nul")).toBe("echo hello &>/dev/null");
+
+		// stdout + stderr append
+		expect(normalizeNulRedirects("echo hello &>> nul")).toBe("echo hello &>>/dev/null");
+		expect(normalizeNulRedirects("echo hello &>>  NuL")).toBe("echo hello &>>/dev/null");
+	});
+
+	it("does not rewrite nul when it is part of a filename", () => {
+		if (process.platform !== "win32") return;
+
+		expect(normalizeNulRedirects("echo data > nul.txt")).toBe("echo data > nul.txt");
+		expect(normalizeNulRedirects("echo data > nul-backup")).toBe("echo data > nul-backup");
+		expect(normalizeNulRedirects("echo data > nul_suffix")).toBe("echo data > nul_suffix");
+		expect(normalizeNulRedirects("echo data 1 > nul.txt")).toBe("echo data 1 > nul.txt");
+	});
+
+	it("preserves fd as an argument when separated from the operator by whitespace", () => {
+		if (process.platform !== "win32") return;
+
+		// When fd is not adjacent to the operator it is a normal argument;
+		// only the redirect target is rewritten.
+		expect(normalizeNulRedirects("echo hello 1 > nul")).toBe("echo hello 1 >/dev/null");
+		expect(normalizeNulRedirects("echo hello 2  >  nul")).toBe("echo hello 2  >/dev/null");
+		expect(normalizeNulRedirects("echo hello 2 >>  nul")).toBe("echo hello 2 >>/dev/null");
+	});
+
+	it("does not replace escaped redirect operators", () => {
+		if (process.platform !== "win32") return;
+
+		// Odd counts: operator is escaped, stays literal.
+		expect(normalizeNulRedirects("echo \\> nul")).toBe("echo \\> nul");
+		expect(normalizeNulRedirects("echo 1\\> nul")).toBe("echo 1\\> nul");
+		expect(normalizeNulRedirects("echo \\\\\\> nul")).toBe("echo \\\\\\> nul");
+
+		// Even counts: operator is NOT escaped, gets replaced.
+		expect(normalizeNulRedirects("echo \\\\\\\\> nul")).toBe("echo \\\\\\\\>/dev/null");
+		expect(normalizeNulRedirects("echo \\\\\\\\\\\\> nul")).toBe("echo \\\\\\\\\\\\>/dev/null");
+	});
+
+	it("handles bare redirects and control-character boundaries", () => {
+		if (process.platform !== "win32") return;
+
+		expect(normalizeNulRedirects(">nul")).toBe(">/dev/null");
+		expect(normalizeNulRedirects("> nul")).toBe(">/dev/null");
+		expect(normalizeNulRedirects("echo a > nul && echo b > nul")).toBe("echo a >/dev/null && echo b >/dev/null");
+		expect(normalizeNulRedirects("echo hello > nul|cat")).toBe("echo hello >/dev/null|cat");
+		expect(normalizeNulRedirects("echo hello > nul; echo world")).toBe("echo hello >/dev/null; echo world");
+	});
+
+	it("does not modify commands on non-Windows platforms", () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		expect(normalizeNulRedirects("echo hello > nul")).toBe("echo hello > nul");
+		expect(normalizeNulRedirects("echo hello 2>> nul")).toBe("echo hello 2>> nul");
+		expect(normalizeNulRedirects("echo hello &>> nul")).toBe("echo hello &>> nul");
+	});
+});
+
+describe.skipIf(process.platform !== "win32")("bash tool NUL redirect integration", () => {
+	let testDir: string;
+
+	afterEach(() => {
+		if (testDir) {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not create a file named nul when redirecting output", async () => {
+		const { createLocalBashOperations } = await import("../src/core/tools/bash.js");
+		const { existsSync } = await import("node:fs");
+
+		testDir = mkdtempSync(join(tmpdir(), "pi-nul-test-"));
+		const ops = createLocalBashOperations();
+
+		await ops.exec("echo hello > nul", testDir, {
+			onData: () => {},
+		});
+
+		expect(existsSync(join(testDir, "nul"))).toBe(false);
+	});
+});


### PR DESCRIPTION
On Windows (e.g. PowerShell in Windows Terminal), pi spawns Git Bash internally to execute commands. AI-generated commands like `echo hello >/dev/null` create a spurious file named `nul` because the MSYS2 runtime used by Git Bash does not treat `nul` as a null device.

This adds `normalizeNulRedirects()` which replaces NUL redirects outside of quoted strings with `/dev/null`, preserving the original operator (`>` or `>>`).

### Behavior
- Only runs on `process.platform === 'win32'`
- Respects quoted strings (no replacement inside `'` or `"`)
- The token `nul` must be a standalone redirect target (followed by whitespace, end-of-string, or a shell control character) to avoid rewriting filenames like `nul.txt` or `nul-backup`
- File descriptors (`1`, `2`, `&`) must be adjacent to the operator (`1>/dev/null`) to be treated as descriptors; when separated by whitespace (`1 >/dev/null`) the number is preserved as a normal shell argument and only the redirect target is rewritten
- Escaped operators such as `\>` are literal arguments in Bash and are not normalized as redirects

### Affected variants
`>/dev/null`, `>>/dev/null`, `1>/dev/null`, `1>>/dev/null`, `2>/dev/null`, `2>>/dev/null`, `&>/dev/null`, `&>>/dev/null`

Fixes #4731
