### PR TITLE
fix(ai/bedrock): use resolved apiKey as a bearer-token fallback

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -3,6 +3,13 @@ let _existsSync: typeof import("node:fs").existsSync | null = null;
 let _homedir: typeof import("node:os").homedir | null = null;
 let _join: typeof import("node:path").join | null = null;
 
+/**
+ * Sentinel returned by getEnvApiKey() for providers that authenticate without a
+ * caller-supplied API key string (AWS SigV4 credentials, Vertex AI ADC). It signals
+ * "credentials are present" but is NOT a usable token and must never be sent as one.
+ */
+export const AUTHENTICATED_SENTINEL = "<authenticated>";
+
 type DynamicImport = (specifier: string) => Promise<unknown>;
 
 const dynamicImport: DynamicImport = (specifier) => import(specifier);
@@ -179,7 +186,7 @@ export function getEnvApiKey(provider: string): string | undefined {
 		const hasLocation = !!(process.env.GOOGLE_CLOUD_LOCATION || getProcEnv("GOOGLE_CLOUD_LOCATION"));
 
 		if (hasCredentials && hasProject && hasLocation) {
-			return "<authenticated>";
+			return AUTHENTICATED_SENTINEL;
 		}
 	}
 
@@ -205,7 +212,7 @@ export function getEnvApiKey(provider: string): string | undefined {
 			getProcEnv("AWS_CONTAINER_CREDENTIALS_FULL_URI") ||
 			getProcEnv("AWS_WEB_IDENTITY_TOKEN_FILE")
 		) {
-			return "<authenticated>";
+			return AUTHENTICATED_SENTINEL;
 		}
 	}
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -23,6 +23,7 @@ import {
 } from "@aws-sdk/client-bedrock-runtime";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import type { BuildMiddleware, DocumentType, MetadataBearer } from "@smithy/types";
+import { AUTHENTICATED_SENTINEL } from "../env-api-keys.ts";
 import { calculateCost } from "../models.ts";
 import type {
 	Api,
@@ -81,7 +82,8 @@ export interface BedrockOptions extends StreamOptions {
 	/** Bearer token for Bedrock API key authentication.
 	 * When set, bypasses SigV4 signing and sends Authorization: Bearer <token> instead.
 	 * Requires `bedrock:CallWithBearerToken` IAM permission on the token's identity.
-	 * Set via AWS_BEARER_TOKEN_BEDROCK env var or pass directly.
+	 * Set via this option, the AWS_BEARER_TOKEN_BEDROCK env var, or the resolved `apiKey`
+	 * (in that precedence order); a gateway token configured as `apiKey` is used as a fallback.
 	 * @see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrock.html */
 	bearerToken?: string;
 }
@@ -138,7 +140,14 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 		}
 
 		// Resolve bearer token for Bedrock API key auth.
-		const bearerToken = options.bearerToken || process.env.AWS_BEARER_TOKEN_BEDROCK || undefined;
+		// Precedence: explicit `bearerToken` option > AWS_BEARER_TOKEN_BEDROCK env var >
+		// resolved `apiKey`. The last source lets a gateway token configured via models.json
+		// `apiKey` (e.g. an OpenAI-style AI gateway fronting Bedrock) authenticate without
+		// also exporting AWS_BEARER_TOKEN_BEDROCK. The "<authenticated>" sentinel that
+		// getEnvApiKey() returns for SigV4/profile/role credentials is not a real token and
+		// must never be promoted to a bearer token, or it would break working SigV4 setups.
+		const apiKeyBearer = options.apiKey && options.apiKey !== AUTHENTICATED_SENTINEL ? options.apiKey : undefined;
+		const bearerToken = options.bearerToken || process.env.AWS_BEARER_TOKEN_BEDROCK || apiKeyBearer || undefined;
 		const useBearerToken = bearerToken !== undefined && process.env.AWS_BEDROCK_SKIP_AUTH !== "1";
 
 		// in Node.js/Bun environment only

--- a/packages/ai/test/bedrock-bearer-token.test.ts
+++ b/packages/ai/test/bedrock-bearer-token.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const bedrockMock = vi.hoisted(() => ({
+	constructorCalls: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+
+	class BedrockRuntimeClient {
+		constructor(config: Record<string, unknown>) {
+			bedrockMock.constructorCalls.push(config);
+		}
+
+		send(): Promise<never> {
+			return Promise.reject(new Error("mock send"));
+		}
+	}
+
+	class ConverseStreamCommand {
+		readonly input: unknown;
+
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+import { AUTHENTICATED_SENTINEL } from "../src/env-api-keys.ts";
+import { getModel } from "../src/models.ts";
+import type { BedrockOptions } from "../src/providers/amazon-bedrock.ts";
+import { streamBedrock, streamSimpleBedrock } from "../src/providers/amazon-bedrock.ts";
+import type { Context, Model } from "../src/types.ts";
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+
+const TOUCHED_ENV = ["AWS_BEARER_TOKEN_BEDROCK", "AWS_BEDROCK_SKIP_AUTH"] as const;
+const originalEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+	bedrockMock.constructorCalls.length = 0;
+	for (const key of TOUCHED_ENV) {
+		originalEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+});
+
+afterEach(() => {
+	for (const key of TOUCHED_ENV) {
+		if (originalEnv[key] === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = originalEnv[key];
+		}
+	}
+});
+
+function getModelFixture(): Model<"bedrock-converse-stream"> {
+	return getModel("amazon-bedrock", "us.anthropic.claude-opus-4-8");
+}
+
+async function captureClientConfig(
+	options: BedrockOptions,
+): Promise<{ token?: { token?: string }; authSchemePreference?: string[] }> {
+	await streamBedrock(getModelFixture(), context, { cacheRetention: "none", ...options }).result();
+	expect(bedrockMock.constructorCalls).toHaveLength(1);
+	return bedrockMock.constructorCalls[0] as {
+		token?: { token?: string };
+		authSchemePreference?: string[];
+	};
+}
+
+describe("bedrock bearer token resolution", () => {
+	it("uses the resolved apiKey as a bearer token when no env var or option is set", async () => {
+		const config = await captureClientConfig({ apiKey: "gateway-token-123" });
+		expect(config.token).toEqual({ token: "gateway-token-123" });
+		expect(config.authSchemePreference).toEqual(["httpBearerAuth"]);
+	});
+
+	it("prefers the explicit bearerToken option over the apiKey", async () => {
+		const config = await captureClientConfig({ apiKey: "gateway-token-123", bearerToken: "explicit-token" });
+		expect(config.token).toEqual({ token: "explicit-token" });
+		expect(config.authSchemePreference).toEqual(["httpBearerAuth"]);
+	});
+
+	it("prefers AWS_BEARER_TOKEN_BEDROCK over the apiKey", async () => {
+		process.env.AWS_BEARER_TOKEN_BEDROCK = "env-token";
+		const config = await captureClientConfig({ apiKey: "gateway-token-123" });
+		expect(config.token).toEqual({ token: "env-token" });
+		expect(config.authSchemePreference).toEqual(["httpBearerAuth"]);
+	});
+
+	it("never promotes the <authenticated> sentinel to a bearer token", async () => {
+		const config = await captureClientConfig({ apiKey: AUTHENTICATED_SENTINEL });
+		expect(config.token).toBeUndefined();
+		expect(config.authSchemePreference).toBeUndefined();
+	});
+
+	it("uses SigV4 (no bearer token) when no apiKey, env var, or option is present", async () => {
+		const config = await captureClientConfig({});
+		expect(config.token).toBeUndefined();
+		expect(config.authSchemePreference).toBeUndefined();
+	});
+
+	it("disables bearer auth when AWS_BEDROCK_SKIP_AUTH=1, even with an apiKey", async () => {
+		process.env.AWS_BEDROCK_SKIP_AUTH = "1";
+		const config = await captureClientConfig({ apiKey: "gateway-token-123" });
+		expect(config.token).toBeUndefined();
+		expect(config.authSchemePreference).toBeUndefined();
+	});
+
+	it("flows the apiKey through the streamSimple entrypoint", async () => {
+		await streamSimpleBedrock(getModelFixture(), context, {
+			cacheRetention: "none",
+			apiKey: "simple-token",
+		}).result();
+		expect(bedrockMock.constructorCalls).toHaveLength(1);
+		const config = bedrockMock.constructorCalls[0] as { token?: { token?: string }; authSchemePreference?: string[] };
+		expect(config.token).toEqual({ token: "simple-token" });
+		expect(config.authSchemePreference).toEqual(["httpBearerAuth"]);
+	});
+});


### PR DESCRIPTION
Fixes #5584.

## Problem

The `bedrock-converse-stream` provider authenticates only via `options.bearerToken` or `AWS_BEARER_TOKEN_BEDROCK`. A gateway token configured through `models.json` `apiKey` (e.g. an AI gateway fronting Bedrock with a bearer token) is silently ignored, so a config that looks complete fails to authenticate unless the same token is *also* exported as `AWS_BEARER_TOKEN_BEDROCK`. Every other provider authenticates from `apiKey`; Bedrock was the surprising exception.

## Change

`packages/ai/src/providers/amazon-bedrock.ts` now uses the resolved `apiKey` as the lowest-precedence bearer-token source:

```
bearerToken option  >  AWS_BEARER_TOKEN_BEDROCK  >  apiKey
```

`apiKey` already reaches the provider via `StreamOptions`, so no signature changes were needed. The `"<authenticated>"` sentinel that `getEnvApiKey()` returns for SigV4 / profile / role credentials is explicitly excluded, so existing SigV4 setups are unaffected, and `AWS_BEDROCK_SKIP_AUTH=1` still disables bearer auth.

The sentinel was a string literal duplicated in two places in `env-api-keys.ts`; it is now an exported `AUTHENTICATED_SENTINEL` constant so the provider guard and the producer cannot drift.

## Tests

New `packages/ai/test/bedrock-bearer-token.test.ts` (7 cases) covers: apiKey → bearer, precedence of `bearerToken` and the env var over apiKey, the sentinel guard, the SigV4 (no-token) path, the `AWS_BEDROCK_SKIP_AUTH` escape hatch, and the `streamSimple` entrypoint.

## Verification

- `npm run check` — passes.
- `packages/ai` test suite — 339 passed / 0 failed (the package I changed).
- `./test.sh` surfaces 3 failures in `packages/coding-agent` (`package-command-paths`, `trust-manager`, `3302-find-path-glob`). These are unrelated to this change — none import the modified modules — and reproduce independently of it; they appear to be environment-sensitive on my machine.
