### PR TITLE
fix(tui): draw Kitty images after reserved rows

### DIFF
--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -88,14 +88,18 @@ export class Image implements Component {
 				}
 
 				if (caps.images === "kitty") {
-					// For Kitty: C=1 prevents cursor movement.
-					// Don't need the cursor movement.
-					lines = [result.sequence];
-
-					// Return `rows` lines so TUI accounts for image height.
+					// Reserve rows first and draw from the last reserved row.
+					// The TUI clears each changed line before writing it; drawing the image
+					// on the first row would let later placeholder-line clears erase all but
+					// the top slice in terminals that clear graphics with line clears.
+					lines = [];
 					for (let i = 0; i < result.rows - 1; i++) {
 						lines.push("");
 					}
+					const rowOffset = result.rows - 1;
+					const moveUp = rowOffset > 0 ? `\x1b[${rowOffset}A` : "";
+					const moveDown = rowOffset > 0 ? `\x1b[${rowOffset}B` : "";
+					lines.push(moveUp + result.sequence + moveDown);
 				} else {
 					// Return `rows` lines so TUI accounts for image height.
 					// First (rows-1) lines are empty and cleared before the image is drawn.

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -388,14 +388,14 @@ describe("Kitty image cursor movement", () => {
 			);
 			const lines = image.render(12);
 			assert.strictEqual(lines.length, 5);
-			assert.ok(lines[0].includes(",c=1,r=5"));
+			assert.ok(lines.at(-1)?.includes(",c=1,r=5"));
 		} finally {
 			resetCapabilitiesCache();
 			setCellDimensions({ widthPx: 9, heightPx: 18 });
 		}
 	});
 
-	it("places image sequence on first line with empty padding rows", () => {
+	it("places Kitty image sequence after empty padding rows", () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
 		setCellDimensions({ widthPx: 10, heightPx: 10 });
 		try {
@@ -409,11 +409,11 @@ describe("Kitty image cursor movement", () => {
 			const lines = image.render(4);
 			const imageId = image.getImageId();
 			assert.strictEqual(typeof imageId, "number");
-			assert.ok(lines[0].startsWith("\x1b_G"));
-			assert.ok(lines[0].includes(",C=1,"));
-			assert.ok(lines[0].includes(`,i=${imageId}`));
-			assert.ok(lines[0].endsWith("\x1b\\"));
-			assert.deepStrictEqual(lines.slice(1, lines.length), [""]);
+			assert.deepStrictEqual(lines.slice(0, -1), [""]);
+			assert.ok(lines[1].startsWith("\x1b[1A\x1b_G"));
+			assert.ok(lines[1].includes(",C=1,"));
+			assert.ok(lines[1].includes(`,i=${imageId}`));
+			assert.ok(lines[1].endsWith("\x1b\\\x1b[1B"));
 		} finally {
 			resetCapabilitiesCache();
 			setCellDimensions({ widthPx: 9, heightPx: 18 });


### PR DESCRIPTION
Fixes Kitty inline images rendering as only the top strip in WezTerm.

Regression introduced by `c08c4624` / #4461. That PR fixed tall image placement by removing the cursor-up/down dance for Kitty images and relying on `C=1` instead. That put the Kitty image sequence on the first reserved row, followed by blank placeholder rows.

The TUI clears each changed line before writing it. In terminals that clear graphics with `ESC[2K`, those later placeholder-row clears can erase the lower rows of the image, leaving only the top strip.

This changes the Kitty image component back to reserving rows first, drawing from the last reserved row, then moving the cursor back down so TUI cursor accounting stays correct.

Tests:
- `node --test packages/tui/test/terminal-image.test.ts`
- `npm test -w packages/tui`
- `npm run build`

The problem:
<img width="918" height="621" alt="image" src="https://github.com/user-attachments/assets/7b25aac3-590a-4b95-a441-c607ef075b01" />
^^ you can see it's truncated. 

With this patch it works like it used to.

I also tested a tall image and seems to work just fine 
<img width="1334" height="940" alt="image" src="https://github.com/user-attachments/assets/df085d33-7eec-473d-b9e7-1d13e2e12318" />
