### PR TITLE
Guard pre-prompt compaction continue() on assistant tails

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -919,11 +919,32 @@ export class AgentSession {
 		try {
 			await this.agent.prompt(messages);
 			while (await this._handlePostAgentRun()) {
-				await this.agent.continue();
+				if (!(await this._continueAgentIfPossible())) {
+					break;
+				}
 			}
 		} finally {
 			this._flushPendingBashMessages();
 		}
+	}
+
+	private async _continueAgentIfPossible(): Promise<boolean> {
+		const messages = this.agent.state.messages;
+		const lastMessage = messages[messages.length - 1];
+		if (!lastMessage) {
+			return false;
+		}
+
+		// Auto-compaction can rebuild session state so the transcript still ends
+		// with an assistant message even though the caller asked to continue.
+		// Guard here so pre-prompt compaction checks do not crash on
+		// "Cannot continue from message role: assistant".
+		if (lastMessage.role === "assistant" && !this.agent.hasQueuedMessages()) {
+			return false;
+		}
+
+		await this.agent.continue();
+		return true;
 	}
 
 	private async _handlePostAgentRun(): Promise<boolean> {
@@ -1042,9 +1063,10 @@ export class AgentSession {
 			const lastAssistant = this._findLastAssistantMessage();
 			if (lastAssistant && (await this._checkCompaction(lastAssistant, false))) {
 				try {
-					await this.agent.continue();
-					while (await this._handlePostAgentRun()) {
-						await this.agent.continue();
+					while (await this._continueAgentIfPossible()) {
+						if (!(await this._handlePostAgentRun())) {
+							break;
+						}
 					}
 				} finally {
 					this._flushPendingBashMessages();

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -222,6 +222,50 @@ describe("AgentSession compaction characterization", () => {
 		await expect(sessionInternals._runAutoCompaction("threshold", false)).resolves.toBe(true);
 	});
 
+	it("pre-prompt threshold compaction does not call continue when the rebuilt transcript still ends with assistant", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { reserveTokens: 127_900, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "auto compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const staleTimestamp = Date.now() - 10_000;
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "before compaction" }],
+			timestamp: staleTimestamp - 1000,
+		});
+		harness.sessionManager.appendMessage(
+			createAssistant(harness, {
+				stopReason: "stop",
+				totalTokens: 500,
+				timestamp: staleTimestamp,
+			}),
+		);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		const continueSpy = vi.spyOn(harness.session.agent, "continue");
+		harness.setResponses([fauxAssistantMessage("after compaction")]);
+
+		await expect(harness.session.prompt("next turn")).resolves.toBeUndefined();
+
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(1);
+		expect(harness.session.messages.at(-1)).toMatchObject({ role: "assistant" });
+	});
+
 	it("does not retry overflow recovery more than once", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);


### PR DESCRIPTION
## Summary
- guard AgentSession continuation after compaction so we do not call `agent.continue()` when the rebuilt transcript still ends with an assistant message and nothing is queued
- route the existing continuation loops through a shared helper so the guard applies to both normal post-run continuation and the pre-prompt compaction path
- add a regression test covering pre-prompt threshold compaction rebuilding a transcript that still ends with `assistant`

## Problem
`AgentSession.prompt()` performs a pre-prompt compaction check and, when compaction runs, unconditionally calls `agent.continue()`. But `agent.continue()` throws if the last message is still `assistant` and there are no queued steering/follow-up messages.

That can happen after auto-compaction rebuilds session state from the compacted transcript: the rebuilt state may still legitimately end with an assistant message, so the unconditional `continue()` crashes with:

`Cannot continue from message role: assistant`

## Fix
Introduce `_continueAgentIfPossible()` and use it anywhere `AgentSession` wants to continue after post-run handling or compaction. The helper bails out when:
- there is no last message, or
- the rebuilt transcript still ends with `assistant` and `agent.hasQueuedMessages()` is false

Otherwise it delegates to `agent.continue()`.

## Testing
- `npm --prefix packages/coding-agent test -- test/agent-session-auto-compaction-queue.test.ts test/suite/agent-session-compaction.test.ts`
