### PR TITLE
fix(tui): skip off-screen lines in differential render scan

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1050,11 +1050,15 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Find first and last changed lines
+		// Find first and last changed lines within the visible viewport only.
+		// Skipping lines above prevViewportTop avoids triggering fullRender(true) when
+		// off-screen content (e.g. a spinner in a scrolled-out tool header) updates at
+		// 80ms intervals — those changes are invisible to the user but were causing a
+		// full screen clear on every tick.
 		let firstChanged = -1;
 		let lastChanged = -1;
 		const maxLines = Math.max(newLines.length, this.previousLines.length);
-		for (let i = 0; i < maxLines; i++) {
+		for (let i = prevViewportTop; i < maxLines; i++) {
 			const oldLine = i < this.previousLines.length ? this.previousLines[i] : "";
 			const newLine = i < newLines.length ? newLines[i] : "";
 


### PR DESCRIPTION
## Problem

When running pi in a small tmux pane with extensions that produce spinner animations (e.g. `pi-subagents`, `pi-ask-tool`), the whole terminal flickers violently at ~12.5 Hz.

**Root cause:** The differential render scan in `doRender()` starts at line `0` and compares every buffered line. When content scrolls above the visible viewport, spinner elements in scrolled-out tool headers keep ticking at 80ms intervals. These changes are at line indices below `prevViewportTop` — invisible to the user, unreachable by relative cursor moves — but they were detected as `firstChanged < prevViewportTop`, which unconditionally triggered `fullRender(true)` (full screen clear + redraw) on every spinner tick.

## Fix

Start the diff scan at `prevViewportTop` instead of `0`.

```ts
// before
for (let i = 0; i < maxLines; i++) {

// after
for (let i = prevViewportTop; i < maxLines; i++) {
```

Changes above the viewport are invisible and cannot be addressed by the differential renderer (which uses relative cursor moves). Skipping them is both correct and sufficient. The existing guard on line 1137 (`if (firstChanged < prevViewportTop) → fullRender(true)`) still covers the rare edge case where the `appendedLines` branch sets `firstChanged` below the viewport.

## Reproduction

1. Launch pi in a tmux pane (~20 rows tall)
2. Run a task that spawns subagents via `pi-subagents` or invokes `pi-ask-tool`
3. Observe: flicker stops with this fix; without it, `fullRender(true)` fires 12.5×/sec

## Testing

Manually verified in tmux with `pi-subagents` spawning 4–5 concurrent agents. The terminal renders smoothly with no screen-clear artifacts regardless of pane size.

Closes #4785
Relates to #4021 (originally reported by @S1M0N38)