### PR TITLE
expose session name change event

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -389,6 +389,17 @@ pi.on("session_start", async (event, ctx) => {
 });
 ```
 
+#### session_info_changed
+
+Fired when the current session display name changes through `/name` or `pi.setSessionName()`.
+For an initial name supplied at startup, read `ctx.sessionManager.getSessionName()` from `session_start`.
+
+```typescript
+pi.on("session_info_changed", (event) => {
+  console.log(`Session name: ${event.name ?? "unnamed"}`);
+});
+```
+
 #### session_before_switch
 
 Fired before starting a new session (`/new`) or switching sessions (`/resume`).
@@ -1382,6 +1393,7 @@ pi.on("session_start", async (_event, ctx) => {
 ### pi.setSessionName(name)
 
 Set the session display name (shown in session selector instead of first message).
+Emits `session_info_changed`.
 
 ```typescript
 pi.setSessionName("Refactor auth module");

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2681,7 +2681,9 @@ export class AgentSession {
 	 */
 	setSessionName(name: string): void {
 		this.sessionManager.appendSessionInfo(name);
-		this._emit({ type: "session_info_changed", name: this.sessionManager.getSessionName() });
+		const currentName = this.sessionManager.getSessionName();
+		void this._extensionRunner.emit({ type: "session_info_changed", name: currentName });
+		this._emit({ type: "session_info_changed", name: currentName });
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -128,6 +128,7 @@ export type {
 	SessionBeforeTreeResult,
 	SessionCompactEvent,
 	SessionEvent,
+	SessionInfoChangedEvent,
 	SessionShutdownEvent,
 	// Events - Session
 	SessionStartEvent,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -551,6 +551,13 @@ export interface SessionStartEvent {
 	previousSessionFile?: string;
 }
 
+/** Fired when the current session display name changes. */
+export interface SessionInfoChangedEvent {
+	type: "session_info_changed";
+	/** Current session display name, or undefined when the title is cleared. */
+	name: string | undefined;
+}
+
 /** Fired before switching to another session (can be cancelled) */
 export interface SessionBeforeSwitchEvent {
 	type: "session_before_switch";
@@ -622,6 +629,7 @@ export interface SessionTreeEvent {
 
 export type SessionEvent =
 	| SessionStartEvent
+	| SessionInfoChangedEvent
 	| SessionBeforeSwitchEvent
 	| SessionBeforeForkEvent
 	| SessionBeforeCompactEvent
@@ -1125,6 +1133,7 @@ export interface ExtensionAPI {
 	on(event: "project_trust", handler: ProjectTrustHandler): void;
 	on(event: "resources_discover", handler: ExtensionHandler<ResourcesDiscoverEvent, ResourcesDiscoverResult>): void;
 	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
+	on(event: "session_info_changed", handler: ExtensionHandler<SessionInfoChangedEvent>): void;
 	on(
 		event: "session_before_switch",
 		handler: ExtensionHandler<SessionBeforeSwitchEvent, SessionBeforeSwitchResult>,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -114,6 +114,7 @@ export type {
 	SessionBeforeSwitchEvent,
 	SessionBeforeTreeEvent,
 	SessionCompactEvent,
+	SessionInfoChangedEvent,
 	SessionShutdownEvent,
 	SessionStartEvent,
 	SessionTreeEvent,

--- a/packages/coding-agent/test/suite/regressions/3686-session-name-event.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3686-session-name-event.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
-import type { ExtensionAPI } from "../../../src/index.ts";
+import type { ExtensionAPI, SessionInfoChangedEvent } from "../../../src/index.ts";
 import { createHarness, type Harness } from "../harness.ts";
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe("regression #3686: session name changes emit an event", () => {
 	const harnesses: Harness[] = [];
@@ -12,29 +14,46 @@ describe("regression #3686: session name changes emit an event", () => {
 	});
 
 	it("emits session_info_changed when AgentSession.setSessionName is called", async () => {
-		const harness = await createHarness();
+		const extensionEvents: SessionInfoChangedEvent[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_info_changed", (event) => {
+						extensionEvents.push(event);
+					});
+				},
+			],
+		});
 		harnesses.push(harness);
 
 		harness.session.setSessionName("hello world");
+		await tick();
 
 		expect(harness.sessionManager.getSessionName()).toBe("hello world");
 		expect(harness.eventsOfType("session_info_changed").map((event) => event.name)).toEqual(["hello world"]);
+		expect(extensionEvents.map((event) => event.name)).toEqual(["hello world"]);
 	});
 
 	it("emits session_info_changed when an extension calls pi.setSessionName", async () => {
 		let api: ExtensionAPI | undefined;
+		const extensionEvents: SessionInfoChangedEvent[] = [];
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
 					api = pi;
+					pi.on("session_info_changed", (event) => {
+						extensionEvents.push(event);
+					});
 				},
 			],
 		});
 		harnesses.push(harness);
 
 		api?.setSessionName("from extension");
+		await tick();
 
 		expect(harness.sessionManager.getSessionName()).toBe("from extension");
 		expect(harness.eventsOfType("session_info_changed").map((event) => event.name)).toEqual(["from extension"]);
+		expect(extensionEvents.map((event) => event.name)).toEqual(["from extension"]);
 	});
 });


### PR DESCRIPTION
[Agent Workbench](https://plugins.jetbrains.com/plugin/30926-agent-workbench/), plugin for IntelliJ IDEA, needs a stable way to observe live `/name` updates without parsing session files. Pi already had an internal `session_info_changed` event for the TUI, but extensions could not subscribe to it.

Publish`session_info_changed` through ExtensionAPI and emit it from`setSessionName` while keeping the internal session event. Extend regression coverage and docs so extension authors can rely on the event.