### PR TITLE
fix(ai): map Bedrock apiKey auth to bearer token env

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1,7 +1,10 @@
 import { bedrockConverseStreamApi } from "../api/bedrock-converse-stream.lazy.ts";
 import type { ApiKeyAuth } from "../auth/types.ts";
 import { createProvider, type Provider } from "../models.ts";
+import type { ProviderStreams, SimpleStreamOptions, StreamOptions } from "../types.ts";
 import { AMAZON_BEDROCK_MODELS } from "./amazon-bedrock.models.ts";
+
+const BEDROCK_BEARER_TOKEN_ENV = "AWS_BEARER_TOKEN_BEDROCK";
 
 /**
  * Bedrock auth is ambient: the AWS SDK's default credential chain handles the
@@ -24,12 +27,27 @@ const bedrockAuth: ApiKeyAuth = {
 	},
 };
 
+function adaptBedrockApiKey<TOptions extends SimpleStreamOptions | StreamOptions>(
+	options?: TOptions,
+): TOptions | undefined {
+	if (!options?.apiKey) return options;
+	const { apiKey, env, ...rest } = options;
+	return { ...rest, env: { ...env, [BEDROCK_BEARER_TOKEN_ENV]: apiKey } } as unknown as TOptions;
+}
+
+function adaptBedrockApi(api: ProviderStreams): ProviderStreams {
+	return {
+		stream: (model, context, options) => api.stream(model, context, adaptBedrockApiKey(options)),
+		streamSimple: (model, context, options) => api.streamSimple(model, context, adaptBedrockApiKey(options)),
+	};
+}
+
 export function amazonBedrockProvider(): Provider<"bedrock-converse-stream"> {
 	return createProvider({
 		id: "amazon-bedrock",
 		name: "Amazon Bedrock",
 		auth: { apiKey: bedrockAuth },
 		models: Object.values(AMAZON_BEDROCK_MODELS),
-		api: bedrockConverseStreamApi(),
+		api: adaptBedrockApi(bedrockConverseStreamApi()),
 	});
 }

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { setBedrockProviderModule } from "../src/api/bedrock-converse-stream.lazy.ts";
+import { InMemoryCredentialStore } from "../src/auth/credential-store.ts";
 import { envApiKeyAuth } from "../src/auth/helpers.ts";
 import type { AuthContext } from "../src/auth/types.ts";
 import { createModels, createProvider } from "../src/models.ts";
@@ -20,6 +22,16 @@ function fakeAuthContext(env: Record<string, string>, files: string[] = []): Aut
 }
 
 const context: Context = { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] };
+const BEDROCK_BEARER_TOKEN_ENV = "AWS_BEARER_TOKEN_BEDROCK";
+
+function doneStream(model: Model<Api>): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	const message = fauxAssistantMessage("ok");
+	stream.push({ type: "start", partial: { ...message, api: model.api, provider: model.provider, model: model.id } });
+	stream.push({ type: "done", reason: "stop", message });
+	stream.end(message);
+	return stream;
+}
 
 describe("builtin providers", () => {
 	it("builtinModels registers every builtin provider with models", async () => {
@@ -66,6 +78,65 @@ describe("builtin providers", () => {
 		const unconfigured = createModels({ authContext: fakeAuthContext({}) });
 		unconfigured.setProvider(amazonBedrockProvider());
 		expect(await unconfigured.getAuth(model)).toBeUndefined();
+	});
+
+	it("maps Bedrock apiKey auth to request-scoped bearer-token env for both stream paths", async () => {
+		const captured: Array<{ apiKey?: string; env?: Record<string, string> } | undefined> = [];
+		setBedrockProviderModule({
+			stream: (model, _context, options) => {
+				captured.push(options);
+				return doneStream(model);
+			},
+			streamSimple: (model, _context, options) => {
+				captured.push(options);
+				return doneStream(model);
+			},
+		});
+
+		const provider = amazonBedrockProvider();
+		const model = provider.getModels()[0];
+
+		await provider
+			.stream(model, context, { apiKey: "bedrock-stream-token", env: { AWS_REGION: "us-west-2" } })
+			.result();
+		await provider
+			.streamSimple(model, context, { apiKey: "bedrock-simple-token", env: { AWS_REGION: "us-east-1" } })
+			.result();
+
+		expect(captured[0]).toMatchObject({
+			env: { AWS_REGION: "us-west-2", [BEDROCK_BEARER_TOKEN_ENV]: "bedrock-stream-token" },
+		});
+		expect(captured[0]?.apiKey).toBeUndefined();
+		expect(captured[1]).toMatchObject({
+			env: { AWS_REGION: "us-east-1", [BEDROCK_BEARER_TOKEN_ENV]: "bedrock-simple-token" },
+		});
+		expect(captured[1]?.apiKey).toBeUndefined();
+	});
+
+	it("maps stored Bedrock credentials resolved by Models into bearer-token env", async () => {
+		const captured: Array<{ apiKey?: string; env?: Record<string, string> } | undefined> = [];
+		setBedrockProviderModule({
+			stream: (model, _context, options) => {
+				captured.push(options);
+				return doneStream(model);
+			},
+			streamSimple: (model, _context, options) => {
+				captured.push(options);
+				return doneStream(model);
+			},
+		});
+
+		const credentials = new InMemoryCredentialStore();
+		await credentials.modify("amazon-bedrock", async () => ({ type: "api_key", key: "stored-bedrock-token" }));
+		const models = createModels({ credentials });
+		models.setProvider(amazonBedrockProvider());
+		const model = models.getModels("amazon-bedrock")[0];
+
+		await models.completeSimple(model, context);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]).toMatchObject({ env: { [BEDROCK_BEARER_TOKEN_ENV]: "stored-bedrock-token" } });
+		expect(captured[0]?.apiKey).toBeUndefined();
 	});
 
 	it("requires Cloudflare Workers AI account config and returns scoped env", async () => {


### PR DESCRIPTION
## Summary
- Map Amazon Bedrock provider apiKey auth into request-scoped env.AWS_BEARER_TOKEN_BEDROCK before calling the Bedrock Converse API.
- Remove apiKey from the forwarded options so the same token is not kept in two option fields.
- Cover both stream and streamSimple, including Models.completeSimple with stored credentials.

## Why
Amazon Bedrock's Converse API implementation reads bearerToken or env.AWS_BEARER_TOKEN_BEDROCK, while provider credential resolution currently supplies apiKey. This means stored Bedrock bearer tokens can be silently ignored by the Bedrock client.

Using request-scoped options.env keeps the token local to the call and does not write process.env.

## Tests
- npx biome check packages/ai/src/providers/amazon-bedrock.ts packages/ai/test/providers.test.ts
- npx tsgo --noEmit -p packages/ai/tsconfig.build.json
- ./packages/ai/node_modules/.bin/vitest --run packages/ai/test/providers.test.ts
- pre-commit npm run check