### PR TITLE
fix(ai): reject malformed final tool call arguments

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -9,7 +9,10 @@ import type {
 	ProviderStreamOptions,
 	SimpleStreamOptions,
 	StreamOptions,
+	ToolCall,
+	Usage,
 } from "./types.ts";
+import { createAssistantMessageEventStream } from "./utils/event-stream.ts";
 
 function hasExplicitApiKey(apiKey: string | undefined): apiKey is string {
 	return typeof apiKey === "string" && apiKey.trim().length > 0;
@@ -33,13 +36,191 @@ function resolveApiProvider(api: Api) {
 	return provider;
 }
 
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStrictToolArguments(rawArguments: string): { arguments: Record<string, unknown> } | { error: string } {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawArguments);
+	} catch (error) {
+		return { error: error instanceof Error ? error.message : String(error) };
+	}
+	if (!isJsonObject(parsed)) {
+		return { error: "Tool call arguments must be a JSON object" };
+	}
+	return { arguments: parsed };
+}
+
+function createStreamErrorMessage(
+	model: Model<Api>,
+	partialMessage: AssistantMessage | undefined,
+	errorMessage: string,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: partialMessage?.content ?? [],
+		api: partialMessage?.api ?? model.api,
+		provider: partialMessage?.provider ?? model.provider,
+		model: partialMessage?.model ?? model.id,
+		responseModel: partialMessage?.responseModel,
+		responseId: partialMessage?.responseId,
+		diagnostics: partialMessage?.diagnostics,
+		usage: partialMessage?.usage ?? emptyUsage(),
+		stopReason: "error",
+		errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+function replaceToolCallArguments(
+	message: AssistantMessage,
+	finalArguments: Map<number, Record<string, unknown>>,
+): AssistantMessage {
+	if (finalArguments.size === 0) return message;
+	let changed = false;
+	const content = message.content.map((block, index) => {
+		const argumentsForBlock = finalArguments.get(index);
+		if (!argumentsForBlock || block.type !== "toolCall") return block;
+		changed = true;
+		return { ...block, arguments: argumentsForBlock };
+	});
+	return changed ? { ...message, content } : message;
+}
+
+function replaceToolCallInPartial(
+	message: AssistantMessage,
+	contentIndex: number,
+	toolCall: ToolCall,
+): AssistantMessage {
+	const existing = message.content[contentIndex];
+	if (!existing || existing.type !== "toolCall") return message;
+	const content = [...message.content];
+	content[contentIndex] = toolCall;
+	return { ...message, content };
+}
+
+function getToolCallName(message: AssistantMessage, contentIndex: number): string {
+	const block = message.content[contentIndex];
+	if (!block || block.type !== "toolCall") return `content index ${contentIndex}`;
+	return `${block.name} (${block.id})`;
+}
+
+function validateFinalToolArgumentsStream<TApi extends Api>(
+	model: Model<TApi>,
+	source: AssistantMessageEventStream,
+): AssistantMessageEventStream {
+	const stream = createAssistantMessageEventStream();
+	const rawArgumentsByIndex = new Map<number, string>();
+	const finalArgumentsByIndex = new Map<number, Record<string, unknown>>();
+	let lastPartial: AssistantMessage | undefined;
+
+	void (async () => {
+		try {
+			for await (const event of source) {
+				if ("partial" in event) {
+					lastPartial = event.partial;
+				}
+
+				if (event.type === "toolcall_delta") {
+					rawArgumentsByIndex.set(
+						event.contentIndex,
+						(rawArgumentsByIndex.get(event.contentIndex) ?? "") + event.delta,
+					);
+					stream.push(event);
+					continue;
+				}
+
+				if (event.type === "toolcall_end") {
+					const rawArguments = rawArgumentsByIndex.get(event.contentIndex);
+					if (rawArguments !== undefined) {
+						const parseResult = parseStrictToolArguments(rawArguments);
+						if ("error" in parseResult) {
+							const errorMessage = `Invalid final tool call arguments for ${getToolCallName(
+								event.partial,
+								event.contentIndex,
+							)}: ${parseResult.error}`;
+							stream.push({
+								type: "error",
+								reason: "error",
+								error: createStreamErrorMessage(model, event.partial, errorMessage),
+							});
+							return;
+						}
+						finalArgumentsByIndex.set(event.contentIndex, parseResult.arguments);
+						const toolCall = { ...event.toolCall, arguments: parseResult.arguments };
+						stream.push({
+							...event,
+							toolCall,
+							partial: replaceToolCallInPartial(event.partial, event.contentIndex, toolCall),
+						});
+						continue;
+					}
+				}
+
+				if (event.type === "done") {
+					const message = replaceToolCallArguments(event.message, finalArgumentsByIndex);
+					const unexpectedToolCall = message.content.find((block) => block.type === "toolCall");
+					if (unexpectedToolCall && event.reason !== "toolUse") {
+						stream.push({
+							type: "error",
+							reason: "error",
+							error: createStreamErrorMessage(
+								model,
+								message,
+								`Tool call ${unexpectedToolCall.name} (${unexpectedToolCall.id}) ended with stop reason ${event.reason}`,
+							),
+						});
+						return;
+					}
+					stream.push({ ...event, message });
+					return;
+				}
+
+				if (event.type === "error") {
+					stream.push(event);
+					return;
+				}
+
+				stream.push(event);
+			}
+
+			const finalMessage = replaceToolCallArguments(await source.result(), finalArgumentsByIndex);
+			stream.end(finalMessage);
+		} catch (error) {
+			stream.push({
+				type: "error",
+				reason: "error",
+				error: createStreamErrorMessage(model, lastPartial, error instanceof Error ? error.message : String(error)),
+			});
+		}
+	})();
+
+	return stream;
+}
+
 export function stream<TApi extends Api>(
 	model: Model<TApi>,
 	context: Context,
 	options?: ProviderStreamOptions,
 ): AssistantMessageEventStream {
 	const provider = resolveApiProvider(model.api);
-	return provider.stream(model, context, withEnvApiKey(model, options) as StreamOptions);
+	return validateFinalToolArgumentsStream(
+		model,
+		provider.stream(model, context, withEnvApiKey(model, options) as StreamOptions),
+	);
 }
 
 export async function complete<TApi extends Api>(
@@ -57,7 +238,7 @@ export function streamSimple<TApi extends Api>(
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
 	const provider = resolveApiProvider(model.api);
-	return provider.streamSimple(model, context, withEnvApiKey(model, options));
+	return validateFinalToolArgumentsStream(model, provider.streamSimple(model, context, withEnvApiKey(model, options)));
 }
 
 export async function completeSimple<TApi extends Api>(

--- a/packages/ai/test/strict-final-tool-arguments.test.ts
+++ b/packages/ai/test/strict-final-tool-arguments.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+	AssistantMessageEventStream,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	StreamFunction,
+	StreamOptions,
+	ToolCall,
+} from "../src/index.ts";
+import { registerApiProvider, stream, unregisterApiProviders } from "../src/index.ts";
+import { createAssistantMessageEventStream } from "../src/utils/event-stream.ts";
+
+const TEST_API = "strict-tool-arguments-test";
+const TEST_SOURCE_ID = "strict-tool-arguments-test-source";
+
+function createModel(): Model<typeof TEST_API> {
+	return {
+		id: "strict-test-model",
+		name: "Strict Test Model",
+		api: TEST_API,
+		provider: "strict-test-provider",
+		baseUrl: "http://localhost:0",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1000,
+		maxTokens: 100,
+	};
+}
+
+function createMessage(model: Model<typeof TEST_API>, content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function toolCall(arguments_: Record<string, unknown>): ToolCall {
+	return {
+		type: "toolCall",
+		id: "call-1",
+		name: "write",
+		arguments: arguments_,
+	};
+}
+
+function registerProvider(
+	pushEvents: (stream: AssistantMessageEventStream, model: Model<typeof TEST_API>) => void,
+): void {
+	const providerStream: StreamFunction<typeof TEST_API, StreamOptions> = (model) => {
+		const eventStream = createAssistantMessageEventStream();
+		queueMicrotask(() => pushEvents(eventStream, model));
+		return eventStream;
+	};
+	const providerStreamSimple: StreamFunction<typeof TEST_API, SimpleStreamOptions> = providerStream;
+	registerApiProvider({ api: TEST_API, stream: providerStream, streamSimple: providerStreamSimple }, TEST_SOURCE_ID);
+}
+
+async function collectEvents(streamResult: ReturnType<typeof stream>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of streamResult) {
+		events.push(event);
+	}
+	return events;
+}
+
+const context: Context = {
+	messages: [{ role: "user", content: "write the file", timestamp: 1 }],
+};
+
+afterEach(() => {
+	unregisterApiProviders(TEST_SOURCE_ID);
+});
+
+describe("strict final tool arguments", () => {
+	it("turns incomplete streamed tool arguments into a terminal error", async () => {
+		registerProvider((eventStream, model) => {
+			const start = createMessage(model, []);
+			const started = createMessage(model, [toolCall({})]);
+			const partial = createMessage(model, [toolCall({ path: "README.md" })]);
+			const done = { ...partial, stopReason: "toolUse" as const };
+			eventStream.push({ type: "start", partial: start });
+			eventStream.push({ type: "toolcall_start", contentIndex: 0, partial: started });
+			eventStream.push({ type: "toolcall_delta", contentIndex: 0, delta: '{"path":"README.md"', partial });
+			eventStream.push({ type: "toolcall_end", contentIndex: 0, toolCall: partial.content[0] as ToolCall, partial });
+			eventStream.push({ type: "done", reason: "toolUse", message: done });
+		});
+
+		const responseStream = stream(createModel(), context);
+		const events = await collectEvents(responseStream);
+		const result = await responseStream.result();
+
+		expect(events.map((event) => event.type)).toEqual(["start", "toolcall_start", "toolcall_delta", "error"]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Invalid final tool call arguments for write (call-1)");
+	});
+
+	it("keeps tool calls when streamed arguments are valid JSON objects", async () => {
+		registerProvider((eventStream, model) => {
+			const start = createMessage(model, []);
+			const started = createMessage(model, [toolCall({})]);
+			const partial = createMessage(model, [toolCall({ path: "README.md" })]);
+			const finalToolCall = toolCall({ path: "README.md", content: "updated" });
+			const done = { ...createMessage(model, [finalToolCall]), stopReason: "toolUse" as const };
+			eventStream.push({ type: "start", partial: start });
+			eventStream.push({ type: "toolcall_start", contentIndex: 0, partial: started });
+			eventStream.push({ type: "toolcall_delta", contentIndex: 0, delta: '{"path":"README.md"', partial });
+			eventStream.push({
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: ',"content":"updated"}',
+				partial: done,
+			});
+			eventStream.push({ type: "toolcall_end", contentIndex: 0, toolCall: finalToolCall, partial: done });
+			eventStream.push({ type: "done", reason: "toolUse", message: done });
+		});
+
+		const responseStream = stream(createModel(), context);
+		const events = await collectEvents(responseStream);
+		const result = await responseStream.result();
+
+		expect(events.map((event) => event.type)).toEqual([
+			"start",
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_delta",
+			"toolcall_end",
+			"done",
+		]);
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content[0]).toMatchObject({
+			type: "toolCall",
+			arguments: { path: "README.md", content: "updated" },
+		});
+	});
+
+	it("turns tool calls with non-toolUse stop reasons into a terminal error", async () => {
+		registerProvider((eventStream, model) => {
+			const start = createMessage(model, []);
+			const finalToolCall = toolCall({ path: "README.md" });
+			const finalMessage = createMessage(model, [finalToolCall]);
+			eventStream.push({ type: "start", partial: start });
+			eventStream.push({ type: "toolcall_start", contentIndex: 0, partial: createMessage(model, [toolCall({})]) });
+			eventStream.push({
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: '{"path":"README.md"}',
+				partial: finalMessage,
+			});
+			eventStream.push({ type: "toolcall_end", contentIndex: 0, toolCall: finalToolCall, partial: finalMessage });
+			eventStream.push({ type: "done", reason: "stop", message: finalMessage });
+		});
+
+		const responseStream = stream(createModel(), context);
+		const events = await collectEvents(responseStream);
+		const result = await responseStream.result();
+
+		expect(events.map((event) => event.type)).toEqual([
+			"start",
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+			"error",
+		]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Tool call write (call-1) ended with stop reason stop");
+	});
+});


### PR DESCRIPTION
## Summary

- validate final streamed tool-call argument JSON in the shared ai stream path
- keep partial JSON parsing for streaming updates, but fail with `stopReason: "error"` before `toolcall_end`/`done` can expose malformed final arguments
- reject assistant messages that contain tool calls but finish with a non-`toolUse` stop reason

## Tests

- `npm run check`
- `cd packages/ai && ./node_modules/.bin/vitest --run test/strict-final-tool-arguments.test.ts`
- `./test.sh` was attempted: agent and ai package tests passed; coding-agent tests then failed because extension tests could not import the unbuilt local `@earendil-works/pi-tui/dist/index.js` after `npm install --ignore-scripts`
