### PR TITLE
fix(prompt): add an overeager scope-discipline rule to the system prompt

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -122,6 +122,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 	}
 
 	// Always include these
+	addGuideline("Guard against overeager actions: pay careful attention to the scope of the user's request. Do what they ask, but no more. Do not improve, comment, fix, or modify unrelated parts of the code in any way.");
 	addGuideline("Be concise in your responses");
 	addGuideline("Show file paths clearly when working with files");
 


### PR DESCRIPTION
Adds a general overeager scope-discipline rule to the system prompt, in the spirit of the `overeager_prompt` line aider ships: the agent stays within the scope of the request -- does what's asked and no more, and does not modify unrelated parts of the code.

Prompt-only change; one line added to `packages/coding-agent/src/core/system-prompt.ts`. No new behavior beyond the scope guidance.