### PR TITLE
fix(tui): account tabs as 3 columns in overlay compositing

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed overlay compositing overflowing the terminal width (and corrupting differential redraw) when overlay content contained tab characters. Tabs are now accounted as 3 columns in the column-slicing primitives (`sliceByColumn`/`sliceWithWidth`/`extractSegments`) to match `visibleWidth`/`truncateToWidth`, and are expanded to spaces before being written so the physical render matches the width model.
+
 ## [0.77.0] - 2026-05-28
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -823,7 +823,12 @@ export class TUI extends Container {
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
 			if (!isImageLine(line)) {
-				lines[i] = normalizeTerminalOutput(line) + reset;
+				// Expand tabs to 3 spaces to match the fixed 3-column tab width used by
+				// visibleWidth/graphemeWidth/truncateToWidth. Emitting a raw "\t" lets the
+				// terminal advance to its own tab stop (commonly 8), desyncing the physical
+				// render from the width model and corrupting differential-redraw cursor math.
+				const expanded = line.includes("\t") ? line.replace(/\t/g, "   ") : line;
+				lines[i] = normalizeTerminalOutput(expanded) + reset;
 			}
 		}
 		return lines;

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -162,6 +162,17 @@ function finalizeTruncatedResult(
  * check to avoid running the RGI_Emoji regex unnecessarily.
  */
 function graphemeWidth(segment: string): number {
+	// Tabs are accounted as 3 columns everywhere else in this module: visibleWidth()
+	// replaces "\t" with 3 spaces, and truncateToWidth()/truncateFragmentToWidth()
+	// advance by 3. graphemeWidth() feeds the column-slicing primitives
+	// (sliceByColumn/sliceWithWidth/extractSegments) used by the overlay compositor, so
+	// it MUST agree. Treating "\t" as a 0-width control char here desynced slice width
+	// from visibleWidth, so overlay compositing added 3 stray padding columns per tab and
+	// overflowed the terminal width (crash: terminal width 179 vs rendered line width 182).
+	if (segment === "\t") {
+		return 3;
+	}
+
 	// Zero-width clusters
 	if (zeroWidthRegex.test(segment)) {
 		return 0;

--- a/packages/tui/test/regression-tab-width-overflow.test.ts
+++ b/packages/tui/test/regression-tab-width-overflow.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { sliceByColumn, sliceWithWidth, visibleWidth } from "../src/utils.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+// Regression context:
+// A literal tab ("\t") was measured as 3 columns by visibleWidth()/truncateToWidth()
+// but as 0 columns by graphemeWidth() (it matches \p{Control}). graphemeWidth() backs the
+// column-slicing primitives used by the overlay compositor, so a tab in an overlay's
+// content (e.g. tab-indented source shown in a popup) made the compositor under-measure
+// the overlay by 3 per tab, append stray padding, and overflow the terminal width. The
+// width guard then tripped (crash log: terminal width 179 vs rendered line width 182) and
+// differential redraw smeared. A second issue: emitting a raw "\t" let the terminal expand
+// it to its own tab stop (commonly 8), desyncing the physical render from the width model.
+
+describe("tab width overflow regression", () => {
+	it("measures a tab as 3 columns consistently across width primitives", () => {
+		assert.strictEqual(visibleWidth("\t"), 3);
+		assert.strictEqual(sliceWithWidth("\t", 0, 10, true).width, 3);
+
+		// sliceWithWidth must agree with visibleWidth for mixed content.
+		assert.strictEqual(sliceWithWidth("a\tb", 0, 10, true).width, visibleWidth("a\tb"));
+		assert.strictEqual(visibleWidth("a\tb"), 5);
+	});
+
+	it("clips tab-bearing lines to the requested column budget (safeguard works)", () => {
+		// 14 tabs == 42 columns under the 3-per-tab model. Slicing to 40 columns must not
+		// exceed 40. Under the old (tab=0) accounting, sliceByColumn kept all 14 tabs and
+		// returned a 42-column line, so the compositor's final safeguard failed to clip.
+		const wide = "\t".repeat(14);
+		assert.strictEqual(visibleWidth(wide), 42);
+		const clipped = sliceByColumn(wide, 0, 40, true);
+		assert.ok(visibleWidth(clipped) <= 40, `expected <= 40, got ${visibleWidth(clipped)}`);
+	});
+});
+
+class StaticLines implements Component {
+	private readonly lines: string[];
+	constructor(lines: string[]) {
+		this.lines = lines;
+	}
+	render(): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+class StaticOverlay implements Component {
+	private readonly line: string;
+	constructor(line: string) {
+		this.line = line;
+	}
+	render(): string[] {
+		return [this.line];
+	}
+	invalidate(): void {}
+}
+
+async function renderAndFlush(tui: TUI, terminal: VirtualTerminal): Promise<void> {
+	tui.requestRender(true);
+	await new Promise<void>((resolve) => process.nextTick(resolve));
+	await terminal.waitForRender();
+}
+
+describe("TUI overlay tab compositing", () => {
+	it("does not overflow or wrap when an overlay line contains a tab", async () => {
+		const width = 40;
+		// Overlay content with a leading tab; 3 (tab) + 37 == exactly `width` columns.
+		const overlayLine = `\t${"X".repeat(37)}`;
+		assert.strictEqual(visibleWidth(overlayLine), width);
+
+		const terminal = new VirtualTerminal(width, 6);
+		const tui = new TUI(terminal);
+		tui.addChild(new StaticLines(["B".repeat(width), "SENTINEL"]));
+		tui.showOverlay(new StaticOverlay(overlayLine), { row: 0, col: 0, width });
+		tui.start();
+		await renderAndFlush(tui, terminal);
+
+		const viewport = terminal.getViewport();
+		const overlayRow = viewport[0] ?? "";
+
+		// Tab must have been expanded to spaces before reaching the terminal.
+		assert.ok(!overlayRow.includes("\t"), "raw tab leaked to terminal");
+		// No physical overflow: the row fits within `width` columns...
+		assert.ok(overlayRow.length <= width, `overlay row overflowed: ${overlayRow.length} > ${width}`);
+		// ...rendered as 3 spaces of indent followed by the content.
+		assert.strictEqual(overlayRow, `   ${"X".repeat(37)}`);
+		// And the following line stayed on its own row (it was not pushed down by a wrap).
+		assert.strictEqual(viewport[1], "SENTINEL");
+
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## Summary

Overlay compositing could render a line **wider than the terminal**, tripping the TUI width guard and corrupting differential redraw (fragmented/duplicated lines, smeared footer/status). The trigger is **tab characters in overlay content** — e.g. tab-indented source code shown in a popup/thread viewer over a live background widget.

### Root cause

A literal tab is measured inconsistently inside `packages/tui/src/utils.ts`:

- `visibleWidth()` treats `\t` as **3 columns** (it replaces `\t` with 3 spaces), and `truncateToWidth()` / `truncateFragmentToWidth()` advance by 3.
- `graphemeWidth()` treats `\t` as **0 columns** — it matches `\p{Control}` in `zeroWidthRegex` and returns `0`. `graphemeWidth()` backs the column-slicing primitives `sliceByColumn` / `sliceWithWidth` / `extractSegments`, which are exactly what the overlay compositor (`compositeLineAt`) uses.

So when an overlay row contains a tab, `sliceWithWidth` reports the row 3 columns narrower than `visibleWidth` does. `compositeLineAt` then adds `overlayWidth - overlay.width` = **3 stray padding columns per tab**, pushing the composed line past the terminal width. The final `sliceByColumn` safeguard *also* undercounts the tab, so it fails to clip the overflow, the width guard fires, and the differential renderer's cursor math drifts.

Observed in the wild as `terminal width 179` vs `rendered line width 182` (one undercounted tab = +3).

A secondary issue: emitting a raw `\t` to the terminal lets it advance to its own tab stop (commonly 8), which desyncs the physical render from the fixed 3-column width model even once the math is consistent.

### Changes

- **`graphemeWidth()`**: treat `\t` as 3 columns so the slicing primitives agree with `visibleWidth`/`truncateToWidth`. (All other callers pre-handle tabs before reaching `graphemeWidth`, so this only affects the slicing/compositing path that was out of sync.)
- **`applyLineResets()`**: expand `\t` → 3 spaces before writing, so the physical render matches the width model.
- **Regression test** (`regression-tab-width-overflow.test.ts`): asserts the width-primitive consistency and an end-to-end overlay-with-tab line that neither overflows nor wraps.

## Test plan

- [x] `node --test test/regression-tab-width-overflow.test.ts` passes
- [x] New test **fails** on `main` (both the primitive and the end-to-end overlay assertions) and **passes** with this change
- [x] Full `packages/tui` suite green: `node --test test/*.test.ts` → 618 passing, 0 failing
