### PR TITLE
Rename model key from 'gpt-5.2-chat-latest' to 'gpt-5.2-chat'

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.models.ts
+++ b/packages/ai/src/providers/azure-openai-responses.models.ts
@@ -390,8 +390,8 @@ export const AZURE_OPENAI_RESPONSES_MODELS = {
 		contextWindow: 400000,
 		maxTokens: 128000,
 	} satisfies Model<"azure-openai-responses">,
-	"gpt-5.2-chat-latest": {
-		id: "gpt-5.2-chat-latest",
+	"gpt-5.2-chat": {
+		id: "gpt-5.2-chat",
 		name: "GPT-5.2 Chat",
 		api: "azure-openai-responses",
 		provider: "azure-openai-responses",


### PR DESCRIPTION
there's no 5.2-chat-latest model. available 5.2 models are 
1. gpt-5.2
2. gpt-5.2-chat
3. gpt-5.2-codex


<img width="1582" height="779" alt="image" src="https://github.com/user-attachments/assets/2c1b052f-9296-4eef-8ba7-819ef16571e7" />
