### PR TITLE
Add Pi agent bus orchestration helpers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Added
 
+- Added an SDK agent-bus mirror helper for publishing redacted Pi session lifecycle events to federated rosters.
 - Exported `convertToPng` for extension authors ([#5167](https://github.com/earendil-works/pi-mono/pull/5167) by [@xl0](https://github.com/xl0)).
 - Exported `parseArgs` and type `Args` for extension authors ([#5202](https://github.com/earendil-works/pi-mono/pull/5202) by [@xl0](https://github.com/xl0)).
 - Added `--name` / `-n` to set the session display name at startup ([#5153](https://github.com/earendil-works/pi-mono/issues/5153)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Added
 
+- Added an Agent Bus mirror example extension for publishing redacted Pi session lifecycle events to nineight federated roster demos.
 - Added an SDK agent-bus mirror helper for publishing redacted Pi session lifecycle events to federated rosters.
 - Exported `convertToPng` for extension authors ([#5167](https://github.com/earendil-works/pi-mono/pull/5167) by [@xl0](https://github.com/xl0)).
 - Exported `parseArgs` and type `Args` for extension authors ([#5202](https://github.com/earendil-works/pi-mono/pull/5202) by [@xl0](https://github.com/xl0)).

--- a/packages/coding-agent/docs/agent-bus.md
+++ b/packages/coding-agent/docs/agent-bus.md
@@ -1,0 +1,89 @@
+# Agent Bus
+
+The agent bus is Pi's read-only mirror seam for federated rosters. It lets a Pi session publish normalized lifecycle events to an external observer such as nineight without handing that observer ownership of the Pi session.
+
+## Ownership rule
+
+- Pi owns Pi sessions and applies Pi-native control (`prompt`, `steer`, `follow_up`, `abort`, session replacement).
+- Claude Code owns Claude sessions and applies Claude-native control.
+- A federated roster mirrors both as read-only actual state, then routes control requests back to the owning harness.
+
+Do not make another system edit Pi session JSONL as a control path. Session files are provenance, not the command API.
+
+## Event mirror
+
+`createAgentBusMirror()` subscribes to an `AgentSession` and emits v0 `AgentBusEvent` records:
+
+```typescript
+import { createAgentBusMirror } from "@mariozechner/pi-coding-agent";
+
+const unsubscribe = createAgentBusMirror(session, {
+  project: "nineight",
+  host: "franks-laptop",
+  sink: async (event) => {
+    await fetch("http://localhost:9888/api/agent-bus/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(event),
+    });
+  },
+});
+
+// Later, when tearing down the runtime:
+unsubscribe();
+```
+
+The helper emits `agent.registered` immediately, then converts Pi `AgentSessionEvent` values into normalized event kinds such as `agent.started`, `message.ended`, `tool.started`, `queue.changed`, and `compaction.ended`.
+
+By default the mirror is safe for roster views: message text, queued prompts, tool arguments, tool results, and error strings are summarized by shape/length only. Set `includeSensitiveData: true` only for a trusted local sink.
+
+High-volume streams are opt-in:
+
+- `includeMessageUpdates: true` mirrors assistant streaming deltas.
+- `includeToolUpdates: true` mirrors partial tool updates.
+
+## Addressing
+
+Pi uses the same address shape as the inter-agent mailbox envelope:
+
+```typescript
+type AgentBusAddress =
+  | { kind: "run"; harness: string; runId: string; host?: string }
+  | { kind: "session"; harness: string; sessionId: string; host?: string }
+  | { kind: "name"; name: string; project?: string; harness?: string; host?: string }
+  | { kind: "role"; role: string; project?: string; harness?: string; host?: string };
+```
+
+A Pi interactive or SDK session should normally register as `{ kind: "session", harness: "pi-agent", sessionId }`.
+
+## Control path
+
+The mirror is not the control path. A federated control layer should accept a `ControlIntent`, check policy/gates, then route to the owner:
+
+| Intent | Pi owner applies | Foreign observer should record |
+| --- | --- | --- |
+| `prompt` | `session.prompt()` / RPC `prompt` | receipt: `applied` or `failed` |
+| `steer` | `session.steer()` / RPC `steer` | receipt: native `steer` applied |
+| `follow_up` | `session.followUp()` / RPC `follow_up` | receipt: native `follow_up` applied |
+| `abort` | `session.abort()` / RPC `abort` | receipt: aborted/failed |
+| `note` | extension custom message or inbox | receipt: delivered/read |
+
+If another harness asks Pi to do something Pi cannot honor, return a degraded/failed receipt. Do not silently emulate unsupported behavior.
+
+## Federated roster shape
+
+A consumer such as nineight can derive a roster entry from `agent.registered` plus later events:
+
+```typescript
+type FederatedRosterEntry = {
+  address: AgentBusAddress;
+  source: "pi-agent" | "claude-code" | string;
+  project?: string;
+  cwd?: string;
+  desiredState?: "active" | "paused" | "retired"; // roster-owned
+  actualState: "working" | "blocked" | "done" | "failed" | "stopped" | "unknown"; // harness-owned
+  lastSeenAt: string;
+};
+```
+
+The important split is desired versus actual state. Pi supplies actual state. The roster/project-lead layer may decide desired state, leases, budgets, or assignments, but must reconcile by asking Pi to act through Pi's native APIs.

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -49,6 +49,8 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `plan-mode/` | Claude Code-style plan mode for read-only exploration with `/plan` command and step tracking |
 | `tools.ts` | Interactive `/tools` command to enable/disable tools with session persistence |
 | `handoff.ts` | Transfer context to a new focused session via `/handoff <goal>` |
+| `agent-bus-mirror.ts` | Mirror Pi session lifecycle events to a nineight Agent Bus endpoint for federated roster demos |
+| `claude-dispatch.ts` | Spawn Claude Code background workers via `/dispatch <prompt-or-plan.md>` without writing Claude Agent View internals |
 | `qna.ts` | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |
 | `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors |
 | `github-issue-autocomplete.ts` | Adds `#1234` issue completions by stacking a custom autocomplete provider that preloads open issues from `gh issue list` |

--- a/packages/coding-agent/examples/extensions/agent-bus-mirror.ts
+++ b/packages/coding-agent/examples/extensions/agent-bus-mirror.ts
@@ -1,0 +1,561 @@
+/**
+ * Agent Bus mirror extension
+ *
+ * Mirrors this Pi session to a nineight Agent Bus endpoint. This is a
+ * read-only observation path for demos and federated rosters: the observer
+ * records actual Pi state, but control still routes back through Pi.
+ *
+ * Usage:
+ *   pi --extension examples/extensions/agent-bus-mirror.ts \
+ *     --agent-bus-url=http://localhost:9888/api/agent-bus/events \
+ *     --agent-bus-project=pi-mono
+ *
+ * Useful env defaults:
+ *   NINEIGHT_AGENT_BUS_URL=http://localhost:9888/api/agent-bus/events
+ *   NINEIGHT_PROJECT=pi-mono
+ *   NINEIGHT_HOST=franks-laptop
+ */
+
+import { randomUUID } from "node:crypto";
+import { hostname } from "node:os";
+import { basename } from "node:path";
+import type {
+	AgentBusAddress,
+	AgentBusEvent,
+	AgentBusMirrorContext,
+	AgentBusProjectionOptions,
+	AgentBusRegistration,
+	AgentSessionEvent,
+	ExtensionAPI,
+	ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
+
+// Keep the Agent Bus projection self-contained so this global extension works
+// with the installed Pi package as well as with pi-mono checkouts where these
+// helpers are exported from @mariozechner/pi-coding-agent.
+const AGENT_BUS_SCHEMA_VERSION = "v0";
+
+const DEFAULT_ENDPOINT = "http://localhost:9888/api/agent-bus/events";
+const SOURCE = "pi-agent";
+const HARNESS = "pi-agent";
+
+interface MirrorConfig {
+	endpoint: string;
+	host: string | undefined;
+	project: string | undefined;
+	branch: string | undefined;
+	includeSensitiveData: boolean;
+	includeMessageUpdates: boolean;
+	includeToolUpdates: boolean;
+}
+
+export default function agentBusMirrorExtension(pi: ExtensionAPI) {
+	pi.registerFlag("agent-bus-url", {
+		type: "string",
+		description: "Agent Bus ingest endpoint. Use 'off' to disable.",
+		default: process.env.NINEIGHT_AGENT_BUS_URL ?? DEFAULT_ENDPOINT,
+	});
+	pi.registerFlag("agent-bus-project", {
+		type: "string",
+		description: "Project label to include in Agent Bus events.",
+		default: process.env.NINEIGHT_PROJECT ?? "",
+	});
+	pi.registerFlag("agent-bus-host", {
+		type: "string",
+		description: "Host label to include in Agent Bus events.",
+		default: process.env.NINEIGHT_HOST ?? hostname(),
+	});
+	pi.registerFlag("agent-bus-branch", {
+		type: "string",
+		description: "Optional branch label to include in Agent Bus events.",
+		default: process.env.NINEIGHT_BRANCH ?? "",
+	});
+	pi.registerFlag("agent-bus-sensitive", {
+		type: "boolean",
+		description: "Include raw messages, tool args, and tool results in mirrored events.",
+		default: false,
+	});
+	pi.registerFlag("agent-bus-message-updates", {
+		type: "boolean",
+		description: "Mirror high-volume assistant streaming updates.",
+		default: false,
+	});
+	pi.registerFlag("agent-bus-tool-updates", {
+		type: "boolean",
+		description: "Mirror high-volume partial tool updates.",
+		default: false,
+	});
+
+	let lastErrorNoticeAt = 0;
+
+	const notifyError = (ctx: ExtensionContext, error: unknown): void => {
+		const now = Date.now();
+		if (now - lastErrorNoticeAt < 30_000) return;
+		lastErrorNoticeAt = now;
+		ctx.ui.notify(`Agent Bus mirror failed: ${error instanceof Error ? error.message : String(error)}`, "error");
+	};
+
+	const emit = (event: AgentBusEvent, ctx: ExtensionContext): void => {
+		const config = readConfig(pi, ctx);
+		if (!config.endpoint) return;
+		void postEvent(config.endpoint, event).catch((error: unknown) => notifyError(ctx, error));
+	};
+
+	const mirror = (event: AgentSessionEvent, ctx: ExtensionContext): void => {
+		const config = readConfig(pi, ctx);
+		if (!config.endpoint) return;
+		const context = mirrorContext(ctx, config);
+		const projection = projectionOptions(config);
+		for (const busEvent of agentSessionEventToAgentBusEvents(event, context, projection)) {
+			emit(busEvent, ctx);
+		}
+	};
+
+	pi.on("session_start", (event, ctx) => {
+		const config = readConfig(pi, ctx);
+		if (!config.endpoint) return;
+		const context = mirrorContext(ctx, config);
+		const registration = createRegistration(ctx, config);
+		emit(
+			createAgentBusEvent(
+				"agent.registered",
+				{ registration, reason: event.reason, previousSessionFile: event.previousSessionFile },
+				context,
+				projectionOptions(config),
+			),
+			ctx,
+		);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		const config = readConfig(pi, ctx);
+		if (!config.endpoint) return;
+		emit(
+			createAgentBusEvent(
+				"agent.ended",
+				{ reason: "shutdown" },
+				mirrorContext(ctx, config),
+				projectionOptions(config),
+			),
+			ctx,
+		);
+	});
+
+	pi.on("agent_start", mirror);
+	pi.on("agent_end", mirror);
+	pi.on("turn_start", mirror);
+	pi.on("turn_end", mirror);
+	pi.on("message_start", mirror);
+	pi.on("message_update", mirror);
+	pi.on("message_end", mirror);
+	pi.on("tool_execution_start", mirror);
+	pi.on("tool_execution_update", mirror);
+	pi.on("tool_execution_end", mirror);
+
+	pi.registerCommand("agent-bus", {
+		description: "Show Agent Bus mirror status or send a heartbeat",
+		handler: async (args, ctx) => {
+			const command = args.trim() || "status";
+			const config = readConfig(pi, ctx);
+			if (command === "heartbeat") {
+				if (!config.endpoint) {
+					ctx.ui.notify("Agent Bus mirror is disabled", "info");
+					return;
+				}
+				emit(
+					createAgentBusEvent(
+						"heartbeat",
+						{ manual: true },
+						mirrorContext(ctx, config),
+						projectionOptions(config),
+					),
+					ctx,
+				);
+				ctx.ui.notify("Agent Bus heartbeat queued", "info");
+				return;
+			}
+			if (command !== "status") {
+				ctx.ui.notify("Usage: /agent-bus [status|heartbeat]", "error");
+				return;
+			}
+
+			const lines = [
+				"## Agent Bus mirror",
+				`Endpoint: ${config.endpoint || "disabled"}`,
+				`Project: ${config.project ?? "none"}`,
+				`Host: ${config.host ?? "none"}`,
+				`Branch: ${config.branch ?? "none"}`,
+				`Session: ${ctx.sessionManager.getSessionId()}`,
+				`Sensitive data: ${config.includeSensitiveData ? "yes" : "no"}`,
+				`Message updates: ${config.includeMessageUpdates ? "yes" : "no"}`,
+				`Tool updates: ${config.includeToolUpdates ? "yes" : "no"}`,
+			];
+			pi.sendMessage({ customType: "agent-bus", content: lines.join("\n"), display: true });
+		},
+	});
+}
+
+function readConfig(pi: ExtensionAPI, ctx: ExtensionContext): MirrorConfig {
+	const endpointFlag = stringFlag(pi, "agent-bus-url", process.env.NINEIGHT_AGENT_BUS_URL ?? DEFAULT_ENDPOINT);
+	const endpoint = endpointFlag.toLowerCase() === "off" ? "" : endpointFlag;
+	const project = optionalStringFlag(pi, "agent-bus-project") ?? process.env.NINEIGHT_PROJECT ?? basename(ctx.cwd);
+	const host = optionalStringFlag(pi, "agent-bus-host") ?? process.env.NINEIGHT_HOST ?? hostname();
+	const branch = optionalStringFlag(pi, "agent-bus-branch") ?? process.env.NINEIGHT_BRANCH;
+	return {
+		endpoint,
+		host,
+		project,
+		branch,
+		includeSensitiveData: booleanFlag(pi, "agent-bus-sensitive"),
+		includeMessageUpdates: booleanFlag(pi, "agent-bus-message-updates"),
+		includeToolUpdates: booleanFlag(pi, "agent-bus-tool-updates"),
+	};
+}
+
+function mirrorContext(ctx: ExtensionContext, config: MirrorConfig): AgentBusMirrorContext {
+	return {
+		source: SOURCE,
+		harness: HARNESS,
+		sessionId: ctx.sessionManager.getSessionId(),
+		host: config.host,
+		project: config.project,
+		cwd: ctx.sessionManager.getCwd(),
+		branch: config.branch,
+		sessionFile: ctx.sessionManager.getSessionFile(),
+		meta: { extension: "agent-bus-mirror" },
+	};
+}
+
+function createRegistration(ctx: ExtensionContext, config: MirrorConfig): AgentBusRegistration {
+	const now = new Date().toISOString();
+	const sessionId = ctx.sessionManager.getSessionId();
+	const address: AgentBusAddress = {
+		kind: "session",
+		harness: HARNESS,
+		sessionId,
+		...(config.host ? { host: config.host } : {}),
+	};
+	return {
+		schemaVersion: AGENT_BUS_SCHEMA_VERSION,
+		address,
+		source: SOURCE,
+		harness: HARNESS,
+		...(config.host ? { host: config.host } : {}),
+		sessionId,
+		...(ctx.sessionManager.getSessionName() ? { name: ctx.sessionManager.getSessionName() } : {}),
+		...(config.project ? { project: config.project } : {}),
+		cwd: ctx.sessionManager.getCwd(),
+		...(ctx.sessionManager.getSessionFile() ? { sessionFile: ctx.sessionManager.getSessionFile() } : {}),
+		roleBindings: [],
+		capabilities: ["prompt", "steer", "follow_up", "abort", "session_events"],
+		status: ctx.isIdle() ? "idle" : "active",
+		registeredAt: now,
+		lastSeenAt: now,
+		meta: { extension: "agent-bus-mirror" },
+	};
+}
+
+function projectionOptions(config: MirrorConfig): AgentBusProjectionOptions {
+	return {
+		includeSensitiveData: config.includeSensitiveData,
+		includeMessageUpdates: config.includeMessageUpdates,
+		includeToolUpdates: config.includeToolUpdates,
+	};
+}
+
+function createAgentBusEvent<TPayload = Record<string, unknown>>(
+	kind: AgentBusEvent["kind"],
+	payload: TPayload,
+	context: AgentBusMirrorContext,
+	options: AgentBusProjectionOptions = {},
+): AgentBusEvent<TPayload> {
+	const source = context.source ?? SOURCE;
+	const harness = context.harness ?? source;
+	const ts = (options.now?.() ?? new Date()).toISOString();
+	return {
+		schemaVersion: AGENT_BUS_SCHEMA_VERSION,
+		id: options.id?.() ?? randomUUID(),
+		source,
+		harness,
+		...(context.sessionId ? { sessionId: context.sessionId } : {}),
+		...(context.runId ? { runId: context.runId } : {}),
+		...(context.host ? { host: context.host } : {}),
+		...(context.project ? { project: context.project } : {}),
+		...(context.cwd ? { cwd: context.cwd } : {}),
+		...(context.branch ? { branch: context.branch } : {}),
+		kind,
+		ts,
+		payload,
+		...(context.cwd || context.sessionFile
+			? {
+					provenance: {
+						...(context.cwd ? { cwd: context.cwd } : {}),
+						...(context.sessionFile ? { sessionFile: context.sessionFile } : {}),
+					},
+				}
+			: {}),
+		...(context.meta ? { meta: context.meta } : {}),
+	};
+}
+
+function agentSessionEventToAgentBusEvents(
+	event: AgentSessionEvent,
+	context: AgentBusMirrorContext,
+	options: AgentBusProjectionOptions = {},
+): AgentBusEvent[] {
+	switch (event.type) {
+		case "agent_start":
+			return [createAgentBusEvent("agent.started", {}, context, options)];
+		case "agent_end":
+			return [
+				createAgentBusEvent(
+					"agent.ended",
+					{ messageCount: event.messages.length, messages: maybeSensitive(event.messages, options) },
+					context,
+					options,
+				),
+			];
+		case "turn_start":
+			return [createAgentBusEvent("turn.started", {}, context, options)];
+		case "turn_end":
+			return [
+				createAgentBusEvent(
+					"turn.ended",
+					{
+						message: summarizeMessage(event.message, options),
+						toolResultCount: event.toolResults.length,
+						toolResults: maybeSensitive(event.toolResults, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "message_start":
+			return [
+				createAgentBusEvent(
+					"message.started",
+					{ message: summarizeMessage(event.message, options) },
+					context,
+					options,
+				),
+			];
+		case "message_update":
+			if (!options.includeMessageUpdates) return [];
+			return [
+				createAgentBusEvent(
+					"message.updated",
+					{
+						message: summarizeMessage(event.message, options),
+						assistantMessageEvent: summarizeAssistantMessageEvent(event.assistantMessageEvent, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "message_end":
+			return [
+				createAgentBusEvent(
+					"message.ended",
+					{ message: summarizeMessage(event.message, options) },
+					context,
+					options,
+				),
+			];
+		case "tool_execution_start":
+			return [
+				createAgentBusEvent(
+					"tool.started",
+					{
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						args: options.includeSensitiveData ? event.args : summarizeValue(event.args),
+					},
+					context,
+					options,
+				),
+			];
+		case "tool_execution_update":
+			if (!options.includeToolUpdates) return [];
+			return [
+				createAgentBusEvent(
+					"tool.updated",
+					{
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						args: options.includeSensitiveData ? event.args : summarizeValue(event.args),
+						partialResult: options.includeSensitiveData
+							? event.partialResult
+							: summarizeValue(event.partialResult),
+					},
+					context,
+					options,
+				),
+			];
+		case "tool_execution_end":
+			return [
+				createAgentBusEvent(
+					"tool.ended",
+					{
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						isError: event.isError,
+						result: options.includeSensitiveData ? event.result : summarizeValue(event.result),
+					},
+					context,
+					options,
+				),
+			];
+		case "queue_update":
+			return [
+				createAgentBusEvent(
+					"queue.changed",
+					{
+						steeringCount: event.steering.length,
+						followUpCount: event.followUp.length,
+						steering: maybeSensitive(event.steering, options),
+						followUp: maybeSensitive(event.followUp, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "compaction_start":
+			return [createAgentBusEvent("compaction.started", { reason: event.reason }, context, options)];
+		case "compaction_end":
+			return [
+				createAgentBusEvent(
+					"compaction.ended",
+					{
+						reason: event.reason,
+						aborted: event.aborted,
+						willRetry: event.willRetry,
+						hasResult: event.result !== undefined,
+						errorMessage: options.includeSensitiveData
+							? event.errorMessage
+							: summarizeOptionalString(event.errorMessage),
+						result: maybeSensitive(event.result, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "auto_retry_start":
+			return [
+				createAgentBusEvent(
+					"retry.started",
+					{
+						attempt: event.attempt,
+						maxAttempts: event.maxAttempts,
+						delayMs: event.delayMs,
+						errorMessage: options.includeSensitiveData
+							? event.errorMessage
+							: summarizeOptionalString(event.errorMessage),
+					},
+					context,
+					options,
+				),
+			];
+		case "auto_retry_end":
+			return [
+				createAgentBusEvent(
+					"retry.ended",
+					{
+						success: event.success,
+						attempt: event.attempt,
+						finalError: options.includeSensitiveData
+							? event.finalError
+							: summarizeOptionalString(event.finalError),
+					},
+					context,
+					options,
+				),
+			];
+	}
+	return [];
+}
+
+function maybeSensitive(value: unknown, options: AgentBusProjectionOptions): unknown {
+	return options.includeSensitiveData ? value : undefined;
+}
+
+function summarizeMessage(message: unknown, options: AgentBusProjectionOptions): Record<string, unknown> {
+	const record = asRecord(message);
+	const content = record?.content;
+	const summary: Record<string, unknown> = {
+		role: typeof record?.role === "string" ? record.role : "unknown",
+	};
+	if (typeof content === "string") {
+		summary.content = options.includeSensitiveData ? content : { kind: "string", length: content.length };
+	} else if (Array.isArray(content)) {
+		summary.content = options.includeSensitiveData
+			? content
+			: {
+					kind: "array",
+					length: content.length,
+					blockTypes: content.map((block) => {
+						const blockRecord = asRecord(block);
+						return typeof blockRecord?.type === "string" ? blockRecord.type : "unknown";
+					}),
+				};
+	}
+	if (options.includeSensitiveData) summary.message = message;
+	return summary;
+}
+
+function summarizeAssistantMessageEvent(value: unknown, options: AgentBusProjectionOptions): unknown {
+	if (options.includeSensitiveData) return value;
+	const record = asRecord(value);
+	if (!record) return summarizeValue(value);
+	const summary: Record<string, unknown> = {
+		type: typeof record.type === "string" ? record.type : "unknown",
+	};
+	if (typeof record.contentIndex === "number") summary.contentIndex = record.contentIndex;
+	if (typeof record.delta === "string") summary.delta = { kind: "string", length: record.delta.length };
+	if (record.toolCall !== undefined) summary.toolCall = summarizeValue(record.toolCall);
+	return summary;
+}
+
+function summarizeValue(value: unknown): Record<string, unknown> {
+	if (value === null) return { kind: "null" };
+	if (Array.isArray(value)) return { kind: "array", length: value.length };
+	if (typeof value === "string") return { kind: "string", length: value.length };
+	const type = typeof value;
+	if (type === "number" || type === "boolean" || type === "undefined") return { kind: type };
+	const record = asRecord(value);
+	if (record) return { kind: "object", keys: Object.keys(record).sort() };
+	return { kind: type };
+}
+
+function summarizeOptionalString(value: string | undefined): Record<string, unknown> | undefined {
+	return value === undefined ? undefined : { kind: "string", length: value.length };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+async function postEvent(endpoint: string, event: AgentBusEvent): Promise<void> {
+	const response = await fetch(endpoint, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(event),
+	});
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 300)}`);
+	}
+}
+
+function stringFlag(pi: ExtensionAPI, name: string, fallback: string): string {
+	const value = pi.getFlag(name);
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function optionalStringFlag(pi: ExtensionAPI, name: string): string | undefined {
+	const value = pi.getFlag(name);
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function booleanFlag(pi: ExtensionAPI, name: string): boolean {
+	return pi.getFlag(name) === true;
+}

--- a/packages/coding-agent/examples/extensions/claude-dispatch.ts
+++ b/packages/coding-agent/examples/extensions/claude-dispatch.ts
@@ -1,0 +1,546 @@
+/**
+ * Claude Dispatch extension
+ *
+ * Adds a Pi `/dispatch` command that spawns Claude Code background workers via
+ * Claude's own CLI (`claude --bg`). This is an owner-routed adapter: Pi does
+ * not write Claude Agent View files and does not claim ownership of the spawned
+ * Claude session. The worker should appear in Claude Agent View, and any
+ * external observer (for example nineight's federated roster) can mirror it.
+ *
+ * Usage:
+ *   /dispatch investigate why auth tests are failing
+ *   /dispatch --cwd ../other-repo --name auth-scout inspect auth flows
+ *   /dispatch --dry-run ./dispatch-proposal.md
+ *   /dispatch --no-confirm ./dispatch-proposal.md
+ */
+
+import { access, readFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { parseDocument } from "yaml";
+
+type Effort = "low" | "medium" | "high" | "xhigh" | "max";
+type PermissionMode = "acceptEdits" | "auto" | "bypassPermissions" | "default" | "dontAsk" | "plan";
+type IsolationMode = "none" | "worktree";
+
+interface ParsedArgs {
+	dryRun: boolean;
+	noConfirm: boolean;
+	cwd?: string;
+	name?: string;
+	effort?: Effort;
+	permissionMode?: PermissionMode;
+	model?: string;
+	isolation?: IsolationMode;
+	addDirs: string[];
+	tools?: string[];
+	prompt: string;
+}
+
+interface DispatchWorker {
+	name?: string;
+	cwd: string;
+	seedPrompt: string;
+	tags: string[];
+	effort?: Effort;
+	permissionMode?: PermissionMode;
+	model?: string;
+	isolation: IsolationMode;
+	addDirs: string[];
+	tools?: string[];
+	targetProject?: string;
+}
+
+interface DispatchPlan {
+	source: "prompt" | "proposal";
+	sourcePath?: string;
+	targetProject?: string;
+	workers: DispatchWorker[];
+}
+
+interface DispatchResult {
+	worker: DispatchWorker;
+	commandPreview: string;
+	stdout: string;
+	stderr: string;
+	code: number;
+	shortId?: string;
+}
+
+export default function claudeDispatchExtension(pi: ExtensionAPI) {
+	pi.registerCommand("dispatch", {
+		description: "Spawn Claude Code background worker(s) with Pi-provided context",
+		getArgumentCompletions: (prefix) => {
+			const flags = [
+				"--dry-run",
+				"--no-confirm",
+				"--cwd=",
+				"--name=",
+				"--effort=high",
+				"--permission-mode=default",
+				"--model=sonnet",
+				"--isolation=worktree",
+			];
+			const filtered = flags.filter((flag) => flag.startsWith(prefix));
+			return filtered.length > 0 ? filtered.map((flag) => ({ value: flag, label: flag })) : null;
+		},
+		handler: async (args, ctx) => {
+			let parsed: ParsedArgs;
+			try {
+				parsed = parseArgs(args);
+			} catch (error) {
+				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+				return;
+			}
+
+			if (!parsed.prompt) {
+				ctx.ui.notify("Usage: /dispatch [--dry-run] [--cwd path] [--name name] <prompt-or-plan.md>", "error");
+				return;
+			}
+
+			let plan: DispatchPlan;
+			try {
+				plan = await buildDispatchPlan(parsed, ctx.cwd);
+			} catch (error) {
+				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+				return;
+			}
+
+			const summary = formatPlanSummary(plan, parsed.dryRun);
+			if (parsed.dryRun) {
+				pi.sendMessage({
+					customType: "claude-dispatch",
+					content: summary,
+					display: true,
+					details: { dryRun: true, plan },
+				});
+				ctx.ui.notify(`Dry run: ${plan.workers.length} worker(s)`, "info");
+				return;
+			}
+
+			if (!parsed.noConfirm) {
+				if (!ctx.hasUI) {
+					ctx.ui.notify("/dispatch requires --no-confirm when UI is unavailable", "error");
+					return;
+				}
+				const confirmed = await ctx.ui.confirm("Dispatch Claude background worker(s)?", summary);
+				if (!confirmed) {
+					ctx.ui.notify("Dispatch cancelled", "info");
+					return;
+				}
+			}
+
+			const results: DispatchResult[] = [];
+			for (const worker of plan.workers) {
+				try {
+					await access(worker.cwd);
+					const result = await spawnClaudeWorker(pi, worker, plan, ctx.cwd, ctx.sessionManager.getSessionFile());
+					results.push(result);
+				} catch (error) {
+					ctx.ui.notify(
+						`Dispatch failed for ${worker.name ?? worker.cwd}: ${error instanceof Error ? error.message : String(error)}`,
+						"error",
+					);
+					break;
+				}
+			}
+
+			const report = formatDispatchReport(results, plan.workers.length);
+			pi.appendEntry("claude-dispatch", {
+				createdAt: new Date().toISOString(),
+				plan,
+				results: results.map((result) => ({
+					worker: result.worker,
+					commandPreview: result.commandPreview,
+					shortId: result.shortId,
+					code: result.code,
+				})),
+			});
+			pi.sendMessage({
+				customType: "claude-dispatch",
+				content: report,
+				display: true,
+				details: { plan, results },
+			});
+			ctx.ui.notify(`Dispatched ${results.length}/${plan.workers.length} Claude worker(s)`, "info");
+		},
+	});
+}
+
+async function buildDispatchPlan(args: ParsedArgs, commandCwd: string): Promise<DispatchPlan> {
+	const maybePath = stripAtPrefix(args.prompt.trim());
+	const proposalPath = resolve(commandCwd, maybePath);
+	if (await isReadableFile(proposalPath)) {
+		return parseProposalFile(proposalPath, args, commandCwd);
+	}
+
+	const cwd = resolve(commandCwd, args.cwd ?? ".");
+	return {
+		source: "prompt",
+		workers: [
+			{
+				name: args.name ?? slugify(args.prompt).slice(0, 48),
+				cwd,
+				seedPrompt: args.prompt,
+				tags: [],
+				effort: args.effort,
+				permissionMode: args.permissionMode,
+				model: args.model,
+				isolation: args.isolation ?? "none",
+				addDirs: args.addDirs.map((dir) => resolve(commandCwd, dir)),
+				tools: args.tools,
+			},
+		],
+	};
+}
+
+async function parseProposalFile(path: string, args: ParsedArgs, commandCwd: string): Promise<DispatchPlan> {
+	const content = await readFile(path, "utf8");
+	const frontmatter = extractFrontmatter(content);
+	if (!frontmatter) throw new Error(`No YAML frontmatter found in ${path}`);
+
+	const parsed = parseDocument(frontmatter).toJS() as unknown;
+	const root = asRecord(parsed);
+	const proposal = asRecord(root?.dispatch_proposal);
+	if (!proposal) throw new Error(`No dispatch_proposal object found in ${path}`);
+
+	const workersValue = proposal.workers;
+	if (!Array.isArray(workersValue)) throw new Error(`dispatch_proposal.workers must be an array in ${path}`);
+
+	const targetProject = optionalString(proposal.target_project);
+	const proposalDir = dirname(path);
+	const workers = workersValue.map((workerValue, index) => {
+		const worker = asRecord(workerValue);
+		if (!worker) throw new Error(`dispatch_proposal.workers[${index}] must be an object`);
+
+		const seedPrompt = optionalString(worker.seed_prompt) ?? optionalString(worker.prompt);
+		if (!seedPrompt) throw new Error(`dispatch_proposal.workers[${index}].seed_prompt is required`);
+
+		const workerCwd = optionalString(worker.cwd) ?? args.cwd ?? commandCwd;
+		return {
+			name: optionalString(worker.name) ?? args.name ?? slugify(seedPrompt).slice(0, 48),
+			cwd: resolveMaybeRelative(proposalDir, workerCwd),
+			seedPrompt,
+			tags: stringArray(worker.tags),
+			effort: parseEffort(optionalString(worker.effort)) ?? args.effort,
+			permissionMode: parsePermissionMode(optionalString(worker.permission_mode)) ?? args.permissionMode,
+			model: optionalString(worker.model) ?? args.model,
+			isolation: parseIsolation(optionalString(worker.isolation)) ?? args.isolation ?? "none",
+			addDirs: [...stringArray(worker.add_dirs), ...stringArray(worker.add_dir), ...args.addDirs].map((dir) =>
+				resolveMaybeRelative(proposalDir, dir),
+			),
+			tools: stringArray(worker.tools).length > 0 ? stringArray(worker.tools) : args.tools,
+			targetProject,
+		} satisfies DispatchWorker;
+	});
+
+	return { source: "proposal", sourcePath: path, targetProject, workers };
+}
+
+async function spawnClaudeWorker(
+	pi: ExtensionAPI,
+	worker: DispatchWorker,
+	plan: DispatchPlan,
+	originCwd: string,
+	originSessionFile: string | undefined,
+): Promise<DispatchResult> {
+	const seed = buildSeedPrompt(worker, plan, originCwd, originSessionFile);
+	const args = buildClaudeArgs(worker, seed);
+	const commandPreview = previewCommand(args);
+	const result = await pi.exec("claude", args, { cwd: worker.cwd, timeout: 60_000 });
+	if (result.code !== 0) {
+		const detail = result.stderr.trim() || result.stdout.trim() || `exit code ${result.code}`;
+		throw new Error(detail);
+	}
+	return {
+		worker,
+		commandPreview,
+		stdout: result.stdout,
+		stderr: result.stderr,
+		code: result.code,
+		shortId: extractClaudeShortId(`${result.stdout}\n${result.stderr}`),
+	};
+}
+
+function buildClaudeArgs(worker: DispatchWorker, seedPrompt: string): string[] {
+	const args = ["--bg"];
+	if (worker.name) args.push("--name", worker.name);
+	if (worker.effort) args.push("--effort", worker.effort);
+	if (worker.permissionMode) args.push("--permission-mode", worker.permissionMode);
+	if (worker.model) args.push("--model", worker.model);
+	for (const dir of worker.addDirs) args.push("--add-dir", dir);
+	if (worker.tools && worker.tools.length > 0) args.push("--tools", worker.tools.join(","));
+	if (worker.isolation === "worktree") args.push("--worktree", worker.name ?? slugify(worker.seedPrompt).slice(0, 32));
+	args.push(seedPrompt);
+	return args;
+}
+
+function buildSeedPrompt(
+	worker: DispatchWorker,
+	plan: DispatchPlan,
+	originCwd: string,
+	originSessionFile: string | undefined,
+): string {
+	const lines = [
+		"You are a Claude Code background worker dispatched from Pi Agent.",
+		"",
+		"## Origin",
+		`- Origin harness: pi-agent`,
+		`- Origin cwd: ${originCwd}`,
+		`- Origin session file: ${originSessionFile ?? "ephemeral"}`,
+		`- Dispatch source: ${plan.sourcePath ?? "inline prompt"}`,
+		`- Worker name: ${worker.name ?? "unnamed"}`,
+		`- Worker cwd: ${worker.cwd}`,
+		...(plan.targetProject ? [`- Target project: ${plan.targetProject}`] : []),
+		...(worker.tags.length > 0 ? [`- Tags: ${worker.tags.join(", ")}`] : []),
+		"",
+		"## Coordination rules",
+		"- Claude Code owns this session lifecycle. Pi/nineight may mirror it, but must not edit Claude Agent View internals.",
+		"- Do not write to ~/.claude/daemon, ~/.claude/jobs, or Pi session JSONL as a control path.",
+		"- If a nineight mailbox or MCP tool is available, register/check in through it; otherwise leave concise status in your final response.",
+		"- Surface blockers, permission needs, and final outcome clearly for HITL/project-lead review.",
+		"",
+		"## Task",
+		worker.seedPrompt.trim(),
+	];
+	return lines.join("\n");
+}
+
+function formatPlanSummary(plan: DispatchPlan, dryRun: boolean): string {
+	const heading = dryRun ? "Claude dispatch dry run" : "Claude dispatch request";
+	const rows = plan.workers.map((worker, index) => {
+		const parts = [
+			`${index + 1}. ${worker.name ?? "unnamed"}`,
+			`cwd=${worker.cwd}`,
+			`isolation=${worker.isolation}`,
+			...(worker.effort ? [`effort=${worker.effort}`] : []),
+			...(worker.permissionMode ? [`permission=${worker.permissionMode}`] : []),
+			...(worker.model ? [`model=${worker.model}`] : []),
+		];
+		return parts.join(" | ");
+	});
+	return [
+		`## ${heading}`,
+		`Source: ${plan.sourcePath ?? "inline prompt"}`,
+		...(plan.targetProject ? [`Target project: ${plan.targetProject}`] : []),
+		`Workers: ${plan.workers.length}`,
+		"",
+		...rows,
+	].join("\n");
+}
+
+function formatDispatchReport(results: DispatchResult[], expected: number): string {
+	const rows = results.map((result, index) => {
+		const id = result.shortId ? `short=${result.shortId}` : "short=unknown";
+		return `${index + 1}. ${result.worker.name ?? "unnamed"} | ${id} | code=${result.code} | cwd=${result.worker.cwd}`;
+	});
+	return ["## Claude dispatch result", `Dispatched: ${results.length}/${expected}`, "", ...rows].join("\n");
+}
+
+function parseArgs(input: string): ParsedArgs {
+	const words = splitShellLike(input.trim());
+	const parsed: ParsedArgs = { dryRun: false, noConfirm: false, addDirs: [], prompt: "" };
+	const promptWords: string[] = [];
+	let parsingFlags = true;
+
+	for (let i = 0; i < words.length; i++) {
+		const word = words[i] ?? "";
+		if (parsingFlags && word === "--") {
+			parsingFlags = false;
+			continue;
+		}
+		if (!parsingFlags || !word.startsWith("--")) {
+			promptWords.push(word);
+			continue;
+		}
+
+		const { key, value } = splitFlag(word);
+		const takeValue = () => {
+			if (value !== undefined) return value;
+			const next = words[++i];
+			if (!next) throw new Error(`Missing value for --${key}`);
+			return next;
+		};
+
+		switch (key) {
+			case "dry-run":
+				parsed.dryRun = true;
+				break;
+			case "yes":
+			case "no-confirm":
+				parsed.noConfirm = true;
+				break;
+			case "cwd":
+				parsed.cwd = takeValue();
+				break;
+			case "name":
+				parsed.name = takeValue();
+				break;
+			case "effort":
+				parsed.effort = parseEffort(takeValue());
+				if (!parsed.effort) throw new Error("--effort must be one of: low, medium, high, xhigh, max");
+				break;
+			case "permission-mode":
+				parsed.permissionMode = parsePermissionMode(takeValue());
+				if (!parsed.permissionMode) {
+					throw new Error(
+						"--permission-mode must be one of: acceptEdits, auto, bypassPermissions, default, dontAsk, plan",
+					);
+				}
+				break;
+			case "model":
+				parsed.model = takeValue();
+				break;
+			case "isolation":
+				parsed.isolation = parseIsolation(takeValue());
+				if (!parsed.isolation) throw new Error("--isolation must be one of: none, worktree");
+				break;
+			case "add-dir":
+				parsed.addDirs.push(takeValue());
+				break;
+			case "tools":
+				parsed.tools = takeValue()
+					.split(",")
+					.map((tool) => tool.trim())
+					.filter(Boolean);
+				break;
+			default:
+				throw new Error(`Unknown /dispatch flag: --${key}`);
+		}
+	}
+
+	parsed.prompt = promptWords.join(" ").trim();
+	return parsed;
+}
+
+function splitShellLike(input: string): string[] {
+	const words: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | undefined;
+	let escaped = false;
+
+	for (const char of input) {
+		if (escaped) {
+			current += char;
+			escaped = false;
+			continue;
+		}
+		if (char === "\\" && quote !== "'") {
+			escaped = true;
+			continue;
+		}
+		if ((char === '"' || char === "'") && (!quote || quote === char)) {
+			quote = quote ? undefined : char;
+			continue;
+		}
+		if (!quote && /\s/.test(char)) {
+			if (current) {
+				words.push(current);
+				current = "";
+			}
+			continue;
+		}
+		current += char;
+	}
+	if (escaped) current += "\\";
+	if (quote) throw new Error("Unterminated quote in /dispatch arguments");
+	if (current) words.push(current);
+	return words;
+}
+
+function splitFlag(word: string): { key: string; value?: string } {
+	const raw = word.slice(2);
+	const equals = raw.indexOf("=");
+	if (equals === -1) return { key: raw };
+	return { key: raw.slice(0, equals), value: raw.slice(equals + 1) };
+}
+
+function extractFrontmatter(content: string): string | undefined {
+	const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+	return match?.[1];
+}
+
+async function isReadableFile(path: string): Promise<boolean> {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function resolveMaybeRelative(baseDir: string, path: string): string {
+	return isAbsolute(path) ? path : resolve(baseDir, path);
+}
+
+function stripAtPrefix(path: string): string {
+	return path.startsWith("@") ? path.slice(1) : path;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+	if (typeof value === "string")
+		return value
+			.split(",")
+			.map((item) => item.trim())
+			.filter(Boolean);
+	if (!Array.isArray(value)) return [];
+	return value
+		.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+		.map((item) => item.trim());
+}
+
+function parseEffort(value: string | undefined): Effort | undefined {
+	if (value === "low" || value === "medium" || value === "high" || value === "xhigh" || value === "max") return value;
+	return undefined;
+}
+
+function parsePermissionMode(value: string | undefined): PermissionMode | undefined {
+	if (
+		value === "acceptEdits" ||
+		value === "auto" ||
+		value === "bypassPermissions" ||
+		value === "default" ||
+		value === "dontAsk" ||
+		value === "plan"
+	) {
+		return value;
+	}
+	return undefined;
+}
+
+function parseIsolation(value: string | undefined): IsolationMode | undefined {
+	if (value === "none" || value === "worktree") return value;
+	return undefined;
+}
+
+function slugify(text: string): string {
+	const slug = text
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return slug || `worker-${Date.now()}`;
+}
+
+function previewCommand(args: string[]): string {
+	const visible = args.map((arg, index) => {
+		if (index === args.length - 1) return `<seed-prompt:${arg.length} chars>`;
+		return quoteForPreview(arg);
+	});
+	return ["claude", ...visible].join(" ");
+}
+
+function quoteForPreview(value: string): string {
+	return /^[a-zA-Z0-9_./:=,-]+$/.test(value) ? value : JSON.stringify(value);
+}
+
+function extractClaudeShortId(output: string): string | undefined {
+	return /backgrounded\s+·\s+([a-z0-9]+)/i.exec(output)?.[1];
+}

--- a/packages/coding-agent/src/core/agent-bus.ts
+++ b/packages/coding-agent/src/core/agent-bus.ts
@@ -1,0 +1,471 @@
+import { randomUUID } from "node:crypto";
+import type { AgentSession, AgentSessionEvent } from "./agent-session.ts";
+
+export const AGENT_BUS_SCHEMA_VERSION = "v0" as const;
+
+export type AgentBusSchemaVersion = typeof AGENT_BUS_SCHEMA_VERSION;
+
+export type AgentBusAddress =
+	| { kind: "run"; harness: string; runId: string; host?: string }
+	| { kind: "session"; harness: string; sessionId: string; host?: string }
+	| { kind: "name"; name: string; project?: string; harness?: string; host?: string }
+	| { kind: "role"; role: string; project?: string; harness?: string; host?: string };
+
+export type AgentBusEventKind =
+	| "agent.registered"
+	| "agent.started"
+	| "agent.ended"
+	| "turn.started"
+	| "turn.ended"
+	| "message.started"
+	| "message.updated"
+	| "message.ended"
+	| "tool.started"
+	| "tool.updated"
+	| "tool.ended"
+	| "queue.changed"
+	| "compaction.started"
+	| "compaction.ended"
+	| "retry.started"
+	| "retry.ended"
+	| "heartbeat";
+
+export type AgentBusRegistrationStatus = "active" | "idle" | "stopped";
+
+export interface AgentBusRegistration {
+	schemaVersion: AgentBusSchemaVersion;
+	address: AgentBusAddress;
+	source: string;
+	harness: string;
+	host?: string;
+	sessionId?: string;
+	runId?: string;
+	name?: string;
+	project?: string;
+	cwd?: string;
+	sessionFile?: string;
+	roleBindings: string[];
+	capabilities: string[];
+	status: AgentBusRegistrationStatus;
+	registeredAt: string;
+	lastSeenAt: string;
+	meta?: Record<string, unknown>;
+}
+
+export interface AgentBusEvent<TPayload = Record<string, unknown>> {
+	schemaVersion: AgentBusSchemaVersion;
+	id: string;
+	source: string;
+	harness: string;
+	sessionId?: string;
+	runId?: string;
+	host?: string;
+	project?: string;
+	cwd?: string;
+	branch?: string;
+	kind: AgentBusEventKind;
+	ts: string;
+	payload: TPayload;
+	provenance?: {
+		cwd?: string;
+		sessionFile?: string;
+		entryIds?: string[];
+	};
+	meta?: Record<string, unknown>;
+}
+
+export interface AgentBusMirrorContext {
+	source?: string;
+	harness?: string;
+	sessionId?: string;
+	runId?: string;
+	host?: string;
+	project?: string;
+	cwd?: string;
+	branch?: string;
+	sessionFile?: string;
+	meta?: Record<string, unknown>;
+}
+
+export interface AgentBusProjectionOptions {
+	/** Include raw message/tool payloads. Defaults to false so mirrors are safe for read-only rosters. */
+	includeSensitiveData?: boolean;
+	/** Include token-level assistant update events. Defaults to false to avoid high-volume feeds. */
+	includeMessageUpdates?: boolean;
+	/** Include partial tool update events. Defaults to false to avoid high-volume feeds. */
+	includeToolUpdates?: boolean;
+	now?: () => Date;
+	id?: () => string;
+}
+
+export type AgentBusEventSink = (event: AgentBusEvent) => void | Promise<void>;
+
+export interface AgentBusMirrorOptions extends AgentBusProjectionOptions {
+	sink: AgentBusEventSink;
+	source?: string;
+	harness?: string;
+	host?: string;
+	project?: string;
+	branch?: string;
+	name?: string;
+	roleBindings?: string[];
+	capabilities?: string[];
+	meta?: Record<string, unknown>;
+	onError?: (error: unknown, event?: AgentBusEvent) => void;
+}
+
+export function createAgentBusEvent<TPayload = Record<string, unknown>>(
+	kind: AgentBusEventKind,
+	payload: TPayload,
+	context: AgentBusMirrorContext,
+	options: AgentBusProjectionOptions = {},
+): AgentBusEvent<TPayload> {
+	const source = context.source ?? "pi-agent";
+	const harness = context.harness ?? source;
+	const ts = (options.now?.() ?? new Date()).toISOString();
+	return {
+		schemaVersion: AGENT_BUS_SCHEMA_VERSION,
+		id: options.id?.() ?? randomUUID(),
+		source,
+		harness,
+		...(context.sessionId ? { sessionId: context.sessionId } : {}),
+		...(context.runId ? { runId: context.runId } : {}),
+		...(context.host ? { host: context.host } : {}),
+		...(context.project ? { project: context.project } : {}),
+		...(context.cwd ? { cwd: context.cwd } : {}),
+		...(context.branch ? { branch: context.branch } : {}),
+		kind,
+		ts,
+		payload,
+		...(context.cwd || context.sessionFile
+			? {
+					provenance: {
+						...(context.cwd ? { cwd: context.cwd } : {}),
+						...(context.sessionFile ? { sessionFile: context.sessionFile } : {}),
+					},
+				}
+			: {}),
+		...(context.meta ? { meta: context.meta } : {}),
+	};
+}
+
+export function createAgentBusRegistration(
+	session: AgentSession,
+	options: Omit<AgentBusMirrorOptions, "sink" | "onError"> = {},
+): AgentBusRegistration {
+	const source = options.source ?? "pi-agent";
+	const harness = options.harness ?? source;
+	const now = (options.now?.() ?? new Date()).toISOString();
+	const sessionId = session.sessionId;
+	const address: AgentBusAddress = {
+		kind: "session",
+		harness,
+		sessionId,
+		...(options.host ? { host: options.host } : {}),
+	};
+	return {
+		schemaVersion: AGENT_BUS_SCHEMA_VERSION,
+		address,
+		source,
+		harness,
+		...(options.host ? { host: options.host } : {}),
+		sessionId,
+		...(options.name ? { name: options.name } : {}),
+		...(options.project ? { project: options.project } : {}),
+		cwd: session.sessionManager.getCwd(),
+		...(session.sessionFile ? { sessionFile: session.sessionFile } : {}),
+		roleBindings: [...(options.roleBindings ?? [])],
+		capabilities: [...(options.capabilities ?? ["prompt", "steer", "follow_up", "abort", "session_events"])],
+		status: session.isStreaming ? "active" : "idle",
+		registeredAt: now,
+		lastSeenAt: now,
+		...(options.meta ? { meta: options.meta } : {}),
+	};
+}
+
+export function createAgentBusMirror(session: AgentSession, options: AgentBusMirrorOptions): () => void {
+	const context = contextFromSession(session, options);
+	const emit = (event: AgentBusEvent): void => {
+		Promise.resolve(options.sink(event)).catch((error: unknown) => {
+			options.onError?.(error, event);
+		});
+	};
+
+	emit(
+		createAgentBusEvent(
+			"agent.registered",
+			{ registration: createAgentBusRegistration(session, options) },
+			context,
+			options,
+		),
+	);
+
+	return session.subscribe((event) => {
+		for (const busEvent of agentSessionEventToAgentBusEvents(event, context, options)) {
+			emit(busEvent);
+		}
+	});
+}
+
+export function agentSessionEventToAgentBusEvents(
+	event: AgentSessionEvent,
+	context: AgentBusMirrorContext,
+	options: AgentBusProjectionOptions = {},
+): AgentBusEvent[] {
+	switch (event.type) {
+		case "agent_start":
+			return [createAgentBusEvent("agent.started", {}, context, options)];
+		case "agent_end":
+			return [
+				createAgentBusEvent(
+					"agent.ended",
+					{ messageCount: event.messages.length, messages: maybeSensitive(event.messages, options) },
+					context,
+					options,
+				),
+			];
+		case "turn_start":
+			return [createAgentBusEvent("turn.started", {}, context, options)];
+		case "turn_end":
+			return [
+				createAgentBusEvent(
+					"turn.ended",
+					{
+						message: summarizeMessage(event.message, options),
+						toolResultCount: event.toolResults.length,
+						toolResults: maybeSensitive(event.toolResults, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "message_start":
+			return [
+				createAgentBusEvent(
+					"message.started",
+					{ message: summarizeMessage(event.message, options) },
+					context,
+					options,
+				),
+			];
+		case "message_update":
+			if (!options.includeMessageUpdates) return [];
+			return [
+				createAgentBusEvent(
+					"message.updated",
+					{
+						message: summarizeMessage(event.message, options),
+						assistantMessageEvent: summarizeAssistantMessageEvent(event.assistantMessageEvent, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "message_end":
+			return [
+				createAgentBusEvent(
+					"message.ended",
+					{ message: summarizeMessage(event.message, options) },
+					context,
+					options,
+				),
+			];
+		case "tool_execution_start":
+			return [
+				createAgentBusEvent(
+					"tool.started",
+					{
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						args: options.includeSensitiveData ? event.args : summarizeValue(event.args),
+					},
+					context,
+					options,
+				),
+			];
+		case "tool_execution_update":
+			if (!options.includeToolUpdates) return [];
+			return [
+				createAgentBusEvent(
+					"tool.updated",
+					{
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						args: options.includeSensitiveData ? event.args : summarizeValue(event.args),
+						partialResult: options.includeSensitiveData
+							? event.partialResult
+							: summarizeValue(event.partialResult),
+					},
+					context,
+					options,
+				),
+			];
+		case "tool_execution_end":
+			return [
+				createAgentBusEvent(
+					"tool.ended",
+					{
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						isError: event.isError,
+						result: options.includeSensitiveData ? event.result : summarizeValue(event.result),
+					},
+					context,
+					options,
+				),
+			];
+		case "queue_update":
+			return [
+				createAgentBusEvent(
+					"queue.changed",
+					{
+						steeringCount: event.steering.length,
+						followUpCount: event.followUp.length,
+						steering: maybeSensitive(event.steering, options),
+						followUp: maybeSensitive(event.followUp, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "compaction_start":
+			return [createAgentBusEvent("compaction.started", { reason: event.reason }, context, options)];
+		case "compaction_end":
+			return [
+				createAgentBusEvent(
+					"compaction.ended",
+					{
+						reason: event.reason,
+						aborted: event.aborted,
+						willRetry: event.willRetry,
+						hasResult: event.result !== undefined,
+						errorMessage: options.includeSensitiveData
+							? event.errorMessage
+							: summarizeOptionalString(event.errorMessage),
+						result: maybeSensitive(event.result, options),
+					},
+					context,
+					options,
+				),
+			];
+		case "auto_retry_start":
+			return [
+				createAgentBusEvent(
+					"retry.started",
+					{
+						attempt: event.attempt,
+						maxAttempts: event.maxAttempts,
+						delayMs: event.delayMs,
+						errorMessage: options.includeSensitiveData
+							? event.errorMessage
+							: summarizeOptionalString(event.errorMessage),
+					},
+					context,
+					options,
+				),
+			];
+		case "auto_retry_end":
+			return [
+				createAgentBusEvent(
+					"retry.ended",
+					{
+						success: event.success,
+						attempt: event.attempt,
+						finalError: options.includeSensitiveData
+							? event.finalError
+							: summarizeOptionalString(event.finalError),
+					},
+					context,
+					options,
+				),
+			];
+	}
+	return [];
+}
+
+export function addressFingerprint(address: AgentBusAddress): string {
+	switch (address.kind) {
+		case "run":
+			return `run:${address.harness}:${address.runId}:${address.host ?? ""}`;
+		case "session":
+			return `session:${address.harness}:${address.sessionId}:${address.host ?? ""}`;
+		case "name":
+			return `name:${address.name}:${address.project ?? ""}:${address.harness ?? ""}:${address.host ?? ""}`;
+		case "role":
+			return `role:${address.role}:${address.project ?? ""}:${address.harness ?? ""}:${address.host ?? ""}`;
+	}
+}
+
+function contextFromSession(session: AgentSession, options: AgentBusMirrorOptions): AgentBusMirrorContext {
+	return {
+		source: options.source ?? "pi-agent",
+		harness: options.harness ?? options.source ?? "pi-agent",
+		sessionId: session.sessionId,
+		host: options.host,
+		project: options.project,
+		cwd: session.sessionManager.getCwd(),
+		branch: options.branch,
+		sessionFile: session.sessionFile,
+		meta: options.meta,
+	};
+}
+
+function maybeSensitive(value: unknown, options: AgentBusProjectionOptions): unknown {
+	return options.includeSensitiveData ? value : undefined;
+}
+
+function summarizeMessage(message: unknown, options: AgentBusProjectionOptions): Record<string, unknown> {
+	const record = asRecord(message);
+	const content = record?.content;
+	const summary: Record<string, unknown> = {
+		role: typeof record?.role === "string" ? record.role : "unknown",
+	};
+	if (typeof content === "string") {
+		summary.content = options.includeSensitiveData ? content : { kind: "string", length: content.length };
+	} else if (Array.isArray(content)) {
+		summary.content = options.includeSensitiveData
+			? content
+			: {
+					kind: "array",
+					length: content.length,
+					blockTypes: content.map((block) => {
+						const blockRecord = asRecord(block);
+						return typeof blockRecord?.type === "string" ? blockRecord.type : "unknown";
+					}),
+				};
+	}
+	if (options.includeSensitiveData) summary.message = message;
+	return summary;
+}
+
+function summarizeAssistantMessageEvent(value: unknown, options: AgentBusProjectionOptions): unknown {
+	if (options.includeSensitiveData) return value;
+	const record = asRecord(value);
+	if (!record) return summarizeValue(value);
+	const summary: Record<string, unknown> = {
+		type: typeof record.type === "string" ? record.type : "unknown",
+	};
+	if (typeof record.contentIndex === "number") summary.contentIndex = record.contentIndex;
+	if (typeof record.delta === "string") summary.delta = { kind: "string", length: record.delta.length };
+	if (record.toolCall !== undefined) summary.toolCall = summarizeValue(record.toolCall);
+	return summary;
+}
+
+function summarizeValue(value: unknown): Record<string, unknown> {
+	if (value === null) return { kind: "null" };
+	if (Array.isArray(value)) return { kind: "array", length: value.length };
+	if (typeof value === "string") return { kind: "string", length: value.length };
+	const type = typeof value;
+	if (type === "number" || type === "boolean" || type === "undefined") return { kind: type };
+	const record = asRecord(value);
+	if (record) return { kind: "object", keys: Object.keys(record).sort() };
+	return { kind: type };
+}
+
+function summarizeOptionalString(value: string | undefined): Record<string, unknown> | undefined {
+	return value === undefined ? undefined : { kind: "string", length: value.length };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -4,6 +4,26 @@ export { type Args, parseArgs } from "./cli/args.ts";
 
 // Config paths
 export { getAgentDir, VERSION } from "./config.ts";
+export type {
+	AgentBusAddress,
+	AgentBusEvent,
+	AgentBusEventKind,
+	AgentBusEventSink,
+	AgentBusMirrorContext,
+	AgentBusMirrorOptions,
+	AgentBusProjectionOptions,
+	AgentBusRegistration,
+	AgentBusRegistrationStatus,
+	AgentBusSchemaVersion,
+} from "./core/agent-bus.ts";
+export {
+	AGENT_BUS_SCHEMA_VERSION,
+	addressFingerprint,
+	agentSessionEventToAgentBusEvents,
+	createAgentBusEvent,
+	createAgentBusMirror,
+	createAgentBusRegistration,
+} from "./core/agent-bus.ts";
 export {
 	AgentSession,
 	type AgentSessionConfig,

--- a/packages/coding-agent/test/agent-bus.test.ts
+++ b/packages/coding-agent/test/agent-bus.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+	type AgentBusMirrorContext,
+	addressFingerprint,
+	agentSessionEventToAgentBusEvents,
+	createAgentBusEvent,
+} from "../src/core/agent-bus.ts";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
+
+const context = {
+	source: "pi-agent",
+	harness: "pi-agent",
+	sessionId: "session-1",
+	cwd: "/repo",
+	sessionFile: "/tmp/session.jsonl",
+} satisfies AgentBusMirrorContext;
+
+const deterministic = {
+	now: () => new Date("2026-05-20T00:00:00.000Z"),
+	id: () => "event-1",
+};
+
+describe("agent bus projection", () => {
+	it("creates stable v0 events with provenance", () => {
+		const event = createAgentBusEvent("agent.started", {}, context, deterministic);
+
+		expect(event).toEqual({
+			schemaVersion: "v0",
+			id: "event-1",
+			source: "pi-agent",
+			harness: "pi-agent",
+			sessionId: "session-1",
+			cwd: "/repo",
+			kind: "agent.started",
+			ts: "2026-05-20T00:00:00.000Z",
+			payload: {},
+			provenance: {
+				cwd: "/repo",
+				sessionFile: "/tmp/session.jsonl",
+			},
+		});
+	});
+
+	it("redacts queued message text by default", () => {
+		const events = agentSessionEventToAgentBusEvents(
+			{
+				type: "queue_update",
+				steering: ["secret steering"],
+				followUp: ["secret follow-up"],
+			},
+			context,
+			deterministic,
+		);
+
+		expect(events).toHaveLength(1);
+		expect(events[0]?.kind).toBe("queue.changed");
+		expect(events[0]?.payload).toEqual({
+			steeringCount: 1,
+			followUpCount: 1,
+			steering: undefined,
+			followUp: undefined,
+		});
+		expect(JSON.stringify(events)).not.toContain("secret");
+	});
+
+	it("includes queued message text when sensitive data is explicitly enabled", () => {
+		const events = agentSessionEventToAgentBusEvents(
+			{
+				type: "queue_update",
+				steering: ["visible steering"],
+				followUp: ["visible follow-up"],
+			},
+			context,
+			{ ...deterministic, includeSensitiveData: true },
+		);
+
+		expect(events[0]?.payload).toEqual({
+			steeringCount: 1,
+			followUpCount: 1,
+			steering: ["visible steering"],
+			followUp: ["visible follow-up"],
+		});
+	});
+
+	it("skips high-volume message updates unless requested", () => {
+		const messageUpdate = {
+			type: "message_update",
+			message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "hello" },
+		} as AgentSessionEvent;
+
+		expect(agentSessionEventToAgentBusEvents(messageUpdate, context, deterministic)).toEqual([]);
+
+		const events = agentSessionEventToAgentBusEvents(messageUpdate, context, {
+			...deterministic,
+			includeMessageUpdates: true,
+		});
+
+		expect(events).toHaveLength(1);
+		expect(events[0]?.kind).toBe("message.updated");
+		expect(events[0]?.payload).toEqual({
+			message: {
+				role: "assistant",
+				content: { kind: "array", length: 1, blockTypes: ["text"] },
+			},
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: { kind: "string", length: 5 },
+			},
+		});
+	});
+
+	it("summarizes tool arguments instead of mirroring them by default", () => {
+		const events = agentSessionEventToAgentBusEvents(
+			{
+				type: "tool_execution_start",
+				toolCallId: "call-1",
+				toolName: "bash",
+				args: { command: "echo secret" },
+			},
+			context,
+			deterministic,
+		);
+
+		expect(events[0]?.payload).toEqual({
+			toolCallId: "call-1",
+			toolName: "bash",
+			args: { kind: "object", keys: ["command"] },
+		});
+		expect(JSON.stringify(events)).not.toContain("echo secret");
+	});
+
+	it("fingerprints addresses compatibly with the envelope schema", () => {
+		expect(addressFingerprint({ kind: "session", harness: "pi-agent", sessionId: "s1", host: "host" })).toBe(
+			"session:pi-agent:s1:host",
+		);
+		expect(addressFingerprint({ kind: "role", role: "project-lead", project: "nineight" })).toBe(
+			"role:project-lead:nineight::",
+		);
+	});
+});


### PR DESCRIPTION
## Summary\n- add Agent Bus event schema/projection helpers for mirroring Pi sessions\n- add Agent Bus mirror and Claude dispatch example extensions\n- document the new examples and changelog entries\n\n## Validation\n- npm run check:ts-imports\n- npx biome check --error-on-warnings packages/coding-agent/src/core/agent-bus.ts packages/coding-agent/test/agent-bus.test.ts packages/coding-agent/examples/extensions/agent-bus-mirror.ts packages/coding-agent/examples/extensions/claude-dispatch.ts packages/coding-agent/examples/extensions/README.md packages/coding-agent/CHANGELOG.md\n- npm --prefix packages/coding-agent test -- agent-bus\n\nNote: full repo pre-commit/tsgo currently fails on this checkout after syncing latest main due missing workspace deps/types such as typebox and @mistralai/mistralai/models/components; targeted checks above pass.