### PR TITLE
fix: reload keybindings before creating custom editor component

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2359,6 +2359,12 @@ export class InteractiveMode {
 		this.editorContainer.clear();
 
 		if (factory) {
+			// Reload keybindings before creating the custom editor to ensure
+			// user overrides from keybindings.json are applied. This avoids a
+			// race where setEditorComponent is called by extensions during
+			// session reload before the reload handler updates keybindings.
+			this.keybindings.reload();
+
 			// Create the custom editor with tui, theme, and keybindings
 			const newEditor = factory(this.ui, getEditorTheme(), this.keybindings);
 


### PR DESCRIPTION
## Problem

User-customized keybindings from `keybindings.json` don't work on initial session start when a custom editor component (like pi-powerline-footer) replaces the default editor. They only work after `/reload`.

## Root Cause

`setCustomEditorComponent` creates the new editor with `this.keybindings`, but when called by extensions during session reload, `this.keybindings.reload()` hasn't been called yet (it happens after `session.reload()` in the reload handler). Even though the keybinding manager is a shared object reference, the timing gap means extensions' `session_start` handlers run before the keybindings are refreshed.

## Fix

Add `this.keybindings.reload()` inside `setCustomEditorComponent` before creating the editor. This ensures user overrides from `keybindings.json` are always applied, regardless of whether the editor is created during initial startup or session reload.

The change is minimal: one line added before `factory(this.ui, getEditorTheme(), this.keybindings)` with a comment explaining the race.