### PR TITLE
fix(tui): avoid offscreen redraws for stable-height updates

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1391,6 +1391,11 @@ export class TUI extends Container {
 			firstChanged = expandedRange.firstChanged;
 			lastChanged = expandedRange.lastChanged;
 		}
+		// Preserve the full changed range for Kitty image cleanup. The repaint range may
+		// later be clamped to the visible viewport, but image deletion is id-based and
+		// must still include off-screen changed image lines.
+		const kittyDeleteFirstChanged = firstChanged;
+		const kittyDeleteLastChanged = lastChanged;
 		const appendStart = appendedLines && firstChanged === this.previousLines.length && firstChanged > 0;
 
 		// No changes - but still need to update hardware cursor position if it moved
@@ -1450,18 +1455,38 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible.
-		// If the first changed line is above the previous viewport, we need a full redraw.
+		// Differential rendering can only touch what was actually visible. If a stable-
+		// height update starts above the viewport, clamp repainting to visible rows
+		// instead of falling back to a full redraw. This avoids replaying large scrollback
+		// for off-screen-only updates (for example, a completed tool block changing
+		// status color) while keeping the visible viewport and cached line state current.
 		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
-			return;
+			if (newLines.length === this.previousLines.length) {
+				if (lastChanged < prevViewportTop) {
+					const imageDeletes = this.deleteChangedKittyImages(kittyDeleteFirstChanged, kittyDeleteLastChanged);
+					if (imageDeletes) {
+						this.terminal.write(imageDeletes);
+					}
+					this.positionHardwareCursor(cursorPos, newLines.length);
+					this.previousLines = newLines;
+					this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+					this.previousWidth = width;
+					this.previousHeight = height;
+					this.previousViewportTop = prevViewportTop;
+					return;
+				}
+				firstChanged = prevViewportTop;
+			} else {
+				logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+				fullRender(true);
+				return;
+			}
 		}
 
 		// Render from first changed line to end
 		// Build buffer with all updates wrapped in synchronized output
 		let buffer = "\x1b[?2026h"; // Begin synchronized output
-		buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
+		buffer += this.deleteChangedKittyImages(kittyDeleteFirstChanged, kittyDeleteLastChanged);
 		const prevViewportBottom = prevViewportTop + height - 1;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
 		if (moveTargetRow > prevViewportBottom) {

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -295,6 +295,45 @@ describe("TUI Kitty image cleanup", () => {
 		tui.stop();
 	});
 
+	it("deletes off-screen Kitty images without forcing full redraws when line count is unchanged", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		try {
+			const terminal = new LoggingVirtualTerminal(40, 5);
+			const tui = new TUI(terminal);
+			const component = new TestComponent();
+			tui.addChild(component);
+
+			const image = new Image(
+				"AAAA",
+				"image/png",
+				{ fallbackColor: (value) => value },
+				{ maxWidthCells: 1, maxHeightCells: 1, imageId: 12345 },
+				{ widthPx: 10, heightPx: 10 },
+			);
+			component.lines = [...image.render(40), ...Array.from({ length: 19 }, (_, i) => `Line ${i + 1}`)];
+			tui.start();
+			await terminal.waitForRender();
+
+			const redrawsAfterInitialRender = tui.fullRedraws;
+			terminal.clearWrites();
+
+			component.lines = ["Removed image", ...Array.from({ length: 19 }, (_, i) => `Line ${i + 1}`)];
+			tui.requestRender();
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.strictEqual(tui.fullRedraws, redrawsAfterInitialRender, "off-screen image removal should not redraw");
+			assert.ok(writes.includes(deleteKittyImage(12345)), "off-screen image should still be deleted by id");
+			assert.ok(!writes.includes("\x1b[2J"), "off-screen image deletion should not clear scrollback");
+
+			tui.stop();
+		} finally {
+			resetCapabilitiesCache();
+			setCellDimensions({ widthPx: 9, heightPx: 18 });
+		}
+	});
+
 	it("deletes previously rendered image ids during full redraws", async () => {
 		const terminal = new LoggingVirtualTerminal(40, 10);
 		const tui = new TUI(terminal);
@@ -704,6 +743,62 @@ describe("TUI differential rendering", () => {
 
 		assert.strictEqual(tui.fullRedraws, redrawsAfterShrink, "Append should stay on the differential path");
 		assert.deepStrictEqual(terminal.getViewport(), ["Line 0", "Line 1", "Line 2", "", ""]);
+
+		tui.stop();
+	});
+
+	it("does not full-redraw when unchanged-height edits start above the viewport", async () => {
+		const terminal = new VirtualTerminal(20, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 20 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+
+		const redrawsAfterInitialRender = tui.fullRedraws;
+
+		component.lines = Array.from({ length: 20 }, (_, i) => (i === 0 ? "CHANGED OFFSCREEN" : `Line ${i}`));
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(
+			tui.fullRedraws,
+			redrawsAfterInitialRender,
+			"off-screen content changes with the same line count should not replay scrollback",
+		);
+		assert.deepStrictEqual(terminal.getViewport(), ["Line 15", "Line 16", "Line 17", "Line 18", "Line 19"]);
+
+		tui.stop();
+	});
+
+	it("clamps unchanged-height changes that begin above the viewport to visible rows", async () => {
+		const terminal = new VirtualTerminal(20, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 20 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+
+		const redrawsAfterInitialRender = tui.fullRedraws;
+
+		component.lines = Array.from({ length: 20 }, (_, i) => {
+			if (i === 0) return "CHANGED OFFSCREEN";
+			if (i === 19) return "CHANGED VISIBLE";
+			return `Line ${i}`;
+		});
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(
+			tui.fullRedraws,
+			redrawsAfterInitialRender,
+			"visible tail changes should render differentially even if an earlier off-screen line changed first",
+		);
+		assert.deepStrictEqual(terminal.getViewport(), ["Line 15", "Line 16", "Line 17", "Line 18", "CHANGED VISIBLE"]);
 
 		tui.stop();
 	});


### PR DESCRIPTION
## Summary

Fix a TUI redraw fallback that replayed large scrollback for stable-height updates whose first changed line was above the visible viewport.

When the rendered line count is unchanged, the renderer now clamps repainting to visible rows instead of forcing a full redraw. Off-screen cached line state is still updated. Kitty image cleanup keeps the full changed range so off-screen image ids are still deleted.

## Why

Long expanded sessions with compacted history can have thousands of rendered lines. A completed off-screen tool block can change styling/status near the top of the transcript, causing `firstChanged < viewportTop` and triggering a full redraw after later local updates.

This made expanded long sessions feel slow even when the visible viewport only needed a small update.

## Validation

- `npm run check`
- `./test.sh`
- `npm run build --workspace @earendil-works/pi-tui`
- `npm test --workspace @earendil-works/pi-tui`
- No-token tmux dogfood against a copied 67MB session with 39 compactions:
  - `Ctrl+O` expand/collapse full-redrawed as expected because line count changed
  - `/session` and `/hotkeys` while expanded did not trigger full redraws
