### PR TITLE
fix(ai): remove stale OpenRouter Kimi free model assertion

### DIFF
--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -890,11 +890,9 @@ describe("openai-completions tool_choice", () => {
 	});
 
 	it("stores OpenRouter Kimi K2.6 reasoning replay compat in built-in metadata", () => {
-		for (const modelId of ["moonshotai/kimi-k2.6", "moonshotai/kimi-k2.6:free"] as const) {
-			const model = getModel("openrouter", modelId)!;
-			expect(model.compat?.supportsDeveloperRole).toBe(false);
-			expect(model.compat?.requiresReasoningContentOnAssistantMessages).toBe(true);
-		}
+		const model = getModel("openrouter", "moonshotai/kimi-k2.6")!;
+		expect(model.compat?.supportsDeveloperRole).toBe(false);
+		expect(model.compat?.requiresReasoningContentOnAssistantMessages).toBe(true);
 	});
 
 	it("stores Xiaomi MiMo reasoning replay compat in built-in metadata", () => {


### PR DESCRIPTION
CI is currently failing, both for PRs and on main:`generate-models.ts` fetches live OpenRouter models from https://openrouter.ai/api/v1/model and only includes models returned by that API and supporting tools. The current OpenRouter response does not include `moonshotai/kimi-k2.6:free`. So after CI regeneration, `moonshotai/kimi-k2.6:free` is gone from `src/models.generated.ts`, then `tsgo --noEmit` type-checks tests against the regenerated file, and the test still references the removed id, causing the type error.

(Not 100% sure about this but seems reasonable!)