### PR TITLE
Fix interactive mode crash on transient terminal EPIPE

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed interactive mode to ignore transient stdout/stderr `EPIPE` write failures instead of aborting active tool turns.
 - Fixed `RpcClient` to reject pending requests and consume stdin pipe errors when the child process exits unexpectedly ([#4764](https://github.com/earendil-works/pi/issues/4764)).
 - Fixed managed npm extension updates to avoid package managers installing or resolving pi host packages as peer dependencies ([#4907](https://github.com/earendil-works/pi/issues/4907)).
 - Fixed RPC mode raw stdout writes to retry transient backpressure errors and flush queued protocol output during shutdown ([#4897](https://github.com/earendil-works/pi/issues/4897)).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -173,14 +173,22 @@ type CompactionQueuedMessage = {
 	mode: "steer" | "followUp";
 };
 
-const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
+const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "ENOTCONN"]);
+
+function getErrorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== "object" || !("code" in error)) {
+		return undefined;
+	}
+	return (error as NodeJS.ErrnoException).code;
+}
 
 function isDeadTerminalError(error: unknown): boolean {
-	if (!error || typeof error !== "object" || !("code" in error)) {
-		return false;
-	}
-	const code = (error as NodeJS.ErrnoException).code;
+	const code = getErrorCode(error);
 	return code !== undefined && DEAD_TERMINAL_ERROR_CODES.has(code);
+}
+
+function isOutputPipeClosedError(error: unknown): boolean {
+	return getErrorCode(error) === "EPIPE";
 }
 
 const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
@@ -3282,7 +3290,13 @@ export class InteractiveMode {
 	 * call ui.stop() to restore cooked mode, the cursor, and disable bracketed
 	 * paste / Kitty / modifyOtherKeys sequences.
 	 */
-	private uncaughtCrash(error: Error): never {
+	private uncaughtCrash(error: Error): void {
+		if (isOutputPipeClosedError(error)) {
+			// Node can surface an async stdout/stderr EPIPE as an uncaught exception
+			// after a render write has already failed. Treat it as a dropped frame
+			// instead of aborting the active agent turn.
+			return;
+		}
 		if (this.isShuttingDown) {
 			process.exit(1);
 		}
@@ -3330,6 +3344,9 @@ export class InteractiveMode {
 		}
 
 		const terminalErrorHandler = (error: Error) => {
+			if (isOutputPipeClosedError(error)) {
+				return;
+			}
 			if (isDeadTerminalError(error)) {
 				this.emergencyTerminalExit();
 			}


### PR DESCRIPTION
This PR intends to solve an interactive-mode crash where large output could abort the agent turn and crash the tui. The fatal error was surfaced as a broken pipe:

```
pi exiting due to uncaughtException:
 Error: write EPIPE
     at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:87:19) {
   errno: -32,
   code: 'EPIPE',
   syscall: 'write'
 }
```

The fix is just bypassing `EPIPE` errors during the TUI rendering, effectively making `EPIPE` a transient error instead a dead-terminal (fatal) one.