### PR TITLE
[codex] Export extension utilities for extensions

### DIFF
--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -1,9 +1,15 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+
+const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
 		globals: true,
 		environment: "node",
 		testTimeout: 30000, // 30 seconds for API calls
+	},
+	resolve: {
+		alias: [{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex }],
 	},
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added public exports for `parseArgs`, `Args`, and `convertToPng` for extensions ([#5171](https://github.com/earendil-works/pi/issues/5171), [#5166](https://github.com/earendil-works/pi/issues/5166)).
+
+### Fixed
+
+- Fixed forked sessions with explicit `--session-id` to reject duplicate target session IDs before creating a new session file.
+
 ## [0.77.0] - 2026-05-28
 
 ### New Features

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -72,26 +72,36 @@ function getAliases(): Record<string, string> {
 	if (_aliases) return _aliases;
 
 	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	const packageIndex = path.resolve(__dirname, "../..", "index.js");
+	const packageRoot = path.resolve(__dirname, "../..");
+	const packageIndexJs = path.join(packageRoot, "index.js");
+	const packageIndexTs = path.join(packageRoot, "index.ts");
 
 	const typeboxEntry = require.resolve("typebox");
 	const typeboxCompileEntry = require.resolve("typebox/compile");
 	const typeboxValueEntry = require.resolve("typebox/value");
 
 	const packagesRoot = path.resolve(__dirname, "../../../../");
-	const resolveWorkspaceOrImport = (workspaceRelativePath: string, specifier: string): string => {
-		const workspacePath = path.join(packagesRoot, workspaceRelativePath);
-		if (fs.existsSync(workspacePath)) {
-			return workspacePath;
+	const resolveWorkspaceOrImport = (workspaceRelativePaths: string[], specifier: string): string => {
+		for (const workspaceRelativePath of workspaceRelativePaths) {
+			const workspacePath = path.join(packagesRoot, workspaceRelativePath);
+			if (fs.existsSync(workspacePath)) {
+				return workspacePath;
+			}
 		}
-		return fileURLToPath(import.meta.resolve(specifier));
+		return require.resolve(specifier);
 	};
 
-	const piCodingAgentEntry = packageIndex;
-	const piAgentCoreEntry = resolveWorkspaceOrImport("agent/dist/index.js", "@earendil-works/pi-agent-core");
-	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "@earendil-works/pi-tui");
-	const piAiEntry = resolveWorkspaceOrImport("ai/dist/index.js", "@earendil-works/pi-ai");
-	const piAiOauthEntry = resolveWorkspaceOrImport("ai/dist/oauth.js", "@earendil-works/pi-ai/oauth");
+	const piCodingAgentEntry = fs.existsSync(packageIndexJs) ? packageIndexJs : packageIndexTs;
+	const piAgentCoreEntry = resolveWorkspaceOrImport(
+		["agent/dist/index.js", "agent/src/index.ts"],
+		"@earendil-works/pi-agent-core",
+	);
+	const piTuiEntry = resolveWorkspaceOrImport(["tui/dist/index.js", "tui/src/index.ts"], "@earendil-works/pi-tui");
+	const piAiEntry = resolveWorkspaceOrImport(["ai/dist/index.js", "ai/src/index.ts"], "@earendil-works/pi-ai");
+	const piAiOauthEntry = resolveWorkspaceOrImport(
+		["ai/dist/oauth.js", "ai/src/oauth.ts"],
+		"@earendil-works/pi-ai/oauth",
+	);
 
 	_aliases = {
 		"@earendil-works/pi-coding-agent": piCodingAgentEntry,

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -527,6 +527,24 @@ export function findMostRecentSession(sessionDir: string, cwd?: string): string 
 	}
 }
 
+function findSessionByExactId(sessionDir: string, sessionId: string, cwd?: string): string | null {
+	const resolvedSessionDir = normalizePath(sessionDir);
+	const resolvedCwd = cwd ? resolvePath(cwd) : undefined;
+	try {
+		for (const file of readdirSync(resolvedSessionDir)) {
+			if (!file.endsWith(".jsonl")) continue;
+			const filePath = join(resolvedSessionDir, file);
+			const header = readSessionHeader(filePath);
+			if (!header || header.id !== sessionId) continue;
+			if (resolvedCwd && !sessionCwdMatches(getSessionHeaderCwd(header), resolvedCwd)) continue;
+			return filePath;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
 function isMessageWithContent(message: AgentMessage): message is Message {
 	return typeof (message as Message).role === "string" && "content" in message;
 }
@@ -1440,6 +1458,9 @@ export class SessionManager {
 		const timestamp = new Date().toISOString();
 		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
 		const newSessionFile = join(dir, `${fileTimestamp}_${newSessionId}.jsonl`);
+		if (findSessionByExactId(dir, newSessionId)) {
+			throw new Error(`Session already exists with id '${newSessionId}'`);
+		}
 
 		// Write new header pointing to source as parent, with updated cwd
 		const newHeader: SessionHeader = {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,5 +1,7 @@
-// Core session management
+// CLI utilities for extensions and SDK users
+export { type Args, parseArgs } from "./cli/args.ts";
 
+// Core session management
 // Config paths
 export { getAgentDir, VERSION } from "./config.ts";
 export {
@@ -349,6 +351,7 @@ export {
 // Clipboard utilities
 export { copyToClipboard } from "./utils/clipboard.ts";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.ts";
+export { convertToPng } from "./utils/image-convert.ts";
 export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.ts";
 // Shell utilities
 export { getShellConfig } from "./utils/shell.ts";

--- a/packages/coding-agent/test/public-api.test.ts
+++ b/packages/coding-agent/test/public-api.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import { type Args, convertToPng, parseArgs } from "../src/index.ts";
+
+const TINY_PNG =
+	"iVBORw0KGgoAAAANSUhEUgAAAAIAAAACAQMAAABIeJ9nAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGUExURf8AAP///0EdNBEAAAABYktHRAH/Ai3eAAAAB3RJTUUH6gEOADM5Ddoh/wAAAAxJREFUCNdjYGBgAAAABAABJzQnCgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAyNi0wMS0xNFQwMDo1MTo1NyswMDowMOnKzHgAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMjYtMDEtMTRUMDA6NTE6NTcrMDA6MDCYl3TEAAAAKHRFWHRkYXRlOnRpbWVzdGFtcAAyMDI2LTAxLTE0VDAwOjUxOjU3KzAwOjAwz4JVGwAAAABJRU5ErkJggg==";
+
+describe("public API", () => {
+	test("exports parseArgs and Args", () => {
+		const parsed: Args = parseArgs(["--print", "hello"]);
+
+		expect(parsed.print).toBe(true);
+		expect(parsed.messages).toEqual(["hello"]);
+	});
+
+	test("exports convertToPng", async () => {
+		await expect(convertToPng(TINY_PNG, "image/png")).resolves.toEqual({
+			data: TINY_PNG,
+			mimeType: "image/png",
+		});
+	});
+});

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,9 +22,11 @@ export default defineConfig({
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@earendil-works\/pi-tui$/, replacement: tuiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},
 });


### PR DESCRIPTION
## Summary

- Export `parseArgs` and `Args` from the coding-agent package root for extension reuse.
- Export `convertToPng` from the coding-agent package root for extension image handling.
- Keep source-checkout tests working without built workspace packages by resolving local workspace sources where needed.
- Reject duplicate explicit fork target session IDs before creating a new session file.

Fixes #5171
Fixes #5166

## Validation

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check`
- `./test.sh`
