### PR TITLE
feat: add stream idle timeout watchdog for streaming providers

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -112,6 +112,11 @@ export interface AgentOptions {
 	thinkingBudgets?: ThinkingBudgets;
 	transport?: Transport;
 	maxRetryDelayMs?: number;
+	/**
+	 * Maximum idle time in milliseconds to wait for a streaming chunk.
+	 * Passed through to the underlying pi-ai provider. Default: 0 (disabled).
+	 */
+	streamIdleTimeoutMs?: number;
 	toolExecution?: ToolExecutionMode;
 }
 
@@ -195,6 +200,8 @@ export class Agent {
 	public transport: Transport;
 	/** Optional cap for provider-requested retry delays. */
 	public maxRetryDelayMs?: number;
+	/** Maximum idle time (ms) before aborting a streaming connection. */
+	public streamIdleTimeoutMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
 
@@ -215,6 +222,7 @@ export class Agent {
 		this.thinkingBudgets = options.thinkingBudgets;
 		this.transport = options.transport ?? "auto";
 		this.maxRetryDelayMs = options.maxRetryDelayMs;
+		this.streamIdleTimeoutMs = options.streamIdleTimeoutMs;
 		this.toolExecution = options.toolExecution ?? "parallel";
 	}
 
@@ -430,6 +438,7 @@ export class Agent {
 			transport: this.transport,
 			thinkingBudgets: this.thinkingBudgets,
 			maxRetryDelayMs: this.maxRetryDelayMs,
+			streamIdleTimeoutMs: this.streamIdleTimeoutMs,
 			toolExecution: this.toolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -43,5 +43,6 @@ export type {
 	OAuthSelectPrompt,
 } from "./utils/oauth/types.ts";
 export * from "./utils/overflow.ts";
+export * from "./utils/stream-idle-timeout.ts";
 export * from "./utils/typebox-helpers.ts";
 export * from "./utils/validation.ts";

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -45,6 +45,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { createHttpProxyAgentsForTarget } from "../utils/node-http-proxy.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
 
@@ -211,7 +212,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				await options?.onResponse?.({ status: response.$metadata.httpStatusCode, headers: responseHeaders }, model);
 			}
 
-			for await (const item of response.stream!) {
+			for await (const item of withStreamIdleTimeout(response.stream!, options?.streamIdleTimeoutMs)) {
 				if (item.messageStart) {
 					if (item.messageStart.role !== ConversationRole.ASSISTANT) {
 						throw new Error("Unexpected assistant message start but got user message start instead");

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -522,7 +522,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
 
-			for await (const event of withStreamIdleTimeout(iterateAnthropicEvents(response, options?.signal), options?.streamIdleTimeoutMs)) {
+			for await (const event of withStreamIdleTimeout(
+				iterateAnthropicEvents(response, options?.signal),
+				options?.streamIdleTimeoutMs,
+			)) {
 				if (event.type === "message_start") {
 					output.responseId = event.message.id;
 					// Capture initial token usage from message_start event

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -32,6 +32,7 @@ import { headersToRecord } from "../utils/headers.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import { resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.ts";
@@ -521,7 +522,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
 
-			for await (const event of iterateAnthropicEvents(response, options?.signal)) {
+			for await (const event of withStreamIdleTimeout(iterateAnthropicEvents(response, options?.signal), options?.streamIdleTimeoutMs)) {
 				if (event.type === "message_start") {
 					output.responseId = event.message.id;
 					// Capture initial token usage from message_start event

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -117,7 +118,12 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
-			await processResponsesStream(openaiStream, output, stream, model);
+			await processResponsesStream(
+				withStreamIdleTimeout(openaiStream, options?.streamIdleTimeoutMs),
+				output,
+				stream,
+				model,
+			);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -24,6 +24,7 @@ import type {
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import type { GoogleThinkingLevel } from "./google-shared.ts";
 import {
 	convertMessages,
@@ -103,7 +104,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 			let currentBlock: TextContent | ThinkingContent | null = null;
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
+			for await (const chunk of withStreamIdleTimeout(googleStream, options?.streamIdleTimeoutMs)) {
 				// Vertex uses the same @google/genai GenerateContentResponse type as Gemini.
 				// responseId is documented there as an output-only identifier for each response.
 				output.responseId ||= chunk.responseId;

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -22,6 +22,7 @@ import type {
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import type { GoogleThinkingLevel } from "./google-shared.ts";
 import {
 	convertMessages,
@@ -85,7 +86,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 			let currentBlock: TextContent | ThinkingContent | null = null;
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
+			for await (const chunk of withStreamIdleTimeout(googleStream, options?.streamIdleTimeoutMs)) {
 				// @google/genai documents GenerateContentResponse.responseId as an output-only field
 				// used to identify each response. Keep the first non-empty one from the stream.
 				output.responseId ||= chunk.responseId;

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -26,6 +26,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
 
@@ -78,7 +79,12 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 			}
 			const mistralStream = await mistral.chat.stream(payload, buildRequestOptions(model, options));
 			stream.push({ type: "start", partial: output });
-			await consumeChatStream(model, output, stream, mistralStream);
+			await consumeChatStream(
+				model,
+				output,
+				stream,
+				withStreamIdleTimeout(mistralStream, options?.streamIdleTimeoutMs),
+			);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,6 +40,7 @@ import {
 } from "../utils/diagnostics.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -478,11 +479,17 @@ async function processStream(
 	model: Model<"openai-codex-responses">,
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
-	await processResponsesStream(mapCodexEvents(parseSSE(response)), output, stream, model, {
-		serviceTier: options?.serviceTier,
-		resolveServiceTier: resolveCodexServiceTier,
-		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
-	});
+	await processResponsesStream(
+		withStreamIdleTimeout(mapCodexEvents(parseSSE(response)), options?.streamIdleTimeoutMs),
+		output,
+		stream,
+		model,
+		{
+			serviceTier: options?.serviceTier,
+			resolveServiceTier: resolveCodexServiceTier,
+			applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+		},
+	);
 }
 
 class CodexApiError extends Error {
@@ -1226,7 +1233,7 @@ async function processWebSocketStream(
 		socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
 		await processResponsesStream(
 			startWebSocketOutputOnFirstEvent(
-				mapCodexEvents(parseWebSocket(socket, options?.signal)),
+				withStreamIdleTimeout(mapCodexEvents(parseWebSocket(socket, options?.signal)), options?.streamIdleTimeoutMs),
 				output,
 				stream,
 				onStart,

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -1233,7 +1233,10 @@ async function processWebSocketStream(
 		socket.send(JSON.stringify({ type: "response.create", ...requestBody }));
 		await processResponsesStream(
 			startWebSocketOutputOnFirstEvent(
-				withStreamIdleTimeout(mapCodexEvents(parseWebSocket(socket, options?.signal)), options?.streamIdleTimeoutMs),
+				withStreamIdleTimeout(
+					mapCodexEvents(parseWebSocket(socket, options?.signal)),
+					options?.streamIdleTimeoutMs,
+				),
 				output,
 				stream,
 				onStart,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -34,6 +34,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
@@ -262,7 +263,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				return block;
 			};
 
-			for await (const chunk of openaiStream) {
+			for await (const chunk of withStreamIdleTimeout(openaiStream, options?.streamIdleTimeoutMs)) {
 				if (!chunk || typeof chunk !== "object") continue;
 
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
+import { withStreamIdleTimeout } from "../utils/stream-idle-timeout.ts";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
@@ -125,10 +126,16 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
-			await processResponsesStream(openaiStream, output, stream, model, {
-				serviceTier: options?.serviceTier,
-				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
-			});
+			await processResponsesStream(
+				withStreamIdleTimeout(openaiStream, options?.streamIdleTimeoutMs),
+				output,
+				stream,
+				model,
+				{
+					serviceTier: options?.serviceTier,
+					applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+				},
+			);
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -137,6 +137,15 @@ export interface StreamOptions {
 	 */
 	maxRetryDelayMs?: number;
 	/**
+	 * Maximum idle time in milliseconds to wait for a streaming chunk before
+	 * aborting. If no data arrives within this window, the stream is terminated
+	 * with a StreamIdleTimeoutError. This guards against silently dropped
+	 * connections where the server stops sending but the TCP socket stays open.
+	 *
+	 * Set to 0 or omit to disable (default). Recommended: 90000 (90 seconds).
+	 */
+	streamIdleTimeoutMs?: number;
+	/**
 	 * Optional metadata to include in API requests.
 	 * Providers extract the fields they understand and ignore the rest.
 	 * For example, Anthropic uses `user_id` for abuse tracking and rate limiting.

--- a/packages/ai/src/utils/stream-idle-timeout.ts
+++ b/packages/ai/src/utils/stream-idle-timeout.ts
@@ -1,0 +1,68 @@
+/**
+ * Error thrown when a streaming connection receives no data for longer than
+ * the configured idle timeout. Consumers can catch this specifically to
+ * distinguish idle timeouts from other errors.
+ */
+export class StreamIdleTimeoutError extends Error {
+	public readonly timeoutMs: number;
+
+	constructor(timeoutMs: number) {
+		super(`Stream idle timeout: no data received for ${timeoutMs / 1000}s`);
+		this.name = "StreamIdleTimeoutError";
+		this.timeoutMs = timeoutMs;
+	}
+}
+
+/**
+ * Wraps an async iterable with a per-chunk idle timeout watchdog.
+ *
+ * After each yielded chunk, a timer is reset. If no chunk arrives within
+ * `timeoutMs`, a {@link StreamIdleTimeoutError} is thrown. This guards
+ * against silently dropped HTTP/SSE connections where the server stops
+ * sending data but the TCP connection stays open.
+ *
+ * When `timeoutMs` is 0, undefined, or negative the source is yielded
+ * through without any timeout logic (zero overhead pass-through).
+ *
+ * @param source   - The upstream async iterable (e.g. SDK stream)
+ * @param timeoutMs - Maximum idle time in milliseconds before aborting
+ */
+export async function* withStreamIdleTimeout<T>(
+	source: AsyncIterable<T>,
+	timeoutMs: number | undefined,
+): AsyncGenerator<T> {
+	if (!timeoutMs || timeoutMs <= 0) {
+		yield* source;
+		return;
+	}
+
+	const iterator = source[Symbol.asyncIterator]();
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	try {
+		while (true) {
+			// Race: next chunk vs idle timeout
+			const result = await Promise.race([
+				iterator.next(),
+				new Promise<never>((_, reject) => {
+					timeoutId = setTimeout(() => reject(new StreamIdleTimeoutError(timeoutMs)), timeoutMs);
+				}),
+			]);
+
+			// Chunk arrived — clear the timeout
+			clearTimeout(timeoutId);
+			timeoutId = undefined;
+
+			if (result.done) break;
+			yield result.value;
+		}
+	} finally {
+		if (timeoutId !== undefined) clearTimeout(timeoutId);
+		// Signal the underlying iterator to release resources (close HTTP connection, etc.)
+		// Reason: we don't await return() because if the iterator is stuck in an
+		// unresolvable promise (the exact scenario this utility guards against),
+		// awaiting return() would hang forever. Fire-and-forget is safe here —
+		// the iterator will be GC'd along with any pending promises.
+		iterator.return?.(undefined);
+	}
+}

--- a/packages/ai/test/stream-idle-timeout.test.ts
+++ b/packages/ai/test/stream-idle-timeout.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { StreamIdleTimeoutError, withStreamIdleTimeout } from "../src/utils/stream-idle-timeout.js";
+
+/** Helper: create an async iterable that yields values with configurable delays */
+async function* delayedStream(items: { value: string; delayMs: number }[]): AsyncGenerator<string> {
+	for (const item of items) {
+		await new Promise((r) => setTimeout(r, item.delayMs));
+		yield item.value;
+	}
+}
+
+/** Helper: create an async iterable that never yields (hangs forever) */
+async function* hangingStream(): AsyncGenerator<string> {
+	await new Promise(() => {}); // never resolves
+	yield "unreachable";
+}
+
+describe("withStreamIdleTimeout", () => {
+	it("passes through all items when no timeout occurs", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 10 },
+			{ value: "c", delayMs: 10 },
+		];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), 500)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["a", "b", "c"]);
+	});
+
+	it("throws StreamIdleTimeoutError when stream hangs before first chunk", async () => {
+		await expect(async () => {
+			for await (const _item of withStreamIdleTimeout(hangingStream(), 100)) {
+				// should not reach here
+			}
+		}).rejects.toThrow(StreamIdleTimeoutError);
+	});
+
+	it("throws StreamIdleTimeoutError when gap between chunks exceeds timeout", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 300 }, // exceeds 100ms timeout
+		];
+		const result: string[] = [];
+		await expect(async () => {
+			for await (const item of withStreamIdleTimeout(delayedStream(items), 100)) {
+				result.push(item);
+			}
+		}).rejects.toThrow(StreamIdleTimeoutError);
+		expect(result).toEqual(["a"]); // only first item received before timeout
+	});
+
+	it("includes timeout duration in error message", async () => {
+		try {
+			for await (const _item of withStreamIdleTimeout(hangingStream(), 150)) {
+				// should not reach here
+			}
+		} catch (error) {
+			expect(error).toBeInstanceOf(StreamIdleTimeoutError);
+			expect((error as StreamIdleTimeoutError).message).toContain("0.15s");
+			expect((error as StreamIdleTimeoutError).timeoutMs).toBe(150);
+		}
+	});
+
+	it("passes through when timeoutMs is 0 (disabled)", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 10 },
+		];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), 0)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["a", "b"]);
+	});
+
+	it("passes through when timeoutMs is undefined", async () => {
+		const items = [
+			{ value: "a", delayMs: 10 },
+			{ value: "b", delayMs: 10 },
+		];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), undefined)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["a", "b"]);
+	});
+
+	it("cleans up timer on normal completion", async () => {
+		const items = [{ value: "done", delayMs: 10 }];
+		const result: string[] = [];
+		for await (const item of withStreamIdleTimeout(delayedStream(items), 5000)) {
+			result.push(item);
+		}
+		expect(result).toEqual(["done"]);
+	});
+});

--- a/packages/ai/test/stream-idle-timeout.test.ts
+++ b/packages/ai/test/stream-idle-timeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { StreamIdleTimeoutError, withStreamIdleTimeout } from "../src/utils/stream-idle-timeout.js";
+import { StreamIdleTimeoutError, withStreamIdleTimeout } from "../src/utils/stream-idle-timeout.ts";
 
 /** Helper: create an async iterable that yields values with configurable delays */
 async function* delayedStream(items: { value: string; delayMs: number }[]): AsyncGenerator<string> {


### PR DESCRIPTION
## Summary

Adds a configurable stream idle timeout watchdog for streaming providers.

This revives and rebases the unmerged implementation from #3019 onto current `main`, adapting it to the current provider sources.

Changes:
- add `withStreamIdleTimeout()` and `StreamIdleTimeoutError`
- add `streamIdleTimeoutMs` to stream options and agent options
- wrap provider streaming iterators so a silent provider connection can terminate with a visible error instead of leaving `agent.prompt()` blocked indefinitely

## Why

When an LLM provider accepts a streaming request but then stops sending events while keeping the connection open, the agent can remain stuck at `Working...` with no useful feedback. A per-chunk idle watchdog gives callers a way to fail fast and recover.

## Tests

- `cd packages/ai && node ../../node_modules/vitest/dist/cli.js --run test/stream-idle-timeout.test.ts` passed
- `npm run check` passed
- `./test.sh` did not complete successfully because package resolution for `@earendil-works/pi-ai` failed in `packages/agent` tests (`Failed to resolve entry for package "@earendil-works/pi-ai"`). The new `packages/ai` stream-idle-timeout test passed separately.
