### PR TITLE
fix(tui): handle non-string value in autocomplete match

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2009,7 +2009,7 @@ export class Editor implements Component, Focusable {
 		let firstPrefixIndex = -1;
 
 		for (let i = 0; i < items.length; i++) {
-			const value = items[i]!.value;
+			const value = String(items[i]!.value ?? "");
 			if (value === prefix) {
 				return i; // Exact match always wins
 			}


### PR DESCRIPTION
## Problem

`getBestAutocompleteMatchIndex` assumed `items[].value` is always a string, but some autocomplete providers return non-string values (e.g. numbers). This caused:

```
TypeError: value.startsWith is not a function
    at CustomEditor.getBestAutocompleteMatchIndex (editor.js:1765:50)
```

## Fix

Add defensive `String()` coercion with null fallback:

```diff
- const value = items[i]!.value;
+ const value = String(items[i]!.value ?? "");
```

## Reproduction

The crash occurs intermittently when using autocomplete in the editor — some extension-registered commands return `getArgumentCompletions` items with non-string `value` fields.