### PR TITLE
feature(coding-agent): show context estimates in session tree

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -84,8 +84,13 @@ import type { BashExecutionMessage, CustomMessage } from "./messages.ts";
 import type { ModelRegistry } from "./model-registry.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.ts";
-import type { BranchSummaryEntry, CompactionEntry, SessionManager } from "./session-manager.ts";
-import { CURRENT_SESSION_VERSION, getLatestCompactionEntry, type SessionHeader } from "./session-manager.ts";
+import type { BranchSummaryEntry, CompactionEntry, SessionEntry, SessionManager } from "./session-manager.ts";
+import {
+	buildSessionContext,
+	CURRENT_SESSION_VERSION,
+	getLatestCompactionEntry,
+	type SessionHeader,
+} from "./session-manager.ts";
 import type { SettingsManager } from "./settings-manager.ts";
 import type { SlashCommandInfo } from "./slash-commands.ts";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.ts";
@@ -2989,6 +2994,23 @@ export class AgentSession {
 	}
 
 	getContextUsage(): ContextUsage | undefined {
+		return this.calculateContextUsage(this.sessionManager.getBranch(), this.messages);
+	}
+
+	getContextUsageForEntry(entryId: string): ContextUsage | undefined {
+		const targetEntry = this.sessionManager.getEntry(entryId);
+		if (!targetEntry) return undefined;
+		const leafId =
+			(targetEntry.type === "message" && targetEntry.message.role === "user") ||
+			targetEntry.type === "custom_message"
+				? targetEntry.parentId
+				: entryId;
+		const entries = this.sessionManager.getEntries();
+		const context = buildSessionContext(entries, leafId);
+		return this.calculateContextUsage(leafId !== null ? this.sessionManager.getBranch(leafId) : [], context.messages);
+	}
+
+	private calculateContextUsage(branchEntries: SessionEntry[], messages: AgentMessage[]): ContextUsage | undefined {
 		const model = this.model;
 		if (!model) return undefined;
 
@@ -2998,7 +3020,6 @@ export class AgentSession {
 		// After compaction, the last assistant usage reflects pre-compaction context size.
 		// We can only trust usage from an assistant that responded after the latest compaction.
 		// If no such assistant exists, context token count is unknown until the next LLM response.
-		const branchEntries = this.sessionManager.getBranch();
 		const latestCompaction = getLatestCompactionEntry(branchEntries);
 
 		if (latestCompaction) {
@@ -3024,7 +3045,7 @@ export class AgentSession {
 			}
 		}
 
-		const estimate = estimateContextTokens(this.messages);
+		const estimate = estimateContextTokens(messages);
 		const percent = (estimate.tokens / contextWindow) * 100;
 
 		return {

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -103,6 +103,10 @@ interface ToolCallInfo {
 	arguments: Record<string, unknown>;
 }
 
+interface TreeContextUsage {
+	percent: number | null;
+}
+
 class TreeList implements Component {
 	private flatNodes: FlatNode[] = [];
 	private filteredNodes: FlatNode[] = [];
@@ -119,6 +123,7 @@ class TreeList implements Component {
 	private visibleChildrenMap: Map<string | null, string[]> = new Map();
 	private lastSelectedId: string | null = null;
 	private foldedNodes: Set<string> = new Set();
+	private getContextUsage?: (entryId: string) => TreeContextUsage | undefined;
 
 	public onSelect?: (entryId: string) => void;
 	public onCancel?: () => void;
@@ -130,10 +135,12 @@ class TreeList implements Component {
 		maxVisibleLines: number,
 		initialSelectedId?: string,
 		initialFilterMode?: FilterMode,
+		getContextUsage?: (entryId: string) => TreeContextUsage | undefined,
 	) {
 		this.currentLeafId = currentLeafId;
 		this.maxVisibleLines = maxVisibleLines;
 		this.filterMode = initialFilterMode ?? "default";
+		this.getContextUsage = getContextUsage;
 		this.multipleRoots = tree.length > 1;
 		this.flatNodes = this.flattenTree(tree);
 		this.buildActivePath();
@@ -737,10 +744,20 @@ class TreeList implements Component {
 					? theme.fg("muted", `${this.formatLabelTimestamp(flatNode.node.labelTimestamp)} `)
 					: "";
 			const content = this.getEntryDisplayText(flatNode.node, isSelected);
+			const rightPart = this.getContextUsageText(entry.id);
 			const prefixPart = theme.fg("dim", prefix) + foldMarker + pathMarker;
 			const anchorCol = visibleWidth(prefixPart);
 			let gutter = cursor;
-			let body = prefixPart + label + labelTimestamp + content;
+			const bodyPrefix = prefixPart + label + labelTimestamp;
+			let body = bodyPrefix + content;
+			if (rightPart) {
+				const viewportWidth = Math.max(0, width - TREE_GUTTER_WIDTH);
+				const rightWidth = visibleWidth(rightPart) + 2;
+				const availableForContent = viewportWidth - visibleWidth(bodyPrefix) - rightWidth;
+				const leftPart = bodyPrefix + truncateToWidth(content, Math.max(10, availableForContent), "…");
+				const spacing = Math.max(1, viewportWidth - visibleWidth(leftPart) - visibleWidth(rightPart));
+				body = leftPart + " ".repeat(spacing) + rightPart;
+			}
 			if (isSelected) {
 				gutter = theme.bg("selectedBg", gutter);
 				body = theme.bg("selectedBg", body);
@@ -757,6 +774,17 @@ class TreeList implements Component {
 		);
 
 		return lines;
+	}
+
+	private getContextUsageText(entryId: string): string {
+		const contextUsage = this.getContextUsage?.(entryId);
+		if (!contextUsage) return "";
+		const percent = contextUsage.percent === null ? "?" : contextUsage.percent.toFixed(1);
+		const display = `${percent}%`;
+		const value = contextUsage.percent ?? 0;
+		if (value > 90) return theme.fg("error", display);
+		if (value > 70) return theme.fg("warning", display);
+		return theme.fg("dim", display);
 	}
 
 	private getEntryDisplayText(node: SessionTreeNode, isSelected: boolean): string {
@@ -1315,13 +1343,21 @@ export class TreeSelectorComponent extends Container implements Focusable {
 		onLabelChange?: (entryId: string, label: string | undefined) => void,
 		initialSelectedId?: string,
 		initialFilterMode?: FilterMode,
+		getContextUsage?: (entryId: string) => TreeContextUsage | undefined,
 	) {
 		super();
 
 		this.onLabelChangeCallback = onLabelChange;
 		const maxVisibleLines = Math.max(5, Math.floor(terminalHeight / 2));
 
-		this.treeList = new TreeList(tree, currentLeafId, maxVisibleLines, initialSelectedId, initialFilterMode);
+		this.treeList = new TreeList(
+			tree,
+			currentLeafId,
+			maxVisibleLines,
+			initialSelectedId,
+			initialFilterMode,
+			getContextUsage,
+		);
 		this.treeList.onSelect = onSelect;
 		this.treeList.onCancel = onCancel;
 		this.treeList.onLabelEdit = (entryId, currentLabel) => this.showLabelInput(entryId, currentLabel);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4539,6 +4539,7 @@ export class InteractiveMode {
 				},
 				initialSelectedId,
 				initialFilterMode,
+				(entryId) => this.session.getContextUsageForEntry(entryId),
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/test/tree-selector.test.ts
+++ b/packages/coding-agent/test/tree-selector.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "../src/core/session-manager.ts";
 import { TreeSelectorComponent } from "../src/modes/interactive/components/tree-selector.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
 
 beforeAll(() => {
 	initTheme("dark");
@@ -269,6 +270,52 @@ describe("TreeSelectorComponent", () => {
 			expect(plain).toContain("label time");
 			expect(plain).not.toContain("...");
 			expect(plainLines.every((line) => visibleWidth(line) <= 30)).toBe(true);
+		});
+	});
+
+	describe("context usage", () => {
+		test("renders context usage percentage right-aligned", () => {
+			const entries = [
+				userMessage("user-1", null, "hello"),
+				assistantMessage("asst-1", "user-1", "a very long response that should leave room for the percent"),
+			];
+			const tree = buildTree(entries);
+
+			const selector = new TreeSelectorComponent(
+				tree,
+				"asst-1",
+				24,
+				() => {},
+				() => {},
+				undefined,
+				undefined,
+				undefined,
+				(entryId) => ({ percent: entryId === "user-1" ? 12.3 : 45.6 }),
+			);
+
+			const lines = selector.getTreeList().render(60).map(stripAnsi);
+			expect(lines[0]).toMatch(/12\.3%$/);
+			expect(lines[1]).toMatch(/45\.6%$/);
+		});
+
+		test("renders unknown context usage as question mark", () => {
+			const entries = [userMessage("user-1", null, "hello")];
+			const tree = buildTree(entries);
+
+			const selector = new TreeSelectorComponent(
+				tree,
+				"user-1",
+				24,
+				() => {},
+				() => {},
+				undefined,
+				undefined,
+				undefined,
+				() => ({ percent: null }),
+			);
+
+			const lines = selector.getTreeList().render(60).map(stripAnsi);
+			expect(lines[0]).toMatch(/\?%$/);
 		});
 	});
 


### PR DESCRIPTION
Here's an idea: show the context usage estimates in the Session Tree. This lets you quickly scan the entries to find the ones where clanker did the work. Here's what it looks like in this PR's session:

<img width="690" height="664" alt="Screenshot 2026-06-23 at 22 34 15" src="https://github.com/user-attachments/assets/8206abef-5d90-4907-aab1-8371246fdeba" />

One thing to note is that it adds the optional `getContextUsage` parameter to the `TreeSelectorComponent`'s constructor, which is public interface.

I've been using this feature for a few weeks and have found it useful, but I'm fine if it doesn't make it into the core. Thank you for your consideration!