### PR TITLE
fix(coding-agent): print benchmark timings after TUI stop

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -810,9 +810,9 @@ export async function main(args: string[], options?: MainOptions) {
 		if (startupBenchmark) {
 			await interactiveMode.init();
 			time("interactiveMode.init");
-			printTimings();
 			interactiveMode.stop();
 			stopThemeWatcher();
+			printTimings();
 			if (process.stdout.writableLength > 0) {
 				await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
 			}


### PR DESCRIPTION
closes #6029

<img width="1168" height="944" alt="image" src="https://github.com/user-attachments/assets/3ed9bbd1-4689-4909-8875-7562a9ccd223" />
