### PR TITLE
Add raw prompt template arguments

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `$RAW_ARGUMENTS` support to prompt template formatting.
+
 ## [0.75.5] - 2026-05-23
 
 ## [0.75.4] - 2026-05-20

--- a/packages/agent/src/harness/prompt-templates.ts
+++ b/packages/agent/src/harness/prompt-templates.ts
@@ -245,8 +245,8 @@ export function parseCommandArgs(argsString: string): string[] {
 	return args;
 }
 
-/** Substitute prompt template placeholders (`$1`, `$@`, `$ARGUMENTS`, `${@:N}`, `${@:N:L}`) with command arguments. */
-export function substituteArgs(content: string, args: string[]): string {
+/** Substitute prompt template placeholders (`$1`, `$@`, `$ARGUMENTS`, `$RAW_ARGUMENTS`, `${@:N}`, `${@:N:L}`) with command arguments. */
+export function substituteArgs(content: string, args: string[], rawArgs = args.join(" ")): string {
 	let result = content;
 	result = result.replace(/\$(\d+)/g, (_, num: string) => args[parseInt(num, 10) - 1] ?? "");
 	result = result.replace(/\$\{@:(\d+)(?::(\d+))?\}/g, (_, startStr: string, lengthStr?: string) => {
@@ -258,10 +258,15 @@ export function substituteArgs(content: string, args: string[]): string {
 	const allArgs = args.join(" ");
 	result = result.replace(/\$ARGUMENTS/g, allArgs);
 	result = result.replace(/\$@/g, allArgs);
+	result = result.replace(/\$RAW_ARGUMENTS/g, rawArgs);
 	return result;
 }
 
 /** Format a prompt template invocation with positional arguments. */
-export function formatPromptTemplateInvocation(template: PromptTemplate, args: string[] = []): string {
-	return substituteArgs(template.content, args);
+export function formatPromptTemplateInvocation(
+	template: PromptTemplate,
+	args: string[] = [],
+	rawArgs?: string,
+): string {
+	return substituteArgs(template.content, args, rawArgs);
 }

--- a/packages/agent/test/harness/prompt-templates.test.ts
+++ b/packages/agent/test/harness/prompt-templates.test.ts
@@ -87,4 +87,11 @@ describe("formatPromptTemplateInvocation", () => {
 			"hello world test hello world test",
 		);
 	});
+
+	it("substitutes raw command arguments", () => {
+		const content = "$RAW_ARGUMENTS\n$ARGUMENTS";
+		expect(formatPromptTemplateInvocation({ name: "one", content }, ["hello", "world"], "hello\nworld")).toBe(
+			"hello\nworld\nhello world",
+		);
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `$RAW_ARGUMENTS` for prompt templates to preserve the raw argument text after the command separator ([#5027](https://github.com/earendil-works/pi/issues/5027)).
+
 ### Fixed
 
 - Fixed `RpcClient` to reject pending requests and consume stdin pipe errors when the child process exits unexpectedly ([#4764](https://github.com/earendil-works/pi/issues/4764)).

--- a/packages/coding-agent/docs/prompt-templates.md
+++ b/packages/coding-agent/docs/prompt-templates.md
@@ -68,6 +68,7 @@ Templates support positional arguments and simple slicing:
 
 - `$1`, `$2`, ... positional args
 - `$@` or `$ARGUMENTS` for all args joined
+- `$RAW_ARGUMENTS` for the raw text after the command separator, preserving newlines and spacing
 - `${@:N}` for args from the Nth position (1-indexed)
 - `${@:N:L}` for `L` args starting at N
 
@@ -81,6 +82,8 @@ Create a React component named $1 with features: $@
 ```
 
 Usage: `/component Button "onClick handler" "disabled support"`
+
+Use `$RAW_ARGUMENTS` when a template should preserve pasted prose, logs, diffs, or other formatted text without quoting.
 
 ## Loading Rules
 

--- a/packages/coding-agent/src/core/prompt-templates.ts
+++ b/packages/coding-agent/src/core/prompt-templates.ts
@@ -59,13 +59,14 @@ export function parseCommandArgs(argsString: string): string[] {
  * Supports:
  * - $1, $2, ... for positional args
  * - $@ and $ARGUMENTS for all args
+ * - $RAW_ARGUMENTS for the unparsed argument string
  * - ${@:N} for args from Nth onwards (bash-style slicing)
  * - ${@:N:L} for L args starting from Nth
  *
  * Note: Replacement happens on the template string only. Argument values
  * containing patterns like $1, $@, or $ARGUMENTS are NOT recursively substituted.
  */
-export function substituteArgs(content: string, args: string[]): string {
+export function substituteArgs(content: string, args: string[], rawArgs = args.join(" ")): string {
 	let result = content;
 
 	// Replace $1, $2, etc. with positional args FIRST (before wildcards)
@@ -97,6 +98,9 @@ export function substituteArgs(content: string, args: string[]): string {
 
 	// Replace $@ with all args joined (existing syntax)
 	result = result.replace(/\$@/g, allArgs);
+
+	// Replace $RAW_ARGUMENTS with the unparsed argument string LAST to avoid recursive substitution
+	result = result.replace(/\$RAW_ARGUMENTS/g, rawArgs);
 
 	return result;
 }
@@ -269,7 +273,7 @@ export function loadPromptTemplates(options: LoadPromptTemplatesOptions): Prompt
 export function expandPromptTemplate(text: string, templates: PromptTemplate[]): string {
 	if (!text.startsWith("/")) return text;
 
-	const match = text.match(/^\/([^\s]+)(?:\s+([\s\S]*))?$/);
+	const match = text.match(/^\/([^\s]+)(?:\s([\s\S]*))?$/);
 	if (!match) return text;
 
 	const templateName = match[1];
@@ -278,7 +282,7 @@ export function expandPromptTemplate(text: string, templates: PromptTemplate[]):
 	const template = templates.find((t) => t.name === templateName);
 	if (template) {
 		const args = parseCommandArgs(argsString);
-		return substituteArgs(template.content, args);
+		return substituteArgs(template.content, args, argsString);
 	}
 
 	return text;

--- a/packages/coding-agent/test/prompt-templates.test.ts
+++ b/packages/coding-agent/test/prompt-templates.test.ts
@@ -25,6 +25,10 @@ import {
 // ============================================================================
 
 describe("substituteArgs", () => {
+	test("should replace $RAW_ARGUMENTS with the raw argument string", () => {
+		expect(substituteArgs("Test: $RAW_ARGUMENTS", ["a", "b", "c"], "a  b\n c")).toBe("Test: a  b\n c");
+	});
+
 	test("should replace $ARGUMENTS with all args joined", () => {
 		expect(substituteArgs("Test: $ARGUMENTS", ["a", "b", "c"])).toBe("Test: a b c");
 	});
@@ -43,6 +47,7 @@ describe("substituteArgs", () => {
 		expect(substituteArgs("$ARGUMENTS", ["$1", "$ARGUMENTS"])).toBe("$1 $ARGUMENTS");
 		expect(substituteArgs("$@", ["$100", "$1"])).toBe("$100 $1");
 		expect(substituteArgs("$ARGUMENTS", ["$100", "$1"])).toBe("$100 $1");
+		expect(substituteArgs("$RAW_ARGUMENTS", [], "$1 $ARGUMENTS $@")).toBe("$1 $ARGUMENTS $@");
 	});
 
 	test("should support mixed $1, $2, and $ARGUMENTS", () => {
@@ -378,6 +383,34 @@ describe("parseCommandArgs", () => {
 // ============================================================================
 
 describe("expandPromptTemplate", () => {
+	test("should preserve raw multiline arguments", () => {
+		const result = expandPromptTemplate("/arg-test label-2\n\nHere is some description #2.", [
+			{
+				name: "arg-test",
+				description: "test",
+				content: `raw: $RAW_ARGUMENTS\njoined: $ARGUMENTS`,
+				sourceInfo: { path: "/tmp/arg-test.md", source: "local", scope: "temporary", origin: "top-level" },
+				filePath: "/tmp/arg-test.md",
+			},
+		]);
+
+		expect(result).toBe("raw: label-2\n\nHere is some description #2.\njoined: label-2 Here is some description #2.");
+	});
+
+	test("should preserve raw spacing after the command separator", () => {
+		const result = expandPromptTemplate("/arg-test   keep spacing", [
+			{
+				name: "arg-test",
+				description: "test",
+				content: "$RAW_ARGUMENTS",
+				sourceInfo: { path: "/tmp/arg-test.md", source: "local", scope: "temporary", origin: "top-level" },
+				filePath: "/tmp/arg-test.md",
+			},
+		]);
+
+		expect(result).toBe("  keep spacing");
+	});
+
 	test("should split template arguments on unquoted newlines", () => {
 		const result = expandPromptTemplate("/arg-test label-2\n\nHere is some description #2.", [
 			{


### PR DESCRIPTION
Adds $RAW_ARGUMENTS support for prompt templates so multiline pasted text can be preserved without quoting.

closes #5027
