### PR TITLE
fix(ai): support GLM-5.2 tool calls

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -292,6 +292,7 @@ const OPENAI_COMPLETIONS_DEFAULT_COMPAT = {
 	vercelGatewayRouting: {},
 	chatTemplateKwargs: {},
 	zaiToolStream: false,
+	disableToolStreaming: false,
 	supportsStrictMode: true,
 	sendSessionAffinityHeaders: false,
 	supportsLongCacheRetention: true,
@@ -378,6 +379,7 @@ function detectOpenAICompletionsCompat(model: Model<"openai-completions">): Open
 		vercelGatewayRouting: {},
 		chatTemplateKwargs: {},
 		zaiToolStream: false,
+		disableToolStreaming: false,
 		supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway && !isNvidia,
 		...(cacheControlFormat ? { cacheControlFormat } : {}),
 		sendSessionAffinityHeaders: false,
@@ -1298,6 +1300,9 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					// OpenCode Kimi K2.6 accepts Anthropic-style thinking objects
 					// and rejects string thinking values or combined reasoning_effort.
 					compat = { ...(compat ?? {}), thinkingFormat: "deepseek", supportsReasoningEffort: false };
+				}
+				if (variant.provider === "opencode-go" && modelId === "glm-5.2") {
+					compat = { ...(compat ?? {}), disableToolStreaming: true };
 				}
 
 				// Fix known mismatches between models.dev npm data and actual

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1,10 +1,12 @@
 import OpenAI from "openai";
 import type {
+	ChatCompletion,
 	ChatCompletionAssistantMessageParam,
 	ChatCompletionChunk,
 	ChatCompletionContentPart,
 	ChatCompletionContentPartImage,
 	ChatCompletionContentPartText,
+	ChatCompletionCreateParamsNonStreaming,
 	ChatCompletionDeveloperMessageParam,
 	ChatCompletionMessageParam,
 	ChatCompletionSystemMessageParam,
@@ -139,6 +141,10 @@ type ChatCompletionToolWithCacheControl = OpenAI.Chat.Completions.ChatCompletion
 	cache_control?: OpenAICompatCacheControl;
 };
 
+type ChatCompletionDeltaWithReasoning = ChatCompletionChunk.Choice.Delta & {
+	reasoning_content?: string;
+};
+
 function resolveCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEnv): CacheRetention {
 	if (cacheRetention) {
 		return cacheRetention;
@@ -147,6 +153,68 @@ function resolveCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEn
 		return "long";
 	}
 	return "short";
+}
+
+function toNonStreamingParams(
+	params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+): ChatCompletionCreateParamsNonStreaming {
+	const { stream_options: _streamOptions, ...rest } = params;
+	return { ...rest, stream: false };
+}
+
+async function* completionToChunks(completion: ChatCompletion): AsyncIterable<ChatCompletionChunk> {
+	const choice = completion.choices[0];
+	const message = choice?.message;
+	const base = {
+		id: completion.id,
+		created: completion.created,
+		model: completion.model,
+		object: "chat.completion.chunk" as const,
+	};
+
+	const messageFields = message as unknown as Record<string, unknown> | undefined;
+	const reasoning = messageFields?.reasoning_content ?? messageFields?.reasoning ?? messageFields?.reasoning_text;
+	if (typeof reasoning === "string" && reasoning.length > 0) {
+		const delta: ChatCompletionDeltaWithReasoning = { reasoning_content: reasoning };
+		yield {
+			...base,
+			choices: [{ index: choice.index, delta, finish_reason: null }],
+		};
+	}
+
+	if (message?.content) {
+		yield {
+			...base,
+			choices: [{ index: choice.index, delta: { content: message.content }, finish_reason: null }],
+		};
+	}
+
+	const functionToolCalls = message?.tool_calls?.filter((toolCall) => toolCall.type === "function") ?? [];
+	if (functionToolCalls.length > 0) {
+		yield {
+			...base,
+			choices: [
+				{
+					index: choice.index,
+					delta: {
+						tool_calls: functionToolCalls.map((toolCall, index) => ({
+							index,
+							id: toolCall.id,
+							type: toolCall.type,
+							function: toolCall.function,
+						})),
+					},
+					finish_reason: null,
+				},
+			],
+		};
+	}
+
+	yield {
+		...base,
+		choices: [{ index: choice?.index ?? 0, delta: {}, finish_reason: choice?.finish_reason ?? "stop" }],
+		usage: completion.usage,
+	};
 }
 
 export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptions> = (
@@ -191,9 +259,18 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
 				maxRetries: options?.maxRetries ?? 0,
 			};
-			const { data: openaiStream, response } = await client.chat.completions
-				.create(params, requestOptions)
-				.withResponse();
+			let openaiStream: AsyncIterable<ChatCompletionChunk>;
+			let response: Response;
+			if (compat.disableToolStreaming && context.tools && context.tools.length > 0) {
+				const nonStreamingParams = toNonStreamingParams(params);
+				const result = await client.chat.completions.create(nonStreamingParams, requestOptions).withResponse();
+				openaiStream = completionToChunks(result.data);
+				response = result.response;
+			} else {
+				const result = await client.chat.completions.create(params, requestOptions).withResponse();
+				openaiStream = result.data;
+				response = result.response;
+			}
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
@@ -1218,6 +1295,8 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
 	const isOpenRouterDeveloperRoleModel =
 		isOpenRouter && (model.id.startsWith("anthropic/") || model.id.startsWith("openai/"));
+	const isOpenCodeGoGlm52 =
+		(provider === "opencode-go" && model.id === "glm-5.2") || model.id === "opencode-go/glm-5.2";
 	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
 	return {
@@ -1246,6 +1325,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		vercelGatewayRouting: {},
 		chatTemplateKwargs: {},
 		zaiToolStream: false,
+		disableToolStreaming: isOpenCodeGoGlm52,
 		supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway && !isNvidia,
 		cacheControlFormat,
 		sendSessionAffinityHeaders: false,
@@ -1285,6 +1365,7 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
 		vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,
 		chatTemplateKwargs: model.compat.chatTemplateKwargs ?? detected.chatTemplateKwargs,
 		zaiToolStream: model.compat.zaiToolStream ?? detected.zaiToolStream,
+		disableToolStreaming: model.compat.disableToolStreaming ?? detected.disableToolStreaming,
 		supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
 		cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
 		sendSessionAffinityHeaders: model.compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,

--- a/packages/ai/src/providers/opencode-go.models.ts
+++ b/packages/ai/src/providers/opencode-go.models.ts
@@ -66,7 +66,7 @@ export const OPENCODE_GO_MODELS = {
 		api: "openai-completions",
 		provider: "opencode-go",
 		baseUrl: "https://opencode.ai/zen/go/v1",
-		compat: {"supportsStore":false,"supportsDeveloperRole":false,"maxTokensField":"max_tokens"},
+		compat: {"supportsStore":false,"supportsDeveloperRole":false,"disableToolStreaming":true,"maxTokensField":"max_tokens"},
 		reasoning: true,
 		thinkingLevelMap: {"off":null,"minimal":null,"low":null,"medium":null,"high":"high","xhigh":"max"},
 		input: ["text"],

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -507,6 +507,8 @@ export interface OpenAICompletionsCompat {
 	vercelGatewayRouting?: VercelGatewayRouting;
 	/** Whether z.ai supports top-level `tool_stream: true` for streaming tool call deltas. Default: false. */
 	zaiToolStream?: boolean;
+	/** Whether tool calls should use non-streaming chat completions because this model drops streaming tool deltas. Default: false. */
+	disableToolStreaming?: boolean;
 	/** Whether the provider supports the `strict` field in tool definitions. Default: true. */
 	supportsStrictMode?: boolean;
 	/** Cache control convention for prompt caching. "anthropic" applies Anthropic-style `cache_control` markers to the system prompt, last tool definition, and last user/assistant text content. */

--- a/packages/ai/test/openai-completions-disable-tool-streaming.test.ts
+++ b/packages/ai/test/openai-completions-disable-tool-streaming.test.ts
@@ -1,0 +1,120 @@
+import { Type } from "typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import type { Model } from "../src/types.ts";
+
+interface CapturedParams {
+	stream?: boolean | null;
+	stream_options?: unknown;
+}
+
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as CapturedParams | undefined,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: (params: CapturedParams) => {
+					mockState.lastParams = params;
+					const completion = {
+						id: "chatcmpl-test",
+						object: "chat.completion",
+						created: 1,
+						model: "glm-5.2",
+						choices: [
+							{
+								index: 0,
+								logprobs: null,
+								finish_reason: "tool_calls",
+								message: {
+									role: "assistant",
+									content: null,
+									reasoning_content: "thinking about graph stats",
+									refusal: null,
+									tool_calls: [
+										{
+											id: "call_1",
+											type: "function",
+											function: { name: "graph_stats", arguments: '{"depth":1}' },
+										},
+									],
+								},
+							},
+						],
+						usage: {
+							prompt_tokens: 10,
+							completion_tokens: 5,
+							prompt_tokens_details: { cached_tokens: 0 },
+							completion_tokens_details: { reasoning_tokens: 2 },
+						},
+					};
+					const promise = Promise.resolve(completion) as Promise<typeof completion> & {
+						withResponse: () => Promise<{
+							data: typeof completion;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: completion,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+describe("openai-completions disableToolStreaming", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+	});
+
+	it("detects routed OpenCode Go GLM-5.2 and preserves tool calls", async () => {
+		const model: Model<"openai-completions"> = {
+			id: "opencode-go/glm-5.2",
+			name: "GLM-5.2",
+			api: "openai-completions",
+			provider: "openai-compatible-proxy",
+			baseUrl: "https://proxy.example/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_000_000,
+			maxTokens: 131_072,
+			compat: { maxTokensField: "max_tokens" },
+		};
+
+		const message = await streamOpenAICompletions(
+			model,
+			{
+				messages: [{ role: "user", content: "check graph stats", timestamp: Date.now() }],
+				tools: [
+					{
+						name: "graph_stats",
+						description: "Get graph stats",
+						parameters: Type.Object({ depth: Type.Number() }),
+					},
+				],
+			},
+			{ apiKey: "test-key" },
+		).result();
+
+		expect(mockState.lastParams?.stream).toBe(false);
+		expect(mockState.lastParams?.stream_options).toBeUndefined();
+		expect(message.stopReason).toBe("toolUse");
+		expect(message.content).toEqual([
+			{
+				type: "thinking",
+				thinking: "thinking about graph stats",
+				thinkingSignature: "reasoning_content",
+			},
+			{ type: "toolCall", id: "call_1", name: "graph_stats", arguments: { depth: 1 } },
+		]);
+		expect(message.usage.output).toBe(5);
+	});
+});

--- a/packages/ai/test/openai-completions-thinking-as-text.test.ts
+++ b/packages/ai/test/openai-completions-thinking-as-text.test.ts
@@ -36,6 +36,7 @@ const compat = {
 	vercelGatewayRouting: {},
 	chatTemplateKwargs: {},
 	zaiToolStream: false,
+	disableToolStreaming: false,
 	supportsStrictMode: true,
 	cacheControlFormat: undefined,
 	sendSessionAffinityHeaders: false,

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1245,6 +1245,7 @@ describe("openai-completions tool_choice", () => {
 				vercelGatewayRouting: {},
 				chatTemplateKwargs: {},
 				zaiToolStream: false,
+				disableToolStreaming: false,
 				supportsStrictMode: true,
 				sendSessionAffinityHeaders: false,
 				supportsLongCacheRetention: true,

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -34,6 +34,7 @@ const compat: Required<OpenAICompletionsCompat> = {
 	vercelGatewayRouting: {},
 	chatTemplateKwargs: {},
 	zaiToolStream: false,
+	disableToolStreaming: false,
 	supportsStrictMode: true,
 	cacheControlFormat: "anthropic",
 	sendSessionAffinityHeaders: false,


### PR DESCRIPTION
## Summary

Fix OpenCode Go GLM-5.2 tool calls by using a non-streaming chat completion when tools are present.

GLM-5.2 returns tool calls correctly in the normal chat completion response, but its streamed response can miss the tool-call deltas. The fallback converts that response back into the same chunk shape the existing parser already handles, including reasoning text, tool calls, finish reason, and usage.

## Tests

- `npm run check`
- `./test.sh`
- `node node_modules/vitest/dist/cli.js --run test/openai-completions-disable-tool-streaming.test.ts test/openai-completions-thinking-as-text.test.ts test/openai-completions-tool-choice.test.ts test/openai-completions-tool-result-images.test.ts`

Also tested locally through Pi with GLM-5.2 calling Graphify MCP tools successfully.
