### PR TITLE
fix(coding-agent): always write branched session file on createBranchedSession

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `createBranchedSession` returning a file path that does not exist on disk when the branched path has no assistant messages, causing forked subagent sessions (`/run scout` then `/run planner`) to fail with "Session manager returned a forked session file that does not exist".
+
 ## [0.75.4] - 2026-05-20
 
 ### New Features

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -710,6 +710,7 @@ export class SessionManager {
 	private cwd: string;
 	private persist: boolean;
 	private flushed: boolean = false;
+	private initialWriteDone: boolean = false;
 	private fileEntries: FileEntry[] = [];
 	private byId: Map<string, SessionEntry> = new Map();
 	private labelsById: Map<string, string> = new Map();
@@ -840,8 +841,13 @@ export class SessionManager {
 
 		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
 		if (!hasAssistant) {
-			// Mark as not flushed so when assistant arrives, all entries get written
-			this.flushed = false;
+			// Defer writing until first assistant message, but only before the
+			// initial full write has happened. After that (e.g., after
+			// createBranchedSession wrote the file), keep flushed=true so new
+			// entries just append and we never duplicate the header.
+			if (!this.initialWriteDone) {
+				this.flushed = false;
+			}
 			return;
 		}
 
@@ -850,6 +856,7 @@ export class SessionManager {
 				appendFileSync(this.sessionFile, `${JSON.stringify(e)}\n`);
 			}
 			this.flushed = true;
+			this.initialWriteDone = true;
 		} else {
 			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
 		}
@@ -1261,18 +1268,13 @@ export class SessionManager {
 			this.sessionFile = newSessionFile;
 			this._buildIndex();
 
-			// Only write the file now if it contains an assistant message.
-			// Otherwise defer to _persist(), which creates the file on the
-			// first assistant response, matching the newSession() contract
-			// and avoiding the duplicate-header bug when _persist()'s
-			// no-assistant guard later resets flushed to false.
-			const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
-			if (hasAssistant) {
-				this._rewriteFile();
-				this.flushed = true;
-			} else {
-				this.flushed = false;
-			}
+			// Always write the branched session file so callers (e.g.,
+			// forked subagent sessions) can rely on the returned path existing.
+			// The initialWriteDone flag in _persist() prevents the old
+			// duplicate-header bug: after this write, flushed stays true and
+			// new entries just append.
+			this._rewriteFile();
+			this.flushed = true;
 
 			return newSessionFile;
 		}

--- a/packages/coding-agent/test/session-manager/tree-traversal.test.ts
+++ b/packages/coding-agent/test/session-manager/tree-traversal.test.ts
@@ -461,8 +461,8 @@ describe("createBranchedSession", () => {
 		expect(entries.map((e) => e.id)).toEqual([id1, id2, id4, id5]);
 	});
 
-	it("does not duplicate entries when forking from first user message", () => {
-		const tempDir = join(tmpdir(), `session-fork-dedup-${Date.now()}`);
+	it("writes file immediately when forking from a point with no assistant messages", () => {
+		const tempDir = join(tmpdir(), `session-fork-no-assistant-${Date.now()}`);
 		mkdirSync(tempDir, { recursive: true });
 
 		try {
@@ -477,22 +477,29 @@ describe("createBranchedSession", () => {
 			const newFile = session.createBranchedSession(id1);
 			expect(newFile).toBeDefined();
 
-			// The branched path has no assistant, so the file should not exist yet
-			// (deferred to _persist on first assistant, matching newSession() contract)
-			expect(existsSync(newFile!)).toBe(false);
+			// File must exist immediately so forked subagent sessions can open it
+			expect(existsSync(newFile!)).toBe(true);
+			let content = readFileSync(newFile!, "utf-8");
+			let lines = content.trim().split("\n").filter(Boolean);
+			let records = lines.map((line) => JSON.parse(line));
+			expect(records.filter((r) => r.type === "session")).toHaveLength(1);
 
 			// Simulate extension adding entry before assistant (like preset on turn_start)
 			session.appendCustomEntry("preset-state", { name: "plan" });
 
+			// File should still have no duplicates
+			content = readFileSync(newFile!, "utf-8");
+			lines = content.trim().split("\n").filter(Boolean);
+			records = lines.map((line) => JSON.parse(line));
+			expect(records.filter((r) => r.type === "session")).toHaveLength(1);
+
 			// Now the assistant responds
 			session.appendMessage(assistantMsg("new answer"));
 
-			// File should now exist with exactly one header and no duplicate IDs
-			expect(existsSync(newFile!)).toBe(true);
-			const content = readFileSync(newFile!, "utf-8");
-			const lines = content.trim().split("\n").filter(Boolean);
-			const records = lines.map((line) => JSON.parse(line));
-
+			// File should still have exactly one header and no duplicate IDs
+			content = readFileSync(newFile!, "utf-8");
+			lines = content.trim().split("\n").filter(Boolean);
+			records = lines.map((line) => JSON.parse(line));
 			expect(records.filter((r) => r.type === "session")).toHaveLength(1);
 
 			const entryIds = records


### PR DESCRIPTION
createBranchedSession returned a file path even when the file was not written to disk (happened when the branched path had no assistant messages). This caused forked subagent sessions to fail with "Session manager returned a forked session file that does not exist".

Always write the file via _rewriteFile() and track whether the initial full write has happened with an initialWriteDone flag. This prevents the duplicate-header bug: after the initial write, _persist keeps flushed=true so new entries just append instead of rewriting all entries including the header.

I tested this using `./pi-test.sh` locally along with

0.
```
pi install npm:pi-subagents
pi
```

1.
```
/run scout "A scout prompt"
```

followed by:

2.
```
/run planner "A planner prompt"
```

Which now works properly.