### PR TITLE
Store user scoped local package installs as absolute paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Added `ctx.mode` to extension contexts so extensions can distinguish TUI, RPC, JSON, and print mode.
 - Added `ctx.getSystemPromptOptions()` for extension commands to inspect the current base system prompt inputs.
 
+### Changed
+
+- Changed user-scoped local package installs to store absolute paths in settings while keeping project-local installs relative to `.pi/settings.json`.
+
 ### Fixed
 
 - Fixed temporary extension package installs to use a private `~/.pi/agent/tmp/extensions` directory with `0700` permissions instead of `os.tmpdir()/pi-extensions`.

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -109,7 +109,7 @@ pi install git:git@github.com:user/repo@v1.0.0
 ./relative/path/to/package
 ```
 
-Local paths point to files or directories on disk and are added to settings without copying. Relative paths are resolved against the settings file they appear in. If the path is a file, it loads as a single extension. If it is a directory, pi loads resources using package rules.
+Local paths point to files or directories on disk and are added to settings without copying. `pi install <path>` writes user-scoped local paths as absolute paths in `~/.pi/agent/settings.json`. `pi install -l <path>` writes project-local paths relative to `.pi/settings.json`. Manually written relative paths are still resolved against the settings file they appear in. If the path is a file, it loads as a single extension. If it is a directory, pi loads resources using package rules.
 
 ## Creating a Pi Package
 

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -1378,8 +1378,10 @@ export class DefaultPackageManager implements PackageManager {
 		if (parsed.type !== "local") {
 			return source;
 		}
-		const baseDir = this.getBaseDirForScope(scope);
 		const resolved = this.resolvePath(parsed.path);
+		if (scope === "user") return resolved;
+
+		const baseDir = this.getBaseDirForScope(scope);
 		const rel = relative(baseDir, resolved);
 		return rel || ".";
 	}

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ENV_AGENT_DIR, PACKAGE_NAME, VERSION } from "../src/config.ts";
 import { main } from "../src/main.ts";
@@ -58,7 +58,7 @@ describe("package commands", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("should persist global relative local package paths relative to settings.json", async () => {
+	it("should persist global local package paths as absolute paths", async () => {
 		const relativePkgDir = join(projectDir, "packages", "local-package");
 		mkdirSync(relativePkgDir, { recursive: true });
 
@@ -68,8 +68,22 @@ describe("package commands", () => {
 		const settings = JSON.parse(readFileSync(settingsPath, "utf-8")) as { packages?: string[] };
 		expect(settings.packages?.length).toBe(1);
 		const stored = settings.packages?.[0] ?? "";
-		const resolvedFromSettings = realpathSync(join(agentDir, stored));
-		expect(resolvedFromSettings).toBe(realpathSync(relativePkgDir));
+		expect(isAbsolute(stored)).toBe(true);
+		expect(realpathSync(stored)).toBe(realpathSync(relativePkgDir));
+	});
+
+	it("should persist project local package paths relative to project settings.json", async () => {
+		const relativePkgDir = join(projectDir, "packages", "local-package");
+		mkdirSync(relativePkgDir, { recursive: true });
+
+		await main(["install", "-l", "./packages/local-package"]);
+
+		const settingsPath = join(projectDir, ".pi", "settings.json");
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8")) as { packages?: string[] };
+		expect(settings.packages?.length).toBe(1);
+		const stored = settings.packages?.[0] ?? "";
+		expect(isAbsolute(stored)).toBe(false);
+		expect(realpathSync(join(projectDir, ".pi", stored))).toBe(realpathSync(relativePkgDir));
 	});
 
 	it("should remove local packages using a path with a trailing slash", async () => {

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -1192,7 +1192,7 @@ Content`,
 	});
 
 	describe("settings source normalization", () => {
-		it("should store global local packages relative to agent settings base", () => {
+		it("should store global local packages as absolute paths", () => {
 			const pkgDir = join(tempDir, "packages", "local-global-pkg");
 			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
 			writeFileSync(join(pkgDir, "extensions", "index.ts"), "export default function() {}");
@@ -1201,9 +1201,7 @@ Content`,
 			expect(added).toBe(true);
 
 			const settings = settingsManager.getGlobalSettings();
-			const rel = relative(agentDir, pkgDir);
-			const expected = rel.startsWith(".") ? rel : `./${rel}`;
-			expect(settings.packages?.[0]).toBe(expected);
+			expect(settings.packages?.[0]).toBe(pkgDir);
 		});
 
 		it("should store project local packages relative to .pi settings base", () => {


### PR DESCRIPTION
In my testing, I did not find any problems with existing configs, as both absolute and relative paths are already ahdnled correctly.

Closes #5378 