### PR TITLE
fix(ai): attach reasoning_details streamed before tool_calls

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -171,6 +171,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			let hasFinishReason = false;
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
+			// #5114: reasoning_details (an encrypted signature keyed by an upcoming
+			// tool call id) can stream BEFORE the tool_calls chunk. Buffer such
+			// orphans by id and attach them once the matching tool call appears.
+			const pendingReasoningById = new Map<string, string>();
 			const blocks = output.content as StreamingBlock[];
 			const getContentIndex = (block: StreamingBlock) => blocks.indexOf(block);
 			const finishBlock = (block: StreamingBlock) => {
@@ -260,6 +264,13 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				}
 				if (toolCall.id) {
 					toolCallBlocksById.set(toolCall.id, block);
+					// Attach any reasoning signature that streamed in before this
+					// tool call existed (#5114).
+					const pending = pendingReasoningById.get(toolCall.id);
+					if (pending && !block.thoughtSignature) {
+						block.thoughtSignature = pending;
+						pendingReasoningById.delete(toolCall.id);
+					}
 				}
 				return block;
 			};
@@ -374,11 +385,16 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 					if (reasoningDetails && Array.isArray(reasoningDetails)) {
 						for (const detail of reasoningDetails) {
 							if (detail.type === "reasoning.encrypted" && detail.id && detail.data) {
+								const signature = JSON.stringify(detail);
 								const matchingToolCall = output.content.find(
 									(b) => b.type === "toolCall" && b.id === detail.id,
 								) as ToolCall | undefined;
 								if (matchingToolCall) {
-									matchingToolCall.thoughtSignature = JSON.stringify(detail);
+									matchingToolCall.thoughtSignature = signature;
+								} else {
+									// The tool call has not streamed yet; buffer the
+									// signature so ensureToolCallBlock can attach it (#5114).
+									pendingReasoningById.set(detail.id, signature);
 								}
 							}
 						}

--- a/packages/ai/test/openai-completions-reasoning-details-order.test.ts
+++ b/packages/ai/test/openai-completions-reasoning-details-order.test.ts
@@ -1,0 +1,136 @@
+import { Type } from "typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/models.ts";
+import { streamSimple } from "../src/stream.ts";
+import type { Model, Tool, ToolCall } from "../src/types.ts";
+
+// Regression for #5114: when a provider streams `reasoning_details` (an
+// encrypted reasoning signature whose `id` matches an upcoming tool call)
+// BEFORE the `tool_calls` chunk, the signature must still be attached to the
+// tool call. The pre-fix code looked the tool call up in `output.content` at
+// the moment the reasoning_details chunk arrived; since the tool call did not
+// exist yet, the signature was silently dropped and never round-tripped.
+
+const mockState = vi.hoisted(() => ({
+	chunks: undefined as Array<unknown> | undefined,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: () => {
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							for (const chunk of mockState.chunks ?? []) {
+								yield chunk;
+							}
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+	return { default: FakeOpenAI };
+});
+
+const USAGE = {
+	prompt_tokens: 1,
+	completion_tokens: 1,
+	prompt_tokens_details: { cached_tokens: 0 },
+	completion_tokens_details: { reasoning_tokens: 0 },
+};
+
+function createModel(): Model<"openai-completions"> {
+	const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+	return { ...baseModel, api: "openai-completions" } as Model<"openai-completions">;
+}
+
+const tools: Tool[] = [
+	{
+		name: "ping",
+		description: "Ping tool",
+		parameters: Type.Object({ ok: Type.Boolean() }),
+	},
+];
+
+const reasoningDetail = {
+	type: "reasoning.encrypted",
+	id: "call_abc",
+	data: "opaque-encrypted-signature",
+};
+
+async function run(): Promise<ToolCall | undefined> {
+	const response = await streamSimple(
+		createModel(),
+		{
+			messages: [{ role: "user", content: "Call ping with ok=true", timestamp: Date.now() }],
+			tools,
+		},
+		{ apiKey: "test" },
+	).result();
+	return response.content.find((b): b is ToolCall => b.type === "toolCall" && b.id === "call_abc") as
+		| ToolCall
+		| undefined;
+}
+
+describe("openai-completions reasoning_details ordering (#5114)", () => {
+	beforeEach(() => {
+		mockState.chunks = undefined;
+	});
+
+	it("attaches the signature when reasoning_details arrives BEFORE the tool_call", async () => {
+		mockState.chunks = [
+			// reasoning_details first — the tool call does not exist yet
+			{ choices: [{ delta: { reasoning_details: [reasoningDetail] }, finish_reason: null }] },
+			// tool_call arrives afterwards
+			{
+				choices: [
+					{
+						delta: {
+							tool_calls: [{ index: 0, id: "call_abc", function: { name: "ping", arguments: '{"ok":true}' } }],
+						},
+						finish_reason: null,
+					},
+				],
+			},
+			{ choices: [{ delta: {}, finish_reason: "tool_calls" }], usage: USAGE },
+		];
+
+		const toolCall = await run();
+		expect(toolCall).toBeDefined();
+		expect(toolCall?.thoughtSignature).toBe(JSON.stringify(reasoningDetail));
+	});
+
+	it("still attaches the signature when reasoning_details arrives AFTER the tool_call", async () => {
+		mockState.chunks = [
+			{
+				choices: [
+					{
+						delta: {
+							tool_calls: [{ index: 0, id: "call_abc", function: { name: "ping", arguments: '{"ok":true}' } }],
+						},
+						finish_reason: null,
+					},
+				],
+			},
+			{ choices: [{ delta: { reasoning_details: [reasoningDetail] }, finish_reason: null }] },
+			{ choices: [{ delta: {}, finish_reason: "tool_calls" }], usage: USAGE },
+		];
+
+		const toolCall = await run();
+		expect(toolCall).toBeDefined();
+		expect(toolCall?.thoughtSignature).toBe(JSON.stringify(reasoningDetail));
+	});
+});


### PR DESCRIPTION
## What

When a provider streams an encrypted `reasoning_details` signature whose `id` matches an upcoming tool call **before** the `tool_calls` chunk (e.g. OpenRouter with Gemini models), the signature was silently dropped.

The handler looked the tool call up in `output.content` at the moment the `reasoning_details` chunk arrived. Since the tool call block did not exist yet, the lookup returned `undefined`, the signature was never stored, and it was never round-tripped on the next request. Providers that require the signature then reject the follow-up turn. The reversed order (`tool_calls` first, then `reasoning_details`) already worked.

## Why

Fixes #5114. The streaming parser assumed `reasoning_details` always arrives after the tool call it annotates, which does not hold for all providers.

## How

`packages/ai/src/providers/openai-completions.ts`:
- Buffer orphan reasoning signatures in a `pendingReasoningById` map when the matching tool call has not streamed yet.
- In `ensureToolCallBlock`, attach any buffered signature once the tool call block receives its id.
- The existing same-chunk / reversed-order path is unchanged.

## Test

New `packages/ai/test/openai-completions-reasoning-details-order.test.ts` with two cases:
- `reasoning_details` BEFORE `tool_calls` (fails on `main`, passes with this change)
- `reasoning_details` AFTER `tool_calls` (regression guard for the existing path)

Validation:
- `cd packages/ai && node ../../node_modules/vitest/dist/cli.js --run test/openai-completions-reasoning-details-order.test.ts` — 2/2 pass
- Related suites (`openai-completions-tool-choice`, `openai-codex-stream`) — no regressions
- `npm run check` — exits 0

---
This PR is AI-assisted (Claude Opus 4.8), authored and reviewed by @alexzhu0.
