### PR TITLE
fix(coding-agent): remove hardcoded RPC wait timeout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the subprocess RPC client to stop imposing an implicit 60s wait timeout on `waitForIdle()`, `collectEvents()`, and `promptAndWait()`; callers can now opt into a client-level `waitTimeoutMs` or disable the client-side wait timer entirely for long-running sessions.
 - Fixed `--session` and `SessionManager.open()` to reject non-empty invalid session files without overwriting them ([#6002](https://github.com/earendil-works/pi/issues/6002)).
 - Fixed assistant messages stopped by output length to show a visible incomplete-response error ([#4290](https://github.com/earendil-works/pi/issues/4290)).
 - Fixed `--no-session --session-id` so ephemeral CLI runs can use deterministic session IDs for provider cache affinity ([#6070](https://github.com/earendil-works/pi/issues/6070)).

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -2,7 +2,7 @@
 
 RPC mode enables headless operation of the coding agent via a JSON protocol over stdin/stdout. This is useful for embedding the agent in other applications, IDEs, or custom UIs.
 
-**Note for Node.js/TypeScript users**: If you're building a Node.js application, consider using `AgentSession` directly from `@earendil-works/pi-coding-agent` instead of spawning a subprocess. See [`src/core/agent-session.ts`](../src/core/agent-session.ts) for the API. For a subprocess-based TypeScript client, see [`src/modes/rpc/rpc-client.ts`](../src/modes/rpc/rpc-client.ts).
+**Note for Node.js/TypeScript users**: If you're building a Node.js application, consider using `AgentSession` directly from `@earendil-works/pi-coding-agent` instead of spawning a subprocess. See [`src/core/agent-session.ts`](../src/core/agent-session.ts) for the API. For a subprocess-based TypeScript client, see [`src/modes/rpc/rpc-client.ts`](../src/modes/rpc/rpc-client.ts). That client now accepts `waitTimeoutMs` so long-running prompt sessions can opt into a larger wait, or disable the client-side wait timer entirely with `0`.
 
 ## Starting RPC Mode
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -34,6 +34,8 @@ export interface RpcClientOptions {
 	provider?: string;
 	/** Model ID to use */
 	model?: string;
+	/** Default timeout for waitForIdle(), collectEvents(), and promptAndWait(); 0 disables it. */
+	waitTimeoutMs?: number;
 	/** Additional CLI arguments */
 	args?: string[];
 }
@@ -47,6 +49,12 @@ export interface ModelInfo {
 
 export type RpcEventListener = (event: AgentEvent) => void;
 
+type RpcWaiter = {
+	reject: (error: Error) => void;
+	timer?: ReturnType<typeof setTimeout>;
+	unsubscribe?: () => void;
+};
+
 // ============================================================================
 // RPC Client
 // ============================================================================
@@ -57,6 +65,7 @@ export class RpcClient {
 	private eventListeners: RpcEventListener[] = [];
 	private pendingRequests: Map<string, { resolve: (response: RpcResponse) => void; reject: (error: Error) => void }> =
 		new Map();
+	private pendingWaiters = new Set<RpcWaiter>();
 	private requestId = 0;
 	private stderr = "";
 	private exitError: Error | null = null;
@@ -107,12 +116,14 @@ export class RpcClient {
 			const error = this.createProcessExitError(code, signal);
 			this.exitError = error;
 			this.rejectPendingRequests(error);
+			this.abortWaitersForError(error);
 		});
 		childProcess.once("error", (error) => {
 			if (this.process !== childProcess) return;
 			const processError = new Error(`Agent process error: ${error.message}. Stderr: ${this.stderr}`);
 			this.exitError = processError;
 			this.rejectPendingRequests(processError);
+			this.abortWaitersForError(processError);
 		});
 		childProcess.stdin?.on("error", (error) => {
 			if (this.process !== childProcess) return;
@@ -120,6 +131,7 @@ export class RpcClient {
 				this.exitError ?? new Error(`Agent process stdin error: ${error.message}. Stderr: ${this.stderr}`);
 			this.exitError = stdinError;
 			this.rejectPendingRequests(stdinError);
+			this.abortWaitersForError(stdinError);
 		});
 
 		// Set up strict JSONL reader for stdout.
@@ -162,6 +174,7 @@ export class RpcClient {
 
 		this.process = null;
 		this.pendingRequests.clear();
+		this.clearPendingWaiters();
 	}
 
 	/**
@@ -427,39 +440,25 @@ export class RpcClient {
 	 * Wait for agent to become idle (no streaming).
 	 * Resolves when agent_end event is received.
 	 */
-	waitForIdle(timeout = 60000): Promise<void> {
-		return new Promise((resolve, reject) => {
-			const timer = setTimeout(() => {
-				unsubscribe();
-				reject(new Error(`Timeout waiting for agent to become idle. Stderr: ${this.stderr}`));
-			}, timeout);
-
-			const unsubscribe = this.onEvent((event) => {
-				if (event.type === "agent_end") {
-					clearTimeout(timer);
-					unsubscribe();
-					resolve();
-				}
-			});
-		});
+	waitForIdle(timeout = this.getWaitTimeoutMs()): Promise<void> {
+		return this.waitForAgentEnd(timeout, "Timeout waiting for agent to become idle.");
 	}
 
 	/**
 	 * Collect events until agent becomes idle.
 	 */
-	collectEvents(timeout = 60000): Promise<AgentEvent[]> {
+	collectEvents(timeout = this.getWaitTimeoutMs()): Promise<AgentEvent[]> {
 		return new Promise((resolve, reject) => {
 			const events: AgentEvent[] = [];
-			const timer = setTimeout(() => {
-				unsubscribe();
-				reject(new Error(`Timeout collecting events. Stderr: ${this.stderr}`));
-			}, timeout);
+			const waiter = this.createWaiter(reject);
+			waiter.timer = this.startWaitTimer(timeout, () => {
+				this.failWaiter(waiter, new Error(`Timeout collecting events. Stderr: ${this.stderr}`));
+			});
 
-			const unsubscribe = this.onEvent((event) => {
+			waiter.unsubscribe = this.onEvent((event) => {
 				events.push(event);
 				if (event.type === "agent_end") {
-					clearTimeout(timer);
-					unsubscribe();
+					this.finishWaiter(waiter);
 					resolve(events);
 				}
 			});
@@ -469,15 +468,85 @@ export class RpcClient {
 	/**
 	 * Send prompt and wait for completion, returning all events.
 	 */
-	async promptAndWait(message: string, images?: ImageContent[], timeout = 60000): Promise<AgentEvent[]> {
+	async promptAndWait(
+		message: string,
+		images?: ImageContent[],
+		timeout = this.getWaitTimeoutMs(),
+	): Promise<AgentEvent[]> {
 		const eventsPromise = this.collectEvents(timeout);
-		await this.prompt(message, images);
+		try {
+			await this.prompt(message, images);
+		} catch (error) {
+			const promptError = error instanceof Error ? error : new Error(String(error));
+			this.abortWaitersForError(promptError);
+			await eventsPromise.catch(() => {});
+			throw promptError;
+		}
 		return eventsPromise;
 	}
 
 	// =========================================================================
 	// Internal
 	// =========================================================================
+
+	private getWaitTimeoutMs(): number | undefined {
+		const timeout = this.options.waitTimeoutMs;
+		if (timeout === undefined || timeout <= 0) return undefined;
+		return timeout;
+	}
+
+	private createWaiter(reject: (error: Error) => void): RpcWaiter {
+		const waiter: RpcWaiter = { reject };
+		this.pendingWaiters.add(waiter);
+		return waiter;
+	}
+
+	private startWaitTimer(
+		timeout: number | undefined,
+		onTimeout: () => void,
+	): ReturnType<typeof setTimeout> | undefined {
+		if (timeout === undefined) return undefined;
+		return setTimeout(onTimeout, timeout);
+	}
+
+	private finishWaiter(waiter: RpcWaiter): void {
+		if (waiter.timer) clearTimeout(waiter.timer);
+		waiter.unsubscribe?.();
+		this.pendingWaiters.delete(waiter);
+	}
+
+	private failWaiter(waiter: RpcWaiter, error: Error): void {
+		this.finishWaiter(waiter);
+		waiter.reject(error);
+	}
+
+	private abortWaitersForError(error: Error): void {
+		for (const waiter of [...this.pendingWaiters]) {
+			this.failWaiter(waiter, error);
+		}
+	}
+
+	private clearPendingWaiters(): void {
+		for (const waiter of [...this.pendingWaiters]) {
+			this.finishWaiter(waiter);
+		}
+	}
+
+	private waitForAgentEnd(timeout: number | undefined, timeoutMessage: string): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const waiter = this.createWaiter(reject);
+			waiter.timer = this.startWaitTimer(timeout, () => {
+				this.failWaiter(waiter, new Error(`${timeoutMessage} Stderr: ${this.stderr}`));
+			});
+
+			waiter.unsubscribe = this.onEvent((event) => {
+				if (event.type === "agent_end") {
+					this.finishWaiter(waiter);
+					resolve();
+				}
+			});
+		});
+	}
 
 	private handleLine(line: string): void {
 		try {

--- a/packages/coding-agent/test/rpc-client-timeout.test.ts
+++ b/packages/coding-agent/test/rpc-client-timeout.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RpcClient } from "../src/modes/rpc/rpc-client.ts";
+
+type RpcClientInternals = {
+	handleLine(line: string): void;
+};
+
+function emitAgentEnd(client: RpcClient): void {
+	(client as unknown as RpcClientInternals).handleLine(JSON.stringify({ type: "agent_end" }));
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("RpcClient wait timeout behavior", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	it("waits past 60s by default and resolves when agent_end arrives", async () => {
+		const client = new RpcClient();
+		const promise = client.waitForIdle();
+
+		setTimeout(() => emitAgentEnd(client), 61_000);
+
+		await vi.advanceTimersByTimeAsync(61_000);
+		await expect(promise).resolves.toBeUndefined();
+	});
+
+	it("uses RpcClientOptions.waitTimeoutMs when no per-call timeout is provided", async () => {
+		const client = new RpcClient({ waitTimeoutMs: 25 });
+		const promise = client.waitForIdle().catch((error: unknown) => error);
+
+		await vi.advanceTimersByTimeAsync(25);
+		await expect(promise).resolves.toBeInstanceOf(Error);
+		await expect(promise).resolves.toHaveProperty(
+			"message",
+			expect.stringContaining("Timeout waiting for agent to become idle"),
+		);
+	});
+
+	it("collectEvents waits past 60s by default and resolves with the final agent_end event", async () => {
+		const client = new RpcClient();
+		const promise = client.collectEvents();
+
+		setTimeout(() => emitAgentEnd(client), 61_000);
+
+		await vi.advanceTimersByTimeAsync(61_000);
+		await expect(promise).resolves.toEqual([{ type: "agent_end" }]);
+	});
+
+	it("promptAndWait waits past 60s by default and resolves after prompt completes", async () => {
+		const client = new RpcClient();
+		vi.spyOn(client, "prompt").mockResolvedValue(undefined);
+
+		const promise = client.promptAndWait("hello");
+		setTimeout(() => emitAgentEnd(client), 61_000);
+
+		await vi.advanceTimersByTimeAsync(61_000);
+		await expect(promise).resolves.toEqual([{ type: "agent_end" }]);
+	});
+});


### PR DESCRIPTION
closes #6088

RpcClient had a hardcoded 60s wait cap in `waitForIdle()`, `collectEvents()`, and `promptAndWait()`. This made long-running tool sessions fail even when the MCP server was still working.

This change removes the implicit client-side completion timeout and adds `RpcClientOptions.waitTimeoutMs` for callers that want one. By default, these helpers now wait for `agent_end` or subprocess failure without a client-side cap. Callers that want a 60-second client-side completion timeout can pass `waitTimeoutMs: 60_000`.

Pending waiters are also rejected cleanly on process exit / error.
