### PR TITLE
feat(coding-agent): configurable clipboard image storage path (#5414)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `images.storagePath` setting to configure where clipboard-pasted images in the TUI are stored, with a `/settings` entry ("Image storage path"). Defaults to `os.tmpdir()`; pi does not create the directory and now surfaces an error instead of silently dropping a pasted image when the directory is missing or not writable ([#5414](https://github.com/earendil-works/pi/issues/5414)).
+
 ### Fixed
 
 - Fixed built-in tool expand hints to style closing parentheses consistently ([#5359](https://github.com/earendil-works/pi/issues/5359)).

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -142,6 +142,17 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
 | `terminal.clearOnShrink` | boolean | `false` | Clear empty rows when content shrinks (can cause flicker) |
 | `images.autoResize` | boolean | `true` | Resize images to 2000x2000 max |
 | `images.blockImages` | boolean | `false` | Block all images from being sent to LLM |
+| `images.storagePath` | string | `os.tmpdir()` | Directory where clipboard-pasted images are written. Accepts absolute or relative paths, plus `~`. |
+
+By default, images pasted into the TUI are written to the OS temp directory (`os.tmpdir()`), which is not a permanent location and may be cleaned up by the system. Set `images.storagePath` to keep pasted images somewhere durable so you can access them across conversations.
+
+```json
+{ "images": { "storagePath": "~/pi-images" } }
+```
+
+> pi does **not** create this directory. Make sure the configured directory already exists and is writable; otherwise saving a pasted image fails and pi shows an error. Leave the value empty to fall back to the OS temp directory.
+
+This can also be configured interactively via the `/settings` menu ("Image storage path").
 
 ### Shell
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1,5 +1,6 @@
 import type { Transport } from "@earendil-works/pi-ai";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
@@ -40,6 +41,7 @@ export interface TerminalSettings {
 export interface ImageSettings {
 	autoResize?: boolean; // default: true (resize images to 2000x2000 max for better model compatibility)
 	blockImages?: boolean; // default: false - when true, prevents all images from being sent to LLM providers
+	storagePath?: string; // default: os.tmpdir() - directory where clipboard-pasted images are written. Accepts absolute/relative paths plus `~`. pi does not create the directory.
 }
 
 export interface ThinkingBudgetsSettings {
@@ -1010,6 +1012,34 @@ export class SettingsManager {
 		}
 		this.globalSettings.images.blockImages = blocked;
 		this.markModified("images", "blockImages");
+		this.save();
+	}
+
+	/**
+	 * Directory where clipboard-pasted images are written.
+	 * Falls back to os.tmpdir() when unset. The configured path is
+	 * normalized (trimmed, `~` expanded, resolved to absolute). pi does
+	 * not create the directory; callers should handle a missing path.
+	 */
+	getImageStoragePath(): string {
+		const storagePath = this.settings.images?.storagePath;
+		if (storagePath && storagePath.trim() !== "") {
+			return normalizePath(storagePath, { trim: true });
+		}
+		return tmpdir();
+	}
+
+	setImageStoragePath(path: string | undefined): void {
+		if (!this.globalSettings.images) {
+			this.globalSettings.images = {};
+		}
+		const trimmed = path?.trim();
+		if (!trimmed) {
+			this.globalSettings.images.storagePath = undefined;
+		} else {
+			this.globalSettings.images.storagePath = trimmed;
+		}
+		this.markModified("images", "storagePath");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -3,6 +3,8 @@ import type { Transport } from "@earendil-works/pi-ai";
 import {
 	Container,
 	getCapabilities,
+	getKeybindings,
+	Input,
 	type SelectItem,
 	SelectList,
 	type SelectListLayoutOptions,
@@ -37,6 +39,7 @@ export interface SettingsConfig {
 	imageWidthCells: number;
 	autoResizeImages: boolean;
 	blockImages: boolean;
+	imageStoragePath: string;
 	enableSkillCommands: boolean;
 	steeringMode: "all" | "one-at-a-time";
 	followUpMode: "all" | "one-at-a-time";
@@ -66,6 +69,7 @@ export interface SettingsCallbacks {
 	onImageWidthCellsChange: (width: number) => void;
 	onAutoResizeImagesChange: (enabled: boolean) => void;
 	onBlockImagesChange: (blocked: boolean) => void;
+	onImageStoragePathChange: (path: string) => void;
 	onEnableSkillCommandsChange: (enabled: boolean) => void;
 	onSteeringModeChange: (mode: "all" | "one-at-a-time") => void;
 	onFollowUpModeChange: (mode: "all" | "one-at-a-time") => void;
@@ -195,6 +199,53 @@ class SelectSubmenu extends Container {
 
 	handleInput(data: string): void {
 		this.selectList.handleInput(data);
+	}
+}
+
+/**
+ * A submenu that prompts for free-form text (e.g. a directory path).
+ */
+class TextInputSubmenu extends Container {
+	private input: Input;
+	private onSubmit: (value: string) => void;
+	private onCancel: () => void;
+
+	constructor(
+		title: string,
+		description: string,
+		currentValue: string,
+		onSubmit: (value: string) => void,
+		onCancel: () => void,
+	) {
+		super();
+
+		this.onSubmit = onSubmit;
+		this.onCancel = onCancel;
+
+		this.addChild(new Text(theme.bold(theme.fg("accent", title)), 0, 0));
+		if (description) {
+			this.addChild(new Spacer(1));
+			this.addChild(new Text(theme.fg("muted", description), 0, 0));
+		}
+		this.addChild(new Spacer(1));
+
+		this.input = new Input();
+		this.input.setValue(currentValue);
+		this.addChild(this.input);
+
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("dim", "  Enter to save · empty to reset to default · Esc to cancel"), 0, 0));
+	}
+
+	handleInput(data: string): void {
+		const kb = getKeybindings();
+		if (kb.matches(data, "tui.select.confirm") || data === "\n") {
+			this.onSubmit(this.input.getValue());
+		} else if (kb.matches(data, "tui.select.cancel")) {
+			this.onCancel();
+		} else {
+			this.input.handleInput(data);
+		}
 	}
 }
 
@@ -397,8 +448,30 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
-		// Skill commands toggle (insert after block-images)
-		const blockImagesIndex = items.findIndex((item) => item.id === "block-images");
+		// Image storage path (insert after block-images)
+		const blockImagesIndexForStorage = items.findIndex((item) => item.id === "block-images");
+		items.splice(blockImagesIndexForStorage + 1, 0, {
+			id: "image-storage-path",
+			label: "Image storage path",
+			description:
+				"Directory where clipboard-pasted images are saved. Empty uses the OS temp dir (may be cleaned up). pi does not create the directory.",
+			currentValue: config.imageStoragePath,
+			submenu: (currentValue, done) =>
+				new TextInputSubmenu(
+					"Image Storage Path",
+					"Directory for clipboard-pasted images. Leave empty to use the OS temp dir. pi does not create the directory.",
+					currentValue,
+					(value) => {
+						const trimmed = value.trim();
+						callbacks.onImageStoragePathChange(trimmed);
+						done(trimmed === "" ? config.imageStoragePath : trimmed);
+					},
+					() => done(),
+				),
+		});
+
+		// Skill commands toggle (insert after image-storage-path)
+		const blockImagesIndex = items.findIndex((item) => item.id === "image-storage-path");
 		items.splice(blockImagesIndex + 1, 0, {
 			id: "skill-commands",
 			label: "Skill commands",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2466,25 +2466,39 @@ export class InteractiveMode {
 	}
 
 	private async handleClipboardImagePaste(): Promise<void> {
+		let image: Awaited<ReturnType<typeof readClipboardImage>>;
 		try {
-			const image = await readClipboardImage();
-			if (!image) {
-				return;
-			}
-
-			// Write to temp file
-			const tmpDir = os.tmpdir();
-			const ext = extensionForImageMimeType(image.mimeType) ?? "png";
-			const fileName = `pi-clipboard-${crypto.randomUUID()}.${ext}`;
-			const filePath = path.join(tmpDir, fileName);
-			fs.writeFileSync(filePath, Buffer.from(image.bytes));
-
-			// Insert file path directly
-			this.editor.insertTextAtCursor?.(filePath);
-			this.ui.requestRender();
+			image = await readClipboardImage();
 		} catch {
-			// Silently ignore clipboard errors (may not have permission, etc.)
+			// Silently ignore clipboard read errors (may not have permission, no image, etc.)
+			return;
 		}
+		if (!image) {
+			return;
+		}
+
+		// Resolve the configured storage directory (falls back to os.tmpdir()).
+		// pi does not create the directory; surface a clear error if it is missing
+		// or not writable so pasted images are never silently lost.
+		const storageDir = this.settingsManager.getImageStoragePath();
+		const ext = extensionForImageMimeType(image.mimeType) ?? "png";
+		const fileName = `pi-clipboard-${crypto.randomUUID()}.${ext}`;
+		const filePath = path.join(storageDir, fileName);
+
+		try {
+			fs.writeFileSync(filePath, Buffer.from(image.bytes));
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			this.showError(
+				`Failed to save pasted image to ${storageDir}: ${reason}\n` +
+					`Check that the directory exists and is writable (configure via images.storagePath in settings.json).`,
+			);
+			return;
+		}
+
+		// Insert file path directly
+		this.editor.insertTextAtCursor?.(filePath);
+		this.ui.requestRender();
 	}
 
 	private setupEditorSubmitHandler(): void {
@@ -3902,6 +3916,7 @@ export class InteractiveMode {
 					imageWidthCells: this.settingsManager.getImageWidthCells(),
 					autoResizeImages: this.settingsManager.getImageAutoResize(),
 					blockImages: this.settingsManager.getBlockImages(),
+					imageStoragePath: this.settingsManager.getImageStoragePath(),
 					enableSkillCommands: this.settingsManager.getEnableSkillCommands(),
 					steeringMode: this.session.steeringMode,
 					followUpMode: this.session.followUpMode,
@@ -3950,6 +3965,10 @@ export class InteractiveMode {
 					},
 					onBlockImagesChange: (blocked) => {
 						this.settingsManager.setBlockImages(blocked);
+					},
+					onImageStoragePathChange: (storagePath) => {
+						this.settingsManager.setImageStoragePath(storagePath === "" ? undefined : storagePath);
+						this.showStatus(`Image storage path: ${this.settingsManager.getImageStoragePath()}`);
 					},
 					onEnableSkillCommandsChange: (enabled) => {
 						this.settingsManager.setEnableSkillCommands(enabled);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS } from "../src/core/http-dispatcher.ts";
@@ -338,6 +338,69 @@ describe("SettingsManager", () => {
 			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ sessionDir: "~/sessions" }));
 			const manager = SettingsManager.create(projectDir, agentDir);
 			expect(manager.getSessionDir()).toBe(join(homedir(), "sessions"));
+		});
+	});
+
+	describe("imageStoragePath", () => {
+		it("should fall back to os.tmpdir() when not set", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ theme: "dark" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getImageStoragePath()).toBe(tmpdir());
+		});
+
+		it("should fall back to os.tmpdir() when set to empty/whitespace", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ images: { storagePath: "   " } }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getImageStoragePath()).toBe(tmpdir());
+		});
+
+		it("should return the configured absolute path", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ images: { storagePath: "/tmp/pi-images" } }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getImageStoragePath()).toBe("/tmp/pi-images");
+		});
+
+		it("should expand ~ to the home directory", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ images: { storagePath: "~/pi-images" } }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getImageStoragePath()).toBe(join(homedir(), "pi-images"));
+		});
+
+		it("should let project settings override global", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ images: { storagePath: "/global/images" } }));
+			writeFileSync(
+				join(projectDir, ".pi", "settings.json"),
+				JSON.stringify({ images: { storagePath: "/project/images" } }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getImageStoragePath()).toBe("/project/images");
+		});
+
+		it("should persist a configured path via setImageStoragePath", async () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({}));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setImageStoragePath("/tmp/pi-images");
+			expect(manager.getImageStoragePath()).toBe("/tmp/pi-images");
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf8"));
+			expect(saved.images.storagePath).toBe("/tmp/pi-images");
+		});
+
+		it("should clear the path and fall back to tmpdir when set to undefined", async () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ images: { storagePath: "/tmp/pi-images" } }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setImageStoragePath(undefined);
+			expect(manager.getImageStoragePath()).toBe(tmpdir());
+			await manager.flush();
+			const saved = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf8"));
+			expect(saved.images.storagePath).toBeUndefined();
+		});
+
+		it("should treat a whitespace-only set value as a reset", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ images: { storagePath: "/tmp/pi-images" } }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			manager.setImageStoragePath("   ");
+			expect(manager.getImageStoragePath()).toBe(tmpdir());
 		});
 	});
 });


### PR DESCRIPTION
Closes #5414

## What

Let clipboard images pasted in the TUI be stored in a configurable directory via `settings.json` (`images.storagePath`) instead of always `os.tmpdir()`, which is not durable and can be cleaned up by the system. The default remains `os.tmpdir()`.

## Changes

- **settings-manager.ts**: add `ImageSettings.storagePath`, plus `getImageStoragePath()` (falls back to `os.tmpdir()`, trims, expands `~`, normalizes) and `setImageStoragePath()` (empty/whitespace resets to default).
- **interactive-mode.ts**: `handleClipboardImagePaste()` writes to the configured directory. Clipboard *read* errors stay silently ignored, but a *write* failure (missing/non-writable directory) now surfaces a clear error via `showError()` instead of silently dropping the pasted image.
- **settings-selector.ts**: new `TextInputSubmenu` and an "Image storage path" entry in `/settings`.
- **docs/settings.md**: document `images.storagePath`, including that pi does **not** create the directory.
- **tests**: 8 cases covering default fallback, empty/whitespace fallback, absolute path, `~` expansion, project-over-global override, persist, and clear-to-default.
- **CHANGELOG**: Unreleased entry.

## Notes

- pi intentionally does not create the configured directory; it must already exist and be writable.

## Verification

- `tsgo --noEmit` clean, full build succeeds, biome formatting applied.
- `vitest run test/settings-manager.test.ts` — 28 passed.
