### PR TITLE
fix(ai): use OpenRouter reported cost for usage accounting

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -563,6 +563,10 @@ function buildParams(
 		(params as any).stream_options = { include_usage: true };
 	}
 
+	if (compat.requestsUsageAccounting) {
+		(params as any).usage = { include: true };
+	}
+
 	if (compat.supportsStore) {
 		params.store = false;
 	}
@@ -1114,6 +1118,7 @@ function parseChunkUsage(
 		prompt_cache_hit_tokens?: number;
 		prompt_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
 		completion_tokens_details?: { reasoning_tokens?: number };
+		cost?: number;
 	},
 	model: Model<"openai-completions">,
 ): AssistantMessage["usage"] {
@@ -1142,6 +1147,12 @@ function parseChunkUsage(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	calculateCost(model, usage);
+	// OpenRouter reports the actual charged amount when the request opts in via
+	// `usage: { include: true }`. Prefer it over the registry-derived total,
+	// which is zero for custom-registered models: https://openrouter.ai/docs/use-cases/usage-accounting
+	if (typeof rawUsage.cost === "number" && rawUsage.cost >= 0) {
+		usage.cost.total = rawUsage.cost;
+	}
 	return usage;
 }
 
@@ -1256,6 +1267,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 			isNvidia ||
 			isAntLing
 		),
+		requestsUsageAccounting: isOpenRouter,
 	};
 }
 
@@ -1289,5 +1301,6 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
 		cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
 		sendSessionAffinityHeaders: model.compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,
 		supportsLongCacheRetention: model.compat.supportsLongCacheRetention ?? detected.supportsLongCacheRetention,
+		requestsUsageAccounting: model.compat.requestsUsageAccounting ?? detected.requestsUsageAccounting,
 	};
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -515,6 +515,8 @@ export interface OpenAICompletionsCompat {
 	sendSessionAffinityHeaders?: boolean;
 	/** Whether the provider supports long prompt cache retention (`prompt_cache_retention: "24h"` or Anthropic-style `cache_control.ttl: "1h"`, depending on format). Default: true. */
 	supportsLongCacheRetention?: boolean;
+	/** Whether to request provider-reported usage accounting (e.g. OpenRouter's `usage: { include: true }`, which returns actual charged cost). Default: auto-detected from URL. */
+	requestsUsageAccounting?: boolean;
 }
 
 /** Compatibility settings for OpenAI Responses APIs. */

--- a/packages/ai/test/openai-completions-thinking-as-text.test.ts
+++ b/packages/ai/test/openai-completions-thinking-as-text.test.ts
@@ -40,6 +40,7 @@ const compat = {
 	cacheControlFormat: undefined,
 	sendSessionAffinityHeaders: false,
 	supportsLongCacheRetention: true,
+	requestsUsageAccounting: false,
 } satisfies Required<Omit<OpenAICompletionsCompat, "cacheControlFormat">> & {
 	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
 };

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1248,6 +1248,7 @@ describe("openai-completions tool_choice", () => {
 				supportsStrictMode: true,
 				sendSessionAffinityHeaders: false,
 				supportsLongCacheRetention: true,
+				requestsUsageAccounting: false,
 			},
 		);
 

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -38,6 +38,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	cacheControlFormat: "anthropic",
 	sendSessionAffinityHeaders: false,
 	supportsLongCacheRetention: true,
+	requestsUsageAccounting: false,
 };
 
 function buildToolResult(toolCallId: string, timestamp: number): ToolResultMessage {

--- a/packages/ai/test/openai-completions-usage-cost.test.ts
+++ b/packages/ai/test/openai-completions-usage-cost.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import { getModel } from "../src/compat.ts";
+import type { Model } from "../src/types.ts";
+
+interface CapturedCompletionsPayload {
+	usage?: { include: boolean };
+}
+
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as CapturedCompletionsPayload | undefined,
+	chunks: [] as unknown[],
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: (params: CapturedCompletionsPayload) => {
+					mockState.lastParams = params;
+					const chunks = mockState.chunks;
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							for (const chunk of chunks) yield chunk;
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+function createModel(overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+	const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+	return {
+		...(baseModel as Omit<Model<"openai-completions">, "api">),
+		api: "openai-completions",
+		...overrides,
+	};
+}
+
+async function captureRequest(model: Model<"openai-completions">) {
+	await streamOpenAICompletions(
+		model,
+		{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+		{ apiKey: "test-key" },
+	).result();
+
+	return mockState.lastParams;
+}
+
+describe("openai-completions usage accounting cost", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+		mockState.chunks = [
+			{
+				id: "chatcmpl-test",
+				choices: [{ delta: {}, finish_reason: "stop" }],
+				usage: {
+					prompt_tokens: 1,
+					completion_tokens: 1,
+					prompt_tokens_details: { cached_tokens: 0 },
+					completion_tokens_details: { reasoning_tokens: 0 },
+				},
+			},
+		];
+	});
+
+	it("requests usage accounting for OpenRouter models", async () => {
+		const model = createModel({ provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1" });
+		const payload = await captureRequest(model);
+
+		expect(payload?.usage).toEqual({ include: true });
+	});
+
+	it("does not request usage accounting for plain OpenAI models", async () => {
+		const payload = await captureRequest(createModel());
+
+		expect(payload?.usage).toBeUndefined();
+	});
+
+	it("uses provider-reported cost when present", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-test",
+				choices: [{ delta: {}, finish_reason: "stop" }],
+				usage: {
+					prompt_tokens: 1,
+					completion_tokens: 1,
+					prompt_tokens_details: { cached_tokens: 0 },
+					completion_tokens_details: { reasoning_tokens: 0 },
+					cost: 0.0123,
+				},
+			},
+		];
+		const model = createModel({ provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1" });
+
+		const message = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test-key" },
+		).result();
+
+		expect(message.usage.cost.total).toBe(0.0123);
+	});
+
+	it("leaves registry-computed cost untouched when cost is absent", async () => {
+		const model = createModel({
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			cost: { input: 1_000_000, output: 0, cacheRead: 0, cacheWrite: 0 },
+		});
+
+		const message = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test-key" },
+		).result();
+
+		expect(message.usage.cost.total).toBe(1);
+	});
+});

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -133,6 +133,7 @@ const OpenAICompletionsCompatSchema = Type.Object({
 	vercelGatewayRouting: Type.Optional(VercelGatewayRoutingSchema),
 	supportsStrictMode: Type.Optional(Type.Boolean()),
 	supportsLongCacheRetention: Type.Optional(Type.Boolean()),
+	requestsUsageAccounting: Type.Optional(Type.Boolean()),
 });
 
 const OpenAIResponsesCompatSchema = Type.Object({


### PR DESCRIPTION
Proposal: #6313

OpenRouter returns the actual charged amount in `usage.cost` when the request opts in with `usage: {"include": true}`. pi's registry-derived cost is zero for custom-registered models, so anything metering spend on top of pi has to patch the adapter to learn what a call really cost (we run exactly that patch in production today).

This adds a `requestsUsageAccounting` compat flag — auto-detected for OpenRouter, explicit `model.compat` wins like the other flags — sends the opt-in next to `stream_options`, and prefers a numeric reported `cost` over the registry total after `calculateCost`. Only the total is reported by OpenRouter, so per-bucket costs stay registry-computed. The extra one-liners in the fixture test files and the coding-agent TypeBox schema are just the new optional field.

Tests: `packages/ai` 66 passed / 25 skipped including the new `openai-completions-usage-cost` cases; `npm run check` clean.