### PR TITLE
feat(coding-agent): restore files on rewind (checkpoints)

### DIFF
--- a/packages/coding-agent/docs/rewind.md
+++ b/packages/coding-agent/docs/rewind.md
@@ -1,0 +1,128 @@
+# Rewind with file restore
+
+Pi can rewind a conversation **and** restore your files on disk to the state they
+were in at that point — like Claude Code's rewind. This document explains how it
+works, how to use it, and its limitations.
+
+## TL;DR
+
+1. Make sure the editor input is **empty**.
+2. Press **`Esc` twice** quickly (double-escape).
+3. Pick the point you want to go back to in the tree selector.
+4. When asked **"Restore files to this point?"** choose:
+   - **Conversation + files** — rewind the chat *and* roll the files back.
+   - **Conversation only** — rewind the chat, leave files as they are (the old behavior).
+5. Pi navigates back, restores files if you asked, and shows a status line telling
+   you exactly what it changed.
+
+> Double-escape can also be configured to open the *fork* selector instead of the
+> tree selector. The file-restore prompt appears in the **tree selector** flow.
+> If `Esc Esc` does nothing, your `double-escape action` setting may be `none` or
+> `fork`.
+
+## What "rewind" means here
+
+A pi session is an append-only log (a tree) of entries: user messages, assistant
+messages, tool calls, etc. Every entry has a `parentId`, so "going back" is just
+moving a pointer (the *leaf*) to an earlier node. The conversation rewind already
+existed; this feature adds the **file** side.
+
+When you rewind to a user message `U`, pi can put your files back to how they were
+**right before pi started working on `U`**.
+
+## How file restore works (under the hood)
+
+### Capture (while pi edits)
+
+- A **checkpoint** is taken per **user turn** (each user message you send).
+- The first time pi's `edit` or `write` tool touches a file in a turn, pi saves
+  that file's **before-content** to a content-addressed blob store. Subsequent
+  edits to the same file in the same turn don't re-save the baseline (first-touch
+  wins).
+- Saved content is deduplicated by SHA-256 hash, so a file with identical content
+  across turns costs one blob.
+
+### Storage
+
+- Blobs live in: `~/.pi/agent/checkpoints/<sessionId>/blobs/<sha256>`
+- A small **manifest** is appended to the session log per turn:
+  `{ turnId, files: [{ path, before, after }] }` where `before`/`after` are
+  content hashes (`before: null` means "the file didn't exist yet").
+- Manifests are stored as `custom` session entries, so they persist across
+  restarts and resumes and never enter the LLM context.
+
+### Restore (when you rewind)
+
+To restore to a point `T`, pi rolls back every turn from the current branch tip
+down to `T`:
+
+- For each file, the **earliest** captured before-state (closest to `T`) is the
+  target content.
+- Files that didn't exist at `T` (created afterward) are **deleted**.
+- Restore is computed as a full plan first, then applied — and each file is
+  written under the same per-file lock pi's tools use, so a restore can't collide
+  with an in-flight edit.
+
+### Safety guards
+
+- **Won't run while the agent is working.** Restore is refused mid-run.
+- **Won't clobber your manual edits.** Before touching a file, pi checks whether
+  its current content matches what pi last wrote. If you (or a `bash` command)
+  changed it since, pi **skips** that file and reports it as
+  *"changed outside pi"* instead of overwriting your work.
+- **Crash-safe.** A restore marker is written before any disk change; if pi
+  crashes mid-restore, it re-applies the plan on next startup (restore is
+  idempotent).
+
+## The status line after a restore
+
+Example:
+
+```
+Navigated to selected point · 3 files restored, 1 deleted, 1 skipped (changed outside pi)
+```
+
+- `N files restored` — files rewritten to their earlier content.
+- `N deleted` — files that were created after the target and got removed.
+- `N skipped (changed outside pi)` — files you/bash changed after pi last wrote
+  them; **left untouched** so your work isn't lost.
+- `files already at this point` — nothing needed changing.
+
+## Limitations (read this)
+
+This uses a **tool-edit content log**, not a full filesystem snapshot. That means:
+
+1. **Only files changed through pi's `edit`/`write` tools are tracked.** Changes
+   made by raw `bash` (e.g. `rm`, `mv`, code generators, `npm install`) or by an
+   external editor are **not** captured and **not** restored. After a restore,
+   your working tree may differ from a true snapshot — the status line's
+   "skipped" count and this caveat are how you know.
+2. **No "code only" mode.** You can rewind *conversation + files* or
+   *conversation only*. Rewinding files without the conversation was intentionally
+   cut: it leaves the model's history describing edits that no longer exist on
+   disk, which desyncs the agent against its own context.
+3. **Hard crash mid-turn.** If pi is killed (e.g. `kill -9`, power loss) after an
+   edit but before the turn finishes, that turn's manifest may not be persisted,
+   so that single turn isn't rewindable (its blobs are harmless orphans). Normal
+   errors and aborts are fine — the manifest is flushed at the end of every turn.
+4. **Blob cleanup is tied to session deletion.** Checkpoint blobs under
+   `~/.pi/agent/checkpoints/<sessionId>/` are deduped and small, and they're
+   removed automatically when you delete the session from the session selector.
+   There's no time-based GC, so very long-lived sessions accumulate blobs; delete
+   the session (or its checkpoint directory) to reclaim the space.
+5. **Custom tool sets.** If an embedder overrides pi's base tools, file restore is
+   disabled for that session and rewind falls back to conversation-only.
+
+## Developer notes
+
+- Core logic: `src/core/file-checkpoint-store.ts` (`FileCheckpointStore`).
+- Wiring: `src/core/agent-session.ts`
+  - constructs the store (skipped when base tools are overridden),
+  - injects capture via `wrapEditOperations()` / `wrapWriteOperations()` into the
+    built-in `edit`/`write` tools,
+  - calls `beginTurn(leafId)` on each user message and `flushPending()` on
+    `agent_end`,
+  - exposes `restoreFilesTo(targetId, fromLeafId)` and `supportsFileRestore`.
+- UI: `src/modes/interactive/interactive-mode.ts` `showTreeSelector()` adds the
+  "Restore files to this point?" prompt and prints the summary.
+- Tests: `test/file-checkpoint-store.test.ts`.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -14,7 +14,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type {
 	Agent,
 	AgentEvent,
@@ -33,6 +33,7 @@ import {
 	resetApiProviders,
 	streamSimple,
 } from "@earendil-works/pi-ai";
+import { getAgentDir } from "../config.ts";
 import { theme } from "../modes/interactive/theme/theme.ts";
 import { stripFrontmatter } from "../utils/frontmatter.ts";
 import { resolvePath } from "../utils/paths.ts";
@@ -79,6 +80,7 @@ import {
 	wrapRegisteredTools,
 } from "./extensions/index.ts";
 import { emitSessionShutdownEvent } from "./extensions/runner.ts";
+import { FileCheckpointStore, type RestoreSummary } from "./file-checkpoint-store.ts";
 import type { BashExecutionMessage, CustomMessage } from "./messages.ts";
 import type { ModelRegistry } from "./model-registry.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
@@ -312,6 +314,9 @@ export class AgentSession {
 	// Model registry for API key resolution
 	private _modelRegistry: ModelRegistry;
 
+	// File checkpoint store for rewind-with-file-restore (undefined when base tools are overridden)
+	private _fileCheckpoints?: FileCheckpointStore;
+
 	// Tool registry for extension getTools/setTools
 	private _toolRegistry: Map<string, AgentTool> = new Map();
 	private _toolDefinitions: Map<string, ToolDefinitionEntry> = new Map();
@@ -337,6 +342,24 @@ export class AgentSession {
 		this._excludedToolNames = config.excludedToolNames ? new Set(config.excludedToolNames) : undefined;
 		this._baseToolsOverride = config.baseToolsOverride;
 		this._sessionStartEvent = config.sessionStartEvent ?? { type: "session_start", reason: "startup" };
+
+		// File checkpoints only apply to the built-in edit/write tools. When an
+		// embedder overrides the base tool set, those tools are not wrapped, so
+		// the store is left undefined and rewind falls back to conversation-only.
+		if (!this._baseToolsOverride) {
+			this._fileCheckpoints = new FileCheckpointStore({
+				sessionId: this.sessionManager.getSessionId(),
+				cwd: this._cwd,
+				checkpointsRoot: join(getAgentDir(), "checkpoints"),
+				appendCustomEntry: (type, data) => this.sessionManager.appendCustomEntry(type, data),
+				getEntries: () => this.sessionManager.getEntries(),
+				getBranch: (fromId) => this.sessionManager.getBranch(fromId),
+				isStreaming: () => this.isStreaming,
+			});
+			// Re-drive any restore that was interrupted by a crash (idempotent).
+			// Best-effort: a recovery failure must not block session startup.
+			void this._fileCheckpoints.recoverIncompleteRestore().catch(() => {});
+		}
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, extensions, auto-compaction, retry logic)
@@ -502,6 +525,11 @@ export class AgentSession {
 		// Notify all listeners
 		this._emit(event.type === "agent_end" ? { ...event, willRetry: this._willRetryAfterAgentEnd(event) } : event);
 
+		// Turn finished: persist this turn's file checkpoint manifest (no-op if nothing changed).
+		if (event.type === "agent_end") {
+			this._fileCheckpoints?.flushPending();
+		}
+
 		// Handle session persistence
 		if (event.type === "message_end") {
 			// Check if this is a custom message from extensions
@@ -520,6 +548,12 @@ export class AgentSession {
 			) {
 				// Regular LLM message - persist as SessionMessageEntry
 				this.sessionManager.appendMessage(event.message);
+				// A new user message starts a new file-checkpoint turn. The just-
+				// appended entry is now the leaf and becomes this turn's checkpoint id.
+				if (event.message.role === "user") {
+					const turnId = this.sessionManager.getLeafId();
+					this._fileCheckpoints?.beginTurn(turnId);
+				}
 			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 
@@ -2390,6 +2424,8 @@ export class AgentSession {
 			: createAllToolDefinitions(this._cwd, {
 					read: { autoResizeImages },
 					bash: { commandPrefix: shellCommandPrefix, shellPath },
+					edit: this._fileCheckpoints ? { operations: this._fileCheckpoints.wrapEditOperations() } : undefined,
+					write: this._fileCheckpoints ? { operations: this._fileCheckpoints.wrapWriteOperations() } : undefined,
 				});
 
 		this._baseToolDefinitions = new Map(
@@ -2877,6 +2913,22 @@ export class AgentSession {
 		} finally {
 			this._branchSummaryAbortController = undefined;
 		}
+	}
+
+	/** Whether file checkpoints are available (built-in edit/write tools in use). */
+	get supportsFileRestore(): boolean {
+		return this._fileCheckpoints !== undefined;
+	}
+
+	/**
+	 * Restore files on disk to their state before `targetId`, rolling back every
+	 * turn from the current leaf down to the target. Call this BEFORE navigateTree
+	 * so the abandoned branch is still reachable; pass the pre-navigation leaf id.
+	 * Returns null if file restore is unavailable. Throws while the agent is running.
+	 */
+	async restoreFilesTo(targetId: string, fromLeafId: string): Promise<RestoreSummary | null> {
+		if (!this._fileCheckpoints) return null;
+		return this._fileCheckpoints.restoreTo(targetId, fromLeafId);
 	}
 
 	/**

--- a/packages/coding-agent/src/core/file-checkpoint-store.ts
+++ b/packages/coding-agent/src/core/file-checkpoint-store.ts
@@ -1,0 +1,433 @@
+import { createHash } from "node:crypto";
+import {
+	accessSync,
+	constants,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { relative, resolve } from "node:path";
+import type { SessionEntry } from "./session-manager.ts";
+import type { EditOperations } from "./tools/edit.ts";
+import { withFileMutationQueue } from "./tools/file-mutation-queue.ts";
+import type { WriteOperations } from "./tools/write.ts";
+
+/**
+ * Custom session-entry types used by the checkpoint store. These are stored via
+ * SessionManager.appendCustomEntry (type: "custom"), so they persist in the
+ * session JSONL without entering the LLM context and without a schema migration.
+ */
+export const FILE_CHECKPOINT_TYPE = "file_checkpoint";
+export const FILE_RESTORE_TYPE = "file_restore";
+export const FILE_RESTORE_DONE_TYPE = "file_restore_done";
+
+/** One file captured within a turn. */
+export interface CheckpointFile {
+	/** Path relative to the session cwd (display + reapply target). */
+	path: string;
+	/**
+	 * Content hash of the file BEFORE pi first touched it this turn, or null if
+	 * the file did not exist yet (so restoring it means deleting the file).
+	 */
+	before: string | null;
+	/** Content hash of what pi last wrote to the file this turn (external-edit guard). */
+	after: string | null;
+}
+
+/** Manifest persisted once per turn that mutated files. */
+export interface FileCheckpointData {
+	turnId: string;
+	files: CheckpointFile[];
+}
+
+interface RestorePlanItem {
+	path: string;
+	/** absolute path resolved against cwd */
+	absolutePath: string;
+	action: "write" | "delete";
+	/** blob hash to write back (action === "write") */
+	before: string | null;
+	/** expected on-disk hash for the external-edit guard */
+	after: string | null;
+}
+
+interface RestoreMarkerData {
+	targetTurnId: string;
+	plan: RestorePlanItem[];
+}
+
+/** Result of a restore, surfaced to the user. */
+export interface RestoreSummary {
+	restored: string[];
+	deleted: string[];
+	/** files skipped because they were edited outside pi (bash / external editor) */
+	skippedExternal: string[];
+	/** files already at the target state */
+	unchanged: number;
+}
+
+interface PendingCapture {
+	relPath: string;
+	absolutePath: string;
+	before: string | null;
+	after: string | null;
+}
+
+const ABSENT = null;
+
+export interface FileCheckpointStoreOptions {
+	sessionId: string;
+	cwd: string;
+	/** Root dir for checkpoint blobs, e.g. ~/.pi/agent/checkpoints */
+	checkpointsRoot: string;
+	/** Append a custom manifest entry to the session; returns its id. */
+	appendCustomEntry: (customType: string, data: unknown) => string;
+	/** Read all session entries (to rebuild manifests / recover restores). */
+	getEntries: () => SessionEntry[];
+	/** Walk root -> fromId, returning entries in order. */
+	getBranch: (fromId: string) => SessionEntry[];
+	/** Whether the agent is mid-run; restore is refused while true. */
+	isStreaming: () => boolean;
+}
+
+/**
+ * Captures the before-state of files pi edits (per user turn) and restores them
+ * on rewind. Capture is content-addressed and deduped by sha256. Only files
+ * written through pi's edit/write tools are tracked; changes made by raw bash
+ * or external editors are NOT captured (and are guarded against on restore).
+ */
+export class FileCheckpointStore {
+	private readonly sessionId: string;
+	private readonly cwd: string;
+	private readonly blobDir: string;
+	private readonly appendCustomEntry: (customType: string, data: unknown) => string;
+	private readonly getEntries: () => SessionEntry[];
+	private readonly getBranch: (fromId: string) => SessionEntry[];
+	private readonly isStreaming: () => boolean;
+
+	private currentTurnId: string | null = null;
+	/** captures for the current turn, keyed by mutation key (realpath) */
+	private pending = new Map<string, PendingCapture>();
+	private flushedTurns = new Set<string>();
+
+	constructor(options: FileCheckpointStoreOptions) {
+		this.sessionId = options.sessionId;
+		this.cwd = options.cwd;
+		this.blobDir = resolve(options.checkpointsRoot, this.sessionId, "blobs");
+		this.appendCustomEntry = options.appendCustomEntry;
+		this.getEntries = options.getEntries;
+		this.getBranch = options.getBranch;
+		this.isStreaming = options.isStreaming;
+	}
+
+	/** Begin a new turn (a user message). Flushes the previous turn's manifest. */
+	beginTurn(turnId: string | null): void {
+		this.flushPending();
+		this.currentTurnId = turnId;
+		this.pending.clear();
+	}
+
+	/**
+	 * Persist the current turn's manifest entry if anything was captured.
+	 * Idempotent: a turn is only flushed once.
+	 */
+	flushPending(): void {
+		const turnId = this.currentTurnId;
+		if (!turnId || this.pending.size === 0 || this.flushedTurns.has(turnId)) {
+			this.pending.clear();
+			return;
+		}
+		const files: CheckpointFile[] = [...this.pending.values()].map((p) => ({
+			path: p.relPath,
+			before: p.before,
+			after: p.after,
+		}));
+		const data: FileCheckpointData = { turnId, files };
+		this.appendCustomEntry(FILE_CHECKPOINT_TYPE, data);
+		this.flushedTurns.add(turnId);
+		this.pending.clear();
+	}
+
+	/** Wrap the edit tool's file operations so writes capture before-state. */
+	wrapEditOperations(): EditOperations {
+		return {
+			readFile: (path) => Promise.resolve(readFileSync(path)),
+			access: (path) => {
+				// Throw if not readable+writable, matching the default edit operations.
+				accessSync(path, constants.R_OK | constants.W_OK);
+				return Promise.resolve();
+			},
+			writeFile: (path, content) => this.captureAndWrite(path, content),
+		};
+	}
+
+	/** Wrap the write tool's file operations so writes capture before-state. */
+	wrapWriteOperations(): WriteOperations {
+		return {
+			mkdir: (dir) => {
+				mkdirSync(dir, { recursive: true });
+				return Promise.resolve();
+			},
+			writeFile: (path, content) => this.captureAndWrite(path, content),
+		};
+	}
+
+	/**
+	 * Capture the file's current content (once per turn), then write the new
+	 * content. Runs inside the tool's per-file mutation lock, so the read sees a
+	 * consistent baseline.
+	 *
+	 * The after-hash is recorded only after the write succeeds: a failed write
+	 * must not leave a manifest claiming pi wrote content it never did (that would
+	 * make the external-edit guard wrongly skip a legitimate restore). If the
+	 * write throws on first touch, the just-added capture is rolled back so no
+	 * phantom entry is persisted.
+	 */
+	private async captureAndWrite(absolutePath: string, content: string): Promise<void> {
+		const key = mutationKey(absolutePath);
+		const newlyCaptured = this.captureBefore(absolutePath, key);
+		try {
+			writeFileSync(absolutePath, content, "utf-8");
+		} catch (error) {
+			if (newlyCaptured) this.pending.delete(key);
+			throw error;
+		}
+		this.recordAfter(key, hashContent(content));
+	}
+
+	/** Returns true if this call inserted a new capture for the turn. */
+	private captureBefore(absolutePath: string, key: string): boolean {
+		// Capture is deduped by realpath (mutationKey), so distinct symlinks
+		// pointing at the same file collapse to one manifest entry per turn.
+		if (!this.currentTurnId || this.pending.has(key)) return false;
+		let before: string | null;
+		try {
+			before = this.writeBlob(readFileSync(absolutePath));
+		} catch (error) {
+			if (isMissingFile(error)) {
+				before = ABSENT;
+			} else {
+				throw error;
+			}
+		}
+		this.pending.set(key, {
+			relPath: relative(this.cwd, absolutePath),
+			absolutePath,
+			before,
+			after: null,
+		});
+		return true;
+	}
+
+	private recordAfter(key: string, afterHash: string): void {
+		const entry = this.pending.get(key);
+		if (entry) entry.after = afterHash;
+	}
+
+	// === Restore ===
+
+	/**
+	 * Restore files to their state before `targetTurnId`, rolling back every turn
+	 * on the path from `fromLeafId` down to (and including) the target turn.
+	 * Must be called BEFORE navigating the conversation, with the pre-navigation
+	 * leaf id, so the abandoned path is still reachable.
+	 */
+	async restoreTo(targetTurnId: string, fromLeafId: string): Promise<RestoreSummary> {
+		if (this.isStreaming()) {
+			throw new Error("Cannot restore files while the agent is running");
+		}
+		this.flushPending();
+
+		const plan = this.buildPlan(targetTurnId, fromLeafId);
+		const summary: RestoreSummary = { restored: [], deleted: [], skippedExternal: [], unchanged: 0 };
+		if (plan.length === 0) return summary;
+
+		// Forensic + crash-recovery marker, written before any disk mutation.
+		this.appendCustomEntry(FILE_RESTORE_TYPE, {
+			targetTurnId,
+			plan,
+		} satisfies RestoreMarkerData);
+
+		await this.applyPlan(plan, summary);
+
+		this.appendCustomEntry(FILE_RESTORE_DONE_TYPE, { targetTurnId });
+		return summary;
+	}
+
+	/** Compute the restore plan: earliest before-state wins, latest after-state guards. */
+	private buildPlan(targetTurnId: string, fromLeafId: string): RestorePlanItem[] {
+		const manifests = this.collectManifests();
+		const path = this.getBranch(fromLeafId);
+		const targetIndex = path.findIndex((e) => e.id === targetTurnId);
+		if (targetIndex === -1) return [];
+		const idsInRange = new Set(path.slice(targetIndex).map((e) => e.id));
+
+		// Walk turns from target forward so the first occurrence of a file is its
+		// state before the target turn; the last occurrence is what pi last wrote.
+		const byPath = new Map<string, RestorePlanItem>();
+		for (const entry of path.slice(targetIndex)) {
+			const manifest = manifests.get(entry.id);
+			if (!manifest) continue;
+			for (const file of manifest.files) {
+				const absolutePath = resolve(this.cwd, file.path);
+				const existing = byPath.get(file.path);
+				if (existing) {
+					existing.after = file.after; // latest write wins for the guard
+				} else {
+					byPath.set(file.path, {
+						path: file.path,
+						absolutePath,
+						action: file.before === ABSENT ? "delete" : "write",
+						before: file.before,
+						after: file.after,
+					});
+				}
+			}
+		}
+		// idsInRange is implied by the slice above; kept for clarity/debugging.
+		void idsInRange;
+		return [...byPath.values()];
+	}
+
+	private async applyPlan(plan: RestorePlanItem[], summary: RestoreSummary): Promise<void> {
+		for (const item of plan) {
+			await withFileMutationQueue(item.absolutePath, async () => {
+				const currentHash = this.currentDiskHash(item.absolutePath);
+
+				// Already at the target state -> nothing to do.
+				const targetHash = item.before; // null means "should not exist"
+				if (currentHash === targetHash) {
+					summary.unchanged++;
+					return;
+				}
+
+				// External-edit guard: only touch files that are exactly as pi last
+				// left them. Otherwise the user changed them outside pi (bash /
+				// editor) and we must not clobber that work.
+				if (item.after !== null && currentHash !== item.after) {
+					summary.skippedExternal.push(item.path);
+					return;
+				}
+				if (item.after === null && currentHash !== null) {
+					// pi's record says it never wrote content, but a file exists now.
+					summary.skippedExternal.push(item.path);
+					return;
+				}
+
+				if (item.action === "delete") {
+					if (currentHash !== null) {
+						rmSync(item.absolutePath, { force: true });
+					}
+					summary.deleted.push(item.path);
+				} else if (item.before !== null) {
+					const content = this.readBlob(item.before);
+					mkdirSync(resolve(item.absolutePath, ".."), { recursive: true });
+					writeFileSync(item.absolutePath, content);
+					summary.restored.push(item.path);
+				}
+			});
+		}
+	}
+
+	/**
+	 * Re-drive an incomplete restore (process crashed mid-restore). Idempotent:
+	 * writing the same blob twice is a no-op. Returns a summary if it ran.
+	 */
+	async recoverIncompleteRestore(): Promise<RestoreSummary | null> {
+		const entries = this.getEntries();
+		let pendingMarker: RestoreMarkerData | null = null;
+		for (const entry of entries) {
+			if (entry.type !== "custom") continue;
+			if (entry.customType === FILE_RESTORE_TYPE) {
+				pendingMarker = entry.data as RestoreMarkerData;
+			} else if (entry.customType === FILE_RESTORE_DONE_TYPE) {
+				pendingMarker = null; // matched completion
+			}
+		}
+		if (!pendingMarker || pendingMarker.plan.length === 0) return null;
+
+		const summary: RestoreSummary = { restored: [], deleted: [], skippedExternal: [], unchanged: 0 };
+		await this.applyPlan(pendingMarker.plan, summary);
+		this.appendCustomEntry(FILE_RESTORE_DONE_TYPE, { targetTurnId: pendingMarker.targetTurnId });
+		return summary;
+	}
+
+	// === blob store ===
+
+	private collectManifests(): Map<string, FileCheckpointData> {
+		const map = new Map<string, FileCheckpointData>();
+		for (const entry of this.getEntries()) {
+			if (entry.type === "custom" && entry.customType === FILE_CHECKPOINT_TYPE) {
+				const data = entry.data as FileCheckpointData;
+				map.set(data.turnId, data); // later manifest for same turn wins
+			}
+		}
+		return map;
+	}
+
+	private writeBlob(content: Buffer): string {
+		const hash = hashBuffer(content);
+		const blobPath = resolve(this.blobDir, hash);
+		if (!existsSync(blobPath)) {
+			mkdirSync(this.blobDir, { recursive: true });
+			writeFileSync(blobPath, content);
+		}
+		return hash;
+	}
+
+	private readBlob(hash: string): Buffer {
+		return readFileSync(resolve(this.blobDir, hash));
+	}
+
+	private currentDiskHash(absolutePath: string): string | null {
+		try {
+			return hashBuffer(readFileSync(absolutePath));
+		} catch (error) {
+			if (isMissingFile(error)) return null;
+			throw error;
+		}
+	}
+}
+
+/**
+ * Remove all checkpoint blobs for a session. Call this when a session is
+ * deleted so its captured file contents don't linger on disk.
+ */
+export function deleteSessionCheckpoints(sessionId: string, checkpointsRoot: string): void {
+	rmSync(resolve(checkpointsRoot, sessionId), { recursive: true, force: true });
+}
+
+function hashBuffer(buffer: Buffer): string {
+	return createHash("sha256").update(buffer).digest("hex");
+}
+
+function hashContent(content: string): string {
+	return createHash("sha256").update(Buffer.from(content, "utf-8")).digest("hex");
+}
+
+function isMissingFile(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		((error as { code: string }).code === "ENOENT" || (error as { code: string }).code === "ENOTDIR")
+	);
+}
+
+/**
+ * Stable key for a file mutation, mirroring file-mutation-queue's keying so
+ * capture and the tool's lock agree. Resolves symlinks when the file exists,
+ * falls back to the absolute path otherwise (new files).
+ */
+function mutationKey(filePath: string): string {
+	const resolved = resolve(filePath);
+	try {
+		return realpathSync(resolved);
+	} catch (error) {
+		if (isMissingFile(error)) return resolved;
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import * as os from "node:os";
+import { join } from "node:path";
 import {
 	type Component,
 	Container,
@@ -13,6 +14,8 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
+import { getAgentDir } from "../../../config.ts";
+import { deleteSessionCheckpoints } from "../../../core/file-checkpoint-store.ts";
 import { KeybindingsManager } from "../../../core/keybindings.ts";
 import type { SessionInfo, SessionListProgress } from "../../../core/session-manager.ts";
 import { canonicalizePath as _canonicalizePath } from "../../../utils/paths.ts";
@@ -818,9 +821,17 @@ export class SessionSelectorComponent extends Container implements Focusable {
 
 		// Handle session deletion
 		this.sessionList.onDeleteSession = async (sessionPath: string) => {
+			// Capture the session id before the lists are filtered below.
+			const deletedSessionId = (this.currentSessions ?? this.allSessions ?? []).find(
+				(s) => s.path === sessionPath,
+			)?.id;
 			const result = await deleteSessionFile(sessionPath);
 
 			if (result.ok) {
+				// Remove the session's checkpoint blobs so they don't linger on disk.
+				if (deletedSessionId) {
+					deleteSessionCheckpoints(deletedSessionId, join(getAgentDir(), "checkpoints"));
+				}
 				if (this.currentSessions) {
 					this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
 				}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -72,6 +72,7 @@ import type {
 	ExtensionWidgetOptions,
 	ProjectTrustContext,
 } from "../../core/extensions/index.ts";
+import type { RestoreSummary } from "../../core/file-checkpoint-store.ts";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.ts";
 import { configureHttpDispatcher, formatHttpIdleTimeoutMs } from "../../core/http-dispatcher.ts";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.ts";
@@ -4406,6 +4407,19 @@ export class InteractiveMode {
 		}
 	}
 
+	/** One-line summary of a file restore for the status bar. */
+	private formatRestoreSummary(summary: RestoreSummary): string {
+		const parts: string[] = [];
+		const changed = summary.restored.length + summary.deleted.length;
+		if (changed > 0) parts.push(`${changed} file${changed === 1 ? "" : "s"} restored`);
+		if (summary.deleted.length > 0) parts.push(`${summary.deleted.length} deleted`);
+		if (summary.skippedExternal.length > 0) {
+			parts.push(`${summary.skippedExternal.length} skipped (changed outside pi)`);
+		}
+		if (parts.length === 0) return "files already at this point";
+		return parts.join(", ");
+	}
+
 	private showTreeSelector(initialSelectedId?: string): void {
 		const tree = this.sessionManager.getTree();
 		const realLeafId = this.sessionManager.getLeafId();
@@ -4466,6 +4480,21 @@ export class InteractiveMode {
 						}
 					}
 
+					// Ask whether to also restore files on disk to this point.
+					let restoreFiles = false;
+					if (this.session.supportsFileRestore) {
+						const restoreChoice = await this.showExtensionSelector("Restore files to this point?", [
+							"Conversation + files",
+							"Conversation only",
+						]);
+						if (restoreChoice === undefined) {
+							// User pressed escape - re-show tree selector with same selection
+							this.showTreeSelector(entryId);
+							return;
+						}
+						restoreFiles = restoreChoice === "Conversation + files";
+					}
+
 					// Set up escape handler and loader if summarizing
 					let summaryLoader: Loader | undefined;
 					const originalOnEscape = this.defaultEditor.onEscape;
@@ -4502,13 +4531,30 @@ export class InteractiveMode {
 							return;
 						}
 
+						// Restore files on disk if requested. Uses the pre-navigation leaf
+						// (realLeafId) so the abandoned branch is still reachable.
+						let restoreStatus = "";
+						if (restoreFiles) {
+							if (!realLeafId) {
+								// No prior leaf to roll back from; tell the user instead of silently skipping.
+								restoreStatus = " · could not restore files (no prior state)";
+							} else {
+								try {
+									const summary = await this.session.restoreFilesTo(entryId, realLeafId);
+									restoreStatus = summary ? ` · ${this.formatRestoreSummary(summary)}` : "";
+								} catch (restoreError) {
+									this.showError(restoreError instanceof Error ? restoreError.message : String(restoreError));
+								}
+							}
+						}
+
 						// Update UI
 						this.chatContainer.clear();
 						this.renderInitialMessages();
 						if (result.editorText && !this.editor.getText().trim()) {
 							this.editor.setText(result.editorText);
 						}
-						this.showStatus("Navigated to selected point");
+						this.showStatus(`Navigated to selected point${restoreStatus}`);
 						void this.flushCompactionQueue({ willRetry: false });
 					} catch (error) {
 						this.showError(error instanceof Error ? error.message : String(error));

--- a/packages/coding-agent/test/file-checkpoint-store.test.ts
+++ b/packages/coding-agent/test/file-checkpoint-store.test.ts
@@ -1,0 +1,246 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	FILE_CHECKPOINT_TYPE,
+	FileCheckpointStore,
+	type FileCheckpointStoreOptions,
+} from "../src/core/file-checkpoint-store.ts";
+
+interface FakeEntry {
+	type: string;
+	id: string;
+	parentId: string | null;
+	customType?: string;
+	data?: unknown;
+}
+
+/** Minimal in-memory stand-in for SessionManager's append-only tree. */
+class FakeSession {
+	entries: FakeEntry[] = [];
+	leaf: string | null = null;
+	private counter = 0;
+
+	private append(entry: FakeEntry): void {
+		entry.parentId = this.leaf;
+		this.leaf = entry.id;
+		this.entries.push(entry);
+	}
+
+	appendUser(id: string): void {
+		this.append({ type: "message", id, parentId: null });
+	}
+
+	appendCustomEntry = (customType: string, data: unknown): string => {
+		const id = `custom-${this.counter++}`;
+		this.append({ type: "custom", id, parentId: null, customType, data });
+		return id;
+	};
+
+	getEntries = (): FakeEntry[] => this.entries;
+
+	getBranch = (fromId: string): FakeEntry[] => {
+		const byId = new Map(this.entries.map((e) => [e.id, e]));
+		const path: FakeEntry[] = [];
+		let current = byId.get(fromId);
+		while (current) {
+			path.unshift(current);
+			current = current.parentId ? byId.get(current.parentId) : undefined;
+		}
+		return path;
+	};
+}
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "pi-file-checkpoint-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createStore(opts?: { isStreaming?: () => boolean }): Promise<{
+	store: FileCheckpointStore;
+	session: FakeSession;
+	cwd: string;
+}> {
+	const cwd = await createTempDir();
+	const session = new FakeSession();
+	// FakeEntry mirrors only the fields the store reads; cast through unknown.
+	const options = {
+		sessionId: "test-session",
+		cwd,
+		checkpointsRoot: join(cwd, ".checkpoints"),
+		appendCustomEntry: session.appendCustomEntry,
+		getEntries: session.getEntries,
+		getBranch: session.getBranch,
+		isStreaming: opts?.isStreaming ?? (() => false),
+	} as unknown as FileCheckpointStoreOptions;
+	return { store: new FileCheckpointStore(options), session, cwd };
+}
+
+describe("FileCheckpointStore", () => {
+	it("captures one manifest per turn and restores files to the target state", async () => {
+		const { store, session, cwd } = await createStore();
+		const fileA = join(cwd, "a.txt");
+		writeFileSync(fileA, "v0");
+
+		// Turn 1: v0 -> v1
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await store.wrapEditOperations().writeFile(fileA, "v1");
+
+		// Turn 2: v1 -> v2
+		session.appendUser("u2");
+		store.beginTurn("u2");
+		await store.wrapEditOperations().writeFile(fileA, "v2");
+
+		expect(readFileSync(fileA, "utf-8")).toBe("v2");
+
+		// Restore to before turn 1 -> v0
+		const summary = await store.restoreTo("u1", "u2");
+		expect(readFileSync(fileA, "utf-8")).toBe("v0");
+		expect(summary.restored).toEqual(["a.txt"]);
+
+		const manifests = session.entries.filter((e) => e.type === "custom" && e.customType === FILE_CHECKPOINT_TYPE);
+		expect(manifests).toHaveLength(2);
+	});
+
+	it("dedups multiple edits to the same file within a turn (first-touch wins)", async () => {
+		const { store, session, cwd } = await createStore();
+		const fileA = join(cwd, "a.txt");
+		writeFileSync(fileA, "v0");
+
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await store.wrapEditOperations().writeFile(fileA, "v1");
+		await store.wrapEditOperations().writeFile(fileA, "v2");
+
+		// Restore to before u1 -> should be v0 (the first-touch baseline), not v1
+		await store.restoreTo("u1", "u1");
+		expect(readFileSync(fileA, "utf-8")).toBe("v0");
+	});
+
+	it("deletes files that were newly created after the target (absent sentinel)", async () => {
+		const { store, session, cwd } = await createStore();
+		const fileB = join(cwd, "b.txt");
+
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		// New file created this turn
+		await store.wrapWriteOperations().writeFile(fileB, "new");
+		expect(existsSync(fileB)).toBe(true);
+
+		const summary = await store.restoreTo("u1", "u1");
+		expect(existsSync(fileB)).toBe(false);
+		expect(summary.deleted).toEqual(["b.txt"]);
+	});
+
+	it("skips files changed outside pi (external-edit guard)", async () => {
+		const { store, session, cwd } = await createStore();
+		const fileA = join(cwd, "a.txt");
+		writeFileSync(fileA, "v0");
+
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await store.wrapEditOperations().writeFile(fileA, "v1");
+
+		// User hand-edits the file outside pi after pi wrote it
+		writeFileSync(fileA, "hand-edited");
+
+		const summary = await store.restoreTo("u1", "u1");
+		expect(readFileSync(fileA, "utf-8")).toBe("hand-edited");
+		expect(summary.skippedExternal).toEqual(["a.txt"]);
+		expect(summary.restored).toEqual([]);
+	});
+
+	it("counts files already at the target state as unchanged", async () => {
+		const { store, session, cwd } = await createStore();
+		const fileA = join(cwd, "a.txt");
+		writeFileSync(fileA, "v0");
+
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await store.wrapEditOperations().writeFile(fileA, "v1");
+
+		// Manually put it back to the pre-turn state, then restore: nothing to do
+		writeFileSync(fileA, "v0");
+		const summary = await store.restoreTo("u1", "u1");
+		expect(summary.unchanged).toBe(1);
+		expect(summary.restored).toEqual([]);
+		expect(summary.skippedExternal).toEqual([]);
+	});
+
+	it("refuses to restore while the agent is streaming", async () => {
+		const { store, session, cwd } = await createStore({ isStreaming: () => true });
+		const fileA = join(cwd, "a.txt");
+		writeFileSync(fileA, "v0");
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await store.wrapEditOperations().writeFile(fileA, "v1");
+
+		await expect(store.restoreTo("u1", "u1")).rejects.toThrow(/agent is running/);
+	});
+
+	it("rolls back the capture when the write fails (no phantom manifest)", async () => {
+		const { store, session, cwd } = await createStore();
+		// A regular file used as a fake parent dir -> writing under it throws ENOTDIR.
+		const blocker = join(cwd, "blocker");
+		writeFileSync(blocker, "i am a file, not a dir");
+		const badPath = join(blocker, "child.txt");
+
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await expect(store.wrapWriteOperations().writeFile(badPath, "x")).rejects.toThrow();
+
+		// The failed write must not leave a captured entry behind.
+		store.flushPending();
+		const manifests = session.entries.filter((e) => e.type === "custom" && e.customType === FILE_CHECKPOINT_TYPE);
+		expect(manifests).toHaveLength(0);
+	});
+
+	it("keeps a prior successful capture when a later write in the turn fails", async () => {
+		const { store, session, cwd } = await createStore();
+		const fileA = join(cwd, "a.txt");
+		writeFileSync(fileA, "v0");
+		const blocker = join(cwd, "blocker");
+		writeFileSync(blocker, "file");
+		const badPath = join(blocker, "child.txt");
+
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await store.wrapEditOperations().writeFile(fileA, "v1"); // succeeds
+		await expect(store.wrapWriteOperations().writeFile(badPath, "x")).rejects.toThrow(); // fails
+
+		// fileA's capture survives; restore still rolls it back to v0.
+		const summary = await store.restoreTo("u1", "u1");
+		expect(readFileSync(fileA, "utf-8")).toBe("v0");
+		expect(summary.restored).toEqual(["a.txt"]);
+	});
+
+	it("re-drives an interrupted restore idempotently", async () => {
+		const { store, session, cwd } = await createStore();
+		const fileA = join(cwd, "a.txt");
+		writeFileSync(fileA, "v0");
+
+		session.appendUser("u1");
+		store.beginTurn("u1");
+		await store.wrapEditOperations().writeFile(fileA, "v1");
+		await store.restoreTo("u1", "u1");
+		expect(readFileSync(fileA, "utf-8")).toBe("v0");
+
+		// Simulate a crash mid-restore: drop the "done" marker and revert the file
+		// to pi's last-written state, then recover. Recovery re-applies the plan.
+		session.entries = session.entries.filter((e) => e.customType !== "file_restore_done");
+		writeFileSync(fileA, "v1");
+		const recovered = await store.recoverIncompleteRestore();
+		expect(recovered).not.toBeNull();
+		expect(readFileSync(fileA, "utf-8")).toBe("v0");
+	});
+});


### PR DESCRIPTION
## Problem

Pi already rewinds the **conversation** (double-`Esc` → tree selector → `navigateTree` repoints the session-tree leaf). But it does **not** restore your **files on disk**. If the agent edited several files and you rewind the chat, the files stay changed — the transcript and the working tree disagree.

This adds file restore to the existing rewind, so going back can undo the agent's edits too.

## Scope boundary (please read first)

This is a **tool-edit content log**, not a full filesystem snapshot:

- Only files changed through pi's `edit`/`write` tools are tracked. Changes from raw `bash` (`rm`, `mv`, codegen, `npm install`) or external editors are **not** captured/restored — and are guarded against on restore (see Safety).
- Two restore modes only: **Conversation + files** and **Conversation only**. "Code only" was deliberately omitted — it desyncs the model's history from disk.

Full notes: `packages/coding-agent/docs/rewind.md`.

## How it works

- **`FileCheckpointStore`** (`src/core/file-checkpoint-store.ts`) captures the before-content of files touched by the edit/write tools, once per user turn, into a content-addressed blob store (`~/.pi/agent/checkpoints/<sessionId>/blobs/<sha256>`). One small manifest per turn is persisted via the existing `appendCustomEntry` — **no new `SessionEntry` type, no schema migration**.
- **Capture seam:** injected by wrapping the tools' pluggable file `operations`, so it runs inside the existing per-file mutation lock (keyed by realpath) — no parallel locking story.
- **Restore:** gated on the agent being idle, acquires the per-file lock, computes the full plan then applies it, writes a restore marker for crash recovery, and reports a one-line summary.
- **UI:** the tree selector gains a "Restore files to this point?" prompt.

## Safety

- **External-edit guard:** before overwriting/deleting, the current on-disk hash is compared to what pi last wrote. Files changed outside pi are **skipped and reported** (`changed outside pi`), never clobbered.
- A failed write rolls back its capture (no phantom manifest), so a legit restore is never wrongly skipped.
- Checkpoint blobs are removed when the session is deleted.

## Tests

`test/file-checkpoint-store.test.ts` (9 tests): capture dedup / first-touch-wins, multi-turn restore, absent→delete, the external-edit guard, idle refusal, failed-write rollback, idempotent crash recovery. Full pre-commit suite (biome, tsgo, shrinkwrap, browser-smoke) passes.

## Follow-ups (not in this PR)

- Skip the restore prompt when the abandoned branch captured zero files.
- Remove empty directories left after deleting restored-away files.