### PR TITLE
Add command_start hook to extension system

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1149,6 +1149,8 @@ export class AgentSession {
 		const ctx = this._extensionRunner.createCommandContext();
 
 		try {
+			const startResult = await this._extensionRunner.emitCommandStart({ type: "command_start", commandName, args });
+			if (startResult?.cancel) return true;
 			await command.handler(args, ctx);
 			return true;
 		} catch (err) {

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -39,6 +39,8 @@ export type {
 	BeforeProviderRequestEventResult,
 	BuildSystemPromptOptions,
 	// Context
+	CommandStartEvent,
+	CommandStartEventResult,
 	CompactOptions,
 	// Events - Agent
 	ContextEvent,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -15,6 +15,8 @@ import type {
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	BeforeProviderRequestEvent,
+	CommandStartEvent,
+	CommandStartEventResult,
 	CompactOptions,
 	ContextEvent,
 	ContextEventResult,
@@ -123,6 +125,7 @@ type RunnerEmitEvent = Exclude<
 	| MessageEndEvent
 	| ResourcesDiscoverEvent
 	| InputEvent
+	| CommandStartEvent
 >;
 
 type SessionBeforeEvent = Extract<
@@ -1075,5 +1078,27 @@ export class ExtensionRunner {
 		return currentText !== text || currentImages !== images
 			? { action: "transform", text: currentText, images: currentImages }
 			: { action: "continue" };
+	}
+
+	async emitCommandStart(event: CommandStartEvent): Promise<CommandStartEventResult | undefined> {
+		const ctx = this.createContext();
+		for (const ext of this.extensions) {
+			const handlers = ext.handlers.get("command_start");
+			if (!handlers || handlers.length === 0) continue;
+			for (const handler of handlers) {
+				try {
+					const result = (await handler(event, ctx)) as CommandStartEventResult | undefined;
+					if (result?.cancel) return result;
+				} catch (err) {
+					this.emitError({
+						extensionPath: ext.path,
+						event: "command_start",
+						error: err instanceof Error ? err.message : String(err),
+						stack: err instanceof Error ? err.stack : undefined,
+					});
+				}
+			}
+		}
+		return undefined;
 	}
 }

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -705,6 +705,24 @@ export interface ToolExecutionEndEvent {
 }
 
 // ============================================================================
+// Command Events
+// ============================================================================
+
+/** Fired before an extension command handler is invoked */
+export interface CommandStartEvent {
+	type: "command_start";
+	/** The command name, without the leading slash */
+	commandName: string;
+	/** The raw argument string passed to the command */
+	args: string;
+}
+
+export interface CommandStartEventResult {
+	/** If true, the command handler is not invoked */
+	cancel?: boolean;
+}
+
+// ============================================================================
 // Model Events
 // ============================================================================
 
@@ -971,7 +989,8 @@ export type ExtensionEvent =
 	| UserBashEvent
 	| InputEvent
 	| ToolCallEvent
-	| ToolResultEvent;
+	| ToolResultEvent
+	| CommandStartEvent;
 
 // ============================================================================
 // Event Results
@@ -1126,6 +1145,7 @@ export interface ExtensionAPI {
 	on(event: "tool_result", handler: ExtensionHandler<ToolResultEvent, ToolResultEventResult>): void;
 	on(event: "user_bash", handler: ExtensionHandler<UserBashEvent, UserBashEventResult>): void;
 	on(event: "input", handler: ExtensionHandler<InputEvent, InputEventResult>): void;
+	on(event: "command_start", handler: ExtensionHandler<CommandStartEvent, CommandStartEventResult>): void;
 
 	// =========================================================================
 	// Tool Registration

--- a/packages/coding-agent/test/suite/agent-session-command-start.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-command-start.test.ts
@@ -1,0 +1,209 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CommandStartEvent } from "../../src/core/extensions/index.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+describe("command_start hook", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("fires with commandName and args before the handler runs", async () => {
+		const events: CommandStartEvent[] = [];
+		const order: string[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", (event) => {
+						events.push(event);
+						order.push("hook");
+					});
+					pi.registerCommand("greet", {
+						handler: async () => {
+							order.push("handler");
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("/greet hello world");
+
+		expect(events).toHaveLength(1);
+		expect(events[0]).toEqual({ type: "command_start", commandName: "greet", args: "hello world" });
+		expect(order).toEqual(["hook", "handler"]);
+	});
+
+	it("fires with empty args when no arguments are provided", async () => {
+		const events: CommandStartEvent[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", (event) => {
+						events.push(event);
+					});
+					pi.registerCommand("noop", { handler: async () => {} });
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("/noop");
+
+		expect(events).toHaveLength(1);
+		expect(events[0]!.args).toBe("");
+	});
+
+	it("cancel: true prevents the command handler from running", async () => {
+		const handlerRuns: string[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", () => ({ cancel: true }));
+					pi.registerCommand("blocked", {
+						handler: async (args) => {
+							handlerRuns.push(args);
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("/blocked some args");
+
+		expect(handlerRuns).toHaveLength(0);
+	});
+
+	it("first cancel wins — remaining handlers and the command handler are skipped", async () => {
+		const order: string[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", () => {
+						order.push("hook-1");
+						return { cancel: true };
+					});
+					pi.on("command_start", () => {
+						order.push("hook-2");
+					});
+					pi.registerCommand("cmd", {
+						handler: async () => {
+							order.push("handler");
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("/cmd");
+
+		expect(order).toEqual(["hook-1"]);
+	});
+
+	it("does not fire for regular prompts", async () => {
+		const events: CommandStartEvent[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", (event) => {
+						events.push(event);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("just a regular message");
+
+		expect(events).toHaveLength(0);
+	});
+
+	it("does not fire when the command name is not registered", async () => {
+		const events: CommandStartEvent[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", (event) => {
+						events.push(event);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("/unknown-command");
+
+		expect(events).toHaveLength(0);
+	});
+
+	it("a throwing hook is swallowed and the command handler still runs", async () => {
+		const handlerRuns: string[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", () => {
+						throw new Error("hook exploded");
+					});
+					pi.registerCommand("resilient", {
+						handler: async (args) => {
+							handlerRuns.push(args);
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("/resilient still runs");
+
+		expect(handlerRuns).toEqual(["still runs"]);
+	});
+
+	it("fires once per invocation across multiple registered commands", async () => {
+		const events: CommandStartEvent[] = [];
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("command_start", (event) => {
+						events.push(event);
+					});
+					pi.registerCommand("alpha", { handler: async () => {} });
+					pi.registerCommand("beta", { handler: async () => {} });
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+
+		await harness.session.prompt("/alpha first");
+		await harness.session.prompt("/beta second");
+
+		expect(events).toHaveLength(2);
+		expect(events[0]).toMatchObject({ commandName: "alpha", args: "first" });
+		expect(events[1]).toMatchObject({ commandName: "beta", args: "second" });
+	});
+});


### PR DESCRIPTION
Fires before any registered extension command handler runs, with the command name and raw argument string. Returning { cancel: true } from a handler prevents the command from executing. Mirrors the pattern of existing hooks (tool_call, input, session_before_*) — errors in handlers are swallowed via emitError so a bad hook cannot crash command dispatch.

Changes:
- types.ts: CommandStartEvent, CommandStartEventResult, ExtensionEvent union, pi.on() overload
- index.ts: re-export both new types from the barrel
- runner.ts: emitCommandStart(), excluded from generic RunnerEmitEvent
- agent-session.ts: emit before command.handler() in _tryExecuteExtensionCommand()
- test: 8 cases covering observability, cancellation, error tolerance, and non-firing cases