### PR TITLE
Add model_selector_open extension event

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -324,6 +324,7 @@ user sends another prompt ◄─────────────────
   └─► session_tree
 
 /model or Ctrl+P (model selection/cycling)
+  ├─► model_selector_open (when the picker opens, fire-and-forget)
   ├─► thinking_level_select (if model change changes/clamps thinking level)
   └─► model_select
 
@@ -653,6 +654,19 @@ pi.on("model_select", async (event, ctx) => {
 ```
 
 Use this to update UI elements (status bars, footers) or perform model-specific initialization when the active model changes.
+
+#### model_selector_open
+
+Fired when the interactive model picker opens (via `/model` or `Ctrl+P`). Dispatched fire-and-forget so the picker is never delayed by extension work, which means provider state changes made in this handler (e.g. re-registering a provider after a remote `/v1/models` fetch) are reflected on the **next** picker open, not the current one.
+
+```typescript
+pi.on("model_selector_open", async () => {
+  // Refresh dynamically discovered models so the next open sees them.
+  await refreshRemoteModels();
+});
+```
+
+Use this for providers backed by a live endpoint where the model list can change between sessions (e.g. a running llama-server with hot-swappable models).
 
 #### thinking_level_select
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -718,6 +718,11 @@ export interface ModelSelectEvent {
 	source: ModelSelectSource;
 }
 
+/** Fired when the interactive model picker opens. Dispatched fire-and-forget so handlers do not block the UI — any provider-state refresh (e.g. fetching a remote model list) will be reflected on the next open. */
+export interface ModelSelectorOpenEvent {
+	type: "model_selector_open";
+}
+
 /** Fired when a new thinking level is selected */
 export interface ThinkingLevelSelectEvent {
 	type: "thinking_level_select";
@@ -965,6 +970,7 @@ export type ExtensionEvent =
 	| ToolExecutionUpdateEvent
 	| ToolExecutionEndEvent
 	| ModelSelectEvent
+	| ModelSelectorOpenEvent
 	| ThinkingLevelSelectEvent
 	| UserBashEvent
 	| InputEvent
@@ -1119,6 +1125,7 @@ export interface ExtensionAPI {
 	on(event: "tool_execution_update", handler: ExtensionHandler<ToolExecutionUpdateEvent>): void;
 	on(event: "tool_execution_end", handler: ExtensionHandler<ToolExecutionEndEvent>): void;
 	on(event: "model_select", handler: ExtensionHandler<ModelSelectEvent>): void;
+	on(event: "model_selector_open", handler: ExtensionHandler<ModelSelectorOpenEvent>): void;
 	on(event: "thinking_level_select", handler: ExtensionHandler<ThinkingLevelSelectEvent>): void;
 	on(event: "tool_call", handler: ExtensionHandler<ToolCallEvent, ToolCallEventResult>): void;
 	on(event: "tool_result", handler: ExtensionHandler<ToolResultEvent, ToolResultEventResult>): void;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4078,6 +4078,7 @@ export class InteractiveMode {
 	}
 
 	private showModelSelector(initialSearchInput?: string): void {
+		void this.session.extensionRunner.emit({ type: "model_selector_open" });
 		this.showSelector((done) => {
 			const selector = new ModelSelectorComponent(
 				this.ui,


### PR DESCRIPTION
New extension event fired when the interactive model picker opens. Lets extensions refresh provider state (e.g. re-fetch a remote model list) on demand.

Currently dispatched fire-and-forget so the UI doesn't block — handler updates land on the next picker open. Open question: should we `await` instead so the picker reflects refreshed data immediately, at the cost of briefly blocking the open on extension handlers?