### PR TITLE
Keep interactive input and footer sticky

### DIFF
--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -186,6 +186,25 @@ await showMenu();  // "Back" = just call again
 
 See [overlay-qa-tests.ts](../examples/extensions/overlay-qa-tests.ts) for comprehensive examples covering anchors, margins, stacking, responsive visibility, and animation.
 
+## Sticky Bottom Layout
+
+For chat-style UIs, the TUI can keep a bottom region fixed while earlier root-level components become a scrollable viewport:
+
+```typescript
+const history = new Container();
+const editor = new Editor();
+const footer = new Footer();
+
+tui.addChild(history);
+tui.addChild(editor);
+tui.addChild(footer);
+
+// `editor` and all following root siblings stay fixed at the bottom.
+tui.setStickyBottomStart(editor);
+```
+
+When enabled, `PageUp` / `PageDown` scroll only the history area. The sticky components keep their existing rendering, layout, and styling.
+
 ## Built-in Components
 
 Import from `@earendil-works/pi-tui`:

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -664,6 +664,7 @@ export class InteractiveMode {
 		this.ui.addChild(this.editorContainer);
 		this.ui.addChild(this.widgetContainerBelow);
 		this.ui.addChild(this.footer);
+		this.ui.setStickyBottomStart(this.widgetContainerAbove);
 		this.ui.setFocus(this.editor);
 
 		this.setupKeyHandlers();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -325,6 +325,10 @@ export class TUI extends Container {
 	private overlayStack: OverlayStackEntry[] = [];
 	private overlayFocusRestore: OverlayFocusRestoreState = { status: "inactive" };
 
+	private stickyBottomStart: Component | null = null;
+	private stickyScrollOffset = 0;
+	private stickyPreviousScrollableLineCount = 0;
+
 	constructor(terminal: Terminal, showHardwareCursor?: boolean) {
 		super();
 		this.terminal = terminal;
@@ -361,6 +365,77 @@ export class TUI extends Container {
 	 */
 	setClearOnShrink(enabled: boolean): void {
 		this.clearOnShrink = enabled;
+	}
+
+	/**
+	 * Keep this component and all following root-level siblings fixed at the bottom of the terminal.
+	 * Components before the boundary become a scrollable viewport. PageUp/PageDown scroll that viewport.
+	 */
+	setStickyBottomStart(component: Component | null): void {
+		this.stickyBottomStart = component;
+		this.stickyScrollOffset = 0;
+		this.stickyPreviousScrollableLineCount = 0;
+		this.requestRender(true);
+	}
+
+	override render(width: number): string[] {
+		if (!this.stickyBottomStart) {
+			return super.render(width);
+		}
+
+		const stickyIndex = this.children.indexOf(this.stickyBottomStart);
+		if (stickyIndex === -1) {
+			return super.render(width);
+		}
+
+		const renderChildren = (children: Component[]): string[] => {
+			const lines: string[] = [];
+			for (const child of children) {
+				const childLines = child.render(width);
+				for (const line of childLines) {
+					lines.push(line);
+				}
+			}
+			return lines;
+		};
+
+		const scrollableLines = renderChildren(this.children.slice(0, stickyIndex));
+		const stickyLines = renderChildren(this.children.slice(stickyIndex));
+		const height = Math.max(1, this.terminal.rows);
+
+		if (stickyLines.length >= height) {
+			this.stickyPreviousScrollableLineCount = scrollableLines.length;
+			this.stickyScrollOffset = 0;
+			return stickyLines.slice(stickyLines.length - height);
+		}
+
+		const scrollableHeight = Math.max(1, height - stickyLines.length);
+		if (this.stickyScrollOffset > 0 && scrollableLines.length > this.stickyPreviousScrollableLineCount) {
+			this.stickyScrollOffset += scrollableLines.length - this.stickyPreviousScrollableLineCount;
+		}
+
+		const maxScrollOffset = Math.max(0, scrollableLines.length - scrollableHeight);
+		this.stickyScrollOffset = Math.max(0, Math.min(this.stickyScrollOffset, maxScrollOffset));
+		this.stickyPreviousScrollableLineCount = scrollableLines.length;
+
+		const start = Math.max(0, scrollableLines.length - scrollableHeight - this.stickyScrollOffset);
+		const visibleScrollable = scrollableLines.slice(start, start + scrollableHeight);
+		while (visibleScrollable.length < scrollableHeight) {
+			visibleScrollable.unshift("");
+		}
+
+		return [...visibleScrollable, ...stickyLines];
+	}
+
+	private scrollStickyViewport(delta: number): boolean {
+		if (!this.stickyBottomStart || delta === 0) return false;
+		const previousOffset = this.stickyScrollOffset;
+		this.stickyScrollOffset = Math.max(0, this.stickyScrollOffset + delta);
+		if (this.stickyScrollOffset !== previousOffset) {
+			this.requestRender();
+			return true;
+		}
+		return false;
 	}
 
 	setFocus(component: Component | null): void {
@@ -792,6 +867,16 @@ export class TUI extends Container {
 		if (matchesKey(data, "shift+ctrl+d") && this.onDebug) {
 			this.onDebug();
 			return;
+		}
+
+		if (matchesKey(data, "pageUp")) {
+			if (this.scrollStickyViewport(Math.max(1, this.terminal.rows - 3))) {
+				return;
+			}
+		} else if (matchesKey(data, "pageDown")) {
+			if (this.scrollStickyViewport(-Math.max(1, this.terminal.rows - 3))) {
+				return;
+			}
 		}
 
 		// If focused component is an overlay, verify it's still visible

--- a/packages/tui/test/sticky-bottom.test.ts
+++ b/packages/tui/test/sticky-bottom.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class TestComponent implements Component {
+	private lines: string[];
+
+	constructor(lines: string[]) {
+		this.lines = lines;
+	}
+
+	setLines(lines: string[]): void {
+		this.lines = lines;
+	}
+
+	render(_width: number): string[] {
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+describe("TUI sticky bottom", () => {
+	it("keeps boundary component and following siblings fixed at the bottom", () => {
+		const terminal = new VirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const history = new TestComponent(["h0", "h1", "h2", "h3", "h4", "h5"]);
+		const editor = new TestComponent(["editor"]);
+		const footer = new TestComponent(["footer"]);
+
+		tui.addChild(history);
+		tui.addChild(editor);
+		tui.addChild(footer);
+		tui.setStickyBottomStart(editor);
+
+		assert.deepStrictEqual(tui.render(40), ["h3", "h4", "h5", "editor", "footer"]);
+	});
+
+	it("scrolls only the history area with PageUp/PageDown", async () => {
+		const terminal = new VirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const history = new TestComponent(["h0", "h1", "h2", "h3", "h4", "h5"]);
+		const editor = new TestComponent(["editor"]);
+		const footer = new TestComponent(["footer"]);
+
+		tui.addChild(history);
+		tui.addChild(editor);
+		tui.addChild(footer);
+		tui.setStickyBottomStart(editor);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[5~");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(tui.render(40), ["h1", "h2", "h3", "editor", "footer"]);
+
+		terminal.sendInput("\x1b[6~");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(tui.render(40), ["h3", "h4", "h5", "editor", "footer"]);
+
+		tui.stop();
+	});
+
+	it("keeps the viewed history stable when new lines append while scrolled up", () => {
+		const terminal = new VirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const history = new TestComponent(["h0", "h1", "h2", "h3", "h4", "h5"]);
+		const editor = new TestComponent(["editor"]);
+
+		tui.addChild(history);
+		tui.addChild(editor);
+		tui.setStickyBottomStart(editor);
+		terminal.sendInput("\x1b[5~");
+		// Direct input is not connected until start(); exercise the render logic by using the private method at runtime.
+		(tui as unknown as { scrollStickyViewport(delta: number): boolean }).scrollStickyViewport(2);
+		assert.deepStrictEqual(tui.render(40), ["h0", "h1", "h2", "h3", "editor"]);
+
+		history.setLines(["h0", "h1", "h2", "h3", "h4", "h5", "h6"]);
+		assert.deepStrictEqual(tui.render(40), ["h0", "h1", "h2", "h3", "editor"]);
+	});
+});


### PR DESCRIPTION
## Summary\n- add a TUI sticky-bottom boundary API so bottom components stay fixed while earlier content scrolls\n- use it in interactive mode to keep widgets/editor/footer visible at the bottom\n- document the API and add sticky-bottom tests\n\n## Tests\n- cd packages/tui && node --test test/sticky-bottom.test.ts\n- cd packages/tui && npm run build\n- cd packages/ai && npm run build && cd ../agent && npm run build && cd ../coding-agent && npm run build\n\nNote: building pi-ai regenerated model catalogs locally; those generated changes were reverted before committing.