### PR TITLE
feat(extensions,tui): APIs for remote-control extensions (RFC)

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -322,6 +322,26 @@ function createExtensionAPI(
 			runtime.unregisterProvider(name, extension.path);
 		},
 
+		async withCommandContext(fn) {
+			runtime.assertActive();
+			if (!runtime.createCommandContext) {
+				throw new Error(
+					"pi.withCommandContext is not available in this mode " +
+						"(no ExtensionCommandContext actions bound by the host).",
+				);
+			}
+			const ctx = runtime.createCommandContext();
+			return await fn(ctx);
+		},
+
+		getMessageRenderer(customType) {
+			return runtime.getMessageRenderer?.(customType);
+		},
+
+		getToolDefinition(toolName) {
+			return runtime.getToolDefinition?.(toolName);
+		},
+
 		events: eventBus,
 	} as ExtensionAPI;
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -171,6 +171,8 @@ export type SwitchSessionHandler = (
 
 export type ReloadHandler = () => Promise<void>;
 
+export type ExecuteInputLineHandler = (text: string) => Promise<void>;
+
 export type ShutdownHandler = () => void;
 
 /**
@@ -243,6 +245,7 @@ export class ExtensionRunner {
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private reloadHandler: ReloadHandler = async () => {};
+	private executeInputLineHandler: ExecuteInputLineHandler = async () => {};
 	private shutdownHandler: ShutdownHandler = () => {};
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
@@ -286,6 +289,16 @@ export class ExtensionRunner {
 		this.runtime.setModel = actions.setModel;
 		this.runtime.getThinkingLevel = actions.getThinkingLevel;
 		this.runtime.setThinkingLevel = actions.setThinkingLevel;
+		// Expose a synth-on-demand command context so pi.withCommandContext can
+		// give extensions access to switchSession/newSession/fork/etc. from
+		// arbitrary callsites (event handlers, WS bridges) instead of only from
+		// inside a registered command handler.
+		this.runtime.createCommandContext = () => this.createCommandContext();
+		// Forward the cross-extension renderer/tool-def lookups (they already
+		// exist on the runner) so pi.getMessageRenderer / pi.getToolDefinition
+		// can re-render another extension's presentation.
+		this.runtime.getMessageRenderer = (customType) => this.getMessageRenderer(customType);
+		this.runtime.getToolDefinition = (toolName) => this.getToolDefinition(toolName);
 
 		// Context actions (required)
 		this.getModel = contextActions.getModel;
@@ -343,6 +356,7 @@ export class ExtensionRunner {
 			this.navigateTreeHandler = actions.navigateTree;
 			this.switchSessionHandler = actions.switchSession;
 			this.reloadHandler = actions.reload;
+			this.executeInputLineHandler = actions.executeInputLine;
 			return;
 		}
 
@@ -352,6 +366,7 @@ export class ExtensionRunner {
 		this.navigateTreeHandler = async () => ({ cancelled: false });
 		this.switchSessionHandler = async () => ({ cancelled: false });
 		this.reloadHandler = async () => {};
+		this.executeInputLineHandler = async () => {};
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext): void {
@@ -664,6 +679,10 @@ export class ExtensionRunner {
 		context.reload = () => {
 			this.assertActive();
 			return this.reloadHandler();
+		};
+		context.executeInputLine = (text) => {
+			this.assertActive();
+			return this.executeInputLineHandler(text);
 		};
 		return context;
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -361,6 +361,22 @@ export interface ExtensionCommandContext extends ExtensionContext {
 
 	/** Reload extensions, skills, prompts, and themes. */
 	reload(): Promise<void>;
+
+	/**
+	 * Submit a line of text through the interactive editor's submit path, as if
+	 * the user typed it and pressed Enter: built-in slash commands (`/model`,
+	 * `/settings`, …) open their selectors, `!`/`!!` run bash, and plain text is
+	 * sent as a prompt. Lets a remote client (phone, WS bridge) drive commands
+	 * that live in the TUI rather than the extension API. No-op outside
+	 * interactive mode.
+	 *
+	 * Fire-and-forget: the returned promise resolves once the line has been
+	 * *scheduled*, not when it finishes processing. This is deliberate — awaiting
+	 * a session-replacing command (`/new`, `/resume`) here would invalidate the
+	 * very command-context the call runs inside. Failures surface in the host UI,
+	 * not as a rejection of this promise.
+	 */
+	executeInputLine(text: string): Promise<void>;
 }
 
 /**
@@ -1306,6 +1322,42 @@ export interface ExtensionAPI {
 	 */
 	unregisterProvider(name: string): void;
 
+	/**
+	 * Run a function with an `ExtensionCommandContext` synthesised on demand.
+	 *
+	 * The context exposes session-control methods (`switchSession`, `newSession`,
+	 * `fork`, `navigateTree`, `reload`, `waitForIdle`) that are otherwise only
+	 * available inside a slash-command `handler`. Use this from event handlers
+	 * or external triggers (HTTP/WS bridges, scheduled jobs) when you need to
+	 * act on user intent that didn't arrive through pi's interactive editor.
+	 *
+	 * The provided callback runs synchronously inside the active extension; it
+	 * does **not** create a new session, swap state, or otherwise change the
+	 * current session by itself — it just hands you the same context shape a
+	 * registered command handler would receive.
+	 *
+	 * @example
+	 *   pi.withCommandContext(async (ctx) => {
+	 *     await ctx.switchSession(pathFromRemoteClient);
+	 *   });
+	 */
+	withCommandContext<T>(fn: (ctx: ExtensionCommandContext) => Promise<T> | T): Promise<T>;
+
+	/**
+	 * Look up the message renderer another extension registered for a custom
+	 * message type, or `undefined` if none. Lets an extension re-render another's
+	 * custom presentation (e.g. to mirror it to a non-TUI client) instead of
+	 * falling back to plain text.
+	 */
+	getMessageRenderer(customType: string): MessageRenderer | undefined;
+
+	/**
+	 * Look up a registered tool's definition by name, or `undefined` if none.
+	 * Exposes the tool's `renderResult` so its rich result can be re-rendered
+	 * outside the normal turn flow.
+	 */
+	getToolDefinition(toolName: string): RegisteredTool["definition"] | undefined;
+
 	/** Shared event bus for extension communication. */
 	events: EventBus;
 }
@@ -1463,6 +1515,23 @@ export interface ExtensionRuntimeState {
 	 */
 	registerProvider: (name: string, config: ProviderConfig, extensionPath?: string) => void;
 	unregisterProvider: (name: string, extensionPath?: string) => void;
+	/**
+	 * Synthesise an `ExtensionCommandContext` on demand.
+	 *
+	 * Bound by the runner during `initialize()`. Undefined before bind, and in
+	 * modes that don't expose command-context actions (e.g., peer-mode loading).
+	 * Called by `pi.withCommandContext()` to give extensions access to
+	 * `switchSession` / `newSession` / `fork` / etc. from outside a registered
+	 * command handler.
+	 */
+	createCommandContext?: () => ExtensionCommandContext;
+	/**
+	 * Look up renderers/tool defs registered across all extensions. Bound by the
+	 * runner during `initialize()`; forwarded by `pi.getMessageRenderer` /
+	 * `pi.getToolDefinition`. Undefined before bind.
+	 */
+	getMessageRenderer?: (customType: string) => MessageRenderer | undefined;
+	getToolDefinition?: (toolName: string) => RegisteredTool["definition"] | undefined;
 }
 
 /**
@@ -1526,6 +1595,7 @@ export interface ExtensionCommandContextActions {
 		options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	) => Promise<{ cancelled: boolean }>;
 	reload: () => Promise<void>;
+	executeInputLine: (text: string) => Promise<void>;
 }
 
 /**

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -228,6 +228,12 @@ export {
 	type Skill,
 	type SkillFrontmatter,
 } from "./core/skills.ts";
+// Built-in slash-command catalogue. Useful for remote-control extensions that
+// want to surface the full set of "/foo" the user can type, not just the
+// extension/skill/template commands returned by pi.getCommands().
+// Types SlashCommandInfo / SlashCommandSource are already re-exported from
+// the extensions/types module above.
+export { BUILTIN_SLASH_COMMANDS, type BuiltinSlashCommand } from "./core/slash-commands.ts";
 export { createSyntheticSourceInfo } from "./core/source-info.ts";
 // Tools
 export {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1545,6 +1545,33 @@ export class InteractiveMode {
 				reload: async () => {
 					await this.handleReloadCommand();
 				},
+				executeInputLine: async (text) => {
+					// Run the line through the editor's submit handler — the same path a
+					// real Enter keypress uses (onSubmit dispatches built-in slash
+					// commands, runs `!` bash, or sends a prompt). Selectors it opens
+					// surface to remotes via SelectList lifecycle events.
+					//
+					// Deferred to a fresh task instead of awaited: session-replacing
+					// commands (/new, /resume) tear down and rebind the extension
+					// runtime, which would invalidate the command-context this call runs
+					// inside ("extension is stale, restart pi to recover"). Running from
+					// the event loop mirrors a keypress, which is never inside a
+					// command-context, so the reload is clean.
+					//
+					// Consequence: this resolves once the line is *scheduled*, not when
+					// it finishes. Surface failures through the host UI rather than
+					// swallowing them (and to avoid an unhandled rejection escaping the
+					// deferred task).
+					const submit = this.defaultEditor.onSubmit;
+					if (!submit) return;
+					setImmediate(() => {
+						void Promise.resolve(submit(text)).catch((err) => {
+							this.showError(
+								`Remote input "${text}" failed: ${err instanceof Error ? err.message : String(err)}`,
+							);
+						});
+					});
+				},
 			},
 			shutdownHandler: () => {
 				this.shutdownRequested = true;

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -93,6 +93,8 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 				reload: async () => {
 					await session.reload();
 				},
+				// No interactive editor in print mode — nothing to submit through.
+				executeInputLine: async () => {},
 			},
 			onError: (err) => {
 				console.error(`Extension error (${err.extensionPath}): ${err.error}`);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -339,6 +339,8 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				reload: async () => {
 					await session.reload();
 				},
+				// No interactive editor in RPC mode — nothing to submit through.
+				executeInputLine: async () => {},
 			},
 			shutdownHandler: () => {
 				shutdownRequested = true;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -775,6 +775,7 @@ describe("ExtensionRunner", () => {
 				navigateTree: async () => ({ cancelled: false }),
 				switchSession: async () => ({ cancelled: false }),
 				reload: async () => {},
+				executeInputLine: async () => {},
 			});
 
 			const commandContext = runner.createCommandContext();

--- a/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
@@ -101,6 +101,7 @@ describe("regression #2860: replaced session callbacks", () => {
 			await session.bindExtensions({
 				commandContextActions: {
 					waitForIdle: () => session.agent.waitForIdle(),
+					executeInputLine: async () => {},
 					newSession: async (options) => runtime.newSession(options),
 					fork: async (entryId, options) => {
 						const result = await runtime.fork(entryId, options);

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { getKeybindings } from "../keybindings.ts";
 import type { Component } from "../tui.ts";
 import { truncateToWidth, visibleWidth } from "../utils.ts";
@@ -5,6 +6,55 @@ import { truncateToWidth, visibleWidth } from "../utils.ts";
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
+
+/**
+ * Module-scope event bus for SelectList lifecycle, intended for remote-control
+ * extensions that want to mirror selectors to a non-TUI client (mobile app, web).
+ *
+ * Events:
+ *   "mount"   ({ id, items })  emitted from the SelectList constructor.
+ *   "dismiss" ({ id })         emitted exactly once when the list is resolved
+ *                              (selection, cancel, or remote response).
+ *
+ * Listeners receive the same `id` they can use with `respondToSelectList(id, value)`
+ * to drive the selection remotely.
+ */
+export const selectListEvents = new EventEmitter();
+
+// Registry of live SelectLists by id so a remote client can find one and drive
+// its selection. Held by WeakRef (with a FinalizationRegistry) so a list the
+// owner drops without an explicit confirm/cancel — there is no Component
+// teardown hook to clean up on — can still be garbage-collected and its entry
+// reclaimed instead of leaking. Settling a list also removes its entry eagerly.
+const liveSelectLists = new Map<string, WeakRef<SelectList>>();
+const selectListFinalizer = new FinalizationRegistry<string>((id) => {
+	liveSelectLists.delete(id);
+});
+
+let __selectListIdCounter = 0;
+function nextSelectListId(): string {
+	__selectListIdCounter++;
+	return `sl_${Date.now().toString(36)}_${__selectListIdCounter.toString(36)}`;
+}
+
+/**
+ * Resolve a live SelectList from outside the TUI focus stack by id.
+ * Pass `value === null` to cancel; otherwise the value is matched against
+ * `SelectItem.value` (preferred) or `SelectItem.label` (fallback) before
+ * invoking the list's onSelect callback.
+ *
+ * @returns for a cancel, true if a live list existed; for a selection, true
+ *   only if `value` matched an item. false if no live list exists for `id`.
+ */
+export function respondToSelectList(id: string, value: string | null): boolean {
+	const list = liveSelectLists.get(id)?.deref();
+	if (!list) return false;
+	if (value === null) {
+		list.cancelRemote();
+		return true;
+	}
+	return list.selectRemote(value);
+}
 
 const normalizeToSingleLine = (text: string): string => text.replace(/[\r\n]+/g, " ").trim();
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(value, max));
@@ -38,12 +88,15 @@ export interface SelectListLayoutOptions {
 }
 
 export class SelectList implements Component {
+	/** Stable id for this instance. See `selectListEvents` for remote control. */
+	public readonly id: string = nextSelectListId();
 	private items: SelectItem[] = [];
 	private filteredItems: SelectItem[] = [];
 	private selectedIndex: number = 0;
 	private maxVisible: number = 5;
 	private theme: SelectListTheme;
 	private layout: SelectListLayoutOptions;
+	private dismissed: boolean = false;
 
 	public onSelect?: (item: SelectItem) => void;
 	public onCancel?: () => void;
@@ -55,6 +108,53 @@ export class SelectList implements Component {
 		this.maxVisible = maxVisible;
 		this.theme = theme;
 		this.layout = layout;
+		liveSelectLists.set(this.id, new WeakRef(this));
+		selectListFinalizer.register(this, this.id, this);
+		selectListEvents.emit("mount", { id: this.id, items });
+	}
+
+	/**
+	 * Transition to the dismissed state exactly once. Returns true if this call
+	 * performed the transition (the caller "won the race"), false if the list was
+	 * already dismissed. Callers must only fire onSelect/onCancel when this
+	 * returns true, so a keyboard confirm and a concurrent remote response can't
+	 * both invoke the callback.
+	 */
+	private settle(): boolean {
+		if (this.dismissed) return false;
+		this.dismissed = true;
+		liveSelectLists.delete(this.id);
+		selectListFinalizer.unregister(this);
+		selectListEvents.emit("dismiss", { id: this.id });
+		return true;
+	}
+
+	/**
+	 * Drive a selection from outside the TUI (e.g., a phone client).
+	 * Matches by `value` first, then `label`.
+	 * @returns true if `value` matched an item, false otherwise.
+	 */
+	selectRemote(value: string): boolean {
+		const item = this.items.find((i) => i.value === value) ?? this.items.find((i) => i.label === value);
+		if (!item) return false;
+		if (this.settle()) this.onSelect?.(item);
+		return true;
+	}
+
+	/** Drive a cancel from outside the TUI. Fires onCancel if not already dismissed. */
+	cancelRemote(): void {
+		if (this.settle()) this.onCancel?.();
+	}
+
+	/**
+	 * Component teardown hook. Called by the TUI's overlay manager when this
+	 * list is permanently removed (hide / pop). Settles the list if it hasn't
+	 * been already, so `dismiss` fires deterministically on every close path —
+	 * not just user pick/cancel and remote response. Does not invoke
+	 * onSelect/onCancel: the unmount itself isn't a user choice.
+	 */
+	dispose(): void {
+		this.settle();
 	}
 
 	setFilter(filter: string): void {
@@ -124,15 +224,13 @@ export class SelectList implements Component {
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			const selectedItem = this.filteredItems[this.selectedIndex];
-			if (selectedItem && this.onSelect) {
-				this.onSelect(selectedItem);
+			if (selectedItem && this.settle()) {
+				this.onSelect?.(selectedItem);
 			}
 		}
 		// Escape or Ctrl+C
 		else if (kb.matches(keyData, "tui.select.cancel")) {
-			if (this.onCancel) {
-				this.onCancel();
-			}
+			if (this.settle()) this.onCancel?.();
 		}
 	}
 

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -17,11 +17,13 @@ export { Input } from "./components/input.ts";
 export { Loader, type LoaderIndicatorOptions } from "./components/loader.ts";
 export { type DefaultTextStyle, Markdown, type MarkdownOptions, type MarkdownTheme } from "./components/markdown.ts";
 export {
+	respondToSelectList,
 	type SelectItem,
 	SelectList,
 	type SelectListLayoutOptions,
 	type SelectListTheme,
 	type SelectListTruncatePrimaryContext,
+	selectListEvents,
 } from "./components/select-list.ts";
 export { type SettingItem, SettingsList, type SettingsListTheme } from "./components/settings-list.ts";
 export { Spacer } from "./components/spacer.ts";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -60,6 +60,15 @@ export interface Component {
 	 * Called when theme changes or when component needs to re-render from scratch.
 	 */
 	invalidate(): void;
+
+	/**
+	 * Optional teardown hook. Called by the overlay manager when this component
+	 * is being permanently removed (hide / pop), giving the component one
+	 * deterministic moment to clean up — e.g. emit a lifecycle event, release
+	 * resources, cancel subscriptions. Not called for transient hides (setHidden),
+	 * which only pause rendering. Implementations must be idempotent.
+	 */
+	dispose?(): void;
 }
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
@@ -355,6 +364,12 @@ export class TUI extends Container {
 					}
 					if (this.overlayStack.length === 0) this.terminal.hideCursor();
 					this.requestRender();
+					// Permanent removal — give the component its teardown moment.
+					try {
+						component.dispose?.();
+					} catch {
+						/* dispose must never block the unmount path */
+					}
 				}
 			},
 			setHidden: (hidden: boolean) => {
@@ -406,6 +421,12 @@ export class TUI extends Container {
 		}
 		if (this.overlayStack.length === 0) this.terminal.hideCursor();
 		this.requestRender();
+		// Permanent removal — give the component its teardown moment.
+		try {
+			overlay.component.dispose?.();
+		} catch {
+			/* dispose must never block the unmount path */
+		}
 	}
 
 	/** Check if there are any visible overlays */


### PR DESCRIPTION
Hey — sharing the patches my [`pi-remote-control`](https://github.com/kolt-mcb/pi-remote-control) extension has been carrying privately, in case any are useful upstream. I'm not sure these fit everyone's needs; happy to split into separate PRs, revise, drop bits, or close this entirely. Just thought I'd share what works for my use case.

Opening as **draft** because it's a single squashed commit aimed at conversation rather than merge.

## Why these patches exist

These are the capabilities a remote-control extension needs to reproduce the interactive pi experience for an *external* client (in my case, an Android app talking to pi over a LAN WebSocket). The base extension API is built for extensions that live *inside* the terminal session and react to the agent — it doesn't surface what a remote client needs to:

1. **drive the same input paths the user drives** — slash commands, bash, prompts;
2. **observe and answer the same on-screen affordances** — the selectors pi pops up; and
3. **reproduce the same rich rendering** — custom message/tool cards, not just text.

Each piece below closes one of those gaps with the smallest change possible — wherever the capability already exists internally on the runner, the patch forwards it rather than reimplements.

## Stock pi vs with these patches

For comparison, [`pi-discord-remote`](https://github.com/t2o2/pi-discord-remote) is a great example of a remote-control extension that stays inside the stock API's surface. It does what stock pi can do well (text bridge + tool replacement) and consciously skips the rest:

| Capability | stock pi extension API | with these patches |
|---|---|---|
| Send a prompt as a user message | ✅ `sendUserMessage` | ✅ same |
| Forward agent responses to the remote | ✅ event listeners | ✅ same |
| Custom **tool** registration | ✅ `registerTool` | ✅ same |
| Replace a tool (block + drop-in) | ✅ `tool_call` interception | ✅ same |
| Lifecycle hook | ✅ `before_agent_start` | ✅ same |
| **Mirror pi's built-in selectors** (model picker, settings, /resume picker) | ❌ | **needs** SelectList lifecycle events |
| **Drive built-in slash commands** (`/new`, `/model`, `/settings`, `/quit`, …) | ❌ | **needs** `ctx.executeInputLine` |
| **Run session-control from non-command callsites** (`switchSession` from a WS message) | ❌ | **needs** `pi.withCommandContext` |
| **Enumerate built-in `/commands`** for the remote's slash menu | ❌ | **needs** `BUILTIN_SLASH_COMMANDS` re-export |
| **Mirror rich custom-message / tool-result cards** at the client's width | ❌ | **needs** `getMessageRenderer` / `getToolDefinition` |
| Deterministic selector dismissal on teardown | ❌ | **needs** `Component.dispose()` hook |

## What each piece adds

### `ctx.executeInputLine` — drive the editor's submit path
**Gap:** `pi.sendUserMessage` can send a prompt, but built-in slash commands (`/model`, `/settings`, `/new`, `/resume`, …), bash (`!`/`!!`), and prompt-template expansion all live in the **TUI editor**, not the extension API. An extension — and therefore a remote client — has no way to trigger any of them.
**Added:** `executeInputLine(text)` runs a line through the editor's real submit path, exactly as if typed and entered. Fire-and-forget by design, so a session-replacing command (`/new`) can't invalidate the calling command-context; no-op outside interactive mode.

### `SelectList` lifecycle events + `respondToSelectList` — mirror and answer selectors
**Gap:** pi renders selectors to the terminal only. The extension API exposes no way to learn that a selector opened/closed, or to answer one. A non-TUI client can neither see nor respond to pi's native pickers.
**Added:** a module-scope `selectListEvents` bus (`mount`/`dismiss`) plus `respondToSelectList(id, value)`, so any `SelectList` mirrors to a remote and can be driven from it.

### `Component.dispose()` — deterministic teardown
**Gap:** `Component` has only `render`/`handleInput`/`invalidate` — no "you're being removed" hook. A `SelectList` dropped from the overlay stack (replaced screen, error path, owner stops drawing it) has no way to emit a `dismiss`, so a remote observer can be left showing a selector that's already gone.
**Added:** an optional `dispose()` on `Component`, called by the overlay manager from its two unmount chokepoints (`hide()` / `hideOverlay()`). `SelectList.dispose()` settles deterministically — `dismiss` then fires on *every* close path.

### `pi.withCommandContext` — session control outside a command handler
**Gap:** the session-control actions (`switchSession`, `newSession`, `fork`, `navigateTree`, `reload`) are only handed to a *registered slash-command handler* via its `ExtensionCommandContext`. An extension reacting to an external trigger — an inbound WebSocket message, a scheduled job — has no way to obtain that context.
**Added:** `withCommandContext(fn)` synthesises the context on demand so those actions are reachable from arbitrary call sites.

### `BUILTIN_SLASH_COMMANDS` (re-export) — enumerate the built-ins
**Gap:** `pi.getCommands()` returns extension/skill/template commands but omits the built-in `/commands`. A remote client can't present the complete set of commands the user could otherwise type.
**Added:** re-export the existing internal `BUILTIN_SLASH_COMMANDS` catalogue from the package entry point.

### `getMessageRenderer` / `getToolDefinition` — reproduce rich rendering
**Gap:** the runner can resolve another extension's custom message renderer and a tool's `renderResult`, but neither is exposed on the extension API. Without them, a remote mirror of a rich card (a tool result, a custom message) degrades to plain text.
**Added:** two read-only accessors that forward the runner's existing lookups, so an extension can re-render another's presentation at the client's column width.

### Self-review hardening (folded in)
`SelectList` settles exactly once (a keypress and a racing remote response can't both fire `onSelect`/`onCancel`); its live-list registry uses `WeakRef` + `FinalizationRegistry` as a safety net for any path that slips past `dispose()`; `executeInputLine` surfaces a failed submit through the host UI instead of swallowing it.

## Status

- Full `npm run check` (biome + typecheck + browser-smoke) passes on the rebased tree.
- Generated files (`packages/ai/src/*.generated.ts`) are intentionally not in the diff — kept this to source changes only.
- Single squashed commit so the diff is one cohesive view; happy to break it back out per-feature if you'd rather review that way.

Totally fine to close if any of this isn't a direction you want pi's extension API to head in — thanks either way for the work the project's already done. 🙏
