### PR TITLE
feat: add gitContextBoundary setting to stop AGENTS.md ancestor walk at git root

### DIFF
--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import chalk from "chalk";
@@ -72,12 +73,27 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
 	return null;
 }
 
+/** Resolve the git root for a given directory, or null if not in a repo. */
+function resolveGitRoot(cwd: string): string | null {
+	try {
+		return execSync("git rev-parse --show-toplevel", {
+			cwd: resolvePath(cwd),
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return null;
+	}
+}
+
 export function loadProjectContextFiles(options: {
 	cwd: string;
 	agentDir: string;
+	gitContextBoundary?: boolean;
 }): Array<{ path: string; content: string }> {
 	const resolvedCwd = resolvePath(options.cwd);
 	const resolvedAgentDir = resolvePath(options.agentDir);
+	const gitRoot = options.gitContextBoundary ? resolveGitRoot(options.cwd) : null;
 
 	const contextFiles: Array<{ path: string; content: string }> = [];
 	const seenPaths = new Set<string>();
@@ -101,6 +117,9 @@ export function loadProjectContextFiles(options: {
 		}
 
 		if (currentDir === root) break;
+		// When gitContextBoundary is set, stop at the git root — context above
+		// the repo doesn't belong to this project.
+		if (gitRoot && resolve(currentDir) === resolve(gitRoot)) break;
 
 		const parentDir = resolve(currentDir, "..");
 		if (parentDir === currentDir) break;
@@ -116,6 +135,7 @@ export interface DefaultResourceLoaderOptions {
 	cwd: string;
 	agentDir: string;
 	settingsManager?: SettingsManager;
+	gitContextBoundary?: boolean;
 	eventBus?: EventBus;
 	additionalExtensionPaths?: string[];
 	additionalSkillPaths?: string[];
@@ -165,6 +185,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private noPromptTemplates: boolean;
 	private noThemes: boolean;
 	private noContextFiles: boolean;
+	private gitContextBoundary: boolean;
 	private systemPromptSource?: string;
 	private appendSystemPromptSource?: string[];
 	private extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
@@ -223,6 +244,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.noPromptTemplates = options.noPromptTemplates ?? false;
 		this.noThemes = options.noThemes ?? false;
 		this.noContextFiles = options.noContextFiles ?? false;
+		this.gitContextBoundary = options.gitContextBoundary ?? false;
 		this.systemPromptSource = options.systemPrompt;
 		this.appendSystemPromptSource = options.appendSystemPrompt;
 		this.extensionsOverride = options.extensionsOverride;
@@ -465,8 +487,11 @@ export class DefaultResourceLoader implements ResourceLoader {
 			}
 		}
 
+		const gitContextBoundary = this.gitContextBoundary || this.settingsManager.getGitContextBoundary();
 		const agentsFiles = {
-			agentsFiles: this.noContextFiles ? [] : loadProjectContextFiles({ cwd: this.cwd, agentDir: this.agentDir }),
+			agentsFiles: this.noContextFiles
+				? []
+				: loadProjectContextFiles({ cwd: this.cwd, agentDir: this.agentDir, gitContextBoundary }),
 		};
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;
 		this.agentsFiles = resolvedAgentsFiles.agentsFiles;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -111,6 +111,7 @@ export interface Settings {
 	markdown?: MarkdownSettings;
 	warnings?: WarningSettings;
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
+	gitContextBoundary?: boolean; // default: false — when true, stop AGENTS.md ancestor walk at git root
 	httpIdleTimeoutMs?: number; // HTTP header/body idle timeout in milliseconds; 0 disables it
 	websocketConnectTimeoutMs?: number; // WebSocket connect/open handshake timeout in milliseconds; 0 disables it
 }
@@ -1077,6 +1078,10 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	getGitContextBoundary(): boolean {
+		return this.settings.gitContextBoundary ?? false;
 	}
 
 	getWarnings(): WarningSettings {

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -640,6 +641,82 @@ export default function(pi: ExtensionAPI) {
 			expect(runner.getCommand("deploy:1")?.description).toBe("explicit command");
 			expect(runner.getCommand("deploy:2")?.description).toBe("global command");
 			expect(runner.getToolDefinition("duplicate-tool")?.description).toBe("explicit tool");
+		});
+	});
+
+	describe("gitContextBoundary", () => {
+		it("should exclude context files above the git root when gitContextBoundary is true", async () => {
+			// Structure:
+			//   tempDir/                     <- no git
+			//     AGENTS.md                  <- should be excluded
+			//     repo/                      <- git root
+			//       .git/
+			//       AGENTS.md                <- repo root context
+			//       project/                 <- cwd
+			//         AGENTS.md              <- project context
+			const repoDir = join(tempDir, "repo");
+			mkdirSync(repoDir, { recursive: true });
+			execSync("git init", { cwd: repoDir, stdio: "ignore" });
+
+			writeFileSync(join(tempDir, "AGENTS.md"), "# Outside the repo — should be excluded.");
+			writeFileSync(join(repoDir, "AGENTS.md"), "# Repo root context.");
+			const projectDir = join(repoDir, "project");
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(projectDir, "AGENTS.md"), "# Project context.");
+
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir, gitContextBoundary: true });
+			await loader.reload();
+
+			const { agentsFiles } = loader.getAgentsFiles();
+			const paths = agentsFiles.map((f) => f.path);
+
+			// repo root and project AGENTS.md should be present
+			expect(paths.some((p) => p.endsWith(join("repo", "AGENTS.md")))).toBe(true);
+			expect(paths.some((p) => p.endsWith(join("repo", "project", "AGENTS.md")))).toBe(true);
+
+			// AGENTS.md above the git root should be excluded
+			expect(paths.some((p) => p === join(tempDir, "AGENTS.md"))).toBe(false);
+		});
+
+		it("should include context files above the git root when gitContextBoundary is false (default)", async () => {
+			const repoDir = join(tempDir, "repo");
+			mkdirSync(repoDir, { recursive: true });
+			execSync("git init", { cwd: repoDir, stdio: "ignore" });
+
+			writeFileSync(join(tempDir, "AGENTS.md"), "# Outside the repo.");
+			writeFileSync(join(repoDir, "AGENTS.md"), "# Repo root context.");
+			const projectDir = join(repoDir, "project");
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(projectDir, "AGENTS.md"), "# Project context.");
+
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir, gitContextBoundary: false });
+			await loader.reload();
+
+			const { agentsFiles } = loader.getAgentsFiles();
+			const paths = agentsFiles.map((f) => f.path);
+
+			// All three should be present — ancestor walk goes to /
+			expect(paths.some((p) => p === join(tempDir, "AGENTS.md"))).toBe(true);
+			expect(paths.some((p) => p.endsWith(join("repo", "AGENTS.md")))).toBe(true);
+			expect(paths.some((p) => p.endsWith(join("repo", "project", "AGENTS.md")))).toBe(true);
+		});
+
+		it("should fall back to full ancestor walk when gitContextBoundary is true but not in a git repo", async () => {
+			const projectDir = join(tempDir, "project");
+			mkdirSync(projectDir, { recursive: true });
+			// No .git directory — not a git repo
+			writeFileSync(join(tempDir, "AGENTS.md"), "# Ancestor context.");
+			writeFileSync(join(projectDir, "AGENTS.md"), "# Project context.");
+
+			const loader = new DefaultResourceLoader({ cwd: projectDir, agentDir, gitContextBoundary: true });
+			await loader.reload();
+
+			const { agentsFiles } = loader.getAgentsFiles();
+			const paths = agentsFiles.map((f) => f.path);
+
+			// Both should be present — no git root, walk goes to /
+			expect(paths.some((p) => p === join(tempDir, "AGENTS.md"))).toBe(true);
+			expect(paths.some((p) => p.endsWith(join("project", "AGENTS.md")))).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
When `gitContextBoundary` is enabled in `settings.json`, the ancestor walk that collects `AGENTS.md` / `CLAUDE.md` context files stops at the git root boundary. This prevents a home-directory `AGENTS.md` from leaking into every project under it when `$HOME` itself is a git repo.

**Default: `false`** — preserves existing behavior (walk to `/`).

**When `true`:** the walk stops once `currentDir` equals the git root. The git root's own `AGENTS.md` is still collected — only ancestors above the repo are excluded. In non-git projects, the walk falls back to `/` as before.

### Changes
- `settings-manager.ts`: new `gitContextBoundary` boolean setting + getter
- `resource-loader.ts`: `resolveGitRoot()` helper, wired through `loadProjectContextFiles()` and `DefaultResourceLoader`
- `resource-loader.test.ts`: 3 new tests covering boundary-on, boundary-off, and non-git fallback