### PR TITLE
fix find paths from Windows drive root

### DIFF
--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -17,6 +17,20 @@ function toPosixPath(value: string): string {
 	return value.split(path.sep).join("/");
 }
 
+function hasTrailingPathSeparator(value: string): boolean {
+	return value.endsWith("/") || value.endsWith("\\");
+}
+
+function formatFindPath(searchPath: string, resultPath: string): string {
+	const hadTrailingSlash = hasTrailingPathSeparator(resultPath);
+	const absolutePath = path.isAbsolute(resultPath) ? resultPath : path.resolve(searchPath, resultPath);
+	let relativePath = path.relative(searchPath, absolutePath);
+	if (hadTrailingSlash && relativePath && !hasTrailingPathSeparator(relativePath)) {
+		relativePath += path.sep;
+	}
+	return toPosixPath(relativePath);
+}
+
 const findSchema = Type.Object({
 	pattern: Type.String({
 		description: "Glob pattern to match files, e.g. '*.ts', '**/*.json', or 'src/**/*.spec.ts'",
@@ -180,10 +194,7 @@ export function createFindToolDefinition(
 							}
 
 							// Relativize paths against the search root for stable output.
-							const relativized = results.map((p) => {
-								if (p.startsWith(searchPath)) return toPosixPath(p.slice(searchPath.length + 1));
-								return toPosixPath(path.relative(searchPath, p));
-							});
+							const relativized = results.map((p) => formatFindPath(searchPath, p));
 							const resultLimitReached = relativized.length >= effectiveLimit;
 							const rawOutput = relativized.join("\n");
 							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
@@ -308,15 +319,7 @@ export function createFindToolDefinition(
 							for (const rawLine of lines) {
 								const line = rawLine.replace(/\r$/, "").trim();
 								if (!line) continue;
-								const hadTrailingSlash = line.endsWith("/") || line.endsWith("\\");
-								let relativePath = line;
-								if (line.startsWith(searchPath)) {
-									relativePath = line.slice(searchPath.length + 1);
-								} else {
-									relativePath = path.relative(searchPath, line);
-								}
-								if (hadTrailingSlash && !relativePath.endsWith("/")) relativePath += "/";
-								relativized.push(toPosixPath(relativePath));
+								relativized.push(formatFindPath(searchPath, line));
 							}
 
 							const resultLimitReached = relativized.length >= effectiveLimit;

--- a/packages/coding-agent/test/suite/regressions/6104-find-windows-drive-root.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6104-find-windows-drive-root.test.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createFindToolDefinition } from "../../../src/core/tools/find.ts";
+
+const describeOnWindows = process.platform === "win32" ? describe : describe.skip;
+
+describeOnWindows("issue #6104 find from a bare Windows drive root", () => {
+	async function runFind(searchRoot: string, resultPath: string): Promise<string> {
+		const def = createFindToolDefinition(searchRoot, {
+			operations: {
+				exists: () => true,
+				glob: () => [resultPath],
+			},
+		});
+		const ctx = {} as Parameters<typeof def.execute>[4];
+		const result = (await def.execute("call-1", { pattern: "*", path: searchRoot }, undefined, undefined, ctx)) as {
+			content: Array<{ type: string; text?: string }>;
+		};
+		return result.content[0]?.text?.trim() ?? "";
+	}
+
+	it("preserves the first path segment and a single directory slash", async () => {
+		const driveRoot = path.parse(process.cwd()).root;
+		const resultPath = `${path.join(driveRoot, "AI", "Models", "TextGen", "gemma4")}${path.sep}`;
+
+		await expect(runFind(driveRoot, resultPath)).resolves.toBe("AI/Models/TextGen/gemma4/");
+	});
+});


### PR DESCRIPTION
﻿Fixes #6104.

## Summary
- Replace manual prefix slicing in the find tool with path.relative-based formatting.
- Preserve directory result trailing slashes without producing doubled slashes.
- Add a Windows-only regression for bare drive-root find results.

## Validation
- `node ./node_modules/vitest/dist/cli.js --run test/suite/regressions/6104-find-windows-drive-root.test.ts`
- `npm run check`
- `node ./node_modules/vitest/dist/cli.js --run test/tools.test.ts -t "find tool"`

`./test.sh` was run from Git Bash after authenticating the local environment. It reached the workspace test suite but failed on existing Windows/Git-Bash environment issues unrelated to this patch, including symlink/path assertions, read-only file error-code expectations, missing built dist imports, and fd/rg availability or Windows path parsing in unrelated tests.
