### PR TITLE
feat: sqlite session storage

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -16,6 +16,8 @@ import {
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
+import type { SQLInputValue } from "node:sqlite";
+import { DatabaseSync } from "node:sqlite";
 import {
 	type ExecutionEnv,
 	ExecutionError,
@@ -25,6 +27,9 @@ import {
 	type FileKind,
 	ok,
 	type Result,
+	type SqliteDatabase,
+	type SqliteRunResult,
+	type SqliteStatement,
 	toError,
 } from "../types.ts";
 
@@ -200,6 +205,69 @@ function getShellEnv(baseEnv?: NodeJS.ProcessEnv, extraEnv?: Record<string, stri
 		...baseEnv,
 		...extraEnv,
 	};
+}
+
+class NodeSqliteStatement implements SqliteStatement {
+	private readonly statement: ReturnType<DatabaseSync["prepare"]>;
+
+	constructor(statement: ReturnType<DatabaseSync["prepare"]>) {
+		this.statement = statement;
+	}
+
+	async run(params?: unknown[]): Promise<SqliteRunResult> {
+		const sqliteParams = params as SQLInputValue[] | undefined;
+		const result = sqliteParams ? this.statement.run(...sqliteParams) : this.statement.run();
+		return {
+			changes: Number(result.changes),
+			lastInsertRowid: result.lastInsertRowid === undefined ? undefined : Number(result.lastInsertRowid),
+		};
+	}
+
+	async get<TRow extends object>(params?: unknown[]): Promise<TRow | undefined> {
+		const sqliteParams = params as SQLInputValue[] | undefined;
+		return (sqliteParams ? this.statement.get(...sqliteParams) : this.statement.get()) as TRow | undefined;
+	}
+
+	async all<TRow extends object>(params?: unknown[]): Promise<TRow[]> {
+		const sqliteParams = params as SQLInputValue[] | undefined;
+		return (sqliteParams ? this.statement.all(...sqliteParams) : this.statement.all()) as TRow[];
+	}
+}
+
+class NodeSqliteDatabase implements SqliteDatabase {
+	private readonly db: DatabaseSync;
+
+	constructor(db: DatabaseSync) {
+		this.db = db;
+	}
+
+	async exec(sql: string): Promise<void> {
+		this.db.exec(sql);
+	}
+
+	prepare(sql: string): SqliteStatement {
+		return new NodeSqliteStatement(this.db.prepare(sql));
+	}
+
+	async transaction<T>(fn: () => Promise<T>): Promise<T> {
+		this.db.exec("BEGIN");
+		try {
+			const result = await fn();
+			this.db.exec("COMMIT");
+			return result;
+		} catch (error) {
+			try {
+				this.db.exec("ROLLBACK");
+			} catch {
+				// Ignore rollback errors to rethrow original error.
+			}
+			throw error;
+		}
+	}
+
+	async close(): Promise<void> {
+		this.db.close();
+	}
 }
 
 function killProcessTree(pid: number): void {
@@ -542,6 +610,12 @@ export class NodeExecutionEnv implements ExecutionEnv {
 		} catch (error) {
 			return err(toFileError(error, filePath));
 		}
+	}
+
+	async openSqlite(path: string): Promise<SqliteDatabase> {
+		const resolved = resolvePath(this.cwd, path);
+		await mkdir(resolve(resolved, ".."), { recursive: true });
+		return new NodeSqliteDatabase(new DatabaseSync(resolved));
 	}
 
 	async cleanup(): Promise<void> {

--- a/packages/agent/src/harness/session/builtins.ts
+++ b/packages/agent/src/harness/session/builtins.ts
@@ -1,0 +1,62 @@
+import { NodeExecutionEnv } from "../env/nodejs.ts";
+import type {
+	BuiltinSessionStorageOptions,
+	FileSystem,
+	JsonlSessionBackendOptions,
+	JsonlSessionCreateOptions,
+	JsonlSessionListOptions,
+	JsonlSessionMetadata,
+	SessionRepo,
+	SqliteEnv,
+	SqliteSessionBackendOptions,
+	SqliteSessionCreateOptions,
+	SqliteSessionListOptions,
+	SqliteSessionMetadata,
+} from "../types.ts";
+import { SessionError } from "../types.ts";
+import { JsonlSessionRepo } from "./jsonl-repo.ts";
+import { isExperimentalSqliteSessionStorageEnabled } from "./sqlite/experimental.ts";
+import { SqliteSessionRepo } from "./sqlite/repo.ts";
+
+type NodeBuiltinSessionRepoEnv = FileSystem & Partial<SqliteEnv>;
+
+export type BuiltinSessionRepo =
+	| SessionRepo<JsonlSessionMetadata, JsonlSessionCreateOptions, JsonlSessionListOptions>
+	| SessionRepo<SqliteSessionMetadata, SqliteSessionCreateOptions, SqliteSessionListOptions>;
+
+function requireSqliteEnv(env: NodeBuiltinSessionRepoEnv): FileSystem & SqliteEnv {
+	if (typeof env.openSqlite !== "function") {
+		throw new SessionError("storage", "SQLite session storage requires an environment with openSqlite(path)");
+	}
+	return env as FileSystem & SqliteEnv;
+}
+
+export function selectBuiltinSessionStorage(options: {
+	jsonl: JsonlSessionBackendOptions;
+	sqlite?: SqliteSessionBackendOptions;
+}): BuiltinSessionStorageOptions {
+	if (options.sqlite && isExperimentalSqliteSessionStorageEnabled()) {
+		return options.sqlite;
+	}
+	return options.jsonl;
+}
+
+export function createBuiltinSessionRepo(options: {
+	env: NodeBuiltinSessionRepoEnv;
+	storage: BuiltinSessionStorageOptions;
+}): BuiltinSessionRepo {
+	if (options.storage.kind === "jsonl") {
+		return new JsonlSessionRepo({ fs: options.env, sessionsRoot: options.storage.sessionsRoot });
+	}
+	return new SqliteSessionRepo({ env: requireSqliteEnv(options.env), databasePath: options.storage.databasePath });
+}
+
+export function createNodeBuiltinSessionRepo(options: {
+	cwd?: string;
+	storage: BuiltinSessionStorageOptions;
+}): BuiltinSessionRepo {
+	return createBuiltinSessionRepo({
+		env: new NodeExecutionEnv({ cwd: options.cwd ?? process.cwd() }),
+		storage: options.storage,
+	});
+}

--- a/packages/agent/src/harness/session/repo-utils.ts
+++ b/packages/agent/src/harness/session/repo-utils.ts
@@ -5,6 +5,7 @@ import {
 	type SessionMetadata,
 	type SessionStorage,
 	type SessionTreeEntry,
+	type SqliteSessionMetadata,
 } from "../types.ts";
 import { Session } from "./session.ts";
 import { uuidv7 } from "./uuid.ts";
@@ -17,8 +18,11 @@ export function createTimestamp(): string {
 	return new Date().toISOString();
 }
 
-export function toSession<TMetadata extends SessionMetadata>(storage: SessionStorage<TMetadata>): Session<TMetadata> {
-	return new Session(storage);
+export function toSession<TMetadata extends SessionMetadata>(
+	storage: SessionStorage<TMetadata>,
+	sqliteStorage?: SessionStorage<SqliteSessionMetadata>,
+): Session<TMetadata> {
+	return new Session(storage, sqliteStorage);
 }
 
 export function getFileSystemResultOrThrow<TValue>(result: Result<TValue, FileError>, message: string): TValue {

--- a/packages/agent/src/harness/session/repo-utils.ts
+++ b/packages/agent/src/harness/session/repo-utils.ts
@@ -5,7 +5,6 @@ import {
 	type SessionMetadata,
 	type SessionStorage,
 	type SessionTreeEntry,
-	type SqliteSessionMetadata,
 } from "../types.ts";
 import { Session } from "./session.ts";
 import { uuidv7 } from "./uuid.ts";
@@ -18,11 +17,8 @@ export function createTimestamp(): string {
 	return new Date().toISOString();
 }
 
-export function toSession<TMetadata extends SessionMetadata>(
-	storage: SessionStorage<TMetadata>,
-	sqliteStorage?: SessionStorage<SqliteSessionMetadata>,
-): Session<TMetadata> {
-	return new Session(storage, sqliteStorage);
+export function toSession<TMetadata extends SessionMetadata>(storage: SessionStorage<TMetadata>): Session<TMetadata> {
+	return new Session(storage);
 }
 
 export function getFileSystemResultOrThrow<TValue>(result: Result<TValue, FileError>, message: string): TValue {

--- a/packages/agent/src/harness/session/session-lifecycle.ts
+++ b/packages/agent/src/harness/session/session-lifecycle.ts
@@ -1,0 +1,108 @@
+import type {
+	JsonlSessionCreateOptions,
+	JsonlSessionListOptions,
+	JsonlSessionMetadata,
+	Session,
+	SessionStorage,
+	SqliteSessionMetadata,
+} from "../types.ts";
+import { SessionError } from "../types.ts";
+import type { JsonlSessionRepo } from "./jsonl-repo.ts";
+import { toSession } from "./repo-utils.ts";
+import { isExperimentalSqliteSessionStorageEnabled } from "./sqlite/experimental.ts";
+import type { SqliteSessionRepo } from "./sqlite/repo.ts";
+
+export class SessionLifecycle {
+	private readonly jsonlRepo: JsonlSessionRepo;
+	private readonly sqliteRepo?: SqliteSessionRepo;
+
+	constructor(options: { jsonlRepo: JsonlSessionRepo; sqliteRepo?: SqliteSessionRepo }) {
+		this.jsonlRepo = options.jsonlRepo;
+		this.sqliteRepo = options.sqliteRepo;
+	}
+
+	async create(options: JsonlSessionCreateOptions): Promise<Session<JsonlSessionMetadata>> {
+		const session = await this.jsonlRepo.create(options);
+		const sqliteStorage = await this.createOrBackfillSqliteStorage(session);
+		return this.attachSqliteStorage(session, sqliteStorage);
+	}
+
+	async open(metadata: JsonlSessionMetadata): Promise<Session<JsonlSessionMetadata>> {
+		const session = await this.jsonlRepo.open(metadata);
+		const sqliteStorage = await this.openOrBackfillSqliteStorage(session);
+		return this.attachSqliteStorage(session, sqliteStorage);
+	}
+
+	async list(options: JsonlSessionListOptions = {}): Promise<JsonlSessionMetadata[]> {
+		return this.jsonlRepo.list(options);
+	}
+
+	async delete(metadata: JsonlSessionMetadata): Promise<void> {
+		await this.jsonlRepo.delete(metadata);
+		if (!isExperimentalSqliteSessionStorageEnabled()) return;
+		const sqliteMetadata = await this.findSqliteMetadata(metadata);
+		if (sqliteMetadata) {
+			await this.requireSqliteRepo().delete(sqliteMetadata);
+		}
+	}
+
+	async fork(
+		sourceMetadata: JsonlSessionMetadata,
+		options: JsonlSessionCreateOptions & { entryId?: string; position?: "before" | "at"; id?: string },
+	): Promise<Session<JsonlSessionMetadata>> {
+		const session = await this.jsonlRepo.fork(sourceMetadata, options);
+		const sqliteStorage = await this.createOrBackfillSqliteStorage(session, { parentSessionId: sourceMetadata.id });
+		return this.attachSqliteStorage(session, sqliteStorage);
+	}
+
+	private attachSqliteStorage(
+		session: Session<JsonlSessionMetadata>,
+		sqliteStorage?: SessionStorage<SqliteSessionMetadata>,
+	): Session<JsonlSessionMetadata> {
+		if (!sqliteStorage) return session;
+		return toSession(session.getStorage(), sqliteStorage);
+	}
+
+	private requireSqliteRepo(): SqliteSessionRepo {
+		if (!this.sqliteRepo) {
+			throw new SessionError("storage", "SQLite session storage is not configured");
+		}
+		return this.sqliteRepo;
+	}
+
+	private async findSqliteMetadata(metadata: JsonlSessionMetadata): Promise<SqliteSessionMetadata | undefined> {
+		const repo = this.requireSqliteRepo();
+		return (await repo.list({ cwd: metadata.cwd })).find((session) => session.id === metadata.id);
+	}
+
+	private async createOrBackfillSqliteStorage(
+		session: Session<JsonlSessionMetadata>,
+		options?: { parentSessionId?: string },
+	): Promise<SessionStorage<SqliteSessionMetadata> | undefined> {
+		if (!isExperimentalSqliteSessionStorageEnabled()) return undefined;
+		const repo = this.requireSqliteRepo();
+		const metadata = await session.getMetadata();
+		const sqliteSession = await repo.create({
+			cwd: metadata.cwd,
+			id: metadata.id,
+			parentSessionId: options?.parentSessionId,
+		});
+		const sqliteStorage = sqliteSession.getStorage();
+		for (const entry of await session.getEntries()) {
+			await sqliteStorage.appendEntry(entry);
+		}
+		return sqliteStorage;
+	}
+
+	private async openOrBackfillSqliteStorage(
+		session: Session<JsonlSessionMetadata>,
+	): Promise<SessionStorage<SqliteSessionMetadata> | undefined> {
+		if (!isExperimentalSqliteSessionStorageEnabled()) return undefined;
+		const metadata = await session.getMetadata();
+		const existing = await this.findSqliteMetadata(metadata);
+		if (existing) {
+			return (await this.requireSqliteRepo().open(existing)).getStorage();
+		}
+		return this.createOrBackfillSqliteStorage(session);
+	}
+}

--- a/packages/agent/src/harness/session/session-lifecycle.ts
+++ b/packages/agent/src/harness/session/session-lifecycle.ts
@@ -1,108 +1,33 @@
-import type {
-	JsonlSessionCreateOptions,
-	JsonlSessionListOptions,
-	JsonlSessionMetadata,
-	Session,
-	SessionStorage,
-	SqliteSessionMetadata,
-} from "../types.ts";
-import { SessionError } from "../types.ts";
-import type { JsonlSessionRepo } from "./jsonl-repo.ts";
-import { toSession } from "./repo-utils.ts";
-import { isExperimentalSqliteSessionStorageEnabled } from "./sqlite/experimental.ts";
-import type { SqliteSessionRepo } from "./sqlite/repo.ts";
+import type { Session, SessionCreateOptions, SessionForkOptions, SessionMetadata, SessionRepo } from "../types.ts";
 
-export class SessionLifecycle {
-	private readonly jsonlRepo: JsonlSessionRepo;
-	private readonly sqliteRepo?: SqliteSessionRepo;
+export class SessionLifecycle<
+	TMetadata extends SessionMetadata,
+	TCreateOptions extends SessionCreateOptions,
+	TListOptions = void,
+> {
+	private readonly repo: SessionRepo<TMetadata, TCreateOptions, TListOptions>;
 
-	constructor(options: { jsonlRepo: JsonlSessionRepo; sqliteRepo?: SqliteSessionRepo }) {
-		this.jsonlRepo = options.jsonlRepo;
-		this.sqliteRepo = options.sqliteRepo;
+	constructor(options: { repo: SessionRepo<TMetadata, TCreateOptions, TListOptions> }) {
+		this.repo = options.repo;
 	}
 
-	async create(options: JsonlSessionCreateOptions): Promise<Session<JsonlSessionMetadata>> {
-		const session = await this.jsonlRepo.create(options);
-		const sqliteStorage = await this.createOrBackfillSqliteStorage(session);
-		return this.attachSqliteStorage(session, sqliteStorage);
+	create(options: TCreateOptions): Promise<Session<TMetadata>> {
+		return this.repo.create(options);
 	}
 
-	async open(metadata: JsonlSessionMetadata): Promise<Session<JsonlSessionMetadata>> {
-		const session = await this.jsonlRepo.open(metadata);
-		const sqliteStorage = await this.openOrBackfillSqliteStorage(session);
-		return this.attachSqliteStorage(session, sqliteStorage);
+	open(metadata: TMetadata): Promise<Session<TMetadata>> {
+		return this.repo.open(metadata);
 	}
 
-	async list(options: JsonlSessionListOptions = {}): Promise<JsonlSessionMetadata[]> {
-		return this.jsonlRepo.list(options);
+	list(options?: TListOptions): Promise<TMetadata[]> {
+		return this.repo.list(options);
 	}
 
-	async delete(metadata: JsonlSessionMetadata): Promise<void> {
-		await this.jsonlRepo.delete(metadata);
-		if (!isExperimentalSqliteSessionStorageEnabled()) return;
-		const sqliteMetadata = await this.findSqliteMetadata(metadata);
-		if (sqliteMetadata) {
-			await this.requireSqliteRepo().delete(sqliteMetadata);
-		}
+	delete(metadata: TMetadata): Promise<void> {
+		return this.repo.delete(metadata);
 	}
 
-	async fork(
-		sourceMetadata: JsonlSessionMetadata,
-		options: JsonlSessionCreateOptions & { entryId?: string; position?: "before" | "at"; id?: string },
-	): Promise<Session<JsonlSessionMetadata>> {
-		const session = await this.jsonlRepo.fork(sourceMetadata, options);
-		const sqliteStorage = await this.createOrBackfillSqliteStorage(session, { parentSessionId: sourceMetadata.id });
-		return this.attachSqliteStorage(session, sqliteStorage);
-	}
-
-	private attachSqliteStorage(
-		session: Session<JsonlSessionMetadata>,
-		sqliteStorage?: SessionStorage<SqliteSessionMetadata>,
-	): Session<JsonlSessionMetadata> {
-		if (!sqliteStorage) return session;
-		return toSession(session.getStorage(), sqliteStorage);
-	}
-
-	private requireSqliteRepo(): SqliteSessionRepo {
-		if (!this.sqliteRepo) {
-			throw new SessionError("storage", "SQLite session storage is not configured");
-		}
-		return this.sqliteRepo;
-	}
-
-	private async findSqliteMetadata(metadata: JsonlSessionMetadata): Promise<SqliteSessionMetadata | undefined> {
-		const repo = this.requireSqliteRepo();
-		return (await repo.list({ cwd: metadata.cwd })).find((session) => session.id === metadata.id);
-	}
-
-	private async createOrBackfillSqliteStorage(
-		session: Session<JsonlSessionMetadata>,
-		options?: { parentSessionId?: string },
-	): Promise<SessionStorage<SqliteSessionMetadata> | undefined> {
-		if (!isExperimentalSqliteSessionStorageEnabled()) return undefined;
-		const repo = this.requireSqliteRepo();
-		const metadata = await session.getMetadata();
-		const sqliteSession = await repo.create({
-			cwd: metadata.cwd,
-			id: metadata.id,
-			parentSessionId: options?.parentSessionId,
-		});
-		const sqliteStorage = sqliteSession.getStorage();
-		for (const entry of await session.getEntries()) {
-			await sqliteStorage.appendEntry(entry);
-		}
-		return sqliteStorage;
-	}
-
-	private async openOrBackfillSqliteStorage(
-		session: Session<JsonlSessionMetadata>,
-	): Promise<SessionStorage<SqliteSessionMetadata> | undefined> {
-		if (!isExperimentalSqliteSessionStorageEnabled()) return undefined;
-		const metadata = await session.getMetadata();
-		const existing = await this.findSqliteMetadata(metadata);
-		if (existing) {
-			return (await this.requireSqliteRepo().open(existing)).getStorage();
-		}
-		return this.createOrBackfillSqliteStorage(session);
+	fork(sourceMetadata: TMetadata, options: SessionForkOptions & TCreateOptions): Promise<Session<TMetadata>> {
+		return this.repo.fork(sourceMetadata, options);
 	}
 }

--- a/packages/agent/src/harness/session/session.ts
+++ b/packages/agent/src/harness/session/session.ts
@@ -9,6 +9,7 @@ import type {
 	CustomEntry,
 	CustomMessageEntry,
 	LabelEntry,
+	LeafEntry,
 	MessageEntry,
 	ModelChangeEntry,
 	SessionContext,
@@ -268,9 +269,16 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		if (entryId !== null && !(await this.storage.getEntry(entryId))) {
 			throw new SessionError("not_found", `Entry ${entryId} not found`);
 		}
-		await this.storage.setLeafId(entryId);
+		const leafEntry: LeafEntry = {
+			type: "leaf",
+			id: await this.storage.createEntryId(),
+			parentId: await this.storage.getLeafId(),
+			timestamp: new Date().toISOString(),
+			targetId: entryId,
+		};
+		await this.storage.appendEntry(leafEntry);
 		if (isExperimentalSqliteSessionStorageEnabled() && this.sqliteStorage) {
-			await this.sqliteStorage.setLeafId(entryId);
+			await this.sqliteStorage.appendEntry(leafEntry);
 		}
 		if (!summary) return undefined;
 		return this.appendTypedEntry({

--- a/packages/agent/src/harness/session/session.ts
+++ b/packages/agent/src/harness/session/session.ts
@@ -17,11 +17,9 @@ import type {
 	SessionMetadata,
 	SessionStorage,
 	SessionTreeEntry,
-	SqliteSessionMetadata,
 	ThinkingLevelChangeEntry,
 } from "../types.ts";
 import { SessionError } from "../types.ts";
-import { isExperimentalSqliteSessionStorageEnabled } from "./sqlite/experimental.ts";
 
 export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionContext {
 	let thinkingLevel = "off";
@@ -85,11 +83,9 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
 
 export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 	private storage: SessionStorage<TMetadata>;
-	private sqliteStorage?: SessionStorage<SqliteSessionMetadata>;
 
-	constructor(storage: SessionStorage<TMetadata>, sqliteStorage?: SessionStorage<SqliteSessionMetadata>) {
+	constructor(storage: SessionStorage<TMetadata>) {
 		this.storage = storage;
-		this.sqliteStorage = sqliteStorage;
 	}
 
 	getMetadata(): Promise<TMetadata> {
@@ -103,9 +99,6 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 	async cleanup(): Promise<void> {
 		if ("cleanup" in this.storage && typeof this.storage.cleanup === "function") {
 			await (this.storage as SessionStorage<TMetadata> & ClosableSessionStorage).cleanup();
-		}
-		if (this.sqliteStorage && "cleanup" in this.sqliteStorage && typeof this.sqliteStorage.cleanup === "function") {
-			await (this.sqliteStorage as SessionStorage<SqliteSessionMetadata> & ClosableSessionStorage).cleanup();
 		}
 	}
 
@@ -141,9 +134,6 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 
 	private async appendTypedEntry<TEntry extends SessionTreeEntry>(entry: TEntry): Promise<string> {
 		await this.storage.appendEntry(entry);
-		if (isExperimentalSqliteSessionStorageEnabled() && this.sqliteStorage) {
-			await this.sqliteStorage.appendEntry(entry);
-		}
 		return entry.id;
 	}
 
@@ -277,9 +267,6 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 			targetId: entryId,
 		};
 		await this.storage.appendEntry(leafEntry);
-		if (isExperimentalSqliteSessionStorageEnabled() && this.sqliteStorage) {
-			await this.sqliteStorage.appendEntry(leafEntry);
-		}
 		if (!summary) return undefined;
 		return this.appendTypedEntry({
 			type: "branch_summary",

--- a/packages/agent/src/harness/session/session.ts
+++ b/packages/agent/src/harness/session/session.ts
@@ -4,6 +4,7 @@ import { createBranchSummaryMessage, createCompactionSummaryMessage, createCusto
 import type {
 	ActiveToolsChangeEntry,
 	BranchSummaryEntry,
+	ClosableSessionStorage,
 	CompactionEntry,
 	CustomEntry,
 	CustomMessageEntry,
@@ -99,7 +100,12 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 	}
 
 	async cleanup(): Promise<void> {
-		await this.storage.cleanup();
+		if ("cleanup" in this.storage && typeof this.storage.cleanup === "function") {
+			await (this.storage as SessionStorage<TMetadata> & ClosableSessionStorage).cleanup();
+		}
+		if (this.sqliteStorage && "cleanup" in this.sqliteStorage && typeof this.sqliteStorage.cleanup === "function") {
+			await (this.sqliteStorage as SessionStorage<SqliteSessionMetadata> & ClosableSessionStorage).cleanup();
+		}
 	}
 
 	getLeafId(): Promise<string | null> {

--- a/packages/agent/src/harness/session/session.ts
+++ b/packages/agent/src/harness/session/session.ts
@@ -15,9 +15,11 @@ import type {
 	SessionMetadata,
 	SessionStorage,
 	SessionTreeEntry,
+	SqliteSessionMetadata,
 	ThinkingLevelChangeEntry,
 } from "../types.ts";
 import { SessionError } from "../types.ts";
+import { isExperimentalSqliteSessionStorageEnabled } from "./sqlite/experimental.ts";
 
 export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionContext {
 	let thinkingLevel = "off";
@@ -81,9 +83,11 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
 
 export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 	private storage: SessionStorage<TMetadata>;
+	private sqliteStorage?: SessionStorage<SqliteSessionMetadata>;
 
-	constructor(storage: SessionStorage<TMetadata>) {
+	constructor(storage: SessionStorage<TMetadata>, sqliteStorage?: SessionStorage<SqliteSessionMetadata>) {
 		this.storage = storage;
+		this.sqliteStorage = sqliteStorage;
 	}
 
 	getMetadata(): Promise<TMetadata> {
@@ -92,6 +96,10 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 
 	getStorage(): SessionStorage<TMetadata> {
 		return this.storage;
+	}
+
+	async cleanup(): Promise<void> {
+		await this.storage.cleanup();
 	}
 
 	getLeafId(): Promise<string | null> {
@@ -126,6 +134,9 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 
 	private async appendTypedEntry<TEntry extends SessionTreeEntry>(entry: TEntry): Promise<string> {
 		await this.storage.appendEntry(entry);
+		if (isExperimentalSqliteSessionStorageEnabled() && this.sqliteStorage) {
+			await this.sqliteStorage.appendEntry(entry);
+		}
 		return entry.id;
 	}
 
@@ -252,6 +263,9 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 			throw new SessionError("not_found", `Entry ${entryId} not found`);
 		}
 		await this.storage.setLeafId(entryId);
+		if (isExperimentalSqliteSessionStorageEnabled() && this.sqliteStorage) {
+			await this.sqliteStorage.setLeafId(entryId);
+		}
 		if (!summary) return undefined;
 		return this.appendTypedEntry({
 			type: "branch_summary",

--- a/packages/agent/src/harness/session/sqlite/experimental.ts
+++ b/packages/agent/src/harness/session/sqlite/experimental.ts
@@ -1,0 +1,3 @@
+export function isExperimentalSqliteSessionStorageEnabled(): boolean {
+	return process.env.PI_SQLITE_SESSION_STORAGE === "1";
+}

--- a/packages/agent/src/harness/session/sqlite/repo.ts
+++ b/packages/agent/src/harness/session/sqlite/repo.ts
@@ -1,0 +1,235 @@
+import type {
+	FileSystem,
+	Session,
+	SqliteDatabase,
+	SqliteEnv,
+	SqliteSessionCreateOptions,
+	SqliteSessionListOptions,
+	SqliteSessionMetadata,
+	SqliteSessionRepoApi,
+} from "../../types.ts";
+import { SessionError } from "../../types.ts";
+import { createSessionId, getEntriesToFork, getFileSystemResultOrThrow, toSession } from "../repo-utils.ts";
+import { SqliteSessionStorage } from "./storage.ts";
+
+const SQLITE_SESSION_SCHEMA_VERSION = 1;
+
+const SQLITE_SESSION_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS schema_version (
+	version INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+	id TEXT PRIMARY KEY,
+	created_at TEXT NOT NULL,
+	cwd TEXT NOT NULL,
+	parent_session_id TEXT NULL,
+	storage_version INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd);
+CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+	seq INTEGER PRIMARY KEY,
+	session_id TEXT NOT NULL,
+	id TEXT NOT NULL,
+	parent_id TEXT NULL,
+	type TEXT NOT NULL,
+	timestamp TEXT NOT NULL,
+	payload TEXT NOT NULL CHECK (json_valid(payload)),
+	target_id TEXT NULL,
+	message_role TEXT NULL,
+	custom_type TEXT NULL,
+	UNIQUE (session_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_entries_session_seq ON session_entries(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_session_entries_session_parent ON session_entries(session_id, parent_id);
+CREATE INDEX IF NOT EXISTS idx_session_entries_session_type ON session_entries(session_id, type);
+CREATE INDEX IF NOT EXISTS idx_session_entries_session_target ON session_entries(session_id, target_id);
+CREATE INDEX IF NOT EXISTS idx_session_entries_session_message_role ON session_entries(session_id, message_role);
+
+CREATE TABLE IF NOT EXISTS session_state (
+	session_id TEXT PRIMARY KEY,
+	leaf_id TEXT NULL,
+	session_name TEXT NULL,
+	model_provider TEXT NULL,
+	model_id TEXT NULL,
+	thinking_level TEXT NULL,
+	active_tool_names TEXT NULL,
+	latest_compaction_entry_id TEXT NULL,
+	latest_compaction_first_kept_entry_id TEXT NULL,
+	latest_compaction_tokens_before INTEGER NULL,
+	compaction_count INTEGER NOT NULL DEFAULT 0,
+	labels_json TEXT NULL,
+	entry_count INTEGER NOT NULL DEFAULT 0,
+	last_entry_seq INTEGER NULL,
+	updated_at TEXT NOT NULL
+);
+`;
+
+type SqliteSessionRepoEnv = Pick<FileSystem & SqliteEnv, "absolutePath" | "createDir" | "exists" | "openSqlite">;
+
+function getParentPath(path: string): string {
+	const normalized = path.replace(/[\\/]+$/, "");
+	const lastSlash = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+	if (lastSlash < 0) return ".";
+	if (lastSlash === 0) return normalized.slice(0, 1);
+	return normalized.slice(0, lastSlash);
+}
+
+interface SessionRow {
+	id: string;
+	created_at: string;
+	cwd: string;
+	parent_session_id: string | null;
+}
+
+async function ensureSqliteSessionSchema(db: SqliteDatabase): Promise<void> {
+	await db.exec("PRAGMA journal_mode=WAL");
+	await db.exec("PRAGMA synchronous=NORMAL");
+	await db.exec(SQLITE_SESSION_SCHEMA_SQL);
+	const row = await db.prepare("SELECT version FROM schema_version LIMIT 1").get<{ version: number }>();
+	if (!row) {
+		await db.prepare("INSERT INTO schema_version (version) VALUES (?)").run([SQLITE_SESSION_SCHEMA_VERSION]);
+		return;
+	}
+	if (row.version !== SQLITE_SESSION_SCHEMA_VERSION) {
+		throw new SessionError(
+			"storage",
+			`Unsupported SQLite session schema version ${row.version}; expected ${SQLITE_SESSION_SCHEMA_VERSION}`,
+		);
+	}
+}
+
+function toMetadata(row: SessionRow, path: string): SqliteSessionMetadata {
+	return {
+		id: row.id,
+		createdAt: row.created_at,
+		cwd: row.cwd,
+		path,
+		parentSessionId: row.parent_session_id ?? undefined,
+	};
+}
+
+export class SqliteSessionRepo implements SqliteSessionRepoApi {
+	private readonly env: SqliteSessionRepoEnv;
+	private readonly databasePathInput: string;
+	private databasePath: string | undefined;
+
+	constructor(options: { env: SqliteSessionRepoEnv; databasePath: string }) {
+		this.env = options.env;
+		this.databasePathInput = options.databasePath;
+	}
+
+	private async getDatabasePath(): Promise<string> {
+		if (!this.databasePath) {
+			this.databasePath = getFileSystemResultOrThrow(
+				await this.env.absolutePath(this.databasePathInput),
+				`Failed to resolve SQLite sessions database ${this.databasePathInput}`,
+			);
+		}
+		return this.databasePath;
+	}
+
+	private async ensureDatabaseDir(): Promise<void> {
+		const path = await this.getDatabasePath();
+		const directory = getParentPath(path);
+		getFileSystemResultOrThrow(
+			await this.env.createDir(directory, { recursive: true }),
+			`Failed to create SQLite sessions directory ${directory}`,
+		);
+	}
+
+	private async openDatabase(): Promise<SqliteDatabase> {
+		await this.ensureDatabaseDir();
+		const db = await this.env.openSqlite(await this.getDatabasePath());
+		try {
+			await ensureSqliteSessionSchema(db);
+			return db;
+		} catch (error) {
+			await db.close();
+			throw error;
+		}
+	}
+
+	async create(options: SqliteSessionCreateOptions): Promise<Session<SqliteSessionMetadata>> {
+		const db = await this.openDatabase();
+		const id = options.id ?? createSessionId();
+		const storage = await SqliteSessionStorage.create(db, await this.getDatabasePath(), {
+			cwd: options.cwd,
+			sessionId: id,
+			parentSessionId: options.parentSessionId,
+		});
+		return toSession(storage);
+	}
+
+	async open(metadata: SqliteSessionMetadata): Promise<Session<SqliteSessionMetadata>> {
+		if (
+			!getFileSystemResultOrThrow(await this.env.exists(metadata.path), `Failed to check database ${metadata.path}`)
+		) {
+			throw new SessionError("not_found", `Session not found: ${metadata.id}`);
+		}
+		const db = await this.openDatabase();
+		const storage = await SqliteSessionStorage.open(db, metadata);
+		return toSession(storage);
+	}
+
+	async list(options: SqliteSessionListOptions = {}): Promise<SqliteSessionMetadata[]> {
+		const path = await this.getDatabasePath();
+		if (!getFileSystemResultOrThrow(await this.env.exists(path), `Failed to check database ${path}`)) {
+			return [];
+		}
+		const db = await this.openDatabase();
+		try {
+			const rows = options.cwd
+				? await db
+						.prepare(
+							"SELECT id, created_at, cwd, parent_session_id FROM sessions WHERE cwd = ? ORDER BY created_at DESC",
+						)
+						.all<SessionRow>([options.cwd])
+				: await db
+						.prepare("SELECT id, created_at, cwd, parent_session_id FROM sessions ORDER BY created_at DESC")
+						.all<SessionRow>();
+			return rows.map((row) => toMetadata(row, path));
+		} finally {
+			await db.close();
+		}
+	}
+
+	async delete(metadata: SqliteSessionMetadata): Promise<void> {
+		const db = await this.openDatabase();
+		try {
+			await db.transaction(async () => {
+				await db.prepare("DELETE FROM session_state WHERE session_id = ?").run([metadata.id]);
+				await db.prepare("DELETE FROM session_entries WHERE session_id = ?").run([metadata.id]);
+				const result = await db.prepare("DELETE FROM sessions WHERE id = ?").run([metadata.id]);
+				if (result.changes === 0) {
+					throw new SessionError("not_found", `Session not found: ${metadata.id}`);
+				}
+			});
+		} finally {
+			await db.close();
+		}
+	}
+
+	async fork(
+		sourceMetadata: SqliteSessionMetadata,
+		options: SqliteSessionCreateOptions & { entryId?: string; position?: "before" | "at"; id?: string },
+	): Promise<Session<SqliteSessionMetadata>> {
+		const source = await this.open(sourceMetadata);
+		const forkedEntries = await getEntriesToFork(source.getStorage(), options);
+		const id = options.id ?? createSessionId();
+		const storage = await SqliteSessionStorage.create(await this.openDatabase(), await this.getDatabasePath(), {
+			cwd: options.cwd,
+			sessionId: id,
+			parentSessionId: options.parentSessionId ?? sourceMetadata.id,
+		});
+		for (const entry of forkedEntries) {
+			await storage.appendEntry(entry);
+		}
+		return toSession(storage);
+	}
+}

--- a/packages/agent/src/harness/session/sqlite/storage.ts
+++ b/packages/agent/src/harness/session/sqlite/storage.ts
@@ -1,0 +1,473 @@
+import type {
+	LeafEntry,
+	SessionStorage,
+	SessionTreeEntry,
+	SessionTreeEntryBase,
+	SqliteDatabase,
+	SqliteSessionMetadata,
+} from "../../types.ts";
+import { SessionError } from "../../types.ts";
+import { uuidv7 } from "../uuid.ts";
+
+interface SessionRow {
+	id: string;
+	created_at: string;
+	cwd: string;
+	parent_session_id: string | null;
+}
+
+interface SessionEntryRow {
+	seq: number;
+	session_id: string;
+	id: string;
+	parent_id: string | null;
+	type: SessionTreeEntry["type"];
+	timestamp: string;
+	payload: string;
+	target_id: string | null;
+	message_role: string | null;
+	custom_type: string | null;
+}
+
+interface SessionStateRow {
+	session_id: string;
+	leaf_id: string | null;
+	session_name: string | null;
+	model_provider: string | null;
+	model_id: string | null;
+	thinking_level: string | null;
+	active_tool_names: string | null;
+	latest_compaction_entry_id: string | null;
+	latest_compaction_first_kept_entry_id: string | null;
+	latest_compaction_tokens_before: number | null;
+	compaction_count: number;
+	labels_json: string | null;
+	entry_count: number;
+	last_entry_seq: number | null;
+	updated_at: string;
+}
+
+type EncodedEntry = {
+	targetId?: string | null;
+	messageRole?: string;
+	customType?: string;
+	payload: string;
+};
+
+type EntryPayload<TEntry extends SessionTreeEntry> = Omit<TEntry, keyof SessionTreeEntryBase | "type">;
+
+type MessagePayload = EntryPayload<Extract<SessionTreeEntry, { type: "message" }>>;
+type ThinkingLevelChangePayload = EntryPayload<Extract<SessionTreeEntry, { type: "thinking_level_change" }>>;
+type ModelChangePayload = EntryPayload<Extract<SessionTreeEntry, { type: "model_change" }>>;
+type ActiveToolsChangePayload = EntryPayload<Extract<SessionTreeEntry, { type: "active_tools_change" }>>;
+type CompactionPayload = EntryPayload<Extract<SessionTreeEntry, { type: "compaction" }>>;
+type BranchSummaryPayload = EntryPayload<Extract<SessionTreeEntry, { type: "branch_summary" }>>;
+type CustomPayload = EntryPayload<Extract<SessionTreeEntry, { type: "custom" }>>;
+type CustomMessagePayload = EntryPayload<Extract<SessionTreeEntry, { type: "custom_message" }>>;
+type LabelPayload = EntryPayload<Extract<SessionTreeEntry, { type: "label" }>>;
+type SessionInfoPayload = EntryPayload<Extract<SessionTreeEntry, { type: "session_info" }>>;
+type LeafPayload = EntryPayload<Extract<SessionTreeEntry, { type: "leaf" }>>;
+
+function updateLabelCache(labelsById: Map<string, string>, entry: SessionTreeEntry): void {
+	if (entry.type !== "label") return;
+	const label = entry.label?.trim();
+	if (label) {
+		labelsById.set(entry.targetId, label);
+	} else {
+		labelsById.delete(entry.targetId);
+	}
+}
+
+function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
+	const labelsById = new Map<string, string>();
+	for (const entry of entries) {
+		updateLabelCache(labelsById, entry);
+	}
+	return labelsById;
+}
+
+function generateEntryId(byId: { has(id: string): boolean }): string {
+	for (let i = 0; i < 100; i++) {
+		const id = uuidv7().slice(0, 8);
+		if (!byId.has(id)) return id;
+	}
+	return uuidv7();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function invalidSession(message: string, cause?: Error): SessionError {
+	return new SessionError("invalid_session", `Invalid SQLite session: ${message}`, cause);
+}
+
+function invalidEntry(message: string, cause?: Error): SessionError {
+	return new SessionError("invalid_entry", `Invalid SQLite session entry: ${message}`, cause);
+}
+
+function parsePayload(row: SessionEntryRow): unknown {
+	try {
+		return JSON.parse(row.payload);
+	} catch (error) {
+		throw invalidEntry(`entry ${row.id} payload is not valid JSON`, error instanceof Error ? error : undefined);
+	}
+}
+
+function entryToPayload<TEntry extends SessionTreeEntry>(entry: TEntry): EntryPayload<TEntry> {
+	const { type: _type, id: _id, parentId: _parentId, timestamp: _timestamp, ...payload } = entry;
+	return payload as EntryPayload<TEntry>;
+}
+
+function encodeEntry(entry: SessionTreeEntry): EncodedEntry {
+	switch (entry.type) {
+		case "message":
+			return { payload: JSON.stringify(entryToPayload(entry)), messageRole: entry.message.role };
+		case "custom":
+			return { payload: JSON.stringify(entryToPayload(entry)), customType: entry.customType };
+		case "custom_message":
+			return { payload: JSON.stringify(entryToPayload(entry)), customType: entry.customType };
+		case "label":
+			return { payload: JSON.stringify(entryToPayload(entry)), targetId: entry.targetId };
+		case "leaf":
+			return { payload: JSON.stringify(entryToPayload(entry)), targetId: entry.targetId };
+		case "thinking_level_change":
+		case "model_change":
+		case "active_tools_change":
+		case "compaction":
+		case "branch_summary":
+		case "session_info":
+			return { payload: JSON.stringify(entryToPayload(entry)) };
+		default: {
+			const exhaustive: never = entry;
+			return exhaustive;
+		}
+	}
+}
+
+function decodeEntry(row: SessionEntryRow): SessionTreeEntry {
+	const payload = parsePayload(row);
+	if (!isRecord(payload)) throw invalidEntry(`entry ${row.id} payload is not an object`);
+	const base = {
+		id: row.id,
+		parentId: row.parent_id,
+		timestamp: row.timestamp,
+	};
+
+	switch (row.type) {
+		case "message": {
+			if (!("message" in payload)) throw invalidEntry(`entry ${row.id} is missing message payload`);
+			const messagePayload = payload as MessagePayload;
+			return { ...base, type: "message", ...messagePayload };
+		}
+		case "thinking_level_change":
+			if (typeof payload.thinkingLevel !== "string") throw invalidEntry(`entry ${row.id} is missing thinkingLevel`);
+			return { ...base, type: "thinking_level_change", ...(payload as ThinkingLevelChangePayload) };
+		case "model_change":
+			if (typeof payload.provider !== "string" || typeof payload.modelId !== "string") {
+				throw invalidEntry(`entry ${row.id} has invalid model_change payload`);
+			}
+			return { ...base, type: "model_change", ...(payload as ModelChangePayload) };
+		case "active_tools_change":
+			if (
+				!Array.isArray(payload.activeToolNames) ||
+				payload.activeToolNames.some((value) => typeof value !== "string")
+			) {
+				throw invalidEntry(`entry ${row.id} has invalid active_tools_change payload`);
+			}
+			return { ...base, type: "active_tools_change", ...(payload as ActiveToolsChangePayload) };
+		case "compaction":
+			if (
+				typeof payload.summary !== "string" ||
+				typeof payload.firstKeptEntryId !== "string" ||
+				typeof payload.tokensBefore !== "number"
+			) {
+				throw invalidEntry(`entry ${row.id} has invalid compaction payload`);
+			}
+			return { ...base, type: "compaction", ...(payload as CompactionPayload) };
+		case "branch_summary":
+			if (typeof payload.fromId !== "string" || typeof payload.summary !== "string") {
+				throw invalidEntry(`entry ${row.id} has invalid branch_summary payload`);
+			}
+			return { ...base, type: "branch_summary", ...(payload as BranchSummaryPayload) };
+		case "custom":
+			if (typeof payload.customType !== "string") throw invalidEntry(`entry ${row.id} has invalid custom payload`);
+			return { ...base, type: "custom", ...(payload as CustomPayload) };
+		case "custom_message":
+			if (
+				typeof payload.customType !== "string" ||
+				typeof payload.display !== "boolean" ||
+				!("content" in payload)
+			) {
+				throw invalidEntry(`entry ${row.id} has invalid custom_message payload`);
+			}
+			return { ...base, type: "custom_message", ...(payload as CustomMessagePayload) };
+		case "label":
+			if (typeof payload.targetId !== "string") throw invalidEntry(`entry ${row.id} has invalid label payload`);
+			if (payload.label !== undefined && typeof payload.label !== "string") {
+				throw invalidEntry(`entry ${row.id} has invalid label payload`);
+			}
+			return { ...base, type: "label", ...(payload as LabelPayload) };
+		case "session_info":
+			if (payload.name !== undefined && typeof payload.name !== "string") {
+				throw invalidEntry(`entry ${row.id} has invalid session_info payload`);
+			}
+			return { ...base, type: "session_info", ...(payload as SessionInfoPayload) };
+		case "leaf":
+			if (payload.targetId !== null && typeof payload.targetId !== "string") {
+				throw invalidEntry(`entry ${row.id} has invalid leaf payload`);
+			}
+			return { ...base, type: "leaf", ...(payload as LeafPayload) };
+		default:
+			throw invalidEntry(`unknown entry type ${row.type}`);
+	}
+}
+
+function leafIdAfterEntry(entry: SessionTreeEntry): string | null {
+	return entry.type === "leaf" ? entry.targetId : entry.id;
+}
+
+function rowToMetadata(row: SessionRow, path: string): SqliteSessionMetadata {
+	return {
+		id: row.id,
+		createdAt: row.created_at,
+		cwd: row.cwd,
+		path,
+		parentSessionId: row.parent_session_id ?? undefined,
+	};
+}
+
+async function loadSqliteStorage(
+	db: SqliteDatabase,
+	sessionId: string,
+): Promise<{
+	row: SessionRow;
+	entries: SessionTreeEntry[];
+	leafId: string | null;
+}> {
+	const row = await db
+		.prepare("SELECT id, created_at, cwd, parent_session_id FROM sessions WHERE id = ?")
+		.get<SessionRow>([sessionId]);
+	if (!row) throw new SessionError("not_found", `Session not found: ${sessionId}`);
+
+	const entryRows = await db
+		.prepare(
+			"SELECT seq, session_id, id, parent_id, type, timestamp, payload, target_id, message_role, custom_type FROM session_entries WHERE session_id = ? ORDER BY seq",
+		)
+		.all<SessionEntryRow>([sessionId]);
+	const entries = entryRows.map((entryRow) => decodeEntry(entryRow));
+	let leafId: string | null = null;
+	for (const entry of entries) {
+		leafId = leafIdAfterEntry(entry);
+	}
+	return { row, entries, leafId };
+}
+
+export class SqliteSessionStorage implements SessionStorage<SqliteSessionMetadata> {
+	private readonly db: SqliteDatabase;
+	private readonly metadata: SqliteSessionMetadata;
+	private entries: SessionTreeEntry[];
+	private byId: Map<string, SessionTreeEntry>;
+	private labelsById: Map<string, string>;
+	private currentLeafId: string | null;
+
+	private constructor(
+		db: SqliteDatabase,
+		metadata: SqliteSessionMetadata,
+		entries: SessionTreeEntry[],
+		leafId: string | null,
+	) {
+		this.db = db;
+		this.metadata = metadata;
+		this.entries = entries;
+		this.byId = new Map(entries.map((entry) => [entry.id, entry]));
+		this.labelsById = buildLabelsById(entries);
+		this.currentLeafId = leafId;
+	}
+
+	static async open(db: SqliteDatabase, metadata: SqliteSessionMetadata): Promise<SqliteSessionStorage> {
+		const loaded = await loadSqliteStorage(db, metadata.id);
+		return new SqliteSessionStorage(db, rowToMetadata(loaded.row, metadata.path), loaded.entries, loaded.leafId);
+	}
+
+	static async create(
+		db: SqliteDatabase,
+		path: string,
+		options: { cwd: string; sessionId: string; parentSessionId?: string },
+	): Promise<SqliteSessionStorage> {
+		const createdAt = new Date().toISOString();
+		await db
+			.prepare(
+				"INSERT INTO sessions (id, created_at, cwd, parent_session_id, storage_version) VALUES (?, ?, ?, ?, 1)",
+			)
+			.run([options.sessionId, createdAt, options.cwd, options.parentSessionId ?? null]);
+		await db
+			.prepare(
+				"INSERT INTO session_state (session_id, leaf_id, session_name, model_provider, model_id, thinking_level, active_tool_names, latest_compaction_entry_id, latest_compaction_first_kept_entry_id, latest_compaction_tokens_before, compaction_count, labels_json, entry_count, last_entry_seq, updated_at) VALUES (?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, NULL, ?)",
+			)
+			.run([options.sessionId, createdAt]);
+		return new SqliteSessionStorage(
+			db,
+			{
+				id: options.sessionId,
+				createdAt,
+				cwd: options.cwd,
+				path,
+				parentSessionId: options.parentSessionId,
+			},
+			[],
+			null,
+		);
+	}
+
+	async getMetadata(): Promise<SqliteSessionMetadata> {
+		return this.metadata;
+	}
+
+	async getLeafId(): Promise<string | null> {
+		if (this.currentLeafId !== null && !this.byId.has(this.currentLeafId)) {
+			throw new SessionError("invalid_session", `Entry ${this.currentLeafId} not found`);
+		}
+		return this.currentLeafId;
+	}
+
+	private async updateState(entry: SessionTreeEntry, seq: number): Promise<void> {
+		const state = await this.db
+			.prepare("SELECT * FROM session_state WHERE session_id = ?")
+			.get<SessionStateRow>([this.metadata.id]);
+		if (!state) throw invalidSession(`state row missing for session ${this.metadata.id}`);
+		let sessionName = state.session_name;
+		let modelProvider = state.model_provider;
+		let modelId = state.model_id;
+		let thinkingLevel = state.thinking_level;
+		let activeToolNames = state.active_tool_names;
+		let latestCompactionEntryId = state.latest_compaction_entry_id;
+		let latestCompactionFirstKeptEntryId = state.latest_compaction_first_kept_entry_id;
+		let latestCompactionTokensBefore = state.latest_compaction_tokens_before;
+		let compactionCount = state.compaction_count;
+
+		if (entry.type === "session_info") {
+			sessionName = entry.name ?? null;
+		} else if (entry.type === "model_change") {
+			modelProvider = entry.provider;
+			modelId = entry.modelId;
+		} else if (entry.type === "thinking_level_change") {
+			thinkingLevel = entry.thinkingLevel;
+		} else if (entry.type === "active_tools_change") {
+			activeToolNames = JSON.stringify(entry.activeToolNames);
+		} else if (entry.type === "compaction") {
+			latestCompactionEntryId = entry.id;
+			latestCompactionFirstKeptEntryId = entry.firstKeptEntryId;
+			latestCompactionTokensBefore = entry.tokensBefore;
+			compactionCount += 1;
+		}
+
+		await this.db
+			.prepare(
+				"UPDATE session_state SET leaf_id = ?, session_name = ?, model_provider = ?, model_id = ?, thinking_level = ?, active_tool_names = ?, latest_compaction_entry_id = ?, latest_compaction_first_kept_entry_id = ?, latest_compaction_tokens_before = ?, compaction_count = ?, labels_json = ?, entry_count = ?, last_entry_seq = ?, updated_at = ? WHERE session_id = ?",
+			)
+			.run([
+				leafIdAfterEntry(entry),
+				sessionName,
+				modelProvider,
+				modelId,
+				thinkingLevel,
+				activeToolNames,
+				latestCompactionEntryId,
+				latestCompactionFirstKeptEntryId,
+				latestCompactionTokensBefore,
+				compactionCount,
+				this.labelsById.size > 0 ? JSON.stringify(Object.fromEntries(this.labelsById)) : null,
+				state.entry_count + 1,
+				seq,
+				new Date().toISOString(),
+				this.metadata.id,
+			]);
+	}
+
+	async setLeafId(leafId: string | null): Promise<void> {
+		if (leafId !== null && !this.byId.has(leafId)) {
+			throw new SessionError("not_found", `Entry ${leafId} not found`);
+		}
+		const entry: LeafEntry = {
+			type: "leaf",
+			id: generateEntryId(this.byId),
+			parentId: this.currentLeafId,
+			timestamp: new Date().toISOString(),
+			targetId: leafId,
+		};
+		await this.appendEntry(entry);
+	}
+
+	async createEntryId(): Promise<string> {
+		return generateEntryId(this.byId);
+	}
+
+	async appendEntry(entry: SessionTreeEntry): Promise<void> {
+		const encoded = encodeEntry(entry);
+		try {
+			await this.db.transaction(async () => {
+				const result = await this.db
+					.prepare(
+						"INSERT INTO session_entries (session_id, id, parent_id, type, timestamp, payload, target_id, message_role, custom_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+					)
+					.run([
+						this.metadata.id,
+						entry.id,
+						entry.parentId,
+						entry.type,
+						entry.timestamp,
+						encoded.payload,
+						encoded.targetId ?? null,
+						encoded.messageRole ?? null,
+						encoded.customType ?? null,
+					]);
+				this.entries.push(entry);
+				this.byId.set(entry.id, entry);
+				updateLabelCache(this.labelsById, entry);
+				this.currentLeafId = leafIdAfterEntry(entry);
+				await this.updateState(entry, result.lastInsertRowid ?? 0);
+			});
+		} catch (error) {
+			if (error instanceof SessionError) throw error;
+			throw new SessionError("storage", `Failed to append SQLite session entry ${entry.id}`);
+		}
+	}
+
+	async getEntry(id: string): Promise<SessionTreeEntry | undefined> {
+		return this.byId.get(id);
+	}
+
+	async findEntries<TType extends SessionTreeEntry["type"]>(
+		type: TType,
+	): Promise<Array<Extract<SessionTreeEntry, { type: TType }>>> {
+		return this.entries.filter((entry): entry is Extract<SessionTreeEntry, { type: TType }> => entry.type === type);
+	}
+
+	async getLabel(id: string): Promise<string | undefined> {
+		return this.labelsById.get(id);
+	}
+
+	async getPathToRoot(leafId: string | null): Promise<SessionTreeEntry[]> {
+		if (leafId === null) return [];
+		const path: SessionTreeEntry[] = [];
+		let current = this.byId.get(leafId);
+		if (!current) throw new SessionError("not_found", `Entry ${leafId} not found`);
+		while (current) {
+			path.unshift(current);
+			if (!current.parentId) break;
+			const parent = this.byId.get(current.parentId);
+			if (!parent) throw new SessionError("invalid_session", `Entry ${current.parentId} not found`);
+			current = parent;
+		}
+		return path;
+	}
+
+	async getEntries(): Promise<SessionTreeEntry[]> {
+		return [...this.entries];
+	}
+
+	async cleanup(): Promise<void> {
+		await this.db.close();
+	}
+}

--- a/packages/agent/src/harness/session/sqlite/storage.ts
+++ b/packages/agent/src/harness/session/sqlite/storage.ts
@@ -1,4 +1,5 @@
 import type {
+	ClosableSessionStorage,
 	LeafEntry,
 	SessionStorage,
 	SessionTreeEntry,
@@ -263,7 +264,7 @@ async function loadSqliteStorage(
 	return { row, entries, leafId };
 }
 
-export class SqliteSessionStorage implements SessionStorage<SqliteSessionMetadata> {
+export class SqliteSessionStorage implements SessionStorage<SqliteSessionMetadata>, ClosableSessionStorage {
 	private readonly db: SqliteDatabase;
 	private readonly metadata: SqliteSessionMetadata;
 	private entries: SessionTreeEntry[];

--- a/packages/agent/src/harness/types.ts
+++ b/packages/agent/src/harness/types.ts
@@ -493,6 +493,9 @@ export interface SessionStorage<TMetadata extends SessionMetadata = SessionMetad
 	getLabel(id: string): Promise<string | undefined>;
 	getPathToRoot(leafId: string | null): Promise<SessionTreeEntry[]>;
 	getEntries(): Promise<SessionTreeEntry[]>;
+}
+
+export interface ClosableSessionStorage {
 	cleanup(): Promise<void>;
 }
 

--- a/packages/agent/src/harness/types.ts
+++ b/packages/agent/src/harness/types.ts
@@ -301,6 +301,42 @@ export interface FileSystem {
 	cleanup(): Promise<void>;
 }
 
+/** Result of a prepared SQLite statement execution. */
+export interface SqliteRunResult {
+	/** Number of rows changed by the statement. */
+	changes: number;
+	/** Inserted row id when the backend exposes one. */
+	lastInsertRowid?: number;
+}
+
+/** Prepared SQLite statement capability used by the harness. */
+export interface SqliteStatement {
+	/** Execute a write/update/delete statement. */
+	run(params?: unknown[]): Promise<SqliteRunResult>;
+	/** Fetch one row from the statement result. */
+	get<TRow extends object>(params?: unknown[]): Promise<TRow | undefined>;
+	/** Fetch all rows from the statement result. */
+	all<TRow extends object>(params?: unknown[]): Promise<TRow[]>;
+}
+
+/** SQLite database capability used by the harness. */
+export interface SqliteDatabase {
+	/** Execute raw SQL, typically for pragmas or schema setup. */
+	exec(sql: string): Promise<void>;
+	/** Prepare a reusable SQL statement. */
+	prepare(sql: string): SqliteStatement;
+	/** Execute work inside a transaction managed by the backend. */
+	transaction<T>(fn: () => Promise<T>): Promise<T>;
+	/** Release database resources. Must be best-effort and must not throw or reject. */
+	close(): Promise<void>;
+}
+
+/** SQLite capability used by the harness. */
+export interface SqliteEnv {
+	/** Open a SQLite database at the addressed path. */
+	openSqlite(path: string): Promise<SqliteDatabase>;
+}
+
 /** Options for {@link Shell.exec}. */
 export interface ShellExecOptions {
 	/** Working directory for the command. Relative paths are resolved against {@link ExecutionEnv.cwd}. Defaults to {@link ExecutionEnv.cwd}. */
@@ -437,6 +473,12 @@ export interface JsonlSessionMetadata extends SessionMetadata {
 	parentSessionPath?: string;
 }
 
+export interface SqliteSessionMetadata extends SessionMetadata {
+	cwd: string;
+	path: string;
+	parentSessionId?: string;
+}
+
 export interface SessionStorage<TMetadata extends SessionMetadata = SessionMetadata> {
 	getMetadata(): Promise<TMetadata>;
 	getLeafId(): Promise<string | null>;
@@ -451,6 +493,7 @@ export interface SessionStorage<TMetadata extends SessionMetadata = SessionMetad
 	getLabel(id: string): Promise<string | undefined>;
 	getPathToRoot(leafId: string | null): Promise<SessionTreeEntry[]>;
 	getEntries(): Promise<SessionTreeEntry[]>;
+	cleanup(): Promise<void>;
 }
 
 export type { Session } from "./session/session.ts";
@@ -482,12 +525,24 @@ export interface JsonlSessionCreateOptions extends SessionCreateOptions {
 	parentSessionPath?: string;
 }
 
+export interface SqliteSessionCreateOptions extends SessionCreateOptions {
+	cwd: string;
+	parentSessionId?: string;
+}
+
 export interface JsonlSessionListOptions {
+	cwd?: string;
+}
+
+export interface SqliteSessionListOptions {
 	cwd?: string;
 }
 
 export interface JsonlSessionRepoApi
 	extends SessionRepo<JsonlSessionMetadata, JsonlSessionCreateOptions, JsonlSessionListOptions> {}
+
+export interface SqliteSessionRepoApi
+	extends SessionRepo<SqliteSessionMetadata, SqliteSessionCreateOptions, SqliteSessionListOptions> {}
 
 export type AgentHarnessPhase = "idle" | "turn" | "compaction" | "branch_summary" | "retry";
 

--- a/packages/agent/src/harness/types.ts
+++ b/packages/agent/src/harness/types.ts
@@ -541,6 +541,18 @@ export interface SqliteSessionListOptions {
 	cwd?: string;
 }
 
+export interface JsonlSessionBackendOptions {
+	kind: "jsonl";
+	sessionsRoot: string;
+}
+
+export interface SqliteSessionBackendOptions {
+	kind: "sqlite";
+	databasePath: string;
+}
+
+export type BuiltinSessionStorageOptions = JsonlSessionBackendOptions | SqliteSessionBackendOptions;
+
 export interface JsonlSessionRepoApi
 	extends SessionRepo<JsonlSessionMetadata, JsonlSessionCreateOptions, JsonlSessionListOptions> {}
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -31,6 +31,7 @@ export * from "./harness/session/jsonl-repo.ts";
 export * from "./harness/session/memory-repo.ts";
 export * from "./harness/session/repo-utils.ts";
 export * from "./harness/session/session.ts";
+export * from "./harness/session/session-lifecycle.ts";
 export { uuidv7 } from "./harness/session/uuid.ts";
 export * from "./harness/skills.ts";
 export * from "./harness/system-prompt.ts";

--- a/packages/agent/src/node.ts
+++ b/packages/agent/src/node.ts
@@ -1,4 +1,5 @@
 export { NodeExecutionEnv } from "./harness/env/nodejs.ts";
+export * from "./harness/session/builtins.ts";
 export * from "./harness/session/sqlite/experimental.ts";
 export * from "./harness/session/sqlite/repo.ts";
 export * from "./harness/session/sqlite/storage.ts";

--- a/packages/agent/src/node.ts
+++ b/packages/agent/src/node.ts
@@ -1,2 +1,5 @@
 export { NodeExecutionEnv } from "./harness/env/nodejs.ts";
+export * from "./harness/session/sqlite/experimental.ts";
+export * from "./harness/session/sqlite/repo.ts";
+export * from "./harness/session/sqlite/storage.ts";
 export * from "./index.ts";

--- a/packages/agent/test/harness/repo.test.ts
+++ b/packages/agent/test/harness/repo.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
+import { createBuiltinSessionRepo, selectBuiltinSessionStorage } from "../../src/harness/session/builtins.ts";
 import { JsonlSessionRepo } from "../../src/harness/session/jsonl-repo.ts";
 import { InMemorySessionRepo } from "../../src/harness/session/memory-repo.ts";
 import { SessionLifecycle } from "../../src/harness/session/session-lifecycle.ts";
@@ -71,7 +72,7 @@ describe("JsonlSessionRepo", () => {
 });
 
 describe("SessionLifecycle", () => {
-	it("mirrors create, open, fork, and delete to sqlite when PI_SQLITE_SESSION_STORAGE=1", async () => {
+	it("wraps a single repo and uses the builtin backend factory to select sqlite under the flag", async () => {
 		const previous = process.env.PI_SQLITE_SESSION_STORAGE;
 		process.env.PI_SQLITE_SESSION_STORAGE = "1";
 		try {
@@ -80,29 +81,43 @@ describe("SessionLifecycle", () => {
 			const jsonlRepo = new JsonlSessionRepo({ fs: env, sessionsRoot: root });
 			const databasePath = join(root, "sessions.sqlite");
 			const sqliteRepo = new SqliteSessionRepo({ env, databasePath });
-			const lifecycle = new SessionLifecycle({ jsonlRepo, sqliteRepo });
+			const repo = createBuiltinSessionRepo({
+				env,
+				storage: selectBuiltinSessionStorage({
+					jsonl: { kind: "jsonl", sessionsRoot: root },
+					sqlite: { kind: "sqlite", databasePath },
+				}),
+			});
+			const lifecycle = new SessionLifecycle({ repo });
 			const session = await lifecycle.create({ cwd: "/tmp/source", id: "source-session" });
 			await session.appendMessage(createUserMessage("one"));
 			await session.appendMessage(createAssistantMessage("two"));
 			await session.moveTo(null);
+			const metadata = await session.getMetadata();
+			expect(metadata.path).toBe(databasePath);
+			expect(await jsonlRepo.list({ cwd: "/tmp/source" })).toEqual([]);
+			const listed = await lifecycle.list({ cwd: "/tmp/source" });
+			expect(listed).toHaveLength(1);
+			expect(listed[0]?.id).toBe("source-session");
 			const sqliteSession = await sqliteRepo.open({
 				id: "source-session",
 				cwd: "/tmp/source",
-				createdAt: (await session.getMetadata()).createdAt,
+				createdAt: metadata.createdAt,
 				path: databasePath,
 			});
 			expect((await sqliteSession.getEntries()).map((entry) => entry.id)).toEqual(
 				(await session.getEntries()).map((entry) => entry.id),
 			);
-			const reopened = await lifecycle.open(await session.getMetadata());
+			const reopened = await lifecycle.open(metadata);
 			expect((await reopened.getEntries()).map((entry) => entry.id)).toEqual(
 				(await session.getEntries()).map((entry) => entry.id),
 			);
-			const fork = await lifecycle.fork(await session.getMetadata(), { cwd: "/tmp/target", id: "fork-session" });
+			const fork = await lifecycle.fork(metadata, { cwd: "/tmp/target", id: "fork-session" });
+			expect((await fork.getMetadata()).path).toBe(databasePath);
 			expect((await fork.getEntries()).map((entry) => entry.id)).toEqual(
 				(await session.getEntries()).map((entry) => entry.id),
 			);
-			await lifecycle.delete(await session.getMetadata());
+			await lifecycle.delete(metadata);
 			expect(await sqliteRepo.list({ cwd: "/tmp/source" })).toEqual([]);
 		} finally {
 			if (previous === undefined) delete process.env.PI_SQLITE_SESSION_STORAGE;

--- a/packages/agent/test/harness/repo.test.ts
+++ b/packages/agent/test/harness/repo.test.ts
@@ -1,8 +1,11 @@
 import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
 import { JsonlSessionRepo } from "../../src/harness/session/jsonl-repo.ts";
 import { InMemorySessionRepo } from "../../src/harness/session/memory-repo.ts";
+import { SessionLifecycle } from "../../src/harness/session/session-lifecycle.ts";
+import { SqliteSessionRepo } from "../../src/harness/session/sqlite/repo.ts";
 import { createAssistantMessage, createTempDir, createUserMessage } from "./session-test-utils.ts";
 
 describe("InMemorySessionRepo", () => {
@@ -64,5 +67,46 @@ describe("JsonlSessionRepo", () => {
 		await repo.delete(sourceMetadata);
 		expect(existsSync(sourceMetadata.path)).toBe(false);
 		await expect(repo.open(sourceMetadata)).rejects.toThrow("Session not found");
+	});
+});
+
+describe("SessionLifecycle", () => {
+	it("mirrors create, open, fork, and delete to sqlite when PI_SQLITE_SESSION_STORAGE=1", async () => {
+		const previous = process.env.PI_SQLITE_SESSION_STORAGE;
+		process.env.PI_SQLITE_SESSION_STORAGE = "1";
+		try {
+			const root = createTempDir();
+			const env = new NodeExecutionEnv({ cwd: root });
+			const jsonlRepo = new JsonlSessionRepo({ fs: env, sessionsRoot: root });
+			const databasePath = join(root, "sessions.sqlite");
+			const sqliteRepo = new SqliteSessionRepo({ env, databasePath });
+			const lifecycle = new SessionLifecycle({ jsonlRepo, sqliteRepo });
+			const session = await lifecycle.create({ cwd: "/tmp/source", id: "source-session" });
+			await session.appendMessage(createUserMessage("one"));
+			await session.appendMessage(createAssistantMessage("two"));
+			await session.moveTo(null);
+			const sqliteSession = await sqliteRepo.open({
+				id: "source-session",
+				cwd: "/tmp/source",
+				createdAt: (await session.getMetadata()).createdAt,
+				path: databasePath,
+			});
+			expect((await sqliteSession.getEntries()).map((entry) => entry.id)).toEqual(
+				(await session.getEntries()).map((entry) => entry.id),
+			);
+			const reopened = await lifecycle.open(await session.getMetadata());
+			expect((await reopened.getEntries()).map((entry) => entry.id)).toEqual(
+				(await session.getEntries()).map((entry) => entry.id),
+			);
+			const fork = await lifecycle.fork(await session.getMetadata(), { cwd: "/tmp/target", id: "fork-session" });
+			expect((await fork.getEntries()).map((entry) => entry.id)).toEqual(
+				(await session.getEntries()).map((entry) => entry.id),
+			);
+			await lifecycle.delete(await session.getMetadata());
+			expect(await sqliteRepo.list({ cwd: "/tmp/source" })).toEqual([]);
+		} finally {
+			if (previous === undefined) delete process.env.PI_SQLITE_SESSION_STORAGE;
+			else process.env.PI_SQLITE_SESSION_STORAGE = previous;
+		}
 	});
 });


### PR DESCRIPTION
This PR adds an option for SQLite session storage. Under the flag `PI_SQLITE_SESSION_STORAGE` (when set to 1), pi will now write it's session "transcripts" both to jsonl (always default), and also in parallel to a SQLite db.

Following the patterns of jsonl, we expose SQLite `NodeSqliteStatement` and `NodeSqliteDatabase` in `NodeExecutionEnv` in `nodejs` to abstract the db location so this works for sandboxes, VMs, etc.

It also refactors `session-lifecycle` for `create`, `fork`, `delete`, etc, as these were only called in `jsonl-repo` and we need counterparts. e.g. even though `create()` just creates a session jsonl file with the header and this is not needed in db, we still create a row in `sessions` and `session_state`, but no session entries ofc.

The SQLite db has 3 tables (well, 4, but 1 is only for the version):
- `sessions`: stores one row per session with its identity and top-level metadata (`id`, `created_at`, `cwd`, `parent_session_id`).
- `session_entries`: stores the full append-only session event/history log as normalized rows (shared fields) plus JSON payloads.
- `session_state`: stores the current derived snapshot for a session (`leaf`, `name`, `model`, `thinking_level`, `labels`, compaction info, counts). This is intended as a "sidecar" for quick access to rebuild context without needing to walk up the full tree/ leaf and process all messages.

For now, the flag only writes to the db, no actual use for the db records yet, will do that in a follow-up PR to not blow this one up.