### PR TITLE
feat(ai): allow custom Anthropic-compatible providers to opt into adaptive thinking

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `compat.forceAdaptiveThinking` to the Anthropic Messages model config, allowing custom Anthropic-compatible providers to opt their models into `thinking.type: "adaptive"` plus `output_config.effort` regardless of model id. Previously adaptive thinking was selected only by id substring match, which broke proxies that expose Opus 4.7 / Sonnet 4.6 under their own id schemes and require the new format ([#4797](https://github.com/earendil-works/pi-mono/pull/4797) by [@mbazso](https://github.com/mbazso)).
+
 ### Changed
 
 - Changed source syntax to avoid TypeScript constructs that require JavaScript emit, keeping the package compatible with Node.js strip-only TypeScript checks.

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -164,7 +164,9 @@ export type AnthropicThinkingDisplay = "summarized" | "omitted";
 const FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
 const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
 
-function getAnthropicCompat(model: Model<"anthropic-messages">): Required<AnthropicMessagesCompat> {
+function getAnthropicCompat(
+	model: Model<"anthropic-messages">,
+): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking">> {
 	// Auto-detect session affinity and cache control support from provider
 	const isFireworks = model.provider === "fireworks";
 	const isCloudflareAiGatewayAnthropic =
@@ -687,17 +689,24 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 };
 
 /**
- * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6)
+ * Check if a model supports adaptive thinking (Opus 4.6+, Sonnet 4.6).
+ * Custom providers can opt in or out explicitly via
+ * `model.compat.forceAdaptiveThinking` regardless of the id.
  */
-function supportsAdaptiveThinking(modelId: string): boolean {
+function supportsAdaptiveThinking(model: Model<"anthropic-messages">): boolean {
+	const override = model.compat?.forceAdaptiveThinking;
+	if (typeof override === "boolean") {
+		return override;
+	}
 	// Adaptive-thinking model IDs (with or without date suffix)
+	const id = model.id;
 	return (
-		modelId.includes("opus-4-6") ||
-		modelId.includes("opus-4.6") ||
-		modelId.includes("opus-4-7") ||
-		modelId.includes("opus-4.7") ||
-		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
+		id.includes("opus-4-6") ||
+		id.includes("opus-4.6") ||
+		id.includes("opus-4-7") ||
+		id.includes("opus-4.7") ||
+		id.includes("sonnet-4-6") ||
+		id.includes("sonnet-4.6")
 	);
 }
 
@@ -742,7 +751,7 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
 
 	// For Opus 4.6 and Sonnet 4.6: use adaptive thinking with effort level
 	// For older models: use budget-based thinking
-	if (supportsAdaptiveThinking(model.id)) {
+	if (supportsAdaptiveThinking(model)) {
 		const effort = mapThinkingLevelToEffort(model, options.reasoning);
 		return streamAnthropic(model, context, {
 			...base,
@@ -783,7 +792,7 @@ function createClient(
 ): { client: Anthropic; isOAuthToken: boolean } {
 	// Adaptive thinking models (Opus 4.6, Sonnet 4.6) have interleaved thinking built-in.
 	// The beta header is deprecated on Opus 4.6 and redundant on Sonnet 4.6, so skip it.
-	const needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinking(model.id);
+	const needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinking(model);
 	const betaFeatures: string[] = [];
 	if (useFineGrainedToolStreamingBeta) {
 		betaFeatures.push(FINE_GRAINED_TOOL_STREAMING_BETA);
@@ -946,7 +955,7 @@ function buildParams(
 			// Default to "summarized" so Opus 4.7 and Mythos Preview behave like
 			// older Claude 4 models (whose API default is also "summarized").
 			const display: AnthropicThinkingDisplay = options.thinkingDisplay ?? "summarized";
-			if (supportsAdaptiveThinking(model.id)) {
+			if (supportsAdaptiveThinking(model)) {
 				// Adaptive thinking: Claude decides when and how much to think.
 				params.thinking = { type: "adaptive", display };
 				if (options.effort) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -435,6 +435,18 @@ export interface AnthropicMessagesCompat {
 	 * Default: true.
 	 */
 	supportsCacheControlOnTools?: boolean;
+	/**
+	 * Whether to force adaptive thinking (`thinking.type: "adaptive"` plus
+	 * `output_config.effort`) regardless of the model id. By default, adaptive
+	 * thinking is selected by matching the model id against known patterns
+	 * (`opus-4-6`, `opus-4-7`, `sonnet-4-6`). Custom Anthropic-compatible
+	 * providers (e.g. corporate proxies) often expose models under their own
+	 * id schemes (e.g. `anthropic--claude-opus-latest`) where the upstream
+	 * already requires the adaptive format. Set this to `true` on those models
+	 * to opt in. Set to `false` to opt out.
+	 * Default: undefined (use id-based detection).
+	 */
+	forceAdaptiveThinking?: boolean;
 }
 
 /**

--- a/packages/ai/test/anthropic-force-adaptive-thinking.test.ts
+++ b/packages/ai/test/anthropic-force-adaptive-thinking.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { streamSimple } from "../src/stream.js";
+import type { Context, Model, SimpleStreamOptions } from "../src/types.js";
+
+interface AnthropicThinkingPayload {
+	thinking?: { type: string; budget_tokens?: number; display?: string };
+	output_config?: { effort?: string };
+}
+
+function makeContext(): Context {
+	return {
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	};
+}
+
+function makeCustomModel(compat?: Model<"anthropic-messages">["compat"]): Model<"anthropic-messages"> {
+	return {
+		// Id intentionally does not match any built-in adaptive substring
+		// (opus-4-6, opus-4-7, sonnet-4-6). This mirrors corporate proxy
+		// schemes such as `anthropic--claude-opus-latest`.
+		id: "vendor--claude-opus-latest",
+		name: "Vendor Proxy Opus Latest",
+		api: "anthropic-messages",
+		provider: "vendor-proxy",
+		baseUrl: "http://127.0.0.1:9",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32000,
+		compat,
+	};
+}
+
+async function capturePayload(
+	model: Model<"anthropic-messages">,
+	options?: SimpleStreamOptions,
+): Promise<AnthropicThinkingPayload> {
+	let capturedPayload: AnthropicThinkingPayload | undefined;
+
+	const s = streamSimple(model, makeContext(), {
+		...options,
+		apiKey: "fake-key",
+		onPayload: (payload) => {
+			capturedPayload = payload as AnthropicThinkingPayload;
+			return payload;
+		},
+	});
+
+	await s.result();
+
+	if (!capturedPayload) {
+		throw new Error("Expected payload to be captured before request failure");
+	}
+
+	return capturedPayload;
+}
+
+describe("Anthropic forceAdaptiveThinking compat override", () => {
+	it("sends legacy thinking payload for custom model ids by default", async () => {
+		const payload = await capturePayload(makeCustomModel(), { reasoning: "medium" });
+
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.output_config).toBeUndefined();
+	});
+
+	it("sends adaptive thinking payload when compat.forceAdaptiveThinking is true", async () => {
+		const payload = await capturePayload(makeCustomModel({ forceAdaptiveThinking: true }), { reasoning: "medium" });
+
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "medium" });
+	});
+
+	it("forces legacy thinking payload when compat.forceAdaptiveThinking is false", async () => {
+		const payload = await capturePayload(makeCustomModel({ forceAdaptiveThinking: false }), { reasoning: "medium" });
+
+		expect(payload.thinking?.type).toBe("enabled");
+		expect(payload.output_config).toBeUndefined();
+	});
+
+	it("preserves thinking.type=disabled when reasoning is off regardless of override", async () => {
+		const payload = await capturePayload(makeCustomModel({ forceAdaptiveThinking: true }));
+
+		expect(payload.thinking).toEqual({ type: "disabled" });
+		expect(payload.output_config).toBeUndefined();
+	});
+});


### PR DESCRIPTION
closes #4790

I use the pi agent against a corporate proxy that exposes a custom `anthropic-messages` provider. After a new Anthropic model rolled out on the proxy, every request started failing with:

```
400 "thinking.type.enabled" is not supported for this model. Use
"thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

My config refers to the latest model through an alias like `anthropic--claude-opus-latest`. `supportsAdaptiveThinking()` only flips to the new payload format when the id contains `opus-4-6`, `opus-4-7`, or `sonnet-4-6`, so the alias misses every check and pi sends the legacy payload. `thinkingLevelMap` doesn't help — that branch is decided before the map is consulted.

This adds an opt-in `compat.forceAdaptiveThinking?: boolean` on `AnthropicMessagesCompat`. When set, `supportsAdaptiveThinking()` uses the override; otherwise the existing id detection runs unchanged. Built-in Anthropic models behave exactly as before.

Files touched:

- `packages/ai/src/types.ts` — new field
- `packages/ai/src/providers/anthropic.ts` — `supportsAdaptiveThinking()` takes the model and consults the override first; `getAnthropicCompat()` excludes the new field from the `Required<>` shape because `undefined` carries meaning here (= use id-based detection)
- `packages/ai/test/anthropic-force-adaptive-thinking.test.ts` — regression test covering legacy default, explicit `true`, explicit `false`, and reasoning-off
- `packages/ai/CHANGELOG.md`

## Verification

- `npm run check` passes
- New regression test passes (4/4)
- Existing `anthropic-thinking-disable` and `anthropic-opus-4-7-smoke` tests still pass
- `./test.sh` hit pre-existing `spawn ENOEXEC` failures in `packages/coding-agent` `grep tool` tests on my Mac — reproduces on `main` without this change, unrelated