### PR TITLE
feat(oauth): Add OpenAI subscription device code flow for nicer login UX when on SSH

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an alternate OpenAI Codex OAuth device-code login method for remote flows alongside the standard browser-based callback flow.
+
 ## [0.75.4] - 2026-05-20
 
 ### Changed

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -2,7 +2,7 @@
 
 import { createInterface } from "node:readline";
 import { existsSync, readFileSync, writeFileSync } from "fs";
-import { getOAuthProvider, getOAuthProviders } from "./utils/oauth/index.ts";
+import { getOAuthCredentialStorageId, getOAuthProvider, getOAuthProviders } from "./utils/oauth/index.ts";
 import type { OAuthCredentials, OAuthProviderId } from "./utils/oauth/types.ts";
 
 const AUTH_FILE = "auth.json";
@@ -49,7 +49,7 @@ async function login(providerId: OAuthProviderId): Promise<void> {
 		});
 
 		const auth = loadAuth();
-		auth[providerId] = { type: "oauth", ...credentials };
+		auth[getOAuthCredentialStorageId(providerId)] = { type: "oauth", ...credentials };
 		saveAuth(auth);
 
 		console.log(`\nCredentials saved to ${AUTH_FILE}`);

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -18,7 +18,13 @@ export {
 	refreshGitHubCopilotToken,
 } from "./github-copilot.ts";
 // OpenAI Codex (ChatGPT OAuth)
-export { loginOpenAICodex, openaiCodexOAuthProvider, refreshOpenAICodexToken } from "./openai-codex.ts";
+export {
+	loginOpenAICodex,
+	loginOpenAICodexDeviceCode,
+	openaiCodexDeviceCodeOAuthProvider,
+	openaiCodexOAuthProvider,
+	refreshOpenAICodexToken,
+} from "./openai-codex.ts";
 
 export * from "./types.ts";
 
@@ -28,13 +34,14 @@ export * from "./types.ts";
 
 import { anthropicOAuthProvider } from "./anthropic.ts";
 import { githubCopilotOAuthProvider } from "./github-copilot.ts";
-import { openaiCodexOAuthProvider } from "./openai-codex.ts";
+import { openaiCodexDeviceCodeOAuthProvider, openaiCodexOAuthProvider } from "./openai-codex.ts";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.ts";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	openaiCodexDeviceCodeOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(
@@ -46,6 +53,14 @@ const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(
  */
 export function getOAuthProvider(id: OAuthProviderId): OAuthProviderInterface | undefined {
 	return oauthProviderRegistry.get(id);
+}
+
+/**
+ * Resolve the credential storage ID for a provider.
+ * Alias providers can share stored credentials with a canonical provider ID.
+ */
+export function getOAuthCredentialStorageId(id: OAuthProviderId): OAuthProviderId {
+	return getOAuthProvider(id)?.credentialsProviderId ?? id;
 }
 
 /**
@@ -133,7 +148,8 @@ export async function getOAuthApiKey(
 		throw new Error(`Unknown OAuth provider: ${providerId}`);
 	}
 
-	let creds = credentials[providerId];
+	const credentialsProviderId = getOAuthCredentialStorageId(providerId);
+	let creds = credentials[credentialsProviderId];
 	if (!creds) {
 		return null;
 	}

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -23,11 +23,16 @@ import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderI
 
 const CALLBACK_HOST = process.env.PI_OAUTH_CALLBACK_HOST || "127.0.0.1";
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
-const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const AUTH_BASE_URL = "https://auth.openai.com";
+const AUTHORIZE_URL = `${AUTH_BASE_URL}/oauth/authorize`;
+const TOKEN_URL = `${AUTH_BASE_URL}/oauth/token`;
+const DEVICE_AUTH_BASE_URL = `${AUTH_BASE_URL}/api/accounts`;
+const DEVICE_VERIFICATION_URL = `${AUTH_BASE_URL}/codex/device`;
+const DEVICE_REDIRECT_URI = `${AUTH_BASE_URL}/deviceauth/callback`;
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
 const SCOPE = "openid profile email offline_access";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+const DEVICE_CODE_MAX_WAIT_MS = 15 * 60 * 1000; // 15 minutes
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
 type TokenFailure = { type: "failed"; message: string; status?: number };
@@ -287,6 +292,185 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 	});
 }
 
+// ============================================================================
+// Device Code Flow (headless / SSH-friendly)
+// ============================================================================
+
+type DeviceCodeUserCodeResponse = {
+	device_auth_id: string;
+	user_code: string;
+	interval: string | number;
+};
+
+type DeviceCodeTokenResponse = {
+	authorization_code: string;
+	code_challenge: string;
+	code_verifier: string;
+};
+
+/**
+ * Request a device code from OpenAI's device auth endpoint.
+ * Returns null if the endpoint is not available (404).
+ */
+async function requestDeviceCode(): Promise<{
+	deviceAuthId: string;
+	userCode: string;
+	interval: number;
+} | null> {
+	const url = `${DEVICE_AUTH_BASE_URL}/deviceauth/usercode`;
+	const response = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ client_id: CLIENT_ID }),
+	});
+
+	if (response.status === 404) {
+		// Device code login not enabled for this client
+		return null;
+	}
+
+	if (!response.ok) {
+		throw new Error(`Device code request failed with status ${response.status}`);
+	}
+
+	const data = (await response.json()) as DeviceCodeUserCodeResponse;
+	const interval = typeof data.interval === "string" ? Number.parseInt(data.interval, 10) : data.interval;
+
+	return {
+		deviceAuthId: data.device_auth_id,
+		userCode: data.user_code,
+		interval: Number.isNaN(interval) ? 5 : interval,
+	};
+}
+
+/**
+ * Poll the device auth token endpoint until the user completes login
+ * or the timeout is reached.
+ */
+async function pollDeviceCodeToken(
+	deviceAuthId: string,
+	userCode: string,
+	intervalSeconds: number,
+	signal?: AbortSignal,
+): Promise<DeviceCodeTokenResponse> {
+	const url = `${DEVICE_AUTH_BASE_URL}/deviceauth/token`;
+	const deadline = Date.now() + DEVICE_CODE_MAX_WAIT_MS;
+
+	while (Date.now() < deadline) {
+		if (signal?.aborted) {
+			throw new Error("Login cancelled");
+		}
+
+		const response = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				device_auth_id: deviceAuthId,
+				user_code: userCode,
+			}),
+		});
+
+		if (response.ok) {
+			return (await response.json()) as DeviceCodeTokenResponse;
+		}
+
+		// 403 = authorization_pending, 404 = not yet authorized - keep polling
+		if (response.status === 403 || response.status === 404) {
+			const remaining = deadline - Date.now();
+			const sleepMs = Math.min(intervalSeconds * 1000, remaining);
+			if (sleepMs <= 0) break;
+			await abortableSleep(sleepMs, signal);
+			continue;
+		}
+
+		throw new Error(`Device auth polling failed with status ${response.status}`);
+	}
+
+	throw new Error("Device code login timed out after 15 minutes");
+}
+
+/**
+ * Sleep that can be interrupted by an AbortSignal.
+ */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Login cancelled"));
+			return;
+		}
+		const timeout = setTimeout(resolve, ms);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timeout);
+				reject(new Error("Login cancelled"));
+			},
+			{ once: true },
+		);
+	});
+}
+
+/**
+ * Login with OpenAI Codex using the device code flow.
+ * No local server or browser redirect needed - works over SSH.
+ *
+ * Flow:
+ * 1. Request a one-time user code from OpenAI
+ * 2. User visits verification URL and enters the code
+ * 3. Poll until the user completes login
+ * 4. Exchange the returned authorization code for tokens
+ */
+export async function loginOpenAICodexDeviceCode(options: {
+	onAuth: (info: { url: string; instructions?: string }) => void;
+	onProgress?: (message: string) => void;
+	onWaiting?: (message: string) => void;
+	signal?: AbortSignal;
+}): Promise<OAuthCredentials> {
+	const deviceCode = await requestDeviceCode();
+	if (!deviceCode) {
+		throw new Error("Device code login is not available for this client");
+	}
+
+	options.onAuth({
+		url: DEVICE_VERIFICATION_URL,
+		instructions: `Enter code: ${deviceCode.userCode}`,
+	});
+
+	options.onWaiting?.("Waiting for you to complete login in your browser...");
+
+	const tokenResponse = await pollDeviceCodeToken(
+		deviceCode.deviceAuthId,
+		deviceCode.userCode,
+		deviceCode.interval,
+		options.signal,
+	);
+
+	options.onProgress?.("Exchanging authorization code for tokens...");
+
+	// The device code flow returns server-generated PKCE values
+	const tokenResult = await exchangeAuthorizationCode(
+		tokenResponse.authorization_code,
+		tokenResponse.code_verifier,
+		DEVICE_REDIRECT_URI,
+	);
+
+	if (tokenResult.type !== "success") {
+		throw new Error("Token exchange failed");
+	}
+
+	const accountId = getAccountId(tokenResult.access);
+	if (!accountId) {
+		throw new Error("Failed to extract accountId from token");
+	}
+
+	return {
+		access: tokenResult.access,
+		refresh: tokenResult.refresh,
+		expires: tokenResult.expires,
+		accountId,
+	};
+}
+
 function getAccountId(accessToken: string): string | null {
 	const payload = decodeJwt(accessToken);
 	const auth = payload?.[JWT_CLAIM_PATH];
@@ -437,6 +621,7 @@ export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAu
 export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 	id: "openai-codex",
 	name: "ChatGPT Plus/Pro (Codex Subscription)",
+	loginOptionLabel: "Browser login (default)",
 	usesCallbackServer: true,
 
 	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
@@ -445,6 +630,32 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 			onPrompt: callbacks.onPrompt,
 			onProgress: callbacks.onProgress,
 			onManualCodeInput: callbacks.onManualCodeInput,
+		});
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		return refreshOpenAICodexToken(credentials.refresh);
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+};
+
+export const openaiCodexDeviceCodeOAuthProvider: OAuthProviderInterface = {
+	id: "openai-codex-device-code",
+	name: "ChatGPT Plus/Pro (Codex Subscription) - Device Code (for remote flows)",
+	credentialsProviderId: "openai-codex",
+	parentProviderId: "openai-codex",
+	loginOptionLabel: "Device Code (for remote flows)",
+	usesCallbackServer: false,
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		return loginOpenAICodexDeviceCode({
+			onAuth: callbacks.onAuth,
+			onProgress: callbacks.onProgress,
+			onWaiting: callbacks.onProgress,
+			signal: callbacks.signal,
 		});
 	},
 

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -47,6 +47,15 @@ export interface OAuthProviderInterface {
 	readonly id: OAuthProviderId;
 	readonly name: string;
 
+	/** Optional canonical provider ID used to store/retrieve credentials for aliases. */
+	readonly credentialsProviderId?: OAuthProviderId;
+
+	/** Optional parent provider ID for alternate login methods shown under a primary provider. */
+	readonly parentProviderId?: OAuthProviderId;
+
+	/** Optional label used when presenting this provider as a login method choice. */
+	readonly loginOptionLabel?: string;
+
 	/** Run the login flow, return credentials to persist */
 	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an OpenAI Codex login-method chooser under `/login`, with the standard browser-based flow as the default and a device-code option for remote flows.
+
 ## [0.75.4] - 2026-05-20
 
 ### New Features

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -13,7 +13,12 @@ import {
 	type OAuthLoginCallbacks,
 	type OAuthProviderId,
 } from "@earendil-works/pi-ai";
-import { getOAuthApiKey, getOAuthProvider, getOAuthProviders } from "@earendil-works/pi-ai/oauth";
+import {
+	getOAuthApiKey,
+	getOAuthCredentialStorageId,
+	getOAuthProvider,
+	getOAuthProviders,
+} from "@earendil-works/pi-ai/oauth";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
@@ -293,27 +298,33 @@ export class AuthStorage {
 		}
 	}
 
+	private resolveCredentialProviderId(provider: string): string {
+		return getOAuthCredentialStorageId(provider);
+	}
+
 	/**
 	 * Get credential for a provider.
 	 */
 	get(provider: string): AuthCredential | undefined {
-		return this.data[provider] ?? undefined;
+		return this.data[this.resolveCredentialProviderId(provider)] ?? undefined;
 	}
 
 	/**
 	 * Set credential for a provider.
 	 */
 	set(provider: string, credential: AuthCredential): void {
-		this.data[provider] = credential;
-		this.persistProviderChange(provider, credential);
+		const credentialProviderId = this.resolveCredentialProviderId(provider);
+		this.data[credentialProviderId] = credential;
+		this.persistProviderChange(credentialProviderId, credential);
 	}
 
 	/**
 	 * Remove credential for a provider.
 	 */
 	remove(provider: string): void {
-		delete this.data[provider];
-		this.persistProviderChange(provider, undefined);
+		const credentialProviderId = this.resolveCredentialProviderId(provider);
+		delete this.data[credentialProviderId];
+		this.persistProviderChange(credentialProviderId, undefined);
 	}
 
 	/**
@@ -327,7 +338,7 @@ export class AuthStorage {
 	 * Check if credentials exist for a provider in auth.json.
 	 */
 	has(provider: string): boolean {
-		return provider in this.data;
+		return this.resolveCredentialProviderId(provider) in this.data;
 	}
 
 	/**
@@ -335,8 +346,9 @@ export class AuthStorage {
 	 * Unlike getApiKey(), this doesn't refresh OAuth tokens.
 	 */
 	hasAuth(provider: string): boolean {
+		const credentialProviderId = this.resolveCredentialProviderId(provider);
 		if (this.runtimeOverrides.has(provider)) return true;
-		if (this.data[provider]) return true;
+		if (this.data[credentialProviderId]) return true;
 		if (getEnvApiKey(provider)) return true;
 		if (this.fallbackResolver?.(provider)) return true;
 		return false;
@@ -411,12 +423,13 @@ export class AuthStorage {
 			return null;
 		}
 
+		const credentialProviderId = this.resolveCredentialProviderId(providerId);
 		const result = await this.storage.withLockAsync(async (current) => {
 			const currentData = this.parseStorageData(current);
 			this.data = currentData;
 			this.loadError = null;
 
-			const cred = currentData[providerId];
+			const cred = currentData[credentialProviderId];
 			if (cred?.type !== "oauth") {
 				return { result: null };
 			}
@@ -439,7 +452,7 @@ export class AuthStorage {
 
 			const merged: AuthStorageData = {
 				...currentData,
-				[providerId]: { type: "oauth", ...refreshed.newCredentials },
+				[credentialProviderId]: { type: "oauth", ...refreshed.newCredentials },
 			};
 			this.data = merged;
 			this.loadError = null;
@@ -459,13 +472,15 @@ export class AuthStorage {
 	 * 5. Fallback resolver (models.json custom providers)
 	 */
 	async getApiKey(providerId: string, options?: { includeFallback?: boolean }): Promise<string | undefined> {
+		const credentialProviderId = this.resolveCredentialProviderId(providerId);
+
 		// Runtime override takes highest priority
 		const runtimeKey = this.runtimeOverrides.get(providerId);
 		if (runtimeKey) {
 			return runtimeKey;
 		}
 
-		const cred = this.data[providerId];
+		const cred = this.data[credentialProviderId];
 
 		if (cred?.type === "api_key") {
 			return resolveConfigValue(cred.key);
@@ -492,7 +507,7 @@ export class AuthStorage {
 					this.recordError(error);
 					// Refresh failed - re-read file to check if another instance succeeded
 					this.reload();
-					const updatedCred = this.data[providerId];
+					const updatedCred = this.data[credentialProviderId];
 
 					if (updatedCred?.type === "oauth" && Date.now() < updatedCred.expires) {
 						// Another instance refreshed successfully, use those credentials

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -15,12 +15,16 @@ export type AuthSelectorProvider = {
 	id: string;
 	name: string;
 	authType: "oauth" | "api_key";
+	credentialsProviderId?: string;
+	parentProviderId?: string;
+	loginOptionLabel?: string;
 };
 
 /**
  * Component that renders an auth provider selector
  */
 export class OAuthSelectorComponent extends Container implements Focusable {
+	private titleContainer: Container;
 	private searchInput: Input;
 
 	// Focusable implementation - propagate to search input for IME cursor positioning
@@ -42,6 +46,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 	private getAuthStatus: (providerId: string) => AuthStatus;
 	private onSelectCallback: (providerId: string) => void;
 	private onCancelCallback: () => void;
+	private loginMethodParentProviderId: string | null = null;
 
 	constructor(
 		mode: "login" | "logout",
@@ -66,16 +71,13 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		this.addChild(new Spacer(1));
 
 		// Add title
-		const title = mode === "login" ? "Select provider to configure:" : "Select provider to logout:";
-		this.addChild(new TruncatedText(theme.fg("accent", theme.bold(title)), 1, 0));
+		this.titleContainer = new Container();
+		this.addChild(this.titleContainer);
 		this.addChild(new Spacer(1));
 
 		this.searchInput = new Input();
 		this.searchInput.onSubmit = () => {
-			const selectedProvider = this.filteredProviders[this.selectedIndex];
-			if (selectedProvider) {
-				this.onSelectCallback(selectedProvider.id);
-			}
+			this.selectCurrentProvider();
 		};
 		this.addChild(this.searchInput);
 		this.addChild(new Spacer(1));
@@ -93,15 +95,63 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		this.filterProviders("");
 	}
 
+	private getParentProvider(): AuthSelectorProvider | undefined {
+		if (!this.loginMethodParentProviderId) return undefined;
+		return this.allProviders.find((provider) => provider.id === this.loginMethodParentProviderId);
+	}
+
+	private getSelectableProviders(): AuthSelectorProvider[] {
+		if (this.mode !== "login" || !this.loginMethodParentProviderId) {
+			return this.allProviders.filter((provider) => !provider.parentProviderId);
+		}
+
+		const parentProvider = this.getParentProvider();
+		if (!parentProvider) {
+			return this.allProviders.filter((provider) => !provider.parentProviderId);
+		}
+
+		const alternateProviders = this.allProviders.filter(
+			(provider) => provider.parentProviderId === this.loginMethodParentProviderId,
+		);
+		return [parentProvider, ...alternateProviders];
+	}
+
 	private filterProviders(query: string): void {
+		const selectableProviders = this.getSelectableProviders();
 		this.filteredProviders = query
-			? fuzzyFilter(this.allProviders, query, (provider) => `${provider.name} ${provider.id} ${provider.authType}`)
-			: this.allProviders;
+			? fuzzyFilter(
+					selectableProviders,
+					query,
+					(provider) => `${provider.name} ${provider.id} ${provider.authType} ${provider.loginOptionLabel ?? ""}`,
+				)
+			: selectableProviders;
 		this.selectedIndex = Math.max(0, Math.min(this.selectedIndex, Math.max(0, this.filteredProviders.length - 1)));
 		this.updateList();
 	}
 
+	private getTitle(): string {
+		if (this.mode === "logout") {
+			return "Select provider to logout:";
+		}
+
+		const parentProvider = this.getParentProvider();
+		if (parentProvider) {
+			return `Select login method for ${parentProvider.name}:`;
+		}
+
+		return "Select provider to configure:";
+	}
+
+	private getProviderLabel(provider: AuthSelectorProvider): string {
+		if (this.mode === "login" && this.loginMethodParentProviderId) {
+			return provider.loginOptionLabel ?? provider.name;
+		}
+		return provider.name;
+	}
+
 	private updateList(): void {
+		this.titleContainer.clear();
+		this.titleContainer.addChild(new TruncatedText(theme.fg("accent", theme.bold(this.getTitle())), 1, 0));
 		this.listContainer.clear();
 
 		const maxVisible = 8;
@@ -116,15 +166,16 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 			if (!provider) continue;
 
 			const isSelected = i === this.selectedIndex;
+			const statusIndicator = this.loginMethodParentProviderId ? "" : this.formatStatusIndicator(provider);
+			const label = this.getProviderLabel(provider);
 
-			const statusIndicator = this.formatStatusIndicator(provider);
 			let line = "";
 			if (isSelected) {
 				const prefix = theme.fg("accent", "→ ");
-				const text = theme.fg("accent", provider.name);
+				const text = theme.fg("accent", label);
 				line = prefix + text + statusIndicator;
 			} else {
-				const text = `  ${theme.fg("text", provider.name)}`;
+				const text = `  ${theme.fg("text", label)}`;
 				line = text + statusIndicator;
 			}
 
@@ -174,6 +225,40 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		}
 	}
 
+	private openLoginMethodSelector(provider: AuthSelectorProvider): void {
+		this.loginMethodParentProviderId = provider.id;
+		this.selectedIndex = 0;
+		this.filterProviders(this.searchInput.getValue());
+	}
+
+	private closeLoginMethodSelector(): boolean {
+		if (!this.loginMethodParentProviderId) {
+			return false;
+		}
+
+		this.loginMethodParentProviderId = null;
+		this.selectedIndex = 0;
+		this.filterProviders(this.searchInput.getValue());
+		return true;
+	}
+
+	private selectCurrentProvider(): void {
+		const selectedProvider = this.filteredProviders[this.selectedIndex];
+		if (!selectedProvider) return;
+
+		const hasAlternateLoginMethods =
+			this.mode === "login" &&
+			!this.loginMethodParentProviderId &&
+			this.allProviders.some((provider) => provider.parentProviderId === selectedProvider.id);
+
+		if (hasAlternateLoginMethods) {
+			this.openLoginMethodSelector(selectedProvider);
+			return;
+		}
+
+		this.onSelectCallback(selectedProvider.id);
+	}
+
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
 		// Up arrow
@@ -190,14 +275,13 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {
-			const selectedProvider = this.filteredProviders[this.selectedIndex];
-			if (selectedProvider) {
-				this.onSelectCallback(selectedProvider.id);
-			}
+			this.selectCurrentProvider();
 		}
 		// Escape or Ctrl+C
 		else if (kb.matches(keyData, "tui.select.cancel")) {
-			this.onCancelCallback();
+			if (!this.closeLoginMethodSelector()) {
+				this.onCancelCallback();
+			}
 		}
 		// Pass everything else to search input
 		else {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4462,6 +4462,9 @@ export class InteractiveMode {
 			id: provider.id,
 			name: provider.name,
 			authType: "oauth",
+			credentialsProviderId: provider.credentialsProviderId,
+			parentProviderId: provider.parentProviderId,
+			loginOptionLabel: provider.loginOptionLabel,
 		}));
 
 		const modelProviders = new Set(this.session.modelRegistry.getAll().map((model) => model.provider));
@@ -4618,18 +4621,23 @@ export class InteractiveMode {
 		this.session.modelRegistry.refresh();
 
 		const actionLabel = authType === "oauth" ? `Logged in to ${providerName}` : `Saved API key for ${providerName}`;
+		const providerInfo =
+			authType === "oauth"
+				? this.session.modelRegistry.authStorage.getOAuthProviders().find((provider) => provider.id === providerId)
+				: undefined;
+		const modelProviderId = providerInfo?.credentialsProviderId ?? providerId;
 
 		let selectedModel: Model<any> | undefined;
 		let selectionError: string | undefined;
 		if (isUnknownModel(previousModel)) {
 			const availableModels = this.session.modelRegistry.getAvailable();
-			const providerModels = availableModels.filter((model) => model.provider === providerId);
-			if (!hasDefaultModelProvider(providerId)) {
-				selectionError = `${actionLabel}, but no default model is configured for provider "${providerId}". Use /model to select a model.`;
+			const providerModels = availableModels.filter((model) => model.provider === modelProviderId);
+			if (!hasDefaultModelProvider(modelProviderId)) {
+				selectionError = `${actionLabel}, but no default model is configured for provider "${modelProviderId}". Use /model to select a model.`;
 			} else if (providerModels.length === 0) {
 				selectionError = `${actionLabel}, but no models are available for that provider. Use /model to select a model.`;
 			} else {
-				const defaultModelId = defaultModelPerProvider[providerId];
+				const defaultModelId = defaultModelPerProvider[modelProviderId];
 				selectedModel = providerModels.find((model) => model.id === defaultModelId);
 				if (!selectedModel) {
 					selectionError = `${actionLabel}, but its default model "${defaultModelId}" is not available. Use /model to select a model.`;


### PR DESCRIPTION
This PR implements #4809 and adds a device code flow for OpenAI subscriptions which is nicer to use when running via ssh on a server. The codex app uses this flow on servers and it is similar to the github device code flow.

Several people have commented on the old, auto-closed issue from March #2253, so there seem to be a few more people who would appreciate this than only me :)

Let me know if anything about this PR should be changed. Thanks!