### PR TITLE
fix(tui): default showHardwareCursor to true for IME support

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -253,7 +253,7 @@ export class TUI extends Container {
 	private static readonly MIN_RENDER_INTERVAL_MS = 16;
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
-	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
+	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR !== "0";
 	private clearOnShrink = process.env.PI_CLEAR_ON_SHRINK === "1"; // Clear empty rows when content shrinks (default: off)
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves


### PR DESCRIPTION
Change showHardwareCursor default from opt-in (=== "1") to opt-out (!== "0"). The hardware cursor is now visible by default when a Focusable component has focus, which is required for IME candidate window positioning in terminals like WezTerm.

This matches the behavior documented in docs/tui.md (step 4: "Shows the hardware cursor"). Users who prefer the old behavior can set PI_HARDWARE_CURSOR=0.