### PR TITLE
fix(ai): allow Fable adaptive thinking models in test

### DIFF
--- a/packages/ai/test/anthropic-adaptive-thinking-models.test.ts
+++ b/packages/ai/test/anthropic-adaptive-thinking-models.test.ts
@@ -22,7 +22,7 @@ describe("Anthropic adaptive thinking model metadata", () => {
 
 		expect(flaggedModels).toEqual(expect.arrayContaining([...EXPECTED_CURRENT_ADAPTIVE_THINKING_MODELS].sort()));
 		expect(flaggedModels).toEqual(
-			flaggedModels.filter((modelId) => /(opus[-.]4[-.][678]|sonnet[-.]4[-.]6)/.test(modelId)),
+			flaggedModels.filter((modelId) => /(claude[-.]fable|opus[-.]4[-.][678]|sonnet[-.]4[-.]6)/.test(modelId)),
 		);
 	});
 });


### PR DESCRIPTION
one-line CI fix!

## Summary
- Allow Claude Fable 5 adaptive-thinking model IDs in the Anthropic adaptive-thinking sentinel test.

## Validation
- `node ../../node_modules/vitest/dist/cli.js --run test/anthropic-adaptive-thinking-models.test.ts`
- `npm run generate-models && npm run check` (mirrors CI build/check order; generated artifact restored before commit so the PR only contains the test fix)
