### PR TITLE
fix: preserve thinking level across models with different tier counts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Added
 
+- Added `thinkingLevelToEffort` and `effortToThinkingLevel` helpers that map between a model's supported thinking levels and a normalised `[0, 1]` effort, so reasoning intent carries consistently across models with different tier counts ([#6329](https://github.com/earendil-works/pi/issues/6329)).
 - Refreshed generated model catalogs from models.dev, adding newly listed models including Kimi K2.7 Code for GitHub Copilot and Fable 5 to several providers ([#6256](https://github.com/earendil-works/pi/issues/6256)).
 - Added Claude Sonnet 5 to the GitHub Copilot model catalog ([#6200](https://github.com/earendil-works/pi/issues/6200)).
 - Added zstd request-body compression for the OpenAI Codex Responses SSE transport. Requests are sent with `Content-Encoding: zstd` when Node/Bun zstd support is available; the WebSocket transport is unchanged.

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -407,6 +407,33 @@ export function getSupportedThinkingLevels<TApi extends Api>(model: Model<TApi>)
 	});
 }
 
+/**
+ * Normalised reasoning effort in [0, 1]. 0 = off, 1 = the highest tier the
+ * model supports. Because it is relative to each model's own ladder length,
+ * it carries consistent meaning across models with different tier counts
+ * (e.g. a 6-level model's `xhigh` and a 5-level model's `high` are both 1.0).
+ */
+export function thinkingLevelToEffort<TApi extends Api>(model: Model<TApi>, level: ModelThinkingLevel): number {
+	const levels = getSupportedThinkingLevels(model);
+	if (levels.length <= 1) return 0;
+	const index = levels.indexOf(level);
+	if (index < 0) return 0;
+	return index / (levels.length - 1);
+}
+
+/**
+ * Project a normalised effort in [0, 1] back onto a model's supported ladder.
+ * Pairs with `thinkingLevelToEffort` so intent survives model switches:
+ * effort is invariant across switches, only its level-name projection changes.
+ */
+export function effortToThinkingLevel<TApi extends Api>(model: Model<TApi>, effort: number): ModelThinkingLevel {
+	const levels = getSupportedThinkingLevels(model);
+	if (levels.length === 0) return "off";
+	const clamped = Math.max(0, Math.min(1, effort));
+	const index = Math.round(clamped * (levels.length - 1));
+	return levels[index] ?? levels[0] ?? "off";
+}
+
 export function clampThinkingLevel<TApi extends Api>(
 	model: Model<TApi>,
 	level: ModelThinkingLevel,

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -42,6 +42,7 @@ export interface FauxModelDefinition {
 	cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 	contextWindow?: number;
 	maxTokens?: number;
+	thinkingLevelMap?: Model<string>["thinkingLevelMap"];
 }
 
 export type FauxContentBlock = TextContent | ThinkingContent | ToolCall;
@@ -437,6 +438,7 @@ export function createFauxCore(options: RegisterFauxProviderOptions) {
 		cost: definition.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: definition.contextWindow ?? 128000,
 		maxTokens: definition.maxTokens ?? 16384,
+		thinkingLevelMap: definition.thinkingLevelMap,
 	})) as [Model<string>, ...Model<string>[]];
 
 	const stream: StreamFunction<string, StreamOptions> = (requestModel, context, streamOptions) => {

--- a/packages/ai/test/thinking-effort.test.ts
+++ b/packages/ai/test/thinking-effort.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampThinkingLevel,
+	effortToThinkingLevel,
+	getSupportedThinkingLevels,
+	thinkingLevelToEffort,
+} from "../src/models.ts";
+import type { Api, Model } from "../src/types.ts";
+
+// Minimal model fixture: only id/reasoning/thinkingLevelMap affect thinking
+// level math. The rest is filled to satisfy the Model type.
+function makeModel(opts: {
+	id: string;
+	reasoning: boolean;
+	thinkingLevelMap?: Record<string, string | null>;
+}): Model<Api> {
+	return {
+		id: opts.id,
+		name: opts.id,
+		api: "anthropic-messages" as Api,
+		provider: "test",
+		baseUrl: "https://example.test",
+		reasoning: opts.reasoning,
+		thinkingLevelMap: opts.thinkingLevelMap,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	};
+}
+
+// 6-level model: off, minimal, low, medium, high, xhigh
+const modelWithXhigh = makeModel({ id: "wide", reasoning: true, thinkingLevelMap: { xhigh: "xhigh" } });
+// 5-level model: off, minimal, low, medium, high (no xhigh)
+const modelWithoutXhigh = makeModel({ id: "narrow", reasoning: true });
+// Non-reasoning model: only off
+const modelNoReasoning = makeModel({ id: "dumb", reasoning: false });
+
+describe("getSupportedThinkingLevels", () => {
+	it("returns the full 6-level ladder for a reasoning model with xhigh", () => {
+		expect(getSupportedThinkingLevels(modelWithXhigh)).toEqual(["off", "minimal", "low", "medium", "high", "xhigh"]);
+	});
+
+	it("drops xhigh when the map does not declare it", () => {
+		expect(getSupportedThinkingLevels(modelWithoutXhigh)).toEqual(["off", "minimal", "low", "medium", "high"]);
+	});
+
+	it("returns only off for a non-reasoning model", () => {
+		expect(getSupportedThinkingLevels(modelNoReasoning)).toEqual(["off"]);
+	});
+});
+
+describe("thinkingLevelToEffort", () => {
+	it("maps the lowest tier to 0 and the highest to 1", () => {
+		expect(thinkingLevelToEffort(modelWithXhigh, "off")).toBe(0);
+		expect(thinkingLevelToEffort(modelWithXhigh, "xhigh")).toBe(1);
+		expect(thinkingLevelToEffort(modelWithoutXhigh, "off")).toBe(0);
+		expect(thinkingLevelToEffort(modelWithoutXhigh, "high")).toBe(1);
+	});
+
+	it("is proportional to position on the model's own ladder", () => {
+		// 6 levels: indices 0..5 -> effort 0, 0.2, 0.4, 0.6, 0.8, 1
+		expect(thinkingLevelToEffort(modelWithXhigh, "medium")).toBe(0.6);
+		// 5 levels: indices 0..4 -> effort 0, 0.25, 0.5, 0.75, 1 (medium = index 3)
+		expect(thinkingLevelToEffort(modelWithoutXhigh, "medium")).toBe(0.75);
+	});
+
+	it("returns 0 for an unknown level", () => {
+		expect(thinkingLevelToEffort(modelWithoutXhigh, "xhigh")).toBe(0);
+	});
+
+	it("returns 0 for a non-reasoning model", () => {
+		expect(thinkingLevelToEffort(modelNoReasoning, "off")).toBe(0);
+	});
+});
+
+describe("effortToThinkingLevel", () => {
+	it("maps 0 to off and 1 to the model's top tier", () => {
+		expect(effortToThinkingLevel(modelWithXhigh, 0)).toBe("off");
+		expect(effortToThinkingLevel(modelWithXhigh, 1)).toBe("xhigh");
+		expect(effortToThinkingLevel(modelWithoutXhigh, 0)).toBe("off");
+		expect(effortToThinkingLevel(modelWithoutXhigh, 1)).toBe("high");
+	});
+
+	it("clamps effort outside [0, 1]", () => {
+		expect(effortToThinkingLevel(modelWithXhigh, -0.5)).toBe("off");
+		expect(effortToThinkingLevel(modelWithXhigh, 2)).toBe("xhigh");
+	});
+
+	it("rounds to the nearest supported tier", () => {
+		// 6 levels (step 0.2): 0.5 -> round(0.5*5)=round(2.5)=3 -> medium
+		expect(effortToThinkingLevel(modelWithXhigh, 0.5)).toBe("medium");
+		// 5 levels (step 0.25): 0.5 -> round(0.5*4)=round(2)=2 -> low
+		expect(effortToThinkingLevel(modelWithoutXhigh, 0.5)).toBe("low");
+	});
+});
+
+describe("effort round-trips across model switches", () => {
+	it("preserves max-effort intent when switching wide -> narrow -> wide", () => {
+		// Start at xhigh on the 6-level model.
+		const effort = thinkingLevelToEffort(modelWithXhigh, "xhigh");
+		expect(effort).toBe(1);
+
+		// Project onto the 5-level model: top tier (high).
+		const narrowLevel = effortToThinkingLevel(modelWithoutXhigh, effort);
+		expect(narrowLevel).toBe("high");
+
+		// Switch back: re-project the narrow model's high onto the wide model.
+		const effortOnNarrow = thinkingLevelToEffort(modelWithoutXhigh, narrowLevel);
+		const wideLevel = effortToThinkingLevel(modelWithXhigh, effortOnNarrow);
+		expect(wideLevel).toBe("xhigh");
+	});
+
+	it("preserves mid-effort intent when switching wide -> narrow -> wide", () => {
+		const effort = thinkingLevelToEffort(modelWithXhigh, "medium"); // 0.6
+		// 5 levels: round(0.6*4)=round(2.4)=2 -> low
+		const narrowLevel = effortToThinkingLevel(modelWithoutXhigh, effort);
+		expect(narrowLevel).toBe("low");
+
+		// low on the 5-level model is effort 0.5; back on the 6-level model
+		// round(0.5*5)=round(2.5)=3 -> medium. Mid-effort intent is preserved.
+		const effortOnNarrow = thinkingLevelToEffort(modelWithoutXhigh, narrowLevel); // 0.5
+		const wideLevel = effortToThinkingLevel(modelWithXhigh, effortOnNarrow);
+		expect(wideLevel).toBe("medium");
+	});
+
+	it("clamps a level unsupported on the target down to the nearest valid one (name clamp)", () => {
+		// xhigh is not valid on the narrow model; clamp must drop to high, not off.
+		expect(clampThinkingLevel(modelWithoutXhigh, "xhigh")).toBe("high");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed thinking level being lost when switching between models with different reasoning tier counts. Name-based clamping only ever clamped down, so going from a model supporting `xhigh` to one without it dropped to `high` and never restored on return. The level is now re-projected by normalised effort (`0 = off`, `1 = max supported`) so intent survives the round-trip ([#6329](https://github.com/earendil-works/pi/issues/6329)).
 - Fixed startup model selection to skip unauthenticated saved defaults so configured local custom models can be selected instead ([#6231](https://github.com/earendil-works/pi/issues/6231)).
 - Fixed Escape aborts to clear runs stuck in extension context hooks that ignore abort signals ([#6234](https://github.com/earendil-works/pi/issues/6234)).
 - Fixed the question extension example to run question tool calls sequentially so multiple questions in one assistant turn remain answerable ([#6189](https://github.com/earendil-works/pi/issues/6189)).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -28,12 +28,14 @@ import type { AssistantMessage, ImageContent, Message, Model, TextContent } from
 import {
 	clampThinkingLevel,
 	cleanupSessionResources,
+	effortToThinkingLevel,
 	getSupportedThinkingLevels,
 	isContextOverflow,
 	isRetryableAssistantError,
 	modelsAreEqual,
 	resetApiProviders,
 	streamSimple,
+	thinkingLevelToEffort,
 } from "@earendil-works/pi-ai/compat";
 import { getThemeByName, theme } from "../modes/interactive/theme/theme.ts";
 import { stripFrontmatter } from "../utils/frontmatter.ts";
@@ -1486,8 +1488,13 @@ export class AgentSession {
 		this.sessionManager.appendModelChange(model.provider, model.id);
 		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 
-		// Re-clamp thinking level for new model's capabilities
-		this.setThinkingLevel(thinkingLevel);
+		// Re-project the thinking level by normalised effort, not by name.
+		// Name-based clamping only ever clamps down: switching from a wider
+		// ladder to a narrower one drops a tier (xhigh -> high), and switching
+		// back keeps it (high is still valid on the wider model), silently
+		// losing the user's "max effort" intent. Effort is invariant across
+		// switches, so projecting it onto the new ladder restores the intent.
+		this.setThinkingLevel(this._thinkingLevelForModelSwitch(previousModel, model, thinkingLevel));
 
 		await this._emitModelSelect(model, previousModel, "set");
 	}
@@ -1516,7 +1523,8 @@ export class AgentSession {
 		const len = scopedModels.length;
 		const nextIndex = direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
 		const next = scopedModels[nextIndex];
-		const thinkingLevel = this._getThinkingLevelForModelSwitch(next.thinkingLevel);
+		const explicitLevel = next.thinkingLevel;
+		const thinkingLevel = this._getThinkingLevelForModelSwitch(explicitLevel);
 
 		// Apply model
 		this.agent.state.model = next.model;
@@ -1525,9 +1533,11 @@ export class AgentSession {
 
 		// Apply thinking level.
 		// - Explicit scoped model thinking level overrides current session level
-		// - Undefined scoped model thinking level inherits the current session preference
-		// setThinkingLevel clamps to model capabilities.
-		this.setThinkingLevel(thinkingLevel);
+		// - Undefined scoped model thinking level inherits the current session preference,
+		//   re-projected by effort so intent survives the ladder-width change.
+		this.setThinkingLevel(
+			this._thinkingLevelForModelSwitch(currentModel, next.model, thinkingLevel, explicitLevel !== undefined),
+		);
 
 		await this._emitModelSelect(next.model, currentModel, "cycle");
 
@@ -1551,8 +1561,8 @@ export class AgentSession {
 		this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
 		this.settingsManager.setDefaultModelAndProvider(nextModel.provider, nextModel.id);
 
-		// Re-clamp thinking level for new model's capabilities
-		this.setThinkingLevel(thinkingLevel);
+		// Re-project the thinking level by normalised effort (see setModel).
+		this.setThinkingLevel(this._thinkingLevelForModelSwitch(currentModel, nextModel, thinkingLevel));
 
 		await this._emitModelSelect(nextModel, currentModel, "cycle");
 
@@ -1632,6 +1642,28 @@ export class AgentSession {
 			return this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
 		}
 		return this.thinkingLevel;
+	}
+
+	/**
+	 * Resolve the thinking level to apply after switching from `previousModel`
+	 * to `nextModel`. By default the level is re-projected by normalised effort
+	 * so that intent (e.g. "max effort") survives ladder-width changes:
+	 * xhigh on a 6-level model (effort 1.0) maps to high on a 5-level model
+	 * (also 1.0) and back to xhigh on return. When `explicit` is set the level
+	 * is a user-configured target for `nextModel`, so it is name-clamped to
+	 * validity instead.
+	 */
+	private _thinkingLevelForModelSwitch(
+		previousModel: Model<any> | null | undefined,
+		nextModel: Model<any>,
+		level: ThinkingLevel,
+		explicit = false,
+	): ThinkingLevel {
+		if (explicit || !previousModel) {
+			return clampThinkingLevel(nextModel, level) as ThinkingLevel;
+		}
+		const effort = thinkingLevelToEffort(previousModel, level);
+		return effortToThinkingLevel(nextModel, effort) as ThinkingLevel;
 	}
 
 	private _clampThinkingLevel(level: ThinkingLevel, _availableLevels: ThinkingLevel[]): ThinkingLevel {

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -131,6 +131,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 				contextWindow: registeredModel.contextWindow,
 				maxTokens: registeredModel.maxTokens,
 				baseUrl: registeredModel.baseUrl,
+				thinkingLevelMap: registeredModel.thinkingLevelMap,
 			})),
 		});
 	}

--- a/packages/coding-agent/test/suite/regressions/thinking-effort-model-switch.test.ts
+++ b/packages/coding-agent/test/suite/regressions/thinking-effort-model-switch.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+// Reproduces the thinking-level loss when switching between models whose
+// supported ladders have different lengths.
+//
+// wide  : off, minimal, low, medium, high, xhigh  (6 levels)
+// narrow: off, minimal, low, medium, high         (5 levels, no xhigh)
+//
+// Pre-fix behaviour: setModel clamped by name only. xhigh on `wide` clamped
+// down to high on `narrow` (correct), but switching back to `wide` kept high
+// (still a valid level there), silently losing the user's max-effort intent.
+// The fix re-projects by normalised effort (1.0 = top of each ladder), so the
+// round-trip restores xhigh.
+
+describe("thinking level survives model switch across ladder widths", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("restores xhigh after wide -> narrow -> wide", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "wide", name: "Wide", reasoning: true, thinkingLevelMap: { xhigh: "xhigh" } },
+				{ id: "narrow", name: "Narrow", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+
+		const wide = harness.getModel("wide")!;
+		const narrow = harness.getModel("narrow")!;
+
+		// wide is the initial model. Pin the session to xhigh.
+		harness.session.setThinkingLevel("xhigh");
+		expect(harness.session.thinkingLevel).toBe("xhigh");
+
+		// Switch to the 5-level model: xhigh is unsupported, so the effort (1.0)
+		// projects onto narrow's top tier (high).
+		await harness.session.setModel(narrow);
+		expect(harness.session.thinkingLevel).toBe("high");
+
+		// Switch back to the 6-level model. The effort is still 1.0, which
+		// projects back onto wide's top tier (xhigh). Pre-fix this stayed "high".
+		await harness.session.setModel(wide);
+		expect(harness.session.thinkingLevel).toBe("xhigh");
+	});
+
+	it("keeps a mid-tier level stable across wide -> narrow -> wide", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "wide", name: "Wide", reasoning: true, thinkingLevelMap: { xhigh: "xhigh" } },
+				{ id: "narrow", name: "Narrow", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+
+		const wide = harness.getModel("wide")!;
+		const narrow = harness.getModel("narrow")!;
+
+		// medium on the 6-level model is effort 0.6.
+		harness.session.setThinkingLevel("medium");
+		expect(harness.session.thinkingLevel).toBe("medium");
+
+		await harness.session.setModel(narrow);
+		// 0.6 on a 5-level ladder rounds to index 2 -> low.
+		expect(harness.session.thinkingLevel).toBe("low");
+
+		await harness.session.setModel(wide);
+		// low on the 5-level model is effort 0.5; round(0.5*5)=3 -> medium on wide.
+		expect(harness.session.thinkingLevel).toBe("medium");
+	});
+});


### PR DESCRIPTION
Fixes #6329

## Problem

`clampThinkingLevel` is name-based and only ever clamps down. Switching from a model whose reasoning ladder includes `xhigh` to one without it drops the level to `high` (correct), but switching back keeps `high` — it's still a valid level on the wider model, so the clamp never re-promotes. The user's "max effort" intent is silently lost.

```
wide   (6 levels: off..xhigh) @ xhigh
  -> narrow (5 levels: off..high) -> high   (correct, narrow's max)
  -> back to wide                -> high    (bug: xhigh lost)
```

## Fix

Re-project the thinking level by **normalised effort** on model switch instead of name-clamping:

- `effort = thinkingLevelToEffort(previousModel, level)` — `0 = off`, `1 = the model's top supported tier`, relative to that model's own ladder length.
- `effortToThinkingLevel(newModel, effort)` — project the same effort onto the new model's ladder.

Effort is invariant across switches; only its level-name projection changes. So `wide(xhigh)` (effort 1.0) → `narrow(high)` (effort 1.0) → `wide(xhigh)` round-trips correctly.

## Changes

**`packages/ai`**
- `models.ts`: add `thinkingLevelToEffort` / `effortToThinkingLevel` (relative to each model's own ladder length). `clampThinkingLevel` is unchanged — still used for the explicit/name-based path (e.g. scoped model levels configured by name, and `sdk.ts` init).
- `test/thinking-effort.test.ts`: 13 unit tests covering the primitives and the wide→narrow→wide round-trip.

**`packages/coding-agent`**
- `agent-session.ts`: `setModel` / `_cycleScopedModel` / `_cycleAvailableModel` re-project inherited levels via effort through a new `_thinkingLevelForModelSwitch(previousModel, nextModel, level, explicit)` helper. Explicit scoped model levels (configured by name for a specific target model) still name-clamp to validity.
- `test/suite/harness.ts` + `packages/ai/providers/faux.ts`: test-infra — `FauxModelDefinition` and the harness `registerProvider` mapping now pass `thinkingLevelMap` through (previously dropped), so the suite can construct models with an `xhigh` tier.
- `test/suite/regressions/thinking-effort-model-switch.test.ts`: regression test. Verified to **fail on current main** (`wide -> narrow -> wide` ends at `high` instead of `xhigh`) and pass with this fix.

## Scope

This is the minimal fix for the within-session model-switch bug. Persisting effort in agent state / session entries / settings (so intent also survives session resume and default-model changes) and a decimal `--thinking 0.8` CLI flag are deliberately deferred — they're separable enhancements and this PR stays surgical.

## Verification

- `npm run check` clean (biome + tsgo + all gates).
- New tests green; existing thinking / scoped-model / model-registry tests green (no regressions).
- Regression test confirmed red-without-fix / green-with-fix.
