### PR TITLE
fix: neutralize SUMMARIZATION_SYSTEM_PROMPT for non-coding agents

### DIFF
--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -376,7 +376,7 @@ export function findCutPoint(
 	};
 }
 
-export const SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI coding assistant, then produce a structured summary following the exact format specified.
+export const SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant, then produce a structured summary following the exact format specified.
 
 Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`;
 


### PR DESCRIPTION
Fixes #5401

## Summary

Replace the hardcoded `"AI coding assistant"` string in `SUMMARIZATION_SYSTEM_PROMPT` with the neutral `"AI assistant"`, so the compaction mechanism is not biased toward coding contexts.

## Change

```diff
- Your task is to read a conversation between a user and an AI coding assistant, then produce a structured summary
+ Your task is to read a conversation between a user and an AI assistant, then produce a structured summary
```

## Why

The `compaction.ts` module is core infrastructure in `@earendil-works/pi`. Baking an application-layer label ("coding assistant") into the summarization path produces suboptimal summaries for non-coding agents that reuse this package.

This is a one-line change with no API surface impact.