### PR TITLE
fix(ai): add required: [] to tool schemas with only optional params

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -990,6 +990,31 @@ export function convertMessages(
 	return params;
 }
 
+/**
+ * Recursively cleans null values and ensures `required: []` for object schemas.
+ * TypeBox omits `required` when all fields are optional; some providers
+ * (Claude, OpenAI Responses API) treat the missing field as null and reject it.
+ */
+function sanitizeSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	if (schema === null || typeof schema !== "object")
+		return schema;
+	if (Array.isArray(schema))
+		return schema.map((item: unknown) => (typeof item === "object" ? sanitizeSchema(item as Record<string, unknown>) : item));
+	const cleaned: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		const cleanedValue = value !== null && typeof value === "object" ? sanitizeSchema(value as Record<string, unknown>) : value;
+		if (cleanedValue === null) continue;
+		cleaned[key] = cleanedValue;
+	}
+	if (cleaned.type === "object" && !Array.isArray(cleaned.required)) {
+		cleaned.required = [];
+	}
+	if (cleaned.type === "array" && cleaned.items === undefined) {
+		cleaned.items = {};
+	}
+	return cleaned;
+}
+
 function convertTools(
 	tools: Tool[],
 	compat: ResolvedOpenAICompletionsCompat,
@@ -999,7 +1024,7 @@ function convertTools(
 		function: {
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters as any, // TypeBox already generates JSON Schema
+			parameters: sanitizeSchema(tool.parameters as Record<string, unknown>),
 			// Only include strict if provider supports it. Some reject unknown fields.
 			...(compat.supportsStrictMode !== false && { strict: false }),
 		},

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -270,13 +270,38 @@ export function convertResponsesMessages<TApi extends Api>(
 // Tool conversion
 // =============================================================================
 
+/**
+ * Recursively cleans null values and ensures `required: []` for object schemas.
+ * TypeBox omits `required` when all fields are optional; some providers
+ * (Claude, OpenAI Responses API) treat the missing field as null and reject it.
+ */
+function sanitizeSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	if (schema === null || typeof schema !== "object")
+		return schema;
+	if (Array.isArray(schema))
+		return schema.map((item: unknown) => (typeof item === "object" ? sanitizeSchema(item as Record<string, unknown>) : item));
+	const cleaned: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		const cleanedValue = value !== null && typeof value === "object" ? sanitizeSchema(value as Record<string, unknown>) : value;
+		if (cleanedValue === null) continue;
+		cleaned[key] = cleanedValue;
+	}
+	if (cleaned.type === "object" && !Array.isArray(cleaned.required)) {
+		cleaned.required = [];
+	}
+	if (cleaned.type === "array" && cleaned.items === undefined) {
+		cleaned.items = {};
+	}
+	return cleaned;
+}
+
 export function convertResponsesTools(tools: Tool[], options?: ConvertResponsesToolsOptions): OpenAITool[] {
 	const strict = options?.strict === undefined ? false : options.strict;
 	return tools.map((tool) => ({
 		type: "function",
 		name: tool.name,
 		description: tool.description,
-		parameters: tool.parameters as any, // TypeBox already generates JSON Schema
+		parameters: sanitizeSchema(tool.parameters as Record<string, unknown>),
 		strict,
 	}));
 }


### PR DESCRIPTION
## Summary

When a tool has only optional parameters (e.g., TypeBox `Type.Optional()` fields), TypeBox omits `required` from the JSON Schema entirely. Some providers (Claude, OpenAI Responses API) treat the missing `required` field as `null` and reject the request with:

```
400 Invalid schema for function 'subagent': null is not of type "array"
```

## Fix

Adds a `sanitizeSchema()` helper that:
1. Strips all `null` values recursively
2. Ensures `required: []` for every object schema that lacks it
3. Ensures `items: {}` for every array schema that lacks it

Applied to both `convertTools()` (openai-completions) and `convertResponsesTools()` (openai-responses-shared).

Fixes #2099, #1964