### PR TITLE
fix(render-utils): bug I found but could not describe in technical terms so had my AI write the specifications

### DIFF
--- a/packages/coding-agent/src/core/tools/render-utils.ts
+++ b/packages/coding-agent/src/core/tools/render-utils.ts
@@ -40,7 +40,7 @@ export function getTextOutput(
 	result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> } | undefined,
 	showImages: boolean,
 ): string {
-	if (!result) return "";
+	if (!result || !Array.isArray(result.content)) return "";
 
 	const textBlocks = result.content.filter((c) => c.type === "text");
 	const imageBlocks = result.content.filter((c) => c.type === "image");


### PR DESCRIPTION
I found a bug in the TUI renderer but could not describe it in technical terms, so I had my AI write the specifications and implementation.

The interactive TUI was crashing when certain tools (like graphify) returned a result without a content array. This was due to getTextOutput() assuming result.content was always present.

This PR adds a guard to check if result.content is an array before filtering for text and image blocks.