### PR TITLE
feat(coding-agent): require bash descriptions and default timeout

### DIFF
--- a/packages/ai/src/utils/node-http-proxy.ts
+++ b/packages/ai/src/utils/node-http-proxy.ts
@@ -117,7 +117,7 @@ export function createHttpProxyAgentsForTarget(targetUrl: string | URL): NodeHtt
 	}
 
 	return {
-		httpAgent: new HttpProxyAgent(proxyUrl),
+		httpAgent: new HttpProxyAgent(proxyUrl) as unknown as HttpAgent,
 		httpsAgent: new HttpsProxyAgent(proxyUrl) as unknown as HttpsAgent,
 	};
 }

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -21,9 +21,16 @@ import { getTextOutput, invalidArgText, str } from "./render-utils.ts";
 import { wrapToolDefinition } from "./tool-definition-wrapper.ts";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult } from "./truncate.ts";
 
+const DEFAULT_TIMEOUT_SECONDS = 300;
+
 const bashSchema = Type.Object({
 	command: Type.String({ description: "Bash command to execute" }),
-	timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (optional, no default timeout)" })),
+	description: Type.String({ description: "Clear, concise description of what this command does in 5-10 words" }),
+	timeout: Type.Optional(
+		Type.Number({
+			description: `Hard timeout in seconds. Process is killed if still running after this duration. Defaults to ${DEFAULT_TIMEOUT_SECONDS}s (5 minutes). Acts as a safety net to prevent zombie processes.`,
+		}),
+	),
 });
 
 export type BashToolInput = Static<typeof bashSchema>;
@@ -176,12 +183,14 @@ function formatDuration(ms: number): string {
 	return `${(ms / 1000).toFixed(1)}s`;
 }
 
-function formatBashCall(args: { command?: string; timeout?: number } | undefined): string {
+function formatBashCall(args: { command?: string; description?: string; timeout?: number } | undefined): string {
 	const command = str(args?.command);
+	const description = str(args?.description);
 	const timeout = args?.timeout as number | undefined;
 	const timeoutSuffix = timeout ? theme.fg("muted", ` (timeout ${timeout}s)`) : "";
 	const commandDisplay = command === null ? invalidArgText(theme) : command ? command : theme.fg("toolOutput", "...");
-	return theme.fg("toolTitle", theme.bold(`$ ${commandDisplay}`)) + timeoutSuffix;
+	const descriptionPrefix = description ? theme.fg("muted", `${description} `) : "";
+	return descriptionPrefix + theme.fg("toolTitle", theme.bold(`$ ${commandDisplay}`)) + timeoutSuffix;
 }
 
 function rebuildBashResultRenderComponent(
@@ -276,16 +285,26 @@ export function createBashToolDefinition(
 	return {
 		name: "bash",
 		label: "bash",
-		description: `Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.`,
+		description: [
+			`Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file.`,
+			"",
+			"Timeout behavior:",
+			`- timeout: Hard limit in seconds. Process is killed after this duration. Default: ${DEFAULT_TIMEOUT_SECONDS}s (5 min).`,
+			"",
+			"Rules:",
+			"- ALWAYS provide a description (5-10 words explaining what the command does).",
+			"- Use the workdir parameter to run commands in a specific directory instead of cd.",
+		].join("\n"),
 		promptSnippet: "Execute bash commands (ls, grep, find, etc.)",
 		parameters: bashSchema,
 		async execute(
 			_toolCallId,
-			{ command, timeout }: { command: string; timeout?: number },
+			{ command, description: _description, timeout }: { command: string; description: string; timeout?: number },
 			signal?: AbortSignal,
 			onUpdate?,
 			_ctx?,
 		) {
+			const effectiveTimeout = timeout ?? DEFAULT_TIMEOUT_SECONDS;
 			const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
 			const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook);
 			const output = new OutputAccumulator({ tempFilePrefix: "pi-bash" });
@@ -375,7 +394,7 @@ export function createBashToolDefinition(
 					const result = await ops.exec(spawnContext.command, spawnContext.cwd, {
 						onData: handleData,
 						signal,
-						timeout,
+						timeout: effectiveTimeout,
 						env: spawnContext.env,
 					});
 					exitCode = result.exitCode;

--- a/packages/coding-agent/test/bash-close-hang-windows.test.ts
+++ b/packages/coding-agent/test/bash-close-hang-windows.test.ts
@@ -113,9 +113,13 @@ describe.skipIf(process.platform !== "win32")("Windows child-process close handl
 		const bashTool = createBashTool(testDir);
 
 		try {
-			const result = await withTimeout(bashTool.execute("test-call", { command }, controller.signal), 3000, () => {
-				controller.abort();
-			});
+			const result = await withTimeout(
+				bashTool.execute("test-call", { description: "Spawn inherited stdio child", command }, controller.signal),
+				3000,
+				() => {
+					controller.abort();
+				},
+			);
 
 			expect(getTextOutput(result)).toContain("child-exiting");
 		} finally {

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -145,7 +145,7 @@ describe("ToolExecutionComponent parity", () => {
 		const tool = createBashToolDefinition(process.cwd(), { operations });
 		const promise = tool.execute(
 			"tool-bash-1",
-			{ command: "sleep 10" },
+			{ description: "Sleep for partial update test", command: "sleep 10" },
 			undefined,
 			(update) => updates.push(update as { content: Array<{ type: string; text?: string }>; details?: unknown }),
 			{} as never,
@@ -166,7 +166,7 @@ describe("ToolExecutionComponent parity", () => {
 		const tool = createBashToolDefinition(process.cwd(), { operations });
 		const result = await tool.execute(
 			"tool-bash-1b",
-			{ command: "generate output" },
+			{ description: "Generate large output", command: "generate output" },
 			undefined,
 			undefined,
 			{} as never,

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -438,22 +438,25 @@ describe("Coding Agent Tools", () => {
 
 	describe("bash tool", () => {
 		it("should execute simple commands", async () => {
-			const result = await bashTool.execute("test-call-8", { command: "echo 'test output'" });
+			const result = await bashTool.execute("test-call-8", {
+				description: "Echo test output",
+				command: "echo 'test output'",
+			});
 
 			expect(getTextOutput(result)).toContain("test output");
 			expect(result.details).toBeUndefined();
 		});
 
 		it("should handle command errors", async () => {
-			await expect(bashTool.execute("test-call-9", { command: "exit 1" })).rejects.toThrow(
-				/(Command failed|code 1)/,
-			);
+			await expect(
+				bashTool.execute("test-call-9", { description: "Exit with code one", command: "exit 1" }),
+			).rejects.toThrow(/(Command failed|code 1)/);
 		});
 
 		it("should respect timeout", async () => {
-			await expect(bashTool.execute("test-call-10", { command: "sleep 5", timeout: 1 })).rejects.toThrow(
-				/timed out/i,
-			);
+			await expect(
+				bashTool.execute("test-call-10", { description: "Sleep for timeout test", command: "sleep 5", timeout: 1 }),
+			).rejects.toThrow(/timed out/i);
 		});
 
 		it("should include full output path for truncated timeout and abort errors", async () => {
@@ -473,7 +476,10 @@ describe("Coding Agent Tools", () => {
 
 				let error: unknown;
 				try {
-					await bash.execute(`test-call-${testCase.error}`, { command: "chatty-fail" });
+					await bash.execute(`test-call-${testCase.error}`, {
+						description: "Chatty fail command",
+						command: "chatty-fail",
+					});
 				} catch (err) {
 					error = err;
 				}
@@ -497,9 +503,9 @@ describe("Coding Agent Tools", () => {
 
 			const bashToolWithBadCwd = createBashTool(nonexistentCwd);
 
-			await expect(bashToolWithBadCwd.execute("test-call-11", { command: "echo test" })).rejects.toThrow(
-				/Working directory does not exist/,
-			);
+			await expect(
+				bashToolWithBadCwd.execute("test-call-11", { description: "Echo test in bad cwd", command: "echo test" }),
+			).rejects.toThrow(/Working directory does not exist/);
 		});
 
 		it("should handle process spawn errors", async () => {
@@ -510,7 +516,9 @@ describe("Coding Agent Tools", () => {
 
 			const bashWithBadShell = createBashTool(testDir);
 
-			await expect(bashWithBadShell.execute("test-call-12", { command: "echo test" })).rejects.toThrow(/ENOENT/);
+			await expect(
+				bashWithBadShell.execute("test-call-12", { description: "Echo test with bad shell", command: "echo test" }),
+			).rejects.toThrow(/ENOENT/);
 		});
 
 		it("should pass shellPath through to shell resolution", async () => {
@@ -522,7 +530,10 @@ describe("Coding Agent Tools", () => {
 				},
 			});
 
-			await bashWithCustomShell.execute("test-call-12b", { command: "echo test" });
+			await bashWithCustomShell.execute("test-call-12b", {
+				description: "Echo test with custom shell",
+				command: "echo test",
+			});
 
 			expect(getShellConfigSpy).not.toHaveBeenCalled();
 
@@ -540,7 +551,10 @@ describe("Coding Agent Tools", () => {
 				commandPrefix: "export TEST_VAR=hello",
 			});
 
-			const result = await bashWithPrefix.execute("test-prefix-1", { command: "echo $TEST_VAR" });
+			const result = await bashWithPrefix.execute("test-prefix-1", {
+				description: "Echo prefix test variable",
+				command: "echo $TEST_VAR",
+			});
 			expect(getTextOutput(result).trim()).toBe("hello");
 		});
 
@@ -549,14 +563,20 @@ describe("Coding Agent Tools", () => {
 				commandPrefix: "echo prefix-output",
 			});
 
-			const result = await bashWithPrefix.execute("test-prefix-2", { command: "echo command-output" });
+			const result = await bashWithPrefix.execute("test-prefix-2", {
+				description: "Echo prefix and command output",
+				command: "echo command-output",
+			});
 			expect(getTextOutput(result).trim()).toBe("prefix-output\ncommand-output");
 		});
 
 		it("should work without command prefix", async () => {
 			const bashWithoutPrefix = createBashTool(testDir, {});
 
-			const result = await bashWithoutPrefix.execute("test-prefix-3", { command: "echo no-prefix" });
+			const result = await bashWithoutPrefix.execute("test-prefix-3", {
+				description: "Echo without prefix",
+				command: "echo no-prefix",
+			});
 			expect(getTextOutput(result).trim()).toBe("no-prefix");
 		});
 
@@ -572,8 +592,11 @@ describe("Coding Agent Tools", () => {
 			const updates: Array<{ content: Array<{ type: string; text?: string }>; details?: unknown }> = [];
 			const bash = createBashTool(testDir, { operations });
 
-			const result = await bash.execute("test-call-chatty-updates", { command: "chatty" }, undefined, (update) =>
-				updates.push(update),
+			const result = await bash.execute(
+				"test-call-chatty-updates",
+				{ description: "Chatty output command", command: "chatty" },
+				undefined,
+				(update) => updates.push(update),
 			);
 
 			expect(updates.length).toBeLessThan(25);
@@ -591,7 +614,10 @@ describe("Coding Agent Tools", () => {
 			};
 			const bash = createBashTool(testDir, { operations });
 
-			const result = await bash.execute("test-call-trailing-newline-line-count", { command: "many-lines" });
+			const result = await bash.execute("test-call-trailing-newline-line-count", {
+				description: "Generate many lines",
+				command: "many-lines",
+			});
 			const output = getTextOutput(result);
 
 			expect(result.details?.truncation?.totalLines).toBe(4000);
@@ -613,7 +639,10 @@ describe("Coding Agent Tools", () => {
 			};
 			const bash = createBashTool(testDir, { operations });
 
-			const result = await bash.execute("test-call-split-utf8", { command: "split-utf8" });
+			const result = await bash.execute("test-call-split-utf8", {
+				description: "Test split UTF-8 decoding",
+				command: "split-utf8",
+			});
 
 			expect(getTextOutput(result).trim()).toBe("€");
 		});
@@ -644,7 +673,10 @@ describe("Coding Agent Tools", () => {
 
 		it("should persist full output when truncation happens by line count only", async () => {
 			const bash = createBashTool(testDir);
-			const result = await bash.execute("test-call-line-truncation", { command: "seq 3000" });
+			const result = await bash.execute("test-call-line-truncation", {
+				description: "Sequence output for truncation",
+				command: "seq 3000",
+			});
 			const output = getTextOutput(result);
 			const fullOutputPath = result.details?.fullOutputPath;
 
@@ -681,6 +713,24 @@ describe("Coding Agent Tools", () => {
 			const fullOutput = readFileSync(fullOutputPath!, "utf-8");
 			expect(fullOutput).toContain("1\n2\n3");
 			expect(fullOutput).toContain("2998\n2999\n3000");
+		});
+
+		it("should default timeout to 300 seconds when not provided", async () => {
+			let receivedTimeout: number | undefined;
+			const operations: BashOperations = {
+				exec: async (_command, _cwd, { timeout }) => {
+					receivedTimeout = timeout;
+					return { exitCode: 0 };
+				},
+			};
+			const bash = createBashTool(testDir, { operations });
+
+			await bash.execute("test-call-default-timeout", {
+				description: "Test default timeout",
+				command: "echo default",
+			});
+
+			expect(receivedTimeout).toBe(300);
 		});
 	});
 


### PR DESCRIPTION
## Summary\n\nTwo improvements to the bash tool:\n\n### 1. Required `description` parameter\n\nAdd a required `description` field to the bash tool schema. This forces the LLM to provide a short (5-10 word) explanation of what each command does. Benefits:\n\n- **Readability**: Session logs show what each command was intended to do, not just the raw command\n- **Auditability**: Easier to review agent actions without reading every shell command\n- **Description is displayed** as a muted prefix before the command in the tool call render\n\n### 2. Default timeout of 300 seconds\n\nPreviously, bash commands could run indefinitely if no timeout was specified, risking zombie processes. This PR sets a default timeout of 5 minutes when none is provided.\n\n## Changes\n\n- `bash.ts`: Add `description` as a required string field in `bashSchema`, add `DEFAULT_TIMEOUT_SECONDS = 300`, update `formatBashCall()` to display description, update tool description text\n- Tests: Add `description` to all bash execute calls, add new test for default timeout behavior\n\n## Example\n\nBefore:\n```\n$ ls -la src/\n```\n\nAfter:\n```\nList source directory contents $ ls -la src/\n```