### PR TITLE
[Luke R] Enforce context window mid-turn via shouldStopAfterTurn

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `shouldStopAfterTurn` on `AgentOptions` and `Agent`, allowing callers to gracefully stop after a completed turn before polling queued messages or starting another LLM call ([#5512](https://github.com/earendil-works/pi/issues/5512)).
+
 ## [0.79.0] - 2026-06-08
 
 ### Fixed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -22,6 +22,7 @@ import type {
 	BeforeToolCallContext,
 	BeforeToolCallResult,
 	QueueMode,
+	ShouldStopAfterTurnContext,
 	StreamFn,
 	ToolExecutionMode,
 } from "./types.ts";
@@ -101,6 +102,7 @@ export interface AgentOptions {
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	onPayload?: SimpleStreamOptions["onPayload"];
 	onResponse?: SimpleStreamOptions["onResponse"];
+	shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 	beforeToolCall?: (context: BeforeToolCallContext, signal?: AbortSignal) => Promise<BeforeToolCallResult | undefined>;
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
 	prepareNextTurn?: (
@@ -175,6 +177,7 @@ export class Agent {
 	public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	public onPayload?: SimpleStreamOptions["onPayload"];
 	public onResponse?: SimpleStreamOptions["onResponse"];
+	public shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 	public beforeToolCall?: (
 		context: BeforeToolCallContext,
 		signal?: AbortSignal,
@@ -206,6 +209,7 @@ export class Agent {
 		this.getApiKey = options.getApiKey;
 		this.onPayload = options.onPayload;
 		this.onResponse = options.onResponse;
+		this.shouldStopAfterTurn = options.shouldStopAfterTurn;
 		this.beforeToolCall = options.beforeToolCall;
 		this.afterToolCall = options.afterToolCall;
 		this.prepareNextTurn = options.prepareNextTurn;
@@ -431,6 +435,7 @@ export class Agent {
 			thinkingBudgets: this.thinkingBudgets,
 			maxRetryDelayMs: this.maxRetryDelayMs,
 			toolExecution: this.toolExecution,
+			shouldStopAfterTurn: this.shouldStopAfterTurn,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
 			prepareNextTurn: this.prepareNextTurn ? async () => await this.prepareNextTurn?.(this.signal) : undefined,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed context growing unbounded during long tool loops when `contextWindow` is set lower than the provider's actual limit. The agent now uses `shouldStopAfterTurn` to stop cleanly after a tool turn crosses the compaction threshold, compacts, and resumes the tool loop ([#5512](https://github.com/earendil-works/pi/issues/5512)).
+
 ## [0.79.0] - 2026-06-08
 
 ### New Features

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1841,31 +1841,38 @@ export class AgentSession {
 			return await this._runAutoCompaction("overflow", true);
 		}
 
-		// Case 2: Threshold - context is getting large
+		// Case 2: Threshold - context is getting large.
 		// For error messages (no usage data), estimate from last successful response.
-		// This ensures sessions that hit persistent API errors (e.g. 529) can still compact.
-		let contextTokens: number;
-		if (assistantMessage.stopReason === "error") {
-			const messages = this.agent.state.messages;
-			const estimate = estimateContextTokens(messages);
-			if (estimate.lastUsageIndex === null) return false; // No usage data at all
+		// For successful messages, also include messages appended after the LLM call
+		// (for example large tool results) so graceful mid-turn stops can compact.
+		const messages = this.agent.state.messages;
+		const estimate = estimateContextTokens(messages);
+		let estimatedContextTokens: number | undefined;
+		if (estimate.lastUsageIndex !== null) {
 			// Verify the usage source is post-compaction. Kept pre-compaction messages
 			// have stale usage reflecting the old (larger) context and would falsely
 			// trigger compaction right after one just finished.
 			const usageMsg = messages[estimate.lastUsageIndex];
-			if (
+			const usageIsFromBeforeCompaction =
 				compactionEntry &&
 				usageMsg.role === "assistant" &&
-				(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
-			) {
-				return false;
+				(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime();
+			if (!usageIsFromBeforeCompaction) {
+				estimatedContextTokens = estimate.tokens;
 			}
-			contextTokens = estimate.tokens;
+		}
+
+		let contextTokens: number;
+		if (assistantMessage.stopReason === "error") {
+			if (estimatedContextTokens === undefined) return false; // No usable usage data at all
+			contextTokens = estimatedContextTokens;
 		} else {
-			contextTokens = calculateContextTokens(assistantMessage.usage);
+			contextTokens = Math.max(calculateContextTokens(assistantMessage.usage), estimatedContextTokens ?? 0);
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
-			return await this._runAutoCompaction("threshold", false);
+			const lastMessage = this.agent.state.messages[this.agent.state.messages.length - 1];
+			const shouldResumeToolLoop = assistantMessage.stopReason !== "error" && lastMessage?.role !== "assistant";
+			return await this._runAutoCompaction("threshold", shouldResumeToolLoop);
 		}
 		return false;
 	}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,11 +1,18 @@
 import { join } from "node:path";
 import { Agent, type AgentMessage, type ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { clampThinkingLevel, type Message, type Model, streamSimple } from "@earendil-works/pi-ai";
+import {
+	type AssistantMessage,
+	clampThinkingLevel,
+	type Message,
+	type Model,
+	streamSimple,
+} from "@earendil-works/pi-ai";
 import { getAgentDir } from "../config.ts";
 import { resolvePath } from "../utils/paths.ts";
 import { AgentSession } from "./agent-session.ts";
 import { formatNoModelsAvailableMessage } from "./auth-guidance.ts";
 import { AuthStorage } from "./auth-storage.ts";
+import { estimateContextTokens, shouldCompact } from "./compaction/index.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import type { ExtensionRunner, LoadExtensionsResult, SessionStartEvent, ToolDefinition } from "./extensions/index.ts";
 import { convertToLlm } from "./messages.ts";
@@ -14,7 +21,7 @@ import { findInitialModel } from "./model-resolver.ts";
 import { mergeProviderAttributionHeaders } from "./provider-attribution.ts";
 import type { ResourceLoader } from "./resource-loader.ts";
 import { DefaultResourceLoader } from "./resource-loader.ts";
-import { getDefaultSessionDir, SessionManager } from "./session-manager.ts";
+import { getDefaultSessionDir, getLatestCompactionEntry, SessionManager } from "./session-manager.ts";
 import { SettingsManager } from "./settings-manager.ts";
 import { time } from "./timings.ts";
 import {
@@ -357,6 +364,43 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
 		maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
 	});
+
+	const shouldCompactMessages = (messages: AgentMessage[]): boolean => {
+		const compactionSettings = settingsManager.getCompactionSettings();
+		if (!compactionSettings.enabled) return false;
+		const currentModel = agent.state.model;
+		const contextWindow = currentModel?.contextWindow ?? 0;
+		if (contextWindow === 0) return false;
+
+		const estimate = estimateContextTokens(messages);
+
+		// Skip if no valid usage data (first call, no prior assistant response)
+		if (estimate.lastUsageIndex === null) return false;
+
+		// Skip if the last usage comes from a pre-compaction kept message.
+		// Kept messages retain their original (large) usage from before compaction,
+		// which would falsely trigger the check right after compaction.
+		const compactionEntry = getLatestCompactionEntry(sessionManager.getBranch());
+		if (compactionEntry && estimate.lastUsageIndex !== null) {
+			const lastUsageMsg = messages[estimate.lastUsageIndex];
+			if (
+				lastUsageMsg.role === "assistant" &&
+				"timestamp" in lastUsageMsg &&
+				(lastUsageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
+			) {
+				return false;
+			}
+		}
+
+		return shouldCompact(estimate.tokens, contextWindow, compactionSettings);
+	};
+
+	// Gracefully stop after each completed tool turn. AgentSession's agent_end
+	// compaction check includes appended tool results, then resumes via agent.continue().
+	agent.shouldStopAfterTurn = ({ message, context }) => {
+		if (message.stopReason === "error" || message.stopReason === "aborted") return false;
+		return shouldCompactMessages(context.messages);
+	};
 
 	// Restore messages if session has existing data
 	if (hasExistingSession) {

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -7,14 +7,21 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
 import { Agent } from "@earendil-works/pi-agent-core";
-import type { FauxModelDefinition, FauxProviderRegistration, FauxResponseStep, Model } from "@earendil-works/pi-ai";
+import type {
+	AssistantMessage,
+	FauxModelDefinition,
+	FauxProviderRegistration,
+	FauxResponseStep,
+	Model,
+} from "@earendil-works/pi-ai";
 import { registerFauxProvider } from "@earendil-works/pi-ai";
 import { AgentSession, type AgentSessionEvent } from "../../src/core/agent-session.ts";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { estimateContextTokens, shouldCompact } from "../../src/core/compaction/index.ts";
 import type { ExtensionRunner } from "../../src/core/extensions/index.ts";
 import { convertToLlm } from "../../src/core/messages.ts";
 import { ModelRegistry } from "../../src/core/model-registry.ts";
-import { SessionManager } from "../../src/core/session-manager.ts";
+import { getLatestCompactionEntry, SessionManager } from "../../src/core/session-manager.ts";
 import type { Settings } from "../../src/core/settings-manager.ts";
 import { SettingsManager } from "../../src/core/settings-manager.ts";
 import type { ExtensionFactory, ResourceLoader } from "../../src/index.ts";
@@ -162,6 +169,38 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 			return runner.emitContext(messages);
 		},
 	});
+
+	// Context window enforcement (mirrors sdk.ts)
+	const shouldCompactMessages = (messages: AgentMessage[]): boolean => {
+		const compactionSettings = settingsManager.getCompactionSettings();
+		if (!compactionSettings.enabled) return false;
+		const currentModel = agent.state.model;
+		const contextWindow = currentModel?.contextWindow ?? 0;
+		if (contextWindow === 0) return false;
+
+		const estimate = estimateContextTokens(messages);
+		if (estimate.lastUsageIndex === null) return false;
+
+		const compactionEntry = getLatestCompactionEntry(sessionManager.getBranch());
+		if (compactionEntry && estimate.lastUsageIndex !== null) {
+			const lastUsageMsg = messages[estimate.lastUsageIndex];
+			if (
+				lastUsageMsg.role === "assistant" &&
+				"timestamp" in lastUsageMsg &&
+				(lastUsageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
+			) {
+				return false;
+			}
+		}
+
+		return shouldCompact(estimate.tokens, contextWindow, compactionSettings);
+	};
+
+	agent.shouldStopAfterTurn = ({ message, context }) => {
+		if (message.stopReason === "error" || message.stopReason === "aborted") return false;
+		return shouldCompactMessages(context.messages);
+	};
+
 	const extensionsResult = options.extensionFactories
 		? await createTestExtensionsResult(options.extensionFactories, tempDir)
 		: undefined;

--- a/packages/coding-agent/test/suite/regressions/5512-mid-turn-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5512-mid-turn-compaction.test.ts
@@ -1,0 +1,265 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * The faux provider always recomputes usage from the serialized context using
+ * ceil(chars/4). We control context size by making tool results large enough
+ * so the faux provider's estimated token count crosses the configured threshold.
+ */
+
+/** Generate a string of approximately `tokens` estimated tokens (chars/4 heuristic). */
+function padToTokens(tokens: number): string {
+	return "x".repeat(tokens * 4);
+}
+
+describe("issue #5512: mid-turn context window enforcement", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("stops after a tool turn, compacts, and resumes when estimated context exceeds threshold", async () => {
+		// Context window 2000, reserve 400 -> threshold at 1600
+		// keepRecentTokens: 200 so compaction keeps very little
+		const contextWindow = 2000;
+		const reserveTokens = 400;
+
+		// Tool that returns a large result to push context past threshold
+		const bigTool: AgentTool = {
+			name: "big_read",
+			label: "Big Read",
+			description: "Returns a large result",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				// ~1200 tokens of tool result content
+				content: [{ type: "text", text: padToTokens(1200) }],
+				details: {},
+			}),
+		};
+
+		const compactionSummaries: string[] = [];
+		const harness = await createHarness({
+			models: [{ id: "test-model", contextWindow }],
+			settings: {
+				compaction: {
+					enabled: true,
+					reserveTokens,
+					keepRecentTokens: 200,
+				},
+			},
+			tools: [bigTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						const summary = "compacted session";
+						compactionSummaries.push(summary);
+						return {
+							compaction: {
+								summary,
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		// Flow:
+		// 1st LLM call: context is small (user message). Returns tool call for big_read.
+		// Tool executes -> 1200 tokens of result added to context.
+		// shouldStopAfterTurn estimates context > 1600 threshold and exits cleanly.
+		// AgentSession compacts, then resumes the tool loop with agent.continue().
+		// 2nd LLM call: compacted context -> small -> succeeds.
+
+		let callCount = 0;
+		harness.setResponses([
+			() => {
+				callCount++;
+				return fauxAssistantMessage(fauxToolCall("big_read", {}), { stopReason: "toolUse" });
+			},
+			() => {
+				callCount++;
+				return fauxAssistantMessage("done after compaction");
+			},
+		]);
+
+		await harness.session.prompt("do something");
+
+		// Verify compaction was triggered by the post-turn stop hook.
+		expect(compactionSummaries.length).toBeGreaterThanOrEqual(1);
+		expect(harness.eventsOfType("compaction_start").map((event) => event.reason)).toContain("threshold");
+
+		// Verify both faux responses were consumed (original + resumed tool loop).
+		expect(callCount).toBe(2);
+		const assistantMessages = harness.session.messages.filter((m) => m.role === "assistant") as AssistantMessage[];
+		expect(assistantMessages.every((message) => message.stopReason !== "error")).toBe(true);
+
+		// Verify the session has a compaction entry
+		const entries = harness.sessionManager.getEntries();
+		const compactionEntries = entries.filter((e) => e.type === "compaction");
+		expect(compactionEntries.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("does not interfere when context is within threshold", async () => {
+		const contextWindow = 200_000;
+		const harness = await createHarness({
+			models: [{ id: "test-model", contextWindow }],
+			settings: {
+				compaction: {
+					enabled: true,
+					reserveTokens: 16384,
+					keepRecentTokens: 20000,
+				},
+			},
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([fauxAssistantMessage("hello")]);
+
+		await harness.session.prompt("hi");
+
+		// Should complete normally without any compaction events
+		const compactionEvents = harness.eventsOfType("compaction_start");
+		expect(compactionEvents).toHaveLength(0);
+	});
+
+	it("does not stop before the first LLM call when there is no prior usage", async () => {
+		const contextWindow = 200_000;
+		const harness = await createHarness({
+			models: [{ id: "test-model", contextWindow }],
+			settings: {
+				compaction: {
+					enabled: true,
+					reserveTokens: 16384,
+					keepRecentTokens: 20000,
+				},
+			},
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([fauxAssistantMessage("first response")]);
+
+		await harness.session.prompt("hi");
+
+		const assistantMessages = harness.session.messages.filter((m) => m.role === "assistant");
+		expect(assistantMessages.length).toBeGreaterThan(0);
+		const lastAssistant = assistantMessages[assistantMessages.length - 1] as AssistantMessage;
+		expect(lastAssistant.stopReason).toBe("stop");
+	});
+
+	it("skips check when compaction is disabled", async () => {
+		const contextWindow = 2000;
+
+		const bigTool: AgentTool = {
+			name: "big_read",
+			label: "Big Read",
+			description: "Returns a large result",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text", text: padToTokens(1200) }],
+				details: {},
+			}),
+		};
+
+		const harness = await createHarness({
+			models: [{ id: "test-model", contextWindow }],
+			settings: {
+				compaction: {
+					enabled: false,
+					reserveTokens: 400,
+					keepRecentTokens: 200,
+				},
+			},
+			tools: [bigTool],
+		});
+		harnesses.push(harness);
+
+		let callCount = 0;
+		harness.setResponses([
+			() => {
+				callCount++;
+				return fauxAssistantMessage(fauxToolCall("big_read", {}), { stopReason: "toolUse" });
+			},
+			() => {
+				callCount++;
+				return fauxAssistantMessage("done");
+			},
+		]);
+
+		await harness.session.prompt("do something");
+
+		// Both LLM calls should run since compaction is disabled
+		expect(callCount).toBe(2);
+	});
+
+	it("does not falsely trigger on stale pre-compaction usage after compaction", async () => {
+		const contextWindow = 2000;
+
+		const bigTool: AgentTool = {
+			name: "big_read",
+			label: "Big Read",
+			description: "Returns a large result",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text", text: padToTokens(1200) }],
+				details: {},
+			}),
+		};
+
+		const harness = await createHarness({
+			models: [{ id: "test-model", contextWindow }],
+			settings: {
+				compaction: {
+					enabled: true,
+					reserveTokens: 400,
+					keepRecentTokens: 200,
+				},
+			},
+			tools: [bigTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([
+			// First prompt: tool call -> large result -> triggers post-turn compaction
+			fauxAssistantMessage(fauxToolCall("big_read", {}), { stopReason: "toolUse" }),
+			// After compaction + retry
+			fauxAssistantMessage("first done"),
+			// Second prompt: should work normally despite stale kept usage
+			fauxAssistantMessage("second done"),
+		]);
+
+		// First prompt triggers compaction via shouldStopAfterTurn.
+		await harness.session.prompt("first prompt");
+
+		// Second prompt should NOT be blocked by stale kept usage.
+		await harness.session.prompt("second prompt");
+
+		// Verify second prompt succeeded (not blocked by stale usage)
+		const assistantMessages = harness.session.messages.filter((m) => m.role === "assistant") as AssistantMessage[];
+		const lastAssistant = assistantMessages[assistantMessages.length - 1];
+		expect(lastAssistant.stopReason).not.toBe("error");
+	});
+});


### PR DESCRIPTION
## Summary

- Exposes the existing `shouldStopAfterTurn` agent-loop hook on `AgentOptions` and `Agent`.
- Wires coding-agent auto-compaction to stop cleanly after a tool turn crosses the compaction threshold, then compact and resume the tool loop.
- Updates threshold checks to include tool results appended after the last assistant usage.
- Adds a regression suite for #5512 using the faux provider and harness.

Fixes #5512.

## Tests

- `cd packages/coding-agent && npx tsx ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/5512-mid-turn-compaction.test.ts`
- `npm run check`
