### PR TITLE
Add Zen mode tool call labels

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -772,7 +772,7 @@ export const streamSimple: StreamFunction<"anthropic-messages", SimpleStreamOpti
 	assertRequestAuth(model.provider, options?.apiKey, options?.headers);
 
 	const base = buildBaseOptions(model, context, options, options?.apiKey);
-	if (!options?.reasoning) {
+	if (!options?.reasoning || options.reasoning === "off") {
 		return stream(model, context, { ...base, thinkingEnabled: false } satisfies AnthropicOptions);
 	}
 

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -388,7 +388,7 @@ export const streamSimple: StreamFunction<"bedrock-converse-stream", SimpleStrea
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream => {
 	const base = buildBaseOptions(model, context, options, undefined);
-	if (!options?.reasoning) {
+	if (!options?.reasoning || options.reasoning === "off") {
 		return stream(model, context, { ...base, reasoning: undefined } satisfies BedrockOptions);
 	}
 

--- a/packages/ai/src/api/google-generative-ai.ts
+++ b/packages/ai/src/api/google-generative-ai.ts
@@ -292,7 +292,7 @@ export const streamSimple: StreamFunction<"google-generative-ai", SimpleStreamOp
 	}
 
 	const base = buildBaseOptions(model, context, options, apiKey);
-	if (!options?.reasoning) {
+	if (!options?.reasoning || options.reasoning === "off") {
 		return stream(model, context, { ...base, thinking: { enabled: false } } satisfies GoogleOptions);
 	}
 

--- a/packages/ai/src/api/google-vertex.ts
+++ b/packages/ai/src/api/google-vertex.ts
@@ -304,7 +304,7 @@ export const streamSimple: StreamFunction<"google-vertex", SimpleStreamOptions> 
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream => {
 	const base = buildBaseOptions(model, context, options, undefined);
-	if (!options?.reasoning) {
+	if (!options?.reasoning || options.reasoning === "off") {
 		return stream(model, context, {
 			...base,
 			thinking: { enabled: false },

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -464,7 +464,7 @@ export const streamSimple: StreamFunction<"openai-codex-responses", SimpleStream
 
 	const base = buildBaseOptions(model, context, options, apiKey);
 	const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
-	const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
+	const reasoningEffort = clampedReasoning === "off" ? "none" : clampedReasoning;
 
 	return stream(model, context, {
 		...base,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -288,7 +288,7 @@ export type ProviderImagesOptions = ImagesOptions & Record<string, unknown>;
 
 // Unified options with reasoning passed to streamSimple() and completeSimple()
 export interface SimpleStreamOptions extends StreamOptions {
-	reasoning?: ThinkingLevel;
+	reasoning?: ModelThinkingLevel;
 	/** Custom token budgets for thinking levels (token-based providers only) */
 	thinkingBudgets?: ThinkingBudgets;
 }

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -698,6 +698,67 @@ describe("openai-codex streaming", () => {
 		expect(requestedReasoning).toEqual({ effort: "xhigh", summary: "auto" });
 	});
 
+	it("maps off reasoning to Codex none reasoning effort", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const sse = buildSSEPayload({ status: "completed" });
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+		let requestedReasoning: unknown;
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				const body = decodeCodexRequestBody(init?.body);
+				requestedReasoning = body?.reasoning;
+				return new Response(stream, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.4-mini",
+			name: "GPT-5.4 Mini",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			thinkingLevelMap: { off: "none" },
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		await streamSimpleOpenAICodexResponses(model, context, {
+			apiKey: token,
+			reasoning: "off",
+			transport: "sse",
+		}).result();
+
+		expect(requestedReasoning).toEqual({ effort: "none", summary: "auto" });
+	});
+
 	it.each(["gpt-5.3-codex", "gpt-5.4", "gpt-5.5"])("clamps %s minimal reasoning effort to low", async (modelId) => {
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
 		process.env.PI_CODING_AGENT_DIR = tempDir;

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -53,6 +53,7 @@ Use `/trust` in interactive mode to save a project trust decision for future ses
 | `theme` | string | `"dark"` | Theme name (`"dark"`, `"light"`, or custom) |
 | `externalEditor` | string | `$VISUAL`, then `$EDITOR`, then Notepad on Windows or `nano` elsewhere | Command for Ctrl+G external editor; takes precedence over environment variables |
 | `quietStartup` | boolean | `false` | Hide startup header |
+| `zenMode` | boolean | `false` | In interactive TUI, show compact summarized tool-call labels instead of verbose arguments/commands. Pi asks an authenticated `gpt-5.4-mini` model for a no-reasoning one-off label when available, and uses a safe deterministic fallback otherwise |
 | `defaultProjectTrust` | string | `"ask"` | Fallback project trust behavior: `"ask"`, `"always"`, or `"never"`. Global setting only |
 | `collapseChangelog` | boolean | `false` | Show condensed changelog after updates |
 | `enableInstallTelemetry` | boolean | `true` | Send an anonymous install/update version ping after first install or changelog-detected updates. This does not control update checks |

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -93,6 +93,7 @@ export interface Settings {
 	externalEditor?: string; // Command for Ctrl+G external editor; takes precedence over VISUAL/EDITOR
 	shellPath?: string; // Custom shell path (e.g., for Cygwin users on Windows)
 	quietStartup?: boolean;
+	zenMode?: boolean; // Compact TUI tool-call labels with fast summaries
 	defaultProjectTrust?: DefaultProjectTrust; // default: "ask"; global setting only
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	npmCommand?: string[]; // Command used for npm package lookup/install operations, argv-style (e.g., ["mise", "exec", "node@20", "--", "npm"])
@@ -878,6 +879,16 @@ export class SettingsManager {
 	setQuietStartup(quiet: boolean): void {
 		this.globalSettings.quietStartup = quiet;
 		this.markModified("quietStartup");
+		this.save();
+	}
+
+	getZenMode(): boolean {
+		return this.settings.zenMode ?? false;
+	}
+
+	setZenMode(enabled: boolean): void {
+		this.globalSettings.zenMode = enabled;
+		this.markModified("zenMode");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -74,6 +74,7 @@ export interface SettingsConfig {
 	outputPad: 0 | 1;
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
+	zenMode: boolean;
 	defaultProjectTrust: DefaultProjectTrust;
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
@@ -104,6 +105,7 @@ export interface SettingsCallbacks {
 	onOutputPadChange: (padding: 0 | 1) => void;
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
+	onZenModeChange: (enabled: boolean) => void;
 	onDefaultProjectTrustChange: (defaultProjectTrust: DefaultProjectTrust) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
@@ -536,6 +538,13 @@ export class SettingsSelectorComponent extends Container {
 				values: ["true", "false"],
 			},
 			{
+				id: "zen-mode",
+				label: "Zen mode",
+				description: "Show compact summarized tool-call labels instead of verbose commands",
+				currentValue: config.zenMode ? "true" : "false",
+				values: ["true", "false"],
+			},
+			{
 				id: "install-telemetry",
 				label: "Install telemetry",
 				description: "Send an anonymous version/update ping after changelog-detected updates",
@@ -769,6 +778,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "quiet-startup":
 						callbacks.onQuietStartupChange(newValue === "true");
+						break;
+					case "zen-mode":
+						callbacks.onZenModeChange(newValue === "true");
 						break;
 					case "install-telemetry":
 						callbacks.onEnableInstallTelemetryChange(newValue === "true");

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -8,6 +8,7 @@ import { theme } from "../theme/theme.ts";
 export interface ToolExecutionOptions {
 	showImages?: boolean;
 	imageWidthCells?: number;
+	zenLabel?: string;
 }
 
 export class ToolExecutionComponent extends Container {
@@ -25,6 +26,7 @@ export class ToolExecutionComponent extends Container {
 	private expanded = false;
 	private showImages: boolean;
 	private imageWidthCells: number;
+	private zenLabel: string | undefined;
 	private isPartial = true;
 	private toolDefinition?: ToolDefinition<any, any>;
 	private builtInToolDefinition?: ToolDefinition<any, any>;
@@ -57,6 +59,7 @@ export class ToolExecutionComponent extends Container {
 		this.builtInToolDefinition = createAllToolDefinitions(cwd)[toolName as ToolName];
 		this.showImages = options.showImages ?? true;
 		this.imageWidthCells = options.imageWidthCells ?? 60;
+		this.zenLabel = options.zenLabel;
 		this.ui = ui;
 		this.cwd = cwd;
 
@@ -136,6 +139,13 @@ export class ToolExecutionComponent extends Container {
 		return new Text(theme.fg("toolTitle", theme.bold(this.toolName)), 0, 0);
 	}
 
+	private createZenCallComponent(): Component | undefined {
+		if (!this.zenLabel) {
+			return undefined;
+		}
+		return new Text(theme.fg("toolTitle", theme.bold(this.zenLabel)), 0, 0);
+	}
+
 	private createResultFallback(): Component | undefined {
 		const output = this.getTextOutput();
 		if (!output) {
@@ -213,6 +223,11 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	setZenLabel(label: string | undefined): void {
+		this.zenLabel = label;
+		this.updateDisplay();
+	}
+
 	override invalidate(): void {
 		super.invalidate();
 		this.updateDisplay();
@@ -266,20 +281,26 @@ export class ToolExecutionComponent extends Container {
 			}
 			renderContainer.clear();
 
-			const callRenderer = this.getCallRenderer();
-			if (!callRenderer) {
-				renderContainer.addChild(this.createCallFallback());
+			const zenCallComponent = this.createZenCallComponent();
+			if (zenCallComponent) {
+				renderContainer.addChild(zenCallComponent);
 				hasContent = true;
 			} else {
-				try {
-					const component = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
-					this.callRendererComponent = component;
-					renderContainer.addChild(component);
-					hasContent = true;
-				} catch {
-					this.callRendererComponent = undefined;
+				const callRenderer = this.getCallRenderer();
+				if (!callRenderer) {
 					renderContainer.addChild(this.createCallFallback());
 					hasContent = true;
+				} else {
+					try {
+						const component = callRenderer(this.args, theme, this.getRenderContext(this.callRendererComponent));
+						this.callRendererComponent = component;
+						renderContainer.addChild(component);
+						hasContent = true;
+					} catch {
+						this.callRendererComponent = undefined;
+						renderContainer.addChild(this.createCallFallback());
+						hasContent = true;
+					}
 				}
 			}
 
@@ -314,7 +335,7 @@ export class ToolExecutionComponent extends Container {
 			}
 		} else {
 			this.contentText.setCustomBgFn(bgFn);
-			this.contentText.setText(this.formatToolExecution());
+			this.contentText.setText(this.zenLabel ? this.formatZenToolExecution() : this.formatToolExecution());
 			hasContent = true;
 		}
 
@@ -360,6 +381,15 @@ export class ToolExecutionComponent extends Container {
 
 	private getTextOutput(): string {
 		return getRenderedTextOutput(this.result, this.showImages);
+	}
+
+	private formatZenToolExecution(): string {
+		let text = theme.fg("toolTitle", theme.bold(this.zenLabel ?? this.toolName));
+		const output = this.getTextOutput();
+		if (output) {
+			text += `\n${output}`;
+		}
+		return text;
 	}
 
 	private formatToolExecution(): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -10,6 +10,7 @@ import * as path from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import {
 	type AssistantMessage,
+	type Context,
 	getProviders,
 	type ImageContent,
 	type Message,
@@ -322,6 +323,9 @@ export class InteractiveMode {
 
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
+	private zenToolSummaryChain: Promise<void> = Promise.resolve();
+	private zenPreviousToolSummary: string | undefined = undefined;
+	private zenToolSummaryGeneration = 0;
 
 	// Tool output expansion state
 	private toolOutputExpanded = false;
@@ -406,6 +410,7 @@ export class InteractiveMode {
 		this.autoTrustOnReloadCwd = options.autoTrustOnReloadCwd;
 		this.runtimeHost.setBeforeSessionInvalidate(() => {
 			this.resetExtensionUI();
+			this.resetZenToolSummaries();
 		});
 		this.runtimeHost.setRebindSession(async () => {
 			await this.rebindCurrentSession({ renderBeforeBind: true });
@@ -447,6 +452,193 @@ export class InteractiveMode {
 			(message) => this.showError(message),
 			() => this.updateEditorBorderColor(),
 		);
+	}
+
+	private resetZenToolSummaries(): void {
+		this.zenPreviousToolSummary = undefined;
+		this.zenToolSummaryChain = Promise.resolve();
+		this.zenToolSummaryGeneration++;
+	}
+
+	private getStringArg(args: unknown, key: string): string | undefined {
+		if (typeof args !== "object" || args === null) {
+			return undefined;
+		}
+		const value = (args as Record<string, unknown>)[key];
+		return typeof value === "string" ? value : undefined;
+	}
+
+	private getToolPathArg(args: unknown): string | undefined {
+		return this.getStringArg(args, "path") ?? this.getStringArg(args, "file_path");
+	}
+
+	private shortPathLabel(filePath: string | undefined): string | undefined {
+		if (!filePath) {
+			return undefined;
+		}
+		return path.basename(filePath) || filePath;
+	}
+
+	private createFallbackZenToolLabel(toolName: string, args: unknown): string {
+		const pathLabel = this.shortPathLabel(this.getToolPathArg(args));
+		switch (toolName) {
+			case "bash":
+				return "Running shell command";
+			case "read":
+				return pathLabel ? `Reading ${pathLabel}` : "Reading file";
+			case "edit":
+				return pathLabel ? `Editing ${pathLabel}` : "Editing file";
+			case "write":
+				return pathLabel ? `Writing ${pathLabel}` : "Writing file";
+			case "grep":
+				return "Searching files";
+			case "find":
+				return "Finding files";
+			case "ls":
+				return pathLabel ? `Listing ${pathLabel}` : "Listing files";
+			default:
+				return `${toolName} tool`;
+		}
+	}
+
+	private createLongZenToolLabel(toolName: string, args: unknown): string {
+		const command = this.getStringArg(args, "command");
+		if (toolName === "bash" && command !== undefined) {
+			return `$ ${command}`;
+		}
+
+		const pathArg = this.getToolPathArg(args);
+		if (pathArg !== undefined) {
+			return `${toolName} ${pathArg}`;
+		}
+
+		const serializedArgs = JSON.stringify(args);
+		return serializedArgs ? `${toolName} ${serializedArgs}` : toolName;
+	}
+
+	private normalizeZenToolLabel(label: string, fallback: string): string {
+		const normalized = label
+			.replace(/[\r\n]+/g, " ")
+			.replace(/^[[({\s"'`]+|[\])}\s"'`.]+$/g, "")
+			.replace(/\s+/g, " ")
+			.trim();
+		if (!normalized) {
+			return fallback;
+		}
+
+		const words = normalized.split(/\s+/).slice(0, 9);
+		return words.join(" ");
+	}
+
+	private getZenToolSummaryModel(): Model<any> | undefined {
+		const candidates = [
+			this.session.modelRegistry.find("openai", "gpt-5.4-mini"),
+			this.session.modelRegistry.find("openai-codex", "gpt-5.4-mini"),
+			this.session.modelRegistry.find("openrouter", "openai/gpt-5.4-mini"),
+		];
+		const configured = candidates.find((model): model is Model<any> => {
+			return model !== undefined && this.session.modelRegistry.hasConfiguredAuth(model);
+		});
+		if (configured) {
+			return configured;
+		}
+
+		return this.session.modelRegistry.getAvailable().find((model): model is Model<any> => {
+			return model.id === "gpt-5.4-mini" || model.id.endsWith("/gpt-5.4-mini");
+		});
+	}
+
+	private async summarizeZenToolLabel(
+		previousSummary: string | undefined,
+		longLabel: string,
+		fallback: string,
+	): Promise<string | undefined> {
+		const model = this.getZenToolSummaryModel();
+		if (!model) {
+			return undefined;
+		}
+
+		const prompt = [
+			`Previous summary: ${previousSummary || "(none)"}`,
+			`Current long label: ${longLabel.slice(0, 2000)}`,
+			"Summarize into under ten words. Return only the label.",
+		].join("\n");
+		const context: Context = {
+			systemPrompt:
+				"You write compact terminal UI labels for coding-agent tool calls. Return only a concise label under ten words. Do not include quotes or explanations.",
+			messages: [{ role: "user", content: [{ type: "text", text: prompt }], timestamp: Date.now() }],
+		};
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), 2500);
+
+		try {
+			const stream = await this.agent.streamFn(model, context, {
+				maxTokens: 32,
+				reasoning: "off",
+				signal: controller.signal,
+				timeoutMs: 2500,
+				maxRetries: 0,
+			});
+			const response = await stream.result();
+			if (response.stopReason === "error" || response.stopReason === "aborted") {
+				return undefined;
+			}
+			const text = response.content
+				.filter((content): content is { type: "text"; text: string } => content.type === "text")
+				.map((content) => content.text)
+				.join(" ");
+			return this.normalizeZenToolLabel(text, fallback);
+		} catch {
+			return undefined;
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+
+	private queueZenToolLabelSummary(component: ToolExecutionComponent, toolName: string, args: unknown): void {
+		const generation = this.zenToolSummaryGeneration;
+		const fallback = this.createFallbackZenToolLabel(toolName, args);
+		const longLabel = this.createLongZenToolLabel(toolName, args);
+		this.zenToolSummaryChain = this.zenToolSummaryChain
+			.then(async () => {
+				if (generation !== this.zenToolSummaryGeneration || !this.settingsManager.getZenMode()) {
+					return;
+				}
+				const summary = await this.summarizeZenToolLabel(this.zenPreviousToolSummary, longLabel, fallback);
+				if (!summary || generation !== this.zenToolSummaryGeneration || !this.settingsManager.getZenMode()) {
+					return;
+				}
+				this.zenPreviousToolSummary = summary;
+				component.setZenLabel(summary);
+				this.ui.requestRender();
+			})
+			.catch(() => {});
+	}
+
+	private createToolExecutionComponent(
+		toolName: string,
+		toolCallId: string,
+		args: unknown,
+		options: { summarizeZenLabel?: boolean } = {},
+	): ToolExecutionComponent {
+		const zenLabel = this.settingsManager.getZenMode() ? this.createFallbackZenToolLabel(toolName, args) : undefined;
+		const component = new ToolExecutionComponent(
+			toolName,
+			toolCallId,
+			args,
+			{
+				showImages: this.settingsManager.getShowImages(),
+				imageWidthCells: this.settingsManager.getImageWidthCells(),
+				zenLabel,
+			},
+			this.getRegisteredToolDefinition(toolName),
+			this.ui,
+			this.sessionManager.getCwd(),
+		);
+		if (zenLabel && options.summarizeZenLabel !== false) {
+			this.queueZenToolLabelSummary(component, toolName, args);
+		}
+		return component;
 	}
 
 	private getAutocompleteSourceTag(sourceInfo?: SourceInfo): string | undefined {
@@ -2760,6 +2952,7 @@ export class InteractiveMode {
 		switch (event.type) {
 			case "agent_start":
 				this.pendingTools.clear();
+				this.resetZenToolSummaries();
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(true);
 				}
@@ -2837,17 +3030,13 @@ export class InteractiveMode {
 					for (const content of this.streamingMessage.content) {
 						if (content.type === "toolCall") {
 							if (!this.pendingTools.has(content.id)) {
-								const component = new ToolExecutionComponent(
+								const component = this.createToolExecutionComponent(
 									content.name,
 									content.id,
 									content.arguments,
 									{
-										showImages: this.settingsManager.getShowImages(),
-										imageWidthCells: this.settingsManager.getImageWidthCells(),
+										summarizeZenLabel: false,
 									},
-									this.getRegisteredToolDefinition(content.name),
-									this.ui,
-									this.sessionManager.getCwd(),
 								);
 								component.setExpanded(this.toolOutputExpanded);
 								this.chatContainer.addChild(component);
@@ -2906,21 +3095,14 @@ export class InteractiveMode {
 			case "tool_execution_start": {
 				let component = this.pendingTools.get(event.toolCallId);
 				if (!component) {
-					component = new ToolExecutionComponent(
-						event.toolName,
-						event.toolCallId,
-						event.args,
-						{
-							showImages: this.settingsManager.getShowImages(),
-							imageWidthCells: this.settingsManager.getImageWidthCells(),
-						},
-						this.getRegisteredToolDefinition(event.toolName),
-						this.ui,
-						this.sessionManager.getCwd(),
-					);
+					component = this.createToolExecutionComponent(event.toolName, event.toolCallId, event.args);
 					component.setExpanded(this.toolOutputExpanded);
 					this.chatContainer.addChild(component);
 					this.pendingTools.set(event.toolCallId, component);
+				} else if (this.settingsManager.getZenMode()) {
+					component.updateArgs(event.args);
+					component.setZenLabel(this.createFallbackZenToolLabel(event.toolName, event.args));
+					this.queueZenToolLabelSummary(component, event.toolName, event.args);
 				}
 				component.markExecutionStarted();
 				this.ui.requestRender();
@@ -3228,18 +3410,9 @@ export class InteractiveMode {
 				// Render tool call components
 				for (const content of message.content) {
 					if (content.type === "toolCall") {
-						const component = new ToolExecutionComponent(
-							content.name,
-							content.id,
-							content.arguments,
-							{
-								showImages: this.settingsManager.getShowImages(),
-								imageWidthCells: this.settingsManager.getImageWidthCells(),
-							},
-							this.getRegisteredToolDefinition(content.name),
-							this.ui,
-							this.sessionManager.getCwd(),
-						);
+						const component = this.createToolExecutionComponent(content.name, content.id, content.arguments, {
+							summarizeZenLabel: false,
+						});
 						component.setExpanded(this.toolOutputExpanded);
 						this.chatContainer.addChild(component);
 
@@ -4025,6 +4198,7 @@ export class InteractiveMode {
 					outputPad: this.settingsManager.getOutputPad(),
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
 					quietStartup: this.settingsManager.getQuietStartup(),
+					zenMode: this.settingsManager.getZenMode(),
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 					showTerminalProgress: this.settingsManager.getShowTerminalProgress(),
 					warnings: this.settingsManager.getWarnings(),
@@ -4104,6 +4278,11 @@ export class InteractiveMode {
 					},
 					onQuietStartupChange: (enabled) => {
 						this.settingsManager.setQuietStartup(enabled);
+					},
+					onZenModeChange: (enabled) => {
+						this.settingsManager.setZenMode(enabled);
+						this.resetZenToolSummaries();
+						this.rebuildChatFromMessages();
 					},
 					onDefaultProjectTrustChange: (defaultProjectTrust) => {
 						this.settingsManager.setDefaultProjectTrust(defaultProjectTrust);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -216,6 +216,23 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("zen mode setting", () => {
+		it("defaults to false and persists zenMode globally", async () => {
+			const settingsPath = join(agentDir, "settings.json");
+			writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getZenMode()).toBe(false);
+
+			manager.setZenMode(true);
+			await manager.flush();
+
+			const savedSettings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			expect(savedSettings.zenMode).toBe(true);
+			expect(savedSettings.theme).toBe("dark");
+		});
+	});
+
 	describe("error tracking", () => {
 		it("should collect and clear load errors via drainErrors", () => {
 			const globalSettingsPath = join(agentDir, "settings.json");

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -41,6 +41,7 @@ type RenderSessionContextThis = {
 	settingsManager: {
 		getShowImages(): boolean;
 		getImageWidthCells(): number;
+		getZenMode(): boolean;
 	};
 	sessionManager: { getCwd(): string };
 	session: { retryAttempt: number };
@@ -48,6 +49,12 @@ type RenderSessionContextThis = {
 	isInitialized: boolean;
 	updateEditorBorderColor(): void;
 	getRegisteredToolDefinition(toolName: string): undefined;
+	createToolExecutionComponent: (
+		toolName: string,
+		toolCallId: string,
+		args: unknown,
+		options?: { summarizeZenLabel?: boolean },
+	) => ToolExecutionComponent;
 	addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void;
 	renderSessionItems: RenderSessionItems;
 };
@@ -70,6 +77,7 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 		settingsManager: {
 			getShowImages: () => false,
 			getImageWidthCells: () => 60,
+			getZenMode: () => false,
 		},
 		sessionManager: { getCwd: () => process.cwd() },
 		session: { retryAttempt: 0 },
@@ -77,6 +85,11 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 		isInitialized: true,
 		updateEditorBorderColor: vi.fn(),
 		getRegisteredToolDefinition: (_toolName: string) => undefined,
+		createToolExecutionComponent: (
+			InteractiveMode.prototype as unknown as {
+				createToolExecutionComponent: RenderSessionContextThis["createToolExecutionComponent"];
+			}
+		).createToolExecutionComponent,
 		renderSessionItems: (InteractiveMode.prototype as unknown as { renderSessionItems: RenderSessionItems })
 			.renderSessionItems,
 		addMessageToChat(message: AgentMessage) {

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -364,6 +364,28 @@ describe("ToolExecutionComponent parity", () => {
 		expect(rendered).toContain("done");
 	});
 
+	test("zen labels replace verbose call rendering and can be updated", () => {
+		const component = new ToolExecutionComponent(
+			"bash",
+			"tool-zen-bash",
+			{ command: "git status --short && rg super-secret-command" },
+			{ zenLabel: "Checking workspace" },
+			createBashToolDefinition(process.cwd()),
+			createFakeTui(),
+			process.cwd(),
+		);
+
+		let rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Checking workspace");
+		expect(rendered).not.toContain("git status --short");
+		expect(rendered).not.toContain("super-secret-command");
+
+		component.setZenLabel("Reviewing files");
+		rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Reviewing files");
+		expect(rendered).not.toContain("Checking workspace");
+	});
+
 	test("trims trailing blank display lines from write previews", () => {
 		const component = new ToolExecutionComponent(
 			"write",


### PR DESCRIPTION
## Summary
- add a `zenMode` setting and `/settings` toggle for compact tool-call labels in the interactive TUI
- render tool calls with deterministic safe fallback labels, then asynchronously replace live tool labels via serialized GPT-5.4-mini no-reasoning summary calls when auth is available
- allow explicit `reasoning: "off"` for simple stream calls and map Codex off reasoning to `none`
- document `zenMode` and add regression coverage for settings, tool rendering, pending tool rendering, and Codex off reasoning

## Validation
- `npm --prefix packages/coding-agent test -- test/settings-manager.test.ts test/tool-execution-component.test.ts test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts`
- `npm --prefix packages/ai test -- test/openai-codex-stream.test.ts`
- `npm run check`
- `npm run build`
- `git diff --check`

## Notes
- Full `npm --prefix packages/coding-agent test` was also attempted after build. It has 2 unrelated failures in `test/clipboard-image.test.ts` (`Non-Wayland: uses clipboard` and `Non-Wayland: returns null when clipboard has no image`); all other coding-agent tests passed (1491 passed, 47 skipped).

Closes WilsonLe/pi#1
