### PR TITLE
fix(amazon-bedrock): extract region from inference profile ARNs

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -143,10 +143,13 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 
 		// in Node.js/Bun environment only
 		if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
-			// Region resolution: explicit option > env vars > SDK default chain.
-			// When AWS_PROFILE is set, we leave region undefined so the SDK can
-			// resovle it from aws profile configs. Otherwise fall back to us-east-1.
-			if (configuredRegion) {
+			// Region resolution: ARN-embedded > explicit option > env vars > SDK default chain.
+			// When the model ID is an inference profile ARN, extract the region from it.
+			// This avoids conflicts with AWS_REGION set for other services.
+			const arnRegionMatch = model.id.match(/^arn:aws(?:-[a-z0-9-]+)?:bedrock:([a-z0-9-]+):/);
+			if (arnRegionMatch) {
+				config.region = arnRegionMatch[1];
+			} else if (configuredRegion) {
 				config.region = configuredRegion;
 			} else if (endpointRegion && useExplicitEndpoint) {
 				config.region = endpointRegion;

--- a/packages/ai/test/bedrock-endpoint-resolution.test.ts
+++ b/packages/ai/test/bedrock-endpoint-resolution.test.ts
@@ -128,4 +128,30 @@ describe("bedrock endpoint resolution", () => {
 		expect(config.endpoint).toBe("https://bedrock-vpc.example.com");
 		expect(config.region).toBe("us-west-2");
 	});
+
+	it("extracts region from inference profile ARN regardless of AWS_REGION", async () => {
+		process.env.AWS_REGION = "us-east-1";
+		const baseModel = getModel("amazon-bedrock", "us.anthropic.claude-opus-4-8");
+		const model: Model<"bedrock-converse-stream"> = {
+			...baseModel,
+			id: "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/abc123",
+		};
+
+		const config = await captureClientConfig(model);
+
+		expect(config.region).toBe("us-west-2");
+	});
+
+	it("extracts region from GovCloud inference profile ARN", async () => {
+		process.env.AWS_REGION = "us-east-1";
+		const baseModel = getModel("amazon-bedrock", "us.anthropic.claude-opus-4-8");
+		const model: Model<"bedrock-converse-stream"> = {
+			...baseModel,
+			id: "arn:aws-us-gov:bedrock:us-gov-west-1:123456789012:application-inference-profile/abc123",
+		};
+
+		const config = await captureClientConfig(model);
+
+		expect(config.region).toBe("us-gov-west-1");
+	});
 });


### PR DESCRIPTION
Application inference profile ARNs encode the region
(`arn:aws:bedrock:<region>:<account>:...`) but the provider ignored it,
falling through to `AWS_REGION` which may point to a different region.
Extract the region from the ARN when present, taking priority over
environment variables.

This is the solution proposed in #4860 (option 1: parse region from ARN).

**Problem:** In enterprise environments, `AWS_REGION` is commonly set to
one region (e.g. `us-east-1`) for general AWS CLI operations, while
Bedrock inference profiles live in a different region (e.g. `us-west-2`).
The provider used `AWS_REGION` for the Bedrock API call, causing
`ValidationException: The provided model identifier is invalid`.

**Fix:** Add an ARN check as the first step in region resolution. If the
model ID matches `arn:aws:bedrock:<region>:...`, use that region. Otherwise
fall through to existing behavior (env vars, endpoint, defaults).

Fixes #4860