### PR TITLE
Fix coding-agent hooks package export

### DIFF
--- a/packages/coding-agent/src/core/hooks/index.ts
+++ b/packages/coding-agent/src/core/hooks/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Deprecated compatibility entry point for the former hooks API.
+ *
+ * Hooks were merged into the extension system, but the published package still
+ * exposes `@earendil-works/pi-coding-agent/hooks`. Keep that subpath
+ * importable and map the common hook names to their extension equivalents.
+ */
+
+export type {
+	AppendEntryHandler,
+	Extension as LoadedHook,
+	ExtensionAPI as HookAPI,
+	ExtensionCommandContext as HookCommandContext,
+	ExtensionContext as HookContext,
+	ExtensionError as HookError,
+	ExtensionErrorListener as HookErrorListener,
+	ExtensionEvent as HookEvent,
+	ExtensionFactory as HookFactory,
+	ExtensionFlag as HookFlag,
+	ExtensionHandler as HookHandler,
+	ExtensionShortcut as HookShortcut,
+	ExtensionUIContext as HookUIContext,
+	ForkHandler as BranchHandler,
+	GetActiveToolsHandler,
+	GetAllToolsHandler,
+	LoadExtensionsResult as LoadHooksResult,
+	NavigateTreeHandler,
+	NewSessionHandler,
+	SendMessageHandler,
+	SetActiveToolsHandler,
+} from "../extensions/index.ts";
+export * from "../extensions/index.ts";
+export {
+	createExtensionRuntime,
+	discoverAndLoadExtensions as discoverAndLoadHooks,
+	loadExtensions as loadHooks,
+} from "../extensions/loader.ts";
+export { ExtensionRunner as HookRunner } from "../extensions/runner.ts";
+export {
+	wrapRegisteredTool as wrapToolWithHooks,
+	wrapRegisteredTools as wrapToolsWithHooks,
+} from "../extensions/wrapper.ts";
+export type { ReadonlySessionManager } from "../session-manager.ts";

--- a/packages/coding-agent/test/hooks-export.test.ts
+++ b/packages/coding-agent/test/hooks-export.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+	discoverAndLoadHooks,
+	HookRunner,
+	loadHooks,
+	wrapToolsWithHooks,
+	wrapToolWithHooks,
+} from "../src/core/hooks/index.ts";
+
+describe("deprecated hooks export", () => {
+	it("maps the hooks entry point to the extension API", () => {
+		expect(discoverAndLoadHooks).toBeTypeOf("function");
+		expect(loadHooks).toBeTypeOf("function");
+		expect(HookRunner).toBeTypeOf("function");
+		expect(wrapToolWithHooks).toBeTypeOf("function");
+		expect(wrapToolsWithHooks).toBeTypeOf("function");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the published `@earendil-works/pi-coding-agent/hooks` subpath export by adding a deprecated compatibility entry point that maps the former hooks API names to the current extension API.

## Root Cause

The package still advertises:

```json
"./hooks": {
  "types": "./dist/core/hooks/index.d.ts",
  "import": "./dist/core/hooks/index.js"
}
```

but `packages/coding-agent/src/core/hooks` was removed when hooks were merged into the extension system, so the published tarball does not contain `dist/core/hooks/index.js` or `dist/core/hooks/index.d.ts`.

## Impact

Consumers importing `@earendil-works/pi-coding-agent/hooks` from the published package hit `ERR_MODULE_NOT_FOUND`. This keeps the subpath importable while preserving the extension-system migration.

## Validation

- `npm run build`
- `npm --prefix packages/coding-agent test -- hooks-export.test.ts`
- `npm run check`
- `npm_config_cache=/private/tmp/npm-cache-earendil npm pack --pack-destination /private/tmp/earendil-pack-0840 --json`
- `tar -tzf /private/tmp/earendil-pack-0840/earendil-works-pi-coding-agent-0.78.1.tgz package/dist/core/hooks/index.js package/dist/core/hooks/index.d.ts`
- Clean consumer install of the packed tarball and runtime import of `@earendil-works/pi-coding-agent/hooks`
