### PR TITLE
fix(tui): keep Kitty images visible in WezTerm

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -213,6 +213,12 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	private getImageMaxHeightCells(): number {
+		const terminalRows = Math.max(1, this.ui.terminal.rows);
+		const availableRows = Math.max(1, terminalRows - 6);
+		return terminalRows < 20 ? Math.max(1, Math.floor(availableRows / 2)) : availableRows;
+	}
+
 	override invalidate(): void {
 		super.invalidate();
 		this.updateDisplay();
@@ -320,7 +326,11 @@ export class ToolExecutionComponent extends Container {
 						imageData,
 						imageMimeType,
 						{ fallbackColor: (s: string) => theme.fg("toolOutput", s) },
-						{ maxWidthCells: this.imageWidthCells },
+						{
+							maxWidthCells: this.imageWidthCells,
+							maxHeightCells: this.getImageMaxHeightCells(),
+							drawAfterReserveRows: true,
+						},
 					);
 					this.imageComponents.push(imageComponent);
 					this.addChild(imageComponent);

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -16,6 +16,7 @@ export interface ImageTheme {
 export interface ImageOptions {
 	maxWidthCells?: number;
 	maxHeightCells?: number;
+	drawAfterReserveRows?: boolean;
 	filename?: string;
 	/** Kitty image ID. If provided, reuses this ID (for animations/updates). */
 	imageId?: number;
@@ -87,7 +88,16 @@ export class Image implements Component {
 					this.imageId = result.imageId;
 				}
 
-				if (caps.images === "kitty") {
+				if (caps.images === "kitty" && this.options.drawAfterReserveRows) {
+					lines = [];
+					for (let i = 0; i < result.rows - 1; i++) {
+						lines.push("");
+					}
+					const rowOffset = result.rows - 1;
+					const moveUp = rowOffset > 0 ? `\x1b[${rowOffset}A` : "";
+					const moveDown = rowOffset > 0 ? `\x1b[${rowOffset}B` : "";
+					lines.push(moveUp + result.sequence + moveDown);
+				} else if (caps.images === "kitty") {
 					// For Kitty: C=1 prevents cursor movement.
 					// Don't need the cursor movement.
 					lines = [result.sequence];

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -419,6 +419,31 @@ describe("Kitty image cursor movement", () => {
 			setCellDimensions({ widthPx: 9, heightPx: 18 });
 		}
 	});
+
+	it("can place Kitty image sequence on the last reserved row", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			const image = new Image(
+				"AAAA",
+				"image/png",
+				{ fallbackColor: (value) => value },
+				{ maxWidthCells: 2, maxHeightCells: 2, drawAfterReserveRows: true },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			const lines = image.render(4);
+			const imageId = image.getImageId();
+			assert.strictEqual(typeof imageId, "number");
+			assert.deepStrictEqual(lines.slice(0, -1), [""]);
+			assert.ok(lines[1].startsWith("\x1b[1A\x1b_G"));
+			assert.ok(lines[1].includes(",C=1,"));
+			assert.ok(lines[1].includes(`,i=${imageId}`));
+			assert.ok(lines[1].endsWith("\x1b\\\x1b[1B"));
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
 });
 
 describe("hyperlink", () => {


### PR DESCRIPTION
Supersedes #5233.

This fixes Kitty images in WezTerm rendering as an empty reserved block in coding-agent tool output.

The previous PR globally restored the old Kitty cursor-up/down placement. That worked for the local repro, but it risked undoing #4461 because tall images can require moving the cursor above the visible viewport.

This version keeps #4461 as the default `Image` behavior. The cursor-up placement is now opt-in via `drawAfterReserveRows`, and coding-agent only enables it after capping tool images to the current terminal height. That keeps the cursor movement bounded, so tall images are scaled before the image is drawn after its reserved rows.

Changes made:
- **`packages/coding-agent/src/modes/interactive/components/tool-execution.ts`**: cap tool image height to a viewport budget and opt those images into draw-after-reserve placement.
- **`packages/tui/src/components/image.ts`**: add `drawAfterReserveRows` without changing the default Kitty path.
- **`packages/tui/test/terminal-image.test.ts`**: keep the #4461 first-row placement test and add coverage for the opt-in last-row placement.

Validated:
- `node --test packages/tui/test/terminal-image.test.ts packages/tui/test/tui-render.test.ts`
- `npm test -w packages/tui`
- `npm --prefix packages/tui run build`
- `npm --prefix packages/coding-agent run build`

Also smoke-tested in WezTerm with the tall portrait image at `79x11` and a taller `~96x23` window, followed by a table render.


Some Screenshots fro the 79x11:
 
<img width="994" height="370" alt="image" src="https://github.com/user-attachments/assets/e7b803d5-70d6-4984-803c-2171b60f0d6d" />

<img width="994" height="373" alt="image" src="https://github.com/user-attachments/assets/d47b5276-1f98-4239-9c79-68e04d0ca0c9" />


And the 96x23 (ish)

<img width="1219" height="741" alt="image" src="https://github.com/user-attachments/assets/6a9ad41f-b547-4e96-8a7d-298fda5b7a82" />
<img width="1215" height="753" alt="image" src="https://github.com/user-attachments/assets/325ef587-0939-42a6-be03-76d0822bbe66" />
