### PR TITLE
fix: persist restored session model as default for new sessions

### DIFF
--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -196,6 +196,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const restoredModel = modelRegistry.find(existingSession.model.provider, existingSession.model.modelId);
 		if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
 			model = restoredModel;
+			// Persist the restored model as the new default so future new sessions use it
+			settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 		}
 		if (!model) {
 			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;


### PR DESCRIPTION
## Problem

When continuing a session (`pi -c`), the model is correctly restored from session history, but `defaultModel`/`defaultProvider` in `settings.json` is never updated to match. This means future new sessions (without `-c`) fall back to a stale default, making model selection feel arbitrary.

All other model-switching paths already call `setDefaultModelAndProvider()`:
- `setModel()` ✓
- `cycleModel()` (`_cycleScopedModel` / `_cycleAvailableModel`) ✓  
- Model selector `handleSelect()` ✓
- Session restoration ❌ (this was the gap)

## Fix

One line added in `createAgentSession()` in `packages/coding-agent/src/core/sdk.ts`: when the model is successfully restored from a session, sync it back to settings as the new default.

```diff
 if (restoredModel && modelRegistry.hasConfiguredAuth(restoredModel)) {
     model = restoredModel;
+    // Persist the restored model as the new default so future new sessions use it
+    settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 }
```

Fixes #5409