### PR TITLE
fix(tui): progressive enhancement keyboard negotiation

### DIFF
--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -817,9 +817,41 @@ function parseKeyId(
  * @param data - Raw input data from terminal
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
+
+/** \x1b\x1b[ / \x1b\x1bO → alt+inner (mixed mode under partial Kitty, e.g. Zellij). */
+function parseEscPrefixedAlt(data: string): string | undefined {
+	if (data.length <= 2 || data.charCodeAt(0) !== 0x1b || data.charCodeAt(1) !== 0x1b) {
+		return undefined;
+	}
+	const third = data.charCodeAt(2);
+	if (third !== 0x5b && third !== 0x4f) {
+		return undefined;
+	}
+	const inner = parseKey(data.slice(1));
+	return inner ? `alt+${inner}` : undefined;
+}
+
+function matchesEscPrefixedAlt(data: string, keyId: KeyId): boolean {
+	const parsed = parseKeyId(keyId);
+	if (!parsed?.alt) return false;
+	if (data.length <= 2 || data.charCodeAt(0) !== 0x1b || data.charCodeAt(1) !== 0x1b) {
+		return false;
+	}
+	const third = data.charCodeAt(2);
+	if (third !== 0x5b && third !== 0x4f) return false;
+	const { key, ctrl, shift } = parsed;
+	const parts: string[] = [];
+	if (ctrl) parts.push("ctrl");
+	if (shift) parts.push("shift");
+	parts.push(key);
+	return matchesKey(data.slice(1), parts.join("+") as KeyId);
+}
+
 export function matchesKey(data: string, keyId: KeyId): boolean {
 	const parsed = parseKeyId(keyId);
 	if (!parsed) return false;
+
+	if (matchesEscPrefixedAlt(data, keyId)) return true;
 
 	const { key, ctrl, shift, alt, super: superModifier } = parsed;
 	let modifier = 0;
@@ -1249,6 +1281,9 @@ function formatParsedKey(codepoint: number, modifier: number, baseLayoutKey?: nu
 }
 
 export function parseKey(data: string): string | undefined {
+	const escPrefixed = parseEscPrefixedAlt(data);
+	if (escPrefixed) return escPrefixed;
+
 	const kitty = parseKittySequence(data);
 	if (kitty) {
 		return formatParsedKey(kitty.codepoint, kitty.modifier, kitty.baseLayoutKey);

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -68,6 +68,16 @@ function isCompleteSequence(data: string): "complete" | "incomplete" | "not-esca
 		return afterEsc.length >= 2 ? "complete" : "incomplete";
 	}
 
+	// ESC-prefixed (metaSendsEscape): incomplete only for CSI/SS3 continuations.
+	if (afterEsc.startsWith(ESC)) {
+		const inner = data.slice(1);
+		const third = inner.charCodeAt(1);
+		if (third === 0x5b || third === 0x4f) {
+			return isCompleteSequence(inner);
+		}
+		return "complete";
+	}
+
 	// Meta key sequences: ESC followed by a single character
 	if (afterEsc.length === 1) {
 		return "complete";

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -78,6 +78,7 @@ export class ProcessTerminal implements Terminal {
 	private resizeHandler?: () => void;
 	private _kittyProtocolActive = false;
 	private _modifyOtherKeysActive = false;
+	private _keyboardProbeDa1Pending = false;
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string) => void;
 	private progressInterval?: ReturnType<typeof setInterval>;
@@ -150,23 +151,36 @@ export class ProcessTerminal implements Terminal {
 		// Kitty protocol response pattern: \x1b[?<flags>u
 		const kittyResponsePattern = /^\x1b\[\?(\d+)u$/;
 
+		const da1ResponsePattern = /^\x1b\[\?[\d;]*c$/;
+
 		// Forward individual sequences to the input handler
 		this.stdinBuffer.on("data", (sequence) => {
-			// Check for Kitty protocol response (only if not already enabled)
-			if (!this._kittyProtocolActive) {
-				const match = sequence.match(kittyResponsePattern);
-				if (match) {
+			if (da1ResponsePattern.test(sequence) && this._keyboardProbeDa1Pending) {
+				this._keyboardProbeDa1Pending = false;
+				if (!this._kittyProtocolActive && !this._modifyOtherKeysActive) {
+					process.stdout.write("\x1b[>4;2m");
+					this._modifyOtherKeysActive = true;
+				}
+				return;
+			}
+
+			const match = sequence.match(kittyResponsePattern);
+			if (match && !this._modifyOtherKeysActive) {
+				this._keyboardProbeDa1Pending = false;
+				const reportedFlags = Number.parseInt(match[1]!, 10);
+				if (reportedFlags >= 3) {
 					this._kittyProtocolActive = true;
 					setKittyProtocolActive(true);
-
-					// Enable Kitty keyboard protocol (push flags)
-					// Flag 1 = disambiguate escape codes
-					// Flag 2 = report event types (press/repeat/release)
-					// Flag 4 = report alternate keys (shifted key, base layout key)
-					// Base layout key enables shortcuts to work with non-Latin keyboard layouts
 					process.stdout.write("\x1b[>7u");
-					return; // Don't forward protocol response to TUI
+				} else if (reportedFlags >= 1) {
+					this._kittyProtocolActive = true;
+					setKittyProtocolActive(true);
+					process.stdout.write("\x1b[>1u");
+				} else if (reportedFlags === 0) {
+					process.stdout.write("\x1b[>4;2m");
+					this._modifyOtherKeysActive = true;
 				}
+				return;
 			}
 
 			if (this.inputHandler) {
@@ -210,8 +224,10 @@ export class ProcessTerminal implements Terminal {
 	private queryAndEnableKittyProtocol(): void {
 		this.setupStdinBuffer();
 		process.stdin.on("data", this.stdinDataHandler!);
-		process.stdout.write("\x1b[?u");
+		this._keyboardProbeDa1Pending = true;
+		process.stdout.write("\x1b[>31u\x1b[?u\x1b[c");
 		setTimeout(() => {
+			this._keyboardProbeDa1Pending = false;
 			if (!this._kittyProtocolActive && !this._modifyOtherKeysActive) {
 				process.stdout.write("\x1b[>4;2m");
 				this._modifyOtherKeysActive = true;

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -610,5 +610,23 @@ describe("parseKey", () => {
 		it("should parse double bracket pageUp", () => {
 			assert.strictEqual(parseKey("\x1b[[5~"), "pageUp");
 		});
+
+		describe("ESC-prefixed alt (mixed mode)", () => {
+			it("parses alt+arrow when kitty protocol is active", () => {
+				setKittyProtocolActive(true);
+				assert.strictEqual(parseKey("\x1b\x1b[A"), "alt+up");
+				assert.strictEqual(parseKey("\x1b\x1b[B"), "alt+down");
+				assert.strictEqual(matchesKey("\x1b\x1b[A", "alt+up"), true);
+				setKittyProtocolActive(false);
+			});
+
+			it("does not treat bare double-ESC as alt+letter", () => {
+				setKittyProtocolActive(true);
+				assert.strictEqual(parseKey("\x1b\x1b"), "ctrl+alt+[");
+				assert.strictEqual(parseKey("\x1b\x1bX"), undefined);
+				setKittyProtocolActive(false);
+			});
+		});
 	});
 });
+


### PR DESCRIPTION
Follow-up on [#3163](https://github.com/earendil-works/pi/issues/3163) / [#3259](https://github.com/earendil-works/pi/issues/3259).

**Problem.** Startup sends `CSI ? u`. Any `CSI ?<n>u` reply turns on full Kitty (`CSI >7u`). In Zellij (often nested: Kitty/Alacritty → Zellij → pi) the effective level is often **1** (disambiguate only). Full `>7u` breaks Alt bindings, can break Shift+Enter with a heavy `modifyOtherKeys` fallback, and double-ESC handling can add ~10ms ESC lag.

Checked `v0.75.5` `packages/tui/src/terminal.ts`: still `?u` → unconditional `>7u`. #3163 closed around `$ZELLIJ` ([#3162](https://github.com/badlogic/pi-mono/pull/3162)); that path is not in current source.

**Fix.** [Progressive enhancement query](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#querying-terminal-for-support): `CSI >31u`, `CSI ?u`, `CSI c` (DA1 sentinel). On `CSI ?<flags>u` before DA1:

| flags | enable |
|-------|--------|
| ≥ 3 | `CSI >7u` |
| ≥ 1 | `CSI >1u` (Zellij level 1; avoids #3259-style `modifyOtherKeys` when not needed) |
| 0 | `modifyOtherKeys` mode 2 |

DA1 before kitty reply → `modifyOtherKeys` immediately (no 150ms wait). `stdin-buffer.ts`: double-ESC incomplete only for `ESC ESC [` / `ESC ESC O`. `keys.ts`: `\x1b\x1b[` / `\x1b\x1bO` → `alt+<inner>` with Kitty on. No `$ZELLIJ`.

Upstream pi has no OSC 11 / Mode 2031 appearance probes (fyi OMP fork does).

**Issues:** Fixes #3163, #3259. Related #439, #2484.

**Test**

- [x] Zellij: ESC, Shift+Enter, Alt+letter, Alt+arrows
- [x] Direct Kitty/Alacritty: same keys, full protocol
- [x] Old terminal: fast `modifyOtherKeys` when DA1 wins probe

**Refs:** [Kitty protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) · [query spec](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#querying-terminal-for-support) · [Zellij #3789](https://github.com/zellij-org/zellij/issues/3789)

---

- @badlogic — #3163 / #3162 context.
- @imsnif — **please sanity-check the flag thresholds** (`≥3` → `>7u`, `≥1` → `>1u`, `0` → modifyOtherKeys) against what Zellij actually reports today ([#3789](https://github.com/zellij-org/zellij/issues/3789)); nested terminal → Zellij is the main failure mode.
- @NigelThorne — #3259 (Shift+Enter in Zellij); would appreciate a quick re-test if still relevant.
