### PR TITLE
fix(ai): default Bedrock `inferenceConfig.maxTokens` to `model.maxTokens`

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Amazon Bedrock provider silently capping output at ~4096 tokens for adaptive-thinking models (Claude Opus 4.6/4.7, Sonnet 4.6) and other paths where the caller did not pass an explicit `maxTokens`. The provider now mirrors the Anthropic-native provider and defaults `inferenceConfig.maxTokens` to `model.maxTokens` when it is not set, preventing `stopReason: "length"` truncation mid-response ([#4871](https://github.com/earendil-works/pi/pull/4871) by [@unexge](https://github.com/unexge)).
+
 ## [0.75.4] - 2026-05-20
 
 ### Changed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -188,7 +188,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				messages: convertMessages(context, model, cacheRetention),
 				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
 				inferenceConfig: {
-					...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
+					// When caller omits `maxTokens`, default to the model's documented cap.
+					// Without this fallback Bedrock applies its own much smaller server-side default (~4096 for Anthropic Claude),
+					// which silently truncates long outputs with stopReason "length".
+					maxTokens: options.maxTokens ?? (model.maxTokens || undefined),
 					...(options.temperature !== undefined && { temperature: options.temperature }),
 				},
 				toolConfig: convertToolConfig(context.tools, options.toolChoice),

--- a/packages/ai/test/bedrock-max-tokens-default.test.ts
+++ b/packages/ai/test/bedrock-max-tokens-default.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.ts";
+import { type BedrockOptions, streamBedrock } from "../src/providers/amazon-bedrock.ts";
+import type { Context, Model } from "../src/types.ts";
+
+interface BedrockInferencePayload {
+	inferenceConfig?: {
+		maxTokens?: number;
+		temperature?: number;
+	};
+}
+
+class PayloadCaptured extends Error {
+	constructor() {
+		super("payload captured");
+		this.name = "PayloadCaptured";
+	}
+}
+
+function makeContext(): Context {
+	return {
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	};
+}
+
+async function capturePayload(
+	model: Model<"bedrock-converse-stream">,
+	options?: BedrockOptions,
+): Promise<BedrockInferencePayload> {
+	let capturedPayload: BedrockInferencePayload | undefined;
+	const s = streamBedrock(model, makeContext(), {
+		...options,
+		onPayload: (payload) => {
+			capturedPayload = payload as BedrockInferencePayload;
+			throw new PayloadCaptured();
+		},
+	});
+
+	for await (const event of s) {
+		if (event.type === "error") {
+			break;
+		}
+	}
+
+	if (!capturedPayload) {
+		throw new Error("Expected Bedrock payload to be captured before request abort");
+	}
+
+	return capturedPayload;
+}
+
+describe("Bedrock inferenceConfig.maxTokens default", () => {
+	// Regression: when callers (notably the coding-agent loop) do not pass an
+	// explicit maxTokens, the Bedrock Converse API silently caps output at its
+	// server-side default (~4096 tokens). This produces stopReason "length"
+	// mid-response, which the agent loop treats as a normal stop. The
+	// Anthropic-native provider already defaults to model.maxTokens; Bedrock
+	// should match that behaviour so the same model is not artificially
+	// truncated when accessed via Bedrock.
+	it("defaults inferenceConfig.maxTokens to model.maxTokens when caller omits maxTokens", async () => {
+		const model = getModel("amazon-bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+		expect(model.maxTokens).toBeGreaterThan(4096); // sanity: registry has the real cap
+
+		const payload = await capturePayload(model);
+
+		expect(payload.inferenceConfig?.maxTokens).toBe(model.maxTokens);
+	});
+
+	it("preserves an explicit caller-supplied maxTokens", async () => {
+		const model = getModel("amazon-bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+
+		const payload = await capturePayload(model, { maxTokens: 1234 });
+
+		expect(payload.inferenceConfig?.maxTokens).toBe(1234);
+	});
+});


### PR DESCRIPTION
When the caller omits `maxTokens`, Bedrock applies its own server-side default (~4096 for Anthropic Claude), silently truncating long outputs with `stopReason: "length"`. This affected adaptive-thinking models (Opus 4.6/4.7, Sonnet 4.6) and any non-thinking path, since none of them populated `inferenceConfig.maxTokens` - and especially using Opus 4.7 with max thinking causes lots of token usage and causes the coding agent to stop midway.

The fix mirrors Anthropic provider's `buildParams()` which already defaults to `model.maxTokens`.

---


<details>
<summary>Also reproduced and verified this issue with and end-to-end test, click to see test and details.</summary>

`packages/ai/test/bedrock-output-cap-e2e.test.ts`:
```ts
import { describe, expect, it } from "vitest";
import { getModel } from "../src/models.ts";
import { completeSimple } from "../src/stream.ts";
import { hasBedrockCredentials } from "./bedrock-utils.ts";

// Real Bedrock e2e: gated on AWS credentials. Skipped in CI without them.
describe.skipIf(!hasBedrockCredentials())("Amazon Bedrock output cap (e2e)", () => {
	// Reproduces the failure where Bedrock silently caps output at 4096 tokens
	// because streamBedrock omits inferenceConfig.maxTokens when the caller
	// does not supply one. The agent loop never supplies one, so users see
	// stopReason="length" mid-task with no warning.
	it(
		"does not silently truncate adaptive-thinking model output at 4096 tokens",
		{ retry: 1, timeout: 600_000 },
		async () => {
			const model = getModel("amazon-bedrock", "global.anthropic.claude-opus-4-7");

			// A creative task the model will actually generate at length.
			// Probe established Opus 4.7 produces ~9700 tokens for this prompt
			// when maxTokens is set to the model cap, and exactly 4096 with
			// stopReason="length" when maxTokens is omitted.
			const result = await completeSimple(model, {
				messages: [
					{
						role: "user",
						content:
							"Write a detailed, fully-fleshed-out fantasy short story of at least 6000 words. " +
							"Include vivid descriptions, multiple characters, dialogue, world-building, and a complete arc " +
							"with beginning, middle, and end. Do not summarize, do not stop early, write the full story.",
						timestamp: Date.now(),
					},
				],
			});

			expect(result.stopReason).not.toBe("length");
			expect(result.usage.output).toBeGreaterThan(4096);
		},
	);
});
```


## Before the fix

`bedrock-output-cap-e2e.test.ts` against the unfixed `streamBedrock` (which omitted `maxTokens` for adaptive-thinking models):

```
 ❯ test/bedrock-output-cap-e2e.test.ts (1 test | 1 failed) 305115ms
   × Amazon Bedrock output cap (e2e) > does not silently truncate adaptive-thinking model output at 4096 tokens 305114ms (retry x1)
     → expected 'length' not to be 'length' // Object.is equality
     → expected 'length' not to be 'length' // Object.is equality

 FAIL  test/bedrock-output-cap-e2e.test.ts > ...
AssertionError: expected 'length' not to be 'length' // Object.is equality
 ❯ test/bedrock-output-cap-e2e.test.ts:35:34
     35|    expect(result.stopReason).not.toBe("length");

 Test Files  1 failed (1)
      Tests  1 failed (1)
   Duration  305.71s
```

Both attempts (initial + 1 retry) returned `stopReason: "length"`. Real Bedrock cut Opus 4.7's output at the 4096 server-side default. Reproduces the exact symptom users hit (`[stop: length]` mid-sentence).

## After the fix

Same test, same model, same prompt, just with `maxTokens: options.maxTokens ?? (model.maxTokens || undefined)` in the provider:

```
 ✓ test/bedrock-output-cap-e2e.test.ts (1 test) 205545ms
   ✓ Amazon Bedrock output cap (e2e) > does not silently truncate adaptive-thinking model output at 4096 tokens  205544ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  206.06s
```

Single attempt, passed. Both assertions held:
- `result.stopReason !== "length"` (response ended naturally)
- `result.usage.output > 4096` (actual output exceeded the previous cap)

## Side-by-side

|                | Before fix              | After fix    |
| -------------- | ----------------------- | ------------ |
| Outcome        | FAIL (x2 with retry)    | PASS         |
| `stopReason`   | `length`                | `!= length`  |
| Output tokens  | 4096 (cap hit)          | `> 4096`     |
| Wall time      | 305s                    | 206s         |


</details>
