### PR TITLE
feat(ai): add OpenAI Codex device login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a device-code login option for OpenAI Codex OAuth so ChatGPT Plus/Pro authentication works on headless hosts ([#3424](https://github.com/earendil-works/pi-mono/issues/3424)).
+
 ### Changed
 
 - Changed source syntax to avoid TypeScript constructs that require JavaScript emit, keeping the package compatible with Node.js strip-only TypeScript checks.

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -19,19 +19,42 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 
 import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.ts";
 import { generatePKCE } from "./pkce.ts";
-import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.ts";
+import type {
+	OAuthAuthInfo,
+	OAuthCredentials,
+	OAuthLoginCallbacks,
+	OAuthPrompt,
+	OAuthProviderInterface,
+} from "./types.ts";
 
 const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const DEVICE_USER_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode";
+const DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token";
+const DEVICE_VERIFICATION_URL = "https://auth.openai.com/codex/device";
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
+const DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback";
 const SCOPE = "openid profile email offline_access";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+const DEVICE_AUTH_TIMEOUT_MS = 15 * 60 * 1000;
+const DEVICE_POLLING_SAFETY_MARGIN_MS = 3000;
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
 type TokenFailure = { type: "failed"; message: string; status?: number };
 type TokenResult = TokenSuccess | TokenFailure;
+
+type DeviceUserCodeResponse = {
+	device_auth_id: string;
+	user_code: string;
+	interval: string;
+};
+
+type DeviceTokenResponse = {
+	authorization_code: string;
+	code_verifier: string;
+};
 
 type JwtPayload = {
 	[JWT_CLAIM_PATH]?: {
@@ -134,6 +157,159 @@ async function exchangeAuthorizationCode(
 		refresh: json.refresh_token,
 		expires: Date.now() + json.expires_in * 1000,
 	};
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+
+		const timeout = setTimeout(resolve, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timeout);
+				reject(new Error("Login cancelled"));
+			},
+			{ once: true },
+		);
+	});
+}
+
+function createRequestSignal(
+	signal: AbortSignal | undefined,
+	timeoutMs?: number,
+): { signal?: AbortSignal; timedOut: () => boolean; cleanup: () => void } {
+	if (!signal && timeoutMs === undefined) {
+		return { timedOut: () => false, cleanup: () => {} };
+	}
+
+	const controller = new AbortController();
+	let timedOut = false;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const abort = () => controller.abort();
+
+	if (signal?.aborted) {
+		controller.abort();
+	} else {
+		signal?.addEventListener("abort", abort, { once: true });
+	}
+
+	if (timeoutMs !== undefined) {
+		timeout = setTimeout(
+			() => {
+				timedOut = true;
+				controller.abort();
+			},
+			Math.max(0, timeoutMs),
+		);
+	}
+
+	return {
+		signal: controller.signal,
+		timedOut: () => timedOut,
+		cleanup: () => {
+			if (timeout) clearTimeout(timeout);
+			signal?.removeEventListener("abort", abort);
+		},
+	};
+}
+
+async function startDeviceFlow(signal?: AbortSignal): Promise<DeviceUserCodeResponse> {
+	const requestSignal = createRequestSignal(signal);
+	let response: Response;
+	try {
+		response = await fetch(DEVICE_USER_CODE_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ client_id: CLIENT_ID }),
+			signal: requestSignal.signal,
+		});
+	} catch (error) {
+		if (signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+		throw error;
+	} finally {
+		requestSignal.cleanup();
+	}
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`OpenAI Codex device authorization failed (${response.status}): ${text || response.statusText}`);
+	}
+
+	const data = (await response.json()) as Partial<DeviceUserCodeResponse>;
+	if (
+		typeof data.device_auth_id !== "string" ||
+		typeof data.user_code !== "string" ||
+		typeof data.interval !== "string"
+	) {
+		throw new Error(`OpenAI Codex device authorization response missing fields: ${JSON.stringify(data)}`);
+	}
+
+	return data as DeviceUserCodeResponse;
+}
+
+async function pollForDeviceAuthorization(
+	device: DeviceUserCodeResponse,
+	signal?: AbortSignal,
+): Promise<DeviceTokenResponse> {
+	const interval = Math.max(Number.parseInt(device.interval, 10) || 5, 1) * 1000;
+	const deadline = Date.now() + DEVICE_AUTH_TIMEOUT_MS;
+
+	while (true) {
+		if (signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+		if (Date.now() >= deadline) {
+			throw new Error("OpenAI Codex device authorization timed out");
+		}
+
+		const remainingMs = deadline - Date.now();
+		const requestSignal = createRequestSignal(signal, remainingMs);
+		let response: Response;
+		try {
+			response = await fetch(DEVICE_TOKEN_URL, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					device_auth_id: device.device_auth_id,
+					user_code: device.user_code,
+				}),
+				signal: requestSignal.signal,
+			});
+		} catch (error) {
+			if (signal?.aborted) {
+				throw new Error("Login cancelled");
+			}
+			if (requestSignal.timedOut()) {
+				throw new Error("OpenAI Codex device authorization timed out");
+			}
+			throw error;
+		} finally {
+			requestSignal.cleanup();
+		}
+
+		if (response.ok) {
+			const data = (await response.json()) as Partial<DeviceTokenResponse>;
+			if (typeof data.authorization_code !== "string" || typeof data.code_verifier !== "string") {
+				throw new Error(`OpenAI Codex device token response missing fields: ${JSON.stringify(data)}`);
+			}
+			return data as DeviceTokenResponse;
+		}
+
+		if (response.status !== 403 && response.status !== 404) {
+			const text = await response.text().catch(() => "");
+			throw new Error(
+				`OpenAI Codex device authorization failed (${response.status}): ${text || response.statusText}`,
+			);
+		}
+
+		await abortableSleep(Math.min(interval + DEVICE_POLLING_SAFETY_MARGIN_MS, remainingMs), signal);
+	}
 }
 
 async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
@@ -306,7 +482,37 @@ function getAccountId(accessToken: string): string | null {
  * @param options.originator - OAuth originator parameter (defaults to "pi")
  */
 export async function loginOpenAICodex(options: {
-	onAuth: (info: { url: string; instructions?: string }) => void;
+	onAuth: (info: OAuthAuthInfo) => void;
+	onPrompt: (prompt: OAuthPrompt) => Promise<string>;
+	onProgress?: (message: string) => void;
+	onManualCodeInput?: () => Promise<string>;
+	onSelect?: OAuthLoginCallbacks["onSelect"];
+	signal?: AbortSignal;
+	originator?: string;
+}): Promise<OAuthCredentials> {
+	const method = options.onSelect
+		? await options.onSelect({
+				message: "Select ChatGPT login method:",
+				options: [
+					{ id: "browser", label: "Browser OAuth" },
+					{ id: "device", label: "Device Code" },
+				],
+			})
+		: "browser";
+
+	if (!method) {
+		throw new Error("Login cancelled");
+	}
+
+	if (method === "device") {
+		return loginOpenAICodexDevice(options);
+	}
+
+	return loginOpenAICodexBrowser(options);
+}
+
+async function loginOpenAICodexBrowser(options: {
+	onAuth: (info: OAuthAuthInfo) => void;
 	onPrompt: (prompt: OAuthPrompt) => Promise<string>;
 	onProgress?: (message: string) => void;
 	onManualCodeInput?: () => Promise<string>;
@@ -412,6 +618,40 @@ export async function loginOpenAICodex(options: {
 	}
 }
 
+async function loginOpenAICodexDevice(options: {
+	onAuth: (info: OAuthAuthInfo) => void;
+	signal?: AbortSignal;
+}): Promise<OAuthCredentials> {
+	const device = await startDeviceFlow(options.signal);
+	options.onAuth({
+		url: DEVICE_VERIFICATION_URL,
+		instructions: `Enter code: ${device.user_code}`,
+		manualCodeInput: false,
+	});
+
+	const deviceToken = await pollForDeviceAuthorization(device, options.signal);
+	const tokenResult = await exchangeAuthorizationCode(
+		deviceToken.authorization_code,
+		deviceToken.code_verifier,
+		DEVICE_REDIRECT_URI,
+	);
+	if (tokenResult.type !== "success") {
+		throw new Error(tokenResult.message);
+	}
+
+	const accountId = getAccountId(tokenResult.access);
+	if (!accountId) {
+		throw new Error("Failed to extract accountId from token");
+	}
+
+	return {
+		access: tokenResult.access,
+		refresh: tokenResult.refresh,
+		expires: tokenResult.expires,
+		accountId,
+	};
+}
+
 /**
  * Refresh OpenAI Codex OAuth token
  */
@@ -445,6 +685,8 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 			onPrompt: callbacks.onPrompt,
 			onProgress: callbacks.onProgress,
 			onManualCodeInput: callbacks.onManualCodeInput,
+			onSelect: callbacks.onSelect,
+			signal: callbacks.signal,
 		});
 	},
 

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -21,6 +21,7 @@ export type OAuthPrompt = {
 export type OAuthAuthInfo = {
 	url: string;
 	instructions?: string;
+	manualCodeInput?: boolean;
 };
 
 export type OAuthSelectOption = {

--- a/packages/ai/test/openai-codex-oauth.test.ts
+++ b/packages/ai/test/openai-codex-oauth.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { refreshOpenAICodexToken } from "../src/utils/oauth/openai-codex.js";
+import { openaiCodexOAuthProvider, refreshOpenAICodexToken } from "../src/utils/oauth/openai-codex.js";
+
+function createJwt(payload: object): string {
+	const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	return `header.${encoded}.signature`;
+}
 
 describe("OpenAI Codex OAuth", () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
 	});
@@ -28,5 +34,209 @@ describe("OpenAI Codex OAuth", () => {
 			/OpenAI Codex token refresh failed \(401\).*Could not validate your token/,
 		);
 		expect(consoleError).not.toHaveBeenCalled();
+	});
+
+	it("defaults to browser OAuth when no login method selector is available", async () => {
+		const accessToken = createJwt({
+			"https://api.openai.com/auth": {
+				chatgpt_account_id: "account-123",
+			},
+		});
+		const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+			expect(String(input)).toBe("https://auth.openai.com/oauth/token");
+			expect(String(init?.body)).toContain("code=browser-code");
+			return new Response(
+				JSON.stringify({
+					access_token: accessToken,
+					refresh_token: "refresh-token",
+					expires_in: 3600,
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const authEvents: Array<{ url: string; instructions?: string; manualCodeInput?: boolean }> = [];
+		const credentials = await openaiCodexOAuthProvider.login({
+			onAuth: (info) => authEvents.push(info),
+			onPrompt: async () => {
+				throw new Error("should not prompt");
+			},
+			onManualCodeInput: async () => "browser-code",
+		});
+
+		expect(credentials.refresh).toBe("refresh-token");
+		expect(authEvents[0]?.url).toMatch(/^https:\/\/auth\.openai\.com\/oauth\/authorize\?/);
+		expect(authEvents[0]?.manualCodeInput).not.toBe(false);
+	});
+
+	it("uses the selected device-code login flow", async () => {
+		const accessToken = createJwt({
+			"https://api.openai.com/auth": {
+				chatgpt_account_id: "account-123",
+			},
+		});
+		const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+			const url = String(input);
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+				expect(init?.method).toBe("POST");
+				expect(init?.headers).toMatchObject({ "Content-Type": "application/json" });
+				expect(String(init?.body)).toBe(JSON.stringify({ client_id: "app_EMoamEEZ73f0CkXaXp7hrann" }));
+				return new Response(
+					JSON.stringify({
+						device_auth_id: "device-auth-id",
+						user_code: "ABCD-EFGH",
+						interval: "1",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			if (url === "https://auth.openai.com/api/accounts/deviceauth/token") {
+				expect(init?.method).toBe("POST");
+				expect(init?.headers).toMatchObject({ "Content-Type": "application/json" });
+				expect(String(init?.body)).toBe(
+					JSON.stringify({ device_auth_id: "device-auth-id", user_code: "ABCD-EFGH" }),
+				);
+				return new Response(
+					JSON.stringify({
+						authorization_code: "auth-code",
+						code_verifier: "device-verifier",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			if (url === "https://auth.openai.com/oauth/token") {
+				expect(String(init?.body)).toContain("code=auth-code");
+				expect(String(init?.body)).toContain("code_verifier=device-verifier");
+				expect(String(init?.body)).toContain("redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback");
+				return new Response(
+					JSON.stringify({
+						access_token: accessToken,
+						refresh_token: "refresh-token",
+						expires_in: 3600,
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const authEvents: Array<{ url: string; instructions?: string; manualCodeInput?: boolean }> = [];
+		const selected = await openaiCodexOAuthProvider.login({
+			onAuth: (info) => authEvents.push(info),
+			onPrompt: async () => {
+				throw new Error("should not prompt");
+			},
+			onManualCodeInput: async () => "browser-code",
+			onSelect: async (prompt) => {
+				expect(prompt.message).toBe("Select ChatGPT login method:");
+				expect(prompt.options).toEqual([
+					{ id: "browser", label: "Browser OAuth" },
+					{ id: "device", label: "Device Code" },
+				]);
+				return "device";
+			},
+		});
+
+		expect(selected.refresh).toBe("refresh-token");
+		expect(authEvents).toEqual([
+			{
+				url: "https://auth.openai.com/codex/device",
+				instructions: "Enter code: ABCD-EFGH",
+				manualCodeInput: false,
+			},
+		]);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://auth.openai.com/api/accounts/deviceauth/usercode",
+			expect.any(Object),
+		);
+	});
+
+	it("times out pending device-code authorization", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: Parameters<typeof fetch>[0]): Promise<Response> => {
+				const url = String(input);
+				if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+					return new Response(
+						JSON.stringify({
+							device_auth_id: "device-auth-id",
+							user_code: "ABCD-EFGH",
+							interval: "900",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (url === "https://auth.openai.com/api/accounts/deviceauth/token") {
+					return new Response("", { status: 403 });
+				}
+
+				throw new Error(`Unexpected fetch: ${url}`);
+			}),
+		);
+
+		const loginPromise = openaiCodexOAuthProvider.login({
+			onAuth: () => {},
+			onPrompt: async () => {
+				throw new Error("should not prompt");
+			},
+			onSelect: async () => "device",
+		});
+
+		const rejection = expect(loginPromise).rejects.toThrow("OpenAI Codex device authorization timed out");
+		await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+		await rejection;
+	});
+
+	it("cancels while device-code polling request is pending", async () => {
+		const abortController = new AbortController();
+		let tokenRequestSignal: AbortSignal | undefined;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+				const url = String(input);
+				if (url === "https://auth.openai.com/api/accounts/deviceauth/usercode") {
+					return new Response(
+						JSON.stringify({
+							device_auth_id: "device-auth-id",
+							user_code: "ABCD-EFGH",
+							interval: "1",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (url === "https://auth.openai.com/api/accounts/deviceauth/token") {
+					tokenRequestSignal = init?.signal ?? undefined;
+					return new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener("abort", () => reject(new Error("fetch aborted")), { once: true });
+					});
+				}
+
+				throw new Error(`Unexpected fetch: ${url}`);
+			}),
+		);
+
+		const loginPromise = openaiCodexOAuthProvider.login({
+			onAuth: () => {},
+			onPrompt: async () => {
+				throw new Error("should not prompt");
+			},
+			onSelect: async () => "device",
+			signal: abortController.signal,
+		});
+
+		await vi.waitFor(() => expect(tokenRequestSignal).toBeDefined());
+		abortController.abort();
+
+		await expect(loginPromise).rejects.toThrow("Login cancelled");
+		expect(tokenRequestSignal?.aborted).toBe(true);
 	});
 });

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -24,6 +24,7 @@ Use `/logout` to clear credentials. Tokens are stored in `~/.pi/agent/auth.json`
 ### OpenAI Codex
 
 - Requires ChatGPT Plus or Pro subscription
+- Select Browser OAuth on local machines, or Device Code when authenticating over SSH or on a headless host
 - Officially endorsed by OpenAI: [Codex for OSS](https://developers.openai.com/community/codex-for-oss)
 
 ### Claude Pro/Max

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -14,6 +14,7 @@ import {
 	type ImageContent,
 	type Message,
 	type Model,
+	type OAuthAuthInfo,
 	type OAuthProviderId,
 	type OAuthSelectPrompt,
 } from "@earendil-works/pi-ai";
@@ -4796,10 +4797,10 @@ export class InteractiveMode {
 
 		try {
 			await this.session.modelRegistry.authStorage.login(providerId as OAuthProviderId, {
-				onAuth: (info: { url: string; instructions?: string }) => {
+				onAuth: (info: OAuthAuthInfo) => {
 					dialog.showAuth(info.url, info.instructions);
 
-					if (usesCallbackServer) {
+					if (usesCallbackServer && info.manualCodeInput !== false) {
 						// Show input for manual paste, racing with callback
 						dialog
 							.showManualInput("Paste redirect URL below, or complete login in browser:")


### PR DESCRIPTION
## Summary

- Add a Device Code login option for OpenAI Codex OAuth while preserving Browser OAuth as the default fallback.
- Suppress redirect paste input for device-code login and support cancellation/timeout during polling.
- Document the headless login option and add OAuth regression coverage.

## Test Plan

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/openai-codex-oauth.test.ts`
- `npm run check`

Fixes #3424
