### PR TITLE
feat(agent,coding-agent): add runParallelAgentTasks + parallel batching system prompt guideline

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `runParallelAgentTasks`: run N independent agent loops concurrently and collect results. Each task gets its own isolated loop; failures are captured per-task rather than thrown. Intended for extensions and harness integrations that have already identified independent work items.
+
 ## [0.80.2] - 2026-06-23
 
 ### Changed

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -38,6 +38,7 @@ export * from "./harness/system-prompt.ts";
 export * from "./harness/types.ts";
 export * from "./harness/utils/shell-output.ts";
 export * from "./harness/utils/truncate.ts";
+export * from "./parallel.ts";
 // Proxy utilities
 export * from "./proxy.ts";
 // Types

--- a/packages/agent/src/parallel.ts
+++ b/packages/agent/src/parallel.ts
@@ -1,0 +1,86 @@
+/**
+ * Parallel sub-task execution for independent agent workloads.
+ *
+ * The main agent loop is inherently sequential: each turn waits for an LLM
+ * response, executes tool calls (possibly concurrently within the turn), then
+ * waits for the next prompt. Many real tasks decompose into independent
+ * sub-tasks that have no shared state and could be handled by separate agent
+ * instances running at the same time.
+ *
+ * `runParallelAgentTasks` runs N independent agent loops concurrently and
+ * collects their results. It does not modify the parent context and does not
+ * require the sub-tasks to coordinate with each other.
+ *
+ * Intended for use by extensions, custom tools, and harness integrations that
+ * have already identified a set of independent work items. Task decomposition
+ * (deciding *what* to run in parallel) is left to the caller — this utility
+ * only handles *how* to run it.
+ */
+
+import { agentLoop } from "./agent-loop.ts";
+import type { AgentContext, AgentLoopConfig, AgentMessage, StreamFn } from "./types.ts";
+
+/** A single sub-task to run in parallel. */
+export interface ParallelAgentTask {
+	/** Initial prompt messages for this sub-task's agent loop. */
+	prompts: AgentMessage[];
+	/** Snapshot of the context this sub-task runs in. */
+	context: AgentContext;
+	/** Loop config (model, tools, hooks, etc.). */
+	config: AgentLoopConfig;
+	/** Optional abort signal scoped to this sub-task. */
+	signal?: AbortSignal;
+	/** Optional stream function override for this sub-task. */
+	streamFn?: StreamFn;
+}
+
+/** Result of one completed (or failed) sub-task. */
+export type ParallelAgentResult =
+	| {
+			status: "fulfilled";
+			/** Messages produced by this sub-task's agent loop. */
+			messages: AgentMessage[];
+	  }
+	| {
+			status: "rejected";
+			/** Reason the sub-task loop failed. */
+			reason: unknown;
+	  };
+
+/**
+ * Run multiple independent agent loops concurrently.
+ *
+ * Each task gets its own isolated agent loop. Results are returned in the same
+ * order as the input tasks regardless of completion order.
+ *
+ * Sub-task failures are captured as `{ status: "rejected" }` entries rather
+ * than thrown, so a single failing sub-task does not abort the others.
+ *
+ * @example
+ * ```typescript
+ * const results = await runParallelAgentTasks([
+ *   { prompts: [userMsg("summarise file A")], context, config },
+ *   { prompts: [userMsg("summarise file B")], context, config },
+ *   { prompts: [userMsg("summarise file C")], context, config },
+ * ]);
+ * for (const result of results) {
+ *   if (result.status === "fulfilled") {
+ *     console.log(result.messages);
+ *   }
+ * }
+ * ```
+ */
+export async function runParallelAgentTasks(tasks: ReadonlyArray<ParallelAgentTask>): Promise<ParallelAgentResult[]> {
+	const settled = await Promise.allSettled(
+		tasks.map(({ prompts, context, config, signal, streamFn }) =>
+			agentLoop(prompts, context, config, signal, streamFn).result(),
+		),
+	);
+
+	return settled.map((outcome): ParallelAgentResult => {
+		if (outcome.status === "fulfilled") {
+			return { status: "fulfilled", messages: outcome.value };
+		}
+		return { status: "rejected", reason: outcome.reason };
+	});
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- System prompt: added guideline instructing the model to batch independent operations into a single response instead of issuing them one at a time, so the parallel tool executor can run them concurrently.
+
 ### Fixed
 
 - Fixed auto-retry for provider stream errors that explicitly tell callers to retry the request ([#6019](https://github.com/earendil-works/pi/issues/6019)).

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -124,6 +124,9 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	// Always include these
 	addGuideline("Be concise in your responses");
 	addGuideline("Show file paths clearly when working with files");
+	addGuideline(
+		"When you have several independent operations (reading multiple files, calling separate APIs, processing unrelated items), issue all of them as tool calls in a single response instead of one at a time — the runtime executes independent calls in parallel",
+	);
 
 	const guidelines = guidelinesList.map((g) => `- ${g}`).join("\n");
 


### PR DESCRIPTION
Closes #6053

## What

- New `runParallelAgentTasks` utility in `@earendil-works/pi-agent-core`
- System prompt guideline telling the model to batch independent tool calls

## Why

The agent runtime already runs tool calls in parallel within a single LLM response (`toolExecution: "parallel"` default). There was no way to run independent *agent loops* concurrently. Tasks that decompose into N independent sub-tasks required N sequential LLM round-trips even when the sub-tasks share no state.

## Changes

**`packages/agent/src/parallel.ts`** (new, ~65 lines)

```ts
export async function runParallelAgentTasks(
  tasks: ReadonlyArray<ParallelAgentTask>,
): Promise<ParallelAgentResult[]>
```

Runs each task as an isolated `agentLoop` via `Promise.allSettled`. Returns results in input order. Per-task failures are `{ status: "rejected", reason }` rather than thrown, so one failing sub-task does not abort the others.

**`packages/agent/src/index.ts`**

One `export * from "./parallel.ts"` line.

**`packages/coding-agent/src/core/system-prompt.ts`**

One `addGuideline(...)` call: tells the model to batch independent operations into a single response. The runtime already executes them in parallel — the model needs to know it should batch them.

## Design decisions

- Task decomposition (deciding *what* is independent) is intentionally left to the caller. The function only handles concurrent dispatch and result collection.
- `Promise.allSettled` rather than `Promise.all` so partial results are preserved when some sub-tasks fail.
- No changes to the agent loop, agent class, or any existing type.
- `ParallelAgentTask` and `ParallelAgentResult` are exported so callers can type-check task lists without importing implementation details.

## Checklist

- `npm run check` passes (biome, ts-imports, shrinkwrap, tsgo --noEmit, browser smoke)
- No new `any` usages
- No inline imports
- Changelog entries added to both packages
