### PR TITLE
fix: guard git commands in non-git directories for example extensions

### DIFF
--- a/packages/coding-agent/examples/extensions/git-checkpoint.ts
+++ b/packages/coding-agent/examples/extensions/git-checkpoint.ts
@@ -10,6 +10,12 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 export default function (pi: ExtensionAPI) {
 	const checkpoints = new Map<string, string>();
 	let currentEntryId: string | undefined;
+	let isGitRepo: boolean | undefined;
+
+	pi.on("session_start", async (_event, ctx) => {
+		const { code } = await pi.exec("git", ["rev-parse", "--git-dir"], { cwd: ctx.cwd, timeout: 3_000 });
+		isGitRepo = code === 0;
+	});
 
 	// Track the current entry ID when user messages are saved
 	pi.on("tool_result", async (_event, ctx) => {
@@ -18,6 +24,8 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("turn_start", async () => {
+		if (isGitRepo !== true) return;
+
 		// Create a git stash entry before LLM makes changes
 		const { stdout } = await pi.exec("git", ["stash", "create"]);
 		const ref = stdout.trim();

--- a/packages/coding-agent/examples/extensions/input-transform-streaming.ts
+++ b/packages/coding-agent/examples/extensions/input-transform-streaming.ts
@@ -16,6 +16,13 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 const TRIGGER = /\b(changes?|diff|modified)\b/i;
 
 export default function (pi: ExtensionAPI) {
+	let isGitRepo: boolean | undefined;
+
+	pi.on("session_start", async (_event, ctx) => {
+		const { code } = await pi.exec("git", ["rev-parse", "--git-dir"], { cwd: ctx.cwd, timeout: 3_000 });
+		isGitRepo = code === 0;
+	});
+
 	pi.on("input", async (event) => {
 		// During steering, skip the exec call — corrections should be fast
 		if (event.streamingBehavior === "steer") {
@@ -23,6 +30,11 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		if (!TRIGGER.test(event.text)) {
+			return { action: "continue" };
+		}
+
+		// Skip git commands if not in a git repository
+		if (isGitRepo !== true) {
 			return { action: "continue" };
 		}
 


### PR DESCRIPTION
## Problem

Two example extensions were throwing git errors when running in non-git directories:

- **input-transform-streaming.ts** — ran `git diff --stat` on every `input` event (fired on every keystroke), causing errors for every character typed in a non-git directory
- **git-checkpoint.ts** — ran `git stash create` on every `turn_start`, throwing errors in non-git directories

## Fix

Both extensions now detect whether the working directory is a git repo once on `session_start` (via `git rev-parse --git-dir`), and skip git commands gracefully when not in a repository.

This pattern already existed in other example extensions like `github-issue-autocomplete.ts` and `git-merge-and-resolve.ts` — this fix applies it consistently to the remaining git-using extensions.