### PR TITLE
perf(tui): avoid redraws for stable offscreen updates

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1401,11 +1401,50 @@ export class TUI extends Container {
 			return;
 		}
 
+		let renderFirstChanged = firstChanged;
+		const prevViewportBottom = prevViewportTop + height - 1;
+		const changedKittyImages = this.deleteChangedKittyImages(firstChanged, lastChanged);
+
+		// Stable-height changes above the viewport do not need a full redraw if
+		// visible rows can still be updated directly.
+		if (firstChanged < prevViewportTop) {
+			if (newLines.length !== this.previousLines.length) {
+				logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+				fullRender(true);
+				return;
+			}
+
+			let firstVisibleChanged = -1;
+			const scanEnd = Math.min(lastChanged, prevViewportBottom, newLines.length - 1);
+			for (let i = prevViewportTop; i <= scanEnd; i++) {
+				if (newLines[i] !== this.previousLines[i]) {
+					firstVisibleChanged = i;
+					break;
+				}
+			}
+
+			if (firstVisibleChanged === -1) {
+				if (changedKittyImages.length > 0) {
+					this.terminal.write(`\x1b[?2026h${changedKittyImages}\x1b[?2026l`);
+				}
+				this.positionHardwareCursor(cursorPos, newLines.length);
+				this.previousLines = newLines;
+				this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+				this.previousWidth = width;
+				this.previousHeight = height;
+				this.previousViewportTop = prevViewportTop;
+				this.cursorRow = Math.max(0, newLines.length - 1);
+				return;
+			}
+
+			renderFirstChanged = firstVisibleChanged;
+		}
+
 		// All changes are in deleted lines (nothing to render, just clear)
 		if (firstChanged >= newLines.length) {
 			if (this.previousLines.length > newLines.length) {
 				let buffer = "\x1b[?2026h";
-				buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
+				buffer += changedKittyImages;
 				// Move to end of new content (clamp to 0 for empty content)
 				const targetRow = Math.max(0, newLines.length - 1);
 				if (targetRow < prevViewportTop) {
@@ -1450,20 +1489,11 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible.
-		// If the first changed line is above the previous viewport, we need a full redraw.
-		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
-			return;
-		}
-
 		// Render from first changed line to end
 		// Build buffer with all updates wrapped in synchronized output
 		let buffer = "\x1b[?2026h"; // Begin synchronized output
-		buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
-		const prevViewportBottom = prevViewportTop + height - 1;
-		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
+		buffer += changedKittyImages;
+		const moveTargetRow = appendStart ? firstChanged - 1 : renderFirstChanged;
 		if (moveTargetRow > prevViewportBottom) {
 			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
 			const moveToBottom = height - 1 - currentScreenRow;
@@ -1487,11 +1517,11 @@ export class TUI extends Container {
 
 		buffer += appendStart ? "\r\n" : "\r"; // Move to column 0
 
-		// Only render changed lines (firstChanged to lastChanged), not all lines to end
+		// Only render changed lines (renderFirstChanged to lastChanged), not all lines to end
 		// This reduces flicker when only a single line changes (e.g., spinner animation)
 		const renderEnd = Math.min(lastChanged, newLines.length - 1);
-		for (let i = firstChanged; i <= renderEnd; i++) {
-			if (i > firstChanged) buffer += "\r\n";
+		for (let i = renderFirstChanged; i <= renderEnd; i++) {
+			if (i > renderFirstChanged) buffer += "\r\n";
 			const line = newLines[i];
 			const isImage = isImageLine(line);
 			const imageReservedRows = isImage ? this.getKittyImageReservedRows(newLines, i, renderEnd) : 1;

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -71,6 +71,10 @@ function getCellItalic(terminal: VirtualTerminal, row: number, col: number): num
 	return cell.isItalic();
 }
 
+function getPreviousLine(tui: TUI, index: number): string {
+	return (tui as unknown as { previousLines: string[] }).previousLines[index] ?? "";
+}
+
 describe("TUI Kitty image cleanup", () => {
 	it("clears reserved Kitty image rows before drawing appended image placements", async () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
@@ -675,6 +679,46 @@ describe("TUI differential rendering", () => {
 
 		assert.ok(tui.fullRedraws > initialRedraws, "Shrink should trigger a full redraw");
 		assert.deepStrictEqual(terminal.getViewport(), ["Line 2", "Line 3", "Line 4", "Line 5", "Line 6"]);
+
+		tui.stop();
+	});
+
+	it("keeps stable-height offscreen changes on the differential path", async () => {
+		const terminal = new LoggingVirtualTerminal(20, 5);
+		const tui = new TUI(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const lines = Array.from({ length: 12 }, (_, i) => `Line ${i}`);
+		component.lines = lines;
+		tui.start();
+		await terminal.waitForRender();
+
+		const initialRedraws = tui.fullRedraws;
+		terminal.clearWrites();
+
+		component.lines = lines.map((line, index) => (index === 1 ? "Changed offscreen" : line));
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, initialRedraws, "Offscreen-only changes should not full redraw");
+		assert.ok(getPreviousLine(tui, 1).startsWith("Changed offscreen"));
+		assert.ok(!terminal.getWrites().includes("\x1b[2J"), "Offscreen-only changes should not clear the screen");
+
+		terminal.clearWrites();
+		component.lines = component.lines.map((line, index) => {
+			if (index === 2) return "Changed offscreen again";
+			if (index === 10) return "Changed visible";
+			return line;
+		});
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, initialRedraws, "Mixed visible/offscreen changes should not full redraw");
+		assert.ok(getPreviousLine(tui, 2).startsWith("Changed offscreen again"));
+		assert.deepStrictEqual(terminal.getViewport(), ["Line 7", "Line 8", "Line 9", "Changed visible", "Line 11"]);
+		assert.ok(terminal.getWrites().includes("Changed visible"), "Visible change should be rendered");
+		assert.ok(!terminal.getWrites().includes("Changed offscreen again"), "Offscreen change should stay cached");
 
 		tui.stop();
 	});


### PR DESCRIPTION
## Summary

- Keep stable-height updates above the current TUI viewport on the differential render path.
- Update cached render state for offscreen-only changes without clearing/redrawing the visible screen.
- When a change set spans offscreen and visible rows, render from the first visible changed row only.
- Add a regression test covering both offscreen-only and mixed offscreen/visible updates.

## Why

The renderer previously forced a full redraw whenever the first changed line was above the previous viewport. That is still needed when the line count changes, but stable-height edits can preserve the viewport and update cached state directly. This avoids large terminal writes when old history lines change while the user is viewing the bottom of a long TUI session.

## Performance

Focused render harness:

```text
baseline pi_tui_render_update_bytes=108149
patched  pi_tui_render_update_bytes=136
```

Optimization run: https://dashboard.weco.ai/share/YtQr0Tu79gQXInbYPnxgzhrqwA6WWxUr

## Related

- Refs #4044, which describes repeated full redraws from offscreen bash-loader updates. This patch keeps the stable-height path differential while still updating cached render state.
- Related to #6241, an open PR for the same stable-height offscreen redraw path. This PR keeps the repaint start at the first visible changed row and includes the focused byte-count harness result above.

## Validation

- `npx biome check --write packages/tui/src/tui.ts packages/tui/test/tui-render.test.ts`
- `cd packages/tui && node --test test/tui-render.test.ts`
- `cd packages/tui && npm test`
- `cd packages/tui && npm run build`
- `npm run check`
