### PR TITLE
feat(tui): add redo support to editors

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -65,6 +65,7 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 | `tui.editor.yank` | `ctrl+y` | Paste most recently deleted text |
 | `tui.editor.yankPop` | `alt+y` | Cycle through deleted text after yank |
 | `tui.editor.undo` | `ctrl+-` | Undo last edit |
+| `tui.editor.redo` | `ctrl+shift+-` | Redo last undone edit |
 
 ### TUI Clipboard and Selection
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -223,6 +223,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	yank: "tui.editor.yank",
 	yankPop: "tui.editor.yankPop",
 	undo: "tui.editor.undo",
+	redo: "tui.editor.redo",
 	newLine: "tui.input.newLine",
 	submit: "tui.input.submit",
 	tab: "tui.input.tab",

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3,7 +3,7 @@ import { getKeybindings } from "../keybindings.ts";
 import { decodePrintableKey, matchesKey } from "../keys.ts";
 import { KillRing } from "../kill-ring.ts";
 import { type Component, CURSOR_MARKER, type Focusable, type TUI } from "../tui.ts";
-import { UndoStack } from "../undo-stack.ts";
+import { RedoStack, UndoStack } from "../undo-stack.ts";
 import {
 	cjkBreakRegex,
 	getGraphemeSegmenter,
@@ -317,8 +317,9 @@ export class Editor implements Component, Focusable {
 	// to.
 	private snappedFromCursorCol: number | null = null;
 
-	// Undo support
+	// Undo/Redo support
 	private undoStack = new UndoStack<EditorState>();
+	private redoStack = new RedoStack<EditorState>();
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
@@ -643,9 +644,13 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
-		// Undo
+		// Undo / redo
 		if (kb.matches(data, "tui.editor.undo")) {
 			this.undo();
+			return;
+		}
+		if (kb.matches(data, "tui.editor.redo")) {
+			this.redo();
 			return;
 		}
 
@@ -1253,6 +1258,7 @@ export class Editor implements Component, Focusable {
 		this.exitHistoryBrowsing();
 		this.scrollOffset = 0;
 		this.undoStack.clear();
+		this.redoStack.clear();
 		this.lastAction = null;
 
 		if (this.onChange) this.onChange("");
@@ -1969,12 +1975,27 @@ export class Editor implements Component, Focusable {
 
 	private pushUndoSnapshot(): void {
 		this.undoStack.push(this.state);
+		this.redoStack.clear();
 	}
 
 	private undo(): void {
 		this.exitHistoryBrowsing();
 		const snapshot = this.undoStack.pop();
 		if (!snapshot) return;
+		this.redoStack.push(this.state);
+		Object.assign(this.state, snapshot);
+		this.lastAction = null;
+		this.preferredVisualCol = null;
+		if (this.onChange) {
+			this.onChange(this.getText());
+		}
+	}
+
+	private redo(): void {
+		this.exitHistoryBrowsing();
+		const snapshot = this.redoStack.pop();
+		if (!snapshot) return;
+		this.undoStack.push(this.state);
 		Object.assign(this.state, snapshot);
 		this.lastAction = null;
 		this.preferredVisualCol = null;

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -2,7 +2,7 @@ import { getKeybindings } from "../keybindings.ts";
 import { decodeKittyPrintable } from "../keys.ts";
 import { KillRing } from "../kill-ring.ts";
 import { type Component, CURSOR_MARKER, type Focusable } from "../tui.ts";
-import { UndoStack } from "../undo-stack.ts";
+import { RedoStack, UndoStack } from "../undo-stack.ts";
 import { getGraphemeSegmenter, isWhitespaceChar, sliceByColumn, visibleWidth } from "../utils.ts";
 import { findWordBackward, findWordForward } from "../word-navigation.ts";
 
@@ -33,8 +33,9 @@ export class Input implements Component, Focusable {
 	private killRing = new KillRing();
 	private lastAction: "kill" | "yank" | "type-word" | null = null;
 
-	// Undo support
+	// Undo/Redo support
 	private undoStack = new UndoStack<InputState>();
+	private redoStack = new RedoStack<InputState>();
 
 	getValue(): string {
 		return this.value;
@@ -91,9 +92,13 @@ export class Input implements Component, Focusable {
 			return;
 		}
 
-		// Undo
+		// Undo / redo
 		if (kb.matches(data, "tui.editor.undo")) {
 			this.undo();
+			return;
+		}
+		if (kb.matches(data, "tui.editor.redo")) {
+			this.redo();
 			return;
 		}
 
@@ -337,11 +342,22 @@ export class Input implements Component, Focusable {
 
 	private pushUndo(): void {
 		this.undoStack.push({ value: this.value, cursor: this.cursor });
+		this.redoStack.clear();
 	}
 
 	private undo(): void {
 		const snapshot = this.undoStack.pop();
 		if (!snapshot) return;
+		this.redoStack.push({ value: this.value, cursor: this.cursor });
+		this.value = snapshot.value;
+		this.cursor = snapshot.cursor;
+		this.lastAction = null;
+	}
+
+	private redo(): void {
+		const snapshot = this.redoStack.pop();
+		if (!snapshot) return;
+		this.undoStack.push({ value: this.value, cursor: this.cursor });
 		this.value = snapshot.value;
 		this.cursor = snapshot.cursor;
 		this.lastAction = null;

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -27,6 +27,7 @@ export interface Keybindings {
 	"tui.editor.yank": true;
 	"tui.editor.yankPop": true;
 	"tui.editor.undo": true;
+	"tui.editor.redo": true;
 	// Generic input actions
 	"tui.input.newLine": true;
 	"tui.input.submit": true;
@@ -115,6 +116,7 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.yank": { defaultKeys: "ctrl+y", description: "Yank" },
 	"tui.editor.yankPop": { defaultKeys: "alt+y", description: "Yank pop" },
 	"tui.editor.undo": { defaultKeys: "ctrl+-", description: "Undo" },
+	"tui.editor.redo": { defaultKeys: "ctrl+shift+-", description: "Redo" },
 	"tui.input.newLine": { defaultKeys: ["shift+enter", "ctrl+j"], description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },

--- a/packages/tui/src/undo-stack.ts
+++ b/packages/tui/src/undo-stack.ts
@@ -26,3 +26,5 @@ export class UndoStack<S> {
 		return this.stack.length;
 	}
 }
+
+export { UndoStack as RedoStack };

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2051,6 +2051,31 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "hello");
 		});
 
+		it("redoes undone edits without clearing the redo stack", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			for (const char of "hello world") editor.handleInput(char);
+			editor.handleInput("\x1b[45;5u"); // Undo to "hello"
+			editor.handleInput("\x1b[45;5u"); // Undo to ""
+			assert.strictEqual(editor.getText(), "");
+
+			editor.handleInput("\x1b[45;6u"); // Ctrl+Shift+- redo to "hello"
+			assert.strictEqual(editor.getText(), "hello");
+			editor.handleInput("\x1b[45;6u"); // Ctrl+Shift+- redo to "hello world"
+			assert.strictEqual(editor.getText(), "hello world");
+		});
+
+		it("clears redo on a new edit after undo", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+
+			for (const char of "hello world") editor.handleInput(char);
+			editor.handleInput("\x1b[45;5u"); // Undo to "hello"
+			editor.handleInput("!");
+			editor.handleInput("\x1b[45;6u"); // Ctrl+Shift+- should be a no-op
+
+			assert.strictEqual(editor.getText(), "hello!");
+		});
+
 		it("undoes autocomplete", async () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -623,6 +623,21 @@ describe("Input component", () => {
 			assert.strictEqual(input.getValue(), "hello world");
 		});
 
+		it("redoes undone edits and clears redo on a new edit", () => {
+			const input = new Input();
+
+			for (const char of "hello world") input.handleInput(char);
+			input.handleInput("\x1b[45;5u"); // Undo to "hello"
+			input.handleInput("\x1b[45;5u"); // Undo to ""
+			assert.strictEqual(input.getValue(), "");
+
+			input.handleInput("\x1b[45;6u"); // Ctrl+Shift+- redo to "hello"
+			assert.strictEqual(input.getValue(), "hello");
+			input.handleInput("!");
+			input.handleInput("\x1b[45;6u"); // Ctrl+Shift+- should be a no-op
+			assert.strictEqual(input.getValue(), "hello!");
+		});
+
 		it("cursor movement starts new undo unit", () => {
 			const input = new Input();
 

--- a/packages/tui/test/keybindings.test.ts
+++ b/packages/tui/test/keybindings.test.ts
@@ -11,6 +11,13 @@ describe("KeybindingsManager", () => {
 		assert.strictEqual(keybindings.matches("\x1b[106;5u", "tui.input.newLine"), true);
 	});
 
+	it("binds Ctrl+Shift+- as the default redo key", () => {
+		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS);
+
+		assert.deepStrictEqual(keybindings.getKeys("tui.editor.redo"), ["ctrl+shift+-"]);
+		assert.strictEqual(keybindings.matches("\x1b[45;6u", "tui.editor.redo"), true);
+	});
+
 	it("does not evict selector confirm when input submit is rebound", () => {
 		const keybindings = new KeybindingsManager(TUI_KEYBINDINGS, {
 			"tui.input.submit": ["enter", "ctrl+enter"],


### PR DESCRIPTION
This follows up on https://github.com/earendil-works/pi/issues/959, specifically, adding support for the redo operation.

The original issue appears to have been closed following agreement over how text selection, cut and copy operations to the system clipboard are not really expected shell app features[^1] (which I agree with, fwiw), however there was no reservation about supporting the redo operation (which is functionally symmetric to the undo operation)[^2].

This implements the redo operation similar to the existing undo mechanism, adopting the proposed default of `Ctrl+Shift+-` as a configurable default (which would also enable users of feature-limited terminal to configure them as required).

[^1]: https://github.com/earendil-works/pi/issues/959#issuecomment-3814691681
[^2]: https://github.com/earendil-works/pi/issues/959#issuecomment-3803705892