### PR TITLE
fix(tui): stabilize overlay compositing at wide char boundary

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1057,7 +1057,7 @@ export class TUI extends Container {
 
 		// Single pass through baseLine extracts both before and after segments
 		const afterStart = startCol + overlayWidth;
-		const base = extractSegments(baseLine, startCol, afterStart, totalWidth - afterStart, true);
+		const base = extractSegments(baseLine, startCol, afterStart, totalWidth - afterStart, true, true);
 
 		// Extract overlay with width tracking (strict=true to exclude wide chars at boundary)
 		const overlay = sliceWithWidth(overlayLine, 0, overlayWidth, true);

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1120,6 +1120,7 @@ export function extractSegments(
 	afterStart: number,
 	afterLen: number,
 	strictAfter = false,
+	strictBefore = false,
 ): { before: string; beforeWidth: number; after: string; afterWidth: number } {
 	let before = "",
 		beforeWidth = 0,
@@ -1157,12 +1158,15 @@ export function extractSegments(
 			const w = graphemeWidth(segment);
 
 			if (currentCol < beforeEnd) {
-				if (pendingAnsiBefore) {
-					before += pendingAnsiBefore;
-					pendingAnsiBefore = "";
+				const fits = !strictBefore || currentCol + w <= beforeEnd;
+				if (fits) {
+					if (pendingAnsiBefore) {
+						before += pendingAnsiBefore;
+						pendingAnsiBefore = "";
+					}
+					before += segment;
+					beforeWidth += w;
 				}
-				before += segment;
-				beforeWidth += w;
 			} else if (currentCol >= afterStart && currentCol < afterEnd) {
 				const fits = !strictAfter || currentCol + w <= afterEnd;
 				if (fits) {

--- a/packages/tui/test/overlay-options.test.ts
+++ b/packages/tui/test/overlay-options.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { Component } from "../src/tui.ts";
 import { TUI } from "../src/tui.ts";
+import { visibleWidth } from "../src/utils.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
 class StaticOverlay implements Component {
@@ -121,6 +122,37 @@ describe("TUI overlay options", () => {
 			// Should not crash
 			const viewport = terminal.getViewport();
 			assert.ok(viewport.length > 0);
+			tui.stop();
+		});
+
+		it("should keep overlay columns stable when base wide characters cross the overlay boundary", async () => {
+			class WideBoundaryContent implements Component {
+				render(): string[] {
+					return ["가나다라마바사아자차", "abcdefghijklmnopqrstuvwxyz"];
+				}
+				invalidate(): void {}
+			}
+
+			const terminal = new VirtualTerminal(40, 10);
+			const tui = new TUI(terminal);
+			const overlay = new StaticOverlay(["|BOX|", "|BOX|"]);
+
+			tui.addChild(new WideBoundaryContent());
+			tui.showOverlay(overlay, { anchor: "top-left", col: 5, width: 5 });
+			tui.start();
+			await renderAndFlush(tui, terminal);
+
+			const viewport = terminal.getViewport();
+			for (const row of [0, 1]) {
+				const line = viewport[row] ?? "";
+				const markerIndex = line.indexOf("|BOX|");
+				assert.notStrictEqual(markerIndex, -1, `Expected overlay marker on row ${row}, got: ${line}`);
+				assert.strictEqual(
+					visibleWidth(line.slice(0, markerIndex)),
+					5,
+					`Expected overlay at column 5 on row ${row}`,
+				);
+			}
 			tui.stop();
 		});
 


### PR DESCRIPTION
## Summary

Fix TUI overlay compositing when the overlay start column lands in the middle of a wide base grapheme, such as CJK text. The base "before" segment can otherwise include the crossing grapheme and become wider than the requested overlay start column, shifting the overlay to the right on only some rows. This makes bordered overlays appear misaligned or squeezed over Korean/Japanese/Chinese content.

## Changes

- Add a `strictBefore` option to `extractSegments`.
- Use strict before slicing for overlay compositing so wide base graphemes crossing the overlay boundary are excluded and replaced by padding.
- Add an overlay regression test that verifies overlay markers keep the same visual column on rows with and without wide base characters.

## Verification

```sh
cd packages/tui
node --test test/overlay-options.test.ts
```

```sh
npm run check
```
