### PR TITLE
coding-agent: add legacy extension api compatibility

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -31,13 +31,20 @@ import { createSyntheticSourceInfo } from "../source-info.ts";
 import type {
 	Extension,
 	ExtensionAPI,
+	ExtensionContext,
 	ExtensionFactory,
 	ExtensionRuntime,
+	LegacyCommandDefinition,
+	LegacyCommandResult,
+	LegacyContextEngineInstance,
+	LegacyHookMetadata,
 	LoadExtensionsResult,
 	MessageRenderer,
 	ProviderConfig,
 	RegisteredCommand,
+	ToolCallEventResult,
 	ToolDefinition,
+	ToolResultEventResult,
 } from "./types.ts";
 
 /** Modules available to extensions via virtualModules (for compiled Bun binary) */
@@ -116,6 +123,7 @@ function getAliases(): Record<string, string> {
 }
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
+type RegisteredCommandOptions = Omit<RegisteredCommand, "name" | "sourceInfo">;
 
 /**
  * Create a runtime with throwing stubs for action methods.
@@ -180,6 +188,29 @@ function createExtensionAPI(
 	cwd: string,
 	eventBus: EventBus,
 ): ExtensionAPI {
+	const warnLegacyUsage = (
+		apiName: "registerHook" | "registerCommand(object)" | "registerContextEngine",
+		subject: string,
+		replacement: string,
+	): void => {
+		console.warn(
+			`[extensions] ${extension.path}: ${apiName} is deprecated (${subject}). Use ${replacement} instead.`,
+		);
+	};
+
+	const setRegisteredCommand = (name: string, options: RegisteredCommandOptions): void => {
+		if (name.trim().length === 0) {
+			throw new Error("registerCommand() requires a non-empty command name.");
+		}
+		if (typeof options.handler !== "function") {
+			throw new Error(`registerCommand("${name}") requires a handler function.`);
+		}
+		extension.commands.set(name, {
+			name,
+			sourceInfo: extension.sourceInfo,
+			...options,
+		});
+	};
 	const api = {
 		// Registration methods - write to extension
 		on(event: string, handler: HandlerFn): void {
@@ -198,12 +229,155 @@ function createExtensionAPI(
 			runtime.refreshTools();
 		},
 
-		registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void {
+		registerCommand(nameOrCommand: string | LegacyCommandDefinition, options?: RegisteredCommandOptions): void {
 			runtime.assertActive();
-			extension.commands.set(name, {
-				name,
-				sourceInfo: extension.sourceInfo,
-				...options,
+			if (typeof nameOrCommand === "string") {
+				if (!options) {
+					throw new Error(`registerCommand("${nameOrCommand}") requires command options.`);
+				}
+				setRegisteredCommand(nameOrCommand, options);
+				return;
+			}
+
+			const command = nameOrCommand;
+			warnLegacyUsage("registerCommand(object)", `name=${command.name}`, "registerCommand(name, options)");
+
+			const name = command.name?.trim();
+			if (!name) {
+				throw new Error("registerCommand(command) requires a non-empty command.name.");
+			}
+
+			const handler: RegisteredCommand["handler"] = async (args) => {
+				const result = await command.handler({
+					args,
+					commandBody: args,
+				});
+				const legacyResult = result as LegacyCommandResult | undefined;
+				if (!legacyResult || typeof legacyResult.text !== "string" || legacyResult.text.length === 0) {
+					return;
+				}
+				runtime.sendMessage(
+					{
+						customType: `legacy-command:${name}`,
+						content: legacyResult.text,
+						display: true,
+					},
+					{ triggerTurn: false },
+				);
+			};
+
+			setRegisteredCommand(name, {
+				description: command.description,
+				handler,
+			});
+		},
+
+		registerHook(
+			event: string,
+			handler: (legacyEvent: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown,
+			meta?: LegacyHookMetadata,
+		): void {
+			runtime.assertActive();
+			const metaName = meta?.name ? `, name=${meta.name}` : "";
+			warnLegacyUsage("registerHook", `event=${event}${metaName}`, "on(event, handler)");
+
+			if (event === "command:new" || event === "command:reset") {
+				api.on("session_before_switch", async (sessionEvent, ctx) => {
+					if (
+						typeof sessionEvent !== "object" ||
+						sessionEvent === null ||
+						!("reason" in sessionEvent) ||
+						sessionEvent.reason !== "new"
+					) {
+						return;
+					}
+					await handler(sessionEvent, ctx);
+				});
+				return;
+			}
+
+			if (event === "command:stop") {
+				api.on("session_shutdown", async (sessionEvent, ctx) => {
+					if (
+						typeof sessionEvent !== "object" ||
+						sessionEvent === null ||
+						!("reason" in sessionEvent) ||
+						sessionEvent.reason !== "quit"
+					) {
+						return;
+					}
+					await handler(sessionEvent, ctx);
+				});
+				return;
+			}
+
+			if (event === "before_tool_call" || event === "tool_call:before") {
+				api.on("tool_call", async (toolEvent, ctx) => {
+					const legacyEvent =
+						typeof toolEvent === "object" && toolEvent !== null && "input" in toolEvent
+							? { ...toolEvent, params: toolEvent.input }
+							: toolEvent;
+					const legacyResult = await handler(legacyEvent, ctx);
+					if (typeof legacyResult !== "object" || legacyResult === null) {
+						return legacyResult as ToolCallEventResult | undefined;
+					}
+					const block = "block" in legacyResult ? legacyResult.block : undefined;
+					const blockReason =
+						"blockReason" in legacyResult && typeof legacyResult.blockReason === "string"
+							? legacyResult.blockReason
+							: undefined;
+					const reason =
+						"reason" in legacyResult && typeof legacyResult.reason === "string" ? legacyResult.reason : undefined;
+					if (block === undefined && blockReason === undefined) {
+						return legacyResult as ToolCallEventResult | undefined;
+					}
+					return {
+						block: Boolean(block),
+						reason: blockReason ?? reason,
+					} satisfies ToolCallEventResult;
+				});
+				return;
+			}
+
+			if (event === "after_tool_call" || event === "tool_call:after") {
+				api.on("tool_result", async (toolEvent, ctx) => {
+					const legacyEvent =
+						typeof toolEvent === "object" && toolEvent !== null && "input" in toolEvent
+							? { ...toolEvent, params: toolEvent.input }
+							: toolEvent;
+					return (await handler(legacyEvent, ctx)) as ToolResultEventResult | undefined;
+				});
+				return;
+			}
+
+			throw new Error(`Unsupported legacy hook event "${event}". Use pi.on() with a supported event name instead.`);
+		},
+
+		registerContextEngine(id: string, factory: () => LegacyContextEngineInstance): void {
+			runtime.assertActive();
+			warnLegacyUsage("registerContextEngine", `id=${id}`, "session hooks (e.g. session_before_compact)");
+
+			const engine = factory();
+			if (!engine || typeof engine !== "object") {
+				throw new Error(`registerContextEngine("${id}") must return a context engine object.`);
+			}
+			if (!engine.info || typeof engine.info !== "object") {
+				throw new Error(`registerContextEngine("${id}") requires engine.info.`);
+			}
+			if (engine.info.ownsCompaction) {
+				throw new Error(
+					`registerContextEngine("${id}") with ownsCompaction=true is not supported. Use session_before_compact and return a compaction result instead.`,
+				);
+			}
+			if (typeof engine.compact !== "function") {
+				throw new Error(`registerContextEngine("${id}") requires an async compact() method.`);
+			}
+
+			api.on("session_before_compact", async () => {
+				const compactResult = await engine.compact();
+				if (!compactResult || typeof compactResult !== "object" || compactResult.ok !== true) {
+					throw new Error(`Legacy context engine "${id}" compact() must return { ok: true, compacted: boolean }.`);
+				}
 			});
 		},
 
@@ -211,7 +385,7 @@ function createExtensionAPI(
 			shortcut: KeyId,
 			options: {
 				description?: string;
-				handler: (ctx: import("./types.ts").ExtensionContext) => Promise<void> | void;
+				handler: (ctx: ExtensionContext) => Promise<void> | void;
 			},
 		): void {
 			runtime.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1065,6 +1065,47 @@ export interface RegisteredCommand {
 	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null | Promise<AutocompleteItem[] | null>;
 	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>;
 }
+/** Legacy command context shape used by OpenClaw-style object command handlers. */
+export interface LegacyCommandContext {
+	senderId?: string;
+	channel?: string;
+	isAuthorizedSender?: boolean;
+	args?: string;
+	commandBody?: string;
+	config?: Record<string, unknown>;
+}
+
+export interface LegacyCommandResult {
+	text: string;
+}
+
+/** Legacy object-style command registration format. */
+export interface LegacyCommandDefinition {
+	name: string;
+	description?: string;
+	acceptsArgs?: boolean;
+	requireAuth?: boolean;
+	handler: (ctx: LegacyCommandContext) => LegacyCommandResult | Promise<LegacyCommandResult>;
+}
+
+/** Metadata passed to legacy registerHook() registrations. */
+export interface LegacyHookMetadata {
+	name?: string;
+	description?: string;
+}
+
+export interface LegacyContextEngineInfo {
+	id: string;
+	name: string;
+	ownsCompaction: boolean;
+}
+
+export interface LegacyContextEngineInstance {
+	info: LegacyContextEngineInfo;
+	ingest: (data: unknown) => Promise<{ ingested: boolean }>;
+	assemble: (ctx: { messages: unknown[] }) => Promise<{ messages: unknown[]; estimatedTokens: number }>;
+	compact: () => Promise<{ ok: boolean; compacted: boolean }>;
+}
 
 export interface ResolvedCommand extends RegisteredCommand {
 	invocationName: string;
@@ -1124,6 +1165,15 @@ export interface ExtensionAPI {
 	on(event: "tool_result", handler: ExtensionHandler<ToolResultEvent, ToolResultEventResult>): void;
 	on(event: "user_bash", handler: ExtensionHandler<UserBashEvent, UserBashEventResult>): void;
 	on(event: "input", handler: ExtensionHandler<InputEvent, InputEventResult>): void;
+	/**
+	 * Legacy compatibility API for older OpenClaw-style plugins.
+	 * New extensions should use `on(...)`.
+	 */
+	registerHook(
+		event: string,
+		handler: (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown,
+		meta?: LegacyHookMetadata,
+	): void;
 
 	// =========================================================================
 	// Tool Registration
@@ -1140,6 +1190,14 @@ export interface ExtensionAPI {
 
 	/** Register a custom command. */
 	registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void;
+	/** Legacy object-style command registration used by older OpenClaw plugins. */
+	registerCommand(command: LegacyCommandDefinition): void;
+
+	/**
+	 * Legacy compatibility API for OpenClaw context engines.
+	 * New extensions should use session lifecycle hooks.
+	 */
+	registerContextEngine(id: string, factory: () => LegacyContextEngineInstance): void;
 
 	/** Register a keyboard shortcut. */
 	registerShortcut(

--- a/packages/coding-agent/test/extensions-legacy-api-compat.test.ts
+++ b/packages/coding-agent/test/extensions-legacy-api-compat.test.ts
@@ -1,0 +1,199 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { discoverAndLoadExtensions } from "../src/core/extensions/loader.ts";
+import { ExtensionRunner } from "../src/core/extensions/runner.ts";
+import type { ExtensionActions, ExtensionContextActions } from "../src/core/extensions/types.ts";
+import { ModelRegistry } from "../src/core/model-registry.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+
+describe("extensions legacy API compatibility", () => {
+	let tempDir: string;
+	let extensionsDir: string;
+	let sessionManager: SessionManager;
+	let modelRegistry: ModelRegistry;
+
+	const extensionActions: ExtensionActions = {
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: () => {},
+		setSessionName: () => {},
+		getSessionName: () => undefined,
+		setLabel: () => {},
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+		refreshTools: () => {},
+		getCommands: () => [],
+		setModel: async () => false,
+		getThinkingLevel: () => "off",
+		setThinkingLevel: () => {},
+	};
+
+	const extensionContextActions: ExtensionContextActions = {
+		getModel: () => undefined,
+		isIdle: () => true,
+		getSignal: () => undefined,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	};
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-legacy-ext-test-"));
+		extensionsDir = path.join(tempDir, "extensions");
+		fs.mkdirSync(extensionsDir);
+		sessionManager = SessionManager.inMemory();
+		modelRegistry = ModelRegistry.create(AuthStorage.create(path.join(tempDir, "auth.json")));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("maps legacy command:new hook to session_before_switch reason=new", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.registerHook("command:new", async () => {
+					pi.registerCommand("from-legacy-hook", {
+						description: "registered during legacy hook",
+						handler: async () => {},
+					});
+				}, { name: "legacy.new", description: "legacy hook mapping" });
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "legacy-hook.ts"), extCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		expect(result.errors).toEqual([]);
+
+		const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+		expect(runner.getCommand("from-legacy-hook")).toBeUndefined();
+
+		await runner.emit({
+			type: "session_before_switch",
+			reason: "resume",
+		});
+		expect(runner.getCommand("from-legacy-hook")).toBeUndefined();
+
+		await runner.emit({
+			type: "session_before_switch",
+			reason: "new",
+		});
+		expect(runner.getCommand("from-legacy-hook")).toBeDefined();
+	});
+
+	it("maps legacy before_tool_call hook result to tool_call blocking result", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.registerHook("before_tool_call", async (event) => {
+					if (event && event.params && event.params.command === "blocked") {
+						return { block: true, blockReason: "legacy blocked command" };
+					}
+					return undefined;
+				}, { name: "legacy.before_tool_call", description: "legacy tool hook mapping" });
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "legacy-before-tool.ts"), extCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		expect(result.errors).toEqual([]);
+
+		const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+		const blocked = await runner.emitToolCall({
+			type: "tool_call",
+			toolName: "bash",
+			toolCallId: "tool-1",
+			input: { command: "blocked" },
+		});
+		expect(blocked).toEqual({
+			block: true,
+			reason: "legacy blocked command",
+		});
+
+		const passthrough = await runner.emitToolCall({
+			type: "tool_call",
+			toolName: "bash",
+			toolCallId: "tool-2",
+			input: { command: "echo ok" },
+		});
+		expect(passthrough).toBeUndefined();
+	});
+
+	it("supports legacy object-style registerCommand and adapts text result output", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.registerCommand({
+					name: "legacy-object-command",
+					description: "legacy object command",
+					handler: async ({ args }) => ({ text: "legacy:" + (args || "") }),
+				});
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "legacy-object-command.ts"), extCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		expect(result.errors).toEqual([]);
+
+		const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+		const sendMessageSpy = vi.fn();
+		runner.bindCore({ ...extensionActions, sendMessage: sendMessageSpy }, extensionContextActions);
+
+		const command = runner.getCommand("legacy-object-command");
+		expect(command).toBeDefined();
+		await command?.handler("hello", runner.createCommandContext());
+
+		expect(sendMessageSpy).toHaveBeenCalledWith(
+			{
+				customType: "legacy-command:legacy-object-command",
+				content: "legacy:hello",
+				display: true,
+			},
+			{ triggerTurn: false },
+		);
+	});
+
+	it("accepts legacy registerContextEngine with ownsCompaction=false", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.registerContextEngine("legacy-context-engine", () => ({
+					info: { id: "legacy-context-engine", name: "Legacy Engine", ownsCompaction: false },
+					ingest: async () => ({ ingested: true }),
+					assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+					compact: async () => ({ ok: true, compacted: false }),
+				}));
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "legacy-context-engine.ts"), extCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		expect(result.errors).toEqual([]);
+
+		const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+		expect(runner.hasHandlers("session_before_compact")).toBe(true);
+	});
+
+	it("fails loudly for legacy registerContextEngine with ownsCompaction=true", async () => {
+		const extCode = `
+			export default function(pi) {
+				pi.registerContextEngine("legacy-context-engine", () => ({
+					info: { id: "legacy-context-engine", name: "Legacy Engine", ownsCompaction: true },
+					ingest: async () => ({ ingested: true }),
+					assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+					compact: async () => ({ ok: true, compacted: true }),
+				}));
+			}
+		`;
+		fs.writeFileSync(path.join(extensionsDir, "legacy-context-engine-unsupported.ts"), extCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+		expect(result.extensions).toHaveLength(0);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]?.error).toContain("ownsCompaction=true is not supported");
+	});
+});


### PR DESCRIPTION
## Summary
- add loader/type compatibility shims for legacy extension API shapes used by OpenClaw integrations
- preserve support for current APIs while mapping legacy fields and call signatures
- add regression coverage for legacy API compatibility behavior

## Validation
- npm --prefix /home/cronus/repos/pi-mono/packages/coding-agent run test -- test/extensions-legacy-api-compat.test.ts
- npm --prefix /home/cronus/repos/pi-mono run check