### PR TITLE
fix(ai): pass custom fetch to openai clients

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import OpenAI, { type ClientOptions } from "openai";
 import type {
 	ChatCompletionAssistantMessageParam,
 	ChatCompletionChunk,
@@ -107,6 +107,11 @@ function isEncryptedReasoningDetail(detail: unknown): detail is OpenAIEncryptedR
 }
 
 export interface OpenAICompletionsOptions extends StreamOptions {
+	/**
+	 * Custom fetch implementation used by the OpenAI SDK client.
+	 * Use this for proxies, custom transports, or request instrumentation.
+	 */
+	fetch?: ClientOptions["fetch"];
 	toolChoice?: "auto" | "none" | "required" | { type: "function"; function: { name: string } };
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
 }
@@ -179,7 +184,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			const compat = getCompat(model);
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
+			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat, options?.fetch);
 			let params = buildParams(model, context, options, compat, cacheRetention);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -501,6 +506,7 @@ function createClient(
 	optionsHeaders?: ProviderHeaders,
 	sessionId?: string,
 	compat: ResolvedOpenAICompletionsCompat = getCompat(model),
+	fetch?: ClientOptions["fetch"],
 ) {
 	const headers: ProviderHeaders = { ...model.headers };
 	if (model.provider === "github-copilot") {
@@ -528,6 +534,7 @@ function createClient(
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: headers,
+		fetch,
 	});
 }
 

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import OpenAI, { type ClientOptions } from "openai";
 import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
 import { clampThinkingLevel } from "../models.ts";
 import type {
@@ -87,6 +87,11 @@ function formatOpenAIResponsesError(error: unknown): string {
 
 // OpenAI Responses-specific options
 export interface OpenAIResponsesOptions extends StreamOptions {
+	/**
+	 * Custom fetch implementation used by the OpenAI SDK client.
+	 * Use this for proxies, custom transports, or request instrumentation.
+	 */
+	fetch?: ClientOptions["fetch"];
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
@@ -127,7 +132,7 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 			const apiKey = getClientApiKey(model.provider, options?.apiKey, options?.headers);
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env);
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId);
+			const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, options?.fetch);
 			let params = buildParams(model, context, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -196,6 +201,7 @@ function createClient(
 	apiKey: string,
 	optionsHeaders?: ProviderHeaders,
 	sessionId?: string,
+	fetch?: ClientOptions["fetch"],
 ) {
 	const compat = getCompat(model);
 	const headers: ProviderHeaders = { ...model.headers };
@@ -225,6 +231,7 @@ function createClient(
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: headers,
+		fetch,
 	});
 }
 

--- a/packages/ai/test/openai-completions-empty-tools.test.ts
+++ b/packages/ai/test/openai-completions-empty-tools.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
 import { getModel, streamSimple } from "../src/compat.ts";
 
 // Empty tools arrays must NOT be serialized as `tools: []` — some OpenAI-compatible
@@ -74,6 +75,23 @@ describe("openai-completions empty tools handling", () => {
 
 		const params = mockState.lastParams as { tools?: unknown };
 		expect("tools" in (params as object)).toBe(false);
+	});
+
+	it("passes custom fetch to the OpenAI client", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = { ...baseModel, api: "openai-completions" } as const;
+		const fetch = vi.fn(async () => new Response(null));
+
+		await streamOpenAICompletions(
+			model,
+			{
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{ apiKey: "test", fetch },
+		).result();
+
+		const clientOptions = mockState.lastClientOptions as { fetch?: unknown };
+		expect(clientOptions.fetch).toBe(fetch);
 	});
 
 	it("omits tools field when context.tools is undefined", async () => {

--- a/packages/ai/test/openai-responses-terminal-event.test.ts
+++ b/packages/ai/test/openai-responses-terminal-event.test.ts
@@ -1,9 +1,13 @@
 import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamOpenAIResponses } from "../src/api/openai-responses.ts";
 import { processResponsesStream } from "../src/api/openai-responses-shared.ts";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model } from "../src/types.ts";
 import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
+
+const mockState = vi.hoisted(() => ({
+	lastClientOptions: undefined as unknown,
+}));
 
 vi.mock("openai", () => {
 	async function* createMockResponsesStream(): AsyncIterable<ResponseStreamEvent> {
@@ -29,6 +33,10 @@ vi.mock("openai", () => {
 	}
 
 	class FakeOpenAI {
+		constructor(options: unknown) {
+			mockState.lastClientOptions = options;
+		}
+
 		responses = {
 			create: () => {
 				const responseStream = createMockResponsesStream();
@@ -154,6 +162,25 @@ async function* createFailedEvents(): AsyncIterable<ResponseStreamEvent> {
 }
 
 describe("OpenAI Responses terminal event handling", () => {
+	beforeEach(() => {
+		mockState.lastClientOptions = undefined;
+	});
+
+	it("passes custom fetch to the OpenAI client", async () => {
+		const model = createModel();
+		const context: Context = {
+			systemPrompt: "",
+			messages: [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 }],
+			tools: [],
+		};
+		const fetch = vi.fn(async () => new Response(null));
+
+		await streamOpenAIResponses(model, context, { apiKey: "test", fetch }).result();
+
+		const clientOptions = mockState.lastClientOptions as { fetch?: unknown };
+		expect(clientOptions.fetch).toBe(fetch);
+	});
+
 	it("rejects streams that end before a terminal response event", async () => {
 		const model = createModel();
 		const output = createOutput(model);


### PR DESCRIPTION
## What

The `openai-completions` and `openai-responses` adapters build their OpenAI SDK client but never forward a custom `fetch`. This adds an optional `fetch` field to `OpenAICompletionsOptions` and `OpenAIResponsesOptions` and threads it through `createClient` into the `new OpenAI({...})` constructor.

## Why it matters

The OpenAI SDK accepts a custom `fetch` (`ClientOptions["fetch"]`) for proxies, custom transports, and request instrumentation. These two adapters silently dropped it, so callers had no way to intercept or route HTTP through them — unlike code that constructs the client directly. The option is opt-in; behavior is unchanged when it's unset.

## Changes

- `OpenAICompletionsOptions` / `OpenAIResponsesOptions`: add optional `fetch?: ClientOptions["fetch"]`.
- `createClient` in both adapters: accept the param and pass it to the OpenAI client.

## Testing

- Added a test to each adapter's suite asserting the provided `fetch` reaches the OpenAI client constructor.
- `npm run check` and `./test.sh` — run before submitting, per CONTRIBUTING.md.
