### PR TITLE
feat(agent): add beforeModel hook and reactive compaction

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -7,6 +7,7 @@ import {
 	type AssistantMessage,
 	type Context,
 	EventStream,
+	type SimpleStreamOptions,
 	streamSimple,
 	type ToolResultMessage,
 	validateToolArguments,
@@ -23,6 +24,28 @@ import type {
 } from "./types.ts";
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
+
+const PROMPT_TOO_LONG_PATTERNS = [
+	"prompt too long",
+	"context_length_exceeded",
+	"context length",
+	"maximum context",
+	"context window",
+	"input tokens exceed",
+	"messages resulted in",
+	"reduce the length of the messages",
+	"configured limit",
+	"too many tokens",
+	"too large for the model",
+	"maximum context length",
+	"exceed_context",
+	"exceeds the available context size",
+];
+
+function isPromptTooLongError(error: unknown): boolean {
+	const text = String(error instanceof Error ? error.message : error).toLowerCase();
+	return PROMPT_TOO_LONG_PATTERNS.some((needle) => text.includes(needle));
+}
 
 /**
  * Start an agent loop with a new prompt message.
@@ -163,6 +186,8 @@ async function runLoop(
 	let currentContext = initialContext;
 	let config = initialConfig;
 	let firstTurn = true;
+	let turnCount = 0;
+	let hasAttemptedReactiveCompact = false;
 	// Check for steering messages at start (user may have typed while waiting)
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 
@@ -177,6 +202,7 @@ async function runLoop(
 			} else {
 				firstTurn = false;
 			}
+			turnCount++;
 
 			// Process pending messages (inject before next assistant response)
 			if (pendingMessages.length > 0) {
@@ -189,8 +215,41 @@ async function runLoop(
 				pendingMessages = [];
 			}
 
-			// Stream assistant response
-			const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFn);
+			// Stream assistant response (with reactive compaction on prompt-too-long)
+			let message: AssistantMessage | undefined;
+			let reactiveCompactError: Error | undefined;
+			try {
+				message = await streamAssistantResponse(currentContext, config, signal, emit, streamFn, turnCount - 1);
+			} catch (error) {
+				if (
+					!hasAttemptedReactiveCompact &&
+					config.onPromptTooLong &&
+					!signal?.aborted &&
+					isPromptTooLongError(error)
+				) {
+					hasAttemptedReactiveCompact = true;
+					try {
+						const compacted = await config.onPromptTooLong(currentContext, error as Error);
+						if (compacted) {
+							currentContext = compacted;
+							// Will retry below
+						} else {
+							reactiveCompactError = error as Error;
+						}
+					} catch {
+						// onPromptTooLong failed — propagate the original prompt-too-long error
+						reactiveCompactError = error as Error;
+					}
+				} else {
+					reactiveCompactError = error as Error;
+				}
+			}
+			if (reactiveCompactError) {
+				throw reactiveCompactError;
+			}
+			if (!message) {
+				continue; // Retry with compacted context
+			}
 			newMessages.push(message);
 
 			if (message.stopReason === "error" || message.stopReason === "aborted") {
@@ -278,6 +337,7 @@ async function streamAssistantResponse(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 	streamFn?: StreamFn,
+	iteration?: number,
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -285,14 +345,48 @@ async function streamAssistantResponse(
 		messages = await config.transformContext(messages, signal);
 	}
 
+	// Apply beforeModel hook if configured (can modify context, stream options, or stop)
+	// streamContext is used for the LLM call; original context is used for storing the response.
+	let streamContext = context;
+	let streamOptions: Partial<SimpleStreamOptions> = {};
+	if (config.beforeModel) {
+		const result = await config.beforeModel(
+			{
+				context: { ...context, messages, tools: context.tools?.slice() },
+				config,
+				model: config.model,
+				iteration: iteration ?? 0,
+			},
+			signal,
+		);
+		if (result?.stop) {
+			// Push a synthetic stop message to the original conversation history
+			const stopMessage = {
+				role: "assistant",
+				content: [],
+				stopReason: "end_turn",
+				timestamp: Date.now(),
+			} as unknown as AssistantMessage;
+			context.messages.push(stopMessage);
+			return stopMessage;
+		}
+		if (result?.context) {
+			streamContext = result.context;
+			messages = streamContext.messages;
+		}
+		if (result?.options) {
+			streamOptions = result.options;
+		}
+	}
+
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
 	const llmMessages = await config.convertToLlm(messages);
 
-	// Build LLM context
+	// Build LLM context (uses streamContext for systemPrompt/tools, llmMessages for messages)
 	const llmContext: Context = {
-		systemPrompt: context.systemPrompt,
+		systemPrompt: streamContext.systemPrompt,
 		messages: llmMessages,
-		tools: context.tools,
+		tools: streamContext.tools,
 	};
 
 	const streamFunction = streamFn || streamSimple;
@@ -303,6 +397,7 @@ async function streamAssistantResponse(
 
 	const response = await streamFunction(config.model, llmContext, {
 		...config,
+		...streamOptions,
 		apiKey: resolvedApiKey,
 		signal,
 	});

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -132,6 +132,28 @@ export interface AgentLoopTurnUpdate {
 
 export interface PrepareNextTurnContext extends ShouldStopAfterTurnContext {}
 
+/** Context passed to `beforeModel` before each LLM call. */
+export interface BeforeModelContext {
+	/** Current agent context (messages, tools, systemPrompt). */
+	context: AgentContext;
+	/** Current loop configuration. */
+	config: AgentLoopConfig;
+	/** Model that will be used for this request. */
+	model: Model<any>;
+	/** Number of assistant turns completed so far in this run. */
+	iteration: number;
+}
+
+/** Result returned from `beforeModel`. */
+export interface BeforeModelResult {
+	/** Replacement context (messages, tools, systemPrompt). Merges field-by-field. */
+	context?: AgentContext;
+	/** Additional stream options to merge into the request. */
+	options?: Partial<SimpleStreamOptions>;
+	/** If set, prevents the LLM call and ends the current turn. */
+	stop?: { reason: string };
+}
+
 export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
 
@@ -274,6 +296,45 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * The hook receives the agent abort signal and is responsible for honoring it.
 	 */
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
+
+	/**
+	 * Called before each LLM request, after `transformContext` but before `convertToLlm`.
+	 *
+	 * Use this to modify the context (messages, tools, systemPrompt), stream options,
+	 * or to block the request entirely based on runtime state.
+	 *
+	 * Return a `BeforeModelResult` to override parts of the request context.
+	 * Return undefined to keep the current context unchanged.
+	 *
+	 * **Important:**
+	 * - Context modifications (messages, tools, systemPrompt) apply only to this LLM call.
+	 *   The original context is used for storing the assistant response. This is the same
+	 *   behavior as `transformContext`.
+	 * - Do not call `config.beforeModel` recursively — it will cause infinite recursion.
+	 * - Do not modify `config` callbacks (beforeToolCall, afterToolCall, etc.) via the
+	 *   returned context; only modify messages, tools, and systemPrompt.
+	 *
+	 * Contract: must not throw or reject. Throwing interrupts the low-level agent loop without producing a normal event sequence.
+	 */
+	beforeModel?: (context: BeforeModelContext, signal?: AbortSignal) => Promise<BeforeModelResult | undefined>;
+
+	/**
+	 * Called when the LLM request fails with a prompt-too-long / context-length-exceeded error.
+	 *
+	 * Return a new `AgentContext` with compacted messages to retry the request in the same run.
+	 * Return undefined to propagate the error normally.
+	 *
+	 * **Important:**
+	 * - The callback is invoked at most once per run — a second prompt-too-long error after
+	 *   a failed reactive compact always propagates.
+	 * - If the callback itself throws, the original prompt-too-long error is propagated
+	 *   (not the callback's error).
+	 * - The callback should honor the `signal` parameter if it performs long-running work.
+	 *   The signal is checked before calling the callback, but not during execution.
+	 *
+	 * Contract: must not throw or reject. Throwing interrupts the low-level agent loop without producing a normal event sequence.
+	 */
+	onPromptTooLong?: (context: AgentContext, error: Error) => Promise<AgentContext | undefined>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add two new optional callbacks to `AgentLoopConfig`:

1. **`beforeModel`** — Called before each LLM request, after `transformContext` but before `convertToLlm`. Allows modifying context (messages, tools, systemPrompt), stream options, or blocking the request entirely. Useful for provider-specific prompt customization, dynamic tool selection, and request gating.

2. **`onPromptTooLong`** — Called when the LLM request fails with a prompt-too-long / context-length-exceeded error. Returns a new `AgentContext` with compacted messages to retry the request in the same run. Invoked at most once per run to prevent compact loops.

## Motivation

These two features were identified as the only changes that truly require core modifications — all other defensive enhancements (completion policy, storm breaker, length recovery, token budget, etc.) can be implemented at the application layer using existing callbacks (`shouldStopAfterTurn`, `getSteeringMessages`, `afterToolCall`, etc.).

- **`beforeModel`** solves the problem of provider-specific prompt/tool customization that `transformContext` cannot address (it only modifies messages, not tools/options).
- **`onPromptTooLong`** solves the problem of transparent context compaction within the same run, avoiding the need to catch errors and start a new run from the application layer.

## Implementation

### New Types (`types.ts`)

```typescript
interface BeforeModelContext {
  context: AgentContext;    // Shallow copy (tools array copied)
  config: AgentLoopConfig;
  model: Model<any>;
  iteration: number;        // Turns completed so far (0-based)
}

interface BeforeModelResult {
  context?: AgentContext;               // Replace context for this LLM call
  options?: Partial<SimpleStreamOptions>; // Merge into stream options
  stop?: { reason: string };            // Block the request, end turn
}
```

### Loop Changes (`agent-loop.ts`)

- **Reactive compaction**: Wrap `streamAssistantResponse` in try-catch. On prompt-too-long error, call `onPromptTooLong` callback. If it returns a new context, retry. If it returns undefined or throws, propagate the original error.
- **beforeModel hook**: In `streamAssistantResponse`, after `transformContext` and before `convertToLlm`, call `beforeModel`. Use `streamContext` (possibly modified) for the LLM call, but keep the original `context` for storing the assistant response.

### Safety Measures

- `hasAttemptedReactiveCompact` flag prevents infinite compact loops (once per run)
- `signal?.aborted` check before calling `onPromptTooLong`
- `onPromptTooLong` failure catches and propagates the original error
- `tools?.slice()` prevents mutation of the original tools array
- `streamContext`/`context` separation preserves conversation history integrity

## Test plan

- [ ] Verify `beforeModel` can modify systemPrompt and tools for a single LLM call
- [ ] Verify `beforeModel` returning `stop` ends the turn gracefully
- [ ] Verify `onPromptTooLong` compacts and retries within the same run
- [ ] Verify `onPromptTooLong` is called at most once per run
- [ ] Verify existing behavior unchanged when callbacks are not provided
- [ ] Verify signal abort during callbacks is handled correctly