### PR TITLE
fix(coding-agent): canonicalize path when loading context files

### DIFF
--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -65,7 +65,7 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
 		if (existsSync(filePath)) {
 			try {
 				return {
-					path: filePath,
+					path: canonicalizePath(filePath),
 					content: readFileSync(filePath, "utf-8"),
 				};
 			} catch (error) {


### PR DESCRIPTION
Issue found when running Pi in a directory that:
- is a symlink, eg: `~/dotfiles/pi/.pi/agent --> ~/.pi/agent`
- contains an `AGENTS.md` file

If you run:
```bash
cd ~/.pi/agent
pi
```

The AGENTS.md file content was duplicated in the system prompt when I exported the session.

`canonicalizePath(...)` resolves the symlink and fixes the duplication issue.