### PR TITLE
fix(coding-agent): use log out copy in auth flow

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -66,7 +66,7 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		this.addChild(new Spacer(1));
 
 		// Add title
-		const title = mode === "login" ? "Select provider to configure:" : "Select provider to logout:";
+		const title = mode === "login" ? "Select provider to configure:" : "Select provider to log out:";
 		this.addChild(new TruncatedText(theme.fg("accent", theme.bold(title)), 1, 0));
 		this.addChild(new Spacer(1));
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4766,7 +4766,7 @@ export class InteractiveMode {
 								: `Removed stored API key for ${providerOption.name}. Environment variables and models.json config are unchanged.`;
 						this.showStatus(message);
 					} catch (error: unknown) {
-						this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
+						this.showError(`Failed to log out: ${error instanceof Error ? error.message : String(error)}`);
 					}
 				},
 				() => {


### PR DESCRIPTION
## Summary
- Update the `/logout` provider selector title to say `log out` instead of `logout`.
- Reword the logout failure message from `Logout failed` to `Failed to log out`.

## Context
- Contribution proposal: #6036

## Validation
- `npm run check` passed.
- `./test.sh` was attempted, but this fresh clone has no built workspace `dist` files, so child-process coding-agent tests failed with missing imports such as `node_modules/@earendil-works/pi-ai/dist/index.js`. I did not run `npm run build` because the local agent instructions require explicit approval before build commands.