### PR TITLE
fix(ai): map maxTokens to max_tokens for opencode providers

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1108,7 +1108,14 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		isAntLing;
 
 	const useMaxTokens =
-		baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isNvidia || isAntLing;
+		baseUrl.includes("chutes.ai") ||
+		isMoonshot ||
+		isCloudflareAiGateway ||
+		isTogether ||
+		isNvidia ||
+		isAntLing ||
+		provider === "opencode" ||
+		baseUrl.includes("opencode.ai");
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
 	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");


### PR DESCRIPTION
opencode and opencode-go use max_tokens (not max_completion_tokens which the backend ignores).

Added the matching condition in detectCompat so maxTokensField resolves correctly for them (they share the opencode.ai base).

Fixes #5331