### PR TITLE
fix(coding-agent): abort in-flight LLM call on AgentSession.dispose()

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -706,8 +706,29 @@ export class AgentSession {
 	/**
 	 * Remove all listeners and disconnect from agent.
 	 * Call this when completely done with the session.
+	 *
+	 * Aborts any in-flight LLM HTTP call before disconnecting so the
+	 * underlying socket tears down cleanly rather than being orphaned.
+	 * Without this, callers that dispose a session mid-stream
+	 * (switchSession / newSession / fork / clone via
+	 * agent-session-runtime.teardownCurrent) leave the previous LLM
+	 * call running in the background — provider billing continues, the
+	 * socket stays ESTABLISHED until the provider responds, and the
+	 * resulting state is externally indistinguishable from a wedged
+	 * process. Discovered by PIRA (PI Remote Access) when tab-reopen
+	 * triggered switchSession against an already-loaded session.
+	 *
+	 * Fire-and-forget: `agent.abort()` is synchronous (just trips the
+	 * AbortController). The fetch rejection lands asynchronously after
+	 * dispose returns. Keeps dispose() synchronous so callers don't
+	 * need to be updated.
 	 */
 	dispose(): void {
+		try {
+			this.agent.abort();
+		} catch {
+			/* defensive: dispose must succeed even if abort throws */
+		}
 		this._extensionRunner.invalidate(
 			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
 		);

--- a/packages/coding-agent/test/agent-session-dispose-aborts.test.ts
+++ b/packages/coding-agent/test/agent-session-dispose-aborts.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for AgentSession.dispose() aborting the agent's in-flight call.
+ *
+ * Discovered by PIRA (PI Remote Access). When `switchSession` /
+ * `newSession` / `fork` / `clone` run while a previous LLM call is
+ * mid-stream, the path is:
+ *
+ *   runtimeHost.switchSession(path)
+ *     → emitBeforeSwitch(...)
+ *     → SessionManager.open(path, ...)
+ *     → teardownCurrent(...)
+ *         → session.dispose()        <-- here
+ *             → _disconnectFromAgent() (removes our event listener)
+ *             → cleanupSessionResources(...)
+ *     → createRuntime(...) (brand new agent at same path)
+ *
+ * Before this fix, `dispose()` removed the event listener but did NOT
+ * abort the agent. The previous agent's in-flight fetch() to the LLM
+ * provider continued running in the background until the provider
+ * responded — orphaned socket, wasted provider quota, and external
+ * observers (PIRA, other hosts) seeing pi at 0 % CPU with one
+ * ESTABLISHED HTTPS socket and no events flowing, indistinguishable
+ * from a wedged process.
+ *
+ * Fix: synchronous `this.agent.abort()` at the top of `dispose()`,
+ * wrapped in try/catch so dispose remains exception-safe. The abort
+ * trips the AbortController immediately; the fetch rejection lands
+ * asynchronously after dispose returns. Keeps dispose() synchronous.
+ */
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../src/core/agent-session.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRegistry } from "../src/core/model-registry.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("AgentSession.dispose aborts in-flight call", () => {
+	let session: AgentSession;
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-dispose-abort-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		if (session) {
+			try {
+				session.dispose();
+			} catch {
+				// already disposed inside the test
+			}
+		}
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+	});
+
+	function createSession(): { session: AgentSession; getAbortSignal: () => AbortSignal | undefined } {
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		let abortSignal: AbortSignal | undefined;
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: "Test",
+				tools: [],
+			},
+			streamFn: (_model, _context, options) => {
+				// Capture the signal so the test can assert on it after
+				// dispose. The stream stays "live" (never resolves) until
+				// the signal aborts, mirroring a real LLM HTTP call.
+				abortSignal = options?.signal;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: createAssistantMessage("") });
+					const checkAbort = () => {
+						if (abortSignal?.aborted) {
+							stream.push({
+								type: "error",
+								reason: "aborted",
+								error: createAssistantMessage("Aborted"),
+							});
+						} else {
+							setTimeout(checkAbort, 5);
+						}
+					};
+					checkAbort();
+				});
+				return stream;
+			},
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = ModelRegistry.create(authStorage, tempDir);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRegistry,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		return { session, getAbortSignal: () => abortSignal };
+	}
+
+	it("trips the agent's abort signal when dispose() is called mid-stream", async () => {
+		const { session, getAbortSignal } = createSession();
+
+		// Start a prompt; intentionally don't await — the mock stream
+		// won't resolve until the signal aborts.
+		const inflight = session.prompt("Long-running prompt").catch(() => {
+			/* expected: rejects with abort */
+		});
+
+		// Wait a microtask cycle so the streamFn runs and captures the signal.
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		const signalBefore = getAbortSignal();
+		expect(signalBefore, "stream should have started and captured an AbortSignal").toBeDefined();
+		expect(signalBefore!.aborted).toBe(false);
+		expect(session.isStreaming).toBe(true);
+
+		// THIS is the behaviour under test.
+		session.dispose();
+
+		// AbortController.abort() is synchronous: the signal trips
+		// immediately even though the fetch rejection lands later.
+		expect(signalBefore!.aborted).toBe(true);
+
+		// Let the in-flight promise settle (it'll reject with the
+		// "aborted" error we queued up in the mock streamFn).
+		await inflight;
+	});
+
+	it("calls agent.abort() exactly once during dispose()", async () => {
+		const { session } = createSession();
+		const abortSpy = vi.spyOn(session.agent, "abort");
+
+		session.dispose();
+
+		expect(abortSpy).toHaveBeenCalledOnce();
+	});
+
+	it("does not throw when agent.abort() throws", () => {
+		const { session } = createSession();
+		vi.spyOn(session.agent, "abort").mockImplementation(() => {
+			throw new Error("simulated abort failure");
+		});
+
+		// The whole point of the try/catch is keeping dispose
+		// exception-safe — a dispose path that can throw blocks
+		// session teardown across the entire host.
+		expect(() => session.dispose()).not.toThrow();
+	});
+
+	it("still tears down listeners + cleans up resources after abort", () => {
+		const { session } = createSession();
+
+		// Sanity: a fresh session has its agent listener wired.
+		// (We don't have a public accessor for the unsubscribe
+		// function, so this is checked indirectly via dispose
+		// not throwing and not leaving the session in a half-state.)
+		session.dispose();
+
+		// Calling dispose() a second time should be safe — _disconnectFromAgent
+		// is idempotent, and the abort() inside the try/catch can run again
+		// without consequences (AbortController.abort() on an already-aborted
+		// controller is a no-op).
+		expect(() => session.dispose()).not.toThrow();
+	});
+});


### PR DESCRIPTION
`AgentSession.dispose()` removes the host's event listener via `_disconnectFromAgent()` but does not abort any in-flight LLM HTTP request. Callers that dispose a session mid-stream (every `switchSession` / `newSession` / `fork` / `clone` via `teardownCurrent`) leave the previous LLM call running in the background:

- Orphaned TCP socket to the LLM provider — stays ESTABLISHED until the provider responds, often minutes for slow-stream APIs.
- Provider billing increments for the orphan call whose output is discarded.
- External observers see the process at 0% CPU with one ESTABLISHED HTTPS socket and no events flowing, indistinguishable from a wedged process.

Adds a synchronous `this.agent.abort()` at the top of `dispose()`, wrapped in `try/catch` so dispose remains exception-safe. `AbortController.abort()` is synchronous: the signal trips immediately even though the fetch rejection lands later. Keeps `dispose()` synchronous so existing callers don't need to be updated.

Discovered by PIRA when a session change against an already-loaded session triggered the orphan path, surfacing as 15-20 minute apparent hangs after any host-driven session change while a stream was in flight. PIRA shipped a host-side workaround (skip the redundant `switch_session` RPC when the bridge already has the session loaded) but the underlying dispose-without-abort behaviour bites any host that legitimately tears down a session mid-stream.

**Recent in-the-wild repro:** captured today (2026-05-26) — bridge sat wedged for 25 min after `switch_session` mid-turn. Trace tagged `switch_session-teardown` + `subscriberless` + `llm-http-hang` by our analyzer. Confirms the failure mode is legitimate.

**Tests:**
- `agent-session-dispose-aborts.test.ts` (4 cases): signal trips on dispose mid-stream, `agent.abort` called exactly once, exception-safe when `agent.abort` throws, idempotent on re-dispose.

**Open question for review:** `dispose()` only aborts the main agent. The session has several other AbortControllers (compaction, autoCompaction, branchSummary, retry, bash) that aren't tripped here. Recommend a follow-up PR (or expanding this one) to abort those too in `dispose()`, same orphan class, same fix pattern.