### PR TITLE
fix: stabilize compaction after reload

### DIFF
--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -153,17 +153,24 @@ export interface ContextUsageEstimate {
 	lastUsageIndex: number | null;
 }
 
-function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; index: number } | undefined {
+function getLastAssistantUsageInfo(
+	messages: AgentMessage[],
+	afterTimestamp?: number,
+): { usage: Usage; index: number } | undefined {
 	for (let i = messages.length - 1; i >= 0; i--) {
-		const usage = getAssistantUsage(messages[i]);
+		const msg = messages[i];
+		if (msg.role === "assistant" && afterTimestamp && msg.timestamp <= afterTimestamp) {
+			continue;
+		}
+		const usage = getAssistantUsage(msg);
 		if (usage) return { usage, index: i };
 	}
 	return undefined;
 }
 
 /** Estimate context tokens for messages using provider usage when available. */
-export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEstimate {
-	const usageInfo = getLastAssistantUsageInfo(messages);
+export function estimateContextTokens(messages: AgentMessage[], afterTimestamp?: number): ContextUsageEstimate {
+	const usageInfo = getLastAssistantUsageInfo(messages, afterTimestamp);
 
 	if (!usageInfo) {
 		let estimated = 0;
@@ -556,16 +563,18 @@ export function prepareCompaction(
 	}
 
 	let previousSummary: string | undefined;
+	let prevCompaction: CompactionEntry | undefined;
 	let boundaryStart = 0;
 	if (prevCompactionIndex >= 0) {
-		const prevCompaction = pathEntries[prevCompactionIndex] as CompactionEntry;
+		prevCompaction = pathEntries[prevCompactionIndex] as CompactionEntry;
 		previousSummary = prevCompaction.summary;
 		const firstKeptEntryIndex = pathEntries.findIndex((entry) => entry.id === prevCompaction.firstKeptEntryId);
 		boundaryStart = firstKeptEntryIndex >= 0 ? firstKeptEntryIndex : prevCompactionIndex + 1;
 	}
 	const boundaryEnd = pathEntries.length;
 
-	const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages).tokens;
+	const compactionTimestamp = prevCompaction ? new Date(prevCompaction.timestamp).getTime() : undefined;
+	const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages, compactionTimestamp).tokens;
 
 	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
 	const firstKeptEntry = pathEntries[cutPoint.firstKeptEntryIndex];

--- a/packages/agent/test/harness/compaction.test.ts
+++ b/packages/agent/test/harness/compaction.test.ts
@@ -349,7 +349,24 @@ describe("harness compaction", () => {
 		expect(preparation).toBeDefined();
 		expect(preparation?.previousSummary).toBe("First summary");
 		expect(preparation?.firstKeptEntryId).toBeTruthy();
-		expect(preparation?.tokensBefore).toBe(estimateContextTokens(buildSessionContext(pathEntries).messages).tokens);
+		const compactionTimestamp = new Date(compaction1.timestamp).getTime();
+		expect(preparation?.tokensBefore).toBe(estimateContextTokens(buildSessionContext(pathEntries).messages, compactionTimestamp).tokens);
+	});
+
+	it("ignores pre-compaction assistant usage when calculating repeated compaction tokens", () => {
+		const u1 = createMessageEntry(createUserMessage("old user msg"));
+		const a1 = createMessageEntry(createAssistantMessage("old assistant msg"), u1.id);
+		const u2 = createMessageEntry(createUserMessage("kept user msg"), a1.id);
+		const a2 = createMessageEntry(createAssistantMessage("kept assistant msg", createMockUsage(500_000, 50_000)), u2.id);
+		const compaction1 = createCompactionEntry("First summary", u2.id, a2.id);
+		const u3 = createMessageEntry(createUserMessage("new user msg after compaction"), compaction1.id);
+		const pathEntries = [u1, a1, u2, a2, compaction1, u3];
+		const contextBefore = buildSessionContext(pathEntries);
+		const preparation = getOrThrow(prepareCompaction(pathEntries, DEFAULT_COMPACTION_SETTINGS));
+		const compactionTimestamp = new Date(compaction1.timestamp).getTime();
+
+		expect(preparation?.tokensBefore).toBe(estimateContextTokens(contextBefore.messages, compactionTimestamp).tokens);
+		expect(preparation?.tokensBefore).not.toBe(estimateContextTokens(contextBefore.messages).tokens);
 	});
 
 	it("prepares split-turn compaction with prior file-operation details", () => {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -318,6 +318,22 @@ export class AgentSession {
 	private _toolPromptSnippets: Map<string, string> = new Map();
 	private _toolPromptGuidelines: Map<string, string[]> = new Map();
 
+	// Context usage cache with version-based invalidation.
+	// Version increments on model/compaction/message changes.
+	private _contextUsageCacheVersion = 0;
+	private _contextUsageCache: { version: number; result: ContextUsage } | null = null;
+
+	// Cached cumulative lifetime token/cost stats for footer display.
+	// Updated incrementally on each assistant message; preserved across compaction.
+	private _lifetimeStatsCache = {
+		totalInput: 0,
+		totalOutput: 0,
+		totalCacheRead: 0,
+		totalCacheWrite: 0,
+		totalCost: 0,
+		latestCacheHitRate: undefined as number | undefined,
+	};
+
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
 	private _baseSystemPromptOptions!: BuildSystemPromptOptions;
@@ -341,6 +357,9 @@ export class AgentSession {
 		// Always subscribe to agent events for internal handling
 		// (session persistence, extensions, auto-compaction, retry logic)
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
+		// Rebuild lifetime stats from existing session entries so resumed sessions
+		// report correct cumulative totals (incremental updates then build on top).
+		this._rebuildLifetimeStatsCache();
 		this._installAgentToolHooks();
 
 		this._buildRuntime({
@@ -520,8 +539,24 @@ export class AgentSession {
 			) {
 				// Regular LLM message - persist as SessionMessageEntry
 				this.sessionManager.appendMessage(event.message);
+				// Invalidate context usage cache: new messages change the session context.
+				this._contextUsageCacheVersion++;
 			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
+
+			// Incrementally update cached lifetime stats for assistant messages.
+			if (event.message.role === "assistant") {
+				const assistantMsg = event.message as AssistantMessage;
+				this._lifetimeStatsCache.totalInput += assistantMsg.usage.input;
+				this._lifetimeStatsCache.totalOutput += assistantMsg.usage.output;
+				this._lifetimeStatsCache.totalCacheRead += assistantMsg.usage.cacheRead;
+				this._lifetimeStatsCache.totalCacheWrite += assistantMsg.usage.cacheWrite;
+				this._lifetimeStatsCache.totalCost += assistantMsg.usage.cost.total;
+				const latestPromptTokens =
+					assistantMsg.usage.input + assistantMsg.usage.cacheRead + assistantMsg.usage.cacheWrite;
+				this._lifetimeStatsCache.latestCacheHitRate =
+					latestPromptTokens > 0 ? (assistantMsg.usage.cacheRead / latestPromptTokens) * 100 : undefined;
+			}
 
 			// Track assistant message for auto-compaction (checked on agent_end)
 			if (event.message.role === "assistant") {
@@ -1450,6 +1485,9 @@ export class AgentSession {
 		this.sessionManager.appendModelChange(model.provider, model.id);
 		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 
+		// Invalidate context usage cache: model change changes context window.
+		this._contextUsageCacheVersion++;
+
 		// Re-clamp thinking level for new model's capabilities
 		this.setThinkingLevel(thinkingLevel);
 
@@ -1541,6 +1579,7 @@ export class AgentSession {
 		const isChanging = effectiveLevel !== previousLevel;
 
 		this.agent.state.thinkingLevel = effectiveLevel;
+		this._contextUsageCacheVersion++;
 
 		if (isChanging) {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
@@ -1723,6 +1762,7 @@ export class AgentSession {
 			const newEntries = this.sessionManager.getEntries();
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._contextUsageCacheVersion++;
 
 			// Get the saved compaction entry for the extension event
 			const savedCompactionEntry = newEntries.find((e) => e.type === "compaction" && e.summary === summary) as
@@ -2003,6 +2043,7 @@ export class AgentSession {
 			const newEntries = this.sessionManager.getEntries();
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._contextUsageCacheVersion++;
 
 			// Get the saved compaction entry for the extension event
 			const savedCompactionEntry = newEntries.find((e) => e.type === "compaction" && e.summary === summary) as
@@ -2604,6 +2645,7 @@ export class AgentSession {
 			return result;
 		} finally {
 			this._bashAbortController = undefined;
+			this._contextUsageCacheVersion++;
 		}
 	}
 
@@ -2670,6 +2712,7 @@ export class AgentSession {
 		}
 
 		this._pendingBashMessages = [];
+		this._contextUsageCacheVersion++;
 	}
 
 	// =========================================================================
@@ -2868,6 +2911,7 @@ export class AgentSession {
 			// Update agent state
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._contextUsageCacheVersion++;
 
 			// Emit session_tree event
 			await this._extensionRunner.emit({
@@ -2966,6 +3010,11 @@ export class AgentSession {
 	}
 
 	getContextUsage(): ContextUsage | undefined {
+		// Return cached result if version hasn't changed.
+		if (this._contextUsageCache && this._contextUsageCache.version === this._contextUsageCacheVersion) {
+			return this._contextUsageCache.result;
+		}
+
 		const model = this.model;
 		if (!model) return undefined;
 
@@ -2977,6 +3026,7 @@ export class AgentSession {
 		// If no such assistant exists, context token count is unknown until the next LLM response.
 		const branchEntries = this.sessionManager.getBranch();
 		const latestCompaction = getLatestCompactionEntry(branchEntries);
+		const compactionTimestamp = latestCompaction ? new Date(latestCompaction.timestamp).getTime() : undefined;
 
 		if (latestCompaction) {
 			// Check if there's a valid assistant usage after the compaction boundary
@@ -2997,18 +3047,80 @@ export class AgentSession {
 			}
 
 			if (!hasPostCompactionUsage) {
-				return { tokens: null, contextWindow, percent: null };
+				const result = { tokens: null, contextWindow, percent: null };
+				this._contextUsageCache = { version: this._contextUsageCacheVersion, result };
+				return result;
 			}
 		}
 
-		const estimate = estimateContextTokens(this.messages);
+		const estimate = estimateContextTokens(this.messages, compactionTimestamp);
 		const percent = (estimate.tokens / contextWindow) * 100;
-
-		return {
+		const result = {
 			tokens: estimate.tokens,
 			contextWindow,
 			percent,
 		};
+		this._contextUsageCache = { version: this._contextUsageCacheVersion, result };
+		return result;
+	}
+
+	/**
+	 * Rebuild lifetime stats cache from all existing session entries.
+	 * Called once in the constructor for resumed/existing sessions so that
+	 * pre-existing assistant messages are counted in cumulative footer totals.
+	 * After this, incremental updates in _handleAgentEvent keep it current.
+	 */
+	private _rebuildLifetimeStatsCache(): void {
+		const entries = this.sessionManager.getEntries();
+		let totalInput = 0;
+		let totalOutput = 0;
+		let totalCacheRead = 0;
+		let totalCacheWrite = 0;
+		let totalCost = 0;
+		let lastAssistantUsage: { cacheRead: number; cacheWrite: number; input: number } | undefined;
+
+		for (const entry of entries) {
+			if (entry.type === "message" && entry.message.role === "assistant") {
+				const msg = entry.message as AssistantMessage;
+				totalInput += msg.usage.input;
+				totalOutput += msg.usage.output;
+				totalCacheRead += msg.usage.cacheRead;
+				totalCacheWrite += msg.usage.cacheWrite;
+				totalCost += msg.usage.cost.total;
+				lastAssistantUsage = { cacheRead: msg.usage.cacheRead, cacheWrite: msg.usage.cacheWrite, input: msg.usage.input };
+			}
+		}
+
+		const latestPromptTokens =
+			(lastAssistantUsage?.input ?? 0) +
+			(lastAssistantUsage?.cacheRead ?? 0) +
+			(lastAssistantUsage?.cacheWrite ?? 0);
+		const latestCacheHitRate =
+			latestPromptTokens > 0 ? (lastAssistantUsage!.cacheRead / latestPromptTokens) * 100 : undefined;
+
+		this._lifetimeStatsCache = {
+			totalInput,
+			totalOutput,
+			totalCacheRead,
+			totalCacheWrite,
+			totalCost,
+			latestCacheHitRate,
+		};
+	}
+
+	/**
+	 * Get cached cumulative lifetime token/cost stats for footer display.
+	 * Includes all assistant messages across the entire session lifetime.
+	 */
+	getLifetimeStats(): {
+		totalInput: number;
+		totalOutput: number;
+		totalCacheRead: number;
+		totalCacheWrite: number;
+		totalCost: number;
+		latestCacheHitRate: number | undefined;
+	} {
+		return this._lifetimeStatsCache;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -171,9 +171,16 @@ export interface ContextUsageEstimate {
 	lastUsageIndex: number | null;
 }
 
-function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; index: number } | undefined {
+function getLastAssistantUsageInfo(
+	messages: AgentMessage[],
+	afterTimestamp?: number,
+): { usage: Usage; index: number } | undefined {
 	for (let i = messages.length - 1; i >= 0; i--) {
-		const usage = getAssistantUsage(messages[i]);
+		const msg = messages[i];
+		if (msg.role === "assistant" && afterTimestamp && msg.timestamp <= afterTimestamp) {
+			continue;
+		}
+		const usage = getAssistantUsage(msg);
 		if (usage) return { usage, index: i };
 	}
 	return undefined;
@@ -182,9 +189,10 @@ function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; in
 /**
  * Estimate context tokens from messages, using the last assistant usage when available.
  * If there are messages after the last usage, estimate their tokens with estimateTokens.
+ * @param afterTimestamp Optional timestamp to filter messages (e.g. compaction boundary).
  */
-export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEstimate {
-	const usageInfo = getLastAssistantUsageInfo(messages);
+export function estimateContextTokens(messages: AgentMessage[], afterTimestamp?: number): ContextUsageEstimate {
+	const usageInfo = getLastAssistantUsageInfo(messages, afterTimestamp);
 
 	if (!usageInfo) {
 		let estimated = 0;
@@ -658,16 +666,18 @@ export function prepareCompaction(
 	}
 
 	let previousSummary: string | undefined;
+	let prevCompaction: CompactionEntry | undefined;
 	let boundaryStart = 0;
 	if (prevCompactionIndex >= 0) {
-		const prevCompaction = pathEntries[prevCompactionIndex] as CompactionEntry;
+		prevCompaction = pathEntries[prevCompactionIndex] as CompactionEntry;
 		previousSummary = prevCompaction.summary;
 		const firstKeptEntryIndex = pathEntries.findIndex((entry) => entry.id === prevCompaction.firstKeptEntryId);
 		boundaryStart = firstKeptEntryIndex >= 0 ? firstKeptEntryIndex : prevCompactionIndex + 1;
 	}
 	const boundaryEnd = pathEntries.length;
 
-	const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages).tokens;
+	const compactionTimestamp = prevCompaction ? new Date(prevCompaction.timestamp).getTime() : undefined;
+	const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages, compactionTimestamp).tokens;
 
 	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
 

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -64,11 +64,11 @@ export class FooterComponent implements Component {
 	}
 
 	/**
-	 * No-op: git branch caching now handled by provider.
-	 * Kept for compatibility with existing call sites in interactive-mode.
+	 * No-op: context usage caching is now handled by AgentSession.
+	 * Kept for backward compatibility with callers that invoke invalidate().
 	 */
 	invalidate(): void {
-		// No-op: git branch is cached/invalidated by provider
+		// No-op
 	}
 
 	/**
@@ -82,31 +82,11 @@ export class FooterComponent implements Component {
 	render(width: number): string[] {
 		const state = this.session.state;
 
-		// Calculate cumulative usage from ALL session entries (not just post-compaction messages)
-		let totalInput = 0;
-		let totalOutput = 0;
-		let totalCacheRead = 0;
-		let totalCacheWrite = 0;
-		let totalCost = 0;
-		let latestCacheHitRate: number | undefined;
+		// Cached cumulative lifetime stats (no per-render getEntries() scan).
+		const lifetimeStats = this.session.getLifetimeStats();
+		const { totalInput, totalOutput, totalCacheRead, totalCacheWrite, totalCost, latestCacheHitRate } = lifetimeStats;
 
-		for (const entry of this.session.sessionManager.getEntries()) {
-			if (entry.type === "message" && entry.message.role === "assistant") {
-				totalInput += entry.message.usage.input;
-				totalOutput += entry.message.usage.output;
-				totalCacheRead += entry.message.usage.cacheRead;
-				totalCacheWrite += entry.message.usage.cacheWrite;
-				totalCost += entry.message.usage.cost.total;
-
-				const latestPromptTokens =
-					entry.message.usage.input + entry.message.usage.cacheRead + entry.message.usage.cacheWrite;
-				latestCacheHitRate =
-					latestPromptTokens > 0 ? (entry.message.usage.cacheRead / latestPromptTokens) * 100 : undefined;
-			}
-		}
-
-		// Calculate context usage from session (handles compaction correctly).
-		// After compaction, tokens are unknown until the next LLM response.
+		// Context usage is cached in AgentSession (version-based invalidation).
 		const contextUsage = this.session.getContextUsage();
 		const contextWindow = contextUsage?.contextWindow ?? state.model?.contextWindow ?? 0;
 		const contextPercentValue = contextUsage?.percent ?? 0;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3860,12 +3860,15 @@ export class InteractiveMode {
 			);
 		};
 
+		const promptQueuedMessage = (message: CompactionQueuedMessage) =>
+			this.session.prompt(message.text, { streamingBehavior: message.mode });
+
 		try {
 			if (options?.willRetry) {
 				// When retry is pending, queue messages for the retry turn
 				for (const message of queuedMessages) {
 					if (this.isExtensionCommand(message.text)) {
-						await this.session.prompt(message.text);
+						await promptQueuedMessage(message);
 					} else if (message.mode === "followUp") {
 						await this.session.followUp(message.text);
 					} else {
@@ -3881,7 +3884,7 @@ export class InteractiveMode {
 			if (firstPromptIndex === -1) {
 				// All extension commands - execute them all
 				for (const message of queuedMessages) {
-					await this.session.prompt(message.text);
+					await promptQueuedMessage(message);
 				}
 				return;
 			}
@@ -3892,18 +3895,18 @@ export class InteractiveMode {
 			const rest = queuedMessages.slice(firstPromptIndex + 1);
 
 			for (const message of preCommands) {
-				await this.session.prompt(message.text);
+				await promptQueuedMessage(message);
 			}
 
 			// Send first prompt (starts streaming)
-			const promptPromise = this.session.prompt(firstPrompt.text).catch((error) => {
+			const promptPromise = promptQueuedMessage(firstPrompt).catch((error) => {
 				restoreQueue(error);
 			});
 
 			// Queue remaining messages
 			for (const message of rest) {
 				if (this.isExtensionCommand(message.text)) {
-					await this.session.prompt(message.text);
+					await promptQueuedMessage(message);
 				} else if (message.mode === "followUp") {
 					await this.session.followUp(message.text);
 				} else {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -415,7 +415,8 @@ describe("prepareCompaction with previous compaction", () => {
 		expect(preparation!.firstKeptEntryId).toBe(u2.id);
 		expect(preparation!.previousSummary).toBe("First summary");
 		expect(extractText(preparation!.messagesToSummarize)).not.toContain("First summary");
-		expect(preparation!.tokensBefore).toBe(estimateContextTokens(contextBefore.messages).tokens);
+		const compactionTimestamp = new Date(compaction1.timestamp).getTime();
+		expect(preparation!.tokensBefore).toBe(estimateContextTokens(contextBefore.messages, compactionTimestamp).tokens);
 
 		const compaction2: CompactionEntry = {
 			type: "compaction",
@@ -431,6 +432,24 @@ describe("prepareCompaction with previous compaction", () => {
 
 		expect(contextAfterText).toContain("user msg 2 - kept by compaction1");
 		expect(contextAfterText).toContain("user msg 3 - kept by compaction1");
+	});
+
+	it("should ignore pre-compaction assistant usage when calculating repeated compaction tokens", () => {
+		const u1 = createMessageEntry(createUserMessage("old user msg"));
+		const a1 = createMessageEntry(createAssistantMessage("old assistant msg"));
+		const u2 = createMessageEntry(createUserMessage("kept user msg"));
+		const a2 = createMessageEntry(createAssistantMessage("kept assistant msg", createMockUsage(500_000, 50_000)));
+		const compaction1 = createCompactionEntry("First summary", u2.id);
+		const u3 = createMessageEntry(createUserMessage("new user msg after compaction"));
+
+		const pathEntries = [u1, a1, u2, a2, compaction1, u3];
+		const contextBefore = buildSessionContext(pathEntries);
+		const preparation = prepareCompaction(pathEntries, DEFAULT_COMPACTION_SETTINGS);
+		const compactionTimestamp = new Date(compaction1.timestamp).getTime();
+
+		expect(preparation).toBeDefined();
+		expect(preparation!.tokensBefore).toBe(estimateContextTokens(contextBefore.messages, compactionTimestamp).tokens);
+		expect(preparation!.tokensBefore).not.toBe(estimateContextTokens(contextBefore.messages).tokens);
 	});
 
 	it("should re-summarize previously kept messages when the recent window moves past them", () => {

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -2,6 +2,107 @@ import { describe, expect, test, vi } from "vitest";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 
 describe("InteractiveMode compaction events", () => {
+	test("routes queued extension commands with streaming behavior after compaction", async () => {
+		const flushCompactionQueue = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue") as (
+			this: Record<string, any>,
+			options?: { willRetry?: boolean },
+		) => Promise<void>;
+		const prompt = vi.fn(async (_text: string, options?: { streamingBehavior?: "steer" | "followUp" }) => {
+			if (!options?.streamingBehavior) {
+				throw new Error("Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.");
+			}
+		});
+		const fakeThis = {
+			compactionQueuedMessages: [{ text: "/TaskUpdate 1", mode: "followUp" }],
+			isExtensionCommand: () => true,
+			session: { prompt, clearQueue: vi.fn() },
+			showError: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+		};
+
+		await flushCompactionQueue.call(fakeThis);
+
+		expect(prompt).toHaveBeenCalledWith("/TaskUpdate 1", { streamingBehavior: "followUp" });
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
+	test("routes the first queued prompt with streaming behavior after compaction", async () => {
+		const flushCompactionQueue = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue") as (
+			this: Record<string, any>,
+			options?: { willRetry?: boolean },
+		) => Promise<void>;
+		const prompt = vi.fn(async (_text: string, options?: { streamingBehavior?: "steer" | "followUp" }) => {
+			if (!options?.streamingBehavior) {
+				throw new Error("Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.");
+			}
+		});
+		const fakeThis = {
+			compactionQueuedMessages: [{ text: "continue after compaction", mode: "steer" }],
+			isExtensionCommand: () => false,
+			session: { prompt, clearQueue: vi.fn(), steer: vi.fn(), followUp: vi.fn() },
+			showError: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+		};
+
+		await flushCompactionQueue.call(fakeThis);
+
+		expect(prompt).toHaveBeenCalledWith("continue after compaction", { streamingBehavior: "steer" });
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
+	test("routes queued extension commands with streaming behavior when retry is pending", async () => {
+		const flushCompactionQueue = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue") as (
+			this: Record<string, any>,
+			options?: { willRetry?: boolean },
+		) => Promise<void>;
+		const prompt = vi.fn(async (_text: string, options?: { streamingBehavior?: "steer" | "followUp" }) => {
+			if (!options?.streamingBehavior) {
+				throw new Error("Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.");
+			}
+		});
+		const fakeThis = {
+			compactionQueuedMessages: [
+				{ text: "/TaskUpdate 1", mode: "followUp" },
+				{ text: "steer retry turn", mode: "steer" },
+			],
+			isExtensionCommand: (text: string) => text.startsWith("/"),
+			session: { prompt, clearQueue: vi.fn(), steer: vi.fn(), followUp: vi.fn() },
+			showError: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+		};
+
+		await flushCompactionQueue.call(fakeThis, { willRetry: true });
+
+		expect(prompt).toHaveBeenCalledWith("/TaskUpdate 1", { streamingBehavior: "followUp" });
+		expect(fakeThis.session.steer).toHaveBeenCalledWith("steer retry turn");
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
+	test("preserves steer and follow-up routing for queued rest messages", async () => {
+		const flushCompactionQueue = Reflect.get(InteractiveMode.prototype, "flushCompactionQueue") as (
+			this: Record<string, any>,
+			options?: { willRetry?: boolean },
+		) => Promise<void>;
+		const fakeThis = {
+			compactionQueuedMessages: [
+				{ text: "first prompt", mode: "steer" },
+				{ text: "second steer", mode: "steer" },
+				{ text: "third follow-up", mode: "followUp" },
+			],
+			isExtensionCommand: () => false,
+			session: { prompt: vi.fn(async () => {}), clearQueue: vi.fn(), steer: vi.fn(), followUp: vi.fn() },
+			showError: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+		};
+
+		await flushCompactionQueue.call(fakeThis);
+
+		expect(fakeThis.session.prompt).toHaveBeenCalledWith("first prompt", { streamingBehavior: "steer" });
+		expect(fakeThis.session.steer).toHaveBeenCalledWith("second steer");
+		expect(fakeThis.session.followUp).toHaveBeenCalledWith("third follow-up");
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+	});
+
 	test("rebuilds chat and appends a synthetic compaction summary at the bottom", async () => {
 		const fakeThis = {
 			isInitialized: true,


### PR DESCRIPTION
## Summary

Fix compaction paths that could fail after reload or while delivering queued messages after compaction.

- Preserve previous-compaction token boundaries when preparing repeated compactions.
- Apply the same previous-compaction boundary fix to the harness compaction copy.
- Route queued post-compaction prompts with `streamingBehavior` so delivery does not call `prompt()` while a turn is still streaming.
- Keep footer context usage and lifetime stats out of the render hot path.

## Validation

- Focused compaction and interactive-mode tests passed.
- Strip-types syntax checks passed for touched TypeScript files.
- Fresh RPC compaction check passed with an existing compaction entry.
