### PR TITLE
fix: guard against undefined content in tool result messages

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -735,7 +735,7 @@ function createToolResultMessage(finalized: FinalizedToolCallOutcome): ToolResul
 		role: "toolResult",
 		toolCallId: finalized.toolCall.id,
 		toolName: finalized.toolCall.name,
-		content: finalized.result.content,
+		content: finalized.result.content ?? [{ type: "text", text: "(empty tool result)" }],
 		details: finalized.result.details,
 		isError: finalized.isError,
 		timestamp: Date.now(),

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1045,7 +1045,7 @@ export function convertMessages(
 				params.push(toolResultMsg);
 
 				if (hasImages && model.input.includes("image")) {
-					for (const block of toolMsg.content) {
+					for (const block of (toolMsg.content || [])) {
 						if (isImageContentBlock(block)) {
 							imageBlocks.push({
 								type: "image_url",

--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -45,7 +45,7 @@ function downgradeUnsupportedImages<TApi extends Api>(messages: Message[], model
 			};
 		}
 
-		if (msg.role === "toolResult") {
+		if (msg.role === "toolResult" && Array.isArray(msg.content)) {
 			return {
 				...msg,
 				content: replaceImagesWithPlaceholder(msg.content, NON_VISION_TOOL_IMAGE_PLACEHOLDER),


### PR DESCRIPTION
## Problem                                                                                                          
                                                                                                                       
   When an extension tool (e.g., `get_kline`) returns a result **without** a `content` field, the agent core crashes   
 with:                                                                                                                 
                                                                                                                       
 ```                                                                                                                   
                                                                                                                       
 Error: content is not iterable                                                                                        
                                                                                                                       
 ```                                                                                                                   
                                                                                                                       
   This happens because `createToolResultMessage` creates a message with `content: undefined`, and downstream code in  
 multiple places iterates over `.content` without null checks.                                                         
                                                                                                                       
   ## Root Cause                                                                                                       
                                                                                                                       
   Trace in the session log showed a `toolResult` message with `isError: false` but no `content` property:             
                                                                                                                       
   ```json                                                                                                             
   {"role":"toolResult","toolName":"get_kline","isError":false}                                                        
 ```                                                                                                                   
                                                                                                                       
 The missing content field propagates through convertToLlm → downgradeUnsupportedImages → replaceImagesWithPlaceholder 
  where for (const block of undefined) throws TypeError.                                                               
                                                                                                                       
 Fix                                                                                                                   
                                                                                                                       
 Three defensive changes (3 lines total):                                                                              
                                                                                                                       
 1. agent-loop.ts: Use ?? to fall back to an empty array when result.content is null/undefined, preventing the issue   
    at the source.                                                                                                     
 2. transform-messages.ts: Add Array.isArray() guard in downgradeUnsupportedImages before calling                      
    replaceImagesWithPlaceholder on toolResult content.                                                                
 3. openai-completions.ts: Add || [] fallback when iterating toolMsg.content for image block extraction in             
    convertMessages. 