### PR TITLE
chore: run pi-test through tsx

### DIFF
--- a/pi-test.sh
+++ b/pi-test.sh
@@ -54,4 +54,4 @@ if [[ "$NO_ENV" == "true" ]]; then
   echo "Running without API keys..."
 fi
 
-node "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}
+"$SCRIPT_DIR/node_modules/.bin/tsx" --tsconfig "$SCRIPT_DIR/tsconfig.json" "$SCRIPT_DIR/packages/coding-agent/src/cli.ts" ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
pi-test.sh is intended to exercise the TypeScript source tree, but running packages/coding-agent/src/cli.ts directly with node still resolves workspace package imports through package.json exports. For @earendil-works/pi-ai, that means @earendil-works/pi-ai/oauth can load packages/ai/dist/oauth.js instead of packages/ai/src/oauth.ts.

Run the CLI via the workspace tsx binary with the root tsconfig so package path aliases are active. This keeps source-mode testing on packages/*/src and prevents stale dist files from masking source changes such as OAuth login flow updates.