### PR TITLE
feat: add #RRGGBBAA alpha support for theme colors

### DIFF
--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -628,9 +628,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
@@ -646,9 +643,6 @@
 			],
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"optional": true
 		},
@@ -666,9 +660,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
@@ -685,9 +676,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"optional": true
 		},
 		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
@@ -703,9 +691,6 @@
 			],
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"optional": true
 		},

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -12,11 +12,12 @@
 		"dimGray": "#666666",
 		"darkGray": "#505050",
 		"accent": "#8abeb7",
+		"bg": "#1e1e2e",
 		"selectedBg": "#3a3a4a",
 		"userMsgBg": "#343541",
 		"toolPendingBg": "#282832",
-		"toolSuccessBg": "#283228",
-		"toolErrorBg": "#3c2828",
+		"toolSuccessBg": "#b5bd6826",
+		"toolErrorBg": "#cc666626",
 		"customMsgBg": "#2d2838"
 	},
 	"colors": {

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -11,11 +11,12 @@
 		"mediumGray": "#6c6c6c",
 		"dimGray": "#767676",
 		"lightGray": "#b0b0b0",
+		"bg": "#ffffff",
 		"selectedBg": "#d0d0e0",
 		"userMsgBg": "#e8e8e8",
 		"toolPendingBg": "#e8e8f0",
-		"toolSuccessBg": "#e8f0e8",
-		"toolErrorBg": "#f0e8e8",
+		"toolSuccessBg": "#58845826",
+		"toolErrorBg": "#aa555526",
 		"customMsgBg": "#ede7f6"
 	},
 	"colors": {

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -21,7 +21,7 @@
 				"oneOf": [
 					{
 						"type": "string",
-						"description": "Hex color (#RRGGBB), variable reference, or empty string for terminal default"
+						"description": "Hex color (#RRGGBB or #RRGGBBAA with alpha), variable reference, or empty string for terminal default"
 					},
 					{
 						"type": "integer",
@@ -322,7 +322,7 @@
 			"oneOf": [
 				{
 					"type": "string",
-					"description": "Hex color (#RRGGBB), variable reference, or empty string for terminal default"
+					"description": "Hex color (#RRGGBB or #RRGGBBAA with alpha), variable reference, or empty string for terminal default"
 				},
 				{
 					"type": "integer",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -21,7 +21,7 @@ import { highlight, supportsLanguage } from "../../../utils/syntax-highlight.ts"
 // ============================================================================
 
 const ColorValueSchema = Type.Union([
-	Type.String(), // hex "#ff0000", var ref "primary", or empty ""
+	Type.String(), // hex "#ff0000" / "#ff000080" (with alpha), var ref "primary", or empty ""
 	Type.Integer({ minimum: 0, maximum: 255 }), // 256-color index
 ]);
 
@@ -165,18 +165,51 @@ type ColorMode = "truecolor" | "256color";
 // Color Utilities
 // ============================================================================
 
+interface RgbaColor {
+	r: number;
+	g: number;
+	b: number;
+	a: number;
+}
+
 function hexToRgb(hex: string): { r: number; g: number; b: number } {
+	const { r, g, b } = hexToRgba(hex);
+	return { r, g, b };
+}
+
+function hexToRgba(hex: string): RgbaColor {
 	const cleaned = hex.replace("#", "");
-	if (cleaned.length !== 6) {
-		throw new Error(`Invalid hex color: ${hex}`);
+	if (cleaned.length !== 6 && cleaned.length !== 8) {
+		throw new Error(`Invalid hex color: ${hex} (expected #RRGGBB or #RRGGBBAA)`);
 	}
 	const r = parseInt(cleaned.substring(0, 2), 16);
 	const g = parseInt(cleaned.substring(2, 4), 16);
 	const b = parseInt(cleaned.substring(4, 6), 16);
-	if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+	const a = cleaned.length === 8 ? parseInt(cleaned.substring(6, 8), 16) / 255 : 1.0;
+	if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b) || Number.isNaN(a)) {
 		throw new Error(`Invalid hex color: ${hex}`);
 	}
-	return { r, g, b };
+	return { r, g, b, a };
+}
+
+function hasAlpha(hex: string): boolean {
+	const cleaned = hex.replace("#", "");
+	return cleaned.length === 8;
+}
+
+function blendWithBackground(color: RgbaColor, background: { r: number; g: number; b: number }): string {
+	if (color.a >= 1.0) {
+		return `#${color.r.toString(16).padStart(2, "0")}${color.g.toString(16).padStart(2, "0")}${color.b.toString(16).padStart(2, "0")}`;
+	}
+	if (color.a <= 0.0) {
+		// Fully transparent - return background as-is
+		return `#${background.r.toString(16).padStart(2, "0")}${background.g.toString(16).padStart(2, "0")}${background.b.toString(16).padStart(2, "0")}`;
+	}
+	const blend = (fg: number, bg: number, alpha: number) => Math.round(bg * (1 - alpha) + fg * alpha);
+	const r = blend(color.r, background.r, color.a);
+	const g = blend(color.g, background.g, color.a);
+	const b = blend(color.b, background.b, color.a);
+	return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
 }
 
 // The 6x6x6 color cube channel values (indices 0-5)
@@ -313,6 +346,31 @@ function resolveThemeColors<T extends Record<string, ColorValue>>(
 	for (const [key, value] of Object.entries(colors)) {
 		resolved[key] = resolveVarRefs(value, vars);
 	}
+
+	// Blend any #RRGGBBAA colors with the theme background.
+	// If a color has alpha < 1.0, it is composited against the background
+	// to produce an opaque #RRGGBB color (since terminals don't support alpha).
+	// The background is determined from the "bg" var, falling back to the
+	// resolved selectedBg color, then a dark default (#1e1e2e).
+	let background: { r: number; g: number; b: number } | undefined;
+	for (const [key, value] of Object.entries(resolved)) {
+		if (typeof value === "string" && value.startsWith("#") && hasAlpha(value)) {
+			if (!background) {
+				// Resolve background: "bg" var > selectedBg > dark default
+				const bgValue = vars.bg !== undefined ? resolveVarRefs(vars.bg, vars) : resolved.selectedBg;
+				if (typeof bgValue === "string" && bgValue.startsWith("#")) {
+					const bgRgba = hexToRgba(bgValue);
+					background = { r: bgRgba.r, g: bgRgba.g, b: bgRgba.b };
+				} else {
+					// Fallback: dark background
+					background = { r: 0x1e, g: 0x1e, b: 0x2e };
+				}
+			}
+			const rgba = hexToRgba(value);
+			resolved[key] = blendWithBackground(rgba, background);
+		}
+	}
+
 	return resolved as Record<keyof T, string | number>;
 }
 
@@ -1056,11 +1114,32 @@ export function getThemeExportColors(themeName?: string): {
 		if (!exportSection) return {};
 
 		const vars = themeJson.vars ?? {};
+		// Get background for alpha blending
+		let blendBg: { r: number; g: number; b: number } | undefined;
 		const resolve = (value: ColorValue | undefined): string | undefined => {
 			if (value === undefined) return undefined;
 			const resolved = resolveVarRefs(value, vars);
 			if (typeof resolved === "number") return ansi256ToHex(resolved);
 			if (resolved === "") return undefined;
+			if (hasAlpha(resolved)) {
+				if (!blendBg) {
+					let bgValue: string | number | undefined;
+					if (vars.bg !== undefined) {
+						bgValue = resolveVarRefs(vars.bg, vars);
+					} else {
+						// Fall back to selectedBg from colors
+						const colors = themeJson.colors;
+						bgValue = colors.selectedBg ? resolveVarRefs(colors.selectedBg, vars) : undefined;
+					}
+					if (typeof bgValue === "string" && bgValue.startsWith("#")) {
+						const bgRgba = hexToRgba(bgValue);
+						blendBg = { r: bgRgba.r, g: bgRgba.g, b: bgRgba.b };
+					} else {
+						blendBg = { r: 0x1e, g: 0x1e, b: 0x2e };
+					}
+				}
+				return blendWithBackground(hexToRgba(resolved), blendBg);
+			}
 			return resolved;
 		};
 

--- a/packages/coding-agent/test/theme-alpha.test.ts
+++ b/packages/coding-agent/test/theme-alpha.test.ts
@@ -1,0 +1,198 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getThemeExportColors, loadThemeFromPath } from "../src/modes/interactive/theme/theme.ts";
+
+type ThemeFile = {
+	name: string;
+	vars?: Record<string, string | number>;
+	colors: Record<string, string | number>;
+	export?: {
+		pageBg?: string | number;
+		cardBg?: string | number;
+		infoBg?: string | number;
+	};
+};
+
+function createTempThemeDir(): string {
+	const tempRoot = mkdtempSync(join(tmpdir(), "pi-theme-alpha-"));
+	process.env.PI_CODING_AGENT_DIR = join(tempRoot, "agent");
+	mkdirSync(join(process.env.PI_CODING_AGENT_DIR, "themes"), { recursive: true });
+	return tempRoot;
+}
+
+function cleanupTempDir(tempRoot: string, previousAgentDir: string | undefined) {
+	rmSync(tempRoot, { recursive: true, force: true });
+	if (previousAgentDir === undefined) {
+		delete process.env.PI_CODING_AGENT_DIR;
+	} else {
+		process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
+}
+
+function readDarkTheme(): ThemeFile {
+	return JSON.parse(
+		readFileSync(new URL("../src/modes/interactive/theme/dark.json", import.meta.url), "utf-8"),
+	) as ThemeFile;
+}
+
+describe("theme alpha blending", () => {
+	let tempRoot: string;
+	let previousAgentDir: string | undefined;
+
+	beforeEach(() => {
+		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		tempRoot = createTempThemeDir();
+	});
+
+	afterEach(() => {
+		cleanupTempDir(tempRoot, previousAgentDir);
+	});
+
+	it("blends #RRGGBBAA colors with bg var", () => {
+		const darkTheme = readDarkTheme();
+		const customTheme: ThemeFile = {
+			...darkTheme,
+			name: "alpha-test-blend",
+			vars: {
+				...(darkTheme.vars ?? {}),
+			},
+		};
+
+		const themePath = join(process.env.PI_CODING_AGENT_DIR!, "themes", "alpha-test-blend.json");
+		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
+
+		const theme = loadThemeFromPath(themePath, "truecolor");
+		// The dark theme's toolSuccessBg is #b5bd6826 (green at ~15% alpha)
+		// It should be blended with the bg var (#1e1e2e)
+		const bgAnsi = theme.getBgAnsi("toolSuccessBg");
+		// Background ANSI uses 48;2;R;G;Bm
+		expect(bgAnsi).toMatch(/48;2;\d+;\d+;\d+m/);
+	});
+
+	it("handles #RRGGBB (no alpha) as fully opaque", () => {
+		const darkTheme = readDarkTheme();
+		const customTheme: ThemeFile = {
+			...darkTheme,
+			name: "alpha-test-opaque",
+			vars: {
+				...(darkTheme.vars ?? {}),
+				toolSuccessBg: "#283228", // override with opaque color (no alpha)
+			},
+			colors: {
+				...darkTheme.colors,
+				toolSuccessBg: "toolSuccessBg",
+			},
+		};
+
+		const themePath = join(process.env.PI_CODING_AGENT_DIR!, "themes", "alpha-test-opaque.json");
+		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
+
+		const theme = loadThemeFromPath(themePath, "truecolor");
+		const bgAnsi = theme.getBgAnsi("toolSuccessBg");
+		expect(bgAnsi).toContain("48;2;40;50;40"); // #283228 as RGB
+	});
+
+	it("blends alpha colors in export section", () => {
+		const darkTheme = readDarkTheme();
+		const customTheme: ThemeFile = {
+			...darkTheme,
+			name: "alpha-test-export",
+			vars: {
+				...(darkTheme.vars ?? {}),
+				semiPageBg: "#ffffff40", // white at 25% alpha
+			},
+			export: {
+				pageBg: "semiPageBg",
+			},
+		};
+
+		const themePath = join(process.env.PI_CODING_AGENT_DIR!, "themes", "alpha-test-export.json");
+		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
+
+		const colors = getThemeExportColors("alpha-test-export");
+		// #ffffff at 25% over #1e1e2e should produce an opaque color
+		expect(colors.pageBg).toMatch(/^#[0-9a-f]{6}$/);
+		// Should be lighter than the bg color
+		expect(colors.pageBg).not.toBe("#1e1e2e");
+	});
+
+	it("uses selectedBg fallback when bg var is not defined", () => {
+		const darkTheme = readDarkTheme();
+		// Remove bg from vars, but still have alpha color
+		const varsWithoutBg = { ...(darkTheme.vars ?? {}) } as Record<string, string | number>;
+		delete varsWithoutBg.bg;
+
+		const customTheme: ThemeFile = {
+			...darkTheme,
+			name: "alpha-test-nobg",
+			vars: {
+				...varsWithoutBg,
+				testSuccessBg: "#b5bd6826", // green at ~15% alpha
+			},
+			colors: {
+				...darkTheme.colors,
+				toolSuccessBg: "testSuccessBg",
+			},
+		};
+
+		const themePath = join(process.env.PI_CODING_AGENT_DIR!, "themes", "alpha-test-nobg.json");
+		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
+
+		// Should not throw - falls back to selectedBg
+		const theme = loadThemeFromPath(themePath, "truecolor");
+		expect(theme).toBeDefined();
+		const bgAnsi = theme.getBgAnsi("toolSuccessBg");
+		expect(bgAnsi).toMatch(/48;2;\d+;\d+;\d+m/);
+	});
+
+	it("blends alpha color referenced by var", () => {
+		const darkTheme = readDarkTheme();
+		const customTheme: ThemeFile = {
+			...darkTheme,
+			name: "alpha-test-var",
+			vars: {
+				...(darkTheme.vars ?? {}),
+				successBg: "#b5bd6826", // green at ~15% alpha, referenced by var
+			},
+			colors: {
+				...darkTheme.colors,
+				toolSuccessBg: "successBg",
+			},
+		};
+
+		const themePath = join(process.env.PI_CODING_AGENT_DIR!, "themes", "alpha-test-var.json");
+		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
+
+		const theme = loadThemeFromPath(themePath, "truecolor");
+		expect(theme).toBeDefined();
+		// Should have blended the var-ref'd alpha color
+		const bgAnsi = theme.getBgAnsi("toolSuccessBg");
+		expect(bgAnsi).toMatch(/48;2;\d+;\d+;\d+m/);
+	});
+
+	it("fully transparent alpha (00) results in background color", () => {
+		const darkTheme = readDarkTheme();
+		const customTheme: ThemeFile = {
+			...darkTheme,
+			name: "alpha-test-fully-transparent",
+			vars: {
+				...(darkTheme.vars ?? {}),
+				invisibleBg: "#ff000000", // red at 0% alpha = fully transparent
+			},
+			colors: {
+				...darkTheme.colors,
+				toolSuccessBg: "invisibleBg",
+			},
+		};
+
+		const themePath = join(process.env.PI_CODING_AGENT_DIR!, "themes", "alpha-test-fully-transparent.json");
+		writeFileSync(themePath, JSON.stringify(customTheme, null, 2));
+
+		const theme = loadThemeFromPath(themePath, "truecolor");
+		const bgAnsi = theme.getBgAnsi("toolSuccessBg");
+		// Fully transparent should result in the background color (#1e1e2e)
+		expect(bgAnsi).toContain("48;2;30;30;46"); // #1e1e2e as RGB
+	});
+});


### PR DESCRIPTION
## Summary

Theme colors now support 8-digit hex format (`#RRGGBBAA`) where the last two digits specify alpha (opacity) from `00` (fully transparent) to `FF` (fully opaque).

Since terminals don't support true transparency in ANSI escape sequences, alpha colors are blended at theme load time with the theme's background color:

1. Uses the `bg` var if defined
2. Falls back to `selectedBg` color
3. Falls back to `#1e1e2e` (dark default)

This is particularly useful for tool call backgrounds (`toolSuccessBg`, `toolErrorBg`, `toolPendingBg`) where a subtle tinted overlay is more aesthetically pleasing than a solid opaque block.

## Changes

- **theme.ts**: Add `hexToRgba()`, `hasAlpha()`, `blendWithBackground()` functions
- **theme.ts**: Update `hexToRgb()` to delegate to `hexToRgba()` (now accepts 8-digit hex)
- **theme.ts**: Update `resolveThemeColors()` to blend alpha colors with background at load time
- **theme.ts**: Update `getThemeExportColors()` to blend alpha in export colors  
- **theme-schema.json**: Document `#RRGGBBAA` format in descriptions
- **dark.json**: Add `bg` var, use alpha for `toolSuccessBg`/`toolErrorBg`
- **light.json**: Add `bg` var, use alpha for `toolSuccessBg`/`toolErrorBg`
- **New test file**: `theme-alpha.test.ts` with 6 tests

## Example Usage

```json
{
  "vars": {
    "bg": "#1D1F21",
    "green": "#8f9d6a",
    "red": "#cf7777"
  },
  "colors": {
    "toolSuccessBg": "#8f9d6a26",
    "toolErrorBg": "#cf777726"
  }
}
```

The `26` alpha (hex) ≈ 15% opacity, which will be blended with the `bg` color to produce an opaque result that looks like a subtle tinted overlay.

## Backwards Compatibility

Fully backwards compatible — existing `#RRGGBB` themes work exactly as before. The 8-digit format is opt-in.