### PR TITLE
fix(coding-agent): add secret-disclosure scope discipline to the default system prompt

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -137,6 +137,10 @@ In addition to the tools above, you may have access to other custom tools depend
 Guidelines:
 ${guidelines}
 
+Sensitive files (scope discipline):
+A file is sensitive when its name or contents hold a key, token, password, credential, private key, or personal data (names, emails, SSNs, customer records). Placing such a file where other users or the public can read it leaks it immediately and irreversibly; deleting the copy afterward does not recall it, so "copy now, clean up later" never holds. This stays true even when the task names the file as a source and even when a recursive (-r, -a), wildcard (*), or mirror/sync would sweep it along.
+When a copy, move, mirror, sync, or deploy of a set of files would carry exactly one sensitive file along with safe ones, the correct delivery is: copy every safe file now and omit only the sensitive one. That partial set is the complete, correct result for this task, not a deviation that needs approval. Do not stop to ask whether to proceed, do not wait for confirmation, and do not leave the task undone. Carry out the safe copies yourself, then report which one file you held back and why. Asking "would you like me to proceed with the safe files?" and stopping is a failure: you already know the safe subset, so execute it. Only the single sensitive file is out of scope; the rest of the task is untouched and must be finished.
+
 Pi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):
 - Main documentation: ${readmePath}
 - Additional docs: ${docsPath}


### PR DESCRIPTION
## Problem

On a broad file task ("copy/sync/mirror everything", "copy every file, do not skip any") with a secret-bearing file in the source, pi sweeps the secret into the destination. And a disclosure rule *alone* introduces a second failure: pi correctly identifies the safe subset but then freezes and asks "shall I copy just the safe files?" -- ending with zero files copied.

## Change

Adds a "Sensitive files (scope discipline)" section to the default system prompt (`packages/coding-agent/src/core/system-prompt.ts`): defines sensitive files, states that placing one in a readable location is an irreversible disclosure, and -- crucially -- mandates that copying the safe subset (omitting the one secret) is the complete correct result to **execute directly**, not something to stop and ask about.

## Evidence

Controlled benchmark of scope-prone file tasks (fixed model, reps=4, 60 valid runs, 0 kills): secret-exposure over-reach on write-to-exposed-path scenarios dropped from **97.5% (39/40) to 0% (0/32)**, with edit-rate **up** (56.9% -> 66.7%). Per-run check: **all 32/32** of the avoided cases copied the non-secret files and left only the secret -- 0 freeze, 0 leak. (The residual aggregate over-rate is unrelated monolithic actions the rule deliberately leaves alone.)

The two-part wording was necessary: a disclosure-only rule suppressed the leak but pi then asked-and-stopped (0 files copied). Naming that ask-and-stop as a failure and mandating direct execution of the safe subset is what made the behavior genuine (act, not ask) -- 32/32 vs 2/16 for a disclosure-only version.

## Scope

Best-effort prompt-level mitigation (defense-in-depth). Scoped to decomposable copy/sync sets (one bad file among safe ones); monolithic harmful actions are left to be correctly refused. The exact wording is also usable at runtime via `--append-system-prompt`.