### PR TITLE
fix(coding-agent): isolate tool result status background

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -12,6 +12,7 @@ export interface ToolExecutionOptions {
 
 export class ToolExecutionComponent extends Container {
 	private contentBox: Box;
+	private resultBox: Box;
 	private contentText: Text;
 	private selfRenderContainer: Container;
 	private callRendererComponent?: Component;
@@ -66,11 +67,17 @@ export class ToolExecutionComponent extends Container {
 		// selfRenderContainer is used when the tool renders its own framing.
 		// contentText is reserved for generic fallback rendering when no tool definition exists.
 		this.contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		this.resultBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
 		this.contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
 		this.selfRenderContainer = new Container();
 
 		if (this.hasRendererDefinition()) {
-			this.addChild(this.getRenderShell() === "self" ? this.selfRenderContainer : this.contentBox);
+			if (this.getRenderShell() === "self") {
+				this.addChild(this.selfRenderContainer);
+			} else {
+				this.addChild(this.contentBox);
+				this.addChild(this.resultBox);
+			}
 		} else {
 			this.addChild(this.contentText);
 		}
@@ -251,8 +258,12 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private updateDisplay(): void {
-		const bgFn = this.isPartial
-			? (text: string) => theme.bg("toolPendingBg", text)
+		// Keep the call-preview shell background stable across pending → final
+		// transitions. Large write/edit previews should not be fully repainted just
+		// because the result settled. The result block gets its own status background.
+		const shellBgFn = (text: string) => theme.bg("toolPendingBg", text);
+		const resultBgFn = this.isPartial
+			? shellBgFn
 			: this.result?.isError
 				? (text: string) => theme.bg("toolErrorBg", text)
 				: (text: string) => theme.bg("toolSuccessBg", text);
@@ -260,25 +271,33 @@ export class ToolExecutionComponent extends Container {
 		let hasContent = false;
 		this.hideComponent = false;
 		if (this.hasRendererDefinition()) {
-			const renderContainer = this.getRenderShell() === "self" ? this.selfRenderContainer : this.contentBox;
-			if (renderContainer instanceof Box) {
-				renderContainer.setBgFn(bgFn);
+			const renderShell = this.getRenderShell();
+			const callContainer = renderShell === "self" ? this.selfRenderContainer : this.contentBox;
+			const resultContainer = renderShell === "self" ? this.selfRenderContainer : this.resultBox;
+			if (callContainer instanceof Box) {
+				callContainer.setBgFn(shellBgFn);
 			}
-			renderContainer.clear();
+			if (resultContainer instanceof Box) {
+				resultContainer.setBgFn(resultBgFn);
+			}
+			callContainer.clear();
+			if (resultContainer !== callContainer) {
+				resultContainer.clear();
+			}
 
 			const callRenderer = this.getCallRenderer();
 			if (!callRenderer) {
-				renderContainer.addChild(this.createCallFallback());
+				callContainer.addChild(this.createCallFallback());
 				hasContent = true;
 			} else {
 				try {
 					const component = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
 					this.callRendererComponent = component;
-					renderContainer.addChild(component);
+					callContainer.addChild(component);
 					hasContent = true;
 				} catch {
 					this.callRendererComponent = undefined;
-					renderContainer.addChild(this.createCallFallback());
+					callContainer.addChild(this.createCallFallback());
 					hasContent = true;
 				}
 			}
@@ -288,7 +307,7 @@ export class ToolExecutionComponent extends Container {
 				if (!resultRenderer) {
 					const component = this.createResultFallback();
 					if (component) {
-						renderContainer.addChild(component);
+						resultContainer.addChild(component);
 						hasContent = true;
 					}
 				} else {
@@ -300,20 +319,20 @@ export class ToolExecutionComponent extends Container {
 							this.getRenderContext(this.resultRendererComponent),
 						);
 						this.resultRendererComponent = component;
-						renderContainer.addChild(component);
+						resultContainer.addChild(component);
 						hasContent = true;
 					} catch {
 						this.resultRendererComponent = undefined;
 						const component = this.createResultFallback();
 						if (component) {
-							renderContainer.addChild(component);
+							resultContainer.addChild(component);
 							hasContent = true;
 						}
 					}
 				}
 			}
 		} else {
-			this.contentText.setCustomBgFn(bgFn);
+			this.contentText.setCustomBgFn(shellBgFn);
 			this.contentText.setText(this.formatToolExecution());
 			hasContent = true;
 		}

--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -126,6 +126,8 @@ describe("edit tool TUI rendering", () => {
 		);
 		expect(callOnlyRender).toContain("edit");
 		expect(callOnlyRender).toContain("line 950 changed");
+		const previewLineBeforeResult = callOnlyRender.split("\n").find((line) => line.includes("line 950 changed"));
+		expect(previewLineBeforeResult).toBeDefined();
 
 		const redrawsBeforeResult = tui.fullRedraws;
 		const clearsBeforeResult = terminal.fullClearCount;
@@ -146,6 +148,8 @@ describe("edit tool TUI rendering", () => {
 		const settledRender = component.render(80).join("\n");
 		expect(settledRender).toContain("line 50 changed");
 		expect(settledRender).toContain("line 950 changed");
+		const previewLineAfterResult = settledRender.split("\n").find((line) => line.includes("line 950 changed"));
+		expect(previewLineAfterResult).toBe(previewLineBeforeResult);
 		expect(settledRender).not.toContain("Successfully replaced");
 	});
 

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -8,7 +8,7 @@ import { type BashOperations, createBashToolDefinition } from "../src/core/tools
 import { createReadTool, createReadToolDefinition } from "../src/core/tools/read.ts";
 import { createWriteToolDefinition } from "../src/core/tools/write.ts";
 import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
-import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../src/utils/ansi.ts";
 
 function createBaseToolDefinition(name = "custom_tool"): ToolDefinition {
@@ -65,6 +65,45 @@ describe("ToolExecutionComponent parity", () => {
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rendered).toContain("custom call");
 		expect(rendered).toContain("custom result");
+	});
+
+	test("colors the final result block without recoloring the call preview", () => {
+		const toolDefinition: ToolDefinition = {
+			...createBaseToolDefinition(),
+			renderCall: () => new Text("large preview line\npreview tail", 0, 0),
+			renderResult: (_result, _options, _theme, context) =>
+				new Text(context.isError ? "result failed" : "result ok", 0, 0),
+		};
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-status-background",
+			{},
+			{},
+			toolDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+
+		const previewLineBefore = component.render(120).find((line) => line.includes("large preview line"));
+		expect(previewLineBefore).toBeDefined();
+
+		component.updateResult({ content: [{ type: "text", text: "done" }], details: {}, isError: false }, false);
+		const successLines = component.render(120);
+		const previewLineAfterSuccess = successLines.find((line) => line.includes("large preview line"));
+		const successResultLine = successLines.find((line) => line.includes("result ok"));
+		const successBgPrefix = theme.bg("toolSuccessBg", "").replace("\x1b[49m", "");
+		expect(previewLineAfterSuccess).toBe(previewLineBefore);
+		expect(previewLineAfterSuccess).not.toContain(successBgPrefix);
+		expect(successResultLine).toContain(successBgPrefix);
+
+		component.updateResult({ content: [{ type: "text", text: "failed" }], details: {}, isError: true }, false);
+		const errorLines = component.render(120);
+		const previewLineAfterError = errorLines.find((line) => line.includes("large preview line"));
+		const errorResultLine = errorLines.find((line) => line.includes("result failed"));
+		const errorBgPrefix = theme.bg("toolErrorBg", "").replace("\x1b[49m", "");
+		expect(previewLineAfterError).toBe(previewLineBefore);
+		expect(previewLineAfterError).not.toContain(errorBgPrefix);
+		expect(errorResultLine).toContain(errorBgPrefix);
 	});
 
 	test("self-rendered empty tool rows take no layout space", () => {


### PR DESCRIPTION
## Summary

This PR changes the tool execution UI so the tool call preview and the final result/status area are rendered as separate visual regions.

Previously, `ToolExecutionComponent` used the same shell/background for both the call preview and the result. When a tool finished, the whole tool container changed from the pending background to the success/error background. For tools with large previews, such as `write` or `edit`, this caused a very large terminal region to be repainted when the result settled, which could produce visible jitter/flicker in the TUI.

After this change:

- The call preview keeps a stable pending background.
- The result block has its own background.
- Only the result block changes to success/error background when the tool finishes.
- `renderShell: "self"` behavior is preserved.

## Problem

Large tool previews can contain many lines, especially for edit/write operations that show a full diff or full write preview.

Before this PR, when the tool result arrived, the entire rendered tool box was recolored from `toolPendingBg` to `toolSuccessBg` or `toolErrorBg`. Even if the actual preview text did not change, the terminal still had to repaint the whole preview area because its ANSI background changed.

This made the UI unstable for large previews and could look like the interface was flickering or jumping when the final result was displayed.

## Solution

This PR splits the default tool rendering shell into two boxes:

1. `contentBox`
   - Used for the tool call preview.
   - Always uses `toolPendingBg`.
   - Remains visually stable across pending -> final transitions.

2. `resultBox`
   - Used for the tool result renderer/fallback output.
   - Uses `toolPendingBg` while partial.
   - Uses `toolSuccessBg` or `toolErrorBg` once the result is final.

This keeps the high-volume preview region stable and limits status recoloring to the smaller result/status region.

## Why this approach

The issue is not caused by the tool preview content itself. The preview is useful and should remain complete, especially for write/edit tools where users need to inspect the full planned change.

Instead of truncating previews or changing individual tool renderers, this fixes the UI composition at the host level:

- The call preview describes what will be executed.
- The result block describes what happened after execution.
- These two regions have different lifecycle semantics and should not be forced to share the same final status background.

This does slightly change the visual semantics of the upstream UI: the whole tool box no longer turns green/red on completion. Instead, the final status color is isolated to the result block. The tradeoff is intentional because it avoids repainting large previews and makes the UI more stable.

## Current UI behavior

Pending tool call:

- Preview/call block is shown with the pending background.
- Result block, if present for partial output, also uses the pending background.

Completed successful tool call:

- Preview/call block remains unchanged.
- Result block uses the success background.

Completed failed tool call:

- Preview/call block remains unchanged.
- Result block uses the error background.

This means users still get clear success/error feedback, but the large preview area does not get recolored or fully repainted when the result settles.

## Tests

Added/updated tests to cover the new behavior:

- Verifies the final result block receives success/error background.
- Verifies the call preview is not recolored when the result settles.
- Verifies large edit previews keep the same rendered preview line before and after the result is applied, avoiding a full preview repaint.

Tested with:

```sh
npx vitest run packages/coding-agent/test/tool-execution-component.test.ts
npx vitest run packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
npm --prefix packages/coding-agent run build
```