### PR TITLE
feat(coding-agent): Support keybindings for all commands

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1376,7 +1376,7 @@ Labels persist in the session and survive restarts. Use them to mark important p
 
 Register a command.
 
-If multiple extensions register the same command name, pi keeps them all and assigns numeric invocation suffixes in load order, for example `/review:1` and `/review:2`.
+If multiple extensions register the same command name, pi keeps them all and assigns numeric invocation suffixes in load order, for example `/review:1` and `/review:2`. Extension commands that conflict with built-in command names are hidden from autocomplete.
 
 ```typescript
 pi.registerCommand("stats", {
@@ -1386,6 +1386,19 @@ pi.registerCommand("stats", {
     ctx.ui.notify(`${count} entries`, "info");
   }
 });
+```
+
+Optional: bind a default keyboard shortcut to the command. Users can override it in `keybindings.json` using the `cmd.<name>` keybinding ID:
+
+```typescript
+pi.registerCommand("deploy", {
+  description: "Deploy to staging",
+  defaultKeys: "ctrl+shift+d",
+  handler: async (args, ctx) => {
+    ctx.ui.notify(`Deploying: ${args || "staging"}`, "info");
+  },
+});
+// User override in keybindings.json: { "cmd.deploy": "ctrl+alt+d" }
 ```
 
 Optional: add argument auto-completion for `/command ...`:
@@ -1424,7 +1437,7 @@ Each entry has this shape:
 {
   name: string; // Invokable command name without the leading slash. May be suffixed like "review:1"
   description?: string;
-  source: "extension" | "prompt" | "skill";
+  source: "builtin" | "extension" | "prompt" | "skill";
   sourceInfo: {
     path: string;
     source: string;
@@ -1437,16 +1450,15 @@ Each entry has this shape:
 
 Use `sourceInfo` as the canonical provenance field. Do not infer ownership from command names or from ad hoc path parsing.
 
-Built-in interactive commands (like `/model` and `/settings`) are not included here. They are handled only in interactive
-mode and would not execute if sent via `prompt`.
-
 ### pi.registerMessageRenderer(customType, renderer)
 
 Register a custom TUI renderer for messages with your `customType`. See [Custom UI](#custom-ui).
 
 ### pi.registerShortcut(shortcut, options)
 
-Register a keyboard shortcut. See [keybindings.md](keybindings.md) for the shortcut format and built-in keybindings.
+Register a keyboard shortcut. The handler receives `ExtensionCommandContext`, the same context that command handlers receive, so shortcuts can use session control methods like `ctx.newSession()`, `ctx.reload()`, etc.
+
+See [keybindings.md](keybindings.md) for the shortcut format and built-in keybindings.
 
 ```typescript
 pi.registerShortcut("ctrl+shift+p", {

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -4,7 +4,7 @@ All keyboard shortcuts can be customized via `~/.pi/agent/keybindings.json`. Eac
 
 The config file uses the same namespaced keybinding ids that pi uses internally and that extension authors use in `keyHint()` and injected `keybindings` managers.
 
-Older configs using pre-namespaced ids such as `cursorUp` or `expandTools` are migrated automatically to the namespaced ids on startup.
+Older configs using pre-namespaced ids such as `cursorUp` or `expandTools` are migrated automatically to the namespaced ids on startup. Configs using the previous `app.model.select`, `app.session.new`, `app.session.tree`, `app.session.fork`, or `app.session.resume` ids are migrated to the corresponding `cmd.*` ids.
 
 After editing `keybindings.json`, run `/reload` in pi to apply the changes without restarting the session.
 
@@ -89,14 +89,14 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image from clipboard |
 
+### Commands
+
+All slash commands are bindable as `cmd.<name>` in `keybindings.json`, e.g., `"cmd.model": "ctrl+l"`, `"cmd.export": "ctrl+shift+e"`.
+
 ### Sessions
 
 | Keybinding id | Default | Description |
 |--------|---------|-------------|
-| `app.session.new` | *(none)* | Start a new session (`/new`) |
-| `app.session.tree` | *(none)* | Open session tree navigator (`/tree`) |
-| `app.session.fork` | *(none)* | Fork current session (`/fork`) |
-| `app.session.resume` | *(none)* | Open session resume picker (`/resume`) |
 | `app.session.togglePath` | `ctrl+p` | Toggle path display |
 | `app.session.toggleSort` | `ctrl+s` | Toggle sort mode |
 | `app.session.toggleNamedFilter` | `ctrl+n` | Toggle named-only filter |
@@ -108,7 +108,6 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 
 | Keybinding id | Default | Description |
 |--------|---------|-------------|
-| `app.model.select` | `ctrl+l` | Open model selector |
 | `app.model.cycleForward` | `ctrl+p` | Cycle to next model |
 | `app.model.cycleBackward` | `shift+ctrl+p` | Cycle to previous model |
 | `app.thinking.cycle` | `shift+tab` | Cycle thinking level |

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1137,29 +1137,7 @@ export class AgentSession {
 	 * Try to execute an extension command. Returns true if command was found and executed.
 	 */
 	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
-		// Parse command name and args
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
-
-		const command = this._extensionRunner.getCommand(commandName);
-		if (!command) return false;
-
-		// Get command context from extension runner (includes session control methods)
-		const ctx = this._extensionRunner.createCommandContext();
-
-		try {
-			await command.handler(args, ctx);
-			return true;
-		} catch (err) {
-			// Emit error via extension runner
-			this._extensionRunner.emitError({
-				extensionPath: `command:${commandName}`,
-				event: "command",
-				error: err instanceof Error ? err.message : String(err),
-			});
-			return true;
-		}
+		return this._extensionRunner.tryExecuteCommand(text);
 	}
 
 	/**
@@ -2164,7 +2142,7 @@ export class AgentSession {
 			const extensionCommands: SlashCommandInfo[] = runner.getRegisteredCommands().map((command) => ({
 				name: command.invocationName,
 				description: command.description,
-				source: "extension",
+				source: command.sourceInfo.source === "builtin" ? "builtin" : "extension",
 				sourceInfo: command.sourceInfo,
 			}));
 

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -211,7 +211,7 @@ function createExtensionAPI(
 			shortcut: KeyId,
 			options: {
 				description?: string;
-				handler: (ctx: import("./types.ts").ExtensionContext) => Promise<void> | void;
+				handler: (ctx: import("./types.ts").ExtensionCommandContext) => Promise<void> | void;
 			},
 		): void {
 			runtime.assertActive();

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -67,7 +67,6 @@ const RESERVED_KEYBINDINGS_FOR_EXTENSION_CONFLICTS = [
 	"app.thinking.cycle",
 	"app.model.cycleForward",
 	"app.model.cycleBackward",
-	"app.model.select",
 	"app.tools.expand",
 	"app.thinking.toggle",
 	"app.editor.external",
@@ -244,6 +243,7 @@ export class ExtensionRunner {
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private reloadHandler: ReloadHandler = async () => {};
 	private shutdownHandler: ShutdownHandler = () => {};
+	private builtinCommands = new Map<string, RegisteredCommand>();
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
 	private staleMessage: string | undefined;
@@ -414,6 +414,25 @@ export class ExtensionRunner {
 		return new Map(this.runtime.flagValues);
 	}
 
+	/**
+	 * Register a built-in command. Built-in commands take precedence over extension commands.
+	 */
+	registerBuiltinCommand(name: string, command: Omit<RegisteredCommand, "name">): void {
+		this.builtinCommands.set(name, { name, ...command });
+	}
+
+	/**
+	 * Get keybinding definitions and command associations for all registered commands.
+	 * Commands without defaultKeys get an empty default so users can bind them in keybindings.json.
+	 */
+	getCommandKeybindings(): Array<{ keybindingId: string; command: ResolvedCommand }> {
+		const result: Array<{ keybindingId: string; command: ResolvedCommand }> = [];
+		for (const command of this.resolveRegisteredCommands()) {
+			result.push({ keybindingId: `cmd.${command.invocationName}`, command });
+		}
+		return result;
+	}
+
 	getShortcuts(resolvedKeybindings: KeybindingsConfig): Map<KeyId, ExtensionShortcut> {
 		this.shortcutDiagnostics = [];
 		const builtinKeybindings = buildBuiltinKeybindings(resolvedKeybindings);
@@ -513,6 +532,12 @@ export class ExtensionRunner {
 		const commands: RegisteredCommand[] = [];
 		const counts = new Map<string, number>();
 
+		// Built-in commands first so they take precedence
+		for (const command of this.builtinCommands.values()) {
+			commands.push(command);
+			counts.set(command.name, (counts.get(command.name) ?? 0) + 1);
+		}
+
 		for (const ext of this.extensions) {
 			for (const command of ext.commands.values()) {
 				commands.push(command);
@@ -527,7 +552,10 @@ export class ExtensionRunner {
 			const occurrence = (seen.get(command.name) ?? 0) + 1;
 			seen.set(command.name, occurrence);
 
-			let invocationName = (counts.get(command.name) ?? 0) > 1 ? `${command.name}:${occurrence}` : command.name;
+			// Built-in commands keep the bare name; only extension duplicates get suffixed
+			const isBuiltin = occurrence === 1 && this.builtinCommands.has(command.name);
+			let invocationName =
+				(counts.get(command.name) ?? 0) > 1 && !isBuiltin ? `${command.name}:${occurrence}` : command.name;
 
 			if (takenInvocationNames.has(invocationName)) {
 				let suffix = occurrence;
@@ -537,10 +565,23 @@ export class ExtensionRunner {
 				} while (takenInvocationNames.has(invocationName));
 			}
 
+			const builtinConflict = invocationName !== command.name && this.builtinCommands.has(command.name);
+			if (invocationName !== command.name) {
+				this.commandDiagnostics.push({
+					type: "warning",
+					message: builtinConflict
+						? `Extension command '/${command.name}' conflicts with built-in command. Skipping.`
+						: `Extension command '/${command.name}' has duplicate registrations. Available as '/${invocationName}'.`,
+					path: command.sourceInfo.path,
+				});
+			}
+
 			takenInvocationNames.add(invocationName);
 			return {
 				...command,
 				invocationName,
+				// Hide extension commands that conflict with built-in names
+				...(builtinConflict && { hidden: true }),
 			};
 		});
 	}
@@ -556,6 +597,36 @@ export class ExtensionRunner {
 
 	getCommand(name: string): ResolvedCommand | undefined {
 		return this.resolveRegisteredCommands().find((command) => command.invocationName === name);
+	}
+
+	/**
+	 * Try to execute a slash command. Returns true if the command was found and executed.
+	 * When includeBuiltin is false (the default), built-in commands are skipped —
+	 * they are only dispatched from the interactive submit handler.
+	 */
+	async tryExecuteCommand(text: string, options?: { includeBuiltin?: boolean }): Promise<boolean> {
+		if (!text.startsWith("/")) return false;
+
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+
+		const command = this.getCommand(commandName);
+		if (!command) return false;
+		if (!options?.includeBuiltin && this.builtinCommands.has(command.name)) return false;
+
+		const ctx = this.createCommandContext();
+		try {
+			await command.handler(args, ctx);
+		} catch (err) {
+			this.emitError({
+				extensionPath: command.sourceInfo.path,
+				event: "command",
+				error: err instanceof Error ? err.message : String(err),
+				stack: err instanceof Error ? err.stack : undefined,
+			});
+		}
+		return true;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1064,6 +1064,9 @@ export interface RegisteredCommand {
 	name: string;
 	sourceInfo: SourceInfo;
 	description?: string;
+	defaultKeys?: KeyId | KeyId[];
+	/** Hide from autocomplete suggestions. */
+	hidden?: boolean;
 	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null | Promise<AutocompleteItem[] | null>;
 	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>;
 }
@@ -1148,7 +1151,7 @@ export interface ExtensionAPI {
 		shortcut: KeyId,
 		options: {
 			description?: string;
-			handler: (ctx: ExtensionContext) => Promise<void> | void;
+			handler: (ctx: ExtensionCommandContext) => Promise<void> | void;
 		},
 	): void;
 
@@ -1400,7 +1403,7 @@ export interface ExtensionFlag {
 export interface ExtensionShortcut {
 	shortcut: KeyId;
 	description?: string;
-	handler: (ctx: ExtensionContext) => Promise<void> | void;
+	handler: (ctx: ExtensionCommandContext) => Promise<void> | void;
 	extensionPath: string;
 }
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -18,7 +18,6 @@ export interface AppKeybindings {
 	"app.thinking.cycle": true;
 	"app.model.cycleForward": true;
 	"app.model.cycleBackward": true;
-	"app.model.select": true;
 	"app.tools.expand": true;
 	"app.thinking.toggle": true;
 	"app.session.toggleNamedFilter": true;
@@ -26,10 +25,6 @@ export interface AppKeybindings {
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
 	"app.clipboard.pasteImage": true;
-	"app.session.new": true;
-	"app.session.tree": true;
-	"app.session.fork": true;
-	"app.session.resume": true;
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
 	"app.tree.editLabel": true;
@@ -81,7 +76,6 @@ export const KEYBINDINGS = {
 		defaultKeys: "shift+ctrl+p",
 		description: "Cycle to previous model",
 	},
-	"app.model.select": { defaultKeys: "ctrl+l", description: "Open model selector" },
 	"app.tools.expand": { defaultKeys: "ctrl+o", description: "Toggle tool output" },
 	"app.thinking.toggle": {
 		defaultKeys: "ctrl+t",
@@ -107,10 +101,6 @@ export const KEYBINDINGS = {
 		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
 		description: "Paste image from clipboard",
 	},
-	"app.session.new": { defaultKeys: [], description: "Start a new session" },
-	"app.session.tree": { defaultKeys: [], description: "Open session tree" },
-	"app.session.fork": { defaultKeys: [], description: "Fork current session" },
-	"app.session.resume": { defaultKeys: [], description: "Resume a session" },
 	"app.tree.foldOrUp": {
 		defaultKeys: ["ctrl+left", "alt+left"],
 		description: "Fold tree branch or move up",
@@ -240,7 +230,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	cycleThinkingLevel: "app.thinking.cycle",
 	cycleModelForward: "app.model.cycleForward",
 	cycleModelBackward: "app.model.cycleBackward",
-	selectModel: "app.model.select",
+	selectModel: "cmd.model",
 	expandTools: "app.tools.expand",
 	toggleThinking: "app.thinking.toggle",
 	toggleSessionNamedFilter: "app.session.toggleNamedFilter",
@@ -248,10 +238,10 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	followUp: "app.message.followUp",
 	dequeue: "app.message.dequeue",
 	pasteImage: "app.clipboard.pasteImage",
-	newSession: "app.session.new",
-	tree: "app.session.tree",
-	fork: "app.session.fork",
-	resume: "app.session.resume",
+	newSession: "cmd.new",
+	tree: "cmd.tree",
+	fork: "cmd.fork",
+	resume: "cmd.resume",
 	treeFoldOrUp: "app.tree.foldOrUp",
 	treeUnfoldOrDown: "app.tree.unfoldOrDown",
 	treeEditLabel: "app.tree.editLabel",
@@ -261,7 +251,13 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	renameSession: "app.session.rename",
 	deleteSession: "app.session.delete",
 	deleteSessionNoninvasive: "app.session.deleteNoninvasive",
-} as const satisfies Record<string, Keybinding>;
+	// app.* → cmd.* migrations (commands moved to unified command system)
+	"app.model.select": "cmd.model",
+	"app.session.new": "cmd.new",
+	"app.session.tree": "cmd.tree",
+	"app.session.fork": "cmd.fork",
+	"app.session.resume": "cmd.resume",
+} as const satisfies Record<string, Keybinding | `cmd.${string}`>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -1,7 +1,6 @@
-import { APP_NAME } from "../config.ts";
 import type { SourceInfo } from "./source-info.ts";
 
-export type SlashCommandSource = "extension" | "prompt" | "skill";
+export type SlashCommandSource = "builtin" | "extension" | "prompt" | "skill";
 
 export interface SlashCommandInfo {
 	name: string;
@@ -9,32 +8,3 @@ export interface SlashCommandInfo {
 	source: SlashCommandSource;
 	sourceInfo: SourceInfo;
 }
-
-export interface BuiltinSlashCommand {
-	name: string;
-	description: string;
-}
-
-export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
-	{ name: "settings", description: "Open settings menu" },
-	{ name: "model", description: "Select model (opens selector UI)" },
-	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
-	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
-	{ name: "import", description: "Import and resume a session from a JSONL file" },
-	{ name: "share", description: "Share session as a secret GitHub gist" },
-	{ name: "copy", description: "Copy last agent message to clipboard" },
-	{ name: "name", description: "Set session display name" },
-	{ name: "session", description: "Show session info and stats" },
-	{ name: "changelog", description: "Show changelog entries" },
-	{ name: "hotkeys", description: "Show all keyboard shortcuts" },
-	{ name: "fork", description: "Create a new fork from a previous user message" },
-	{ name: "clone", description: "Duplicate the current session at the current position" },
-	{ name: "tree", description: "Navigate session tree (switch branches)" },
-	{ name: "login", description: "Configure provider authentication" },
-	{ name: "logout", description: "Remove provider authentication" },
-	{ name: "new", description: "Start a new session" },
-	{ name: "compact", description: "Manually compact the session context" },
-	{ name: "resume", description: "Resume a different session" },
-	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
-	{ name: "quit", description: `Quit ${APP_NAME}` },
-];

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -7,6 +7,7 @@ import type { AppKeybinding, KeybindingsManager } from "../../../core/keybinding
 export class CustomEditor extends Editor {
 	private keybindings: KeybindingsManager;
 	public actionHandlers: Map<AppKeybinding, () => void> = new Map();
+	public commandHandlers: Map<string, () => void> = new Map();
 
 	// Special handlers that can be dynamically replaced
 	public onEscape?: () => void;
@@ -25,6 +26,13 @@ export class CustomEditor extends Editor {
 	 */
 	onAction(action: AppKeybinding, handler: () => void): void {
 		this.actionHandlers.set(action, handler);
+	}
+
+	/**
+	 * Register a handler for a command keybinding.
+	 */
+	onCommandAction(keybindingId: string, handler: () => void): void {
+		this.commandHandlers.set(keybindingId, handler);
 	}
 
 	handleInput(data: string): void {
@@ -69,6 +77,14 @@ export class CustomEditor extends Editor {
 		// Check all other app actions
 		for (const [action, handler] of this.actionHandlers) {
 			if (action !== "app.interrupt" && action !== "app.exit" && this.keybindings.matches(data, action)) {
+				handler();
+				return;
+			}
+		}
+
+		// Check command keybindings
+		for (const [keybindingId, handler] of this.commandHandlers) {
+			if (this.keybindings.matches(data, keybindingId)) {
 				handler();
 				return;
 			}

--- a/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
@@ -31,15 +31,15 @@ function formatKeys(keys: KeyId[], options: KeyTextFormatOptions = {}): string {
 	return formatKeyText(keys.join("/"), options);
 }
 
-export function keyText(keybinding: Keybinding): string {
+export function keyText(keybinding: Keybinding | string): string {
 	return formatKeys(getKeybindings().getKeys(keybinding));
 }
 
-export function keyDisplayText(keybinding: Keybinding): string {
+export function keyDisplayText(keybinding: Keybinding | string): string {
 	return formatKeys(getKeybindings().getKeys(keybinding), { capitalize: true });
 }
 
-export function keyHint(keybinding: Keybinding, description: string): string {
+export function keyHint(keybinding: Keybinding | string, description: string): string {
 	return theme.fg("dim", keyText(keybinding)) + theme.fg("muted", ` ${description}`);
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -65,7 +65,6 @@ import type {
 	AutocompleteProviderFactory,
 	EditorFactory,
 	ExtensionCommandContext,
-	ExtensionContext,
 	ExtensionRunner,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
@@ -81,8 +80,8 @@ import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../../core/provider-display-nam
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.ts";
 import { type SessionContext, SessionManager } from "../../core/session-manager.ts";
-import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.ts";
 import type { SourceInfo } from "../../core/source-info.ts";
+import { createSyntheticSourceInfo } from "../../core/source-info.ts";
 import { isInstallTelemetryEnabled } from "../../core/telemetry.ts";
 import type { TruncationResult } from "../../core/tools/truncate.ts";
 import { getChangelogPath, getNewEntries, parseChangelog } from "../../utils/changelog.ts";
@@ -454,58 +453,19 @@ export class InteractiveMode {
 		return description ? `[${sourceTag}] ${description}` : `[${sourceTag}]`;
 	}
 
-	private getBuiltInCommandConflictDiagnostics(extensionRunner: ExtensionRunner): ResourceDiagnostic[] {
-		const builtinNames = new Set(BUILTIN_SLASH_COMMANDS.map((command) => command.name));
-		return extensionRunner
-			.getRegisteredCommands()
-			.filter((command) => builtinNames.has(command.name))
-			.map((command) => ({
-				type: "warning" as const,
-				message:
-					command.invocationName === command.name
-						? `Extension command '/${command.name}' conflicts with built-in interactive command. Skipping in autocomplete.`
-						: `Extension command '/${command.name}' conflicts with built-in interactive command. Available as '/${command.invocationName}'.`,
-				path: command.sourceInfo.path,
-			}));
-	}
-
 	private createBaseAutocompleteProvider(): AutocompleteProvider {
-		// Define commands for autocomplete
-		const slashCommands: SlashCommand[] = BUILTIN_SLASH_COMMANDS.map((command) => ({
-			name: command.name,
-			description: command.description,
-		}));
-
-		const modelCommand = slashCommands.find((command) => command.name === "model");
-		if (modelCommand) {
-			modelCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] | null => {
-				// Get available models (scoped or from registry)
-				const models =
-					this.session.scopedModels.length > 0
-						? this.session.scopedModels.map((s) => s.model)
-						: this.session.modelRegistry.getAvailable();
-
-				if (models.length === 0) return null;
-
-				// Create items with provider/id format
-				const items = models.map((m) => ({
-					id: m.id,
-					provider: m.provider,
-					label: `${m.provider}/${m.id}`,
-				}));
-
-				// Fuzzy filter by model ID + provider (allows "opus anthropic" to match)
-				const filtered = fuzzyFilter(items, prefix, (item) => `${item.id} ${item.provider}`);
-
-				if (filtered.length === 0) return null;
-
-				return filtered.map((item) => ({
-					value: item.label,
-					label: item.id,
-					description: item.provider,
-				}));
-			};
-		}
+		// All registered commands (built-in + extension) are in the unified list
+		const commandList: SlashCommand[] = this.session.extensionRunner
+			.getRegisteredCommands()
+			.filter((cmd) => !cmd.hidden)
+			.map((cmd) => ({
+				name: cmd.invocationName,
+				description:
+					cmd.sourceInfo.source === "builtin"
+						? cmd.description
+						: this.prefixAutocompleteDescription(cmd.description, cmd.sourceInfo),
+				getArgumentCompletions: cmd.getArgumentCompletions,
+			}));
 
 		// Convert prompt templates to SlashCommand format for autocomplete
 		const templateCommands: SlashCommand[] = this.session.promptTemplates.map((cmd) => ({
@@ -513,17 +473,6 @@ export class InteractiveMode {
 			description: this.prefixAutocompleteDescription(cmd.description, cmd.sourceInfo),
 			...(cmd.argumentHint && { argumentHint: cmd.argumentHint }),
 		}));
-
-		// Convert extension commands to SlashCommand format
-		const builtinCommandNames = new Set(slashCommands.map((c) => c.name));
-		const extensionCommands: SlashCommand[] = this.session.extensionRunner
-			.getRegisteredCommands()
-			.filter((cmd) => !builtinCommandNames.has(cmd.name))
-			.map((cmd) => ({
-				name: cmd.invocationName,
-				description: this.prefixAutocompleteDescription(cmd.description, cmd.sourceInfo),
-				getArgumentCompletions: cmd.getArgumentCompletions,
-			}));
 
 		// Build skill commands from session.skills (if enabled)
 		this.skillCommands.clear();
@@ -540,7 +489,7 @@ export class InteractiveMode {
 		}
 
 		return new CombinedAutocompleteProvider(
-			[...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList],
+			[...commandList, ...templateCommands, ...skillCommandList],
 			this.sessionManager.getCwd(),
 			this.fdPath,
 		);
@@ -625,7 +574,7 @@ export class InteractiveMode {
 			const logo = theme.bold(theme.fg("accent", APP_NAME)) + theme.fg("dim", ` v${this.version}`);
 
 			// Build startup instructions using keybinding hint helpers
-			const hint = (keybinding: AppKeybinding, description: string) => keyHint(keybinding, description);
+			const hint = (keybinding: AppKeybinding | string, description: string) => keyHint(keybinding, description);
 
 			const expandedInstructions = [
 				hint("app.interrupt", "to interrupt"),
@@ -636,7 +585,7 @@ export class InteractiveMode {
 				keyHint("tui.editor.deleteToLineEnd", "to delete to end"),
 				hint("app.thinking.cycle", "to cycle thinking level"),
 				rawKeyHint(`${keyText("app.model.cycleForward")}/${keyText("app.model.cycleBackward")}`, "to cycle models"),
-				hint("app.model.select", "to select model"),
+				hint("cmd.model", "to select model"),
 				hint("app.tools.expand", "to expand tools"),
 				hint("app.thinking.toggle", "to expand thinking"),
 				hint("app.editor.external", "for external editor"),
@@ -1479,7 +1428,6 @@ export class InteractiveMode {
 
 			const commandDiagnostics = this.session.extensionRunner.getCommandDiagnostics();
 			extensionDiagnostics.push(...commandDiagnostics);
-			extensionDiagnostics.push(...this.getBuiltInCommandConflictDiagnostics(this.session.extensionRunner));
 
 			const shortcutDiagnostics = this.session.extensionRunner.getShortcutDiagnostics();
 			extensionDiagnostics.push(...shortcutDiagnostics);
@@ -1501,10 +1449,185 @@ export class InteractiveMode {
 		}
 	}
 
+	private static readonly BUILTIN_SOURCE_INFO = createSyntheticSourceInfo("<builtin>", { source: "builtin" });
+
+	/**
+	 * Register built-in slash commands on the extension runner so they participate
+	 * in the unified command system (autocomplete, keybinding dispatch, precedence).
+	 */
+	private registerBuiltinCommands(): void {
+		const runner = this.session.extensionRunner;
+		const sourceInfo = InteractiveMode.BUILTIN_SOURCE_INFO;
+
+		const register = (
+			name: string,
+			description: string,
+			handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>,
+			options?: {
+				defaultKeys?: KeyId | KeyId[];
+				hidden?: boolean;
+				getArgumentCompletions?: (prefix: string) => AutocompleteItem[] | null;
+			},
+		) => {
+			runner.registerBuiltinCommand(name, {
+				sourceInfo,
+				description,
+				handler,
+				defaultKeys: options?.defaultKeys,
+				hidden: options?.hidden,
+				getArgumentCompletions: options?.getArgumentCompletions,
+			});
+		};
+
+		register("settings", "Open settings menu", async () => {
+			this.showSettingsSelector();
+		});
+
+		register("scoped-models", "Enable/disable models for Ctrl+P cycling", async () => {
+			await this.showModelsSelector();
+		});
+
+		register(
+			"model",
+			"Select model (opens selector UI)",
+			async (args) => {
+				const searchTerm = args.trim() || undefined;
+				await this.handleModelCommand(searchTerm);
+			},
+			{
+				defaultKeys: "ctrl+l",
+				getArgumentCompletions: (prefix) => {
+					const models =
+						this.session.scopedModels.length > 0
+							? this.session.scopedModels.map((s) => s.model)
+							: this.session.modelRegistry.getAvailable();
+					if (models.length === 0) return null;
+					const items = models.map((m) => ({
+						id: m.id,
+						provider: m.provider,
+						label: `${m.provider}/${m.id}`,
+					}));
+					const filtered = fuzzyFilter(items, prefix, (item) => `${item.id} ${item.provider}`);
+					if (filtered.length === 0) return null;
+					return filtered.map((item) => ({
+						value: item.label,
+						label: item.id,
+						description: item.provider,
+					}));
+				},
+			},
+		);
+
+		register("export", "Export session (HTML default, or specify path: .html/.jsonl)", async (args) => {
+			const text = args ? `/export ${args}` : "/export";
+			await this.handleExportCommand(text);
+		});
+
+		register("import", "Import and resume a session from a JSONL file", async (args) => {
+			const text = args ? `/import ${args}` : "/import";
+			await this.handleImportCommand(text);
+		});
+
+		register("share", "Share session as a secret GitHub gist", async () => {
+			await this.handleShareCommand();
+		});
+
+		register("copy", "Copy last agent message to clipboard", async () => {
+			await this.handleCopyCommand();
+		});
+
+		register("name", "Set session display name", async (args) => {
+			const text = args ? `/name ${args}` : "/name";
+			this.handleNameCommand(text);
+		});
+
+		register("session", "Show session info and stats", async () => {
+			this.handleSessionCommand();
+		});
+
+		register("changelog", "Show changelog entries", async () => {
+			this.handleChangelogCommand();
+		});
+
+		register("hotkeys", "Show all keyboard shortcuts", async () => {
+			this.handleHotkeysCommand();
+		});
+
+		register("fork", "Create a new fork from a previous user message", async () => {
+			this.showUserMessageSelector();
+		});
+
+		register("clone", "Duplicate the current session at the current position", async () => {
+			await this.handleCloneCommand();
+		});
+
+		register("tree", "Navigate session tree (switch branches)", async () => {
+			this.showTreeSelector();
+		});
+
+		register("login", "Configure provider authentication", async () => {
+			this.showOAuthSelector("login");
+		});
+
+		register("logout", "Remove provider authentication", async () => {
+			this.showOAuthSelector("logout");
+		});
+
+		register("new", "Start a new session", async () => {
+			await this.handleClearCommand();
+		});
+
+		register("compact", "Manually compact the session context", async (args) => {
+			const customInstructions = args.trim() || undefined;
+			await this.handleCompactCommand(customInstructions);
+		});
+
+		register("resume", "Resume a different session", async () => {
+			this.showSessionSelector();
+		});
+
+		register("reload", "Reload keybindings, extensions, skills, prompts, and themes", async (_args, ctx) => {
+			await ctx.reload();
+		});
+
+		register("quit", `Quit ${APP_NAME}`, async () => {
+			await this.shutdown();
+		});
+
+		// Easter eggs (not shown in autocomplete but still dispatchable)
+		register(
+			"debug",
+			"Show debug info",
+			async () => {
+				this.handleDebugCommand();
+			},
+			{ hidden: true },
+		);
+
+		register(
+			"arminsayshi",
+			"",
+			async () => {
+				this.handleArminSaysHi();
+			},
+			{ hidden: true },
+		);
+
+		register(
+			"dementedelves",
+			"",
+			async () => {
+				this.handleDementedDelves();
+			},
+			{ hidden: true },
+		);
+	}
+
 	/**
 	 * Initialize the extension system with TUI-based UI context.
 	 */
 	private async bindCurrentSessionExtensions(): Promise<void> {
+		this.registerBuiltinCommands();
 		const uiContext = this.createExtensionUIContext();
 		await this.session.bindExtensions({
 			uiContext,
@@ -1582,9 +1705,10 @@ export class InteractiveMode {
 		});
 
 		setRegisteredThemes(this.session.resourceLoader.getThemes().themes);
-		this.setupAutocompleteProvider();
 
 		const extensionRunner = this.session.extensionRunner;
+		this.bindCommandKeybindings(extensionRunner);
+		this.setupAutocompleteProvider();
 		this.setupExtensionShortcuts(extensionRunner);
 		this.showLoadedResources({ force: false, showDiagnosticsWhenQuiet: true });
 		this.showStartupNoticesIfNeeded();
@@ -1647,41 +1771,37 @@ export class InteractiveMode {
 	/**
 	 * Set up keyboard shortcuts registered by extensions.
 	 */
+	/**
+	 * Inject command keybinding definitions and register keyboard handlers.
+	 */
+	private bindCommandKeybindings(extensionRunner: ExtensionRunner): void {
+		const bindings = extensionRunner.getCommandKeybindings();
+		if (bindings.length > 0) {
+			const definitions: Record<string, { defaultKeys: KeyId | KeyId[]; description?: string }> = {};
+			for (const { keybindingId, command } of bindings) {
+				definitions[keybindingId] = { defaultKeys: command.defaultKeys ?? [], description: command.description };
+			}
+			this.keybindings.addDefinitions(definitions);
+		}
+		this.defaultEditor.commandHandlers.clear();
+		for (const { keybindingId, command } of bindings) {
+			this.defaultEditor.onCommandAction(keybindingId, () => {
+				const ctx = extensionRunner.createCommandContext();
+				Promise.resolve(command.handler("", ctx)).catch((err) => {
+					extensionRunner.emitError({
+						extensionPath: command.sourceInfo.path,
+						event: "command",
+						error: err instanceof Error ? err.message : String(err),
+						stack: err instanceof Error ? err.stack : undefined,
+					});
+				});
+			});
+		}
+	}
+
 	private setupExtensionShortcuts(extensionRunner: ExtensionRunner): void {
 		const shortcuts = extensionRunner.getShortcuts(this.keybindings.getEffectiveConfig());
 		if (shortcuts.size === 0) return;
-
-		// Create a context for shortcut handlers
-		const createContext = (): ExtensionContext => ({
-			ui: this.createExtensionUIContext(),
-			hasUI: true,
-			cwd: this.sessionManager.getCwd(),
-			sessionManager: this.sessionManager,
-			modelRegistry: this.session.modelRegistry,
-			model: this.session.model,
-			isIdle: () => !this.session.isStreaming,
-			signal: this.session.agent.signal,
-			abort: () => {
-				this.restoreQueuedMessagesToEditor({ abort: true });
-			},
-			hasPendingMessages: () => this.session.pendingMessageCount > 0,
-			shutdown: () => {
-				this.shutdownRequested = true;
-			},
-			getContextUsage: () => this.session.getContextUsage(),
-			compact: (options) => {
-				void (async () => {
-					try {
-						const result = await this.session.compact(options?.customInstructions);
-						options?.onComplete?.(result);
-					} catch (error) {
-						const err = error instanceof Error ? error : new Error(String(error));
-						options?.onError?.(err);
-					}
-				})();
-			},
-			getSystemPrompt: () => this.session.systemPrompt,
-		});
 
 		// Set up the extension shortcut handler on the default editor
 		this.defaultEditor.onExtensionShortcut = (data: string) => {
@@ -1689,7 +1809,7 @@ export class InteractiveMode {
 				// Cast to KeyId - extension shortcuts use the same format
 				if (matchesKey(data, shortcutStr as KeyId)) {
 					// Run handler async, don't block input
-					Promise.resolve(shortcut.handler(createContext())).catch((err) => {
+					Promise.resolve(shortcut.handler(extensionRunner.createCommandContext())).catch((err) => {
 						this.showError(`Shortcut handler error: ${err instanceof Error ? err.message : String(err)}`);
 					});
 					return true;
@@ -2438,16 +2558,11 @@ export class InteractiveMode {
 
 		// Global debug handler on TUI (works regardless of focus)
 		this.ui.onDebug = () => this.handleDebugCommand();
-		this.defaultEditor.onAction("app.model.select", () => this.showModelSelector());
 		this.defaultEditor.onAction("app.tools.expand", () => this.toggleToolOutputExpansion());
 		this.defaultEditor.onAction("app.thinking.toggle", () => this.toggleThinkingBlockVisibility());
 		this.defaultEditor.onAction("app.editor.external", () => this.openExternalEditor());
 		this.defaultEditor.onAction("app.message.followUp", () => this.handleFollowUp());
 		this.defaultEditor.onAction("app.message.dequeue", () => this.handleDequeue());
-		this.defaultEditor.onAction("app.session.new", () => this.handleClearCommand());
-		this.defaultEditor.onAction("app.session.tree", () => this.showTreeSelector());
-		this.defaultEditor.onAction("app.session.fork", () => this.showUserMessageSelector());
-		this.defaultEditor.onAction("app.session.resume", () => this.showSessionSelector());
 
 		this.defaultEditor.onChange = (text: string) => {
 			const wasBashMode = this.isBashMode;
@@ -2490,127 +2605,11 @@ export class InteractiveMode {
 			text = text.trim();
 			if (!text) return;
 
-			// Handle commands
-			if (text === "/settings") {
-				this.showSettingsSelector();
+			// Handle registered commands (built-in + extension)
+			if (text.startsWith("/") && this.session.extensionRunner.getCommand(text.slice(1).split(" ")[0]!)) {
+				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				return;
-			}
-			if (text === "/scoped-models") {
-				this.editor.setText("");
-				await this.showModelsSelector();
-				return;
-			}
-			if (text === "/model" || text.startsWith("/model ")) {
-				const searchTerm = text.startsWith("/model ") ? text.slice(7).trim() : undefined;
-				this.editor.setText("");
-				await this.handleModelCommand(searchTerm);
-				return;
-			}
-			if (text === "/export" || text.startsWith("/export ")) {
-				await this.handleExportCommand(text);
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/import" || text.startsWith("/import ")) {
-				await this.handleImportCommand(text);
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/share") {
-				await this.handleShareCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/copy") {
-				await this.handleCopyCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/name" || text.startsWith("/name ")) {
-				this.handleNameCommand(text);
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/session") {
-				this.handleSessionCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/changelog") {
-				this.handleChangelogCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/hotkeys") {
-				this.handleHotkeysCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/fork") {
-				this.showUserMessageSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/clone") {
-				this.editor.setText("");
-				await this.handleCloneCommand();
-				return;
-			}
-			if (text === "/tree") {
-				this.showTreeSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/login") {
-				this.showOAuthSelector("login");
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/logout") {
-				this.showOAuthSelector("logout");
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/new") {
-				this.editor.setText("");
-				await this.handleClearCommand();
-				return;
-			}
-			if (text === "/compact" || text.startsWith("/compact ")) {
-				const customInstructions = text.startsWith("/compact ") ? text.slice(9).trim() : undefined;
-				this.editor.setText("");
-				await this.handleCompactCommand(customInstructions);
-				return;
-			}
-			if (text === "/reload") {
-				this.editor.setText("");
-				await this.handleReloadCommand();
-				return;
-			}
-			if (text === "/debug") {
-				this.handleDebugCommand();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/arminsayshi") {
-				this.handleArminSaysHi();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/dementedelves") {
-				this.handleDementedDelves();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/resume") {
-				this.showSessionSelector();
-				this.editor.setText("");
-				return;
-			}
-			if (text === "/quit") {
-				this.editor.setText("");
-				await this.shutdown();
+				await this.session.extensionRunner.tryExecuteCommand(text, { includeBuiltin: true });
 				return;
 			}
 
@@ -2634,7 +2633,7 @@ export class InteractiveMode {
 
 			// Queue input during compaction (extension commands execute immediately)
 			if (this.session.isCompacting) {
-				if (this.isExtensionCommand(text)) {
+				if (this.isRegisteredCommand(text)) {
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
 					await this.session.prompt(text);
@@ -3453,7 +3452,7 @@ export class InteractiveMode {
 
 		// Queue input during compaction (extension commands execute immediately)
 		if (this.session.isCompacting) {
-			if (this.isExtensionCommand(text)) {
+			if (this.isRegisteredCommand(text)) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
 				await this.session.prompt(text);
@@ -3773,7 +3772,7 @@ export class InteractiveMode {
 		this.showStatus("Queued message for after compaction");
 	}
 
-	private isExtensionCommand(text: string): boolean {
+	private isRegisteredCommand(text: string): boolean {
 		if (!text.startsWith("/")) return false;
 
 		const extensionRunner = this.session.extensionRunner;
@@ -3807,7 +3806,7 @@ export class InteractiveMode {
 			if (options?.willRetry) {
 				// When retry is pending, queue messages for the retry turn
 				for (const message of queuedMessages) {
-					if (this.isExtensionCommand(message.text)) {
+					if (this.isRegisteredCommand(message.text)) {
 						await this.session.prompt(message.text);
 					} else if (message.mode === "followUp") {
 						await this.session.followUp(message.text);
@@ -3820,7 +3819,7 @@ export class InteractiveMode {
 			}
 
 			// Find first non-extension-command message to use as prompt
-			const firstPromptIndex = queuedMessages.findIndex((message) => !this.isExtensionCommand(message.text));
+			const firstPromptIndex = queuedMessages.findIndex((message) => !this.isRegisteredCommand(message.text));
 			if (firstPromptIndex === -1) {
 				// All extension commands - execute them all
 				for (const message of queuedMessages) {
@@ -3845,7 +3844,7 @@ export class InteractiveMode {
 
 			// Queue remaining messages
 			for (const message of rest) {
-				if (this.isExtensionCommand(message.text)) {
+				if (this.isRegisteredCommand(message.text)) {
 					await this.session.prompt(message.text);
 				} else if (message.mode === "followUp") {
 					await this.session.followUp(message.text);
@@ -4982,8 +4981,10 @@ export class InteractiveMode {
 			}
 			this.ui.setShowHardwareCursor(this.settingsManager.getShowHardwareCursor());
 			this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
-			this.setupAutocompleteProvider();
+			this.registerBuiltinCommands();
 			const runner = this.session.extensionRunner;
+			this.bindCommandKeybindings(runner);
+			this.setupAutocompleteProvider();
 			this.setupExtensionShortcuts(runner);
 			this.rebuildChatFromMessages();
 			dismissReloadBox(this.editor as Component);
@@ -5287,7 +5288,7 @@ export class InteractiveMode {
 	/**
 	 * Get capitalized display string for an app keybinding action.
 	 */
-	private getAppKeyDisplay(action: AppKeybinding): string {
+	private getAppKeyDisplay(action: AppKeybinding | string): string {
 		return keyDisplayText(action);
 	}
 
@@ -5332,7 +5333,7 @@ export class InteractiveMode {
 		const suspend = this.getAppKeyDisplay("app.suspend");
 		const cycleThinkingLevel = this.getAppKeyDisplay("app.thinking.cycle");
 		const cycleModelForward = this.getAppKeyDisplay("app.model.cycleForward");
-		const selectModel = this.getAppKeyDisplay("app.model.select");
+		const selectModel = this.getAppKeyDisplay("cmd.model");
 		const expandTools = this.getAppKeyDisplay("app.tools.expand");
 		const toggleThinking = this.getAppKeyDisplay("app.thinking.toggle");
 		const externalEditor = this.getAppKeyDisplay("app.editor.external");

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -638,7 +638,7 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 					commands.push({
 						name: command.invocationName,
 						description: command.description,
-						source: "extension",
+						source: command.sourceInfo.source === "builtin" ? "builtin" : "extension",
 						sourceInfo: command.sourceInfo,
 					});
 				}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -79,7 +79,7 @@ export interface RpcSlashCommand {
 	/** Human-readable description */
 	description?: string;
 	/** What kind of command this is */
-	source: "extension" | "prompt" | "skill";
+	source: "builtin" | "extension" | "prompt" | "skill";
 	/** Source metadata for the owning resource */
 	sourceInfo: SourceInfo;
 }

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -417,9 +417,128 @@ describe("ExtensionRunner", () => {
 			expect(commands.map((command) => command.name)).toEqual(["shared-cmd", "shared-cmd"]);
 			expect(commands.map((command) => command.invocationName)).toEqual(["shared-cmd:1", "shared-cmd:2"]);
 			expect(commands.map((command) => command.description)).toEqual(["First command", "Second command"]);
-			expect(diagnostics).toEqual([]);
+			expect(diagnostics).toHaveLength(2);
+			expect(diagnostics[0]?.message).toContain("duplicate registrations");
+			expect(diagnostics[0]?.message).toContain("/shared-cmd:1");
+			expect(diagnostics[1]?.message).toContain("/shared-cmd:2");
 			expect(runner.getCommand("shared-cmd:1")?.description).toBe("First command");
 			expect(runner.getCommand("shared-cmd:2")?.description).toBe("Second command");
+		});
+
+		it("hides extension commands that conflict with built-in names", async () => {
+			const cmdCode = `
+				export default function(pi) {
+					pi.registerCommand("model", {
+						description: "Extension model command",
+						handler: async () => {},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "cmd-conflict.ts"), cmdCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			// Built-in must be registered before getRegisteredCommands() for precedence
+			runner.registerBuiltinCommand("model", {
+				sourceInfo: { path: "<builtin>", source: "builtin", scope: "temporary", origin: "top-level" },
+				description: "Built-in model command",
+				handler: async () => {},
+			});
+
+			const commands = runner.getRegisteredCommands();
+			const diagnostics = runner.getCommandDiagnostics();
+
+			const builtin = commands.find((c) => c.invocationName === "model");
+			expect(builtin?.description).toBe("Built-in model command");
+			expect(builtin?.hidden).toBeFalsy();
+
+			const extension = commands.find((c) => c.invocationName === "model:2");
+			expect(extension?.description).toBe("Extension model command");
+			expect(extension?.hidden).toBe(true);
+
+			expect(diagnostics).toHaveLength(1);
+			expect(diagnostics[0]?.message).toContain("conflicts with built-in command");
+			expect(diagnostics[0]?.message).toContain("Skipping");
+		});
+	});
+
+	describe("command keybindings", () => {
+		it("returns keybinding entries for all commands including those without defaultKeys", async () => {
+			const cmdCode = `
+				export default function(pi) {
+					pi.registerCommand("with-keys", {
+						description: "Has default keys",
+						defaultKeys: "ctrl+shift+w",
+						handler: async () => {},
+					});
+					pi.registerCommand("no-keys", {
+						description: "No default keys",
+						handler: async () => {},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "cmd-keys.ts"), cmdCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const bindings = runner.getCommandKeybindings();
+
+			expect(bindings).toHaveLength(2);
+			const withKeys = bindings.find((b) => b.keybindingId === "cmd.with-keys");
+			const noKeys = bindings.find((b) => b.keybindingId === "cmd.no-keys");
+			expect(withKeys?.command.defaultKeys).toBe("ctrl+shift+w");
+			expect(noKeys?.command.defaultKeys).toBeUndefined();
+		});
+	});
+
+	describe("tryExecuteCommand", () => {
+		it("dispatches built-in commands with includeBuiltin", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			runner.bindCore(extensionActions, extensionContextActions);
+			runner.bindCommandContext();
+
+			let called = false;
+			runner.registerBuiltinCommand("test-cmd", {
+				sourceInfo: { path: "<builtin>", source: "builtin", scope: "temporary", origin: "top-level" },
+				description: "Test command",
+				handler: async (args) => {
+					called = true;
+					expect(args).toBe("hello");
+				},
+			});
+
+			const handled = await runner.tryExecuteCommand("/test-cmd hello", { includeBuiltin: true });
+			expect(handled).toBe(true);
+			expect(called).toBe(true);
+		});
+
+		it("skips built-in commands by default", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			runner.bindCore(extensionActions, extensionContextActions);
+			runner.bindCommandContext();
+
+			let called = false;
+			runner.registerBuiltinCommand("model", {
+				sourceInfo: { path: "<builtin>", source: "builtin", scope: "temporary", origin: "top-level" },
+				description: "Built-in model command",
+				handler: async () => {
+					called = true;
+				},
+			});
+
+			const handled = await runner.tryExecuteCommand("/model");
+			expect(handled).toBe(false);
+			expect(called).toBe(false);
+		});
+
+		it("returns false for non-command text", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			const handled = await runner.tryExecuteCommand("hello world");
+			expect(handled).toBe(false);
 		});
 	});
 

--- a/packages/coding-agent/test/keybindings-migration.test.ts
+++ b/packages/coding-agent/test/keybindings-migration.test.ts
@@ -69,6 +69,83 @@ describe("keybindings migration", () => {
 		});
 	});
 
+	it("migrates app.* command keybindings to cmd.*", () => {
+		const agentDir = createAgentDir({
+			"app.model.select": "ctrl+m",
+			"app.session.new": "ctrl+shift+n",
+			"app.session.tree": "ctrl+shift+t",
+			"app.session.fork": "ctrl+shift+f",
+			"app.session.resume": "ctrl+shift+r",
+		});
+		const previousAgentDir = process.env[ENV_AGENT_DIR];
+		process.env[ENV_AGENT_DIR] = agentDir;
+		runMigrations(agentDir);
+		if (previousAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = previousAgentDir;
+		}
+
+		const migrated = JSON.parse(fs.readFileSync(path.join(agentDir, "keybindings.json"), "utf-8")) as Record<
+			string,
+			unknown
+		>;
+		expect(migrated).toEqual({
+			"cmd.model": "ctrl+m",
+			"cmd.new": "ctrl+shift+n",
+			"cmd.tree": "ctrl+shift+t",
+			"cmd.fork": "ctrl+shift+f",
+			"cmd.resume": "ctrl+shift+r",
+		});
+	});
+
+	it("prefers cmd.* value when both app.* and cmd.* exist", () => {
+		const agentDir = createAgentDir({
+			"app.model.select": "ctrl+m",
+			"cmd.model": "ctrl+l",
+		});
+		const previousAgentDir = process.env[ENV_AGENT_DIR];
+		process.env[ENV_AGENT_DIR] = agentDir;
+		runMigrations(agentDir);
+		if (previousAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = previousAgentDir;
+		}
+
+		const migrated = JSON.parse(fs.readFileSync(path.join(agentDir, "keybindings.json"), "utf-8")) as Record<
+			string,
+			unknown
+		>;
+		expect(migrated).toEqual({
+			"cmd.model": "ctrl+l",
+		});
+	});
+
+	it("migrates legacy names through to cmd.* in one step", () => {
+		const agentDir = createAgentDir({
+			selectModel: "ctrl+m",
+			newSession: "ctrl+shift+n",
+		});
+		const previousAgentDir = process.env[ENV_AGENT_DIR];
+		process.env[ENV_AGENT_DIR] = agentDir;
+		runMigrations(agentDir);
+		if (previousAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = previousAgentDir;
+		}
+
+		const migrated = JSON.parse(fs.readFileSync(path.join(agentDir, "keybindings.json"), "utf-8")) as Record<
+			string,
+			unknown
+		>;
+		expect(migrated).toEqual({
+			"cmd.model": "ctrl+m",
+			"cmd.new": "ctrl+shift+n",
+		});
+	});
+
 	it("loads old key names in memory before the file is rewritten", () => {
 		const agentDir = createAgentDir({
 			selectConfirm: "enter",

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -191,16 +191,16 @@ export class KeybindingsManager {
 		}
 	}
 
-	matches(data: string, keybinding: Keybinding): boolean {
-		const keys = this.keysById.get(keybinding) ?? [];
+	matches(data: string, keybinding: Keybinding | string): boolean {
+		const keys = this.keysById.get(keybinding as Keybinding) ?? [];
 		for (const key of keys) {
 			if (matchesKey(data, key)) return true;
 		}
 		return false;
 	}
 
-	getKeys(keybinding: Keybinding): KeyId[] {
-		return [...(this.keysById.get(keybinding) ?? [])];
+	getKeys(keybinding: Keybinding | string): KeyId[] {
+		return [...(this.keysById.get(keybinding as Keybinding) ?? [])];
 	}
 
 	getDefinition(keybinding: Keybinding): KeybindingDefinition {
@@ -209,6 +209,11 @@ export class KeybindingsManager {
 
 	getConflicts(): KeybindingConflict[] {
 		return this.conflicts.map((conflict) => ({ ...conflict, keybindings: [...conflict.keybindings] }));
+	}
+
+	addDefinitions(definitions: KeybindingDefinitions): void {
+		this.definitions = { ...this.definitions, ...definitions };
+		this.rebuild();
 	}
 
 	setUserBindings(userBindings: KeybindingsConfig): void {


### PR DESCRIPTION
This unifies the handling of built-in and extension registered commands and adds a `cmd.<name>` keybinding convention to allow for configuration of keybindings for any command.

The impetus for this change was I have an extension command also available by a registered shortcut, but the command  requires `ExtensionCommandContext` for some features and when invoked via shortcut I only had a `ExtensionContext`. When I looked into improving that it turns out to be almost net-zero in production code, and provides something really useful (I, for one, will find a `/reload` shortcut for development testing really handy).

Existing bindings are aliased when keybindings as loaded via the existing migration mechanism.