### PR TITLE
fix(coding-agent): cancel auto-retry when switching models

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1540,6 +1540,7 @@ export class AgentSession {
 		}
 
 		const previousModel = this.model;
+		this.abortRetry();
 		const thinkingLevel = this._getThinkingLevelForModelSwitch();
 		this.agent.state.model = model;
 		this.sessionManager.appendModelChange(model.provider, model.id);
@@ -2599,6 +2600,7 @@ export class AgentSession {
 		}
 
 		const delayMs = settings.baseDelayMs * 2 ** (this._retryAttempt - 1);
+		this._retryAbortController = new AbortController();
 
 		this._emit({
 			type: "auto_retry_start",
@@ -2615,7 +2617,6 @@ export class AgentSession {
 		}
 
 		// Wait with exponential backoff (abortable)
-		this._retryAbortController = new AbortController();
 		try {
 			await sleep(delayMs, this._retryAbortController.signal);
 		} catch {

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -170,6 +170,28 @@ describe("AgentSession retry", () => {
 		expect(created.session.isRetrying).toBe(false);
 	});
 
+	it("setModel cancels an in-flight retry instead of resuming the old turn", async () => {
+		const created = createSession({ failCount: 99, maxRetries: 3 });
+		const retryEnds: string[] = [];
+		const nextModel = getModel("anthropic", "claude-opus-4-8")!;
+
+		created.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") {
+				void created.session.setModel(nextModel);
+			}
+			if (event.type === "auto_retry_end") {
+				retryEnds.push(event.finalError ?? "");
+			}
+		});
+
+		await created.session.prompt("Test");
+
+		expect(created.getCallCount()).toBe(1);
+		expect(created.session.model?.id).toBe(nextModel.id);
+		expect(created.session.isRetrying).toBe(false);
+		expect(retryEnds).toContain("Retry cancelled");
+	});
+
 	it("retries provider network_error failures", async () => {
 		const created = createSession({ failCount: 0 });
 		let callCount = 0;


### PR DESCRIPTION
## Summary
- cancel any in-flight auto-retry when `AgentSession.setModel()` applies a new model
- create the retry abort controller before emitting `auto_retry_start`
- add a regression test proving model switches do not resume the old retry turn

## Root Cause
`/model` in interactive mode already calls `session.setModel(model)`, but `setModel()` did not cancel an in-flight retry. Worse, `_prepareRetry()` emitted `auto_retry_start` before `_retryAbortController` existed, so even a model switch triggered from that window could not abort the pending retry sleep.

That let the old turn resume under the previous retry flow after the user had already switched models/providers.

## Test Plan
- `cd packages/coding-agent && npx vitest run test/agent-session-retry.test.ts -t "setModel cancels an in-flight retry instead of resuming the old turn"`
- `cd packages/coding-agent && npx vitest run test/agent-session-retry.test.ts`

Closes #6462
