### PR TITLE
feat(coding-agent): add externalEditor setting for Ctrl+G

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -112,6 +112,7 @@ export interface Settings {
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default filter when opening /tree
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
+	externalEditor?: string; // External editor command for Ctrl+G (takes precedence over $VISUAL/$EDITOR)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
@@ -1161,6 +1162,11 @@ export class SettingsManager {
 
 	getEditorPaddingX(): number {
 		return this.settings.editorPaddingX ?? 0;
+	}
+
+	/** External editor command for Ctrl+G. Falls back to $VISUAL, then $EDITOR. */
+	getExternalEditor(): string | undefined {
+		return this.settings.externalEditor;
 	}
 
 	setEditorPaddingX(padding: number): void {

--- a/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
@@ -38,6 +38,8 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		this.editor.focused = value;
 	}
 
+	private externalEditorCmd?: string;
+
 	constructor(
 		tui: TUI,
 		keybindings: KeybindingsManager,
@@ -45,7 +47,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		prefill: string | undefined,
 		onSubmit: (value: string) => void,
 		onCancel: () => void,
-		options?: EditorOptions,
+		options?: EditorOptions & { externalEditorCmd?: string },
 	) {
 		super();
 
@@ -53,6 +55,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		this.keybindings = keybindings;
 		this.onSubmitCallback = onSubmit;
 		this.onCancelCallback = onCancel;
+		this.externalEditorCmd = options?.externalEditorCmd;
 
 		// Add top border
 		this.addChild(new DynamicBorder());
@@ -76,7 +79,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		this.addChild(new Spacer(1));
 
 		// Add hint
-		const hasExternalEditor = !!(process.env.VISUAL || process.env.EDITOR);
+		const hasExternalEditor = !!(this.externalEditorCmd || process.env.VISUAL || process.env.EDITOR);
 		const hint =
 			keyHint("tui.select.confirm", "submit") +
 			"  " +
@@ -111,7 +114,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 	}
 
 	private async openExternalEditor(): Promise<void> {
-		const editorCmd = process.env.VISUAL || process.env.EDITOR;
+		const editorCmd = this.externalEditorCmd || process.env.VISUAL || process.env.EDITOR;
 		if (!editorCmd) {
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2239,6 +2239,7 @@ export class InteractiveMode {
 					this.hideExtensionEditor();
 					resolve(undefined);
 				},
+				{ externalEditorCmd: this.settingsManager.getExternalEditor() },
 			);
 
 			this.editorContainer.clear();
@@ -3647,10 +3648,10 @@ export class InteractiveMode {
 	}
 
 	private async openExternalEditor(): Promise<void> {
-		// Determine editor (respect $VISUAL, then $EDITOR)
-		const editorCmd = process.env.VISUAL || process.env.EDITOR;
+		// Determine editor (settings.externalEditor > $VISUAL > $EDITOR)
+		const editorCmd = this.settingsManager.getExternalEditor() || process.env.VISUAL || process.env.EDITOR;
 		if (!editorCmd) {
-			this.showWarning("No editor configured. Set $VISUAL or $EDITOR environment variable.");
+			this.showWarning('No editor configured. Set "externalEditor" in settings, or $VISUAL/$EDITOR environment variable.');
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Allow users to configure the external editor for Ctrl+G via `~/.pi/agent/settings.json` instead of relying solely on `$VISUAL`/`$EDITOR` environment variables.

## Motivation

On some systems (particularly Windows with VS Code + Git Bash), environment variables can be unreliable—values set in the registry may not propagate to child processes. This makes it impossible to configure `code --wait` (or any editor with arguments) via `$EDITOR` alone.

## Changes

- **Settings interface**: Added `externalEditor?: string` field
- **SettingsManager**: Added `getExternalEditor()` method
- **interactive-mode.ts**: `openExternalEditor()` now respects priority: `settings.externalEditor > $VISUAL > $EDITOR`
- **extension-editor.ts**: ExtensionEditorComponent accepts `externalEditorCmd` via constructor options, with same priority

## Usage

```json
{
  "externalEditor": "code --wait"
}
```

## Related

Fixes the issue described in #6122