### PR TITLE
fix(tui): keep hardware cursor marker during slash-command autocomplete

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -469,8 +469,10 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Render each visible layout line
-		// Emit hardware cursor marker only when focused and not showing autocomplete
-		const emitCursorMarker = this.focused && !this.autocompleteState;
+		// Emit hardware cursor marker when focused so TUI can position the
+		// hardware cursor for IME candidate-window placement even while
+		// autocomplete (e.g. slash-command menu) is visible.
+		const emitCursorMarker = this.focused;
 
 		for (const layoutLine of visibleLines) {
 			let displayText = layoutLine.text;


### PR DESCRIPTION
Remove the !autocompleteState guard so CURSOR_MARKER is still emitted while the slash-command menu is visible. This lets the TUI position the hardware cursor correctly, which fixes IME candidate-window placement for CJK input methods.