### PR TITLE
fix(minimax): default thinking on for MiniMax-M3

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -298,6 +298,10 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	if (model.api === "anthropic-messages" && isAnthropicAdaptiveThinkingModel(model.id)) {
 		mergeAnthropicMessagesCompat(model, { forceAdaptiveThinking: true });
 	}
+	if (model.api === "anthropic-messages" && model.id.toLowerCase().includes("minimax-m3")) {
+		// MiniMax-M3 returns an empty response unless thinking is enabled.
+		mergeAnthropicMessagesCompat(model, { defaultThinkingEnabled: true });
+	}
 	if (model.api === "anthropic-messages" && isAnthropicTemperatureUnsupportedModel(model.id)) {
 		mergeAnthropicMessagesCompat(model, { supportsTemperature: false });
 	}

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -5715,6 +5715,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "minimax",
 			baseUrl: "https://api.minimax.io/anthropic",
+			compat: {"defaultThinkingEnabled":true},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -5768,6 +5769,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "minimax-cn",
 			baseUrl: "https://api.minimaxi.com/anthropic",
+			compat: {"defaultThinkingEnabled":true},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -8695,6 +8697,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "opencode-go",
 			baseUrl: "https://opencode.ai/zen/go",
+			compat: {"defaultThinkingEnabled":true},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
@@ -14753,6 +14756,7 @@ export const MODELS = {
 			api: "anthropic-messages",
 			provider: "vercel-ai-gateway",
 			baseUrl: "https://ai-gateway.vercel.sh",
+			compat: {"defaultThinkingEnabled":true},
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -165,7 +165,7 @@ const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
 
 function getAnthropicCompat(
 	model: Model<"anthropic-messages">,
-): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking">> {
+): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking" | "defaultThinkingEnabled">> {
 	// Auto-detect session affinity and cache control support from provider
 	const isFireworks = model.provider === "fireworks";
 	const isCloudflareAiGatewayAnthropic =
@@ -745,7 +745,10 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
 
 	const base = buildBaseOptions(model, options, apiKey);
 	if (!options?.reasoning) {
-		return streamAnthropic(model, context, { ...base, thinkingEnabled: false } satisfies AnthropicOptions);
+		// Some models (e.g. MiniMax-M3) return an empty response unless thinking
+		// is enabled, so honor a per-model default when the caller picked no level.
+		const thinkingEnabled = model.compat?.defaultThinkingEnabled === true;
+		return streamAnthropic(model, context, { ...base, thinkingEnabled } satisfies AnthropicOptions);
 	}
 
 	// For models with adaptive thinking: use an effort level.

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -473,6 +473,14 @@ export interface AnthropicMessagesCompat {
 	 * Default: false.
 	 */
 	forceAdaptiveThinking?: boolean;
+	/**
+	 * Whether to enable thinking by default when the caller requests no
+	 * reasoning level. Models like MiniMax-M3 return an empty response unless
+	 * thinking is enabled, so they set this in generated metadata. An explicit
+	 * reasoning level (or `reasoning: "off"`) still takes precedence.
+	 * Default: false.
+	 */
+	defaultThinkingEnabled?: boolean;
 	/** Whether to replay empty thinking signatures as `signature: ""` instead of converting thinking to text. Default: false. */
 	allowEmptySignature?: boolean;
 }

--- a/packages/ai/test/anthropic-default-thinking.test.ts
+++ b/packages/ai/test/anthropic-default-thinking.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.ts";
+import { streamSimple } from "../src/stream.ts";
+import type { Context, Model, SimpleStreamOptions } from "../src/types.ts";
+
+interface AnthropicThinkingPayload {
+	thinking?: { type: string; budget_tokens?: number; display?: string };
+}
+
+class PayloadCaptured extends Error {
+	constructor() {
+		super("payload captured");
+		this.name = "PayloadCaptured";
+	}
+}
+
+function makeContext(): Context {
+	return { messages: [{ role: "user", content: "Hello", timestamp: Date.now() }] };
+}
+
+function makeCustomModel(compat?: Model<"anthropic-messages">["compat"]): Model<"anthropic-messages"> {
+	return {
+		id: "vendor--anthropic-compat",
+		name: "Vendor Anthropic Compat",
+		api: "anthropic-messages",
+		provider: "vendor-proxy",
+		baseUrl: "http://127.0.0.1:9",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32000,
+		compat,
+	};
+}
+
+async function capturePayload(
+	model: Model<"anthropic-messages">,
+	options?: SimpleStreamOptions,
+): Promise<AnthropicThinkingPayload> {
+	let capturedPayload: AnthropicThinkingPayload | undefined;
+	const s = streamSimple({ ...model, baseUrl: "http://127.0.0.1:9" }, makeContext(), {
+		...options,
+		apiKey: "fake-key",
+		onPayload: (payload) => {
+			capturedPayload = payload as AnthropicThinkingPayload;
+			throw new PayloadCaptured();
+		},
+	});
+	await s.result();
+	if (!capturedPayload) {
+		throw new Error("Expected payload to be captured before request failure");
+	}
+	return capturedPayload;
+}
+
+describe("Anthropic defaultThinkingEnabled compat", () => {
+	it("enables thinking with no reasoning level when compat.defaultThinkingEnabled is true", async () => {
+		const payload = await capturePayload(makeCustomModel({ defaultThinkingEnabled: true }));
+		expect(payload.thinking?.type).toBe("enabled");
+	});
+
+	it("leaves thinking off with no reasoning level when the flag is not set", async () => {
+		const payload = await capturePayload(makeCustomModel());
+		expect(payload.thinking).toEqual({ type: "disabled" });
+	});
+
+	it("defaults thinking on for the built-in MiniMax-M3 model", async () => {
+		const payload = await capturePayload(getModel("minimax", "MiniMax-M3"));
+		expect(payload.thinking?.type).toBe("enabled");
+	});
+
+	it("still honors an explicit reasoning level over the default", async () => {
+		const payload = await capturePayload(getModel("minimax", "MiniMax-M3"), { reasoning: "medium" });
+		expect(payload.thinking?.type).toBe("enabled");
+	});
+});


### PR DESCRIPTION
## Summary

`MiniMax-M3`'s Anthropic-compatible endpoint **requires thinking to be enabled**: a request that omits the `thinking` parameter returns an empty response (`content: null`, 1 output token) — verified against `api.minimax.io`.

`streamSimpleAnthropic` sets `thinkingEnabled: false` whenever the caller picks no reasoning level, so M3 used without an explicit reasoning level comes back empty.

## Change

Add a `compat.defaultThinkingEnabled` flag (mirroring the existing `forceAdaptiveThinking`):
- `packages/ai/src/types.ts` — new optional flag on `AnthropicMessagesCompat`.
- `packages/ai/src/providers/anthropic.ts` — when no reasoning level is given, `thinkingEnabled = model.compat?.defaultThinkingEnabled === true` (was hardcoded `false`). Added the flag to the `getAnthropicCompat` `Omit` set, same as `forceAdaptiveThinking` (it's read directly, not a resolved default).
- `packages/ai/scripts/generate-models.ts` — mark M3 anthropic-messages entries with `defaultThinkingEnabled: true`; regenerated `models.generated.ts` (only the 4 M3 entries changed — unrelated live-catalog drift excluded).

M3 then sends `{type:"enabled"}` by default. An explicit reasoning level (or `reasoning: "off"`) still takes precedence; non-M3 models are unaffected (they still get `thinkingEnabled: false` → `{type:"disabled"}` when no level is set, exactly as before).

## Tests

`packages/ai/test/anthropic-default-thinking.test.ts` (new):
- `defaultThinkingEnabled:true` + no reasoning ⇒ `thinking.type==="enabled"`.
- without the flag + no reasoning ⇒ `{type:"disabled"}` (unchanged behavior).
- built-in `MiniMax-M3` ⇒ thinking on by default.
- explicit reasoning level still honored.

`vitest` green; `tsgo` and the full pre-commit gate pass.
