### PR TITLE
Preserve stream options during compaction

### DIFF
--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -689,6 +689,7 @@ export class AgentHarness<
 			const auth = await this.getApiKeyAndHeaders?.(model);
 			if (!auth) throw new AgentHarnessError("auth", "No auth available for compaction");
 			const branchEntries = await this.session.getBranch();
+			const sessionMetadata = await this.session.getMetadata();
 			const preparationResult = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS);
 			if (!preparationResult.ok) throw preparationResult.error;
 			const preparation = preparationResult.value;
@@ -712,6 +713,7 @@ export class AgentHarness<
 						customInstructions,
 						undefined,
 						this.thinkingLevel,
+						{ sessionId: sessionMetadata.id, transport: this.streamOptions.transport },
 					);
 			if (!compactResult.ok) throw compactResult.error;
 			const result = compactResult.value;

--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -1,4 +1,11 @@
-import type { AssistantMessage, ImageContent, Model, TextContent, Usage } from "@earendil-works/pi-ai";
+import type {
+	AssistantMessage,
+	ImageContent,
+	Model,
+	SimpleStreamOptions,
+	TextContent,
+	Usage,
+} from "@earendil-works/pi-ai";
 import { completeSimple } from "@earendil-works/pi-ai";
 import type { AgentMessage, ThinkingLevel } from "../../types.ts";
 import {
@@ -25,6 +32,9 @@ export interface CompactionDetails {
 	/** Files modified in the compacted history. */
 	modifiedFiles: string[];
 }
+
+type CompactionStreamOptions = Pick<SimpleStreamOptions, "sessionId" | "transport">;
+
 function safeJsonStringify(value: unknown): string {
 	try {
 		return JSON.stringify(value) ?? "undefined";
@@ -462,6 +472,7 @@ export async function generateSummary(
 	customInstructions?: string,
 	previousSummary?: string,
 	thinkingLevel?: ThinkingLevel,
+	streamOptions?: CompactionStreamOptions,
 ): Promise<Result<string, CompactionError>> {
 	const maxTokens = Math.min(
 		Math.floor(0.8 * reserveTokens),
@@ -487,10 +498,10 @@ export async function generateSummary(
 		},
 	];
 
-	const completionOptions =
-		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers };
+	const completionOptions: SimpleStreamOptions = { ...streamOptions, maxTokens, signal, apiKey, headers };
+	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
+		completionOptions.reasoning = thinkingLevel;
+	}
 
 	const response = await completeSimple(
 		model,
@@ -631,6 +642,7 @@ export async function compact(
 	customInstructions?: string,
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
+	streamOptions?: CompactionStreamOptions,
 ): Promise<Result<CompactionResult, CompactionError>> {
 	const {
 		firstKeptEntryId,
@@ -662,6 +674,7 @@ export async function compact(
 						customInstructions,
 						previousSummary,
 						thinkingLevel,
+						streamOptions,
 					)
 				: Promise.resolve(ok<string, CompactionError>("No prior history.")),
 			generateTurnPrefixSummary(
@@ -672,6 +685,7 @@ export async function compact(
 				headers,
 				signal,
 				thinkingLevel,
+				streamOptions,
 			),
 		]);
 		if (!historyResult.ok) return err(historyResult.error);
@@ -688,6 +702,7 @@ export async function compact(
 			customInstructions,
 			previousSummary,
 			thinkingLevel,
+			streamOptions,
 		);
 		if (!summaryResult.ok) return err(summaryResult.error);
 		summary = summaryResult.value;
@@ -711,6 +726,7 @@ async function generateTurnPrefixSummary(
 	headers?: Record<string, string>,
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
+	streamOptions?: CompactionStreamOptions,
 ): Promise<Result<string, CompactionError>> {
 	const maxTokens = Math.min(
 		Math.floor(0.5 * reserveTokens),
@@ -727,12 +743,15 @@ async function generateTurnPrefixSummary(
 		},
 	];
 
+	const completionOptions: SimpleStreamOptions = { ...streamOptions, maxTokens, signal, apiKey, headers };
+	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
+		completionOptions.reasoning = thinkingLevel;
+	}
+
 	const response = await completeSimple(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		model.reasoning && thinkingLevel && thinkingLevel !== "off"
-			? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
-			: { maxTokens, signal, apiKey, headers },
+		completionOptions,
 	);
 	if (response.stopReason === "aborted") {
 		return err(new CompactionError("aborted", response.errorMessage || "Turn prefix summarization aborted"));

--- a/packages/agent/test/harness/compaction.test.ts
+++ b/packages/agent/test/harness/compaction.test.ts
@@ -597,6 +597,43 @@ describe("harness compaction", () => {
 		expect(invalidResult).toMatchObject({ ok: false, error: { code: "invalid_session" } });
 	});
 
+	it("passes stream options through compaction summaries", async () => {
+		const messages: AgentMessage[] = [createUserMessage("Summarize this.")];
+		const seenOptions: Array<Record<string, unknown> | undefined> = [];
+		const { faux, model } = createFauxModel(false);
+		faux.setResponses([
+			(_context, options) => {
+				seenOptions.push(options as Record<string, unknown> | undefined);
+				return fauxAssistantMessage("## Goal\nTest summary");
+			},
+			(_context, options) => {
+				seenOptions.push(options as Record<string, unknown> | undefined);
+				return fauxAssistantMessage("## Original Request\nTest summary");
+			},
+		]);
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "entry-keep",
+			messagesToSummarize: messages,
+			turnPrefixMessages: messages,
+			isSplitTurn: true,
+			tokensBefore: 100,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { enabled: true, reserveTokens: 2000, keepRecentTokens: 20 },
+		};
+
+		getOrThrow(
+			await compact(preparation, model, "test-key", undefined, undefined, undefined, undefined, {
+				sessionId: "session-123",
+				transport: "sse",
+			}),
+		);
+
+		expect(seenOptions).toEqual([
+			expect.objectContaining({ sessionId: "session-123", transport: "sse" }),
+			expect.objectContaining({ sessionId: "session-123", transport: "sse" }),
+		]);
+	});
+
 	it("passes reasoning through turn-prefix summaries when enabled", async () => {
 		const messages: AgentMessage[] = [createUserMessage("Summarize this.")];
 		const seenOptions: Array<Record<string, unknown> | undefined> = [];

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1678,6 +1678,7 @@ export class AgentSession {
 					this._compactionAbortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFn,
+					{ sessionId: this.sessionId, transport: this.agent.transport },
 				);
 				summary = result.summary;
 				firstKeptEntryId = result.firstKeptEntryId;
@@ -1951,6 +1952,7 @@ export class AgentSession {
 					this._autoCompactionAbortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFn,
+					{ sessionId: this.sessionId, transport: this.agent.transport },
 				);
 				summary = compactResult.summary;
 				firstKeptEntryId = compactResult.firstKeptEntryId;

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -35,6 +35,8 @@ export interface CompactionDetails {
 	modifiedFiles: string[];
 }
 
+type CompactionStreamOptions = Pick<SimpleStreamOptions, "sessionId" | "transport">;
+
 /**
  * Extract file operations from messages and previous compaction entries.
  */
@@ -530,8 +532,9 @@ function createSummarizationOptions(
 	headers: Record<string, string> | undefined,
 	signal: AbortSignal | undefined,
 	thinkingLevel: ThinkingLevel | undefined,
+	streamOptions?: CompactionStreamOptions,
 ): SimpleStreamOptions {
-	const options: SimpleStreamOptions = { maxTokens, signal, apiKey, headers };
+	const options: SimpleStreamOptions = { ...streamOptions, maxTokens, signal, apiKey, headers };
 	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
 		options.reasoning = thinkingLevel;
 	}
@@ -566,6 +569,7 @@ export async function generateSummary(
 	previousSummary?: string,
 	thinkingLevel?: ThinkingLevel,
 	streamFn?: StreamFn,
+	streamOptions?: CompactionStreamOptions,
 ): Promise<string> {
 	const maxTokens = Math.min(
 		Math.floor(0.8 * reserveTokens),
@@ -598,7 +602,15 @@ export async function generateSummary(
 		},
 	];
 
-	const completionOptions = createSummarizationOptions(model, maxTokens, apiKey, headers, signal, thinkingLevel);
+	const completionOptions = createSummarizationOptions(
+		model,
+		maxTokens,
+		apiKey,
+		headers,
+		signal,
+		thinkingLevel,
+		streamOptions,
+	);
 
 	const response = await completeSummarization(
 		model,
@@ -753,6 +765,7 @@ export async function compact(
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
 	streamFn?: StreamFn,
+	streamOptions?: CompactionStreamOptions,
 ): Promise<CompactionResult> {
 	const {
 		firstKeptEntryId,
@@ -783,6 +796,7 @@ export async function compact(
 						previousSummary,
 						thinkingLevel,
 						streamFn,
+						streamOptions,
 					)
 				: Promise.resolve("No prior history."),
 			generateTurnPrefixSummary(
@@ -794,6 +808,7 @@ export async function compact(
 				signal,
 				thinkingLevel,
 				streamFn,
+				streamOptions,
 			),
 		]);
 		// Merge into single summary
@@ -811,6 +826,7 @@ export async function compact(
 			previousSummary,
 			thinkingLevel,
 			streamFn,
+			streamOptions,
 		);
 	}
 
@@ -842,6 +858,7 @@ async function generateTurnPrefixSummary(
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
 	streamFn?: StreamFn,
+	streamOptions?: CompactionStreamOptions,
 ): Promise<string> {
 	const maxTokens = Math.min(
 		Math.floor(0.5 * reserveTokens),
@@ -861,7 +878,7 @@ async function generateTurnPrefixSummary(
 	const response = await completeSummarization(
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		createSummarizationOptions(model, maxTokens, apiKey, headers, signal, thinkingLevel),
+		createSummarizationOptions(model, maxTokens, apiKey, headers, signal, thinkingLevel, streamOptions),
 		streamFn,
 	);
 

--- a/packages/coding-agent/test/compaction-summary-reasoning.test.ts
+++ b/packages/coding-agent/test/compaction-summary-reasoning.test.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, StreamFn } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type CompactionPreparation, compact, generateSummary } from "../src/core/compaction/index.ts";
@@ -116,6 +116,31 @@ describe("generateSummary reasoning options", () => {
 		expect(completeSimpleMock.mock.calls[0][2]).not.toHaveProperty("reasoning");
 	});
 
+	it("passes compaction stream options to a custom stream function", async () => {
+		const streamFn = vi.fn<StreamFn>(async () => ({ result: async () => mockSummaryResponse }) as any);
+
+		await generateSummary(
+			messages,
+			createModel(false),
+			2000,
+			"test-key",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			streamFn,
+			{ sessionId: "session-123", transport: "sse" },
+		);
+
+		expect(streamFn).toHaveBeenCalledTimes(1);
+		expect(streamFn.mock.calls[0][2]).toMatchObject({
+			apiKey: "test-key",
+			sessionId: "session-123",
+			transport: "sse",
+		});
+	});
+
 	it("clamps compaction summary maxTokens to the model output cap", async () => {
 		const preparation: CompactionPreparation = {
 			firstKeptEntryId: "entry-keep",
@@ -130,5 +155,29 @@ describe("generateSummary reasoning options", () => {
 		await compact(preparation, createModel(false, 128000), "test-key");
 
 		expect(completeSimpleMock.mock.calls.map((call) => call[2]?.maxTokens)).toEqual([128000, 128000]);
+	});
+
+	it("passes compaction stream options through split-turn summaries", async () => {
+		const streamFn = vi.fn<StreamFn>(async () => ({ result: async () => mockSummaryResponse }) as any);
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "entry-keep",
+			messagesToSummarize: messages,
+			turnPrefixMessages: messages,
+			isSplitTurn: true,
+			tokensBefore: 600000,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { enabled: true, reserveTokens: 500000, keepRecentTokens: 20000 },
+		};
+
+		await compact(preparation, createModel(false), "test-key", undefined, undefined, undefined, undefined, streamFn, {
+			sessionId: "session-123",
+			transport: "sse",
+		});
+
+		expect(streamFn).toHaveBeenCalledTimes(2);
+		expect(streamFn.mock.calls.map((call) => call[2])).toEqual([
+			expect.objectContaining({ sessionId: "session-123", transport: "sse" }),
+			expect.objectContaining({ sessionId: "session-123", transport: "sse" }),
+		]);
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -46,10 +46,15 @@ function createAssistant(
 	};
 }
 
-function useSummaryStreamFn(harness: Harness, summary: string): () => number {
+function useSummaryStreamFn(
+	harness: Harness,
+	summary: string,
+	seenOptions?: Array<Record<string, unknown> | undefined>,
+): () => number {
 	let callCount = 0;
-	harness.session.agent.streamFn = (model) => {
+	harness.session.agent.streamFn = (model, _context, options) => {
 		callCount++;
+		seenOptions?.push(options as Record<string, unknown> | undefined);
 		const stream = createAssistantMessageEventStream();
 		queueMicrotask(() => {
 			const message: AssistantMessage = {
@@ -141,19 +146,24 @@ describe("AgentSession compaction characterization", () => {
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);
 		seedCompactableSession(harness);
-		const getStreamCallCount = useSummaryStreamFn(harness, "summary from custom stream");
+		harness.session.agent.transport = "sse";
+		const seenOptions: Array<Record<string, unknown> | undefined> = [];
+		const getStreamCallCount = useSummaryStreamFn(harness, "summary from custom stream", seenOptions);
 
 		const result = await harness.session.compact();
 
 		expect(result.summary).toBe("summary from custom stream");
 		expect(getStreamCallCount()).toBe(1);
+		expect(seenOptions[0]).toMatchObject({ sessionId: harness.session.sessionId, transport: "sse" });
 	});
 
 	it("auto-compacts with a custom streamFn when registry auth is absent", async () => {
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);
 		seedCompactableSession(harness);
-		const getStreamCallCount = useSummaryStreamFn(harness, "auto summary from custom stream");
+		harness.session.agent.transport = "sse";
+		const seenOptions: Array<Record<string, unknown> | undefined> = [];
+		const getStreamCallCount = useSummaryStreamFn(harness, "auto summary from custom stream", seenOptions);
 		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
 
 		await sessionInternals._runAutoCompaction("threshold", false);
@@ -161,6 +171,7 @@ describe("AgentSession compaction characterization", () => {
 		const compactionEntries = harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction");
 		expect(compactionEntries).toHaveLength(1);
 		expect(getStreamCallCount()).toBe(1);
+		expect(seenOptions[0]).toMatchObject({ sessionId: harness.session.sessionId, transport: "sse" });
 	});
 
 	it("cancels in-progress manual compaction when abortCompaction is called", async () => {


### PR DESCRIPTION
## Summary
- pass compaction stream options (`sessionId`, `transport`) into summarization requests
- wire AgentSession and AgentHarness compaction to use the active session/transport values
- add regression coverage for manual, auto, split-turn, and harness compaction paths

## Root cause
Normal turns pass `sessionId` and `transport` through the stream options, but compaction summarization rebuilt its own options with only `maxTokens`, auth, headers, signal, and reasoning. Providers that default missing transport to `auto` could therefore ignore a configured `transport: "sse"` during compaction.

## Verification
- `npm --prefix packages/coding-agent test -- test/suite/agent-session-compaction.test.ts test/sdk-stream-options.test.ts test/compaction-summary-reasoning.test.ts`
- `npm --prefix packages/agent test -- test/harness/compaction.test.ts test/harness/agent-harness-stream.test.ts`
- `npm --prefix packages/agent run build`
- `npm --prefix packages/coding-agent run build`
- pre-commit `npm run check` passed
