### PR TITLE
Add tool permissions and yolo mode

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -213,6 +213,19 @@ export interface ModelCycleResult {
 	isScoped: boolean;
 }
 
+export type ToolPermissionDecision = "allow" | "allow_always" | "deny";
+
+export interface ToolPermissionRequest {
+	toolName: string;
+	toolCallId: string;
+	args: unknown;
+}
+
+export type ToolPermissionHandler = (
+	request: ToolPermissionRequest,
+	signal?: AbortSignal,
+) => Promise<ToolPermissionDecision>;
+
 /** Session statistics for /session command */
 export interface SessionStats {
 	sessionFile: string | undefined;
@@ -311,6 +324,10 @@ export class AgentSession {
 	private _toolDefinitions: Map<string, ToolDefinitionEntry> = new Map();
 	private _toolPromptSnippets: Map<string, string> = new Map();
 	private _toolPromptGuidelines: Map<string, string[]> = new Map();
+	private _toolPermissionHandler: ToolPermissionHandler | undefined;
+	private _toolPermissionQueue: Promise<void> = Promise.resolve();
+	private _sessionAllowedToolNames = new Set<string>();
+	private _yoloMode = false;
 
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
@@ -394,25 +411,39 @@ export class AgentSession {
 	 * happens here instead of in wrappers.
 	 */
 	private _installAgentToolHooks(): void {
-		this.agent.beforeToolCall = async ({ toolCall, args }) => {
+		this.agent.beforeToolCall = async ({ toolCall, args }, signal) => {
 			const runner = this._extensionRunner;
-			if (!runner.hasHandlers("tool_call")) {
-				return undefined;
+			if (runner.hasHandlers("tool_call")) {
+				try {
+					const result = await runner.emitToolCall({
+						type: "tool_call",
+						toolName: toolCall.name,
+						toolCallId: toolCall.id,
+						input: args as Record<string, unknown>,
+					});
+					if (result?.block) {
+						return result;
+					}
+				} catch (err) {
+					if (err instanceof Error) {
+						throw err;
+					}
+					throw new Error(`Extension failed, blocking execution: ${String(err)}`);
+				}
 			}
 
-			try {
-				return await runner.emitToolCall({
-					type: "tool_call",
+			const permission = await this._requestToolPermission(
+				{
 					toolName: toolCall.name,
 					toolCallId: toolCall.id,
-					input: args as Record<string, unknown>,
-				});
-			} catch (err) {
-				if (err instanceof Error) {
-					throw err;
-				}
-				throw new Error(`Extension failed, blocking execution: ${String(err)}`);
+					args,
+				},
+				signal,
+			);
+			if (permission === "deny") {
+				return { block: true, reason: "Tool execution denied by user" };
 			}
+			return undefined;
 		};
 
 		this.agent.afterToolCall = async ({ toolCall, args, result, isError }) => {
@@ -756,6 +787,62 @@ export class AgentSession {
 	 */
 	getActiveToolNames(): string[] {
 		return this.agent.state.tools.map((t) => t.name);
+	}
+
+	get yoloMode(): boolean {
+		return this._yoloMode;
+	}
+
+	setYoloMode(enabled: boolean): void {
+		this._yoloMode = enabled;
+	}
+
+	toggleYoloMode(): boolean {
+		this._yoloMode = !this._yoloMode;
+		return this._yoloMode;
+	}
+
+	setToolPermissionHandler(handler: ToolPermissionHandler | undefined): void {
+		this._toolPermissionHandler = handler;
+	}
+
+	private _requiresToolPermission(toolName: string): boolean {
+		return !["read", "grep", "find", "ls"].includes(toolName);
+	}
+
+	private async _requestToolPermission(
+		request: ToolPermissionRequest,
+		signal?: AbortSignal,
+	): Promise<ToolPermissionDecision> {
+		if (
+			this._yoloMode ||
+			this._sessionAllowedToolNames.has(request.toolName) ||
+			!this._requiresToolPermission(request.toolName) ||
+			!this._toolPermissionHandler
+		) {
+			return "allow";
+		}
+
+		let release: () => void;
+		const previous = this._toolPermissionQueue;
+		this._toolPermissionQueue = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previous;
+
+		try {
+			if (signal?.aborted) {
+				return "deny";
+			}
+			const decision = await this._toolPermissionHandler(request, signal);
+			if (decision === "allow_always") {
+				this._sessionAllowedToolNames.add(request.toolName);
+				return "allow";
+			}
+			return decision;
+		} finally {
+			release!();
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -36,5 +36,6 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "compact", description: "Manually compact the session context" },
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
+	{ name: "yolo", description: "Toggle tool permission prompts for this session" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -58,7 +58,13 @@ import {
 	getShareViewerUrl,
 	VERSION,
 } from "../../config.ts";
-import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
+import {
+	type AgentSession,
+	type AgentSessionEvent,
+	parseSkillBlock,
+	type ToolPermissionDecision,
+	type ToolPermissionRequest,
+} from "../../core/agent-session.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 import type {
 	AutocompleteProviderFactory,
@@ -1588,6 +1594,7 @@ export class InteractiveMode {
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
 		this.applyRuntimeSettings();
+		this.session.setToolPermissionHandler((request, signal) => this.requestToolPermission(request, signal));
 		await this.bindCurrentSessionExtensions();
 		this.subscribeToAgent();
 		await this.updateAvailableProviderCount();
@@ -2085,6 +2092,32 @@ export class InteractiveMode {
 		return result === "Yes";
 	}
 
+	private formatToolPermissionArgs(args: unknown): string {
+		try {
+			const text = JSON.stringify(args, null, 2);
+			if (!text) return "";
+			return text.length > 1200 ? `${text.slice(0, 1200)}\n...` : text;
+		} catch {
+			return String(args);
+		}
+	}
+
+	private async requestToolPermission(
+		request: ToolPermissionRequest,
+		signal?: AbortSignal,
+	): Promise<ToolPermissionDecision> {
+		const args = this.formatToolPermissionArgs(request.args);
+		const message = args ? `${request.toolName}\n\n${args}` : request.toolName;
+		const result = await this.showExtensionSelector(
+			`Allow tool execution?\n${message}`,
+			["Yes", "Yes, always for this tool", "No"],
+			{ signal },
+		);
+		if (result === "Yes") return "allow";
+		if (result === "Yes, always for this tool") return "allow_always";
+		return "deny";
+	}
+
 	private async promptForMissingSessionCwd(error: MissingSessionCwdError): Promise<string | undefined> {
 		const confirmed = await this.showExtensionConfirm(
 			"Session cwd not found",
@@ -2562,6 +2595,11 @@ export class InteractiveMode {
 			if (text === "/reload") {
 				this.editor.setText("");
 				await this.handleReloadCommand();
+				return;
+			}
+			if (text === "/yolo" || text.startsWith("/yolo ")) {
+				this.handleYoloCommand(text);
+				this.editor.setText("");
 				return;
 			}
 			if (text === "/debug") {
@@ -5406,6 +5444,25 @@ export class InteractiveMode {
 			new Text(`${theme.fg("accent", "✓ Debug log written")}\n${theme.fg("muted", debugLogPath)}`, 1, 1),
 		);
 		this.ui.requestRender();
+	}
+
+	private handleYoloCommand(text: string): void {
+		const arg = text.slice("/yolo".length).trim().toLowerCase();
+		let enabled: boolean;
+		if (arg === "on" || arg === "true" || arg === "1") {
+			enabled = true;
+			this.session.setYoloMode(true);
+		} else if (arg === "off" || arg === "false" || arg === "0") {
+			enabled = false;
+			this.session.setYoloMode(false);
+		} else if (arg.length === 0) {
+			enabled = this.session.toggleYoloMode();
+		} else {
+			this.showWarning("Usage: /yolo [on|off]");
+			return;
+		}
+
+		this.showStatus(enabled ? "YOLO mode enabled: tool permission prompts disabled" : "YOLO mode disabled");
 	}
 
 	private handleArminSaysHi(): void {

--- a/packages/coding-agent/test/interactive-mode-yolo-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-yolo-command.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type YoloCommandContext = {
+	session: {
+		setYoloMode: (enabled: boolean) => void;
+		toggleYoloMode: () => boolean;
+	};
+	showStatus: (message: string) => void;
+	showWarning: (message: string) => void;
+};
+
+type InteractiveModePrototype = {
+	handleYoloCommand(this: YoloCommandContext, text: string): void;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
+
+describe("InteractiveMode /yolo", () => {
+	it("toggles yolo mode when no argument is provided", () => {
+		const showStatus = vi.fn();
+		const context: YoloCommandContext = {
+			session: {
+				setYoloMode: vi.fn(),
+				toggleYoloMode: vi.fn(() => true),
+			},
+			showStatus,
+			showWarning: vi.fn(),
+		};
+
+		interactiveModePrototype.handleYoloCommand.call(context, "/yolo");
+
+		expect(context.session.toggleYoloMode).toHaveBeenCalledTimes(1);
+		expect(showStatus).toHaveBeenCalledWith("YOLO mode enabled: tool permission prompts disabled");
+	});
+
+	it("supports explicit off", () => {
+		const setYoloMode = vi.fn();
+		const showStatus = vi.fn();
+		const context: YoloCommandContext = {
+			session: {
+				setYoloMode,
+				toggleYoloMode: vi.fn(),
+			},
+			showStatus,
+			showWarning: vi.fn(),
+		};
+
+		interactiveModePrototype.handleYoloCommand.call(context, "/yolo off");
+
+		expect(setYoloMode).toHaveBeenCalledWith(false);
+		expect(context.session.toggleYoloMode).not.toHaveBeenCalled();
+		expect(showStatus).toHaveBeenCalledWith("YOLO mode disabled");
+	});
+
+	it("warns on invalid arguments", () => {
+		const showWarning = vi.fn();
+		const context: YoloCommandContext = {
+			session: {
+				setYoloMode: vi.fn(),
+				toggleYoloMode: vi.fn(),
+			},
+			showStatus: vi.fn(),
+			showWarning,
+		};
+
+		interactiveModePrototype.handleYoloCommand.call(context, "/yolo maybe");
+
+		expect(showWarning).toHaveBeenCalledWith("Usage: /yolo [on|off]");
+		expect(context.session.setYoloMode).not.toHaveBeenCalled();
+		expect(context.session.toggleYoloMode).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/tool-permissions.test.ts
+++ b/packages/coding-agent/test/tool-permissions.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.ts";
+
+type PermissionContext = {
+	_yoloMode: boolean;
+	_sessionAllowedToolNames: Set<string>;
+	_toolPermissionHandler?: (...args: any[]) => Promise<any>;
+	_toolPermissionQueue: Promise<void>;
+	_requiresToolPermission(toolName: string): boolean;
+};
+
+const proto = AgentSession.prototype as any;
+
+function makeContext(handler?: PermissionContext["_toolPermissionHandler"]): PermissionContext {
+	return {
+		_yoloMode: false,
+		_sessionAllowedToolNames: new Set(),
+		_toolPermissionHandler: handler,
+		_toolPermissionQueue: Promise.resolve(),
+		_requiresToolPermission: proto._requiresToolPermission,
+	};
+}
+
+describe("AgentSession tool permissions", () => {
+	it("allows read-only tools without prompting", async () => {
+		const handler = vi.fn(async () => "deny");
+		const ctx = makeContext(handler);
+
+		const decision = await proto._requestToolPermission.call(ctx, {
+			toolName: "read",
+			toolCallId: "tool-1",
+			args: { path: "README.md" },
+		});
+
+		expect(decision).toBe("allow");
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it("uses the permission handler for side-effect tools", async () => {
+		const handler = vi.fn(async () => "deny");
+		const ctx = makeContext(handler);
+
+		const decision = await proto._requestToolPermission.call(ctx, {
+			toolName: "bash",
+			toolCallId: "tool-1",
+			args: { command: "npm test" },
+		});
+
+		expect(decision).toBe("deny");
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it("remembers allow_always decisions by tool name", async () => {
+		const handler = vi.fn(async () => "allow_always");
+		const ctx = makeContext(handler);
+
+		await proto._requestToolPermission.call(ctx, {
+			toolName: "edit",
+			toolCallId: "tool-1",
+			args: {},
+		});
+		const secondDecision = await proto._requestToolPermission.call(ctx, {
+			toolName: "edit",
+			toolCallId: "tool-2",
+			args: {},
+		});
+
+		expect(secondDecision).toBe("allow");
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it("bypasses prompts in yolo mode", async () => {
+		const handler = vi.fn(async () => "deny");
+		const ctx = makeContext(handler);
+		ctx._yoloMode = true;
+
+		const decision = await proto._requestToolPermission.call(ctx, {
+			toolName: "write",
+			toolCallId: "tool-1",
+			args: { path: "out.txt" },
+		});
+
+		expect(decision).toBe("allow");
+		expect(handler).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- add a session-level tool permission gate before side-effect tool execution
- prompt for bash/edit/write and unknown tools, while allowing read-only tools without prompting
- add /yolo to toggle permission prompts for the active session
- add focused tests for permission decisions and /yolo command handling

## Verification
- npm run build -w @earendil-works/pi-coding-agent
- npx biome check packages/coding-agent/src/core/agent-session.ts packages/coding-agent/src/core/slash-commands.ts packages/coding-agent/src/modes/interactive/interactive-mode.ts packages/coding-agent/test/tool-permissions.test.ts packages/coding-agent/test/interactive-mode-yolo-command.test.ts
- npx -p node@22 node ./node_modules/vitest/vitest.mjs --run packages/coding-agent/test/tool-permissions.test.ts packages/coding-agent/test/interactive-mode-yolo-command.test.ts