### PR TITLE
feat(ai): add custom fetch hook to StreamOptions and ImagesOptions

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -500,6 +500,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					options?.headers,
 					copilotDynamicHeaders,
 					cacheSessionId,
+					options?.fetch,
 				);
 				client = created.client;
 				isOAuth = created.isOAuthToken;
@@ -784,6 +785,7 @@ function createClient(
 	optionsHeaders?: Record<string, string>,
 	dynamicHeaders?: Record<string, string>,
 	sessionId?: string,
+	customFetch?: typeof fetch,
 ): { client: Anthropic; isOAuthToken: boolean } {
 	// Adaptive thinking models have interleaved thinking built in, so skip the beta header.
 	const needsInterleavedBeta = interleavedThinking && model.compat?.forceAdaptiveThinking !== true;
@@ -794,6 +796,8 @@ function createClient(
 	if (needsInterleavedBeta) {
 		betaFeatures.push(INTERLEAVED_THINKING_BETA);
 	}
+
+	const fetchOption = customFetch ? { fetch: customFetch } : {};
 
 	if (model.provider === "cloudflare-ai-gateway") {
 		const client = new Anthropic({
@@ -813,6 +817,7 @@ function createClient(
 				model.headers,
 				optionsHeaders,
 			),
+			...fetchOption,
 		});
 
 		return { client, isOAuthToken: false };
@@ -835,6 +840,7 @@ function createClient(
 				dynamicHeaders,
 				optionsHeaders,
 			),
+			...fetchOption,
 		});
 
 		return { client, isOAuthToken: false };
@@ -858,6 +864,7 @@ function createClient(
 				model.headers,
 				optionsHeaders,
 			),
+			...fetchOption,
 		});
 
 		return { client, isOAuthToken: true };
@@ -881,6 +888,7 @@ function createClient(
 			model.headers,
 			optionsHeaders,
 		),
+		...fetchOption,
 	});
 
 	return { client, isOAuthToken: false };

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -247,6 +247,7 @@ function createClient(model: Model<"azure-openai-responses">, apiKey: string, op
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: headers,
 		baseURL: baseUrl,
+		...(options?.fetch ? { fetch: options.fetch } : {}),
 	});
 }
 

--- a/packages/ai/src/providers/images/openrouter.ts
+++ b/packages/ai/src/providers/images/openrouter.ts
@@ -54,7 +54,7 @@ export const generateImagesOpenRouter: ImagesFunction<"openrouter-images", Image
 		if (!apiKey) {
 			throw new Error(`No API key available for provider: ${model.provider}`);
 		}
-		const client = createClient(model, apiKey, options?.headers);
+		const client = createClient(model, apiKey, options?.headers, options?.fetch);
 		let params = buildParams(model, context);
 		const nextParams = await options?.onPayload?.(params, model);
 		if (nextParams !== undefined) {
@@ -108,6 +108,7 @@ function createClient(
 	model: ImagesModel<"openrouter-images">,
 	apiKey: string,
 	optionsHeaders?: Record<string, string>,
+	customFetch?: typeof fetch,
 ): OpenAI {
 	return new OpenAI({
 		apiKey,
@@ -117,6 +118,7 @@ function createClient(
 			...model.headers,
 			...optionsHeaders,
 		},
+		...(customFetch ? { fetch: customFetch } : {}),
 	});
 }
 

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -1,4 +1,4 @@
-import { Mistral } from "@mistralai/mistralai";
+import { HTTPClient, Mistral } from "@mistralai/mistralai";
 import type {
 	ChatCompletionStreamRequest,
 	ChatCompletionStreamRequestMessage,
@@ -66,6 +66,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 			const mistral = new Mistral({
 				apiKey,
 				serverURL: model.baseUrl,
+				...(options?.fetch ? { httpClient: new HTTPClient({ fetcher: options.fetch }) } : {}),
 			});
 
 			const normalizeMistralToolCallId = createMistralToolCallIdNormalizer();

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -281,7 +281,8 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				}
 
 				try {
-					response = await fetch(resolveCodexUrl(model.baseUrl), {
+					const fetchImpl = options?.fetch ?? globalThis.fetch;
+					response = await fetchImpl(resolveCodexUrl(model.baseUrl), {
 						method: "POST",
 						headers: sseHeaders,
 						body: bodyJson,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -140,7 +140,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			const compat = getCompat(model);
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
+			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat, options?.fetch);
 			let params = buildParams(model, context, options, compat, cacheRetention);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -452,6 +452,7 @@ function createClient(
 	optionsHeaders?: Record<string, string>,
 	sessionId?: string,
 	compat: ResolvedOpenAICompletionsCompat = getCompat(model),
+	customFetch?: typeof fetch,
 ) {
 	if (!apiKey) {
 		if (!process.env.OPENAI_API_KEY) {
@@ -497,6 +498,7 @@ function createClient(
 		baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders,
+		...(customFetch ? { fetch: customFetch } : {}),
 	});
 }
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -110,7 +110,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId);
+			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, options?.fetch);
 			let params = buildParams(model, context, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -182,6 +182,7 @@ function createClient(
 	apiKey?: string,
 	optionsHeaders?: Record<string, string>,
 	sessionId?: string,
+	customFetch?: typeof fetch,
 ) {
 	if (!apiKey) {
 		if (!process.env.OPENAI_API_KEY) {
@@ -229,6 +230,7 @@ function createClient(
 		baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders,
+		...(customFetch ? { fetch: customFetch } : {}),
 	});
 }
 

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -16,6 +16,7 @@ export function buildBaseOptions(_model: Model<Api>, options?: SimpleStreamOptio
 		maxRetries: options?.maxRetries,
 		maxRetryDelayMs: options?.maxRetryDelayMs,
 		metadata: options?.metadata,
+		fetch: options?.fetch,
 	};
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -142,6 +142,21 @@ export interface StreamOptions {
 	 * For example, Anthropic uses `user_id` for abuse tracking and rate limiting.
 	 */
 	metadata?: Record<string, unknown>;
+	/**
+	 * Optional custom HTTP transport. When provided, replaces the default
+	 * `globalThis.fetch` for SDKs and raw HTTP calls that accept a fetch hook.
+	 * Use this to route requests through confidential-inference proxies, corp
+	 * HTTP proxies with mTLS, OTel-instrumented transports, in-process mocks,
+	 * or custom retry/backoff middleware.
+	 *
+	 * Supported by: OpenAI Completions, OpenAI Responses, Azure OpenAI
+	 * Responses, OpenAI Codex Responses, Anthropic (all auth modes), Mistral.
+	 * Providers that do not support this option ignore it: Bedrock (uses the
+	 * AWS SDK over Node http/https), Google Gemini and Vertex (the
+	 * `@google/genai` SDK does not expose a fetch hook). OAuth token refresh
+	 * paths also ignore this option; they have their own transport.
+	 */
+	fetch?: typeof fetch;
 }
 
 export type ProviderStreamOptions = StreamOptions & Record<string, unknown>;
@@ -184,6 +199,13 @@ export interface ImagesOptions {
 	 * Providers extract the fields they understand and ignore the rest.
 	 */
 	metadata?: Record<string, unknown>;
+	/**
+	 * Optional custom HTTP transport. When provided, replaces the default
+	 * `globalThis.fetch` for image providers backed by SDKs that accept a
+	 * fetch hook (currently OpenRouter via the OpenAI SDK). Providers that
+	 * do not support this option ignore it.
+	 */
+	fetch?: typeof fetch;
 }
 
 export type ProviderImagesOptions = ImagesOptions & Record<string, unknown>;

--- a/packages/ai/test/custom-fetch.test.ts
+++ b/packages/ai/test/custom-fetch.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.ts";
+import { streamAnthropic, streamSimpleAnthropic } from "../src/providers/anthropic.ts";
+import { streamMistral } from "../src/providers/mistral.ts";
+import { streamOpenAICodexResponses } from "../src/providers/openai-codex-responses.ts";
+import { streamOpenAICompletions } from "../src/providers/openai-completions.ts";
+import { streamOpenAIResponses } from "../src/providers/openai-responses.ts";
+import type { Context, Model } from "../src/types.ts";
+
+/**
+ * Regression coverage for the optional `fetch` hook on StreamOptions
+ * Providers must thread the caller-supplied fetch implementation
+ * into the underlying SDK client or use it for raw HTTP transport.
+ */
+
+const openaiState = vi.hoisted(() => ({
+	constructorOpts: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		constructor(opts: Record<string, unknown>) {
+			openaiState.constructorOpts = opts;
+		}
+
+		chat = {
+			completions: {
+				create: () => {
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							yield {
+								id: "chatcmpl-fetch-test",
+								choices: [{ index: 0, delta: { content: "ok" } }],
+							};
+							yield {
+								id: "chatcmpl-fetch-test",
+								choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+							};
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+
+		responses = {
+			create: () => {
+				const stream = {
+					async *[Symbol.asyncIterator]() {
+						yield { type: "response.completed", response: { status: "completed" } };
+					},
+				};
+				const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+					withResponse: () => Promise<{
+						data: typeof stream;
+						response: { status: number; headers: Headers };
+					}>;
+				};
+				promise.withResponse = async () => ({
+					data: stream,
+					response: { status: 200, headers: new Headers() },
+				});
+				return promise;
+			},
+		};
+	}
+
+	return { default: FakeOpenAI, AzureOpenAI: FakeOpenAI };
+});
+
+const anthropicState = vi.hoisted(() => ({
+	constructorOpts: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	function createSseResponse(): Response {
+		const body = [
+			`event: message_start\ndata: ${JSON.stringify({
+				type: "message_start",
+				message: { id: "msg_fetch_test", usage: { input_tokens: 1, output_tokens: 0 } },
+			})}\n`,
+			`event: message_delta\ndata: ${JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 1 },
+			})}\n`,
+			`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n`,
+		].join("\n");
+		return new Response(body, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	}
+
+	class FakeAnthropic {
+		constructor(opts: Record<string, unknown>) {
+			anthropicState.constructorOpts = opts;
+		}
+		messages = {
+			create: () => ({
+				asResponse: async () => createSseResponse(),
+			}),
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+const mistralState = vi.hoisted(() => ({
+	constructorOpts: undefined as Record<string, unknown> | undefined,
+	httpClientOpts: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("@mistralai/mistralai", () => {
+	class FakeHTTPClient {
+		constructor(opts: Record<string, unknown>) {
+			mistralState.httpClientOpts = opts;
+		}
+	}
+
+	class FakeMistral {
+		constructor(opts: Record<string, unknown>) {
+			mistralState.constructorOpts = opts;
+		}
+		chat = {
+			stream: () =>
+				Promise.resolve({
+					async *[Symbol.asyncIterator]() {
+						yield {
+							data: {
+								id: "mistral-fetch-test",
+								choices: [{ delta: { content: "ok" }, finishReason: "stop" }],
+								usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+							},
+						};
+					},
+				}),
+		};
+	}
+
+	return { Mistral: FakeMistral, HTTPClient: FakeHTTPClient };
+});
+
+const context: Context = {
+	messages: [{ role: "user", content: "hi", timestamp: 0 }],
+};
+
+describe("StreamOptions.fetch", () => {
+	it("passes options.fetch to the OpenAI SDK for openai-completions", async () => {
+		openaiState.constructorOpts = undefined;
+		const customFetch: typeof fetch = async () => new Response();
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model: Model<"openai-completions"> = { ...baseModel, api: "openai-completions" };
+
+		const stream = streamOpenAICompletions(model, context, {
+			apiKey: "test",
+			fetch: customFetch,
+		});
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		const opts = openaiState.constructorOpts as Record<string, unknown> | undefined;
+		expect(opts).toBeDefined();
+		expect(opts?.fetch).toBe(customFetch);
+	});
+
+	it("omits the fetch option when none is provided", async () => {
+		openaiState.constructorOpts = undefined;
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model: Model<"openai-completions"> = { ...baseModel, api: "openai-completions" };
+
+		const stream = streamOpenAICompletions(model, context, { apiKey: "test" });
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		const opts = openaiState.constructorOpts as Record<string, unknown> | undefined;
+		expect(opts).toBeDefined();
+		expect(opts && "fetch" in opts).toBe(false);
+	});
+
+	it("passes options.fetch to the OpenAI SDK for openai-responses", async () => {
+		openaiState.constructorOpts = undefined;
+		const customFetch: typeof fetch = async () => new Response();
+		const baseModel = getModel("openai", "gpt-4o-mini")!;
+		const model: Model<"openai-responses"> = {
+			...baseModel,
+			api: "openai-responses",
+			compat: undefined,
+		} as Model<"openai-responses">;
+
+		const stream = streamOpenAIResponses(model, context, {
+			apiKey: "test",
+			fetch: customFetch,
+		});
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		const opts = openaiState.constructorOpts as Record<string, unknown> | undefined;
+		expect(opts).toBeDefined();
+		expect(opts?.fetch).toBe(customFetch);
+	});
+
+	it("passes options.fetch to the Anthropic SDK", async () => {
+		anthropicState.constructorOpts = undefined;
+		const customFetch: typeof fetch = async () => new Response();
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+
+		const stream = streamAnthropic(model, context, {
+			apiKey: "sk-ant-test",
+			fetch: customFetch,
+		});
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		const opts = anthropicState.constructorOpts as Record<string, unknown> | undefined;
+		expect(opts).toBeDefined();
+		expect(opts?.fetch).toBe(customFetch);
+	});
+
+	it("omits the fetch option from the Anthropic SDK when none is provided", async () => {
+		anthropicState.constructorOpts = undefined;
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		const opts = anthropicState.constructorOpts as Record<string, unknown> | undefined;
+		expect(opts).toBeDefined();
+		expect(opts && "fetch" in opts).toBe(false);
+	});
+
+	it("wraps options.fetch with HTTPClient for Mistral", async () => {
+		mistralState.constructorOpts = undefined;
+		mistralState.httpClientOpts = undefined;
+		const customFetch: typeof fetch = async () => new Response();
+		const model = getModel("mistral", "mistral-medium-3.5");
+
+		const stream = streamMistral(model, context, {
+			apiKey: "test",
+			fetch: customFetch,
+		});
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		const httpOpts = mistralState.httpClientOpts as Record<string, unknown> | undefined;
+		const sdkOpts = mistralState.constructorOpts as Record<string, unknown> | undefined;
+		expect(httpOpts?.fetcher).toBe(customFetch);
+		expect(sdkOpts?.httpClient).toBeDefined();
+	});
+
+	it("propagates options.fetch through buildBaseOptions for streamSimple*", async () => {
+		anthropicState.constructorOpts = undefined;
+		const customFetch: typeof fetch = async () => new Response();
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+
+		const stream = streamSimpleAnthropic(model, context, {
+			apiKey: "sk-ant-test",
+			fetch: customFetch,
+		});
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		const opts = anthropicState.constructorOpts as Record<string, unknown> | undefined;
+		expect(opts?.fetch).toBe(customFetch);
+	});
+
+	it("uses options.fetch for the raw HTTP transport in openai-codex-responses", async () => {
+		const calls: Array<{ url: string }> = [];
+		const sseBody = `data: ${JSON.stringify({ type: "response.created", response: { id: "resp_test" } })}\n\ndata: ${JSON.stringify({ type: "response.completed", response: { status: "completed" } })}\n\n`;
+		const customFetch: typeof fetch = async (input) => {
+			calls.push({ url: typeof input === "string" ? input : String(input) });
+			return new Response(sseBody, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		};
+
+		// Construct a Codex JWT-shaped token so accountId extraction succeeds.
+		const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+		const payload = Buffer.from(
+			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" } }),
+		).toString("base64url");
+		const fakeJwt = `${header}.${payload}.sig`;
+
+		const model = getModel("openai-codex", "gpt-5.3-codex");
+		const stream = streamOpenAICodexResponses(model, context, {
+			apiKey: fakeJwt,
+			fetch: customFetch,
+			transport: "sse",
+		});
+		for await (const _event of stream) {
+			void _event;
+		}
+
+		expect(calls.length).toBeGreaterThan(0);
+		expect(calls[0].url).toContain("/codex/responses");
+	});
+});


### PR DESCRIPTION
Threads an optional `fetch?: typeof fetch` through OpenAI, Anthropic, Mistral, Azure OpenAI, OpenAI Codex Responses (raw HTTP), and OpenRouter Images SDK constructors. Honored via SimpleStreamOptions through buildBaseOptions(). Bedrock and Google providers silently ignore the option; their SDKs do not expose a fetch hook.