### PR TITLE
fix(coding-agent): avoid continuing after pre-prompt threshold compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1062,15 +1062,8 @@ export class AgentSession {
 
 			// Check if we need to compact before sending (catches aborted responses)
 			const lastAssistant = this._findLastAssistantMessage();
-			if (lastAssistant && (await this._checkCompaction(lastAssistant, false))) {
-				try {
-					await this.agent.continue();
-					while (await this._handlePostAgentRun()) {
-						await this.agent.continue();
-					}
-				} finally {
-					this._flushPendingBashMessages();
-				}
+			if (lastAssistant) {
+				await this._checkCompaction(lastAssistant, false);
 			}
 
 			// Build messages array (custom message if any, then user message)

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1060,7 +1060,7 @@ export class AgentSession {
 				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
 			}
 
-			// Check if we need to compact before sending (catches aborted responses)
+			// Check if we need to compact before sending
 			const lastAssistant = this._findLastAssistantMessage();
 			if (lastAssistant) {
 				await this._checkCompaction(lastAssistant, false);

--- a/packages/coding-agent/test/suite/regressions/5236-pre-prompt-threshold-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5236-pre-prompt-threshold-compaction.test.ts
@@ -1,0 +1,53 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createHarness } from "../harness.ts";
+
+function createUsage(totalTokens: number) {
+	return {
+		input: totalTokens,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+describe("regression #5236: pre-prompt threshold compaction", () => {
+	it("does not continue before appending the new user prompt", async () => {
+		const harness = await createHarness({ models: [{ id: "faux-1", contextWindow: 1_010_000 }] });
+		try {
+			const model = harness.getModel();
+			const assistant = {
+				...fauxAssistantMessage("large response", { timestamp: Date.now() - 500 }),
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: createUsage(1_000_000),
+			};
+
+			const previousUser = {
+				role: "user" as const,
+				content: [{ type: "text" as const, text: "previous" }],
+				timestamp: Date.now() - 1000,
+			};
+			harness.session.agent.state.messages = [previousUser, assistant];
+			harness.sessionManager.appendMessage(previousUser);
+			harness.sessionManager.appendMessage(assistant);
+			harness.setResponses([fauxAssistantMessage("next response")]);
+
+			const sessionInternals = harness.session as unknown as {
+				_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+			};
+			const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(true);
+
+			await expect(harness.session.prompt("next message")).resolves.toBeUndefined();
+
+			expect(runAutoCompactionSpy).toHaveBeenCalledWith("threshold", false);
+			expect(harness.session.messages.at(-2)?.role).toBe("user");
+			expect(harness.session.messages.at(-1)?.role).toBe("assistant");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
Fixes #5236.

Completely removes the `agent.continue()` path and adds a regression test.