### PR TITLE
fix(ai/model): adjust minimax-m3 context size

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1394,6 +1394,13 @@ async function generateModels() {
 			candidate.cost.output = 1.9;
 			candidate.cost.cacheRead = 0.119;
 		}
+		if (candidate.provider === "openrouter" && candidate.id === "minimax/minimax-m3") {
+			// OpenRouter reports 1M context / 512K output, but the Minimax endpoint
+			// rejects requests above 524288 total tokens. Keep the generated metadata
+			// aligned with the provider-enforced limit so callers do not over-allocate output.
+			candidate.contextWindow = 524288;
+			candidate.maxTokens = 64000;
+		}
 
 	}
 

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -10086,8 +10086,8 @@ export const MODELS = {
 				cacheRead: 0.06,
 				cacheWrite: 0,
 			},
-			contextWindow: 1048576,
-			maxTokens: 512000,
+			contextWindow: 524288,
+			maxTokens: 64000,
 		} satisfies Model<"openai-completions">,
 		"mistralai/codestral-2508": {
 			id: "mistralai/codestral-2508",

--- a/packages/ai/test/openrouter-models.test.ts
+++ b/packages/ai/test/openrouter-models.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.ts";
+
+describe("OpenRouter model metadata", () => {
+	it("caps MiniMax M3 at the provider-enforced context and output limits", () => {
+		const model = getModel("openrouter", "minimax/minimax-m3");
+
+		expect(model).toBeDefined();
+		expect(model.contextWindow).toBe(524288);
+		expect(model.maxTokens).toBe(64000);
+	});
+});


### PR DESCRIPTION
### Summary

This PR will update the context size of Minimax-M3 from 1M to 524288. This happens because I was interacting with the model through OpenRouter and when I input a prompt it gave me an error which says 

> _This endpoint's maximum context length is 524288 tokens._

I've added a script to test it on Appendix A and the full output in the Appendix B. I'm open to any feedback in case this happen to be my misconfiguration.

### Appendix A: Script

Script to test maximum Minimax-M3 context size on OpenRouter

```py
import json
import os

import requests

API_KEY = os.environ.get("OPENROUTER_API_KEY")
if not API_KEY:
    raise SystemExit("Set OPENROUTER_API_KEY first")

url = "https://openrouter.ai/api/v1/chat/completions"

headers = {
    "Authorization": f"Bearer {API_KEY}",
    "Content-Type": "application/json",
    "HTTP-Referer": "http://localhost",
    "X-Title": "Letta Code MiniMax context test",
}

# Approximate Letta's non-user text overhead. The earlier Letta error showed
# roughly 14k text input before counting tools, even though the user sent "Hi".
large_system_prompt = (
    "You are a coding agent. Follow all instructions carefully.\n"
    + ("System prompt filler. " * 4500)
)

# Approximate Letta's tool-schema overhead. OpenRouter reports tool definitions
# separately as "tool input"; the earlier error showed roughly 12k tool input.
tools = []
for i in range(60):
    tools.append(
        {
            "type": "function",
            "function": {
                "name": f"tool_{i}",
                "description": "A test tool with a verbose schema. " * 20,
                "parameters": {
                    "type": "object",
                    "properties": {
                        "path": {
                            "type": "string",
                            "description": "A filesystem path or identifier. " * 20,
                        },
                        "query": {
                            "type": "string",
                            "description": "A search query or instruction. " * 20,
                        },
                        "options": {
                            "type": "object",
                            "description": "Additional execution options. " * 20,
                            "properties": {
                                "recursive": {"type": "boolean"},
                                "max_results": {"type": "integer"},
                            },
                        },
                    },
                    "required": ["path"],
                },
            },
        }
    )

for label, max_tokens in [("problem", 512000), ("fixed", 64000)]:
    payload = {
        "model": "minimax/minimax-m3",
        "messages": [
            {"role": "system", "content": large_system_prompt},
            {"role": "user", "content": "Hi"},
        ],
        "tools": tools,
        "max_tokens": max_tokens,
    }

    print(f"\n=== {label} max_tokens={max_tokens} ===")
    print("Approx payload bytes:", len(json.dumps(payload)))
    print("Tools:", len(tools))

    resp = requests.post(url, headers=headers, json=payload, timeout=120)

    print("Status:", resp.status_code)
    try:
        print(json.dumps(resp.json(), indent=2, ensure_ascii=False))
    except Exception:
        print(resp.text)
```

### Appendix B: Output

```
=== problem max_tokens=512000 ===
Approx payload bytes: 276618
Tools: 60
Status: 400
{
  "error": {
    "message": "This endpoint's maximum context length is 524288 tokens. However, you requested about 580252 tokens (24768 of text input, 43484 of tool input, 512000 in the output). Please reduce the length of either one, or use the context-compression plugin to compress your prompt automatically.",
    "code": 400,
    "metadata": {
      "provider_name": null
    }
  },
  "user_id": "user_3EWGEkIgiQkwZ1QsyJSI6npAtMT"
}

=== fixed max_tokens=64000 ===
Approx payload bytes: 276617
Tools: 60
Status: 200
{
  "id": "gen-1781351822-RiCRrOJnPAni2fNIl68m",
  "object": "chat.completion",
  "created": 1781351822,
  "model": "minimax/minimax-m3-20260531",
  "provider": "Minimax",
  "system_fingerprint": null,
  "service_tier": null,
  "choices": [
    {                                                                                                                
      "index": 0,                                                                                                    
      "logprobs": null,                                                                                              
      "finish_reason": "stop",                                                                                       
      "native_finish_reason": "stop",                                                                                
      "message": {                                                                                                   
        "role": "assistant",                                                                                         
        "content": "Hi there! 👋 How can I help you today? Whether it's coding, debugging, exploring ideas, or something else, I'm ready to assist.",                                                                                     
        "refusal": null,                                                                                             
        "reasoning": "The user just said \"Hi\". This is a simple greeting. I should respond in a friendly manner. Let me think about whether I need to use any tools here.\n\nThe user is just saying hello. No tool use is needed. I should just respond with a greeting. Let me keep it short and friendly, and ask how I can help.\n\nThe system prompt mentions I'm a coding agent, but the user is just greeting me. I'll respond warmly and ask what they'd like to work on.",                                                                                                                    
        "reasoning_details": [                                                                                       
          {                                                                                                          
            "type": "reasoning.text",                                                                                
            "text": "The user just said \"Hi\". This is a simple greeting. I should respond in a friendly manner. Let me think about whether I need to use any tools here.\n\nThe user is just saying hello. No tool use is needed. I should just respond with a greeting. Let me keep it short and friendly, and ask how I can help.\n\nThe system prompt mentions I'm a coding agent, but the user is just greeting me. I'll respond warmly and ask what they'd like to work on.",
            "format": "unknown",                                                                                     
            "index": 0                                                                                               
          }                                                                                                          
        ]
      }
    }
  ],
  "usage": {
    "prompt_tokens": 53397,
    "completion_tokens": 131,
    "total_tokens": 53528,
    "cost": 0.01614894,
    "is_byok": false,
    "prompt_tokens_details": {
      "cached_tokens": 114,
      "cache_write_tokens": 0,
      "audio_tokens": 0,
      "video_tokens": 0
    },
    "cost_details": {
      "upstream_inference_cost": 0.01614894,
      "upstream_inference_prompt_cost": 0.01599174,
      "upstream_inference_completions_cost": 0.0001572
    },
    "completion_tokens_details": {
      "reasoning_tokens": 113,
      "image_tokens": 0,
      "audio_tokens": 0
    }
  }
}
```