### PR TITLE
fix(ai): return empty string for empty tool results instead of "(see attached image)"

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1018,19 +1018,17 @@ export function convertMessages(
 			for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
 				const toolMsg = transformedMessages[j] as ToolResultMessage;
 
-				// Extract text and image content
 				const textResult = toolMsg.content
 					.filter(isTextContentBlock)
 					.map((block) => block.text)
 					.join("\n");
-				const hasImages = toolMsg.content.some((c) => c.type === "image");
+				const imageContent = model.input.includes("image") ? toolMsg.content.filter(isImageContentBlock) : [];
+				const hasImages = imageContent.length > 0;
 
-				// Always send tool result with text (or placeholder if only images)
 				const hasText = textResult.length > 0;
-				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
-					content: sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : ""),
+					content: sanitizeSurrogates(hasText ? textResult : ""),
 					tool_call_id: toolMsg.toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {
@@ -1038,16 +1036,14 @@ export function convertMessages(
 				}
 				params.push(toolResultMsg);
 
-				if (hasImages && model.input.includes("image")) {
-					for (const block of toolMsg.content) {
-						if (isImageContentBlock(block)) {
-							imageBlocks.push({
-								type: "image_url",
-								image_url: {
-									url: `data:${block.mimeType};base64,${block.data}`,
-								},
-							});
-						}
+				if (hasImages) {
+					for (const block of imageContent) {
+						imageBlocks.push({
+							type: "image_url",
+							image_url: {
+								url: `data:${block.mimeType};base64,${block.data}`,
+							},
+						});
 					}
 				}
 			}

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1030,7 +1030,7 @@ export function convertMessages(
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
-					content: sanitizeSurrogates(hasText ? textResult : "(see attached image)"),
+					content: sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : ""),
 					tool_call_id: toolMsg.toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -220,16 +220,18 @@ export function convertResponsesMessages<TApi extends Api>(
 			if (output.length === 0) continue;
 			messages.push(...output);
 		} else if (msg.role === "toolResult") {
-			const textResult = msg.content
-				.filter((c): c is TextContent => c.type === "text")
-				.map((c) => c.text)
-				.join("\n");
-			const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
+			const textContent = msg.content.filter((c): c is TextContent => c.type === "text");
+			const textResult = textContent.map((c) => c.text).join("\n");
+			const imageContent = model.input.includes("image")
+				? msg.content.filter((c): c is ImageContent => c.type === "image")
+				: [];
+
 			const hasText = textResult.length > 0;
+			const hasImages = imageContent.length > 0;
 			const [callId] = msg.toolCallId.split("|");
 
 			let output: string | ResponseFunctionCallOutputItemList;
-			if (hasImages && model.input.includes("image")) {
+			if (hasImages) {
 				const contentParts: ResponseFunctionCallOutputItemList = [];
 
 				if (hasText) {
@@ -239,19 +241,17 @@ export function convertResponsesMessages<TApi extends Api>(
 					});
 				}
 
-				for (const block of msg.content) {
-					if (block.type === "image") {
-						contentParts.push({
-							type: "input_image",
-							detail: "auto",
-							image_url: `data:${block.mimeType};base64,${block.data}`,
-						});
-					}
+				for (const block of imageContent) {
+					contentParts.push({
+						type: "input_image",
+						detail: "auto",
+						image_url: `data:${block.mimeType};base64,${block.data}`,
+					});
 				}
 
 				output = contentParts;
 			} else {
-				output = sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : "");
+				output = sanitizeSurrogates(hasText ? textResult : "");
 			}
 
 			messages.push({

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -251,7 +251,7 @@ export function convertResponsesMessages<TApi extends Api>(
 
 				output = contentParts;
 			} else {
-				output = sanitizeSurrogates(hasText ? textResult : "(see attached image)");
+				output = sanitizeSurrogates(hasText ? textResult : hasImages ? "(see attached image)" : "");
 			}
 
 			messages.push({


### PR DESCRIPTION
Fixes #6103.

## Problem
When a tool call returns empty text with no images (e.g., a successful replace/edit operation that produces no output), both the OpenAI Responses and Completions API handlers incorrectly returned "(see attached image)" as the tool message content. This misleads the model into thinking an image was attached when none exists.

## Root Cause
The ternary expression `hasText ? textResult : "(see attached image)"` fell through to the image placeholder whenever text was empty, without checking whether images were actually present.

## Fix
Mirrors the existing correct behavior in `google-shared.ts` (line 193): `hasText ? text : hasImages ? "(see attached image)" : ""`.

Additionally, for the Completions API path, images are already sent as separate `image_url` content blocks in `imageBlocks`, so the `tool` message text content never needs the "(see attached image)" placeholder at all - an empty string is correct when there is no text.

- Pre-filters `imageContent` once (guarded by `model.input.includes("image")`) instead of filtering twice
- For Responses API: uses structured content parts when images exist, empty string when no images and no text
- For Completions API: always uses `textResult` or empty string (images go to imageBlocks separately)

## Verification
- All pre-commit checks pass (`npm run check`)
- AI package tests pass (419 passed, 727 skipped due to missing API keys)