### PR TITLE
fix(tui): decrement paste counter on paste marker delete and terminal clear

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1276,26 +1276,26 @@ export class Editor implements Component, Focusable {
 			const graphemes = [...this.segment(beforeCursor, "grapheme")];
 			const lastGrapheme = graphemes[graphemes.length - 1];
 			const graphemeLength = lastGrapheme ? lastGrapheme.segment.length : 1;
-			const isPastedSegmented = PASTE_MARKER_SINGLE.exec(lastGrapheme.segment)
+			const isPastedSegmented = PASTE_MARKER_SINGLE.exec(lastGrapheme.segment);
 
 			if (isPastedSegmented) {
 				// This contains the id part e.g 4 from [paste #4 +123 lines]
 				const targetId = Number(isPastedSegmented[1]);
-				this.pastes.delete(targetId)
+				this.pastes.delete(targetId);
 				this.pasteCounter--;
 
 				// We got to update id of markers which are greater than the removed one
-				this.state.lines = this.state.lines.map(line =>
+				this.state.lines = this.state.lines.map((line) =>
 					line.replace(PASTE_MARKER_REGEX, (fullMatch, idGroup, suffixGroup) => {
 						const x = Number(idGroup);
 						if (x <= targetId) return fullMatch;
 
 						// [paste #3] become [paste #2] if we remove [paste #1]
-						const newText = `[paste #${x - 1}${suffixGroup || ''}]`;
+						const newText = `[paste #${x - 1}${suffixGroup}]`;
 						this.pastes.set(x - 1, this.pastes.get(x) ?? newText);
 						this.pastes.delete(x);
 						return newText;
-					})
+					}),
 				);
 			}
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -999,6 +999,8 @@ export class Editor implements Component, Focusable {
 		this.cancelAutocomplete();
 		this.lastAction = null;
 		this.exitHistoryBrowsing();
+		this.pastes.clear();
+		this.pasteCounter = 0;
 		const normalized = this.normalizeText(text);
 		// Push undo snapshot if content differs (makes programmatic changes undoable)
 		if (this.getText() !== normalized) {
@@ -1267,20 +1269,43 @@ export class Editor implements Component, Focusable {
 			this.pushUndoSnapshot();
 
 			// Delete grapheme before cursor (handles emojis, combining characters, etc.)
-			const line = this.state.lines[this.state.cursorLine] || "";
+			let line = this.state.lines[this.state.cursorLine] || "";
 			const beforeCursor = line.slice(0, this.state.cursorCol);
 
 			// Find the last grapheme in the text before cursor
 			const graphemes = [...this.segment(beforeCursor, "grapheme")];
 			const lastGrapheme = graphemes[graphemes.length - 1];
 			const graphemeLength = lastGrapheme ? lastGrapheme.segment.length : 1;
+			const isPastedSegmented = PASTE_MARKER_SINGLE.exec(lastGrapheme.segment)
+
+			if (isPastedSegmented) {
+				// This contains the id part e.g 4 from [paste #4 +123 lines]
+				const targetId = Number(isPastedSegmented[1]);
+				this.pastes.delete(targetId)
+				this.pasteCounter--;
+
+				// We got to update id of markers which are greater than the removed one
+				this.state.lines = this.state.lines.map(line =>
+					line.replace(PASTE_MARKER_REGEX, (fullMatch, idGroup, suffixGroup) => {
+						const x = Number(idGroup);
+						if (x <= targetId) return fullMatch;
+
+						// [paste #3] become [paste #2] if we remove [paste #1]
+						const newText = `[paste #${x - 1}${suffixGroup || ''}]`;
+						this.pastes.set(x - 1, this.pastes.get(x) ?? newText);
+						this.pastes.delete(x);
+						return newText;
+					})
+				);
+			}
+
+			line = this.state.lines[this.state.cursorLine] || "";
 
 			const before = line.slice(0, this.state.cursorCol - graphemeLength);
 			const after = line.slice(this.state.cursorCol);
 
 			this.state.lines[this.state.cursorLine] = before + after;
 			this.setCursorCol(this.state.cursorCol - graphemeLength);
-			this.pasteCounter--;
 		} else if (this.state.cursorLine > 0) {
 			this.pushUndoSnapshot();
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1280,6 +1280,7 @@ export class Editor implements Component, Focusable {
 
 			this.state.lines[this.state.cursorLine] = before + after;
 			this.setCursorCol(this.state.cursorCol - graphemeLength);
+			this.pasteCounter--;
 		} else if (this.state.cursorLine > 0) {
 			this.pushUndoSnapshot();
 


### PR DESCRIPTION
Issue: #6362 

Turns out it was not a really simple decrement on deleting a paste marker. Our existing code had bigger issues too like elements in `this.pastes` were not even removed when we remove paste markers so I did that. Also, when we press `ctrl+c` to clear terminal that too did not do a `this.pastes.clear` so I added that too.

Also, theres the case e.g [paste #1 123 lines]<cursor position here> [paste #2 123 lines] [paste#3 123 lines] now if I press backspace to remove [paste #1 123 lines] it did not update the [paste #2 123 lines] [paste #3 123 lines]. If you see the code I added case for that in which I update the `this.state.lines` and check those markers which has ids greater than the deleted one and decrement those.

Let me know if some changes are required. I tried my best to follow coding style.