### PR TITLE
fix(coding-agent): correct cache hit rate denominator and context token double-count

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -134,7 +134,7 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
  * Uses the native totalTokens field when available, falls back to computing from components.
  */
 export function calculateContextTokens(usage: Usage): number {
-	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+	return usage.totalTokens || usage.input + usage.output;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -99,10 +99,8 @@ export class FooterComponent implements Component {
 				totalCacheWrite += entry.message.usage.cacheWrite;
 				totalCost += entry.message.usage.cost.total;
 
-				const latestPromptTokens =
-					entry.message.usage.input + entry.message.usage.cacheRead + entry.message.usage.cacheWrite;
 				latestCacheHitRate =
-					latestPromptTokens > 0 ? (entry.message.usage.cacheRead / latestPromptTokens) * 100 : undefined;
+					entry.message.usage.input > 0 ? (entry.message.usage.cacheRead / entry.message.usage.input) * 100 : undefined;
 			}
 		}
 


### PR DESCRIPTION
## Problem

The Anthropic API convention (which pi follows) is that `input_tokens` **already includes** `cache_read` and `cache_write` tokens — they are sub-fields, not additive. Two places in the codebase were double-counting cache tokens on top of `input`:

### 1. Footer CH% denominator inflated (footer.ts)

```ts
// Before (wrong)
const latestPromptTokens = usage.input + usage.cacheRead + usage.cacheWrite;
latestCacheHitRate = (usage.cacheRead / latestPromptTokens) * 100;
// e.g. input=1000, cacheRead=500 → denominator=1500 → CH=33.3%
//                                    correct denominator=1000 → CH=50.0%
```

### 2. calculateContextTokens fallback inflated (compaction.ts)

```ts
// Before (wrong)
return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
//                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache double-counted
```

Both lead to: underestimated cache hit rate displayed in footer, and overestimated context token count for compaction decisions and the context percentage display.

## Fix

- **footer.ts**: Use `usage.input` directly as the CH% denominator (cache read is a subset of input, not additive)
- **compaction.ts**: Remove `+ usage.cacheRead + usage.cacheWrite` from the fallback sum

## Verification

```
Before: input=1000, cacheRead=500, cacheWrite=0
  CH% = 500 / (1000+500+0) = 33.3%  ← wrong
  context fallback = 1000 + 500 + 0 = 1500 ← wrong

After:
  CH% = 500 / 1000 = 50.0%  ← correct
  context fallback = 1000   ← correct
```

No existing tests directly cover these functions, and no API behavior change — only numeric corrections to existing calculations.