### PR TITLE
feat(ai): add claudinio provider (OpenAI-compatible)

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -127,6 +127,7 @@ function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
 		"xiaomi-token-plan-cn": "XIAOMI_TOKEN_PLAN_CN_API_KEY",
 		"xiaomi-token-plan-ams": "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
 		"xiaomi-token-plan-sgp": "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+		claudinio: "CLAUDINIO_API_KEY",
 	};
 
 	const envVar = envMap[provider];

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -52,7 +52,8 @@ export type KnownProvider =
 	| "xiaomi"
 	| "xiaomi-token-plan-cn"
 	| "xiaomi-token-plan-ams"
-	| "xiaomi-token-plan-sgp";
+	| "xiaomi-token-plan-sgp"
+	| "claudinio";
 export type Provider = KnownProvider | string;
 
 export type KnownImagesProvider = "openrouter";

--- a/packages/ai/test/cross-provider-handoff.test.ts
+++ b/packages/ai/test/cross-provider-handoff.test.ts
@@ -126,6 +126,8 @@ const PROVIDER_MODEL_PAIRS: ProviderModelPair[] = [
 	// OpenCode Go
 	{ provider: "opencode-go", model: "kimi-k2.5", label: "go-kimi-k2.5" },
 	{ provider: "opencode-go", model: "minimax-m2.5", label: "go-minimax-m2.5" },
+	// Claudinio
+	{ provider: "claudinio", model: "claudinio", label: "claudinio" },
 	// Xiaomi MiMo
 	{ provider: "xiaomi", model: "mimo-v2.5-pro", label: "xiaomi-mimo-v2.5-pro" },
 	{ provider: "xiaomi-token-plan-cn", model: "mimo-v2.5-pro", label: "xiaomi-token-plan-cn-mimo-v2.5-pro" },

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -615,6 +615,30 @@ describe("Generate E2E Tests", () => {
 		});
 	});
 
+	describe.skipIf(!process.env.CLAUDINIO_API_KEY)("Claudinio Provider (claudinio via OpenAI Completions)", () => {
+		const llm = getModel("claudinio", "claudinio");
+
+		it("should complete basic text generation", { retry: 3 }, async () => {
+			await basicTextGeneration(llm);
+		});
+
+		it("should handle tool calling", { retry: 3 }, async () => {
+			await handleToolCall(llm);
+		});
+
+		it("should handle streaming", { retry: 3 }, async () => {
+			await handleStreaming(llm);
+		});
+
+		it("should handle thinking mode", { retry: 3 }, async () => {
+			await handleThinking(llm, { reasoningEffort: "medium" });
+		});
+
+		it("should handle multi-turn with thinking and tools", { retry: 3 }, async () => {
+			await multiTurn(llm, { reasoningEffort: "medium" });
+		});
+	});
+
 	describe.skipIf(!hasCloudflareWorkersAICredentials())(
 		"Cloudflare Workers AI Provider (Kimi K2.6 via OpenAI Completions)",
 		() => {

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -70,6 +70,7 @@ pi
 | Kimi For Coding | `KIMI_API_KEY` | `kimi-coding` |
 | MiniMax | `MINIMAX_API_KEY` | `minimax` |
 | MiniMax (China) | `MINIMAX_CN_API_KEY` | `minimax-cn` |
+| Claudinio | `CLAUDINIO_API_KEY` | `claudinio` |
 | Xiaomi MiMo | `XIAOMI_API_KEY` | `xiaomi` |
 | Xiaomi MiMo Token Plan (China) | `XIAOMI_TOKEN_PLAN_CN_API_KEY` | `xiaomi-token-plan-cn` |
 | Xiaomi MiMo Token Plan (Amsterdam) | `XIAOMI_TOKEN_PLAN_AMS_API_KEY` | `xiaomi-token-plan-ams` |
@@ -93,7 +94,8 @@ Store credentials in `~/.pi/agent/auth.json`:
   "xiaomi": { "type": "api_key", "key": "..." },
   "xiaomi-token-plan-cn":  { "type": "api_key", "key": "..." },
   "xiaomi-token-plan-ams": { "type": "api_key", "key": "..." },
-  "xiaomi-token-plan-sgp": { "type": "api_key", "key": "..." }
+  "xiaomi-token-plan-sgp": { "type": "api_key", "key": "..." },
+  "claudinio": { "type": "api_key", "key": "..." }
 }
 ```
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -326,6 +326,7 @@ ${chalk.bold("Environment Variables:")}
   CLOUDFLARE_API_KEY               - Cloudflare API token (Workers AI and AI Gateway)
   CLOUDFLARE_ACCOUNT_ID            - Cloudflare account id (required for both)
   CLOUDFLARE_GATEWAY_ID            - Cloudflare AI Gateway slug (required for AI Gateway)
+  CLAUDINIO_API_KEY                - Claudinio API key (api.claudin.io billing)
   XIAOMI_API_KEY                   - Xiaomi MiMo API key (api.xiaomimimo.com billing)
   XIAOMI_TOKEN_PLAN_CN_API_KEY     - Xiaomi MiMo Token Plan API key (China region)
   XIAOMI_TOKEN_PLAN_AMS_API_KEY    - Xiaomi MiMo Token Plan API key (Amsterdam region)

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -44,6 +44,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"xiaomi-token-plan-cn": "mimo-v2.5-pro",
 	"xiaomi-token-plan-ams": "mimo-v2.5-pro",
 	"xiaomi-token-plan-sgp": "mimo-v2.5-pro",
+	claudinio: "claudinio",
 };
 
 export interface ScopedModel {

--- a/packages/coding-agent/src/core/provider-display-names.ts
+++ b/packages/coding-agent/src/core/provider-display-names.ts
@@ -29,4 +29,5 @@ export const BUILT_IN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	"xiaomi-token-plan-cn": "Xiaomi MiMo Token Plan (China)",
 	"xiaomi-token-plan-ams": "Xiaomi MiMo Token Plan (Amsterdam)",
 	"xiaomi-token-plan-sgp": "Xiaomi MiMo Token Plan (Singapore)",
+	claudinio: "Claudinio",
 };


### PR DESCRIPTION
Adds the Claudinio provider — an OpenAI-compatible API at `api.claudin.io`.

Since Claudinio is fully OpenAI-compatible, it reuses the `"openai-completions"` API protocol. No new stream implementation needed.

### Files changed

**Core registration:**
- `packages/ai/src/types.ts` — add `claudinio` to `KnownProvider` union
- `packages/ai/src/env-api-keys.ts` — add `CLAUDINIO_API_KEY` env var mapping
- `packages/coding-agent/src/core/model-resolver.ts` — set `claudinio` as default model
- `packages/coding-agent/src/core/provider-display-names.ts` — register display name for `/login` UI
- `packages/coding-agent/src/cli/args.ts` — document `CLAUDINIO_API_KEY` in help output

**Tests:**
- `packages/ai/test/stream.test.ts` — add describe block (skipped without `CLAUDINIO_API_KEY`)
- `packages/ai/test/cross-provider-handoff.test.ts` — add provider/model pair

**Documentation:**
- `packages/coding-agent/docs/providers.md` — add to env var table and auth.json example

### Usage

```bash
export CLAUDINIO_API_KEY=sk-...
```

Or store in `~/.pi/agent/auth.json`:
```json
{ "claudinio": { "type": "api_key", "key": "sk-..." } }
```