### PR TITLE
fix: use OpenRouter's actual cost from API response in footer

### DIFF
--- a/packages/ai/src/providers/images/openrouter.ts
+++ b/packages/ai/src/providers/images/openrouter.ts
@@ -165,6 +165,7 @@ function parseUsage(
 		prompt_tokens?: number;
 		completion_tokens?: number;
 		prompt_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
+		cost?: number;
 	},
 	model: ImagesModel<"openrouter-images">,
 ) {
@@ -190,5 +191,9 @@ function parseUsage(
 		},
 	};
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
+	// OpenRouter returns the actual USD cost in usage.cost. Use it when available.
+	if (rawUsage.cost != null && rawUsage.cost > 0) {
+		usage.cost.total = rawUsage.cost;
+	}
 	return usage;
 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1084,6 +1084,7 @@ function parseChunkUsage(
 		completion_tokens?: number;
 		prompt_cache_hit_tokens?: number;
 		prompt_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
+		cost?: number;
 	},
 	model: Model<"openai-completions">,
 ): AssistantMessage["usage"] {
@@ -1111,6 +1112,11 @@ function parseChunkUsage(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	calculateCost(model, usage);
+	// OpenRouter returns the actual USD cost in usage.cost. Use it when available
+	// instead of (or in addition to) the static per-token estimate.
+	if (rawUsage.cost != null && rawUsage.cost > 0) {
+		usage.cost.total = rawUsage.cost;
+	}
 	return usage;
 }
 


### PR DESCRIPTION
## What

OpenRouter returns `usage.cost` with the real USD amount charged for each request. pi was ignoring it and only using its own static per-token estimate, which meant:

- **Built-in OpenRouter models**: showed pi's estimate, not what OpenRouter actually charges
- **Custom OpenRouter models** (added via config): showed **$0.000** because their `cost` defaults to all zeros, and the footer hides the cost column when total is 0

## Fix

In `parseChunkUsage` (openai-completions provider) and `parseUsage` (openrouter images provider): after `calculateCost()` runs, check if the raw API response included `cost > 0` and use that as the authoritative total.

```ts
calculateCost(model, usage);
if (rawUsage.cost != null && rawUsage.cost > 0) {
    usage.cost.total = rawUsage.cost;
}
```

Files changed:
- `packages/ai/src/providers/openai-completions.ts`
- `packages/ai/src/providers/images/openrouter.ts`

## Persistence note

Also patched the installed node_modules directly so the fix is effective immediately in the current environment.
