### PR TITLE
fix(tui): overlay CJK before-segment strict wide-char boundary

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1121,7 +1121,7 @@ export function extractSegments(
 		for (const { segment } of graphemeSegmenter.segment(line.slice(i, textEnd))) {
 			const w = graphemeWidth(segment);
 
-			if (currentCol < beforeEnd) {
+			if (currentCol + w <= beforeEnd) {
 				if (pendingAnsiBefore) {
 					before += pendingAnsiBefore;
 					pendingAnsiBefore = "";

--- a/packages/tui/test/regression-overlay-cjk-boundary.test.ts
+++ b/packages/tui/test/regression-overlay-cjk-boundary.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { extractSegments, visibleWidth } from "../src/utils.ts";
+import { TUI } from "../src/tui.ts";
+
+const dummyTerminal = {
+	columns: 80,
+	rows: 24,
+	write() {},
+	hideCursor() {},
+	showCursor() {},
+	start() {},
+	stop() {},
+};
+
+describe("overlay CJK boundary regression", () => {
+	it("does not keep a wide grapheme in before when overlay starts inside it", () => {
+		const { before, beforeWidth } = extractSegments("abcd让EFGH", 5, 9, 11, true);
+		assert.strictEqual(before.includes("让"), false);
+		assert.strictEqual(beforeWidth, 4);
+		assert.strictEqual(before, "abcd");
+	});
+
+	it("composites overlay without leaking wide char before overlay (col 5)", () => {
+		const tui = new TUI(dummyTerminal);
+		const out = tui.compositeLineAt("abcd让EFGH", "│XX│", 5, 4, 20);
+		assert.strictEqual(out.includes("让"), false);
+		assert.strictEqual(visibleWidth(out), 20);
+	});
+
+	it("composites overlay at wide char start (col 4)", () => {
+		const tui = new TUI(dummyTerminal);
+		const out = tui.compositeLineAt("abcd让EFGH", "│XX│", 4, 4, 20);
+		assert.strictEqual(out.includes("让"), false);
+		assert.strictEqual(visibleWidth(out), 20);
+	});
+
+	it("keeps ASCII control behavior when overlay starts at col 5", () => {
+		const { before, beforeWidth } = extractSegments("abcdG EFGH", 5, 9, 11, true);
+		assert.strictEqual(before, "abcdG");
+		assert.strictEqual(beforeWidth, 5);
+	});
+});


### PR DESCRIPTION
## Summary

- Fix `extractSegments()` so wide graphemes are not kept in the `before` segment when the overlay start column falls inside their two-cell footprint.
- Align `before` boundary handling with existing `strictAfter` / `sliceWithWidth(strict)` behavior.
- Add `regression-overlay-cjk-boundary.test.ts`.

## Problem

When an overlay starts at column 5 over base text `abcd让EFGH`, the full-width `让` (columns 4–5) was preserved in `before`, pushing overlay content right and causing vertical border artifacts (e.g. pi-btw `/btw` over Chinese background).

## Test plan

- [x] `cd packages/tui && npm test` (includes new regression tests)
- [x] Local repro: `node notes/pi-tui-overlay-cjk-repro.mjs` against patched pi-tui
- [ ] Manual: Ghostty + pi `/btw` over CJK background — border columns no longer split

## Risk

- `extractSegments` is only used by `compositeLineAt` (overlay compositing).
- Single-line condition change; rollback is reverting `currentCol + w <= beforeEnd` → `currentCol < beforeEnd`.


Made with [Cursor](https://cursor.com)