### PR TITLE
fix(tui): truncate oversized lines instead of crashing

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1178,34 +1178,12 @@ export class TUI extends Container {
 			const line = newLines[i];
 			const isImage = isImageLine(line);
 			if (!isImage && visibleWidth(line) > width) {
-				// Log all lines to crash file for debugging
-				const crashLogPath = path.join(os.homedir(), ".pi", "agent", "pi-crash.log");
-				const crashData = [
-					`Crash at ${new Date().toISOString()}`,
-					`Terminal width: ${width}`,
-					`Line ${i} visible width: ${visibleWidth(line)}`,
-					"",
-					"=== All rendered lines ===",
-					...newLines.map((l, idx) => `[${idx}] (w=${visibleWidth(l)}) ${l}`),
-					"",
-				].join("\n");
-				fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-				fs.writeFileSync(crashLogPath, crashData);
-
-				// Clean up terminal state before throwing
-				this.stop();
-
-				const errorMsg = [
-					`Rendered line ${i} exceeds terminal width (${visibleWidth(line)} > ${width}).`,
-					"",
-					"This is likely caused by a custom TUI component not truncating its output.",
-					"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
-					"",
-					`Debug log written to: ${crashLogPath}`,
-				].join("\n");
-				throw new Error(errorMsg);
+				// Auto-truncate oversized lines instead of crashing.
+				// Width can drift from actual visible width due to complex ANSI/OSC
+				// sequences, wide characters, or edge cases in segment extraction.
+				newLines[i] = sliceByColumn(line, 0, width, true);
 			}
-			buffer += line;
+			buffer += newLines[i];
 		}
 
 		// Track where cursor ended up after rendering


### PR DESCRIPTION
## Problem

The TUI crashes with an `uncaughtException` when a rendered line exceeds terminal width:

```
Error: Rendered line 400 exceeds terminal width (138 > 136).
```

This happens because the width-tracking in the rendering pipeline can drift from actual visible width due to:
- Complex ANSI/OSC sequences (hyperlinks, colors)
- Wide characters at segment boundaries
- Edge cases in segment extraction

## Fix

Instead of throwing a hard error (which crashes the entire agent), auto-truncate oversized lines using the existing `sliceByColumn()` utility with `strict=true`. This is the same function already used for identical overflow protection in `compositeLineAt()` (line ~922) and overlay compositing (line ~810).

## Changes

- `packages/tui/src/tui.ts`: Replace the crash-on-overflow block (crash log + `throw new Error`) with `sliceByColumn(line, 0, width, true)` truncation.

## Testing

Verified locally that `pi` no longer crashes when rendering content with long lines (e.g., file paths, CSV data, goal descriptions).