### PR TITLE
fix(coding-agent): skip first-time setup for forks

### DIFF
--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -1,6 +1,6 @@
 import { ProcessTerminal, setKeybindings, TUI } from "@earendil-works/pi-tui";
 import { existsSync } from "fs";
-import { ENV_AGENT_DIR, getSettingsPath } from "../config.ts";
+import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, getSettingsPath, PACKAGE_NAME } from "../config.ts";
 import { areExperimentalFeaturesEnabled } from "../core/experimental.ts";
 import { KeybindingsManager } from "../core/keybindings.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";
@@ -11,6 +11,24 @@ import {
 	type FirstTimeSetupResult,
 } from "../modes/interactive/components/first-time-setup.ts";
 import { detectTerminalBackground, initTheme, setTheme } from "../modes/interactive/theme/theme.ts";
+
+const OFFICIAL_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
+const OFFICIAL_APP_NAME = "pi";
+const OFFICIAL_CONFIG_DIR_NAME = ".pi";
+
+interface DistributionMetadata {
+	packageName: string;
+	appName: string;
+	configDirName: string;
+}
+
+function isOfficialDistribution({ packageName, appName, configDirName }: DistributionMetadata): boolean {
+	return (
+		packageName === OFFICIAL_PACKAGE_NAME &&
+		appName === OFFICIAL_APP_NAME &&
+		configDirName === OFFICIAL_CONFIG_DIR_NAME
+	);
+}
 
 function createStartupTui(settingsManager: SettingsManager): TUI {
 	initTheme(settingsManager.getTheme());
@@ -28,11 +46,21 @@ async function clearStartupTui(ui: TUI): Promise<void> {
 
 /**
  * First-time setup runs when all of these hold:
+ * - this is the official Pi distribution (not a fork/rebrand)
  * - experimental features are enabled (PI_EXPERIMENTAL=1)
  * - the default agent directory is used (no custom agent dir override)
  * - setup was not completed before (settings.json does not exist)
  */
 export function shouldRunFirstTimeSetup(settingsPath: string = getSettingsPath()): boolean {
+	if (
+		!isOfficialDistribution({
+			packageName: PACKAGE_NAME,
+			appName: APP_NAME,
+			configDirName: CONFIG_DIR_NAME,
+		})
+	) {
+		return false;
+	}
 	if (!areExperimentalFeaturesEnabled()) {
 		return false;
 	}

--- a/packages/coding-agent/test/first-time-setup-fork.test.ts
+++ b/packages/coding-agent/test/first-time-setup-fork.test.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/config.ts", async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...(actual as Record<string, unknown>),
+		PACKAGE_NAME: "@example/pi-coding-agent",
+	};
+});
+
+import { shouldRunFirstTimeSetup } from "../src/cli/startup-ui.ts";
+
+describe("shouldRunFirstTimeSetup in forked distributions", () => {
+	const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+	let tempDir: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-first-time-setup-fork-"));
+		settingsPath = join(tempDir, "settings.json");
+		process.env.PI_EXPERIMENTAL = "1";
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		if (originalPiExperimental === undefined) {
+			delete process.env.PI_EXPERIMENTAL;
+		} else {
+			process.env.PI_EXPERIMENTAL = originalPiExperimental;
+		}
+	});
+
+	it("returns false for a forked package", () => {
+		expect(shouldRunFirstTimeSetup(settingsPath)).toBe(false);
+	});
+});


### PR DESCRIPTION
Small follow up to 0ab2aa86af862ca1cf4b0b86fcbee14d00e1441f. Not updating changelog here because it doesn't impact it