### PR TITLE
fix: prevent stdout EPIPE from crashing the process 

### DIFF
--- a/packages/coding-agent/src/core/output-guard.ts
+++ b/packages/coding-agent/src/core/output-guard.ts
@@ -47,6 +47,14 @@ export function takeOverStdout(): void {
 		return;
 	}
 
+	process.stdout.on("error", (err) => {
+		if (err.code === "EPIPE") {
+			return;
+		}
+		console.error(`Error: Failed to write to stdout: ${err.message}`);
+		process.exit(1);
+	});
+
 	const rawStdoutWrite = process.stdout.write.bind(process.stdout) as StdoutTakeoverState["rawStdoutWrite"];
 	const rawStderrWrite = process.stderr.write.bind(process.stderr) as StdoutTakeoverState["rawStderrWrite"];
 	const originalStdoutWrite = process.stdout.write;


### PR DESCRIPTION
fixes #4984

npm run check: ...Checked 618 files in 2s. No fixes applied...
tests: ...fail 0...
