### PR TITLE
perf(tui): cache line resets across frames for long transcripts

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -265,6 +265,14 @@ export class Container implements Component {
 export class TUI extends Container {
 	public terminal: Terminal;
 	private previousLines: string[] = [];
+	// Incremental applyLineResets cache: the raw input array and processed output
+	// from the previous frame. Child components cache their rendered lines, so a
+	// static transcript keeps identical string references across frames; unchanged
+	// lines are reused via a pointer compare instead of being re-normalized and
+	// re-allocated on every render tick. This keeps per-frame cost proportional to
+	// the lines that actually changed rather than the full conversation length.
+	private lineResetPrevRaw: string[] | null = null;
+	private lineResetPrevOut: string[] | null = null;
 	private previousKittyImageIds = new Set<number>();
 	private previousWidth = 0;
 	private previousHeight = 0;
@@ -994,13 +1002,26 @@ export class TUI extends Container {
 
 	private applyLineResets(lines: string[]): string[] {
 		const reset = TUI.SEGMENT_RESET;
-		for (let i = 0; i < lines.length; i++) {
+		const n = lines.length;
+		const out = new Array<string>(n);
+		const prevRaw = this.lineResetPrevRaw;
+		const prevOut = this.lineResetPrevOut;
+		const prevLen = prevRaw === null ? 0 : prevRaw.length;
+		for (let i = 0; i < n; i++) {
 			const line = lines[i];
-			if (!isImageLine(line)) {
-				lines[i] = normalizeTerminalOutput(line) + reset;
+			// Reuse the previous frame's processed line when the raw input is the
+			// same string reference at the same index. For a long, mostly-static
+			// transcript this is a pointer compare for the bulk of the lines,
+			// avoiding per-line re-normalization and string allocation every frame.
+			if (prevRaw !== null && i < prevLen && prevRaw[i] === line) {
+				out[i] = (prevOut as string[])[i];
+				continue;
 			}
+			out[i] = isImageLine(line) ? line : normalizeTerminalOutput(line) + reset;
 		}
-		return lines;
+		this.lineResetPrevRaw = lines;
+		this.lineResetPrevOut = out;
+		return out;
 	}
 
 	private collectKittyImageIds(lines: string[]): Set<number> {


### PR DESCRIPTION
## Problem

In a long interactive session the TUI gets progressively slower and less responsive — typing lags, and the lag grows with conversation length. A fresh session in another tab stays snappy, so it's clearly tied to transcript size.

The cause is in `TUI.applyLineResets`. Because the TUI owns the entire transcript as one live, app-managed surface, every `requestRender` (including every keystroke) re-composites the full-height line array and then runs `applyLineResets` over **all** of it — calling `normalizeTerminalOutput` and allocating a new string for every line of history, every frame. Per-frame cost scales with total conversation length rather than with what actually changed.

At realistic scale (tool outputs of 100–600 lines each), this pass alone blows the frame budget:

| transcript | lines | per-frame (before) |
| ---------- | ----- | ------------------ |
| ~2.4k msgs | 273k  | 12.6 ms            |
| ~5k msgs   | 695k  | 42.3 ms            |

## Fix

Child components already cache their rendered lines (e.g. `Markdown.cachedLines`), so a static transcript hands `applyLineResets` the **same string references** frame to frame. This patch caches the previous frame's raw input array and its processed output, and reuses a processed line when the raw input is the same reference at the same index.

Unchanged history becomes a pointer compare instead of a re-normalization + allocation, so per-frame cost tracks the lines that actually changed rather than the full history length. Changed/streaming lines and the Thai/Lao normalization branch are unaffected.

It holds only one extra array (the previous frame's output) — same order of memory as the `previousLines` the TUI already keeps — so there's no unbounded cache and no eviction policy to tune.

## Results

Measured against the real compiled module with a realistic transcript:

| transcript | lines | before  | after  | speedup  |
| ---------- | ----- | ------- | ------ | -------- |
| ~2.4k msgs | 273k  | 12.6 ms | 2.7 ms | **4.6x** |
| ~5k msgs   | 695k  | 42.3 ms | 4.3 ms | **9.9x** |

The speedup grows with conversation length, which is exactly where the lag was worst.

## Correctness

Output is byte-identical to the previous implementation across: cold (first frame), static (cache hits), tail-edit (streaming/last-line change → new ref), grow (appended lines), shrink (removed lines), and the Thai/Lao normalization path. `biome check` passes.

The only behavioral change is that `applyLineResets` now returns a fresh array instead of mutating the input in place; the sole caller (`newLines = this.applyLineResets(newLines)`) already uses the return value, so this is transparent.
