### PR TITLE
fix(coding-agent): prevent uppercase header values from being falsely treated as env vars

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -253,10 +253,15 @@ function migrateLegacyRegisterProviderHeaders(
 	if (!headers) return undefined;
 	let migratedHeaders: Record<string, string> | undefined;
 	for (const [key, value] of Object.entries(headers)) {
-		const migratedValue = migrateLegacyRegisterProviderConfigValue(providerName, `${field} header "${key}"`, value);
-		if (migratedValue === value) continue;
+		if (!isLegacyEnvVarNameConfigValue(value)) continue;
+		// Only migrate header values when the env var actually exists,
+		// to avoid false positives with literal uppercase values like "BEARER".
+		if (!(value in process.env)) continue;
+		warnDeprecation(
+			`registerProvider("${providerName}") ${field} header "${key}" value "${value}" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "$${value}" instead.`,
+		);
 		migratedHeaders ??= { ...headers };
-		migratedHeaders[key] = migratedValue;
+		migratedHeaders[key] = `$${value}`;
 	}
 	return migratedHeaders ?? headers;
 }

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -84,6 +84,18 @@ function migrateLegacyEnvVarString(value: string): string | undefined {
 	return isLegacyEnvVarNameConfigValue(value) ? `$${value}` : undefined;
 }
 
+/**
+ * Like migrateLegacyEnvVarString, but only migrates header values when the
+ * corresponding environment variable actually exists.  This prevents literal
+ * uppercase header values (e.g. "BEARER", "ACCEPT_JSON") from being
+ * incorrectly rewritten as environment-variable references.
+ */
+function migrateLegacyEnvVarHeaderString(value: string): string | undefined {
+	if (!isLegacyEnvVarNameConfigValue(value)) return undefined;
+	// Only migrate if the env var is actually set — avoids false positives
+	return value in process.env ? `$${value}` : undefined;
+}
+
 function migrateStringProperty(
 	record: Record<string, unknown>,
 	key: string,
@@ -105,7 +117,7 @@ function migrateHeadersConfig(headers: unknown, location: string, migrations: Co
 	let migrated = false;
 	for (const [key, value] of Object.entries(headerRecord)) {
 		if (typeof value !== "string") continue;
-		const migratedValue = migrateLegacyEnvVarString(value);
+		const migratedValue = migrateLegacyEnvVarHeaderString(value);
 		if (migratedValue === undefined) continue;
 		headerRecord[key] = migratedValue;
 		migrations.push({ location: `${location}[${JSON.stringify(key)}]`, from: value, to: migratedValue });

--- a/packages/coding-agent/test/config-value-migration.test.ts
+++ b/packages/coding-agent/test/config-value-migration.test.ts
@@ -87,7 +87,7 @@ describe("config value env var syntax migration", () => {
 		expect(loadError).toContain(`File: ${modelsPath}`);
 	});
 
-	it("rewrites legacy uppercase models.json API key and header values", () => {
+	it("rewrites legacy uppercase models.json API key and header values when env vars exist", () => {
 		const agentDir = createAgentDir();
 		fs.writeFileSync(
 			path.join(agentDir, "models.json"),
@@ -119,39 +119,161 @@ describe("config value env var syntax migration", () => {
 			)}\n`,
 			"utf-8",
 		);
+		// Set env vars so header values are recognized as env var references
+		const savedEnv: Record<string, string | undefined> = {};
+		const envKeys = ["HEADER_API_KEY", "MODEL_API_KEY", "OVERRIDE_API_KEY"];
+		for (const key of envKeys) {
+			savedEnv[key] = process.env[key];
+			process.env[key] = "test-value";
+		}
 		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		withAgentDir(agentDir, () => runMigrations(agentDir));
+		try {
+			withAgentDir(agentDir, () => runMigrations(agentDir));
 
-		const migrated = JSON.parse(fs.readFileSync(path.join(agentDir, "models.json"), "utf-8")) as {
-			providers: Record<
-				string,
-				{
-					apiKey?: string;
-					headers?: Record<string, string>;
-					models?: Array<{ headers?: Record<string, string> }>;
-					modelOverrides?: Record<string, { headers?: Record<string, string> }>;
+			const migrated = JSON.parse(fs.readFileSync(path.join(agentDir, "models.json"), "utf-8")) as {
+				providers: Record<
+					string,
+					{
+						apiKey?: string;
+						headers?: Record<string, string>;
+						models?: Array<{ headers?: Record<string, string> }>;
+						modelOverrides?: Record<string, { headers?: Record<string, string> }>;
+					}
+				>;
+			};
+			const provider = migrated.providers["custom-provider"]!;
+			expect(provider.apiKey).toBe("$CUSTOM_API_KEY");
+			expect(provider.headers?.["x-api-key"]).toBe("$HEADER_API_KEY");
+			expect(provider.headers?.["x-literal"]).toBe("literal");
+			expect(provider.models?.[0]?.headers?.["x-model-key"]).toBe("$MODEL_API_KEY");
+			expect(provider.modelOverrides?.["model-b"]?.headers?.["x-override-key"]).toBe("$OVERRIDE_API_KEY");
+			const logMessage = String(logSpy.mock.calls[0]?.[0] ?? "");
+			expect(logMessage).toContain(
+				'models.json.providers["custom-provider"].apiKey: CUSTOM_API_KEY -> $CUSTOM_API_KEY',
+			);
+			expect(logMessage).toContain(
+				'models.json.providers["custom-provider"].headers["x-api-key"]: HEADER_API_KEY -> $HEADER_API_KEY',
+			);
+			expect(logMessage).toContain(
+				'models.json.providers["custom-provider"].models["model-a"].headers["x-model-key"]: MODEL_API_KEY -> $MODEL_API_KEY',
+			);
+			expect(logMessage).toContain(
+				'models.json.providers["custom-provider"].modelOverrides["model-b"].headers["x-override-key"]: OVERRIDE_API_KEY -> $OVERRIDE_API_KEY',
+			);
+		} finally {
+			for (const key of envKeys) {
+				if (savedEnv[key] === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = savedEnv[key];
 				}
-			>;
-		};
-		const provider = migrated.providers["custom-provider"]!;
-		expect(provider.apiKey).toBe("$CUSTOM_API_KEY");
-		expect(provider.headers?.["x-api-key"]).toBe("$HEADER_API_KEY");
-		expect(provider.headers?.["x-literal"]).toBe("literal");
-		expect(provider.models?.[0]?.headers?.["x-model-key"]).toBe("$MODEL_API_KEY");
-		expect(provider.modelOverrides?.["model-b"]?.headers?.["x-override-key"]).toBe("$OVERRIDE_API_KEY");
-		const logMessage = String(logSpy.mock.calls[0]?.[0] ?? "");
-		expect(logMessage).toContain(
-			'models.json.providers["custom-provider"].apiKey: CUSTOM_API_KEY -> $CUSTOM_API_KEY',
+			}
+		}
+	});
+
+	it("does NOT rewrite uppercase header values when env var does not exist", () => {
+		const agentDir = createAgentDir();
+		// Ensure env vars are NOT set
+		const envKeys = ["BEARER", "AUTH_TOKEN", "ACCEPT_JSON"];
+		const savedEnv: Record<string, string | undefined> = {};
+		for (const key of envKeys) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+		fs.writeFileSync(
+			path.join(agentDir, "models.json"),
+			`${JSON.stringify(
+				{
+					providers: {
+						"custom-provider": {
+							baseUrl: "https://example.com/v1",
+							apiKey: "CUSTOM_API_KEY",
+							api: "openai-completions",
+							headers: {
+								Authorization: "BEARER",
+								"x-auth-type": "AUTH_TOKEN",
+								Accept: "ACCEPT_JSON",
+							},
+						},
+					},
+				},
+				null,
+				2,
+			)}\n`,
+			"utf-8",
 		);
-		expect(logMessage).toContain(
-			'models.json.providers["custom-provider"].headers["x-api-key"]: HEADER_API_KEY -> $HEADER_API_KEY',
-		);
-		expect(logMessage).toContain(
-			'models.json.providers["custom-provider"].models["model-a"].headers["x-model-key"]: MODEL_API_KEY -> $MODEL_API_KEY',
-		);
-		expect(logMessage).toContain(
-			'models.json.providers["custom-provider"].modelOverrides["model-b"].headers["x-override-key"]: OVERRIDE_API_KEY -> $OVERRIDE_API_KEY',
-		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			withAgentDir(agentDir, () => runMigrations(agentDir));
+
+			const migrated = JSON.parse(fs.readFileSync(path.join(agentDir, "models.json"), "utf-8")) as {
+				providers: Record<
+					string,
+					{
+						apiKey?: string;
+						headers?: Record<string, string>;
+					}
+				>;
+			};
+			const provider = migrated.providers["custom-provider"]!;
+			// apiKey should still be migrated (it always uses the env-check-free path)
+			expect(provider.apiKey).toBe("$CUSTOM_API_KEY");
+			// Header values should NOT be rewritten — they are literal uppercase strings
+			expect(provider.headers?.["Authorization"]).toBe("BEARER");
+			expect(provider.headers?.["x-auth-type"]).toBe("AUTH_TOKEN");
+			expect(provider.headers?.["Accept"]).toBe("ACCEPT_JSON");
+			// Header values should not appear in migration log
+			const logMessage = String(logSpy.mock.calls[0]?.[0] ?? "");
+			expect(logMessage).not.toContain("BEARER");
+			expect(logMessage).not.toContain("AUTH_TOKEN");
+			expect(logMessage).not.toContain("ACCEPT_JSON");
+		} finally {
+			for (const key of envKeys) {
+				if (savedEnv[key] === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = savedEnv[key];
+				}
+			}
+		}
+	});
+
+	describe("header value migration with env var existence check", () => {
+		it("migrates header value only when env var exists", () => {
+			const agentDir = createAgentDir();
+			const savedEnv = process.env["MY_HEADER_VALUE"];
+			process.env["MY_HEADER_VALUE"] = "resolved-secret";
+			fs.writeFileSync(
+				path.join(agentDir, "models.json"),
+				`${JSON.stringify(
+					{
+						providers: {
+							"test-provider": {
+								baseUrl: "https://example.com",
+								api: "openai-completions",
+								headers: { "x-token": "MY_HEADER_VALUE" },
+							},
+						},
+					},
+					null,
+					2,
+				)}\n`,
+				"utf-8",
+			);
+
+			try {
+				withAgentDir(agentDir, () => runMigrations(agentDir));
+				const migrated = JSON.parse(fs.readFileSync(path.join(agentDir, "models.json"), "utf-8"));
+				expect(migrated.providers["test-provider"].headers["x-token"]).toBe("$MY_HEADER_VALUE");
+			} finally {
+				if (savedEnv === undefined) {
+					delete process.env["MY_HEADER_VALUE"];
+				} else {
+					process.env["MY_HEADER_VALUE"] = savedEnv;
+				}
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Problem

Header values in `models.json` that happen to be all-uppercase (e.g. `"BEARER"`, `"AUTH_TOKEN"`, `"ACCEPT_JSON"`) are incorrectly rewritten to `"$BEARER"` etc. by the legacy env-var migration.

### Root Cause

The regex `/^[A-Z_][A-Z0-9_]*$/` in `resolve-config-value.ts:13` matches **any** all-uppercase string. It cannot distinguish between:
- `"ANTHROPIC_API_KEY"` — intended as an env var reference ✅
- `"BEARER"` — a literal header value that gets corrupted ❌

### Impact

The startup migration in `migrations.ts` **destructively rewrites** `models.json` on disk. Once a literal uppercase header value is rewritten to `$BEARER`, the env var lookup fails and the header is **silently dropped** from HTTP requests.

| Original Value | Rewritten To | Result |
|---|---|---|
| `"BEARER"` | `"$BEARER"` | Env var not found → header silently dropped |
| `"AUTH_TOKEN"` | `"$AUTH_TOKEN"` | Env var not found → header silently dropped |
| `"ACCEPT_JSON"` | `"$ACCEPT_JSON"` | Env var not found → header silently dropped |

## Fix

Only migrate header values when the corresponding environment variable **actually exists** in `process.env`. This preserves literal uppercase header values while still correctly migrating genuine env-var references.

### Changes

| File | Change |
|---|---|
| `src/migrations.ts` | Add `migrateLegacyEnvVarHeaderString()` with env-var existence check; `migrateHeadersConfig` uses it |
| `src/core/model-registry.ts` | `migrateLegacyRegisterProviderHeaders` adds `value in process.env` guard |
| `test/config-value-migration.test.ts` | 2 new tests: env var exists → migrates; env var absent → preserves literal |

The `apiKey` field migration is intentionally left unchanged — an all-uppercase `apiKey` value is almost always an env var reference.

### Tests

```
✓ config-value-migration.test.ts (6 tests)
✓ model-registry.test.ts (72 tests)
```