### PR TITLE
fix(tui): make Tab submit slash commands from autocomplete like Enter

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -625,10 +625,18 @@ export class Editor implements Component, Focusable {
 					this.state.lines = result.lines;
 					this.state.cursorLine = result.cursorLine;
 					this.setCursorCol(result.cursorCol);
-					this.cancelAutocomplete();
-					if (this.onChange) this.onChange(this.getText());
+
+					if (this.autocompletePrefix.startsWith("/")) {
+						this.cancelAutocomplete();
+						// Fall through to submit (same behavior as Enter/select.confirm)
+					} else {
+						this.cancelAutocomplete();
+						if (this.onChange) this.onChange(this.getText());
+						return;
+					}
+				} else {
+					return;
 				}
-				return;
 			}
 
 			if (kb.matches(data, "tui.select.confirm")) {


### PR DESCRIPTION
## Problem

When typing a slash command (e.g. `/settings`) and pressing **Tab** to accept the autocomplete suggestion, the editor applies the completion text but does **not** submit it. Instead, the slash command text remains in the input field, which triggers the slash command handler to spawn an extension component (selector/input/editor). That component steals keyboard focus, making **Enter unable to submit** the prompt until the user manually dismisses the extension UI.

**Enter** does not have this issue — it cancels autocomplete and falls through to the submit handler.

## Fix

In `packages/tui/src/components/editor.ts`, the Tab handler (`tui.input.tab`) now mirrors the Enter handler (`tui.select.confirm`): when the autocomplete prefix starts with `/`, the autocomplete is cancelled and execution falls through to the submit logic instead of returning early.

Non-slash-command completions (file paths, `@` mentions) are unaffected — they continue to insert text and return as before.

## Reproduction

1. Open Pi interactive mode
2. Type `/`
3. When autocomplete popup appears, press **Tab** to accept a command (e.g. `settings`)
4. **Before fix**: Extension component opens and steals focus; Enter does not submit
5. **After fix**: Slash command is immediately submitted, same as pressing Enter

## Testing

- Manual verification: Tab on slash commands now submits immediately
- Tab on file path / `@` completions still inserts text without submitting
- Enter on slash command autocomplete still works as before