### PR TITLE
feat(coding-agent): export package path helpers from root API

### DIFF
--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -3,7 +3,7 @@
 export { type Args, parseArgs } from "./cli/args.ts";
 
 // Config paths
-export { getAgentDir, VERSION } from "./config.ts";
+export { getAgentDir, getDocsPath, getExamplesPath, getPackageDir, getReadmePath, VERSION } from "./config.ts";
 export {
 	AgentSession,
 	type AgentSessionConfig,


### PR DESCRIPTION
## Summary

Export `getPackageDir()`, `getReadmePath()`, `getDocsPath()`, and `getExamplesPath()` from the coding-agent package root API alongside the existing `getAgentDir` and `VERSION` exports.

These helpers already exist in `config.ts` but were not reachable through the public `exports` map, forcing extension authors to duplicate path-resolution logic or rely on unsupported deep imports.

Closes #5415

#### Test plan

- `npm run check` passes (biome, pinned-deps, ts-imports, shrinkwrap, tsgo, browser-smoke).
- The four new exports are type-checked alongside the existing root API surface.
- No runtime change — the helpers are unchanged; only the re-export is new.
