### PR TITLE
fix(ai): handle orphaned tool result messages to prevent Moonshot 400 errors

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1004,6 +1004,31 @@ export function convertMessages(
 		lastRole = msg.role;
 	}
 
+	// Safety net: ensure no orphaned tool messages exist.
+	// Some providers (e.g., Moonshot AI) strictly require every 'tool' role message
+	// to be preceded by an assistant message with tool_calls (possibly with other
+	// tool messages in between for consecutive results from the same assistant call).
+	// The transformMessages function should prevent these from reaching this point,
+	// but convert any that slip through to user messages to guarantee API compatibility.
+	for (let i = 0; i < params.length; i++) {
+		if (params[i].role === "tool") {
+			// Walk backward past consecutive tool messages to find the preceding
+			// non-tool message. Multiple tool messages can legitimately follow
+			// a single assistant with tool_calls.
+			let prevIndex = i - 1;
+			while (prevIndex >= 0 && params[prevIndex].role === "tool") {
+				prevIndex--;
+			}
+			const prevMsg = prevIndex >= 0 ? params[prevIndex] : null;
+			if (!prevMsg || prevMsg.role !== "assistant" || !prevMsg.tool_calls) {
+				params[i] = {
+					role: "user",
+					content: `(tool result: ${typeof params[i].content === "string" ? params[i].content : "(see content above)"})`,
+				} as ChatCompletionMessageParam;
+			}
+		}
+	}
+
 	return params;
 }
 

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -202,8 +202,27 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
-			existingToolResultIds.add(msg.toolCallId);
-			result.push(msg);
+			// If there are no pending tool calls from a preceding assistant message,
+			// this tool result is orphaned (e.g., after compaction, history load, or
+			// when a preceding errored/aborted assistant was filtered).
+			// Convert to user message to prevent API errors from providers that strictly
+			// require every tool role message to follow an assistant message with tool_calls.
+			if (pendingToolCalls.length === 0) {
+				const textContent = Array.isArray(msg.content)
+					? msg.content
+							.filter((b) => b.type === "text")
+							.map((b) => (b as TextContent).text)
+							.join("\n")
+					: "";
+				result.push({
+					role: "user",
+					content: [{ type: "text", text: textContent || "(tool result from previous context)" }],
+					timestamp: msg.timestamp,
+				});
+			} else {
+				existingToolResultIds.add(msg.toolCallId);
+				result.push(msg);
+			}
 		} else if (msg.role === "user") {
 			// User message interrupts tool flow - insert synthetic results for orphaned calls
 			insertSyntheticToolResults();


### PR DESCRIPTION
### What

Adds two guards to prevent orphaned `tool` role messages — `toolResult` entries that have no preceding `assistant` message with `tool_calls`.

### Why

Moonshot AI (and potentially other strict OpenAI-compatible providers) returns HTTP 400:

> `messages with role 'tool' must be a response to a preceeding message with 'tool_calls'`

This happens when `toolResult` messages survive in the conversation context without their corresponding assistant `tool_calls` — after session compaction, branch navigation, or when an errored/aborted assistant message is filtered.

### How

1. **`transformMessages()`**: When a `toolResult` is encountered with no pending tool calls (`pendingToolCalls.length === 0`), convert it to a `user` message. This fixes the root cause for all providers.

2. **`convertMessages()` in `openai-completions.ts`**: Add a safety net that walks backward past consecutive `tool` messages to verify a preceding assistant with `tool_calls` exists. Converts orphaned tool messages to user messages as a final safeguard.

This is AI-generated by a developer using an agent (per CONTRIBUTING.md: "Using AI to write code is fine.").
