### PR TITLE
fix: resolveConfigValue corrupts literal API keys via case-insensitive env var on Windows

### DIFF
--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -1322,7 +1322,8 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
-			}
+			},
+			"peer": true
 		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
@@ -1775,7 +1776,8 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
+			},
+			"peer": true
 		},
 		"node_modules/zod-to-json-schema": {
 			"version": "3.25.2",

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -134,6 +134,33 @@ describe("AuthStorage", () => {
 			}
 		});
 
+		test("literal API key is not corrupted by case-insensitive env var match on Windows", async () => {
+			// On Windows, process.env is case-insensitive, so "public" matches
+			// the PUBLIC env var (C:\Users\Public). A literal API key "public"
+			// must be returned as-is, not resolved to the PUBLIC env var value.
+			const originalPublic = process.env.PUBLIC;
+			process.env.PUBLIC = "C:\\Users\\Public";
+
+			try {
+				writeAuthJson({
+					opencode: { type: "api_key", key: "public" },
+				});
+
+				authStorage = AuthStorage.create(authJsonPath);
+				const apiKey = await authStorage.getApiKey("opencode");
+
+				expect(apiKey).toBe("public");
+				// The key must NOT be the env var value
+				expect(apiKey).not.toBe("C:\\Users\\Public");
+			} finally {
+				if (originalPublic === undefined) {
+					delete process.env.PUBLIC;
+				} else {
+					process.env.PUBLIC = originalPublic;
+				}
+			}
+		});
+
 		test("apiKey as literal value is used directly when not an env var", async () => {
 			// Make sure this isn't an env var
 			delete process.env.literal_api_key_value;


### PR DESCRIPTION
## Problem

On Windows, `process.env` is case-insensitive. When `resolveConfigValue("public")` is called, it does `process.env["public"]` which matches the `PUBLIC` environment variable (`C:\Users\Public`) and returns that instead of the literal string `"public"`.

This breaks the opencode free tier, which uses `"public"` as a sentinel API key. The Zen proxy expects the literal string `"public"` but receives `"C:\Users\Public"` and returns 401.

## Reproduction

1. Ensure `OPENCODE_API_KEY` env var is not set
2. Store `{"opencode": {"type": "api_key", "key": "public"}}` in `~/.pi/agent/auth.json`
3. Run `pi --model opencode/mimo-v2.5-free -p "hi"`
4. Gets `401 Invalid API key`

The `--api-key public` flag works because it bypasses `resolveConfigValue` entirely via runtime overrides.

## Root cause

`resolveConfigValue` treats all non-`!`-prefixed strings as potential env var names:

```typescript
const envValue = process.env[config];  // case-insensitive on Windows!
return envValue || config;
```

On Windows, `process.env["public"]` returns `"C:\Users\Public"` (the PUBLIC env var), so the literal string is never returned.

## Test

This PR adds a failing test demonstrating the bug. A follow-up commit will fix `resolveConfigValue` to treat plain strings as literals, with explicit `$` prefix syntax for env var references.
