### PR TITLE
Fix OpenAI GPT-5.5 context window

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1185,7 +1185,7 @@ async function generateModels() {
 			candidate.contextWindow = 272000;
 			candidate.maxTokens = 128000;
 		}
-		if (candidate.provider === "openai" && (candidate.id === "gpt-5.4" || candidate.id === "gpt-5.5")) {
+		if (candidate.provider === "openai" && candidate.id === "gpt-5.4") {
 			candidate.contextWindow = 272000;
 			candidate.maxTokens = 128000;
 		}

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -6767,7 +6767,7 @@ export const MODELS = {
 				cacheRead: 0.5,
 				cacheWrite: 0,
 			},
-			contextWindow: 272000,
+			contextWindow: 1050000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-responses">,
 		"gpt-5.5-pro": {


### PR DESCRIPTION
## What

Updates OpenAI `gpt-5.5` model metadata so Pi treats it as a 1,050,000-token context model instead of 272,000 tokens.

## Why

OpenAI's current model docs and Shopify AI Proxy `/v1/models` metadata both report `gpt-5.5` with a 1,050,000-token context window. Pi's generator still had a temporary override that forced both `gpt-5.4` and `gpt-5.5` down to 272,000 tokens, causing Pi sessions to compact far earlier than the provider supports.

## Details

- Keeps the explicit 272k override for `gpt-5.4`.
- Removes `gpt-5.5` from that override so generated metadata uses upstream `models.dev` context metadata.
- Regenerates the OpenAI `gpt-5.5` entry to `contextWindow: 1050000`.

## Verification

- Verified Shopify AI Proxy `/v1/models` reports `models_dev.limit.context = 1050000` for `gpt-5.5`.
- Ran `npm run check` successfully.
