### PR TITLE
feat(tui): add /config and /exit as aliases for /settings and /quit

### DIFF
--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -17,6 +17,7 @@ export interface BuiltinSlashCommand {
 
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
+	{ name: "config", description: "Open settings menu (alias for /settings)" },
 	{ name: "model", description: "Select model (opens selector UI)" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },
@@ -37,4 +38,5 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
+	{ name: "exit", description: `Quit ${APP_NAME} (alias for /quit)` },
 ];

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2493,7 +2493,7 @@ export class InteractiveMode {
 			if (!text) return;
 
 			// Handle commands
-			if (text === "/settings") {
+			if (text === "/settings" || text === "/config") {
 				this.showSettingsSelector();
 				this.editor.setText("");
 				return;
@@ -2610,7 +2610,7 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/quit") {
+			if (text === "/quit" || text === "/exit") {
 				this.editor.setText("");
 				await this.shutdown();
 				return;


### PR DESCRIPTION
Mirror Claude Code's command names so users can trigger the settings menu with either /settings or /config, and quit with either /quit or /exit. Both aliases are registered in BUILTIN_SLASH_COMMANDS so they appear in autocomplete.