### PR TITLE
fix(interactive): clear workingVisible flag on agent_end to prevent spinner persist

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2842,11 +2842,8 @@ export class InteractiveMode {
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(false);
 				}
-				if (this.loadingAnimation) {
-					this.loadingAnimation.stop();
-					this.loadingAnimation = undefined;
-					this.statusContainer.clear();
-				}
+				this.workingVisible = false;
+				this.stopWorkingLoader();
 				if (this.streamingComponent) {
 					this.chatContainer.removeChild(this.streamingComponent);
 					this.streamingComponent = undefined;


### PR DESCRIPTION
## Bug: Working spinner persists after agent response completes

**Issue:** #5003

### Root Cause

In the `agent_end` handler, `stopWorkingLoader()` was called (removing the spinner from the DOM), but `this.workingVisible` remained `true`. When `activateMode()` re-fired (on session resume, `/new`, `/reload` completion, etc.), it saw `workingVisible=true` and immediately recreated the loader via `setWorkingVisible(true)`.

### Fix

Two changes in `agent_end`:

1. `this.workingVisible = false` — prevents any re-activation path from recreating the spinner
2. Replaced the 3-line manual clear with `this.stopWorkingLoader()` — the helper already does exactly this (`loadingAnimation.stop()` + `undefined` + `statusContainer.clear()`), so the manual block was redundant

```diff
 case "agent_end":
     if (this.settingsManager.getShowTerminalProgress()) {
         this.ui.terminal.setProgress(false);
     }
-    if (this.loadingAnimation) {
-        this.loadingAnimation.stop();
-        this.loadingAnimation = undefined;
-        this.statusContainer.clear();
-    }
+    this.workingVisible = false;
+    this.stopWorkingLoader();
     if (this.streamingComponent) {
```