### PR TITLE
fix(coding-agent): bind image paste to Alt+V on WSL

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
 
+### Fixed
+
+- Fixed clipboard image paste on WSL by binding image paste to Alt+V there, matching native Windows. Windows Terminal intercepts Ctrl+V as a text paste, so the Ctrl+V keypress never reached the app and image paste silently did nothing.
+
 ## [0.79.1] - 2026-06-09
 
 ### New Features

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -9,6 +9,7 @@ import {
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { getAgentDir } from "../config.ts";
+import { isWSL } from "../utils/wsl.ts";
 
 export interface AppKeybindings {
 	"app.interrupt": true;
@@ -104,7 +105,10 @@ export const KEYBINDINGS = {
 		description: "Restore queued messages",
 	},
 	"app.clipboard.pasteImage": {
-		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
+		// On Windows Terminal (including WSL), Ctrl+V is intercepted by the terminal
+		// as a text paste, so the image-paste keypress never reaches the app. Alt+V
+		// (ESC v) passes through, so use it on Windows and WSL.
+		defaultKeys: process.platform === "win32" || isWSL() ? "alt+v" : "ctrl+v",
 		description: "Paste image from clipboard",
 	},
 	"app.session.new": { defaultKeys: [], description: "Start a new session" },

--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 
 import { clipboard } from "./clipboard-native.ts";
 import { loadPhoton } from "./photon.ts";
+import { isWSL } from "./wsl.ts";
 
 export type ClipboardImage = {
 	bytes: Uint8Array;
@@ -138,19 +139,6 @@ function readClipboardImageViaWlPaste(): ClipboardImage | null {
 	}
 
 	return { bytes: data.stdout, mimeType: baseMimeType(selectedType) };
-}
-
-function isWSL(env: NodeJS.ProcessEnv = process.env): boolean {
-	if (env.WSL_DISTRO_NAME || env.WSLENV) {
-		return true;
-	}
-
-	try {
-		const release = readFileSync("/proc/version", "utf-8");
-		return /microsoft|wsl/i.test(release);
-	} catch {
-		return false;
-	}
 }
 
 /**

--- a/packages/coding-agent/src/utils/wsl.ts
+++ b/packages/coding-agent/src/utils/wsl.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "fs";
+
+/**
+ * Detect whether the current process is running under Windows Subsystem for Linux.
+ *
+ * Checks the WSL-specific environment variables first, then falls back to the
+ * kernel release string in `/proc/version`.
+ */
+export function isWSL(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.WSL_DISTRO_NAME || env.WSLENV) {
+		return true;
+	}
+
+	try {
+		const release = readFileSync("/proc/version", "utf-8");
+		return /microsoft|wsl/i.test(release);
+	} catch {
+		return false;
+	}
+}

--- a/packages/coding-agent/test/wsl.test.ts
+++ b/packages/coding-agent/test/wsl.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isWSL } from "../src/utils/wsl.ts";
+
+describe("isWSL", () => {
+	it("detects WSL via WSL_DISTRO_NAME", () => {
+		expect(isWSL({ WSL_DISTRO_NAME: "Ubuntu" })).toBe(true);
+	});
+
+	it("detects WSL via WSLENV", () => {
+		expect(isWSL({ WSLENV: "PATH/l" })).toBe(true);
+	});
+
+	it("returns false for a plain Linux environment without /proc/version markers", () => {
+		// No WSL env vars set; /proc/version on the test host (real Linux CI) does
+		// not contain microsoft/wsl, and on non-Linux the read throws and returns false.
+		const result = isWSL({});
+		expect(typeof result).toBe("boolean");
+	});
+});


### PR DESCRIPTION
Windows terminal (and conhost, and hyper on windows) swallows Ctl+V as text paste (if image, just expands into [] -> empty text) so the keypress never reaches the app, thus silently doing nothing. 

This is already handled on windows through using alternative binding (Alt-V) but WT/conhost can also be used for WSL (linux platform). This fixes the issue through extending the detection to windows or wsl.

Fixes #5632 

---

I also have an alternative solution through heuristically handling [] as possible image paste coming in a separate PR if that was preferable. That solution would have the benefit of (possibly) correctly handing pasting from [clipboard history view](https://www.microsoft.com/en-us/windows/learning-center/how-to-use-clipboard-history-in-windows-11?msockid=2b1380b8bb8569f23202960abae96883). #5640

^^ would probably be preferred solution, but providing both for completness 

---

Since some Windows terminals (Alacritty, WezTerm, mintty) don't swallow ctrl-v, I also briefly considered detecting based on terminal / adding both but that just seem a bit more confusing UX (even if it allows standard crtl-v for the terminals that can handle that).

---

Feel free to let me know if there's another preference on how to handle this.