### PR TITLE
fix(ai): honor Codex SSE header timeout setting

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -173,13 +173,21 @@ function normalizeTimeoutMs(value: number | undefined): number | undefined {
 	return Math.floor(value);
 }
 
-function createSSEHeaderTimeout(): { signal: AbortSignal; clear: () => void; error: () => Error | undefined } {
+function createSSEHeaderTimeout(timeoutMs = DEFAULT_SSE_HEADER_TIMEOUT_MS): {
+	signal?: AbortSignal;
+	clear: () => void;
+	error: () => Error | undefined;
+} {
+	if (timeoutMs === 0) {
+		return { clear: () => {}, error: () => undefined };
+	}
+
 	const controller = new AbortController();
 	let error: Error | undefined;
 	const timeout = setTimeout(() => {
-		error = new Error(`Codex SSE response headers timed out after ${DEFAULT_SSE_HEADER_TIMEOUT_MS}ms`);
+		error = new Error(`Codex SSE response headers timed out after ${timeoutMs}ms`);
 		controller.abort(error);
-	}, DEFAULT_SSE_HEADER_TIMEOUT_MS);
+	}, timeoutMs);
 	return {
 		signal: controller.signal,
 		clear: () => clearTimeout(timeout),
@@ -309,7 +317,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				}
 
 				try {
-					const headerTimeout = createSSEHeaderTimeout();
+					const headerTimeout = createSSEHeaderTimeout(idleTimeoutMs);
 					const combinedSignal = combineAbortSignals([options?.signal, headerTimeout.signal]);
 					try {
 						response = await fetch(resolveCodexUrl(model.baseUrl), {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -370,6 +370,61 @@ describe("openai-codex streaming", () => {
 		expect(result.errorMessage).toBe("Codex SSE response headers timed out after 10000ms");
 	});
 
+	it("uses timeoutMs for the SSE response-header timeout", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-13T00:00:00Z"));
+		const token = mockToken();
+		const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+			const signal = init?.signal;
+			if (!signal) {
+				throw new Error("Expected SSE fetch to receive an abort signal");
+			}
+
+			return new Promise<Response>((_, reject) => {
+				const onAbort = () => {
+					const reason = signal.reason;
+					reject(reason instanceof Error ? reason : new Error("SSE fetch aborted"));
+				};
+				if (signal.aborted) {
+					onAbort();
+					return;
+				}
+				signal.addEventListener("abort", onAbort, { once: true });
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const resultPromise = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+			timeoutMs: 30_000,
+		}).result();
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(20_000);
+		const result = await resultPromise;
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Codex SSE response headers timed out after 30000ms");
+	});
+
 	it("aborts SSE body reads after response headers arrive", async () => {
 		const token = mockToken();
 		const encoder = new TextEncoder();


### PR DESCRIPTION
## Summary

Codex SSE has a separate timeout while waiting for response headers. It was hardcoded to 10 seconds, so slow or unstable connections could fail with `Codex SSE response headers timed out after 10000ms` even when the caller configured a longer `timeoutMs`/`httpIdleTimeoutMs`.

This changes the Codex SSE header timeout to use the same normalized `timeoutMs` value used for stream idleness. `timeoutMs: 0` disables the header timeout, matching the existing WebSocket idle-timeout behavior.

## Testing

- `git diff --check`
- `cd packages/ai && node ../../node_modules/vitest/dist/cli.js --run test/openai-codex-stream.test.ts`
- `npm run check`

Note: `./test.sh` currently fails on clean `upstream/main` in unrelated Claude Fable 5 thinking tests. I verified the same failures after restoring this branch's two changed files.
