### PR TITLE
fix(coding-agent): don't unconditionally continue after compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -966,7 +966,11 @@ export class AgentSession {
 		}
 
 		if (await this._checkCompaction(msg)) {
-			return true;
+			// Only continue if there are actually queued messages (e.g. from extension
+			// agent_end handlers). If compaction completed on an idle assistant turn,
+			// continuing would fail with "Cannot continue from message role: assistant"
+			// because the last message is still an assistant message with no pending work.
+			return this.agent.hasQueuedMessages();
 		}
 
 		// The agent loop drains both queues before emitting agent_end. Any messages


### PR DESCRIPTION
Fixes #5463

## Problem

After threshold-based auto-compaction completes, `_handlePostAgentRun` returns `true` unconditionally, even when no queued messages (steering / follow-up / extension) are pending. This triggers `agent.continue()`, which throws because the last message is still an assistant message and both queues are empty.

## Fix

Replace the unconditional `return true` in `_handlePostAgentRun`'s compaction branch with `return this.agent.hasQueuedMessages()` — the same guard already used at the bottom of the function and in `_runAutoCompaction`.

The overflow retry path in `_runAutoCompaction` is unaffected (it removes the error message from state before continuing, so queued messages are guaranteed).

## Changes

- `packages/coding-agent/src/core/agent-session.ts`: 1 insertion, 1 deletion
