### PR TITLE
fix(coding-agent): warn instead of fatal on extension load failures

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -617,7 +617,7 @@ export async function main(args: string[], options?: MainOptions) {
 			...services.diagnostics,
 			...collectSettingsDiagnostics(settingsManager, "runtime creation"),
 			...resourceLoader.getExtensions().errors.map(({ path, error }) => ({
-				type: "error" as const,
+				type: "warning" as const,
 				message: `Failed to load extension "${path}": ${error}`,
 			})),
 		];


### PR DESCRIPTION
Extension loading failures (e.g. missing dependencies, syntax errors, runtime throws in the factory) currently prevent pi from booting at all: the error is classified as `type: "error"` in diagnostics, which triggers `process.exit(1)` before the session loop starts.

This is unnecessarily harsh. A broken extension should not take down the whole editor. The error is already logged either way.

This changes the diagnostic type from `"error"` to `"warning"`, so pi continues to boot and the user gets a yellow warning for the failed extension instead of an abort.

Fixes: https://github.com/earendil-works/pi/issues/NEW
