### PR TITLE
feat(ui): Improved project approval settings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Added
 
+<<<<<<< Updated upstream
 - Added `areExperimentalFeaturesEnabled` feature guard to allow users to opt-in to early features.
 - Added `ctx.isProjectTrusted()` for extensions to observe the effective project trust decision, including temporary trust decisions ([#5523](https://github.com/earendil-works/pi/issues/5523)).
+=======
+- Added a global `defaultProjectTrust` setting to choose whether unresolved project trust asks, always trusts, or never trusts by default.
+>>>>>>> Stashed changes
 
 ### Fixed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -291,15 +291,17 @@ See [docs/settings.md](docs/settings.md) for all options.
 
 ### Project Trust
 
-On interactive startup, pi asks before trusting a project folder that contains project-local inputs and has no saved decision in `~/.pi/agent/trust.json`. Trusting a project allows pi to read project instructions (`AGENTS.md`/`CLAUDE.md`), load `.pi/settings.json` and `.pi` resources, install missing project packages, and execute project extensions.
+On interactive startup, pi asks before trusting a project folder that contains project-local extensions or settings and has no saved decision for the folder or a parent folder in `~/.pi/agent/trust.json`. Trusting a project allows pi to load `.pi/settings.json` and `.pi` resources, install missing project packages, and execute project extensions.
 
-Before the trust decision, pi loads only user/global extensions and CLI `-e` extensions so they can handle the `project_trust` event. Project-local extensions, project package-managed extensions, project settings, and project instructions are loaded only after the project is trusted. This split also applies when switching to a session from a different cwd whose trust has not been resolved in the current process.
+Before the trust decision, pi loads only context files, user/global extensions, and CLI `-e` extensions so they can handle the `project_trust` event. Project-local extensions, project package-managed extensions, and project settings are loaded only after the project is trusted. This split also applies when switching to a session from a different cwd whose trust has not been resolved in the current process.
 
-Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without a saved trust decision, they ignore project-local inputs unless `--approve`/`-a` is passed. Use `--no-approve`/`-na` to ignore project-local inputs for one run even when the project is trusted.
+Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without an applicable saved trust decision, they use `defaultProjectTrust` from global settings: `ask` (default) and `never` ignore trust-gated project inputs, while `always` trusts them. Pass `--approve`/`-a` or `--no-approve`/`-na` to override project trust for one run.
 
-`pi config` assumes project trust for that command so you can view and change project resource settings before starting a session. It does not save a trust decision; starting a session in that folder still prompts. Pass `--no-approve` to hide project-local inputs in `pi config`.
+If no extension or saved decision applies, `defaultProjectTrust` controls the fallback behavior. Set it to `"ask"`, `"always"`, or `"never"` in `~/.pi/agent/settings.json`, or change it with `/settings`.
 
-Use `/trust` in interactive mode to save a project trust decision for future sessions. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
+`pi config` and package commands use the same project trust flow. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
+
+Use `/trust` in interactive mode to save a project trust decision for future sessions, including trust for the immediate parent folder. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
 ### Telemetry and update checks
 
@@ -316,8 +318,8 @@ Use `--offline` or `PI_OFFLINE=1` to disable all startup network operations desc
 
 Pi loads `AGENTS.md` (or `CLAUDE.md`) at startup from:
 - `~/.pi/agent/AGENTS.md` (global)
-- Parent directories (walking up from cwd, only when the project is trusted)
-- Current directory (only when the project is trusted)
+- Parent directories (walking up from cwd)
+- Current directory
 
 Use for project instructions (`AGENTS.md`/`CLAUDE.md`), conventions, common commands. All matching files are concatenated.
 
@@ -525,7 +527,7 @@ pi list                      # List installed packages
 pi config                    # Enable/disable package resources
 ```
 
-Project package commands accept `--approve`/`--no-approve` to trust or ignore project-local package settings for one command.
+`pi config` and project package commands accept `--approve`/`--no-approve` to trust or ignore project-local settings for one command.
 
 ### Modes
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -339,7 +339,7 @@ exit (Ctrl+C, Ctrl+D, SIGHUP, SIGTERM)
 
 #### project_trust
 
-Fired before pi decides whether to trust a project with trust inputs (`.pi`, `AGENTS.md`/`CLAUDE.md`, or `.agents/skills`). It runs during startup and when session replacement (for example `/resume`) enters a cwd whose trust has not been resolved in the current process. Only user/global extensions and CLI `-e` extensions participate; project-local extensions are not loaded until after trust is resolved.
+Fired before pi decides whether to trust a project with dynamic configs (`.pi` or `.agents/skills`). It runs during startup and when session replacement (for example `/resume`) enters a cwd whose trust has not been resolved in the current process. Only user/global extensions and CLI `-e` extensions participate; project-local extensions are not loaded until after trust is resolved.
 
 ```typescript
 pi.on("project_trust", async (event, ctx) => {
@@ -352,7 +352,7 @@ pi.on("project_trust", async (event, ctx) => {
 });
 ```
 
-A `project_trust` handler must return `{ trusted: "yes" | "no" | "undecided" }`. A user/global or CLI extension that returns `"yes"` or `"no"` owns the decision; the first yes/no decision wins and suppresses the built-in trust prompt. Use `remember: true` to persist a yes/no decision; otherwise it applies only to the current process. Return `"undecided"` to let later handlers or the built-in trust flow decide. Check `ctx.hasUI` before prompting. If no handler returns yes/no, normal trust resolution continues, including the built-in trust prompt when UI is available.
+A `project_trust` handler must return `{ trusted: "yes" | "no" | "undecided" }`. A user/global or CLI extension that returns `"yes"` or `"no"` owns the decision; the first yes/no decision wins and suppresses the built-in trust prompt. Use `remember: true` to persist a yes/no decision; otherwise it applies only to the current process. Return `"undecided"` to let later handlers or the built-in trust flow decide. Check `ctx.hasUI` before prompting. If no handler returns yes/no, normal trust resolution continues: saved `trust.json` decisions apply first, then `defaultProjectTrust` controls whether pi asks, trusts, or declines by default.
 
 ### Resource Events
 

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -40,8 +40,6 @@ These commands manage pi packages, not the pi CLI installation. To uninstall pi 
 
 By default, `install` and `remove` write to user settings (`~/.pi/agent/settings.json`). Use `-l` to write to project settings (`.pi/settings.json`) instead. Project settings can be shared with your team, and pi installs any missing packages automatically on startup after the project is trusted.
 
-Project package commands read project settings only when the project is trusted. Use `--approve` to trust project-local files for one command, or `--no-approve` to ignore them for one command.
-
 To try a package without installing it, use `--extension` or `-e`. This installs to a temporary directory for the current run only:
 
 ```bash

--- a/packages/coding-agent/docs/security.md
+++ b/packages/coding-agent/docs/security.md
@@ -4,27 +4,25 @@ Pi is a local coding agent. It runs with the permissions of the user account tha
 
 ## Project Trust
 
-Project trust controls whether pi loads project-local inputs. It is not a sandbox and it does not restrict what the model can ask tools to do after you start working in a directory.
+Project trust controls whether pi loads project-local settings, resources, packages, and extensions. It is not a sandbox and it does not restrict what the model can ask tools to do after you start working in a directory.
 
 Pi considers a project to have trust inputs when it finds any of these from the current working directory:
 
 - `.pi/` in the current directory
-- `AGENTS.md` or `CLAUDE.md` in the current directory or an ancestor directory
 - `.agents/skills` in the current directory or an ancestor directory
 
-When an interactive session starts in a project with trust inputs and no saved decision, pi asks whether to trust the project. Saved decisions are stored per canonical working directory in `~/.pi/agent/trust.json`.
+When an interactive session starts in a project with configs in `.pi` or `.agents/skills` and no saved decision for the current directory or a parent directory, pi follows `defaultProjectTrust` from global settings. The default value is `"ask"`, which asks whether to trust the project when UI is available. Saved decisions are stored by canonical directory in `~/.pi/agent/trust.json`, and the closest saved decision on the current or parent path applies before the global default.
 
-Trusting a project allows pi to load project-local inputs, including:
+Trusting a project allows pi to load trust-gated project inputs, including:
 
-- project instructions from `AGENTS.md` or `CLAUDE.md`
 - `.pi/settings.json`
 - `.pi` resources such as extensions, skills, prompt templates, themes, and system prompt files
 - missing project packages configured through project settings
 - project-local extensions and project package-managed extensions
 
-Declining trust skips those project-local inputs. Before trust is resolved, pi only loads user/global extensions and CLI `-e` extensions. User/global and CLI extensions can handle the `project_trust` event; the first extension that returns a yes/no decision owns the decision.
+Declining trust skips protected resources. `AGENTS.md` and `CLAUDE.md` context files are loaded regardless of project trust unless context loading is disabled. Before trust is resolved, pi only loads context files, user/global extensions, and CLI `-e` extensions. User/global and CLI extensions can handle the `project_trust` event; the first extension that returns a yes/no decision owns the decision.
 
-Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without a saved trust decision, they ignore project-local inputs unless `--approve`/`-a` is passed. Use `--no-approve`/`-na` to ignore project-local inputs for one run even when the project is trusted.
+Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without an applicable saved trust decision, `defaultProjectTrust: "ask"` and `"never"` ignore such resources, while `"always"` trusts them. Use `--approve`/`-a` or `--no-approve`/`-na` to override project trust for one run.
 
 ## No Built-in Sandbox
 
@@ -32,7 +30,7 @@ Pi does not include a built-in sandbox. Built-in tools can read files, write fil
 
 This is intentional. Pi is designed to operate on local source trees, invoke project toolchains, and integrate with the user's existing development environment. A partial in-process sandbox would be easy to misunderstand as a security boundary while still depending on the host shell, filesystem, package managers, credentials, and extension code. Real isolation needs to come from the operating system or a virtualization/container boundary.
 
-Project trust is only an input-loading guard. It prevents a repository from silently changing pi's instructions, settings, or extensions before you approve it. It does not make untrusted code, untrusted prompts, or untrusted model output safe. Prompt injection from repository files, comments, documentation, or build output is expected local-agent risk and cannot be reliably prevented by pi.
+Project trust is only an input-loading guard. It prevents a repository from silently changing pi's settings or extensions before you approve it. It does not make untrusted code, untrusted prompts, or untrusted model output safe. Prompt injection from repository files, comments, documentation, context files, or build output is expected local-agent risk and cannot be reliably prevented by pi.
 
 ## Running Untrusted or Unmonitored Work
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -11,13 +11,15 @@ Edit directly or use `/settings` for common options.
 
 ## Project Trust
 
-On interactive startup, pi asks before trusting a project folder that contains project-local inputs and has no saved decision in `~/.pi/agent/trust.json`. Trusting a project allows pi to read project instructions (`AGENTS.md`/`CLAUDE.md`), load `.pi/settings.json` and `.pi` resources, install missing project packages, and execute project extensions.
+On interactive startup, pi asks before trusting a project folder that contains trust-gated project inputs and has no saved decision for the folder or a parent folder in `~/.pi/agent/trust.json`. Trusting a project allows pi to load `.pi/settings.json` and `.pi` resources, install missing project packages, and execute project extensions.
 
-Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without a saved trust decision, they ignore project-local inputs unless `--approve`/`-a` is passed. Use `--no-approve`/`-na` to ignore project-local inputs for one run even when the project is trusted.
+Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without an applicable saved trust decision, they use `defaultProjectTrust` from global settings: `ask` (default) and `never` ignore trust-gated project inputs, while `always` trusts them. Pass `--approve`/`-a` or `--no-approve`/`-na` to override project trust for one run.
 
-`pi config` assumes project trust for that command so you can view and change project resource settings before starting a session. It does not save a trust decision; starting a session in that folder still prompts. Pass `--no-approve` to hide project-local inputs in `pi config`.
+If no extension or saved decision applies, `defaultProjectTrust` controls the fallback behavior. Set it to `"ask"`, `"always"`, or `"never"` in `~/.pi/agent/settings.json`, or change it with `/settings`.
 
-Use `/trust` in interactive mode to save a project trust decision for future sessions. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
+`pi config` and package commands use the same project trust flow. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
+
+Use `/trust` in interactive mode to save a project trust decision for future sessions, including trust for the immediate parent folder. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
 ## All Settings
 
@@ -50,6 +52,7 @@ Use `/trust` in interactive mode to save a project trust decision for future ses
 |---------|------|---------|-------------|
 | `theme` | string | `"dark"` | Theme name (`"dark"`, `"light"`, or custom) |
 | `quietStartup` | boolean | `false` | Hide startup header |
+| `defaultProjectTrust` | string | `"ask"` | Fallback project trust behavior: `"ask"`, `"always"`, or `"never"`. Global setting only |
 | `collapseChangelog` | boolean | `false` | Show condensed changelog after updates |
 | `enableInstallTelemetry` | boolean | `true` | Send an anonymous install/update version ping after first install or changelog-detected updates. This does not control update checks |
 | `doubleEscapeAction` | string | `"tree"` | Action for double-escape: `"tree"`, `"fork"`, or `"none"` |

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -96,8 +96,8 @@ See [Sessions](sessions.md) and [Compaction](compaction.md) for details.
 Pi loads `AGENTS.md` or `CLAUDE.md` at startup from:
 
 - `~/.pi/agent/AGENTS.md` for global instructions
-- parent directories, walking up from the current working directory when the project is trusted
-- the current directory when the project is trusted
+- parent directories, walking up from the current working directory
+- the current directory
 
 Use context files for project conventions, commands, safety rules, and preferences. Disable loading with `--no-context-files` or `-nc`.
 
@@ -112,13 +112,18 @@ Append to the default prompt without replacing it with `APPEND_SYSTEM.md` in eit
 
 ### Project Trust
 
-On interactive startup, pi asks before trusting a project folder that contains project-local inputs and has no saved decision in `~/.pi/agent/trust.json`. Trusting a project allows pi to read project instructions (`AGENTS.md`/`CLAUDE.md`), load `.pi/settings.json` and `.pi` resources, install missing project packages, and execute project extensions.
+On interactive startup, pi asks before trusting a project folder that contains project-local extensions or settings and has no saved decision for the folder or a parent folder in `~/.pi/agent/trust.json`. Trusting a project allows pi to load `.pi/settings.json` and `.pi` resources, install missing project packages, and execute project extensions.
 
-Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without a saved trust decision, they ignore project-local inputs unless `--approve`/`-a` is passed. Use `--no-approve`/`-na` to ignore project-local inputs for one run even when the project is trusted.
+Before the trust decision, pi loads only context files, user/global extensions, and CLI `-e` extensions so they can handle the `project_trust` event. Project-local extensions, project package-managed extensions, and project settings are loaded only after the project is trusted. This split also applies when switching to a session from a different cwd whose trust has not been resolved in the current process.
 
-`pi config` assumes project trust for that command so you can view and change project resource settings before starting a session. It does not save a trust decision; starting a session in that folder still prompts. Pass `--no-approve` to hide project-local inputs in `pi config`.
+Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trust prompt. Without an applicable saved trust decision, they use `defaultProjectTrust` from global settings: `ask` (default) and `never` ignore trust-gated project inputs, while `always` trusts them. Pass `--approve`/`-a` or `--no-approve`/`-na` to override project trust for one run.
 
-Use `/trust` in interactive mode to save a project trust decision for future sessions. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
+If no extension or saved decision applies, `defaultProjectTrust` controls the fallback behavior. Set it to `"ask"`, `"always"`, or `"never"` in `~/.pi/agent/settings.json`, or change it with `/settings`.
+
+`pi config` and package commands use the same project trust flow. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
+
+Use `/trust` in interactive mode to save a project trust decision for future sessions, including trust for the immediate parent folder. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
+
 
 ## Exporting and Sharing Sessions
 
@@ -148,7 +153,7 @@ pi list                      # List installed packages
 pi config                    # Enable/disable package resources
 ```
 
-These commands manage pi packages, not the pi CLI installation. To uninstall pi itself, see [Quickstart](quickstart.md#uninstall). Project package commands accept `--approve`/`--no-approve` to trust or ignore project-local package settings for one command.
+These commands manage pi packages, not the pi CLI installation. To uninstall pi itself, see [Quickstart](quickstart.md#uninstall). `pi config` and project package commands accept `--approve`/`--no-approve` to trust or ignore project-local settings for one command.
 
 See [Pi Packages](packages.md) for package sources and security notes.
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -232,7 +232,7 @@ ${chalk.bold("Commands:")}
   ${APP_NAME} update [source|self|pi]   Update pi and installed extensions
   ${APP_NAME} list [--approve|--no-approve]
                                  List installed extensions from settings
-  ${APP_NAME} config [--no-approve]
+  ${APP_NAME} config [--approve|--no-approve]
                                  Open TUI to enable/disable package resources
   ${APP_NAME} <command> --help          Show help for install/remove/uninstall/update/list
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -230,10 +230,8 @@ ${chalk.bold("Commands:")}
   ${APP_NAME} remove <source> [-l]      Remove extension source from settings
   ${APP_NAME} uninstall <source> [-l]   Alias for remove
   ${APP_NAME} update [source|self|pi]   Update pi and installed extensions
-  ${APP_NAME} list [--approve|--no-approve]
-                                 List installed extensions from settings
-  ${APP_NAME} config [--approve|--no-approve]
-                                 Open TUI to enable/disable package resources
+  ${APP_NAME} list                      List installed extensions from settings
+  ${APP_NAME} config                    Open TUI to enable/disable package resources
   ${APP_NAME} <command> --help          Show help for install/remove/uninstall/update/list
 
 ${chalk.bold("Options:")}

--- a/packages/coding-agent/src/cli/project-trust.ts
+++ b/packages/coding-agent/src/cli/project-trust.ts
@@ -1,0 +1,62 @@
+import chalk from "chalk";
+import type { ProjectTrustContext } from "../core/extensions/types.ts";
+import type { AppMode } from "../core/project-trust.ts";
+import type { SettingsManager } from "../core/settings-manager.ts";
+import { showStartupInput, showStartupSelector } from "./startup-ui.ts";
+
+export function createProjectTrustContext(options: {
+	cwd: string;
+	mode: AppMode;
+	settingsManager: SettingsManager;
+	hasUI: boolean;
+}): ProjectTrustContext {
+	return {
+		cwd: options.cwd,
+		mode: options.mode === "interactive" ? "tui" : options.mode,
+		hasUI: options.hasUI,
+		ui: {
+			select: async (title, selectOptions) => {
+				if (!options.hasUI) {
+					return undefined;
+				}
+				if (options.mode !== "interactive") {
+					return undefined;
+				}
+				return showStartupSelector(
+					options.settingsManager,
+					title,
+					selectOptions.map((option) => ({ label: option, value: option })),
+				);
+			},
+			confirm: async (title, message) => {
+				if (!options.hasUI) {
+					return false;
+				}
+				if (options.mode !== "interactive") {
+					return false;
+				}
+				return (
+					(await showStartupSelector(options.settingsManager, `${title}\n${message}`, [
+						{ label: "Yes", value: true },
+						{ label: "No", value: false },
+					])) ?? false
+				);
+			},
+			input: async (title, placeholder) => {
+				if (!options.hasUI) {
+					return undefined;
+				}
+				if (options.mode !== "interactive") {
+					return undefined;
+				}
+				return showStartupInput(options.settingsManager, title, placeholder);
+			},
+			notify: (message, type = "info") => {
+				if (options.mode !== "interactive") {
+					const color = type === "error" ? chalk.red : type === "warning" ? chalk.yellow : chalk.cyan;
+					console.error(color(message));
+				}
+			},
+		},
+	};
+}

--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -1,0 +1,87 @@
+import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
+import { KeybindingsManager } from "../core/keybindings.ts";
+import type { SettingsManager } from "../core/settings-manager.ts";
+import { ExtensionInputComponent } from "../modes/interactive/components/extension-input.ts";
+import { ExtensionSelectorComponent } from "../modes/interactive/components/extension-selector.ts";
+import { initTheme } from "../modes/interactive/theme/theme.ts";
+
+function createStartupTui(settingsManager: SettingsManager): TUI {
+	initTheme(settingsManager.getTheme());
+	setKeybindings(KeybindingsManager.create());
+	const ui = new TUI(new ProcessTerminal(), settingsManager.getShowHardwareCursor());
+	ui.setClearOnShrink(settingsManager.getClearOnShrink());
+	return ui;
+}
+
+async function clearStartupTui(ui: TUI): Promise<void> {
+	ui.clear();
+	ui.requestRender();
+	await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+export async function showStartupSelector<T>(
+	settingsManager: SettingsManager,
+	title: string,
+	options: Array<{ label: string; value: T }>,
+): Promise<T | undefined> {
+	return new Promise((resolve) => {
+		const ui = createStartupTui(settingsManager);
+
+		let settled = false;
+		const finish = async (result: T | undefined) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			await clearStartupTui(ui);
+			ui.stop();
+			resolve(result);
+		};
+
+		const selector = new ExtensionSelectorComponent(
+			title,
+			options.map((option) => option.label),
+			(option) => void finish(options.find((entry) => entry.label === option)?.value),
+			() => void finish(undefined),
+			{ tui: ui },
+		);
+		ui.addChild(selector);
+		ui.setFocus(selector);
+		ui.start();
+	});
+}
+
+export async function showStartupInput(
+	settingsManager: SettingsManager,
+	title: string,
+	placeholder?: string,
+): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		const ui = createStartupTui(settingsManager);
+
+		let settled = false;
+		const finish = async (result: string | undefined) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			input.dispose();
+			await clearStartupTui(ui);
+			ui.stop();
+			resolve(result);
+		};
+
+		const input = new ExtensionInputComponent(
+			title,
+			placeholder,
+			(value) => void finish(value),
+			() => void finish(undefined),
+			{
+				tui: ui,
+			},
+		);
+		ui.addChild(input);
+		ui.setFocus(input);
+		ui.start();
+	});
+}

--- a/packages/coding-agent/src/core/project-trust.ts
+++ b/packages/coding-agent/src/core/project-trust.ts
@@ -1,0 +1,95 @@
+import { emitProjectTrustEvent } from "./extensions/runner.ts";
+import type { LoadExtensionsResult, ProjectTrustContext } from "./extensions/types.ts";
+import type { DefaultProjectTrust } from "./settings-manager.ts";
+import {
+	getProjectTrustOptions,
+	hasProjectTrustInputs,
+	type ProjectTrustOption,
+	type ProjectTrustStore,
+} from "./trust-manager.ts";
+
+export type AppMode = "interactive" | "print" | "json" | "rpc";
+
+export interface ResolveProjectTrustedOptions {
+	cwd: string;
+	trustStore: ProjectTrustStore;
+	trustOverride?: boolean;
+	defaultProjectTrust?: DefaultProjectTrust;
+	extensionsResult?: LoadExtensionsResult;
+	projectTrustContext: ProjectTrustContext;
+	onExtensionError?: (message: string) => void;
+}
+
+function formatProjectTrustPrompt(cwd: string): string {
+	return `Trust project folder?\n${cwd}\n\nThis allows pi to load .pi settings and resources, install missing project packages, and execute project extensions.`;
+}
+
+async function selectProjectTrustOption(
+	cwd: string,
+	ctx: ProjectTrustContext,
+): Promise<ProjectTrustOption | undefined> {
+	const options = getProjectTrustOptions(cwd, { includeSessionOnly: true });
+	const selected = await ctx.ui.select(
+		formatProjectTrustPrompt(cwd),
+		options.map((option) => option.label),
+	);
+	return options.find((option) => option.label === selected);
+}
+
+function saveProjectTrustPromptResult(trustStore: ProjectTrustStore, result: ProjectTrustOption): void {
+	if (result.updates.length > 0) {
+		trustStore.setMany(result.updates);
+	}
+}
+
+export async function resolveProjectTrusted(options: ResolveProjectTrustedOptions): Promise<boolean> {
+	if (options.trustOverride !== undefined) {
+		return options.trustOverride;
+	}
+	if (!hasProjectTrustInputs(options.cwd)) {
+		return true;
+	}
+
+	if (options.extensionsResult) {
+		const { result, errors } = await emitProjectTrustEvent(
+			options.extensionsResult,
+			{ type: "project_trust", cwd: options.cwd },
+			options.projectTrustContext,
+		);
+		for (const error of errors) {
+			options.onExtensionError?.(`Extension "${error.extensionPath}" project_trust error: ${error.error}`);
+		}
+		if (result) {
+			const trusted = result.trusted === "yes";
+			if (result.remember === true) {
+				options.trustStore.set(options.cwd, trusted);
+			}
+			return trusted;
+		}
+	}
+
+	const decision = options.trustStore.get(options.cwd);
+	if (decision !== null) {
+		return decision;
+	}
+
+	switch (options.defaultProjectTrust ?? "ask") {
+		case "always":
+			return true;
+		case "never":
+			return false;
+		case "ask":
+			break;
+	}
+
+	if (!options.projectTrustContext.hasUI) {
+		return false;
+	}
+
+	const selected = await selectProjectTrustOption(options.cwd, options.projectTrustContext);
+	if (selected !== undefined) {
+		saveProjectTrustPromptResult(options.trustStore, selected);
+		return selected.trusted;
+	}
+	return false;
+}

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -79,7 +79,6 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
 export function loadProjectContextFiles(options: {
 	cwd: string;
 	agentDir: string;
-	projectTrusted?: boolean;
 }): Array<{ path: string; content: string }> {
 	const resolvedCwd = resolvePath(options.cwd);
 	const resolvedAgentDir = resolvePath(options.agentDir);
@@ -93,28 +92,26 @@ export function loadProjectContextFiles(options: {
 		seenPaths.add(globalContext.path);
 	}
 
-	if (options.projectTrusted !== false) {
-		const ancestorContextFiles: Array<{ path: string; content: string }> = [];
+	const ancestorContextFiles: Array<{ path: string; content: string }> = [];
 
-		let currentDir = resolvedCwd;
-		const root = resolve("/");
+	let currentDir = resolvedCwd;
+	const root = resolve("/");
 
-		while (true) {
-			const contextFile = loadContextFileFromDir(currentDir);
-			if (contextFile && !seenPaths.has(contextFile.path)) {
-				ancestorContextFiles.unshift(contextFile);
-				seenPaths.add(contextFile.path);
-			}
-
-			if (currentDir === root) break;
-
-			const parentDir = resolve(currentDir, "..");
-			if (parentDir === currentDir) break;
-			currentDir = parentDir;
+	while (true) {
+		const contextFile = loadContextFileFromDir(currentDir);
+		if (contextFile && !seenPaths.has(contextFile.path)) {
+			ancestorContextFiles.unshift(contextFile);
+			seenPaths.add(contextFile.path);
 		}
 
-		contextFiles.push(...ancestorContextFiles);
+		if (currentDir === root) break;
+
+		const parentDir = resolve(currentDir, "..");
+		if (parentDir === currentDir) break;
+		currentDir = parentDir;
 	}
+
+	contextFiles.push(...ancestorContextFiles);
 
 	return contextFiles;
 }
@@ -325,14 +322,18 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 	}
 
+	async loadProjectTrustExtensions(): Promise<LoadExtensionsResult> {
+		// Force untrusted project settings for the bootstrap pass. This keeps project-local
+		// extensions/packages out while still loading user/global and temporary CLI extensions.
+		this.settingsManager.setProjectTrusted(false);
+		await this.settingsManager.reload();
+		return this.loadCurrentExtensionSet({ includeInlineFactories: true });
+	}
+
 	async reload(options?: ResourceLoaderReloadOptions): Promise<void> {
 		let preTrustExtensions: LoadExtensionsResult | undefined;
 		if (options?.resolveProjectTrust) {
-			// Force untrusted project settings for the bootstrap pass. This keeps project-local
-			// extensions/packages out while still loading user/global and temporary CLI extensions.
-			this.settingsManager.setProjectTrusted(false);
-			await this.settingsManager.reload();
-			preTrustExtensions = await this.loadCurrentExtensionSet({ includeInlineFactories: true });
+			preTrustExtensions = await this.loadProjectTrustExtensions();
 			const projectTrusted = await options.resolveProjectTrust({ extensionsResult: preTrustExtensions });
 			this.settingsManager.setProjectTrusted(projectTrusted);
 		}
@@ -454,7 +455,6 @@ export class DefaultResourceLoader implements ResourceLoader {
 				: loadProjectContextFiles({
 						cwd: this.cwd,
 						agentDir: this.agentDir,
-						projectTrusted: this.settingsManager.isProjectTrusted(),
 					}),
 		};
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -57,6 +57,8 @@ export interface WarningSettings {
 	anthropicExtraUsage?: boolean; // default: true
 }
 
+export type DefaultProjectTrust = "ask" | "always" | "never";
+
 export type TransportSetting = Transport;
 
 /**
@@ -89,6 +91,7 @@ export interface Settings {
 	hideThinkingBlock?: boolean;
 	shellPath?: string; // Custom shell path (e.g., for Cygwin users on Windows)
 	quietStartup?: boolean;
+	defaultProjectTrust?: DefaultProjectTrust; // default: "ask"; global setting only
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
 	collapseChangelog?: boolean; // Show condensed changelog after update (use /changelog for full)
@@ -850,6 +853,17 @@ export class SettingsManager {
 	setQuietStartup(quiet: boolean): void {
 		this.globalSettings.quietStartup = quiet;
 		this.markModified("quietStartup");
+		this.save();
+	}
+
+	getDefaultProjectTrust(): DefaultProjectTrust {
+		const value = this.globalSettings.defaultProjectTrust;
+		return value === "always" || value === "never" ? value : "ask";
+	}
+
+	setDefaultProjectTrust(defaultProjectTrust: DefaultProjectTrust): void {
+		this.globalSettings.defaultProjectTrust = defaultProjectTrust;
+		this.markModified("defaultProjectTrust");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/core/trust-manager.ts
+++ b/packages/coding-agent/src/core/trust-manager.ts
@@ -6,12 +6,85 @@ import { canonicalizePath, resolvePath } from "../utils/paths.ts";
 
 export type ProjectTrustDecision = boolean | null;
 
-type TrustFile = Record<string, boolean | null | undefined>;
+export interface ProjectTrustStoreEntry {
+	path: string;
+	decision: boolean;
+}
 
-const CONTEXT_FILE_NAMES = ["AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"];
+export interface ProjectTrustUpdate {
+	path: string;
+	decision: ProjectTrustDecision;
+}
+
+export interface ProjectTrustOption {
+	label: string;
+	trusted: boolean;
+	updates: ProjectTrustUpdate[];
+	savedPath?: string;
+}
+
+type TrustFile = Record<string, boolean | null | undefined>;
 
 function normalizeCwd(cwd: string): string {
 	return canonicalizePath(resolvePath(cwd));
+}
+
+function findNearestTrustEntry(data: TrustFile, cwd: string): ProjectTrustStoreEntry | null {
+	let currentDir = normalizeCwd(cwd);
+	while (true) {
+		const value = data[currentDir];
+		if (value === true || value === false) {
+			return { path: currentDir, decision: value };
+		}
+
+		const parentDir = dirname(currentDir);
+		if (parentDir === currentDir) {
+			return null;
+		}
+		currentDir = parentDir;
+	}
+}
+
+export function getProjectTrustPath(cwd: string): string {
+	return normalizeCwd(cwd);
+}
+
+export function getProjectTrustParentPath(cwd: string): string | undefined {
+	const trustPath = getProjectTrustPath(cwd);
+	const parentDir = dirname(trustPath);
+	return parentDir === trustPath ? undefined : parentDir;
+}
+
+export function getProjectTrustOptions(cwd: string, options?: { includeSessionOnly?: boolean }): ProjectTrustOption[] {
+	const trustPath = getProjectTrustPath(cwd);
+	const trustOptions: ProjectTrustOption[] = [
+		{ label: "Trust", trusted: true, updates: [{ path: trustPath, decision: true }], savedPath: trustPath },
+	];
+	const parentPath = getProjectTrustParentPath(cwd);
+	if (parentPath !== undefined) {
+		trustOptions.push({
+			label: `Trust parent folder (${parentPath})`,
+			trusted: true,
+			updates: [
+				{ path: parentPath, decision: true },
+				{ path: trustPath, decision: null },
+			],
+			savedPath: parentPath,
+		});
+	}
+	if (options?.includeSessionOnly) {
+		trustOptions.push({ label: "Trust (this session only)", trusted: true, updates: [] });
+	}
+	trustOptions.push({
+		label: "Do not trust",
+		trusted: false,
+		updates: [{ path: trustPath, decision: false }],
+		savedPath: trustPath,
+	});
+	if (options?.includeSessionOnly) {
+		trustOptions.push({ label: "Do not trust (this session only)", trusted: false, updates: [] });
+	}
+	return trustOptions;
 }
 
 function readTrustFile(path: string): TrustFile {
@@ -105,11 +178,6 @@ export function hasProjectTrustInputs(cwd: string): boolean {
 	}
 
 	while (true) {
-		for (const filename of CONTEXT_FILE_NAMES) {
-			if (existsSync(join(currentDir, filename))) {
-				return true;
-			}
-		}
 		if (existsSync(join(currentDir, ".agents", "skills"))) {
 			return true;
 		}
@@ -130,21 +198,30 @@ export class ProjectTrustStore {
 	}
 
 	get(cwd: string): ProjectTrustDecision {
+		return this.getEntry(cwd)?.decision ?? null;
+	}
+
+	getEntry(cwd: string): ProjectTrustStoreEntry | null {
 		return withTrustFileLock(this.trustPath, () => {
 			const data = readTrustFile(this.trustPath);
-			const value = data[normalizeCwd(cwd)];
-			return value === true || value === false ? value : null;
+			return findNearestTrustEntry(data, cwd);
 		});
 	}
 
 	set(cwd: string, decision: ProjectTrustDecision): void {
+		this.setMany([{ path: cwd, decision }]);
+	}
+
+	setMany(decisions: ProjectTrustUpdate[]): void {
 		withTrustFileLock(this.trustPath, () => {
 			const data = readTrustFile(this.trustPath);
-			const key = normalizeCwd(cwd);
-			if (decision === null) {
-				delete data[key];
-			} else {
-				data[key] = decision;
+			for (const { path, decision } of decisions) {
+				const key = normalizeCwd(path);
+				if (decision === null) {
+					delete data[key];
+				} else {
+					data[key] = decision;
+				}
 			}
 			writeTrustFile(this.trustPath, data);
 		});

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -220,6 +220,7 @@ export {
 } from "./core/session-manager.ts";
 export {
 	type CompactionSettings,
+	type DefaultProjectTrust,
 	type ImageSettings,
 	type PackageSource,
 	type RetrySettings,
@@ -287,7 +288,13 @@ export {
 	type WriteToolOptions,
 	withFileMutationQueue,
 } from "./core/tools/index.ts";
-export { hasProjectTrustInputs, type ProjectTrustDecision, ProjectTrustStore } from "./core/trust-manager.ts";
+export {
+	hasProjectTrustInputs,
+	type ProjectTrustDecision,
+	ProjectTrustStore,
+	type ProjectTrustStoreEntry,
+	type ProjectTrustUpdate,
+} from "./core/trust-manager.ts";
 // Main entry point
 export { type MainOptions, main } from "./main.ts";
 // Run modes for programmatic SDK usage

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -112,6 +112,10 @@ function toPrintOutputMode(appMode: AppMode): Exclude<Mode, "rpc"> {
 	return appMode === "json" ? "json" : "text";
 }
 
+function isPlainRuntimeMetadataCommand(parsed: Args): boolean {
+	return !parsed.print && parsed.mode === undefined && (parsed.help === true || parsed.listModels !== undefined);
+}
+
 async function prepareInitialMessage(
 	parsed: Args,
 	autoResizeImages: boolean,
@@ -480,11 +484,6 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 	}
 	time("parseArgs");
-	let appMode = resolveAppMode(parsed, process.stdin.isTTY, process.stdout.isTTY);
-	const shouldTakeOverStdout = appMode !== "interactive";
-	if (shouldTakeOverStdout) {
-		takeOverStdout();
-	}
 
 	if (parsed.version) {
 		console.log(VERSION);
@@ -503,6 +502,12 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 		console.log(`Exported to: ${result}`);
 		process.exit(0);
+	}
+
+	let appMode = resolveAppMode(parsed, process.stdin.isTTY, process.stdout.isTTY);
+	const shouldTakeOverStdout = appMode !== "interactive" && !isPlainRuntimeMetadataCommand(parsed);
+	if (shouldTakeOverStdout) {
+		takeOverStdout();
 	}
 
 	if (parsed.mode === "rpc" && parsed.fileArgs.length > 0) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -7,13 +7,14 @@
 
 import { createInterface } from "node:readline";
 import { type ImageContent, modelsAreEqual } from "@earendil-works/pi-ai";
-import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
 import chalk from "chalk";
 import { type Args, type Mode, parseArgs, printHelp } from "./cli/args.ts";
 import { processFileArguments } from "./cli/file-processor.ts";
 import { buildInitialMessage } from "./cli/initial-message.ts";
 import { listModels } from "./cli/list-models.ts";
+import { createProjectTrustContext } from "./cli/project-trust.ts";
 import { selectSession } from "./cli/session-picker.ts";
+import { showStartupSelector } from "./cli/startup-ui.ts";
 import { ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir, VERSION } from "./config.ts";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.ts";
 import {
@@ -24,13 +25,12 @@ import {
 import { formatNoModelsAvailableMessage } from "./core/auth-guidance.ts";
 import { AuthStorage } from "./core/auth-storage.ts";
 import { exportFromFile } from "./core/export-html/index.ts";
-import { emitProjectTrustEvent } from "./core/extensions/runner.ts";
-import type { ExtensionFactory, LoadExtensionsResult, ProjectTrustContext } from "./core/extensions/types.ts";
+import type { ExtensionFactory } from "./core/extensions/types.ts";
 import { configureHttpDispatcher } from "./core/http-dispatcher.ts";
-import { KeybindingsManager } from "./core/keybindings.ts";
 import type { ModelRegistry } from "./core/model-registry.ts";
 import { resolveCliModel, resolveModelScope, type ScopedModel } from "./core/model-resolver.ts";
 import { restoreStdout, takeOverStdout } from "./core/output-guard.ts";
+import { type AppMode, resolveProjectTrusted } from "./core/project-trust.ts";
 import type { CreateAgentSessionOptions } from "./core/sdk.ts";
 import {
 	formatMissingSessionCwdPrompt,
@@ -44,8 +44,6 @@ import { printTimings, resetTimings, time } from "./core/timings.ts";
 import { hasProjectTrustInputs, ProjectTrustStore } from "./core/trust-manager.ts";
 import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
 import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.ts";
-import { ExtensionInputComponent } from "./modes/interactive/components/extension-input.ts";
-import { ExtensionSelectorComponent } from "./modes/interactive/components/extension-selector.ts";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.ts";
 import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
 import { isLocalPath, normalizePath, resolvePath } from "./utils/paths.ts";
@@ -97,16 +95,14 @@ function isTruthyEnvFlag(value: string | undefined): boolean {
 	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
 }
 
-type AppMode = "interactive" | "print" | "json" | "rpc";
-
-function resolveAppMode(parsed: Args, stdinIsTTY: boolean): AppMode {
+function resolveAppMode(parsed: Args, stdinIsTTY: boolean, stdoutIsTTY: boolean): AppMode {
 	if (parsed.mode === "rpc") {
 		return "rpc";
 	}
 	if (parsed.mode === "json") {
 		return "json";
 	}
-	if (parsed.print || !stdinIsTTY) {
+	if (parsed.print || !stdinIsTTY || !stdoutIsTTY) {
 		return "print";
 	}
 	return "interactive";
@@ -439,87 +435,6 @@ function resolveCliPaths(cwd: string, paths: string[] | undefined): string[] | u
 	return paths?.map((value) => (isLocalPath(value) ? resolvePath(value, cwd) : value));
 }
 
-function createStartupTui(settingsManager: SettingsManager): TUI {
-	initTheme(settingsManager.getTheme());
-	setKeybindings(KeybindingsManager.create());
-	const ui = new TUI(new ProcessTerminal(), settingsManager.getShowHardwareCursor());
-	ui.setClearOnShrink(settingsManager.getClearOnShrink());
-	return ui;
-}
-
-async function clearStartupTui(ui: TUI): Promise<void> {
-	ui.clear();
-	ui.requestRender();
-	await new Promise((resolve) => setTimeout(resolve, 25));
-}
-
-async function showStartupSelector<T>(
-	settingsManager: SettingsManager,
-	title: string,
-	options: Array<{ label: string; value: T }>,
-): Promise<T | undefined> {
-	return new Promise((resolve) => {
-		const ui = createStartupTui(settingsManager);
-
-		let settled = false;
-		const finish = async (result: T | undefined) => {
-			if (settled) {
-				return;
-			}
-			settled = true;
-			await clearStartupTui(ui);
-			ui.stop();
-			resolve(result);
-		};
-
-		const selector = new ExtensionSelectorComponent(
-			title,
-			options.map((option) => option.label),
-			(option) => void finish(options.find((entry) => entry.label === option)?.value),
-			() => void finish(undefined),
-			{ tui: ui },
-		);
-		ui.addChild(selector);
-		ui.setFocus(selector);
-		ui.start();
-	});
-}
-
-async function showStartupInput(
-	settingsManager: SettingsManager,
-	title: string,
-	placeholder?: string,
-): Promise<string | undefined> {
-	return new Promise((resolve) => {
-		const ui = createStartupTui(settingsManager);
-
-		let settled = false;
-		const finish = async (result: string | undefined) => {
-			if (settled) {
-				return;
-			}
-			settled = true;
-			input.dispose();
-			await clearStartupTui(ui);
-			ui.stop();
-			resolve(result);
-		};
-
-		const input = new ExtensionInputComponent(
-			title,
-			placeholder,
-			(value) => void finish(value),
-			() => void finish(undefined),
-			{
-				tui: ui,
-			},
-		);
-		ui.addChild(input);
-		ui.setFocus(input);
-		ui.start();
-	});
-}
-
 async function promptForMissingSessionCwd(
 	issue: SessionCwdIssue,
 	settingsManager: SettingsManager,
@@ -528,160 +443,6 @@ async function promptForMissingSessionCwd(
 		{ label: "Continue", value: issue.fallbackCwd },
 		{ label: "Cancel", value: undefined },
 	]);
-}
-
-interface ProjectTrustPromptResult {
-	trusted: boolean;
-	remember: boolean;
-}
-
-const PROJECT_TRUST_PROMPT_OPTIONS: Array<{ label: string; value: ProjectTrustPromptResult }> = [
-	{ label: "Trust", value: { trusted: true, remember: true } },
-	{ label: "Trust (this session only)", value: { trusted: true, remember: false } },
-	{ label: "Do not trust", value: { trusted: false, remember: true } },
-	{ label: "Do not trust (this session only)", value: { trusted: false, remember: false } },
-];
-
-function formatProjectTrustPrompt(cwd: string): string {
-	return `Trust project folder?\n${cwd}\n\nThis allows pi to read project instructions (AGENTS.md/CLAUDE.md), load .pi settings and resources, install missing project packages, and execute project extensions.`;
-}
-
-async function promptForProjectTrust(
-	cwd: string,
-	settingsManager: SettingsManager,
-): Promise<ProjectTrustPromptResult | undefined> {
-	return showStartupSelector(settingsManager, formatProjectTrustPrompt(cwd), PROJECT_TRUST_PROMPT_OPTIONS);
-}
-
-async function promptForProjectTrustWithContext(
-	cwd: string,
-	ctx: ProjectTrustContext,
-): Promise<ProjectTrustPromptResult | undefined> {
-	const selected = await ctx.ui.select(
-		formatProjectTrustPrompt(cwd),
-		PROJECT_TRUST_PROMPT_OPTIONS.map((option) => option.label),
-	);
-	return PROJECT_TRUST_PROMPT_OPTIONS.find((option) => option.label === selected)?.value;
-}
-
-function createProjectTrustContext(options: {
-	cwd: string;
-	mode: AppMode;
-	settingsManager: SettingsManager;
-	hasUI: boolean;
-}): ProjectTrustContext {
-	return {
-		cwd: options.cwd,
-		mode: options.mode === "interactive" ? "tui" : options.mode,
-		hasUI: options.hasUI,
-		ui: {
-			select: async (title, selectOptions) => {
-				if (!options.hasUI) {
-					return undefined;
-				}
-				if (options.mode !== "interactive") {
-					return undefined;
-				}
-				return showStartupSelector(
-					options.settingsManager,
-					title,
-					selectOptions.map((option) => ({ label: option, value: option })),
-				);
-			},
-			confirm: async (title, message) => {
-				if (!options.hasUI) {
-					return false;
-				}
-				if (options.mode !== "interactive") {
-					return false;
-				}
-				return (
-					(await showStartupSelector(options.settingsManager, `${title}\n${message}`, [
-						{ label: "Yes", value: true },
-						{ label: "No", value: false },
-					])) ?? false
-				);
-			},
-			input: async (title, placeholder) => {
-				if (!options.hasUI) {
-					return undefined;
-				}
-				if (options.mode !== "interactive") {
-					return undefined;
-				}
-				return showStartupInput(options.settingsManager, title, placeholder);
-			},
-			notify: (message, type = "info") => {
-				if (options.mode !== "interactive") {
-					const color = type === "error" ? chalk.red : type === "warning" ? chalk.yellow : chalk.cyan;
-					console.error(color(message));
-				}
-			},
-		},
-	};
-}
-
-async function resolveProjectTrusted(options: {
-	cwd: string;
-	trustStore: ProjectTrustStore;
-	trustOverride?: boolean;
-	appMode: AppMode;
-	settingsManagerForPrompt: SettingsManager;
-	extensionsResult?: LoadExtensionsResult;
-	projectTrustContext?: ProjectTrustContext;
-	onExtensionError?: (message: string) => void;
-}): Promise<boolean> {
-	if (options.trustOverride !== undefined) {
-		return options.trustOverride;
-	}
-	if (!hasProjectTrustInputs(options.cwd)) {
-		return true;
-	}
-
-	if (options.extensionsResult && options.projectTrustContext) {
-		const { result, errors } = await emitProjectTrustEvent(
-			options.extensionsResult,
-			{ type: "project_trust", cwd: options.cwd },
-			options.projectTrustContext,
-		);
-		for (const error of errors) {
-			options.onExtensionError?.(`Extension "${error.extensionPath}" project_trust error: ${error.error}`);
-		}
-		if (result) {
-			const trusted = result.trusted === "yes";
-			if (result.remember === true) {
-				options.trustStore.set(options.cwd, trusted);
-			}
-			return trusted;
-		}
-	}
-
-	const decision = options.trustStore.get(options.cwd);
-	if (decision !== null) {
-		return decision;
-	}
-	if (options.projectTrustContext?.hasUI) {
-		const selected = await promptForProjectTrustWithContext(options.cwd, options.projectTrustContext);
-		if (selected !== undefined) {
-			if (selected.remember) {
-				options.trustStore.set(options.cwd, selected.trusted);
-			}
-			return selected.trusted;
-		}
-		return false;
-	}
-	if (options.appMode !== "interactive") {
-		return false;
-	}
-
-	const selected = await promptForProjectTrust(options.cwd, options.settingsManagerForPrompt);
-	if (selected !== undefined) {
-		if (selected.remember) {
-			options.trustStore.set(options.cwd, selected.trusted);
-		}
-		return selected.trusted;
-	}
-	return false;
 }
 
 export interface MainOptions {
@@ -700,11 +461,11 @@ export async function main(args: string[], options?: MainOptions) {
 		cleanupWindowsSelfUpdateQuarantine(getPackageDir());
 	}
 
-	if (await handlePackageCommand(args)) {
+	if (await handlePackageCommand(args, { extensionFactories: options?.extensionFactories })) {
 		return;
 	}
 
-	if (await handleConfigCommand(args)) {
+	if (await handleConfigCommand(args, { extensionFactories: options?.extensionFactories })) {
 		return;
 	}
 
@@ -719,7 +480,7 @@ export async function main(args: string[], options?: MainOptions) {
 		}
 	}
 	time("parseArgs");
-	let appMode = resolveAppMode(parsed, process.stdin.isTTY);
+	let appMode = resolveAppMode(parsed, process.stdin.isTTY, process.stdout.isTTY);
 	const shouldTakeOverStdout = appMode !== "interactive";
 	if (shouldTakeOverStdout) {
 		takeOverStdout();
@@ -837,8 +598,7 @@ export async function main(args: string[], options?: MainOptions) {
 								cwd,
 								trustStore,
 								trustOverride: parsed.projectTrustOverride,
-								appMode: isInitialRuntime ? trustPromptMode : "print",
-								settingsManagerForPrompt: startupSettingsManager,
+								defaultProjectTrust: startupSettingsManager.getDefaultProjectTrust(),
 								extensionsResult,
 								projectTrustContext:
 									projectTrustContext ??

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -12,7 +12,7 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import { formatHttpIdleTimeoutMs, HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-dispatcher.ts";
-import type { WarningSettings } from "../../../core/settings-manager.ts";
+import type { DefaultProjectTrust, WarningSettings } from "../../../core/settings-manager.ts";
 import { getSelectListTheme, getSettingsListTheme, theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyDisplayText } from "./keybinding-hints.ts";
@@ -30,6 +30,16 @@ const THINKING_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	high: "Deep reasoning (~16k tokens)",
 	xhigh: "Maximum reasoning (~32k tokens)",
 };
+
+const DEFAULT_PROJECT_TRUST_LABELS: Record<DefaultProjectTrust, string> = {
+	ask: "Ask",
+	always: "Always trust",
+	never: "Never trust",
+};
+
+const DEFAULT_PROJECT_TRUST_BY_LABEL = new Map(
+	Object.entries(DEFAULT_PROJECT_TRUST_LABELS).map(([value, label]) => [label, value as DefaultProjectTrust]),
+);
 
 export interface SettingsConfig {
 	autoCompact: boolean;
@@ -55,6 +65,7 @@ export interface SettingsConfig {
 	editorPaddingX: number;
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
+	defaultProjectTrust: DefaultProjectTrust;
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
 	warnings: WarningSettings;
@@ -83,6 +94,7 @@ export interface SettingsCallbacks {
 	onEditorPaddingXChange: (padding: number) => void;
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
+	onDefaultProjectTrustChange: (defaultProjectTrust: DefaultProjectTrust) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
 	onWarningsChange: (warnings: WarningSettings) => void;
@@ -276,6 +288,13 @@ export class SettingsSelectorComponent extends Container {
 				description: "Send an anonymous version/update ping after changelog-detected updates",
 				currentValue: config.enableInstallTelemetry ? "true" : "false",
 				values: ["true", "false"],
+			},
+			{
+				id: "default-project-trust",
+				label: "Default project trust",
+				description: "Fallback behavior when no extension or saved trust decision decides project trust",
+				currentValue: DEFAULT_PROJECT_TRUST_LABELS[config.defaultProjectTrust],
+				values: Object.values(DEFAULT_PROJECT_TRUST_LABELS),
 			},
 			{
 				id: "double-escape-action",
@@ -512,6 +531,13 @@ export class SettingsSelectorComponent extends Container {
 					case "install-telemetry":
 						callbacks.onEnableInstallTelemetryChange(newValue === "true");
 						break;
+					case "default-project-trust": {
+						const defaultProjectTrust = DEFAULT_PROJECT_TRUST_BY_LABEL.get(newValue);
+						if (defaultProjectTrust) {
+							callbacks.onDefaultProjectTrustChange(defaultProjectTrust);
+						}
+						break;
+					}
 					case "double-escape-action":
 						callbacks.onDoubleEscapeActionChange(newValue as "fork" | "tree");
 						break;

--- a/packages/coding-agent/src/modes/interactive/components/trust-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/trust-selector.ts
@@ -1,51 +1,51 @@
 import { Container, getKeybindings, Spacer, Text } from "@earendil-works/pi-tui";
-import type { ProjectTrustDecision } from "../../../core/trust-manager.ts";
+import {
+	getProjectTrustOptions,
+	getProjectTrustPath,
+	type ProjectTrustOption,
+	type ProjectTrustStoreEntry,
+} from "../../../core/trust-manager.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint, rawKeyHint } from "./keybinding-hints.ts";
 
-interface TrustOption {
-	label: string;
-	trusted: boolean;
-}
+export type TrustSelection = Pick<ProjectTrustOption, "trusted" | "updates">;
 
 export interface TrustSelectorOptions {
 	cwd: string;
-	savedDecision: ProjectTrustDecision;
+	savedDecision: ProjectTrustStoreEntry | null;
 	projectTrusted: boolean;
-	onSelect: (trusted: boolean) => void;
+	onSelect: (selection: TrustSelection) => void;
 	onCancel: () => void;
 }
 
-const TRUST_OPTIONS: TrustOption[] = [
-	{ label: "Trust", trusted: true },
-	{ label: "Do not trust", trusted: false },
-];
-
-function formatDecision(decision: ProjectTrustDecision): string {
-	if (decision === true) {
-		return "trusted";
+function formatDecision(cwd: string, decision: ProjectTrustStoreEntry | null): string {
+	if (decision === null) {
+		return "none";
 	}
-	if (decision === false) {
-		return "untrusted";
+	const label = decision.decision ? "trusted" : "untrusted";
+	if (decision.path !== getProjectTrustPath(cwd)) {
+		return `${label} (inherited from ${decision.path})`;
 	}
-	return "none";
+	return `${label} (${decision.path})`;
 }
 
 export class TrustSelectorComponent extends Container {
 	private selectedIndex: number;
 	private readonly listContainer: Container;
-	private readonly savedDecision: ProjectTrustDecision;
-	private readonly onSelectCallback: (trusted: boolean) => void;
+	private readonly trustOptions: ProjectTrustOption[];
+	private readonly savedDecision: ProjectTrustStoreEntry | null;
+	private readonly onSelectCallback: (selection: TrustSelection) => void;
 	private readonly onCancelCallback: () => void;
 
 	constructor(options: TrustSelectorOptions) {
 		super();
 
 		this.savedDecision = options.savedDecision;
+		this.trustOptions = getProjectTrustOptions(options.cwd);
 		this.selectedIndex = Math.max(
 			0,
-			TRUST_OPTIONS.findIndex((option) => option.trusted === options.savedDecision),
+			this.trustOptions.findIndex((option) => this.isSavedOption(option)),
 		);
 		this.onSelectCallback = options.onSelect;
 		this.onCancelCallback = options.onCancel;
@@ -55,7 +55,9 @@ export class TrustSelectorComponent extends Container {
 		this.addChild(new Text(theme.fg("accent", theme.bold("Project trust")), 1, 0));
 		this.addChild(new Text(theme.fg("muted", options.cwd), 1, 0));
 		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("muted", `Saved decision: ${formatDecision(options.savedDecision)}`), 1, 0));
+		this.addChild(
+			new Text(theme.fg("muted", `Saved decision: ${formatDecision(options.cwd, options.savedDecision)}`), 1, 0),
+		);
 		this.addChild(
 			new Text(theme.fg("muted", `Current session: ${options.projectTrusted ? "trusted" : "untrusted"}`), 1, 0),
 		);
@@ -81,16 +83,24 @@ export class TrustSelectorComponent extends Container {
 		this.updateList();
 	}
 
+	private isSavedOption(option: ProjectTrustOption): boolean {
+		return (
+			option.savedPath !== undefined &&
+			this.savedDecision?.decision === option.trusted &&
+			this.savedDecision.path === option.savedPath
+		);
+	}
+
 	private updateList(): void {
 		this.listContainer.clear();
-		for (let i = 0; i < TRUST_OPTIONS.length; i++) {
-			const option = TRUST_OPTIONS[i];
+		for (let i = 0; i < this.trustOptions.length; i++) {
+			const option = this.trustOptions[i];
 			if (!option) {
 				continue;
 			}
 
 			const isSelected = i === this.selectedIndex;
-			const isCurrent = option.trusted === this.savedDecision;
+			const isCurrent = this.isSavedOption(option);
 			const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
 			const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
 			const label = isSelected ? theme.fg("accent", option.label) : theme.fg("text", option.label);
@@ -104,12 +114,12 @@ export class TrustSelectorComponent extends Container {
 			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
 			this.updateList();
 		} else if (kb.matches(keyData, "tui.select.down") || keyData === "j") {
-			this.selectedIndex = Math.min(TRUST_OPTIONS.length - 1, this.selectedIndex + 1);
+			this.selectedIndex = Math.min(this.trustOptions.length - 1, this.selectedIndex + 1);
 			this.updateList();
 		} else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
-			const selected = TRUST_OPTIONS[this.selectedIndex];
+			const selected = this.trustOptions[this.selectedIndex];
 			if (selected) {
-				this.onSelectCallback(selected.trusted);
+				this.onSelectCallback({ trusted: selected.trusted, updates: selected.updates });
 			}
 		} else if (kb.matches(keyData, "tui.select.cancel")) {
 			this.onCancelCallback();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3277,7 +3277,7 @@ export class InteractiveMode {
 			new Text(
 				theme.fg(
 					"warning",
-					"This project is not trusted. Project instructions (AGENTS.md/CLAUDE.md), .pi resources, and project packages are ignored. Use /trust to save a trust decision, then restart pi.",
+					"This project is not trusted. Project .pi resources and packages are ignored. Use /trust to save a trust decision, then restart pi.",
 				),
 				1,
 				0,
@@ -3966,6 +3966,7 @@ export class InteractiveMode {
 					doubleEscapeAction: this.settingsManager.getDoubleEscapeAction(),
 					treeFilterMode: this.settingsManager.getTreeFilterMode(),
 					showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
+					defaultProjectTrust: this.settingsManager.getDefaultProjectTrust(),
 					editorPaddingX: this.settingsManager.getEditorPaddingX(),
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
 					quietStartup: this.settingsManager.getQuietStartup(),
@@ -4058,6 +4059,9 @@ export class InteractiveMode {
 					},
 					onQuietStartupChange: (enabled) => {
 						this.settingsManager.setQuietStartup(enabled);
+					},
+					onDefaultProjectTrustChange: (defaultProjectTrust) => {
+						this.settingsManager.setDefaultProjectTrust(defaultProjectTrust);
 					},
 					onDoubleEscapeActionChange: (action) => {
 						this.settingsManager.setDoubleEscapeAction(action);
@@ -4213,17 +4217,17 @@ export class InteractiveMode {
 	private showTrustSelector(): void {
 		const cwd = this.sessionManager.getCwd();
 		const trustStore = new ProjectTrustStore(this.runtimeHost.services.agentDir);
-		const savedDecision = trustStore.get(cwd);
+		const savedDecision = trustStore.getEntry(cwd);
 		this.showSelector((done) => {
 			const selector = new TrustSelectorComponent({
 				cwd,
 				savedDecision,
 				projectTrusted: this.settingsManager.isProjectTrusted(),
-				onSelect: (trusted) => {
-					trustStore.set(cwd, trusted);
+				onSelect: (selection) => {
+					trustStore.setMany(selection.updates);
 					done();
 					this.showStatus(
-						`Saved trust decision: ${trusted ? "trusted" : "untrusted"}. Restart pi for this to take effect.`,
+						`Saved trust decision: ${selection.trusted ? "trusted" : "untrusted"}. Restart pi for this to take effect.`,
 					);
 				},
 				onCancel: () => {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1,6 +1,7 @@
 import { Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
 import chalk from "chalk";
 import { selectConfig } from "./cli/config-selector.ts";
+import { createProjectTrustContext } from "./cli/project-trust.ts";
 import {
 	APP_NAME,
 	detectInstallMethod,
@@ -12,7 +13,10 @@ import {
 	type SelfUpdateCommand,
 	VERSION,
 } from "./config.ts";
+import type { ExtensionFactory } from "./core/extensions/types.ts";
 import { DefaultPackageManager } from "./core/package-manager.ts";
+import { type AppMode, resolveProjectTrusted } from "./core/project-trust.ts";
+import { DefaultResourceLoader } from "./core/resource-loader.ts";
 import { SettingsManager } from "./core/settings-manager.ts";
 import { hasProjectTrustInputs, ProjectTrustStore } from "./core/trust-manager.ts";
 import { spawnProcess } from "./utils/child-process.ts";
@@ -425,22 +429,82 @@ function parseProjectTrustOverride(args: readonly string[]): boolean | undefined
 	return trustOverride;
 }
 
-function resolveProjectTrusted(cwd: string, agentDir: string, trustOverride: boolean | undefined): boolean {
-	if (trustOverride !== undefined) {
-		return trustOverride;
-	}
-	return !hasProjectTrustInputs(cwd) || new ProjectTrustStore(agentDir).get(cwd) === true;
+export interface PackageCommandRuntimeOptions {
+	extensionFactories?: ExtensionFactory[];
 }
 
-export async function handleConfigCommand(args: string[]): Promise<boolean> {
+interface CommandSettingsResult {
+	settingsManager: SettingsManager;
+	projectTrustWarnings: string[];
+}
+
+function getCommandAppMode(): AppMode {
+	return process.stdin.isTTY && process.stdout.isTTY ? "interactive" : "print";
+}
+
+function reportProjectTrustWarnings(warnings: readonly string[]): void {
+	for (const warning of warnings) {
+		console.error(chalk.yellow(`Warning: ${warning}`));
+	}
+}
+
+async function createCommandSettingsManager(options: {
+	cwd: string;
+	agentDir: string;
+	projectTrustOverride?: boolean;
+	extensionFactories?: ExtensionFactory[];
+}): Promise<CommandSettingsResult> {
+	const settingsManager = SettingsManager.create(options.cwd, options.agentDir, { projectTrusted: false });
+	const projectTrustWarnings: string[] = [];
+	const appMode = getCommandAppMode();
+	const extensionsResult =
+		options.projectTrustOverride === undefined && hasProjectTrustInputs(options.cwd)
+			? await new DefaultResourceLoader({
+					cwd: options.cwd,
+					agentDir: options.agentDir,
+					settingsManager,
+					extensionFactories: options.extensionFactories,
+				}).loadProjectTrustExtensions()
+			: undefined;
+	for (const error of extensionsResult?.errors ?? []) {
+		projectTrustWarnings.push(`Failed to load extension "${error.path}": ${error.error}`);
+	}
+
+	const projectTrusted = await resolveProjectTrusted({
+		cwd: options.cwd,
+		trustStore: new ProjectTrustStore(options.agentDir),
+		trustOverride: options.projectTrustOverride,
+		defaultProjectTrust: settingsManager.getDefaultProjectTrust(),
+		extensionsResult,
+		projectTrustContext: createProjectTrustContext({
+			cwd: options.cwd,
+			mode: appMode,
+			settingsManager,
+			hasUI: appMode === "interactive",
+		}),
+		onExtensionError: (message) => projectTrustWarnings.push(message),
+	});
+	settingsManager.setProjectTrusted(projectTrusted);
+	return { settingsManager, projectTrustWarnings };
+}
+
+export async function handleConfigCommand(
+	args: string[],
+	runtimeOptions: PackageCommandRuntimeOptions = {},
+): Promise<boolean> {
 	if (args[0] !== "config") {
 		return false;
 	}
 
 	const cwd = process.cwd();
 	const agentDir = getAgentDir();
-	const projectTrusted = parseProjectTrustOverride(args) ?? true;
-	const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
+	const { settingsManager, projectTrustWarnings } = await createCommandSettingsManager({
+		cwd,
+		agentDir,
+		projectTrustOverride: parseProjectTrustOverride(args),
+		extensionFactories: runtimeOptions.extensionFactories,
+	});
+	reportProjectTrustWarnings(projectTrustWarnings);
 	reportSettingsErrors(settingsManager, "config command");
 	const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
 	const resolvedPaths = await packageManager.resolve();
@@ -455,7 +519,10 @@ export async function handleConfigCommand(args: string[]): Promise<boolean> {
 	process.exit(0);
 }
 
-export async function handlePackageCommand(args: string[]): Promise<boolean> {
+export async function handlePackageCommand(
+	args: string[],
+	runtimeOptions: PackageCommandRuntimeOptions = {},
+): Promise<boolean> {
 	const options = parsePackageCommand(args);
 	if (!options) {
 		return false;
@@ -505,13 +572,18 @@ export async function handlePackageCommand(args: string[]): Promise<boolean> {
 	const cwd = process.cwd();
 	const agentDir = getAgentDir();
 	const writesProjectPackageConfig = (options.command === "install" || options.command === "remove") && options.local;
-	const projectTrusted = resolveProjectTrusted(cwd, agentDir, options.projectTrustOverride);
-	if (!projectTrusted && writesProjectPackageConfig) {
+	const { settingsManager, projectTrustWarnings } = await createCommandSettingsManager({
+		cwd,
+		agentDir,
+		projectTrustOverride: options.projectTrustOverride,
+		extensionFactories: runtimeOptions.extensionFactories,
+	});
+	reportProjectTrustWarnings(projectTrustWarnings);
+	if (!settingsManager.isProjectTrusted() && writesProjectPackageConfig) {
 		console.error(chalk.red("Project is not trusted. Use --approve to modify local package config."));
 		process.exitCode = 1;
 		return true;
 	}
-	const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted });
 	reportSettingsErrors(settingsManager, "package command");
 	const selfUpdateNpmCommand = settingsManager.getGlobalSettings().npmCommand;
 

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -157,6 +157,70 @@ describe("package commands", () => {
 		}
 	});
 
+	it("uses default project trust for list", async () => {
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ defaultProjectTrust: "always" }));
+		writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ packages: ["npm:@project/pkg"] }));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await expect(main(["list"])).resolves.toBeUndefined();
+
+			const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+			expect(stdout).toContain("Project packages:");
+			expect(stdout).toContain("npm:@project/pkg");
+			expect(stdout).not.toContain("No packages installed.");
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("uses project_trust extensions for package commands", async () => {
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ packages: ["npm:@project/pkg"] }));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await expect(
+				main(["list"], {
+					extensionFactories: [
+						(pi) => {
+							pi.on("project_trust", () => ({ trusted: "yes" }));
+						},
+					],
+				}),
+			).resolves.toBeUndefined();
+
+			const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+			expect(stdout).toContain("Project packages:");
+			expect(stdout).toContain("npm:@project/pkg");
+			expect(stdout).not.toContain("No packages installed.");
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("lets trust.json override default project trust", async () => {
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ defaultProjectTrust: "always" }));
+		writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ packages: ["npm:@project/pkg"] }));
+		new ProjectTrustStore(agentDir).set(projectDir, false);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await expect(main(["list"])).resolves.toBeUndefined();
+
+			const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+			expect(stdout).toContain("No packages installed.");
+			expect(stdout).not.toContain("Project packages:");
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
 	it("blocks local package changes when project is untrusted", async () => {
 		mkdirSync(join(projectDir, ".pi"), { recursive: true });
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -376,7 +376,7 @@ Content`,
 			expect(loader.getSystemPrompt()).toBe("You are a helpful assistant.");
 		});
 
-		it("should skip project resources when project is not trusted", async () => {
+		it("should skip trust-gated project resources when project is not trusted", async () => {
 			const piDir = join(cwd, ".pi");
 			const extensionsDir = join(piDir, "extensions");
 			const skillDir = join(piDir, "skills", "project-skill");
@@ -414,7 +414,7 @@ Project skill content`,
 			expect(loader.getAgentsFiles().agentsFiles.some((file) => file.path === join(agentDir, "AGENTS.md"))).toBe(
 				true,
 			);
-			expect(loader.getAgentsFiles().agentsFiles.some((file) => file.path === join(cwd, "AGENTS.md"))).toBe(false);
+			expect(loader.getAgentsFiles().agentsFiles.some((file) => file.path === join(cwd, "AGENTS.md"))).toBe(true);
 			expect(loader.getExtensions().extensions).toHaveLength(0);
 			expect(loader.getExtensions().errors).toEqual([]);
 			expect(loader.getSkills().skills.some((skill) => skill.name === "project-skill")).toBe(false);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -250,6 +250,23 @@ describe("SettingsManager", () => {
 			expect(manager.getProjectSettings()).toEqual({});
 			expect(JSON.parse(readFileSync(projectSettingsPath, "utf-8"))).toEqual({ packages: ["npm:existing"] });
 		});
+
+		it("should read default project trust from global settings only", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ defaultProjectTrust: "always" }));
+			writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ defaultProjectTrust: "never" }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getDefaultProjectTrust()).toBe("always");
+		});
+
+		it("should default invalid project trust settings to ask", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ defaultProjectTrust: "sometimes" }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getDefaultProjectTrust()).toBe("ask");
+		});
 	});
 
 	describe("project settings directory creation", () => {

--- a/packages/coding-agent/test/stdout-cleanliness.test.ts
+++ b/packages/coding-agent/test/stdout-cleanliness.test.ts
@@ -80,6 +80,22 @@ async function runCli(args: string[]): Promise<{ stdout: string; stderr: string;
 }
 
 describe("stdout cleanliness in non-interactive modes", () => {
+	it("prints --version to stdout when stdout is redirected", async () => {
+		const result = await runCli(["--version"]);
+
+		expect(result.code).toBe(0);
+		expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+		expect(result.stderr).toBe("");
+	});
+
+	it("prints plain --help to stdout when stdout is redirected", async () => {
+		const result = await runCli(["--help"]);
+
+		expect(result.code).toBe(0);
+		expect(result.stdout).toContain("Usage:");
+		expect(result.stderr).not.toContain("Usage:");
+	});
+
 	it("keeps stdout empty for --mode json --help while routing trusted startup chatter to stderr", async () => {
 		const result = await runCli(["--mode", "json", "--help", "--approve"]);
 

--- a/packages/coding-agent/test/trust-manager.test.ts
+++ b/packages/coding-agent/test/trust-manager.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { hasProjectConfigDir, hasProjectTrustInputs, ProjectTrustStore } from "../src/core/trust-manager.ts";
+import {
+	getProjectTrustPath,
+	hasProjectConfigDir,
+	hasProjectTrustInputs,
+	ProjectTrustStore,
+} from "../src/core/trust-manager.ts";
 
 describe("ProjectTrustStore", () => {
 	let tempDir: string;
@@ -25,12 +30,52 @@ describe("ProjectTrustStore", () => {
 		const store = new ProjectTrustStore(agentDir);
 
 		expect(store.get(cwd)).toBeNull();
+		expect(store.getEntry(cwd)).toBeNull();
 		store.set(cwd, true);
 		expect(store.get(cwd)).toBe(true);
+		expect(store.getEntry(cwd)).toEqual({ path: getProjectTrustPath(cwd), decision: true });
 		store.set(cwd, false);
 		expect(store.get(cwd)).toBe(false);
+		expect(store.getEntry(cwd)).toEqual({ path: getProjectTrustPath(cwd), decision: false });
 		store.set(cwd, null);
 		expect(store.get(cwd)).toBeNull();
+		expect(store.getEntry(cwd)).toBeNull();
+	});
+
+	it("inherits the closest saved decision from parent directories", () => {
+		const store = new ProjectTrustStore(agentDir);
+		const parentDir = join(tempDir, "trusted-parent");
+		const childDir = join(parentDir, "project");
+		const grandchildDir = join(childDir, "nested");
+		mkdirSync(grandchildDir, { recursive: true });
+
+		store.set(parentDir, true);
+		expect(store.get(childDir)).toBe(true);
+		expect(store.getEntry(childDir)).toEqual({ path: getProjectTrustPath(parentDir), decision: true });
+		expect(store.get(grandchildDir)).toBe(true);
+		expect(store.getEntry(grandchildDir)).toEqual({ path: getProjectTrustPath(parentDir), decision: true });
+
+		store.set(childDir, false);
+		expect(store.get(grandchildDir)).toBe(false);
+		expect(store.getEntry(grandchildDir)).toEqual({ path: getProjectTrustPath(childDir), decision: false });
+	});
+
+	it("can clear a child override to inherit parent trust", () => {
+		const store = new ProjectTrustStore(agentDir);
+		const parentDir = join(tempDir, "trusted-parent");
+		const childDir = join(parentDir, "project");
+		mkdirSync(childDir, { recursive: true });
+
+		store.set(parentDir, true);
+		store.set(childDir, false);
+		expect(store.getEntry(childDir)).toEqual({ path: getProjectTrustPath(childDir), decision: false });
+
+		store.setMany([
+			{ path: parentDir, decision: true },
+			{ path: childDir, decision: null },
+		]);
+		expect(store.get(childDir)).toBe(true);
+		expect(store.getEntry(childDir)).toEqual({ path: getProjectTrustPath(parentDir), decision: true });
 	});
 
 	it("fails loudly without overwriting malformed trust stores", () => {
@@ -53,8 +98,12 @@ describe("ProjectTrustStore", () => {
 		rmSync(join(cwd, ".pi"), { recursive: true, force: true });
 
 		writeFileSync(join(cwd, "AGENTS.md"), "Project instructions");
-		expect(hasProjectTrustInputs(cwd)).toBe(true);
+		expect(hasProjectTrustInputs(cwd)).toBe(false);
 		rmSync(join(cwd, "AGENTS.md"), { force: true });
+
+		writeFileSync(join(cwd, "CLAUDE.md"), "Legacy project instructions");
+		expect(hasProjectTrustInputs(cwd)).toBe(false);
+		rmSync(join(cwd, "CLAUDE.md"), { force: true });
 
 		mkdirSync(join(cwd, ".agents", "skills"), { recursive: true });
 		expect(hasProjectTrustInputs(cwd)).toBe(true);

--- a/packages/coding-agent/test/trust-selector.test.ts
+++ b/packages/coding-agent/test/trust-selector.test.ts
@@ -17,7 +17,7 @@ describe("TrustSelectorComponent", () => {
 	it("marks the saved trusted decision", () => {
 		const selector = new TrustSelectorComponent({
 			cwd: "/project",
-			savedDecision: true,
+			savedDecision: { path: "/project", decision: true },
 			projectTrusted: true,
 			onSelect: () => {},
 			onCancel: () => {},
@@ -25,7 +25,7 @@ describe("TrustSelectorComponent", () => {
 
 		const output = stripAnsi(selector.render(120).join("\n"));
 
-		expect(output).toContain("Saved decision: trusted");
+		expect(output).toContain("Saved decision: trusted (/project)");
 		expect(output).toContain("Current session: trusted");
 		expect(output).toContain("Trust ✓");
 		expect(output).not.toContain("Do not trust ✓");
@@ -43,6 +43,45 @@ describe("TrustSelectorComponent", () => {
 
 		selector.handleInput("\n");
 
-		expect(onSelect).toHaveBeenCalledWith(true);
+		expect(onSelect).toHaveBeenCalledWith({ trusted: true, updates: [{ path: "/project", decision: true }] });
+	});
+
+	it("labels saved ancestor decisions as inherited", () => {
+		const selector = new TrustSelectorComponent({
+			cwd: "/parent/project/nested",
+			savedDecision: { path: "/parent", decision: true },
+			projectTrusted: true,
+			onSelect: () => {},
+			onCancel: () => {},
+		});
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+
+		expect(output).toContain("Saved decision: trusted (inherited from /parent)");
+	});
+
+	it("adds a trust parent option", () => {
+		const onSelect = vi.fn();
+		const selector = new TrustSelectorComponent({
+			cwd: "/parent/project",
+			savedDecision: { path: "/parent", decision: true },
+			projectTrusted: true,
+			onSelect,
+			onCancel: () => {},
+		});
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).toContain("Saved decision: trusted (inherited from /parent)");
+		expect(output).toContain("Trust parent folder (/parent) ✓");
+
+		selector.handleInput("\n");
+
+		expect(onSelect).toHaveBeenCalledWith({
+			trusted: true,
+			updates: [
+				{ path: "/parent", decision: true },
+				{ path: "/parent/project", decision: null },
+			],
+		});
 	});
 });


### PR DESCRIPTION
This PR adds the following:

* Global settings flag to enable/disable it
* Inherit values from the parent folder
* Make it trivially possible to trust the parent folder in the approval dialog (like vscode does)
* Aligns `config` and `list` etc. with the default `project_trust` behavior instead of reimplementing it

<img width="1092" height="376" alt="Screenshot 2026-06-09 at 13 27 54" src="https://github.com/user-attachments/assets/3c058390-7b1d-4d55-915e-c97bad1c90b1" />

<img width="674" height="283" alt="image" src="https://github.com/user-attachments/assets/3fb893e9-1f0f-42fe-97fd-c0eab5cb356a" />

<img width="772" height="268" alt="Screenshot 2026-06-09 at 13 28 25" src="https://github.com/user-attachments/assets/3e1c48ce-24af-450c-b14e-a4fd607a025b" />

Refs #5514