### PR TITLE
Require terminal events for OpenAI Responses streams

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -294,8 +294,41 @@ export async function processResponsesStream<TApi extends Api>(
 ): Promise<void> {
 	let currentItem: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | null = null;
 	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
+	let sawTerminalResponseEvent = false;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
+	const finalizeResponse = (
+		response: Extract<ResponseStreamEvent, { type: "response.completed" | "response.incomplete" }>["response"],
+	): void => {
+		sawTerminalResponseEvent = true;
+		if (response?.id) {
+			output.responseId = response.id;
+		}
+		if (response?.usage) {
+			const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
+			output.usage = {
+				// OpenAI includes cached tokens in input_tokens, so subtract to get non-cached input
+				input: (response.usage.input_tokens || 0) - cachedTokens,
+				output: response.usage.output_tokens || 0,
+				cacheRead: cachedTokens,
+				cacheWrite: 0,
+				totalTokens: response.usage.total_tokens || 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			};
+		}
+		calculateCost(model, output.usage);
+		if (options?.applyServiceTierPricing) {
+			const serviceTier = options.resolveServiceTier
+				? options.resolveServiceTier(response?.service_tier, options.serviceTier)
+				: (response?.service_tier ?? options.serviceTier);
+			options.applyServiceTierPricing(output.usage, serviceTier);
+		}
+		// Map status to stop reason
+		output.stopReason = mapStopReason(response?.status);
+		if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
+			output.stopReason = "toolUse";
+		}
+	};
 
 	for await (const event of openaiStream) {
 		if (event.type === "response.created") {
@@ -490,38 +523,12 @@ export async function processResponsesStream<TApi extends Api>(
 				currentBlock = null;
 				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 			}
-		} else if (event.type === "response.completed") {
-			const response = event.response;
-			if (response?.id) {
-				output.responseId = response.id;
-			}
-			if (response?.usage) {
-				const cachedTokens = response.usage.input_tokens_details?.cached_tokens || 0;
-				output.usage = {
-					// OpenAI includes cached tokens in input_tokens, so subtract to get non-cached input
-					input: (response.usage.input_tokens || 0) - cachedTokens,
-					output: response.usage.output_tokens || 0,
-					cacheRead: cachedTokens,
-					cacheWrite: 0,
-					totalTokens: response.usage.total_tokens || 0,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				};
-			}
-			calculateCost(model, output.usage);
-			if (options?.applyServiceTierPricing) {
-				const serviceTier = options.resolveServiceTier
-					? options.resolveServiceTier(response?.service_tier, options.serviceTier)
-					: (response?.service_tier ?? options.serviceTier);
-				options.applyServiceTierPricing(output.usage, serviceTier);
-			}
-			// Map status to stop reason
-			output.stopReason = mapStopReason(response?.status);
-			if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
-				output.stopReason = "toolUse";
-			}
+		} else if (event.type === "response.completed" || event.type === "response.incomplete") {
+			finalizeResponse(event.response);
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}` || "Unknown error");
 		} else if (event.type === "response.failed") {
+			sawTerminalResponseEvent = true;
 			const error = event.response?.error;
 			const details = event.response?.incomplete_details;
 			const msg = error
@@ -531,6 +538,9 @@ export async function processResponsesStream<TApi extends Api>(
 					: "Unknown error (no error details in response)";
 			throw new Error(msg);
 		}
+	}
+	if (!sawTerminalResponseEvent) {
+		throw new Error("OpenAI Responses stream ended before a terminal response event");
 	}
 }
 

--- a/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
+++ b/packages/ai/test/openai-responses-partial-json-cleanup.test.ts
@@ -57,6 +57,11 @@ async function* createFunctionCallEvents(argumentsJson: string): AsyncIterable<R
 			arguments: argumentsJson,
 		},
 	} as ResponseStreamEvent;
+	yield {
+		type: "response.completed",
+		sequence_number: 5,
+		response: { id: "resp_test", status: "completed" },
+	} as ResponseStreamEvent;
 }
 
 describe("openai responses partialJson cleanup", () => {

--- a/packages/ai/test/openai-responses-terminal-event.test.ts
+++ b/packages/ai/test/openai-responses-terminal-event.test.ts
@@ -1,0 +1,233 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it, vi } from "vitest";
+import { streamOpenAIResponses } from "../src/providers/openai-responses.ts";
+import { processResponsesStream } from "../src/providers/openai-responses-shared.ts";
+import type { AssistantMessage, AssistantMessageEvent, Context, Model } from "../src/types.ts";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
+
+vi.mock("openai", () => {
+	async function* createMockResponsesStream(): AsyncIterable<ResponseStreamEvent> {
+		yield {
+			type: "response.created",
+			sequence_number: 0,
+			response: { id: "resp_wrapper_early_eof" },
+		} as ResponseStreamEvent;
+		yield {
+			type: "response.output_item.added",
+			sequence_number: 1,
+			output_index: 0,
+			item: { type: "reasoning", id: "rs_wrapper_early_eof", summary: [] },
+		} as ResponseStreamEvent;
+		yield {
+			type: "response.reasoning_text.delta",
+			sequence_number: 2,
+			output_index: 0,
+			content_index: 0,
+			item_id: "rs_wrapper_early_eof",
+			delta: "partial reasoning before the wrapper stream ends",
+		} as ResponseStreamEvent;
+	}
+
+	class FakeOpenAI {
+		responses = {
+			create: () => {
+				const responseStream = createMockResponsesStream();
+				const promise = Promise.resolve(responseStream) as Promise<AsyncIterable<ResponseStreamEvent>> & {
+					withResponse: () => Promise<{
+						data: AsyncIterable<ResponseStreamEvent>;
+						response: { status: number; headers: Headers };
+					}>;
+				};
+				promise.withResponse = async () => ({
+					data: responseStream,
+					response: { status: 200, headers: new Headers() },
+				});
+				return promise;
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "gpt-5-mini",
+		name: "GPT-5 Mini",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	};
+}
+
+function createOutput(model: Model<"openai-responses">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+async function* createEarlyEofEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.created",
+		sequence_number: 0,
+		response: { id: "resp_early_eof" },
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.output_item.added",
+		sequence_number: 1,
+		output_index: 0,
+		item: { type: "reasoning", id: "rs_early_eof", summary: [] },
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.reasoning_text.delta",
+		sequence_number: 2,
+		output_index: 0,
+		content_index: 0,
+		item_id: "rs_early_eof",
+		delta: "partial reasoning before the stream ends",
+	} as ResponseStreamEvent;
+}
+
+async function* createCompletedEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.completed",
+		sequence_number: 0,
+		response: {
+			id: "resp_completed",
+			status: "completed",
+			usage: {
+				input_tokens: 20,
+				output_tokens: 7,
+				total_tokens: 27,
+				input_tokens_details: { cached_tokens: 2 },
+			},
+		},
+	} as ResponseStreamEvent;
+}
+
+async function* createIncompleteEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.incomplete",
+		sequence_number: 0,
+		response: {
+			id: "resp_incomplete",
+			status: "incomplete",
+			usage: {
+				input_tokens: 30,
+				output_tokens: 12,
+				total_tokens: 42,
+				input_tokens_details: { cached_tokens: 5 },
+			},
+		},
+	} as ResponseStreamEvent;
+}
+
+async function* createFailedEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.failed",
+		sequence_number: 0,
+		response: {
+			id: "resp_failed",
+			status: "failed",
+			error: { code: "server_error", message: "boom" },
+		},
+	} as ResponseStreamEvent;
+}
+
+describe("OpenAI Responses terminal event handling", () => {
+	it("rejects streams that end before a terminal response event", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+
+		await expect(processResponsesStream(createEarlyEofEvents(), output, stream, model)).rejects.toThrow(
+			"OpenAI Responses stream ended before a terminal response event",
+		);
+	});
+
+	it("emits an error final result when the wrapper stream ends before a terminal response event", async () => {
+		const model = createModel();
+		const context: Context = {
+			systemPrompt: "",
+			messages: [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 }],
+			tools: [],
+		};
+		const stream = streamOpenAIResponses(model, context, { apiKey: "test" });
+		const events: AssistantMessageEvent[] = [];
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const result = await stream.result();
+		const lastEvent = events.at(-1);
+		expect(lastEvent?.type).toBe("error");
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("OpenAI Responses stream ended before a terminal response event");
+	});
+
+	it("finalizes completed terminal events as stop", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+
+		await processResponsesStream(createCompletedEvents(), output, stream, model);
+
+		expect(output.responseId).toBe("resp_completed");
+		expect(output.stopReason).toBe("stop");
+		expect(output.usage).toMatchObject({
+			input: 18,
+			output: 7,
+			cacheRead: 2,
+			cacheWrite: 0,
+			totalTokens: 27,
+		});
+	});
+
+	it("finalizes incomplete terminal events as length stops", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+
+		await processResponsesStream(createIncompleteEvents(), output, stream, model);
+
+		expect(output.responseId).toBe("resp_incomplete");
+		expect(output.stopReason).toBe("length");
+		expect(output.usage).toMatchObject({
+			input: 25,
+			output: 12,
+			cacheRead: 5,
+			cacheWrite: 0,
+			totalTokens: 42,
+		});
+	});
+
+	it("rejects failed terminal events with the provider error", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+
+		await expect(processResponsesStream(createFailedEvents(), output, stream, model)).rejects.toThrow(
+			"server_error: boom",
+		);
+	});
+});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1842,10 +1842,12 @@ export class AgentSession {
 		}
 
 		// Case 2: Threshold - context is getting large
-		// For error messages (no usage data), estimate from last successful response.
-		// This ensures sessions that hit persistent API errors (e.g. 529) can still compact.
+		// For error messages or all-zero usage messages, estimate from the last valid response.
+		// This ensures sessions that hit persistent API errors (e.g. 529) or malformed zero-usage
+		// responses can still compact and do not reset context accounting.
 		let contextTokens: number;
-		if (assistantMessage.stopReason === "error") {
+		const directContextTokens = assistantMessage.usage ? calculateContextTokens(assistantMessage.usage) : 0;
+		if (assistantMessage.stopReason === "error" || directContextTokens === 0) {
 			const messages = this.agent.state.messages;
 			const estimate = estimateContextTokens(messages);
 			if (estimate.lastUsageIndex === null) return false; // No usage data at all
@@ -1862,7 +1864,7 @@ export class AgentSession {
 			}
 			contextTokens = estimate.tokens;
 		} else {
-			contextTokens = calculateContextTokens(assistantMessage.usage);
+			contextTokens = directContextTokens;
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			return await this._runAutoCompaction("threshold", false);
@@ -2983,8 +2985,8 @@ export class AgentSession {
 						const contextTokens = calculateContextTokens(assistant.usage);
 						if (contextTokens > 0) {
 							hasPostCompactionUsage = true;
+							break;
 						}
-						break;
 					}
 				}
 			}

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -138,12 +138,17 @@ export function calculateContextTokens(usage: Usage): number {
 
 /**
  * Get usage from an assistant message if available.
- * Skips aborted and error messages as they don't have valid usage data.
+ * Skips aborted, error, and all-zero usage messages as they don't have valid usage data.
  */
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {
 	if (msg.role === "assistant" && "usage" in msg) {
 		const assistantMsg = msg as AssistantMessage;
-		if (assistantMsg.stopReason !== "aborted" && assistantMsg.stopReason !== "error" && assistantMsg.usage) {
+		if (
+			assistantMsg.stopReason !== "aborted" &&
+			assistantMsg.stopReason !== "error" &&
+			assistantMsg.usage &&
+			calculateContextTokens(assistantMsg.usage) > 0
+		) {
 			return assistantMsg.usage;
 		}
 	}
@@ -151,7 +156,7 @@ function getAssistantUsage(msg: AgentMessage): Usage | undefined {
 }
 
 /**
- * Find the last non-aborted assistant message usage from session entries.
+ * Find the last valid assistant message usage from session entries.
  */
 export function getLastAssistantUsage(entries: SessionEntry[]): Usage | undefined {
 	for (let i = entries.length - 1; i >= 0; i--) {

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -140,4 +140,28 @@ describe("AgentSession.getSessionStats", () => {
 			session.dispose();
 		}
 	});
+
+	it("ignores zero-usage messages when checking for post-compaction context usage", () => {
+		const { session, sessionManager } = createSession();
+
+		try {
+			sessionManager.appendMessage(createUserMessage("first", 1));
+			sessionManager.appendMessage(createAssistantMessage("response1", 180_000, 2));
+			const keptUserId = sessionManager.appendMessage(createUserMessage("second", 3));
+			sessionManager.appendMessage(createAssistantMessage("response2", 195_000, 4));
+			sessionManager.appendCompaction("summary", keptUserId, 195_000);
+			sessionManager.appendMessage(createUserMessage("third", 5));
+			sessionManager.appendMessage(createAssistantMessage("response3", 25_000, 6));
+			sessionManager.appendMessage(createUserMessage("continue", 7));
+			sessionManager.appendMessage(createAssistantMessage("partial", 0, 8));
+			syncAgentMessages(session, sessionManager);
+
+			const stats = session.getSessionStats();
+			expect(stats.contextUsage).toBeDefined();
+			expect(stats.contextUsage?.tokens).not.toBeNull();
+			expect(stats.contextUsage?.tokens ?? 0).toBeGreaterThan(25_000);
+		} finally {
+			session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -218,9 +218,40 @@ describe("getLastAssistantUsage", () => {
 		expect(usage!.input).toBe(100);
 	});
 
+	it("should skip all-zero assistant usage", () => {
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("Hello")),
+			createMessageEntry(createAssistantMessage("Hi", createMockUsage(100, 50))),
+			createMessageEntry(createUserMessage("continue")),
+			createMessageEntry(createAssistantMessage("Partial", createMockUsage(0, 0))),
+		];
+
+		const usage = getLastAssistantUsage(entries);
+		expect(usage).not.toBeNull();
+		expect(usage!.input).toBe(100);
+	});
+
 	it("should return undefined if no assistant messages", () => {
 		const entries: SessionEntry[] = [createMessageEntry(createUserMessage("Hello"))];
 		expect(getLastAssistantUsage(entries)).toBeUndefined();
+	});
+});
+
+describe("estimateContextTokens", () => {
+	it("uses the last non-zero assistant usage as the context anchor", () => {
+		const messages: AgentMessage[] = [
+			createUserMessage("Hello"),
+			createAssistantMessage("Hi", createMockUsage(100, 50)),
+			createUserMessage("continue"),
+			createAssistantMessage("Partial thinking", createMockUsage(0, 0)),
+		];
+
+		const estimate = estimateContextTokens(messages);
+
+		expect(estimate.usageTokens).toBe(150);
+		expect(estimate.lastUsageIndex).toBe(1);
+		expect(estimate.trailingTokens).toBeGreaterThan(0);
+		expect(estimate.tokens).toBe(150 + estimate.trailingTokens);
 	});
 });
 

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
+const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,9 +22,11 @@ export default defineConfig({
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@earendil-works\/pi-tui$/, replacement: tuiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@mariozechner\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
 			{ find: /^@mariozechner\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@mariozechner\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},
 });


### PR DESCRIPTION
I was regularly finding my self having to type `continue` b/c openai response streams randomly stopped + the context counter got all borked. investigated and came to this solution - happy to make changes.

## Fixes

- Require OpenAI Responses streams to end with a terminal response event before treating them as successful.
- Finalize `response.incomplete` as a length stop and keep `response.failed` as a provider error.
- Ignore all-zero assistant usage when estimating coding-agent context after malformed or partial responses.

## Tests

- `cd packages/ai && node ../../node_modules/vitest/dist/cli.js --run test/openai-responses-terminal-event.test.ts test/openai-responses-partial-json-cleanup.test.ts`
- `npm run check`

Created with Pi using GPT-5.5 on high, directly guided and steered by Dillon Mulroy <dillon@cloudflare.com>.
