### PR TITLE
fix(interactive): reload steeringMode and followUpMode on /reload

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4962,6 +4962,8 @@ export class InteractiveMode {
 		try {
 			await this.session.reload();
 			configureHttpDispatcher(this.settingsManager.getHttpIdleTimeoutMs());
+			this.session.setSteeringMode(this.settingsManager.getSteeringMode());
+			this.session.setFollowUpMode(this.settingsManager.getFollowUpMode());
 			this.keybindings.reload();
 			const activeHeader = this.customHeader ?? this.builtInHeader;
 			if (isExpandable(activeHeader)) {
@@ -4997,7 +4999,7 @@ export class InteractiveMode {
 			if (modelsJsonError) {
 				this.showError(`models.json error: ${modelsJsonError}`);
 			}
-			this.showStatus("Reloaded keybindings, extensions, skills, prompts, themes");
+			this.showStatus("Reloaded keybindings, extensions, skills, prompts, themes, queue modes");
 		} catch (error) {
 			dismissReloadBox(previousEditor as Component);
 			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
## Problem

The `/reload` command did not re-sync `steeringMode` and `followUpMode` from `settings.json` to the running `AgentSession`. These queue mode settings were only read at session creation time, meaning changes to `settings.json` required a full restart to take effect.

Related to [#2753](https://github.com/earendil-works/pi/issues/2753) (stale settings after /reload).

## Root Cause

In `interactive-mode.ts`, `handleReloadCommand()` reloads keybindings, themes, editor settings, etc. — but never re-reads `steeringMode`/`followUpMode` from the settings manager.

The `AgentSession` already has `setSteeringMode()` and `setFollowUpMode()` methods that update both the agent and persist to settings — they just weren't called during reload.

## Fix

Add two lines to `handleReloadCommand()` after `session.reload()`:

```typescript
this.session.setSteeringMode(this.settingsManager.getSteeringMode());
this.session.setFollowUpMode(this.settingsManager.getFollowUpMode());
```

Also updated the reload status message to mention queue modes.

## Testing

1. Set `"followUpMode": "all"` in `settings.json`
2. Start pi, queue multiple follow-ups — they fire all at once
3. Change to `"followUpMode": "one-at-a-time"` in `settings.json`
4. Run `/reload`
5. Queue multiple follow-ups — they now fire one at a time ✓