### PR TITLE
fix(coding-agent): recover from request-size overflow by dropping oldest images

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -81,6 +81,7 @@ import {
 import { emitSessionShutdownEvent } from "./extensions/runner.ts";
 import type { BashExecutionMessage, CustomMessage } from "./messages.ts";
 import type { ModelRegistry } from "./model-registry.ts";
+import { capImagesToByteBudget } from "./overflow-images.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.ts";
 import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.ts";
@@ -2025,6 +2026,14 @@ export class AgentSession {
 				const lastMsg = messages[messages.length - 1];
 				if (lastMsg?.role === "assistant" && (lastMsg as AssistantMessage).stopReason === "error") {
 					this.agent.state.messages = messages.slice(0, -1);
+				}
+				// Compaction only summarizes text; it cannot shrink images. Drop the oldest
+				// images so a request-size overflow (Anthropic 413 request_too_large from many
+				// accumulated screenshots) can actually recover instead of overflowing the retry
+				// and failing after a single compact-and-retry attempt.
+				const capped = capImagesToByteBudget(this.agent.state.messages);
+				if (capped.droppedImages > 0) {
+					this.agent.state.messages = capped.messages;
 				}
 				return true;
 			}

--- a/packages/coding-agent/src/core/overflow-images.ts
+++ b/packages/coding-agent/src/core/overflow-images.ts
@@ -1,0 +1,72 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
+
+/**
+ * Cumulative base64 budget for images kept when recovering from a request-size overflow.
+ *
+ * Anthropic's hard request limit is 32 MB (HTTP 413 `request_too_large`), independent of the
+ * token context window. Images are capped at ~4.5 MB each on the read/file paths, but nothing
+ * bounds the *aggregate* across a session, so a transcript with many screenshots can exceed
+ * 32 MB while still under the token window. We keep recent images well under the request limit
+ * to leave room for text, tool results, and headers.
+ */
+export const DEFAULT_OVERFLOW_IMAGE_BUDGET_BYTES = 16 * 1024 * 1024;
+
+const DROPPED_IMAGE_PLACEHOLDER = "[older image omitted to recover from a context/request-size overflow]";
+
+function hasImageBearingContent(
+	message: AgentMessage,
+): message is AgentMessage & { content: (TextContent | ImageContent)[] } {
+	return (message.role === "user" || message.role === "toolResult") && Array.isArray(message.content);
+}
+
+/**
+ * Drop the OLDEST image blocks — replacing each with a short text note — until the cumulative
+ * base64 size of the remaining (newest) images is within `budgetBytes`. Text, tool calls, and
+ * the most recent images are preserved. Pure: the input is not mutated; a new message array is
+ * returned together with the number of images that were replaced.
+ *
+ * Why this is needed: compaction only summarizes TEXT — it cannot shrink images — so an
+ * image-heavy session can stay above Anthropic's 32 MB request limit even after a successful
+ * compaction. Without this, context-overflow recovery (compact + retry) fails after a single
+ * attempt and the session becomes unusable.
+ */
+export function capImagesToByteBudget(
+	messages: AgentMessage[],
+	budgetBytes: number = DEFAULT_OVERFLOW_IMAGE_BUDGET_BYTES,
+): { messages: AgentMessage[]; droppedImages: number } {
+	// Walk newest-first; keep images while under budget, mark older ones for dropping.
+	const toDrop = new Set<ImageContent>();
+	let running = 0;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (!hasImageBearingContent(message)) continue;
+		for (let j = message.content.length - 1; j >= 0; j--) {
+			const block = message.content[j];
+			if (block.type !== "image") continue;
+			const size = block.data.length;
+			if (running + size <= budgetBytes) {
+				running += size;
+			} else {
+				toDrop.add(block);
+			}
+		}
+	}
+
+	if (toDrop.size === 0) return { messages, droppedImages: 0 };
+
+	const cappedMessages = messages.map((message): AgentMessage => {
+		if (!hasImageBearingContent(message)) return message;
+		if (!message.content.some((block) => block.type === "image" && toDrop.has(block))) {
+			return message;
+		}
+		const content = message.content.map((block) =>
+			block.type === "image" && toDrop.has(block)
+				? ({ type: "text", text: DROPPED_IMAGE_PLACEHOLDER } satisfies TextContent)
+				: block,
+		);
+		return { ...message, content } as AgentMessage;
+	});
+
+	return { messages: cappedMessages, droppedImages: toDrop.size };
+}

--- a/packages/coding-agent/test/overflow-images.test.ts
+++ b/packages/coding-agent/test/overflow-images.test.ts
@@ -1,0 +1,78 @@
+import type { ImageContent, Message, ToolResultMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { capImagesToByteBudget } from "../src/core/overflow-images.ts";
+
+function img(bytes: number): ImageContent {
+	return { type: "image", data: "x".repeat(bytes), mimeType: "image/png" };
+}
+
+function toolResult(content: (ImageContent | { type: "text"; text: string })[], id: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "screenshot",
+		content: content as ToolResultMessage["content"],
+		isError: false,
+		timestamp: Number(id),
+	};
+}
+
+describe("capImagesToByteBudget", () => {
+	it("keeps everything (same reference) when images fit the budget", () => {
+		const messages: Message[] = [
+			toolResult([{ type: "text", text: "a" }, img(100)], "1"),
+			toolResult([img(100)], "2"),
+		];
+		const result = capImagesToByteBudget(messages, 1000);
+		expect(result.droppedImages).toBe(0);
+		expect(result.messages).toBe(messages);
+	});
+
+	it("drops the OLDEST images first until within the byte budget", () => {
+		const messages: Message[] = [
+			toolResult([img(100)], "1"), // oldest
+			toolResult([img(100)], "2"),
+			toolResult([img(100)], "3"), // newest
+		];
+		// budget 250 -> keep newest two (200), drop oldest one
+		const result = capImagesToByteBudget(messages, 250);
+		expect(result.droppedImages).toBe(1);
+		expect((result.messages[0] as ToolResultMessage).content[0].type).toBe("text");
+		expect((result.messages[1] as ToolResultMessage).content[0].type).toBe("image");
+		expect((result.messages[2] as ToolResultMessage).content[0].type).toBe("image");
+	});
+
+	it("preserves sibling text blocks when dropping an image", () => {
+		const messages: Message[] = [toolResult([{ type: "text", text: "keep me" }, img(100)], "1")];
+		const result = capImagesToByteBudget(messages, 0);
+		expect(result.droppedImages).toBe(1);
+		const content = (result.messages[0] as ToolResultMessage).content;
+		expect(content[0]).toEqual({ type: "text", text: "keep me" });
+		expect(content[1].type).toBe("text"); // image replaced by placeholder text
+	});
+
+	it("does not mutate the input array", () => {
+		const messages: Message[] = [toolResult([img(100)], "1"), toolResult([img(100)], "2")];
+		const before = JSON.stringify(messages);
+		capImagesToByteBudget(messages, 50);
+		expect(JSON.stringify(messages)).toBe(before);
+	});
+
+	it("ignores user string content and assistant messages", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "hello", timestamp: 1 },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "hi" }],
+				timestamp: 2,
+				model: "m",
+				provider: "p",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				stopReason: "stop",
+			} as Message,
+			toolResult([img(100)], "1"),
+		];
+		const result = capImagesToByteBudget(messages, 10);
+		expect(result.droppedImages).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

Image-heavy sessions (many screenshots from browser/winshot/MCP tools) can exceed Anthropic's 32 MB request limit (HTTP 413 `request_too_large`) while still under the token window. `isContextOverflow()` already detects this (#2734), so overflow recovery (compact + retry) fires — but **compaction only summarizes text; it cannot shrink images.** The kept-recent image blocks keep the retried request over the limit, so recovery fails after a single attempt and the session becomes unusable.

Addresses the gap described in #5369.

## Change

- New pure helper `capImagesToByteBudget(messages, budgetBytes)` in `src/core/overflow-images.ts`: drops the **oldest** image blocks — replacing each with a short text placeholder — until the cumulative base64 size of the remaining (newest) images is within a budget (default 16 MB, well under the 32 MB request limit). Text, tool calls, and recent images are preserved; the input array is not mutated.
- Wired into the `willRetry` branch of `_runAutoCompaction` in `agent-session.ts`, so it runs **only during overflow recovery** (not on the normal success path). After compaction rebuilds `agent.state.messages` from the session, the oldest images are dropped so the retried request actually fits.

Scoped to overflow recovery to keep the hot path untouched. Follow-ups could apply a budget proactively and/or expose it via `CompactionSettings`.

## Why not just resize?

`resizeImage` already caps each image at ~4.5 MB, but the failure here is the **aggregate** (e.g. 99 screenshots × ~1 MB ≈ 107 MB) crossing the 32 MB *request* limit, not any single oversized image. Per-image resize doesn't help that; bounding the total does.

## Testing

- New unit tests `test/overflow-images.test.ts` (5 cases: within-budget no-op + same-reference, oldest-first dropping, sibling-text preservation, input immutability, ignoring user-string / assistant messages). All pass.
- `npx tsgo -p tsconfig.build.json` — clean.
- `biome check` — clean.
- Regression: `agent-session-retry`, `agent-session-auto-compaction-queue`, `image-resize-callers` pass; no new failures in compaction suites.

## Notes

- Dependency-free change (no `package.json` / lockfile edits). The `check:shrinkwrap` pre-commit hook flagged `npm-shrinkwrap.json` as out of date in my environment, but this PR adds no dependencies — happy to regenerate if you prefer.
- `DEFAULT_OVERFLOW_IMAGE_BUDGET_BYTES = 16 MB`; open to a different default or making it configurable.
