### PR TITLE
fix(cli): handle main() promise to prevent hanging process

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -17,4 +17,4 @@ process.emitWarning = (() => {}) as typeof process.emitWarning;
 // Runtime settings are applied once SettingsManager has loaded global/project settings.
 configureHttpDispatcher();
 
-main(process.argv.slice(2));
+main(process.argv.slice(2)).finally(() => process.exit());


### PR DESCRIPTION
## Problem

`main(process.argv.slice(2))` is an async call without await. The returned Promise is never awaited, causing the process to hang indefinitely after main() completes.

## Root Cause

In `packages/coding-agent/src/cli.ts`, the async `main()` function is called without handling the returned Promise:

```ts
main(process.argv.slice(2));
```

When `main()` is async, this returns a Promise that is discarded. Node.js detects pending async operations and keeps the process alive.

## Fix

Use `.finally(() => process.exit())` to ensure the process exits once main() completes, regardless of success or failure:

```ts
main(process.argv.slice(2)).finally(() => process.exit());
```