### PR TITLE
[Withdrawn] Fix compaction abort controller race

### DIFF
--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -287,7 +287,10 @@ pi.on("session_before_compact", async (event, ctx) => {
   // preparation.settings - compaction settings
 
   // branchEntries - all entries on current branch (for custom state)
-  // signal - AbortSignal (pass to LLM calls)
+  // signal - AbortSignal for this compaction run (pass to LLM calls)
+
+  // Honor cancellation before starting long-running work:
+  if (signal.aborted) return { cancel: true };
 
   // Cancel:
   return { cancel: true };

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -413,6 +413,10 @@ Fired on compaction. See [compaction.md](compaction.md) for details.
 pi.on("session_before_compact", async (event, ctx) => {
   const { preparation, branchEntries, customInstructions, signal } = event;
 
+  // Honor compaction cancellation. Pass `signal` to fetch/model calls and
+  // return `{ cancel: true }` if the signal is already aborted or an abort is caught.
+  if (signal.aborted) return { cancel: true };
+
   // Cancel:
   return { cancel: true };
 

--- a/packages/coding-agent/examples/extensions/custom-compaction.ts
+++ b/packages/coding-agent/examples/extensions/custom-compaction.ts
@@ -118,6 +118,9 @@ ${conversationText}
 				},
 			};
 		} catch (error) {
+			if (signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+				return { cancel: true };
+			}
 			const message = error instanceof Error ? error.message : String(error);
 			ctx.ui.notify(`Compaction failed: ${message}`, "error");
 			// Fall back to default compaction on error

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1609,9 +1609,17 @@ export class AgentSession {
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
+		if (this._compactionAbortController) {
+			throw new Error("Compaction already in progress");
+		}
+		// User-initiated compaction wins over an in-flight auto-compaction. The
+		// auto-compaction flow checks its own local signal before mutating session state.
+		this._autoCompactionAbortController?.abort();
+
 		this._disconnectFromAgent();
 		await this.abort();
-		this._compactionAbortController = new AbortController();
+		const abortController = new AbortController();
+		this._compactionAbortController = abortController;
 		this._emit({ type: "compaction_start", reason: "manual" });
 
 		try {
@@ -1643,7 +1651,7 @@ export class AgentSession {
 					preparation,
 					branchEntries: pathEntries,
 					customInstructions,
-					signal: this._compactionAbortController.signal,
+					signal: abortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (result?.cancel) {
@@ -1675,7 +1683,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					customInstructions,
-					this._compactionAbortController.signal,
+					abortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFn,
 				);
@@ -1685,7 +1693,7 @@ export class AgentSession {
 				details = result.details;
 			}
 
-			if (this._compactionAbortController.signal.aborted) {
+			if (abortController.signal.aborted) {
 				throw new Error("Compaction cancelled");
 			}
 
@@ -1734,7 +1742,9 @@ export class AgentSession {
 			});
 			throw error;
 		} finally {
-			this._compactionAbortController = undefined;
+			if (this._compactionAbortController === abortController) {
+				this._compactionAbortController = undefined;
+			}
 			this._reconnectToAgent();
 		}
 	}
@@ -1849,10 +1859,15 @@ export class AgentSession {
 	 * Internal: Run auto-compaction with events.
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
+		if (this._compactionAbortController || this._autoCompactionAbortController) {
+			return false;
+		}
+
 		const settings = this.settingsManager.getCompactionSettings();
 
 		this._emit({ type: "compaction_start", reason });
-		this._autoCompactionAbortController = new AbortController();
+		const abortController = new AbortController();
+		this._autoCompactionAbortController = abortController;
 
 		try {
 			if (!this.model) {
@@ -1909,7 +1924,7 @@ export class AgentSession {
 					preparation,
 					branchEntries: pathEntries,
 					customInstructions: undefined,
-					signal: this._autoCompactionAbortController.signal,
+					signal: abortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (extensionResult?.cancel) {
@@ -1948,7 +1963,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					undefined,
-					this._autoCompactionAbortController.signal,
+					abortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFn,
 				);
@@ -1958,7 +1973,7 @@ export class AgentSession {
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (abortController.signal.aborted) {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -2009,20 +2024,24 @@ export class AgentSession {
 			return this.agent.hasQueuedMessages();
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
+			const aborted = abortController.signal.aborted || (error instanceof Error && error.name === "AbortError");
 			this._emit({
 				type: "compaction_end",
 				reason,
 				result: undefined,
-				aborted: false,
+				aborted,
 				willRetry: false,
-				errorMessage:
-					reason === "overflow"
+				errorMessage: aborted
+					? undefined
+					: reason === "overflow"
 						? `Context overflow recovery failed: ${errorMessage}`
 						: `Auto-compaction failed: ${errorMessage}`,
 			});
 			return false;
 		} finally {
-			this._autoCompactionAbortController = undefined;
+			if (this._autoCompactionAbortController === abortController) {
+				this._autoCompactionAbortController = undefined;
+			}
 		}
 	}
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -234,6 +234,94 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(runAutoCompactionSpy).not.toHaveBeenCalled();
 	});
 
+	it("should keep auto-compaction signal stable if the controller field changes while awaiting auth", async () => {
+		let resolveAuth!: (value: { ok: true; apiKey: string }) => void;
+		vi.spyOn(session.modelRegistry, "getApiKeyAndHeaders").mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveAuth = resolve as (value: { ok: true; apiKey: string }) => void;
+				}),
+		);
+
+		const events: Array<{ type: string; errorMessage?: string }> = [];
+		session.subscribe((event) => {
+			if (event.type === "compaction_end") events.push(event);
+		});
+
+		const runAutoCompaction = (
+			session as unknown as {
+				_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+			}
+		)._runAutoCompaction.bind(session);
+
+		const promise = runAutoCompaction("threshold", false);
+		expect(
+			(session as unknown as { _autoCompactionAbortController?: AbortController })._autoCompactionAbortController,
+		).toBeDefined();
+
+		// Simulate a stale overlapping cleanup clearing the shared field while this
+		// compaction is awaiting auth. The compaction flow must keep using its local
+		// controller reference instead of reading `.signal` from the mutable field.
+		(session as unknown as { _autoCompactionAbortController?: AbortController })._autoCompactionAbortController =
+			undefined;
+
+		resolveAuth({ ok: true, apiKey: "test-key" });
+		await promise;
+
+		expect(events).toHaveLength(1);
+		expect(events[0].errorMessage).toBeUndefined();
+	});
+
+	it("should not clear a newer auto-compaction controller from stale cleanup", async () => {
+		let resolveAuth!: (value: { ok: true; apiKey: string }) => void;
+		vi.spyOn(session.modelRegistry, "getApiKeyAndHeaders").mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					resolveAuth = resolve as (value: { ok: true; apiKey: string }) => void;
+				}),
+		);
+
+		const runAutoCompaction = (
+			session as unknown as {
+				_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+			}
+		)._runAutoCompaction.bind(session);
+
+		const promise = runAutoCompaction("threshold", false);
+		const replacement = new AbortController();
+		(session as unknown as { _autoCompactionAbortController?: AbortController })._autoCompactionAbortController =
+			replacement;
+
+		resolveAuth({ ok: true, apiKey: "test-key" });
+		await promise;
+
+		expect(
+			(session as unknown as { _autoCompactionAbortController?: AbortController })._autoCompactionAbortController,
+		).toBe(replacement);
+		(session as unknown as { _autoCompactionAbortController?: AbortController })._autoCompactionAbortController =
+			undefined;
+	});
+
+	it("should skip a second auto-compaction while one is already in progress", async () => {
+		(session as unknown as { _autoCompactionAbortController?: AbortController })._autoCompactionAbortController =
+			new AbortController();
+		const events: string[] = [];
+		session.subscribe((event) => {
+			if (event.type === "compaction_start" || event.type === "compaction_end") events.push(event.type);
+		});
+
+		const runAutoCompaction = (
+			session as unknown as {
+				_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+			}
+		)._runAutoCompaction.bind(session);
+
+		await expect(runAutoCompaction("threshold", false)).resolves.toBe(false);
+		expect(events).toEqual([]);
+		(session as unknown as { _autoCompactionAbortController?: AbortController })._autoCompactionAbortController =
+			undefined;
+	});
+
 	it("should trigger threshold compaction for error messages using last successful usage", async () => {
 		const model = session.model!;
 


### PR DESCRIPTION
## Summary

Fixes a compaction lifecycle race where manual/auto compaction reads `.signal` from mutable session fields after async boundaries. If another compaction/cleanup clears or replaces the field while an in-flight compaction is awaiting auth, extension hooks, or model compaction, Pi can crash with:

```txt
Auto-compaction failed: Cannot read properties of undefined (reading 'signal')
```

## Changes

- Keep a local `AbortController` reference inside both manual `compact()` and `_runAutoCompaction()`.
- Pass the local `abortController.signal` to extension hooks and native compaction instead of re-reading the mutable session field.
- Only clear `_compactionAbortController` / `_autoCompactionAbortController` in `finally` if the field still points at the same controller.
- Skip duplicate auto-compaction while any compaction is already in progress.
- Let user-initiated manual compaction abort an in-flight auto-compaction before starting.
- Treat auto-compaction `AbortError` / aborted signal as an aborted compaction event instead of an error.
- Document that `session_before_compact` handlers should pass `event.signal` to long-running work and return `{ cancel: true }` on abort.
- Update the custom compaction example to return `{ cancel: true }` when its model call is aborted.

## Why

`_compactionAbortController` and `_autoCompactionAbortController` are session-level fields so `abortCompaction()` and UI state can see the active compaction. They should not be used as the authoritative controller inside an async compaction flow after `await` points, because a stale cleanup or overlapping compaction can mutate those fields.

This keeps the existing architecture while making controller ownership race-safe.

## Validation

- `npm run build`
- `npm --prefix packages/coding-agent test -- agent-session-auto-compaction-queue.test.ts`
- `git diff --check`
