### PR TITLE
Harden opt-in auto-compaction at between-turn checkpoint

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a contextual between-turn `prepareNextTurnWithContext` hook while preserving the existing `prepareNextTurn` hook.
+
 ## [0.79.9] - 2026-06-20
 
 ### Fixed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -21,6 +21,7 @@ import type {
 	AgentTool,
 	BeforeToolCallContext,
 	BeforeToolCallResult,
+	PrepareNextTurnContext,
 	QueueMode,
 	StreamFn,
 	ToolExecutionMode,
@@ -106,6 +107,10 @@ export interface AgentOptions {
 	prepareNextTurn?: (
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
+	prepareNextTurnWithContext?: (
+		context: PrepareNextTurnContext,
+		signal?: AbortSignal,
+	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
 	steeringMode?: QueueMode;
 	followUpMode?: QueueMode;
 	sessionId?: string;
@@ -186,6 +191,10 @@ export class Agent {
 	public prepareNextTurn?: (
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
+	public prepareNextTurnWithContext?: (
+		context: PrepareNextTurnContext,
+		signal?: AbortSignal,
+	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
 	private activeRun?: ActiveRun;
 	/** Session identifier forwarded to providers for cache-aware backends. */
 	public sessionId?: string;
@@ -209,6 +218,7 @@ export class Agent {
 		this.beforeToolCall = options.beforeToolCall;
 		this.afterToolCall = options.afterToolCall;
 		this.prepareNextTurn = options.prepareNextTurn;
+		this.prepareNextTurnWithContext = options.prepareNextTurnWithContext;
 		this.steeringQueue = new PendingMessageQueue(options.steeringMode ?? "one-at-a-time");
 		this.followUpQueue = new PendingMessageQueue(options.followUpMode ?? "one-at-a-time");
 		this.sessionId = options.sessionId;
@@ -421,6 +431,27 @@ export class Agent {
 
 	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean } = {}): AgentLoopConfig {
 		let skipInitialSteeringPoll = options.skipInitialSteeringPoll === true;
+		const prepareNextTurn = this.prepareNextTurn;
+		const prepareNextTurnWithContext = this.prepareNextTurnWithContext;
+		const prepareNextTurnForLoop =
+			prepareNextTurn || prepareNextTurnWithContext
+				? async (context: PrepareNextTurnContext) => {
+						const update = await prepareNextTurn?.(this.signal);
+						const contextUpdate = await prepareNextTurnWithContext?.(
+							update?.context ? { ...context, context: update.context } : context,
+							this.signal,
+						);
+						if (!update) return contextUpdate;
+						if (!contextUpdate) return update;
+						return {
+							...update,
+							...contextUpdate,
+							context: contextUpdate.context ?? update.context,
+							model: contextUpdate.model ?? update.model,
+							thinkingLevel: contextUpdate.thinkingLevel ?? update.thinkingLevel,
+						};
+					}
+				: undefined;
 		return {
 			model: this._state.model,
 			reasoning: this._state.thinkingLevel === "off" ? undefined : this._state.thinkingLevel,
@@ -433,7 +464,7 @@ export class Agent {
 			toolExecution: this.toolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
-			prepareNextTurn: this.prepareNextTurn ? async () => await this.prepareNextTurn?.(this.signal) : undefined,
+			prepareNextTurn: prepareNextTurnForLoop,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,

--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -116,7 +116,7 @@ export interface CompactionSettings {
 
 /** Default compaction settings used by the harness. */
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
-	enabled: true,
+	enabled: false,
 	reserveTokens: 16384,
 	keepRecentTokens: 20000,
 };

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed automatic compaction to be opt-in by default and run threshold compaction at a between-turn checkpoint before the next provider request.
+
 ### Fixed
 
 - Fixed `pi update` to install the exact version returned by the Pi update check, make `--force` reinstall that checked version, fail instead of falling back to an unversioned reinstall when no version is available, and report both the old and updated versions.

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -1,8 +1,9 @@
 # Compaction & Branch Summarization
 
-LLMs have limited context windows. When conversations grow too long, pi uses compaction to summarize older content while preserving recent work. This page covers both auto-compaction and branch summarization.
+LLMs have limited context windows. When conversations grow too long, pi can compact older content while preserving recent work. This page covers both auto-compaction and branch summarization.
 
 **Source files** ([pi-mono](https://github.com/earendil-works/pi-mono)):
+- [`packages/coding-agent/src/core/agent-session.ts`](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/core/agent-session.ts) - Session wiring and auto-compaction checkpoints
 - [`packages/coding-agent/src/core/compaction/compaction.ts`](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/core/compaction/compaction.ts) - Auto-compaction logic
 - [`packages/coding-agent/src/core/compaction/branch-summarization.ts`](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/core/compaction/branch-summarization.ts) - Branch summarization
 - [`packages/coding-agent/src/core/compaction/utils.ts`](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/core/compaction/utils.ts) - Shared utilities (file tracking, serialization)
@@ -26,13 +27,13 @@ Both use the same structured summary format and track file operations cumulative
 
 ### When It Triggers
 
-Auto-compaction triggers when:
+When enabled, auto-compaction triggers when:
 
 ```
 contextTokens > contextWindow - reserveTokens
 ```
 
-By default, `reserveTokens` is 16384 tokens (configurable in `~/.pi/agent/settings.json` or `<project-dir>/.pi/settings.json`). This leaves room for the LLM's response.
+Auto-compaction is off by default. Enable it with `"compaction": { "enabled": true }` if you want pi to keep the context window in a healthy range automatically. During tool loops, pi checks at the turn boundary before the next provider request. By default, `reserveTokens` is 16384 tokens (configurable in `~/.pi/agent/settings.json` or `<project-dir>/.pi/settings.json`). This leaves room for the LLM's response.
 
 You can also trigger manually with `/compact [instructions]`, where optional instructions focus the summary.
 
@@ -387,8 +388,8 @@ Configure compaction in `~/.pi/agent/settings.json` or `<project-dir>/.pi/settin
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `enabled` | `true` | Enable auto-compaction |
+| `enabled` | `false` | Enable auto-compaction |
 | `reserveTokens` | `16384` | Tokens to reserve for LLM response |
 | `keepRecentTokens` | `20000` | Recent tokens to keep (not summarized) |
 
-Disable auto-compaction with `"enabled": false`. You can still compact manually with `/compact`.
+Auto-compaction is opt-in with `"enabled": true`. You can always compact manually with `/compact`.

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -574,7 +574,7 @@ export default function (pi: ExtensionAPI) {
 }
 ```
 
-`message_end` runs before pi tracks the assistant message for auto-compaction, so the rewritten `errorMessage` is what pi checks. With this in place, pi will:
+`message_end` runs before pi tracks the assistant message for auto-compaction, so the rewritten `errorMessage` is what pi checks. When auto-compaction is enabled, pi will:
 
 1. Detect the overflow from `errorMessage`.
 2. Drop the failed assistant message from live context.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -99,14 +99,14 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `compaction.enabled` | boolean | `true` | Enable auto-compaction |
+| `compaction.enabled` | boolean | `false` | Enable auto-compaction |
 | `compaction.reserveTokens` | number | `16384` | Tokens reserved for LLM response |
 | `compaction.keepRecentTokens` | number | `20000` | Recent tokens to keep (not summarized) |
 
 ```json
 {
   "compaction": {
-    "enabled": true,
+    "enabled": false,
     "reserveTokens": 16384,
     "keepRecentTokens": 20000
   }
@@ -268,7 +268,7 @@ See [packages.md](packages.md) for package management details.
   "defaultThinkingLevel": "medium",
   "theme": "dark",
   "compaction": {
-    "enabled": true,
+    "enabled": false,
     "reserveTokens": 16384,
     "keepRecentTokens": 20000
   },
@@ -292,7 +292,7 @@ Project settings (`.pi/settings.json`) override global settings. Nested objects 
 // ~/.pi/agent/settings.json (global)
 {
   "theme": "dark",
-  "compaction": { "enabled": true, "reserveTokens": 16384 }
+  "compaction": { "enabled": false, "reserveTokens": 16384 }
 }
 
 // .pi/settings.json (project)
@@ -303,6 +303,6 @@ Project settings (`.pi/settings.json`) override global settings. Nested objects 
 // Result
 {
   "theme": "dark",
-  "compaction": { "enabled": true, "reserveTokens": 8192 }
+  "compaction": { "enabled": false, "reserveTokens": 8192 }
 }
 ```

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -18,9 +18,11 @@ import { basename, dirname } from "node:path";
 import type {
 	Agent,
 	AgentEvent,
+	AgentLoopTurnUpdate,
 	AgentMessage,
 	AgentState,
 	AgentTool,
+	PrepareNextTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent } from "@earendil-works/pi-ai";
@@ -351,6 +353,7 @@ export class AgentSession {
 		// (session persistence, extensions, auto-compaction, retry logic)
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
 		this._installAgentToolHooks();
+		this._installAgentTurnCheckpoint();
 
 		this._buildRuntime({
 			activeToolNames: this._initialActiveToolNames,
@@ -458,6 +461,52 @@ export class AgentSession {
 				details: hookResult.details,
 				isError: hookResult.isError ?? isError,
 			};
+		};
+	}
+
+	private _installAgentTurnCheckpoint(): void {
+		const prepareNextTurn = this.agent.prepareNextTurnWithContext?.bind(this.agent);
+		this.agent.prepareNextTurnWithContext = async (context, signal) => {
+			const update = await prepareNextTurn?.(context, signal);
+			const checkpointContext = update?.context ? { ...context, context: update.context } : context;
+			const compactionUpdate = await this._compactBeforeNextTurn(checkpointContext);
+			if (!update) return compactionUpdate;
+			if (!compactionUpdate) return update;
+			return { ...update, context: compactionUpdate.context ?? update.context };
+		};
+	}
+
+	private async _compactBeforeNextTurn(context: PrepareNextTurnContext): Promise<AgentLoopTurnUpdate | undefined> {
+		const message = context.message;
+		const settings = this.settingsManager.getCompactionSettings();
+		const contextWindow = this.model?.contextWindow ?? 0;
+		if (!settings.enabled || message.stopReason !== "toolUse" || contextWindow <= 0) {
+			return undefined;
+		}
+		if (!this.model || message.provider !== this.model.provider || message.model !== this.model.id) {
+			return undefined;
+		}
+
+		const contextTokens = Math.max(
+			calculateContextTokens(message.usage),
+			estimateMessagesTokens(context.context.messages),
+		);
+		if (!shouldCompact(contextTokens, contextWindow, settings)) {
+			return undefined;
+		}
+
+		const before = getLatestCompactionEntry(this.sessionManager.getBranch());
+		await this._runAutoCompaction("threshold", false);
+		const after = getLatestCompactionEntry(this.sessionManager.getBranch());
+		if (after === null || after.id === before?.id) {
+			throw new Error("Auto-compaction required before the next turn, but compaction did not complete.");
+		}
+
+		return {
+			context: {
+				...context.context,
+				messages: this.agent.state.messages.slice(),
+			},
 		};
 	}
 

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -120,7 +120,7 @@ export interface CompactionSettings {
 }
 
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
-	enabled: true,
+	enabled: false,
 	reserveTokens: 16384,
 	keepRecentTokens: 20000,
 };

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -8,7 +8,7 @@ import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 
 export interface CompactionSettings {
-	enabled?: boolean; // default: true
+	enabled?: boolean; // default: false
 	reserveTokens?: number; // default: 16384
 	keepRecentTokens?: number; // default: 20000
 }
@@ -752,7 +752,7 @@ export class SettingsManager {
 	}
 
 	getCompactionEnabled(): boolean {
-		return this.settings.compaction?.enabled ?? true;
+		return this.settings.compaction?.enabled ?? false;
 	}
 
 	setCompactionEnabled(enabled: boolean): void {

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -47,7 +47,7 @@ export function formatCwdForFooter(cwd: string, home: string | undefined): strin
  * Computes token/context stats from session, gets git branch and extension statuses from provider.
  */
 export class FooterComponent implements Component {
-	private autoCompactEnabled = true;
+	private autoCompactEnabled = false;
 	private session: AgentSession;
 	private footerData: ReadonlyFooterDataProvider;
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -38,6 +38,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 		sessionManager = SessionManager.inMemory();
 		settingsManager = SettingsManager.create(tempDir, tempDir);
+		settingsManager.applyOverrides({ compaction: { enabled: true } });
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
 		const modelRegistry = ModelRegistry.create(authStorage, tempDir);

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -231,7 +231,7 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("does not retry overflow recovery more than once", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ settings: { compaction: { enabled: true } } });
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
 		const overflowMessage = createAssistant(harness, {
@@ -288,7 +288,7 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("ignores stale pre-compaction assistant usage on pre-prompt checks", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ settings: { compaction: { enabled: true } } });
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
 		const staleTimestamp = Date.now() - 10_000;
@@ -326,7 +326,7 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("triggers threshold compaction for error messages using the last successful usage", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ settings: { compaction: { enabled: true } } });
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
 		const successfulAssistant = createAssistant(harness, {
@@ -354,7 +354,7 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("does not trigger threshold compaction for error messages when no prior usage exists", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ settings: { compaction: { enabled: true } } });
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
 		const errorAssistant = createAssistant(harness, {
@@ -375,7 +375,7 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("does not trigger threshold compaction when only kept pre-compaction usage exists", async () => {
-		const harness = await createHarness();
+		const harness = await createHarness({ settings: { compaction: { enabled: true } } });
 		harnesses.push(harness);
 		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
 		const preCompactionTimestamp = Date.now() - 10_000;


### PR DESCRIPTION
## What

This PR makes automatic context compaction opt-in and hardens it for long tool loops.

It adds a contextual between-turn checkpoint so Pi can compact after an assistant turn and its tool results have completed, but before the next provider request starts. Manual `/compact` remains available regardless of the auto-compaction setting.

## Why

Context windows should be managed because excessive context can make models overlook relevant information or hit token limits. Developer educator Matt Pocock has helped spread this practical understanding through his videos on context limits and the “lost in the middle” problem.

Some users want Pi to keep the active context in a healthier zone automatically during long-running tool loops. Other users prefer explicit/manual compaction. This PR keeps the automatic behavior off by default and only enables it when configured.

## How

- Adds `prepareNextTurnWithContext(context, signal)` on `Agent` while preserving the existing `prepareNextTurn(signal)` hook.
- Wires `AgentSession` into that contextual checkpoint.
- Runs threshold auto-compaction only when:
  - `compaction.enabled` is explicitly `true`
  - the completed assistant turn requested tools (`stopReason === "toolUse"`)
  - the estimated context exceeds the configured reserve threshold
- Returns the compacted session context to the loop before the next provider request.
- Fails before the next provider request if compaction was required but did not produce a compaction entry.
- Changes the default auto-compaction setting to disabled.

## Scope

In scope:

- Opt-in automatic compaction during multi-turn tool loops.
- Settings/docs updates for `compaction.enabled` defaulting to `false`.
- Compatibility with existing `prepareNextTurn(signal)` users.

Out of scope:

- New threshold settings.
- Broad token-estimation rewrites.
- UI redesign for compaction status.
- Changes to manual `/compact` behavior.

## Tests

- `npm run check`
- `cd packages/coding-agent && node node_modules/vitest/dist/cli.js --run test/agent-session-auto-compaction-queue.test.ts test/suite/agent-session-compaction.test.ts`
- `cd packages/agent && node node_modules/vitest/dist/cli.js --run test/agent.test.ts test/agent-loop.test.ts`
