### PR TITLE
fix: add vLLM context overflow error patterns to OVERFLOW_PATTERNS

### DIFF
--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -31,6 +31,7 @@ import type { AssistantMessage } from "../types.ts";
  *   with output=0 (no room left to generate). Detected via stopReason "length" + zero output +
  *   input filling the context window.
  * - Ollama: Some deployments truncate silently, others return errors like "prompt too long; exceeded max context length by X tokens"
+ * - vLLM (v0.8+): "This model's maximum context length is X tokens. However, you requested Y output tokens and your prompt contains at least Z input tokens"
  */
 const OVERFLOW_PATTERNS = [
 	/prompt is too long/i, // Anthropic token overflow
@@ -52,6 +53,10 @@ const OVERFLOW_PATTERNS = [
 	/too large for model with \d+ maximum context length/i, // Mistral
 	/model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
 	/prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
+	/this model.?s maximum context length is \d+/i, // vLLM: "This model's maximum context length is X tokens"
+	/requested \d+ output tokens/i, // vLLM: "requested Y output tokens"
+	/prompt contains.*\d+ input tokens/i, // vLLM: "prompt contains at least Z input tokens"
+	/for a total of.*\d+ tokens/i, // vLLM: "for a total of at least Z tokens"
 	/context[_ ]length[_ ]exceeded/i, // Generic fallback
 	/too many tokens/i, // Generic fallback
 	/token limit exceeded/i, // Generic fallback
@@ -87,6 +92,7 @@ const NON_OVERFLOW_PATTERNS = [
  * **Reliable detection (returns error with detectable message):**
  * - Anthropic: "prompt is too long: X tokens > Y maximum" or "request_too_large"
  * - OpenAI (Completions & Responses): "exceeds the context window", "exceeds the model's maximum context length of X tokens", or "exceeds model's maximum context length (X)"
+ * - vLLM: "This model's maximum context length is X tokens"
  * - Google Gemini: "input token count exceeds the maximum"
  * - xAI (Grok): "maximum prompt length is X but request contains Y"
  * - Groq: "reduce the length of the messages"


### PR DESCRIPTION
# fix: add vLLM context overflow error patterns to OVERFLOW_PATTERNS

## Problem

When using vLLM (v0.8+) with models that have large context windows (e.g., 262k tokens), context overflow errors are not detected by `isContextOverflow()`, causing the agent to loop on the same 400 error instead of triggering auto-compaction and retry.

### User-facing error

```
Error: 400 This model's maximum context length is 262144 tokens. However, you requested 0 output tokens
and your prompt contains at least 262145 input tokens, for a total of at least 262145 tokens. Please
reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens,
value=262145)
```

## Root cause

The error message format returned by vLLM's OpenAI-compatible API is distinct from the formats covered by existing `OVERFLOW_PATTERNS`:

| Provider | Error format |
|---|---|
| **vLLM** (this PR) | `"This model's maximum context length is X tokens. However, you requested Y output tokens and your prompt contains at least Z input tokens, for a total of at least T tokens."` |
| OpenAI | `"exceeds the context window"`, `"exceeds the model's maximum context length of X tokens"` |
| Anthropic | `"prompt is too long: X tokens > Y maximum"` |

The vLLM format was not matched by any existing pattern, so `isContextOverflow()` returned `false` and the error propagated to the user as an unhandled exception.

## Source verification

The error is raised in **`vllm/renderers/params.py`** at line 428 in the `_token_len_check()` method:

```python
raise VLLMValidationError(
    f"This model's maximum context length is "
    f"{self.max_total_tokens} tokens. However, you requested "
    f"{self.max_output_tokens} output tokens and your prompt "
    f"contains {qualifier}{token_count} input tokens, "
    f"for a total of {qualifier}{total} tokens. "
    f"Please reduce the length of the input prompt or the "
    f"number of requested output tokens.",
    parameter="input_tokens",
    value=token_count,
)
```

## Fix

Adds 4 new regex patterns to `OVERFLOW_PATTERNS` in `packages/ai/src/utils/overflow.ts`:

| Pattern | Matches |
|---|---|
| `/this model.?s maximum context length is \d+/i` | `"This model's maximum context length is 262144"` |
| `/requested \d+ output tokens/i` | `"you requested 0 output tokens"` |
| `/prompt contains.*\d+ input tokens/i` | `"your prompt contains at least 262145 input tokens"` |
| `/for a total of.*\d+ tokens/i` | `"for a total of at least 262145 tokens"` |

All 4 match the vLLM error → auto-compaction triggers correctly.

## Changes

- `packages/ai/src/utils/overflow.ts` — add 4 new patterns, update JSDoc docs and reliability section

## Verification

```bash
node -e "
const patterns = [
    /this model.?s maximum context length is \\d+/i,
    /requested \\d+ output tokens/i,
    /prompt contains.*\\d+ input tokens/i,
    /for a total of.*\\d+ tokens/i,
];
const msg = \"Error: 400 This model's maximum context length is 262144 tokens. However, you requested 0 output tokens and your prompt contains at least 262145 input tokens, for a total of at least 262145 tokens.\";
console.log(patterns.map(p => p.test(msg)).filter(Boolean).length + '/4 matched');
"
# Output: 4/4 matched
```

## Related

- Issue #2626: Ollama context overflow errors not detected by auto-compaction
