### PR TITLE
fix(coding-agent): strip hallucinated extra keys from edit tool edits[]

### DIFF
--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -106,12 +106,30 @@ function prepareEditArguments(input: unknown): EditToolInput {
 		} catch {}
 	}
 
+	// Strip hallucinated keys (like newText_x, in_file) emitted by newer Claude models.
+	// Only reallocate when extra keys are actually present to preserve reference equality for clean input.
+	if (Array.isArray(args.edits)) {
+		const hasExtraKeys = args.edits.some(
+			(edit) =>
+				edit !== null &&
+				typeof edit === "object" &&
+				Object.keys(edit as object).some((k) => k !== "oldText" && k !== "newText"),
+		);
+		if (hasExtraKeys) {
+			args.edits = args.edits.map((edit: unknown) => {
+				if (!edit || typeof edit !== "object") return edit;
+				const { oldText, newText } = edit as Record<string, unknown>;
+				return { oldText, newText };
+			});
+		}
+	}
+
 	const legacy = args as LegacyEditToolInput;
 	if (typeof legacy.oldText !== "string" || typeof legacy.newText !== "string") {
 		return args as EditToolInput;
 	}
 
-	const edits = Array.isArray(legacy.edits) ? [...legacy.edits] : [];
+	const edits = Array.isArray(args.edits) ? [...args.edits] : [];
 	edits.push({ oldText: legacy.oldText, newText: legacy.newText });
 	const { oldText: _oldText, newText: _newText, ...rest } = legacy;
 	return { ...rest, edits } as EditToolInput;

--- a/packages/coding-agent/test/edit-tool-legacy-input.test.ts
+++ b/packages/coding-agent/test/edit-tool-legacy-input.test.ts
@@ -114,3 +114,44 @@ describe("edit tool stringified edits", () => {
 		});
 	});
 });
+
+describe("edit tool hallucinated keys", () => {
+	it("strips extra keys like newText_x emitted by newer Claude models", () => {
+		const definition = createEditToolDefinition(process.cwd());
+		const prepared = definition.prepareArguments!({
+			path: "file.txt",
+			edits: [{ oldText: "a", newText: "b", newText_x: "", in_file: "file.txt" }],
+		});
+		expect(prepared).toEqual({
+			path: "file.txt",
+			edits: [{ oldText: "a", newText: "b" }],
+		});
+	});
+
+	it("strips extra keys from the first edit only, preserving clean subsequent edits", () => {
+		const definition = createEditToolDefinition(process.cwd());
+		const prepared = definition.prepareArguments!({
+			path: "file.txt",
+			edits: [
+				{ oldText: "a", newText: "b", newText_unused: "" },
+				{ oldText: "c", newText: "d" },
+			],
+		});
+		expect(prepared).toEqual({
+			path: "file.txt",
+			edits: [
+				{ oldText: "a", newText: "b" },
+				{ oldText: "c", newText: "d" },
+			],
+		});
+	});
+
+	it("does not reallocate the edits array when all edits are clean", () => {
+		const definition = createEditToolDefinition(process.cwd());
+		const edits = [{ oldText: "a", newText: "b" }];
+		const input = { path: "file.txt", edits };
+		const prepared = definition.prepareArguments!(input);
+		expect(prepared).toBe(input);
+		expect((prepared as typeof input).edits).toBe(edits);
+	});
+});


### PR DESCRIPTION
Fixes #6278

## Problem

Newer Claude models (Sonnet 5, Fable 5, Opus 4.8) occasionally emit hallucinated extra keys alongside the valid `oldText`/`newText` fields inside `edits[]` items. Observed examples: `newText_x`, `newText_unused`, `in_file`, `type`, `closeenough`. They are always at the end of the first edit object and always hold an empty string value.

`validateToolArguments` enforces `additionalProperties: false` via TypeBox and rejects these calls as a recoverable error, forcing the model to retry. This produces the reported failure message:

```
Validation failed for tool "edit": - edits.0: must not have additional properties
```

Empirical measurement shows roughly 20% of edit calls fail this way in affected sessions.

## Root cause

In non-strict mode the Anthropic API does not constrain token sampling to the schema, so the model is free to emit any key it believes is useful. The `edits[]` item schema declares `additionalProperties: false`, but newer models with adaptive thinking do not reliably honour it during generation.

## Fix

`prepareEditArguments` already coerces two known model shape mistakes before validation: stringified `edits` and the legacy top-level `oldText`/`newText` form. This extends that same coercion to strip any key that is not `oldText` or `newText` from each edit object.

The strip is guarded by a prior scan so no reallocation occurs when all edits are already clean, preserving the existing reference-equality contract tested by `passes through valid input unchanged`.

## Changes

- `packages/coding-agent/src/core/tools/edit.ts` — extend `prepareEditArguments` to strip extra keys from `edits[]` items
- `packages/coding-agent/test/edit-tool-legacy-input.test.ts` — three new regression tests in a `"edit tool hallucinated keys"` describe block

## Testing

```
npm run check   # clean
node packages/coding-agent/node_modules/vitest/dist/cli.js run \
  packages/coding-agent/test/edit-tool-legacy-input.test.ts
# 11 passed (8 existing + 3 new)
```