### PR TITLE
fix(edit): tolerate extraneous keys in edits[] (robustness for noisy/weak models)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fixed built-in tool expand hints to style closing parentheses consistently ([#5359](https://github.com/earendil-works/pi/issues/5359)).
+- Fixed the edit tool to tolerate extraneous keys in `edits[]` items (robustness for noisy/weak models). Weaker models intermittently append a near-duplicate filler key after a long `newText` value (e.g. `{ oldText, newText, newText_strip: "" }`); the strict schema rejected the whole call. The schema now ignores unknown keys, matching the already-lenient runtime handlers. `oldText`/`newText` remain required strings and only those reach the edit logic.
 
 ## [0.78.1] - 2026-06-04
 

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -38,7 +38,18 @@ const replaceEditSchema = Type.Object(
 		}),
 		newText: Type.String({ description: "Replacement text for this targeted edit." }),
 	},
-	{ additionalProperties: false },
+	// No additionalProperties constraint: omitting it (rather than setting `true`) tolerates
+	// extraneous keys at validation while NOT advertising to the model that extra fields are
+	// welcome. tool.parameters is sent verbatim to providers as the wire tool schema, so
+	// `additionalProperties: false` emits "no extra keys" and `true` emits "extras are fine";
+	// omitting it emits neither, so the model is still steered toward clean { oldText, newText }
+	// and only the occasional artifact is silently accepted. oldText/newText stay required
+	// strings; only those reach the edit logic (see applyEditsToNormalizedContent), so unknown
+	// keys are harmlessly ignored. Weaker/smaller models intermittently append a near-duplicate
+	// filler key after a long newText value (e.g. { newText_strip: "" }) as a structural-
+	// completion artifact (also seen on frontier models for large single edits); strict
+	// rejection turned that harmless tic into a hard failure. This aligns the schema with the
+	// already-lenient runtime handlers.
 );
 
 const editSchema = Type.Object(

--- a/packages/coding-agent/test/edit-tool-extraneous-keys.test.ts
+++ b/packages/coding-agent/test/edit-tool-extraneous-keys.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateToolArguments } from "../../ai/src/utils/validation.ts";
+import type { ExtensionContext } from "../src/core/extensions/types.ts";
+import { createEditTool, createEditToolDefinition } from "../src/core/tools/edit.ts";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "pi-edit-extraneous-keys-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+// The model should not emit extra keys, but weaker/smaller models intermittently append a
+// near-duplicate filler key after a long newText value (e.g. { newText_strip: "" }) as a
+// structural-completion artifact. These tests assert the schema tolerates that artifact and
+// that only oldText/newText ever reach the edit logic.
+describe("edit tool schema tolerates extraneous keys", () => {
+	function validate(args: unknown): unknown {
+		const tool = createEditTool(process.cwd());
+		return validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-1",
+			name: "edit",
+			arguments: args as Record<string, any>,
+		});
+	}
+
+	it("accepts an edits[] item with an extra empty-string key", () => {
+		expect(() =>
+			validate({
+				path: "file.txt",
+				edits: [{ oldText: "a", newText: "b", newText_strip: "" }],
+			}),
+		).not.toThrow();
+	});
+
+	it("accepts an edits[] item with an extra non-empty-string key", () => {
+		expect(() =>
+			validate({
+				path: "file.txt",
+				edits: [{ oldText: "a", newText: "b", newText_x: "garbage" }],
+			}),
+		).not.toThrow();
+	});
+
+	it("still accepts a clean edit", () => {
+		expect(() =>
+			validate({
+				path: "file.txt",
+				edits: [{ oldText: "a", newText: "b" }],
+			}),
+		).not.toThrow();
+	});
+
+	it("still rejects an edit missing newText", () => {
+		expect(() =>
+			validate({
+				path: "file.txt",
+				edits: [{ oldText: "a" }],
+			}),
+		).toThrow(/Validation failed/);
+	});
+
+	it("still rejects an edit whose oldText is not a string (non-coercible)", () => {
+		// An object cannot be coerced to a string by Value.Convert, so it surfaces a clear error.
+		expect(() =>
+			validate({
+				path: "file.txt",
+				edits: [{ oldText: { nested: true }, newText: "b" }],
+			}),
+		).toThrow(/Validation failed/);
+	});
+});
+
+describe("edit tool ignores extraneous keys at execution", () => {
+	it("applies the same change with an extra key as without it", async () => {
+		const dir = await createTempDir();
+		const filePath = join(dir, "noisy.txt");
+		await writeFile(filePath, "before\n", "utf8");
+
+		const definition = createEditToolDefinition(dir);
+		const input = {
+			path: "noisy.txt",
+			edits: [{ oldText: "before", newText: "after", newText_strip: "" }],
+		};
+
+		const result = await definition.execute("tool-1", input as any, undefined, undefined, {} as ExtensionContext);
+		expect(result.content).toEqual([{ type: "text", text: "Successfully replaced 1 block(s) in noisy.txt." }]);
+		expect(await readFile(filePath, "utf8")).toBe("after\n");
+	});
+
+	it("ignores an extra key whose value is a non-empty string", async () => {
+		const dir = await createTempDir();
+		const filePath = join(dir, "noisy2.txt");
+		await writeFile(filePath, "before\n", "utf8");
+
+		const definition = createEditToolDefinition(dir);
+		const input = {
+			path: "noisy2.txt",
+			edits: [{ oldText: "before", newText: "after", newText_x: "should be ignored" }],
+		};
+
+		const result = await definition.execute("tool-2", input as any, undefined, undefined, {} as ExtensionContext);
+		expect(result.content).toEqual([{ type: "text", text: "Successfully replaced 1 block(s) in noisy2.txt." }]);
+		expect(await readFile(filePath, "utf8")).toBe("after\n");
+	});
+});


### PR DESCRIPTION
## What

Drop `additionalProperties: false` on the edit tool's **inner** `replaceEditSchema` (the `edits[]` item objects). The constraint is omitted, not set to `true`: validation tolerates an unknown key, while the wire schema still steers the model toward a clean `{ oldText, newText }`. `oldText`/`newText` stay required strings, and only those two reach `applyEditsToNormalizedContent`, so any extra key is harmlessly ignored.

The outer `editSchema` (`{ path, edits }`) stays strict — see Scope.

## Why

Models intermittently append a near-duplicate filler key after a long multi-line `newText` — names like `newText_strip`, `newText_2`, almost always with an empty-string value. It is not intent, and only `oldText`/`newText` ever reach the edit logic, so the extra key is already harmless. But the strict schema rejects the whole call first:

```
Validation failed for tool "edit":
  - edits.0: must not have additional properties
```

This turns a generation artifact into a hard failure, and it hits the weakest models hardest — they can't infer *which* field "additional properties" refers to, so they retry the same shape and burn round-trips. A single local-model session hit this ~9 times in 8 minutes, only recovering once it shrank `oldText` to single lines. Frontier models hit it intermittently on large edits too.

pi's runtime handlers already tolerate extras (`validateEditInput` only checks `edits` is a non-empty array; `getRenderablePreviewInput` ignores unknown keys), so the strict schema was out of step with how the handlers behave. This change aligns them.

### Omit vs. `additionalProperties: true`

`tool.parameters` is sent verbatim to providers as the wire tool definition, so the constraint is also advice to the model:

- `false` → "do not add keys" — the source of the hard rejection.
- `true` → "extra keys are fine" — would actively invite junk keys.
- omitted → nothing on the wire; validation tolerates extras (JSON Schema default) while the model is still steered toward a clean object.

No strict grammar-constrained sampling is used on this path, so omitting is the right lever.

### Scope

`edit.ts` has two `additionalProperties: false` declarations; only the inner one is relaxed:

- **Inner `replaceEditSchema`** (`edits[]` items) — relaxed. This is where the artifact lands.
- **Outer `editSchema`** (`{ path, edits }`) — kept strict. `prepareEditArguments` folds the legacy top-level `oldText`/`newText` shape into `edits[]` before validation; relaxing the outer schema would let `{ path, edits: [], oldText, newText }` pass and then hit the empty-edits error or silently drop the edit.

A sweep of `packages/coding-agent/src` confirms these are the only two `additionalProperties: false` declarations, and `replaceEditSchema` is the only nested, model-populated object guarded by one.

## Guardrails preserved

- `oldText`/`newText` remain required `Type.String()`; a missing field still errors.
- Only `oldText`/`newText` reach the edit logic; an unknown key can never change behavior.
- Legacy tolerant paths in `prepareEditArguments` (edits-as-JSON-string, legacy top-level form) are untouched.
- Empty-edits and "at least one replacement" errors are intact.

## Tests

New `packages/coding-agent/test/edit-tool-extraneous-keys.test.ts`:

- An `edits[]` item with an extra empty-string key validates and applies the same change as the clean call.
- An extra key with a non-empty string value is also ignored.
- A clean edit still validates; a genuinely invalid edit (`oldText` a non-coercible object) still errors.
- Execution-level checks confirm the extra key is ignored end-to-end.

Existing `edit-tool-legacy-input.test.ts` still passes. `npm run check` is green.
