### PR TITLE
fix(coding-agent): bail before toString("utf-8") on non-image binaries

### DIFF
--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -9,7 +9,7 @@ import { getReadmePath } from "../../config.ts";
 import { keyHint, keyText } from "../../modes/interactive/components/keybinding-hints.ts";
 import { getLanguageFromPath, highlightCode, type Theme } from "../../modes/interactive/theme/theme.ts";
 import { formatDimensionNote, resizeImage } from "../../utils/image-resize.ts";
-import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.ts";
+import { detectNonImageBinaryLabel, detectSupportedImageMimeTypeFromFile } from "../../utils/mime.ts";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { resolveReadPathAsync, resolveToCwd } from "./path-utils.ts";
@@ -278,6 +278,24 @@ export function createReadToolDefinition(
 							} else {
 								// Read text content.
 								const buffer = await ops.readFile(absolutePath);
+								// Bail before .toString("utf-8") on non-image binaries (PDF / ZIP /
+								// Office / audio / video / executable / etc.). Decoding raw binary
+								// bytes as UTF-8 produces NUL bytes and invalid sequences, which
+								// (a) corrupt downstream persistence (e.g. Postgres jsonb columns
+								// reject  ) and (b) hand the model a gibberish blob.
+								const binaryLabel = detectNonImageBinaryLabel(buffer);
+								if (binaryLabel !== null) {
+									content = [
+										{
+											type: "text",
+											text: `[read: ${path} looks like a binary file (${binaryLabel}). The read tool only supports text files and supported images (jpg/png/gif/webp). Use a dedicated extractor for this format.]`,
+										},
+									];
+									if (aborted) return;
+									signal?.removeEventListener("abort", onAbort);
+									resolve({ content, details });
+									return;
+								}
 								const textContent = buffer.toString("utf-8");
 								const allLines = textContent.split("\n");
 								const totalFileLines = allLines.length;

--- a/packages/coding-agent/src/utils/mime.ts
+++ b/packages/coding-agent/src/utils/mime.ts
@@ -1,7 +1,20 @@
 import { open } from "node:fs/promises";
 
 const IMAGE_TYPE_SNIFF_BYTES = 4100;
+const BINARY_SNIFF_BYTES = 8192;
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const PDF_SIGNATURE = [0x25, 0x50, 0x44, 0x46]; // %PDF
+const ZIP_SIGNATURE = [0x50, 0x4b, 0x03, 0x04]; // PK\x03\x04 — ods/xlsx/docx/pptx/jar/apk/epub
+const ZIP_EMPTY_SIGNATURE = [0x50, 0x4b, 0x05, 0x06]; // empty archive
+const ZIP_SPANNED_SIGNATURE = [0x50, 0x4b, 0x07, 0x08]; // spanned archive
+const ELF_SIGNATURE = [0x7f, 0x45, 0x4c, 0x46];
+const SQLITE_SIGNATURE = [0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x20, 0x33, 0x00];
+const GZIP_SIGNATURE = [0x1f, 0x8b];
+const SEVEN_ZIP_SIGNATURE = [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c];
+const RAR_SIGNATURE = [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07];
+const MP3_ID3_SIGNATURE = [0x49, 0x44, 0x33]; // ID3
+const OGG_SIGNATURE = [0x4f, 0x67, 0x67, 0x53]; // OggS
+const FLAC_SIGNATURE = [0x66, 0x4c, 0x61, 0x43]; // fLaC
 
 export function detectSupportedImageMimeType(buffer: Uint8Array): string | null {
 	if (startsWith(buffer, [0xff, 0xd8, 0xff])) {
@@ -28,6 +41,58 @@ export async function detectSupportedImageMimeTypeFromFile(filePath: string): Pr
 	} finally {
 		await fileHandle.close();
 	}
+}
+
+/**
+ * Detect non-image binary files by magic bytes plus a NUL-byte heuristic.
+ *
+ * Returns a short label (e.g. "PDF", "ZIP-based archive (Office, jar, apk, ...)",
+ * "binary") when the file looks binary, or null when the content appears to be
+ * text. Used by the `read` tool to avoid handing the model a `buffer.toString("utf-8")`
+ * of raw binary bytes, which corrupts downstream persistence (NUL bytes in jsonb)
+ * and degrades the conversation (the model receives a gibberish blob).
+ *
+ * The check is conservative: known text-shaped formats (JSON, XML, source code,
+ * even with no magic bytes) all return null because they have no NUL bytes in
+ * the first 8 KB.
+ */
+export function detectNonImageBinaryLabel(buffer: Uint8Array): string | null {
+	if (startsWith(buffer, PDF_SIGNATURE)) return "PDF";
+	if (
+		startsWith(buffer, ZIP_SIGNATURE) ||
+		startsWith(buffer, ZIP_EMPTY_SIGNATURE) ||
+		startsWith(buffer, ZIP_SPANNED_SIGNATURE)
+	) {
+		return "ZIP-based archive (Office document, jar, apk, epub, ...)";
+	}
+	if (startsWith(buffer, ELF_SIGNATURE)) return "ELF executable";
+	if (startsWith(buffer, SQLITE_SIGNATURE)) return "SQLite database";
+	if (startsWith(buffer, GZIP_SIGNATURE)) return "gzip";
+	if (startsWith(buffer, SEVEN_ZIP_SIGNATURE)) return "7-Zip archive";
+	if (startsWith(buffer, RAR_SIGNATURE)) return "RAR archive";
+	if (startsWith(buffer, MP3_ID3_SIGNATURE)) return "MP3 (ID3-tagged)";
+	if (startsWith(buffer, OGG_SIGNATURE)) return "Ogg media";
+	if (startsWith(buffer, FLAC_SIGNATURE)) return "FLAC audio";
+	// MP3 frame sync: 0xFF followed by 0xFB / 0xFA / 0xF3 / 0xF2.
+	if (buffer.length >= 2 && buffer[0] === 0xff && [0xfb, 0xfa, 0xf3, 0xf2].includes(buffer[1] ?? -1)) {
+		return "MP3 audio";
+	}
+	// RIFF container — WAV / AVI / WEBP. WEBP is handled by the image sniff above
+	// and would never reach this function; flag the rest as binary.
+	if (startsWithAscii(buffer, 0, "RIFF") && !startsWithAscii(buffer, 8, "WEBP")) {
+		return "RIFF container (WAV/AVI/...)";
+	}
+	// MP4 / QuickTime: 4 size bytes + "ftyp".
+	if (buffer.length >= 12 && startsWithAscii(buffer, 4, "ftyp")) {
+		return "MP4/QuickTime media";
+	}
+	// Final heuristic: NUL bytes in the first 8 KB. Real text files (UTF-8) do
+	// not contain NUL. UTF-16/UTF-32 files do, but they are rare and would be
+	// mojibake under .toString("utf-8") anyway — flagging them as binary is the
+	// safer call.
+	const probe = buffer.subarray(0, Math.min(buffer.length, BINARY_SNIFF_BYTES));
+	if (probe.indexOf(0) !== -1) return "binary";
+	return null;
 }
 
 function isPng(buffer: Uint8Array): boolean {


### PR DESCRIPTION
## Resumen

Hasta v32 el bridge reiniciaba el gateway por TCP-connect fallido pero no capturaba *por qué* había caído. En Telegram solo veíamos "Gateway auto-recuperado" sin información para depurar. Esta versión convierte cada caída en evidencia accionable, y prepara el terreno para los fixes de fondo (límites de memoria al gateway, cgroup para spawns, compactación MEMORY.md).

Detonante: la madrugada del 23-may caen 4 VPS (1004, 1008, 1023, 1025) en menos de un minuto, con 1025 cayendo tres veces. El changelog v12/v31/v32 muestra que el equipo ya sabe que es OOM, pero los fixes son reactivos (reiniciar rápido), no diagnósticos.

## Qué hace esta PR

### Bridge (`ops/openclaw-bridge.mjs`)
- **`captureGatewayDiagnostics()`** — antes de cada restart (watchdog interno o `/restart-gateway` externo) recoge:
  - `journalctl --user -u openclaw-gateway -n 80`
  - `systemctl show` (Result, ExecMainStatus, ExecMainCode, NRestarts, ActiveState, MemoryCurrent)
  - `dmesg | grep -iE 'killed|oom|gateway|openclaw|node'`
  - `/proc/meminfo`
  - Clasifica en `reason`: `oom_kill_kernel | oom_kill_systemd | exit_137_sigkill | panic | event_loop_stalled | exit_<N> | unknown`.
- **`reportToBackend()`** — postea a `/functions/v1/log-event` con `event=gateway_restart`, payload diagnóstico, level error/warn según gravedad. Aparece en `/admin?tab=logs`.
- **`_gwAlive()`** migrado de TCP-connect (falso-positivo cuando event loop está ocupado pero vivo) a **HTTP GET `127.0.0.1:18789/healthz`** con timeout 4s y fallback TCP para gateways < v33.
- **`/restart-gateway`** devuelve `{ reason, memory_rss_mb, exit_status, result, n_restarts }` en el JSON.
- **`/health`** expone `last_failure { reason, captured_at, memory_rss_mb }` si hubo caída reciente.
- **`ensureGatewayMemoryCaps()`** — al arrancar, si el unit del gateway no tiene `MemoryHigh`/`MemoryMax`, escribe drop-in `50-memory.conf` con `MemoryHigh=900M MemoryMax=1200M OOMPolicy=stop`. Idempotente. Sin restart automático del gateway (efecto en el próximo reinicio).

### Monitor (`ops/monitor/vps-monitor.py`)
- `restart_gateway()` devuelve ahora `(restarted, info_dict)`. Timeout 8s → 15s para dar margen a la captura.
- `humanize_reason()` traduce el enum a texto legible (`oom_kill_kernel` → "OOM-killed (kernel mató el proceso)").
- Alertas Telegram añaden `Motivo: <reason>`, `RSS antes del kill: N MB`, `Restarts totales: N`.
- Compatible con bridges v30-v32: si la respuesta no trae `reason`, alerta como antes.
- `state[vmid].last_reason` persiste el último motivo para correlación cross-VPS.

## Test plan

- [x] `node --input-type=module --check < ops/openclaw-bridge.mjs` pasa
- [x] `python3 -m py_compile ops/monitor/vps-monitor.py` pasa
- [ ] Tras desplegar (publicar nuevo `/static/openclaw-bridge.mjs`), el polling de self-update lo aplica en todas las VPS en ≤1h
- [ ] Provocar caída controlada del gateway en una VPS test (`systemctl --user kill -s SIGKILL openclaw-gateway`) y verificar:
  - Mensaje Telegram contiene `Motivo: exit 137 / SIGKILL`
  - Tabla `app_logs` tiene fila con `event=gateway_restart`
- [ ] Tras restart natural posterior, comprobar que `/etc/systemd/user/.../openclaw-gateway.service.d/50-memory.conf` existe en la VPS y que `systemctl --user show openclaw-gateway -p MemoryMax` devuelve 1.25G

## Próximos pasos (NO en esta PR)

1. Cgroup separado / sub-unit para spawns Python (`tesseract`, `pdfplumber`, `send_pdf.py`) — que la víctima del OOM sea el helper, no el gateway.
2. Timer systemd que reinicia el plugin de Baileys (WhatsApp) cada 12-24 h — leak conocido.
3. Compactación más agresiva de `MEMORY.md` — la inyección RAG v22/v23 carga el archivo entero por mensaje; si crece sin freno, cada turno cuesta más memoria.
4. Healthcheck `GET /healthz` en el gateway (ahora mismo solo se cae al fallback TCP en bridges v33; cuando el gateway lo implemente, ganamos detección de event-loop bloqueado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
