### PR TITLE
Add allowEmptySignature compat option for Anthropic-compatible providers

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -177,6 +177,7 @@ function getAnthropicCompat(
 		sendSessionAffinityHeaders:
 			model.compat?.sendSessionAffinityHeaders ?? !!(isFireworks || isCloudflareAiGatewayAnthropic),
 		supportsCacheControlOnTools: model.compat?.supportsCacheControlOnTools ?? !isFireworks,
+		allowEmptySignature: model.compat?.allowEmptySignature ?? false,
 	};
 }
 
@@ -895,7 +896,13 @@ function buildParams(
 	const { cacheControl } = getCacheControl(model, options?.cacheRetention);
 	const params: MessageCreateParamsStreaming = {
 		model: model.id,
-		messages: convertMessages(context.messages, model, isOAuthToken, cacheControl),
+		messages: convertMessages(
+			context.messages,
+			model,
+			isOAuthToken,
+			cacheControl,
+			getAnthropicCompat(model).allowEmptySignature,
+		),
 		max_tokens: options?.maxTokens ?? model.maxTokens,
 		stream: true,
 	};
@@ -1001,6 +1008,7 @@ function convertMessages(
 	model: Model<"anthropic-messages">,
 	isOAuthToken: boolean,
 	cacheControl?: CacheControlEphemeral,
+	allowEmptySignature?: boolean,
 ): MessageParam[] {
 	const params: MessageParam[] = [];
 
@@ -1070,12 +1078,22 @@ function convertMessages(
 					if (block.thinking.trim().length === 0) continue;
 					// If thinking signature is missing/empty (e.g., from aborted stream),
 					// convert to plain text block without <thinking> tags to avoid API rejection
-					// and prevent Claude from mimicking the tags in responses
+					// and prevent Claude from mimicking the tags in responses.
+					// Exception: when allowEmptySignature is true (Anthropic-compatible providers
+					// that don't provide signatures but accept empty ones on replay).
 					if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
-						blocks.push({
-							type: "text",
-							text: sanitizeSurrogates(block.thinking),
-						});
+						if (allowEmptySignature) {
+							blocks.push({
+								type: "thinking",
+								thinking: sanitizeSurrogates(block.thinking),
+								signature: "",
+							});
+						} else {
+							blocks.push({
+								type: "text",
+								text: sanitizeSurrogates(block.thinking),
+							});
+						}
 					} else {
 						blocks.push({
 							type: "thinking",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -445,6 +445,16 @@ export interface AnthropicMessagesCompat {
 	 * Default: false.
 	 */
 	forceAdaptiveThinking?: boolean;
+	/**
+	 * When true, thinking blocks with an empty `thinkingSignature` are sent
+	 * back to the API as `type: "thinking"` with `signature: ""` instead of
+	 * being converted to plain text blocks. Some Anthropic-compatible providers
+	 * do not return a meaningful signature but still accept empty ones on
+	 * replay. Real Anthropic API rejects empty signatures, so this defaults
+	 * to false.
+	 * Default: false.
+	 */
+	allowEmptySignature?: boolean;
 }
 
 /**

--- a/packages/ai/test/anthropic-allow-empty-thinking-signature.test.ts
+++ b/packages/ai/test/anthropic-allow-empty-thinking-signature.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage, Context, Model } from "../src/types.ts";
+
+interface AnthropicMessagesPayload {
+	messages?: Array<{
+		role: string;
+		content: Array<{
+			type: string;
+			thinking?: string;
+			signature?: string;
+			text?: string;
+		}>;
+	}>;
+}
+
+class PayloadCaptured extends Error {
+	constructor() {
+		super("payload captured");
+		this.name = "PayloadCaptured";
+	}
+}
+
+function makeCustomModel(allowEmptySignature?: boolean): Model<"anthropic-messages"> {
+	return {
+		id: "vendor--claude-opus",
+		name: "Vendor Claude Opus",
+		api: "anthropic-messages",
+		provider: "vendor-proxy",
+		baseUrl: "http://127.0.0.1:9",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32000,
+		compat: { allowEmptySignature },
+	};
+}
+
+function makeContextWithThinkingBlock(thinkingSignature: string): Context {
+	const assistantMessage: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{
+				type: "thinking",
+				thinking: "Let me think about this...",
+				thinkingSignature,
+			},
+		],
+		provider: "vendor-proxy",
+		api: "anthropic-messages",
+		model: "vendor--claude-opus",
+		timestamp: Date.now(),
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+
+	return {
+		messages: [
+			{ role: "user", content: "Hello", timestamp: Date.now() },
+			assistantMessage,
+			{ role: "user", content: "Continue", timestamp: Date.now() },
+		],
+	};
+}
+
+async function captureMessages(
+	model: Model<"anthropic-messages">,
+	context: Context,
+): Promise<AnthropicMessagesPayload> {
+	let capturedPayload: AnthropicMessagesPayload | undefined;
+
+	const { streamSimple } = await import("../src/stream.ts");
+
+	const s = streamSimple(model, context, {
+		apiKey: "fake-key",
+		onPayload: (payload) => {
+			capturedPayload = payload as AnthropicMessagesPayload;
+			throw new PayloadCaptured();
+		},
+	});
+
+	await s.result();
+
+	if (!capturedPayload) {
+		throw new Error("Expected payload to be captured before request failure");
+	}
+
+	return capturedPayload;
+}
+
+describe("Anthropic allowEmptySignature compat option", () => {
+	it("converts thinking blocks with empty signature to text by default", async () => {
+		const model = makeCustomModel(); // allowEmptySignature undefined/false
+		const context = makeContextWithThinkingBlock(""); // empty signature
+
+		const payload = await captureMessages(model, context);
+
+		const assistantMsg = payload.messages?.find((m) => m.role === "assistant");
+		expect(assistantMsg).toBeDefined();
+		expect(assistantMsg!.content).toHaveLength(1);
+		expect(assistantMsg!.content[0].type).toBe("text");
+		expect(assistantMsg!.content[0].text).toBe("Let me think about this...");
+	});
+
+	it("preserves thinking block with empty signature when allowEmptySignature is true", async () => {
+		const model = makeCustomModel(true);
+		const context = makeContextWithThinkingBlock(""); // empty signature
+
+		const payload = await captureMessages(model, context);
+
+		const assistantMsg = payload.messages?.find((m) => m.role === "assistant");
+		expect(assistantMsg).toBeDefined();
+		expect(assistantMsg!.content).toHaveLength(1);
+		expect(assistantMsg!.content[0].type).toBe("thinking");
+		expect(assistantMsg!.content[0].thinking).toBe("Let me think about this...");
+		expect(assistantMsg!.content[0].signature).toBe("");
+	});
+
+	it("preserves thinking block with valid signature regardless of allowEmptySignature", async () => {
+		const model = makeCustomModel(false);
+		const context = makeContextWithThinkingBlock("valid-signature-123");
+
+		const payload = await captureMessages(model, context);
+
+		const assistantMsg = payload.messages?.find((m) => m.role === "assistant");
+		expect(assistantMsg).toBeDefined();
+		expect(assistantMsg!.content).toHaveLength(1);
+		expect(assistantMsg!.content[0].type).toBe("thinking");
+		expect(assistantMsg!.content[0].thinking).toBe("Let me think about this...");
+		expect(assistantMsg!.content[0].signature).toBe("valid-signature-123");
+	});
+});


### PR DESCRIPTION
Some Anthropic-compatible providers return thinking blocks with empty thinkingSignature but still accept them on replay. Previously, empty signatures caused thinking blocks to be rewritten as plain text blocks, which breaks prompt caching and causes some providers to return 400.

Add allowEmptySignature to AnthropicMessagesCompat (default: false). When
true, empty signatures are passed through as type: "thinking" with
signature: "" instead of being downgraded to text blocks.