### PR TITLE
fix(package-manager): restore missing git package deps + pnpm-friendly install flags

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -1289,8 +1289,15 @@ export class DefaultPackageManager implements PackageManager {
 				if (!existsSync(installedPath)) {
 					const installed = await installMissing();
 					if (!installed) continue;
-				} else if (resolvedScope === "temporary" && !parsed.pinned && !isOfflineModeEnabled()) {
-					await this.refreshTemporaryGitSource(parsed, resolvedSource);
+				} else {
+					if (resolvedScope === "temporary" && !parsed.pinned && !isOfflineModeEnabled()) {
+						await this.refreshTemporaryGitSource(parsed, resolvedSource);
+					}
+					// A git checkout can lose its node_modules after a manual `git clean -fdx`, a
+					// fresh clone by another tool, or a partial state. The load path only checks for
+					// the checkout directory, so reinstall runtime dependencies when they are missing
+					// to avoid loading extensions with broken imports (e.g. `Cannot find module`).
+					await this.ensureGitPackageDependencies(installedPath, resolvedScope);
 				}
 				metadata.baseDir = installedPath;
 				this.collectPackageResources(installedPath, accumulator, filter, metadata);
@@ -1761,6 +1768,17 @@ export class DefaultPackageManager implements PackageManager {
 	private getGitDependencyInstallArgs(): string[] {
 		const configuredCommand = this.settingsManager.getNpmCommand();
 		if (configuredCommand && configuredCommand.length > 0) {
+			// pnpm exits non-zero on unapproved build scripts ([ERR_PNPM_IGNORED_BUILDS]), which would
+			// abort install/update/restore even though dependencies are installed successfully. Mirror
+			// the npm-package install flags so git package installs stay pnpm-friendly.
+			if (this.getPackageManagerName() === "pnpm") {
+				return [
+					"install",
+					"--config.auto-install-peers=false",
+					"--config.strict-peer-dependencies=false",
+					"--config.strict-dep-builds=false",
+				];
+			}
 			return ["install"];
 		}
 		return ["install", "--omit=dev"];
@@ -1881,6 +1899,40 @@ export class DefaultPackageManager implements PackageManager {
 		if (existsSync(packageJsonPath)) {
 			await this.runNpmCommand(this.getGitDependencyInstallArgs(), { cwd: targetDir });
 		}
+	}
+
+	/**
+	 * Reinstall runtime dependencies for an existing git checkout when its node_modules is missing.
+	 *
+	 * The load path (`resolvePackageSources`) only checks for the checkout directory, not for
+	 * `node_modules`. A checkout can lose its dependencies after a manual `git clean -fdx`, a
+	 * fresh clone by another tool, or a partial state, which leaves extensions importing third-party
+	 * packages (e.g. `croner`) unable to load with `Cannot find module`. This restores them.
+	 *
+	 * Only packages that declare runtime `dependencies` are reinstalled: a no-deps checkout has
+	 * nothing to restore, and `npm install` does not create `node_modules` for such packages, so
+	 * checking for it would cause spurious reinstalls on every startup for npm users.
+	 */
+	private async ensureGitPackageDependencies(targetDir: string, scope: SourceScope): Promise<void> {
+		if (isOfflineModeEnabled()) return;
+		const packageJsonPath = join(targetDir, "package.json");
+		if (!existsSync(packageJsonPath)) return;
+		if (existsSync(join(targetDir, "node_modules"))) return;
+		let pkg: { dependencies?: Record<string, string> };
+		try {
+			pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { dependencies?: Record<string, string> };
+		} catch {
+			return;
+		}
+		if (!pkg.dependencies || Object.keys(pkg.dependencies).length === 0) return;
+		await this.withProgress(
+			"install",
+			targetDir,
+			`Restoring dependencies for ${relative(this.getBaseDirForScope(scope), targetDir) || targetDir}...`,
+			async () => {
+				await this.runNpmCommand(this.getGitDependencyInstallArgs(), { cwd: targetDir });
+			},
+		);
 	}
 
 	private async refreshTemporaryGitSource(source: GitSource, sourceStr: string): Promise<void> {

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -845,7 +845,16 @@ Content`,
 
 			await packageManager.install(source);
 
-			expect(runCommandSpy).toHaveBeenCalledWith("pnpm", ["install"], { cwd: targetDir });
+			expect(runCommandSpy).toHaveBeenCalledWith(
+				"pnpm",
+				[
+					"install",
+					"--config.auto-install-peers=false",
+					"--config.strict-peer-dependencies=false",
+					"--config.strict-dep-builds=false",
+				],
+				{ cwd: targetDir },
+			);
 		});
 
 		it("should update git package dependencies with --omit=dev", async () => {
@@ -908,9 +917,107 @@ Content`,
 
 			await packageManager.update(source);
 
-			expect(runCommandSpy).toHaveBeenCalledWith("mise", ["exec", "node@20", "--", "pnpm", "install"], {
-				cwd: targetDir,
+			expect(runCommandSpy).toHaveBeenCalledWith(
+				"mise",
+				[
+					"exec",
+					"node@20",
+					"--",
+					"pnpm",
+					"install",
+					"--config.auto-install-peers=false",
+					"--config.strict-peer-dependencies=false",
+					"--config.strict-dep-builds=false",
+				],
+				{
+					cwd: targetDir,
+				},
+			);
+		});
+
+		it("should reinstall git package dependencies on resolve when node_modules is missing", async () => {
+			const source = "git:github.com/user/repo";
+			const targetDir = join(agentDir, "git", "github.com", "user", "repo");
+			mkdirSync(targetDir, { recursive: true });
+			// Checkout exists with runtime dependencies but no node_modules (e.g. after git clean -fdx).
+			writeFileSync(
+				join(targetDir, "package.json"),
+				JSON.stringify({ name: "repo", version: "1.0.0", dependencies: { croner: "^10.0.0" } }),
+			);
+			settingsManager.setPackages([source]);
+
+			const runCommandSpy = vi.spyOn(packageManager as any, "runCommand").mockResolvedValue(undefined);
+
+			await packageManager.resolve();
+
+			expect(runCommandSpy).toHaveBeenCalledWith("npm", ["install", "--omit=dev"], { cwd: targetDir });
+		});
+
+		it("should use plain install when reinstalling missing git package dependencies with npmCommand configured", async () => {
+			settingsManager = SettingsManager.inMemory({
+				npmCommand: ["pnpm"],
 			});
+			packageManager = new DefaultPackageManager({
+				cwd: tempDir,
+				agentDir,
+				settingsManager,
+			});
+
+			const source = "git:github.com/user/repo";
+			const targetDir = join(agentDir, "git", "github.com", "user", "repo");
+			mkdirSync(targetDir, { recursive: true });
+			writeFileSync(
+				join(targetDir, "package.json"),
+				JSON.stringify({ name: "repo", version: "1.0.0", dependencies: { croner: "^10.0.0" } }),
+			);
+			settingsManager.setPackages([source]);
+
+			const runCommandSpy = vi.spyOn(packageManager as any, "runCommand").mockResolvedValue(undefined);
+
+			await packageManager.resolve();
+
+			expect(runCommandSpy).toHaveBeenCalledWith(
+				"pnpm",
+				[
+					"install",
+					"--config.auto-install-peers=false",
+					"--config.strict-peer-dependencies=false",
+					"--config.strict-dep-builds=false",
+				],
+				{ cwd: targetDir },
+			);
+		});
+
+		it("should not reinstall git package dependencies on resolve when node_modules exists", async () => {
+			const source = "git:github.com/user/repo";
+			const targetDir = join(agentDir, "git", "github.com", "user", "repo");
+			mkdirSync(targetDir, { recursive: true });
+			writeFileSync(
+				join(targetDir, "package.json"),
+				JSON.stringify({ name: "repo", version: "1.0.0", dependencies: { croner: "^10.0.0" } }),
+			);
+			mkdirSync(join(targetDir, "node_modules"), { recursive: true });
+			settingsManager.setPackages([source]);
+
+			const runCommandSpy = vi.spyOn(packageManager as any, "runCommand").mockResolvedValue(undefined);
+
+			await packageManager.resolve();
+
+			expect(runCommandSpy).not.toHaveBeenCalledWith("npm", expect.any(Array), expect.anything());
+		});
+
+		it("should not reinstall git package dependencies on resolve when package has no dependencies", async () => {
+			const source = "git:github.com/user/repo";
+			const targetDir = join(agentDir, "git", "github.com", "user", "repo");
+			mkdirSync(targetDir, { recursive: true });
+			writeFileSync(join(targetDir, "package.json"), JSON.stringify({ name: "repo", version: "1.0.0" }));
+			settingsManager.setPackages([source]);
+
+			const runCommandSpy = vi.spyOn(packageManager as any, "runCommand").mockResolvedValue(undefined);
+
+			await packageManager.resolve();
+
+			expect(runCommandSpy).not.toHaveBeenCalledWith("npm", expect.any(Array), expect.anything());
 		});
 
 		it("should use npmCommand argv for npm root lookup and invalidate cached root when npmCommand changes", () => {


### PR DESCRIPTION
## Problem

A git package whose checkout exists but whose `node_modules` is missing fails to load with `Cannot find module '<dep>'`. This hits pnpm users in particular.

Repro (the case I hit): `@tintinweb/pi-subagents` is installed as `git:github.com/cad0p/tintinweb-pi-subagents@master` with `"npmCommand": ["pnpm"]`. After the checkout lost its `node_modules` (a `git clean -fdx` during reconcile, a fresh clone by another tool, or a partial state), `pi` failed at startup:

```
Error: Failed to load extension ".../tintinweb-pi-subagents/src/index.ts": Failed to load extension: Cannot find module 'croner'
Require stack:
- .../tintinweb-pi-subagents/src/schedule.ts
Hint: Start without extensions using "pi -ne".
```

## Root cause

The package load path (`resolvePackageSources`) only checks for the git checkout **directory**, not for `node_modules`:

```ts
if (parsed.type === "git") {
  const installedPath = this.getGitInstallPath(parsed, resolvedScope);
  if (!existsSync(installedPath)) {        // ← checks the dir only
    const installed = await installMissing();
    ...
  } else if (resolvedScope === "temporary" && !parsed.pinned && !isOfflineModeEnabled()) {
    await this.refreshTemporaryGitSource(parsed, resolvedSource);
  }
  metadata.baseDir = installedPath;
  this.collectPackageResources(installedPath, accumulator, filter, metadata);
}
```

So a checkout that exists but has no `node_modules` is loaded as-is, and extensions importing third-party packages fail to resolve. The install/reconcile paths (`installGit`/`ensureGitRef`) do reinstall after a ref change, but the load path on a plain `pi` startup does not.

A second, related pnpm issue: `getGitDependencyInstallArgs()` returns a bare `["install"]` when `npmCommand` is configured. pnpm 11 exits non-zero on unapproved build scripts (`[ERR_PNPM_IGNORED_BUILDS]`), which would abort install/update/restore even though the dependencies are installed successfully. The npm-package install path (`getNpmInstallArgs`) already passes `--config.strict-dep-builds=false` for pnpm; the git path did not.

## Fix

Two changes in `packages/coding-agent/src/core/package-manager.ts`:

1. **`ensureGitPackageDependencies()`** — on `resolve`, when a git checkout exists but has a `package.json` with runtime `dependencies` and no `node_modules`, reinstall them. No-deps packages are skipped: `npm install` does not create `node_modules` for a package with no dependencies, so checking for it would cause spurious reinstalls on every startup for npm users. Respects offline mode.

2. **`getGitDependencyInstallArgs()`** — when the configured package manager is pnpm, return the same pnpm-friendly flags the npm-package path uses (`--config.auto-install-peers=false`, `--config.strict-peer-dependencies=false`, `--config.strict-dep-builds=false`), so `[ERR_PNPM_IGNORED_BUILDS]` no longer aborts git package installs/updates/restores.

## Verification

End-to-end with `npmCommand: ["pnpm"]` and `@tintinweb/pi-subagents` (which depends on `croner`):

```
$ rm -rf .../tintinweb-pi-subagents/node_modules   # reproduce broken state
$ node packages/coding-agent/dist/cli.js -p "say hi"
+ croner 10.0.1
$ echo $?
0
```

Before the fix: `Cannot find module 'croner'` and startup abort. After: deps restored, extension loads, exit 0.

- `npm run check` ✅
- `npx vitest run test/package-manager.test.ts` — 119 passed (4 new regression tests added)
- The 2 failures in `test/suite/regressions/4167-...` are pre-existing on `main` (verified by stashing this change) and unrelated to package-manager.

## Notes

- Did not edit `CHANGELOG.md` per CONTRIBUTING.
- This is a load-path robustness fix; it does not change install/update semantics for healthy checkouts (the `node_modules`-exists and no-deps cases short-circuit before any install).
