### PR TITLE
Add ui_prompt_start/ui_prompt_end extension events

### DIFF
--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -666,10 +666,10 @@ describe("totalTokens field", () => {
 		);
 
 		it(
-			"google/gemini-2.0-flash-001 - should return totalTokens equal to sum of components",
+			"google/gemini-2.5-flash - should return totalTokens equal to sum of components",
 			{ retry: 3, timeout: 60000 },
 			async () => {
-				const llm = getModel("openrouter", "google/gemini-2.0-flash-001");
+				const llm = getModel("openrouter", "google/gemini-2.5-flash");
 
 				console.log(`\nOpenRouter / ${llm.id}:`);
 				const { first, second } = await testTotalTokensWithCache(llm, { apiKey: process.env.OPENROUTER_API_KEY });

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -294,6 +294,7 @@ user sends prompt ────────────────────�
   │   │     ├─► tool_execution_start               │       │
   │   │     ├─► tool_call (can block)              │       │
   │   │     ├─► tool_execution_update              │       │
+  │   │     ├─► (ui_prompt_start / ui_prompt_end around any blocking ctx.ui prompt)
   │   │     ├─► tool_result (can modify)           │       │
   │   │     └─► tool_execution_end                 │       │
   │   │                                            │       │
@@ -583,6 +584,28 @@ pi.on("tool_execution_update", async (event, ctx) => {
 
 pi.on("tool_execution_end", async (event, ctx) => {
   // event.toolCallId, event.toolName, event.result, event.isError
+});
+```
+
+#### ui_prompt_start / ui_prompt_end
+
+Fired when an interactive `ctx.ui` prompt opens and closes — i.e. when the agent is blocked waiting on the user mid-turn. Because every prompt (`select`, `confirm`, `input`, `editor`, `custom`) routes through `ctx.ui`, these events cover both the built-in prompts and any prompt raised by an extension, with no per-call instrumentation.
+
+Use them to distinguish "waiting for input" from "working" in host integrations (status bars, terminal multiplexers, notifiers) that otherwise see the whole turn as "running".
+
+- Only the outermost prompt fires the pair; nested or parallel prompts are coalesced.
+- Notification-only and fire-and-forget: handler return values are ignored and the prompt is never delayed waiting on a handler, so do not run slow work inline.
+- These fire only for mid-turn `ctx.ui` prompts, not for the main composer (use `agent_end` for the idle/awaiting-prompt transition).
+
+```typescript
+pi.on("ui_prompt_start", async (event, ctx) => {
+  // event.kind  - "select" | "confirm" | "input" | "editor" | "custom"
+  // event.title - prompt title, when available
+  // ctx.sessionManager.getSessionId(), ctx.cwd available as usual
+});
+
+pi.on("ui_prompt_end", async (event, ctx) => {
+  // event.kind - matches the outermost prompt
 });
 ```
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -54,6 +54,9 @@ import type {
 	ToolCallEventResult,
 	ToolResultEvent,
 	ToolResultEventResult,
+	UiPromptEndEvent,
+	UiPromptKind,
+	UiPromptStartEvent,
 	UserBashEvent,
 	UserBashEventResult,
 } from "./types.ts";
@@ -249,6 +252,8 @@ export class ExtensionRunner {
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
 	private staleMessage: string | undefined;
+	/** Depth of currently open interactive ctx.ui prompts; >0 means blocked on user input. */
+	private activePromptDepth = 0;
 
 	constructor(
 		extensions: Extension[],
@@ -357,8 +362,52 @@ export class ExtensionRunner {
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext, mode: ExtensionMode = "print"): void {
-		this.uiContext = uiContext ?? noOpUIContext;
+		this.uiContext = uiContext ? this.wrapUIContextWithPromptEvents(uiContext) : noOpUIContext;
 		this.mode = mode;
+	}
+
+	/**
+	 * Wrap a UI context so the blocking dialog methods emit `ui_prompt_start` /
+	 * `ui_prompt_end` around the time the agent is waiting on user input. This is
+	 * the single chokepoint every `ctx.ui` flows through, so all prompts (built-in
+	 * and extension-raised) are covered without per-call instrumentation.
+	 *
+	 * Non-blocking methods and getters (e.g. `theme`) are inherited unchanged via
+	 * the prototype chain.
+	 */
+	private wrapUIContextWithPromptEvents(ui: ExtensionUIContext): ExtensionUIContext {
+		const wrapped: ExtensionUIContext = Object.create(ui);
+		wrapped.select = (title, options, opts) =>
+			this.withPromptEvent("select", title, () => ui.select(title, options, opts));
+		wrapped.confirm = (title, message, opts) =>
+			this.withPromptEvent("confirm", title, () => ui.confirm(title, message, opts));
+		wrapped.input = (title, placeholder, opts) =>
+			this.withPromptEvent("input", title, () => ui.input(title, placeholder, opts));
+		wrapped.editor = (title, prefill) => this.withPromptEvent("editor", title, () => ui.editor(title, prefill));
+		type CustomParams = Parameters<ExtensionUIContext["custom"]>;
+		wrapped.custom = ((factory: CustomParams[0], options: CustomParams[1]) =>
+			this.withPromptEvent("custom", undefined, () => ui.custom(factory, options))) as ExtensionUIContext["custom"];
+		return wrapped;
+	}
+
+	/**
+	 * Run a blocking ctx.ui prompt, emitting prompt lifecycle events for the
+	 * outermost prompt only (nested or parallel prompts are coalesced). Events
+	 * are fire-and-forget so handlers never delay the user-facing dialog.
+	 */
+	private withPromptEvent<T>(kind: UiPromptKind, title: string | undefined, run: () => Promise<T>): Promise<T> {
+		if (this.activePromptDepth === 0) {
+			const startEvent: UiPromptStartEvent = { type: "ui_prompt_start", kind, title };
+			void this.emit(startEvent);
+		}
+		this.activePromptDepth += 1;
+		return run().finally(() => {
+			this.activePromptDepth -= 1;
+			if (this.activePromptDepth === 0) {
+				const endEvent: UiPromptEndEvent = { type: "ui_prompt_end", kind };
+				void this.emit(endEvent);
+			}
+		});
 	}
 
 	getUIContext(): ExtensionUIContext {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -254,6 +254,8 @@ export class ExtensionRunner {
 	private staleMessage: string | undefined;
 	/** Depth of currently open interactive ctx.ui prompts; >0 means blocked on user input. */
 	private activePromptDepth = 0;
+	/** Kind of the outermost currently open prompt, used for the matching end event. */
+	private activePromptKind: UiPromptKind | undefined;
 
 	constructor(
 		extensions: Extension[],
@@ -372,22 +374,37 @@ export class ExtensionRunner {
 	 * the single chokepoint every `ctx.ui` flows through, so all prompts (built-in
 	 * and extension-raised) are covered without per-call instrumentation.
 	 *
-	 * Non-blocking methods and getters (e.g. `theme`) are inherited unchanged via
-	 * the prototype chain.
+	 * Non-blocking methods and getters (e.g. `theme`) are delegated with the
+	 * original UI context as `this`, so future class-based implementations keep
+	 * private fields and instance-bound state intact.
 	 */
 	private wrapUIContextWithPromptEvents(ui: ExtensionUIContext): ExtensionUIContext {
-		const wrapped: ExtensionUIContext = Object.create(ui);
-		wrapped.select = (title, options, opts) =>
-			this.withPromptEvent("select", title, () => ui.select(title, options, opts));
-		wrapped.confirm = (title, message, opts) =>
-			this.withPromptEvent("confirm", title, () => ui.confirm(title, message, opts));
-		wrapped.input = (title, placeholder, opts) =>
-			this.withPromptEvent("input", title, () => ui.input(title, placeholder, opts));
-		wrapped.editor = (title, prefill) => this.withPromptEvent("editor", title, () => ui.editor(title, prefill));
 		type CustomParams = Parameters<ExtensionUIContext["custom"]>;
-		wrapped.custom = ((factory: CustomParams[0], options: CustomParams[1]) =>
-			this.withPromptEvent("custom", undefined, () => ui.custom(factory, options))) as ExtensionUIContext["custom"];
-		return wrapped;
+		const wrappedPrompts = {
+			select: (title, options, opts) => this.withPromptEvent("select", title, () => ui.select(title, options, opts)),
+			confirm: (title, message, opts) =>
+				this.withPromptEvent("confirm", title, () => ui.confirm(title, message, opts)),
+			input: (title, placeholder, opts) =>
+				this.withPromptEvent("input", title, () => ui.input(title, placeholder, opts)),
+			editor: (title, prefill) => this.withPromptEvent("editor", title, () => ui.editor(title, prefill)),
+			custom: ((factory: CustomParams[0], options: CustomParams[1]) =>
+				this.withPromptEvent("custom", undefined, () =>
+					ui.custom(factory, options),
+				)) as ExtensionUIContext["custom"],
+		} satisfies Pick<ExtensionUIContext, "select" | "confirm" | "input" | "editor" | "custom">;
+
+		return new Proxy(ui, {
+			get(target, property) {
+				if (property === "select") return wrappedPrompts.select;
+				if (property === "confirm") return wrappedPrompts.confirm;
+				if (property === "input") return wrappedPrompts.input;
+				if (property === "editor") return wrappedPrompts.editor;
+				if (property === "custom") return wrappedPrompts.custom;
+
+				const value = Reflect.get(target, property, target) as unknown;
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		});
 	}
 
 	/**
@@ -396,15 +413,28 @@ export class ExtensionRunner {
 	 * are fire-and-forget so handlers never delay the user-facing dialog.
 	 */
 	private withPromptEvent<T>(kind: UiPromptKind, title: string | undefined, run: () => Promise<T>): Promise<T> {
-		if (this.activePromptDepth === 0) {
+		const isOutermostPrompt = this.activePromptDepth === 0;
+		if (isOutermostPrompt) {
+			this.activePromptKind = kind;
+		}
+		this.activePromptDepth += 1;
+		if (isOutermostPrompt) {
 			const startEvent: UiPromptStartEvent = { type: "ui_prompt_start", kind, title };
 			void this.emit(startEvent);
 		}
-		this.activePromptDepth += 1;
-		return run().finally(() => {
+
+		let result: Promise<T>;
+		try {
+			result = run();
+		} catch (error) {
+			result = Promise.reject(error);
+		}
+
+		return result.finally(() => {
 			this.activePromptDepth -= 1;
 			if (this.activePromptDepth === 0) {
-				const endEvent: UiPromptEndEvent = { type: "ui_prompt_end", kind };
+				const endEvent: UiPromptEndEvent = { type: "ui_prompt_end", kind: this.activePromptKind ?? kind };
+				this.activePromptKind = undefined;
 				void this.emit(endEvent);
 			}
 		});

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -709,6 +709,40 @@ export interface ToolExecutionEndEvent {
 }
 
 // ============================================================================
+// UI Events
+// ============================================================================
+
+/** Kind of interactive UI prompt that blocks the agent on user input. */
+export type UiPromptKind = "select" | "confirm" | "input" | "editor" | "custom";
+
+/**
+ * Fired when an interactive `ctx.ui` prompt opens and the agent is blocked
+ * waiting for user input (e.g. `select`, `confirm`, `input`, `editor`,
+ * `custom`). This covers the built-in prompts and any prompt raised by an
+ * extension, since all of them route through `ctx.ui`.
+ *
+ * Only the outermost prompt fires this when prompts nest. Pairs with
+ * `ui_prompt_end`. Handlers are notified fire-and-forget and must not block:
+ * their return values are ignored and the prompt is not delayed on them.
+ *
+ * Use this to signal "waiting for input" to host integrations such as status
+ * bars or terminal multiplexers, which otherwise see the agent as "running"
+ * for the whole turn.
+ */
+export interface UiPromptStartEvent {
+	type: "ui_prompt_start";
+	kind: UiPromptKind;
+	/** Prompt title, when the prompt provides one. */
+	title?: string;
+}
+
+/** Fired when the outermost interactive `ctx.ui` prompt closes. Pairs with `ui_prompt_start`. */
+export interface UiPromptEndEvent {
+	type: "ui_prompt_end";
+	kind: UiPromptKind;
+}
+
+// ============================================================================
 // Model Events
 // ============================================================================
 
@@ -970,6 +1004,8 @@ export type ExtensionEvent =
 	| ToolExecutionStartEvent
 	| ToolExecutionUpdateEvent
 	| ToolExecutionEndEvent
+	| UiPromptStartEvent
+	| UiPromptEndEvent
 	| ModelSelectEvent
 	| ThinkingLevelSelectEvent
 	| UserBashEvent
@@ -1124,6 +1160,8 @@ export interface ExtensionAPI {
 	on(event: "tool_execution_start", handler: ExtensionHandler<ToolExecutionStartEvent>): void;
 	on(event: "tool_execution_update", handler: ExtensionHandler<ToolExecutionUpdateEvent>): void;
 	on(event: "tool_execution_end", handler: ExtensionHandler<ToolExecutionEndEvent>): void;
+	on(event: "ui_prompt_start", handler: ExtensionHandler<UiPromptStartEvent>): void;
+	on(event: "ui_prompt_end", handler: ExtensionHandler<UiPromptEndEvent>): void;
 	on(event: "model_select", handler: ExtensionHandler<ModelSelectEvent>): void;
 	on(event: "thinking_level_select", handler: ExtensionHandler<ThinkingLevelSelectEvent>): void;
 	on(event: "tool_call", handler: ExtensionHandler<ToolCallEvent, ToolCallEventResult>): void;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -739,6 +739,7 @@ export interface UiPromptStartEvent {
 /** Fired when the outermost interactive `ctx.ui` prompt closes. Pairs with `ui_prompt_start`. */
 export interface UiPromptEndEvent {
 	type: "ui_prompt_end";
+	/** Matches the outermost prompt that fired `ui_prompt_start`. */
 	kind: UiPromptKind;
 }
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -823,6 +823,90 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("ui prompt events", () => {
+		const loadPromptRecorderRunner = async (eventsFile: string) => {
+			const extCode = `
+				import * as fs from "node:fs";
+				export default function(pi) {
+					const record = (entry) => fs.appendFileSync(${JSON.stringify(eventsFile)}, JSON.stringify(entry) + "\\n");
+					pi.on("ui_prompt_start", async (event) => { record(["start", event.kind, event.title ?? null]); });
+					pi.on("ui_prompt_end", async (event) => { record(["end", event.kind]); });
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "prompt-recorder.ts"), extCode);
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			expect(result.errors).toEqual([]);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			runner.bindCore(extensionActions, extensionContextActions);
+			return runner;
+		};
+
+		const readEvents = (eventsFile: string): unknown[] =>
+			fs.existsSync(eventsFile)
+				? fs
+						.readFileSync(eventsFile, "utf8")
+						.split("\n")
+						.filter((line) => line.length > 0)
+						.map((line) => JSON.parse(line))
+				: [];
+
+		it("emits ui_prompt_start/end around a blocking ctx.ui prompt", async () => {
+			const eventsFile = path.join(tempDir, "ui-events.log");
+			const runner = await loadPromptRecorderRunner(eventsFile);
+			runner.setUIContext({ select: async () => "a" } as unknown as ExtensionUIContext, "tui");
+
+			const choice = await runner.getUIContext().select("Pick one", ["a", "b"]);
+
+			expect(choice).toBe("a");
+			expect(readEvents(eventsFile)).toEqual([
+				["start", "select", "Pick one"],
+				["end", "select"],
+			]);
+		});
+
+		it("coalesces nested prompts into a single outer start/end pair", async () => {
+			const eventsFile = path.join(tempDir, "ui-events-nested.log");
+			const runner = await loadPromptRecorderRunner(eventsFile);
+			// confirm() runs an input() prompt while it is still open: only the
+			// outer confirm should produce lifecycle events.
+			const uiContext = {
+				confirm: async () => {
+					await runner.getUIContext().input("Inner", "");
+					return true;
+				},
+				input: async () => "inner-value",
+			} as unknown as ExtensionUIContext;
+			runner.setUIContext(uiContext, "tui");
+
+			const confirmed = await runner.getUIContext().confirm("Outer", "Proceed?");
+
+			expect(confirmed).toBe(true);
+			expect(readEvents(eventsFile)).toEqual([
+				["start", "confirm", "Outer"],
+				["end", "confirm"],
+			]);
+		});
+
+		it("emits ui_prompt_end even when the prompt rejects", async () => {
+			const eventsFile = path.join(tempDir, "ui-events-reject.log");
+			const runner = await loadPromptRecorderRunner(eventsFile);
+			runner.setUIContext(
+				{
+					input: async () => {
+						throw new Error("dismissed");
+					},
+				} as unknown as ExtensionUIContext,
+				"tui",
+			);
+
+			await expect(runner.getUIContext().input("Name")).rejects.toThrow("dismissed");
+			expect(readEvents(eventsFile)).toEqual([
+				["start", "input", "Name"],
+				["end", "input"],
+			]);
+		});
+	});
+
 	describe("hasHandlers", () => {
 		it("returns true when handlers exist for event type", async () => {
 			const extCode = `

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -18,6 +18,7 @@ import type {
 import { KeybindingsManager, type KeyId } from "../src/core/keybindings.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
+import type { Theme } from "../src/modes/interactive/theme/theme.ts";
 
 describe("ExtensionRunner", () => {
 	let tempDir: string;
@@ -864,6 +865,34 @@ describe("ExtensionRunner", () => {
 			]);
 		});
 
+		it("delegates non-prompt UI members with the original context as this", async () => {
+			const eventsFile = path.join(tempDir, "ui-events-private.log");
+			const runner = await loadPromptRecorderRunner(eventsFile);
+			class PrivateStateUI {
+				#notified = false;
+				#theme = { name: "private-theme" } as Theme;
+
+				get notified() {
+					return this.#notified;
+				}
+
+				get theme() {
+					return this.#theme;
+				}
+
+				notify(_message: string) {
+					this.#notified = true;
+				}
+			}
+			const uiContext = new PrivateStateUI();
+			runner.setUIContext(uiContext as unknown as ExtensionUIContext, "tui");
+
+			expect(runner.getUIContext().theme).toBe(uiContext.theme);
+			expect(() => runner.getUIContext().notify("Hello")).not.toThrow();
+			expect(uiContext.notified).toBe(true);
+			expect(readEvents(eventsFile)).toEqual([]);
+		});
+
 		it("coalesces nested prompts into a single outer start/end pair", async () => {
 			const eventsFile = path.join(tempDir, "ui-events-nested.log");
 			const runner = await loadPromptRecorderRunner(eventsFile);
@@ -884,6 +913,39 @@ describe("ExtensionRunner", () => {
 			expect(readEvents(eventsFile)).toEqual([
 				["start", "confirm", "Outer"],
 				["end", "confirm"],
+			]);
+		});
+
+		it("coalesces parallel prompts into a single outer start/end pair", async () => {
+			const eventsFile = path.join(tempDir, "ui-events-parallel.log");
+			const runner = await loadPromptRecorderRunner(eventsFile);
+			let resolveSelect!: (value: string | undefined) => void;
+			let resolveConfirm!: (value: boolean) => void;
+			const uiContext = {
+				select: async () =>
+					new Promise<string | undefined>((resolve) => {
+						resolveSelect = resolve;
+					}),
+				confirm: async () =>
+					new Promise<boolean>((resolve) => {
+						resolveConfirm = resolve;
+					}),
+			} as unknown as ExtensionUIContext;
+			runner.setUIContext(uiContext, "tui");
+
+			const selectPromise = runner.getUIContext().select("First", ["a", "b"]);
+			const confirmPromise = runner.getUIContext().confirm("Second", "Proceed?");
+			expect(readEvents(eventsFile)).toEqual([["start", "select", "First"]]);
+
+			resolveSelect("a");
+			expect(await selectPromise).toBe("a");
+			expect(readEvents(eventsFile)).toEqual([["start", "select", "First"]]);
+
+			resolveConfirm(true);
+			expect(await confirmPromise).toBe(true);
+			expect(readEvents(eventsFile)).toEqual([
+				["start", "select", "First"],
+				["end", "select"],
 			]);
 		});
 


### PR DESCRIPTION
## What

Two new extension events fired when a blocking `ctx.ui` dialog opens and
closes:

- `ui_prompt_start` `{ kind, title? }`
- `ui_prompt_end` `{ kind }`

`kind` is `"select" | "confirm" | "input" | "editor" | "custom"`.

## Why

A host integration (status bar, terminal multiplexer like cmux, notifier)
that subscribes to lifecycle events today only sees `before_agent_start`
(running) and `agent_end` (idle). When a tool or extension prompts the user
mid-turn (the `ask` tool, a `ctx.ui.select`, a wizard), the agent is blocked
on the human but still looks "running" for the whole turn. There is no signal
that says "waiting for input", so panes/indicators cannot light up for
attention.

## How

Every prompt routes through `ExtensionRunner.setUIContext`, so the runner
wraps that single chokepoint instead of instrumenting each call site. The
wrapper decorates only the blocking dialog methods (`select`, `confirm`,
`input`, `editor`, `custom`) and delegates every other getter/method to the
original UI context with the original object as `this`, so class-based UI
contexts and private fields remain safe.

- General by construction: built-in prompts and any extension-raised prompt
  are covered with zero per-plugin work.
- Nested/parallel prompts are coalesced to one outer start/end pair via a
  depth counter; `ui_prompt_end.kind` matches the outer prompt that fired
  `ui_prompt_start`.
- Fire-and-forget: handler return values are ignored and the dialog is never
  delayed waiting on a handler (a slow hook must not stall the user's prompt).
- Mid-turn only: the main composer's idle/awaiting-prompt transition stays on
  `agent_end`; these events are for in-turn `ctx.ui` prompts.

## CI fix

The CI build regenerates `packages/ai/src/models.generated.ts` before running
the repository check. OpenRouter no longer returns
`google/gemini-2.0-flash-001`, so `tsgo --noEmit` failed on
`total-tokens.test.ts` against the regenerated `ModelId` union. This PR also
switches that test to `google/gemini-2.5-flash`, which exists in both the
committed model snapshot and the regenerated OpenRouter list.

## Files

- `packages/coding-agent/src/core/extensions/types.ts` - `UiPromptKind`,
  `UiPromptStartEvent`, `UiPromptEndEvent`; added to `ExtensionEvent` and two
  `on()` overloads.
- `packages/coding-agent/src/core/extensions/runner.ts` - prompt-event UI
  wrapper and coalescing state.
- `packages/coding-agent/docs/extensions.md` - event reference + lifecycle
  diagram entry.
- `packages/coding-agent/test/extensions-runner.test.ts` - emits around a
  prompt, preserves non-prompt UI delegation, coalesces nested/parallel
  prompts, emits end on rejection.
- `packages/ai/test/total-tokens.test.ts` - stable OpenRouter Gemini model id.

## Validation

- `npm run build && npm run check` passes locally.
- `npm run check` passes locally with generated artifacts restored.
- `packages/coding-agent/test/extensions-runner.test.ts` passes locally (35
  tests).

pkg:coding-agent
pkg:ai
