### PR TITLE
feat(ai): add durationMs and timeToFirstTokenMs to Usage, display tokens/sec in footer

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -75,6 +75,14 @@ export interface OpenAIResponsesStreamOptions {
 	) => void;
 }
 
+/** Mutable timing context passed from caller to processResponsesStream */
+export interface TimingContext {
+	/** When stream started (set by caller) */
+	startTime: number;
+	/** When first content token arrived (set by processResponsesStream) */
+	firstTokenTime?: number;
+}
+
 export interface ConvertResponsesMessagesOptions {
 	includeSystemPrompt?: boolean;
 }
@@ -290,12 +298,13 @@ export async function processResponsesStream<TApi extends Api>(
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
 	model: Model<TApi>,
-	options?: OpenAIResponsesStreamOptions,
+	options?: OpenAIResponsesStreamOptions & { timing?: TimingContext },
 ): Promise<void> {
 	let currentItem: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | null = null;
 	let currentBlock: ThinkingContent | TextContent | (ToolCall & { partialJson: string }) | null = null;
 	const blocks = output.content;
 	const blockIndex = () => blocks.length - 1;
+	const timing = options?.timing;
 
 	for await (const event of openaiStream) {
 		if (event.type === "response.created") {
@@ -361,6 +370,7 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.reasoning_text.delta") {
 			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
+				if (timing && !timing.firstTokenTime) timing.firstTokenTime = Date.now();
 				currentBlock.thinking += event.delta;
 				stream.push({
 					type: "thinking_delta",
@@ -384,6 +394,7 @@ export async function processResponsesStream<TApi extends Api>(
 				}
 				const lastPart = currentItem.content[currentItem.content.length - 1];
 				if (lastPart?.type === "output_text") {
+					if (timing && !timing.firstTokenTime) timing.firstTokenTime = Date.now();
 					currentBlock.text += event.delta;
 					lastPart.text += event.delta;
 					stream.push({

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -126,12 +126,20 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 			};
 			const { data: openaiStream, response } = await client.responses.create(params, requestOptions).withResponse();
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
+			const timing: { startTime: number; firstTokenTime?: number } = { startTime: Date.now() };
 			stream.push({ type: "start", partial: output });
 
 			await processResponsesStream(openaiStream, output, stream, model, {
 				serviceTier: options?.serviceTier,
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
+				timing,
 			});
+
+			// Set timing on usage
+			output.usage.durationMs = Date.now() - timing.startTime;
+			if (timing.firstTokenTime) {
+				output.usage.timeToFirstTokenMs = timing.firstTokenTime - timing.startTime;
+			}
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -277,6 +277,10 @@ export interface Usage {
 		cacheWrite: number;
 		total: number;
 	};
+	/** Total response duration in milliseconds (stream start to response.completed) */
+	durationMs?: number;
+	/** Time from stream start to first content token in milliseconds */
+	timeToFirstTokenMs?: number;
 }
 
 export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -90,6 +90,9 @@ export class FooterComponent implements Component {
 		let totalCacheWrite = 0;
 		let totalCost = 0;
 		let latestCacheHitRate: number | undefined;
+		let latestDurationMs: number | undefined;
+		let latestOutputTokens: number | undefined;
+		let latestTtfbMs: number | undefined;
 
 		for (const entry of this.session.sessionManager.getEntries()) {
 			if (entry.type === "message" && entry.message.role === "assistant") {
@@ -103,6 +106,13 @@ export class FooterComponent implements Component {
 					entry.message.usage.input + entry.message.usage.cacheRead + entry.message.usage.cacheWrite;
 				latestCacheHitRate =
 					latestPromptTokens > 0 ? (entry.message.usage.cacheRead / latestPromptTokens) * 100 : undefined;
+
+				// Track latest message timing
+				if (entry.message.usage.durationMs != null) {
+					latestDurationMs = entry.message.usage.durationMs;
+					latestOutputTokens = entry.message.usage.output;
+					latestTtfbMs = entry.message.usage.timeToFirstTokenMs;
+				}
 			}
 		}
 
@@ -136,6 +146,16 @@ export class FooterComponent implements Component {
 		if (totalCacheWrite) statsParts.push(`W${formatTokens(totalCacheWrite)}`);
 		if ((totalCacheRead > 0 || totalCacheWrite > 0) && latestCacheHitRate !== undefined) {
 			statsParts.push(`CH${latestCacheHitRate.toFixed(1)}%`);
+		}
+
+		// Show throughput (tokens/sec) from latest message
+		if (latestDurationMs != null && latestDurationMs > 0 && latestOutputTokens != null) {
+			const tps = (latestOutputTokens / (latestDurationMs / 1000)).toFixed(1);
+			statsParts.push(`${tps}t/s`);
+			if (latestTtfbMs != null) {
+				const ttfb = latestTtfbMs >= 1000 ? `${(latestTtfbMs / 1000).toFixed(1)}s` : `${latestTtfbMs}ms`;
+				statsParts.push(`(TTFB ${ttfb})`);
+			}
 		}
 
 		// Show cost with "(sub)" indicator if using OAuth subscription


### PR DESCRIPTION
## Problem
`AssistantMessage.usage` exposes only token counts and cost — no timing data. Footer extensions and any consumer wanting latency or throughput metrics hit this wall.

## Changes

### 1. Usage interface (`packages/ai/src/types.ts`)
Added two optional timing fields:
```ts
durationMs?: number;         // total response time
timeToFirstTokenMs?: number; // TTFB
```

### 2. OpenAI Responses provider (`openai-responses.ts`, `openai-responses-shared.ts`)
- Capture `startTime` when stream begins
- Capture `firstTokenTime` on first `reasoning_text.delta` or `output_text.delta`
- Compute `durationMs` = end - start after `processResponsesStream` completes
- Compute `timeToFirstTokenMs` = firstToken - start

### 3. Footer (`footer.ts`)
- Track latest assistant message timing in session loop
- Display **throughput** (`X.Xt/s`) when duration available
- Display **TTFB** in parentheses (`(TTFB Yms)` or `(TTFB Y.Ys)`) when available

## Impact
- **Low risk**: optional fields, backward compatible
- **OpenAI provider only** for now — other providers follow same pattern
- **Footer auto-shows** timing when data available, nothing changes for providers without timing yet

## Files
- `packages/ai/src/types.ts` — Usage interface
- `packages/ai/src/providers/openai-responses-shared.ts` — timing capture
- `packages/ai/src/providers/openai-responses.ts` — timing context
- `packages/coding-agent/src/modes/interactive/components/footer.ts` — display