### PR TITLE
fix(coding-agent): don't decode non-image binary files as UTF-8 in the read tool

### DIFF
--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -275,6 +275,14 @@ export function createReadToolDefinition(
 							} else {
 								// Read text content.
 								const buffer = await ops.readFile(absolutePath);
+								// Non-image binary files (ZIP/PDF/Office/audio/video/executables, ...) must not be decoded
+								// as UTF-8: that injects NUL bytes and invalid sequences which corrupt downstream persistence
+								// (e.g. Postgres jsonb columns reject NUL) and hand the model an unusable blob. A NUL byte in
+								// the first few KB is the canonical binary signature; valid UTF-8 text never contains one.
+								// Zero-dependency, matching the manual magic-byte sniffing already used for images in utils/mime.ts.
+								if (buffer.subarray(0, 4096).includes(0)) {
+									throw new Error(`${path} appears to be a binary file (NUL byte within the first 4 KB). The read tool supports text files and images (jpg/png/gif/webp); use a dedicated extractor for other binary formats.`);
+								}
 								const textContent = buffer.toString("utf-8");
 								const allLines = textContent.split("\n");
 								const totalFileLines = allLines.length;


### PR DESCRIPTION
## Summary

The `read` tool decodes any non-image file as UTF-8. In
`packages/coding-agent/src/core/tools/read.ts`, once a file's MIME type is not
one of the four supported image types, the text branch does:

```ts
const buffer = await ops.readFile(absolutePath);
const textContent = buffer.toString("utf-8");   // ← runs on binary too
```

Feeding raw binary bytes through `toString("utf-8")` yields a string full of
NUL bytes and invalid UTF-8. Two things break:

1. **Downstream persistence.** Any consumer that stores tool output in a
   Postgres `jsonb` column (or anything that rejects ``) gets a write
   failure. We had to add a `stripNul` mitigator in our persistence layer just
   to stop the 500s — and the stored content was still garbage.
2. **The model loses the thread.** It receives a ZIP/PDF/etc. blob decoded as
   text and then either emits "[assistant turn failed before producing
   content]" or gets stuck repeating "I can't read this file" for the rest of
   the conversation.

Real production reproducer: a user uploaded a `.ods` (LibreOffice Calc — a ZIP
archive, magic bytes `PK\x03\x04`) to a chatbot built on this package. The model
called `read` on the path, got the binary back as a corrupt string, and the
conversation was dead for ~an hour.

This is the same class of issue already fixed for the bash tool (*"Fix crash
when bash command outputs binary data, e.g. `curl` downloading a video file"*) —
just on the read path.

## Reproduction

```bash
printf 'PK\x03\x04dummy' > /tmp/foo.ods
pi --print 'read /tmp/foo.ods'
```

Before: corrupted "text" output containing NUL bytes. After: a clear error
telling the model the file is binary.

## Fix

Add a zero-dependency guard between `ops.readFile()` and `.toString("utf-8")`:
if any of the first 4 KB is a NUL byte, throw instead of decoding.

```ts
const buffer = await ops.readFile(absolutePath);
if (buffer.subarray(0, 4096).includes(0)) {
    throw new Error(`${path} appears to be a binary file (NUL byte within the first 4 KB). The read tool supports text files and images (jpg/png/gif/webp); use a dedicated extractor for other binary formats.`);
}
const textContent = buffer.toString("utf-8");
```

(Full diff below.)

## Design choices

- **Zero new dependency.** A NUL byte in the first few KB is the canonical
  signature of binary content — valid UTF-8 text never contains `U+0000`. This
  mirrors the manual magic-byte sniffing the package already uses for images in
  `utils/mime.ts`, and adds nothing to `package.json`. (An earlier draft used
  `file-type`/`fileTypeFromBuffer` for precise MIME detection, but that isn't a
  declared dependency here and a 1-byte heuristic covers the real-world cases
  without one.)
- **`throw`, consistent with the file.** The text branch already
  `throw`s for the out-of-bounds-offset case a few lines down; the surrounding
  `try/catch` turns it into a normal tool error the model can read and act on.
  If you'd rather return a soft text note (like the truncation notices) instead
  of an error, that's a one-line change — happy to switch.
- **4 KB window.** Bounded, O(1)-ish, and well past every common header
  (ZIP/Office, SQLite at byte 15, ELF, PDF object streams, etc.). The buffer is
  already fully read, so there's no extra IO.

## Known tradeoff

The NUL heuristic has two corner cases, both acceptable for a coding agent's
`read`:

- **UTF-16/UTF-32 text** contains NUL bytes and would be flagged as binary.
  These are vanishingly rare as source/text inputs, and decoding them as UTF-8
  was already broken anyway.
- **A binary whose first 4 KB happens to be NUL-free** (e.g. some PDFs with a
  pure-ASCII header region) would still slip through. If you'd prefer airtight
  detection, I'm glad to follow up with a magic-byte set (or `file-type` as a
  real dependency) — but the zero-dep guard already fixes every case we've hit
  in production.

## Test plan

Functional test of the exact predicate (`buffer.subarray(0, 4096).includes(0)`)
against representative fixtures — attached as `test-guard-functional.mjs`:

| Input                                   | Expected | Result |
|-----------------------------------------|----------|--------|
| ods/xlsx/docx (ZIP `PK\x03\x04\x14\x00`)| block    | block  |
| sqlite (`SQLite format 3\0`)            | block    | block  |
| ELF (`\x7fELF\x02\x01\x01\x00`)         | block    | block  |
| mp3 / ID3 + frame                       | block    | block  |
| utf-16le text (documented FP)           | block    | block  |
| plain `.txt`                            | pass     | pass   |
| `.xml`                                  | pass     | pass   |
| `.json`                                 | pass     | pass   |
| `.js` source                            | pass     | pass   |
| markdown with emoji (multibyte UTF-8)   | pass     | pass   |

`10/10`. Happy to add a proper unit test in the read tool's existing test shape
if you point me at it.
