### PR TITLE
feat(coding-agent): add experimental feature guard

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `areExperimentalFeaturesEnabled` feature guard to allow users to opt-in to early features.
 - Added `ctx.isProjectTrusted()` for extensions to observe the effective project trust decision, including temporary trust decisions ([#5523](https://github.com/earendil-works/pi/issues/5523)).
 
 ### Fixed

--- a/packages/coding-agent/src/core/experimental.ts
+++ b/packages/coding-agent/src/core/experimental.ts
@@ -1,0 +1,3 @@
+export function areExperimentalFeaturesEnabled(): boolean {
+	return process.env.PI_EXPERIMENTAL === "1";
+}

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -28,6 +28,7 @@ export {
 export { type BashExecutorOptions, type BashResult, executeBashWithOperations } from "./bash-executor.ts";
 export type { CompactionResult } from "./compaction/index.ts";
 export { createEventBus, type EventBus, type EventBusController } from "./event-bus.ts";
+export { areExperimentalFeaturesEnabled } from "./experimental.ts";
 // Extensions system
 export {
 	type AgentEndEvent,

--- a/packages/coding-agent/test/experimental.test.ts
+++ b/packages/coding-agent/test/experimental.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { areExperimentalFeaturesEnabled } from "../src/core/experimental.ts";
+
+describe("areExperimentalFeaturesEnabled", () => {
+	const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+
+	afterEach(() => {
+		if (originalPiExperimental === undefined) {
+			delete process.env.PI_EXPERIMENTAL;
+		} else {
+			process.env.PI_EXPERIMENTAL = originalPiExperimental;
+		}
+	});
+
+	it("returns false when PI_EXPERIMENTAL is unset", () => {
+		delete process.env.PI_EXPERIMENTAL;
+
+		expect(areExperimentalFeaturesEnabled()).toBe(false);
+	});
+
+	it("returns false when PI_EXPERIMENTAL is empty", () => {
+		process.env.PI_EXPERIMENTAL = "";
+
+		expect(areExperimentalFeaturesEnabled()).toBe(false);
+	});
+
+	it("returns true when PI_EXPERIMENTAL is set to 1", () => {
+		process.env.PI_EXPERIMENTAL = "1";
+
+		expect(areExperimentalFeaturesEnabled()).toBe(true);
+	});
+
+	it("returns false when PI_EXPERIMENTAL is set to 0", () => {
+		process.env.PI_EXPERIMENTAL = "0";
+
+		expect(areExperimentalFeaturesEnabled()).toBe(false);
+	});
+
+	it("returns false when PI_EXPERIMENTAL is set to a non-1 value", () => {
+		process.env.PI_EXPERIMENTAL = "true";
+
+		expect(areExperimentalFeaturesEnabled()).toBe(false);
+	});
+});


### PR DESCRIPTION
As described in [RFC 0043](https://rfc.earendil.com/0043), this PR adds an experimental feature guard which can be  trigged by running Pi with `PI_EXPERIMENTAL=1`.