### PR TITLE
feat(agent): validate LLM messages after extension transforms

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -7,6 +7,7 @@ import {
 	type AssistantMessage,
 	type Context,
 	EventStream,
+	type Message,
 	streamSimple,
 	type ToolResultMessage,
 	validateToolArguments,
@@ -287,6 +288,12 @@ async function streamAssistantResponse(
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
 	const llmMessages = await config.convertToLlm(messages);
+	// Validate message integrity after extension transforms.
+	// Extensions can modify messages via the `context` event hook. Bugs in
+	// extensions may produce invalid sequences that providers reject with
+	// confusing errors (e.g., MiniMax error 2013 "tool call result does not
+	// follow tool call"). Catch these before the provider sees them.
+	validateLlmMessages(llmMessages);
 
 	// Build LLM context
 	const llmContext: Context = {
@@ -739,4 +746,72 @@ function createToolResultMessage(finalized: FinalizedToolCallOutcome): ToolResul
 async function emitToolResultMessage(toolResultMessage: ToolResultMessage, emit: AgentEventSink): Promise<void> {
 	await emit({ type: "message_start", message: toolResultMessage });
 	await emit({ type: "message_end", message: toolResultMessage });
+}
+
+
+// ============================================================================
+// LLM message validation
+// ============================================================================
+
+/**
+ * Validate LLM messages for structural integrity after extension transforms.
+ *
+ * Extensions can modify messages via the `context` event hook. Bugs in
+ * extensions may produce invalid sequences that providers reject with
+ * confusing errors:
+ *
+ * - **MiniMax error 2013**: "tool call result does not follow tool call" —
+ *   a `toolResult` message has no preceding `assistant` message containing
+ *   a matching `toolCall` block.
+ *
+ * - **"Cannot continue from message role: assistant"**: the last message
+ *   is an `assistant` message. Some providers refuse to generate a
+ *   continuation when the conversation already ends with the assistant.
+ *
+ * Throws a descriptive error so the user knows an extension caused the
+ * problem rather than seeing an opaque provider rejection.
+ */
+export function validateLlmMessages(messages: Message[]): void {
+	if (messages.length === 0) return;
+
+	// Collect all toolCall IDs from assistant messages.
+	const assistantToolCallIds = new Set<string>();
+	for (const msg of messages) {
+		if (msg.role === "assistant") {
+			for (const block of msg.content) {
+				if (block.type === "toolCall" && block.id) {
+					assistantToolCallIds.add(block.id);
+				}
+			}
+		}
+	}
+
+	// Check for orphaned toolResult messages.
+	for (const msg of messages) {
+		if (msg.role === "toolResult") {
+			const toolResult = msg as ToolResultMessage;
+			if (toolResult.toolCallId && !assistantToolCallIds.has(toolResult.toolCallId)) {
+				throw new Error(
+					`Extension produced invalid message sequence: ` +
+					`toolResult for tool call "${toolResult.toolCallId}" (tool: ${toolResult.toolName}) ` +
+					`has no matching assistant toolCall. ` +
+					`This is usually caused by an extension's context hook removing or modifying ` +
+					`assistant messages that contained tool calls. ` +
+					`Check your active extensions or disable them with /extensions.`
+				);
+			}
+		}
+	}
+
+	// Check that the last message is not an assistant message.
+	const lastMsg = messages[messages.length - 1];
+	if (lastMsg && lastMsg.role === "assistant") {
+		throw new Error(
+			`Extension produced invalid message sequence: ` +
+			`the last message has role "assistant". ` +
+			`LLM providers require the conversation to end with a user or toolResult message. ` +
+			`This is usually caused by an extension's context hook inserting an assistant-typed ` +
+			`message at the end. Check your active extensions or disable them with /extensions.`
+		);
+	}
 }

--- a/packages/agent/test/validate-llm-messages.test.ts
+++ b/packages/agent/test/validate-llm-messages.test.ts
@@ -1,0 +1,115 @@
+import {
+	type AssistantMessage,
+	type Message,
+	type ToolResultMessage,
+	type UserMessage,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { validateLlmMessages } from "../src/agent-loop.ts";
+
+function createUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function userMsg(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function assistantMsg(toolCallIds: string[] = []): AssistantMessage {
+	const content: AssistantMessage["content"] = [];
+	if (toolCallIds.length === 0) {
+		content.push({ type: "text", text: "hello" });
+	}
+	for (const id of toolCallIds) {
+		content.push({ type: "toolCall", id, name: "test_tool", arguments: {} });
+	}
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: createUsage(),
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function toolResultMsg(toolCallId: string, toolName = "test_tool"): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text: "result" }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+describe("validateLlmMessages", () => {
+	it("passes for empty messages", () => {
+		expect(() => validateLlmMessages([])).not.toThrow();
+	});
+
+	it("passes for valid user-assistant-toolResult sequence", () => {
+		const messages: Message[] = [
+			userMsg("do something"),
+			assistantMsg(["call_1"]),
+			toolResultMsg("call_1"),
+		];
+		expect(() => validateLlmMessages(messages)).not.toThrow();
+	});
+
+	it("passes when last message is user", () => {
+		const messages: Message[] = [userMsg("hello")];
+		expect(() => validateLlmMessages(messages)).not.toThrow();
+	});
+
+	it("passes when last message is toolResult", () => {
+		const messages: Message[] = [
+			userMsg("do it"),
+			assistantMsg(["call_1"]),
+			toolResultMsg("call_1"),
+		];
+		expect(() => validateLlmMessages(messages)).not.toThrow();
+	});
+
+	it("throws when toolResult has no matching assistant toolCall", () => {
+		const messages: Message[] = [
+			userMsg("do it"),
+			assistantMsg([]), // no tool calls
+			toolResultMsg("orphaned_call"),
+		];
+		expect(() => validateLlmMessages(messages)).toThrowError(
+			/Extension produced invalid message sequence.*orphaned_call/s,
+		);
+	});
+
+	it("throws when last message is assistant", () => {
+		const messages: Message[] = [
+			userMsg("hello"),
+			assistantMsg([]),
+		];
+		expect(() => validateLlmMessages(messages)).toThrowError(
+			/Extension produced invalid message sequence.*last message has role "assistant"/s,
+		);
+	});
+
+	it("passes for multiple valid tool calls", () => {
+		const messages: Message[] = [
+			userMsg("do things"),
+			assistantMsg(["call_1", "call_2"]),
+			toolResultMsg("call_1"),
+			toolResultMsg("call_2"),
+			userMsg("more"),
+		];
+		expect(() => validateLlmMessages(messages)).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Problem

Extensions that modify messages via the `context` event hook can inadvertently produce invalid message sequences. LLM providers reject these with confusing, opaque errors:

- **MiniMax error 2013**: `"tool call result does not follow tool call"` — a `toolResult` message exists but no preceding `assistant` message contains a matching `toolCall` block. This happens when an extension's compaction or context-cleanup logic strips assistant messages containing tool calls while leaving the corresponding tool results.

- **`"Cannot continue from message role: assistant"`** — an extension inserts a message with assistant-like role at the end of the conversation, causing the provider to refuse continuation.

Both errors are particularly hard to debug because they surface as provider rejections with no indication that an extension caused them.

## Solution

Add `validateLlmMessages()` in `packages/agent/src/agent-loop.ts`, called after `convertToLlm` in `streamAssistantResponse`. It validates:

1. **Tool-call chain integrity**: every `toolResult` message has a preceding `assistant` message with a matching `toolCall` ID.
2. **Terminal message role**: the last message is not an `assistant` message (providers require user or toolResult).

On failure, a descriptive error is thrown pointing users to their active extensions.

## Changes

- `packages/agent/src/agent-loop.ts`: Added `validateLlmMessages()` function and call site after `convertToLlm`.
- `packages/agent/test/validate-llm-messages.test.ts`: 7 unit tests covering valid sequences, orphaned tool results, and invalid terminal messages.

## Testing

All 7 new tests pass. All 19 existing `agent-loop.test.ts` tests continue to pass.

```
✓ test/validate-llm-messages.test.ts (7 tests)
✓ test/agent-loop.test.ts (19 tests)
```
