### PR TITLE
fix(ai): omit store for Google OpenAI-compatible completions

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1077,6 +1077,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
 	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
 	const isCloudflareAiGateway = provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
+	const isGoogleOpenAICompat = baseUrl.includes("generativelanguage.googleapis.com");
 
 	const isNonStandard =
 		provider === "cerebras" ||
@@ -1100,7 +1101,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
 	return {
-		supportsStore: !isNonStandard,
+		supportsStore: !isNonStandard && !isGoogleOpenAICompat,
 		supportsDeveloperRole: !isNonStandard,
 		supportsReasoningEffort: !isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway,
 		supportsUsageInStreaming: true,

--- a/packages/ai/test/openai-completions-empty-tools.test.ts
+++ b/packages/ai/test/openai-completions-empty-tools.test.ts
@@ -163,6 +163,30 @@ describe("openai-completions empty tools handling", () => {
 		expect(clientOptions.defaultHeaders?.["cf-aig-authorization"]).toBe("Bearer test");
 	});
 
+	it("omits store for Google OpenAI-compatible endpoints", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = {
+			...baseModel,
+			id: "gemini-3.1-pro-preview",
+			name: "Gemini 3.1 Pro Preview",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+		} as const;
+
+		await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as { store?: boolean };
+		expect(params.store).toBeUndefined();
+		expect("store" in (params as object)).toBe(false);
+	});
+
 	it("preserves inline upstream Authorization for Cloudflare AI Gateway BYOK requests", async () => {
 		process.env.CLOUDFLARE_ACCOUNT_ID = "account-id";
 		process.env.CLOUDFLARE_GATEWAY_ID = "gateway-id";


### PR DESCRIPTION
## Summary
- detect Google OpenAI-compatible completions endpoints by base URL
- avoid sending `store: false` because Google rejects unknown fields
- add a regression test for Gemini via `generativelanguage.googleapis.com/v1beta/openai`

## Test
- `npm test --workspace packages/ai -- test/openai-completions-empty-tools.test.ts`