### PR TITLE
chore: replace chalk with util.styleText

### DIFF
--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -13,7 +13,6 @@
 				"@earendil-works/pi-ai": "^0.78.0",
 				"@earendil-works/pi-tui": "^0.78.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
-				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
 				"diff": "8.0.4",
 				"glob": "13.0.6",
@@ -1030,18 +1029,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -43,7 +43,6 @@
 		"@earendil-works/pi-ai": "^0.78.0",
 		"@earendil-works/pi-tui": "^0.78.0",
 		"@silvia-odwyer/photon-node": "0.3.4",
-		"chalk": "5.6.2",
 		"cross-spawn": "7.0.6",
 		"diff": "8.0.4",
 		"glob": "13.0.6",

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -2,8 +2,8 @@
  * CLI argument parsing and help display
  */
 
+import { styleText } from "node:util";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import chalk from "chalk";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_SESSION_DIR } from "../config.ts";
 import type { ExtensionFlag } from "../core/extensions/types.ts";
 
@@ -207,7 +207,7 @@ export function parseArgs(args: string[]): Args {
 export function printHelp(extensionFlags?: ExtensionFlag[]): void {
 	const extensionFlagsText =
 		extensionFlags && extensionFlags.length > 0
-			? `\n${chalk.bold("Extension CLI Flags:")}\n${extensionFlags
+			? `\n${styleText("bold", "Extension CLI Flags:")}\n${extensionFlags
 					.map((flag) => {
 						const value = flag.type === "string" ? " <value>" : "";
 						const description = flag.description ?? `Registered by ${flag.extensionPath}`;
@@ -215,12 +215,12 @@ export function printHelp(extensionFlags?: ExtensionFlag[]): void {
 					})
 					.join("\n")}\n`
 			: "";
-	console.log(`${chalk.bold(APP_NAME)} - AI coding assistant with read, bash, edit, write tools
+	console.log(`${styleText("bold", APP_NAME)} - AI coding assistant with read, bash, edit, write tools
 
-${chalk.bold("Usage:")}
+${styleText("bold", "Usage:")}
   ${APP_NAME} [options] [@files...] [messages...]
 
-${chalk.bold("Commands:")}
+${styleText("bold", "Commands:")}
   ${APP_NAME} install <source> [-l]     Install extension source and add to settings
   ${APP_NAME} remove <source> [-l]      Remove extension source from settings
   ${APP_NAME} uninstall <source> [-l]   Alias for remove
@@ -229,7 +229,7 @@ ${chalk.bold("Commands:")}
   ${APP_NAME} config                    Open TUI to enable/disable package resources
   ${APP_NAME} <command> --help          Show help for install/remove/uninstall/update/list
 
-${chalk.bold("Options:")}
+${styleText("bold", "Options:")}
   --provider <name>              Provider name (default: google)
   --model <pattern>              Model pattern or ID (supports "provider/id" and optional ":<thinking>")
   --api-key <key>                API key (defaults to env vars)
@@ -272,7 +272,7 @@ ${chalk.bold("Options:")}
 
 Extensions can register additional flags (e.g., --plan from plan-mode extension).${extensionFlagsText}
 
-${chalk.bold("Examples:")}
+${styleText("bold", "Examples:")}
   # Interactive mode
   ${APP_NAME}
 
@@ -325,7 +325,7 @@ ${chalk.bold("Examples:")}
   ${APP_NAME} --export ~/${CONFIG_DIR_NAME}/agent/sessions/--path--/session.jsonl
   ${APP_NAME} --export session.jsonl output.html
 
-${chalk.bold("Environment Variables:")}
+${styleText("bold", "Environment Variables:")}
   ANTHROPIC_API_KEY                - Anthropic Claude API key
   ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
   OPENAI_API_KEY                   - OpenAI GPT API key
@@ -368,7 +368,7 @@ ${chalk.bold("Environment Variables:")}
   PI_TELEMETRY                     - Override install telemetry when set to 1/true/yes or 0/false/no
   PI_SHARE_VIEWER_URL              - Base URL for /share command (default: https://pi.dev/session/)
 
-${chalk.bold("Built-in Tool Names:")}
+${styleText("bold", "Built-in Tool Names:")}
   read   - Read file contents
   bash   - Execute bash commands
   edit   - Edit files with find/replace

--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -3,8 +3,8 @@
  */
 
 import { access, readFile, stat } from "node:fs/promises";
+import { styleText } from "node:util";
 import type { ImageContent } from "@earendil-works/pi-ai";
-import chalk from "chalk";
 import { resolve } from "path";
 import { resolveReadPath } from "../core/tools/path-utils.ts";
 import { formatDimensionNote, resizeImage } from "../utils/image-resize.ts";
@@ -34,7 +34,7 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 		try {
 			await access(absolutePath);
 		} catch {
-			console.error(chalk.red(`Error: File not found: ${absolutePath}`));
+			console.error(styleText("red", `Error: File not found: ${absolutePath}`));
 			process.exit(1);
 		}
 
@@ -89,7 +89,7 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 				text += `<file name="${absolutePath}">\n${content}\n</file>\n`;
 			} catch (error: unknown) {
 				const message = error instanceof Error ? error.message : String(error);
-				console.error(chalk.red(`Error: Could not read file ${absolutePath}: ${message}`));
+				console.error(styleText("red", `Error: Could not read file ${absolutePath}: ${message}`));
 				process.exit(1);
 			}
 		}

--- a/packages/coding-agent/src/cli/list-models.ts
+++ b/packages/coding-agent/src/cli/list-models.ts
@@ -2,9 +2,9 @@
  * List available models with optional fuzzy search
  */
 
+import { styleText } from "node:util";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { fuzzyFilter } from "@earendil-works/pi-tui";
-import chalk from "chalk";
 import { formatNoModelsAvailableMessage } from "../core/auth-guidance.ts";
 import type { ModelRegistry } from "../core/model-registry.ts";
 
@@ -29,7 +29,7 @@ function formatTokenCount(count: number): string {
 export async function listModels(modelRegistry: ModelRegistry, searchPattern?: string): Promise<void> {
 	const loadError = modelRegistry.getError();
 	if (loadError) {
-		console.error(chalk.yellow(`Warning: errors loading models.json:\n${loadError}`));
+		console.error(styleText("yellow", `Warning: errors loading models.json:\n${loadError}`));
 	}
 
 	const models = modelRegistry.getAvailable();

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -2,9 +2,9 @@
  * Model resolution, scoping, and initial selection
  */
 
+import { styleText } from "node:util";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { type Api, type KnownProvider, type Model, modelsAreEqual } from "@earendil-works/pi-ai";
-import chalk from "chalk";
 import { minimatch } from "minimatch";
 import { isValidThinkingLevel } from "../cli/args.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
@@ -280,7 +280,7 @@ export async function resolveModelScope(patterns: string[], modelRegistry: Model
 			});
 
 			if (matchingModels.length === 0) {
-				console.warn(chalk.yellow(`Warning: No models match pattern "${pattern}"`));
+				console.warn(styleText("yellow", `Warning: No models match pattern "${pattern}"`));
 				continue;
 			}
 
@@ -295,11 +295,11 @@ export async function resolveModelScope(patterns: string[], modelRegistry: Model
 		const { model, thinkingLevel, warning } = parseModelPattern(pattern, availableModels);
 
 		if (warning) {
-			console.warn(chalk.yellow(`Warning: ${warning}`));
+			console.warn(styleText("yellow", `Warning: ${warning}`));
 		}
 
 		if (!model) {
-			console.warn(chalk.yellow(`Warning: No models match pattern "${pattern}"`));
+			console.warn(styleText("yellow", `Warning: No models match pattern "${pattern}"`));
 			continue;
 		}
 
@@ -512,7 +512,7 @@ export async function findInitialModel(options: {
 			modelRegistry,
 		});
 		if (resolved.error) {
-			console.error(chalk.red(resolved.error));
+			console.error(styleText("red", resolved.error));
 			process.exit(1);
 		}
 		if (resolved.model) {
@@ -579,7 +579,7 @@ export async function restoreModelFromSession(
 
 	if (restoredModel && hasConfiguredAuth) {
 		if (shouldPrintMessages) {
-			console.log(chalk.dim(`Restored model: ${savedProvider}/${savedModelId}`));
+			console.log(styleText("dim", `Restored model: ${savedProvider}/${savedModelId}`));
 		}
 		return { model: restoredModel, fallbackMessage: undefined };
 	}
@@ -588,13 +588,15 @@ export async function restoreModelFromSession(
 	const reason = !restoredModel ? "model no longer exists" : "no auth configured";
 
 	if (shouldPrintMessages) {
-		console.error(chalk.yellow(`Warning: Could not restore model ${savedProvider}/${savedModelId} (${reason}).`));
+		console.error(
+			styleText("yellow", `Warning: Could not restore model ${savedProvider}/${savedModelId} (${reason}).`),
+		);
 	}
 
 	// If we already have a model, use it as fallback
 	if (currentModel) {
 		if (shouldPrintMessages) {
-			console.log(chalk.dim(`Falling back to: ${currentModel.provider}/${currentModel.id}`));
+			console.log(styleText("dim", `Falling back to: ${currentModel.provider}/${currentModel.id}`));
 		}
 		return {
 			model: currentModel,
@@ -623,7 +625,7 @@ export async function restoreModelFromSession(
 		}
 
 		if (shouldPrintMessages) {
-			console.log(chalk.dim(`Falling back to: ${fallbackModel.provider}/${fallbackModel.id}`));
+			console.log(styleText("dim", `Falling back to: ${fallbackModel.provider}/${fallbackModel.id}`));
 		}
 
 		return {

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
-import chalk from "chalk";
+import { styleText } from "node:util";
 import { CONFIG_DIR_NAME } from "../config.ts";
 import { loadThemeFromPath, type Theme } from "../modes/interactive/theme/theme.ts";
 import type { ResourceDiagnostic } from "./diagnostics.ts";
@@ -46,7 +46,7 @@ function resolvePromptInput(input: string | undefined, description: string): str
 		try {
 			return readFileSync(input, "utf-8");
 		} catch (error) {
-			console.error(chalk.yellow(`Warning: Could not read ${description} file ${input}: ${error}`));
+			console.error(styleText("yellow", `Warning: Could not read ${description} file ${input}: ${error}`));
 			return input;
 		}
 	}
@@ -65,7 +65,7 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
 					content: readFileSync(filePath, "utf-8"),
 				};
 			} catch (error) {
-				console.error(chalk.yellow(`Warning: Could not read ${filePath}: ${error}`));
+				console.error(styleText("yellow", `Warning: Could not read ${filePath}: ${error}`));
 			}
 		}
 	}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -6,9 +6,9 @@
  */
 
 import { createInterface } from "node:readline";
+import { styleText } from "node:util";
 import { type ImageContent, modelsAreEqual } from "@earendil-works/pi-ai";
 import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
-import chalk from "chalk";
 import { type Args, type Mode, parseArgs, printHelp } from "./cli/args.ts";
 import { processFileArguments } from "./cli/file-processor.ts";
 import { buildInitialMessage } from "./cli/initial-message.ts";
@@ -83,9 +83,9 @@ function collectSettingsDiagnostics(
 
 function reportDiagnostics(diagnostics: readonly AgentSessionRuntimeDiagnostic[]): void {
 	for (const diagnostic of diagnostics) {
-		const color = diagnostic.type === "error" ? chalk.red : diagnostic.type === "warning" ? chalk.yellow : chalk.dim;
+		const color = diagnostic.type === "error" ? "red" : diagnostic.type === "warning" ? "yellow" : "dim";
 		const prefix = diagnostic.type === "error" ? "Error: " : diagnostic.type === "warning" ? "Warning: " : "";
-		console.error(color(`${prefix}${diagnostic.message}`));
+		console.error(styleText(color, `${prefix}${diagnostic.message}`));
 	}
 }
 
@@ -208,7 +208,7 @@ function validateForkFlags(parsed: Args): void {
 	].filter((flag): flag is string => flag !== undefined);
 
 	if (conflictingFlags.length > 0) {
-		console.error(chalk.red(`Error: --fork cannot be combined with ${conflictingFlags.join(", ")}`));
+		console.error(styleText("red", `Error: --fork cannot be combined with ${conflictingFlags.join(", ")}`));
 		process.exit(1);
 	}
 }
@@ -224,7 +224,7 @@ function validateSessionIdFlags(parsed: Args): void {
 	].filter((flag): flag is string => flag !== undefined);
 
 	if (conflictingFlags.length > 0) {
-		console.error(chalk.red(`Error: --session-id cannot be combined with ${conflictingFlags.join(", ")}`));
+		console.error(styleText("red", `Error: --session-id cannot be combined with ${conflictingFlags.join(", ")}`));
 		process.exit(1);
 	}
 
@@ -232,7 +232,7 @@ function validateSessionIdFlags(parsed: Args): void {
 		assertValidSessionId(parsed.sessionId);
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
-		console.error(chalk.red(`Error: ${message}`));
+		console.error(styleText("red", `Error: ${message}`));
 		process.exit(1);
 	}
 }
@@ -242,7 +242,7 @@ function forkSessionOrExit(sourcePath: string, cwd: string, sessionDir?: string,
 		return SessionManager.forkFrom(sourcePath, cwd, sessionDir, { id: sessionId });
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
-		console.error(chalk.red(`Error: ${message}`));
+		console.error(styleText("red", `Error: ${message}`));
 		process.exit(1);
 	}
 }
@@ -261,7 +261,7 @@ async function createSessionManager(
 		if (parsed.sessionId) {
 			const existingTarget = await findLocalSessionByExactId(parsed.sessionId, cwd, sessionDir);
 			if (existingTarget) {
-				console.error(chalk.red(`Session already exists with id '${parsed.sessionId}'`));
+				console.error(styleText("red", `Session already exists with id '${parsed.sessionId}'`));
 				process.exit(1);
 			}
 		}
@@ -275,7 +275,7 @@ async function createSessionManager(
 				return forkSessionOrExit(resolved.path, cwd, sessionDir, parsed.sessionId);
 
 			case "not_found":
-				console.error(chalk.red(`No session found matching '${resolved.arg}'`));
+				console.error(styleText("red", `No session found matching '${resolved.arg}'`));
 				process.exit(1);
 		}
 	}
@@ -289,17 +289,17 @@ async function createSessionManager(
 				return SessionManager.open(resolved.path, sessionDir);
 
 			case "global": {
-				console.log(chalk.yellow(`Session found in different project: ${resolved.cwd}`));
+				console.log(styleText("yellow", `Session found in different project: ${resolved.cwd}`));
 				const shouldFork = await promptConfirm("Fork this session into current directory?");
 				if (!shouldFork) {
-					console.log(chalk.dim("Aborted."));
+					console.log(styleText("dim", "Aborted."));
 					process.exit(0);
 				}
 				return forkSessionOrExit(resolved.path, cwd, sessionDir);
 			}
 
 			case "not_found":
-				console.error(chalk.red(`No session found matching '${resolved.arg}'`));
+				console.error(styleText("red", `No session found matching '${resolved.arg}'`));
 				process.exit(1);
 		}
 	}
@@ -312,7 +312,7 @@ async function createSessionManager(
 				(onProgress) => SessionManager.listAll(sessionDir, onProgress),
 			);
 			if (!selectedPath) {
-				console.log(chalk.dim("No session selected"));
+				console.log(styleText("dim", "No session selected"));
 				process.exit(0);
 			}
 			return SessionManager.open(selectedPath, sessionDir);
@@ -497,7 +497,8 @@ export async function main(args: string[], options?: MainOptions) {
 	const parsed = parseArgs(args);
 	if (parsed.diagnostics.length > 0) {
 		for (const d of parsed.diagnostics) {
-			const color = d.type === "error" ? chalk.red : chalk.yellow;
+			const color =
+				d.type === "error" ? (text: string) => styleText("red", text) : (text: string) => styleText("yellow", text);
 			console.error(color(`${d.type === "error" ? "Error" : "Warning"}: ${d.message}`));
 		}
 		if (parsed.diagnostics.some((d) => d.type === "error")) {
@@ -523,7 +524,7 @@ export async function main(args: string[], options?: MainOptions) {
 			result = await exportFromFile(parsed.export, outputPath);
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : "Failed to export session";
-			console.error(chalk.red(`Error: ${message}`));
+			console.error(styleText("red", `Error: ${message}`));
 			process.exit(1);
 		}
 		console.log(`Exported to: ${result}`);
@@ -531,7 +532,7 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	if (parsed.mode === "rpc" && parsed.fileArgs.length > 0) {
-		console.error(chalk.red("Error: @file arguments are not supported in RPC mode"));
+		console.error(styleText("red", "Error: @file arguments are not supported in RPC mode"));
 		process.exit(1);
 	}
 
@@ -567,14 +568,14 @@ export async function main(args: string[], options?: MainOptions) {
 			}
 			sessionManager = SessionManager.open(missingSessionCwdIssue.sessionFile!, sessionDir, selectedCwd);
 		} else {
-			console.error(chalk.red(new MissingSessionCwdError(missingSessionCwdIssue).message));
+			console.error(styleText("red", new MissingSessionCwdError(missingSessionCwdIssue).message));
 			process.exit(1);
 		}
 	}
 	if (parsed.name !== undefined) {
 		const name = parsed.name.trim();
 		if (!name) {
-			console.error(chalk.red("Error: --name requires a non-empty value"));
+			console.error(styleText("red", "Error: --name requires a non-empty value"));
 			process.exit(1);
 		}
 		sessionManager.appendSessionInfo(name);
@@ -729,13 +730,13 @@ export async function main(args: string[], options?: MainOptions) {
 	time("createAgentSession");
 
 	if (appMode !== "interactive" && !session.model) {
-		console.error(chalk.red(formatNoModelsAvailableMessage()));
+		console.error(styleText("red", formatNoModelsAvailableMessage()));
 		process.exit(1);
 	}
 
 	const startupBenchmark = isTruthyEnvFlag(process.env.PI_STARTUP_BENCHMARK);
 	if (startupBenchmark && appMode !== "interactive") {
-		console.error(chalk.red("Error: PI_STARTUP_BENCHMARK only supports interactive mode"));
+		console.error(styleText("red", "Error: PI_STARTUP_BENCHMARK only supports interactive mode"));
 		process.exit(1);
 	}
 

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -2,7 +2,7 @@
  * One-time migrations that run on startup.
  */
 
-import chalk from "chalk";
+import { styleText } from "node:util";
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { CONFIG_DIR_NAME, getAgentDir, getBinDir } from "./config.ts";
@@ -194,7 +194,8 @@ function migrateExplicitEnvVarConfigValues(): void {
 
 	const details = migrations.map((migration) => `  - ${migration.location}: ${migration.from} -> ${migration.to}`);
 	console.log(
-		chalk.yellow(
+		styleText(
+			"yellow",
 			[
 				"Warning: Migrated API key/header environment references to explicit $ENV_VAR syntax. Plain strings will be treated as literals.",
 				...details,
@@ -272,11 +273,12 @@ function migrateCommandsToPrompts(baseDir: string, label: string): boolean {
 	if (existsSync(commandsDir) && !existsSync(promptsDir)) {
 		try {
 			renameSync(commandsDir, promptsDir);
-			console.log(chalk.green(`Migrated ${label} commands/ → prompts/`));
+			console.log(styleText("green", `Migrated ${label} commands/ → prompts/`));
 			return true;
 		} catch (err) {
 			console.log(
-				chalk.yellow(
+				styleText(
+					"yellow",
 					`Warning: Could not migrate ${label} commands/ to prompts/: ${err instanceof Error ? err.message : err}`,
 				),
 			);
@@ -342,7 +344,7 @@ function migrateToolsToBin(): void {
 	}
 
 	if (movedAny) {
-		console.log(chalk.green(`Migrated managed binaries tools/ → bin/`));
+		console.log(styleText("green", `Migrated managed binaries tools/ → bin/`));
 	}
 }
 
@@ -409,12 +411,12 @@ export async function showDeprecationWarnings(warnings: string[]): Promise<void>
 	if (warnings.length === 0) return;
 
 	for (const warning of warnings) {
-		console.log(chalk.yellow(`Warning: ${warning}`));
+		console.log(styleText("yellow", `Warning: ${warning}`));
 	}
-	console.log(chalk.yellow(`\nMove your extensions to the extensions/ directory.`));
-	console.log(chalk.yellow(`Migration guide: ${MIGRATION_GUIDE_URL}`));
-	console.log(chalk.yellow(`Documentation: ${EXTENSIONS_DOC_URL}`));
-	console.log(chalk.dim(`\nPress any key to continue...`));
+	console.log(styleText("yellow", `\nMove your extensions to the extensions/ directory.`));
+	console.log(styleText("yellow", `Migration guide: ${MIGRATION_GUIDE_URL}`));
+	console.log(styleText("yellow", `Documentation: ${EXTENSIONS_DOC_URL}`));
+	console.log(styleText("dim", `\nPress any key to continue...`));
 
 	await new Promise<void>((resolve) => {
 		process.stdin.setRawMode?.(true);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,6 +7,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { styleText } from "node:util";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import {
 	type AssistantMessage,
@@ -47,7 +48,6 @@ import {
 	TUI,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import chalk from "chalk";
 import { spawn, spawnSync } from "child_process";
 import {
 	APP_NAME,
@@ -3310,7 +3310,7 @@ export class InteractiveMode {
 
 		const resumeCommand = formatResumeCommand(this.sessionManager);
 		if (resumeCommand) {
-			process.stdout.write(`${chalk.dim("To resume this session:")} ${resumeCommand}\n`);
+			process.stdout.write(`${styleText("dim", "To resume this session:")} ${resumeCommand}\n`);
 		}
 
 		process.exit(0);

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { styleText } from "node:util";
 import {
 	type EditorTheme,
 	getCapabilities,
@@ -7,7 +8,6 @@ import {
 	type SelectListTheme,
 	type SettingsListTheme,
 } from "@earendil-works/pi-tui";
-import chalk from "chalk";
 import { type Static, Type } from "typebox";
 import { Compile } from "typebox/compile";
 import { getCustomThemesDir, getThemesDir } from "../../../config.ts";
@@ -360,23 +360,23 @@ export class Theme {
 	}
 
 	bold(text: string): string {
-		return chalk.bold(text);
+		return styleText("bold", text);
 	}
 
 	italic(text: string): string {
-		return chalk.italic(text);
+		return styleText("italic", text);
 	}
 
 	underline(text: string): string {
-		return chalk.underline(text);
+		return styleText("underline", text);
 	}
 
 	inverse(text: string): string {
-		return chalk.inverse(text);
+		return styleText("inverse", text);
 	}
 
 	strikethrough(text: string): string {
-		return chalk.strikethrough(text);
+		return styleText("strikethrough", text);
 	}
 
 	getFgAnsi(color: ThemeColor): string {
@@ -1185,7 +1185,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 		bold: (text: string) => theme.bold(text),
 		italic: (text: string) => theme.italic(text),
 		underline: (text: string) => theme.underline(text),
-		strikethrough: (text: string) => chalk.strikethrough(text),
+		strikethrough: (text: string) => styleText("strikethrough", text),
 		highlightCode: (code: string, lang?: string): string[] => {
 			// Validate language before highlighting to avoid stderr spam from cli-highlight
 			const validLang = lang && supportsLanguage(lang) ? lang : undefined;

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1,5 +1,5 @@
+import { styleText } from "node:util";
 import { Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
-import chalk from "chalk";
 import { selectConfig } from "./cli/config-selector.ts";
 import {
 	APP_NAME,
@@ -26,20 +26,20 @@ export type PackageCommand = "install" | "remove" | "update" | "list";
 type UpdateTarget = { type: "all" } | { type: "self" } | { type: "extensions"; source?: string };
 
 const SELF_UPDATE_NOTE_MARKDOWN_THEME: MarkdownTheme = {
-	heading: (text) => chalk.bold(chalk.yellow(text)),
-	link: (text) => chalk.cyan(text),
-	linkUrl: (text) => chalk.dim(text),
-	code: (text) => chalk.yellow(text),
-	codeBlock: (text) => chalk.dim(text),
-	codeBlockBorder: (text) => chalk.dim(text),
-	quote: (text) => chalk.dim(text),
-	quoteBorder: (text) => chalk.dim(text),
-	hr: (text) => chalk.dim(text),
-	listBullet: (text) => chalk.yellow(text),
-	bold: (text) => chalk.bold(text),
-	italic: (text) => chalk.italic(text),
-	strikethrough: (text) => chalk.strikethrough(text),
-	underline: (text) => chalk.underline(text),
+	heading: (text) => styleText(["bold", "yellow"], text),
+	link: (text) => styleText("cyan", text),
+	linkUrl: (text) => styleText("dim", text),
+	code: (text) => styleText("yellow", text),
+	codeBlock: (text) => styleText("dim", text),
+	codeBlockBorder: (text) => styleText("dim", text),
+	quote: (text) => styleText("dim", text),
+	quoteBorder: (text) => styleText("dim", text),
+	hr: (text) => styleText("dim", text),
+	listBullet: (text) => styleText("yellow", text),
+	bold: (text) => styleText("bold", text),
+	italic: (text) => styleText("italic", text),
+	strikethrough: (text) => styleText("strikethrough", text),
+	underline: (text) => styleText("underline", text),
 };
 
 interface PackageCommandOptions {
@@ -58,9 +58,9 @@ interface PackageCommandOptions {
 function reportSettingsErrors(settingsManager: SettingsManager, context: string): void {
 	const errors = settingsManager.drainErrors();
 	for (const { scope, error } of errors) {
-		console.error(chalk.yellow(`Warning (${context}, ${scope} settings): ${error.message}`));
+		console.error(styleText("yellow", `Warning (${context}, ${scope} settings): ${error.message}`));
 		if (error.stack) {
-			console.error(chalk.dim(error.stack));
+			console.error(styleText("dim", error.stack));
 		}
 	}
 }
@@ -81,7 +81,7 @@ function getPackageCommandUsage(command: PackageCommand): string {
 function printPackageCommandHelp(command: PackageCommand): void {
 	switch (command) {
 		case "install":
-			console.log(`${chalk.bold("Usage:")}
+			console.log(`${styleText("bold", "Usage:")}
   ${getPackageCommandUsage("install")}
 
 Install a package and add it to settings.
@@ -100,7 +100,7 @@ Examples:
 			return;
 
 		case "remove":
-			console.log(`${chalk.bold("Usage:")}
+			console.log(`${styleText("bold", "Usage:")}
   ${getPackageCommandUsage("remove")}
 
 Remove a package and its source from settings.
@@ -116,7 +116,7 @@ Examples:
 			return;
 
 		case "update":
-			console.log(`${chalk.bold("Usage:")}
+			console.log(`${styleText("bold", "Usage:")}
   ${getPackageCommandUsage("update")}
 
 Update pi and installed packages.
@@ -135,7 +135,7 @@ Short forms:
 			return;
 
 		case "list":
-			console.log(`${chalk.bold("Usage:")}
+			console.log(`${styleText("bold", "Usage:")}
   ${getPackageCommandUsage("list")}
 
 List installed packages from user and project settings.
@@ -308,7 +308,7 @@ function printSelfUpdateUnavailable(npmCommand?: string[], updatePackageName = P
 }
 
 function printSelfUpdateFallback(command: SelfUpdateCommand): void {
-	console.error(chalk.dim(`If this keeps failing, run this command yourself: ${command.display}`));
+	console.error(styleText("dim", `If this keeps failing, run this command yourself: ${command.display}`));
 }
 
 function printSelfUpdateNote(note: string): void {
@@ -318,7 +318,7 @@ function printSelfUpdateNote(note: string): void {
 	}
 
 	console.log();
-	console.log(chalk.bold(chalk.yellow("Update note")));
+	console.log(styleText(["bold", "yellow"], "Update note"));
 	try {
 		const width = Math.max(20, process.stdout.columns ?? 80);
 		const renderedLines = new Markdown(trimmedNote, 0, 0, SELF_UPDATE_NOTE_MARKDOWN_THEME)
@@ -352,12 +352,12 @@ async function getSelfUpdatePlan(force: boolean): Promise<SelfUpdatePlan> {
 		return { packageName: PACKAGE_NAME, shouldRun: true };
 	}
 
-	console.log(chalk.green(`${APP_NAME} is already up to date (v${VERSION})`));
+	console.log(styleText("green", `${APP_NAME} is already up to date (v${VERSION})`));
 	return { packageName: PACKAGE_NAME, shouldRun: false };
 }
 
 async function runSelfUpdate(command: SelfUpdateCommand): Promise<void> {
-	console.log(chalk.dim(`Updating ${APP_NAME} with ${command.display}...`));
+	console.log(styleText("dim", `Updating ${APP_NAME} with ${command.display}...`));
 	for (const step of command.steps ?? [command]) {
 		await new Promise<void>((resolve, reject) => {
 			const child = spawnProcess(step.command, step.args, {
@@ -423,37 +423,37 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 	}
 
 	if (options.invalidOption) {
-		console.error(chalk.red(`Unknown option ${options.invalidOption} for "${options.command}".`));
-		console.error(chalk.dim(`Use "${APP_NAME} --help" or "${getPackageCommandUsage(options.command)}".`));
+		console.error(styleText("red", `Unknown option ${options.invalidOption} for "${options.command}".`));
+		console.error(styleText("dim", `Use "${APP_NAME} --help" or "${getPackageCommandUsage(options.command)}".`));
 		process.exitCode = 1;
 		return true;
 	}
 
 	if (options.missingOptionValue) {
-		console.error(chalk.red(`Missing value for ${options.missingOptionValue}.`));
-		console.error(chalk.dim(`Usage: ${getPackageCommandUsage(options.command)}`));
+		console.error(styleText("red", `Missing value for ${options.missingOptionValue}.`));
+		console.error(styleText("dim", `Usage: ${getPackageCommandUsage(options.command)}`));
 		process.exitCode = 1;
 		return true;
 	}
 
 	if (options.invalidArgument) {
-		console.error(chalk.red(`Unexpected argument ${options.invalidArgument}.`));
-		console.error(chalk.dim(`Usage: ${getPackageCommandUsage(options.command)}`));
+		console.error(styleText("red", `Unexpected argument ${options.invalidArgument}.`));
+		console.error(styleText("dim", `Usage: ${getPackageCommandUsage(options.command)}`));
 		process.exitCode = 1;
 		return true;
 	}
 
 	if (options.conflictingOptions) {
-		console.error(chalk.red(options.conflictingOptions));
-		console.error(chalk.dim(`Usage: ${getPackageCommandUsage(options.command)}`));
+		console.error(styleText("red", options.conflictingOptions));
+		console.error(styleText("dim", `Usage: ${getPackageCommandUsage(options.command)}`));
 		process.exitCode = 1;
 		return true;
 	}
 
 	const source = options.source;
 	if ((options.command === "install" || options.command === "remove") && !source) {
-		console.error(chalk.red(`Missing ${options.command} source.`));
-		console.error(chalk.dim(`Usage: ${getPackageCommandUsage(options.command)}`));
+		console.error(styleText("red", `Missing ${options.command} source.`));
+		console.error(styleText("dim", `Usage: ${getPackageCommandUsage(options.command)}`));
 		process.exitCode = 1;
 		return true;
 	}
@@ -468,7 +468,7 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 
 	packageManager.setProgressCallback((event) => {
 		if (event.type === "start") {
-			process.stdout.write(chalk.dim(`${event.message}\n`));
+			process.stdout.write(styleText("dim", `${event.message}\n`));
 		}
 	});
 
@@ -476,17 +476,17 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 		switch (options.command) {
 			case "install":
 				await packageManager.installAndPersist(source!, { local: options.local });
-				console.log(chalk.green(`Installed ${source}`));
+				console.log(styleText("green", `Installed ${source}`));
 				return true;
 
 			case "remove": {
 				const removed = await packageManager.removeAndPersist(source!, { local: options.local });
 				if (!removed) {
-					console.error(chalk.red(`No matching package found for ${source}`));
+					console.error(styleText("red", `No matching package found for ${source}`));
 					process.exitCode = 1;
 					return true;
 				}
-				console.log(chalk.green(`Removed ${source}`));
+				console.log(styleText("green", `Removed ${source}`));
 				return true;
 			}
 
@@ -496,7 +496,7 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 				const projectPackages = configuredPackages.filter((pkg) => pkg.scope === "project");
 
 				if (configuredPackages.length === 0) {
-					console.log(chalk.dim("No packages installed."));
+					console.log(styleText("dim", "No packages installed."));
 					return true;
 				}
 
@@ -504,12 +504,12 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 					const display = pkg.filtered ? `${pkg.source} (filtered)` : pkg.source;
 					console.log(`  ${display}`);
 					if (pkg.installedPath) {
-						console.log(chalk.dim(`    ${pkg.installedPath}`));
+						console.log(styleText("dim", `    ${pkg.installedPath}`));
 					}
 				};
 
 				if (userPackages.length > 0) {
-					console.log(chalk.bold("User packages:"));
+					console.log(styleText("bold", "User packages:"));
 					for (const pkg of userPackages) {
 						formatPackage(pkg);
 					}
@@ -517,7 +517,7 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 
 				if (projectPackages.length > 0) {
 					if (userPackages.length > 0) console.log();
-					console.log(chalk.bold("Project packages:"));
+					console.log(styleText("bold", "Project packages:"));
 					for (const pkg of projectPackages) {
 						formatPackage(pkg);
 					}
@@ -532,9 +532,9 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 					const updateSource = target.type === "extensions" ? target.source : undefined;
 					await packageManager.update(updateSource);
 					if (updateSource) {
-						console.log(chalk.green(`Updated ${updateSource}`));
+						console.log(styleText("green", `Updated ${updateSource}`));
 					} else {
-						console.log(chalk.green("Updated packages"));
+						console.log(styleText("green", "Updated packages"));
 					}
 				}
 				if (updateTargetIncludesSelf(target)) {
@@ -545,9 +545,14 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 					const installMethod = detectInstallMethod();
 					if (process.platform === "win32" && installMethod !== "npm" && installMethod !== "pnpm") {
 						console.error(
-							chalk.red(`${APP_NAME} self-update on Windows is only supported for npm and pnpm installs.`),
+							styleText(
+								"red",
+								`${APP_NAME} self-update on Windows is only supported for npm and pnpm installs.`,
+							),
 						);
-						console.error(chalk.dim(`Detected install method: ${installMethod}. Update ${APP_NAME} manually.`));
+						console.error(
+							styleText("dim", `Detected install method: ${installMethod}. Update ${APP_NAME} manually.`),
+						);
 						process.exitCode = 1;
 						return true;
 					}
@@ -571,19 +576,19 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 						await runSelfUpdate(selfUpdateCommand);
 					} catch (error: unknown) {
 						const message = error instanceof Error ? error.message : "Unknown package command error";
-						console.error(chalk.red(`Error: ${message}`));
+						console.error(styleText("red", `Error: ${message}`));
 						printSelfUpdateFallback(selfUpdateCommand);
 						process.exitCode = 1;
 						return true;
 					}
-					console.log(chalk.green(`Updated ${APP_NAME}`));
+					console.log(styleText("green", `Updated ${APP_NAME}`));
 				}
 				return true;
 			}
 		}
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : "Unknown package command error";
-		console.error(chalk.red(`Error: ${message}`));
+		console.error(styleText("red", `Error: ${message}`));
 		process.exitCode = 1;
 		return true;
 	}

--- a/packages/coding-agent/src/utils/deprecation.ts
+++ b/packages/coding-agent/src/utils/deprecation.ts
@@ -1,11 +1,11 @@
-import chalk from "chalk";
+import { styleText } from "node:util";
 
 const emittedDeprecationWarnings = new Set<string>();
 
 export function warnDeprecation(message: string): void {
 	if (emittedDeprecationWarnings.has(message)) return;
 	emittedDeprecationWarnings.add(message);
-	console.warn(chalk.yellow(`Deprecation warning: ${message}`));
+	console.warn(styleText("yellow", `Deprecation warning: ${message}`));
 }
 
 /** Clear deprecation warning state. Exported for tests. */

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import { styleText } from "node:util";
 import { type SpawnSyncReturns, spawnSync } from "child_process";
 import { chmodSync, createWriteStream, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "fs";
 import { arch, platform } from "os";
@@ -334,7 +334,7 @@ export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Pr
 
 	if (isOfflineModeEnabled()) {
 		if (!silent) {
-			console.log(chalk.yellow(`${config.name} not found. Offline mode enabled, skipping download.`));
+			console.log(styleText("yellow", `${config.name} not found. Offline mode enabled, skipping download.`));
 		}
 		return undefined;
 	}
@@ -344,25 +344,25 @@ export async function ensureTool(tool: "fd" | "rg", silent: boolean = false): Pr
 	if (platform() === "android") {
 		const pkgName = TERMUX_PACKAGES[tool] ?? tool;
 		if (!silent) {
-			console.log(chalk.yellow(`${config.name} not found. Install with: pkg install ${pkgName}`));
+			console.log(styleText("yellow", `${config.name} not found. Install with: pkg install ${pkgName}`));
 		}
 		return undefined;
 	}
 
 	// Tool not found - download it
 	if (!silent) {
-		console.log(chalk.dim(`${config.name} not found. Downloading...`));
+		console.log(styleText("dim", `${config.name} not found. Downloading...`));
 	}
 
 	try {
 		const path = await downloadTool(tool);
 		if (!silent) {
-			console.log(chalk.dim(`${config.name} installed to ${path}`));
+			console.log(styleText("dim", `${config.name} installed to ${path}`));
 		}
 		return path;
 	} catch (e) {
 		if (!silent) {
-			console.log(chalk.yellow(`Failed to download ${config.name}: ${e instanceof Error ? e.message : e}`));
+			console.log(styleText("yellow", `Failed to download ${config.name}: ${e instanceof Error ? e.message : e}`));
 		}
 		return undefined;
 	}

--- a/packages/coding-agent/test/suite/regressions/5080-signal-shutdown-extension-cleanup.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5080-signal-shutdown-extension-cleanup.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import chalk from "chalk";
+import { styleText } from "node:util";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { APP_NAME } from "../../../src/config.ts";
 import type { SessionManager } from "../../../src/core/session-manager.ts";
@@ -146,7 +146,7 @@ describe("InteractiveMode.shutdown ordering (#5080)", () => {
 
 		expect(order).toEqual(["drainInput", "stop", "dispose"]);
 		expect(stdoutWrite).toHaveBeenCalledWith(
-			`${chalk.dim("To resume this session:")} ${APP_NAME} --session test-session\n`,
+			`${styleText("dim", "To resume this session:")} ${APP_NAME} --session test-session\n`,
 		);
 	});
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -41,7 +41,6 @@
 		"marked": "15.0.12"
 	},
 	"devDependencies": {
-		"@xterm/headless": "5.5.0",
-		"chalk": "5.6.2"
+		"@xterm/headless": "5.5.0"
 	}
 }

--- a/packages/tui/test/chat-simple.ts
+++ b/packages/tui/test/chat-simple.ts
@@ -2,7 +2,7 @@
  * Simple chat interface demo using tui.ts
  */
 
-import chalk from "chalk";
+import { styleText } from "node:util";
 import { CombinedAutocompleteProvider } from "../src/autocomplete.ts";
 import { Editor } from "../src/components/editor.ts";
 import { Loader } from "../src/components/loader.ts";
@@ -87,8 +87,8 @@ editor.onSubmit = (value: string) => {
 
 		const loader = new Loader(
 			tui,
-			(s) => chalk.cyan(s),
-			(s) => chalk.dim(s),
+			(s) => styleText("cyan", s),
+			(s) => styleText("dim", s),
 			"Thinking...",
 		);
 		children.splice(children.length - 1, 0, loader);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1,15 +1,12 @@
 import assert from "node:assert";
 import { afterEach, describe, it } from "node:test";
+import { styleText } from "node:util";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
-import { Chalk } from "chalk";
 import { Markdown } from "../src/components/markdown.ts";
 import { resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.ts";
 import { type Component, TUI } from "../src/tui.ts";
 import { defaultMarkdownTheme } from "./test-themes.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
-
-// Force full color in CI so ANSI assertions are deterministic
-const chalk = new Chalk({ level: 3 });
 
 function getCellItalic(terminal: VirtualTerminal, row: number, col: number): number {
 	const xterm = (terminal as unknown as { xterm: XtermTerminalType }).xterm;
@@ -621,7 +618,7 @@ describe("Markdown component", () => {
 				0,
 				defaultMarkdownTheme,
 				{
-					color: (text) => chalk.gray(text),
+					color: (text) => styleText("gray", text),
 					italic: true,
 				},
 			);
@@ -648,7 +645,7 @@ describe("Markdown component", () => {
 				0,
 				defaultMarkdownTheme,
 				{
-					color: (text) => chalk.gray(text),
+					color: (text) => styleText("gray", text),
 					italic: true,
 				},
 			);
@@ -688,7 +685,7 @@ describe("Markdown component", () => {
 			}
 
 			const markdown = new Markdown("This is thinking with `inline code`", 1, 0, defaultMarkdownTheme, {
-				color: (text) => chalk.gray(text),
+				color: (text) => styleText("gray", text),
 				italic: true,
 			});
 
@@ -918,7 +915,7 @@ bar`,
 				0,
 				defaultMarkdownTheme,
 				{
-					color: (text) => chalk.magenta(text), // This should NOT be applied to blockquotes
+					color: (text) => styleText("magenta", text), // This should NOT be applied to blockquotes
 				},
 			);
 
@@ -952,7 +949,7 @@ bar`,
 				0,
 				defaultMarkdownTheme,
 				{
-					color: (text) => chalk.cyan(text), // This should NOT be applied to blockquotes
+					color: (text) => styleText("cyan", text), // This should NOT be applied to blockquotes
 				},
 			);
 
@@ -1030,7 +1027,7 @@ bar`,
 				0,
 				defaultMarkdownTheme,
 				{
-					color: (text) => chalk.yellow(text), // This should NOT be applied to blockquotes
+					color: (text) => styleText("yellow", text), // This should NOT be applied to blockquotes
 					italic: true,
 				},
 			);

--- a/packages/tui/test/test-themes.ts
+++ b/packages/tui/test/test-themes.ts
@@ -2,37 +2,35 @@
  * Default themes for TUI tests using chalk
  */
 
-import { Chalk } from "chalk";
+import { styleText } from "node:util";
 import type { EditorTheme, MarkdownTheme, SelectListTheme } from "../src/index.ts";
 
-const chalk = new Chalk({ level: 3 });
-
 export const defaultSelectListTheme: SelectListTheme = {
-	selectedPrefix: (text: string) => chalk.blue(text),
-	selectedText: (text: string) => chalk.bold(text),
-	description: (text: string) => chalk.dim(text),
-	scrollInfo: (text: string) => chalk.dim(text),
-	noMatch: (text: string) => chalk.dim(text),
+	selectedPrefix: (text: string) => styleText("blue", text),
+	selectedText: (text: string) => styleText("bold", text),
+	description: (text: string) => styleText("dim", text),
+	scrollInfo: (text: string) => styleText("dim", text),
+	noMatch: (text: string) => styleText("dim", text),
 };
 
 export const defaultMarkdownTheme: MarkdownTheme = {
-	heading: (text: string) => chalk.bold.cyan(text),
-	link: (text: string) => chalk.blue(text),
-	linkUrl: (text: string) => chalk.dim(text),
-	code: (text: string) => chalk.yellow(text),
-	codeBlock: (text: string) => chalk.green(text),
-	codeBlockBorder: (text: string) => chalk.dim(text),
-	quote: (text: string) => chalk.italic(text),
-	quoteBorder: (text: string) => chalk.dim(text),
-	hr: (text: string) => chalk.dim(text),
-	listBullet: (text: string) => chalk.cyan(text),
-	bold: (text: string) => chalk.bold(text),
-	italic: (text: string) => chalk.italic(text),
-	strikethrough: (text: string) => chalk.strikethrough(text),
-	underline: (text: string) => chalk.underline(text),
+	heading: (text: string) => styleText(["bold", "cyan"], text),
+	link: (text: string) => styleText("blue", text),
+	linkUrl: (text: string) => styleText("dim", text),
+	code: (text: string) => styleText("yellow", text),
+	codeBlock: (text: string) => styleText("green", text),
+	codeBlockBorder: (text: string) => styleText("dim", text),
+	quote: (text: string) => styleText("italic", text),
+	quoteBorder: (text: string) => styleText("dim", text),
+	hr: (text: string) => styleText("dim", text),
+	listBullet: (text: string) => styleText("cyan", text),
+	bold: (text: string) => styleText("bold", text),
+	italic: (text: string) => styleText("italic", text),
+	strikethrough: (text: string) => styleText("strikethrough", text),
+	underline: (text: string) => styleText("underline", text),
 };
 
 export const defaultEditorTheme: EditorTheme = {
-	borderColor: (text: string) => chalk.dim(text),
+	borderColor: (text: string) => styleText("dim", text),
 	selectList: defaultSelectListTheme,
 };

--- a/packages/tui/test/truncated-text.test.ts
+++ b/packages/tui/test/truncated-text.test.ts
@@ -1,11 +1,8 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { Chalk } from "chalk";
+import { styleText } from "node:util";
 import { TruncatedText } from "../src/components/truncated-text.ts";
 import { visibleWidth } from "../src/utils.ts";
-
-// Force full color in CI so ANSI assertions are deterministic
-const chalk = new Chalk({ level: 3 });
 
 describe("TruncatedText component", () => {
 	it("pads output lines to exactly match width", () => {
@@ -49,7 +46,7 @@ describe("TruncatedText component", () => {
 	});
 
 	it("preserves ANSI codes in output and pads correctly", () => {
-		const styledText = `${chalk.red("Hello")} ${chalk.blue("world")}`;
+		const styledText = `${styleText("red", "Hello")} ${styleText("blue", "world")}`;
 		const text = new TruncatedText(styledText, 1, 0);
 		const lines = text.render(40);
 
@@ -63,7 +60,7 @@ describe("TruncatedText component", () => {
 	});
 
 	it("truncates styled text and adds reset code before ellipsis", () => {
-		const longStyledText = chalk.red("This is a very long red text that will be truncated");
+		const longStyledText = styleText("red", "This is a very long red text that will be truncated");
 		const text = new TruncatedText(longStyledText, 1, 0);
 		const lines = text.render(20);
 

--- a/scripts/session-transcripts.ts
+++ b/scripts/session-transcripts.ts
@@ -15,7 +15,7 @@ import { createInterface } from "node:readline";
 import { homedir } from "os";
 import { join, resolve } from "path";
 import { parseSessionEntries, type SessionMessageEntry } from "../packages/coding-agent/src/core/session-manager.ts";
-import chalk from "chalk";
+import { styleText } from "node:util";
 
 const MAX_CHARS_PER_FILE = 100_000; // ~20k tokens, leaving room for prompt + analysis + output
 
@@ -98,7 +98,7 @@ function runSubagent(prompt: string, cwd: string): Promise<{ success: boolean }>
 				} else if (event.type === "tool_execution_start" && event.toolName) {
 					// Print accumulated text before tool starts
 					if (textBuffer.trim()) {
-						console.log(chalk.dim("  " + truncateLine(textBuffer, MAX_DISPLAY_WIDTH)));
+						console.log(styleText("dim", "  " + truncateLine(textBuffer, MAX_DISPLAY_WIDTH)));
 						textBuffer = "";
 					}
 					// Format tool call with args
@@ -112,11 +112,11 @@ function runSubagent(prompt: string, cwd: string): Promise<{ success: boolean }>
 							argsStr = event.args.path || "";
 						}
 					}
-					console.log(chalk.cyan(`  [${event.toolName}] ${argsStr}`));
+					console.log(styleText("cyan", `  [${event.toolName}] ${argsStr}`));
 				} else if (event.type === "turn_end") {
 					// Print any remaining text at turn end
 					if (textBuffer.trim()) {
-						console.log(chalk.dim("  " + truncateLine(textBuffer, MAX_DISPLAY_WIDTH)));
+						console.log(styleText("dim", "  " + truncateLine(textBuffer, MAX_DISPLAY_WIDTH)));
 					}
 					textBuffer = "";
 				}
@@ -126,7 +126,7 @@ function runSubagent(prompt: string, cwd: string): Promise<{ success: boolean }>
 		});
 
 		child.stderr.on("data", (data) => {
-			process.stderr.write(chalk.red(data.toString()));
+			process.stderr.write(styleText("red", data.toString()));
 		});
 
 		child.on("close", (code) => {
@@ -134,7 +134,7 @@ function runSubagent(prompt: string, cwd: string): Promise<{ success: boolean }>
 		});
 
 		child.on("error", (err) => {
-			console.error(chalk.red(`  Failed to spawn pi: ${err.message}`));
+			console.error(styleText("red", `  Failed to spawn pi: ${err.message}`));
 			resolve({ success: false });
 		});
 	});
@@ -224,7 +224,7 @@ async function main() {
 			const filename = `session-transcripts-${String(fileIndex).padStart(3, "0")}.txt`;
 			writeFileSync(join(outputDir, filename), transcript);
 			outputFiles.push(filename);
-			console.log(chalk.yellow(`Wrote ${filename} (${transcript.length} chars) - oversized`));
+			console.log(styleText("yellow", `Wrote ${filename} (${transcript.length} chars) - oversized`));
 			fileIndex++;
 			continue;
 		}
@@ -314,11 +314,11 @@ Rules:
 		const result = await runSubagent(fullPrompt, outputDir);
 
 		if (result.success && existsSync(summaryPath)) {
-			console.log(chalk.green(`  -> ${summaryFile}`));
+			console.log(styleText("green", `  -> ${summaryFile}`));
 		} else if (result.success) {
-			console.error(chalk.yellow(`  Agent finished but did not write ${summaryFile}`));
+			console.error(styleText("yellow", `  Agent finished but did not write ${summaryFile}`));
 		} else {
-			console.error(chalk.red(`  Failed to analyze ${file}`));
+			console.error(styleText("red", `  Failed to analyze ${file}`));
 		}
 	}
 
@@ -331,7 +331,7 @@ Rules:
 	console.log(`Created ${summaryFiles.length} summary files`);
 
 	if (summaryFiles.length === 0) {
-		console.log(chalk.yellow("No summary files created. Nothing to aggregate."));
+		console.log(styleText("yellow", "No summary files created. Nothing to aggregate."));
 		return;
 	}
 
@@ -394,12 +394,12 @@ Write the final summary to ${finalSummaryPath}`;
 	const aggregateResult = await runSubagent(aggregationPrompt, outputDir);
 
 	if (aggregateResult.success && existsSync(finalSummaryPath)) {
-		console.log(chalk.green(`\n=== Final Summary Created ===`));
-		console.log(chalk.green(`  ${finalSummaryPath}`));
+		console.log(styleText("green", `\n=== Final Summary Created ===`));
+		console.log(styleText("green", `  ${finalSummaryPath}`));
 	} else if (aggregateResult.success) {
-		console.error(chalk.yellow(`Agent finished but did not write final summary`));
+		console.error(styleText("yellow", `Agent finished but did not write final summary`));
 	} else {
-		console.error(chalk.red(`Failed to create final summary`));
+		console.error(styleText("red", `Failed to create final summary`));
 	}
 }
 


### PR DESCRIPTION
chore: Replace chalk with util.styleText. which available since node >= 20, this is fine with engine version node 22. For more information, please check [here](https://e18e.dev/docs/replacements/chalk.html).