### PR TITLE
fix: normalize tabs to spaces in edit tool fuzzy matching

### DIFF
--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -26,6 +26,7 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
 /**
  * Normalize text for fuzzy matching. Applies progressive transformations:
  * - Strip trailing whitespace from each line
+ * - Normalize tabs to 4 spaces (handles tab vs space indentation mismatch)
  * - Normalize smart quotes to ASCII equivalents
  * - Normalize Unicode dashes/hyphens to ASCII hyphen
  * - Normalize special Unicode spaces to regular space
@@ -37,6 +38,8 @@ export function normalizeForFuzzyMatch(text: string): string {
 			// Strip trailing whitespace per line
 			.split("\n")
 			.map((line) => line.trimEnd())
+			// Normalize tabs to 4 spaces for fuzzy matching (handles tab vs space indentation mismatch)
+			.map((line) => line.replace(/\t/g, "    "))
 			.join("\n")
 			// Smart single quotes → '
 			.replace(/[\u2018\u2019\u201A\u201B]/g, "'")

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -300,6 +300,7 @@ export function createEditToolDefinition(
 			"Use edit for precise changes (edits[].oldText must match exactly)",
 			"When changing multiple separate locations in one file, use one edit call with multiple entries in edits[] instead of multiple edit calls",
 			"Each edits[].oldText is matched against the original file, not after earlier edits are applied. Do not emit overlapping or nested edits. Merge nearby changes into one edit.",
+			"Indentation is normalized for matching: tabs and spaces (4 per tab) are treated as equivalent, so you can use whichever style you prefer in oldText without worrying about mismatches caused by different indentation styles.",
 			"Keep edits[].oldText as small as possible while still being unique in the file. Do not pad with large unchanged regions.",
 		],
 		parameters: editSchema,


### PR DESCRIPTION
## Problem

When LLMs generate `oldText` for the `edit` tool, they almost always use space-based indentation. But many source files use tab characters for indentation (or different numbers of spaces). This causes both exact and fuzzy matching to fail because `\t` ≠ `"    "` in string comparison.

The existing `normalizeForFuzzyMatch` function handles Unicode normalization (smart quotes, dashes, special spaces) but does not reconcile tab vs space differences.

## Solution

Add a `.map(line => line.replace(/\t/g, "    "))` step after `trimEnd()` in `normalizeForFuzzyMatch`, normalizing tabs to 4 spaces before comparison. This way:

- AI generates `oldText` with spaces → file uses tabs → ✅ matches
- AI generates `oldText` with tab (rare) → file uses spaces → ✅ also matches  
- Both use same style → exact match succeeds first, no fuzzy needed

Unchanged lines preserve their original bytes via the existing `applyReplacementsPreservingUnchangedLines` mechanism.

## Changes

1. **edit-diff.ts**: Added `.map((line) => line.replace(/\t/g, "    "))` to `normalizeForFuzzyMatch`, with JSDoc update
2. **edit.ts**: Added new prompt guideline informing the AI that indentation is normalized for matching