### PR TITLE
fix(ai): add opus-4-8 to supportsAdaptiveThinking in Anthropic and Bedrock providers

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -491,12 +491,12 @@ function getModelMatchCandidates(modelId: string, modelName?: string): string[] 
 
 function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
 	const candidates = getModelMatchCandidates(modelId, modelName);
-	return candidates.some((s) => s.includes("opus-4-6") || s.includes("opus-4-7") || s.includes("sonnet-4-6"));
+	return candidates.some((s) => s.includes("opus-4-6") || s.includes("opus-4-7") || s.includes("opus-4-8") || s.includes("sonnet-4-6"));
 }
 
 function supportsNativeXhighEffort(model: Model<"bedrock-converse-stream">): boolean {
 	const candidates = getModelMatchCandidates(model.id, model.name);
-	return candidates.some((s) => s.includes("opus-4-7"));
+	return candidates.some((s) => s.includes("opus-4-7") || s.includes("opus-4-8"));
 }
 
 function mapThinkingLevelToEffort(

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -685,6 +685,8 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 		modelId.includes("opus-4.6") ||
 		modelId.includes("opus-4-7") ||
 		modelId.includes("opus-4.7") ||
+		modelId.includes("opus-4-8") ||
+		modelId.includes("opus-4.8") ||
 		modelId.includes("sonnet-4-6") ||
 		modelId.includes("sonnet-4.6")
 	);


### PR DESCRIPTION
## Problem

Claude Opus 4.8 supports adaptive thinking but was not included in the `supportsAdaptiveThinking` function, causing the model to fall into the legacy thinking path which returns a 400 error from the Anthropic API.

The `@mariozechner/pi-ai` package published at v0.73.1 still uses `supportsAdaptiveThinking` and needs this fix.

## Changes

- **anthropic.ts**: add `opus-4-8`/`opus-4.8` to `supportsAdaptiveThinking`
- **amazon-bedrock.ts**: add `opus-4-8` to `supportsAdaptiveThinking` and `supportsNativeXhighEffort`

## Note

The main branch has already refactored this to use `model.compat?.forceAdaptiveThinking` which does include opus-4-8. This PR ensures the fix is also available for consumers still on the v0.73.x code path and provides a commit trail for backporting.

Fixes: Paperclip issue CPL-2806