### PR TITLE
fix(ai): send store: false on Azure OpenAI Responses requests

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -256,6 +256,12 @@ function buildParams(
 		input: messages,
 		stream: true,
 		prompt_cache_key: clampOpenAIPromptCacheKey(options?.sessionId),
+		// Reasoning is replayed statelessly via reasoning.encrypted_content (set below),
+		// so server-side storage must be off. With store left at its default, Azure runs
+		// stateful and tries to resolve replayed rs_* reasoning item ids against its store;
+		// on a replayed transcript those ids are usually absent, yielding an intermittent
+		// 400 "Item with id 'rs_...' not found". Matches openai-responses / openai-codex-responses.
+		store: false,
 	};
 
 	if (options?.maxTokens) {

--- a/packages/ai/test/azure-openai-base-url.test.ts
+++ b/packages/ai/test/azure-openai-base-url.test.ts
@@ -13,6 +13,7 @@ interface CapturedAzureClientOptions {
 
 interface CapturedAzureResponsesPayload {
 	prompt_cache_key?: string;
+	store?: boolean;
 }
 
 const azureMock = vi.hoisted(() => ({
@@ -142,6 +143,16 @@ describe("azure-openai-responses base URL normalization", () => {
 		}).result();
 
 		expect(azureMock.lastParams?.prompt_cache_key).toBe("x".repeat(64));
+	});
+
+	it("sends store: false so reasoning replays statelessly via encrypted_content", async () => {
+		const model = getModel("azure-openai-responses", "gpt-4o-mini");
+		await streamAzureOpenAIResponses(model, context, {
+			apiKey: "test-api-key",
+			azureBaseUrl: "https://my-resource.openai.azure.com",
+		}).result();
+
+		expect(azureMock.lastParams?.store).toBe(false);
 	});
 
 	it("builds correct default URL from AZURE_OPENAI_RESOURCE_NAME", async () => {


### PR DESCRIPTION
**To maintainers: This is a THREE LINE change which fixes a nasty bug.** Also I opened this before I read CONTRIBUTING.md telling me not to open PRs. Sorry! Please don't ban me!


## Summary

`packages/ai/src/providers/azure-openai-responses.ts` requests `include: ["reasoning.encrypted_content"]` (the stateless reasoning-replay path) but never sets `store`, so Azure runs in its default **stateful** mode. The sibling `openai-responses` and `openai-codex-responses` providers both set `store: false` alongside the same `include`; Azure is the only Responses provider that omits it.

## Symptom

Intermittent `400 Item with id 'rs_...' not found` on multi-turn conversations, which clears if you retry the same request.

## Root cause

When a transcript is replayed, `convertResponsesMessages` re-emits each prior assistant reasoning item with its original `rs_*` id inlined in `input` (the item is round-tripped through `thinkingSignature`). In stateful mode Azure tries to *resolve* that `rs_*` id against its server-side store rather than using the inlined `encrypted_content`. Azure's Responses endpoint is load-balanced and stored items are tied to a specific response/backend with a retention window, so whether the lookup succeeds is non-deterministic — replays that land on a backend without the item fail, and retrying eventually routes to one that resolves (or regenerates), which is why "try again" clears it.

This bites hardest when the transcript is rebuilt from persisted messages each turn (no `previous_response_id` threading), so the replayed reasoning ids reference responses the serving backend no longer has.

## Fix

Set `store: false` in `buildParams`. With `store: false` + `include: ["reasoning.encrypted_content"]`, every request is self-contained: the reasoning travels inline as encrypted content and Azure never does a store lookup, so the call is deterministic. This matches the existing behavior of `openai-responses` and `openai-codex-responses`.

```diff
 	const params: ResponseCreateParamsStreaming = {
 		model: deploymentName,
 		input: messages,
 		stream: true,
 		prompt_cache_key: clampOpenAIPromptCacheKey(options?.sessionId),
+		store: false,
 	};
```

## Test

Extended `packages/ai/test/azure-openai-base-url.test.ts` to assert the provider sends `store: false`. `npm run check` and the full `packages/ai` test suite pass (323 passed, e2e/keyed tests skipped).
