### PR TITLE
refactor(agent): remove duplicate stream finalization in agent-loop

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -338,24 +338,12 @@ async function streamAssistantResponse(
 					});
 				}
 				break;
-
-			case "done":
-			case "error": {
-				const finalMessage = await response.result();
-				if (addedPartial) {
-					context.messages[context.messages.length - 1] = finalMessage;
-				} else {
-					context.messages.push(finalMessage);
-				}
-				if (!addedPartial) {
-					await emit({ type: "message_start", message: { ...finalMessage } });
-				}
-				await emit({ type: "message_end", message: finalMessage });
-				return finalMessage;
-			}
 		}
 	}
 
+	// Stream exhausted — finalize with the completed message.
+	// Covers both explicit done/error termination (stream closes after the event)
+	// and edge cases where the iterator ends without emitting a terminal event.
 	const finalMessage = await response.result();
 	if (addedPartial) {
 		context.messages[context.messages.length - 1] = finalMessage;


### PR DESCRIPTION
## Summary
- Remove the `done`/`error` case inside the `for await` loop in `streamAssistantResponse()`, which duplicated the post-loop finalization logic
- The stream naturally exhausts after `done`/`error` events, so a single finalization point after the loop is sufficient and covers all termination paths
- Added comments clarifying the single-exit-point design

## Details
The previous code had two identical finalization blocks:
1. Inside the switch `case "done"/"error"` — early return
2. After the for-await loop — fallback for streams that end without a terminal event

Since `response.result()` resolves the final message regardless of how the stream terminates, the post-loop block alone handles both cases correctly. Removing the in-loop case eliminates duplication without changing behavior.

## Test plan
- [ ] Existing tests pass (`packages/agent/test/`)
- [ ] Manual verification: stream responses with `done`, `error`, and iterator-exhaustion all finalize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)