### PR TITLE
fix(session): prevent UUID collisions and race conditions in session storage

### DIFF
--- a/packages/agent/src/harness/session/jsonl-storage.ts
+++ b/packages/agent/src/harness/session/jsonl-storage.ts
@@ -33,8 +33,11 @@ function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
 }
 
 function generateEntryId(byId: { has(id: string): boolean }): string {
+	// Use 12 characters (8 timestamp + 4 random) to avoid collisions within 65-second windows.
+	// UUIDv7 first 8 chars = upper 32 bits of timestamp, only changes every ~65 seconds.
+	// Including chars 9-12 (random bits) ensures uniqueness for rapid successive calls.
 	for (let i = 0; i < 100; i++) {
-		const id = uuidv7().slice(0, 8);
+		const id = uuidv7().slice(0, 12);
 		if (!byId.has(id)) return id;
 	}
 	return uuidv7();
@@ -234,13 +237,14 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 			timestamp: new Date().toISOString(),
 			targetId: leafId,
 		};
+		// Update in-memory structures synchronously BEFORE async I/O.
+		this.entries.push(entry);
+		this.byId.set(entry.id, entry);
+		this.currentLeafId = leafId;
 		getFileSystemResultOrThrow(
 			await this.fs.appendFile(this.filePath, `${JSON.stringify(entry)}\n`),
 			`Failed to append session leaf ${entry.id}`,
 		);
-		this.entries.push(entry);
-		this.byId.set(entry.id, entry);
-		this.currentLeafId = leafId;
 	}
 
 	async createEntryId(): Promise<string> {
@@ -248,14 +252,17 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 	}
 
 	async appendEntry(entry: SessionTreeEntry): Promise<void> {
-		getFileSystemResultOrThrow(
-			await this.fs.appendFile(this.filePath, `${JSON.stringify(entry)}\n`),
-			`Failed to append session entry ${entry.id}`,
-		);
+		// Update in-memory structures synchronously BEFORE async I/O.
+		// This prevents race conditions where concurrent createEntryId() calls
+		// would generate duplicate IDs because byId hasn't been updated yet.
 		this.entries.push(entry);
 		this.byId.set(entry.id, entry);
 		updateLabelCache(this.labelsById, entry);
 		this.currentLeafId = leafIdAfterEntry(entry);
+		getFileSystemResultOrThrow(
+			await this.fs.appendFile(this.filePath, `${JSON.stringify(entry)}\n`),
+			`Failed to append session entry ${entry.id}`,
+		);
 	}
 
 	async getEntry(id: string): Promise<SessionTreeEntry | undefined> {

--- a/packages/agent/src/harness/session/memory-storage.ts
+++ b/packages/agent/src/harness/session/memory-storage.ts
@@ -26,8 +26,9 @@ function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
 }
 
 function generateEntryId(byId: { has(id: string): boolean }): string {
+	// Use 12 characters (8 timestamp + 4 random) to avoid collisions within 65-second windows.
 	for (let i = 0; i < 100; i++) {
-		const id = uuidv7().slice(0, 8);
+		const id = uuidv7().slice(0, 12);
 		if (!byId.has(id)) return id;
 	}
 	return uuidv7();


### PR DESCRIPTION
## Overview

This PR fixes three critical data integrity bugs in the session storage layer (`JsonlSessionStorage` and `InMemorySessionStorage`) that can cause corrupted session trees, duplicate entry IDs, and unreadable sessions.

Closes #6242

## Changes

### 1. `generateEntryId()` — UUID truncation 8 → 12 characters

**Files:** `jsonl-storage.ts`, `memory-storage.ts`

UUIDv7's first 8 characters encode the upper 32 bits of the Unix timestamp, which only changes every ~65.5 seconds. Within that window, rapid successive `createEntryId()` calls produce identical prefixes, making the 100-iteration retry loop ineffective.

**Fix:** Extend to 12 characters (8 timestamp + 4 random bits) to ensure uniqueness within the same timestamp window.

### 2. `appendEntry()` — Update in-memory state before async I/O

**File:** `jsonl-storage.ts`

The original code performs `await appendFile()` before updating `entries`, `byId`, and `currentLeafId`. This creates a window where concurrent `createEntryId()` and `getLeafId()` calls read stale state, resulting in duplicate IDs or broken parent chains.

**Fix:** Move in-memory updates synchronously before the async I/O call.

### 3. `setLeafId()` — Same race condition fix

**File:** `jsonl-storage.ts`

Same pattern as `appendEntry()` — memory updates moved before I/O.

## Testing

- Verified no duplicate IDs generated under rapid sequential `appendMessage()` calls
- Verified session tree integrity maintained during concurrent entry appends
- Existing session files with 8-char IDs remain compatible (IDs are only generated, never parsed by length)

## Impact

These fixes prevent the session corruption observed in production where 18+ session files became unreadable due to broken parent chains over several weeks of usage.