### PR TITLE
session-id-readonly.test.ts fails on clean main due to missing API key pre-flight check

### DIFF
--- a/packages/coding-agent/test/session-id-readonly.test.ts
+++ b/packages/coding-agent/test/session-id-readonly.test.ts
@@ -80,6 +80,8 @@ async function runCli(
 				[ENV_AGENT_DIR]: dirs.agentDir,
 				PI_OFFLINE: "1",
 				TSX_TSCONFIG_PATH: resolve(__dirname, "../../../tsconfig.json"),
+				ANTHROPIC_API_KEY: "sk-ant-api03-dummy",
+				OPENAI_API_KEY: "dummy",
 			},
 			stdio: ["ignore", "ignore", "pipe"],
 		});


### PR DESCRIPTION
### What do you want to change?
The test suite on the `main` branch is currently failing locally for `test/session-id-readonly.test.ts`. We need to either mock the API key check or provide a dummy key in the test environment so the test can reach the actual session-ID rejection logic.

### Why?
Currently, if you clone a clean `main` branch and run `./test.sh`, this specific test fails with an assertion error expecting `Session already exists` but receiving `No API key found`. 

Because `main` recently added stricter pre-flight API key checks before session creation, this test (which runs in an isolated `PI_OFFLINE=1` environment) immediately throws an error before it ever reaches the session-ID code path that it is actually trying to test. 

### How? 
Update the test environment setup in `session-id-readonly.test.ts` to inject a dummy API key so the pre-flight check passes and the session-ID rejection logic can actually be evaluated.

*(Note: I also have a local PR fully complete and ready to push for Issue #5871, but the contributor bot requires `lgtm` approval for new contributors to open PRs!)*