### PR TITLE
Polish terminal markdown rendering

### DIFF
--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -1160,6 +1160,54 @@ export function getLanguageFromPath(filePath: string): string | undefined {
 	return extToLang[ext];
 }
 
+function highlightFallbackMarkdownCode(code: string): string[] {
+	const highlightStrings = (text: string): string => {
+		let result = "";
+		let offset = 0;
+		const stringRegex = /(["'`])(?:\\.|(?!\1).)*\1/g;
+		for (const match of text.matchAll(stringRegex)) {
+			const index = match.index ?? 0;
+			if (index > offset) {
+				result += theme.fg("mdCodeBlock", text.slice(offset, index));
+			}
+			result += theme.fg("syntaxString", match[0]);
+			offset = index + match[0].length;
+		}
+		if (offset < text.length) {
+			result += theme.fg("mdCodeBlock", text.slice(offset));
+		}
+		return result;
+	};
+
+	return code.split("\n").map((line) => {
+		const leadingWhitespaceLength = line.length - line.trimStart().length;
+		const leadingWhitespace = line.slice(0, leadingWhitespaceLength);
+		const content = line.slice(leadingWhitespaceLength);
+
+		if (content.startsWith("#")) {
+			return theme.fg("mdCodeBlock", leadingWhitespace) + theme.fg("syntaxComment", content);
+		}
+
+		const commandMatch = /^(\$ |>\s*)?([A-Za-z0-9_./-]+)(.*)$/.exec(content);
+		if (!commandMatch) {
+			return theme.fg("mdCodeBlock", leadingWhitespace) + highlightStrings(content);
+		}
+
+		const prompt = commandMatch[1] ?? "";
+		const command = commandMatch[2] ?? "";
+		const rest = commandMatch[3] ?? "";
+		const looksLikeCommand = rest.trim().length > 0 || command.startsWith("./");
+		if (!looksLikeCommand || command.startsWith("/")) {
+			return theme.fg("mdCodeBlock", leadingWhitespace) + highlightStrings(content);
+		}
+
+		return (
+			theme.fg("mdCodeBlock", leadingWhitespace + prompt) +
+			theme.fg("syntaxFunction", command) +
+			highlightStrings(rest)
+		);
+	});
+}
 export function getMarkdownTheme(): MarkdownTheme {
 	return {
 		heading: (text: string) => theme.fg("mdHeading", text),
@@ -1168,6 +1216,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 		code: (text: string) => theme.fg("mdCode", text),
 		codeBlock: (text: string) => theme.fg("mdCodeBlock", text),
 		codeBlockBorder: (text: string) => theme.fg("mdCodeBlockBorder", text),
+		codeBlockLineNumber: (text: string) => theme.fg("dim", text),
 		quote: (text: string) => theme.fg("mdQuote", text),
 		quoteBorder: (text: string) => theme.fg("mdQuoteBorder", text),
 		hr: (text: string) => theme.fg("mdHr", text),
@@ -1179,11 +1228,10 @@ export function getMarkdownTheme(): MarkdownTheme {
 		highlightCode: (code: string, lang?: string): string[] => {
 			// Validate language before highlighting to avoid stderr spam from cli-highlight
 			const validLang = lang && supportsLanguage(lang) ? lang : undefined;
-			// Skip highlighting when no valid language is specified. cli-highlight's
-			// auto-detection is unreliable and can misidentify prose as AppleScript,
-			// LiveCodeServer, etc., coloring random English words as keywords.
+			// Avoid highlight.js auto-detection for unlabeled fences, but still apply
+			// conservative shell-like styling so agent command blocks are readable.
 			if (!validLang) {
-				return code.split("\n").map((line) => theme.fg("mdCodeBlock", line));
+				return highlightFallbackMarkdownCode(code);
 			}
 			const opts = {
 				language: validLang,
@@ -1193,7 +1241,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 			try {
 				return highlight(code, opts).split("\n");
 			} catch {
-				return code.split("\n").map((line) => theme.fg("mdCodeBlock", line));
+				return highlightFallbackMarkdownCode(code);
 			}
 		},
 	};

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -66,6 +66,8 @@ export interface MarkdownTheme {
 	strikethrough: (text: string) => string;
 	underline: (text: string) => string;
 	highlightCode?: (code: string, lang?: string) => string[];
+	/** Style applied to code block line numbers and language labels. */
+	codeBlockLineNumber?: (text: string) => string;
 	/** Prefix applied to each rendered code block line (default: "  ") */
 	codeBlockIndent?: string;
 }
@@ -299,7 +301,6 @@ export class Markdown implements Component {
 		switch (token.type) {
 			case "heading": {
 				const headingLevel = token.depth;
-				const headingPrefix = `${"#".repeat(headingLevel)} `;
 
 				// Build a heading-specific style context so inline tokens (codespan, bold, etc.)
 				// restore heading styling after their own ANSI resets instead of falling back to
@@ -316,8 +317,7 @@ export class Markdown implements Component {
 					stylePrefix: this.getStylePrefix(headingStyleFn),
 				};
 
-				const headingText = this.renderInlineTokens(token.tokens || [], headingStyleContext);
-				const styledHeading = headingLevel >= 3 ? headingStyleFn(headingPrefix) + headingText : headingText;
+				const styledHeading = this.renderInlineTokens(token.tokens || [], headingStyleContext);
 				lines.push(styledHeading);
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after headings (unless space token follows)
@@ -341,20 +341,29 @@ export class Markdown implements Component {
 
 			case "code": {
 				const indent = this.theme.codeBlockIndent ?? "  ";
-				lines.push(this.theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
-				if (this.theme.highlightCode) {
-					const highlightedLines = this.theme.highlightCode(token.text, token.lang);
-					for (const hlLine of highlightedLines) {
-						lines.push(`${indent}${hlLine}`);
-					}
-				} else {
-					// Split code by newlines and style each line
-					const codeLines = token.text.split("\n");
-					for (const codeLine of codeLines) {
-						lines.push(`${indent}${this.theme.codeBlock(codeLine)}`);
+				const codeLines = this.theme.highlightCode
+					? this.theme.highlightCode(token.text, token.lang)
+					: token.text.split("\n").map((codeLine: string) => this.theme.codeBlock(codeLine));
+				const languageLabel = typeof token.lang === "string" && token.lang.trim() ? token.lang.trim() : undefined;
+				const lineNumberWidth = Math.max(codeLines.length.toString().length, languageLabel?.length ?? 0);
+				const continuationNumber = " ".repeat(lineNumberWidth);
+				const styleLineNumber = this.theme.codeBlockLineNumber ?? this.theme.codeBlockBorder;
+				const makePrefix = (marker: string) =>
+					this.theme.codeBlockBorder("│ ") + styleLineNumber(marker) + this.theme.codeBlockBorder(" │ ") + indent;
+				const codeContentWidth = Math.max(1, width - visibleWidth(makePrefix(continuationNumber)));
+				for (let lineIndex = 0; lineIndex < codeLines.length; lineIndex++) {
+					const codeLine = codeLines[lineIndex] ?? "";
+					const marker =
+						lineIndex === 0 && languageLabel
+							? languageLabel.padStart(lineNumberWidth, " ")
+							: (lineIndex + 1).toString().padStart(lineNumberWidth, " ");
+					const firstPrefix = makePrefix(marker);
+					const continuationPrefix = makePrefix(continuationNumber);
+					const wrappedLines = wrapTextWithAnsi(codeLine, codeContentWidth);
+					for (let wrapIndex = 0; wrapIndex < wrappedLines.length; wrapIndex++) {
+						lines.push((wrapIndex === 0 ? firstPrefix : continuationPrefix) + wrappedLines[wrapIndex]);
 					}
 				}
-				lines.push(this.theme.codeBlockBorder("```"));
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after code blocks (unless space token follows)
 				}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -227,7 +227,7 @@ describe("Markdown component", () => {
 
 			const lines = markdown.render(24).map((line) => stripAnsi(line).trimEnd());
 
-			assert.deepStrictEqual(lines, ["- ```ts", "    alpha beta gamma", "  delta epsilon zeta", "  ```"]);
+			assert.deepStrictEqual(lines, ["- │ ts │   alpha beta", "  │    │   gamma delta", "  │    │   epsilon zeta"]);
 		});
 	});
 
@@ -699,16 +699,16 @@ again, hello world`,
 			const lines = markdown.render(80);
 			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
 
-			const closingBackticksIndex = plainLines.indexOf("```");
-			assert.ok(closingBackticksIndex !== -1, "Should have closing backticks");
+			const codeLineIndex = plainLines.indexOf('│ js │   const hello = "world";');
+			assert.ok(codeLineIndex !== -1, "Should have rendered code content");
 
-			const afterBackticks = plainLines.slice(closingBackticksIndex + 1);
-			const emptyLineCount = afterBackticks.findIndex((line) => line !== "");
+			const afterCode = plainLines.slice(codeLineIndex + 1);
+			const emptyLineCount = afterCode.findIndex((line) => line !== "");
 
 			assert.strictEqual(
 				emptyLineCount,
 				1,
-				`Expected 1 empty line after code block, but found ${emptyLineCount}. Lines after backticks: ${JSON.stringify(afterBackticks.slice(0, 5))}`,
+				`Expected 1 empty line after code block, but found ${emptyLineCount}. Lines after code: ${JSON.stringify(afterCode.slice(0, 5))}`,
 			);
 		});
 
@@ -727,7 +727,7 @@ code block
 
 more text`,
 			];
-			const expectedLines = ["hello this is text", "", "```", "  code block", "```", "", "more text"];
+			const expectedLines = ["hello this is text", "", "│ 1 │   code block", "", "more text"];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
@@ -1066,6 +1066,9 @@ bar`,
 
 			const lines = markdown.render(80);
 			const joinedOutput = lines.join("\n");
+			const plainLines = lines.map((line) => stripAnsi(line).trimEnd());
+
+			assert.strictEqual(plainLines[0], "Why sourceInfo should not be optional");
 
 			// The heading theme is bold+cyan. After the yellow inline code, the heading
 			// styling (bold+cyan) must be restored so subsequent text is styled correctly.

--- a/packages/tui/test/test-themes.ts
+++ b/packages/tui/test/test-themes.ts
@@ -22,6 +22,7 @@ export const defaultMarkdownTheme: MarkdownTheme = {
 	code: (text: string) => chalk.yellow(text),
 	codeBlock: (text: string) => chalk.green(text),
 	codeBlockBorder: (text: string) => chalk.dim(text),
+	codeBlockLineNumber: (text: string) => chalk.dim(text),
 	quote: (text: string) => chalk.italic(text),
 	quoteBorder: (text: string) => chalk.dim(text),
 	hr: (text: string) => chalk.dim(text),


### PR DESCRIPTION
## What changed

This improves how markdown renders in the terminal, especially for agent output that includes headings and code blocks.

### Markdown headings

Headings now render like native terminal UI text instead of showing raw markdown markers.

Before:

```text
### Option B: fork repo and install your fork
```

After:

```text
Option B: fork repo and install your fork
```

### Code blocks

Code blocks now render with a cleaner terminal-style gutter:

- no visible triple-backtick fences
- dim gutter and line markers
- language label on the first line when available, e.g. `bash`, `ts`, `json`
- line numbers for unlabeled blocks
- wrapped lines align under the same gutter
- existing syntax highlighting is preserved

### Fallback highlighting

Unlabeled code fences now get conservative fallback highlighting for common command-style output:

- command token
- quoted strings
- comment lines

This avoids noisy language auto-detection while making plain command blocks easier to scan.

## Screenshots

Screenshot from local terminal test: `image.png`.

## Verification

- `node --test test/markdown.test.ts` from `packages/tui`
- `npm run check`