### PR TITLE
fix(ai): hide responses reasoning comment markers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed OpenAI Responses reasoning summaries to strip provider-inserted HTML comment separators from visible thinking while preserving signed replay payloads.
 - Fixed Xiaomi Token Plan model metadata to follow the upstream models.dev token-plan catalogs, removing unsupported `mimo-v2-omni` variants ([#6204](https://github.com/earendil-works/pi/issues/6204)).
 - Fixed GitHub Copilot device-code login polling to wait before the first token poll, avoiding incorrect device-code failures for some users after browser authorization ([#6187](https://github.com/earendil-works/pi/issues/6187)).
 - Fixed OAuth device-code polling to honor the server-provided `slow_down` interval instead of only applying the RFC 8628 5-second increment, so GitHub Copilot login recovers instead of appearing to hang when polls arrive early (e.g. WSL/VM clock drift) ([#6187](https://github.com/earendil-works/pi/issues/6187)).

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -63,6 +63,10 @@ function parseTextSignature(
 	return { id: signature };
 }
 
+function sanitizeResponsesReasoningText(text: string): string {
+	return text.replace(/[ \t]*<!--\s*-->[ \t]*/g, "").replace(/\n{3,}/g, "\n\n");
+}
+
 export interface OpenAIResponsesStreamOptions {
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	resolveServiceTier?: (
@@ -394,11 +398,12 @@ export async function processResponsesStream<TApi extends Api>(
 		} else if (event.type === "response.reasoning_summary_text.delta") {
 			const slot = getSlot(event.output_index, "thinking");
 			if (!slot) continue;
-			slot.block.thinking += event.delta;
+			const previousThinking = slot.block.thinking;
+			slot.block.thinking = sanitizeResponsesReasoningText(slot.block.thinking + event.delta);
 			stream.push({
 				type: "thinking_delta",
 				contentIndex: slot.contentIndex,
-				delta: event.delta,
+				delta: slot.block.thinking.slice(previousThinking.length),
 				partial: output,
 			});
 		} else if (event.type === "response.reasoning_summary_part.done") {
@@ -477,7 +482,9 @@ export async function processResponsesStream<TApi extends Api>(
 			if (item.type === "reasoning" && slot?.type === "thinking") {
 				const summaryText = item.summary?.map((s) => s.text).join("\n\n") || "";
 				const contentText = item.content?.map((c) => c.text).join("\n\n") || "";
-				slot.block.thinking = summaryText || contentText || slot.block.thinking;
+				slot.block.thinking = sanitizeResponsesReasoningText(
+					summaryText || contentText || slot.block.thinking,
+				).trimEnd();
 				slot.block.thinkingSignature = JSON.stringify(item);
 				stream.push({
 					type: "thinking_end",

--- a/packages/ai/test/openai-responses-reasoning-summary-sanitization.test.ts
+++ b/packages/ai/test/openai-responses-reasoning-summary-sanitization.test.ts
@@ -1,0 +1,116 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it, vi } from "vitest";
+import { processResponsesStream } from "../src/api/openai-responses-shared.ts";
+import type { AssistantMessage, AssistantMessageEvent, Model } from "../src/types.ts";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
+
+function createOutput(model: Model<"openai-responses">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+async function* createReasoningSummaryEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield {
+		type: "response.output_item.added",
+		sequence_number: 1,
+		output_index: 0,
+		item: { type: "reasoning", id: "rs_test", summary: [] },
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.reasoning_summary_text.delta",
+		sequence_number: 2,
+		output_index: 0,
+		delta: "**Planning CI test suite optimization**\n\n<!-- -->",
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.reasoning_summary_part.done",
+		sequence_number: 3,
+		output_index: 0,
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.reasoning_summary_text.delta",
+		sequence_number: 4,
+		output_index: 0,
+		delta: "**Evaluating test duration reduction strategies**\n\n<!-- -->",
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.output_item.done",
+		sequence_number: 5,
+		output_index: 0,
+		item: {
+			type: "reasoning",
+			id: "rs_test",
+			summary: [
+				{ type: "summary_text", text: "**Planning CI test suite optimization**\n\n<!-- -->" },
+				{ type: "summary_text", text: "**Evaluating test duration reduction strategies**\n\n<!-- -->" },
+			],
+		},
+	} as ResponseStreamEvent;
+	yield {
+		type: "response.completed",
+		sequence_number: 5,
+		response: { id: "resp_test", status: "completed" },
+	} as ResponseStreamEvent;
+}
+
+describe("openai responses reasoning summary sanitization", () => {
+	it("removes provider-inserted HTML comment separators from visible thinking", async () => {
+		const model: Model<"openai-responses"> = {
+			id: "gpt-5-mini",
+			name: "GPT-5 Mini",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const pushSpy = vi.spyOn(stream, "push");
+
+		await processResponsesStream(createReasoningSummaryEvents(), output, stream, model);
+
+		expect(output.content).toHaveLength(1);
+		const thinkingBlock = output.content[0];
+		expect(thinkingBlock?.type).toBe("thinking");
+		if (!thinkingBlock || thinkingBlock.type !== "thinking") {
+			throw new Error("Expected thinking block");
+		}
+		expect(thinkingBlock.thinking).toBe(
+			"**Planning CI test suite optimization**\n\n**Evaluating test duration reduction strategies**",
+		);
+		expect(thinkingBlock.thinking).not.toContain("<!-- -->");
+		expect(thinkingBlock.thinkingSignature).toContain("<!-- -->");
+
+		const emittedEvents = pushSpy.mock.calls.map(([event]) => event as AssistantMessageEvent);
+		const thinkingEvents = emittedEvents.filter(
+			(event) => event.type === "thinking_delta" || event.type === "thinking_end",
+		);
+		expect(thinkingEvents.length).toBeGreaterThan(0);
+		for (const event of thinkingEvents) {
+			if (event.type === "thinking_delta") {
+				expect(event.delta).not.toContain("<!-- -->");
+			} else {
+				expect(event.content).not.toContain("<!-- -->");
+			}
+		}
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Fixed assistant thinking rendering to hide OpenAI Responses HTML comment separators in existing sessions.
 - Fixed Xiaomi Token Plan model metadata to follow the upstream models.dev token-plan catalogs, removing unsupported `mimo-v2-omni` variants ([#6204](https://github.com/earendil-works/pi/issues/6204)).
 - Fixed startup model selection to skip unauthenticated saved defaults so configured local custom models can be selected instead ([#6231](https://github.com/earendil-works/pi/issues/6231)).
 - Fixed the question extension example to run question tool calls sequentially so multiple questions in one assistant turn remain answerable ([#6189](https://github.com/earendil-works/pi/issues/6189)).

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -6,6 +6,13 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
+function sanitizeThinkingDisplayText(text: string): string {
+	return text
+		.replace(/[ \t]*<!--\s*-->[ \t]*/g, "")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+}
+
 /**
  * Component that renders a complete assistant message
  */
@@ -87,7 +94,8 @@ export class AssistantMessageComponent extends Container {
 		this.contentContainer.clear();
 
 		const hasVisibleContent = message.content.some(
-			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
+			(c) =>
+				(c.type === "text" && c.text.trim()) || (c.type === "thinking" && sanitizeThinkingDisplayText(c.thinking)),
 		);
 
 		if (hasVisibleContent) {
@@ -101,12 +109,19 @@ export class AssistantMessageComponent extends Container {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				this.contentContainer.addChild(new Markdown(content.text.trim(), this.outputPad, 0, this.markdownTheme));
-			} else if (content.type === "thinking" && content.thinking.trim()) {
+			} else if (content.type === "thinking") {
+				const thinkingText = sanitizeThinkingDisplayText(content.thinking);
+				if (!thinkingText) continue;
+
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
 				const hasVisibleContentAfter = message.content
 					.slice(i + 1)
-					.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
+					.some(
+						(c) =>
+							(c.type === "text" && c.text.trim()) ||
+							(c.type === "thinking" && sanitizeThinkingDisplayText(c.thinking)),
+					);
 
 				if (this.hideThinkingBlock) {
 					// Show static thinking label when hidden
@@ -119,7 +134,7 @@ export class AssistantMessageComponent extends Container {
 				} else {
 					// Thinking traces in thinkingText color, italic
 					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), this.outputPad, 0, this.markdownTheme, {
+						new Markdown(thinkingText, this.outputPad, 0, this.markdownTheme, {
 							color: (text: string) => theme.fg("thinkingText", text),
 							italic: true,
 						}),

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -98,6 +98,32 @@ describe("AssistantMessageComponent", () => {
 		expect(updatedLines.some((line) => line.startsWith("reasoning"))).toBe(true);
 	});
 
+	test("does not render OpenAI Responses comment separators in thinking", () => {
+		initTheme("dark");
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([
+				{
+					type: "thinking",
+					thinking:
+						"**Planning CI test suite optimization**\n\n<!-- -->\n\n**Evaluating test duration reduction strategies**\n\n<!-- -->",
+				},
+			]),
+			false,
+			undefined,
+			"Thinking...",
+			0,
+		);
+		const rendered = component
+			.render(100)
+			.map((line) => stripAnsi(line))
+			.join("\n");
+
+		expect(rendered).toContain("Planning CI test suite optimization");
+		expect(rendered).toContain("Evaluating test duration reduction strategies");
+		expect(rendered).not.toContain("<!-- -->");
+	});
+
 	test("uses configured output padding for user messages", () => {
 		initTheme("dark");
 


### PR DESCRIPTION
## Summary

- Strip provider-inserted `<!-- -->` separators from visible OpenAI Responses reasoning summaries while preserving the raw signed reasoning item for replay.
- Sanitize assistant thinking rendering so existing persisted sessions no longer show those separators.
- Add regression coverage for the provider stream and TUI rendering paths.

## Testing

- `cd packages/ai && node node_modules/vitest/dist/cli.js --run test/openai-responses-reasoning-summary-sanitization.test.ts`
- `cd packages/coding-agent && node node_modules/vitest/dist/cli.js --run test/assistant-message.test.ts`
- `npm run check`
- `./test.sh` attempted; fails in this fresh clone before these changes are exercised because workspace package dist outputs are absent (for example `node_modules/@earendil-works/pi-ai/dist/index.js` and `node_modules/@earendil-works/pi-tui/dist/index.js`).
