### PR TITLE
fix(coding-agent): exit package commands from CLI entrypoint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
 
+### Fixed
+
+- Fixed package CLI commands hanging after completion when project-trust extensions leave active handles open ([#5626](https://github.com/earendil-works/pi/issues/5626)).
+
 ## [0.79.1] - 2026-06-09
 
 ### New Features

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -17,4 +17,4 @@ process.emitWarning = (() => {}) as typeof process.emitWarning;
 // Runtime settings are applied once SettingsManager has loaded global/project settings.
 configureHttpDispatcher();
 
-main(process.argv.slice(2));
+main(process.argv.slice(2), { exitAfterPackageCommand: true });

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -452,6 +452,7 @@ async function promptForMissingSessionCwd(
 
 export interface MainOptions {
 	extensionFactories?: ExtensionFactory[];
+	exitAfterPackageCommand?: boolean;
 }
 
 export async function main(args: string[], options?: MainOptions) {
@@ -467,6 +468,9 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	if (await handlePackageCommand(args, { extensionFactories: options?.extensionFactories })) {
+		if (options?.exitAfterPackageCommand) {
+			process.exit(process.exitCode ?? 0);
+		}
 		return;
 	}
 

--- a/packages/coding-agent/test/suite/regressions/5626-package-command-exit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5626-package-command-exit.test.ts
@@ -1,0 +1,110 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+import { ENV_AGENT_DIR } from "../../../src/config.ts";
+
+interface CliResult {
+	code: number | null;
+	signal: NodeJS.Signals | null;
+	stdout: string;
+	stderr: string;
+}
+
+const tempDirs: string[] = [];
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const tsxPath = join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const cliPath = join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+
+function createTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pi-5626-package-exit-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function runCli(args: string[], options: { cwd: string; agentDir: string; timeoutMs?: number }): Promise<CliResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(
+			process.execPath,
+			[tsxPath, "--tsconfig", join(repoRoot, "tsconfig.json"), cliPath, ...args],
+			{
+				cwd: options.cwd,
+				env: {
+					...process.env,
+					[ENV_AGENT_DIR]: options.agentDir,
+					PI_SKIP_VERSION_CHECK: "1",
+				},
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		let stdout = "";
+		let stderr = "";
+		const timeout = setTimeout(() => {
+			child.kill();
+			reject(new Error(`pi child did not exit. stdout:\n${stdout}\nstderr:\n${stderr}`));
+		}, options.timeoutMs ?? 5000);
+
+		child.stdout.on("data", (data) => {
+			stdout += data.toString();
+		});
+		child.stderr.on("data", (data) => {
+			stderr += data.toString();
+		});
+		child.once("error", (error) => {
+			clearTimeout(timeout);
+			reject(error);
+		});
+		child.once("close", (code, signal) => {
+			clearTimeout(timeout);
+			resolve({ code, signal, stdout, stderr });
+		});
+	});
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("package command process exit (#5626)", () => {
+	test("package commands exit even when project-trust extensions leave active handles", async () => {
+		const tempDir = createTempDir();
+		const agentDir = join(tempDir, "agent");
+		const projectDir = join(tempDir, "project");
+		const extensionPath = join(tempDir, "leaky-extension.ts");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		writeFileSync(
+			extensionPath,
+			`export default function () {
+	setInterval(() => {}, 60_000);
+}
+`,
+		);
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ extensions: [extensionPath] }));
+
+		const result = await runCli(["list"], { cwd: projectDir, agentDir });
+
+		expect(result.code).toBe(0);
+		expect(result.signal).toBeNull();
+		expect(result.stdout).toContain("No packages installed.");
+		expect(result.stderr).toBe("");
+	});
+
+	test("package commands preserve non-zero exit codes", async () => {
+		const tempDir = createTempDir();
+		const agentDir = join(tempDir, "agent");
+		const projectDir = join(tempDir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(projectDir, { recursive: true });
+
+		const result = await runCli(["install"], { cwd: projectDir, agentDir });
+
+		expect(result.code).toBe(1);
+		expect(result.signal).toBeNull();
+		expect(result.stderr).toContain("Missing install source.");
+	});
+});


### PR DESCRIPTION
## Summary

- make the real CLI entrypoint exit after package commands are handled, preserving `process.exitCode`
- keep `main()` embeddable/testable by gating the hard exit behind an entrypoint option
- add a regression test that loads a project-trust extension leaving an active interval and verifies `pi list` still exits

## Related closed issues

- #5626 — `pi update` hangs after printing completion
- #5630 — CLI commands hang / process never exits when active handles remain
- #5619 — `pi update` goes through project-trust / extension loading during update

## Validation

- `node ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/5626-package-command-exit.test.ts`
- `npm run check`
