### PR TITLE
Compaction-related fixes

### DIFF
--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -250,21 +250,19 @@ path/to/changed.ts
 </modified-files>
 ```
 
-### Message Serialization
+### KV Cache Reuse for Summarization
 
-Before summarization, messages are serialized to text via [`serializeConversation()`](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/core/compaction/utils.ts):
+Compaction summarization reuses the LLM's KV cache by keeping messages in their original format (not serializing to text). The summarization call uses:
 
 ```
-[User]: What they said
-[Assistant thinking]: Internal reasoning
-[Assistant]: Response text
-[Assistant tool calls]: read(path="foo.ts"); edit(path="bar.ts", ...)
-[Tool result]: Output from tool
+[systemPrompt] + [conversation messages] + [summarization instruction]
 ```
 
-This prevents the model from treating it as a conversation to continue.
+The `systemPrompt` is passed through from the original session, allowing the KV cache to cover the entire conversation prefix. Only the summarization instruction (~200 tokens) requires fresh processing.
 
-Tool results are truncated to 2000 characters during serialization. Content beyond that limit is replaced with a marker indicating how many characters were truncated. This keeps summarization requests within reasonable token budgets, since tool results (especially from `read` and `bash`) are typically the largest contributors to context size.
+If no `systemPrompt` is available, `SUMMARIZATION_SYSTEM_PROMPT` is used as a fallback.
+
+Extensions that provide custom summarization via `session_before_compact` can still use `serializeConversation()` for their own purposes — the built-in compaction no longer does.
 
 ## Custom Summarization via Extensions
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1711,6 +1711,7 @@ export class AgentSession {
 					this.thinkingLevel,
 					this.agent.streamFn,
 					env,
+					this.systemPrompt,
 				);
 				summary = result.summary;
 				firstKeptEntryId = result.firstKeptEntryId;
@@ -1987,6 +1988,7 @@ export class AgentSession {
 					this.thinkingLevel,
 					this.agent.streamFn,
 					env,
+					this.systemPrompt,
 				);
 				summary = compactResult.summary;
 				firstKeptEntryId = compactResult.firstKeptEntryId;

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -243,6 +243,24 @@ function estimateTextAndImageContentChars(content: string | Array<{ type: string
 }
 
 /**
+ * Calculate a scaling factor to correct the chars/4 heuristic for code-heavy content.
+ * Compares actual token count (from LLM usage) against estimated count.
+ */
+function calculateTokenScale(
+	pathEntries: SessionEntry[],
+	boundaryStart: number,
+	boundaryEnd: number,
+	actualTokens: number,
+): number {
+	let estimatedTotalTokens = 0;
+	for (let i = boundaryStart; i < boundaryEnd; i++) {
+		const msg = getMessageFromEntry(pathEntries[i]);
+		if (msg) estimatedTotalTokens += estimateTokens(msg);
+	}
+	return estimatedTotalTokens > 0 ? actualTokens / estimatedTotalTokens : 1.0;
+}
+
+/**
  * Estimate token count for a message using chars/4 heuristic.
  * This is conservative (overestimates tokens).
  */
@@ -671,9 +689,14 @@ export function prepareCompaction(
 	}
 	const boundaryEnd = pathEntries.length;
 
-	const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages).tokens;
+	// Get actual token count from LLM usage data for the range we're estimating
+	const sessionContext = buildSessionContext(pathEntries.slice(boundaryStart, boundaryEnd));
+	const tokensBefore = estimateContextTokens(sessionContext.messages).tokens;
 
-	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
+	// Calculate scaling factor to correct chars/4 heuristic for code-heavy content
+	const tokenScale = calculateTokenScale(pathEntries, boundaryStart, boundaryEnd, tokensBefore);
+
+	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens, tokenScale);
 
 	// Get UUID of first kept entry
 	const firstKeptEntry = pathEntries[cutPoint.firstKeptEntryIndex];

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -22,7 +22,6 @@ import {
 	type FileOperations,
 	formatFileOperations,
 	SUMMARIZATION_SYSTEM_PROMPT,
-	serializeConversation,
 } from "./utils.ts";
 
 // ============================================================================
@@ -320,20 +319,17 @@ function findValidCutPoints(entries: SessionEntry[], startIndex: number, endInde
 			case "thinking_level_change":
 			case "model_change":
 			case "compaction":
-			case "branch_summary":
 			case "custom":
-			case "custom_message":
 			case "label":
 			case "session_info":
 				break;
+			case "branch_summary":
+			case "custom_message":
+				cutPoints.push(i);
+				break;
 		}
-
-		// branch_summary and custom_message are user-role messages, valid cut points
-		if (entry.type === "branch_summary" || entry.type === "custom_message") {
-			cutPoints.push(i);
 		}
-	}
-	return cutPoints;
+		return cutPoints;
 }
 
 /**
@@ -388,6 +384,7 @@ export function findCutPoint(
 	startIndex: number,
 	endIndex: number,
 	keepRecentTokens: number,
+	tokenScale = 1.0,
 ): CutPointResult {
 	const cutPoints = findValidCutPoints(entries, startIndex, endIndex);
 
@@ -403,8 +400,8 @@ export function findCutPoint(
 		const entry = entries[i];
 		if (entry.type !== "message") continue;
 
-		// Estimate this message's size
-		const messageTokens = estimateTokens(entry.message);
+		// Estimate this message's size, scaled by actual vs estimated ratio
+		const messageTokens = Math.ceil(estimateTokens(entry.message) * tokenScale);
 		accumulatedTokens += messageTokens;
 
 		// Check if we've exceeded the budget
@@ -568,11 +565,16 @@ export async function generateSummary(
 	thinkingLevel?: ThinkingLevel,
 	streamFn?: StreamFn,
 	env?: Record<string, string>,
+	systemPrompt?: string,
 ): Promise<string> {
 	const maxTokens = Math.min(
 		Math.floor(0.8 * reserveTokens),
 		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
 	);
+
+	// Use the conversation's systemPrompt for KV cache prefix matching.
+	// Falls back to SUMMARIZATION_SYSTEM_PROMPT if not provided.
+	const effectiveSystemPrompt = systemPrompt ?? SUMMARIZATION_SYSTEM_PROMPT;
 
 	// Use update prompt if we have a previous summary, otherwise initial prompt
 	let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
@@ -580,31 +582,31 @@ export async function generateSummary(
 		basePrompt = `${basePrompt}\n\nAdditional focus: ${customInstructions}`;
 	}
 
-	// Serialize conversation to text so model doesn't try to continue it
-	// Convert to LLM messages first (handles custom types like bashExecution, custom, etc.)
-	const llmMessages = convertToLlm(currentMessages);
-	const conversationText = serializeConversation(llmMessages);
+	// Convert to LLM messages (handles custom types like bashExecution, custom, etc.)
+	// These are the SAME messages already in the KV cache - no re-serialization needed
+	const conversationMessages = convertToLlm(currentMessages);
 
-	// Build the prompt with conversation wrapped in tags
-	let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
+	// Build summarization messages: original conversation + summarization instruction
+	const summarizationMessages: AgentMessage[] = [...conversationMessages];
+
+	// Include previous summary if updating
 	if (previousSummary) {
-		promptText += `<previous-summary>\n${previousSummary}\n</previous-summary>\n\n`;
-	}
-	promptText += basePrompt;
-
-	const summarizationMessages = [
-		{
+		summarizationMessages.push({
 			role: "user" as const,
-			content: [{ type: "text" as const, text: promptText }],
-			timestamp: Date.now(),
-		},
-	];
+			content: [{ type: "text" as const, text: `<previous-summary>\n${previousSummary}\n</previous-summary>` }],
+		});
+	}
+
+	// Summarization instruction as final user message (~200 new tokens)
+	summarizationMessages.push({ role: "user" as const, content: [{ type: "text" as const, text: basePrompt }] });
 
 	const completionOptions = createSummarizationOptions(model, maxTokens, apiKey, headers, env, signal, thinkingLevel);
 
+	// Use the conversation's systemPrompt for KV cache prefix matching.
+	// Falls back to SUMMARIZATION_SYSTEM_PROMPT if not provided.
 	const response = await completeSummarization(
 		model,
-		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
+		{ systemPrompt: effectiveSystemPrompt, messages: summarizationMessages },
 		completionOptions,
 		streamFn,
 	);
@@ -756,6 +758,7 @@ export async function compact(
 	thinkingLevel?: ThinkingLevel,
 	streamFn?: StreamFn,
 	env?: Record<string, string>,
+	systemPrompt?: string,
 ): Promise<CompactionResult> {
 	const {
 		firstKeptEntryId,
@@ -787,6 +790,7 @@ export async function compact(
 						thinkingLevel,
 						streamFn,
 						env,
+						systemPrompt,
 					)
 				: Promise.resolve("No prior history."),
 			generateTurnPrefixSummary(
@@ -799,6 +803,7 @@ export async function compact(
 				signal,
 				thinkingLevel,
 				streamFn,
+				systemPrompt,
 			),
 		]);
 		// Merge into single summary
@@ -817,6 +822,7 @@ export async function compact(
 			thinkingLevel,
 			streamFn,
 			env,
+			systemPrompt,
 		);
 	}
 
@@ -849,25 +855,29 @@ async function generateTurnPrefixSummary(
 	signal?: AbortSignal,
 	thinkingLevel?: ThinkingLevel,
 	streamFn?: StreamFn,
+	systemPrompt?: string,
 ): Promise<string> {
 	const maxTokens = Math.min(
 		Math.floor(0.5 * reserveTokens),
 		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
 	); // Smaller budget for turn prefix
-	const llmMessages = convertToLlm(messages);
-	const conversationText = serializeConversation(llmMessages);
-	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;
-	const summarizationMessages = [
-		{
-			role: "user" as const,
-			content: [{ type: "text" as const, text: promptText }],
-			timestamp: Date.now(),
-		},
+
+	// Convert to LLM messages - preserves KV cache prefix
+	const conversationMessages = convertToLlm(messages);
+
+	// Build summarization messages: original messages + instruction
+	const summarizationMessages: AgentMessage[] = [
+		...conversationMessages,
+		{ role: "user" as const, content: [{ type: "text" as const, text: TURN_PREFIX_SUMMARIZATION_PROMPT }] },
 	];
+
+	// Use the conversation's systemPrompt for KV cache prefix matching.
+	// Falls back to SUMMARIZATION_SYSTEM_PROMPT if not provided.
+	const effectiveSystemPrompt = systemPrompt ?? SUMMARIZATION_SYSTEM_PROMPT;
 
 	const response = await completeSummarization(
 		model,
-		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
+		{ systemPrompt: effectiveSystemPrompt, messages: summarizationMessages },
 		createSummarizationOptions(model, maxTokens, apiKey, headers, env, signal, thinkingLevel),
 		streamFn,
 	);


### PR DESCRIPTION
I've been using Pi regularly for a while and noticed certain inefficiencies in the compaction process. They were easy to spot and diagnose because I'm deploying my LLM locally with llama.cpp.

So there are 3 small things this PR fixes, all related to the compaction mechanism:
1. Reordering the summarization task's prompt to benefit from the already existing KV cache of the soon-to-be-compacted session context

I'm keeping the summarization prompt structure as close to the original session as possible, moving all the summarization instructions towards the end. This way llama (or any other inference engine) has to reprocess only the latter part of the prompt (what is actually new) as opposed to starting from scratch because something changed in the beginning.

On my hardware this cache hit saves around **20-30 second per compaction**. Or obviously if you're using a paid API it saves money instead.

2. Improving token estimation accuracy especially for code-heavy sessions by a simple calibration

Currently Pi is using the fixed heuristic approach of chars/4 to estimate the amount of tokens used by session entries (messages, tool calls, etc.) when finding a cut point for keepRecentTokens (20,000 tokens by default). This approach works fine for mostly text-based sessions. However the more code there is in a session, the less accurate this estimation becomes.

E.g. for a 75K context session with a lot of code in it, compaction kept 36K tokens (instead of 20K, so ~80% more) and summarized only 39K instead of 55K. I'm adding a multiplier/scale logic which allows Pi to achieve a much better accuracy especially for code-heavy sessions. Should be within 5% or so of the target value.

3. Fixing cut point detection for branch summaries and custom messages

Branch summaries and custom messages can start a new turn but were not recognized as valid compaction boundaries. Moving them into the right case so now compaction can cut at these points correctly.