### PR TITLE
Include models.json path in migration parse errors

### DIFF
--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -4,7 +4,7 @@
 
 import chalk from "chalk";
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { CONFIG_DIR_NAME, getAgentDir, getBinDir } from "./config.ts";
 import { migrateKeybindingsConfig } from "./core/keybindings.ts";
 import { isLegacyEnvVarNameConfigValue } from "./core/resolve-config-value.ts";
@@ -141,10 +141,18 @@ function migrateAuthJsonConfigValues(agentDir: string): ConfigValueMigration[] {
 }
 
 function migrateModelsJsonConfigValues(agentDir: string): ConfigValueMigration[] {
-	const modelsPath = join(agentDir, "models.json");
+	const modelsPath = resolve(agentDir, "models.json");
 	if (!existsSync(modelsPath)) return [];
 
-	const parsed = JSON.parse(stripJsonComments(readFileSync(modelsPath, "utf-8"))) as unknown;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(stripJsonComments(readFileSync(modelsPath, "utf-8"))) as unknown;
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			throw new Error(`Failed to parse models.json: ${error.message}\n\nFile: ${modelsPath}`);
+		}
+		throw error;
+	}
 	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return [];
 	const modelsData = parsed as Record<string, unknown>;
 	const providers = modelsData.providers;

--- a/packages/coding-agent/test/config-value-migration.test.ts
+++ b/packages/coding-agent/test/config-value-migration.test.ts
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.ts";
 import { runMigrations } from "../src/migrations.ts";
 
+vi.mock("../src/core/keybindings.ts", () => ({
+	migrateKeybindingsConfig: (config: Record<string, unknown>) => ({ config, migrated: false }),
+}));
+
 describe("config value env var syntax migration", () => {
 	const tempDirs: string[] = [];
 
@@ -134,5 +138,23 @@ describe("config value env var syntax migration", () => {
 		expect(logMessage).toContain(
 			'models.json.providers["custom-provider"].modelOverrides["model-b"].headers["x-override-key"]: OVERRIDE_API_KEY -> $OVERRIDE_API_KEY',
 		);
+	});
+
+	it("reports models.json parse errors with the file path during config value migration", () => {
+		const agentDir = createAgentDir();
+		const modelsJsonPath = path.join(agentDir, "models.json");
+		fs.writeFileSync(modelsJsonPath, '{ "providers": { "custom-provider": }', "utf-8");
+
+		let thrown: unknown;
+		try {
+			withAgentDir(agentDir, () => runMigrations(agentDir));
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(Error);
+		const message = thrown instanceof Error ? thrown.message : String(thrown);
+		expect(message).toContain("Failed to parse models.json:");
+		expect(message).toContain(`File: ${modelsJsonPath}`);
 	});
 });


### PR DESCRIPTION
## Summary
- report malformed `models.json` migration parse errors with the absolute file path
- keep non-syntax parsing errors unchanged
- add a regression test for config value migration failures

## Verification
- Docker Linux verification with `node:22.19.0-bookworm`: `npm ci --ignore-scripts && npm run build && npm --workspace @earendil-works/pi-coding-agent test`
  - `Test Files 132 passed | 6 skipped (138)`
  - `Tests 1357 passed | 44 skipped (1401)`
- `wsl bash -lc 'cd /mnt/d/CodeWorkSpace/github-10-pr-pr-5-pr/work/pi-5418-restart && npm run check'`
- `git diff --check`
- `git diff --cached --check`

Note: the Docker verification overrides `/proc/version` inside the privileged container because Docker Desktop on WSL2 exposes a Microsoft/WSL kernel string, which makes clipboard tests take the WSL path even though this is intended to simulate ordinary Linux CI.