### PR TITLE
fix(ai): recover from hung streams and retry unmodeled Bedrock errors

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -28,11 +28,13 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.ts";
+import { combineAbortSignals } from "../utils/abort-signals.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { createConnectTimeout, resolveTimeoutMs, withStreamIdleTimeout } from "../utils/stream-timeouts.ts";
 
 import { resolveCloudflareBaseUrl } from "./cloudflare.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
@@ -449,6 +451,11 @@ async function* iterateAnthropicEvents(
 	}
 }
 
+// Idle window for the SSE read loop and connect window for the pre-stream phase; both
+// default-on and overridable via streamIdleTimeoutMs / connectTimeoutMs (0 disables).
+const DEFAULT_ANTHROPIC_STREAM_IDLE_TIMEOUT_MS = 240_000;
+const DEFAULT_ANTHROPIC_CONNECT_TIMEOUT_MS = 30_000;
+
 export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 	model: Model<"anthropic-messages">,
 	context: Context,
@@ -523,14 +530,43 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
 				maxRetries: options?.maxRetries ?? 0,
 			};
-			const response = await client.messages.create({ ...params, stream: true }, requestOptions).asResponse();
+			// Abort the request if response headers don't arrive in time (pre-stream phase only).
+			const connectTimeoutMs = resolveTimeoutMs(options?.connectTimeoutMs, DEFAULT_ANTHROPIC_CONNECT_TIMEOUT_MS);
+			const connectTimeout = createConnectTimeout(connectTimeoutMs);
+			const connectSignals = combineAbortSignals([options?.signal, connectTimeout.signal]);
+			let response: Response;
+			try {
+				response = await client.messages
+					.create({ ...params, stream: true }, { ...requestOptions, signal: connectSignals.signal })
+					.asResponse();
+			} catch (error) {
+				if (connectTimeout.signal.aborted && !options?.signal?.aborted) {
+					throw new Error(`Anthropic connect/first-byte timeout after ${connectTimeoutMs}ms`);
+				}
+				throw error;
+			} finally {
+				connectTimeout.clearTimeout();
+				connectSignals.cleanup();
+			}
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
 			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
 			const blocks = output.content as Block[];
 
-			for await (const event of iterateAnthropicEvents(response, options?.signal)) {
+			const streamIdleTimeoutMs = resolveTimeoutMs(
+				options?.streamIdleTimeoutMs,
+				DEFAULT_ANTHROPIC_STREAM_IDLE_TIMEOUT_MS,
+			);
+			const eventSource =
+				streamIdleTimeoutMs > 0
+					? withStreamIdleTimeout(
+							iterateAnthropicEvents(response, options?.signal),
+							streamIdleTimeoutMs,
+							() => new Error(`Anthropic stream idle timeout after ${streamIdleTimeoutMs}ms`),
+						)
+					: iterateAnthropicEvents(response, options?.signal);
+			for await (const event of eventSource) {
 				if (event.type === "message_start") {
 					output.responseId = event.message.id;
 					// Capture initial token usage from message_start event

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -13,6 +13,7 @@ import {
 	type ContentBlockStopEvent,
 	ConversationRole,
 	ConverseStreamCommand,
+	type ConverseStreamCommandOutput,
 	type ConverseStreamMetadataEvent,
 	ImageFormat,
 	type Message,
@@ -47,11 +48,13 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.ts";
+import { combineAbortSignals } from "../utils/abort-signals.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { createConnectTimeout, resolveTimeoutMs, withStreamIdleTimeout } from "../utils/stream-timeouts.ts";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
 
@@ -94,6 +97,11 @@ export interface BedrockOptions extends StreamOptions {
 type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
 
 const EMPTY_TEXT_PLACEHOLDER = "<empty>";
+
+// Idle window for the stream read loop and connect window for the pre-stream phase; both
+// default-on and overridable via streamIdleTimeoutMs / connectTimeoutMs (0 disables).
+const DEFAULT_BEDROCK_STREAM_IDLE_TIMEOUT_MS = 240_000;
+const DEFAULT_BEDROCK_CONNECT_TIMEOUT_MS = 30_000;
 
 export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> = (
 	model: Model<"bedrock-converse-stream">,
@@ -227,7 +235,22 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 			}
 			const command = new ConverseStreamCommand(commandInput);
 
-			const response = await client.send(command, { abortSignal: options.signal });
+			// Abort the request if response headers don't arrive in time (pre-stream phase only).
+			const connectTimeoutMs = resolveTimeoutMs(options.connectTimeoutMs, DEFAULT_BEDROCK_CONNECT_TIMEOUT_MS);
+			const connectTimeout = createConnectTimeout(connectTimeoutMs);
+			const connectSignals = combineAbortSignals([options.signal, connectTimeout.signal]);
+			let response: ConverseStreamCommandOutput;
+			try {
+				response = await client.send(command, { abortSignal: connectSignals.signal });
+			} catch (error) {
+				if (connectTimeout.signal.aborted && !options?.signal?.aborted) {
+					throw new Error(`Bedrock connect/first-byte timeout after ${connectTimeoutMs}ms`);
+				}
+				throw error;
+			} finally {
+				connectTimeout.clearTimeout();
+				connectSignals.cleanup();
+			}
 			if (response.$metadata.httpStatusCode !== undefined) {
 				const responseHeaders: Record<string, string> = {};
 				if (response.$metadata.requestId) {
@@ -236,7 +259,19 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 				await options?.onResponse?.({ status: response.$metadata.httpStatusCode, headers: responseHeaders }, model);
 			}
 
-			for await (const item of response.stream!) {
+			const streamIdleTimeoutMs = resolveTimeoutMs(
+				options.streamIdleTimeoutMs,
+				DEFAULT_BEDROCK_STREAM_IDLE_TIMEOUT_MS,
+			);
+			const streamSource =
+				streamIdleTimeoutMs > 0
+					? withStreamIdleTimeout(
+							response.stream!,
+							streamIdleTimeoutMs,
+							() => new Error(`Bedrock stream idle timeout after ${streamIdleTimeoutMs}ms`),
+						)
+					: response.stream!;
+			for await (const item of streamSource) {
 				if (item.messageStart) {
 					if (item.messageStart.role !== ConversationRole.ASSISTANT) {
 						throw new Error("Unexpected assistant message start but got user message start instead");
@@ -325,6 +360,14 @@ function formatBedrockError(error: unknown): string {
 		? ` See ${BEDROCK_DATA_RETENTION_DOCS_URL} for supported data retention modes.`
 		: "";
 	if (error instanceof BedrockRuntimeServiceException) {
+		const prefix = BEDROCK_ERROR_PREFIXES[error.name] ?? error.name;
+		return `${prefix}: ${message}${dataRetentionHint}`;
+	}
+	// Unmodeled stream exceptions are thrown by the Smithy unmarshaller as a plain
+	// `Error` (not a BedrockRuntimeServiceException), so without this branch they reach
+	// the caller with no category prefix and defeat the retry classifier. Apply the same
+	// prefix convention using the wire exception type on `.name`.
+	if (error instanceof Error && typeof error.name === "string" && error.name && error.name !== "Error") {
 		const prefix = BEDROCK_ERROR_PREFIXES[error.name] ?? error.name;
 		return `${prefix}: ${message}${dataRetentionHint}`;
 	}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -156,6 +156,23 @@ export interface StreamOptions {
 	 */
 	websocketConnectTimeoutMs?: number;
 	/**
+	 * Idle-timeout watchdog (ms) for the streaming read loop on HTTP/SSE providers
+	 * such as Bedrock and Anthropic. The timer resets on every stream event; on
+	 * prolonged silence (a half-open socket) the provider throws a retryable timeout
+	 * instead of hanging. Distinct from `timeoutMs` (the SDK request timeout).
+	 * `undefined` uses the provider default; `0`/invalid disables it.
+	 */
+	streamIdleTimeoutMs?: number;
+	/**
+	 * Pre-stream connect/first-byte timeout (ms) for providers that support it (e.g.
+	 * Bedrock `client.send()`, Anthropic `asResponse()`). The idle watchdog guards the
+	 * event stream only; obtaining response headers has no fast timeout, so a stalled
+	 * connection hangs silently. Aborts the request and throws a retryable timeout;
+	 * safe because no tokens were generated yet. `undefined` uses the provider default;
+	 * `0`/invalid disables it.
+	 */
+	connectTimeoutMs?: number;
+	/**
 	 * Maximum retry attempts for providers/SDKs that support client-side retries.
 	 * For example, OpenAI and Anthropic SDK clients default to 2.
 	 */

--- a/packages/ai/src/utils/stream-timeouts.ts
+++ b/packages/ai/src/utils/stream-timeouts.ts
@@ -1,0 +1,70 @@
+/**
+ * Connect/idle timeout helpers shared by the streaming providers. Kept here so Bedrock,
+ * Anthropic (and any future provider) wire the same logic rather than re-implementing it.
+ */
+
+const TIMEOUT_SYMBOL = Symbol("idle-timeout");
+
+/**
+ * Resolve a timeout option (ms): `undefined`/`null` uses `defaultMs`; a non-positive or
+ * non-finite value disables the timeout (returns `0`).
+ */
+export function resolveTimeoutMs(value: number | null | undefined, defaultMs: number): number {
+	if (value === undefined || value === null) return defaultMs;
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+	return Math.floor(value);
+}
+
+/**
+ * Idle-timeout watchdog for a streaming read loop. A half-open socket (open, but no further
+ * events and no FIN/RST) otherwise blocks the underlying `next()` forever. The timer resets on
+ * every event; on prolonged silence the generator throws `makeError()`, which callers classify
+ * as retryable. The race resolves a sentinel on timeout rather than rejecting, so the throw
+ * happens once, at the top of the loop.
+ */
+export async function* withStreamIdleTimeout<T>(
+	source: AsyncIterable<T>,
+	idleMs: number,
+	makeError: () => Error,
+): AsyncGenerator<T> {
+	const iterator = source[Symbol.asyncIterator]();
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		while (true) {
+			const idle = new Promise<typeof TIMEOUT_SYMBOL>((resolve) => {
+				timer = setTimeout(() => resolve(TIMEOUT_SYMBOL), idleMs);
+			});
+			const result = await Promise.race([iterator.next(), idle]);
+			if (result === TIMEOUT_SYMBOL) throw makeError();
+			clearTimeout(timer);
+			if (result.done) return;
+			yield result.value;
+		}
+	} finally {
+		clearTimeout(timer);
+		try {
+			// Release the underlying stream on early exit (timeout / abort / break).
+			await iterator.return?.();
+		} catch {
+			/* ignore */
+		}
+	}
+}
+
+/**
+ * @param connectMs The timeout in milliseconds. 0 value disables the timeout (and the signal never aborts).
+ *
+ * @returns A signal that is aborted if the timeout elapses, and a clearTimeout function to stop the timer.
+ */
+export function createConnectTimeout(connectMs: number): { signal: AbortSignal; clearTimeout: () => void } {
+	const controller = new AbortController();
+	const timer = setTimeout(() => {
+		if (connectMs > 0) {
+			controller.abort();
+		}
+	}, connectMs);
+	return {
+		signal: controller.signal,
+		clearTimeout: () => clearTimeout(timer),
+	};
+}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2500,9 +2500,17 @@ export class AgentSession {
 		const err = message.errorMessage;
 		if (this._isNonRetryableProviderLimitError(err)) return false;
 		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), WebSocket transport closes/errors, fetch failed, premature stream endings, HTTP/2 closed before response, terminated, retry delay exceeded
-		return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
-			err,
-		);
+		if (
+			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
+				err,
+			)
+		)
+			return true;
+		// Narrow fallback for transient errors that carry none of the signals above —
+		// e.g. an unmodeled Bedrock stream exception ("...unexpected error during
+		// processing. Try your request again."). The billing/quota veto runs first, so
+		// this never overrides a genuine usage-limit error.
+		return /unexpected error during processing|try (?:your )?request again/i.test(err);
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses a few issues with Bedrock and Anthropic connectivity:

- **Idle timeout** (`streamIdleTimeoutMs`, default 240s): if a stream goes silent on a half-open socket, throw a retryable timeout instead of blocking the read loop forever.

- **Connect timeout** (`connectTimeoutMs`, default 30s): if the request stalls before any response comes back, time out and retry (nothing has streamed yet, so it's safe).

- **Retry a couple more Bedrock errors**: some transient Bedrock errors ("…try your request again") weren't recognized as retryable, so they ended the turn. Now they retry.

The shared timeout logic lives in `utils/stream-timeouts` so Bedrock and Anthropic use the same code. Both timeouts are on by default and configurable; `0` disables either. `npm run check` passes.

refs #5291

**Disclosure:** the code and description were written with AI assistance (Claude via pi); I've reviewed/edited them.