### PR TITLE
fix(ai): include raw provider error bodies

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider HTTP errors to include raw response bodies when SDKs expose only opaque status messages ([#5763](https://github.com/earendil-works/pi/issues/5763)).
+
 ## [0.79.6] - 2026-06-16
 
 ### Fixed

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -51,6 +51,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
@@ -320,15 +321,16 @@ const BEDROCK_DATA_RETENTION_DOCS_URL = "https://docs.aws.amazon.com/bedrock/lat
  * detection) can distinguish error categories via simple string matching.
  */
 function formatBedrockError(error: unknown): string {
-	const message = error instanceof Error ? error.message : JSON.stringify(error);
-	const dataRetentionHint = /data retention mode/i.test(message)
+	const formatted = formatProviderError(error, { providerName: "Bedrock" });
+	const message = error instanceof Error ? error.message : formatted;
+	const dataRetentionHint = /data retention mode/i.test(formatted)
 		? ` See ${BEDROCK_DATA_RETENTION_DOCS_URL} for supported data retention modes.`
 		: "";
 	if (error instanceof BedrockRuntimeServiceException) {
 		const prefix = BEDROCK_ERROR_PREFIXES[error.name] ?? error.name;
-		return `${prefix}: ${message}${dataRetentionHint}`;
+		return `${prefix}: ${formatted === message ? message : formatted}${dataRetentionHint}`;
 	}
-	return `${message}${dataRetentionHint}`;
+	return `${formatted}${dataRetentionHint}`;
 }
 
 /**

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -13,6 +13,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -41,22 +42,6 @@ function resolveDeploymentName(model: Model<"azure-openai-responses">, options?:
 		getProviderEnvValue("AZURE_OPENAI_DEPLOYMENT_NAME_MAP", options?.env),
 	).get(model.id);
 	return mappedDeployment || model.id;
-}
-
-function formatAzureOpenAIError(error: unknown): string {
-	if (error instanceof Error) {
-		const status = (error as Error & { status?: unknown }).status;
-		const statusCode = typeof status === "number" ? status : undefined;
-		if (statusCode !== undefined) {
-			return `Azure OpenAI API error (${statusCode}): ${error.message}`;
-		}
-		return error.message;
-	}
-	try {
-		return JSON.stringify(error);
-	} catch {
-		return String(error);
-	}
 }
 
 // Azure OpenAI Responses-specific options
@@ -141,7 +126,7 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 				delete (block as { partialJson?: string }).partialJson;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = formatAzureOpenAIError(error);
+			output.errorMessage = formatProviderError(error, { providerName: "Azure OpenAI" });
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -25,6 +25,7 @@ import type {
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import type { GoogleThinkingLevel } from "./google-shared.ts";
 import {
@@ -285,7 +286,7 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 				}
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error, { providerName: "Google Vertex" });
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -20,6 +20,7 @@ import type {
 	ToolCall,
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import type { GoogleThinkingLevel } from "./google-shared.ts";
 import {
@@ -268,7 +269,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 				}
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error, { providerName: "Google" });
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -24,12 +24,12 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
-const MAX_MISTRAL_ERROR_BODY_CHARS = 4000;
 
 /**
  * Provider-specific options for the Mistral API.
@@ -95,7 +95,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 				delete (block as { partialArgs?: string }).partialArgs;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = formatMistralError(error);
+			output.errorMessage = formatProviderError(error, { providerName: "Mistral" });
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}
@@ -180,34 +180,6 @@ function deriveMistralToolCallId(id: string, attempt: number): string {
 	return shortHash(seed)
 		.replace(/[^a-zA-Z0-9]/g, "")
 		.slice(0, MISTRAL_TOOL_CALL_ID_LENGTH);
-}
-
-function formatMistralError(error: unknown): string {
-	if (error instanceof Error) {
-		const sdkError = error as Error & { statusCode?: unknown; body?: unknown };
-		const statusCode = typeof sdkError.statusCode === "number" ? sdkError.statusCode : undefined;
-		const bodyText = typeof sdkError.body === "string" ? sdkError.body.trim() : undefined;
-		if (statusCode !== undefined && bodyText) {
-			return `Mistral API error (${statusCode}): ${truncateErrorText(bodyText, MAX_MISTRAL_ERROR_BODY_CHARS)}`;
-		}
-		if (statusCode !== undefined) return `Mistral API error (${statusCode}): ${error.message}`;
-		return error.message;
-	}
-	return safeJsonStringify(error);
-}
-
-function truncateErrorText(text: string, maxChars: number): string {
-	if (text.length <= maxChars) return text;
-	return `${text.slice(0, maxChars)}... [truncated ${text.length - maxChars} chars]`;
-}
-
-function safeJsonStringify(value: unknown): string {
-	try {
-		const serialized = JSON.stringify(value);
-		return serialized === undefined ? String(value) : serialized;
-	} catch {
-		return String(value);
-	}
 }
 
 function buildRequestOptions(model: Model<"mistral-conversations">, options?: MistralOptions) {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -42,6 +42,7 @@ import {
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -399,7 +400,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				delete (block as { partialJson?: string }).partialJson;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : String(error);
+			output.errorMessage = formatProviderError(error, { providerName: "OpenAI Codex" });
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -34,6 +34,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
@@ -415,10 +416,10 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				delete (block as { streamIndex?: number }).streamIndex;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			output.errorMessage = formatProviderError(error, { providerName: "OpenAI" });
 			// Some providers via OpenRouter give additional information in this field.
-			const rawMetadata = (error as any)?.error?.metadata?.raw;
-			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
+			const rawMetadata = (error as { error?: { metadata?: { raw?: unknown } } }).error?.metadata?.raw;
+			if (typeof rawMetadata === "string" && rawMetadata) output.errorMessage += `\n${rawMetadata}`;
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -17,6 +17,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { formatProviderError } from "../utils/provider-errors.ts";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
@@ -52,22 +53,6 @@ function getPromptCacheRetention(
 	cacheRetention: CacheRetention,
 ): "24h" | undefined {
 	return cacheRetention === "long" && compat.supportsLongCacheRetention ? "24h" : undefined;
-}
-
-function formatOpenAIResponsesError(error: unknown): string {
-	if (error instanceof Error) {
-		const status = (error as Error & { status?: unknown }).status;
-		const statusCode = typeof status === "number" ? status : undefined;
-		if (statusCode !== undefined) {
-			return `OpenAI API error (${statusCode}): ${error.message}`;
-		}
-		return error.message;
-	}
-	try {
-		return JSON.stringify(error);
-	} catch {
-		return String(error);
-	}
 }
 
 // OpenAI Responses-specific options
@@ -152,7 +137,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 				delete (block as { partialJson?: string }).partialJson;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = formatOpenAIResponsesError(error);
+			output.errorMessage = formatProviderError(error, { providerName: "OpenAI" });
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/utils/provider-errors.ts
+++ b/packages/ai/src/utils/provider-errors.ts
@@ -1,0 +1,74 @@
+const DEFAULT_MAX_ERROR_BODY_CHARS = 4000;
+
+interface ProviderErrorOptions {
+	providerName?: string;
+	maxBodyChars?: number;
+}
+
+interface ErrorWithHttpFields extends Error {
+	status?: unknown;
+	statusCode?: unknown;
+	body?: unknown;
+	$metadata?: {
+		httpStatusCode?: unknown;
+	};
+}
+
+export function formatProviderError(error: unknown, options: ProviderErrorOptions = {}): string {
+	if (error instanceof Error) {
+		const httpError = error as ErrorWithHttpFields;
+		const statusCode = getStatusCode(httpError);
+		const bodyText = formatBodyText(httpError.body, options.maxBodyChars ?? DEFAULT_MAX_ERROR_BODY_CHARS);
+		const message = error.message.trim();
+		const prefix = options.providerName ? `${options.providerName} API error` : "Provider API error";
+
+		if (statusCode !== undefined && bodyText && shouldPreferBody(message, statusCode)) {
+			return `${prefix} (${statusCode}): ${bodyText}`;
+		}
+		if (statusCode !== undefined) {
+			return `${prefix} (${statusCode}): ${message}`;
+		}
+		return message;
+	}
+	return safeJsonStringify(error);
+}
+
+export function truncateErrorText(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	return `${text.slice(0, maxChars)}... [truncated ${text.length - maxChars} chars]`;
+}
+
+function getStatusCode(error: ErrorWithHttpFields): number | undefined {
+	if (typeof error.status === "number") return error.status;
+	if (typeof error.statusCode === "number") return error.statusCode;
+	if (typeof error.$metadata?.httpStatusCode === "number") return error.$metadata.httpStatusCode;
+	return undefined;
+}
+
+function formatBodyText(body: unknown, maxChars: number): string | undefined {
+	if (typeof body === "string") {
+		const trimmed = body.trim();
+		return trimmed ? truncateErrorText(trimmed, maxChars) : undefined;
+	}
+	if (body === undefined || body === null) return undefined;
+	return truncateErrorText(safeJsonStringify(body), maxChars);
+}
+
+function shouldPreferBody(message: string, statusCode: number): boolean {
+	if (!message) return true;
+	const escapedStatusCode = String(statusCode).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return (
+		new RegExp(`^${escapedStatusCode}\\s+status code(?: \\(no body\\))?$`, "i").test(message) ||
+		/^\(?no body\)?$/i.test(message) ||
+		/^unknown(?::\s*unknownerror)?$/i.test(message)
+	);
+}
+
+function safeJsonStringify(value: unknown): string {
+	try {
+		const serialized = JSON.stringify(value);
+		return serialized === undefined ? String(value) : serialized;
+	} catch {
+		return String(value);
+	}
+}

--- a/packages/ai/test/provider-errors.test.ts
+++ b/packages/ai/test/provider-errors.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatProviderError } from "../src/utils/provider-errors.ts";
+
+describe("formatProviderError", () => {
+	it("falls back to raw body for opaque no-body SDK messages", () => {
+		const error = new Error("403 status code (no body)") as Error & { status?: number; body?: string };
+		error.status = 403;
+		error.body = '{"error":"gateway rejected request"}';
+
+		expect(formatProviderError(error, { providerName: "OpenAI" })).toBe(
+			'OpenAI API error (403): {"error":"gateway rejected request"}',
+		);
+	});
+
+	it("keeps parsed SDK messages when they are useful", () => {
+		const error = new Error("gateway rejected request") as Error & { status?: number; body?: string };
+		error.status = 403;
+		error.body = '{"error":"gateway rejected request"}';
+
+		expect(formatProviderError(error, { providerName: "OpenAI" })).toBe(
+			"OpenAI API error (403): gateway rejected request",
+		);
+	});
+
+	it("uses statusCode and object bodies from non-OpenAI SDKs", () => {
+		const error = new Error("Unknown: UnknownError") as Error & {
+			statusCode?: number;
+			body?: Record<string, string>;
+		};
+		error.statusCode = 403;
+		error.body = { error: "bedrock gateway rejected request" };
+
+		expect(formatProviderError(error, { providerName: "Bedrock" })).toBe(
+			'Bedrock API error (403): {"error":"bedrock gateway rejected request"}',
+		);
+	});
+
+	it("truncates long raw bodies", () => {
+		const error = new Error("500 status code (no body)") as Error & { status?: number; body?: string };
+		error.status = 500;
+		error.body = "x".repeat(12);
+
+		expect(formatProviderError(error, { providerName: "OpenAI", maxBodyChars: 5 })).toBe(
+			"OpenAI API error (500): xxxxx... [truncated 7 chars]",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add a shared provider error formatter that falls back to raw HTTP response bodies for opaque SDK status errors
- route OpenAI, Azure OpenAI, OpenAI Codex, Google, Vertex, Bedrock, and Mistral provider catch blocks through the shared formatter
- add regression coverage for opaque status messages, parsed SDK messages, object bodies, and truncation

Fixes #5763

## Testing
- node ../../node_modules/vitest/dist/cli.js --run test/provider-errors.test.ts
- npm run check
