### PR TITLE
fix(ai): correct GPT-5.6 Codex context window

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1885,9 +1885,10 @@ async function generateModels() {
 
 	// OpenAI Codex (ChatGPT OAuth) models
 	// NOTE: These are not fetched from models.dev; we keep a small, explicit list to avoid aliases.
-	// Context window is based on observed server limits (400s above ~272k), not marketing numbers.
+	// Context window is based on observed server limits (400s above ~272k), except GPT-5.6 uses Codex metadata.
 	const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 	const CODEX_CONTEXT = 272000;
+	const CODEX_5_6_CONTEXT = 372000;
 	const CODEX_SPARK_CONTEXT = 128000;
 	const CODEX_MAX_TOKENS = 128000;
 	const codexModels: Model<"openai-codex-responses">[] = [
@@ -1948,7 +1949,7 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 0 },
-			contextWindow: CODEX_CONTEXT,
+			contextWindow: CODEX_5_6_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{
@@ -1960,7 +1961,7 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
-			contextWindow: CODEX_CONTEXT,
+			contextWindow: CODEX_5_6_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{
@@ -1972,7 +1973,7 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
-			contextWindow: CODEX_CONTEXT,
+			contextWindow: CODEX_5_6_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 	];

--- a/packages/ai/src/providers/openai-codex.models.ts
+++ b/packages/ai/src/providers/openai-codex.models.ts
@@ -91,7 +91,7 @@ export const OPENAI_CODEX_MODELS = {
 			cacheRead: 0.1,
 			cacheWrite: 0,
 		},
-		contextWindow: 272000,
+		contextWindow: 372000,
 		maxTokens: 128000,
 	} satisfies Model<"openai-codex-responses">,
 	"gpt-5.6-sol": {
@@ -109,7 +109,7 @@ export const OPENAI_CODEX_MODELS = {
 			cacheRead: 0.5,
 			cacheWrite: 0,
 		},
-		contextWindow: 272000,
+		contextWindow: 372000,
 		maxTokens: 128000,
 	} satisfies Model<"openai-codex-responses">,
 	"gpt-5.6-terra": {
@@ -127,7 +127,7 @@ export const OPENAI_CODEX_MODELS = {
 			cacheRead: 0.25,
 			cacheWrite: 0,
 		},
-		contextWindow: 272000,
+		contextWindow: 372000,
 		maxTokens: 128000,
 	} satisfies Model<"openai-codex-responses">,
 } as const;


### PR DESCRIPTION
Correct the OpenAI Codex models context window for GPT-5.6 Sol, Terra, and Luna from 272k to 372k tokens, matching the [upstream](https://github.com/openai/codex/blob/2e8c3756f95789c215d9ea9a5ade6ec377934b3f/codex-rs/models-manager/models.json#L4-L26) OpenAI Codex model metadata

