### PR TITLE
fix(ai): return empty string for empty tool results instead of '(see attached image)'

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1030,7 +1030,7 @@ export function convertMessages(
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
-					content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
+					content: sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : ""),
 					tool_call_id: toolMsg.toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -251,7 +251,7 @@ export function convertResponsesMessages<TApi extends Api>(
 
 				output = contentParts;
 			} else {
-				output = sanitizeSurrogates(hasText ? textResult : "(see attached image)");
+				output = sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : "");
 			}
 
 			messages.push({


### PR DESCRIPTION
## Summary

Fixes #6103

When a tool call returns empty text with no images (e.g., a successful replace/edit operation), the OpenAI Responses and Completions API handlers incorrectly returned `(see attached image)` as the tool output. This was confusing to the model since no image was present.

## Root Cause

In both `openai-responses-shared.ts` and `openai-completions.ts`, the tool result conversion logic used a simple ternary:

```ts
hasText ? textResult : "(see attached image)"
```

This assumed that if there was no text, there must be an image. However, tools can legitimately return empty output (e.g., the `replace` tool on success), which has neither text nor images.

## Fix

Added a `hasImages` check before falling back to the image placeholder string, matching the existing correct behavior in `google-shared.ts` (line 193):

```ts
hasText ? textResult : hasImages ? "(see attached image)" : ""
```

## Files Changed

- `packages/ai/src/api/openai-responses-shared.ts`: Added `hasImages` guard for empty tool results
- `packages/ai/src/api/openai-completions.ts`: Same fix for the Chat Completions API path