### PR TITLE
fix(ai): send responses prompts as instructions

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -14,7 +14,12 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
-import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
+import {
+	buildResponsesInstructions,
+	convertResponsesMessages,
+	convertResponsesTools,
+	processResponsesStream,
+} from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 
 const DEFAULT_AZURE_API_VERSION = "v1";
@@ -260,6 +265,7 @@ function buildParams(
 
 	const params: ResponseCreateParamsStreaming = {
 		model: deploymentName,
+		instructions: buildResponsesInstructions(context),
 		input: messages,
 		stream: true,
 		prompt_cache_key: clampOpenAIPromptCacheKey(options?.sessionId),

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -43,7 +43,12 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
-import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
+import {
+	buildResponsesInstructions,
+	convertResponsesMessages,
+	convertResponsesTools,
+	processResponsesStream,
+} from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 
 // ============================================================================
@@ -437,15 +442,13 @@ function buildRequestBody(
 	context: Context,
 	options?: OpenAICodexResponsesOptions,
 ): RequestBody {
-	const messages = convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, {
-		includeSystemPrompt: false,
-	});
+	const messages = convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS);
 
 	const body: RequestBody = {
 		model: model.id,
 		store: false,
 		stream: true,
-		instructions: context.systemPrompt || "You are a helpful assistant.",
+		instructions: buildResponsesInstructions(context) || "You are a helpful assistant.",
 		input: messages,
 		text: { verbosity: options?.textVerbosity || "low" },
 		include: ["reasoning.encrypted_content"],
@@ -1363,9 +1366,11 @@ async function processWebSocketStream(
 		if (options?.signal?.aborted) {
 			keepConnection = false;
 		} else if (useCachedContext && entry && output.responseId) {
-			const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
-				includeSystemPrompt: false,
-			}).filter((item) => item.type !== "function_call_output");
+			const responseItems = convertResponsesMessages(
+				model,
+				{ messages: [output] },
+				CODEX_TOOL_CALL_PROVIDERS,
+			).filter((item) => item.type !== "function_call_output");
 			entry.continuation = {
 				lastRequestBody: fullBody,
 				lastResponseId: output.responseId,

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -75,10 +75,6 @@ export interface OpenAIResponsesStreamOptions {
 	) => void;
 }
 
-export interface ConvertResponsesMessagesOptions {
-	includeSystemPrompt?: boolean;
-}
-
 export interface ConvertResponsesToolsOptions {
 	strict?: boolean | null;
 }
@@ -87,11 +83,14 @@ export interface ConvertResponsesToolsOptions {
 // Message conversion
 // =============================================================================
 
+export function buildResponsesInstructions(context: Context): string | undefined {
+	return context.systemPrompt ? sanitizeSurrogates(context.systemPrompt) : undefined;
+}
+
 export function convertResponsesMessages<TApi extends Api>(
 	model: Model<TApi>,
 	context: Context,
 	allowedToolCallProviders: ReadonlySet<string>,
-	options?: ConvertResponsesMessagesOptions,
 ): ResponseInput {
 	const messages: ResponseInput = [];
 
@@ -121,16 +120,6 @@ export function convertResponsesMessages<TApi extends Api>(
 	};
 
 	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
-
-	const includeSystemPrompt = options?.includeSystemPrompt ?? true;
-	if (includeSystemPrompt && context.systemPrompt) {
-		const compat = model.compat as { supportsDeveloperRole?: boolean } | undefined;
-		const role = model.reasoning && compat?.supportsDeveloperRole !== false ? "developer" : "system";
-		messages.push({
-			role,
-			content: sanitizeSurrogates(context.systemPrompt),
-		});
-	}
 
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -7,7 +7,6 @@ import type {
 	CacheRetention,
 	Context,
 	Model,
-	OpenAIResponsesCompat,
 	ProviderEnv,
 	SimpleStreamOptions,
 	StreamFunction,
@@ -20,7 +19,12 @@ import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
-import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
+import {
+	buildResponsesInstructions,
+	convertResponsesMessages,
+	convertResponsesTools,
+	processResponsesStream,
+} from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
@@ -39,19 +43,10 @@ function resolveCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEn
 	return "short";
 }
 
-function getCompat(model: Model<"openai-responses">): Required<OpenAIResponsesCompat> {
-	return {
-		supportsDeveloperRole: model.compat?.supportsDeveloperRole ?? true,
-		sendSessionIdHeader: model.compat?.sendSessionIdHeader ?? true,
-		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
-	};
-}
-
-function getPromptCacheRetention(
-	compat: Required<OpenAIResponsesCompat>,
-	cacheRetention: CacheRetention,
-): "24h" | undefined {
-	return cacheRetention === "long" && compat.supportsLongCacheRetention ? "24h" : undefined;
+function getPromptCacheRetention(model: Model<"openai-responses">, cacheRetention: CacheRetention): "24h" | undefined {
+	const supportsLongCacheRetention = model.compat?.supportsLongCacheRetention ?? true;
+	if (cacheRetention !== "long" || !supportsLongCacheRetention) return undefined;
+	return "24h";
 }
 
 function formatOpenAIResponsesError(error: unknown): string {
@@ -189,7 +184,6 @@ function createClient(
 	sessionId?: string,
 	env?: ProviderEnv,
 ) {
-	const compat = getCompat(model);
 	const headers = { ...model.headers };
 	if (model.provider === "github-copilot") {
 		const hasImages = hasCopilotVisionInput(context.messages);
@@ -201,7 +195,8 @@ function createClient(
 	}
 
 	if (sessionId) {
-		if (compat.sendSessionIdHeader) {
+		const sendSessionIdHeader = model.compat?.sendSessionIdHeader ?? true;
+		if (sendSessionIdHeader) {
 			headers.session_id = sessionId;
 		}
 		headers["x-client-request-id"] = sessionId;
@@ -233,13 +228,13 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 	const messages = convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS);
 
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env);
-	const compat = getCompat(model);
 	const params: ResponseCreateParamsStreaming = {
 		model: model.id,
+		instructions: buildResponsesInstructions(context),
 		input: messages,
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : clampOpenAIPromptCacheKey(options?.sessionId),
-		prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
+		prompt_cache_retention: getPromptCacheRetention(model, cacheRetention),
 		store: false,
 	};
 

--- a/packages/ai/test/azure-openai-base-url.test.ts
+++ b/packages/ai/test/azure-openai-base-url.test.ts
@@ -12,6 +12,8 @@ interface CapturedAzureClientOptions {
 }
 
 interface CapturedAzureResponsesPayload {
+	instructions?: string;
+	input?: unknown[];
 	prompt_cache_key?: string;
 	store?: boolean;
 }
@@ -132,6 +134,24 @@ describe("azure-openai-responses base URL normalization", () => {
 		const result = await streamAzureOpenAIResponses(model, context, { apiKey: "test-api-key" }).result();
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toContain("Invalid Azure OpenAI base URL");
+	});
+
+	it("sends system prompt as instructions outside input", async () => {
+		const model = getModel("azure-openai-responses", "gpt-4o-mini");
+		await streamAzureOpenAIResponses(
+			model,
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-api-key",
+				azureBaseUrl: "https://my-resource.openai.azure.com",
+			},
+		).result();
+
+		expect(azureMock.lastParams?.instructions).toBe("sys");
+		expect(azureMock.lastParams?.input).toEqual([{ role: "user", content: [{ type: "input_text", text: "hello" }] }]);
 	});
 
 	it("clamps prompt_cache_key to OpenAI's 64-character limit", async () => {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -551,9 +551,13 @@ describe("openai-codex streaming", () => {
 				expect(headers?.has("session_id")).toBe(false);
 				expect(headers?.get("x-client-request-id")).toBe(sessionId);
 
-				// Verify sessionId is set in request body as prompt_cache_key
-				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+				const body =
+					typeof init?.body === "string"
+						? (JSON.parse(init.body) as { input?: unknown[]; instructions?: string; prompt_cache_key?: string })
+						: null;
 				expect(body?.prompt_cache_key).toBe(sessionId);
+				expect(body?.instructions).toBe("You are a helpful assistant.");
+				expect(body?.input).toEqual([{ role: "user", content: [{ type: "input_text", text: "Say hello" }] }]);
 
 				return new Response(stream, {
 					status: 200,

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -56,6 +56,39 @@ describe("openai-responses provider defaults", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("sends system prompt as instructions outside input", async () => {
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			getModel("openai", "gpt-5.4"),
+			{
+				systemPrompt: "sys",
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		const payload = capturedPayload as { input?: unknown[]; instructions?: string };
+		expect(payload.instructions).toBe("sys");
+		expect(payload.input).toEqual([{ role: "user", content: [{ type: "input_text", text: "hi" }] }]);
+	});
+
 	it("omits reasoning when no reasoning is requested", async () => {
 		const model = getModel("github-copilot", "gpt-5-mini");
 		let capturedPayload: unknown;


### PR DESCRIPTION
OpenAI Responses APIs expect system prompts in top-level `instructions`, not as replayed `input` messages.

###### Summary
- Send `context.systemPrompt` through shared Responses `instructions` handling.
- Keep `input` limited to conversation and tool replay for OpenAI, Azure OpenAI, and Codex Responses.
- Lock the payload shape in provider tests.

###### Testing
- `cd packages/ai && node ../../node_modules/vitest/dist/cli.js --run test/openai-responses-copilot-provider.test.ts test/azure-openai-base-url.test.ts test/openai-codex-stream.test.ts`
- `npm run check`

###### Issue
ref: #5858 