### PR TITLE
chore: bump TS target and lib to ES2024, use Promise.withResolvers()

### DIFF
--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -59,17 +59,6 @@ function createAssistantToolUseMessage(content: ToolCallContent[]): AssistantMes
 	};
 }
 
-function createDeferred(): {
-	promise: Promise<void>;
-	resolve: () => void;
-} {
-	let resolve = () => {};
-	const promise = new Promise<void>((resolvePromise) => {
-		resolve = resolvePromise;
-	});
-	return { promise, resolve };
-}
-
 describe("Agent", () => {
 	it("should create an agent instance with default state", () => {
 		const agent = new Agent();
@@ -155,7 +144,7 @@ describe("Agent", () => {
 	});
 
 	it("should await async subscribers before prompt resolves", async () => {
-		const barrier = createDeferred();
+		const barrier = Promise.withResolvers<void>();
 		const agent = new Agent({
 			streamFn: () => {
 				const stream = new MockAssistantStream();
@@ -193,7 +182,7 @@ describe("Agent", () => {
 	});
 
 	it("waitForIdle should wait for async subscribers", async () => {
-		const barrier = createDeferred();
+		const barrier = Promise.withResolvers<void>();
 		const agent = new Agent({
 			streamFn: () => {
 				const stream = new MockAssistantStream();
@@ -332,9 +321,9 @@ describe("Agent", () => {
 
 	it("should ignore a settled parallel tool update while another tool is still running", async () => {
 		const toolSchema = Type.Object({});
-		const slowStarted = createDeferred();
-		const settledToolEnded = createDeferred();
-		const releaseSlow = createDeferred();
+		const slowStarted = Promise.withResolvers<void>();
+		const settledToolEnded = Promise.withResolvers<void>();
+		const releaseSlow = Promise.withResolvers<void>();
 		let settledToolUpdate: AgentToolUpdateCallback<{ status: string }> | undefined;
 		const events: AgentEvent[] = [];
 		const settledTool: AgentTool<typeof toolSchema, { status: string }> = {

--- a/packages/agent/test/harness/agent-harness.test.ts
+++ b/packages/agent/test/harness/agent-harness.test.ts
@@ -31,14 +31,6 @@ function textFromUserMessages(messages: Array<{ role: string; content: unknown }
 	});
 }
 
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-	let resolve = () => {};
-	const promise = new Promise<void>((resolvePromise) => {
-		resolve = resolvePromise;
-	});
-	return { promise, resolve };
-}
-
 function getReasoning(options: unknown): unknown {
 	if (!options || typeof options !== "object" || !("reasoning" in options)) return undefined;
 	return options.reasoning;
@@ -379,7 +371,7 @@ describe("AgentHarness", () => {
 		const registration = registerFauxProvider();
 		registrations.push(registration);
 		registration.setResponses([() => fauxAssistantMessage("ok")]);
-		const barrier = deferred();
+		const barrier = Promise.withResolvers<void>();
 		const harness = new AgentHarness({
 			env: new NodeExecutionEnv({ cwd: process.cwd() }),
 			session: new Session(new InMemorySessionStorage()),

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -6,16 +6,16 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	private waiting: ((value: IteratorResult<T>) => void)[] = [];
 	private done = false;
 	private finalResultPromise: Promise<R>;
-	private resolveFinalResult!: (result: R) => void;
+	private resolveFinalResult: (result: R) => void;
 	private isComplete: (event: T) => boolean;
 	private extractResult: (event: T) => R;
 
 	constructor(isComplete: (event: T) => boolean, extractResult: (event: T) => R) {
 		this.isComplete = isComplete;
 		this.extractResult = extractResult;
-		this.finalResultPromise = new Promise((resolve) => {
-			this.resolveFinalResult = resolve;
-		});
+		const finalResult = Promise.withResolvers<R>();
+		this.finalResultPromise = finalResult.promise;
+		this.resolveFinalResult = finalResult.resolve;
 	}
 
 	push(event: T): void {
@@ -54,7 +54,9 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 			} else if (this.done) {
 				return;
 			} else {
-				const result = await new Promise<IteratorResult<T>>((resolve) => this.waiting.push(resolve));
+				const waiter = Promise.withResolvers<IteratorResult<T>>();
+				this.waiting.push(waiter.resolve);
+				const result = await waiter.promise;
 				if (result.done) return;
 				yield result.value;
 			}

--- a/packages/coding-agent/test/file-mutation-queue.test.ts
+++ b/packages/coding-agent/test/file-mutation-queue.test.ts
@@ -10,14 +10,6 @@ function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function createDeferred(): { promise: Promise<void>; resolve: () => void } {
-	let resolve!: () => void;
-	const promise = new Promise<void>((promiseResolve) => {
-		resolve = promiseResolve;
-	});
-	return { promise, resolve };
-}
-
 async function resolvesWithin(promise: Promise<unknown>, ms: number): Promise<boolean> {
 	return Promise.race([promise.then(() => true), delay(ms).then(() => false)]);
 }
@@ -176,9 +168,9 @@ describe("built-in edit and write tools", () => {
 	it("keeps write queue locked while an aborted write is still in flight", async () => {
 		const dir = await createTempDir();
 		const filePath = join(dir, "abort-write.txt");
-		const firstWriteStarted = createDeferred();
-		const finishFirstWrite = createDeferred();
-		const secondWriteStarted = createDeferred();
+		const firstWriteStarted = Promise.withResolvers<void>();
+		const finishFirstWrite = Promise.withResolvers<void>();
+		const secondWriteStarted = Promise.withResolvers<void>();
 		let firstWriteSettled = false;
 
 		const writeTool = createWriteTool(dir, {
@@ -222,9 +214,9 @@ describe("built-in edit and write tools", () => {
 		const dir = await createTempDir();
 		const filePath = join(dir, "abort-edit.txt");
 		await writeFile(filePath, "alpha\nbeta\n", "utf8");
-		const firstWriteStarted = createDeferred();
-		const finishFirstWrite = createDeferred();
-		const secondWriteStarted = createDeferred();
+		const firstWriteStarted = Promise.withResolvers<void>();
+		const finishFirstWrite = Promise.withResolvers<void>();
+		const secondWriteStarted = Promise.withResolvers<void>();
 		let firstWriteSettled = false;
 
 		const editTool = createEditTool(dir, {

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -7,31 +7,12 @@ import { KeybindingsManager } from "../src/core/keybindings.ts";
 import type { SessionInfo } from "../src/core/session-manager.ts";
 import { SessionSelectorComponent } from "../src/modes/interactive/components/session-selector.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
-
-type Deferred<T> = {
-	promise: Promise<T>;
-	resolve: (value: T) => void;
-	reject: (err: unknown) => void;
-};
-
-function createDeferred<T>(): Deferred<T> {
-	let resolve: (value: T) => void = () => {};
-	let reject: (err: unknown) => void = () => {};
-	const promise = new Promise<T>((res, rej) => {
-		resolve = res;
-		reject = rej;
-	});
-	return { promise, resolve, reject };
-}
+import { stripAnsi } from "../src/utils/ansi.ts";
 
 async function flushPromises(): Promise<void> {
 	await new Promise<void>((resolve) => {
 		setImmediate(resolve);
 	});
-}
-
-function stripAnsi(text: string): string {
-	return text.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
 function makeSession(overrides: Partial<SessionInfo> & { id: string }): SessionInfo {
@@ -186,7 +167,7 @@ describe("session selector path/delete interactions", () => {
 
 	it("does not switch scope back to All when All load resolves after toggling back to Current", async () => {
 		const currentSessions = [makeSession({ id: "current" })];
-		const allDeferred = createDeferred<SessionInfo[]>();
+		const allDeferred = Promise.withResolvers<SessionInfo[]>();
 		let allLoadCalls = 0;
 
 		const selector = new SessionSelectorComponent(
@@ -218,7 +199,7 @@ describe("session selector path/delete interactions", () => {
 
 	it("does not start redundant All loads when toggling scopes while All is already loading", async () => {
 		const currentSessions = [makeSession({ id: "current" })];
-		const allDeferred = createDeferred<SessionInfo[]>();
+		const allDeferred = Promise.withResolvers<SessionInfo[]>();
 		let allLoadCalls = 0;
 
 		const selector = new SessionSelectorComponent(

--- a/packages/coding-agent/test/suite/regressions/5724-sigterm-signal-exit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5724-sigterm-signal-exit.test.ts
@@ -24,17 +24,6 @@ const interactiveModePrototype = InteractiveMode.prototype as unknown;
 
 class ProcessExitError extends Error {}
 
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-	let resolve: (() => void) | undefined;
-	const promise = new Promise<void>((res) => {
-		resolve = res;
-	});
-	return {
-		promise,
-		resolve: () => resolve?.(),
-	};
-}
-
 async function callShutdown(context: ShutdownThis, options?: { fromSignal?: boolean }): Promise<void> {
 	try {
 		await (interactiveModePrototype as InteractiveModePrototypeWithShutdown).shutdown.call(context, options);
@@ -54,7 +43,7 @@ describe("InteractiveMode SIGTERM shutdown with signal-exit (#5724)", () => {
 		}) as typeof process.exit);
 
 		const order: string[] = [];
-		const dispose = deferred();
+		const dispose = Promise.withResolvers<void>();
 		const context: ShutdownThis = {
 			isShuttingDown: false,
 			unregisterSignalHandlers: vi.fn(() => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
-		"target": "ES2022",
+		"target": "ES2024",
 		"module": "Node16",
-		"lib": ["ES2022"],
+		"lib": ["ES2024"],
 		"strict": true,
 		"erasableSyntaxOnly": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
I noticed that there are a couple of hand-rolled implementations of `Promise.withResolvers()` likely because we can't use it directly since the TypeScript lib version is ES2022.

I bumped the versions in tsconfig.base.json and replaced those instances with `Promise.withResolvers()`. I checked the new syntax, including the hashbang grammar and the RegExp `v` flag, as well as the library additions in ES2023 and ES2024, on Node 22.19.0, and they all passed.

I also noticed that instances of the RegExp `v` flag already exist in the codebase. This worked with the ES2022 target because `tsgo` doesn't care and emits them unchanged. However, `tsc` rejects them with the error "TS1501: This regular expression flag is only available when targeting 'es2024' or later."