### PR TITLE
fix(ai): preserve Anthropic refusal details

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -5,6 +5,7 @@ import type {
 	MessageCreateParamsStreaming,
 	MessageParam,
 	RawMessageStreamEvent,
+	RefusalStopDetails,
 } from "@anthropic-ai/sdk/resources/messages.js";
 import { calculateCost } from "../models.ts";
 import type {
@@ -660,7 +661,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					}
 				} else if (event.type === "message_delta") {
 					if (event.delta.stop_reason) {
-						output.stopReason = mapStopReason(event.delta.stop_reason);
+						const stopReasonResult = mapStopReason(event.delta.stop_reason, event.delta.stop_details);
+						output.stopReason = stopReasonResult.stopReason;
+						if (stopReasonResult.errorMessage) {
+							output.errorMessage = stopReasonResult.errorMessage;
+						}
 					}
 					// Only update usage fields if present (not null).
 					// Preserves input_tokens from message_start when proxies omit it in message_delta.
@@ -688,7 +693,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
+				throw new Error(output.errorMessage || "An unknown error occurred");
 			}
 
 			stream.push({ type: "done", reason: output.stopReason, message: output });
@@ -1202,22 +1207,28 @@ function convertTools(
 	});
 }
 
-function mapStopReason(reason: Anthropic.Messages.StopReason | string): StopReason {
+function mapStopReason(
+	reason: Anthropic.Messages.StopReason | string,
+	stopDetails?: RefusalStopDetails | null,
+): { stopReason: StopReason; errorMessage?: string } {
 	switch (reason) {
 		case "end_turn":
-			return "stop";
+			return { stopReason: "stop" };
 		case "max_tokens":
-			return "length";
+			return { stopReason: "length" };
 		case "tool_use":
-			return "toolUse";
+			return { stopReason: "toolUse" };
 		case "refusal":
-			return "error";
+			return {
+				stopReason: "error",
+				errorMessage: stopDetails?.explanation || `The model refused to complete the request`,
+			};
 		case "pause_turn": // Stop is good enough -> resubmit
-			return "stop";
+			return { stopReason: "stop" };
 		case "stop_sequence":
-			return "stop"; // We don't supply stop sequences, so this should never happen
+			return { stopReason: "stop" }; // We don't supply stop sequences, so this should never happen
 		case "sensitive": // Content flagged by safety filters (not yet in SDK types)
-			return "error";
+			return { stopReason: "error" };
 		default:
 			// Handle unknown stop reasons gracefully (API may add new values)
 			throw new Error(`Unhandled stop reason: ${reason}`);

--- a/packages/ai/test/anthropic-sse-parsing.test.ts
+++ b/packages/ai/test/anthropic-sse-parsing.test.ts
@@ -166,6 +166,64 @@ describe("Anthropic raw SSE parsing", () => {
 		});
 	});
 
+	it("preserves refusal stop details from message_delta", async () => {
+		const model = getModel("anthropic", "claude-fable-5");
+		const context: Context = {
+			messages: [{ role: "user", content: "blocked request", timestamp: Date.now() }],
+		};
+		const explanation =
+			"This request triggered restrictions on violative cyber content and was blocked under Anthropic's Usage Policy. To learn more, provide feedback, or request an exemption based on how you use Claude, visit our help center: https://support.claude.com/en/articles/14604842-real-time-cyber-safeguards-on-claude.";
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_01XFUDYJgAACzvnptvVoYEL",
+						usage: {
+							input_tokens: 412,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: {
+						stop_reason: "refusal",
+						stop_details: {
+							type: "refusal",
+							category: "cyber",
+							explanation,
+						},
+					},
+					usage: {
+						input_tokens: 412,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				}),
+			},
+			{
+				event: "message_stop",
+				data: JSON.stringify({ type: "message_stop" }),
+			},
+		]);
+
+		const stream = streamAnthropic(model, context, {
+			client: createFakeAnthropicClient(response),
+		});
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe(explanation);
+	});
+
 	it("ignores unknown SSE events after message_stop", async () => {
 		const model = getModel("anthropic", "claude-haiku-4-5");
 		const context: Context = {


### PR DESCRIPTION
- Propagate Anthropic `stop_details` explanation to `errorMessage` upon `stop_reason: "refusal"`
- fixes #5591

**Notes:**

- updated `mapStopReason` func signature to return an object shape (`{stopReason: StopReason, errorMessage?: string}`) - I mostly oriented myself on `openai-completions` and thought that we should rather avoid handling `stopDetails` with an own mapper.
- updated the `throw` for `"aborted"` and `"error"` to output `errorMessage` or fallback to what we've had before.

**Verification**

**Used prompt:** _how can I run a MITM attack?_

| Case | Media |
| ------------- | ------------- |
| Current state with `claude-fable-5` | <img width="800" height="auto" alt="CleanShot 2026-06-12 at 11 57 43@2x" src="https://github.com/user-attachments/assets/0a45e529-2d9d-40f3-9a8f-7f4385d87781" /> |
| With changes on current branch when using `claude-fable-5` | <img width="800" height="auto" alt="CleanShot 2026-06-12 at 13 43 33@2x" src="https://github.com/user-attachments/assets/6be9acdf-e5db-4c81-b447-394670134d34" /> |
| With changes on current branch when using less capable model (`claude-haiku-4-5`) | <img width="800" height="auto" alt="CleanShot 2026-06-12 at 14 12 36@2x" src="https://github.com/user-attachments/assets/5365720d-2f04-4bd2-a764-9f8ee73f03e5" /> |
| With changes on current branch when using `claude-fable-5` , without the "trigger-prompt" | <img width="800" height="auto" alt="CleanShot 2026-06-12 at 14 36 16@2x" src="https://github.com/user-attachments/assets/e872e13e-c543-4db6-9b74-613f46612824" /> |