### PR TITLE
fix(coding-agent): preserve first path segment when find relativizes from a bare root

### DIFF
--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -17,6 +17,25 @@ function toPosixPath(value: string): string {
 	return value.split(path.sep).join("/");
 }
 
+// Relativizes an absolute result path against the search root and returns it in
+// POSIX form. `path.resolve` strips a trailing separator from every path except a
+// bare root (e.g. "/", "C:\"), where it is kept. The previous `slice(len + 1)`
+// assumed a separator always follows `searchPath`, so for a bare root it ate the
+// first real character (and, on Windows, the trailing-slash guard ran before
+// `toPosixPath`, turning a "\"-terminated path into "//"). See #6104.
+export function relativizeSearchResult(p: string, searchPath: string): string {
+	let rel: string;
+	if (p.startsWith(searchPath)) {
+		const start = searchPath.endsWith(path.sep) ? searchPath.length : searchPath.length + 1;
+		rel = p.slice(start);
+	} else {
+		rel = path.relative(searchPath, p);
+	}
+	rel = toPosixPath(rel);
+	if ((p.endsWith("/") || p.endsWith("\\")) && !rel.endsWith("/")) rel += "/";
+	return rel;
+}
+
 const findSchema = Type.Object({
 	pattern: Type.String({
 		description: "Glob pattern to match files, e.g. '*.ts', '**/*.json', or 'src/**/*.spec.ts'",
@@ -180,10 +199,7 @@ export function createFindToolDefinition(
 							}
 
 							// Relativize paths against the search root for stable output.
-							const relativized = results.map((p) => {
-								if (p.startsWith(searchPath)) return toPosixPath(p.slice(searchPath.length + 1));
-								return toPosixPath(path.relative(searchPath, p));
-							});
+							const relativized = results.map((p) => relativizeSearchResult(p, searchPath));
 							const resultLimitReached = relativized.length >= effectiveLimit;
 							const rawOutput = relativized.join("\n");
 							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
@@ -308,15 +324,7 @@ export function createFindToolDefinition(
 							for (const rawLine of lines) {
 								const line = rawLine.replace(/\r$/, "").trim();
 								if (!line) continue;
-								const hadTrailingSlash = line.endsWith("/") || line.endsWith("\\");
-								let relativePath = line;
-								if (line.startsWith(searchPath)) {
-									relativePath = line.slice(searchPath.length + 1);
-								} else {
-									relativePath = path.relative(searchPath, line);
-								}
-								if (hadTrailingSlash && !relativePath.endsWith("/")) relativePath += "/";
-								relativized.push(toPosixPath(relativePath));
+								relativized.push(relativizeSearchResult(line, searchPath));
 							}
 
 							const resultLimitReached = relativized.length >= effectiveLimit;

--- a/packages/coding-agent/test/suite/regressions/6104-find-bare-root-relativization.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6104-find-bare-root-relativization.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { relativizeSearchResult } from "../../../src/core/tools/find.ts";
+
+/**
+ * Regression test for https://github.com/earendil-works/pi/issues/6104
+ *
+ * `path.resolve` strips a trailing separator from every path except a bare root
+ * (e.g. "/", "C:\"), where it is kept. The find tool relativized results with
+ * `slice(searchPath.length + 1)`, assuming a separator always follows the search
+ * root — so for a bare root it dropped the first character of the first segment.
+ * On Windows the trailing-slash guard also ran before `toPosixPath`, turning a
+ * "\"-terminated path into a doubled "//".
+ *
+ * The bare-root case cannot be exercised through a temp directory, so this tests
+ * the extracted relativization helper directly. The "/" cases run on any POSIX
+ * host (the confirmed Linux reproduction); the fix's POSIX-first ordering handles
+ * the Windows "\" separator by construction.
+ */
+describe("issue #6104 find relativization from a bare root", () => {
+	it("preserves the full first segment when the search root is the filesystem root", () => {
+		// Previously returned "I/Models/gemma4/" — the first character of "AI" was eaten.
+		expect(relativizeSearchResult("/AI/Models/gemma4/", "/")).toBe("AI/Models/gemma4/");
+		expect(relativizeSearchResult("/AI/notes.txt", "/")).toBe("AI/notes.txt");
+	});
+
+	it("keeps a single trailing slash for a directory result from a bare root", () => {
+		expect(relativizeSearchResult("/dir/", "/")).toBe("dir/");
+	});
+
+	it("still strips the separator for non-root search paths", () => {
+		expect(relativizeSearchResult("/deeper/dir/sub/", "/deeper")).toBe("dir/sub/");
+		expect(relativizeSearchResult("/deeper/file.txt", "/deeper")).toBe("file.txt");
+	});
+});


### PR DESCRIPTION
Fixes #6104.

`path.resolve` strips a trailing separator from every path except a bare root (`/`, `C:\`), where it keeps it. The `find` relativization used `slice(searchPath.length + 1)`, which assumes a separator always follows the search root — so for a bare root the `+ 1` ate the first character of the first segment. On Windows the trailing-slash guard also ran before `toPosixPath`, so a `\`-terminated result became `//`.

Both the fd branch and the custom-glob branch had the same code, so I pulled the relativization into one `relativizeSearchResult` helper and fixed it there:

- skip a following separator only when `searchPath` doesn't already end with one (so a bare root keeps its full first segment);
- run `toPosixPath` before the trailing-slash guard, so a `\`-terminated path doesn't gain a second slash.

@petrroll's note on the issue is right that this isn't Windows-only — it reproduces from `/` on Linux too, which is what the test uses. The bare-root case can't be set up through a temp directory, so `6104-find-bare-root-relativization.test.ts` exercises the extracted helper directly; the two first-segment assertions fail on the old `+ 1` logic and pass with the fix. `biome check` and `tsgo --noEmit` are clean.

<sub>Disclosure per CONTRIBUTING.md: this change was written with AI assistance (Claude); I reviewed the diff, ran the tests, and understand how it works.</sub>
