### PR TITLE
fix(model-registry): inherit cost from built-in model for custom OpenRouter models

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -519,7 +519,7 @@ export class ModelRegistry {
 		for (const customModel of customModels) {
 			const existingIndex = merged.findIndex((m) => m.provider === customModel.provider && m.id === customModel.id);
 			if (existingIndex >= 0) {
-				merged[existingIndex] = customModel;
+				merged[existingIndex] = { ...customModel, cost: customModel.cost ?? merged[existingIndex].cost };
 			} else {
 				merged.push(customModel);
 			}
@@ -663,7 +663,6 @@ export class ModelRegistry {
 				const compat = mergeCompat(providerConfig.compat, modelDef.compat);
 				this.storeModelHeaders(providerName, modelDef.id, modelDef.headers);
 
-				const defaultCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 				models.push({
 					id: modelDef.id,
 					name: modelDef.name ?? modelDef.id,
@@ -673,7 +672,7 @@ export class ModelRegistry {
 					reasoning: modelDef.reasoning ?? false,
 					thinkingLevelMap: modelDef.thinkingLevelMap,
 					input: (modelDef.input ?? ["text"]) as ("text" | "image")[],
-					cost: modelDef.cost ?? defaultCost,
+					cost: modelDef.cost,
 					contextWindow: modelDef.contextWindow ?? 128000,
 					maxTokens: modelDef.maxTokens ?? 16384,
 					headers: undefined,


### PR DESCRIPTION
## Problem

When users define custom models in `models.json` without a `cost` field, the cost displays as $0.00 even though token counts are correct.

**Root cause:** Two interacting bugs in `model-registry.ts`:

1. **`parseModels()`** (L676): `cost: modelDef.cost ?? defaultCost` substitutes `undefined` with `defaultCost = {input:0, output:0, cacheRead:0, cacheWrite:0}`, so custom models without an explicit cost get zeroed out.

2. **`mergeCustomModels()`** (L522): `merged[existingIndex] = customModel` does a **full replacement** of the built-in model with the custom one. Even if a built-in model had correct pricing, the custom model (with cost=0 from bug #1) overwrites it completely.

`calculateCost` then honestly multiplies 0 by the token counts → costs=$0.00.

## Fix

Two minimal changes:

1. **`parseModels()`**: keep `cost` as `undefined` when not specified in `models.json` — don't substitute `defaultCost`.
2. **`mergeCustomModels()`**: when merging, inherit `cost` from the existing built-in model if the custom model doesn't specify it: `cost: customModel.cost ?? existing.cost`.

Also removes the now-unused `defaultCost` variable.

## Testing

This fix was validated locally by patching `dist/core/model-registry.js` in `@mariozechner/pi-coding-agent` v0.73.1. Custom OpenRouter models without explicit `cost` now correctly inherit the built-in pricing and display non-zero costs.

- Related Paperclip issue: CPL-2733, CPL-2744