### PR TITLE
fix: Alt+Delete word deletion on Mac OS

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed `Alt+Delete` in interactive text inputs to delete the previous word by default on macOS-style keyboards.
 - Fixed temporary extension package installs to use a private `~/.pi/agent/tmp/extensions` directory with `0700` permissions instead of `os.tmpdir()/pi-extensions`.
 - Fixed git package source handling to reject unsafe host/path components and keep managed clone paths inside install roots.
 - Fixed stored XSS in HTML session exports by sanitizing Markdown link and image URLs with a scheme allow-list after stripping control characters.

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -45,8 +45,8 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 |--------|---------|-------------|
 | `tui.editor.deleteCharBackward` | `backspace` | Delete character backward |
 | `tui.editor.deleteCharForward` | `delete`, `ctrl+d` | Delete character forward |
-| `tui.editor.deleteWordBackward` | `ctrl+w`, `alt+backspace` | Delete word backward |
-| `tui.editor.deleteWordForward` | `alt+d`, `alt+delete` | Delete word forward |
+| `tui.editor.deleteWordBackward` | `ctrl+w`, `alt+backspace`, `alt+delete` | Delete word backward |
+| `tui.editor.deleteWordForward` | `alt+d` | Delete word forward |
 | `tui.editor.deleteToLineStart` | `ctrl+u` | Delete to line start |
 | `tui.editor.deleteToLineEnd` | `ctrl+k` | Delete to line end |
 
@@ -159,7 +159,7 @@ Create `~/.pi/agent/keybindings.json`:
 {
   "tui.editor.cursorUp": ["up", "ctrl+p"],
   "tui.editor.cursorDown": ["down", "ctrl+n"],
-  "tui.editor.deleteWordBackward": ["ctrl+w", "alt+backspace"]
+  "tui.editor.deleteWordBackward": ["ctrl+w", "alt+backspace", "alt+delete"]
 }
 ```
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed `Alt+Delete` in TUI text inputs to delete the previous word by default on macOS-style keyboards.
 - Fixed tab width accounting in column slicing and overlay compositing so tab-containing output cannot exceed the terminal width ([#5218](https://github.com/earendil-works/pi/issues/5218)).
 
 ## [0.78.0] - 2026-05-29

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -97,11 +97,11 @@ export const TUI_KEYBINDINGS = {
 		description: "Delete character forward",
 	},
 	"tui.editor.deleteWordBackward": {
-		defaultKeys: ["ctrl+w", "alt+backspace"],
+		defaultKeys: ["ctrl+w", "alt+backspace", "alt+delete"],
 		description: "Delete word backward",
 	},
 	"tui.editor.deleteWordForward": {
-		defaultKeys: ["alt+d", "alt+delete"],
+		defaultKeys: "alt+d",
 		description: "Delete word forward",
 	},
 	"tui.editor.deleteToLineStart": {

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -100,6 +100,16 @@ describe("Input component", () => {
 			assert.strictEqual(input.getValue(), "bazfoo bar ");
 		});
 
+		it("Alt+Delete deletes the previous word", () => {
+			const input = new Input();
+
+			input.setValue("foo bar baz");
+			input.handleInput("\x05"); // Ctrl+E
+			input.handleInput("\x1b\x7f"); // Alt+Delete/Backspace on macOS
+
+			assert.strictEqual(input.getValue(), "foo bar ");
+		});
+
 		it("Ctrl+W preserves ASCII punctuation boundaries", () => {
 			const input = new Input();
 


### PR DESCRIPTION
When on Mac OS. I expect to be able to ALT + DELETE and delete more than just the previous character. This is how all text fields work in Mac OS.

In PI the text field handles cursor movement correctly:

* CMD + LEFT ARROW -> Cursor goes to the start of the string
* ALT + LEFT ARROW -> Cursor goes to start of the word
* CMD + DELETE -> Deletes from Cursor to start of the string

This PR fixes:

* ALT + DELETE -> Deletes from Cursor to start of the word.