### PR TITLE
fix(coding-agent): keep fork session id aligned

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -292,12 +292,11 @@ export class AgentSessionRuntime {
 				return { cancelled: false, selectedText };
 			}
 
-			const sourceManager = SessionManager.open(currentSessionFile, sessionDir);
-			const forkedSessionPath = sourceManager.createBranchedSession(targetLeafId);
+			const sessionManager = SessionManager.open(currentSessionFile, sessionDir);
+			const forkedSessionPath = sessionManager.createBranchedSession(targetLeafId);
 			if (!forkedSessionPath) {
 				throw new Error("Failed to create forked session");
 			}
-			const sessionManager = SessionManager.open(forkedSessionPath, sessionDir);
 			await this.teardownCurrent("fork", sessionManager.getSessionFile());
 			this.apply(
 				await this.createRuntime({

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
 import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -274,6 +274,8 @@ describe("AgentSessionRuntime characterization", () => {
 			{ type: "session_shutdown", reason: "fork", targetSessionFile: runtime.session.sessionFile },
 			{ type: "session_start", reason: "fork", previousSessionFile },
 		]);
+		const sessionFileName = parse(runtime.session.sessionFile!).name;
+		expect(sessionFileName.endsWith(`_${runtime.session.sessionId}`)).toBe(true);
 
 		events.length = 0;
 		cancelNextFork = true;


### PR DESCRIPTION
Forking a session from the first message would generate two different session IDs: one is used in the file name and the other in the JSONL header.

How to reproduce:

1. Resume a session
2. Run `/fork`
3. Select the first message
5. Delete the prompt
6. Run `/session`

**Expected result:** the file and the header IDs are the same.

**Actual result:** the IDs are different:

> File: /Users/sviatoslav/.pi/agent/sessions/--Users-sviatoslav-Workspace-pi--/2026-05-20T11-55-16-126Z_019e453d-751e-7dbd-b023-**2d1b72265502**.jsonl
> ID: 019e453d-751e-7dbd-b023-**30c799c88944**

Also, the forked session does not reference the original one as its parent. The two sessions are stand-alone.

This PR aligns the IDs and fixes the parent reference:

> File: /Users/sviatoslav/.pi/agent/sessions/--Users-sviatoslav-Workspace-pi--/2026-05-20T11-56-12-049Z_019e453e-4f91-7545-8524-**5555ce807ae2**.jsonl
> ID: 019e453e-4f91-7545-8524-**5555ce807ae2**

The ID mismatch was problematic for me, because my session search script would get the _header_ session ID and try to `find` the session file by that ID – to no avail.