### PR TITLE
feat: add PI_GIT_TOKEN / GITHUB_TOKEN support for private HTTPS git installs

### DIFF
--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -85,6 +85,7 @@ ssh://git@github.com/user/repo@v1
 - HTTPS and SSH URLs are both supported.
 - SSH URLs use your configured SSH keys automatically (respects `~/.ssh/config`).
 - For non-interactive runs (for example CI), you can set `GIT_TERMINAL_PROMPT=0` to disable credential prompts and set `GIT_SSH_COMMAND` (for example `ssh -o BatchMode=yes -o ConnectTimeout=5`) to fail fast.
+- For private HTTPS repositories, set `PI_GIT_TOKEN` (or `GITHUB_TOKEN`) to a personal access token. The token is embedded in the HTTPS clone URL and persisted in the clone's remote config so that subsequent updates authenticate automatically. SSH remotes are unaffected.
 - Refs are pinned tags or commits. `pi update` and `pi update --extensions` do not move them to newer refs, but they do reconcile an existing clone to the configured ref.
 - Use `pi install git:host/user/repo@new-ref` to update settings and move an existing package to a new pinned ref.
 - Cloned to `~/.pi/agent/git/<host>/<path>` (global) or `.pi/git/<host>/<path>` (project).

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -29,7 +29,7 @@ import ignore from "ignore";
 import { minimatch } from "minimatch";
 import { CONFIG_DIR_NAME } from "../config.ts";
 import { spawnProcess, spawnProcessSync } from "../utils/child-process.ts";
-import { type GitSource, parseGitUrl } from "../utils/git.ts";
+import { applyGitHttpsToken, type GitSource, parseGitUrl } from "../utils/git.ts";
 import { canonicalizePath, isLocalPath, markPathIgnoredByCloudSync, resolvePath } from "../utils/paths.ts";
 import { isStdoutTakenOver } from "./output-guard.ts";
 import type { PackageSource, SettingsManager } from "./settings-manager.ts";
@@ -42,6 +42,20 @@ function isOfflineModeEnabled(): boolean {
 	const value = process.env.PI_OFFLINE;
 	if (!value) return false;
 	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
+}
+
+/**
+ * Return a git credential token for HTTPS clones, if one is configured.
+ *
+ * Checks PI_GIT_TOKEN first (pi-specific), then falls back to GITHUB_TOKEN
+ * (widely-used by CI environments). The token is embedded in the HTTPS clone
+ * URL so that both the initial clone and subsequent `git fetch` calls (which
+ * use the persisted remote URL) authenticate correctly.
+ *
+ * Only HTTPS URLs are affected — SSH remotes ignore this value entirely.
+ */
+function getGitToken(): string | undefined {
+	return process.env.PI_GIT_TOKEN || process.env.GITHUB_TOKEN || undefined;
 }
 
 export interface PathMetadata {
@@ -1777,7 +1791,8 @@ export class DefaultPackageManager implements PackageManager {
 		}
 		mkdirSync(dirname(targetDir), { recursive: true });
 
-		await this.runCommand("git", ["clone", source.repo, targetDir]);
+		const cloneUrl = applyGitHttpsToken(source.repo, getGitToken());
+		await this.runCommand("git", ["clone", cloneUrl, targetDir]);
 		if (source.ref) {
 			await this.runCommand("git", ["checkout", source.ref], { cwd: targetDir });
 		}

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -163,6 +163,30 @@ function parseGenericGitUrl(url: string): GitSource | null {
 }
 
 /**
+ * Embed a token into an HTTPS clone URL for private-repo authentication.
+ *
+ * Only modifies `https://` URLs; SSH URLs are left unchanged because they
+ * rely on the configured SSH key. If the URL already contains credentials,
+ * it is returned as-is to avoid overwriting explicit configuration.
+ *
+ * @param repo - The clone URL (from GitSource.repo)
+ * @param token - A personal-access token or password, or undefined to skip
+ * @returns The URL with the token embedded, or the original URL unchanged
+ */
+export function applyGitHttpsToken(repo: string, token: string | undefined): string {
+	if (!token) return repo;
+	if (!/^https:\/\//i.test(repo)) return repo;
+	try {
+		const url = new URL(repo);
+		if (url.username || url.password) return repo;
+		url.username = token;
+		return url.toString();
+	} catch {
+		return repo;
+	}
+}
+
+/**
  * Parse git source into a GitSource.
  *
  * Rules:

--- a/packages/coding-agent/test/git-ssh-url.test.ts
+++ b/packages/coding-agent/test/git-ssh-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseGitUrl } from "../src/utils/git.ts";
+import { applyGitHttpsToken, parseGitUrl } from "../src/utils/git.ts";
 
 describe("Git URL Parsing", () => {
 	describe("protocol URLs (accepted without git: prefix)", () => {
@@ -87,5 +87,37 @@ describe("Git URL Parsing", () => {
 		it("should reject user/repo shorthand", () => {
 			expect(parseGitUrl("user/repo")).toBeNull();
 		});
+	});
+});
+
+describe("applyGitHttpsToken", () => {
+	it("embeds token into an HTTPS URL", () => {
+		expect(applyGitHttpsToken("https://github.com/org/repo", "mytoken")).toBe("https://mytoken@github.com/org/repo");
+	});
+
+	it("leaves SSH SCP-like URLs unchanged", () => {
+		const url = "git@github.com:org/repo";
+		expect(applyGitHttpsToken(url, "mytoken")).toBe(url);
+	});
+
+	it("leaves ssh:// URLs unchanged", () => {
+		const url = "ssh://git@github.com/org/repo";
+		expect(applyGitHttpsToken(url, "mytoken")).toBe(url);
+	});
+
+	it("returns original URL when token is undefined", () => {
+		const url = "https://github.com/org/repo";
+		expect(applyGitHttpsToken(url, undefined)).toBe(url);
+	});
+
+	it("does not override existing credentials in URL", () => {
+		const url = "https://existinguser@github.com/org/repo";
+		expect(applyGitHttpsToken(url, "newtoken")).toBe(url);
+	});
+
+	it("handles HTTPS URL with path segments", () => {
+		expect(applyGitHttpsToken("https://example.com/org/nested/repo", "tok")).toBe(
+			"https://tok@example.com/org/nested/repo",
+		);
 	});
 });

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -743,6 +743,102 @@ Content`,
 			);
 		});
 
+		it("should embed PI_GIT_TOKEN in HTTPS clone URL", async () => {
+			const previousToken = process.env.PI_GIT_TOKEN;
+			process.env.PI_GIT_TOKEN = "mytoken123";
+			try {
+				const source = "git:github.com/user/private-repo";
+				const targetDir = join(agentDir, "git", "github.com", "user", "private-repo");
+				const runCommandSpy = vi
+					.spyOn(packageManager as any, "runCommand")
+					.mockImplementation(async (...callArgs: unknown[]) => {
+						const [command, args] = callArgs as [string, string[]];
+						if (command === "git" && args[0] === "clone") {
+							mkdirSync(targetDir, { recursive: true });
+						}
+					});
+
+				await packageManager.install(source);
+
+				expect(runCommandSpy).toHaveBeenCalledWith("git", [
+					"clone",
+					"https://mytoken123@github.com/user/private-repo",
+					targetDir,
+				]);
+			} finally {
+				if (previousToken === undefined) {
+					delete process.env.PI_GIT_TOKEN;
+				} else {
+					process.env.PI_GIT_TOKEN = previousToken;
+				}
+			}
+		});
+
+		it("should embed GITHUB_TOKEN in HTTPS clone URL when PI_GIT_TOKEN is absent", async () => {
+			const previousPiToken = process.env.PI_GIT_TOKEN;
+			const previousGhToken = process.env.GITHUB_TOKEN;
+			delete process.env.PI_GIT_TOKEN;
+			process.env.GITHUB_TOKEN = "ghtoken456";
+			try {
+				const source = "git:github.com/user/private-repo";
+				const targetDir = join(agentDir, "git", "github.com", "user", "private-repo");
+				const runCommandSpy = vi
+					.spyOn(packageManager as any, "runCommand")
+					.mockImplementation(async (...callArgs: unknown[]) => {
+						const [command, args] = callArgs as [string, string[]];
+						if (command === "git" && args[0] === "clone") {
+							mkdirSync(targetDir, { recursive: true });
+						}
+					});
+
+				await packageManager.install(source);
+
+				expect(runCommandSpy).toHaveBeenCalledWith("git", [
+					"clone",
+					"https://ghtoken456@github.com/user/private-repo",
+					targetDir,
+				]);
+			} finally {
+				if (previousPiToken === undefined) {
+					delete process.env.PI_GIT_TOKEN;
+				} else {
+					process.env.PI_GIT_TOKEN = previousPiToken;
+				}
+				if (previousGhToken === undefined) {
+					delete process.env.GITHUB_TOKEN;
+				} else {
+					process.env.GITHUB_TOKEN = previousGhToken;
+				}
+			}
+		});
+
+		it("should not embed token in SSH clone URLs", async () => {
+			const previousToken = process.env.PI_GIT_TOKEN;
+			process.env.PI_GIT_TOKEN = "mytoken123";
+			try {
+				const source = "git:git@github.com:user/private-repo";
+				const targetDir = join(agentDir, "git", "github.com", "user", "private-repo");
+				const runCommandSpy = vi
+					.spyOn(packageManager as any, "runCommand")
+					.mockImplementation(async (...callArgs: unknown[]) => {
+						const [command, args] = callArgs as [string, string[]];
+						if (command === "git" && args[0] === "clone") {
+							mkdirSync(targetDir, { recursive: true });
+						}
+					});
+
+				await packageManager.install(source);
+
+				expect(runCommandSpy).toHaveBeenCalledWith("git", ["clone", "git@github.com:user/private-repo", targetDir]);
+			} finally {
+				if (previousToken === undefined) {
+					delete process.env.PI_GIT_TOKEN;
+				} else {
+					process.env.PI_GIT_TOKEN = previousToken;
+				}
+			}
+		});
+
 		it("should install git package dependencies with --omit=dev", async () => {
 			const source = "git:github.com/user/repo";
 			const targetDir = join(agentDir, "git", "github.com", "user", "repo");


### PR DESCRIPTION
When PI_GIT_TOKEN or GITHUB_TOKEN is set, the token is embedded in the HTTPS clone URL so private repositories can be installed with pi install git:github.com/org/private-repo. SSH remotes are unaffected. The token persists in the clone's remote URL so that subsequent pi update fetches also authenticate.