### PR TITLE
fix: stop padding TUI lines with trailing spaces

### DIFF
--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -125,13 +125,16 @@ export class Box implements Component {
 	}
 
 	private applyBg(line: string, width: number): string {
-		const visLen = visibleWidth(line);
-		const padNeeded = Math.max(0, width - visLen);
-		const padded = line + " ".repeat(padNeeded);
-
 		if (this.bgFn) {
+			const visLen = visibleWidth(line);
+			const padNeeded = Math.max(0, width - visLen);
+			const padded = line + " ".repeat(padNeeded);
 			return applyBackgroundToLine(padded, width, this.bgFn);
 		}
-		return padded;
+		// No background - don't pad to width.
+		// The TUI renderer clears each line with \x1b[2K before writing,
+		// so trailing spaces are unnecessary. Omitting them keeps xterm.js
+		// cells empty, which allows proper whitespace trimming on copy.
+		return line;
 	}
 }

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -215,18 +215,18 @@ export class Markdown implements Component {
 			if (bgFn) {
 				contentLines.push(applyBackgroundToLine(lineWithMargins, width, bgFn));
 			} else {
-				// No background - just pad to width
-				const visibleLen = visibleWidth(lineWithMargins);
-				const paddingNeeded = Math.max(0, width - visibleLen);
-				contentLines.push(lineWithMargins + " ".repeat(paddingNeeded));
+				// No background - don't pad to width.
+				// The TUI renderer clears each line with \x1b[2K before writing,
+				// so trailing spaces are unnecessary. Omitting them keeps xterm.js
+				// cells empty, which allows proper whitespace trimming on copy.
+				contentLines.push(lineWithMargins);
 			}
 		}
 
 		// Add top/bottom padding (empty lines)
-		const emptyLine = " ".repeat(width);
 		const emptyLines: string[] = [];
 		for (let i = 0; i < this.paddingY; i++) {
-			const line = bgFn ? applyBackgroundToLine(emptyLine, width, bgFn) : emptyLine;
+			const line = bgFn ? applyBackgroundToLine(" ".repeat(width), width, bgFn) : "";
 			emptyLines.push(line);
 		}
 

--- a/packages/tui/src/components/text.ts
+++ b/packages/tui/src/components/text.ts
@@ -1,5 +1,5 @@
 import type { Component } from "../tui.ts";
-import { applyBackgroundToLine, visibleWidth, wrapTextWithAnsi } from "../utils.ts";
+import { applyBackgroundToLine, wrapTextWithAnsi } from "../utils.ts";
 
 /**
  * Text component - displays multi-line text with word wrapping
@@ -79,18 +79,18 @@ export class Text implements Component {
 			if (this.customBgFn) {
 				contentLines.push(applyBackgroundToLine(lineWithMargins, width, this.customBgFn));
 			} else {
-				// No background - just pad to width with spaces
-				const visibleLen = visibleWidth(lineWithMargins);
-				const paddingNeeded = Math.max(0, width - visibleLen);
-				contentLines.push(lineWithMargins + " ".repeat(paddingNeeded));
+				// No background - don't pad to width.
+				// The TUI renderer clears each line with \x1b[2K before writing,
+				// so trailing spaces are unnecessary. Omitting them keeps xterm.js
+				// cells empty, which allows proper whitespace trimming on copy.
+				contentLines.push(lineWithMargins);
 			}
 		}
 
 		// Add top/bottom padding (empty lines)
-		const emptyLine = " ".repeat(width);
 		const emptyLines: string[] = [];
 		for (let i = 0; i < this.paddingY; i++) {
-			const line = this.customBgFn ? applyBackgroundToLine(emptyLine, width, this.customBgFn) : emptyLine;
+			const line = this.customBgFn ? applyBackgroundToLine(" ".repeat(width), width, this.customBgFn) : "";
 			emptyLines.push(line);
 		}
 

--- a/packages/tui/src/components/truncated-text.ts
+++ b/packages/tui/src/components/truncated-text.ts
@@ -1,5 +1,5 @@
 import type { Component } from "../tui.ts";
-import { truncateToWidth, visibleWidth } from "../utils.ts";
+import { truncateToWidth } from "../utils.ts";
 
 /**
  * Text component that truncates to fit viewport width
@@ -22,12 +22,11 @@ export class TruncatedText implements Component {
 	render(width: number): string[] {
 		const result: string[] = [];
 
-		// Empty line padded to width
-		const emptyLine = " ".repeat(width);
-
-		// Add vertical padding above
+		// Add vertical padding above (empty lines, not space-padded —
+		// the TUI renderer clears lines with \x1b[2K so xterm.js cells
+		// stay empty and get trimmed on copy)
 		for (let i = 0; i < this.paddingY; i++) {
-			result.push(emptyLine);
+			result.push("");
 		}
 
 		// Calculate available width after horizontal padding
@@ -48,16 +47,14 @@ export class TruncatedText implements Component {
 		const rightPadding = " ".repeat(this.paddingX);
 		const lineWithPadding = leftPadding + displayText + rightPadding;
 
-		// Pad line to exactly width characters
-		const lineVisibleWidth = visibleWidth(lineWithPadding);
-		const paddingNeeded = Math.max(0, width - lineVisibleWidth);
-		const finalLine = lineWithPadding + " ".repeat(paddingNeeded);
-
-		result.push(finalLine);
+		// Don't pad to width — the TUI renderer clears each line with
+		// \x1b[2K, so trailing spaces are unnecessary. Omitting them keeps
+		// xterm.js cells empty, which allows proper whitespace trimming on copy.
+		result.push(lineWithPadding);
 
 		// Add vertical padding below
 		for (let i = 0; i < this.paddingY; i++) {
-			result.push(emptyLine);
+			result.push("");
 		}
 
 		return result;

--- a/packages/tui/test/truncated-text.test.ts
+++ b/packages/tui/test/truncated-text.test.ts
@@ -8,55 +8,61 @@ import { visibleWidth } from "../src/utils.ts";
 const chalk = new Chalk({ level: 3 });
 
 describe("TruncatedText component", () => {
-	it("pads output lines to exactly match width", () => {
+	it("does not pad output lines to full width", () => {
 		const text = new TruncatedText("Hello world", 1, 0);
 		const lines = text.render(50);
 
 		// Should have exactly one content line (no vertical padding)
 		assert.strictEqual(lines.length, 1);
 
-		// Line should be exactly 50 visible characters
+		// Line should contain the text with left/right padding but NOT
+		// be padded to the full width — trailing cells stay empty so
+		// xterm.js trims whitespace on copy.
 		const visibleLen = visibleWidth(lines[0]);
-		assert.strictEqual(visibleLen, 50);
+		assert.strictEqual(visibleLen, 13); // 1 + 11 + 1
 	});
 
-	it("pads output with vertical padding lines to width", () => {
+	it("vertical padding lines are empty", () => {
 		const text = new TruncatedText("Hello", 0, 2);
 		const lines = text.render(40);
 
 		// Should have 2 padding lines + 1 content line + 2 padding lines = 5 total
 		assert.strictEqual(lines.length, 5);
 
-		// All lines should be exactly 40 characters
-		for (const line of lines) {
-			assert.strictEqual(visibleWidth(line), 40);
-		}
+		// Padding lines should be empty (not space-filled)
+		assert.strictEqual(lines[0], "");
+		assert.strictEqual(lines[1], "");
+		assert.strictEqual(lines[3], "");
+		assert.strictEqual(lines[4], "");
+
+		// Content line should contain text but not be padded to width
+		assert.strictEqual(visibleWidth(lines[2]), 5);
 	});
 
-	it("truncates long text and pads to width", () => {
+	it("truncates long text with ellipsis", () => {
 		const longText = "This is a very long piece of text that will definitely exceed the available width";
 		const text = new TruncatedText(longText, 1, 0);
 		const lines = text.render(30);
 
 		assert.strictEqual(lines.length, 1);
 
-		// Should be exactly 30 characters
-		assert.strictEqual(visibleWidth(lines[0]), 30);
+		// Should not exceed 30 characters (content width 28 + 2 padding)
+		assert.ok(visibleWidth(lines[0]) <= 30);
 
 		// Should contain ellipsis
 		const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "");
 		assert.ok(stripped.includes("..."));
 	});
 
-	it("preserves ANSI codes in output and pads correctly", () => {
+	it("preserves ANSI codes in output", () => {
 		const styledText = `${chalk.red("Hello")} ${chalk.blue("world")}`;
 		const text = new TruncatedText(styledText, 1, 0);
 		const lines = text.render(40);
 
 		assert.strictEqual(lines.length, 1);
 
-		// Should be exactly 40 visible characters (ANSI codes don't count)
-		assert.strictEqual(visibleWidth(lines[0]), 40);
+		// Visible width should be content + padding, not padded to 40
+		assert.strictEqual(visibleWidth(lines[0]), 13); // 1 + 11 + 1
 
 		// Should preserve the color codes
 		assert.ok(lines[0].includes("\x1b["));
@@ -69,21 +75,21 @@ describe("TruncatedText component", () => {
 
 		assert.strictEqual(lines.length, 1);
 
-		// Should be exactly 20 visible characters
-		assert.strictEqual(visibleWidth(lines[0]), 20);
+		// Should not exceed 20 visible characters
+		assert.ok(visibleWidth(lines[0]) <= 20);
 
 		// Should contain reset code before ellipsis
 		assert.ok(lines[0].includes("\x1b[0m..."));
 	});
 
-	it("handles text that fits exactly", () => {
+	it("handles text that fits without truncation", () => {
 		// With paddingX=1, available width is 30-2=28
 		// "Hello world" is 11 chars, fits comfortably
 		const text = new TruncatedText("Hello world", 1, 0);
 		const lines = text.render(30);
 
 		assert.strictEqual(lines.length, 1);
-		assert.strictEqual(visibleWidth(lines[0]), 30);
+		assert.strictEqual(visibleWidth(lines[0]), 13); // 1 + 11 + 1
 
 		// Should NOT contain ellipsis
 		const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "");
@@ -95,7 +101,8 @@ describe("TruncatedText component", () => {
 		const lines = text.render(30);
 
 		assert.strictEqual(lines.length, 1);
-		assert.strictEqual(visibleWidth(lines[0]), 30);
+		// Empty text with paddingX=1: just left + right padding
+		assert.strictEqual(visibleWidth(lines[0]), 2);
 	});
 
 	it("stops at newline and only shows first line", () => {
@@ -104,7 +111,7 @@ describe("TruncatedText component", () => {
 		const lines = text.render(40);
 
 		assert.strictEqual(lines.length, 1);
-		assert.strictEqual(visibleWidth(lines[0]), 40);
+		assert.strictEqual(visibleWidth(lines[0]), 12); // 1 + 10 + 1
 
 		// Should only contain "First line"
 		const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "").trim();
@@ -119,7 +126,7 @@ describe("TruncatedText component", () => {
 		const lines = text.render(25);
 
 		assert.strictEqual(lines.length, 1);
-		assert.strictEqual(visibleWidth(lines[0]), 25);
+		assert.ok(visibleWidth(lines[0]) <= 25);
 
 		// Should contain ellipsis and not second line
 		const stripped = lines[0].replace(/\x1b\[[0-9;]*m/g, "");


### PR DESCRIPTION
## Problem

Copying output from the VS Code integrated terminal (xterm.js) includes trailing whitespace on every line.

The TUI components (`Markdown`, `Text`, `Box`, `TruncatedText`) pad every rendered line to the full terminal width with real space characters. xterm.js distinguishes real space cells from empty/unwritten cells, only empty cells get trimmed on copy. Since the TUI renderer already clears each line with `\x1b[2K` before writing, the trailing spaces serve no visual purpose.

## Change Context

For lines **without** a background color, stop appending trailing spaces. The `\x1b[2K` erase-line already clears previous content, and leaving cells unwritten lets xterm.js trim them on copy.

Lines **with** a background color still pad with spaces (the background needs to extend to the full width). A follow-up could replace those with `\x1b[K` (erase-to-EOL, which inherits the current bg color and marks cells as empty) for the same benefit.

Related: #2033 