### PR TITLE
fix(coding-agent): save enabledModels to project settings instead of global

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1018,9 +1018,10 @@ export class SettingsManager {
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {
-		this.globalSettings.enabledModels = patterns;
-		this.markModified("enabledModels");
-		this.save();
+		const projectSettings = structuredClone(this.projectSettings);
+		projectSettings.enabledModels = patterns;
+		this.markProjectModified("enabledModels");
+		this.saveProjectSettings(projectSettings);
 	}
 
 	getDoubleEscapeAction(): "fork" | "tree" | "none" {


### PR DESCRIPTION
## Problem

When using `pi update` to enable/disable models, the `enabledModels` setting was always saved to the global settings file (`~/.pi/settings.json`), causing the setting to leak across all projects.

## Fix

Changed `SettingsManager.setEnabledModels()` to save to project settings instead of global settings, so the setting is scoped to the current project.

## Changes

- `packages/coding-agent/src/core/settings-manager.ts`: `setEnabledModels()` now uses `saveProjectSettings()` instead of `save()`

## Verification

After the fix, `enabledModels` is correctly saved to `<project>/.pi/settings.json` and does not affect other projects.