### PR TITLE
Avoid replaying historical inline images

### DIFF
--- a/packages/coding-agent/src/core/export-html/tool-renderer.ts
+++ b/packages/coding-agent/src/core/export-html/tool-renderer.ts
@@ -91,6 +91,7 @@ export function createToolHtmlRenderer(deps: ToolHtmlRendererDeps): ToolHtmlRend
 			isPartial,
 			expanded,
 			showImages: false,
+			includeImageDimensions: true,
 			isError,
 		};
 	};

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -425,6 +425,8 @@ export interface ToolRenderContext<TState = any, TArgs = any> {
 	expanded: boolean;
 	/** Whether inline images are currently shown in the TUI. */
 	showImages: boolean;
+	/** Whether image fallback labels may parse dimensions from base64 data. */
+	includeImageDimensions: boolean;
 	/** Whether the current result is an error. */
 	isError: boolean;
 }

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -197,13 +197,14 @@ function rebuildBashResultRenderComponent(
 	},
 	options: ToolRenderResultOptions,
 	showImages: boolean,
+	includeImageDimensions: boolean,
 	startedAt: number | undefined,
 	endedAt: number | undefined,
 ): void {
 	const state = component.state;
 	component.clear();
 
-	let output = getTextOutput(result as any, showImages).trim();
+	let output = getTextOutput(result as any, showImages, { includeImageDimensions }).trim();
 	const truncation = result.details?.truncation;
 	const fullOutputPath = result.details?.fullOutputPath;
 	if (!options.isPartial && truncation?.truncated && fullOutputPath && output.endsWith("]")) {
@@ -439,6 +440,7 @@ export function createBashToolDefinition(
 				result as any,
 				options,
 				context.showImages,
+				context.includeImageDimensions,
 				state.startedAt,
 				state.endedAt,
 			);

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -81,8 +81,9 @@ function formatFindResult(
 	options: ToolRenderResultOptions,
 	theme: Theme,
 	showImages: boolean,
+	includeImageDimensions: boolean,
 ): string {
-	const output = getTextOutput(result, showImages).trim();
+	const output = getTextOutput(result, showImages, { includeImageDimensions }).trim();
 	let text = "";
 	if (output) {
 		const lines = output.split("\n");
@@ -363,7 +364,9 @@ export function createFindToolDefinition(
 		},
 		renderResult(result, options, theme, context) {
 			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-			text.setText(formatFindResult(result as any, options, theme, context.showImages));
+			text.setText(
+				formatFindResult(result as any, options, theme, context.showImages, context.includeImageDimensions),
+			);
 			return text;
 		},
 	};

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -93,8 +93,9 @@ function formatGrepResult(
 	options: ToolRenderResultOptions,
 	theme: Theme,
 	showImages: boolean,
+	includeImageDimensions: boolean,
 ): string {
-	const output = getTextOutput(result, showImages).trim();
+	const output = getTextOutput(result, showImages, { includeImageDimensions }).trim();
 	let text = "";
 	if (output) {
 		const lines = output.split("\n");
@@ -374,7 +375,9 @@ export function createGrepToolDefinition(
 		},
 		renderResult(result, options, theme, context) {
 			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-			text.setText(formatGrepResult(result as any, options, theme, context.showImages));
+			text.setText(
+				formatGrepResult(result as any, options, theme, context.showImages, context.includeImageDimensions),
+			);
 			return text;
 		},
 	};

--- a/packages/coding-agent/src/core/tools/ls.ts
+++ b/packages/coding-agent/src/core/tools/ls.ts
@@ -67,8 +67,9 @@ function formatLsResult(
 	options: ToolRenderResultOptions,
 	theme: Theme,
 	showImages: boolean,
+	includeImageDimensions: boolean,
 ): string {
-	const output = getTextOutput(result, showImages).trim();
+	const output = getTextOutput(result, showImages, { includeImageDimensions }).trim();
 	let text = "";
 	if (output) {
 		const lines = output.split("\n");
@@ -214,7 +215,9 @@ export function createLsToolDefinition(
 		},
 		renderResult(result, options, theme, context) {
 			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-			text.setText(formatLsResult(result as any, options, theme, context.showImages));
+			text.setText(
+				formatLsResult(result as any, options, theme, context.showImages, context.includeImageDimensions),
+			);
 			return text;
 		},
 	};

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -167,6 +167,7 @@ function formatReadResult(
 	options: ToolRenderResultOptions,
 	theme: Theme,
 	showImages: boolean,
+	includeImageDimensions: boolean,
 	_cwd: string,
 	isError: boolean,
 ): string {
@@ -175,7 +176,7 @@ function formatReadResult(
 	}
 
 	const rawPath = str(args?.file_path ?? args?.path);
-	const output = getTextOutput(result, showImages);
+	const output = getTextOutput(result, showImages, { includeImageDimensions });
 	const lang = rawPath ? getLanguageFromPath(rawPath) : undefined;
 	const renderedLines = lang ? highlightCode(replaceTabs(output), lang) : output.split("\n");
 	const lines = trimTrailingEmptyLines(renderedLines);
@@ -339,7 +340,16 @@ export function createReadToolDefinition(
 		renderResult(result, options, theme, context) {
 			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
 			text.setText(
-				formatReadResult(context.args, result, options, theme, context.showImages, context.cwd, context.isError),
+				formatReadResult(
+					context.args,
+					result,
+					options,
+					theme,
+					context.showImages,
+					context.includeImageDimensions,
+					context.cwd,
+					context.isError,
+				),
 			);
 			return text;
 		},

--- a/packages/coding-agent/src/core/tools/render-utils.ts
+++ b/packages/coding-agent/src/core/tools/render-utils.ts
@@ -36,9 +36,15 @@ export function normalizeDisplayText(text: string): string {
 	return text.replace(/\r/g, "");
 }
 
+export interface TextOutputOptions {
+	/** Whether image fallbacks should parse image dimensions from base64 data. */
+	includeImageDimensions?: boolean;
+}
+
 export function getTextOutput(
 	result: { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> } | undefined,
 	showImages: boolean,
+	options: TextOutputOptions = {},
 ): string {
 	if (!result) return "";
 
@@ -48,12 +54,15 @@ export function getTextOutput(
 	let output = textBlocks.map((c) => sanitizeBinaryOutput(stripAnsi(c.text || "")).replace(/\r/g, "")).join("\n");
 
 	const caps = getCapabilities();
+	const includeImageDimensions = options.includeImageDimensions ?? true;
 	if (imageBlocks.length > 0 && (!caps.images || !showImages)) {
 		const imageIndicators = imageBlocks
 			.map((img) => {
 				const mimeType = img.mimeType ?? "image/unknown";
 				const dims =
-					img.data && img.mimeType ? (getImageDimensions(img.data, img.mimeType) ?? undefined) : undefined;
+					includeImageDimensions && img.data && img.mimeType
+						? (getImageDimensions(img.data, img.mimeType) ?? undefined)
+						: undefined;
 				return imageFallback(mimeType, dims);
 			})
 			.join("\n");

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -8,6 +8,12 @@ import { theme } from "../theme/theme.ts";
 export interface ToolExecutionOptions {
 	showImages?: boolean;
 	imageWidthCells?: number;
+	/**
+	 * Whether this component may emit inline terminal image escape sequences.
+	 * Historical session replay disables this so loading image-heavy sessions does
+	 * not re-send every image in the scrollback.
+	 */
+	allowInlineImages?: boolean;
 }
 
 export class ToolExecutionComponent extends Container {
@@ -24,6 +30,7 @@ export class ToolExecutionComponent extends Container {
 	private args: any;
 	private expanded = false;
 	private showImages: boolean;
+	private allowInlineImages: boolean;
 	private imageWidthCells: number;
 	private isPartial = true;
 	private toolDefinition?: ToolDefinition<any, any>;
@@ -56,6 +63,7 @@ export class ToolExecutionComponent extends Container {
 		this.toolDefinition = toolDefinition;
 		this.builtInToolDefinition = createAllToolDefinitions(cwd)[toolName as ToolName];
 		this.showImages = options.showImages ?? true;
+		this.allowInlineImages = options.allowInlineImages ?? true;
 		this.imageWidthCells = options.imageWidthCells ?? 60;
 		this.ui = ui;
 		this.cwd = cwd;
@@ -112,7 +120,12 @@ export class ToolExecutionComponent extends Container {
 		return this.toolDefinition.renderShell ?? this.builtInToolDefinition.renderShell ?? "default";
 	}
 
+	private shouldRenderInlineImages(): boolean {
+		return this.showImages && this.allowInlineImages;
+	}
+
 	private getRenderContext(lastComponent: Component | undefined): ToolRenderContext {
+		const renderInlineImages = this.shouldRenderInlineImages();
 		return {
 			args: this.args,
 			toolCallId: this.toolCallId,
@@ -127,7 +140,8 @@ export class ToolExecutionComponent extends Container {
 			argsComplete: this.argsComplete,
 			isPartial: this.isPartial,
 			expanded: this.expanded,
-			showImages: this.showImages,
+			showImages: renderInlineImages,
+			includeImageDimensions: this.allowInlineImages,
 			isError: this.result?.isError ?? false,
 		};
 	}
@@ -176,6 +190,7 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private maybeConvertImagesForKitty(): void {
+		if (!this.shouldRenderInlineImages()) return;
 		const caps = getCapabilities();
 		if (caps.images !== "kitty") return;
 		if (!this.result) return;
@@ -330,9 +345,10 @@ export class ToolExecutionComponent extends Container {
 		if (this.result) {
 			const imageBlocks = this.result.content.filter((c) => c.type === "image");
 			const caps = getCapabilities();
+			const renderInlineImages = this.shouldRenderInlineImages();
 			for (let i = 0; i < imageBlocks.length; i++) {
 				const img = imageBlocks[i];
-				if (caps.images && this.showImages && img.data && img.mimeType) {
+				if (caps.images && renderInlineImages && img.data && img.mimeType) {
 					const converted = this.convertedImages.get(i);
 					const imageData = converted?.data ?? img.data;
 					const imageMimeType = converted?.mimeType ?? img.mimeType;
@@ -359,7 +375,9 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private getTextOutput(): string {
-		return getRenderedTextOutput(this.result, this.showImages);
+		return getRenderedTextOutput(this.result, this.shouldRenderInlineImages(), {
+			includeImageDimensions: this.allowInlineImages,
+		});
 	}
 
 	private formatToolExecution(): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3189,6 +3189,8 @@ export class InteractiveMode {
 							{
 								showImages: this.settingsManager.getShowImages(),
 								imageWidthCells: this.settingsManager.getImageWidthCells(),
+								// Do not replay historical inline image payloads on session load/rebuild.
+								allowInlineImages: false,
 							},
 							this.getRegisteredToolDefinition(content.name),
 							this.ui,

--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -7,6 +7,7 @@ import { createEditToolDefinition } from "../src/core/tools/edit.ts";
 import { computeEditsDiff, type Edit } from "../src/core/tools/edit-diff.ts";
 import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
 
 class FakeTerminal implements Terminal {
 	columns = 80;
@@ -50,7 +51,7 @@ async function waitForRenderedText(
 		onRetry?.();
 		await waitForRender();
 		lastRender = getRender();
-		if (lastRender.includes(expectedText)) {
+		if (stripAnsi(lastRender).includes(expectedText)) {
 			return lastRender;
 		}
 	}
@@ -119,10 +120,12 @@ describe("edit tool TUI rendering", () => {
 		await waitForRender();
 		await waitForRender();
 
-		const callOnlyRender = await waitForRenderedText(
-			() => component.render(80).join("\n"),
-			"line 50 changed",
-			() => tui.requestRender(true),
+		const callOnlyRender = stripAnsi(
+			await waitForRenderedText(
+				() => component.render(80).join("\n"),
+				"line 50 changed",
+				() => tui.requestRender(true),
+			),
 		);
 		expect(callOnlyRender).toContain("edit");
 		expect(callOnlyRender).toContain("line 950 changed");
@@ -143,7 +146,7 @@ describe("edit tool TUI rendering", () => {
 		expect(tui.fullRedraws).toBe(redrawsBeforeResult);
 		expect(terminal.fullClearCount).toBe(clearsBeforeResult);
 
-		const settledRender = component.render(80).join("\n");
+		const settledRender = stripAnsi(component.render(80).join("\n"));
 		expect(settledRender).toContain("line 50 changed");
 		expect(settledRender).toContain("line 950 changed");
 		expect(settledRender).not.toContain("Successfully replaced");
@@ -193,7 +196,7 @@ describe("edit tool TUI rendering", () => {
 		await waitForRender();
 		await waitForRender();
 
-		const rendered = component.render(80).join("\n");
+		const rendered = stripAnsi(component.render(80).join("\n"));
 		expect(rendered).toContain("line 50 changed");
 		expect(rendered).toContain("line 150 changed");
 	});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1,6 +1,11 @@
 import { homedir } from "node:os";
 import * as path from "node:path";
-import { type AutocompleteProvider, CombinedAutocompleteProvider } from "@earendil-works/pi-tui";
+import {
+	type AutocompleteProvider,
+	CombinedAutocompleteProvider,
+	resetCapabilitiesCache,
+	setCapabilities,
+} from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, test, vi } from "vitest";
 import { type Component, Container, type Focusable, TUI } from "../../tui/src/tui.ts";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal.ts";
@@ -113,6 +118,59 @@ describe("InteractiveMode.showStatus", () => {
 		// adds spacer + text
 		expect(fakeThis.chatContainer.children).toHaveLength(5);
 		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
+	});
+});
+
+describe("InteractiveMode.renderSessionContext", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("renders historical tool result images as fallbacks instead of replaying inline payloads", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		try {
+			const chatContainer = new Container();
+			const fakeThis: any = {
+				pendingTools: new Map(),
+				toolOutputExpanded: false,
+				chatContainer,
+				footer: { invalidate: vi.fn() },
+				updateEditorBorderColor: vi.fn(),
+				settingsManager: {
+					getShowImages: () => true,
+					getImageWidthCells: () => 60,
+				},
+				getRegisteredToolDefinition: () => undefined,
+				ui: { requestRender: vi.fn() },
+				sessionManager: { getCwd: () => process.cwd() },
+				addMessageToChat: vi.fn(() => {
+					chatContainer.addChild({ render: () => ["assistant"], invalidate: () => {} });
+				}),
+			};
+
+			(InteractiveMode as any).prototype.renderSessionContext.call(fakeThis, {
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "toolCall", name: "custom_tool", id: "tool-1", arguments: {} }],
+					},
+					{
+						role: "toolResult",
+						toolCallId: "tool-1",
+						content: [{ type: "image", data: "AAAA", mimeType: "image/png" }],
+						isError: false,
+					},
+				],
+				thinkingLevel: "medium",
+				model: null,
+			});
+
+			const rendered = renderAll(chatContainer);
+			expect(rendered).not.toContain("_G");
+			expect(normalizeRenderedOutput(chatContainer)).toContain("[Image: [image/png]]");
+		} finally {
+			resetCapabilitiesCache();
+		}
 	});
 });
 

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from "node:path";
-import { Text, type TUI } from "@earendil-works/pi-tui";
+import { resetCapabilitiesCache, setCapabilities, Text, type TUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { beforeAll, describe, expect, test } from "vitest";
 import { getReadmePath } from "../src/config.ts";
@@ -65,6 +65,80 @@ describe("ToolExecutionComponent parity", () => {
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rendered).toContain("custom call");
 		expect(rendered).toContain("custom result");
+	});
+
+	test("renders inline images by default when terminal supports them", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		try {
+			const component = new ToolExecutionComponent(
+				"custom_tool",
+				"tool-image-default",
+				{},
+				{ showImages: true },
+				undefined,
+				createFakeTui(),
+				process.cwd(),
+			);
+			component.updateResult({ content: [{ type: "image", data: "AAAA", mimeType: "image/png" }], isError: false });
+
+			expect(component.render(120).join("\n")).toContain("\x1b_G");
+		} finally {
+			resetCapabilitiesCache();
+		}
+	});
+
+	test("can suppress inline image escape sequences for session history", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		try {
+			const component = new ToolExecutionComponent(
+				"custom_tool",
+				"tool-image-history",
+				{},
+				{ showImages: true, allowInlineImages: false },
+				undefined,
+				createFakeTui(),
+				process.cwd(),
+			);
+			component.updateResult({ content: [{ type: "image", data: "AAAA", mimeType: "image/png" }], isError: false });
+
+			let rendered = component.render(120).join("\n");
+			expect(rendered).not.toContain("\x1b_G");
+			expect(stripAnsi(rendered)).toContain("[Image: [image/png]]");
+
+			component.setShowImages(false);
+			component.setShowImages(true);
+			rendered = component.render(120).join("\n");
+			expect(rendered).not.toContain("\x1b_G");
+		} finally {
+			resetCapabilitiesCache();
+		}
+	});
+
+	test("suppressed history image fallbacks skip dimension parsing", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		try {
+			const onePixelPng =
+				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+			const component = new ToolExecutionComponent(
+				"custom_tool",
+				"tool-image-history-dims",
+				{},
+				{ showImages: true, allowInlineImages: false },
+				undefined,
+				createFakeTui(),
+				process.cwd(),
+			);
+			component.updateResult({
+				content: [{ type: "image", data: onePixelPng, mimeType: "image/png" }],
+				isError: false,
+			});
+
+			const rendered = stripAnsi(component.render(120).join("\n"));
+			expect(rendered).toContain("[Image: [image/png]]");
+			expect(rendered).not.toContain("1x1");
+		} finally {
+			resetCapabilitiesCache();
+		}
 	});
 
 	test("self-rendered empty tool rows take no layout space", () => {


### PR DESCRIPTION
## Summary
- stop replaying inline terminal image escape payloads when rebuilding historical session context
- keep current/live tool results rendering images by default, while history falls back to lightweight `[Image: ...]` labels
- skip image dimension parsing for suppressed history fallbacks to avoid decoding large base64 payloads during TUI load

## Tests
- npm run check
- npm run build
- npm --workspace packages/coding-agent exec -- vitest --run
- npm test
