### PR TITLE
feat(coding-agent): support command/env expansion in provider baseUrl

### DIFF
--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -34,6 +34,7 @@ import {
 	getConfigValueEnvVarNames,
 	isCommandConfigValue,
 	isConfigValueConfigured,
+	resolveConfigValue,
 	resolveConfigValueOrThrow,
 	resolveConfigValueUncached,
 	resolveHeadersOrThrow,
@@ -500,9 +501,11 @@ export class ModelRegistry {
 			const modelOverrides = new Map<string, Map<string, ModelOverride>>();
 
 			for (const [providerName, providerConfig] of Object.entries(config.providers)) {
-				if (providerConfig.baseUrl || providerConfig.compat) {
+				const resolvedBaseUrl =
+					providerConfig.baseUrl !== undefined ? resolveConfigValue(providerConfig.baseUrl) : undefined;
+				if (resolvedBaseUrl || providerConfig.compat) {
 					overrides.set(providerName, {
-						baseUrl: providerConfig.baseUrl,
+						baseUrl: resolvedBaseUrl,
 						compat: providerConfig.compat,
 					});
 				}
@@ -601,7 +604,11 @@ export class ModelRegistry {
 				const api = modelDef.api ?? providerConfig.api ?? builtInDefaults?.api;
 				if (!api) continue;
 
-				const baseUrl = modelDef.baseUrl ?? providerConfig.baseUrl ?? builtInDefaults?.baseUrl;
+				const resolvedModelBaseUrl =
+					modelDef.baseUrl !== undefined ? resolveConfigValue(modelDef.baseUrl) : undefined;
+				const resolvedProviderBaseUrl =
+					providerConfig.baseUrl !== undefined ? resolveConfigValue(providerConfig.baseUrl) : undefined;
+				const baseUrl = resolvedModelBaseUrl ?? resolvedProviderBaseUrl ?? builtInDefaults?.baseUrl;
 				if (!baseUrl) continue;
 
 				const compat = mergeCompat(providerConfig.compat, modelDef.compat);
@@ -919,16 +926,19 @@ export class ModelRegistry {
 			this.models = this.models.filter((m) => m.provider !== providerName);
 
 			// Parse and add new models
+			const resolvedConfigBaseUrl = config.baseUrl !== undefined ? resolveConfigValue(config.baseUrl) : undefined;
 			for (const modelDef of config.models) {
 				const api = modelDef.api || config.api;
 				this.storeModelHeaders(providerName, modelDef.id, modelDef.headers);
 
+				const resolvedModelBaseUrl =
+					modelDef.baseUrl !== undefined ? resolveConfigValue(modelDef.baseUrl) : undefined;
 				this.models.push({
 					id: modelDef.id,
 					name: modelDef.name,
 					api: api as Api,
 					provider: providerName,
-					baseUrl: modelDef.baseUrl ?? config.baseUrl!,
+					baseUrl: resolvedModelBaseUrl ?? resolvedConfigBaseUrl ?? config.baseUrl!,
 					reasoning: modelDef.reasoning,
 					thinkingLevelMap: modelDef.thinkingLevelMap,
 					input: modelDef.input as ("text" | "image")[],
@@ -949,11 +959,12 @@ export class ModelRegistry {
 			}
 		} else if (config.baseUrl || config.headers) {
 			// Override-only: update baseUrl for existing models. Request headers are resolved per request.
+			const resolvedBaseUrl = config.baseUrl !== undefined ? resolveConfigValue(config.baseUrl) : undefined;
 			this.models = this.models.map((m) => {
 				if (m.provider !== providerName) return m;
 				return {
 					...m,
-					baseUrl: config.baseUrl ?? m.baseUrl,
+					baseUrl: resolvedBaseUrl ?? m.baseUrl,
 				};
 			});
 		}

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -13,6 +13,7 @@ import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { clearApiKeyCache, ModelRegistry, type ProviderConfigInput } from "../src/core/model-registry.ts";
+import { clearConfigValueCache } from "../src/core/resolve-config-value.ts";
 
 describe("ModelRegistry", () => {
 	let tempDir: string;
@@ -31,6 +32,7 @@ describe("ModelRegistry", () => {
 			rmSync(tempDir, { recursive: true });
 		}
 		clearApiKeyCache();
+		clearConfigValueCache();
 		vi.restoreAllMocks();
 	});
 
@@ -217,6 +219,150 @@ describe("ModelRegistry", () => {
 			registry.refresh();
 
 			expect(getModelsForProvider(registry, "anthropic")[0].baseUrl).toBe("https://second-proxy.example.com/v1");
+		});
+	});
+
+	describe("baseUrl command/env expansion", () => {
+		test("baseUrl with ! prefix executes command and uses stdout for override", () => {
+			writeRawModelsJson({
+				anthropic: overrideConfig("!echo https://command-proxy.example.com/v1"),
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const anthropicModels = getModelsForProvider(registry, "anthropic");
+
+			expect(anthropicModels.length).toBeGreaterThan(1);
+			for (const model of anthropicModels) {
+				expect(model.baseUrl).toBe("https://command-proxy.example.com/v1");
+			}
+		});
+
+		test("baseUrl with ! prefix executes command for custom models", () => {
+			writeRawModelsJson({
+				"custom-provider": providerConfig("!echo https://command-proxy.example.com/v1", [{ id: "test-model" }]),
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const model = registry.find("custom-provider", "test-model");
+
+			expect(model).toBeDefined();
+			expect(model!.baseUrl).toBe("https://command-proxy.example.com/v1");
+		});
+
+		test("baseUrl with $ env var interpolation resolves to env value for override", () => {
+			const originalEnv = process.env.TEST_BASE_URL_ENV_12345;
+			process.env.TEST_BASE_URL_ENV_12345 = "https://env-proxy.example.com/v1";
+
+			try {
+				writeRawModelsJson({
+					anthropic: overrideConfig("$TEST_BASE_URL_ENV_12345"),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+				const anthropicModels = getModelsForProvider(registry, "anthropic");
+
+				expect(anthropicModels.length).toBeGreaterThan(1);
+				for (const model of anthropicModels) {
+					expect(model.baseUrl).toBe("https://env-proxy.example.com/v1");
+				}
+			} finally {
+				if (originalEnv === undefined) {
+					delete process.env.TEST_BASE_URL_ENV_12345;
+				} else {
+					process.env.TEST_BASE_URL_ENV_12345 = originalEnv;
+				}
+			}
+		});
+
+		test("baseUrl with braced env syntax resolves to env value for custom models", () => {
+			const originalEnv = process.env.TEST_BRACED_BASE_URL_12345;
+			process.env.TEST_BRACED_BASE_URL_12345 = "https://braced-env-proxy.example.com/v1";
+			const bracedUrl = "$" + "{TEST_BRACED_BASE_URL_12345}";
+
+			try {
+				writeRawModelsJson({
+					"custom-provider": providerConfig(bracedUrl, [{ id: "test-model" }]),
+				});
+
+				const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+				const model = registry.find("custom-provider", "test-model");
+
+				expect(model).toBeDefined();
+				expect(model!.baseUrl).toBe("https://braced-env-proxy.example.com/v1");
+			} finally {
+				if (originalEnv === undefined) {
+					delete process.env.TEST_BRACED_BASE_URL_12345;
+				} else {
+					process.env.TEST_BRACED_BASE_URL_12345 = originalEnv;
+				}
+			}
+		});
+
+		test("baseUrl with ! prefix handles multiline output (uses trimmed result)", () => {
+			writeRawModelsJson({
+				"custom-provider": providerConfig("!printf 'https://multiline-proxy.example.com\\n/v1'", [
+					{ id: "test-model" },
+				]),
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const model = registry.find("custom-provider", "test-model");
+
+			expect(model).toBeDefined();
+			expect(model!.baseUrl).toBe("https://multiline-proxy.example.com\n/v1");
+		});
+
+		test("baseUrl with ! prefix falls back to built-in URL when command fails", () => {
+			writeRawModelsJson({
+				anthropic: overrideConfig("!exit 1"),
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+			const anthropicModels = getModelsForProvider(registry, "anthropic");
+
+			// Should have models with their original (built-in) baseUrl
+			expect(anthropicModels.length).toBeGreaterThan(0);
+			// The models should not have the command string as their baseUrl
+			for (const model of anthropicModels) {
+				expect(model.baseUrl).not.toBe("!exit 1");
+				expect(model.baseUrl).toBeTruthy();
+			}
+		});
+
+		test("model-level baseUrl with ! prefix supersedes provider-level baseUrl", () => {
+			writeRawModelsJson({
+				"custom-provider": {
+					baseUrl: "!echo https://provider-level.example.com/v1",
+					apiKey: "test-key",
+					api: "openai-completions",
+					models: [
+						{
+							id: "default-model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 100000,
+							maxTokens: 8000,
+						},
+						{
+							id: "override-model",
+							baseUrl: "!echo https://model-level.example.com/v1",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 100000,
+							maxTokens: 8000,
+						},
+					],
+				},
+			});
+
+			const registry = ModelRegistry.create(authStorage, modelsJsonPath);
+
+			expect(registry.find("custom-provider", "default-model")!.baseUrl).toBe(
+				"https://provider-level.example.com/v1",
+			);
+			expect(registry.find("custom-provider", "override-model")!.baseUrl).toBe("https://model-level.example.com/v1");
 		});
 	});
 


### PR DESCRIPTION
Using pi I wanted to transfer my configuration from another agent.. and realized that I could not use the link from the secrets.  I have a public nixos config and this is a fairly critical function for me

To test, build nixos and specify the secret baseUrl in the same way as you specified apiKey