### PR TITLE
fix(coding-agent): alias firepass model references

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed built-in tool expand hints to style closing parentheses consistently ([#5359](https://github.com/earendil-works/pi/issues/5359)).
+- Fixed Fireworks model resolution for models.dev-style `firepass/...` references by normalizing them to the canonical `fireworks/...` provider.
 
 ## [0.78.1] - 2026-06-04
 

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -29,6 +29,7 @@ import { warnDeprecation } from "../utils/deprecation.ts";
 import { stripJsonComments } from "../utils/json.ts";
 import { normalizePath } from "../utils/paths.ts";
 import type { AuthStatus, AuthStorage } from "./auth-storage.ts";
+import { normalizeProviderName } from "./provider-aliases.ts";
 import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "./provider-display-names.ts";
 import {
 	clearConfigValueCache,
@@ -704,7 +705,8 @@ export class ModelRegistry {
 	 * Find a model by provider and ID.
 	 */
 	find(provider: string, modelId: string): Model<Api> | undefined {
-		return this.models.find((m) => m.provider === provider && m.id === modelId);
+		const normalizedProvider = normalizeProviderName(provider);
+		return this.models.find((m) => m.provider === normalizedProvider && m.id === modelId);
 	}
 
 	/**

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -9,6 +9,7 @@ import { minimatch } from "minimatch";
 import { isValidThinkingLevel } from "../cli/args.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import type { ModelRegistry } from "./model-registry.ts";
+import { normalizeProviderInModelReference, normalizeProviderName } from "./provider-aliases.ts";
 
 /** Default model IDs for each known provider */
 export const defaultModelPerProvider: Record<KnownProvider, string> = {
@@ -83,9 +84,10 @@ export function findExactModelReferenceMatch(
 	}
 
 	const normalizedReference = trimmedReference.toLowerCase();
+	const normalizedProviderReference = normalizeProviderInModelReference(trimmedReference).toLowerCase();
 
 	const canonicalMatches = availableModels.filter(
-		(model) => `${model.provider}/${model.id}`.toLowerCase() === normalizedReference,
+		(model) => `${model.provider}/${model.id}`.toLowerCase() === normalizedProviderReference,
 	);
 	if (canonicalMatches.length === 1) {
 		return canonicalMatches[0];
@@ -99,9 +101,10 @@ export function findExactModelReferenceMatch(
 		const provider = trimmedReference.substring(0, slashIndex).trim();
 		const modelId = trimmedReference.substring(slashIndex + 1).trim();
 		if (provider && modelId) {
+			const normalizedProvider = normalizeProviderName(provider);
 			const providerMatches = availableModels.filter(
 				(model) =>
-					model.provider.toLowerCase() === provider.toLowerCase() &&
+					model.provider.toLowerCase() === normalizedProvider.toLowerCase() &&
 					model.id.toLowerCase() === modelId.toLowerCase(),
 			);
 			if (providerMatches.length === 1) {
@@ -365,7 +368,7 @@ export function resolveCliModel(options: {
 		providerMap.set(m.provider.toLowerCase(), m.provider);
 	}
 
-	let provider = cliProvider ? providerMap.get(cliProvider.toLowerCase()) : undefined;
+	let provider = cliProvider ? providerMap.get(normalizeProviderName(cliProvider).toLowerCase()) : undefined;
 	if (cliProvider && !provider) {
 		return {
 			model: undefined,
@@ -386,7 +389,7 @@ export function resolveCliModel(options: {
 		const slashIndex = cliModel.indexOf("/");
 		if (slashIndex !== -1) {
 			const maybeProvider = cliModel.substring(0, slashIndex);
-			const canonical = providerMap.get(maybeProvider.toLowerCase());
+			const canonical = providerMap.get(normalizeProviderName(maybeProvider).toLowerCase());
 			if (canonical) {
 				provider = canonical;
 				pattern = cliModel.substring(slashIndex + 1);

--- a/packages/coding-agent/src/core/provider-aliases.ts
+++ b/packages/coding-agent/src/core/provider-aliases.ts
@@ -1,0 +1,22 @@
+const PROVIDER_NAME_ALIASES: Record<string, string> = {
+	firepass: "fireworks",
+};
+
+export function normalizeProviderName(provider: string): string {
+	return PROVIDER_NAME_ALIASES[provider.toLowerCase()] ?? provider;
+}
+
+export function normalizeProviderInModelReference(reference: string): string {
+	const slashIndex = reference.indexOf("/");
+	if (slashIndex === -1) {
+		return reference;
+	}
+
+	const provider = reference.substring(0, slashIndex);
+	const normalizedProvider = normalizeProviderName(provider);
+	if (normalizedProvider === provider) {
+		return reference;
+	}
+
+	return `${normalizedProvider}${reference.substring(slashIndex)}`;
+}

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -896,6 +896,15 @@ describe("ModelRegistry", () => {
 			expect(registry.getProviderDisplayName("oauth-provider")).toBe("OAuth Provider");
 		});
 
+		test("find resolves firepass as the canonical Fireworks provider", () => {
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+			const model = registry.find("firepass", "accounts/fireworks/routers/kimi-k2p6-turbo");
+
+			expect(model?.provider).toBe("fireworks");
+			expect(model?.id).toBe("accounts/fireworks/routers/kimi-k2p6-turbo");
+		});
+
 		test("registerProvider warns and temporarily treats uppercase apiKey as an env reference", async () => {
 			const originalEnv = process.env.CUSTOM_NAME;
 			process.env.CUSTOM_NAME = "legacy-env-key";

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -63,7 +63,20 @@ const mockOpenRouterModels: Model<"anthropic-messages">[] = [
 	},
 ];
 
-const allModels = [...mockModels, ...mockOpenRouterModels];
+const mockFireworksModel: Model<"anthropic-messages"> = {
+	id: "accounts/fireworks/routers/kimi-k2p6-turbo",
+	name: "Kimi K2.6 Turbo",
+	api: "anthropic-messages",
+	provider: "fireworks",
+	baseUrl: "https://api.fireworks.ai/inference",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 },
+	contextWindow: 262000,
+	maxTokens: 262000,
+};
+
+const allModels = [...mockModels, ...mockOpenRouterModels, mockFireworksModel];
 
 describe("parseModelPattern", () => {
 	describe("simple patterns without colons", () => {
@@ -369,6 +382,37 @@ describe("resolveCliModel", () => {
 		expect(result.error).toBeUndefined();
 		expect(result.model?.provider).toBe("openrouter");
 		expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
+	});
+
+	test("resolves firepass model references to the canonical Fireworks provider", () => {
+		const registry = {
+			getAll: () => allModels,
+		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "firepass/accounts/fireworks/routers/kimi-k2p6-turbo",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("fireworks");
+		expect(result.model?.id).toBe("accounts/fireworks/routers/kimi-k2p6-turbo");
+	});
+
+	test("resolves explicit firepass provider references to Fireworks", () => {
+		const registry = {
+			getAll: () => allModels,
+		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliProvider: "firepass",
+			cliModel: "accounts/fireworks/routers/kimi-k2p6-turbo",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("fireworks");
+		expect(result.model?.id).toBe("accounts/fireworks/routers/kimi-k2p6-turbo");
 	});
 });
 


### PR DESCRIPTION
## Summary

- normalize models.dev-style `firepass/...` model references to the canonical `fireworks/...` provider
- allow saved/default model lookup through the same provider alias path
- add resolver and registry regressions for Fireworks/Kimi references

## Verification

- `npx tsx ../../node_modules/vitest/dist/cli.js --run test/model-resolver.test.ts test/model-registry.test.ts`
- `npm run check`
