### PR TITLE
Ignore invalid empty tool calls before execution

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -200,7 +200,7 @@ async function runLoop(
 			}
 
 			// Check for tool calls
-			const toolCalls = message.content.filter((c) => c.type === "toolCall");
+			const toolCalls = message.content.filter(isExecutableToolCall);
 
 			const toolResults: ToolResultMessage[] = [];
 			hasMoreToolCalls = false;
@@ -377,7 +377,7 @@ async function executeToolCalls(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 ): Promise<ExecutedToolCallBatch> {
-	const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
+	const toolCalls = assistantMessage.content.filter(isExecutableToolCall);
 	const hasSequentialToolCall = toolCalls.some(
 		(tc) => currentContext.tools?.find((t) => t.name === tc.name)?.executionMode === "sequential",
 	);
@@ -385,6 +385,10 @@ async function executeToolCalls(
 		return executeToolCallsSequential(currentContext, assistantMessage, toolCalls, config, signal, emit);
 	}
 	return executeToolCallsParallel(currentContext, assistantMessage, toolCalls, config, signal, emit);
+}
+
+function isExecutableToolCall(content: AssistantMessage["content"][number]): content is AgentToolCall {
+	return content.type === "toolCall" && content.id.trim().length > 0 && content.name.trim().length > 0;
 }
 
 type ExecutedToolCallBatch = {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -307,6 +307,78 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
+	it("should ignore empty tool calls before execution", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const executed: Array<{ id: string; value: string }> = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(toolCallId, params) {
+				executed.push({ id: toolCallId, value: params.value });
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+		};
+
+		let callIndex = 0;
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					const message = createAssistantMessage(
+						[
+							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } },
+							{ type: "toolCall", id: "", name: "", arguments: { value: "ghost" } },
+						],
+						"toolUse",
+					);
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					});
+				}
+				callIndex++;
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const messages = await stream.result();
+
+		expect(executed).toEqual([{ id: "tool-1", value: "hello" }]);
+
+		const toolStarts = events.filter((event) => event.type === "tool_execution_start");
+		expect(toolStarts).toHaveLength(1);
+		expect(toolStarts[0]).toMatchObject({ toolCallId: "tool-1", toolName: "echo" });
+
+		const toolResults = messages.filter((message) => message.role === "toolResult");
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]).toMatchObject({ toolCallId: "tool-1", toolName: "echo", isError: false });
+		expect(JSON.stringify(messages)).not.toContain("Tool  not found");
+	});
+
 	it("should execute mutated beforeToolCall args without revalidation", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: Array<string | number> = [];


### PR DESCRIPTION
## Summary

This is a small defense-in-depth fix for malformed provider output. If an assistant response contains a tool-call block with an empty `id` and empty `name`, the agent loop should not execute it and should not emit a tool-result message for it.

That malformed result is especially harmful because it can later be replayed to OpenAI-compatible APIs as an empty `tool_call_id` / `call_id`, which those APIs reject.

## Changes

- Treat only tool-call blocks with non-empty `id` and `name` as executable.
- Use that same filter both when deciding whether a tool turn exists and when dispatching sequential/parallel tool execution.
- Preserve normal behavior for valid tool calls, including valid calls that appear in the same assistant response as an invalid fragment.
- Add a regression test covering one valid call plus one empty ghost call.

## Relationship to provider-layer fix

This complements #4852. The provider layer should prevent malformed replay payloads from being generated. This agent-layer guard prevents malformed provider fragments from becoming tool execution events and tool-result messages in the first place.

## Validation

- `npm test --workspace packages/agent -- test/agent-loop.test.ts`
- `npm run build --workspace packages/agent`
- `npx biome check packages/agent/src/agent-loop.ts packages/agent/test/agent-loop.test.ts`
- `npm run check` via the pre-commit hook
