### PR TITLE
fix(tui): support inline images and arrow keys inside tmux

### DIFF
--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -107,7 +107,8 @@ export class Image implements Component {
 					}
 					const rowOffset = result.rows - 1;
 					const moveUp = rowOffset > 0 ? `\x1b[${rowOffset}A` : "";
-					lines.push(moveUp + result.sequence);
+					const moveDown = rowOffset > 0 ? `\x1b[${rowOffset}B` : "";
+					lines.push(moveUp + result.sequence + moveDown);
 				}
 			} else {
 				const fallback = imageFallback(this.mimeType, this.dimensions, this.options.filename);

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -366,10 +366,10 @@ function normalizeShiftedLetterIdentityCodepoint(codepoint: number, modifier: nu
 }
 
 const LEGACY_KEY_SEQUENCES = {
-	up: ["\x1b[A", "\x1bOA"],
-	down: ["\x1b[B", "\x1bOB"],
-	right: ["\x1b[C", "\x1bOC"],
-	left: ["\x1b[D", "\x1bOD"],
+	up: ["\x1b[A", "\x1bOA", "\x1b[1;1A"],
+	down: ["\x1b[B", "\x1bOB", "\x1b[1;1B"],
+	right: ["\x1b[C", "\x1bOC", "\x1b[1;1C"],
+	left: ["\x1b[D", "\x1bOD", "\x1b[1;1D"],
 	home: ["\x1b[H", "\x1bOH", "\x1b[1~", "\x1b[7~"],
 	end: ["\x1b[F", "\x1bOF", "\x1b[4~", "\x1b[8~"],
 	insert: ["\x1b[2~"],

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -1,3 +1,5 @@
+import { execSync } from "node:child_process";
+
 export type ImageProtocol = "kitty" | "iterm2" | null;
 
 export interface TerminalCapabilities {
@@ -39,6 +41,50 @@ export function setCellDimensions(dims: CellDimensions): void {
 	cellDimensions = dims;
 }
 
+/**
+ * Detect the parent terminal when running inside tmux with allow-passthrough enabled.
+ * Reads tmux's environment variables to identify the outer terminal emulator.
+ * Returns null if passthrough is not available or the parent terminal is unknown.
+ */
+function detectParentTerminal(): TerminalCapabilities | null {
+	try {
+		const passthrough = execSync("tmux show-option -gv allow-passthrough 2>/dev/null", {
+			encoding: "utf-8",
+			timeout: 500,
+		}).trim();
+		if (passthrough !== "on" && passthrough !== "all") return null;
+
+		const raw = execSync("tmux show-environment -g 2>/dev/null", {
+			encoding: "utf-8",
+			timeout: 500,
+		});
+
+		const env: Record<string, string> = {};
+		for (const line of raw.split("\n")) {
+			const eq = line.indexOf("=");
+			if (eq > 0) env[line.slice(0, eq)] = line.slice(eq + 1);
+		}
+
+		const tp = (env.TERM_PROGRAM || "").toLowerCase();
+
+		if (env.KITTY_WINDOW_ID || tp === "kitty") {
+			return { images: "kitty", trueColor: true, hyperlinks: true };
+		}
+		if (env.GHOSTTY_RESOURCES_DIR || tp === "ghostty") {
+			return { images: "kitty", trueColor: true, hyperlinks: true };
+		}
+		if (env.WEZTERM_PANE || tp === "wezterm") {
+			return { images: "kitty", trueColor: true, hyperlinks: true };
+		}
+		if (env.ITERM_SESSION_ID || env.LC_TERMINAL === "iTerm2" || tp === "iterm.app") {
+			return { images: "iterm2", trueColor: true, hyperlinks: true };
+		}
+	} catch {
+		// tmux not available or command failed
+	}
+	return null;
+}
+
 export function detectCapabilities(): TerminalCapabilities {
 	const termProgram = process.env.TERM_PROGRAM?.toLowerCase() || "";
 	const terminalEmulator = process.env.TERMINAL_EMULATOR?.toLowerCase() || "";
@@ -52,6 +98,10 @@ export function detectCapabilities(): TerminalCapabilities {
 	// also unreliable under tmux/screen, so leave `images: null` for safety.
 	const inTmuxOrScreen = !!process.env.TMUX || term.startsWith("tmux") || term.startsWith("screen");
 	if (inTmuxOrScreen) {
+		const parentCaps = detectParentTerminal();
+		if (parentCaps) {
+			return { ...parentCaps, trueColor: parentCaps.trueColor || hasTrueColorHint };
+		}
 		return { images: null, trueColor: hasTrueColorHint, hyperlinks: false };
 	}
 
@@ -399,6 +449,16 @@ export function getImageDimensions(base64Data: string, mimeType: string): ImageD
 	return null;
 }
 
+/**
+ * Wrap an escape sequence in tmux DCS passthrough format.
+ * When not inside tmux, returns the sequence unchanged.
+ */
+function wrapForTmux(sequence: string): string {
+	if (!process.env.TMUX) return sequence;
+	const escaped = sequence.replace(/\x1b/g, "\x1b\x1b");
+	return `\x1bPtmux;${escaped}\x1b\\`;
+}
+
 export function renderImage(
 	base64Data: string,
 	imageDimensions: ImageDimensions,
@@ -424,11 +484,12 @@ export function renderImage(
 	}
 
 	if (caps.images === "iterm2") {
-		const sequence = encodeITerm2(base64Data, {
+		let sequence = encodeITerm2(base64Data, {
 			width: size.columns,
 			height: "auto",
 			preserveAspectRatio: options.preserveAspectRatio ?? true,
 		});
+		sequence = wrapForTmux(sequence);
 		return { sequence, rows: size.rows };
 	}
 


### PR DESCRIPTION
## Problem

When running inside tmux, `pi-tui` cannot display inline images and arrow key navigation breaks:

1. `detectCapabilities()` unconditionally returns `images: null` when `$TMUX` is set
2. Arrow keys sent with CSI-u format (`\x1b[1;1A`) are not recognized
3. After DCS passthrough image sequences, tmux's cursor desynchronizes from the actual terminal cursor

## Solution

### 1. Detect parent terminal through tmux passthrough

Added `detectParentTerminal()` which:
- Checks `tmux show-option -gv allow-passthrough` (requires `on` or `all`)
- Reads `tmux show-environment -g` to identify the outer terminal
- Supports: iTerm2, Kitty, Ghostty, WezTerm

### 2. Wrap iTerm2 sequences in DCS passthrough

Added `wrapForTmux()` which wraps OSC 1337 sequences in the tmux DCS passthrough format:
```
\x1bPtmux;\x1b\x1b]1337;File=inline=1;...\x07\x1b\\
```
All ESC bytes in the inner sequence are doubled per the tmux passthrough protocol.

### 3. CSI-u arrow key support

Added `\x1b[1;1A/B/C/D` to `LEGACY_KEY_SEQUENCES`. tmux with `extended-keys-format csi-u` sends unmodified arrow keys with explicit modifier=1 (none), which previously didn't match any recognized sequence.

### 4. Cursor resync after DCS passthrough

Added `moveDown` after the iTerm2 image sequence in `Image.render()`. tmux's virtual terminal cursor doesn't advance during DCS passthrough (only the real terminal cursor does), causing subsequent renders to overlap.

## Testing

Tested with:
- macOS (arm64)
- iTerm2 3.6.4 → tmux 3.5a → Pi
- `allow-passthrough on`
- `extended-keys on` + `extended-keys-format csi-u`

## Files Changed

- `packages/tui/src/terminal-image.ts` — `detectParentTerminal()`, `wrapForTmux()`, render wrapping
- `packages/tui/src/keys.ts` — CSI-u arrow sequences in `LEGACY_KEY_SEQUENCES`
- `packages/tui/src/components/image.ts` — `moveDown` cursor resync
