### PR TITLE
fix(coding-agent): preserve clickable subscription login URLs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- Fixed subscription login URL wrapping so terminal click detection does not see inserted spaces.
 - Fixed inherited Amazon Bedrock inference profile ARN region resolution to prefer the ARN's embedded region over `AWS_REGION` ([#5527](https://github.com/earendil-works/pi/pull/5527) by [@AJM10565](https://github.com/AJM10565)).
 - Fixed inherited IME hardware cursor positioning while slash-command autocomplete is visible ([#5283](https://github.com/earendil-works/pi/pull/5283) by [@smoosex](https://github.com/smoosex)).
 - Fixed inherited z.ai thinking-off requests to send the provider's `thinking: { type: "disabled" }` compatibility parameter ([#5330](https://github.com/earendil-works/pi/issues/5330)).

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -98,7 +98,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.contentContainer.clear();
 		this.contentContainer.addChild(new Spacer(1));
 		const linkedUrl = `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`;
-		this.contentContainer.addChild(new Text(theme.fg("accent", linkedUrl), 1, 0));
+		this.contentContainer.addChild(new Text(theme.fg("accent", linkedUrl), 0, 0));
 
 		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
 		const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;
@@ -120,7 +120,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.contentContainer.clear();
 		this.contentContainer.addChild(new Spacer(1));
 		const linkedUrl = `\x1b]8;;${info.verificationUri}\x07${info.verificationUri}\x1b]8;;\x07`;
-		this.contentContainer.addChild(new Text(theme.fg("accent", linkedUrl), 1, 0));
+		this.contentContainer.addChild(new Text(theme.fg("accent", linkedUrl), 0, 0));
 
 		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
 		const hyperlink = `\x1b]8;;${info.verificationUri}\x07${clickHint}\x1b]8;;\x07`;

--- a/packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts
@@ -18,8 +18,8 @@ function createDialog(): LoginDialogComponent {
 	);
 }
 
-function renderDialog(dialog: LoginDialogComponent): string[] {
-	return stripAnsi(dialog.render(120).join("\n"))
+function renderDialog(dialog: LoginDialogComponent, width = 120): string[] {
+	return stripAnsi(dialog.render(width).join("\n"))
 		.split("\n")
 		.map((line) => line.trimEnd());
 }
@@ -68,6 +68,25 @@ describe("LoginDialogComponent OAuth prompts", () => {
 		expect(output).toContain("https://example.invalid/login");
 		expect(output).toContain("Authorize the extension");
 		expect(output).toContain("First prompt:");
+	});
+
+	test("wraps auth URLs without inserting spaces", () => {
+		const dialog = createDialog();
+		const url =
+			"https://claude.ai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A53692%2Fcallback&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference+user%3Asessions%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload";
+
+		dialog.showAuth(url);
+
+		const lines = renderDialog(dialog, 80);
+		const urlStart = lines.findIndex((line) => line.startsWith("https://"));
+		expect(urlStart).toBeGreaterThanOrEqual(0);
+
+		const urlLines = lines.slice(
+			urlStart,
+			lines.findIndex((line, index) => index > urlStart && line.includes("click to open")),
+		);
+		expect(urlLines.length).toBeGreaterThan(1);
+		expect(urlLines.join("")).toBe(url);
 	});
 
 	test("keeps previous manual input stable when a later prompt is active", async () => {


### PR DESCRIPTION
When logging in to a provider, Pi prints the URL to click, but since Pi by default adds a space as left padding, a long link will be broken. This fixes that.

<img width="690" height="292" alt="CleanShot-2026-06-10-at-09 16 00@2x" src="https://github.com/user-attachments/assets/49b8eb98-0568-4168-8b12-061c89c71e0b" />