### PR TITLE
fix(tui): avoid splitting URLs during wrapping

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -695,9 +695,60 @@ function wrapSingleLine(line: string, width: number): string[] {
 	let currentLine = "";
 	let currentVisibleLength = 0;
 
-	for (const token of tokens) {
+	for (let i = 0; i < tokens.length; i++) {
+		const token = tokens[i];
 		const tokenVisibleLength = visibleWidth(token);
 		const isWhitespace = token.trim() === "";
+
+		// Avoid splitting plain-text URLs when the URL itself fits on one line.
+		// This keeps terminal-native URL detection reliable for CLI output such as
+		// `gh auth login`, without requiring the producer to emit OSC 8 metadata.
+		if (
+			currentVisibleLength > 0 &&
+			tokenVisibleLength <= width &&
+			!isWhitespace &&
+			isLikelyUrlToken(token) &&
+			currentVisibleLength + tokenVisibleLength > width
+		) {
+			let lineToWrap = currentLine.trimEnd();
+			const lineEndReset = tracker.getLineEndReset();
+			if (lineEndReset) {
+				lineToWrap += lineEndReset;
+			}
+			wrapped.push(lineToWrap);
+			currentLine = tracker.getActiveCodes() + token;
+			currentVisibleLength = tokenVisibleLength;
+			updateTrackerFromText(token, tracker);
+			continue;
+		}
+
+		const nextToken = tokens[i + 1];
+		const nextTokenVisibleLength = nextToken === undefined ? 0 : visibleWidth(nextToken);
+
+		// If this whitespace would leave a URL to be split mid-token, wrap before
+		// the URL instead. This produces:
+		//   Open this URL to continue in your web browser:
+		//   https://github.com/login/device
+		// instead of splitting the URL after the line prefix.
+		if (
+			isWhitespace &&
+			currentVisibleLength > 0 &&
+			nextToken !== undefined &&
+			nextTokenVisibleLength <= width &&
+			isLikelyUrlToken(nextToken) &&
+			currentVisibleLength + tokenVisibleLength + nextTokenVisibleLength > width
+		) {
+			let lineToWrap = currentLine.trimEnd();
+			const lineEndReset = tracker.getLineEndReset();
+			if (lineEndReset) {
+				lineToWrap += lineEndReset;
+			}
+			wrapped.push(lineToWrap);
+			updateTrackerFromText(token, tracker);
+			currentLine = tracker.getActiveCodes();
+			currentVisibleLength = 0;
+			continue;
+		}
 
 		// Token itself is too long - break it character by character
 		if (tokenVisibleLength > width && !isWhitespace) {
@@ -755,6 +806,10 @@ function wrapSingleLine(line: string, width: number): string[] {
 
 	// Trailing whitespace can cause lines to exceed the requested width
 	return wrapped.length > 0 ? wrapped.map((line) => line.trimEnd()) : [""];
+}
+
+function isLikelyUrlToken(token: string): boolean {
+	return /(?:^|\x1b\[[0-9;]*m)https?:\/\/\S+/u.test(token);
 }
 
 export const PUNCTUATION_REGEX = /[(){}[\]<>.,;:'"!?+\-=*/\\|&%^$#@~`]/;

--- a/packages/tui/test/wrap-ansi.test.ts
+++ b/packages/tui/test/wrap-ansi.test.ts
@@ -131,6 +131,26 @@ describe("wrapTextWithAnsi", () => {
 			assert.ok(visibleWidth(twoSpacesWrappedToWidth1[0]) <= 1);
 		});
 
+		it("should avoid splitting URLs that fit on the next line", () => {
+			const text = "Open this URL to continue in your web browser: https://github.com/login/device";
+			const wrapped = wrapTextWithAnsi(text, 60);
+
+			assert.deepStrictEqual(wrapped, [
+				"Open this URL to continue in your web browser:",
+				"https://github.com/login/device",
+			]);
+		});
+
+		it("should still split URLs that are longer than the line width", () => {
+			const url = `https://example.com/${"a".repeat(40)}`;
+			const wrapped = wrapTextWithAnsi(url, 20);
+
+			assert.ok(wrapped.length > 1);
+			for (const line of wrapped) {
+				assert.ok(visibleWidth(line) <= 20);
+			}
+		});
+
 		it("should preserve color codes across wraps", () => {
 			const red = "\x1b[31m";
 			const reset = "\x1b[0m";


### PR DESCRIPTION
```markdown
## Summary

This PR makes TUI text wrapping avoid splitting plain-text HTTP(S) URLs in the middle when the full URL can fit on its own line.

Instead of rendering CLI output like this:

```text
Open this URL to continue in your web browser: https://github.com/login/dev
ice
```

the wrapper now prefers:

```text
Open this URL to continue in your web browser:
https://github.com/login/device
```

This keeps terminal-native URL detection more reliable for common CLI flows such as `gh auth login`, without requiring bash output to emit OSC 8 hyperlinks.

## Why

When a CLI prints a URL near the right edge of the console output, `wrapTextWithAnsi()` may currently split the URL across visual lines. In terminals that rely on plain-text URL detection, Cmd-click / Ctrl-click may then detect only the first visual segment of the URL.

For example, if:

```text
https://github.com/login/device
```

is wrapped as:

```text
https://github.com/login/dev
ice
```

the terminal may open only:

```text
https://github.com/login/dev
```

which is an invalid truncated URL.

This PR does not add OSC 8 hyperlink parsing or emission for shell output. It only improves plain-text wrapping so URLs that fit within the line width are kept intact.

## Implementation

- Detect likely plain-text HTTP(S) URL tokens during wrapping.
- If a URL token would overflow the current line but can fit on a fresh line, wrap before the URL instead of splitting it.
- If the URL itself is longer than the available width, keep the existing fallback behavior and split it as before.
- Preserve existing ANSI handling and active style tracking behavior.

## Tests

Added regression coverage for:

- URLs that fit on the next line should not be split.
- URLs longer than the available line width should still be split safely.

Tested with:

```bash
node --test packages/tui/test/wrap-ansi.test.ts
```

Result:

```text
17 tests passed
0 failed
```

Fixes #5054.
```