### PR TITLE
fix(coding-agent): guard compaction continuation with hasQueuedMessages check

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -978,7 +978,7 @@ export class AgentSession {
 		}
 
 		if (await this._checkCompaction(msg)) {
-			return true;
+			return this.agent.hasQueuedMessages();
 		}
 
 		// The agent loop drains both queues before emitting agent_end. Any messages


### PR DESCRIPTION
## Summary

When threshold compaction completes after a normal assistant turn, `_checkCompaction` returns `true` but there are no queued messages to continue. Previously `_handlePostAgentRun` returned `true` unconditionally after compaction, causing `agent.continue()` to be called on an agent with no pending work, which threw:

```
Error("Cannot continue from message role: assistant")
```

## Fix

Changed `_handlePostAgentRun` to return `this.agent.hasQueuedMessages()` after compaction, matching the same guard already used:
- At the bottom of `_handlePostAgentRun` (line 986)
- In `_runAutoCompaction` (line 2059)

The overflow retry path is unaffected — it removes the error message from state before continuing.

## Before/After

```diff
 if (await this._checkCompaction(msg)) {
-    return true;
+    return this.agent.hasQueuedMessages();
 }
```

Fixes #5463