### PR TITLE
fix(tui): clamp over-width rendered lines

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -9,7 +9,14 @@ import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.ts";
 import type { Terminal } from "./terminal.ts";
 import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.ts";
-import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.ts";
+import {
+	extractSegments,
+	normalizeTerminalOutput,
+	sliceByColumn,
+	sliceWithWidth,
+	truncateToWidth,
+	visibleWidth,
+} from "./utils.ts";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
@@ -978,6 +985,9 @@ export class TUI extends Container {
 		const cursorPos = this.extractCursorPosition(newLines, height);
 
 		newLines = this.applyLineResets(newLines);
+		newLines = newLines.map((line) =>
+			isImageLine(line) || visibleWidth(line) <= width ? line : truncateToWidth(line, width, ""),
+		);
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
@@ -1175,37 +1185,7 @@ export class TUI extends Container {
 		for (let i = firstChanged; i <= renderEnd; i++) {
 			if (i > firstChanged) buffer += "\r\n";
 			buffer += "\x1b[2K"; // Clear current line
-			const line = newLines[i];
-			const isImage = isImageLine(line);
-			if (!isImage && visibleWidth(line) > width) {
-				// Log all lines to crash file for debugging
-				const crashLogPath = path.join(os.homedir(), ".pi", "agent", "pi-crash.log");
-				const crashData = [
-					`Crash at ${new Date().toISOString()}`,
-					`Terminal width: ${width}`,
-					`Line ${i} visible width: ${visibleWidth(line)}`,
-					"",
-					"=== All rendered lines ===",
-					...newLines.map((l, idx) => `[${idx}] (w=${visibleWidth(l)}) ${l}`),
-					"",
-				].join("\n");
-				fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-				fs.writeFileSync(crashLogPath, crashData);
-
-				// Clean up terminal state before throwing
-				this.stop();
-
-				const errorMsg = [
-					`Rendered line ${i} exceeds terminal width (${visibleWidth(line)} > ${width}).`,
-					"",
-					"This is likely caused by a custom TUI component not truncating its output.",
-					"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
-					"",
-					`Debug log written to: ${crashLogPath}`,
-				].join("\n");
-				throw new Error(errorMsg);
-			}
-			buffer += line;
+			buffer += newLines[i];
 		}
 
 		// Track where cursor ended up after rendering

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -589,3 +589,45 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI over-width line handling", () => {
+	it("clamps over-width text lines during first/full render without crashing", async () => {
+		const terminal = new VirtualTerminal(10, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["1234567890EXTRA", "short"];
+		tui.start();
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		assert.ok(!viewport.join("").includes("EXTRA"), "Over-width content should be truncated");
+		assert.ok(viewport[0]?.startsWith("1234567890"), "First 10 chars should be preserved");
+		assert.ok(viewport[1]?.includes("short"), "Normal line should be unchanged");
+
+		tui.stop();
+	});
+
+	it("clamps over-width text lines during differential render without crashing", async () => {
+		const terminal = new VirtualTerminal(10, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = ["short", "short"];
+		tui.start();
+		await terminal.waitForRender();
+
+		component.lines = ["short", "1234567890EXTRA"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const viewport = terminal.getViewport();
+		assert.ok(!viewport.join("").includes("EXTRA"), "Over-width content should be truncated in differential render");
+		assert.ok(viewport[0]?.includes("short"), "Unchanged line should be preserved");
+		assert.ok(viewport[1]?.startsWith("1234567890"), "First 10 chars of changed line should be preserved");
+
+		tui.stop();
+	});
+});


### PR DESCRIPTION
 ```markdown                                                                                                           
   ## Summary                                                                                                          
                                                                                                                       
   - Clamp non-image TUI render lines to the current terminal width before rendering.                                  
   - Prevent Pi from exiting with an uncaught exception when tool output contains a single over-width line.            
   - Add regression tests for first/full render and differential render paths.                                         
                                                                                                                       
   ## Repro                                                                                                            
                                                                                                                       
   In Pi 0.75.5, a `ctx_execute_file` result containing a long Markdown table row caused:                              
                                                                                                                       
   ```text                                                                                                             
   Rendered line 1763 exceeds terminal width (147 > 119)                                                               
 ```                                                                                                                   
                                                                                                                       
 The process exited from @earendil-works/pi-tui instead of safely rendering the line.                                  
                                                                                                                       
 Tests                                                                                                                 
                                                                                                                       
 - npm --workspace @earendil-works/pi-tui test                                                                         
 - npm --workspace @earendil-works/pi-tui run build                                                                    
 - git diff --check                                                                                                    
 - pre-commit npm run check                                                                                            
 ```                                                                                                                   
