### PR TITLE
fix(coding-agent): reconcile git ref on install, update settings on ref change

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -778,9 +778,21 @@ export class DefaultPackageManager implements PackageManager {
 			scope === "project" ? this.settingsManager.getProjectSettings() : this.settingsManager.getGlobalSettings();
 		const currentPackages = currentSettings.packages ?? [];
 		const normalizedSource = this.normalizePackageSourceForSettings(source, scope);
-		const exists = currentPackages.some((existing) => this.packageSourcesMatch(existing, source, scope));
-		if (exists) {
-			return false;
+		const matchIndex = currentPackages.findIndex((existing) => this.packageSourcesMatch(existing, source, scope));
+		if (matchIndex !== -1) {
+			const existingStr = this.getPackageSourceString(currentPackages[matchIndex]);
+			if (existingStr === normalizedSource) {
+				return false;
+			}
+			// Replace existing entry with updated source (e.g. different ref/version)
+			const nextPackages = [...currentPackages];
+			nextPackages[matchIndex] = normalizedSource;
+			if (scope === "project") {
+				this.settingsManager.setProjectPackages(nextPackages);
+			} else {
+				this.settingsManager.setPackages(nextPackages);
+			}
+			return true;
 		}
 		const nextPackages = [...currentPackages, normalizedSource];
 		if (scope === "project") {
@@ -1723,6 +1735,9 @@ export class DefaultPackageManager implements PackageManager {
 	private async installGit(source: GitSource, scope: SourceScope): Promise<void> {
 		const targetDir = this.getGitInstallPath(source, scope);
 		if (existsSync(targetDir)) {
+			if (source.ref) {
+				await this.ensureGitRef(targetDir, ["fetch", "origin", source.ref], "FETCH_HEAD");
+			}
 			return;
 		}
 		const gitRoot = this.getGitInstallRoot(scope);
@@ -1749,24 +1764,29 @@ export class DefaultPackageManager implements PackageManager {
 		}
 
 		const target = await this.getLocalGitUpdateTarget(targetDir);
+		await this.ensureGitRef(targetDir, target.fetchArgs, target.ref);
+	}
 
-		// Fetch only the ref we will reset to, avoiding unrelated branch/tag noise.
-		await this.runCommand("git", target.fetchArgs, { cwd: targetDir });
+	/**
+	 * Ensure the checkout at targetDir is at the given ref.
+	 * Fetches first, then compares with HEAD and resets if needed.
+	 */
+	private async ensureGitRef(targetDir: string, fetchArgs: string[], ref: string): Promise<void> {
+		await this.runCommand("git", fetchArgs, { cwd: targetDir });
 
 		const localHead = await this.runCommandCapture("git", ["rev-parse", "HEAD"], {
 			cwd: targetDir,
 			timeoutMs: NETWORK_TIMEOUT_MS,
 		});
-		const refreshedTargetHead = await this.runCommandCapture("git", ["rev-parse", target.ref], {
+		const targetHead = await this.runCommandCapture("git", ["rev-parse", ref], {
 			cwd: targetDir,
 			timeoutMs: NETWORK_TIMEOUT_MS,
 		});
-		if (localHead.trim() === refreshedTargetHead.trim()) {
+		if (localHead.trim() === targetHead.trim()) {
 			return;
 		}
 
-		await this.runCommand("git", ["reset", "--hard", target.ref], { cwd: targetDir });
-
+		await this.runCommand("git", ["reset", "--hard", ref], { cwd: targetDir });
 		// Clean untracked files (extensions should be pristine)
 		await this.runCommand("git", ["clean", "-fdx"], { cwd: targetDir });
 

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -1061,6 +1061,41 @@ Content`,
 			expect(removed).toBe(true);
 			expect(settingsManager.getGlobalSettings().packages ?? []).toHaveLength(0);
 		});
+
+		it("should return false when adding the same git source with the same ref", () => {
+			const first = packageManager.addSourceToSettings("git:github.com/user/repo@v1");
+			expect(first).toBe(true);
+			const second = packageManager.addSourceToSettings("git:github.com/user/repo@v1");
+			expect(second).toBe(false);
+			expect(settingsManager.getGlobalSettings().packages).toHaveLength(1);
+		});
+
+		it("should update the ref when adding the same git source with a different ref", () => {
+			packageManager.addSourceToSettings("git:github.com/user/repo@v1");
+			const updated = packageManager.addSourceToSettings("git:github.com/user/repo@v2");
+			expect(updated).toBe(true);
+			const packages = settingsManager.getGlobalSettings().packages;
+			expect(packages).toHaveLength(1);
+			expect(packages![0]).toBe("git:github.com/user/repo@v2");
+		});
+
+		it("should update when adding a git source with a ref where none existed", () => {
+			packageManager.addSourceToSettings("git:github.com/user/repo");
+			const updated = packageManager.addSourceToSettings("git:github.com/user/repo@v1");
+			expect(updated).toBe(true);
+			const packages = settingsManager.getGlobalSettings().packages;
+			expect(packages).toHaveLength(1);
+			expect(packages![0]).toBe("git:github.com/user/repo@v1");
+		});
+
+		it("should update when removing a ref from a git source", () => {
+			packageManager.addSourceToSettings("git:github.com/user/repo@v1");
+			const updated = packageManager.addSourceToSettings("git:github.com/user/repo");
+			expect(updated).toBe(true);
+			const packages = settingsManager.getGlobalSettings().packages;
+			expect(packages).toHaveLength(1);
+			expect(packages![0]).toBe("git:github.com/user/repo");
+		});
 	});
 
 	describe("HTTPS git URL parsing (old behavior)", () => {


### PR DESCRIPTION
This PR extracts `ensureGitRef` to share fetch/reset login between `installGit` and `updateGit`. `installGit` now checks out the pinned ref when the directory already exists. `addSourceToSettings` replaces the existing entry when the same source is re-added with a different ref.

fixes #4870