### PR TITLE
WITHDRAWN: Expose loaded skills to extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `--no-session --session-id` so ephemeral CLI runs can use deterministic session IDs for provider cache affinity ([#6070](https://github.com/earendil-works/pi/issues/6070)).
 - Fixed disk BMP image files to be detected, converted to PNG, and attached through `read` and CLI `@file` inputs ([#6047](https://github.com/earendil-works/pi/issues/6047)).
 - Fixed auto-retry for provider stream errors that explicitly tell callers to retry the request ([#6019](https://github.com/earendil-works/pi/issues/6019)).
+- Exposed loaded skills on `ExtensionContext` so extensions can use the same skill inventory as `/skill`.
 
 ## [0.80.2] - 2026-06-23
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2292,6 +2292,7 @@ export class AgentSession {
 					})();
 				},
 				getSystemPrompt: () => this.systemPrompt,
+				getSkills: () => this._resourceLoader.getSkills().skills,
 				getSystemPromptOptions: () => this._baseSystemPromptOptions,
 			},
 			{

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -10,6 +10,7 @@ import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
 import type { ModelRegistry } from "../model-registry.ts";
 import type { SessionManager } from "../session-manager.ts";
+import { type Skill, snapshotSkills } from "../skills.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import type {
 	BeforeAgentStartEvent,
@@ -278,6 +279,7 @@ export class ExtensionRunner {
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
 	private getSystemPromptFn: () => string = () => "";
+	private getSkillsFn: () => readonly Skill[] = () => [];
 	private getSystemPromptOptionsFn: () => BuildSystemPromptOptions = () => ({ cwd: this.cwd });
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
@@ -339,6 +341,7 @@ export class ExtensionRunner {
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
+		this.getSkillsFn = contextActions.getSkills ?? (() => []);
 		this.getSystemPromptOptionsFn = contextActions.getSystemPromptOptions ?? (() => ({ cwd: this.cwd }));
 
 		// Flush provider registrations queued during extension loading
@@ -681,6 +684,10 @@ export class ExtensionRunner {
 			getSystemPrompt: () => {
 				runner.assertActive();
 				return runner.getSystemPromptFn();
+			},
+			getSkills: () => {
+				runner.assertActive();
+				return snapshotSkills(runner.getSkillsFn());
 			},
 		};
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -56,6 +56,7 @@ import type {
 	SessionEntry,
 	SessionManager,
 } from "../session-manager.ts";
+import type { Skill } from "../skills.ts";
 import type { SlashCommandInfo } from "../slash-commands.ts";
 import type { SourceInfo } from "../source-info.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
@@ -330,6 +331,8 @@ export interface ExtensionContext {
 	compact(options?: CompactOptions): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/** Get the currently loaded skills from the same inventory used by /skill. */
+	getSkills(): readonly Skill[];
 }
 
 /**
@@ -1546,6 +1549,7 @@ export interface ExtensionContextActions {
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;
+	getSkills?: () => readonly Skill[];
 	getSystemPromptOptions?: () => BuildSystemPromptOptions;
 }
 

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -85,6 +85,13 @@ export interface LoadSkillsResult {
 	diagnostics: ResourceDiagnostic[];
 }
 
+export function snapshotSkills(skills: readonly Skill[]): Skill[] {
+	return skills.map((skill) => ({
+		...skill,
+		sourceInfo: { ...skill.sourceInfo },
+	}));
+}
+
 /**
  * Validate skill name per Agent Skills spec.
  * Returns array of validation error messages (empty if valid).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -83,6 +83,7 @@ import { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../../core/provider-display-nam
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.ts";
 import { type SessionContext, SessionManager } from "../../core/session-manager.ts";
+import { snapshotSkills } from "../../core/skills.ts";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.ts";
 import type { SourceInfo } from "../../core/source-info.ts";
 import { isInstallTelemetryEnabled } from "../../core/telemetry.ts";
@@ -1718,6 +1719,7 @@ export class InteractiveMode {
 				})();
 			},
 			getSystemPrompt: () => this.session.systemPrompt,
+			getSkills: () => snapshotSkills(this.session.resourceLoader.getSkills().skills),
 		});
 
 		// Set up the extension shortcut handler on the default editor

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -18,6 +18,7 @@ import type {
 import { KeybindingsManager, type KeyId } from "../src/core/keybindings.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
+import type { Skill } from "../src/core/skills.ts";
 
 describe("ExtensionRunner", () => {
 	let tempDir: string;
@@ -507,6 +508,37 @@ describe("ExtensionRunner", () => {
 
 			const ctx = runner.createContext();
 			expect(ctx.isProjectTrusted()).toBe(false);
+		});
+
+		it("exposes loaded skills on ExtensionContext", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const skills = [
+				{
+					name: "stronkpi-agents",
+					description: "Subagent orchestration",
+					filePath: path.join(tempDir, "skills", "stronkpi-agents", "SKILL.md"),
+					baseDir: path.join(tempDir, "skills", "stronkpi-agents"),
+					sourceInfo: {
+						path: path.join(tempDir, "skills", "stronkpi-agents", "SKILL.md"),
+						source: "local",
+						scope: "project",
+						origin: "top-level",
+						baseDir: path.join(tempDir, "skills", "stronkpi-agents"),
+					},
+					disableModelInvocation: false,
+				},
+			] satisfies Skill[];
+			runner.bindCore(extensionActions, {
+				...extensionContextActions,
+				getSkills: () => skills,
+			});
+
+			const ctx = runner.createContext();
+			expect(ctx.getSkills()).toEqual(skills);
+			expect(ctx.getSkills()).not.toBe(skills);
+			expect(ctx.getSkills()[0]).not.toBe(skills[0]);
+			expect(ctx.getSkills()[0].sourceInfo).not.toBe(skills[0].sourceInfo);
 		});
 
 		it("exposes rpc mode with hasUI true when an RPC UI context is provided", async () => {

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -105,5 +105,10 @@ This is a test skill.
 
 		expect(session.resourceLoader.getSkills().skills).toEqual([customSkill]);
 		expect(session.resourceLoader.getSkills().diagnostics).toEqual([]);
+		expect(session.extensionRunner.createContext().getSkills()).toEqual(session.resourceLoader.getSkills().skills);
+		expect(session.extensionRunner.createContext().getSkills()).not.toBe(session.resourceLoader.getSkills().skills);
+		expect(session.extensionRunner.createContext().getSkills()[0]).not.toBe(
+			session.resourceLoader.getSkills().skills[0],
+		);
 	});
 });

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -20,6 +20,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,
 		getSystemPrompt: () => "",
+		getSkills: () => [],
 	};
 }
 


### PR DESCRIPTION
Withdrawn. This was opened in error for a personal StronkPi fork/runtime path and should not have been sent upstream.

No maintainer action is needed. Please disregard this PR.