### PR TITLE
Harden OpenAI tool-call replay against empty IDs

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -31,6 +31,7 @@ import type {
 	ToolResultMessage,
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
+import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
@@ -39,6 +40,30 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
+
+function normalizeCompletionToolCallIdPart(part: string | undefined, fallback: string): string {
+	const raw = typeof part === "string" ? part : "";
+	const sanitized = raw.replace(/[^a-zA-Z0-9_-]/g, "_");
+	const normalized = (sanitized.length > 40 ? sanitized.slice(0, 40) : sanitized).replace(/_+$/, "");
+	return normalized || fallback;
+}
+
+function fallbackCompletionToolCallId(seed: string | undefined): string {
+	return `call_${shortHash(seed || "missing_tool_call_id")}`;
+}
+
+function normalizeCompletionToolCallId(id: string | undefined, normalizePlainId: boolean, seed?: string): string {
+	const rawId = typeof id === "string" ? id : "";
+	if (rawId.includes("|")) {
+		const [rawCallId, rawItemId] = rawId.split("|");
+		return normalizeCompletionToolCallIdPart(
+			rawCallId,
+			fallbackCompletionToolCallId(rawCallId || rawItemId || seed || rawId),
+		);
+	}
+	if (!normalizePlainId && rawId) return rawId;
+	return normalizeCompletionToolCallIdPart(rawId, fallbackCompletionToolCallId(seed || rawId));
+}
 
 /**
  * Check if conversation messages contain tool calls or tool results.
@@ -169,6 +194,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			let hasFinishReason = false;
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
+			let lastToolCallBlock: StreamingToolCallBlock | null = null;
 			const blocks = output.content as StreamingBlock[];
 			const getContentIndex = (block: StreamingBlock) => blocks.indexOf(block);
 			const finishBlock = (block: StreamingBlock) => {
@@ -230,6 +256,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				if (!block && toolCall.id) {
 					block = toolCallBlocksById.get(toolCall.id);
 				}
+				if (!block && !toolCall.id && !toolCall.function?.name && lastToolCallBlock) {
+					block = lastToolCallBlock;
+				}
 				if (!block) {
 					block = {
 						type: "toolCall",
@@ -252,6 +281,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 						partial: output,
 					});
 				}
+				lastToolCallBlock = block;
 				if (streamIndex !== undefined && block.streamIndex === undefined) {
 					block.streamIndex = streamIndex;
 					toolCallBlocksByIndex.set(streamIndex, block);
@@ -745,22 +775,11 @@ export function convertMessages(
 ): ChatCompletionMessageParam[] {
 	const params: ChatCompletionMessageParam[] = [];
 
-	const normalizeToolCallId = (id: string): string => {
-		// Handle pipe-separated IDs from OpenAI Responses API
-		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
-		// These come from providers like github-copilot, openai-codex, opencode
-		// Extract just the call_id part and normalize it
-		if (id.includes("|")) {
-			const [callId] = id.split("|");
-			// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
-			return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
-		}
-
-		if (model.provider === "openai") return id.length > 40 ? id.slice(0, 40) : id;
-		return id;
-	};
+	const normalizeToolCallId = (id: string): string =>
+		normalizeCompletionToolCallId(id, model.provider === "openai", id);
 
 	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));
+	const emittedToolCallIds = new Set<string>();
 
 	if (context.systemPrompt) {
 		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
@@ -866,16 +885,20 @@ export function convertMessages(
 				assistantMsg.content = assistantText;
 			}
 
-			const toolCalls = msg.content.filter(isToolCallBlock);
+			const toolCalls = msg.content.filter(isToolCallBlock).filter((tc) => tc.id && tc.name);
 			if (toolCalls.length > 0) {
-				assistantMsg.tool_calls = toolCalls.map((tc) => ({
-					id: tc.id,
-					type: "function" as const,
-					function: {
-						name: tc.name,
-						arguments: JSON.stringify(tc.arguments),
-					},
-				}));
+				assistantMsg.tool_calls = toolCalls.map((tc) => {
+					const id = normalizeToolCallId(tc.id);
+					emittedToolCallIds.add(id);
+					return {
+						id,
+						type: "function" as const,
+						function: {
+							name: tc.name,
+							arguments: JSON.stringify(tc.arguments),
+						},
+					};
+				});
 				const reasoningDetails = toolCalls
 					.filter((tc) => tc.thoughtSignature)
 					.map((tc) => {
@@ -926,11 +949,15 @@ export function convertMessages(
 
 				// Always send tool result with text (or placeholder if only images)
 				const hasText = textResult.length > 0;
+				const toolCallId = normalizeToolCallId(toolMsg.toolCallId);
+				if (!emittedToolCallIds.has(toolCallId)) {
+					continue;
+				}
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
 					content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
-					tool_call_id: toolMsg.toolCallId,
+					tool_call_id: toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {
 					(toolResultMsg as any).name = toolMsg.toolName;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -63,6 +63,39 @@ function parseTextSignature(
 	return { id: signature };
 }
 
+function normalizeResponsesIdPart(part: string | undefined, fallback: string): string {
+	const raw = typeof part === "string" ? part : "";
+	const sanitized = raw.replace(/[^a-zA-Z0-9_-]/g, "_");
+	const normalized = (sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized).replace(/_+$/, "");
+	return normalized || fallback;
+}
+
+function fallbackResponsesCallId(seed: string | undefined): string {
+	return `call_${shortHash(seed || "missing_call_id")}`;
+}
+
+function fallbackResponsesItemId(seed: string | undefined): string {
+	return `fc_${shortHash(seed || "missing_item_id")}`;
+}
+
+function splitResponsesToolId(id: string | undefined, seed?: string): { callId: string; itemId?: string } {
+	const rawId = typeof id === "string" ? id : "";
+	const separatorIndex = rawId.indexOf("|");
+	if (separatorIndex === -1) {
+		return {
+			callId: normalizeResponsesIdPart(rawId, fallbackResponsesCallId(seed || rawId)),
+			itemId: undefined,
+		};
+	}
+	const rawCallId = rawId.slice(0, separatorIndex);
+	const rawItemId = rawId.slice(separatorIndex + 1);
+	const fallbackSeed = rawCallId || rawItemId || seed || rawId;
+	return {
+		callId: normalizeResponsesIdPart(rawCallId, fallbackResponsesCallId(fallbackSeed)),
+		itemId: rawItemId,
+	};
+}
+
 export interface OpenAIResponsesStreamOptions {
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	resolveServiceTier?: (
@@ -94,12 +127,7 @@ export function convertResponsesMessages<TApi extends Api>(
 	options?: ConvertResponsesMessagesOptions,
 ): ResponseInput {
 	const messages: ResponseInput = [];
-
-	const normalizeIdPart = (part: string): string => {
-		const sanitized = part.replace(/[^a-zA-Z0-9_-]/g, "_");
-		const normalized = sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
-		return normalized.replace(/_+$/, "");
-	};
+	const emittedCallIds = new Set<string>();
 
 	const buildForeignResponsesItemId = (itemId: string): string => {
 		const normalized = `fc_${shortHash(itemId)}`;
@@ -107,15 +135,24 @@ export function convertResponsesMessages<TApi extends Api>(
 	};
 
 	const normalizeToolCallId = (id: string, _targetModel: Model<TApi>, source: AssistantMessage): string => {
-		if (!allowedToolCallProviders.has(model.provider)) return normalizeIdPart(id);
-		if (!id.includes("|")) return normalizeIdPart(id);
+		if (!allowedToolCallProviders.has(model.provider))
+			return normalizeResponsesIdPart(id, fallbackResponsesCallId(id));
+		if (!id.includes("|")) return normalizeResponsesIdPart(id, fallbackResponsesCallId(id));
 		const [callId, itemId] = id.split("|");
-		const normalizedCallId = normalizeIdPart(callId);
+		const normalizedCallId = normalizeResponsesIdPart(
+			callId,
+			fallbackResponsesCallId(`${source.provider}|${source.api}|${source.model}|${itemId}|${id}`),
+		);
 		const isForeignToolCall = source.provider !== model.provider || source.api !== model.api;
-		let normalizedItemId = isForeignToolCall ? buildForeignResponsesItemId(itemId) : normalizeIdPart(itemId);
+		let normalizedItemId = isForeignToolCall
+			? buildForeignResponsesItemId(itemId)
+			: normalizeResponsesIdPart(itemId, fallbackResponsesItemId(`${id}|${normalizedCallId}`));
 		// OpenAI Responses API requires item id to start with "fc"
 		if (!normalizedItemId.startsWith("fc_")) {
-			normalizedItemId = normalizeIdPart(`fc_${normalizedItemId}`);
+			normalizedItemId = normalizeResponsesIdPart(
+				`fc_${normalizedItemId}`,
+				fallbackResponsesItemId(normalizedItemId),
+			);
 		}
 		return `${normalizedCallId}|${normalizedItemId}`;
 	};
@@ -193,7 +230,10 @@ export function convertResponsesMessages<TApi extends Api>(
 					} satisfies ResponseOutputMessage);
 				} else if (block.type === "toolCall") {
 					const toolCall = block as ToolCall;
-					const [callId, itemIdRaw] = toolCall.id.split("|");
+					const toolCallSeed = `${assistantMsg.provider}|${assistantMsg.api}|${assistantMsg.model}|${toolCall.name}|${JSON.stringify(
+						toolCall.arguments,
+					)}|${msgIndex}`;
+					const { callId, itemId: itemIdRaw } = splitResponsesToolId(toolCall.id, toolCallSeed);
 					let itemId: string | undefined = itemIdRaw;
 
 					// For different-model messages, set id to undefined to avoid pairing validation.
@@ -201,6 +241,12 @@ export function convertResponsesMessages<TApi extends Api>(
 					// By omitting the id, we avoid triggering that validation (like cross-provider does).
 					if (isDifferentModel && itemId?.startsWith("fc_")) {
 						itemId = undefined;
+					}
+					if (itemId !== undefined) {
+						itemId = normalizeResponsesIdPart(itemId, fallbackResponsesItemId(`${toolCallSeed}|${callId}`));
+						if (!itemId.startsWith("fc_")) {
+							itemId = normalizeResponsesIdPart(`fc_${itemId}`, fallbackResponsesItemId(itemId));
+						}
 					}
 
 					output.push({
@@ -210,6 +256,7 @@ export function convertResponsesMessages<TApi extends Api>(
 						name: toolCall.name,
 						arguments: JSON.stringify(toolCall.arguments),
 					});
+					emittedCallIds.add(callId);
 				}
 			}
 			if (output.length === 0) continue;
@@ -221,7 +268,11 @@ export function convertResponsesMessages<TApi extends Api>(
 				.join("\n");
 			const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
 			const hasText = textResult.length > 0;
-			const [callId] = msg.toolCallId.split("|");
+			const { callId } = splitResponsesToolId(msg.toolCallId, `${msg.toolName}|${textResult}|${msgIndex}`);
+			if (!emittedCallIds.has(callId)) {
+				msgIndex++;
+				continue;
+			}
 
 			let output: string | ResponseFunctionCallOutputItemList;
 			if (hasImages && model.input.includes("image")) {
@@ -308,10 +359,25 @@ export async function processResponsesStream<TApi extends Api>(
 				output.content.push(currentBlock);
 				stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
 			} else if (item.type === "function_call") {
-				currentItem = item;
+				const rawItemId =
+					typeof item.id === "string" && item.id.trim()
+						? item.id
+						: fallbackResponsesItemId(`${item.name}|${item.arguments}|${blocks.length}`);
+				let itemId = normalizeResponsesIdPart(
+					rawItemId,
+					fallbackResponsesItemId(`${item.name}|${item.arguments}|${blocks.length}`),
+				);
+				if (!itemId.startsWith("fc_")) {
+					itemId = normalizeResponsesIdPart(`fc_${itemId}`, fallbackResponsesItemId(`${rawItemId}|${item.name}`));
+				}
+				const callId = normalizeResponsesIdPart(
+					item.call_id,
+					fallbackResponsesCallId(`${itemId}|${item.name}|${item.arguments}|${blocks.length}`),
+				);
+				currentItem = { ...item, id: itemId, call_id: callId };
 				currentBlock = {
 					type: "toolCall",
-					id: `${item.call_id}|${item.id}`,
+					id: `${callId}|${itemId}`,
 					name: item.name,
 					arguments: {},
 					partialJson: item.arguments || "",
@@ -474,9 +540,27 @@ export async function processResponsesStream<TApi extends Api>(
 					delete (currentBlock as { partialJson?: string }).partialJson;
 					toolCall = currentBlock;
 				} else {
+					const rawItemId =
+						typeof item.id === "string" && item.id.trim()
+							? item.id
+							: fallbackResponsesItemId(`${item.name}|${item.arguments}|${blocks.length}`);
+					let itemId = normalizeResponsesIdPart(
+						rawItemId,
+						fallbackResponsesItemId(`${item.name}|${item.arguments}|${blocks.length}`),
+					);
+					if (!itemId.startsWith("fc_")) {
+						itemId = normalizeResponsesIdPart(
+							`fc_${itemId}`,
+							fallbackResponsesItemId(`${rawItemId}|${item.name}`),
+						);
+					}
+					const callId = normalizeResponsesIdPart(
+						item.call_id,
+						fallbackResponsesCallId(`${itemId}|${item.name}|${item.arguments}|${blocks.length}`),
+					);
 					toolCall = {
 						type: "toolCall",
-						id: `${item.call_id}|${item.id}`,
+						id: `${callId}|${itemId}`,
 						name: item.name,
 						arguments: args,
 					};

--- a/packages/ai/test/openai-tool-call-empty-id-replay.test.ts
+++ b/packages/ai/test/openai-tool-call-empty-id-replay.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/providers/openai-completions.ts";
+import { convertResponsesMessages } from "../src/providers/openai-responses-shared.ts";
+import type { AssistantMessage, Context, Model, ToolResultMessage, Usage } from "../src/types.ts";
+
+const usage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const completionsModel: Model<"openai-completions"> = {
+	id: "test-model",
+	name: "Test OpenAI-compatible chat model",
+	api: "openai-completions",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 4096,
+};
+
+const responsesModel: Model<"openai-responses"> = {
+	...completionsModel,
+	api: "openai-responses",
+	name: "Test OpenAI-compatible responses model",
+};
+
+const completionsCompat: Parameters<typeof convertMessages>[2] = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: false,
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+	sendSessionAffinityHeaders: false,
+	supportsLongCacheRetention: false,
+};
+
+function buildGhostToolContext(api: "openai-completions" | "openai-responses"): Context {
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		api,
+		provider: "openai",
+		model: "test-model",
+		usage,
+		stopReason: "toolUse",
+		timestamp: Date.now() - 2000,
+		content: [
+			{ type: "toolCall", id: "call_real", name: "echo", arguments: {} },
+			{ type: "toolCall", id: "", name: "", arguments: { message: "stranded arguments" } },
+		],
+	};
+	const validToolResult: ToolResultMessage = {
+		role: "toolResult",
+		toolCallId: "call_real",
+		toolName: "echo",
+		content: [{ type: "text", text: "ok" }],
+		isError: false,
+		timestamp: Date.now() - 1000,
+	};
+	const ghostToolResult: ToolResultMessage = {
+		role: "toolResult",
+		toolCallId: "",
+		toolName: "",
+		content: [{ type: "text", text: "Tool  not found" }],
+		isError: true,
+		timestamp: Date.now() - 900,
+	};
+	return {
+		systemPrompt: "You are concise.",
+		messages: [
+			{ role: "user", content: "Use the tool.", timestamp: Date.now() - 3000 },
+			assistant,
+			validToolResult,
+			ghostToolResult,
+		],
+	};
+}
+
+describe("OpenAI-compatible tool-call replay hardening", () => {
+	it("drops orphan chat tool results created from empty-id ghost tool calls", () => {
+		const payload = convertMessages(completionsModel, buildGhostToolContext("openai-completions"), completionsCompat);
+		const toolMessages = payload.filter((message) => message.role === "tool");
+
+		expect(toolMessages).toHaveLength(1);
+		expect(toolMessages[0]).toMatchObject({ tool_call_id: "call_real", content: "ok" });
+		expect(JSON.stringify(payload)).not.toContain("Tool  not found");
+		expect(toolMessages.every((message) => message.tool_call_id.length > 0)).toBe(true);
+	});
+
+	it("drops orphan Responses tool outputs created from empty-id ghost tool calls", () => {
+		const payload = convertResponsesMessages(
+			responsesModel,
+			buildGhostToolContext("openai-responses"),
+			new Set(["openai"]),
+		);
+		const toolOutputs = payload.filter((item) => item.type === "function_call_output");
+
+		expect(toolOutputs).toHaveLength(1);
+		expect(toolOutputs[0]).toMatchObject({ call_id: "call_real", output: "ok" });
+		expect(JSON.stringify(payload)).not.toContain("Tool  not found");
+		expect(toolOutputs.every((item) => item.call_id.length > 0)).toBe(true);
+	});
+
+	it("normalizes empty pipe-prefixed Responses call ids consistently", () => {
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			api: "openai-responses",
+			provider: "openai",
+			model: "test-model",
+			usage,
+			stopReason: "toolUse",
+			timestamp: Date.now() - 2000,
+			content: [{ type: "toolCall", id: "|fc_bad", name: "echo", arguments: { message: "hello" } }],
+		};
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "|fc_bad",
+			toolName: "echo",
+			content: [{ type: "text", text: "hello" }],
+			isError: false,
+			timestamp: Date.now() - 1000,
+		};
+		const payload = convertResponsesMessages(
+			responsesModel,
+			{ systemPrompt: "", messages: [assistant, toolResult] },
+			new Set(["openai"]),
+		);
+		const callIds = payload
+			.filter((item) => item.type === "function_call" || item.type === "function_call_output")
+			.map((item) => item.call_id);
+
+		expect(callIds).toHaveLength(2);
+		expect(callIds.every((id) => id.length > 0)).toBe(true);
+		expect(new Set(callIds).size).toBe(1);
+	});
+
+	it("normalizes empty pipe-prefixed chat tool ids consistently", () => {
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			api: "openai-completions",
+			provider: "openai",
+			model: "test-model",
+			usage,
+			stopReason: "toolUse",
+			timestamp: Date.now() - 2000,
+			content: [{ type: "toolCall", id: "|fc_bad", name: "echo", arguments: { message: "hello" } }],
+		};
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "|fc_bad",
+			toolName: "echo",
+			content: [{ type: "text", text: "hello" }],
+			isError: false,
+			timestamp: Date.now() - 1000,
+		};
+		const payload = convertMessages(
+			completionsModel,
+			{ systemPrompt: "", messages: [assistant, toolResult] },
+			completionsCompat,
+		);
+		const toolCallId = payload.find((message) => message.role === "assistant")?.tool_calls?.[0]?.id;
+		const toolResultId = payload.find((message) => message.role === "tool")?.tool_call_id;
+
+		expect(toolCallId).toBeDefined();
+		expect(toolResultId).toBeDefined();
+		expect(toolCallId).toBe(toolResultId);
+		expect(toolCallId?.startsWith("|")).toBe(false);
+	});
+});


### PR DESCRIPTION
OpenAI-compatible providers can stream or persist malformed tool-call fragments: empty call ids, pipe-prefixed Responses ids with an empty call-id half, and argument-only chat deltas that belong to the previous tool call.

This normalizes replay ids to non-empty OpenAI-safe values, merges argument-only chat deltas into the last active tool call, and drops orphan tool outputs that do not correspond to an emitted assistant tool call. That prevents replay payloads from sending empty tool_call_id / call_id values back to OpenAI-compatible APIs.

Constraint: OpenAI rejects empty tool call identifiers during conversation replay.

Rejected: Patch only the agent execution layer | replay would still persist and resend invalid provider payloads.

Confidence: high

Scope-risk: moderate

Directive: Keep assistant tool calls and tool outputs paired by normalized id; do not replay orphan outputs.

Tested: npm test --workspace packages/ai -- test/openai-tool-call-empty-id-replay.test.ts

Tested: npx tsgo -p packages/ai/tsconfig.build.json

Tested: npx biome check packages/ai/src/providers/openai-completions.ts packages/ai/src/providers/openai-responses-shared.ts packages/ai/test/openai-tool-call-empty-id-replay.test.ts

Tested: npm run check (pre-commit hook)

Not-tested: Full workspace test suite