### PR TITLE
feat(ai): add xAI Grok SuperGrok OAuth provider

### DIFF
--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -30,6 +30,7 @@ import { OPENROUTER_MODELS } from "./providers/openrouter.models.ts";
 import { TOGETHER_MODELS } from "./providers/together.models.ts";
 import { VERCEL_AI_GATEWAY_MODELS } from "./providers/vercel-ai-gateway.models.ts";
 import { XAI_MODELS } from "./providers/xai.models.ts";
+import { XAI_OAUTH_MODELS } from "./providers/xai-oauth.models.ts";
 import { XIAOMI_MODELS } from "./providers/xiaomi.models.ts";
 import { XIAOMI_TOKEN_PLAN_AMS_MODELS } from "./providers/xiaomi-token-plan-ams.models.ts";
 import { XIAOMI_TOKEN_PLAN_CN_MODELS } from "./providers/xiaomi-token-plan-cn.models.ts";
@@ -67,6 +68,7 @@ export const MODELS = {
 	"together": TOGETHER_MODELS,
 	"vercel-ai-gateway": VERCEL_AI_GATEWAY_MODELS,
 	"xai": XAI_MODELS,
+	"xai-oauth": XAI_OAUTH_MODELS,
 	"xiaomi": XIAOMI_MODELS,
 	"xiaomi-token-plan-ams": XIAOMI_TOKEN_PLAN_AMS_MODELS,
 	"xiaomi-token-plan-cn": XIAOMI_TOKEN_PLAN_CN_MODELS,

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -32,6 +32,7 @@ import { openrouterImagesProvider } from "./openrouter-images.ts";
 import { togetherProvider } from "./together.ts";
 import { vercelAIGatewayProvider } from "./vercel-ai-gateway.ts";
 import { xaiProvider } from "./xai.ts";
+import { xaiOAuthProvider } from "./xai-oauth.ts";
 import { xiaomiProvider } from "./xiaomi.ts";
 import { xiaomiTokenPlanAmsProvider } from "./xiaomi-token-plan-ams.ts";
 import { xiaomiTokenPlanCnProvider } from "./xiaomi-token-plan-cn.ts";
@@ -98,6 +99,7 @@ export function builtinProviders(): Provider[] {
 		togetherProvider(),
 		vercelAIGatewayProvider(),
 		xaiProvider(),
+		xaiOAuthProvider(),
 		xiaomiProvider(),
 		xiaomiTokenPlanAmsProvider(),
 		xiaomiTokenPlanCnProvider(),

--- a/packages/ai/src/providers/xai-oauth.models.ts
+++ b/packages/ai/src/providers/xai-oauth.models.ts
@@ -1,0 +1,24 @@
+// Derived from xai.models.ts for the SuperGrok OAuth provider surface.
+// Keep model metadata aligned with the API-key xAI catalog.
+
+import type { Model } from "../types.ts";
+import { XAI_MODELS } from "./xai.models.ts";
+
+function asXaiOauthModel(model: Model<"openai-completions">): Model<"openai-completions"> {
+	return {
+		...model,
+		provider: "xai-oauth",
+		compat: {
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+			...(model.compat ?? {}),
+		},
+	} satisfies Model<"openai-completions">;
+}
+
+export const XAI_OAUTH_MODELS = Object.fromEntries(
+	Object.entries(XAI_MODELS).map(([id, model]) => [id, asXaiOauthModel(model)]),
+) as {
+	[K in keyof typeof XAI_MODELS]: Model<"openai-completions">;
+};

--- a/packages/ai/src/providers/xai-oauth.ts
+++ b/packages/ai/src/providers/xai-oauth.ts
@@ -1,0 +1,18 @@
+import { openAICompletionsApi } from "../api/openai-completions.lazy.ts";
+import { lazyOAuth } from "../auth/helpers.ts";
+import { createProvider, type Provider } from "../models.ts";
+import { loadXaiOAuth } from "../utils/oauth/load.ts";
+import { XAI_OAUTH_MODELS } from "./xai-oauth.models.ts";
+
+export function xaiOAuthProvider(): Provider<"openai-completions"> {
+	return createProvider({
+		id: "xai-oauth",
+		name: "xAI Grok OAuth (SuperGrok)",
+		baseUrl: "https://api.x.ai/v1",
+		auth: {
+			oauth: lazyOAuth({ name: "xAI Grok OAuth (SuperGrok)", load: loadXaiOAuth }),
+		},
+		models: Object.values(XAI_OAUTH_MODELS),
+		api: openAICompletionsApi(),
+	});
+}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -42,6 +42,7 @@ export type KnownProvider =
 	| "deepseek"
 	| "github-copilot"
 	| "xai"
+	| "xai-oauth"
 	| "groq"
 	| "cerebras"
 	| "openrouter"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -5,6 +5,8 @@
  * for OAuth-based providers:
  * - Anthropic (Claude Pro/Max)
  * - GitHub Copilot
+ * - OpenAI Codex (ChatGPT Plus/Pro)
+ * - xAI Grok (SuperGrok)
  */
 
 // Anthropic
@@ -27,6 +29,8 @@ export {
 	openaiCodexOAuthProvider,
 	refreshOpenAICodexToken,
 } from "./openai-codex.ts";
+// xAI Grok OAuth (SuperGrok)
+export { loginXaiOAuth, refreshXaiOAuthToken, xaiOAuthProvider } from "./xai.ts";
 
 export * from "./types.ts";
 
@@ -37,12 +41,14 @@ export * from "./types.ts";
 import { anthropicOAuthProvider } from "./anthropic.ts";
 import { githubCopilotOAuthProvider } from "./github-copilot.ts";
 import { openaiCodexOAuthProvider } from "./openai-codex.ts";
+import { xaiOAuthProvider } from "./xai.ts";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInfo, OAuthProviderInterface } from "./types.ts";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
 	anthropicOAuthProvider,
 	githubCopilotOAuthProvider,
 	openaiCodexOAuthProvider,
+	xaiOAuthProvider,
 ];
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>(

--- a/packages/ai/src/utils/oauth/load.ts
+++ b/packages/ai/src/utils/oauth/load.ts
@@ -19,3 +19,6 @@ export const loadOpenAICodexOAuth = async (): Promise<OAuthAuth> =>
 
 export const loadGitHubCopilotOAuth = async (): Promise<OAuthAuth> =>
 	((await importOAuthModule("./github-copilot.ts")) as { githubCopilotOAuth: OAuthAuth }).githubCopilotOAuth;
+
+export const loadXaiOAuth = async (): Promise<OAuthAuth> =>
+	((await importOAuthModule("./xai.ts")) as { xaiOAuth: OAuthAuth }).xaiOAuth;

--- a/packages/ai/src/utils/oauth/xai.ts
+++ b/packages/ai/src/utils/oauth/xai.ts
@@ -1,0 +1,297 @@
+/**
+ * xAI Grok OAuth flow (SuperGrok subscription)
+ *
+ * Device-code login against auth.x.ai. Uses the public Grok CLI client id.
+ * Inference goes through https://api.x.ai/v1 with the access token as a Bearer key.
+ */
+
+import type { OAuthAuth } from "../../auth/types.ts";
+import { pollOAuthDeviceCodeFlow } from "./device-code.ts";
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from "./types.ts";
+
+const XAI_BASE_URL = "https://api.x.ai/v1";
+const XAI_ISSUER = "https://auth.x.ai";
+const XAI_DISCOVERY_URL = `${XAI_ISSUER}/.well-known/openid-configuration`;
+const XAI_DEVICE_CODE_URL = `${XAI_ISSUER}/oauth2/device/code`;
+const XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const XAI_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+
+type JsonObject = Record<string, unknown>;
+
+type XaiDiscovery = {
+	authorization_endpoint: string;
+	token_endpoint: string;
+};
+
+type XaiDeviceCodeResponse = {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	verification_uri_complete?: string;
+	expires_in: number;
+	interval: number;
+};
+
+type XaiTokenResponse = {
+	access_token?: string;
+	refresh_token?: string;
+	id_token?: string;
+	expires_in?: number;
+	token_type?: string;
+	error?: string;
+	error_description?: string;
+};
+
+async function readJsonResponse(response: Response): Promise<JsonObject> {
+	const text = await response.text();
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			throw new Error("response was not a JSON object");
+		}
+		return parsed as JsonObject;
+	} catch (error) {
+		throw new Error(`Invalid JSON response (${response.status}): ${text || String(error)}`);
+	}
+}
+
+function validateXaiEndpoint(rawUrl: unknown, field: string): string {
+	if (typeof rawUrl !== "string" || !rawUrl.trim()) {
+		throw new Error(`xAI discovery response is missing ${field}`);
+	}
+	const url = new URL(rawUrl);
+	const host = url.hostname.toLowerCase();
+	if (url.protocol !== "https:" || (host !== "x.ai" && !host.endsWith(".x.ai"))) {
+		throw new Error(`Refusing non-xAI OAuth endpoint for ${field}: ${rawUrl}`);
+	}
+	return url.toString();
+}
+
+async function postForm(url: string, fields: Record<string, string>, signal?: AbortSignal): Promise<JsonObject> {
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
+		},
+		body: new URLSearchParams(fields).toString(),
+		signal,
+	});
+	const payload = await readJsonResponse(response);
+	if (!response.ok) {
+		const message =
+			(typeof payload.error_description === "string" && payload.error_description) ||
+			(typeof payload.error === "string" && payload.error) ||
+			JSON.stringify(payload);
+		if (response.status === 403) {
+			throw new Error(
+				`xAI OAuth was rejected with HTTP 403: ${message}. SuperGrok API access may require a standalone SuperGrok tier; X Premium+ alone may not include this API path.`,
+			);
+		}
+		throw new Error(`xAI OAuth request failed with HTTP ${response.status}: ${message}`);
+	}
+	return payload;
+}
+
+async function discoverXai(signal?: AbortSignal): Promise<XaiDiscovery> {
+	const response = await fetch(XAI_DISCOVERY_URL, {
+		headers: { Accept: "application/json" },
+		signal,
+	});
+	if (!response.ok) {
+		throw new Error(`xAI OIDC discovery failed with HTTP ${response.status}`);
+	}
+	const payload = await readJsonResponse(response);
+	return {
+		authorization_endpoint: validateXaiEndpoint(payload.authorization_endpoint, "authorization_endpoint"),
+		token_endpoint: validateXaiEndpoint(payload.token_endpoint, "token_endpoint"),
+	};
+}
+
+async function requestDeviceCode(signal?: AbortSignal): Promise<XaiDeviceCodeResponse> {
+	const payload = await postForm(
+		XAI_DEVICE_CODE_URL,
+		{
+			client_id: XAI_CLIENT_ID,
+			scope: XAI_SCOPE,
+		},
+		signal,
+	);
+	const required = ["device_code", "user_code", "verification_uri", "expires_in", "interval"] as const;
+	for (const key of required) {
+		if (payload[key] === undefined || payload[key] === null || payload[key] === "") {
+			throw new Error(`xAI device-code response missing ${key}`);
+		}
+	}
+	return {
+		device_code: String(payload.device_code),
+		user_code: String(payload.user_code),
+		verification_uri: String(payload.verification_uri),
+		verification_uri_complete:
+			typeof payload.verification_uri_complete === "string" ? payload.verification_uri_complete : undefined,
+		expires_in: Number(payload.expires_in),
+		interval: Number(payload.interval),
+	};
+}
+
+function jwtExpiryMs(accessToken: string): number | undefined {
+	try {
+		const [, payloadPart] = accessToken.split(".");
+		if (!payloadPart) return undefined;
+		const padded = payloadPart.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(payloadPart.length / 4) * 4, "=");
+		const payload = JSON.parse(Buffer.from(padded, "base64").toString("utf8")) as { exp?: unknown };
+		if (typeof payload.exp !== "number") return undefined;
+		return payload.exp * 1000;
+	} catch {
+		return undefined;
+	}
+}
+
+function credentialsFromTokenPayload(payload: XaiTokenResponse, previousRefresh?: string): OAuthCredentials {
+	const access = String(payload.access_token || "").trim();
+	const refresh = String(payload.refresh_token || previousRefresh || "").trim();
+	if (!access) throw new Error("xAI token response was missing access_token");
+	if (!refresh) throw new Error("xAI token response was missing refresh_token");
+
+	const expiresIn = typeof payload.expires_in === "number" ? payload.expires_in : Number(payload.expires_in || 0);
+	const skewSeconds = expiresIn > 0 ? Math.min(300, Math.max(60, Math.floor(expiresIn / 3))) : 120;
+	const expires =
+		expiresIn > 0
+			? Date.now() + Math.max(0, expiresIn - skewSeconds) * 1000
+			: (jwtExpiryMs(access) || Date.now() + 10 * 60 * 1000) - 120 * 1000;
+
+	return { access, refresh, expires };
+}
+
+/**
+ * Login with xAI Grok OAuth using device-code flow.
+ */
+export async function loginXaiOAuth(options: {
+	onDeviceCode: OAuthLoginCallbacks["onDeviceCode"];
+	onAuth?: OAuthLoginCallbacks["onAuth"];
+	onProgress?: OAuthLoginCallbacks["onProgress"];
+	signal?: AbortSignal;
+}): Promise<OAuthCredentials> {
+	options.onProgress?.("Discovering xAI OAuth endpoints...");
+	const discovery = await discoverXai(options.signal);
+	options.onProgress?.("Requesting device code...");
+	const device = await requestDeviceCode(options.signal);
+	const verificationUrl = device.verification_uri_complete || device.verification_uri;
+
+	options.onDeviceCode({
+		userCode: device.user_code,
+		verificationUri: verificationUrl,
+		intervalSeconds: Math.max(1, device.interval),
+		expiresInSeconds: Math.max(1, device.expires_in),
+	});
+	options.onAuth?.({
+		url: verificationUrl,
+		instructions: "Approve the device code in your browser to finish xAI Grok OAuth login.",
+	});
+
+	const tokenPayload = await pollOAuthDeviceCodeFlow<XaiTokenResponse>({
+		intervalSeconds: Math.max(1, device.interval),
+		expiresInSeconds: Math.max(1, device.expires_in),
+		signal: options.signal,
+		poll: async () => {
+			const response = await fetch(discovery.token_endpoint, {
+				method: "POST",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					client_id: XAI_CLIENT_ID,
+					device_code: device.device_code,
+				}).toString(),
+				signal: options.signal,
+			});
+			const payload = (await readJsonResponse(response)) as XaiTokenResponse;
+			if (response.ok) {
+				if (!payload.access_token || !payload.refresh_token) {
+					return {
+						status: "failed",
+						message: "xAI token response did not include access_token and refresh_token",
+					};
+				}
+				return { status: "complete", value: payload };
+			}
+			const errorCode = String(payload.error || "");
+			if (errorCode === "authorization_pending") {
+				return { status: "pending" };
+			}
+			if (errorCode === "slow_down") {
+				return { status: "slow_down" };
+			}
+			return {
+				status: "failed",
+				message: `xAI device-code polling failed: ${payload.error_description || payload.error || response.status}`,
+			};
+		},
+	});
+
+	return credentialsFromTokenPayload(tokenPayload);
+}
+
+/**
+ * Refresh xAI Grok OAuth token.
+ */
+export async function refreshXaiOAuthToken(refreshToken: string, signal?: AbortSignal): Promise<OAuthCredentials> {
+	const discovery = await discoverXai(signal);
+	const payload = await postForm(
+		discovery.token_endpoint,
+		{
+			grant_type: "refresh_token",
+			client_id: XAI_CLIENT_ID,
+			refresh_token: refreshToken,
+		},
+		signal,
+	);
+	return credentialsFromTokenPayload(payload as XaiTokenResponse, refreshToken);
+}
+
+export const xaiOAuth: OAuthAuth = {
+	name: "xAI Grok OAuth (SuperGrok)",
+
+	async login(callbacks) {
+		const credentials = await loginXaiOAuth({
+			onDeviceCode: (info) => callbacks.notify({ type: "device_code", ...info }),
+			onAuth: (info) => callbacks.notify({ type: "auth_url", url: info.url, instructions: info.instructions }),
+			onProgress: (message) => callbacks.notify({ type: "progress", message }),
+			signal: callbacks.signal,
+		});
+		return { ...credentials, type: "oauth" };
+	},
+
+	async refresh(credential) {
+		return { ...(await refreshXaiOAuthToken(credential.refresh)), type: "oauth" };
+	},
+
+	async toAuth(credential) {
+		return { apiKey: credential.access, baseUrl: XAI_BASE_URL };
+	},
+};
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+	id: "xai-oauth",
+	name: "xAI Grok OAuth (SuperGrok)",
+
+	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+		return loginXaiOAuth({
+			onDeviceCode: callbacks.onDeviceCode,
+			onAuth: callbacks.onAuth,
+			onProgress: callbacks.onProgress,
+			signal: callbacks.signal,
+		});
+	},
+
+	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+		return refreshXaiOAuthToken(credentials.refresh);
+	},
+
+	getApiKey(credentials: OAuthCredentials): string {
+		return credentials.access;
+	},
+};
+

--- a/packages/ai/test/xai-oauth.test.ts
+++ b/packages/ai/test/xai-oauth.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loginXaiOAuth, refreshXaiOAuthToken, xaiOAuthProvider } from "../src/utils/oauth/xai.ts";
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function getUrl(input: unknown): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+	if (input instanceof Request) return input.url;
+	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+describe("xAI Grok OAuth", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it("logs in with the xAI device code flow", async () => {
+		vi.useFakeTimers();
+		const startTime = new Date("2026-05-20T00:00:00Z");
+		vi.setSystemTime(startTime);
+
+		const deviceInfos: Array<{
+			userCode: string;
+			verificationUri: string;
+			intervalSeconds?: number;
+			expiresInSeconds?: number;
+		}> = [];
+		const pollTimes: number[] = [];
+		const pollResponses = [
+			jsonResponse({ error: "authorization_pending" }, 400),
+			jsonResponse({
+				access_token: "access-token",
+				refresh_token: "refresh-token",
+				expires_in: 21600,
+				token_type: "Bearer",
+			}),
+		];
+
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+
+			if (url === "https://auth.x.ai/.well-known/openid-configuration") {
+				return jsonResponse({
+					authorization_endpoint: "https://auth.x.ai/oauth2/auth",
+					token_endpoint: "https://auth.x.ai/oauth2/token",
+				});
+			}
+
+			if (url === "https://auth.x.ai/oauth2/device/code") {
+				expect(init?.method).toBe("POST");
+				const body = new URLSearchParams(String(init?.body));
+				expect(body.get("client_id")).toBe("b1a00492-073a-47ea-816f-4c329264a828");
+				expect(body.get("scope")).toContain("grok-cli:access");
+				return jsonResponse({
+					device_code: "device-code",
+					user_code: "WXYZ-9876",
+					verification_uri: "https://auth.x.ai/device",
+					verification_uri_complete: "https://auth.x.ai/device?user_code=WXYZ-9876",
+					expires_in: 900,
+					interval: 5,
+				});
+			}
+
+			if (url === "https://auth.x.ai/oauth2/token") {
+				pollTimes.push(Date.now());
+				const body = new URLSearchParams(String(init?.body));
+				expect(body.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:device_code");
+				expect(body.get("device_code")).toBe("device-code");
+				const response = pollResponses.shift();
+				if (!response) throw new Error("Unexpected extra token poll");
+				return response;
+			}
+
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const resultPromise = loginXaiOAuth({
+			onDeviceCode: (info) => {
+				deviceInfos.push(info);
+			},
+		});
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(deviceInfos).toEqual([
+			{
+				userCode: "WXYZ-9876",
+				verificationUri: "https://auth.x.ai/device?user_code=WXYZ-9876",
+				intervalSeconds: 5,
+				expiresInSeconds: 900,
+			},
+		]);
+		expect(pollTimes).toEqual([startTime.getTime()]);
+
+		await vi.advanceTimersByTimeAsync(5000);
+		const credentials = await resultPromise;
+		expect(credentials.access).toBe("access-token");
+		expect(credentials.refresh).toBe("refresh-token");
+		expect(credentials.expires).toBeLessThan(Date.now() + 21600 * 1000);
+		expect(xaiOAuthProvider.id).toBe("xai-oauth");
+	});
+
+	it("refreshes xAI OAuth tokens", async () => {
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit): Promise<Response> => {
+			const url = getUrl(input);
+			if (url === "https://auth.x.ai/.well-known/openid-configuration") {
+				return jsonResponse({
+					authorization_endpoint: "https://auth.x.ai/oauth2/auth",
+					token_endpoint: "https://auth.x.ai/oauth2/token",
+				});
+			}
+			if (url === "https://auth.x.ai/oauth2/token") {
+				const body = new URLSearchParams(String(init?.body));
+				expect(body.get("grant_type")).toBe("refresh_token");
+				expect(body.get("refresh_token")).toBe("old-refresh");
+				return jsonResponse({
+					access_token: "new-access",
+					refresh_token: "new-refresh",
+					expires_in: 3600,
+				});
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credentials = await refreshXaiOAuthToken("old-refresh");
+		expect(credentials.access).toBe("new-access");
+		expect(credentials.refresh).toBe("new-refresh");
+	});
+});

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -102,6 +102,7 @@ For each built-in provider, pi maintains a list of tool-capable models, updated 
 - Anthropic Claude Pro/Max
 - OpenAI ChatGPT Plus/Pro (Codex)
 - GitHub Copilot
+- xAI Grok OAuth (SuperGrok)
 
 **API keys:**
 - Anthropic

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -18,6 +18,7 @@ Use `/login` in interactive mode, then select a provider:
 - ChatGPT Plus/Pro (Codex)
 - Claude Pro/Max
 - GitHub Copilot
+- xAI Grok OAuth (SuperGrok)
 
 Use `/logout` to clear credentials. Tokens are stored in `~/.pi/agent/auth.json` and auto-refresh when expired.
 
@@ -34,6 +35,13 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 
 - Press Enter for github.com, or enter your GitHub Enterprise Server domain
 - If you get "model not supported", enable it in VS Code: Copilot Chat → model selector → select model → "Enable"
+
+### xAI Grok OAuth (SuperGrok)
+
+- Uses device-code login against `auth.x.ai`
+- Requires a SuperGrok-capable subscription with API access (X Premium+ alone may not include this path)
+- Models appear under the `xai-oauth` provider after login
+- Direct xAI API-key models remain available under `xai` when `XAI_API_KEY` is configured
 
 ## API Keys
 

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -51,7 +51,7 @@ Start pi and run:
 /login
 ```
 
-Then select a provider. Built-in subscription logins include Claude Pro/Max, ChatGPT Plus/Pro (Codex), and GitHub Copilot.
+Then select a provider. Built-in subscription logins include Claude Pro/Max, ChatGPT Plus/Pro (Codex), GitHub Copilot, and xAI Grok OAuth (SuperGrok).
 
 ### Option 2: API key
 

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -26,6 +26,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	openrouter: "moonshotai/kimi-k2.6",
 	"vercel-ai-gateway": "zai/glm-5.1",
 	xai: "grok-4.20-0309-reasoning",
+	"xai-oauth": "grok-4.20-0309-reasoning",
 	groq: "openai/gpt-oss-120b",
 	cerebras: "zai-glm-4.7",
 	zai: "glm-5.1",

--- a/packages/coding-agent/src/core/provider-display-names.ts
+++ b/packages/coding-agent/src/core/provider-display-names.ts
@@ -26,6 +26,7 @@ export const BUILT_IN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	together: "Together AI",
 	"vercel-ai-gateway": "Vercel AI Gateway",
 	xai: "xAI",
+	"xai-oauth": "xAI Grok OAuth (SuperGrok)",
 	zai: "ZAI Coding Plan (Global)",
 	"zai-coding-cn": "ZAI Coding Plan (China)",
 	xiaomi: "Xiaomi MiMo",


### PR DESCRIPTION
## Summary
- Adds a built-in `xai-oauth` provider for SuperGrok subscription login via device-code OAuth (`auth.x.ai`).
- Keeps the existing API-key `xai` provider intact (`XAI_API_KEY`).
- Documents the new subscription login and includes unit tests for login/refresh.

## Why
Pi currently supports OAuth subscriptions for Claude, Codex, and GitHub Copilot, but Grok SuperGrok is API-key only. This adds first-class Grok OAuth so users can `/login` and use Grok models under `xai-oauth/*` without an API key.

## Notes / caveats
- Uses the public Grok CLI OAuth client id and device-code flow.
- SuperGrok entitlement is required; X Premium+ alone may not include API access.
- Models are served via OpenAI-compatible completions at `https://api.x.ai/v1`.
- Listing behavior: OAuth-only shows `xai-oauth/*`; API-key-only shows `xai/*`.

## Test plan
- [x] `npx vitest --run test/xai-oauth.test.ts` in `packages/ai`
- [x] `tsc -p packages/ai/tsconfig.build.json --noEmit` (no errors from this change)
- [ ] Manual: `/login` → xAI Grok OAuth → approve device code → `/model` shows `xai-oauth/*`
- [ ] Manual: prompt with `xai-oauth/grok-3` or `xai-oauth/grok-4.20-0309-reasoning`
- [ ] Manual: ensure API-key `xai` still works when `XAI_API_KEY` is set