### PR TITLE
fix(ai): buffer reasoning_details that arrive before tool_calls

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -169,6 +169,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			let hasFinishReason = false;
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
+			const unmatchedDetails = new Map<string, { id: string; [key: string]: unknown }>();
 			const blocks = output.content as StreamingBlock[];
 			const getContentIndex = (block: StreamingBlock) => blocks.indexOf(block);
 			const finishBlock = (block: StreamingBlock) => {
@@ -239,6 +240,12 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 						partialArgs: "",
 						streamIndex,
 					};
+					// Attach any reasoning_details that arrived before this tool call
+					const pending = unmatchedDetails.get(block.id);
+					if (pending) {
+						block.thoughtSignature = JSON.stringify(pending);
+						unmatchedDetails.delete(block.id);
+					}
 					if (streamIndex !== undefined) {
 						toolCallBlocksByIndex.set(streamIndex, block);
 					}
@@ -377,6 +384,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 								) as ToolCall | undefined;
 								if (matchingToolCall) {
 									matchingToolCall.thoughtSignature = JSON.stringify(detail);
+								} else {
+									unmatchedDetails.set(detail.id, detail);
 								}
 							}
 						}

--- a/packages/ai/test/openai-completions-reasoning-details-ordering.test.ts
+++ b/packages/ai/test/openai-completions-reasoning-details-ordering.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { complete } from "../src/stream.ts";
+import type { Model } from "../src/types.ts";
+
+const mockState = vi.hoisted(() => ({
+	chunks: [] as unknown[],
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: () => {
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							for (const chunk of mockState.chunks) yield chunk;
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+	return { default: FakeOpenAI };
+});
+
+const TOOL_CALL_ID = "call_test_abc123";
+const ENCRYPTED_SIG = "AY89a18_test_encrypted_signature_data==";
+
+function geminiModel(): Model<"openai-completions"> {
+	return {
+		id: "google/gemini-3-flash-preview",
+		name: "Gemini 3 Flash",
+		api: "openai-completions",
+		provider: "openrouter",
+		baseUrl: "http://127.0.0.1:1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 16384,
+	};
+}
+
+const toolCallChunk = {
+	id: "gen-1",
+	choices: [
+		{
+			index: 0,
+			delta: {
+				tool_calls: [
+					{
+						index: 0,
+						id: TOOL_CALL_ID,
+						type: "function",
+						function: { name: "calculator", arguments: '{"expr":"2+2"}' },
+					},
+				],
+			},
+		},
+	],
+};
+
+const reasoningDetailsChunk = {
+	id: "gen-1",
+	choices: [
+		{
+			index: 0,
+			delta: {
+				reasoning_details: [
+					{ type: "reasoning.encrypted", id: TOOL_CALL_ID, data: ENCRYPTED_SIG, format: "google-gemini-v1" },
+				],
+			},
+		},
+	],
+};
+
+const finishChunk = {
+	id: "gen-1",
+	choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+	usage: { prompt_tokens: 10, completion_tokens: 5 },
+};
+
+describe("openai-completions reasoning_details ordering", () => {
+	beforeEach(() => {
+		mockState.chunks = [];
+	});
+
+	it("captures reasoning_details streamed AFTER tool_calls", async () => {
+		mockState.chunks = [toolCallChunk, reasoningDetailsChunk, finishChunk];
+
+		const message = await complete(
+			geminiModel(),
+			{ messages: [{ role: "user", content: "compute 2+2", timestamp: Date.now() }] },
+			{ apiKey: "test" },
+		);
+
+		const toolCall = message.content.find((b) => b.type === "toolCall");
+		expect(toolCall).toBeDefined();
+		expect(toolCall!.thoughtSignature).toBeDefined();
+		expect(JSON.parse(toolCall!.thoughtSignature!).data).toBe(ENCRYPTED_SIG);
+	});
+
+	it("captures reasoning_details streamed BEFORE tool_calls", async () => {
+		mockState.chunks = [reasoningDetailsChunk, toolCallChunk, finishChunk];
+
+		const message = await complete(
+			geminiModel(),
+			{ messages: [{ role: "user", content: "compute 2+2", timestamp: Date.now() }] },
+			{ apiKey: "test" },
+		);
+
+		const toolCall = message.content.find((b) => b.type === "toolCall");
+		expect(toolCall).toBeDefined();
+		expect(toolCall!.thoughtSignature).toBeDefined();
+		expect(JSON.parse(toolCall!.thoughtSignature!).data).toBe(ENCRYPTED_SIG);
+	});
+});


### PR DESCRIPTION
### What happened?

Providers like OpenRouter stream `reasoning_details` (with encrypted thought signatures keyed by tool call ID) before the `tool_calls` chunk. The existing matching logic looked up tool calls by ID in `output.content`, but they didn't exist yet — silently dropping the signature.

This means the encrypted thought signature is never echoed back on the next request, breaking providers that require round-tripping it.

### Fix

Buffer unmatched details in a Map and attach them eagerly when the corresponding tool call is created in `ensureToolCallBlock`.

### Test plan

- Added `openai-completions-reasoning-details-ordering.test.ts` covering both orderings
- "BEFORE" case fails without the fix, passes with it
- Full `npm run check` and test suite pass

Fixes #5114