### PR TITLE
fix(ai): strip const from tool schemas in openai-completions provider

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -984,6 +984,22 @@ export function convertMessages(
 	return params;
 }
 
+/**
+ * Recursively removes `const` fields from JSON Schema objects.
+ * Some providers (e.g., Gemini) reject schemas containing the `const` keyword,
+ * which TypeBox generates for `Type.Literal` values.
+ */
+function stripJsonSchemaConst(schema: unknown): unknown {
+	if (!schema || typeof schema !== "object") return schema;
+	if (Array.isArray(schema)) return schema.map(stripJsonSchemaConst);
+	const result: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
+		if (k === "const") continue;
+		result[k] = stripJsonSchemaConst(v);
+	}
+	return result;
+}
+
 function convertTools(
 	tools: Tool[],
 	compat: ResolvedOpenAICompletionsCompat,
@@ -993,7 +1009,7 @@ function convertTools(
 		function: {
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters as any, // TypeBox already generates JSON Schema
+			parameters: stripJsonSchemaConst(tool.parameters) as Record<string, unknown>,
 			// Only include strict if provider supports it. Some reject unknown fields.
 			...(compat.supportsStrictMode !== false && { strict: false }),
 		},


### PR DESCRIPTION
## Problem

   Gemini API returns 400 errors when tool parameter schemas contain the `const` keyword. TypeBox (used internally by Pi) generates `const` for `Type.Literal` values,
 which is valid JSON Schema but rejected by Gemini.

   Error:
   `400 Invalid JSON payload received. Unknown name "const" at 'tools[0].function_declarations[...]'`

   ## Fix

   Added `stripJsonSchemaConst` utility to recursively remove `const` fields from tool parameter schemas in the `openai-completions` provider. Applied in `convertTools`.

   ## Testing

   - Pi v0.75.5
   - Model: Gemini via OpenAI-compatible endpoint
   - Before: 400 error on every request with tools enabled
   - After: All tools (read, bash, edit, write, etc.) function correctly without errors