### PR TITLE
[codex] Restrict GitHub Actions triggers

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,9 +1,6 @@
 name: Build Binaries
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/openclaw-gate.yml
+++ b/.github/workflows/openclaw-gate.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
   pull_request_target:
+    branches:
+      - development
+      - test
+      - main
     types: [opened]
 
 jobs:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -2,6 +2,10 @@ name: PR Gate
 
 on:
   pull_request_target:
+    branches:
+      - development
+      - test
+      - main
     types: [opened]
 
 jobs:


### PR DESCRIPTION
## Summary
- Restricts branch-based GitHub Actions triggers to development, test, and main.
- Removes automatic tag-push binary builds so release builds are manual-only.
- Adds branch filters to pull_request_target gates.

## Validation
- Parsed all workflow YAML in the changed worktree with PyYAML.
- Ran the branch trigger policy scan and confirmed zero remaining branch/tag trigger violations in the targeted worktree.
- Ran agent-final-check with a clean base checkout.
