### PR TITLE
fix(ai): update Copilot extended context windows

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -212,6 +212,20 @@ const OPENCODE_OPENAI_COMPLETIONS_LONG_CACHE_RETENTION_UNSUPPORTED_MODELS = new 
 	"opencode-go:kimi-k2.6",
 ]);
 
+// GitHub's "Models with extended capabilities" table lists these Copilot models as supporting
+// the extended 1 million token context window.
+const GITHUB_COPILOT_EXTENDED_CONTEXT_MODELS = new Set([
+	"claude-fable-5",
+	"claude-opus-4.6",
+	"claude-opus-4.7",
+	"claude-opus-4.8",
+	"claude-sonnet-4.6",
+	"claude-sonnet-5",
+	"gpt-5.3-codex",
+	"gpt-5.4",
+	"gpt-5.5",
+]);
+
 // Checked manually against the authenticated GitHub Copilot /models endpoint on 2026-06-15.
 // Keep this to narrow corrections over models.dev metadata instead of snapshotting Copilot's catalog.
 const GITHUB_COPILOT_THINKING_LEVEL_OVERRIDES = {
@@ -1606,11 +1620,14 @@ async function generateModels() {
 
 	// Temporary overrides until upstream model metadata is corrected.
 	for (const candidate of allModels) {
+		if (candidate.provider === "github-copilot" && GITHUB_COPILOT_EXTENDED_CONTEXT_MODELS.has(candidate.id)) {
+			candidate.contextWindow = 1000000;
+		}
+
 		if (
 			(candidate.provider === "anthropic" ||
 				candidate.provider === "opencode" ||
-				candidate.provider === "opencode-go" ||
-				candidate.provider === "github-copilot") &&
+				candidate.provider === "opencode-go") &&
 			(candidate.id === "claude-opus-4-6" ||
 				candidate.id === "claude-sonnet-4-6" ||
 				candidate.id === "claude-opus-4.6" ||

--- a/packages/ai/src/providers/github-copilot.models.ts
+++ b/packages/ai/src/providers/github-copilot.models.ts
@@ -97,7 +97,7 @@ export const GITHUB_COPILOT_MODELS = {
 			cacheRead: 0.5,
 			cacheWrite: 6.25,
 		},
-		contextWindow: 200000,
+		contextWindow: 1000000,
 		maxTokens: 32000,
 	} satisfies Model<"anthropic-messages">,
 	"claude-opus-4.8": {
@@ -117,7 +117,7 @@ export const GITHUB_COPILOT_MODELS = {
 			cacheRead: 0.5,
 			cacheWrite: 6.25,
 		},
-		contextWindow: 200000,
+		contextWindow: 1000000,
 		maxTokens: 64000,
 	} satisfies Model<"anthropic-messages">,
 	"claude-sonnet-4": {
@@ -365,7 +365,7 @@ export const GITHUB_COPILOT_MODELS = {
 			cacheRead: 0.175,
 			cacheWrite: 0,
 		},
-		contextWindow: 400000,
+		contextWindow: 1000000,
 		maxTokens: 128000,
 	} satisfies Model<"openai-responses">,
 	"gpt-5.4": {
@@ -384,7 +384,7 @@ export const GITHUB_COPILOT_MODELS = {
 			cacheRead: 0.25,
 			cacheWrite: 0,
 		},
-		contextWindow: 400000,
+		contextWindow: 1000000,
 		maxTokens: 128000,
 	} satisfies Model<"openai-responses">,
 	"gpt-5.4-mini": {
@@ -441,7 +441,7 @@ export const GITHUB_COPILOT_MODELS = {
 			cacheRead: 0.5,
 			cacheWrite: 0,
 		},
-		contextWindow: 400000,
+		contextWindow: 1000000,
 		maxTokens: 128000,
 	} satisfies Model<"openai-responses">,
 	"kimi-k2.7-code": {


### PR DESCRIPTION
## Summary

Updates GitHub Copilot built-in model metadata so models with GitHub's extended context capability use a 1,000,000 token `contextWindow` in Pi.

## Reason

GitHub announced larger context windows for Copilot on June 4, 2026:
https://github.blog/changelog/2026-06-04-larger-context-windows-and-configurable-reasoning-levels-for-github-copilot/

The current supported-models table lists which Copilot models support the 1 million token context window:
https://docs.github.com/en/copilot/reference/ai-models/supported-models#models-with-extended-capabilities

This aligns Pi's generated GitHub Copilot model metadata with that table.

## Changes

- Adds a generator override set for GitHub Copilot models with extended 1M context.
- Updates generated `github-copilot.models.ts` context windows for the affected existing models.

## Validation

- `npm run check`
