### PR TITLE
fix(coding-agent): estimate context usage after compaction instead of showing null

### DIFF
--- a/packages/ai/src/utils/node-http-proxy.ts
+++ b/packages/ai/src/utils/node-http-proxy.ts
@@ -117,7 +117,7 @@ export function createHttpProxyAgentsForTarget(targetUrl: string | URL): NodeHtt
 	}
 
 	return {
-		httpAgent: new HttpProxyAgent(proxyUrl),
+		httpAgent: new HttpProxyAgent(proxyUrl) as unknown as HttpAgent,
 		httpsAgent: new HttpsProxyAgent(proxyUrl) as unknown as HttpsAgent,
 	};
 }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2965,16 +2965,11 @@ export class AgentSession {
 		const contextWindow = model.contextWindow ?? 0;
 		if (contextWindow <= 0) return undefined;
 
-		// After compaction, the last assistant usage reflects pre-compaction context size.
-		// We can only trust usage from an assistant that responded after the latest compaction.
-		// If no such assistant exists, context token count is unknown until the next LLM response.
 		const branchEntries = this.sessionManager.getBranch();
 		const latestCompaction = getLatestCompactionEntry(branchEntries);
 
 		if (latestCompaction) {
-			// Check if there's a valid assistant usage after the compaction boundary
 			const compactionIndex = branchEntries.lastIndexOf(latestCompaction);
-			let hasPostCompactionUsage = false;
 			for (let i = branchEntries.length - 1; i > compactionIndex; i--) {
 				const entry = branchEntries[i];
 				if (entry.type === "message" && entry.message.role === "assistant") {
@@ -2982,15 +2977,15 @@ export class AgentSession {
 					if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error") {
 						const contextTokens = calculateContextTokens(assistant.usage);
 						if (contextTokens > 0) {
-							hasPostCompactionUsage = true;
+							return {
+								tokens: contextTokens,
+								contextWindow,
+								percent: (contextTokens / contextWindow) * 100,
+							};
 						}
-						break;
 					}
+					break;
 				}
-			}
-
-			if (!hasPostCompactionUsage) {
-				return { tokens: null, contextWindow, percent: null };
 			}
 		}
 

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -96,7 +96,7 @@ describe("AgentSession.getSessionStats", () => {
 		}
 	});
 
-	it("reports unknown current context usage immediately after compaction", () => {
+	it("falls back to estimated context usage immediately after compaction", () => {
 		const { session, sessionManager } = createSession();
 
 		try {
@@ -111,8 +111,8 @@ describe("AgentSession.getSessionStats", () => {
 			const stats = session.getSessionStats();
 			expect(stats.tokens.input).toBe(195_000);
 			expect(stats.contextUsage).toBeDefined();
-			expect(stats.contextUsage?.tokens).toBeNull();
-			expect(stats.contextUsage?.percent).toBeNull();
+			expect(typeof stats.contextUsage?.tokens).toBe("number");
+			expect(typeof stats.contextUsage?.percent).toBe("number");
 		} finally {
 			session.dispose();
 		}


### PR DESCRIPTION
## Summary\n\nAfter compaction, `getContextUsage()` currently returns `{ tokens: null, percent: null }` when no post-compaction assistant usage is available. This shows \"?/200k\" in the footer, giving the user no information about their context usage until the next LLM response.\n\nThis PR changes the behavior to fall through to `estimateContextTokens()` instead, which provides a reasonable approximation based on the current message history. When a valid post-compaction assistant usage exists, it is still returned directly (more accurate than the estimate).\n\n## Changes\n\n- `agent-session.ts`: Remove the `hasPostCompactionUsage` flag and early `null` return. When no post-compaction usage is found, fall through to the existing `estimateContextTokens()` path.\n- Updated test to expect numeric values instead of `null`.\n\n## Before/After\n\n| Scenario | Before | After |\n|----------|--------|-------|\n| Post-compaction, no assistant response yet | `?/200k` | `~45k/200k` (estimate) |\n| Post-compaction, assistant responded | `52k/200k` | `52k/200k` (unchanged) |\n| No compaction | `52k/200k` | `52k/200k` (unchanged) |