### PR TITLE
Nixify pi 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
+fi
+
+watch_file flake.nix
+watch_file flake.lock
+if ! use flake . --no-pure-eval; then
+  echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to flake.nix and hit enter to try again." >&2
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ plans/
 .pi/hf-sessions/
 .pi/hf-sessions-backup/
 collect.sh
+.devenv
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,353 @@
+{
+  "nodes": {
+    "cachix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "git-hooks": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "ghostty": "ghostty",
+        "git-hooks": "git-hooks",
+        "nix": "nix",
+        "nixd": "nixd",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1781456191,
+        "narHash": "sha256-aZb6/djq1Msd1oi9L2BEHx7rnRRJEtvWUy2A59zaZVQ=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "48a93d1fd74ca3fb4f3f64e942cfcb19a1d9f7e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779069789,
+        "narHash": "sha256-ojo+gso45/6CVSuqfSVnlWpQ4d0QeLgwok+v/g3yu0E=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "4b7bf0b20e3baf9c1ba10c63f2ad1fd853faea8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779748925,
+        "narHash": "sha256-meIhqGC04O5VXbKSFXSQoOKp+XCq5RMnwAk1Guo0VQo=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "0bc443c8ff235c3547d09327b48aaa2ab98b15f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "devenv-2.34",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1778381404,
+        "narHash": "sha256-FqhdOTA8vyoIpkHhbs2cCT7h6EWM7nsLeOYJc1ifQLE=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "e3e45eb76663f522e196b7f0cf34cab201db7779",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779074409,
+        "narHash": "sha256-6aXy8Ga41iLVM8ibddFU1O5+wYWcBGNEfZzZuL91eIc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2a77b5b1dc952f214e8102acdef1622b68515560",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  inputs = {
+    nixpkgs.url = "github:cachix/devenv-nixpkgs/rolling";
+    systems.url = "github:nix-systems/default";
+    devenv.url = "github:cachix/devenv";
+    devenv.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  nixConfig = {
+    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
+    extra-substituters = "https://devenv.cachix.org";
+  };
+
+  outputs = { self, nixpkgs, devenv, systems, ... } @ inputs:
+    let
+      forEachSystem = nixpkgs.lib.genAttrs (import systems);
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forEachSystem
+        (system:
+          let
+            pkgs = pkgsFor system;
+            pi = import ./nix/package.nix {
+              inherit pkgs;
+              srcRoot = ./.;
+            };
+          in
+          {
+            default = pi;
+            pi = pi;
+          });
+
+      apps = forEachSystem
+        (system:
+          import ./nix/apps.nix {
+            pi = self.packages.${system}.pi;
+          });
+
+      devShells = forEachSystem
+        (system:
+          let
+            pkgs = pkgsFor system;
+          in
+          {
+            default = import ./nix/devshell.nix {
+              inherit devenv inputs pkgs self;
+            };
+          });
+
+      formatter = forEachSystem (system: (pkgsFor system).nixpkgs-fmt);
+    };
+}

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,15 @@
+{ pi }:
+
+let
+  app = {
+    type = "app";
+    program = "${pi}/bin/pi";
+    meta = {
+      description = "Minimal terminal coding harness";
+    };
+  };
+in
+{
+  default = app;
+  pi = app;
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,33 @@
+{ devenv, inputs, pkgs, self }:
+
+let
+  nodejs = import ./nodejs.nix { inherit pkgs; };
+in
+devenv.lib.mkShell {
+  inherit inputs pkgs;
+
+  modules = [
+    {
+      # https://devenv.sh/reference/options/
+      devenv.root =
+        let
+          pwd = builtins.getEnv "PWD";
+        in
+        if pwd != "" then pwd else self.outPath;
+
+      languages.javascript = {
+        enable = true;
+        package = nodejs;
+        npm.enable = true;
+      };
+
+      packages = [
+        pkgs.fd
+        pkgs.git
+        pkgs.gnutar
+        pkgs.ripgrep
+        pkgs.unzip
+      ];
+    }
+  ];
+}

--- a/nix/nodejs.nix
+++ b/nix/nodejs.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+
+if pkgs ? nodejs_24 then
+  pkgs.nodejs_24
+else if pkgs ? nodejs_22 then
+  pkgs.nodejs_22
+else
+  pkgs.nodejs_latest

--- a/nix/package-source.nix
+++ b/nix/package-source.nix
@@ -1,0 +1,18 @@
+{ lib, srcRoot }:
+
+let
+  fromRoot = path: srcRoot + path;
+in
+lib.fileset.toSource {
+  root = srcRoot;
+  fileset = lib.fileset.unions (map fromRoot [
+    "/.npmrc"
+    "/package-lock.json"
+    "/package.json"
+    "/packages/agent"
+    "/packages/ai"
+    "/packages/coding-agent"
+    "/packages/tui"
+    "/tsconfig.base.json"
+  ]);
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,53 @@
+{ pkgs, srcRoot }:
+
+let
+  lib = pkgs.lib;
+  nodejs = import ./nodejs.nix { inherit pkgs; };
+  npmPackage =
+    if builtins.elem "npm" (nodejs.outputs or [ ]) then
+      lib.getOutput "npm" nodejs
+    else
+      nodejs;
+  codingAgentPackage = builtins.fromJSON (builtins.readFile (srcRoot + "/packages/coding-agent/package.json"));
+  runtimePackages = [
+    pkgs.fd
+    pkgs.git
+    pkgs.gnutar
+    nodejs
+    npmPackage
+    pkgs.ripgrep
+    pkgs.unzip
+  ];
+in
+pkgs.buildNpmPackage {
+  pname = "pi";
+  version = codingAgentPackage.version;
+  src = import ./package-source.nix { inherit lib srcRoot; };
+
+  npmDepsHash = "sha256-y3wwz0orFrUPu4XRJnHRkO9x9s+GMtBP/2g7kN336vQ=";
+  npmFlags = [ "--ignore-scripts" ];
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+
+  PI_NIX_ASSERT_RUNTIME_PATH = ./scripts/assert-runtime-path.cjs;
+  PI_NIX_NODE = "${nodejs}/bin/node";
+  PI_NIX_RUNTIME_PATH = lib.makeBinPath runtimePackages;
+
+  buildPhase = "source ${./scripts/build-phase.sh}";
+  installPhase = "source ${./scripts/install-phase.sh}";
+
+  doInstallCheck = true;
+  installCheckPhase = "source ${./scripts/install-check-phase.sh}";
+
+  passthru = {
+    inherit nodejs runtimePackages;
+  };
+
+  meta = {
+    description = "Minimal terminal coding harness";
+    homepage = "https://github.com/earendil-works/pi";
+    license = lib.licenses.mit;
+    mainProgram = "pi";
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -24,7 +24,7 @@ pkgs.buildNpmPackage {
   version = codingAgentPackage.version;
   src = import ./package-source.nix { inherit lib srcRoot; };
 
-  npmDepsHash = "sha256-y3wwz0orFrUPu4XRJnHRkO9x9s+GMtBP/2g7kN336vQ=";
+  npmDepsHash = "sha256-fVsU+TkX9XSDsb0/h53pug/oXwD8lle5blWlw6hbfDw=";
   npmFlags = [ "--ignore-scripts" ];
   npmRebuildFlags = [ "--ignore-scripts" ];
 

--- a/nix/scripts/assert-runtime-path.cjs
+++ b/nix/scripts/assert-runtime-path.cjs
@@ -1,0 +1,25 @@
+const { spawnSync } = require("node:child_process");
+
+const childEnv = { ...process.env };
+delete childEnv.NODE_OPTIONS;
+
+const checks = [
+  ["node", ["--version"]],
+  ["npm", ["--version"]],
+  ["fd", ["--version"]],
+  ["git", ["--version"]],
+  ["rg", ["--version"]],
+  ["tar", ["--version"]],
+  ["unzip", ["-v"]],
+];
+
+for (const [command, args] of checks) {
+  const result = spawnSync(command, args, {
+    env: childEnv,
+    stdio: "ignore",
+    timeout: 10000,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error("runtime command is unavailable: " + command);
+  }
+}

--- a/nix/scripts/build-phase.sh
+++ b/nix/scripts/build-phase.sh
@@ -1,0 +1,10 @@
+set -eo pipefail
+
+runHook preBuild
+
+npm run --workspace @earendil-works/pi-tui build
+node_modules/.bin/tsgo -p packages/ai/tsconfig.build.json
+npm run --workspace @earendil-works/pi-agent-core build
+npm run --workspace @earendil-works/pi-coding-agent build
+
+runHook postBuild

--- a/nix/scripts/install-check-phase.sh
+++ b/nix/scripts/install-check-phase.sh
@@ -1,0 +1,13 @@
+set -eo pipefail
+
+runHook preInstallCheck
+
+export HOME="$TMPDIR/home"
+mkdir -p "$HOME"
+
+NODE_OPTIONS="--require $PI_NIX_ASSERT_RUNTIME_PATH" "$out/bin/pi" --version
+"$out/bin/pi" --version
+"$out/bin/pi" --help > /dev/null
+PI_OFFLINE=1 "$out/bin/pi" --list-models > /dev/null
+
+runHook postInstallCheck

--- a/nix/scripts/install-phase.sh
+++ b/nix/scripts/install-phase.sh
@@ -1,0 +1,45 @@
+set -eo pipefail
+
+runHook preInstall
+
+npm prune --omit=dev --workspaces --ignore-scripts --no-save
+
+packageRoot="$out/lib/node_modules/@earendil-works/pi-coding-agent"
+scopedModules="$packageRoot/node_modules/@earendil-works"
+mkdir -p "$packageRoot" "$scopedModules" "$out/bin"
+
+cp -R node_modules "$packageRoot/"
+rm -rf "$scopedModules"
+mkdir -p "$scopedModules"
+
+copyWorkspacePackage() {
+  local src="$1"
+  local dest="$2"
+  shift 2
+  mkdir -p "$dest"
+  for path in "$@"; do
+    if [ -e "$src/$path" ]; then
+      cp -R "$src/$path" "$dest/"
+    fi
+  done
+}
+
+copyWorkspacePackage packages/coding-agent "$packageRoot" \
+  package.json README.md CHANGELOG.md npm-shrinkwrap.json dist docs examples
+copyWorkspacePackage packages/agent "$scopedModules/pi-agent-core" \
+  package.json README.md CHANGELOG.md dist
+copyWorkspacePackage packages/ai "$scopedModules/pi-ai" \
+  package.json README.md CHANGELOG.md bedrock-provider.d.ts bedrock-provider.js dist
+copyWorkspacePackage packages/tui "$scopedModules/pi-tui" \
+  package.json README.md CHANGELOG.md dist native
+
+ln -s "$packageRoot" "$scopedModules/pi-coding-agent"
+find "$packageRoot/node_modules" -xtype l -delete
+chmod +x "$packageRoot/dist/cli.js"
+
+makeBinaryWrapper "$PI_NIX_NODE" "$out/bin/pi" \
+  --add-flags "$packageRoot/dist/cli.js" \
+  --prefix PATH : "$PI_NIX_RUNTIME_PATH" \
+  --set-default PI_PACKAGE_DIR "$packageRoot"
+
+runHook postInstall

--- a/package-lock.json
+++ b/package-lock.json
@@ -1720,9 +1720,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
@@ -1738,12 +1738,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
 			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -4461,24 +4455,23 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-			"integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
 				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/eventemitter": "^1.1.1",
 				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"long": "^5.3.2"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -5340,9 +5333,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-			"integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+			"integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6106,9 +6099,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `pi uninstall`/`pi remove` for npm packages to avoid starting project-trust extensions during global removal and to use peer-relaxed package-manager flags, avoiding failures caused by unrelated stale peer dependencies in the managed package root.
+
 ## [0.79.4] - 2026-06-15
 
 ### New Features

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -782,9 +782,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
@@ -800,12 +800,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
 			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -1585,23 +1579,22 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-			"integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
 				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/eventemitter": "^1.1.1",
 				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"long": "^5.3.2"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -1746,9 +1739,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -1757,6 +1757,25 @@ export class DefaultPackageManager implements PackageManager {
 		return ["install", ...specs, "--prefix", installRoot, "--legacy-peer-deps"];
 	}
 
+	private getNpmUninstallArgs(packageName: string, installRoot: string): string[] {
+		const packageManagerName = this.getPackageManagerName();
+		if (packageManagerName === "bun") {
+			return ["uninstall", packageName, "--cwd", installRoot];
+		}
+		if (packageManagerName === "pnpm") {
+			return [
+				"uninstall",
+				packageName,
+				"--prefix",
+				installRoot,
+				"--config.auto-install-peers=false",
+				"--config.strict-peer-dependencies=false",
+				"--config.strict-dep-builds=false",
+			];
+		}
+		return ["uninstall", packageName, "--prefix", installRoot, "--legacy-peer-deps"];
+	}
+
 	private async installNpm(source: NpmSource, scope: SourceScope, temporary: boolean): Promise<void> {
 		const installRoot = this.getNpmInstallRoot(scope, temporary);
 		this.ensureNpmProject(installRoot);
@@ -1768,11 +1787,7 @@ export class DefaultPackageManager implements PackageManager {
 		if (!existsSync(installRoot)) {
 			return;
 		}
-		if (this.getPackageManagerName() === "bun") {
-			await this.runNpmCommand(["uninstall", source.name, "--cwd", installRoot]);
-			return;
-		}
-		await this.runNpmCommand(["uninstall", source.name, "--prefix", installRoot]);
+		await this.runNpmCommand(this.getNpmUninstallArgs(source.name, installRoot));
 	}
 
 	private async installGit(source: GitSource, scope: SourceScope): Promise<void> {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -580,11 +580,14 @@ export async function handlePackageCommand(
 	const cwd = process.cwd();
 	const agentDir = getAgentDir();
 	const writesProjectPackageConfig = (options.command === "install" || options.command === "remove") && options.local;
+	const usesSavedProjectTrustOnly =
+		options.command === "update" ||
+		((options.command === "install" || options.command === "remove") && !options.local);
 	const { settingsManager, projectTrustWarnings } = await createCommandSettingsManager({
 		cwd,
 		agentDir,
 		projectTrustOverride: options.projectTrustOverride,
-		useSavedProjectTrustOnly: options.command === "update",
+		useSavedProjectTrustOnly: usesSavedProjectTrustOnly,
 		extensionFactories: runtimeOptions.extensionFactories,
 	});
 	reportProjectTrustWarnings(projectTrustWarnings);

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -249,6 +249,54 @@ describe("package commands", () => {
 		}
 	});
 
+	it("does not ask extensions for project trust during global package removal", async () => {
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+		mkdirSync(join(agentDir, "npm"), { recursive: true });
+		const fakeNpmPath = join(tempDir, "fake-remove-npm.cjs");
+		const recordPath = join(tempDir, "global-remove.json");
+		writeFileSync(
+			fakeNpmPath,
+			`const fs=require("node:fs");fs.writeFileSync(${JSON.stringify(recordPath)},JSON.stringify(process.argv.slice(2)));`,
+		);
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ packages: ["npm:pi-lean-ctx"], npmCommand: [originalExecPath, fakeNpmPath] }),
+		);
+		writeFileSync(join(projectDir, ".pi", "settings.json"), JSON.stringify({ packages: ["npm:@project/pkg"] }));
+		let projectTrustCalled = false;
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await expect(
+				main(["remove", "npm:pi-lean-ctx"], {
+					extensionFactories: [
+						(pi) => {
+							pi.on("project_trust", () => {
+								projectTrustCalled = true;
+								return { trusted: "yes" };
+							});
+						},
+					],
+				}),
+			).resolves.toBeUndefined();
+
+			const recordedArgs = JSON.parse(readFileSync(recordPath, "utf-8")) as string[];
+			const settings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8")) as { packages?: string[] };
+			expect(projectTrustCalled).toBe(false);
+			expect(recordedArgs).toEqual([
+				"uninstall",
+				"pi-lean-ctx",
+				"--prefix",
+				join(agentDir, "npm"),
+				"--legacy-peer-deps",
+			]);
+			expect(settings.packages ?? []).toEqual([]);
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
 	it("uses saved project trust during update", async () => {
 		mkdirSync(join(projectDir, ".pi"), { recursive: true });
 		const fakeNpmPath = join(tempDir, "fake-trusted-project-npm.cjs");

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -743,6 +743,52 @@ Content`,
 			);
 		});
 
+		it("should use legacy peer deps for npm package uninstalls", async () => {
+			mkdirSync(join(agentDir, "npm"), { recursive: true });
+			const runCommandSpy = vi.spyOn(packageManager as any, "runCommand").mockResolvedValue(undefined);
+
+			await packageManager.remove("npm:pi-lean-ctx");
+
+			expect(runCommandSpy).toHaveBeenCalledWith(
+				"npm",
+				["uninstall", "pi-lean-ctx", "--prefix", join(agentDir, "npm"), "--legacy-peer-deps"],
+				undefined,
+			);
+		});
+
+		it("should use peer-relaxed pnpm args for npm package uninstalls", async () => {
+			settingsManager = SettingsManager.inMemory({
+				npmCommand: ["mise", "exec", "node@20", "--", "pnpm"],
+			});
+			packageManager = new DefaultPackageManager({
+				cwd: tempDir,
+				agentDir,
+				settingsManager,
+			});
+			mkdirSync(join(agentDir, "npm"), { recursive: true });
+			const runCommandSpy = vi.spyOn(packageManager as any, "runCommand").mockResolvedValue(undefined);
+
+			await packageManager.remove("npm:pi-lean-ctx");
+
+			expect(runCommandSpy).toHaveBeenCalledWith(
+				"mise",
+				[
+					"exec",
+					"node@20",
+					"--",
+					"pnpm",
+					"uninstall",
+					"pi-lean-ctx",
+					"--prefix",
+					join(agentDir, "npm"),
+					"--config.auto-install-peers=false",
+					"--config.strict-peer-dependencies=false",
+					"--config.strict-dep-builds=false",
+				],
+				undefined,
+			);
+		});
+
 		it("should install git package dependencies with --omit=dev", async () => {
 			const source = "git:github.com/user/repo";
 			const targetDir = join(agentDir, "git", "github.com", "user", "repo");
@@ -1088,13 +1134,9 @@ Content`,
 		it("should emit progress events on install attempt", async () => {
 			const events: ProgressEvent[] = [];
 			packageManager.setProgressCallback((event) => events.push(event));
+			vi.spyOn(packageManager as any, "runCommand").mockRejectedValue(new Error("install failed"));
 
-			// Use public install method which emits progress events
-			try {
-				await packageManager.install("npm:nonexistent-package@1.0.0");
-			} catch {
-				// Expected to fail - package doesn't exist
-			}
+			await expect(packageManager.install("npm:nonexistent-package@1.0.0")).rejects.toThrow("install failed");
 
 			// Should have emitted start event before failure
 			expect(events.some((e) => e.type === "start" && e.action === "install")).toBe(true);

--- a/scripts/generate-coding-agent-shrinkwrap.mjs
+++ b/scripts/generate-coding-agent-shrinkwrap.mjs
@@ -12,7 +12,7 @@ const shrinkwrapPath = join(codingAgentDir, "npm-shrinkwrap.json");
 const internalPackagePrefix = "@earendil-works/pi-";
 const allowedInstallScriptPackages = new Map([
 	["@google/genai@1.52.0", "preinstall is a no-op in the published package"],
-	["protobufjs@7.5.9", "postinstall only warns about protobufjs version scheme mismatches"],
+	["protobufjs@7.6.4", "postinstall only warns about protobufjs version scheme mismatches"],
 ]);
 
 const args = new Set(process.argv.slice(2));


### PR DESCRIPTION
This PR add nix flake packaging to pi.


## How to Use the Flake

  From the repo root:

  ```bash
  nix build path:$PWD#pi
  nix run path:$PWD#pi -- --version
  nix run path:$PWD#pi -- --help
  ```
  Install the local flake build into your user profile:
```bash
  nix profile add path:$PWD#pi
```
  After changing the checkout, refresh the installed profile entry:
```bash
  nix profile upgrade pi
```
  Enter the development shell:
```bash
  nix develop --impure path:$PWD
```
  Run validation:
```bash
  nix build path:$PWD#pi --no-link
  nix run path:$PWD#pi -- --version
  npm run check
```
  The flake packages the core pi CLI only. Runtime state such as installed pi packages, extensions, settings, sessions,
  and credentials remains outside the Nix store under the normal user/project locations like ~/.pi/agent and .pi/.
  
  You can also install it to a nix profile directly from github:
  
  ```bash
  nix profile add github:o1lo01ol1o/pi/feat/nix-flake-package#pi
```
  Run it:
 ```bash
  pi --version
  pi --help
```
  Upgrade later from the same branch:
 ```bash
  nix profile upgrade pi
```
  For a specific commit:
 ```bash
  nix profile add github:o1lo01ol1o/pi/<commit-sha>#pi
  ```