### PR TITLE
fix(ai): reverts #4110 - both models now work on OpenCode Go

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1300,26 +1300,6 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					compat = { ...(compat ?? {}), thinkingFormat: "deepseek", supportsReasoningEffort: false };
 				}
 
-				// Fix known mismatches between models.dev npm data and actual
-				// OpenCode Go endpoint behaviour. models.dev reports these models
-				// as @ai-sdk/anthropic, but the OpenCode Go endpoints either don't
-				// accept Anthropic SDK auth (MiniMax M2.7) or are served through
-				// the OpenAI-compatible /v1/chat/completions path (Qwen 3.5/3.6).
-				// Switch them to openai-completions so requests use Bearer auth
-				// and the standard /v1/chat/completions endpoint.
-				if (variant.provider === "opencode-go") {
-					if (modelId === "minimax-m2.7") {
-						api = "openai-completions";
-						baseUrl = `${variant.basePath}/v1`;
-					}
-					if (modelId === "qwen3.5-plus" || modelId === "qwen3.6-plus") {
-						api = "openai-completions";
-						baseUrl = `${variant.basePath}/v1`;
-						// Qwen/DashScope uses enable_thinking at the top level.
-						compat = { ...(compat ?? {}), thinkingFormat: "qwen" };
-					}
-				}
-
 				if (api === "openai-completions") {
 					compat = { ...(compat ?? {}), maxTokensField: "max_tokens" };
 					if (

--- a/packages/ai/src/providers/opencode-go.models.ts
+++ b/packages/ai/src/providers/opencode-go.models.ts
@@ -155,10 +155,9 @@ export const OPENCODE_GO_MODELS = {
 	"minimax-m2.7": {
 		id: "minimax-m2.7",
 		name: "MiniMax M2.7",
-		api: "openai-completions",
+		api: "anthropic-messages",
 		provider: "opencode-go",
-		baseUrl: "https://opencode.ai/zen/go/v1",
-		compat: {"supportsStore":false,"supportsDeveloperRole":false,"maxTokensField":"max_tokens"},
+		baseUrl: "https://opencode.ai/zen/go",
 		reasoning: true,
 		input: ["text"],
 		cost: {
@@ -169,7 +168,7 @@ export const OPENCODE_GO_MODELS = {
 		},
 		contextWindow: 204800,
 		maxTokens: 131072,
-	} satisfies Model<"openai-completions">,
+	} satisfies Model<"anthropic-messages">,
 	"minimax-m3": {
 		id: "minimax-m3",
 		name: "MiniMax M3 (3x usage)",
@@ -190,10 +189,9 @@ export const OPENCODE_GO_MODELS = {
 	"qwen3.6-plus": {
 		id: "qwen3.6-plus",
 		name: "Qwen3.6 Plus",
-		api: "openai-completions",
+		api: "anthropic-messages",
 		provider: "opencode-go",
-		baseUrl: "https://opencode.ai/zen/go/v1",
-		compat: {"supportsStore":false,"supportsDeveloperRole":false,"thinkingFormat":"qwen","maxTokensField":"max_tokens"},
+		baseUrl: "https://opencode.ai/zen/go",
 		reasoning: true,
 		input: ["text", "image"],
 		cost: {
@@ -204,7 +202,7 @@ export const OPENCODE_GO_MODELS = {
 		},
 		contextWindow: 1000000,
 		maxTokens: 65536,
-	} satisfies Model<"openai-completions">,
+	} satisfies Model<"anthropic-messages">,
 	"qwen3.7-max": {
 		id: "qwen3.7-max",
 		name: "Qwen3.7 Max",


### PR DESCRIPTION
This removes the previous workaround from #4110.

Minimax M2.7 and Qwen 3.6 Plus now work correctly with anthropic-messages on OpenCode Go. Qwen 3.5 Plus is no longer available.

Tested locally.

I've followed the CONTRIBUTING.md and AGENTS.md. I understand what this codes does.

- [x]  npm run check
- [x]  ./test.sh
- [~]  cd packages/ai && npm run generate-models

The scripts generates more updates than what I changed. I assume it's because the upstream models.dev changed. I only committed the relevant changes in generated models, but if needed, can generate again and commit everything.