### PR TITLE
fix(tool-execution): collapse all-empty-line renders to zero height

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -222,7 +222,13 @@ export class ToolExecutionComponent extends Container {
 		if (this.hideComponent) {
 			return [];
 		}
-		return super.render(width);
+		const lines = super.render(width);
+		// If every line is empty (Spacer-only with a zero-height custom renderer),
+		// treat the component as invisible so it takes no layout space.
+		if (lines.length > 0 && lines.every((l) => l === "")) {
+			return [];
+		}
+		return lines;
 	}
 
 	private updateDisplay(): void {


### PR DESCRIPTION
## Problem

When an extension registers a tool with `renderShell: "self"` and returns a zero-height component from `renderCall`/`renderResult` (e.g. to hide tool output in a focus/collapse mode), the `ToolExecutionComponent` still occupies **one blank line** of layout space due to the unconditional `new Spacer(1)` added in the constructor.

The existing `hideComponent` escape hatch returns `[]` and avoids this, but it is only reachable when `hasContent === false` — which never occurs when any renderer is defined, because `hasContent = true` is set unconditionally after the renderer callback returns (even when the callback returns a zero-height widget).

## Fix

After `super.render()`, check whether every line in the output is an empty string. If so, return `[]` instead. This is the exact same result as `hideComponent = true`, but triggered by the rendered output rather than by the `hasContent` flag.

```ts
const lines = super.render(width);
if (lines.length > 0 && lines.every((l) => l === "")) {
    return [];
}
return lines;
```

**Safety:** the check only fires when the renderer deliberately emits no visible content. Normal tool renders produce at least one non-empty line, so existing behaviour is entirely unaffected.

## Reproduction

Register any tool with `renderShell: "self"` whose `renderCall` and `renderResult` both return `new Text("", 0, 0)`. The component renders as a single blank line instead of disappearing. After this fix it renders as nothing.