### PR TITLE
Ephemeral session model and thinking level selection

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -207,6 +207,18 @@ export interface PromptOptions {
 	preflightResult?: (success: boolean) => void;
 }
 
+/** Options for setThinkingLevel() / cycleThinkingLevel() */
+export interface SetThinkingLevelOptions {
+	/**
+	 * When true, also update the global settings file
+	 * (`~/.pi/agent/settings.json` defaultThinkingLevel) so future sessions
+	 * inherit this thinking level. Defaults to false so in-session toggles
+	 * (Ctrl+T, extension RPC) stay ephemeral and only affect the current
+	 * session.
+	 */
+	persist?: boolean;
+}
+
 /** Result from cycleModel() */
 export interface ModelCycleResult {
 	model: Model<any>;
@@ -1527,13 +1539,18 @@ export class AgentSession {
 	/**
 	 * Set thinking level.
 	 * Clamps to model capabilities based on available thinking levels.
-	 * Saves to session and settings only if the level actually changes.
+	 * Updates session state and appends a `thinking_level_change` entry to the
+	 * session transcript only if the effective level actually changes.
+	 *
+	 * By default the change is ephemeral: it does NOT touch the global settings
+	 * file. Pass `{ persist: true }` from `/settings` (or other surfaces the
+	 * user has explicitly opted into) to also update `defaultThinkingLevel` in
+	 * the global settings.
 	 */
-	setThinkingLevel(level: ThinkingLevel): void {
+	setThinkingLevel(level: ThinkingLevel, opts: SetThinkingLevelOptions = {}): void {
 		const availableLevels = this.getAvailableThinkingLevels();
 		const effectiveLevel = availableLevels.includes(level) ? level : this._clampThinkingLevel(level, availableLevels);
 
-		// Only persist if actually changing
 		const previousLevel = this.agent.state.thinkingLevel;
 		const isChanging = effectiveLevel !== previousLevel;
 
@@ -1541,7 +1558,7 @@ export class AgentSession {
 
 		if (isChanging) {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
-			if (this.supportsThinking() || effectiveLevel !== "off") {
+			if (opts.persist && (this.supportsThinking() || effectiveLevel !== "off")) {
 				this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
 			}
 			this._emit({ type: "thinking_level_changed", level: effectiveLevel });
@@ -1555,9 +1572,10 @@ export class AgentSession {
 
 	/**
 	 * Cycle to next thinking level.
+	 * Ephemeral by default — Ctrl+T cycling never touches the global settings.
 	 * @returns New level, or undefined if model doesn't support thinking
 	 */
-	cycleThinkingLevel(): ThinkingLevel | undefined {
+	cycleThinkingLevel(opts: SetThinkingLevelOptions = {}): ThinkingLevel | undefined {
 		if (!this.supportsThinking()) return undefined;
 
 		const levels = this.getAvailableThinkingLevels();
@@ -1565,7 +1583,7 @@ export class AgentSession {
 		const nextIndex = (currentIndex + 1) % levels.length;
 		const nextLevel = levels[nextIndex];
 
-		this.setThinkingLevel(nextLevel);
+		this.setThinkingLevel(nextLevel, opts);
 		return nextLevel;
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -219,6 +219,18 @@ export interface SetThinkingLevelOptions {
 	persist?: boolean;
 }
 
+/** Options for setModel() / cycleModel() */
+export interface SetModelOptions {
+	/**
+	 * When true, also update the global settings file
+	 * (`~/.pi/agent/settings.json` defaultProvider/defaultModel) so future
+	 * sessions inherit this model. Defaults to false so in-session toggles
+	 * (`/model`, Ctrl+P cycling, extension RPC) stay ephemeral and only
+	 * affect the current session.
+	 */
+	persist?: boolean;
+}
+
 /** Result from cycleModel() */
 export interface ModelCycleResult {
 	model: Model<any>;
@@ -1445,10 +1457,17 @@ export class AgentSession {
 
 	/**
 	 * Set model directly.
-	 * Validates that auth is configured, saves to session and settings.
+	 * Validates that auth is configured and updates session state.
+	 *
+	 * By default the change is ephemeral: it updates the in-memory session and
+	 * appends a `model_change` entry to the session transcript (so `/resume`
+	 * restores it), but does NOT touch the global settings file. Pass
+	 * `{ persist: true }` from `/settings` or onboarding flows when the user
+	 * has explicitly asked to make this the new global default.
+	 *
 	 * @throws Error if no auth is configured for the model
 	 */
-	async setModel(model: Model<any>): Promise<void> {
+	async setModel(model: Model<any>, opts: SetModelOptions = {}): Promise<void> {
 		if (!this._modelRegistry.hasConfiguredAuth(model)) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
@@ -1457,10 +1476,14 @@ export class AgentSession {
 		const thinkingLevel = this._getThinkingLevelForModelSwitch();
 		this.agent.state.model = model;
 		this.sessionManager.appendModelChange(model.provider, model.id);
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		if (opts.persist) {
+			this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		}
 
-		// Re-clamp thinking level for new model's capabilities
-		this.setThinkingLevel(thinkingLevel);
+		// Re-clamp thinking level for new model's capabilities. Inherit the
+		// caller's persistence preference — a persisted model change carries the
+		// re-clamped thinking level into settings too.
+		this.setThinkingLevel(thinkingLevel, opts);
 
 		await this._emitModelSelect(model, previousModel, "set");
 	}
@@ -1471,14 +1494,20 @@ export class AgentSession {
 	 * @param direction - "forward" (default) or "backward"
 	 * @returns The new model info, or undefined if only one model available
 	 */
-	async cycleModel(direction: "forward" | "backward" = "forward"): Promise<ModelCycleResult | undefined> {
+	async cycleModel(
+		direction: "forward" | "backward" = "forward",
+		opts: SetModelOptions = {},
+	): Promise<ModelCycleResult | undefined> {
 		if (this._scopedModels.length > 0) {
-			return this._cycleScopedModel(direction);
+			return this._cycleScopedModel(direction, opts);
 		}
-		return this._cycleAvailableModel(direction);
+		return this._cycleAvailableModel(direction, opts);
 	}
 
-	private async _cycleScopedModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined> {
+	private async _cycleScopedModel(
+		direction: "forward" | "backward",
+		opts: SetModelOptions,
+	): Promise<ModelCycleResult | undefined> {
 		const scopedModels = this._scopedModels.filter((scoped) => this._modelRegistry.hasConfiguredAuth(scoped.model));
 		if (scopedModels.length <= 1) return undefined;
 
@@ -1491,23 +1520,28 @@ export class AgentSession {
 		const next = scopedModels[nextIndex];
 		const thinkingLevel = this._getThinkingLevelForModelSwitch(next.thinkingLevel);
 
-		// Apply model
+		// Apply model. Cycling is ephemeral by default — see setModel docs.
 		this.agent.state.model = next.model;
 		this.sessionManager.appendModelChange(next.model.provider, next.model.id);
-		this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
+		if (opts.persist) {
+			this.settingsManager.setDefaultModelAndProvider(next.model.provider, next.model.id);
+		}
 
 		// Apply thinking level.
 		// - Explicit scoped model thinking level overrides current session level
 		// - Undefined scoped model thinking level inherits the current session preference
 		// setThinkingLevel clamps to model capabilities.
-		this.setThinkingLevel(thinkingLevel);
+		this.setThinkingLevel(thinkingLevel, opts);
 
 		await this._emitModelSelect(next.model, currentModel, "cycle");
 
 		return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };
 	}
 
-	private async _cycleAvailableModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined> {
+	private async _cycleAvailableModel(
+		direction: "forward" | "backward",
+		opts: SetModelOptions,
+	): Promise<ModelCycleResult | undefined> {
 		const availableModels = await this._modelRegistry.getAvailable();
 		if (availableModels.length <= 1) return undefined;
 
@@ -1522,10 +1556,12 @@ export class AgentSession {
 		const thinkingLevel = this._getThinkingLevelForModelSwitch();
 		this.agent.state.model = nextModel;
 		this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
-		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+		if (opts.persist) {
+			this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
+		}
 
 		// Re-clamp thinking level for new model's capabilities
-		this.setThinkingLevel(thinkingLevel);
+		this.setThinkingLevel(thinkingLevel, opts);
 
 		await this._emitModelSelect(nextModel, currentModel, "cycle");
 

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -10,7 +10,6 @@ import {
 	type TUI,
 } from "@earendil-works/pi-tui";
 import type { ModelRegistry } from "../../../core/model-registry.ts";
-import type { SettingsManager } from "../../../core/settings-manager.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint } from "./keybinding-hints.ts";
@@ -50,7 +49,6 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private filteredModels: ModelItem[] = [];
 	private selectedIndex: number = 0;
 	private currentModel?: Model<any>;
-	private settingsManager: SettingsManager;
 	private modelRegistry: ModelRegistry;
 	private onSelectCallback: (model: Model<any>) => void;
 	private onCancelCallback: () => void;
@@ -64,7 +62,6 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	constructor(
 		tui: TUI,
 		currentModel: Model<any> | undefined,
-		settingsManager: SettingsManager,
 		modelRegistry: ModelRegistry,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: (model: Model<any>) => void,
@@ -75,7 +72,6 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 		this.tui = tui;
 		this.currentModel = currentModel;
-		this.settingsManager = settingsManager;
 		this.modelRegistry = modelRegistry;
 		this.scopedModels = scopedModels;
 		this.scope = scopedModels.length > 0 ? "scoped" : "all";
@@ -327,8 +323,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private handleSelect(model: Model<any>): void {
-		// Save as new default
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		// In-session selection is ephemeral. The caller's onSelectCallback
+		// runs `session.setModel(model)` which updates session state and the
+		// session transcript but does NOT touch the global settings file.
+		// Use `/settings` to change the persisted default model.
 		this.onSelectCallback(model);
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -42,6 +42,7 @@ export interface SettingsConfig {
 	followUpMode: "all" | "one-at-a-time";
 	transport: Transport;
 	httpIdleTimeoutMs: number;
+	defaultModelLabel: string;
 	thinkingLevel: ThinkingLevel;
 	availableThinkingLevels: ThinkingLevel[];
 	currentTheme: string;
@@ -71,6 +72,7 @@ export interface SettingsCallbacks {
 	onFollowUpModeChange: (mode: "all" | "one-at-a-time") => void;
 	onTransportChange: (transport: Transport) => void;
 	onHttpIdleTimeoutMsChange: (timeoutMs: number) => void;
+	onDefaultModelSubmenu: (done: (selectedValue?: string) => void) => Container;
 	onThinkingLevelChange: (level: ThinkingLevel) => void;
 	onThemeChange: (theme: string) => void;
 	onThemePreview?: (theme: string) => void;
@@ -305,6 +307,13 @@ export class SettingsSelectorComponent extends Container {
 						},
 						() => done(),
 					),
+			},
+			{
+				id: "default-model",
+				label: "Default model",
+				description: "Global default model for new sessions",
+				currentValue: config.defaultModelLabel,
+				submenu: (_currentValue, done) => callbacks.onDefaultModelSubmenu(done),
 			},
 			{
 				id: "thinking",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3891,6 +3891,15 @@ export class InteractiveMode {
 	}
 
 	private showSettingsSelector(): void {
+		const persistedProvider = this.settingsManager.getDefaultProvider();
+		const persistedModelId = this.settingsManager.getDefaultModel();
+		const sessionModel = this.session.model;
+		const defaultModelLabel =
+			persistedProvider && persistedModelId
+				? persistedModelId
+				: sessionModel
+					? `${sessionModel.name || sessionModel.id} (session-only)`
+					: "(none)";
 		this.showSelector((done) => {
 			const selector = new SettingsSelectorComponent(
 				{
@@ -3904,6 +3913,7 @@ export class InteractiveMode {
 					followUpMode: this.session.followUpMode,
 					transport: this.settingsManager.getTransport(),
 					httpIdleTimeoutMs: this.settingsManager.getHttpIdleTimeoutMs(),
+					defaultModelLabel,
 					thinkingLevel: this.settingsManager.getDefaultThinkingLevel() ?? this.session.thinkingLevel,
 					availableThinkingLevels: this.session.getAvailableThinkingLevels(),
 					currentTheme: this.settingsManager.getTheme() || "dark",
@@ -3966,6 +3976,32 @@ export class InteractiveMode {
 						this.settingsManager.setHttpIdleTimeoutMs(timeoutMs);
 						configureHttpDispatcher(timeoutMs);
 						this.showStatus(`HTTP idle timeout: ${formatHttpIdleTimeoutMs(timeoutMs)}`);
+					},
+					onDefaultModelSubmenu: (done) => {
+						const persistedModel =
+							persistedProvider && persistedModelId
+								? this.session.modelRegistry.find(persistedProvider, persistedModelId)
+								: undefined;
+						return new ModelSelectorComponent(
+							this.ui,
+							persistedModel ?? this.session.model,
+							this.session.modelRegistry,
+							this.session.scopedModels,
+							async (model) => {
+								try {
+									await this.session.setModel(model, { persist: true });
+									this.footer.invalidate();
+									this.updateEditorBorderColor();
+									done(`${model.provider}:${model.id}`);
+									this.showStatus(`Default model: ${model.name || model.id}`);
+									void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
+								} catch (error) {
+									done();
+									this.showError(error instanceof Error ? error.message : String(error));
+								}
+							},
+							() => done(),
+						);
 					},
 					onThinkingLevelChange: (level) => {
 						// `/settings` is the canonical surface for changing the
@@ -4140,7 +4176,6 @@ export class InteractiveMode {
 			const selector = new ModelSelectorComponent(
 				this.ui,
 				this.session.model,
-				this.settingsManager,
 				this.session.modelRegistry,
 				this.session.scopedModels,
 				async (model) => {
@@ -4696,7 +4731,9 @@ export class InteractiveMode {
 					selectionError = `${actionLabel}, but its default model "${defaultModelId}" is not available. Use /model to select a model.`;
 				} else {
 					try {
-						await this.session.setModel(selectedModel);
+						// Onboarding/auth completion: persist the freshly chosen
+						// provider's default model so future sessions inherit it.
+						await this.session.setModel(selectedModel, { persist: true });
 					} catch (error: unknown) {
 						selectedModel = undefined;
 						const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3904,7 +3904,7 @@ export class InteractiveMode {
 					followUpMode: this.session.followUpMode,
 					transport: this.settingsManager.getTransport(),
 					httpIdleTimeoutMs: this.settingsManager.getHttpIdleTimeoutMs(),
-					thinkingLevel: this.session.thinkingLevel,
+					thinkingLevel: this.settingsManager.getDefaultThinkingLevel() ?? this.session.thinkingLevel,
 					availableThinkingLevels: this.session.getAvailableThinkingLevels(),
 					currentTheme: this.settingsManager.getTheme() || "dark",
 					availableThemes: getAvailableThemes(),
@@ -3968,7 +3968,10 @@ export class InteractiveMode {
 						this.showStatus(`HTTP idle timeout: ${formatHttpIdleTimeoutMs(timeoutMs)}`);
 					},
 					onThinkingLevelChange: (level) => {
-						this.session.setThinkingLevel(level);
+						// `/settings` is the canonical surface for changing the
+						// persisted default thinking level. All other surfaces
+						// (Ctrl+T cycling, /model, extension RPC) stay ephemeral.
+						this.session.setThinkingLevel(level, { persist: true });
 						this.footer.invalidate();
 						this.updateEditorBorderColor();
 					},

--- a/packages/coding-agent/test/suite/agent-session-persist-settings.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-persist-settings.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression: in-session thinking-level changes must not bleed into the
+ * global settings file. Only callers that pass `{ persist: true }` (currently:
+ * `/settings` UI) update `defaultThinkingLevel`.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.ts";
+
+describe("AgentSession does not persist in-session thinking changes by default", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("setThinkingLevel without persist leaves the global thinking level untouched", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", name: "One", reasoning: true }],
+		});
+		harnesses.push(harness);
+		const initial = harness.settingsManager.getDefaultThinkingLevel();
+
+		harness.session.setThinkingLevel("high");
+
+		expect(harness.session.thinkingLevel).toBe("high");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe(initial);
+	});
+
+	it("setThinkingLevel with persist:true updates the global thinking level", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", name: "One", reasoning: true }],
+		});
+		harnesses.push(harness);
+
+		harness.session.setThinkingLevel("high", { persist: true });
+
+		expect(harness.session.thinkingLevel).toBe("high");
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("high");
+	});
+
+	it("cycleThinkingLevel does not persist by default", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", name: "One", reasoning: true }],
+		});
+		harnesses.push(harness);
+		// Establish a known starting in-session level without persisting.
+		harness.session.setThinkingLevel("low");
+		const initial = harness.settingsManager.getDefaultThinkingLevel();
+
+		const next = harness.session.cycleThinkingLevel();
+
+		expect(next).toBeDefined();
+		expect(harness.session.thinkingLevel).toBe(next);
+		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe(initial);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-persist-settings.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-persist-settings.test.ts
@@ -1,19 +1,59 @@
 /**
- * Regression: in-session thinking-level changes must not bleed into the
+ * Regression: in-session model/thinking-level changes must not bleed into the
  * global settings file. Only callers that pass `{ persist: true }` (currently:
- * `/settings` UI) update `defaultThinkingLevel`.
+ * `/settings` UI and the post-auth onboarding flow) update
+ * `defaultProvider` / `defaultModel` / `defaultThinkingLevel`.
  */
 
 import { afterEach, describe, expect, it } from "vitest";
 import { createHarness, type Harness } from "./harness.ts";
 
-describe("AgentSession does not persist in-session thinking changes by default", () => {
+describe("AgentSession does not persist in-session model/thinking changes by default", () => {
 	const harnesses: Harness[] = [];
 
 	afterEach(() => {
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
 		}
+	});
+
+	it("setModel without persist leaves the global default model untouched", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		// Capture whatever the harness started with (may be undefined if the
+		// harness doesn't initialize defaultModel; that's exactly the state we
+		// want preserved across an in-session toggle).
+		const initialModel = harness.settingsManager.getDefaultModel();
+		const initialProvider = harness.settingsManager.getDefaultProvider();
+
+		await harness.session.setModel(harness.getModel("faux-2")!);
+
+		// Session state updates...
+		expect(harness.session.model?.id).toBe("faux-2");
+		// ...but global settings do not.
+		expect(harness.settingsManager.getDefaultModel()).toBe(initialModel);
+		expect(harness.settingsManager.getDefaultProvider()).toBe(initialProvider);
+	});
+
+	it("setModel with persist:true updates the global default model", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const target = harness.getModel("faux-2")!;
+
+		await harness.session.setModel(target, { persist: true });
+
+		expect(harness.settingsManager.getDefaultModel()).toBe(target.id);
+		expect(harness.settingsManager.getDefaultProvider()).toBe(target.provider);
 	});
 
 	it("setThinkingLevel without persist leaves the global thinking level untouched", async () => {
@@ -41,6 +81,26 @@ describe("AgentSession does not persist in-session thinking changes by default",
 		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe("high");
 	});
 
+	it("cycleModel does not persist by default", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const initialModel = harness.settingsManager.getDefaultModel();
+		const initialProvider = harness.settingsManager.getDefaultProvider();
+
+		await harness.session.cycleModel();
+
+		// The session moved to a different model...
+		expect(harness.session.model?.id).not.toBe("faux-1");
+		// ...but the global default is unchanged.
+		expect(harness.settingsManager.getDefaultModel()).toBe(initialModel);
+		expect(harness.settingsManager.getDefaultProvider()).toBe(initialProvider);
+	});
+
 	it("cycleThinkingLevel does not persist by default", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1", name: "One", reasoning: true }],
@@ -55,5 +115,24 @@ describe("AgentSession does not persist in-session thinking changes by default",
 		expect(next).toBeDefined();
 		expect(harness.session.thinkingLevel).toBe(next);
 		expect(harness.settingsManager.getDefaultThinkingLevel()).toBe(initial);
+	});
+
+	it("session transcript still records in-session model/thinking changes", async () => {
+		// Resume must keep working after the patch — transcript entries are
+		// the per-session source of truth.
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.setModel(harness.getModel("faux-2")!);
+		harness.session.setThinkingLevel("high");
+
+		const entries = harness.sessionManager.getEntries();
+		expect(entries.some((entry) => entry.type === "model_change")).toBe(true);
+		expect(entries.some((entry) => entry.type === "thinking_level_change")).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/3217-scoped-model-order.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3217-scoped-model-order.test.ts
@@ -82,7 +82,6 @@ describe("issue #3217 scoped model ordering", () => {
 		const selector = new ModelSelectorComponent(
 			createFakeTui(),
 			modelOne,
-			harness.settingsManager,
 			harness.session.modelRegistry,
 			[{ model: modelTwo }, { model: modelOne }, { model: modelThree }],
 			() => {},


### PR DESCRIPTION
Defaulted `setModel()`, `cycleModel()`, `setThinkingLevel()`, and `cycleThinkingLevel()` to session-only mode unless an explicit `{ persist: true }` flag is passed. This stops in-session configuration changes (Ctrl+P, Ctrl+T, `/model` list, and extension RPC) from overwriting global default settings in `settings.json`.

A new `{ persist: true }` flag is passed from two contexts: the `/settings` UI and the post-auth onboarding flow. All other selection paths remain ephemeral

The `/settings` default model submenu now embeds the `ModelSelectorComponent` directly. The list pre-selects the persisted default from `settings.json` rather than the active session model. Similarly, the `/settings` thinking level row queries the persisted default from `settingsManager.getDefaultThinkingLevel()`.

I removed the unused `SettingsManager` reference from `ModelSelectorComponent` since it no longer writes configuration changes directly.

 Closes #5046, Closes #5263