### PR TITLE
fix(tui): preserve custom widget render order on background tick refreshes

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1819,6 +1819,14 @@ export class InteractiveMode {
 		removeExisting(this.extensionWidgetsBelow);
 
 		if (content === undefined) {
+			const above = this.extensionWidgetsAbove as any;
+			const below = this.extensionWidgetsBelow as any;
+			if (above.__orderedKeys) {
+				above.__orderedKeys = above.__orderedKeys.filter((k: string) => k !== key);
+			}
+			if (below.__orderedKeys) {
+				below.__orderedKeys = below.__orderedKeys.filter((k: string) => k !== key);
+			}
 			this.renderWidgets();
 			return;
 		}
@@ -1840,7 +1848,17 @@ export class InteractiveMode {
 			component = content(this.ui, theme);
 		}
 
-		const targetMap = placement === "belowEditor" ? this.extensionWidgetsBelow : this.extensionWidgetsAbove;
+		const targetMap = (placement === "belowEditor" ? this.extensionWidgetsBelow : this.extensionWidgetsAbove) as any;
+		if (!targetMap.__orderedKeys) {
+			targetMap.__orderedKeys = [];
+		}
+		const stack = new Error().stack || "";
+		const isUserTriggered = stack.includes("_tryExecuteExtensionCommand") || stack.includes("prompt") || stack.includes("executeSlashCommand");
+		
+		if (isUserTriggered || !targetMap.__orderedKeys.includes(key)) {
+			targetMap.__orderedKeys = [key, ...targetMap.__orderedKeys.filter((k: string) => k !== key)];
+		}
+
 		targetMap.set(key, component);
 		this.renderWidgets();
 	}
@@ -1919,8 +1937,12 @@ export class InteractiveMode {
 		if (leadingSpacer) {
 			container.addChild(new Spacer(1));
 		}
-		for (const component of widgets.values()) {
-			container.addChild(component);
+		const ordered = (widgets as any).__orderedKeys || Array.from(widgets.keys());
+		for (const key of ordered) {
+			const component = widgets.get(key);
+			if (component) {
+				container.addChild(component);
+			}
 		}
 	}
 


### PR DESCRIPTION
### 🐛 The Bug
Currently, custom widgets in the interactive TUI mode are rendered according to their JS `Map` insertion order. Because the extension runner executes `map.delete(key)` and then `map.set(key, component)` during high-frequency refreshes (such as background timers, clock ticks, and turn-end triggers), refreshed widgets are continuously pushed to the bottom. This results in a constantly shifting and jarring layout.

### 🛡️ The Solution
This patch implements an activation-aware ordering mechanism:
1. It maintains an array of ordered keys (`__orderedKeys`) on the widget maps.
2. It uses call-stack introspection to differentiate background tick/timer refreshes from explicit user-initiated command executions (such as typing `/wtft` or `/tpm`).
3. If a widget is refreshed in the background, its render position remains stable.
4. If a user explicitly executes a command, it is pulled to the top of the render stack.

This has been extensively field-tested. A public reference implementation of this patch and widgets can be found at:
👉 **https://github.com/duppypro/princess-pi-packages**