### PR TITLE
feat(minimax): use adaptive thinking for MiniMax-M3

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -233,7 +233,8 @@ function isAnthropicAdaptiveThinkingModel(modelId: string): boolean {
 		modelId.includes("opus-4-8") ||
 		modelId.includes("opus-4.8") ||
 		modelId.includes("sonnet-4-6") ||
-		modelId.includes("sonnet-4.6")
+		modelId.includes("sonnet-4.6") ||
+		modelId.includes("MiniMax-M3")
 	);
 }
 

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -5627,6 +5627,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "minimax",
 			baseUrl: "https://api.minimax.io/anthropic",
+			compat: {"forceAdaptiveThinking":true},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -5680,6 +5681,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "minimax-cn",
 			baseUrl: "https://api.minimaxi.com/anthropic",
+			compat: {"forceAdaptiveThinking":true},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {

--- a/packages/ai/test/anthropic-adaptive-thinking-models.test.ts
+++ b/packages/ai/test/anthropic-adaptive-thinking-models.test.ts
@@ -6,6 +6,7 @@ const EXPECTED_CURRENT_ADAPTIVE_THINKING_MODELS = [
 	"anthropic/claude-opus-4-8",
 	"opencode/claude-opus-4-8",
 	"vercel-ai-gateway/anthropic/claude-opus-4.8",
+	"minimax/MiniMax-M3",
 ];
 
 function getAllModels(): Model<Api>[] {
@@ -22,7 +23,7 @@ describe("Anthropic adaptive thinking model metadata", () => {
 
 		expect(flaggedModels).toEqual(expect.arrayContaining([...EXPECTED_CURRENT_ADAPTIVE_THINKING_MODELS].sort()));
 		expect(flaggedModels).toEqual(
-			flaggedModels.filter((modelId) => /(opus[-.]4[-.][678]|sonnet[-.]4[-.]6)/.test(modelId)),
+			flaggedModels.filter((modelId) => /(opus[-.]4[-.][678]|sonnet[-.]4[-.]6|MiniMax-M3)/.test(modelId)),
 		);
 	});
 });

--- a/packages/ai/test/anthropic-force-adaptive-thinking.test.ts
+++ b/packages/ai/test/anthropic-force-adaptive-thinking.test.ts
@@ -100,4 +100,11 @@ describe("Anthropic forceAdaptiveThinking compat override", () => {
 		expect(payload.thinking).toEqual({ type: "disabled" });
 		expect(payload.output_config).toBeUndefined();
 	});
+
+	it("sends adaptive thinking payload for the built-in MiniMax-M3 model", async () => {
+		const payload = await capturePayload(getModel("minimax", "MiniMax-M3"), { reasoning: "medium" });
+
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "medium" });
+	});
 });


### PR DESCRIPTION
## Summary

`MiniMax-M3` is an Anthropic Messages–compatible model that supports the **adaptive thinking** request format (`thinking: { type: "adaptive" }` + `output_config.effort`) — the same shape pi already emits for Claude Opus 4.6+/4.7+/4.8 and Sonnet 4.6.

Today M3 is **not** flagged as adaptive, so it falls through to budget-based thinking (`{ type: "enabled", budget_tokens }`) and ends up reasoning even on trivial prompts. This adds M3 to the existing adaptive gate so the built-in `minimax` / `minimax-cn` M3 entries carry `compat.forceAdaptiveThinking`, letting the model self-scale how much it thinks.

## Changes

- `packages/ai/scripts/generate-models.ts` — add `MiniMax-M3` to `isAnthropicAdaptiveThinkingModel()` (matches the existing Opus/Sonnet substring style).
- `packages/ai/src/models.generated.ts` — regenerated: the two M3 entries gain `compat: { "forceAdaptiveThinking": true }` (only the M3 lines are included; unrelated live-catalog drift was excluded).
- `packages/ai/test/anthropic-adaptive-thinking-models.test.ts` — admit M3 in the metadata guard.
- `packages/ai/test/anthropic-force-adaptive-thinking.test.ts` — add a payload-capture test that drives the real built-in `getModel("minimax", "MiniMax-M3")` and asserts it emits adaptive thinking.

## Verification

- New test confirms `MiniMax-M3` produces `thinking: { type: "adaptive", display: "summarized" }` + `output_config: { effort: "medium" }` through pi's actual stream path.
- Full pre-commit gate (biome, ts-imports, shrinkwrap, `tsgo --noEmit`, browser-smoke) passes.
- Live-checked against the M3 endpoint: the adaptive format is accepted, thinking self-scales by prompt difficulty, and all five effort levels (low/medium/high/xhigh/max) are honored.
