### PR TITLE
fix: guard against undefined result.content in getTextOutput

### DIFF
--- a/packages/coding-agent/src/core/tools/render-utils.ts
+++ b/packages/coding-agent/src/core/tools/render-utils.ts
@@ -28,10 +28,10 @@ export function normalizeDisplayText(text: string): string {
 }
 
 export function getTextOutput(
-	result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> } | undefined,
+	result: { content?: Array<{ type: string; text?: string; data?: string; mimeType?: string }> } | undefined,
 	showImages: boolean,
 ): string {
-	if (!result) return "";
+	if (!result || !result.content) return "";
 
 	const textBlocks = result.content.filter((c) => c.type === "text");
 	const imageBlocks = result.content.filter((c) => c.type === "image");

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -178,7 +178,7 @@ export class ToolExecutionComponent extends Container {
 	private maybeConvertImagesForKitty(): void {
 		const caps = getCapabilities();
 		if (caps.images !== "kitty") return;
-		if (!this.result) return;
+		if (!this.result || !this.result.content) return;
 
 		const imageBlocks = this.result.content.filter((c) => c.type === "image");
 		for (let i = 0; i < imageBlocks.length; i++) {
@@ -302,7 +302,7 @@ export class ToolExecutionComponent extends Container {
 		}
 		this.imageSpacers = [];
 
-		if (this.result) {
+		if (this.result?.content) {
 			const imageBlocks = this.result.content.filter((c) => c.type === "image");
 			const caps = getCapabilities();
 			for (let i = 0; i < imageBlocks.length; i++) {


### PR DESCRIPTION
## Problem

When a tool (e.g. `project_status`) returns a result object without a `content` property, `getTextOutput()` and `ToolExecutionComponent` crash with:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at getTextOutput (render-utils.js:30:39)
```

This is an **uncaught exception** that kills the entire pi process.

## Root Cause

`getTextOutput()` checks `if (!result)` but not `if (!result.content)`. When `result` is a truthy object with no `content` array, `.filter()` is called on `undefined`.

## Fix

**`render-utils.ts`** — `getTextOutput()`:
- Make `content` optional in the type signature (`content?`)
- Add `!result.content` to the early-return guard

**`tool-execution.ts`** — `ToolExecutionComponent`:
- `maybeConvertImagesForKitty()`: guard `!this.result.content`
- `updateImageComponents()`: use `this.result?.content` optional chaining

All 3 call sites that access `result.content.filter(...)` are now guarded.

## Reproduction

1. Run any tool that returns a result without `content` (e.g. `project_status` in certain states)
2. pi crashes with `uncaughtException`

## Testing

- [x] Verified fix resolves the crash locally
- [x] No other unguarded `result.content` access in `src/`