### PR TITLE
feat: inline skill mentions in editor

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -85,6 +85,7 @@ import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.t
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.ts";
 import { CURRENT_SESSION_VERSION, getLatestCompactionEntry, type SessionHeader } from "./session-manager.ts";
 import type { SettingsManager } from "./settings-manager.ts";
+import type { Skill } from "./skills.ts";
 import type { SlashCommandInfo } from "./slash-commands.ts";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.ts";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.ts";
@@ -995,11 +996,12 @@ export class AgentSession {
 				}
 			}
 
-			// Expand skill commands (/skill:name args) and prompt templates (/template args)
+			// Expand skill commands (/skill:name args), prompt templates (/template args), and inline skill mentions.
 			let expandedText = currentText;
 			if (expandPromptTemplates) {
 				expandedText = this._expandSkillCommand(expandedText);
 				expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
+				expandedText = this._expandInlineSkillMentions(expandedText);
 			}
 
 			// If streaming, queue via steer() or followUp() based on option
@@ -1155,20 +1157,51 @@ export class AgentSession {
 		const skill = this.resourceLoader.getSkills().skills.find((s) => s.name === skillName);
 		if (!skill) return text; // Unknown skill, pass through
 
+		const skillBlock = this._buildSkillBlock(skill);
+		if (!skillBlock) return text;
+		return args ? `${skillBlock}\n\n${args}` : skillBlock;
+	}
+
+	private _buildSkillBlock(skill: Skill): string | null {
 		try {
 			const content = readFileSync(skill.filePath, "utf-8");
 			const body = stripFrontmatter(content).trim();
-			const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
-			return args ? `${skillBlock}\n\n${args}` : skillBlock;
+			return `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
 		} catch (err) {
-			// Emit error like extension commands do
 			this._extensionRunner.emitError({
 				extensionPath: skill.filePath,
 				event: "skill_expansion",
 				error: err instanceof Error ? err.message : String(err),
 			});
-			return text; // Return original on error
+			return null;
 		}
+	}
+
+	private _expandInlineSkillMentions(text: string): string {
+		const skills = this.resourceLoader.getSkills().skills;
+		if (skills.length === 0) return text;
+
+		const skillByName = new Map(skills.map((skill) => [skill.name, skill]));
+		const mentionedNames: string[] = [];
+		const mentionPattern = /(^|[\s([{])\/(?:skill:)?([a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?)(?=$|[\s\]).,;:!?}])/g;
+		let match: RegExpExecArray | null;
+		for (let execResult = mentionPattern.exec(text); execResult !== null; execResult = mentionPattern.exec(text)) {
+			match = execResult;
+			const skillName = match[2];
+			if (!skillName || !skillByName.has(skillName) || mentionedNames.includes(skillName)) continue;
+			mentionedNames.push(skillName);
+		}
+
+		if (mentionedNames.length === 0) return text;
+
+		const skillBlocks = mentionedNames
+			.map((name) => skillByName.get(name))
+			.filter((skill): skill is Skill => Boolean(skill))
+			.map((skill) => this._buildSkillBlock(skill))
+			.filter((block): block is string => Boolean(block));
+
+		if (skillBlocks.length === 0) return text;
+		return `The user mentioned these skills in the prompt. Load and apply them as task constraints.\n\n${skillBlocks.join("\n\n")}\n\nUser prompt:\n${text}`;
 	}
 
 	/**
@@ -1185,9 +1218,10 @@ export class AgentSession {
 			this._throwIfExtensionCommand(text);
 		}
 
-		// Expand skill commands and prompt templates
+		// Expand skill commands, prompt templates, and inline skill mentions
 		let expandedText = this._expandSkillCommand(text);
 		expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
+		expandedText = this._expandInlineSkillMentions(expandedText);
 
 		await this._queueSteer(expandedText, images);
 	}
@@ -1205,9 +1239,10 @@ export class AgentSession {
 			this._throwIfExtensionCommand(text);
 		}
 
-		// Expand skill commands and prompt templates
+		// Expand skill commands, prompt templates, and inline skill mentions
 		let expandedText = this._expandSkillCommand(text);
 		expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
+		expandedText = this._expandInlineSkillMentions(expandedText);
 
 		await this._queueFollowUp(expandedText, images);
 	}

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join } from "path";
 import { fuzzyFilter } from "./fuzzy.ts";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
+const TOKEN_DELIMITERS = new Set([" ", "\t", '"', "'", "=", "(", "[", "{"]);
 
 function toDisplayPath(value: string): string {
 	return value.replace(/\\/g, "/");
@@ -45,6 +46,15 @@ function buildFdPathQuery(query: string): string {
 function findLastDelimiter(text: string): number {
 	for (let i = text.length - 1; i >= 0; i -= 1) {
 		if (PATH_DELIMITERS.has(text[i] ?? "")) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+function findLastTokenDelimiter(text: string): number {
+	for (let i = text.length - 1; i >= 0; i -= 1) {
+		if (TOKEN_DELIMITERS.has(text[i] ?? "")) {
 			return i;
 		}
 	}
@@ -302,21 +312,31 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			};
 		}
 
-		if (!options.force && textBeforeCursor.startsWith("/")) {
-			const spaceIndex = textBeforeCursor.indexOf(" ");
+		const slashPrefix = textBeforeCursor.startsWith("/")
+			? { prefix: textBeforeCursor, tokenStart: 0, inline: false }
+			: this.extractSlashPrefix(textBeforeCursor);
+		if (!options.force && slashPrefix) {
+			const { prefix: slashText, inline } = slashPrefix;
+			const spaceIndex = slashText.indexOf(" ");
 
 			if (spaceIndex === -1) {
-				const prefix = textBeforeCursor.slice(1);
-				const commandItems = this.commands.map((cmd) => {
+				const prefix = slashText.slice(1);
+				const commandItems = this.commands.flatMap((cmd) => {
 					const name = "name" in cmd ? cmd.name : cmd.value;
+					if (inline && !name.startsWith("skill:")) {
+						return [];
+					}
+					const value = inline && name.startsWith("skill:") ? name.slice("skill:".length) : name;
 					const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
 					const desc = cmd.description ?? "";
 					const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-					return {
-						name,
-						label: name,
-						description: fullDesc || undefined,
-					};
+					return [
+						{
+							name: value,
+							label: value,
+							description: inline ? (fullDesc ? `skill — ${fullDesc}` : "skill") : fullDesc || undefined,
+						},
+					];
 				});
 
 				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name).map((item) => ({
@@ -329,12 +349,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 				return {
 					items: filtered,
-					prefix: textBeforeCursor,
+					prefix: slashText,
 				};
 			}
 
-			const commandName = textBeforeCursor.slice(1, spaceIndex);
-			const argumentText = textBeforeCursor.slice(spaceIndex + 1);
+			if (inline) return null;
+
+			const commandName = slashText.slice(1, spaceIndex);
+			const argumentText = slashText.slice(spaceIndex + 1);
 
 			const command = this.commands.find((cmd) => {
 				const name = "name" in cmd ? cmd.name : cmd.value;
@@ -385,11 +407,10 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const adjustedAfterCursor =
 			isQuotedPrefix && hasTrailingQuoteInItem && hasLeadingQuoteAfterCursor ? afterCursor.slice(1) : afterCursor;
 
-		// Check if we're completing a slash command (prefix starts with "/" but NOT a file path)
-		// Slash commands are at the start of the line and don't contain path separators after the first /
-		const isSlashCommand = prefix.startsWith("/") && beforePrefix.trim() === "" && !prefix.slice(1).includes("/");
-		if (isSlashCommand) {
-			// This is a command name completion
+		// Check if we're completing a slash command or inline skill mention.
+		// These do not contain path separators after the first slash.
+		const isSlashCompletion = prefix.startsWith("/") && !prefix.slice(1).includes("/");
+		if (isSlashCompletion) {
 			const newLine = `${beforePrefix}/${item.value} ${adjustedAfterCursor}`;
 			const newLines = [...lines];
 			newLines[cursorLine] = newLine;
@@ -453,6 +474,19 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			lines: newLines,
 			cursorLine,
 			cursorCol: beforePrefix.length + cursorOffset,
+		};
+	}
+
+	private extractSlashPrefix(text: string): { prefix: string; tokenStart: number; inline: boolean } | null {
+		const tokenDelimiterIndex = findLastTokenDelimiter(text);
+		const tokenStart = tokenDelimiterIndex === -1 ? 0 : tokenDelimiterIndex + 1;
+		const token = text.slice(tokenStart);
+		if (!token.startsWith("/")) return null;
+		if (token.slice(1).includes("/")) return null;
+		return {
+			prefix: token,
+			tokenStart,
+			inline: text.slice(0, tokenStart).trim().length > 0,
 		};
 	}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1050,9 +1050,13 @@ export class Editor implements Component, Focusable {
 
 		// Check if we should trigger or update autocomplete
 		if (!this.autocompleteState) {
-			// Auto-trigger for "/" at the start of a line (slash commands)
-			if (char === "/" && this.isAtStartOfMessage()) {
-				this.tryTriggerAutocomplete();
+			// Auto-trigger for "/" at the start of the message (commands) or at token boundaries (inline skill mentions)
+			if (char === "/") {
+				const currentLine = this.state.lines[this.state.cursorLine] || "";
+				const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
+				if (this.isAtSlashTokenBoundary(textBeforeCursor)) {
+					this.tryTriggerAutocomplete();
+				}
 			}
 			// Auto-trigger for symbol-based completion like @ or # at token boundaries
 			else if (char === "@" || char === "#") {
@@ -2035,21 +2039,28 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(newCol);
 	}
 
-	// Slash menu only allowed on the first line of the editor
-	private isSlashMenuAllowed(): boolean {
-		return this.state.cursorLine === 0;
-	}
-
 	// Helper method to check if cursor is at start of message (for slash command detection)
 	private isAtStartOfMessage(): boolean {
-		if (!this.isSlashMenuAllowed()) return false;
 		const currentLine = this.state.lines[this.state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-		return beforeCursor.trim() === "" || beforeCursor.trim() === "/";
+		return this.state.cursorLine === 0 && (beforeCursor.trim() === "" || beforeCursor.trim() === "/");
+	}
+
+	private isAtSlashTokenBoundary(textBeforeCursor: string): boolean {
+		if (!textBeforeCursor.endsWith("/")) return false;
+		if (this.isAtStartOfMessage()) return true;
+		const charBeforeSlash = textBeforeCursor[textBeforeCursor.length - 2];
+		return (
+			charBeforeSlash === " " ||
+			charBeforeSlash === "\t" ||
+			charBeforeSlash === "(" ||
+			charBeforeSlash === "[" ||
+			charBeforeSlash === "{"
+		);
 	}
 
 	private isInSlashCommandContext(textBeforeCursor: string): boolean {
-		return this.isSlashMenuAllowed() && textBeforeCursor.trimStart().startsWith("/");
+		return /(?:^|[\s([{])\/[^\s/]*$/.test(textBeforeCursor);
 	}
 
 	// Autocomplete methods

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -112,6 +112,47 @@ describe("CombinedAutocompleteProvider", () => {
 				assert.strictEqual(result.prefix, "/", "Prefix should be '/'");
 			}
 		});
+
+		it("suggests skill aliases for inline slash mentions", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{ name: "reload", description: "Reload" },
+					{ name: "skill:deep-research", description: "Deep research" },
+					{ name: "skill:quick-page", description: "Quick page" },
+				],
+				"/tmp",
+			);
+			const lines = ["please use /deep"];
+
+			const result = await getSuggestions(provider, lines, 0, lines[0]!.length, false);
+
+			assert.notEqual(result, null);
+			assert.strictEqual(result?.prefix, "/deep");
+			assert.deepStrictEqual(
+				result?.items.map((item) => item.value),
+				["deep-research"],
+			);
+		});
+
+		it("keeps built-in commands for message-start slash completion", async () => {
+			const provider = new CombinedAutocompleteProvider(
+				[
+					{ name: "reload", description: "Reload" },
+					{ name: "skill:deep-research", description: "Deep research" },
+				],
+				"/tmp",
+			);
+			const lines = ["/rel"];
+
+			const result = await getSuggestions(provider, lines, 0, lines[0]!.length, false);
+
+			assert.notEqual(result, null);
+			assert.strictEqual(result?.prefix, "/rel");
+			assert.deepStrictEqual(
+				result?.items.map((item) => item.value),
+				["reload"],
+			);
+		});
 	});
 
 	describe("fd @ file suggestions", { skip: !isFdInstalled }, () => {


### PR DESCRIPTION
## Summary

Allow typing `/skill-name` anywhere in the prompt, not just at the start of the first line.

Inline `/skill-name` mentions function as **context annotations**: they tell the model "load this skill as a task constraint" without replacing the full prompt. Commands like `/reload` and `/model` remain line-start only.

## Before vs After

**Before:**
```
/skill:deep-research
please research topic X     ← skill invocation monopolizes the prompt
```

**After:**
```
Please research /deep-research topic X and output using /quick-page
                         ↑ inline mention           ↑ inline mention
```

## Changes

### 1. Editor autocomplete (`packages/tui/`)

- `extractSlashPrefix()` detects `/` at token boundaries (after space, tab, `(`, `[`, `{`), not just line start
- Inline completions show only skill names without the `skill:` prefix (so typing `/deep` completes to `deep-research`)
- `isAtSlashTokenBoundary()` replaces the old `isAtStartOfMessage()` check for auto-triggering autocomplete
- `isInSlashCommandContext()` uses a portable regex that works for both line-start and inline

### 2. Prompt expansion (`packages/coding-agent/`)

- `_expandInlineSkillMentions()` scans the full prompt for `/skill-name` patterns (matching the Agent Skills naming spec: 1-64 chars, lowercase alphanumeric with hyphens)
- Each matched skill has its `SKILL.md` content injected before the user prompt as `<skill>` blocks
- Injected skills are prefixed with: `The user mentioned these skills in the prompt. Load and apply them as task constraints.`
- `_buildSkillBlock()` extracted from `_expandSkillCommand()` for reuse in inline expansion
- Inline expansion runs in all three paths: direct `prompt()`, `steer()`, and `followUp()`

### 3. Tests (`packages/tui/test/`)

- Inline skill alias suggestions: typing `/deep` in mid-prompt shows only `deep-research`
- Message-start slash completion still shows built-in commands like `/reload`

## Files Changed

| File | Lines |
|------|-------|
| `packages/tui/src/autocomplete.ts` | +89, -40 |
| `packages/tui/src/components/editor.ts` | +14, -9 |
| `packages/coding-agent/src/core/agent-session.ts` | +48, -14 |
| `packages/tui/test/autocomplete.test.ts` | +31, -0 |

## Testing

- All 600 TUI tests pass (1 pre-existing failure in `awaits async slash command argument completions`, unrelated)
- All 1238 coding-agent tests pass
- Manual test: type `please use /deep` in editor → `/` triggers autocomplete → fuzzy match shows `deep-research` → Enter inserts