### PR TITLE
feat (coding-agent): Expose `getToolDefinition` to command context

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -988,6 +988,19 @@ pi.registerCommand("my-cmd", {
 });
 ```
 
+### ctx.getToolDefinition(name)
+
+Return the full configured `ToolDefinition` for a tool name, including execute and render hooks. Treat the returned definition as read-only; use `pi.registerTool()` to override tools.
+
+```typescript
+pi.registerCommand("inspect-read", {
+  handler: async (_args, ctx) => {
+    const readTool = ctx.getToolDefinition("read");
+    ctx.ui.notify(readTool?.description ?? "read tool not available");
+  },
+});
+```
+
 ### ctx.newSession(options?)
 
 Create a new session:

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2197,6 +2197,7 @@ export class AgentSession {
 				},
 				getActiveTools: () => this.getActiveToolNames(),
 				getAllTools: () => this.getAllTools(),
+				getToolDefinition: (name) => this.getToolDefinition(name),
 				setActiveTools: (toolNames) => this.setActiveToolsByName(toolNames),
 				refreshTools: () => this._refreshToolRegistry(),
 				getCommands,

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -78,6 +78,7 @@ export type {
 	GetAllToolsHandler,
 	GetCommandsHandler,
 	GetThinkingLevelHandler,
+	GetToolDefinitionHandler,
 	GrepToolCallEvent,
 	GrepToolResultEvent,
 	// Events - Input

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -141,6 +141,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		setLabel: notInitialized,
 		getActiveTools: notInitialized,
 		getAllTools: notInitialized,
+		getToolDefinition: notInitialized,
 		setActiveTools: notInitialized,
 		// registerTool() is valid during extension load; refresh is only needed post-bind.
 		refreshTools: () => {},

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -280,6 +280,7 @@ export class ExtensionRunner {
 		this.runtime.setLabel = actions.setLabel;
 		this.runtime.getActiveTools = actions.getActiveTools;
 		this.runtime.getAllTools = actions.getAllTools;
+		this.runtime.getToolDefinition = actions.getToolDefinition;
 		this.runtime.setActiveTools = actions.setActiveTools;
 		this.runtime.refreshTools = actions.refreshTools;
 		this.runtime.getCommands = actions.getCommands;
@@ -644,6 +645,10 @@ export class ExtensionRunner {
 		context.waitForIdle = () => {
 			this.assertActive();
 			return this.waitForIdleFn();
+		};
+		context.getToolDefinition = (name) => {
+			this.assertActive();
+			return this.runtime.getToolDefinition(name);
 		};
 		context.newSession = (options) => {
 			this.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -334,6 +334,9 @@ export interface ExtensionCommandContext extends ExtensionContext {
 	/** Wait for the agent to finish streaming */
 	waitForIdle(): Promise<void>;
 
+	/** Get the full configured tool definition by name. The returned definition is read-only. */
+	getToolDefinition(name: string): Readonly<ToolDefinition> | undefined;
+
 	/** Start a new session, optionally with initialization. */
 	newSession(options?: {
 		parentSession?: string;
@@ -1429,6 +1432,8 @@ export type ToolInfo = Pick<ToolDefinition, "name" | "description" | "parameters
 
 export type GetAllToolsHandler = () => ToolInfo[];
 
+export type GetToolDefinitionHandler = (name: string) => Readonly<ToolDefinition> | undefined;
+
 export type GetCommandsHandler = () => SlashCommandInfo[];
 
 export type SetActiveToolsHandler = (toolNames: string[]) => void;
@@ -1478,6 +1483,7 @@ export interface ExtensionActions {
 	setLabel: SetLabelHandler;
 	getActiveTools: GetActiveToolsHandler;
 	getAllTools: GetAllToolsHandler;
+	getToolDefinition: GetToolDefinitionHandler;
 	setActiveTools: SetActiveToolsHandler;
 	refreshTools: RefreshToolsHandler;
 	getCommands: GetCommandsHandler;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -349,6 +349,7 @@ export {
 // Clipboard utilities
 export { copyToClipboard } from "./utils/clipboard.ts";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.ts";
+export { convertToPng } from "./utils/image-convert.ts";
 export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.ts";
 // Shell utilities
 export { getShellConfig } from "./utils/shell.ts";

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -60,6 +60,7 @@ describe("ExtensionRunner", () => {
 		setLabel: () => {},
 		getActiveTools: () => [],
 		getAllTools: () => [],
+		getToolDefinition: () => undefined,
 		setActiveTools: () => {},
 		refreshTools: () => {},
 		getCommands: () => [],

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -247,6 +247,34 @@ describe("AgentSession prompt characterization", () => {
 		expect(harness.getPendingResponseCount()).toBe(1);
 	});
 
+	it("exposes full tool definitions to extension commands", async () => {
+		let ctxReadLabel: string | undefined;
+		let ctxReadHasExecute = false;
+		let missingWasUndefined = false;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("inspect-tools", {
+						description: "Inspect tools",
+						handler: async (_args, ctx) => {
+							const ctxRead = ctx.getToolDefinition("read");
+							ctxReadLabel = ctxRead?.label;
+							ctxReadHasExecute = typeof ctxRead?.execute === "function";
+							missingWasUndefined = ctx.getToolDefinition("missing") === undefined;
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.prompt("/inspect-tools");
+
+		expect(ctxReadLabel).toBe("read");
+		expect(ctxReadHasExecute).toBe(true);
+		expect(missingWasUndefined).toBe(true);
+	});
+
 	it("sendUserMessage while idle triggers a turn", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);


### PR DESCRIPTION
I've seen more than enough tools and mcp servers where the author clearly never reviewed the actual output of those tools.

I made a `/tool` command extension that lets you call the agent tools manually. It does not add the calls to the context, just adds a nice ui to fill in the input schema and displays the tool output mostly raw - no custom rendering.

https://github.com/user-attachments/assets/6faed6c3-2c09-4233-9ef5-462dc273b9c1

Right now we actually don't have a way to grab the tool definitions from a command context. We have `getAllTools` that resurns `ToolInfo[]`:
```ts
export type ToolInfo = Pick<ToolDefinition, "name" | "description" | "parameters"> & {
	sourceInfo: SourceInfo;
};
```

which picks out just a few items from the `ToolDefinition`.

This PR just adds a `getToolDefinition` to the command context, which calls the AgentSession `getToolDefinition` and wraps the output in ReadOnly as a hint. Not married to the implementation. Maybe we could just expose the AgentSession to the commands and tools?


P.S.
Also a somewhat unrelated
```ts
export { convertToPng } from "./utils/image-convert.ts";
```