### PR TITLE
feat(coding-agent): expose streaming behavior to input events

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -819,6 +819,7 @@ pi.on("input", async (event, ctx) => {
   // event.text - raw input (before skill/template expansion)
   // event.images - attached images, if any
   // event.source - "interactive" (typed), "rpc" (API), or "extension" (via sendUserMessage)
+  // event.streamingBehavior - "steer" or "followUp" when prompt() was called with queue behavior
 
   // Transform: rewrite input before expansion
   if (event.text.startsWith("?quick "))
@@ -848,6 +849,8 @@ pi.on("input", async (event, ctx) => {
 - `handled` - skip agent entirely (first handler to return this wins)
 
 Transforms chain across handlers. See [input-transform.ts](../examples/extensions/input-transform.ts).
+
+`event.streamingBehavior` is optional. It is set when the input came through `prompt()` with a queueing mode while the agent was already streaming. Idle prompts normally leave it undefined. Direct `steer()` and `followUp()` calls do not fire the `input` event.
 
 ## ExtensionContext
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -237,6 +237,8 @@ await session.followUp("After you're done, also do this");
 
 Both `steer()` and `followUp()` expand file-based prompt templates but error on extension commands (extension commands cannot be queued).
 
+When a prompt is submitted through `prompt()` with `streamingBehavior`, extension `input` handlers receive that value as `event.streamingBehavior`. Direct `steer()` and `followUp()` calls do not fire `input` handlers.
+
 ### Agent and AgentState
 
 The `Agent` class (from `@earendil-works/pi-agent-core`) handles the core LLM interaction. Access it via `session.agent`.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1002,6 +1002,7 @@ export class AgentSession {
 					currentText,
 					currentImages,
 					options?.source ?? "interactive",
+					options?.streamingBehavior,
 				);
 				if (inputResult.action === "handled") {
 					preflightResult?.(true);

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -1036,7 +1036,12 @@ export class ExtensionRunner {
 	}
 
 	/** Emit input event. Transforms chain, "handled" short-circuits. */
-	async emitInput(text: string, images: ImageContent[] | undefined, source: InputSource): Promise<InputEventResult> {
+	async emitInput(
+		text: string,
+		images: ImageContent[] | undefined,
+		source: InputSource,
+		streamingBehavior?: "steer" | "followUp",
+	): Promise<InputEventResult> {
 		const ctx = this.createContext();
 		let currentText = text;
 		let currentImages = images;
@@ -1044,7 +1049,13 @@ export class ExtensionRunner {
 		for (const ext of this.extensions) {
 			for (const handler of ext.handlers.get("input") ?? []) {
 				try {
-					const event: InputEvent = { type: "input", text: currentText, images: currentImages, source };
+					const event: InputEvent = {
+						type: "input",
+						text: currentText,
+						images: currentImages,
+						source,
+						streamingBehavior,
+					};
 					const result = (await handler(event, ctx)) as InputEventResult | undefined;
 					if (result?.action === "handled") return result;
 					if (result?.action === "transform") {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -756,6 +756,8 @@ export interface InputEvent {
 	images?: ImageContent[];
 	/** Where the input came from */
 	source: InputSource;
+	/** Queue behavior requested for this prompt while streaming, if submitted via prompt(). */
+	streamingBehavior?: "steer" | "followUp";
 }
 
 /** Result from input event handler */

--- a/packages/coding-agent/test/extensions-input-event.test.ts
+++ b/packages/coding-agent/test/extensions-input-event.test.ts
@@ -94,6 +94,24 @@ describe("Input Event", () => {
 		}
 	});
 
+	it("passes streaming behavior when provided", async () => {
+		const r = await createRunner(
+			`export default p => p.on("input", async e => { globalThis.testVar = e.streamingBehavior; return { action: "continue" }; });`,
+		);
+		await r.emitInput("x", undefined, "interactive", "followUp");
+		expect((globalThis as any).testVar).toBe("followUp");
+	});
+
+	it("preserves streaming behavior across transform chains", async () => {
+		const r = await createRunner(
+			`export default p => p.on("input", async e => ({ action: "transform", text: e.text + "!" }));`,
+			`export default p => p.on("input", async e => { globalThis.testVar = e.streamingBehavior; return { action: "continue" }; });`,
+		);
+		const result = await r.emitInput("x", undefined, "interactive", "steer");
+		expect(result).toEqual({ action: "transform", text: "x!", images: undefined });
+		expect((globalThis as any).testVar).toBe("steer");
+	});
+
 	it("catches handler errors and continues", async () => {
 		const r = await createRunner(`export default p => p.on("input", async () => { throw new Error("boom"); });`);
 		const errs: string[] = [];


### PR DESCRIPTION
## Summary

- Add optional `streamingBehavior` to extension `input` events.
- Thread the existing `PromptOptions.streamingBehavior` through `AgentSession.prompt()` into `ExtensionRunner.emitInput()`.
- Document the field and cover direct runner behavior in input-event tests.

## Testing

- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/extensions-input-event.test.ts`
- `npm run check`

Related issue: #4977
