### PR TITLE
fix: pi.sendUserMessage/sendMessage return Promise

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2208,7 +2208,7 @@ export class AgentSession {
 					});
 				},
 				sendUserMessage: (content, options) => {
-					this.sendUserMessage(content, options).catch((err) => {
+					return this.sendUserMessage(content, options).catch((err) => {
 						runner.emitError({
 							extensionPath: "<runtime>",
 							event: "send_user_message",

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -244,12 +244,12 @@ function createExtensionAPI(
 		// Action methods - delegate to shared runtime
 		sendMessage(message, options): void {
 			runtime.assertActive();
-			runtime.sendMessage(message, options);
+			return runtime.sendMessage(message, options);
 		},
 
 		sendUserMessage(content, options): void {
 			runtime.assertActive();
-			runtime.sendUserMessage(content, options);
+			return runtime.sendUserMessage(content, options);
 		},
 
 		appendEntry(customType: string, data?: unknown): void {


### PR DESCRIPTION
## Problem

`pi.sendUserMessage()` and `pi.sendMessage()` in the extension API do not return their underlying Promise. This means `await pi.sendUserMessage(...)` resolves immediately (after ~1ms) instead of waiting for the agent to finish.

## Impact

In print mode (`pi -p`), extensions that call `pi.sendUserMessage()` in `session_start` hooks cause a race condition where print-mode's `session.prompt()` sees `isStreaming === true` and throws:

```
Agent is already processing. Specify streamingBehavior...
```

This breaks subagent calls and any print-mode usage.

## Fix

Two missing `return` statements:

1. **`packages/coding-agent/src/core/extensions/loader.ts`**:  
   `sendMessage()` and `sendUserMessage()` delegate to runtime but don't return the Promise.

2. **`packages/coding-agent/src/core/agent-session.ts`**:  
   The runtime `sendUserMessage` binding also drops the Promise.

Closes #5751