### PR TITLE
bump bun to 1.3.14

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.14
 
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0


### PR DESCRIPTION
this supports BUN_CONFIG_HTTP_IDLE_TIMEOUT
related to #6476

bun has a builtin 5 min http idle timeout and our global http idle timeout doesn't affect it. this allows to override it from an env var setting