### PR TITLE
feat: add /exit and /bye as alternative quit commands

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -37,4 +37,6 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
+	{ name: "exit", description: `Quit ${APP_NAME}` },
+	{ name: "bye", description: `Quit ${APP_NAME}` },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2584,7 +2584,7 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/quit") {
+			if (text === "/quit" || text === "/exit" || text === "/bye") {
 				this.editor.setText("");
 				await this.shutdown();
 				return;


### PR DESCRIPTION
## Summary

Add support for  and  slash commands as alternatives to  for exiting the interactive coding agent.

## Changes

- Added  and  to the builtin slash commands list in 
- Updated interactive mode handler in  to recognize  and  commands
- All three commands (, , ) now trigger the same shutdown behavior
- Maintains full backward compatibility with existing  command

## Testing

- All 631 existing tests pass
- Code style and type checks pass

## Motivation

Users expect common exit commands to work. While  is the original command, many users naturally type  or  when they want to leave the program. Supporting these alternatives improves user experience without any downside.