### PR TITLE
feat: add mineru document-parsing skill

### DIFF
--- a/.pi/skills/mineru/SKILL.md
+++ b/.pi/skills/mineru/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: mineru
+description: Convert PDF, Office (DOC/DOCX/PPT/PPTX), images (PNG/JPG/JPEG), and HTML into clean Markdown and structured JSON using the MinerU document-parsing API. Supports OCR (109 languages), formula and table recognition, page ranges, and extra output formats (docx/html/latex). Use when extracting, parsing, or converting documents to Markdown.
+metadata:
+  source: https://mineru.net
+---
+
+# MinerU Document Parsing
+
+Converts PDF, DOC, DOCX, PPT, PPTX, PNG, JPG, JPEG, and HTML into Markdown plus structured JSON via the MinerU cloud API (`https://mineru.net/api/v4`). No local GPU required.
+
+## Setup
+
+Get a token (90-day validity) at https://mineru.net/apiManage/token, then store it:
+
+```bash
+mkdir -p ~/.config/mineru
+echo "YOUR_TOKEN" > ~/.config/mineru/token
+chmod 600 ~/.config/mineru/token
+```
+
+The helper reads `MINERU_TOKEN` or `~/.config/mineru/token`. Requires `curl` and `jq`.
+
+## Usage
+
+```bash
+# Parse a URL; prints the result-zip download link
+./scripts/mineru-parse.sh https://arxiv.org/pdf/2301.00001.pdf
+
+# Parse a local file; download + extract the markdown into ./out
+./scripts/mineru-parse.sh paper.pdf --output ./out --extract
+
+# Options
+./scripts/mineru-parse.sh doc.pdf --model vlm --ocr --pages "1-5,8" --format docx
+```
+
+Run `./scripts/mineru-parse.sh --help` for all options.
+
+## Models
+
+| Model | When to use |
+|-------|-------------|
+| `hybrid` | Default. Best general accuracy. |
+| `pipeline` | CPU-friendly, fast, general documents. |
+| `vlm` | Complex layouts or scanned pages. |
+| `MinerU-HTML` | Preserve HTML structure (web content). |
+
+Extra formats (`--format`, repeatable): `docx`, `html`, `latex`.
+
+## Limits
+
+Single file ≤200 MB / ≤600 pages; 2000 priority pages/day per account; ≤200 files per batch upload.
+
+## Output
+
+The result zip contains the main Markdown, `content_list.json` (structured content), an `images/` folder (extracted figures), and `layout.json` (layout analysis).
+
+See [references/api.md](references/api.md) for the full endpoint, parameter, and error-code reference, including the direct `curl` flow.

--- a/.pi/skills/mineru/references/api.md
+++ b/.pi/skills/mineru/references/api.md
@@ -1,0 +1,78 @@
+# MinerU API v4 Reference
+
+Base URL: `https://mineru.net/api/v4`. Auth header: `Authorization: Bearer <token>` (token valid 90 days; get one at https://mineru.net/apiManage/token).
+
+## 1. Create extraction task (single URL)
+
+`POST /extract/task`
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | yes | - | File URL (remote fetch; no direct upload) |
+| `model_version` | string | no | `hybrid` | `hybrid` / `pipeline` / `vlm` / `MinerU-HTML` |
+| `is_ocr` | bool | no | `false` | Force OCR |
+| `enable_formula` | bool | no | `true` | Formula recognition |
+| `enable_table` | bool | no | `true` | Table recognition |
+| `language` | string | no | `ch` | Document language |
+| `page_ranges` | string | no | - | e.g. `"2,4-6"` |
+| `data_id` | string | no | - | Custom tracking id |
+| `callback` | string | no | - | Webhook URL for async result |
+| `extra_formats` | array | no | - | Any of `["docx","html","latex"]` |
+
+Response: `{"code":0,"data":{"task_id":"..."},"msg":"ok"}`
+
+## 2. Get task result
+
+`GET /extract/task/{task_id}`
+
+States: `pending` → `running` → `done` / `failed` / `converting`. While running, `data.extract_progress` reports `extracted_pages`/`total_pages`. On `done`, `data.full_zip_url` holds the download link. On `failed`, `data.err_msg` explains why.
+
+## 3. Upload local files (batch)
+
+`POST /file-urls/batch` with `{"files":[{"name":"demo.pdf", ...per-file options...}]}` returns `data.batch_id` and `data.file_urls` (presigned PUT URLs, valid 24h).
+
+- `file_urls[i]` may be a plain string or `{ "url": ... }` — handle both.
+- `PUT` the raw file bytes to the presigned URL with an empty `Content-Type` (the OSS signature excludes it).
+- After upload the system auto-submits extraction; poll the batch results endpoint.
+
+## 4. Batch URL extraction
+
+`POST /extract/task/batch` submits multiple URLs at once and returns `data.batch_id`.
+
+## 5. Batch results
+
+`GET /extract-results/batch/{batch_id}` returns `data.extract_result[]`, each entry shaped like a single-task result (`state`, `full_zip_url`, `err_msg`).
+
+## Direct curl flow (URL)
+
+```bash
+TOKEN=$(cat ~/.config/mineru/token)
+curl -s -X POST https://mineru.net/api/v4/extract/task \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/doc.pdf","model_version":"hybrid"}'
+# -> {"code":0,"data":{"task_id":"TID"}}
+curl -s https://mineru.net/api/v4/extract/task/TID -H "Authorization: Bearer $TOKEN"
+# poll until {"data":{"state":"done","full_zip_url":"..."}}
+```
+
+## Output zip contents
+
+| Item | Description |
+|------|-------------|
+| `*.md` | Main Markdown output |
+| `content_list.json` | Ordered structured content blocks |
+| `images/` | Extracted figures/tables as images |
+| `layout.json` | Page layout analysis |
+| `*.docx` / `*.html` / `*.tex` | Present when requested via `extra_formats` |
+
+## Error codes
+
+| Code | Issue | Fix |
+|------|-------|-----|
+| A0202 | Token invalid | Check the `Bearer` prefix and token value |
+| A0211 | Token expired | Recreate at mineru.net (90-day validity) |
+| -60002 | Unrecognized format | Check the file extension |
+| -60005 | File too large | Max 200 MB |
+| -60006 | Too many pages | Max 600; split the document |
+| -60008 | URL timeout | Ensure the URL is publicly reachable |
+| -60012 | Task not found | Verify `task_id` / `batch_id` |

--- a/.pi/skills/mineru/scripts/mineru-parse.sh
+++ b/.pi/skills/mineru/scripts/mineru-parse.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# MinerU document parser: submit a URL or local file, poll, optionally download + extract.
+# Token: $MINERU_TOKEN or ~/.config/mineru/token  (get one at https://mineru.net/apiManage/token)
+set -euo pipefail
+
+TOKEN_FILE="${MINERU_TOKEN_FILE:-$HOME/.config/mineru/token}"
+BASE="${MINERU_API_BASE:-https://mineru.net/api/v4}"
+POLL="${MINERU_POLL_INTERVAL:-5}"
+MAX="${MINERU_MAX_POLL:-360}"
+
+MODEL=hybrid; OCR=false; FORMULA=true; TABLE=true
+OUTPUT=""; PAGES=""; EXTRACT=false; FORMATS=(); INPUT=""
+
+usage() {
+  cat <<'EOF'
+MinerU Document Parser
+Usage: mineru-parse.sh <url|file> [options]
+
+  --model <m>     hybrid (default) | pipeline | vlm | MinerU-HTML
+  --ocr           force OCR
+  --no-formula    disable formula recognition
+  --no-table      disable table recognition
+  --pages <r>     page ranges, e.g. "1-5,8"
+  --format <f>    extra output format docx|html|latex (repeatable)
+  --output <dir>  download the result zip into <dir>
+  --extract       unzip the result and print the markdown (use with --output)
+  -h, --help      show this help
+
+Env: MINERU_TOKEN / MINERU_TOKEN_FILE / MINERU_API_BASE / MINERU_POLL_INTERVAL / MINERU_MAX_POLL
+Supported inputs: PDF, DOC, DOCX, PPT, PPTX, PNG, JPG, JPEG, HTML
+EOF
+  exit 0
+}
+
+for c in curl jq; do command -v "$c" >/dev/null 2>&1 || { echo "error: '$c' is required" >&2; exit 1; }; done
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --ocr) OCR=true; shift ;;
+    --no-formula) FORMULA=false; shift ;;
+    --no-table) TABLE=false; shift ;;
+    --pages) PAGES="$2"; shift 2 ;;
+    --format) FORMATS+=("$2"); shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    --extract) EXTRACT=true; shift ;;
+    -*) echo "error: unknown option $1" >&2; exit 1 ;;
+    *) INPUT="$1"; shift ;;
+  esac
+done
+[ -n "$INPUT" ] || { echo "error: no input given (use -h)" >&2; exit 1; }
+
+TOKEN="${MINERU_TOKEN:-}"
+[ -n "$TOKEN" ] || TOKEN="$(cat "$TOKEN_FILE" 2>/dev/null || true)"
+[ -n "$TOKEN" ] || { echo "error: no token. Set MINERU_TOKEN or write $TOKEN_FILE (https://mineru.net/apiManage/token)" >&2; exit 1; }
+AUTH="Authorization: Bearer $TOKEN"
+
+# Common option object shared by URL and upload bodies.
+opts_json() {
+  jq -n --arg m "$MODEL" --argjson o "$OCR" --argjson f "$FORMULA" --argjson t "$TABLE" --arg p "$PAGES" \
+    '{model_version:$m, is_ocr:$o, enable_formula:$f, enable_table:$t}
+     + (if $p != "" then {page_ranges:$p} else {} end)'
+}
+
+add_formats() {  # merge extra_formats array into the json object on stdin
+  if [ ${#FORMATS[@]} -gt 0 ]; then
+    local arr; arr="$(printf '%s\n' "${FORMATS[@]}" | jq -R . | jq -s .)"
+    jq --argjson a "$arr" '. + {extra_formats:$a}'
+  else
+    cat
+  fi
+}
+
+download() {  # $1 = zip url
+  if [ -z "$OUTPUT" ]; then echo "$1"; return; fi
+  mkdir -p "$OUTPUT"
+  local zip="$OUTPUT/mineru_result.zip"
+  curl -fsSL -o "$zip" "$1"
+  echo "saved: $zip"
+  if $EXTRACT; then
+    unzip -qo "$zip" -d "$OUTPUT"
+    local md; md="$(find "$OUTPUT" -name '*.md' -type f | head -1)"
+    [ -n "$md" ] && { echo "--- $md ---"; cat "$md"; }
+  fi
+}
+
+poll() {  # $1 = task|batch, $2 = id
+  local url filt i=0 d
+  if [ "$1" = task ]; then url="$BASE/extract/task/$2"; filt='.data'
+  else url="$BASE/extract-results/batch/$2"; filt='.data.extract_result[0]'; fi
+  while [ "$i" -lt "$MAX" ]; do
+    i=$((i+1))
+    d="$(curl -fsS "$url" -H "$AUTH" | jq "$filt")"
+    case "$(echo "$d" | jq -r '.state')" in
+      done) download "$(echo "$d" | jq -r '.full_zip_url')"; return ;;
+      failed) echo "error: extraction failed: $(echo "$d" | jq -r '.err_msg // empty')" >&2; exit 1 ;;
+      *) echo "[$(echo "$d" | jq -r '.state')] $i/$MAX" >&2 ;;
+    esac
+    sleep "$POLL"
+  done
+  echo "error: timed out after $((MAX*POLL))s" >&2; exit 1
+}
+
+if [[ "$INPUT" =~ ^https?:// ]]; then
+  body="$(opts_json | jq --arg u "$INPUT" '. + {url:$u}' | add_formats)"
+  tid="$(curl -fsS -X POST "$BASE/extract/task" -H "$AUTH" -H 'Content-Type: application/json' -d "$body" | jq -r '.data.task_id')"
+  echo "task_id=$tid" >&2
+  poll task "$tid"
+else
+  [ -f "$INPUT" ] || { echo "error: file not found: $INPUT" >&2; exit 1; }
+  fbody="$(opts_json | jq --arg n "$(basename "$INPUT")" '{files:[. + {name:$n}]}')"
+  if [ ${#FORMATS[@]} -gt 0 ]; then
+    arr="$(printf '%s\n' "${FORMATS[@]}" | jq -R . | jq -s .)"
+    fbody="$(echo "$fbody" | jq --argjson a "$arr" '.files[0] += {extra_formats:$a}')"
+  fi
+  resp="$(curl -fsS -X POST "$BASE/file-urls/batch" -H "$AUTH" -H 'Content-Type: application/json' -d "$fbody")"
+  up="$(echo "$resp" | jq -r 'if (.data.file_urls[0]|type)=="string" then .data.file_urls[0] else .data.file_urls[0].url end')"
+  bid="$(echo "$resp" | jq -r '.data.batch_id')"
+  curl -fsS -X PUT "$up" -H 'Content-Type:' -T "$INPUT"
+  echo "batch_id=$bid" >&2
+  poll batch "$bid"
+fi


### PR DESCRIPTION
## What
Adds a mineru skill under .pi/skills/mineru/ (Agent Skills standard):
- SKILL.md: frontmatter (name/description) plus usage, models, limits
- scripts/mineru-parse.sh: curl+jq CLI wrapper (URL and local-file upload, polling, --extract)
- references/api.md: endpoint / parameter / error-code reference

## Why
Exposes MinerU (https://mineru.net) document to Markdown/JSON parsing as an on-demand skill.

## Testing
- npm run check passes (biome + tsgo + dependency checks).
- bash -n scripts/mineru-parse.sh passes.