### PR TITLE
fix(coding-agent): preserve dependency cache on extension reload

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -67,6 +67,24 @@ const VIRTUAL_MODULES: Record<string, unknown> = {
 };
 
 const require = createRequire(import.meta.url);
+let extensionJiti: ReturnType<typeof createJiti> | undefined;
+
+function getExtensionJiti(): ReturnType<typeof createJiti> {
+	if (!extensionJiti) {
+		extensionJiti = createJiti(import.meta.url, {
+			// Keep jiti's module cache enabled so dependencies are evaluated once across
+			// extension reloads. loadExtensionModule explicitly evicts extension-owned
+			// modules while preserving nested node_modules entries, which lets /reload
+			// pick up extension edits without re-running dependency module side effects.
+			moduleCache: true,
+			// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
+			// Also disable tryNative so jiti handles ALL imports (not just the entry point)
+			// In Node.js/dev: use aliases to resolve to node_modules paths
+			...(isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() }),
+		});
+	}
+	return extensionJiti;
+}
 
 /**
  * Get aliases for jiti (used in Node.js/development mode).
@@ -371,6 +389,27 @@ function isCurrentCacheToken(cacheToken: ExtensionCacheToken | undefined): cache
 	);
 }
 
+function getNodeModulesPackageRoot(modulePath: string): string | undefined {
+	const parts = modulePath.split(path.sep);
+	const nodeModulesIndex = parts.lastIndexOf("node_modules");
+	if (nodeModulesIndex === -1 || nodeModulesIndex + 1 >= parts.length) {
+		return undefined;
+	}
+	const packageEndIndex = parts[nodeModulesIndex + 1]?.startsWith("@") ? nodeModulesIndex + 3 : nodeModulesIndex + 2;
+	return parts.slice(0, packageEndIndex).join(path.sep);
+}
+
+function clearExtensionOwnedModuleCache(extensionPath: string): void {
+	const packageRoot = getNodeModulesPackageRoot(extensionPath);
+	const reloadRoot = packageRoot ?? path.dirname(extensionPath);
+	for (const cachePath of Object.keys(require.cache)) {
+		const relativePath = path.relative(reloadRoot, cachePath);
+		if (relativePath !== "" && (relativePath.startsWith("..") || path.isAbsolute(relativePath))) continue;
+		if (relativePath.split(path.sep).includes("node_modules")) continue;
+		delete require.cache[cachePath];
+	}
+}
+
 async function loadExtensionModule(extensionPath: string, cacheToken?: ExtensionCacheToken) {
 	if (isCurrentCacheToken(cacheToken)) {
 		const cachedFactory = extensionCache.get(extensionPath);
@@ -379,15 +418,8 @@ async function loadExtensionModule(extensionPath: string, cacheToken?: Extension
 		}
 	}
 
-	const jiti = createJiti(import.meta.url, {
-		moduleCache: false,
-		// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
-		// Also disable tryNative so jiti handles ALL imports (not just the entry point)
-		// In Node.js/dev: use aliases to resolve to node_modules paths
-		...(isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() }),
-	});
-
-	const module = await jiti.import(extensionPath, { default: true });
+	clearExtensionOwnedModuleCache(extensionPath);
+	const module = await getExtensionJiti().import(extensionPath, { default: true });
 	const factory = module as ExtensionFactory;
 	if (typeof factory !== "function") {
 		return undefined;

--- a/packages/coding-agent/test/suite/regressions/extension-factory-cache.test.ts
+++ b/packages/coding-agent/test/suite/regressions/extension-factory-cache.test.ts
@@ -7,6 +7,8 @@ import { DefaultResourceLoader } from "../../../src/core/resource-loader.ts";
 
 interface TestState {
 	moduleLoads?: number;
+	dependencyLoads?: number;
+	localHelperLoads?: number;
 	factoryRuns?: number;
 }
 
@@ -30,6 +32,95 @@ const state = (globalThis.__extensionFactoryCacheTest ??= {});
 state.moduleLoads = (state.moduleLoads ?? 0) + 1;
 
 export default function () {
+	state.factoryRuns = (state.factoryRuns ?? 0) + 1;
+}
+`,
+		"utf-8",
+	);
+}
+
+function writeVersionCommandExtension(filePath: string, version: string): void {
+	writeFileSync(
+		filePath,
+		`
+export default function (pi) {
+	pi.registerCommand("version", {
+		description: ${JSON.stringify(version)},
+		handler() {},
+	});
+}
+`,
+		"utf-8",
+	);
+}
+
+function writeModulePackageJson(directory: string): void {
+	writeFileSync(join(directory, "package.json"), JSON.stringify({ type: "module", main: "./index.ts" }), "utf-8");
+}
+
+function createTestResourceLoader(cwd: string, agentDir: string): DefaultResourceLoader {
+	return new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+	});
+}
+
+function writeCountingDependency(filePath: string): void {
+	writeFileSync(
+		filePath,
+		`
+const state = (globalThis.__extensionFactoryCacheTest ??= {});
+state.dependencyLoads = (state.dependencyLoads ?? 0) + 1;
+export const value = state.dependencyLoads;
+`,
+		"utf-8",
+	);
+}
+
+function writeExtensionWithDependency(filePath: string, specifier = "side-effect-dependency"): void {
+	writeFileSync(
+		filePath,
+		`
+import { value } from ${JSON.stringify(specifier)};
+
+const state = (globalThis.__extensionFactoryCacheTest ??= {});
+state.moduleLoads = (state.moduleLoads ?? 0) + 1;
+
+export default function () {
+	if (value < 1) throw new Error("Dependency was not loaded");
+	state.factoryRuns = (state.factoryRuns ?? 0) + 1;
+}
+`,
+		"utf-8",
+	);
+}
+
+function writeCountingLocalHelper(filePath: string): void {
+	writeFileSync(
+		filePath,
+		`
+const state = (globalThis.__extensionFactoryCacheTest ??= {});
+state.localHelperLoads = (state.localHelperLoads ?? 0) + 1;
+export const value = state.localHelperLoads;
+`,
+		"utf-8",
+	);
+}
+
+function writeExtensionWithLocalHelper(filePath: string): void {
+	writeFileSync(
+		filePath,
+		`
+import { value } from "./lib/helper.ts";
+
+const state = (globalThis.__extensionFactoryCacheTest ??= {});
+state.moduleLoads = (state.moduleLoads ?? 0) + 1;
+
+export default function () {
+	if (value < 1) throw new Error("Local helper was not loaded");
 	state.factoryRuns = (state.factoryRuns ?? 0) + 1;
 }
 `,
@@ -74,6 +165,8 @@ describe("extension factory cache", () => {
 		const first = await loadExtensionsCached([extensionPath], cwd);
 		const second = await loadExtensionsCached([extensionPath], cwd);
 
+		expect(first.errors).toEqual([]);
+		expect(second.errors).toEqual([]);
 		expect(state().moduleLoads).toBe(1);
 		expect(state().factoryRuns).toBe(2);
 		expect(first.extensions[0]).not.toBe(second.extensions[0]);
@@ -92,23 +185,142 @@ describe("extension factory cache", () => {
 		expect(state().factoryRuns).toBe(2);
 	});
 
-	it("clears the cache on resource loader reload", async () => {
+	it("clears the entrypoint cache on resource loader reload", async () => {
 		const { cwd, agentDir } = fixture("reload");
 		const extensionDir = join(agentDir, "extensions");
 		mkdirSync(extensionDir, { recursive: true });
 		writeCountingExtension(join(extensionDir, "counting.ts"));
-		const loader = new DefaultResourceLoader({
-			cwd,
-			agentDir,
-			noSkills: true,
-			noPromptTemplates: true,
-			noThemes: true,
-		});
+		const loader = createTestResourceLoader(cwd, agentDir);
 
 		await loader.reload();
 		await loader.reload();
 
 		expect(state().moduleLoads).toBe(2);
+		expect(state().factoryRuns).toBe(2);
+	});
+
+	it.each(["ts", "js"])("reloads changed extension entrypoint code from .%s files", async (extension) => {
+		const { cwd, agentDir } = fixture(`reload-entrypoint-change-${extension}`);
+		const extensionDir = join(agentDir, "extensions");
+		const extensionPath = join(extensionDir, `version.${extension}`);
+		mkdirSync(extensionDir, { recursive: true });
+		writeVersionCommandExtension(extensionPath, "v1");
+		const loader = createTestResourceLoader(cwd, agentDir);
+
+		await loader.reload();
+		expect(loader.getExtensions().extensions[0]?.commands.get("version")?.description).toBe("v1");
+
+		writeVersionCommandExtension(extensionPath, "v2");
+		await loader.reload();
+
+		expect(loader.getExtensions().extensions[0]?.commands.get("version")?.description).toBe("v2");
+	});
+
+	it("reloads local extension helpers on resource loader reload", async () => {
+		const { cwd, agentDir } = fixture("reload-local-helper");
+		const extensionDir = join(agentDir, "extensions");
+		mkdirSync(extensionDir, { recursive: true });
+		mkdirSync(join(extensionDir, "lib"), { recursive: true });
+		writeCountingLocalHelper(join(extensionDir, "lib", "helper.ts"));
+		writeExtensionWithLocalHelper(join(extensionDir, "extension.ts"));
+		const loader = createTestResourceLoader(cwd, agentDir);
+
+		await loader.reload();
+		await loader.reload();
+
+		expect(state().moduleLoads).toBe(2);
+		expect(state().localHelperLoads).toBe(2);
+		expect(state().factoryRuns).toBe(2);
+	});
+
+	it("preserves dependency cache on resource loader reload", async () => {
+		const { cwd, agentDir } = fixture("reload-dependency");
+		const extensionDir = join(agentDir, "extensions");
+		const dependencyDir = join(extensionDir, "node_modules", "side-effect-dependency");
+		mkdirSync(extensionDir, { recursive: true });
+		mkdirSync(dependencyDir, { recursive: true });
+		writeModulePackageJson(dependencyDir);
+		writeCountingDependency(join(dependencyDir, "index.ts"));
+		writeExtensionWithDependency(join(extensionDir, "extension.ts"));
+		const loader = createTestResourceLoader(cwd, agentDir);
+
+		await loader.reload();
+		await loader.reload();
+
+		expect(state().moduleLoads).toBe(2);
+		expect(state().dependencyLoads).toBe(1);
+		expect(state().factoryRuns).toBe(2);
+	});
+
+	it("reloads changed package extension entrypoint code", async () => {
+		const { root, cwd } = fixture("reload-package-entrypoint-change");
+		const extensionDir = join(root, "node_modules", "extension-package");
+		const extensionPath = join(extensionDir, "index.ts");
+		mkdirSync(extensionDir, { recursive: true });
+		writeModulePackageJson(extensionDir);
+		writeVersionCommandExtension(extensionPath, "v1");
+
+		const first = await loadExtensions([extensionPath], cwd);
+		expect(first.errors).toEqual([]);
+		expect(first.extensions[0]?.commands.get("version")?.description).toBe("v1");
+
+		writeVersionCommandExtension(extensionPath, "v2");
+		const second = await loadExtensions([extensionPath], cwd);
+
+		expect(second.errors).toEqual([]);
+		expect(second.extensions[0]?.commands.get("version")?.description).toBe("v2");
+	});
+
+	it("reloads local helpers for package extension reload", async () => {
+		const { root, cwd } = fixture("reload-package-local-helper");
+		const extensionDir = join(root, "node_modules", "extension-package");
+		mkdirSync(join(extensionDir, "lib"), { recursive: true });
+		writeModulePackageJson(extensionDir);
+		writeCountingLocalHelper(join(extensionDir, "lib", "helper.ts"));
+		writeExtensionWithLocalHelper(join(extensionDir, "index.ts"));
+
+		await loadExtensions([join(extensionDir, "index.ts")], cwd);
+		await loadExtensions([join(extensionDir, "index.ts")], cwd);
+
+		expect(state().moduleLoads).toBe(2);
+		expect(state().localHelperLoads).toBe(2);
+		expect(state().factoryRuns).toBe(2);
+	});
+
+	it("preserves nested dependency cache for package extension reload", async () => {
+		const { root, cwd } = fixture("reload-package-dependency");
+		const extensionDir = join(root, "node_modules", "extension-package");
+		const dependencyDir = join(extensionDir, "node_modules", "side-effect-dependency");
+		mkdirSync(dependencyDir, { recursive: true });
+		writeModulePackageJson(extensionDir);
+		writeModulePackageJson(dependencyDir);
+		writeCountingDependency(join(dependencyDir, "index.ts"));
+		writeExtensionWithDependency(join(extensionDir, "index.ts"));
+
+		await loadExtensions([join(extensionDir, "index.ts")], cwd);
+		await loadExtensions([join(extensionDir, "index.ts")], cwd);
+
+		expect(state().moduleLoads).toBe(2);
+		expect(state().dependencyLoads).toBe(1);
+		expect(state().factoryRuns).toBe(2);
+	});
+
+	it("preserves hoisted scoped dependency cache for scoped package extension reload", async () => {
+		const { root, cwd } = fixture("reload-hoisted-scoped-dependency");
+		const extensionDir = join(root, "node_modules", "@plannotator", "pi-extension");
+		const dependencyDir = join(root, "node_modules", "@pierre", "diffs");
+		mkdirSync(extensionDir, { recursive: true });
+		mkdirSync(dependencyDir, { recursive: true });
+		writeModulePackageJson(extensionDir);
+		writeModulePackageJson(dependencyDir);
+		writeCountingDependency(join(dependencyDir, "index.ts"));
+		writeExtensionWithDependency(join(extensionDir, "index.ts"), "@pierre/diffs");
+
+		await loadExtensions([join(extensionDir, "index.ts")], cwd);
+		await loadExtensions([join(extensionDir, "index.ts")], cwd);
+
+		expect(state().moduleLoads).toBe(2);
+		expect(state().dependencyLoads).toBe(1);
 		expect(state().factoryRuns).toBe(2);
 	});
 


### PR DESCRIPTION
Fixes #6108

## Summary

Fix release binary extension reloads re-evaluating dependency modules on `/reload`.

As described in #6108, the compiled release binary could reload an extension by reprocessing its dependency graph. That meant dependencies with module evaluation side effects could run those side effects again on every `/reload`.

This change keeps `/reload` behavior for extension code, while preserving cached third-party dependency modules across reloads.

## Code changes

- Reuse one extension jiti instance instead of creating a cache-disabled jiti loader per extension import.
- Enable jiti module caching for extension loading.
- Before loading an extension, explicitly clear cached modules owned by that extension:
  - source extensions under the extension file directory
  - package extensions under the extension package root
- Do not clear nested `node_modules` entries while clearing extension-owned modules.

The result is:

- extension entrypoints are reloaded on `/reload`
- local extension helper modules are reloaded on `/reload`
- dependency modules under `node_modules` are preserved and evaluated once per process

## Regression coverage

Added tests for extension reload cache behavior:

- cached factory reuse outside resource-loader reloads
- entrypoint cache clearing on resource-loader reload
- changed `.ts` and `.js` extension entrypoint code reloading
- local extension helper modules reloading
- nested dependency modules staying cached
- package extension entrypoints and helpers reloading
- nested package dependencies staying cached
- hoisted scoped dependencies staying cached for a scoped extension package shape

## Verification

Issue repro:

- Official v0.80.2 Linux release binary in Docker:
  - 2 reloads produced 8 duplicate dependency side-effect warnings
- Current rebuilt release binary in the same Docker shape:
  - 2 reloads produced 0 duplicate dependency side-effect warnings
  - the extension loaded successfully
- Separate Docker reload edit check:
  - custom extension entrypoint changed from `v1` to `v2` after `/reload`

Tests:

- `cd packages/coding-agent && node node_modules/vitest/dist/cli.js --run test/suite/regressions/extension-factory-cache.test.ts`
  - 12 passed
- `npm run check`
  - passed in Docker
- `./test.sh`
  - passed on host

## Notes

No changelog entry included, per `CONTRIBUTING.md`.

Do not submit this PR unless the contributor account already has maintainer `lgtm`, per `CONTRIBUTING.md`.