### PR TITLE
fix(coding-agent): hide display false custom messages in tree

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -9,7 +9,7 @@ import {
 	TruncatedText,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
-import type { SessionTreeNode } from "../../../core/session-manager.ts";
+import type { SessionEntry, SessionTreeNode } from "../../../core/session-manager.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint, keyText } from "./keybinding-hints.ts";
@@ -270,6 +270,10 @@ class TreeList implements Component {
 		return result;
 	}
 
+	private isUiHiddenEntry(entry: SessionEntry): boolean {
+		return entry.type === "custom_message" && entry.display === false;
+	}
+
 	private applyFilter(): void {
 		// Update lastSelectedId only when we have a valid selection (non-empty list)
 		// This preserves the selection when switching through empty filter results
@@ -282,6 +286,10 @@ class TreeList implements Component {
 		this.filteredNodes = this.flatNodes.filter((flatNode) => {
 			const entry = flatNode.node.entry;
 			const isCurrentLeaf = entry.id === this.currentLeafId;
+
+			if (this.isUiHiddenEntry(entry)) {
+				return false;
+			}
 
 			// Skip assistant messages with only tool calls (no text) unless error/aborted
 			// Always show current leaf so active position is visible

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -3,6 +3,7 @@ import {
 	type BranchSummaryEntry,
 	buildSessionContext,
 	type CompactionEntry,
+	type CustomMessageEntry,
 	type ModelChangeEntry,
 	type SessionEntry,
 	type SessionMessageEntry,
@@ -60,6 +61,24 @@ function modelChange(id: string, parentId: string | null, provider: string, mode
 	return { type: "model_change", id, parentId, timestamp: "2025-01-01T00:00:00Z", provider, modelId };
 }
 
+function customMessage(
+	id: string,
+	parentId: string | null,
+	customType: string,
+	content: string,
+	display: boolean,
+): CustomMessageEntry {
+	return {
+		type: "custom_message",
+		id,
+		parentId,
+		timestamp: "2025-01-01T00:00:00Z",
+		customType,
+		content,
+		display,
+	};
+}
+
 describe("buildSessionContext", () => {
 	describe("trivial cases", () => {
 		it("empty entries returns empty context", () => {
@@ -86,6 +105,24 @@ describe("buildSessionContext", () => {
 			const ctx = buildSessionContext(entries);
 			expect(ctx.messages).toHaveLength(4);
 			expect(ctx.messages.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+		});
+
+		it("includes display:false custom messages in context", () => {
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "hello"),
+				customMessage("2", "1", "pi-inline-skill-snapshot", "hidden context", false),
+				msg("3", "2", "assistant", "hi"),
+			];
+
+			const ctx = buildSessionContext(entries, "3");
+
+			expect(ctx.messages).toHaveLength(3);
+			expect(ctx.messages[0].role).toBe("user");
+			expect(ctx.messages[1].role).toBe("custom");
+			expect((ctx.messages[1] as any).customType).toBe("pi-inline-skill-snapshot");
+			expect((ctx.messages[1] as any).content).toBe("hidden context");
+			expect((ctx.messages[1] as any).display).toBe(false);
+			expect(ctx.messages[2].role).toBe("assistant");
 		});
 
 		it("tracks thinking level changes", () => {

--- a/packages/coding-agent/test/tree-selector.test.ts
+++ b/packages/coding-agent/test/tree-selector.test.ts
@@ -2,6 +2,7 @@ import { setKeybindings } from "@earendil-works/pi-tui";
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
 import type {
+	CustomMessageEntry,
 	ModelChangeEntry,
 	SessionEntry,
 	SessionMessageEntry,
@@ -9,6 +10,7 @@ import type {
 } from "../src/core/session-manager.ts";
 import { TreeSelectorComponent } from "../src/modes/interactive/components/tree-selector.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
 
 beforeAll(() => {
 	initTheme("dark");
@@ -93,6 +95,25 @@ function modelChange(id: string, parentId: string | null): ModelChangeEntry {
 		timestamp: new Date().toISOString(),
 		provider: "anthropic",
 		modelId: "claude-sonnet-4",
+	};
+}
+
+// Helper to create a custom message entry
+function customMessage(
+	id: string,
+	parentId: string | null,
+	customType: string,
+	content: string,
+	display: boolean,
+): CustomMessageEntry {
+	return {
+		type: "custom_message",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		customType,
+		content,
+		display,
 	};
 }
 
@@ -182,6 +203,80 @@ describe("TreeSelectorComponent", () => {
 
 			const list = selector.getTreeList();
 			expect(list.getSelectedNode()?.entry.id).toBe("user-2");
+		});
+	});
+
+	describe("hidden custom messages", () => {
+		test("hides display:false custom messages in the default tree view", () => {
+			const entries: SessionEntry[] = [
+				userMessage("user-1", null, "hello"),
+				customMessage("custom-1", "user-1", "pi-inline-skill-snapshot", "hidden skill snapshot", false),
+				assistantMessage("asst-1", "custom-1", "response"),
+			];
+			const tree = buildTree(entries);
+
+			const selector = new TreeSelectorComponent(
+				tree,
+				"asst-1",
+				24,
+				() => {},
+				() => {},
+			);
+			const list = selector.getTreeList();
+			const rendered = stripAnsi(list.render(200).join("\n"));
+
+			expect(rendered).toContain("user: hello");
+			expect(rendered).toContain("assistant: response");
+			expect(rendered).not.toContain("pi-inline-skill-snapshot");
+			expect(rendered).not.toContain("hidden skill snapshot");
+			expect(list.getSelectedNode()?.entry.id).toBe("asst-1");
+		});
+
+		test("hides display:false custom messages even in all filter mode", () => {
+			const entries: SessionEntry[] = [
+				userMessage("user-1", null, "hello"),
+				customMessage("custom-1", "user-1", "pi-inline-skill-snapshot", "hidden skill snapshot", false),
+				assistantMessage("asst-1", "custom-1", "response"),
+			];
+			const tree = buildTree(entries);
+
+			const selector = new TreeSelectorComponent(
+				tree,
+				"custom-1",
+				24,
+				() => {},
+				() => {},
+			);
+			selector.handleInput("\x01"); // Ctrl+A: all filter
+			const list = selector.getTreeList();
+			const rendered = stripAnsi(list.render(200).join("\n"));
+
+			expect(rendered).toContain("user: hello");
+			expect(rendered).toContain("assistant: response");
+			expect(rendered).not.toContain("pi-inline-skill-snapshot");
+			expect(rendered).not.toContain("hidden skill snapshot");
+			expect(list.getSelectedNode()?.entry.id).toBe("user-1");
+		});
+
+		test("keeps display:true custom messages visible", () => {
+			const entries: SessionEntry[] = [
+				userMessage("user-1", null, "hello"),
+				customMessage("custom-1", "user-1", "visible-note", "visible context", true),
+				assistantMessage("asst-1", "custom-1", "response"),
+			];
+			const tree = buildTree(entries);
+
+			const selector = new TreeSelectorComponent(
+				tree,
+				"asst-1",
+				24,
+				() => {},
+				() => {},
+			);
+			const rendered = stripAnsi(selector.getTreeList().render(200).join("\n"));
+
+			expect(rendered).toContain("[visible-note]: visible context");
+			expect(rendered).toContain("assistant: response");
 		});
 	});
 


### PR DESCRIPTION
## Summary

Make `display:false` custom messages hidden from the session tree/editor UI while keeping them persisted and included in LLM context.

## Why

Extensions can inject custom messages for persisted context. `display:false` already means the message should be hidden from normal UI, but the session tree can still render hidden custom messages. This makes it hard for extensions to store context snapshots without polluting tree navigation and editor restore flows.

## Changes

- Hide `custom_message` entries with `display === false` from tree projection, including the all filter.
- Keep visible descendants reachable by relying on the existing visible-parent recalculation.
- Add tree selector tests for hidden custom messages.
- Add a buildSessionContext non-regression test showing hidden custom messages remain context-visible.

## Non-goals

- No skill-specific logic.
- No prompt expansion changes.
- No provider payload changes.
- No session format changes.

## Tests

```bash
cd packages/coding-agent && node ../../node_modules/vitest/dist/cli.js --run test/tree-selector.test.ts test/session-manager/build-context.test.ts
```
