### PR TITLE
feat(ai): add ultra thinking level

### DIFF
--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -283,10 +283,10 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 
 /**
  * Thinking/reasoning level for models that support it.
- * Note: "xhigh" and "max" are only supported by selected model families. Use model
- * thinking-level metadata from @earendil-works/pi-ai to detect support for a concrete model.
+ * Note: "xhigh", "max", and "ultra" are only supported by selected model families. Use
+ * model thinking-level metadata from @earendil-works/pi-ai to detect support for a concrete model.
  */
-export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 
 /**
  * Extensible interface for custom app messages.

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -314,6 +314,14 @@ function supportsOpenAiMax(model: Model<Api>): boolean {
 	);
 }
 
+function supportsOpenAiUltra(model: Model<Api>): boolean {
+	return (
+		model.provider === "openai-codex" &&
+		model.api === "openai-codex-responses" &&
+		(model.id === "gpt-5.6-sol" || model.id === "gpt-5.6-terra")
+	);
+}
+
 function isGoogleThinkingApi(model: Model<any>): boolean {
 	return model.api === "google-generative-ai" || model.api === "google-vertex";
 }
@@ -517,6 +525,9 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	}
 	if (supportsOpenAiMax(model)) {
 		mergeThinkingLevelMap(model, { max: "max" });
+	}
+	if (supportsOpenAiUltra(model)) {
+		mergeThinkingLevelMap(model, { ultra: "max" });
 	}
 	if (model.provider === "openai" && model.id === "gpt-5.5") {
 		mergeThinkingLevelMap(model, { minimal: null });

--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -153,7 +153,8 @@ export const streamSimple: StreamFunction<"azure-openai-responses", SimpleStream
 
 	const base = buildBaseOptions(model, context, options, apiKey);
 	const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
-	const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
+	const reasoningEffort =
+		clampedReasoning === "off" ? undefined : clampedReasoning === "ultra" ? "max" : clampedReasoning;
 
 	return stream(model, context, {
 		...base,

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -1029,10 +1029,14 @@ function buildAdditionalModelRequestFields(
 						high: 16384,
 						xhigh: 16384, // Budget-based Claude clamps extended levels to high
 						max: 16384,
+						ultra: 16384,
 					};
 
 					// Custom budgets only cover token-based levels through high.
-					const level = options.reasoning === "xhigh" || options.reasoning === "max" ? "high" : options.reasoning;
+					const level =
+						options.reasoning === "xhigh" || options.reasoning === "max" || options.reasoning === "ultra"
+							? "high"
+							: options.reasoning;
 					const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[options.reasoning];
 
 					return {

--- a/packages/ai/src/api/google-generative-ai.ts
+++ b/packages/ai/src/api/google-generative-ai.ts
@@ -400,7 +400,7 @@ function buildParams(
 	return params;
 }
 
-type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh" | "max">;
+type ClampedThinkingLevel = Exclude<ThinkingLevel, "xhigh" | "max" | "ultra">;
 
 function isGemma4Model(model: Model<"google-generative-ai">): boolean {
 	return /gemma-?4/.test(model.id.toLowerCase());

--- a/packages/ai/src/api/google-vertex.ts
+++ b/packages/ai/src/api/google-vertex.ts
@@ -498,7 +498,7 @@ function buildParams(
 	return params;
 }
 
-type ClampedThinkingLevel = Exclude<PiThinkingLevel, "xhigh" | "max">;
+type ClampedThinkingLevel = Exclude<PiThinkingLevel, "xhigh" | "max" | "ultra">;
 
 function isGemini3ProModel(model: Model<"google-generative-ai">): boolean {
 	return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -80,7 +80,7 @@ const CODEX_RESPONSE_STATUSES = new Set<CodexResponseStatus>([
 // ============================================================================
 
 export interface OpenAICodexResponsesOptions extends StreamOptions {
-	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 	reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	textVerbosity?: "low" | "medium" | "high";
@@ -511,10 +511,11 @@ function buildRequestBody(
 	}
 
 	if (options?.reasoningEffort !== undefined) {
+		const requestEffort = options.reasoningEffort === "ultra" ? "max" : options.reasoningEffort;
 		const effort =
 			options.reasoningEffort === "none"
 				? (model.thinkingLevelMap?.off ?? "none")
-				: (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort);
+				: (model.thinkingLevelMap?.[options.reasoningEffort] ?? requestEffort);
 		if (effort !== null) {
 			body.reasoning = {
 				effort,

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -490,7 +490,8 @@ export const streamSimple: StreamFunction<"openai-completions", SimpleStreamOpti
 
 	const base = buildBaseOptions(model, context, options, options?.apiKey);
 	const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
-	const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
+	const reasoningEffort =
+		clampedReasoning === "off" ? undefined : clampedReasoning === "ultra" ? "max" : clampedReasoning;
 	const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;
 
 	return stream(model, context, {

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -173,7 +173,8 @@ export const streamSimple: StreamFunction<"openai-responses", SimpleStreamOption
 
 	const base = buildBaseOptions(model, context, options, options?.apiKey);
 	const clampedReasoning = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
-	const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
+	const reasoningEffort =
+		clampedReasoning === "off" ? undefined : clampedReasoning === "ultra" ? "max" : clampedReasoning;
 
 	return stream(model, context, {
 		...base,

--- a/packages/ai/src/api/simple-options.ts
+++ b/packages/ai/src/api/simple-options.ts
@@ -44,8 +44,10 @@ export function buildBaseOptions(
 	};
 }
 
-export function clampReasoning(effort: ThinkingLevel | undefined): Exclude<ThinkingLevel, "xhigh" | "max"> | undefined {
-	return effort === "xhigh" || effort === "max" ? "high" : effort;
+export function clampReasoning(
+	effort: ThinkingLevel | undefined,
+): Exclude<ThinkingLevel, "xhigh" | "max" | "ultra"> | undefined {
+	return effort === "xhigh" || effort === "max" || effort === "ultra" ? "high" : effort;
 }
 
 export function adjustMaxTokensForThinking(

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -405,7 +405,16 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
 	return usage.cost;
 }
 
-const EXTENDED_THINKING_LEVELS: ModelThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+const EXTENDED_THINKING_LEVELS: ModelThinkingLevel[] = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+	"ultra",
+];
 
 export function getSupportedThinkingLevels<TApi extends Api>(model: Model<TApi>): ModelThinkingLevel[] {
 	if (!model.reasoning) return ["off"];
@@ -413,7 +422,7 @@ export function getSupportedThinkingLevels<TApi extends Api>(model: Model<TApi>)
 	return EXTENDED_THINKING_LEVELS.filter((level) => {
 		const mapped = model.thinkingLevelMap?.[level];
 		if (mapped === null) return false;
-		if (level === "xhigh" || level === "max") return mapped !== undefined;
+		if (level === "xhigh" || level === "max" || level === "ultra") return mapped !== undefined;
 		return true;
 	});
 }

--- a/packages/ai/src/providers/openai-codex.models.ts
+++ b/packages/ai/src/providers/openai-codex.models.ts
@@ -104,7 +104,7 @@ export const OPENAI_CODEX_MODELS = {
 		provider: "openai-codex",
 		baseUrl: "https://chatgpt.com/backend-api",
 		reasoning: true,
-		thinkingLevelMap: {"xhigh":"xhigh","max":"max","minimal":"low"},
+		thinkingLevelMap: {"xhigh":"xhigh","max":"max","ultra":"max","minimal":"low"},
 		input: ["text", "image"],
 		cost: {
 			input: 5,
@@ -123,7 +123,7 @@ export const OPENAI_CODEX_MODELS = {
 		provider: "openai-codex",
 		baseUrl: "https://chatgpt.com/backend-api",
 		reasoning: true,
-		thinkingLevelMap: {"xhigh":"xhigh","max":"max","minimal":"low"},
+		thinkingLevelMap: {"xhigh":"xhigh","max":"max","ultra":"max","minimal":"low"},
 		input: ["text", "image"],
 		cost: {
 			input: 2.5,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -71,7 +71,7 @@ export type KnownImagesProvider = "openrouter";
 
 export type ImagesProviderId = KnownImagesProvider | string;
 
-export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 export type ModelThinkingLevel = "off" | ThinkingLevel;
 export type ThinkingLevelMap = Partial<Record<ModelThinkingLevel, string | null>>;
 export type ChatTemplateKwargValue =

--- a/packages/ai/test/ultra-thinking.test.ts
+++ b/packages/ai/test/ultra-thinking.test.ts
@@ -11,7 +11,7 @@ function mockToken(): string {
 	return `aaa.${payload}.bbb`;
 }
 
-describe("max thinking level", () => {
+describe("ultra thinking level", () => {
 	it("is opt-in for ordinary reasoning models", () => {
 		const model: Model<"openai-completions"> = {
 			id: "ordinary-reasoning",
@@ -27,47 +27,33 @@ describe("max thinking level", () => {
 		};
 
 		expect(getSupportedThinkingLevels(model)).toEqual(["off", "minimal", "low", "medium", "high"]);
-		expect(clampThinkingLevel(model, "max")).toBe("high");
+		expect(clampThinkingLevel(model, "ultra")).toBe("high");
 	});
 
-	it.each(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"] as const)(
-		"exposes xhigh and max for openai-codex/%s",
-		(modelId) => {
-			const model = getModel("openai-codex", modelId);
-			expect(model).toBeDefined();
-			expect(model?.thinkingLevelMap).toMatchObject({ xhigh: "xhigh", max: "max" });
-			expect(getSupportedThinkingLevels(model!).slice(0, 7)).toEqual([
-				"off",
-				"minimal",
-				"low",
-				"medium",
-				"high",
-				"xhigh",
-				"max",
-			]);
-		},
-	);
-
-	it("supports a hole between high and max", () => {
-		const model: Model<"openai-completions"> = {
-			id: "high-and-max",
-			name: "High and Max",
-			api: "openai-completions",
-			provider: "test",
-			baseUrl: "https://example.com/v1",
-			reasoning: true,
-			thinkingLevelMap: { xhigh: null, max: "max" },
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128000,
-			maxTokens: 4096,
-		};
-
-		expect(getSupportedThinkingLevels(model)).toEqual(["off", "minimal", "low", "medium", "high", "max"]);
-		expect(clampThinkingLevel(model, "xhigh")).toBe("max");
+	it.each(["gpt-5.6-sol", "gpt-5.6-terra"] as const)("exposes ultra for openai-codex/%s", (modelId) => {
+		const model = getModel("openai-codex", modelId);
+		expect(model).toBeDefined();
+		expect(model?.thinkingLevelMap).toMatchObject({ xhigh: "xhigh", max: "max", ultra: "max" });
+		expect(getSupportedThinkingLevels(model!)).toEqual([
+			"off",
+			"minimal",
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+			"ultra",
+		]);
 	});
 
-	it("sends max to the Codex Responses API", async () => {
+	it("does not expose ultra for openai-codex/gpt-5.6-luna", () => {
+		const model = getModel("openai-codex", "gpt-5.6-luna")!;
+		expect(model.thinkingLevelMap?.ultra).toBeUndefined();
+		expect(getSupportedThinkingLevels(model)).toEqual(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+		expect(clampThinkingLevel(model, "ultra")).toBe("max");
+	});
+
+	it("sends max to the Codex Responses API when ultra is selected", async () => {
 		const model = getModel("openai-codex", "gpt-5.6-sol")!;
 		const context: Context = {
 			systemPrompt: "You are a helpful assistant.",
@@ -77,7 +63,7 @@ describe("max thinking level", () => {
 
 		await streamSimpleOpenAICodexResponses(model, context, {
 			apiKey: mockToken(),
-			reasoning: "max",
+			reasoning: "ultra",
 			onPayload: (request) => {
 				payload = request;
 				throw new Error("payload captured");

--- a/packages/coding-agent/examples/extensions/preset.ts
+++ b/packages/coding-agent/examples/extensions/preset.ts
@@ -52,7 +52,7 @@ interface Preset {
 	/** Model ID (e.g., "claude-sonnet-4-5") */
 	model?: string;
 	/** Thinking level */
-	thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+	thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 	/** Tools to enable (replaces default set) */
 	tools?: string[];
 	/** Instructions to append to system prompt */
@@ -100,7 +100,7 @@ function loadPresets(cwd: string): PresetsConfig {
 
 interface OriginalState {
 	model: Model<Api> | undefined;
-	thinkingLevel: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+	thinkingLevel: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
 	tools: string[];
 }
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -54,7 +54,7 @@ export interface Args {
 	diagnostics: Array<{ type: "warning" | "error"; message: string }>;
 }
 
-const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const;
 
 export function isValidThinkingLevel(level: string): level is ThinkingLevel {
 	return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
@@ -258,7 +258,7 @@ ${chalk.bold("Options:")}
                                  Applies to built-in, extension, and custom tools
   --exclude-tools, -xt <tools>   Comma-separated denylist of tool names to disable
                                  Applies to built-in, extension, and custom tools
-  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh, max
+  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh, max, ultra
   --extension, -e <path>         Load an extension file (can be used multiple times)
   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)
   --skill <path>                 Load a skill file or directory (can be used multiple times)

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -95,6 +95,7 @@ const ThinkingLevelMapSchema = Type.Object({
 	high: Type.Optional(ThinkingLevelMapValueSchema),
 	xhigh: Type.Optional(ThinkingLevelMapValueSchema),
 	max: Type.Optional(ThinkingLevelMapValueSchema),
+	ultra: Type.Optional(ThinkingLevelMapValueSchema),
 });
 
 const ChatTemplateKwargScalarSchema = Type.Union([Type.String(), Type.Number(), Type.Boolean(), Type.Null()]);

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -37,6 +37,7 @@ const THINKING_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	high: "Deep reasoning (~16k tokens)",
 	xhigh: "Extra-high reasoning (~32k tokens)",
 	max: "Maximum reasoning",
+	ultra: "Maximum reasoning with proactive task delegation when available",
 };
 
 const DEFAULT_PROJECT_TRUST_LABELS: Record<DefaultProjectTrust, string> = {

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -16,6 +16,7 @@ const LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	high: "Deep reasoning (~16k tokens)",
 	xhigh: "Extra-high reasoning (~32k tokens)",
 	max: "Maximum reasoning",
+	ultra: "Maximum reasoning with proactive task delegation when available",
 };
 
 /**

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -420,6 +420,7 @@ export class Theme {
 			case "xhigh":
 				return (str: string) => this.fg("thinkingXhigh", str);
 			case "max":
+			case "ultra":
 				return (str: string) => this.fg("thinkingMax", str);
 			default:
 				return (str: string) => this.fg("thinkingOff", str);

--- a/packages/coding-agent/test/ultra-thinking.test.ts
+++ b/packages/coding-agent/test/ultra-thinking.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isValidThinkingLevel } from "../src/cli/args.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+
+describe("ultra thinking level", () => {
+	it("is accepted by CLI and settings", async () => {
+		expect(isValidThinkingLevel("ultra")).toBe(true);
+
+		const settings = SettingsManager.inMemory();
+		settings.setDefaultThinkingLevel("ultra");
+		await settings.flush();
+		expect(settings.getDefaultThinkingLevel()).toBe("ultra");
+	});
+
+	it("uses the max thinking border color", () => {
+		initTheme("dark");
+		expect(theme.getThinkingBorderColor("ultra")("border")).toBe(theme.getThinkingBorderColor("max")("border"));
+	});
+});


### PR DESCRIPTION
## Summary

- add `ultra` as a first-class thinking level across the shared AI types, coding-agent selector, settings, CLI, session state, SDK/RPC surfaces, and theme
- advertise Ultra for GPT-5.6 Sol and Terra while keeping Luna capped at Max
- map OpenAI Codex `ultra` requests to API `reasoning.effort = "max"`, and clamp unsupported providers to their existing highest supported level
- add focused regression coverage for model metadata, provider payload mapping, and coding-agent state

## Why

Codex treats Ultra as a client-side composite mode rather than a new API reasoning effort. It maps Ultra to Max for the outgoing request, while the host can separately enable proactive multi-agent delegation. Sending `reasoning.effort = "ultra"` directly is rejected.

Keeping Ultra as first-class local state lets extensions observe the selected mode and provide delegation policy without adding subagent orchestration to Pi core.

Codex references: [`reasoning_effort_for_request`](https://github.com/openai/codex/blob/44918ea10c0f99151c6710411b4322c2f5c96bea/codex-rs/core/src/client.rs#L174-L178) and [`effective_multi_agent_mode`](https://github.com/openai/codex/blob/44918ea10c0f99151c6710411b4322c2f5c96bea/codex-rs/core/src/session/multi_agents.rs#L41-L55).

## Verification

- `npm run check`
- AI focused regression: existing Max tests + new Ultra tests (11 passed)
- coding-agent focused regression: Max/Ultra tests (4 passed)
- no external provider/API requests were sent; payload tests stop at `onPayload`

This PR was prepared with AI assistance and reviewed by the submitter.
