### PR TITLE
fix(tui): provide the JetBrains terminal capabilities

### DIFF
--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -41,6 +41,7 @@ export function setCellDimensions(dims: CellDimensions): void {
 
 export function detectCapabilities(): TerminalCapabilities {
 	const termProgram = process.env.TERM_PROGRAM?.toLowerCase() || "";
+	const terminalEmulator = process.env.TERMINAL_EMULATOR?.toLowerCase() || "";
 	const term = process.env.TERM?.toLowerCase() || "";
 	const colorTerm = process.env.COLORTERM?.toLowerCase() || "";
 	const hasTrueColorHint = colorTerm === "truecolor" || colorTerm === "24bit";
@@ -80,6 +81,10 @@ export function detectCapabilities(): TerminalCapabilities {
 
 	if (termProgram === "alacritty") {
 		return { images: null, trueColor: true, hyperlinks: true };
+	}
+
+	if (terminalEmulator === "jetbrains-jediterm") {
+		return { images: null, trueColor: true, hyperlinks: false };
 	}
 
 	// Unknown terminal: be conservative. OSC 8 is rendered invisibly as "just

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -21,6 +21,7 @@ import {
 const ENV_KEYS = [
 	"TERM",
 	"TERM_PROGRAM",
+	"TERMINAL_EMULATOR",
 	"COLORTERM",
 	"TMUX",
 	"KITTY_WINDOW_ID",
@@ -278,6 +279,15 @@ describe("detectCapabilities", () => {
 			const caps = detectCapabilities();
 			assert.strictEqual(caps.trueColor, true);
 			assert.strictEqual(caps.hyperlinks, true);
+			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("enables truecolor without hyperlinks for JetBrains terminal", () => {
+		withEnv({ TERMINAL_EMULATOR: "JetBrains-JediTerm", TERM: "xterm-256color" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.trueColor, true);
+			assert.strictEqual(caps.hyperlinks, false);
 			assert.strictEqual(caps.images, null);
 		});
 	});


### PR DESCRIPTION
I checked the capabilities in WebStorm 2026.1. True color support [was added in 2021.3](https://youtrack.jetbrains.com/issue/IJPL-111971/24bit-color-support-in-terminal). However, images and OSC 8 links are not supported.