### PR TITLE
fix(extensions,theme): support embedded library hosts

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -192,6 +192,12 @@ export function createExtensionRuntime(): ExtensionRuntime {
 				message ??
 				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
 		},
+		// A runtime reused across sessions (e.g. an embedded host sharing the
+		// resource loader, or a module-cached extension factory) can be
+		// reactivated by bindCore() after the previous session's dispose().
+		clearInvalidation: () => {
+			state.staleMessage = undefined;
+		},
 		// Pre-bind: queue registrations so bindCore() can flush them once the
 		// model registry is available. bindCore() replaces both with direct calls.
 		registerProvider: (name, config, extensionPath = "<unknown>") => {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -315,6 +315,9 @@ export class ExtensionRunner {
 			unregisterProvider?: (name: string) => void;
 		},
 	): void {
+		// A runtime reused across sessions may still carry the stale marker from
+		// the previous session's dispose(); clear it before rebinding.
+		this.runtime.clearInvalidation?.();
 		// Copy actions into the shared runtime (all extension APIs reference this)
 		this.runtime.sendMessage = actions.sendMessage;
 		this.runtime.sendUserMessage = actions.sendUserMessage;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1551,6 +1551,8 @@ export interface ExtensionRuntimeState {
 	assertActive: () => void;
 	/** Marks this extension instance as stale after runtime replacement or reload. */
 	invalidate: (message?: string) => void;
+	/** Clears the stale marker so a reused runtime can be reactivated by bindCore(). */
+	clearInvalidation?: () => void;
 	/**
 	 * Register or unregister a provider.
 	 *

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -804,7 +804,20 @@ const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme");
 // This ensures all module instances (tsx, jiti) see the same theme
 export const theme: Theme = new Proxy({} as Theme, {
 	get(_target, prop) {
-		const t = (globalThis as Record<symbol, Theme>)[THEME_KEY];
+		let t = (globalThis as Record<symbol, Theme>)[THEME_KEY];
+		// Library hosts embed pi without the TUI and never call initTheme().
+		// Bootstrap a builtin theme on first access instead of throwing, so
+		// shared code paths that read `theme` stay usable. An explicit initTheme()
+		// call still wins; if even the builtin cannot be loaded we keep the
+		// original error so misconfiguration stays visible.
+		if (!t) {
+			try {
+				setGlobalTheme(loadTheme("dark"));
+				t = (globalThis as Record<symbol, Theme>)[THEME_KEY];
+			} catch {
+				t = undefined;
+			}
+		}
 		if (!t) throw new Error("Theme not initialized. Call initTheme() first.");
 		return (t as unknown as Record<string | symbol, unknown>)[prop];
 	},

--- a/packages/coding-agent/test/suite/regressions/6101-stale-ctx-reused-runtime.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6101-stale-ctx-reused-runtime.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { createEventBus } from "../../../src/core/event-bus.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../../src/core/extensions/loader.ts";
+import { ExtensionRunner } from "../../../src/core/extensions/runner.ts";
+
+describe("regression #6101: reused extension runtime is reactivated on bindCore()", () => {
+	it("clears the stale marker when a new session rebinds the same runtime", async () => {
+		let captured: { getFlag: (name: string) => unknown } | undefined;
+		const factory = (pi: {
+			on: (event: string, handler: () => Promise<unknown>) => void;
+			getFlag: (name: string) => unknown;
+		}) => {
+			captured = pi;
+			pi.on("session_start", async () => captured!.getFlag("foo"));
+		};
+
+		const runtime = createExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			factory as never,
+			process.cwd(),
+			createEventBus(),
+			runtime,
+			"<inline:test>",
+		);
+		const handler = extension.handlers.get("session_start")![0] as () => Promise<unknown>;
+
+		// session 1: runtime is active
+		await expect(handler()).resolves.toBeUndefined();
+
+		// dispose session 1 poisons the shared runtime
+		runtime.invalidate();
+		expect(() => runtime.assertActive()).toThrow(/stale/);
+
+		// session 2 reuses the same runtime; bindCore() must reactivate it
+		const runner = new ExtensionRunner(
+			[extension],
+			runtime,
+			process.cwd(),
+			{} as never,
+			{} as never,
+		);
+		runner.bindCore({} as never, {} as never, undefined);
+		await expect(handler()).resolves.toBeUndefined();
+	});
+
+	it("still throws when invalidated and never rebinded", () => {
+		const runtime = createExtensionRuntime();
+		runtime.invalidate();
+		expect(() => runtime.assertActive()).toThrow(/stale/);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/6102-theme-library-init.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6102-theme-library-init.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { theme, initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+
+const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme");
+
+describe("regression #6102: theme is usable from library hosts without initTheme()", () => {
+	const saved = (globalThis as Record<symbol, unknown>)[THEME_KEY];
+
+	afterEach(() => {
+		if (saved === undefined) {
+			delete (globalThis as Record<symbol, unknown>)[THEME_KEY];
+		} else {
+			(globalThis as Record<symbol, unknown>)[THEME_KEY] = saved;
+		}
+		initTheme("dark");
+	});
+
+	it("auto-bootstraps the dark builtin on first access instead of throwing", () => {
+		delete (globalThis as Record<symbol, unknown>)[THEME_KEY];
+		expect(() => (theme as unknown as { name: string }).name).not.toThrow();
+		expect((theme as unknown as { name: string }).name).toBe("dark");
+	});
+
+	it("still honors an explicit initTheme() call over the auto-bootstrap", () => {
+		delete (globalThis as Record<symbol, unknown>)[THEME_KEY];
+		// trigger auto-init first
+		expect((theme as unknown as { name: string }).name).toBe("dark");
+		// explicit selection wins
+		initTheme("light");
+		expect((theme as unknown as { name: string }).name).toBe("light");
+	});
+});


### PR DESCRIPTION
## Embedded library hosts: theme init + reused extension runtime

Closes #6102
Addresses part of #6101

This picks up two issues I filed earlier (both were auto-closed by the
new-contributor auto-close policy and not reopened). Filing this PR to move
them forward with a concrete fix.

### #6102 — theme not initialized in non-TUI hosts (fully fixed)

`theme` is a Proxy that throws `Theme not initialized. Call initTheme()
first.` until the TUI calls `initTheme()` at startup. Library hosts never run
the TUI, so shared code paths that read `theme` (e.g. the extension loader)
throw.

Fix: lazily bootstrap the builtin `dark` theme on first `theme` access instead
of throwing, so library hosts work without `initTheme()`. An explicit
`initTheme()` call still wins; if even the builtin cannot be loaded, the
original error is preserved so misconfiguration stays visible.

### #6101 — reused extension runtime stays poisoned (partial)

`AgentSession.dispose()` calls `ExtensionRunner.invalidate()`, which sets a
write-only stale marker on the extension runtime. When a host reuses the same
resource loader across sequential sessions (`createAgentSession` with a shared
`resourceLoader` — a supported SDK option), every later session reuses that
runtime and throws `This extension ctx is stale ...` from
`runtime.assertActive()` on every Extension API call.

Fix: add `clearInvalidation()` to the runtime and call it at the top of
`ExtensionRunner.bindCore()`, so a reused runtime is reactivated when a new
session rebinds it. `invalidate()` keeps its write-only `??=` semantics; only
an explicit rebind clears the marker. This is safe because `invalidate()` is
only ever called from `AgentSession.dispose()` (a terminal teardown) —
`newSession`/`fork`/`switchSession`/`reload` rebind the same runtime without
invalidating, and an invalidated runtime that is never rebound still throws.

**Out of scope:** this does NOT fix the separate captured-stale-ctx case where
an idempotent extension factory holds on to a ctx from a disposed session. Each
session gets a fresh runtime by default (`createAgentSessionServices` creates a
new `DefaultResourceLoader` per call), so there is nothing shared to reactivate;
that needs a different fix (a ctx that resolves to the current active session)
and will be handled separately.

### Tests

`test/suite/regressions/6102-theme-library-init.test.ts` covers the theme
auto-bootstrap. `test/suite/regressions/6101-stale-ctx-reused-runtime.test.ts`
covers the reused-runtime reactivation. Both fail on current `main` and pass
with this change.