### PR TITLE
feat(coding-agent): add Vercel AI Gateway attribution

### DIFF
--- a/packages/coding-agent/src/core/provider-attribution.ts
+++ b/packages/coding-agent/src/core/provider-attribution.ts
@@ -7,6 +7,7 @@ const NVIDIA_NIM_HOST = "integrate.api.nvidia.com";
 const CLOUDFLARE_API_HOST = "api.cloudflare.com";
 const CLOUDFLARE_AI_GATEWAY_HOST = "gateway.ai.cloudflare.com";
 const OPENCODE_HOST = "opencode.ai";
+const VERCEL_GATEWAY_HOST = "ai-gateway.vercel.sh";
 
 function matchesHost(baseUrl: string, expectedHost: string): boolean {
 	try {
@@ -31,6 +32,10 @@ function isCloudflareModel(model: Model<Api>): boolean {
 		matchesHost(model.baseUrl, CLOUDFLARE_API_HOST) ||
 		matchesHost(model.baseUrl, CLOUDFLARE_AI_GATEWAY_HOST)
 	);
+}
+
+function isVercelGatewayModel(model: Model<Api>): boolean {
+	return model.provider === "vercel-ai-gateway" || matchesHost(model.baseUrl, VERCEL_GATEWAY_HOST);
 }
 
 function getDefaultAttributionHeaders(
@@ -58,6 +63,13 @@ function getDefaultAttributionHeaders(
 	if (isCloudflareModel(model)) {
 		return {
 			"User-Agent": "pi-coding-agent",
+		};
+	}
+
+	if (isVercelGatewayModel(model)) {
+		return {
+			"http-referer": "https://pi.dev",
+			"x-title": "pi",
 		};
 	}
 

--- a/packages/coding-agent/test/sdk-openrouter-attribution.test.ts
+++ b/packages/coding-agent/test/sdk-openrouter-attribution.test.ts
@@ -196,6 +196,13 @@ describe("createAgentSession provider attribution headers", () => {
 		expect(headers?.["X-OpenRouter-Categories"]).toBe("provider-category");
 	});
 
+	it("adds default attribution headers for Vercel AI Gateway models", async () => {
+		const headers = await captureHeaders(createModel("vercel-ai-gateway", "https://ai-gateway.vercel.sh/v1"));
+
+		expect(headers?.["http-referer"]).toBe("https://pi.dev");
+		expect(headers?.["x-title"]).toBe("pi");
+	});
+
 	it("adds default attribution headers for direct NVIDIA NIM endpoints", async () => {
 		const headers = await captureHeaders(createModel("custom-nim", "https://integrate.api.nvidia.com/v1"));
 


### PR DESCRIPTION
**Description**

- added attribution headers to support identification for Vercel AI Gateway
  - adds `http-referer` and `x-title` as documented [here](https://vercel.com/docs/ai-gateway/ecosystem/app-attribution) 

**Verification**

| Case | Media |
| ------------- | ------------- |
| Pi | <video src="https://github.com/user-attachments/assets/66a79687-5591-4802-8e4a-d1f0126fd68e" /> |
| Proxyman | <img width="800" height="auto" alt="CleanShot 2026-06-16 at 09 05 17@2x" src="https://github.com/user-attachments/assets/d90d3122-4006-415f-acc3-820e9a9c521a" /> |

