### PR TITLE
Fix skill command restore in session editors

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -1,7 +1,7 @@
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { resolvePath } from "../utils/paths.ts";
-import type { AgentSession } from "./agent-session.ts";
+import { type AgentSession, collapseSkillBlockToCommand, extractTextContentForEditor } from "./agent-session.ts";
 import type { AgentSessionRuntimeDiagnostic, AgentSessionServices } from "./agent-session-services.ts";
 import type { ReplacedSessionContext, SessionShutdownEvent, SessionStartEvent } from "./extensions/index.ts";
 import { emitSessionShutdownEvent } from "./extensions/runner.ts";
@@ -48,14 +48,7 @@ export class SessionImportFileNotFoundError extends Error {
 }
 
 function extractUserMessageText(content: string | Array<{ type: string; text?: string }>): string {
-	if (typeof content === "string") {
-		return content;
-	}
-
-	return content
-		.filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
-		.map((part) => part.text)
-		.join("");
+	return collapseSkillBlockToCommand(extractTextContentForEditor(content));
 }
 
 /**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -119,6 +119,22 @@ export function parseSkillBlock(text: string): ParsedSkillBlock | null {
 	};
 }
 
+export function extractTextContentForEditor(content: string | Array<{ type: string; text?: string }>): string {
+	if (typeof content === "string") return content;
+	return content
+		.filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
+		.map((part) => part.text)
+		.join("");
+}
+
+export function collapseSkillBlockToCommand(text: string): string {
+	const skillBlock = parseSkillBlock(text);
+	if (!skillBlock) return text;
+
+	const command = `/skill:${skillBlock.name}`;
+	return skillBlock.userMessage ? `${command} ${skillBlock.userMessage}` : command;
+}
+
 /** Session-specific events that extend the core AgentEvent */
 export type AgentSessionEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
@@ -2861,14 +2877,8 @@ export class AgentSession {
 	}
 
 	private _extractUserMessageText(content: string | Array<{ type: string; text?: string }>): string {
-		if (typeof content === "string") return content;
-		if (Array.isArray(content)) {
-			return content
-				.filter((c): c is { type: "text"; text: string } => c.type === "text")
-				.map((c) => c.text)
-				.join("");
-		}
-		return "";
+		const text = extractTextContentForEditor(content);
+		return collapseSkillBlockToCommand(text);
 	}
 
 	/**

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -290,6 +290,44 @@ describe("AgentSessionRuntime characterization", () => {
 		expect(events).toEqual([{ type: "session_before_fork", entryId: "missing-entry", position: "at" }]);
 	});
 
+	it("returns slash command text when forking before a skill invocation", async () => {
+		const { runtime } = await createRuntimeForTest(() => {});
+		const skillInvocation = `<skill name="browser-use" location="/tmp/skills/browser-use/SKILL.md">
+References are relative to /tmp/skills/browser-use.
+
+# Browser Use
+
+Use browser automation.
+</skill>\n\nopen the dashboard`;
+		const entryId = runtime.session.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: skillInvocation }],
+			timestamp: Date.now(),
+		});
+		runtime.session.sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "done" }],
+			api: "faux",
+			provider: "faux",
+			model: "faux-1",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+
+		const result = await runtime.fork(entryId);
+
+		expect(result.cancelled).toBe(false);
+		expect(result.selectedText).toBe("/skill:browser-use open the dashboard");
+	});
+
 	it("duplicates the current active branch when forking at the current position", async () => {
 		const { runtime } = await createRuntimeForTest(() => {});
 		await runtime.session.prompt("hello");

--- a/packages/coding-agent/test/suite/skill-command-restore.test.ts
+++ b/packages/coding-agent/test/suite/skill-command-restore.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { assistantMsg, userMsg } from "../utilities.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const skillInvocation = `<skill name="browser-use" location="/tmp/skills/browser-use/SKILL.md">
+References are relative to /tmp/skills/browser-use.
+
+# Browser Use
+
+Use browser automation.
+</skill>`;
+
+const skillInvocationWithArgs = `${skillInvocation}\n\nopen the dashboard`;
+
+describe("skill command restore", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("restores slash command text when tree navigation selects a skill invocation", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		const skillEntryId = harness.sessionManager.appendMessage(userMsg(skillInvocationWithArgs));
+		harness.sessionManager.appendMessage(assistantMsg("done"));
+		const currentLeafId = harness.sessionManager.appendMessage(userMsg("next"));
+
+		expect(harness.sessionManager.getLeafId()).toBe(currentLeafId);
+
+		const result = await harness.session.navigateTree(skillEntryId, { summarize: false });
+
+		expect(result.cancelled).toBe(false);
+		expect(result.editorText).toBe("/skill:browser-use open the dashboard");
+		expect(harness.sessionManager.getLeafId()).toBeNull();
+	});
+
+	it("restores a bare slash command when the skill invocation has no arguments", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		const skillEntryId = harness.sessionManager.appendMessage(userMsg(skillInvocation));
+		harness.sessionManager.appendMessage(assistantMsg("done"));
+		harness.sessionManager.appendMessage(userMsg("next"));
+
+		const result = await harness.session.navigateTree(skillEntryId, { summarize: false });
+
+		expect(result.cancelled).toBe(false);
+		expect(result.editorText).toBe("/skill:browser-use");
+	});
+
+	it("returns slash command text for skill invocations in the fork selector", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		harness.sessionManager.appendMessage(userMsg(skillInvocationWithArgs));
+
+		expect(harness.session.getUserMessagesForForking()).toEqual([
+			{ entryId: expect.any(String), text: "/skill:browser-use open the dashboard" },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- Collapse stored expanded skill blocks back to `/skill:<name>` when restoring editor text from `/tree`, `/fork`, and the fork selector.
- Keep the stored session message unchanged so LLM context and existing skill rendering behavior remain intact.
- Add regression coverage for skill invocations with and without arguments.

## Tests

- `npm run check`
- `./test.sh`
- `node ../../node_modules/vitest/dist/cli.js --run test/suite/skill-command-restore.test.ts test/suite/agent-session-runtime.test.ts`
