### PR TITLE
fix: propagate setModel/setThinkingLevel/setActiveTools to running agent loop

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -226,6 +226,12 @@ async function runLoop(
 			const nextTurnSnapshot = await config.prepareNextTurn?.(nextTurnContext);
 			if (nextTurnSnapshot) {
 				currentContext = nextTurnSnapshot.context ?? currentContext;
+				if (nextTurnSnapshot.tools) {
+					currentContext.tools = nextTurnSnapshot.tools;
+				}
+				if (nextTurnSnapshot.systemPrompt !== undefined) {
+					currentContext.systemPrompt = nextTurnSnapshot.systemPrompt;
+				}
 				config = {
 					...config,
 					model: nextTurnSnapshot.model ?? config.model,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -128,6 +128,8 @@ export interface AgentLoopTurnUpdate {
 	model?: Model<any>;
 	/** Thinking level for the next provider request. */
 	thinkingLevel?: ThinkingLevel;
+	tools?: AgentTool<any>[];
+	systemPrompt?: string;
 }
 
 export interface PrepareNextTurnContext extends ShouldStopAfterTurnContext {}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -394,6 +394,15 @@ export class AgentSession {
 	 * happens here instead of in wrappers.
 	 */
 	private _installAgentToolHooks(): void {
+		this.agent.prepareNextTurn = () => {
+			return {
+				model: this.agent.state.model,
+				thinkingLevel: this.agent.state.thinkingLevel,
+				tools: this.agent.state.tools,
+				systemPrompt: this.agent.state.systemPrompt,
+			};
+		};
+
 		this.agent.beforeToolCall = async ({ toolCall, args }) => {
 			const runner = this._extensionRunner;
 			if (!runner.hasHandlers("tool_call")) {


### PR DESCRIPTION
## Summary

Extensions that call `setModel()`, `setThinkingLevel()`, or `setActiveTools()` from `tool_result` handlers update `agent.state` but the running loop uses a snapshot from `createLoopConfig()`. Changes don't take effect until the next user message.

This is a problem for workflow extensions that need to switch models or tools mid-turn — for example, switching from a frontier model for planning to a local model for implementation after a state transition.

## Changes

- **`agent-session.ts`**: Set `agent.prepareNextTurn` in `_installAgentToolHooks()` to sync model, thinkingLevel, tools, and systemPrompt from `agent.state` back into the loop config between turns
- **`agent-loop.ts`**: Apply `tools` and `systemPrompt` from `prepareNextTurn` result to `currentContext` without replacing messages
- **`types.ts`**: Add `tools` and `systemPrompt` fields to `AgentLoopTurnUpdate`

## Test plan

- [x] Existing test `setModel saves the model and emits model_select` passes
- [x] New test `setModel called in tool_result handler takes effect for the next LLM call` — verifies model switch propagates via faux provider
- [x] New test `setThinkingLevel called in tool_result handler takes effect for the next LLM call` — verifies thinking level propagates
- [x] All 12 tests in `agent-session-model-extension.test.ts` pass
- [x] Full `npm run check` passes (biome, tsgo, pinned deps, shrinkwrap)