### PR TITLE
feat(codex): hydrate account models from chatgpt backend

### DIFF
--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -53,7 +53,12 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
  * - Anthropic Messages API Opus 4.6 models (xhigh maps to adaptive effort "max")
  */
 export function supportsXhigh<TApi extends Api>(model: Model<TApi>): boolean {
-	if (model.id.includes("gpt-5.2") || model.id.includes("gpt-5.3") || model.id.includes("gpt-5.4")) {
+	if (
+		model.id.includes("gpt-5.2") ||
+		model.id.includes("gpt-5.3") ||
+		model.id.includes("gpt-5.4") ||
+		model.id.includes("gpt-5.5")
+	) {
 		return true;
 	}
 

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -18,6 +18,7 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 }
 
 import { generatePKCE } from "./pkce.js";
+import type { Api, Model } from "../../types.js";
 import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from "./types.js";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -26,6 +27,9 @@ const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
 const SCOPE = "openid profile email offline_access";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+const OPENAI_CODEX_MODELS_CLIENT_VERSION = process.env.PI_OPENAI_CODEX_CLIENT_VERSION || "0.124.0";
+const OPENAI_CODEX_MODELS_CACHE_TTL_MS = 5 * 60 * 1000;
+const OPENAI_CODEX_MODELS_URL = `https://chatgpt.com/backend-api/codex/models?client_version=${OPENAI_CODEX_MODELS_CLIENT_VERSION}`;
 
 const SUCCESS_HTML = `<!doctype html>
 <html lang="en">
@@ -49,6 +53,22 @@ type JwtPayload = {
 	};
 	[key: string]: unknown;
 };
+
+type OpenAICodexCredentials = OAuthCredentials & {
+	accountId?: string;
+};
+
+type OpenAICodexCatalogModel = {
+	slug?: string;
+	display_name?: string;
+	context_window?: number;
+	max_context_window?: number;
+	input_modalities?: string[];
+	supported_reasoning_levels?: Array<{ effort?: string }>;
+	visibility?: string;
+};
+
+const openAICodexModelsCache = new Map<string, { expiresAt: number; models: OpenAICodexCatalogModel[] }>();
 
 function createState(): string {
 	if (!_randomBytes) {
@@ -291,6 +311,124 @@ function getAccountId(accessToken: string): string | null {
 	return typeof accountId === "string" && accountId.length > 0 ? accountId : null;
 }
 
+function getCredentialAccountId(credentials: OpenAICodexCredentials): string | null {
+	if (typeof credentials.accountId === "string" && credentials.accountId.length > 0) {
+		return credentials.accountId;
+	}
+	return getAccountId(credentials.access);
+}
+
+function normalizeOpenAICodexInputModalities(
+	modalities: string[] | undefined,
+	fallback: ("text" | "image")[],
+): ("text" | "image")[] {
+	const normalized = new Set<"text" | "image">();
+	for (const modality of modalities ?? []) {
+		if (modality === "text" || modality === "image") {
+			normalized.add(modality);
+		}
+	}
+	return normalized.size > 0 ? Array.from(normalized) : fallback;
+}
+
+function normalizeOpenAICodexReasoning(model: OpenAICodexCatalogModel, fallback: boolean): boolean {
+	if (!Array.isArray(model.supported_reasoning_levels)) {
+		return fallback;
+	}
+	return model.supported_reasoning_levels.some((level) => typeof level?.effort === "string" && level.effort.length > 0);
+}
+
+async function fetchOpenAICodexCatalog(
+	credentials: OpenAICodexCredentials,
+): Promise<OpenAICodexCatalogModel[] | undefined> {
+	if (process.env.PI_OFFLINE) {
+		return undefined;
+	}
+
+	const accountId = getCredentialAccountId(credentials);
+	if (!credentials.access || !accountId) {
+		return undefined;
+	}
+
+	const now = Date.now();
+	const cached = openAICodexModelsCache.get(accountId);
+	if (cached && cached.expiresAt > now) {
+		return cached.models;
+	}
+
+	const response = await fetch(OPENAI_CODEX_MODELS_URL, {
+		headers: {
+			Authorization: `Bearer ${credentials.access}`,
+			"chatgpt-account-id": accountId,
+			"User-Agent": `pi/${OPENAI_CODEX_MODELS_CLIENT_VERSION}`,
+		},
+	});
+	if (!response.ok) {
+		return undefined;
+	}
+
+	const payload = (await response.json()) as { models?: OpenAICodexCatalogModel[] };
+	if (!Array.isArray(payload.models)) {
+		return undefined;
+	}
+
+	openAICodexModelsCache.set(accountId, {
+		expiresAt: now + OPENAI_CODEX_MODELS_CACHE_TTL_MS,
+		models: payload.models,
+	});
+	return payload.models;
+}
+
+export async function hydrateOpenAICodexModels(
+	models: Model<Api>[],
+	credentials: OAuthCredentials,
+): Promise<Model<Api>[]> {
+	const catalog = await fetchOpenAICodexCatalog(credentials as OpenAICodexCredentials);
+	if (!catalog) {
+		return models;
+	}
+
+	const providerModels = models.filter((model) => model.provider === "openai-codex");
+	const providerTemplate = providerModels[0];
+	const byId = new Map(providerModels.map((model) => [model.id, model]));
+	const hydratedProviderModels: Model<Api>[] = [];
+
+	for (const entry of catalog) {
+		const id = entry.slug?.trim();
+		if (!id || entry.visibility === "hide") {
+			continue;
+		}
+
+		const existing = byId.get(id);
+		const fallbackInput = existing?.input ?? providerTemplate?.input ?? ["text"];
+		const fallbackContextWindow = existing?.contextWindow ?? providerTemplate?.contextWindow ?? 272000;
+		const fallbackMaxTokens = existing?.maxTokens ?? providerTemplate?.maxTokens ?? 128000;
+		const fallbackCost = existing?.cost ?? providerTemplate?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+		hydratedProviderModels.push({
+			id,
+			name: entry.display_name?.trim() || existing?.name || id,
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: existing?.baseUrl ?? providerTemplate?.baseUrl ?? "https://chatgpt.com/backend-api",
+			reasoning: normalizeOpenAICodexReasoning(entry, existing?.reasoning ?? providerTemplate?.reasoning ?? true),
+			input: normalizeOpenAICodexInputModalities(entry.input_modalities, fallbackInput),
+			cost: fallbackCost,
+			contextWindow: entry.context_window ?? entry.max_context_window ?? fallbackContextWindow,
+			maxTokens: fallbackMaxTokens,
+			headers: existing?.headers ?? providerTemplate?.headers,
+			compat: existing?.compat ?? providerTemplate?.compat,
+		} satisfies Model<Api>);
+	}
+
+	if (hydratedProviderModels.length === 0) {
+		return models;
+	}
+
+	const otherModels = models.filter((model) => model.provider !== "openai-codex");
+	return [...otherModels, ...hydratedProviderModels];
+}
+
 /**
  * Login with OpenAI Codex OAuth
  *
@@ -451,5 +589,9 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 
 	getApiKey(credentials: OAuthCredentials): string {
 		return credentials.access;
+	},
+
+	async modifyModelsAsync(models: Model<Api>[], credentials: OAuthCredentials): Promise<Model<Api>[]> {
+		return hydrateOpenAICodexModels(models, credentials);
 	},
 };

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -47,8 +47,11 @@ export interface OAuthProviderInterface {
 	/** Convert credentials to API key string for the provider */
 	getApiKey(credentials: OAuthCredentials): string;
 
-	/** Optional: modify models for this provider (e.g., update baseUrl) */
+	/** Optional: modify models for this provider synchronously (e.g., update baseUrl) */
 	modifyModels?(models: Model<Api>[], credentials: OAuthCredentials): Model<Api>[];
+
+	/** Optional: hydrate models for this provider asynchronously (e.g., fetch a per-account catalog) */
+	modifyModelsAsync?(models: Model<Api>[], credentials: OAuthCredentials): Promise<Model<Api>[]>;
 }
 
 /** @deprecated Use OAuthProviderInterface instead */

--- a/packages/ai/test/openai-codex-models.test.ts
+++ b/packages/ai/test/openai-codex-models.test.ts
@@ -1,0 +1,112 @@
+import type { Api, Model } from "../src/types.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { hydrateOpenAICodexModels } from "../src/utils/oauth/openai-codex.js";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+	delete process.env.PI_OFFLINE;
+});
+
+describe("hydrateOpenAICodexModels", () => {
+	test("replaces the static catalog with visible account models and preserves other providers", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					models: [
+						{
+							slug: "gpt-5.5",
+							display_name: "GPT-5.5",
+							context_window: 272000,
+							input_modalities: ["text", "image"],
+							supported_reasoning_levels: [{ effort: "low" }, { effort: "xhigh" }],
+							visibility: "list",
+						},
+						{
+							slug: "gpt-5.4-mini",
+							display_name: "GPT-5.4 Mini",
+							context_window: 272000,
+							input_modalities: ["text", "image"],
+							supported_reasoning_levels: [{ effort: "low" }],
+							visibility: "list",
+						},
+						{
+							slug: "gpt-5.4",
+							display_name: "GPT-5.4",
+							context_window: 272000,
+							input_modalities: ["text", "image"],
+							supported_reasoning_levels: [{ effort: "low" }],
+							visibility: "list",
+						},
+						{
+							slug: "codex-auto-review",
+							display_name: "Codex Auto Review",
+							visibility: "hide",
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			),
+		);
+		global.fetch = fetchMock as typeof fetch;
+
+		const models: Model<Api>[] = [
+			{
+				id: "gpt-5.1",
+				name: "GPT-5.1",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				baseUrl: "https://chatgpt.com/backend-api",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 272000,
+				maxTokens: 128000,
+			},
+			{
+				id: "gpt-5.4",
+				name: "GPT-5.4",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				baseUrl: "https://chatgpt.com/backend-api",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+				contextWindow: 272000,
+				maxTokens: 128000,
+			},
+			{
+				id: "claude-sonnet-4",
+				name: "Claude Sonnet 4",
+				api: "anthropic-messages",
+				provider: "anthropic",
+				baseUrl: "https://api.anthropic.com/v1",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+				contextWindow: 200000,
+				maxTokens: 8192,
+			},
+		];
+
+		const hydrated = await hydrateOpenAICodexModels(models, {
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			accountId: "acct_123",
+		});
+
+		expect(hydrated.filter((model) => model.provider === "openai-codex").map((model) => model.id)).toEqual([
+			"gpt-5.5",
+			"gpt-5.4-mini",
+			"gpt-5.4",
+		]);
+		expect(hydrated.find((model) => model.provider === "openai-codex" && model.id === "gpt-5.5")?.maxTokens).toBe(
+			128000,
+		);
+		expect(hydrated.some((model) => model.provider === "anthropic" && model.id === "claude-sonnet-4")).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -535,6 +535,7 @@ interface ProviderConfig {
     refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
     getApiKey(credentials: OAuthCredentials): string;
     modifyModels?(models: Model<Api>[], credentials: OAuthCredentials): Model<Api>[];
+    modifyModelsAsync?(models: Model<Api>[], credentials: OAuthCredentials): Promise<Model<Api>[]>;
   };
 }
 ```

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -39,6 +39,7 @@ Use `/logout` to clear credentials. Tokens are stored in `~/.pi/agent/auth.json`
 
 - Requires ChatGPT Plus or Pro subscription
 - Personal use only; for production, use the OpenAI Platform API
+- After `/login`, pi hydrates the visible Codex model catalog from the ChatGPT backend for that account and hides internal entries not meant for the picker
 
 ## API Keys
 

--- a/packages/coding-agent/src/cli/list-models.ts
+++ b/packages/coding-agent/src/cli/list-models.ts
@@ -25,7 +25,7 @@ function formatTokenCount(count: number): string {
  * List available models, optionally filtered by search pattern
  */
 export async function listModels(modelRegistry: ModelRegistry, searchPattern?: string): Promise<void> {
-	const models = modelRegistry.getAvailable();
+	const models = await modelRegistry.hydrateAvailableModels();
 
 	if (models.length === 0) {
 		console.log("No models available. Set API keys in environment variables.");

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1391,7 +1391,7 @@ export class AgentSession {
 	}
 
 	private async _cycleAvailableModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined> {
-		const availableModels = await this._modelRegistry.getAvailable();
+		const availableModels = await this._modelRegistry.hydrateAvailableModels();
 		if (availableModels.length <= 1) return undefined;
 
 		const currentModel = this.model;
@@ -2546,7 +2546,7 @@ export class AgentSession {
 		// Restore model if saved
 		if (sessionContext.model) {
 			const previousModel = this.model;
-			const availableModels = await this._modelRegistry.getAvailable();
+			const availableModels = await this._modelRegistry.hydrateAvailableModels();
 			const match = availableModels.find(
 				(m) => m.provider === sessionContext.model!.provider && m.id === sessionContext.model!.modelId,
 			);

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1205,8 +1205,10 @@ export interface ProviderConfig {
 		refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
 		/** Convert credentials to API key string for the provider. */
 		getApiKey(credentials: OAuthCredentials): string;
-		/** Optional: modify models for this provider (e.g., update baseUrl based on credentials). */
+		/** Optional: modify models for this provider synchronously (e.g., update baseUrl based on credentials). */
 		modifyModels?(models: Model<Api>[], credentials: OAuthCredentials): Model<Api>[];
+		/** Optional: hydrate models asynchronously (e.g., fetch a per-account catalog). */
+		modifyModelsAsync?(models: Model<Api>[], credentials: OAuthCredentials): Promise<Model<Api>[]>;
 	};
 }
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -221,9 +221,11 @@ export const clearApiKeyCache = clearConfigValueCache;
  */
 export class ModelRegistry {
 	private models: Model<Api>[] = [];
+	private baseModels: Model<Api>[] = [];
 	private customProviderApiKeys: Map<string, string> = new Map();
 	private registeredProviders: Map<string, ProviderConfigInput> = new Map();
 	private loadError: string | undefined = undefined;
+	private hydrationPromise: Promise<Model<Api>[]> | undefined = undefined;
 
 	constructor(
 		readonly authStorage: AuthStorage,
@@ -248,6 +250,7 @@ export class ModelRegistry {
 	refresh(): void {
 		this.customProviderApiKeys.clear();
 		this.loadError = undefined;
+		this.hydrationPromise = undefined;
 
 		// Ensure dynamic API/OAuth registrations are rebuilt from current provider state.
 		resetApiProviders();
@@ -292,6 +295,7 @@ export class ModelRegistry {
 			}
 		}
 
+		this.baseModels = combined;
 		this.models = combined;
 	}
 
@@ -498,6 +502,49 @@ export class ModelRegistry {
 	 */
 	getAll(): Model<Api>[] {
 		return this.models;
+	}
+
+	/**
+	 * Hydrate provider model lists that depend on async account-scoped discovery.
+	 * Falls back to the current cached model list if hydration fails.
+	 */
+	async hydrateAvailableModels(): Promise<Model<Api>[]> {
+		if (this.hydrationPromise) {
+			return this.hydrationPromise;
+		}
+
+		this.hydrationPromise = (async () => {
+			let hydrated = this.baseModels;
+
+			for (const oauthProvider of this.authStorage.getOAuthProviders()) {
+				if (!oauthProvider.modifyModelsAsync) continue;
+
+				const providerId = oauthProvider.id;
+				const credential = this.authStorage.get(providerId);
+				if (credential?.type !== "oauth") continue;
+
+				try {
+					const apiKey = await this.authStorage.getApiKey(providerId);
+					if (!apiKey) continue;
+
+					const refreshedCredential = this.authStorage.get(providerId);
+					if (refreshedCredential?.type !== "oauth") continue;
+
+					hydrated = await oauthProvider.modifyModelsAsync(hydrated, refreshedCredential);
+				} catch {
+					// Ignore hydration failures and keep the cached/static model list.
+				}
+			}
+
+			this.models = hydrated;
+			return this.getAvailable();
+		})();
+
+		try {
+			return await this.hydrationPromise;
+		} finally {
+			this.hydrationPromise = undefined;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -210,7 +210,7 @@ export function parseModelPattern(
  * strips colon-suffixes to find a match.
  */
 export async function resolveModelScope(patterns: string[], modelRegistry: ModelRegistry): Promise<ScopedModel[]> {
-	const availableModels = await modelRegistry.getAvailable();
+	const availableModels = await modelRegistry.hydrateAvailableModels();
 	const scopedModels: ScopedModel[] = [];
 
 	for (const pattern of patterns) {
@@ -499,7 +499,7 @@ export async function findInitialModel(options: {
 	}
 
 	// 4. Try first available model with valid API key
-	const availableModels = await modelRegistry.getAvailable();
+	const availableModels = await modelRegistry.hydrateAvailableModels();
 
 	if (availableModels.length > 0) {
 		// Try to find a default model from known providers
@@ -560,7 +560,7 @@ export async function restoreModelFromSession(
 	}
 
 	// Try to find any available model
-	const availableModels = await modelRegistry.getAvailable();
+	const availableModels = await modelRegistry.hydrateAvailableModels();
 
 	if (availableModels.length > 0) {
 		// Try to find a default model from known providers

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -187,6 +187,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const hasExistingSession = existingSession.messages.length > 0;
 	const hasThinkingEntry = sessionManager.getBranch().some((entry) => entry.type === "thinking_level_change");
 
+	await modelRegistry.hydrateAvailableModels();
+
 	let model = options.model;
 	let modelFallbackMessage: string | undefined;
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -706,6 +706,8 @@ export async function main(args: string[]) {
 		await showDeprecationWarnings(deprecationWarnings);
 	}
 
+	await modelRegistry.hydrateAvailableModels();
+
 	let scopedModels: ScopedModel[] = [];
 	const modelPatterns = parsed.models ?? settingsManager.getEnabledModels();
 	if (modelPatterns && modelPatterns.length > 0) {

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -148,7 +148,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 		// Load available models (built-in models still work even if models.json failed)
 		try {
-			const availableModels = await this.modelRegistry.getAvailable();
+			const availableModels = await this.modelRegistry.hydrateAvailableModels();
 			models = availableModels.map((model: Model<any>) => ({
 				provider: model.provider,
 				id: model.id,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3277,7 +3277,7 @@ export class InteractiveMode {
 
 		this.session.modelRegistry.refresh();
 		try {
-			return await this.session.modelRegistry.getAvailable();
+			return await this.session.modelRegistry.hydrateAvailableModels();
 		} catch {
 			return [];
 		}
@@ -3324,7 +3324,7 @@ export class InteractiveMode {
 	private async showModelsSelector(): Promise<void> {
 		// Get all available models
 		this.session.modelRegistry.refresh();
-		const allModels = this.session.modelRegistry.getAvailable();
+		const allModels = await this.session.modelRegistry.hydrateAvailableModels();
 
 		if (allModels.length === 0) {
 			this.showStatus("No models available");

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -388,7 +388,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			// =================================================================
 
 			case "set_model": {
-				const models = await session.modelRegistry.getAvailable();
+				const models = await session.modelRegistry.hydrateAvailableModels();
 				const model = models.find((m) => m.provider === command.provider && m.id === command.modelId);
 				if (!model) {
 					return error(id, "set_model", `Model not found: ${command.provider}/${command.modelId}`);
@@ -406,7 +406,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 			}
 
 			case "get_available_models": {
-				const models = await session.modelRegistry.getAvailable();
+				const models = await session.modelRegistry.hydrateAvailableModels();
 				return success(id, "get_available_models", { models });
 			}
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { Api, Context, Model, OpenAICompletionsCompat } from "@mariozechner/pi-ai";
 import { getApiProvider } from "@mariozechner/pi-ai";
 import { getOAuthProvider } from "@mariozechner/pi-ai/oauth";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import { clearApiKeyCache, ModelRegistry } from "../src/core/model-registry.js";
 
@@ -904,6 +904,60 @@ describe("ModelRegistry", () => {
 					}
 				}
 			});
+		});
+	});
+
+	describe("async OAuth model hydration", () => {
+		test("hydrates openai-codex models from the live account catalog", async () => {
+			const originalFetch = global.fetch;
+			const fetchMock = vi.fn(async () =>
+				new Response(
+					JSON.stringify({
+						models: [
+							{
+								slug: "gpt-5.5",
+								display_name: "GPT-5.5",
+								context_window: 272000,
+								input_modalities: ["text", "image"],
+								supported_reasoning_levels: [{ effort: "low" }, { effort: "xhigh" }],
+								visibility: "list",
+							},
+							{
+								slug: "gpt-5.4-mini",
+								display_name: "GPT-5.4 Mini",
+								context_window: 272000,
+								input_modalities: ["text", "image"],
+								supported_reasoning_levels: [{ effort: "low" }],
+								visibility: "list",
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
+			global.fetch = fetchMock as typeof fetch;
+
+			try {
+				authStorage.set("openai-codex", {
+					type: "oauth",
+					access: "access-token",
+					refresh: "refresh-token",
+					expires: Date.now() + 60_000,
+					accountId: "acct_123",
+				});
+
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				const models = await registry.hydrateAvailableModels();
+
+				expect(models.filter((model) => model.provider === "openai-codex").map((model) => model.id)).toEqual([
+					"gpt-5.5",
+					"gpt-5.4-mini",
+				]);
+				expect(registry.find("openai-codex", "gpt-5.5")?.name).toBe("GPT-5.5");
+				expect(fetchMock).toHaveBeenCalledTimes(1);
+			} finally {
+				global.fetch = originalFetch;
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- hydrate the OpenAI Codex model catalog from the live ChatGPT backend for the logged-in account
- thread async model hydration through model registry, startup, model listing, interactive selection, RPC, and session restore flows
- add tests for live catalog filtering/merging and registry hydration behavior

## Testing
- npm --workspace packages/ai test -- openai-codex-models.test.ts
- npm --workspace packages/coding-agent test -- model-registry.test.ts

## Notes
- adds `PI_OPENAI_CODEX_CLIENT_VERSION` override for backend-gated model version negotiation
- did not use full `packages/coding-agent` build as the merge base had unrelated workspace/type-resolution issues outside this patch
