### PR TITLE
fix(coding-agent): reclaim stale auth/settings locks in sync path

### DIFF
--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -78,7 +78,7 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 			try {
-				return lockfile.lockSync(path, { realpath: false });
+				return lockfile.lockSync(path, { realpath: false, stale: 2000 });
 			} catch (error) {
 				const code =
 					typeof error === "object" && error !== null && "code" in error

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -174,7 +174,7 @@ export class FileSettingsStorage implements SettingsStorage {
 
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 			try {
-				return lockfile.lockSync(path, { realpath: false });
+				return lockfile.lockSync(path, { realpath: false, stale: 2000 });
 			} catch (error) {
 				const code =
 					typeof error === "object" && error !== null && "code" in error

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerOAuthProvider } from "@earendil-works/pi-ai/oauth";
@@ -448,6 +448,41 @@ describe("AuthStorage", () => {
 			expect(JSON.stringify(authStorage.getAuthStatus("anthropic"))).not.toContain("secret-api-key");
 			expect(JSON.stringify(authStorage.getAuthStatus("openai"))).not.toContain("secret-access-token");
 			expect(JSON.stringify(authStorage.getAuthStatus("openai"))).not.toContain("secret-refresh-token");
+		});
+	});
+
+	describe("stale lock recovery", () => {
+		// Covers the shared acquireLockSyncWithRetry helper used by both
+		// FileAuthStorageBackend (here) and FileSettingsStorage. The sync lock path
+		// lowers `stale` to the proper-lockfile floor (2000ms) so a lock orphaned by a
+		// crashed/concurrent pi instance is reclaimed quickly rather than blocking for
+		// the 10s library default (the sync retry budget is only ~200ms, so it cannot
+		// wait out the stale window) and failing with "No API key found".
+		test("reclaims a sync lock orphaned ~3s ago (stale floor 2000ms)", () => {
+			writeAuthJson({
+				anthropic: { type: "api_key", key: "anthropic-key" },
+			});
+
+			authStorage = AuthStorage.create(authJsonPath);
+
+			// Fabricate a proper-lockfile lock directory and backdate its mtime to 3s
+			// ago: stale under the new 2000ms floor (reclaimed) but NOT under the old
+			// 10000ms default (would throw ELOCKED after the ~200ms retry budget).
+			const lockDir = `${authJsonPath}.lock`;
+			mkdirSync(lockDir);
+			const t = new Date(Date.now() - 3000);
+			utimesSync(lockDir, t, t);
+
+			// A subsequent write must succeed without any manual lock cleanup.
+			authStorage.set("openai", { type: "api_key", key: "openai-key" });
+
+			// No lock-acquisition error should have been recorded.
+			expect(authStorage.drainErrors()).toHaveLength(0);
+
+			// The write actually landed on disk (it would not if the lock blocked it).
+			const updated = JSON.parse(readFileSync(authJsonPath, "utf-8")) as Record<string, { key: string }>;
+			expect(updated.anthropic.key).toBe("anthropic-key");
+			expect(updated.openai.key).toBe("openai-key");
 		});
 	});
 


### PR DESCRIPTION
## What

The **sync** lock path around `auth.json` / `settings.json` used `proper-lockfile`'s default `stale` (10000ms) while its retry budget is only ~200ms (10 × 20ms). So a lock orphaned by a crashed or concurrent `pi` instance can't be waited out — it blocks credential reads with **`No API key found for ...`** for up to 10s before self-healing.

This lowers the sync path's `stale` to the library floor (`2000`) in both `acquireLockSyncWithRetry` helpers, so an orphaned lock is reclaimed in ~2s instead of ~10s.

```diff
- return lockfile.lockSync(path, { realpath: false });
+ return lockfile.lockSync(path, { realpath: false, stale: 2000 });
```

## Why this value (and why not the async path)

The sync critical section is a bounded, fast synchronous read-modify-write (read file → transform → write), so it never legitimately holds the lock for seconds — a 10s stale just delays recovery. The **async** `withLockAsync` keeps `stale: 30000` and is left untouched, because its critical section runs a user-supplied async fn that can take arbitrarily long; shortening it there would risk overtaking a legitimately-held lock.

## Test

Adds a regression test in `packages/coding-agent/test/auth-storage.test.ts`: it fabricates the proper-lockfile lock dir, backdates its mtime to 3s ago (between the new 2000ms floor and the old 10000ms default), and asserts the write succeeds. Verified it **fails on the pre-fix code** (lock not yet stale → `ELOCKED` after the retry budget) and **passes** after.

Closes #4919

🤖 Generated with [Claude Code](https://claude.com/claude-code)
