### PR TITLE
Fix/models json migration error path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,6 @@
 ### Fixed
 
 - Fixed built-in tool expand hints to style closing parentheses consistently ([#5359](https://github.com/earendil-works/pi/issues/5359)).
-- Fixed invalid `models.json` syntax during config migration to report the file path instead of a raw JSON parse stack trace ([#5418](https://github.com/earendil-works/pi/issues/5418)).
 
 ## [0.78.1] - 2026-06-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fixed built-in tool expand hints to style closing parentheses consistently ([#5359](https://github.com/earendil-works/pi/issues/5359)).
+- Fixed invalid `models.json` syntax during config migration to report the file path instead of a raw JSON parse stack trace ([#5418](https://github.com/earendil-works/pi/issues/5418)).
 
 ## [0.78.1] - 2026-06-04
 

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -144,7 +144,15 @@ function migrateModelsJsonConfigValues(agentDir: string): ConfigValueMigration[]
 	const modelsPath = join(agentDir, "models.json");
 	if (!existsSync(modelsPath)) return [];
 
-	const parsed = JSON.parse(stripJsonComments(readFileSync(modelsPath, "utf-8"))) as unknown;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stripJsonComments(readFileSync(modelsPath, "utf-8"))) as unknown;
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			throw new Error(`Failed to parse models.json: ${error.message}\n\nFile: ${modelsPath}`);
+		}
+		throw error;
+	}
 	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return [];
 	const modelsData = parsed as Record<string, unknown>;
 	const providers = modelsData.providers;

--- a/packages/coding-agent/test/config-value-migration.test.ts
+++ b/packages/coding-agent/test/config-value-migration.test.ts
@@ -135,4 +135,22 @@ describe("config value env var syntax migration", () => {
 			'models.json.providers["custom-provider"].modelOverrides["model-b"].headers["x-override-key"]: OVERRIDE_API_KEY -> $OVERRIDE_API_KEY',
 		);
 	});
+
+	it("reports the models.json path when migration sees invalid JSON", () => {
+		const agentDir = createAgentDir();
+		const modelsPath = path.join(agentDir, "models.json");
+		fs.writeFileSync(modelsPath, '{\n  "providers": {\n', "utf-8");
+
+		let thrown: unknown;
+		try {
+			withAgentDir(agentDir, () => runMigrations(agentDir));
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(Error);
+		const message = (thrown as Error).message;
+		expect(message).toContain("Failed to parse models.json:");
+		expect(message).toContain(`File: ${modelsPath}`);
+	});
 });


### PR DESCRIPTION
## Summary
Fixes #5418.

Invalid JSON in `~/.pi/agent/models.json` could crash during startup migrations with a raw `JSON.parse` stack trace. The migration path now reports a `models.json` parse error with the resolved file path, matching the existing `ModelRegistry.loadCustomModels()` error style.

## Changes
- Wrap `migrateModelsJsonConfigValues()` parsing in a `SyntaxError` handler.
- Re-throw malformed `models.json` as:
  - `Failed to parse models.json: ...`
  - `File: <resolved models.json path>`
- Add a regression test covering invalid `models.json` during config value migration.
- No changelog entry included, per `CONTRIBUTING.md`.

## Verification
- Passed: focused `config-value-migration.test.ts`
- Passed: `npm run check`
- Passed: `./test.sh` on macOS

## Notes
The final PR diff only touches:
- `packages/coding-agent/src/migrations.ts`
- `packages/coding-agent/test/config-value-migration.test.ts`