### PR TITLE
feat(coding-agent): paste clipboard images via Ctrl+V on Windows term…

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 - Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
+- Added Ctrl+V clipboard image paste in Windows Terminal (including WSL). Windows Terminal intercepts Ctrl+V as a text paste and emits an empty bracketed paste when the clipboard holds an image; pi now detects that and reads the image from the clipboard, so Ctrl+V pastes images as it does in other terminals.
+
+### Changed
+
+- Changed clipboard image paste to bind to Ctrl+V on all platforms (previously Alt+V on Windows), relying on the Windows Terminal empty-bracketed-paste heuristic for terminals that intercept Ctrl+V.
 
 ## [0.79.1] - 2026-06-09
 

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -87,7 +87,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `app.exit` | `ctrl+d` | Exit (when editor empty) |
 | `app.suspend` | `ctrl+z` (none on Windows) | Suspend to background |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
-| `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image from clipboard |
+| `app.clipboard.pasteImage` | `ctrl+v` | Paste image from clipboard |
 
 ### Sessions
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -104,7 +104,7 @@ export const KEYBINDINGS = {
 		description: "Restore queued messages",
 	},
 	"app.clipboard.pasteImage": {
-		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
+		defaultKeys: "ctrl+v",
 		description: "Paste image from clipboard",
 	},
 	"app.session.new": { defaultKeys: [], description: "Start a new session" },

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -1,5 +1,6 @@
 import { Editor, type EditorOptions, type EditorTheme, type TUI } from "@earendil-works/pi-tui";
 import type { AppKeybinding, KeybindingsManager } from "../../../core/keybindings.ts";
+import { isCtrlVPasteInterceptingTerminal, isEmptyBracketedPaste } from "../../../utils/terminal-env.ts";
 
 /**
  * Custom editor that handles app-level keybindings for coding-agent.
@@ -36,6 +37,18 @@ export class CustomEditor extends Editor {
 		// Check for paste image keybinding
 		if (this.keybindings.matches(data, "app.clipboard.pasteImage")) {
 			this.onPasteImage?.();
+			return;
+		}
+
+		// app.clipboard.pasteImage is bound to Ctrl+V on all platforms, but some
+		// terminals (Windows Terminal including WSL, Hyper, conhost) intercept
+		// Ctrl+V as a text paste, so that keypress never reaches the keybinding
+		// check above. When the clipboard holds an image rather than text, those
+		// terminals emit an empty bracketed paste with no payload. Treat that as a
+		// request to paste an image from the clipboard so Ctrl+V pastes images like
+		// it does in other terminals.
+		if (this.onPasteImage && isCtrlVPasteInterceptingTerminal() && isEmptyBracketedPaste(data)) {
+			this.onPasteImage();
 			return;
 		}
 

--- a/packages/coding-agent/src/utils/terminal-env.ts
+++ b/packages/coding-agent/src/utils/terminal-env.ts
@@ -1,0 +1,57 @@
+/**
+ * Detect a Windows host terminal that intercepts Ctrl+V as a text paste.
+ *
+ * Covers the common Windows terminals:
+ * - Windows Terminal: sets `WT_SESSION` (and `WT_PROFILE_ID`). These are
+ *   inherited by processes running inside a WSL session launched from a
+ *   Windows Terminal tab.
+ * - Hyper: sets `TERM_PROGRAM=Hyper`.
+ * - conhost (the legacy Windows console host): exposes no dedicated env
+ *   marker, so it is detected as the Windows fallback: `win32` with neither
+ *   `WT_SESSION` nor `TERM_PROGRAM` set.
+ *
+ * This enables the empty-bracketed-paste clipboard-image heuristic, because
+ * these terminals intercept Ctrl+V as a text paste and emit an empty bracketed
+ * paste when the clipboard holds an image rather than text.
+ */
+export function isCtrlVPasteInterceptingTerminal(
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	if (env.WT_SESSION) {
+		return true;
+	}
+	if (env.TERM_PROGRAM === "Hyper") {
+		return true;
+	}
+	// conhost has no distinguishing env var; treat a Windows console with no
+	// terminal markers (no WT_SESSION, no TERM_PROGRAM) as conhost. A set
+	// TERM_PROGRAM means some other terminal we don't know intercepts Ctrl+V.
+	return platform === "win32" && !env.WT_SESSION && !env.TERM_PROGRAM;
+}
+
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
+
+/**
+ * Detect a self-contained empty bracketed paste.
+ *
+ * Returns true only when the start and end markers appear in the same chunk
+ * with an empty payload between them. Ongoing multi-chunk pastes (a start
+ * marker without a matching end marker) return false so the editor can buffer
+ * them normally. A whitespace-only payload is treated as real pasted text
+ * (e.g. copied indentation or blank lines), not the image signal. Windows host
+ * terminals (Windows Terminal, Hyper, conhost) emit exactly this empty form
+ * when Ctrl+V is pressed while the clipboard holds an image instead of text.
+ */
+export function isEmptyBracketedPaste(data: string): boolean {
+	const start = data.indexOf(BRACKETED_PASTE_START);
+	if (start === -1) {
+		return false;
+	}
+	const end = data.indexOf(BRACKETED_PASTE_END, start + BRACKETED_PASTE_START.length);
+	if (end === -1) {
+		return false;
+	}
+	return end === start + BRACKETED_PASTE_START.length;
+}

--- a/packages/coding-agent/test/terminal-env.test.ts
+++ b/packages/coding-agent/test/terminal-env.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { isCtrlVPasteInterceptingTerminal, isEmptyBracketedPaste } from "../src/utils/terminal-env.ts";
+
+describe("isCtrlVPasteInterceptingTerminal", () => {
+	it("detects Windows Terminal via WT_SESSION", () => {
+		expect(isCtrlVPasteInterceptingTerminal({ WT_SESSION: "abc-123" }, "linux")).toBe(true);
+	});
+
+	it("detects Hyper via TERM_PROGRAM", () => {
+		expect(isCtrlVPasteInterceptingTerminal({ TERM_PROGRAM: "Hyper" }, "linux")).toBe(true);
+	});
+
+	it("detects conhost as the Windows fallback (win32, no terminal markers)", () => {
+		expect(isCtrlVPasteInterceptingTerminal({}, "win32")).toBe(true);
+		expect(isCtrlVPasteInterceptingTerminal({ WT_SESSION: "", TERM_PROGRAM: "" }, "win32")).toBe(true);
+	});
+
+	it("does not treat a win32 terminal we know forwards Ctrl+V (VS Code) as conhost", () => {
+		// VS Code's integrated terminal sets TERM_PROGRAM=vscode and delivers Ctrl+V
+		// to the app, so the empty-bracketed-paste heuristic must not kick in.
+		expect(isCtrlVPasteInterceptingTerminal({ TERM_PROGRAM: "vscode" }, "win32")).toBe(false);
+	});
+
+	it("returns false on non-Windows without a known terminal marker", () => {
+		expect(isCtrlVPasteInterceptingTerminal({}, "linux")).toBe(false);
+		expect(isCtrlVPasteInterceptingTerminal({ WT_SESSION: "" }, "linux")).toBe(false);
+		expect(isCtrlVPasteInterceptingTerminal({ TERM_PROGRAM: "iTerm.app" }, "darwin")).toBe(false);
+	});
+});
+
+describe("isEmptyBracketedPaste", () => {
+	it("matches a self-contained empty bracketed paste", () => {
+		expect(isEmptyBracketedPaste("\x1b[200~\x1b[201~")).toBe(true);
+	});
+
+	it("does not match when the payload is only whitespace (real pasted text)", () => {
+		expect(isEmptyBracketedPaste("\x1b[200~   \t \x1b[201~")).toBe(false);
+	});
+
+	it("does not match a paste with text content", () => {
+		expect(isEmptyBracketedPaste("\x1b[200~hello\x1b[201~")).toBe(false);
+	});
+
+	it("does not match a start marker without an end marker (multi-chunk paste)", () => {
+		expect(isEmptyBracketedPaste("\x1b[200~partial")).toBe(false);
+	});
+
+	it("does not match plain input without paste markers", () => {
+		expect(isEmptyBracketedPaste("\x16")).toBe(false);
+		expect(isEmptyBracketedPaste("")).toBe(false);
+	});
+});


### PR DESCRIPTION
Windows terminal (and conhost, and hyper on windows) swallows Ctl+V as text paste (if image, just expands into [] -> empty text) so the keypress never reaches the app, thus silently doing nothing (#5632)

This is currentl handled on windows through using alternative binding (Alt-V) + with WSL via alternative solution to this problem in #5635. 

This situation could, however, be heuristically handled by observing the empty [] sequence and trying to see if anything is in clipboard. This PR does just that.

It makes ctrl-v work in WT, no matter if in windows or via WSL. As bonus, it also handles using windows clipboard history pastes (all validated manually) and should not mess anything up for better-conforming windows terminals (s.a. the one in vscode - also manually tested).