### PR TITLE
Fix OpenRouter reasoning instruction role

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1075,6 +1075,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const isTogether =
 		provider === "together" || baseUrl.includes("api.together.ai") || baseUrl.includes("api.together.xyz");
 	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
+	const isOpenRouter = provider === "openrouter" || baseUrl.includes("openrouter.ai");
 	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
 	const isCloudflareAiGateway = provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
 
@@ -1101,7 +1102,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 
 	return {
 		supportsStore: !isNonStandard,
-		supportsDeveloperRole: !isNonStandard,
+		supportsDeveloperRole: !isNonStandard && !isOpenRouter,
 		supportsReasoningEffort: !isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway,
 		supportsUsageInStreaming: true,
 		maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
@@ -1115,7 +1116,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 				? "zai"
 				: isTogether
 					? "together"
-					: provider === "openrouter" || baseUrl.includes("openrouter.ai")
+					: isOpenRouter
 						? "openrouter"
 						: "openai",
 		openRouterRouting: {},

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -817,6 +817,50 @@ describe("openai-completions tool_choice", () => {
 		expect(writeCall).not.toHaveProperty("partialArgs");
 	});
 
+	it("uses system messages for OpenRouter reasoning model instructions", async () => {
+		const model = getModel("openrouter", "deepseek/deepseek-v4-pro")!;
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				systemPrompt: "Follow instructions.",
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = payload as { messages?: Array<{ role?: string }> };
+		expect(params.messages?.[0]?.role).toBe("system");
+	});
+
+	it("keeps developer messages for OpenAI reasoning model instructions", async () => {
+		const model = getModel("openai", "gpt-5.5")!;
+		let payload: unknown;
+
+		await streamSimple(
+			model,
+			{
+				systemPrompt: "Follow instructions.",
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test",
+				onPayload: (params: unknown) => {
+					payload = params;
+				},
+			},
+		).result();
+
+		const params = payload as { messages?: Array<{ role?: string }> };
+		expect(params.messages?.[0]?.role).toBe("developer");
+	});
+
 	it("stores Xiaomi MiMo reasoning replay compat in built-in metadata", () => {
 		const providers = ["xiaomi", "xiaomi-token-plan-cn", "xiaomi-token-plan-ams", "xiaomi-token-plan-sgp"] as const;
 

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -840,7 +840,8 @@ describe("openai-completions tool_choice", () => {
 	});
 
 	it("keeps developer messages for OpenAI reasoning model instructions", async () => {
-		const model = getModel("openai", "gpt-5.5")!;
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-5.5")!;
+		const model = { ...baseModel, api: "openai-completions" } as const;
 		let payload: unknown;
 
 		await streamSimple(


### PR DESCRIPTION
## Summary

OpenRouter reasoning requests now use `system` messages for system prompts by default instead of `developer` messages. OpenAI reasoning models keep the existing `developer` behavior.

## Why

OpenRouter docs describe the Chat Completions request schema with `system`, `user`, `assistant`, and `tool` roles, while its OpenAPI spec also includes `developer`, so role support is not consistently documented across surfaces:

- API reference request schema: https://openrouter.ai/docs/api/reference/overview.md
- OpenAPI schema includes `ChatDeveloperMessage`: https://openrouter.ai/openapi.json
- Reasoning docs document the unified `reasoning` parameter but do not require `developer` messages: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens.md

Some routed providers behind OpenRouter reject `developer` messages for reasoning requests. Using `system` is the safer common denominator for OpenRouter chat completions while retaining `developer` for OpenAI reasoning models.

Fixes #5117 #5229 