### PR TITLE
add environment variable for PI_SKILL_PATH

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -374,6 +374,7 @@ ${chalk.bold("Environment Variables:")}
   ${ENV_AGENT_DIR.padEnd(32)} - Config directory (default: ~/${CONFIG_DIR_NAME}/agent)
   ${ENV_SESSION_DIR.padEnd(32)} - Session storage directory (overridden by --session-dir)
   PI_PACKAGE_DIR                   - Override package directory (for Nix/Guix store paths)
+  PI_SKILL_PATH                    - Colon-separated list of skill paths (merged with --skill)
   PI_OFFLINE                       - Disable startup network operations when set to 1/true/yes
   PI_TELEMETRY                     - Override install telemetry when set to 1/true/yes or 0/false/no
   PI_SHARE_VIEWER_URL              - Base URL for /share command (default: https://pi.dev/session/)

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -5,6 +5,7 @@
  * createAgentSession() options. The SDK does the heavy lifting.
  */
 
+import { delimiter } from "node:path";
 import { createInterface } from "node:readline";
 import { type ImageContent, modelsAreEqual } from "@earendil-works/pi-ai";
 import chalk from "chalk";
@@ -603,7 +604,9 @@ export async function main(args: string[], options?: MainOptions) {
 	const projectTrustByCwd = new Map<string, boolean>();
 
 	const resolvedExtensionPaths = resolveCliPaths(cwd, parsed.extensions);
-	const resolvedSkillPaths = resolveCliPaths(cwd, parsed.skills);
+	const envSkillPaths = process.env.PI_SKILL_PATH?.split(delimiter) ?? [];
+	const resolvedSkillPaths = resolveCliPaths(cwd, [...envSkillPaths, ...(parsed.skills ?? [])]);
+
 	const resolvedPromptTemplatePaths = resolveCliPaths(cwd, parsed.promptTemplates);
 	const resolvedThemePaths = resolveCliPaths(cwd, parsed.themes);
 	const authStorage = AuthStorage.create();


### PR DESCRIPTION
I have skills in different locations for my repos. 

Rather than remember to use the CLI to point to different skills, I would like to set a .envrc file to point to the skills location per repo.

Testing:

```
PI_SKILL_PATH="cmd/experimental/skills" node ../pi/packages/coding-agent/dist/cli.js
[Context]                                                                                                                                                                                                                                                                                 
  AGENTS.md                                                                                                                                                                                                                                                                               

[Skills]                                                                                                                                                                                                                                                                                  
  algorithm-comments, api-field-comments, architectural-decisions, buggy-behavior, code-eval, code-style, comments, encapsulate-paired-ops, extract-helpers, feature-gated-code, integration-tests-for-updates, kueue-flake-debugger, kueue-lineage, kueue-release-notes,                 
kueue-who-preempted, metrics-feature-gates, metrics-label-sets, push-guards-to-callees, race-conditions, security, split-test-files, table-driven-tests, terminology-semantics, visibility-exports, was-cluster                                                                           

[Extensions]                                                                                                                                                                                                                                                                              
  @twogiants/pi-anthropic-vertex, huggingface/pi-llama                                                                                                                                                                                                                                    

[Skill conflicts]                                                                                                                                                                                                                                                                         
  ~/Work/kueue/cmd/experimental/skills/README.md                                                                                                                                                                                                                                          
    description is required                                                                                                                                                                                                                                                               
```