### PR TITLE
fix(tui): guard against undefined children in Box and Container render/invalidate loops

### DIFF
--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -626,9 +626,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
@@ -644,9 +641,6 @@
 			],
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"optional": true
 		},
@@ -664,9 +658,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
@@ -683,9 +674,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
@@ -701,9 +689,6 @@
 			],
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"optional": true
 		},

--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -67,7 +67,7 @@ export class Box implements Component {
 	invalidate(): void {
 		this.invalidateCache();
 		for (const child of this.children) {
-			child.invalidate?.();
+			child?.invalidate?.();
 		}
 	}
 
@@ -82,6 +82,7 @@ export class Box implements Component {
 		// Render all children
 		const childLines: string[] = [];
 		for (const child of this.children) {
+			if (!child) continue;
 			const lines = child.render(contentWidth);
 			for (const line of lines) {
 				childLines.push(leftPad + line);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -243,13 +243,14 @@ export class Container implements Component {
 
 	invalidate(): void {
 		for (const child of this.children) {
-			child.invalidate?.();
+			child?.invalidate?.();
 		}
 	}
 
 	render(width: number): string[] {
 		const lines: string[] = [];
 		for (const child of this.children) {
+			if (!child) continue;
 			const childLines = child.render(width);
 			for (const line of childLines) {
 				lines.push(line);


### PR DESCRIPTION
A tool extension's `renderCall` or `renderResult` may return `undefined` without throwing, which gets pushed into a Box's children array. On the next render cycle, `child.render()` crashes with:

```
TypeError: Cannot read properties of undefined (reading 'render')
    at Box.render (box.js:62:33)
    at ToolExecutionComponent.render (tool-execution.js:181:22)
    at Container.render (tui.js:85:38)
```

This adds `!child` guards in the render and invalidate loops for both `Box` and `Container`, skipping undefined entries rather than crashing.