### PR TITLE
feat(coding-agent): add alwaysTrust setting to skip project trust gating

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -301,6 +301,8 @@ Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trus
 
 Use `/trust` in interactive mode to save a project trust decision for future sessions. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
+Set `alwaysTrust` to `true` in global settings (`~/.pi/agent/settings.json`) to skip all trust gating and automatically trust every project. When enabled, pi will not prompt for trust, and all project-local inputs are loaded without restriction.
+
 ### Telemetry and update checks
 
 Pi has two separate startup features:

--- a/packages/coding-agent/docs/security.md
+++ b/packages/coding-agent/docs/security.md
@@ -26,6 +26,8 @@ Declining trust skips those project-local inputs. Before trust is resolved, pi o
 
 Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without a saved trust decision, they ignore project-local inputs unless `--approve`/`-a` is passed. Use `--no-approve`/`-na` to ignore project-local inputs for one run even when the project is trusted.
 
+Setting `alwaysTrust` to `true` in global settings disables all trust gating — every project is treated as trusted without prompting. This is equivalent to permanently passing `--approve`.
+
 ## No Built-in Sandbox
 
 Pi does not include a built-in sandbox. Built-in tools can read files, write files, edit files, and run shell commands with the permissions of the pi process. Extensions are TypeScript modules that run with the same permissions. Package installs, shell commands, language servers, test commands, and other developer tools behave as ordinary local processes.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -19,7 +19,15 @@ Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trus
 
 Use `/trust` in interactive mode to save a project trust decision for future sessions. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
+Set `alwaysTrust` to `true` in global settings to skip all trust gating and automatically trust every project. When enabled, pi will not prompt for trust, and all project-local inputs (instructions, settings, resources, packages, extensions) are loaded without restriction.
+
 ## All Settings
+
+### Project Trust
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `alwaysTrust` | boolean | `false` | Skip all trust gating — permanently trust every project |
 
 ### Model & Thinking
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -120,6 +120,8 @@ Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trus
 
 Use `/trust` in interactive mode to save a project trust decision for future sessions. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
+Set `alwaysTrust` to `true` in global settings to skip all trust gating and automatically trust every project. When enabled, pi will not prompt for trust, and all project-local inputs are loaded without restriction.
+
 ## Exporting and Sharing Sessions
 
 Use `/export [file]` to write a session to HTML.

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -76,6 +76,7 @@ export type PackageSource =
 
 export interface Settings {
 	lastChangelogVersion?: string;
+	alwaysTrust?: boolean; // Skip all trust gating prompts — permanently trust every project
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -435,6 +436,9 @@ export class SettingsManager {
 	}
 
 	isProjectTrusted(): boolean {
+		if (this.settings.alwaysTrust) {
+			return true;
+		}
 		return this.projectTrusted;
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -634,6 +634,9 @@ async function resolveProjectTrusted(options: {
 	if (options.trustOverride !== undefined) {
 		return options.trustOverride;
 	}
+	if (options.settingsManagerForPrompt.getGlobalSettings().alwaysTrust) {
+		return true;
+	}
 	if (!hasProjectTrustInputs(options.cwd)) {
 		return true;
 	}
@@ -817,12 +820,18 @@ export async function main(args: string[], options?: MainOptions) {
 		const isInitialRuntime = sessionStartEvent === undefined;
 		const projectTrustDiagnostics: AgentSessionRuntimeDiagnostic[] = [];
 		const cachedProjectTrust = projectTrustByCwd.get(cwd);
+		const alwaysTrust = startupSettingsManager.getGlobalSettings().alwaysTrust === true;
 		const hasTrustInputs = hasProjectTrustInputs(cwd);
 		const shouldResolveProjectTrust =
-			parsed.projectTrustOverride === undefined && cachedProjectTrust === undefined && hasTrustInputs;
-		const projectTrusted = shouldResolveProjectTrust
-			? false
-			: (cachedProjectTrust ?? parsed.projectTrustOverride ?? (!hasTrustInputs || trustStore.get(cwd) === true));
+			!alwaysTrust &&
+			parsed.projectTrustOverride === undefined &&
+			cachedProjectTrust === undefined &&
+			hasTrustInputs;
+		const projectTrusted = alwaysTrust
+			? true
+			: shouldResolveProjectTrust
+				? false
+				: (cachedProjectTrust ?? parsed.projectTrustOverride ?? (!hasTrustInputs || trustStore.get(cwd) === true));
 		const runtimeSettingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
 		const services = await createAgentSessionServices({
 			cwd,

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -429,6 +429,10 @@ function resolveProjectTrusted(cwd: string, agentDir: string, trustOverride: boo
 	if (trustOverride !== undefined) {
 		return trustOverride;
 	}
+	const globalSettings = SettingsManager.create(cwd, agentDir).getGlobalSettings();
+	if (globalSettings.alwaysTrust) {
+		return true;
+	}
 	return !hasProjectTrustInputs(cwd) || new ProjectTrustStore(agentDir).get(cwd) === true;
 }
 


### PR DESCRIPTION
This adds a flag to completely disable trust gating (disabled by default).