### PR TITLE
fix(coding-agent): add a space between the skill and user messages

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3106,6 +3106,7 @@ export class InteractiveMode {
 						this.chatContainer.addChild(component);
 						// Render user message separately if present
 						if (skillBlock.userMessage) {
+							this.chatContainer.addChild(new Spacer(1));
 							const userComponent = new UserMessageComponent(
 								skillBlock.userMessage,
 								this.getMarkdownThemeWithSettings(),


### PR DESCRIPTION
Before, if you ran `/skill:<skill-name> something something`, it would show the skill custom message and the user message `something something` without a space in between. This PR fixes it:

<img width="1250" height="462" alt="Screenshot 2026-06-03 at 22 40 04" src="https://github.com/user-attachments/assets/e3b8a3e9-6f7e-4cb3-976c-6998fecdc386" />
