### PR TITLE
feat: add reportUsage API for extensions to contribute session cost

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -566,6 +566,11 @@ export default function (pi: ExtensionAPI) {
 					const isError = isFailedResult(result);
 					if (isError) {
 						const errorMsg = getResultOutput(result);
+						for (const r of results) {
+							if (r.usage.cost > 0 || r.usage.input > 0) {
+								pi.reportUsage(r.usage.input, r.usage.output, r.usage.cacheRead, r.usage.cacheWrite, r.usage.cost, `subagent:${r.agent}`);
+							}
+						}
 						return {
 							content: [{ type: "text", text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}` }],
 							details: makeDetails("chain")(results),
@@ -573,6 +578,11 @@ export default function (pi: ExtensionAPI) {
 						};
 					}
 					previousOutput = getFinalOutput(result.messages);
+				}
+				for (const r of results) {
+					if (r.usage.cost > 0 || r.usage.input > 0) {
+						pi.reportUsage(r.usage.input, r.usage.output, r.usage.cacheRead, r.usage.cacheWrite, r.usage.cost, `subagent:${r.agent}`);
+					}
 				}
 				return {
 					content: [{ type: "text", text: getFinalOutput(results[results.length - 1].messages) || "(no output)" }],
@@ -652,6 +662,11 @@ export default function (pi: ExtensionAPI) {
 						: "completed";
 					return `### [${r.agent}] ${status}\n\n${output}`;
 				});
+				for (const r of results) {
+					if (r.usage.cost > 0 || r.usage.input > 0) {
+						pi.reportUsage(r.usage.input, r.usage.output, r.usage.cacheRead, r.usage.cacheWrite, r.usage.cost, `subagent:${r.agent}`);
+					}
+				}
 				return {
 					content: [
 						{
@@ -678,11 +693,17 @@ export default function (pi: ExtensionAPI) {
 				const isError = isFailedResult(result);
 				if (isError) {
 					const errorMsg = getResultOutput(result);
+					if (result.usage.cost > 0 || result.usage.input > 0) {
+						pi.reportUsage(result.usage.input, result.usage.output, result.usage.cacheRead, result.usage.cacheWrite, result.usage.cost, `subagent:${result.agent}`);
+					}
 					return {
 						content: [{ type: "text", text: `Agent ${result.stopReason || "failed"}: ${errorMsg}` }],
 						details: makeDetails("single")([result]),
 						isError: true,
 					};
+				}
+				if (result.usage.cost > 0 || result.usage.input > 0) {
+					pi.reportUsage(result.usage.input, result.usage.output, result.usage.cacheRead, result.usage.cacheWrite, result.usage.cost, `subagent:${result.agent}`);
 				}
 				return {
 					content: [{ type: "text", text: getFinalOutput(result.messages) || "(no output)" }],

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2241,6 +2241,9 @@ export class AgentSession {
 				appendEntry: (customType, data) => {
 					this.sessionManager.appendCustomEntry(customType, data);
 				},
+				reportUsage: (input: number, output: number, cacheRead: number, cacheWrite: number, cost: number, source?: string) => {
+					this.sessionManager.appendExternalUsage(input, output, cacheRead, cacheWrite, cost, source);
+				},
 				setSessionName: (name) => {
 					this.setSessionName(name);
 				},

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -171,6 +171,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		sendMessage: notInitialized,
 		sendUserMessage: notInitialized,
 		appendEntry: notInitialized,
+		reportUsage: notInitialized,
 		setSessionName: notInitialized,
 		getSessionName: notInitialized,
 		setLabel: notInitialized,
@@ -290,6 +291,11 @@ function createExtensionAPI(
 		appendEntry(customType: string, data?: unknown): void {
 			runtime.assertActive();
 			runtime.appendEntry(customType, data);
+		},
+
+		reportUsage(input: number, output: number, cacheRead: number, cacheWrite: number, cost: number, source?: string): void {
+			runtime.assertActive();
+			runtime.reportUsage(input, output, cacheRead, cacheWrite, cost, source);
 		},
 
 		setSessionName(name: string): void {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -316,6 +316,7 @@ export class ExtensionRunner {
 		this.runtime.sendMessage = actions.sendMessage;
 		this.runtime.sendUserMessage = actions.sendUserMessage;
 		this.runtime.appendEntry = actions.appendEntry;
+		this.runtime.reportUsage = actions.reportUsage;
 		this.runtime.setSessionName = actions.setSessionName;
 		this.runtime.getSessionName = actions.getSessionName;
 		this.runtime.setLabel = actions.setLabel;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1237,6 +1237,15 @@ export interface ExtensionAPI {
 	/** Append a custom entry to the session for state persistence (not sent to LLM). */
 	appendEntry<T = unknown>(customType: string, data?: T): void;
 
+	/**
+	 * Report API usage from an external source (e.g., subagent, tool, or extension).
+	 *
+	 * The reported usage is appended to the session as an external_usage entry,
+	 * persisted in the session file, and included in footer cost/token totals.
+	 * Not sent to the LLM context.
+	 */
+	reportUsage(input: number, output: number, cacheRead: number, cacheWrite: number, cost: number, source?: string): void;
+
 	// =========================================================================
 	// Session Metadata
 	// =========================================================================
@@ -1461,6 +1470,15 @@ export type SendUserMessageHandler = (
 
 export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
 
+export type ReportUsageHandler = (
+	input: number,
+	output: number,
+	cacheRead: number,
+	cacheWrite: number,
+	cost: number,
+	source?: string,
+) => void;
+
 export type SetSessionNameHandler = (name: string) => void;
 
 export type GetSessionNameHandler = () => string | undefined;
@@ -1518,6 +1536,7 @@ export interface ExtensionActions {
 	sendMessage: SendMessageHandler;
 	sendUserMessage: SendUserMessageHandler;
 	appendEntry: AppendEntryHandler;
+	reportUsage: ReportUsageHandler;
 	setSessionName: SetSessionNameHandler;
 	getSessionName: GetSessionNameHandler;
 	setLabel: SetLabelHandler;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -136,6 +136,22 @@ export interface CustomMessageEntry<T = unknown> extends SessionEntryBase {
 	display: boolean;
 }
 
+/**
+ * Records API usage from an external source (e.g., subagent, tool, extension).
+ * Picked up by the footer for cumulative cost tracking.
+ * Not sent to LLM context.
+ */
+export interface ExternalUsageEntry extends SessionEntryBase {
+	type: "external_usage";
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	cost: number;
+	/** Human-readable source label, e.g. "subagent:code-review" */
+	source?: string;
+}
+
 /** Session entry - has id/parentId for tree structure (returned by "read" methods in SessionManager) */
 export type SessionEntry =
 	| SessionMessageEntry
@@ -145,6 +161,7 @@ export type SessionEntry =
 	| BranchSummaryEntry
 	| CustomEntry
 	| CustomMessageEntry
+	| ExternalUsageEntry
 	| LabelEntry
 	| SessionInfoEntry;
 
@@ -1019,6 +1036,27 @@ export class SessionManager {
 			type: "custom",
 			customType,
 			data,
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	/**
+	 * Append an external usage entry (for extensions) as child of current leaf, then advance leaf.
+	 * These entries are picked up by the footer for cumulative cost tracking.
+	 */
+	appendExternalUsage(input: number, output: number, cacheRead: number, cacheWrite: number, cost: number, source?: string): string {
+		const entry: ExternalUsageEntry = {
+			type: "external_usage",
+			input,
+			output,
+			cacheRead,
+			cacheWrite,
+			cost,
+			source,
 			id: generateId(this.byId),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -103,6 +103,12 @@ export class FooterComponent implements Component {
 					entry.message.usage.input + entry.message.usage.cacheRead + entry.message.usage.cacheWrite;
 				latestCacheHitRate =
 					latestPromptTokens > 0 ? (entry.message.usage.cacheRead / latestPromptTokens) * 100 : undefined;
+			} else if (entry.type === "external_usage") {
+				totalInput += entry.input;
+				totalOutput += entry.output;
+				totalCacheRead += entry.cacheRead;
+				totalCacheWrite += entry.cacheWrite;
+				totalCost += entry.cost;
 			}
 		}
 


### PR DESCRIPTION
## Problem
The subagent extension tracks token and cost usage per subagent, but there is no way for extensions to feed usage back into the main session footer or `/session` totals. Subagent costs only appear in individual tool result cards (expand with Ctrl+O).

## Solution
Add `pi.reportUsage(input, output, cacheRead, cacheWrite, cost, source?)` to ExtensionAPI.

### Changes (7 files, +94 lines)
- **core/session-manager.ts** — New `ExternalUsageEntry` type + `appendExternalUsage()` method
- **core/extensions/types.ts** — `ReportUsageHandler` type + `reportUsage()` on ExtensionAPI/ExtensionActions
- **core/extensions/loader.ts** — Wire `reportUsage` through loader with `assertActive()` guard
- **core/extensions/runner.ts** — Bind `reportUsage` handler in `bindCore()`
- **core/agent-session.ts** — Handler delegates to `sessionManager.appendExternalUsage()`
- **modes/interactive/components/footer.ts** — Footer picks up `external_usage` entries in cost summation
- **examples/extensions/subagent/index.ts** — Call `pi.reportUsage()` after each subagent completes (5 return points)

### Verification
- Builds clean with `npm run build`
- Tested end-to-end: `external_usage` entries appear in session JSONL with correct token counts and parentId chaining
- Footer correctly sums external usage alongside message usage
- Guard clause (`cost > 0 || input > 0`) prevents zero-entry noise

## No breaking changes
All new code is additive. Existing session files without `external_usage` entries are unaffected.