### PR TITLE
feat(coding-agent): diagnose when a child holds stdio open past exit

### DIFF
--- a/packages/coding-agent/src/utils/child-process.ts
+++ b/packages/coding-agent/src/utils/child-process.ts
@@ -15,6 +15,19 @@ import crossSpawn from "cross-spawn";
 
 const EXIT_STDIO_GRACE_MS = 100;
 
+/**
+ * Opt-in diagnostic for the held-open-pipe case. Enable with PI_STDIO_DEBUG=1.
+ *
+ * When a child exits but a detached descendant keeps emitting on the inherited
+ * stdout/stderr pipe, we keep reading (re-arming the grace on each chunk) rather
+ * than truncate the tail. A descendant that writes continuously can therefore
+ * hold the wait open until the command's own timeout kills the tree. That is the
+ * right trade-off, but it is otherwise invisible: the command reads as a slow
+ * hang with no indication that the process itself had already exited. This flag
+ * surfaces the case so it can be diagnosed instead of guessed at.
+ */
+const STDIO_DEBUG = process.env.PI_STDIO_DEBUG === "1";
+
 export function spawnProcess(
 	command: string,
 	args: string[],
@@ -45,6 +58,9 @@ export function spawnProcessSync(
  * the grace timer is re-armed on every chunk, so an actively writing descendant keeps
  * us reading, while a quiet inherited handle (e.g. a Windows daemonized descendant
  * that never lets `close` fire) still releases us after the grace elapses.
+ *
+ * Set PI_STDIO_DEBUG=1 to log when a process exits but keeps emitting output past
+ * exit (see {@link STDIO_DEBUG}).
  */
 export function waitForChildProcess(child: ChildProcess): Promise<number | null> {
 	return new Promise((resolve, reject) => {
@@ -54,6 +70,11 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 		let postExitTimer: NodeJS.Timeout | undefined;
 		let stdoutEnded = child.stdout === null;
 		let stderrEnded = child.stderr === null;
+
+		// Diagnostics for the held-open-pipe case (only collected under PI_STDIO_DEBUG).
+		let exitedAt = 0;
+		let postExitChunks = 0;
+		let postExitBytes = 0;
 
 		const cleanup = () => {
 			if (postExitTimer) {
@@ -69,31 +90,45 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 			child.stderr?.removeListener("data", onData);
 		};
 
-		const finalize = (code: number | null) => {
+		const finalize = (code: number | null, reason: "eof" | "idle-grace" | "close") => {
 			if (settled) return;
 			settled = true;
 			cleanup();
 			child.stdout?.destroy();
 			child.stderr?.destroy();
+			// Only the held-open case is worth a line: the process had already exited
+			// yet kept emitting, which is what can stretch a command to its timeout.
+			if (STDIO_DEBUG && exited && postExitChunks > 0) {
+				console.error(
+					`[stdio] pid ${child.pid ?? "?"} exited but held stdio open for ${Date.now() - exitedAt}ms past exit ` +
+						`(${postExitChunks} chunk(s), ${postExitBytes}B read after exit; resolved via ${reason})`,
+				);
+			}
 			resolve(code);
 		};
 
 		const maybeFinalizeAfterExit = () => {
 			if (!exited || settled) return;
 			if (stdoutEnded && stderrEnded) {
-				finalize(exitCode);
+				finalize(exitCode, "eof");
 			}
 		};
 
 		const armIdleTimer = () => {
 			if (postExitTimer) clearTimeout(postExitTimer);
-			postExitTimer = setTimeout(() => finalize(exitCode), EXIT_STDIO_GRACE_MS);
+			postExitTimer = setTimeout(() => finalize(exitCode, "idle-grace"), EXIT_STDIO_GRACE_MS);
 		};
 
-		const onData = () => {
+		const onData = (chunk: Buffer) => {
 			// Output is still arriving after exit; defer finalizing so we don't
 			// destroy the stream mid-write and truncate the tail.
-			if (exited && !settled) armIdleTimer();
+			if (exited && !settled) {
+				if (STDIO_DEBUG) {
+					postExitChunks += 1;
+					postExitBytes += chunk.length;
+				}
+				armIdleTimer();
+			}
 		};
 
 		const onStdoutEnd = () => {
@@ -116,6 +151,7 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 		const onExit = (code: number | null) => {
 			exited = true;
 			exitCode = code;
+			if (STDIO_DEBUG) exitedAt = Date.now();
 			maybeFinalizeAfterExit();
 			if (!settled) {
 				armIdleTimer();
@@ -123,7 +159,7 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 		};
 
 		const onClose = (code: number | null) => {
-			finalize(code);
+			finalize(code, "close");
 		};
 
 		child.stdout?.once("end", onStdoutEnd);

--- a/packages/coding-agent/test/child-process-stdio-debug.test.ts
+++ b/packages/coding-agent/test/child-process-stdio-debug.test.ts
@@ -1,0 +1,80 @@
+import type { ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * PI_STDIO_DEBUG surfaces the held-open-pipe case that #5753 left in place: a
+ * child that exits while a detached descendant keeps emitting on the inherited
+ * stdout pipe. We keep reading rather than truncate the tail, which means a
+ * descendant writing continuously can hold the wait open until the command's own
+ * timeout. The flag makes that diagnosable instead of reading as a silent hang.
+ *
+ * STDIO_DEBUG is read once at module load, so each case re-imports the module
+ * under the desired env via vi.resetModules().
+ */
+async function loadWaitForChildProcess(debug: boolean): Promise<typeof import("../src/utils/child-process.ts")> {
+	vi.resetModules();
+	if (debug) {
+		vi.stubEnv("PI_STDIO_DEBUG", "1");
+	} else {
+		vi.stubEnv("PI_STDIO_DEBUG", "");
+	}
+	return import("../src/utils/child-process.ts");
+}
+
+describe.skipIf(process.platform === "win32")("PI_STDIO_DEBUG held-open-pipe diagnostic", () => {
+	let child: ChildProcessByStdio<null, Readable, Readable> | undefined;
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+		if (child?.pid) {
+			try {
+				process.kill(-child.pid, "SIGKILL");
+			} catch {
+				// Already gone.
+			}
+		}
+		child = undefined;
+	});
+
+	// The shell exits immediately; a backgrounded subshell keeps stdout open and
+	// emits ticks every 50ms past exit. Each chunk re-arms the grace, so the wait
+	// is held open by output rather than released at the fixed deadline.
+	const heldOpenCommand = 'printf "HEAD\\n"; ( for i in 1 2 3 4; do sleep 0.05; printf "TICK$i\\n"; done ) &';
+
+	it("logs how long a process held stdio open past exit when enabled", async () => {
+		const { spawnProcess, waitForChildProcess } = await loadWaitForChildProcess(true);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		child = spawnProcess("/bin/sh", ["-c", heldOpenCommand], {
+			stdio: ["ignore", "pipe", "pipe"],
+			detached: true,
+		}) as ChildProcessByStdio<null, Readable, Readable>;
+		child.stdout.on("data", () => {});
+
+		const exitCode = await waitForChildProcess(child);
+
+		expect(exitCode).toBe(0);
+		const line = errorSpy.mock.calls.map((args) => String(args[0])).find((text) => text.includes("[stdio]"));
+		expect(line).toBeDefined();
+		expect(line).toContain("held stdio open");
+		expect(line).toMatch(/\d+ms past exit/);
+	});
+
+	it("stays silent when the flag is unset", async () => {
+		const { spawnProcess, waitForChildProcess } = await loadWaitForChildProcess(false);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		child = spawnProcess("/bin/sh", ["-c", heldOpenCommand], {
+			stdio: ["ignore", "pipe", "pipe"],
+			detached: true,
+		}) as ChildProcessByStdio<null, Readable, Readable>;
+		child.stdout.on("data", () => {});
+
+		const exitCode = await waitForChildProcess(child);
+
+		expect(exitCode).toBe(0);
+		expect(errorSpy.mock.calls.some((args) => String(args[0]).includes("[stdio]"))).toBe(false);
+	});
+});


### PR DESCRIPTION
Follow-up to #5753. When reviewing that PR you noted it doesn't change that we can end up waiting for the actual bash timeout to kick in. That's true and it's the right behaviour — if a detached descendant keeps writing after the shell exits, re-arming the grace is what stops us truncating the tail. But it's invisible: the command reads as a slow hang with nothing to say the process itself had already exited and a held-open pipe is what kept us reading.

This adds an opt-in `PI_STDIO_DEBUG=1` that logs, when the wait resolves, how long a process held stdio open past exit, how much it read in that window, and which path released us (clean eof / idle grace / close). Gated exactly like `PI_TIMING`, off by default, zero overhead when unset, and it only fires when output actually arrived after exit — i.e. the case that can stretch to the timeout, not every backgrounded handle.

Example line:

```
[stdio] pid 41234 exited but held stdio open for 4920ms past exit (98 chunk(s), 31610B read after exit; resolved via close)
```

`npm run check` and `./test.sh` both pass. Two tests in `test/child-process-stdio-debug.test.ts`: one that the line is emitted with the flag on, one that it stays silent with it off.