### PR TITLE
fix(ai): omit reasoning replay items for Codex responses

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -451,6 +451,7 @@ function buildRequestBody(
 ): RequestBody {
 	const messages = convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, {
 		includeSystemPrompt: false,
+		includeReasoningItems: false,
 	});
 
 	const body: RequestBody = {
@@ -1393,6 +1394,7 @@ async function processWebSocketStream(
 		} else if (useCachedContext && entry && output.responseId) {
 			const responseItems = convertResponsesMessages(model, { messages: [output] }, CODEX_TOOL_CALL_PROVIDERS, {
 				includeSystemPrompt: false,
+				includeReasoningItems: false,
 			}).filter((item) => item.type !== "function_call_output");
 			entry.continuation = {
 				lastRequestBody: fullBody,

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -77,6 +77,7 @@ export interface OpenAIResponsesStreamOptions {
 
 export interface ConvertResponsesMessagesOptions {
 	includeSystemPrompt?: boolean;
+	includeReasoningItems?: boolean;
 }
 
 export interface ConvertResponsesToolsOptions {
@@ -123,6 +124,7 @@ export function convertResponsesMessages<TApi extends Api>(
 	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
 
 	const includeSystemPrompt = options?.includeSystemPrompt ?? true;
+	const includeReasoningItems = options?.includeReasoningItems ?? true;
 	if (includeSystemPrompt && context.systemPrompt) {
 		const compat = model.compat as { supportsDeveloperRole?: boolean } | undefined;
 		const role = model.reasoning && compat?.supportsDeveloperRole !== false ? "developer" : "system";
@@ -171,7 +173,7 @@ export function convertResponsesMessages<TApi extends Api>(
 
 			for (const block of msg.content) {
 				if (block.type === "thinking") {
-					if (block.thinkingSignature) {
+					if (includeReasoningItems && block.thinkingSignature) {
 						const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
 						output.push(reasoningItem);
 					}

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -8,7 +8,7 @@ import {
 	stream as streamOpenAICodexResponses,
 	streamSimple as streamSimpleOpenAICodexResponses,
 } from "../src/api/openai-codex-responses.ts";
-import type { Context, Model } from "../src/types.ts";
+import type { AssistantMessage, Context, Model, ToolResultMessage } from "../src/types.ts";
 
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 
@@ -635,6 +635,109 @@ describe("openai-codex streaming", () => {
 		}).result();
 
 		expect(capturedPayload?.prompt_cache_key).toBe("x".repeat(64));
+	});
+
+	it("omits replayed reasoning items from Codex request input while preserving tool continuity", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const sse = buildSSEPayload({ status: "completed" });
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+		let capturedInput: unknown;
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
+				capturedInput = body?.input;
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			model: "gpt-5.5",
+			content: [
+				{
+					type: "thinking",
+					thinking: "",
+					thinkingSignature: JSON.stringify({
+						type: "reasoning",
+						id: "rs_test",
+						status: "completed",
+						encrypted_content: "opaque-encrypted-reasoning",
+						summary: [],
+					}),
+				},
+				{ type: "toolCall", id: "call_test|fc_test", name: "lookup", arguments: { value: 1 } },
+			],
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "call_test|fc_test",
+			toolName: "lookup",
+			content: [{ type: "text", text: "lookup result" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Use the lookup tool", timestamp: Date.now() }, assistant, toolResult],
+		};
+
+		await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+		}).result();
+
+		expect(Array.isArray(capturedInput)).toBe(true);
+		const input = capturedInput as Array<Record<string, unknown>>;
+		expect(input.some((item) => item.type === "reasoning")).toBe(false);
+		expect(input.some((item) => item.type === "function_call")).toBe(true);
+		expect(input.some((item) => item.type === "function_call_output")).toBe(true);
+		expect(JSON.stringify(input)).not.toContain("encrypted_content");
+		expect(JSON.stringify(input)).not.toContain("opaque-encrypted-reasoning");
 	});
 
 	it("preserves gpt-5.5 xhigh reasoning effort from simple options", async () => {


### PR DESCRIPTION
## Summary

Codex Responses rejects replayed `reasoning` input items with `encrypted_content` in some follow-up requests. This PR adds a shared Responses conversion option for replayed reasoning items and uses it in the Codex provider so Codex request `input` preserves text/tool continuity without replaying provider-private reasoning payloads.

## Details

- Adds `includeReasoningItems?: boolean` to `convertResponsesMessages` options, defaulting to the existing behavior (`true`).
- Sets `includeReasoningItems: false` for Codex request-body conversion and websocket cached continuation conversion.
- Leaves non-Codex OpenAI/Azure Responses behavior unchanged.
- Adds a Codex payload regression test that starts with a prior assistant turn containing:
  - `thinkingSignature` serialized from a `reasoning` item with `encrypted_content`
  - a tool call
  - a matching tool result

The test asserts Codex request `input` has no `reasoning` or `encrypted_content` replay, while preserving `function_call` and `function_call_output` items.

## Why

A real Expo/background-agent run repeatedly failed on `openai-codex/gpt-5.5` after normal tool results with:

```text
{"detail":"Unsupported content type"}
```

Local sanitized session inspection showed prior assistant turns contained Codex `thinkingSignature` values serialized from `reasoning` response items, including `encrypted_content`. The current shared converter blindly parses and replays those as raw Responses `reasoning` input items for same-model replay. The Codex backend appears not to accept that content type in `input` even though it may emit it when `include: ["reasoning.encrypted_content"]` is requested.

## Validation

```bash
npm exec --workspace packages/ai -- vitest --run test/openai-codex-stream.test.ts test/openai-responses-foreign-toolcall-id.test.ts
# 2 files / 28 tests passed

npm --workspace packages/ai run build
# passed; generated model catalog drift from remote APIs was reverted

npm exec --workspace packages/ai -- tsgo -p tsconfig.build.json
# passed

npm exec -- biome check packages/ai/src/api/openai-codex-responses.ts packages/ai/src/api/openai-responses-shared.ts packages/ai/test/openai-codex-stream.test.ts
# passed
```

The repo pre-commit hook also ran `npm run check` during commit and passed.
