### PR TITLE
feat(coding-agent): add goal extension example for multi-turn autonomous task execution

### DIFF
--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -51,6 +51,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `plan-mode/` | Claude Code-style plan mode for read-only exploration with `/plan` command and step tracking |
 | `tools.ts` | Interactive `/tools` command to enable/disable tools with session persistence |
 | `handoff.ts` | Transfer context to a new focused session via `/handoff <goal>` |
+| `goal/` | Autonomous multi-turn goal execution with auto-continuation, pause/resume, and session persistence |
 | `qna.ts` | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |
 | `status-line.ts` | Shows turn progress in footer via `ctx.ui.setStatus()` with themed colors |
 | `github-issue-autocomplete.ts` | Adds `#1234` issue completions by stacking a custom autocomplete provider that preloads open issues from `gh issue list` |

--- a/packages/coding-agent/examples/extensions/goal/README.md
+++ b/packages/coding-agent/examples/extensions/goal/README.md
@@ -1,0 +1,58 @@
+# Goal Extension
+
+Autonomous multi-turn goal execution for long-running tasks.
+
+## Features
+
+- **Persistent goals**: Goals survive session resume via session entry persistence
+- **Auto-continuation**: Agent keeps working until the goal is complete or blocked
+- **Esc abort safety**: Pressing Escape pauses the goal instead of losing progress
+- **Context injection**: Active goals are injected into each turn's context as structured XML
+- **Blocked detection**: Goals are paused after persistent blocking conditions (3+ consecutive turns)
+- **Pause/resume/cancel**: Full lifecycle control via `/goal` slash command
+
+## Commands
+
+- `/goal <objective>` - Create a new goal (e.g., `/goal refactor auth to use OAuth`)
+- `/goal status` - Show current goal status
+- `/goal pause` - Pause the active goal
+- `/goal resume` - Resume a paused or blocked goal
+- `/goal cancel` - Cancel the current goal
+
+## Agent Tools
+
+- `create_goal` - Create a new autonomous goal (user-requested, long-running tasks only)
+- `update_goal` - Mark goal as complete or blocked
+- `get_goal` - Check current goal state (status and objective)
+
+## How It Works
+
+### State Machine
+
+Goals transition through a minimal state machine:
+
+```
+active → paused → active
+active → blocked → active (via resume)
+any*   → complete → undefined (transient, emits then clears)
+any*   → undefined (via cancel)
+```
+
+### Persistence
+
+Goal state is stored as custom session entries (`goal_state` type), using pi's built-in session persistence. When a session is resumed, the goal is loaded and automatically paused to prevent the agent from continuing without confirmation.
+
+### Auto-Continuation
+
+When a goal is active and the agent finishes a turn naturally (`stopReason === "stop"`), a follow-up message is automatically sent to continue working. The agent can call `update_goal(status="complete")` when finished, or `update_goal(status="blocked")` when stuck.
+
+### Context Injection
+
+An active goal injects a structured XML block at the start of each turn with the objective, completion criterion, and behavioral rules. Paused and blocked goals inject a lighter reminder.
+
+## Design
+
+- No external dependencies beyond pi's own packages
+- Pure state machine (`goal-mode.ts`) testable in isolation
+- Persistence via pi session entries (same mechanism as `todo.ts`)
+- No new runtime mechanisms — uses only existing extension APIs

--- a/packages/coding-agent/examples/extensions/goal/goal-extension.ts
+++ b/packages/coding-agent/examples/extensions/goal/goal-extension.ts
@@ -1,0 +1,273 @@
+/**
+ * GoalExtension — Wiring Module
+ *
+ * Centralizes all pi runtime wiring for the goal extension:
+ *   - Hook registration (session_start, context, message_end, turn_end)
+ *   - Tool registration (create_goal, update_goal, get_goal)
+ *   - /goal command registration & subcommand dispatch
+ *   - Status display updates
+ *   - Esc abort detection → pause
+ *   - Auto-continuation loop via turn_end + followUp
+ *   - Persistence triggers on state changes
+ *
+ * Dependency:
+ *   GoalMode — pure state machine (goal-mode.ts)
+ *   GoalExtension owns a GoalMode instance. A custom factory can be
+ *   injected via constructor for testing.
+ */
+
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { GoalMode, type GoalEventListener } from "./goal-mode.ts";
+import { loadGoalState, saveGoalState } from "./goal-persistence.ts";
+import {
+	buildGoalInjection,
+	CONTINUATION_PROMPT,
+} from "./goal-injector.ts";
+import { registerCreateGoal } from "./tools/create-goal.ts";
+import { registerUpdateGoal } from "./tools/update-goal.ts";
+import { registerGetGoal } from "./tools/get-goal.ts";
+import type { GoalDefinition, GoalStatus } from "./goal-types.ts";
+
+// ── Shared helpers ───────────────────────────────────────────────
+
+/** Single icon for each goal status — shared by updateStatus and formatGoalStatus. */
+function getStatusIcon(s: GoalStatus): string {
+	switch (s) {
+		case "active": return "▶";
+		case "paused": return "⏸";
+		case "blocked": return "⊘";
+		default: return "?";
+	}
+}
+
+function formatGoalStatus(mode: GoalMode): string {
+	const s = mode.getStatus();
+	if (s === "undefined") return "No active goal.";
+
+	const goal = mode.getGoal();
+	const reason = mode.getState().statusReason;
+	const icon = getStatusIcon(s);
+	let text = `Goal: ${icon} ${goal?.title ?? "(untitled)"} [${s}]`;
+	if (goal?.description) text += `\nCriterion: ${goal.description}`;
+	if (reason) text += `\nReason: ${reason}`;
+	return text;
+}
+
+// ── GoalExtension class ──────────────────────────────────────────
+
+export class GoalExtension {
+	private mode: GoalMode;
+	private lastCtx: ExtensionContext | null = null;
+	private pi: ExtensionAPI;
+
+	/**
+	 * @param pi         The extension API from the pi runtime.
+	 * @param modeFactory Optional factory to create/inject a GoalMode.
+	 *                    Receives the onTransition callback. Defaults to
+	 *                    creating a fresh GoalMode.
+	 */
+	constructor(
+		pi: ExtensionAPI,
+		modeFactory?: (onTransition: GoalEventListener) => GoalMode,
+	) {
+		this.pi = pi;
+
+		const onTransition: GoalEventListener = () => {
+			if (this.lastCtx) this.updateStatus(this.lastCtx);
+			saveGoalState(pi, this.mode);
+		};
+
+		this.mode = modeFactory
+			? modeFactory(onTransition)
+			: new GoalMode(undefined, onTransition);
+
+		// ── Session start: load persisted state ───────────────────────
+		pi.on("session_start", async (_event: unknown, ctx: ExtensionContext) => {
+			this.lastCtx = ctx;
+			const loaded = loadGoalState(ctx, onTransition);
+			if (loaded) {
+				this.mode = loaded;
+			}
+			this.updateStatus(ctx);
+		});
+
+		// ── Context hook: inject goal reminder before each LLM call ────
+		pi.on("context", async (event: any, _ctx: ExtensionContext) => {
+			const injection = buildGoalInjection(this.mode);
+			if (!injection) return;
+
+			const goalMessage = {
+				role: "user" as const,
+				content: [{ type: "text" as const, text: injection }],
+				timestamp: Date.now(),
+			};
+
+			if (Array.isArray(event.messages)) {
+				event.messages.unshift(goalMessage);
+			}
+
+			return { messages: event.messages };
+		});
+
+		// ── message_end: detect Esc abort → pause goal ─────────────────
+		pi.on("message_end", async (event: any, ctx: ExtensionContext) => {
+			this.lastCtx = ctx;
+
+			if (
+				event.message?.role === "assistant" &&
+				event.message?.stopReason === "aborted"
+			) {
+				if (this.mode.getStatus() === "active") {
+					this.mode.pauseGoal("Paused by user (Esc)");
+					this.updateStatus(ctx);
+				}
+			}
+		});
+
+		// ── turn_end: auto-continuation if goal is active ──────────────
+		pi.on("turn_end", async (event: any, ctx: ExtensionContext) => {
+			this.lastCtx = ctx;
+
+			if (
+				this.mode.getStatus() === "active" &&
+				event.message?.stopReason === "stop"
+			) {
+				pi.sendUserMessage(CONTINUATION_PROMPT, {
+					deliverAs: "followUp",
+				});
+			}
+		});
+
+		// ── Register tools ────────────────────────────────────────────
+		const getMode = (): GoalMode => this.mode;
+		registerCreateGoal(pi, getMode);
+		registerUpdateGoal(pi, getMode);
+		registerGetGoal(pi, getMode);
+
+		// ── Register /goal command ────────────────────────────────────
+		pi.registerCommand("goal", {
+			description:
+				"Manage goals — type an objective to create, or use: status, pause, resume, cancel",
+			handler: async (args: string, ctx: ExtensionContext) => {
+				this.lastCtx = ctx;
+
+				if (!args || args.trim() === "") {
+					ctx.ui.notify(formatGoalStatus(this.mode), "info");
+					return;
+				}
+
+				const trimmed = args.trim();
+				const firstWord = trimmed.split(/\s+/)[0].toLowerCase();
+				const rest = trimmed.slice(firstWord.length).trim();
+
+				if (this.subcommands[firstWord]) {
+					try {
+						const msg = this.subcommands[firstWord].fn(ctx, rest || undefined);
+						ctx.ui.notify(msg, "success");
+					} catch (e: any) {
+						ctx.ui.notify(`Error: ${e.message}`, "error");
+					}
+					return;
+				}
+
+				// Not a subcommand → treat as goal objective → create directly
+				const def: GoalDefinition = { title: trimmed };
+				const existingStatus = this.mode.getStatus();
+
+				try {
+					if (existingStatus !== "undefined") {
+						const choice = await ctx.ui.select(
+							`A goal is already ${existingStatus}. Replace it?`,
+							["Replace existing goal", "Cancel"],
+						);
+						if (!choice?.startsWith("Replace")) {
+							ctx.ui.notify("Goal creation cancelled.", "info");
+							return;
+						}
+						this.mode.createGoal(def, { replace: true });
+					} else {
+						this.mode.createGoal(def);
+					}
+					this.updateStatus(ctx);
+					ctx.ui.notify(`Goal created: "${trimmed}"`, "success");
+					pi.sendUserMessage(
+						`Work on this goal: "${trimmed}". Use get_goal to confirm the objective, then proceed.`,
+						{ deliverAs: "followUp" },
+					);
+				} catch (e: any) {
+					ctx.ui.notify(`Error: ${e.message}`, "error");
+				}
+			},
+		});
+	}
+
+	// ── Public accessors ───────────────────────────────────────────
+
+	/** Expose the current GoalMode (for tests and external inspection). */
+	getMode(): GoalMode {
+		return this.mode;
+	}
+
+	// ── Subcommand dispatch ═════════════════════════════════════════
+	//   /goal <objective>  → directly create goal
+	//   /goal status       → check goal status
+	//   /goal pause        → pause active goal
+	//   /goal resume       → resume paused/blocked goal
+	//   /goal cancel       → remove goal (pauses first if active)
+	// 'block' is agent-only (update_goal tool), not exposed as command.
+
+	private get subcommands(): Record<string, {
+		desc: string;
+		fn: (ctx: ExtensionContext, reason?: string) => string;
+	}> {
+		return {
+			status: {
+				desc: "Show current goal status",
+				fn: (_ctx) => formatGoalStatus(this.mode),
+			},
+			pause: {
+				desc: "Pause the active goal",
+				fn: (ctx, reason) => {
+					this.mode.pauseGoal(reason || "Paused by user");
+					this.updateStatus(ctx);
+					return `Goal paused${reason ? `: ${reason}` : "."}`;
+				},
+			},
+			resume: {
+				desc: "Resume a paused or blocked goal",
+				fn: (ctx, reason) => {
+					this.mode.resumeGoal(reason);
+					this.updateStatus(ctx);
+					this.pi.sendUserMessage(
+						"Goal resumed. Continue working toward the goal.",
+						{ deliverAs: "followUp" },
+					);
+					return `Goal resumed${reason ? `: ${reason}` : "."}`;
+				},
+			},
+			cancel: {
+				desc: "Cancel the current goal",
+				fn: (ctx, reason) => {
+					this.mode.cancelGoal(reason || "Cancelled by user");
+					this.updateStatus(ctx);
+					return `Goal cancelled${reason ? `: ${reason}` : "."}`;
+				},
+			},
+		};
+	}
+
+	// ── Internal helpers ───────────────────────────────────────────
+
+	private updateStatus(ctx: ExtensionContext): void {
+		const s = this.mode.getStatus();
+		if (s === "undefined") {
+			ctx.ui.setStatus("goal", undefined);
+			return;
+		}
+		const icon = getStatusIcon(s);
+		ctx.ui.setStatus("goal", ctx.ui.theme.fg("accent", `${icon} Goal [${s}]`));
+	}
+}

--- a/packages/coding-agent/examples/extensions/goal/goal-injector.ts
+++ b/packages/coding-agent/examples/extensions/goal/goal-injector.ts
@@ -1,0 +1,154 @@
+/**
+ * Goal Injector — Context Injection Text Generator
+ *
+ * Generates active/paused/blocked reminder text for the context hook.
+ * Pure functions — no pi runtime dependency, testable in isolation.
+ */
+
+import type { GoalMode } from "./goal-mode.ts";
+
+/**
+ * Escape XML special characters to prevent prompt injection.
+ */
+function xmlEscape(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}
+
+/**
+ * Generate the active-goal injection text.
+ *
+ * Full reminder including objective, completion criterion, behavioral rules,
+ * continuation instructions, and termination conditions.
+ */
+function buildActiveInjection(mode: GoalMode): string {
+	const goal = mode.getGoal();
+	const title = goal?.title ?? "(untitled)";
+	const description = goal?.description ?? "";
+
+	let text = `<goal_state>
+	<status>active</status>
+	<objective>${xmlEscape(title)}</objective>`;
+
+	if (description) {
+		text += `\n  <completion_criterion>${xmlEscape(description)}</completion_criterion>`;
+	}
+
+	text += `\n</goal_state>
+
+You are actively working toward the goal described above. Rules for this goal:
+
+1. **Continue working.** Each turn you receive this reminder at the start. Keep
+	 self-audit brief. Follow the most direct interpretation once the goal can
+	 be decided.
+
+2. **When to stop.** Only call update_goal(status="complete") when:
+	 - The objective described in <objective> has actually been achieved, OR
+	 - The objective is impossible, unsafe, or contradictory
+
+3. **Do not stop prematurely.** Most goal turns should NOT call update_goal.
+	 After completing a useful slice of work, end the turn normally — the runtime
+	 will automatically continue the goal.
+
+4. **Blocked audit.** A blocking condition must repeat for at least 3
+	 consecutive goal turns before calling update_goal(status="blocked").
+	 Only conditions that persist across turns qualify.
+
+`;
+
+	return text;
+}
+
+/**
+ * Generate the paused-goal injection text.
+ *
+ * Light reminder: objective is visible but the model is instructed not to work
+ * on it.
+ */
+function buildPausedInjection(mode: GoalMode): string {
+	const goal = mode.getGoal();
+	const title = goal?.title ?? "(untitled)";
+	const reason = mode.getState().statusReason;
+
+	let text = `<goal_state>
+	<status>paused</status>
+	<objective>${xmlEscape(title)}</objective>`;
+
+	if (reason) {
+		text += `\n  <pause_reason>${xmlEscape(reason)}</pause_reason>`;
+	}
+
+	text += `\n</goal_state>
+
+A goal exists but is currently paused. **Do not work on this goal.** The user has
+not yet asked you to resume it. Respond to the user's current prompt normally
+and do not continue or complete the paused goal.`;
+
+	return text;
+}
+
+/**
+ * Generate the blocked-goal injection text.
+ *
+ * Light reminder with objective wrapped in <untrusted_objective>, explicitly
+ * telling the model no action is required.
+ */
+function buildBlockedInjection(mode: GoalMode): string {
+	const goal = mode.getGoal();
+	const title = goal?.title ?? "(untitled)";
+	const reason = mode.getState().statusReason ?? "unknown";
+
+	let text = `<goal_state>
+	<status>blocked</status>
+	<block_reason>${xmlEscape(reason)}</block_reason>
+	<untrusted_objective>${xmlEscape(title)}</untrusted_objective>
+</goal_state>
+
+The current goal is blocked: ${xmlEscape(reason)}. **No action is required from
+you.** Do not work on this goal or attempt to resume it. Respond to the user's
+current prompt normally.`;
+
+	return text;
+}
+
+/**
+ * Generate context injection text for the current goal status.
+ *
+ * Returns null when there is no active goal (undefined status).
+ */
+export function buildGoalInjection(mode: GoalMode): string | null {
+	const status = mode.getStatus();
+	switch (status) {
+		case "active":
+			return buildActiveInjection(mode);
+		case "paused":
+			return buildPausedInjection(mode);
+		case "blocked":
+			return buildBlockedInjection(mode);
+		case "complete":
+		case "undefined":
+			return null;
+	}
+}
+
+/**
+ * The continuation prompt sent as a followUp message to trigger the next
+ * auto-continuation turn.
+ */
+export const CONTINUATION_PROMPT = `Continue working toward the active goal.
+
+1. Keep self-audit brief. Do not explore unrelated interpretations once the
+	 goal can be decided.
+
+2. If the objective is already achieved, impossible, unsafe, or contradictory,
+	 call update_goal(status="complete") immediately — do not run another turn.
+
+3. Most goal turns should NOT call update_goal. After completing a useful
+	 slice of work, end the turn normally so the runtime continues the goal.
+
+4. A blocking condition must repeat for at least 3 consecutive goal turns
+	 before calling update_goal(status="blocked").`;

--- a/packages/coding-agent/examples/extensions/goal/goal-mode.ts
+++ b/packages/coding-agent/examples/extensions/goal/goal-mode.ts
@@ -1,0 +1,274 @@
+/**
+ * GoalMode — State Machine
+ *
+ * Pure in-memory state machine for goal lifecycle management.
+ * No pi runtime dependency — testable in isolation.
+ *
+ * States:  active → paused → active
+ *          active → blocked → active (via resume)
+ *          any*   → complete → undefined (transient, emits then clears)
+ *          any*   → undefined (via cancel)
+ *   *any non-undefined state
+ */
+
+import type {
+	CreateGoalOptions,
+	GoalDefinition,
+	GoalEvent,
+	GoalSnapshot,
+	GoalState,
+	GoalStatus,
+} from "./goal-types.ts";
+
+export type GoalEventListener = (event: GoalEvent) => void;
+
+export class GoalMode {
+	private state: GoalState;
+	private history: GoalEvent[] = [];
+	private listeners: GoalEventListener[] = [];
+	private onTransition: GoalEventListener | undefined;
+
+	constructor(initialState?: GoalState, onTransition?: GoalEventListener) {
+		if (initialState) {
+			this.state = { ...initialState };
+		} else {
+			this.state = {
+				status: "undefined",
+				goal: null,
+				timestamp: Date.now(),
+			};
+		}
+		this.onTransition = onTransition;
+	}
+
+	// --- Public accessors ----------------------------------------------
+
+	getStatus(): GoalStatus {
+		return this.state.status;
+	}
+
+	getGoal(): GoalDefinition | null {
+		return this.state.goal;
+	}
+
+	getState(): Readonly<GoalState> {
+		return { ...this.state };
+	}
+
+	getSnapshot(): GoalSnapshot {
+		return {
+			status: this.state.status,
+			goal: this.state.goal,
+			statusReason: this.state.statusReason,
+			timestamp: this.state.timestamp,
+			history: [...this.history],
+		};
+	}
+
+	onEvent(listener: GoalEventListener): void {
+		this.listeners.push(listener);
+	}
+
+	// --- State transitions ---------------------------------------------
+
+	/**
+	 * Create a new goal. Transitions to active.
+	 * If a goal already exists, replace:true overwrites it; otherwise throws.
+	 */
+	createGoal(definition: GoalDefinition, options?: CreateGoalOptions): GoalEvent {
+		if (this.state.status !== "undefined" && !options?.replace) {
+			throw new Error(
+				`Cannot create goal: a goal is already ${this.state.status}`,
+			);
+		}
+
+		const previousStatus = this.state.status;
+		this.state = {
+			status: "active",
+			goal: { ...definition },
+			timestamp: Date.now(),
+		};
+		const event = this.emit("created", { previousStatus });
+		return event;
+	}
+
+	/**
+	 * Pause the current active goal.
+	 */
+	pauseGoal(reason?: string): GoalEvent {
+		if (this.state.status === "undefined") {
+			throw new Error("Cannot pause: no active goal");
+		}
+		if (this.state.status === "paused") {
+			throw new Error("Goal is already paused");
+		}
+		if (this.state.status === "blocked") {
+			throw new Error("Cannot pause a blocked goal — unblock first");
+		}
+
+		const previousStatus = this.state.status;
+		this.state = {
+			...this.state,
+			status: "paused",
+			statusReason: reason,
+			timestamp: Date.now(),
+		};
+		return this.emit("paused", { previousStatus, reason });
+	}
+
+	/**
+	 * Resume a paused or blocked goal.
+	 */
+	resumeGoal(reason?: string): GoalEvent {
+		if (this.state.status === "undefined") {
+			throw new Error("Cannot resume: no goal to resume");
+		}
+		if (this.state.status === "active") {
+			throw new Error("Goal is already active");
+		}
+		// Allow resume from paused or blocked
+
+		const previousStatus = this.state.status;
+		this.state = {
+			...this.state,
+			status: "active",
+			statusReason: reason,
+			timestamp: Date.now(),
+		};
+		return this.emit("resumed", { previousStatus, reason });
+	}
+
+	/**
+	 * Mark the goal as blocked by an external dependency.
+	 */
+	markBlocked(reason: string): GoalEvent {
+		if (this.state.status === "undefined") {
+			throw new Error("Cannot block: no goal to block");
+		}
+		if (this.state.status === "blocked") {
+			throw new Error("Goal is already blocked");
+		}
+
+		const previousStatus = this.state.status;
+		this.state = {
+			...this.state,
+			status: "blocked",
+			statusReason: reason,
+			timestamp: Date.now(),
+		};
+		return this.emit("blocked", { previousStatus, reason });
+	}
+
+	/**
+	 * Mark the goal as complete.
+	 * Transient: emits a "completed" event, then immediately clears to undefined.
+	 * clearInternal() runs before emit(), so re-entrant calls are caught by the
+	 * status guard ("Cannot complete: no goal to complete").
+	 */
+	markComplete(reason?: string): GoalEvent {
+		if (this.state.status === "undefined") {
+			throw new Error("Cannot complete: no goal to complete");
+		}
+
+		const previousStatus = this.state.status;
+		// Clear first, then emit — so listeners (persist) see the post-transition state.
+		// Matches cancelGoal's pattern: clearInternal → emit.
+		this.clearInternal();
+		return this.emit("completed", { previousStatus, reason });
+	}
+
+	/**
+	 * Cancel the current goal from any non-undefined state.
+	 *
+	 * Safety: when cancelling from "active", the method internally
+	 * transitions to "paused" first (emitting a "paused" event) before
+	 * clearing to undefined (emitting "cancelled").  This guarantees
+	 * that callers — including index.ts command handlers — don't have
+	 * to perform the two-step dance themselves.
+	 */
+	cancelGoal(reason?: string): GoalEvent {
+		if (this.state.status === "undefined") {
+			throw new Error("Cannot cancel: no goal to cancel");
+		}
+
+		// Safety: active → paused → cancelled
+		if (this.state.status === "active") {
+			const pauseReason = reason ?? "Paused before cancel";
+			this.state = {
+				...this.state,
+				status: "paused",
+				statusReason: pauseReason,
+				timestamp: Date.now(),
+			};
+			this.emit("paused", { previousStatus: "active", reason: pauseReason });
+		}
+
+		const previousStatus = this.state.status;
+		this.clearInternal();
+		return this.emit("cancelled", { previousStatus, reason });
+	}
+
+	/**
+	 * After session resume, downgrade active → paused so the agent doesn't
+	 * start working on a goal without explicit user confirmation.
+	 */
+	normalizeAfterReplay(): GoalEvent | null {
+		if (this.state.status === "active") {
+			const previousStatus = this.state.status;
+			this.state = {
+				...this.state,
+				status: "paused",
+				statusReason: "Paused after agent resume",
+				timestamp: Date.now(),
+			};
+			return this.emit("normalized", { previousStatus });
+		}
+		// paused, blocked, undefined — no change needed
+		return null;
+	}
+
+	/**
+	 * Reconstruct a GoalMode from a persisted snapshot.
+	 */
+	static fromSnapshot(snapshot: GoalSnapshot, onTransition?: GoalEventListener): GoalMode {
+		const mode = new GoalMode(undefined, onTransition);
+		// Directly restore state and history from the snapshot
+		mode.state = {
+			status: snapshot.status,
+			goal: snapshot.goal,
+			statusReason: snapshot.statusReason,
+			timestamp: snapshot.timestamp,
+		};
+		mode.history = [...snapshot.history];
+		return mode;
+	}
+
+	// --- Internal helpers ----------------------------------------------
+
+	private clearInternal(): void {
+		this.state = {
+			status: "undefined",
+			goal: null,
+			timestamp: Date.now(),
+		};
+	}
+
+	private emit(
+		type: GoalEvent["type"],
+		opts: { previousStatus: GoalStatus; reason?: string },
+	): GoalEvent {
+		const event: GoalEvent = {
+			type,
+			timestamp: Date.now(),
+			reason: opts.reason,
+			previousStatus: opts.previousStatus,
+			currentStatus: this.state.status,
+		};
+		this.history.push(event);
+		for (const listener of this.listeners) {
+			listener(event);
+		}
+		this.onTransition?.(event);
+		return event;
+	}
+}

--- a/packages/coding-agent/examples/extensions/goal/goal-persistence.ts
+++ b/packages/coding-agent/examples/extensions/goal/goal-persistence.ts
@@ -1,0 +1,83 @@
+/**
+ * Goal Persistence — Save / Load GoalMode snapshots
+ *
+ * Uses pi session custom entries for durable storage.
+ * Load logic is pure and testable in isolation:
+ *   - scan entries for the last goal_state
+ *   - call GoalMode.fromSnapshot() + normalizeAfterReplay()
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { GoalSnapshot } from "./goal-types.ts";
+import { GoalMode, type GoalEventListener } from "./goal-mode.ts";
+
+/** Custom entry type used for goal state persistence. */
+export const GOAL_STATE_CUSTOM_TYPE = "goal_state";
+
+// --- Pure helpers (testable without pi runtime) ----------------------
+
+/** Type shape of a session entry we care about. */
+export interface SessionEntry {
+	type: string;
+	customType?: string;
+	data?: unknown;
+}
+
+/**
+ * Find the last goal_state entry in the list.
+ * Returns undefined if none found.
+ */
+export function findLastGoalStateEntry(
+	entries: readonly SessionEntry[],
+): GoalSnapshot | undefined {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (
+			entry.type === "custom" &&
+			entry.customType === GOAL_STATE_CUSTOM_TYPE
+		) {
+			return entry.data as GoalSnapshot;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Rebuild a GoalMode from a snapshot and apply normalizeAfterReplay.
+ */
+export function rebuildFromSnapshot(snapshot: GoalSnapshot, onTransition?: GoalEventListener): GoalMode {
+	const mode = GoalMode.fromSnapshot(snapshot, onTransition);
+	mode.normalizeAfterReplay();
+	return mode;
+}
+
+/**
+ * Scan entries, find the last goal_state, rebuild GoalMode with replay normalization.
+ * Returns null if no saved state found.
+ */
+export function loadGoalStateFromEntries(
+	entries: readonly SessionEntry[],
+	onTransition?: GoalEventListener,
+): GoalMode | null {
+	const snapshot = findLastGoalStateEntry(entries);
+	if (!snapshot) return null;
+	return rebuildFromSnapshot(snapshot, onTransition);
+}
+
+// --- Pi runtime helpers (require ExtensionAPI) -----------------------
+
+/**
+ * Persist the current goal state as a custom session entry.
+ */
+export function saveGoalState(pi: ExtensionAPI, mode: GoalMode): void {
+	pi.appendEntry(GOAL_STATE_CUSTOM_TYPE, mode.getSnapshot());
+}
+
+/**
+ * Load goal state from the current session via ExtensionContext.
+ * Returns null if no saved state, or a rebuilt GoalMode with replay normalization.
+ */
+export function loadGoalState(ctx: ExtensionContext, onTransition?: GoalEventListener): GoalMode | null {
+	const entries = ctx.sessionManager.getEntries() as SessionEntry[];
+	return loadGoalStateFromEntries(entries, onTransition);
+}

--- a/packages/coding-agent/examples/extensions/goal/goal-types.ts
+++ b/packages/coding-agent/examples/extensions/goal/goal-types.ts
@@ -1,0 +1,52 @@
+/**
+ * Goal Extension — Core Types
+ *
+ * Defines the status enum, state shape, snapshot format, and event types
+ * for the GoalMode state machine and persistence layer.
+ */
+
+/** Possible states a goal can be in. */
+export type GoalStatus =
+	| "active"
+	| "paused"
+	| "blocked"
+	| "complete"   // transient — emitted then immediately cleared
+	| "undefined";
+
+/** User-facing definition of a goal. */
+export interface GoalDefinition {
+	title: string;
+	description?: string;
+}
+
+/** Internal runtime state of the goal machine. */
+export interface GoalState {
+	status: GoalStatus;
+	goal: GoalDefinition | null;
+	statusReason?: string;
+	timestamp: number;
+}
+
+/** Serializable snapshot used for persistence. */
+export interface GoalSnapshot {
+	status: GoalStatus;
+	goal: GoalDefinition | null;
+	statusReason?: string;
+	timestamp: number;
+	history: GoalEvent[];
+}
+
+/** Lifecycle event emitted on every state transition. */
+export interface GoalEvent {
+	type: "created" | "paused" | "resumed" | "blocked" | "completed" | "cancelled" | "normalized";
+	timestamp: number;
+	reason?: string;
+	previousStatus: GoalStatus;
+	currentStatus: GoalStatus;
+}
+
+/** Options for createGoal(). */
+export interface CreateGoalOptions {
+	/** If true, replace any existing unfinished goal. Default false. */
+	replace?: boolean;
+}

--- a/packages/coding-agent/examples/extensions/goal/index.ts
+++ b/packages/coding-agent/examples/extensions/goal/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Goal Extension — Entry Point
+ *
+ * Thin shell that delegates all wiring to GoalExtension.
+ *
+ * File layout:
+ *   - goal-mode.ts       (pure state machine, #46)
+ *   - goal-persistence.ts (session entry save/load, #46)
+ *   - goal-types.ts       (shared types, #46)
+ *   - goal-injector.ts    (injection text generator, #47)
+ *   - goal-extension.ts   (wiring: hooks, tools, command, status, #53)
+ *   - tools/create-goal.ts (#47)
+ *   - tools/update-goal.ts (#47)
+ *   - tools/get-goal.ts   (#47)
+ *   - index.ts            (entry point — this file)
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { GoalExtension } from "./goal-extension.ts";
+
+export default function goalExtension(pi: ExtensionAPI): void {
+	new GoalExtension(pi);
+}

--- a/packages/coding-agent/examples/extensions/goal/tools/create-goal.ts
+++ b/packages/coding-agent/examples/extensions/goal/tools/create-goal.ts
@@ -1,0 +1,111 @@
+/**
+ * create_goal Tool — Create a new goal
+ *
+ * Agent-facing tool. The model calls this when the user explicitly requests
+ * a goal. Fails if an unfinished goal already exists unless replace: true.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import type { GoalMode } from "../goal-mode.ts";
+import type { GoalDefinition } from "../goal-types.ts";
+
+const MAX_FIELD_LENGTH = 4000;
+
+const CreateGoalParams = Type.Object({
+	objective: Type.String({
+		description:
+			"The goal objective — what should be achieved. Max 4000 characters.",
+		maxLength: MAX_FIELD_LENGTH,
+	}),
+	completionCriterion: Type.Optional(
+		Type.String({
+			description:
+				"Optional criterion for completion. Describes what 'done' looks like. " +
+					"Max 4000 characters.",
+			maxLength: MAX_FIELD_LENGTH,
+		}),
+	),
+	replace: Type.Optional(
+		Type.Boolean({
+			description:
+				"If true, replace any existing unfinished goal. Default: false.",
+		}),
+	),
+});
+
+export function registerCreateGoal(pi: ExtensionAPI, getMode: () => GoalMode): void {
+	pi.registerTool({
+		name: "create_goal",
+		label: "Create Goal",
+		description:
+			"Create a new goal that the agent will autonomously work toward across " +
+			"multiple turns. Only create a goal when explicitly requested by the user. " +
+			"Do NOT infer goals from ordinary tasks — goals are for long-running " +
+			"multi-turn objectives.",
+		promptSnippet:
+			"Create a new autonomous goal (user-requested, long-running tasks only)",
+		promptGuidelines: [
+			"Use create_goal only when the user explicitly asks you to create " +
+				"a goal. Do NOT create goals from ordinary conversation or single-turn tasks.",
+			"Goals are for long-running objectives that require multiple turns " +
+				"of autonomous work. Single-turn tasks should be handled directly.",
+		],
+		parameters: CreateGoalParams,
+
+		async execute(
+			_toolCallId: string,
+			params: Record<string, unknown>,
+			_signal: AbortSignal | undefined,
+			_onUpdate: unknown,
+			_ctx: unknown,
+		) {
+			const objective = params.objective as string;
+			const completionCriterion = params.completionCriterion as
+				| string
+				| undefined;
+			const replace = (params.replace as boolean) ?? false;
+
+			if (!objective || objective.trim() === "") {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: "Error: objective is required and cannot be empty.",
+						},
+					],
+					isError: true,
+				};
+			}
+
+			const def: GoalDefinition = { title: objective.trim() };
+			if (completionCriterion?.trim()) {
+				def.description = completionCriterion.trim();
+			}
+
+			try {
+				const mode = getMode();
+				mode.createGoal(def, { replace });
+				let msg = `Goal created: "${def.title}"`;
+				if (def.description) {
+					msg += `\nCompletion criterion: ${def.description}`;
+				}
+				return {
+					content: [{ type: "text" as const, text: msg }],
+					details: mode.getSnapshot() as unknown as Record<string, unknown>,
+				};
+			} catch (e: any) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Failed to create goal: ${e.message}. ` +
+								`Use replace=true to overwrite the existing goal.`,
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	});
+}

--- a/packages/coding-agent/examples/extensions/goal/tools/get-goal.ts
+++ b/packages/coding-agent/examples/extensions/goal/tools/get-goal.ts
@@ -1,0 +1,82 @@
+/**
+ * get_goal Tool — Retrieve current goal state
+ *
+ * Returns the current goal snapshot or null if no goal exists.
+ * Minimal field set — status, objective, completionCriterion, terminalReason.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import type { GoalMode } from "../goal-mode.ts";
+
+/** Fields returned by the get_goal tool. */
+export interface GetGoalResult {
+	status: string;
+	objective: string;
+	completionCriterion?: string;
+	terminalReason?: string;
+}
+
+/**
+ * Build a GetGoalResult from a GoalMode instance.
+ * Returns null when there is no active goal (undefined or complete status).
+ */
+export function buildGetGoalResult(mode: GoalMode): GetGoalResult | null {
+	const status = mode.getStatus();
+	if (status === "undefined" || status === "complete") {
+		return null;
+	}
+
+	const goal = mode.getGoal();
+	const state = mode.getState();
+	const result: GetGoalResult = {
+		status,
+		objective: goal?.title ?? "(untitled)",
+	};
+	if (goal?.description) {
+		result.completionCriterion = goal.description;
+	}
+	if (state.statusReason) {
+		result.terminalReason = state.statusReason;
+	}
+
+	return result;
+}
+
+export function registerGetGoal(pi: ExtensionAPI, getMode: () => GoalMode): void {
+	pi.registerTool({
+		name: "get_goal",
+		label: "Get Goal",
+		description:
+			"Check the current goal state. Returns the objective, status, and " +
+			"any terminal reason if blocked or paused. Use this to verify your " +
+			"understanding of the objective and current status during a long task.",
+		promptSnippet: "Check current goal state (status and objective)",
+		promptGuidelines: [
+			"Use get_goal to verify the current goal objective and status before " +
+				"making decisions about goal lifecycle.",
+		],
+		parameters: Type.Object({}),
+
+		async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+			const mode = getMode();
+			const result = buildGetGoalResult(mode);
+			if (result === null) {
+				return {
+					content: [{ type: "text" as const, text: "No active goal." }],
+					details: { goal: null },
+				};
+			}
+
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify(result, null, 2),
+					},
+				],
+				details: { goal: result },
+			};
+		},
+	});
+}

--- a/packages/coding-agent/examples/extensions/goal/tools/update-goal.ts
+++ b/packages/coding-agent/examples/extensions/goal/tools/update-goal.ts
@@ -1,0 +1,102 @@
+/**
+ * update_goal Tool — Mark goal as complete or blocked
+ *
+ * Agent calls this to signal completion or a blocking condition.
+ * The tool description includes behavioral rules from the PRD.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { GoalMode } from "../goal-mode.ts";
+
+const UpdateGoalStatus = StringEnum(["complete", "blocked"] as const, {
+	description:
+		"New goal status. 'complete' = objective achieved, 'blocked' = cannot proceed due to external dependency.",
+});
+
+const UpdateGoalParams = Type.Object({
+	status: UpdateGoalStatus,
+	reason: Type.Optional(
+		Type.String({
+			description:
+				"Explanation for the status change. For 'complete': what was achieved. " +
+					"For 'blocked': what external condition is blocking progress.",
+		}),
+	),
+});
+
+export function registerUpdateGoal(pi: ExtensionAPI, getMode: () => GoalMode): void {
+	pi.registerTool({
+		name: "update_goal",
+		label: "Update Goal",
+		description:
+			"Signal goal completion or a blocking condition. " +
+			"ONLY call this when the objective is truly complete OR genuinely blocked. " +
+			"Rules:\n" +
+			"1. Do NOT call for routine progress — most turns should end normally.\n" +
+			"2. Only call complete when the objective described in the goal has actually been achieved.\n" +
+			"3. A non-terminal blocking condition must repeat for at least 3 consecutive goal turns before calling blocked.\n" +
+			"4. Temporary obstacles (e.g., a single failing test, a missing file that might appear) do NOT count as blocked.",
+		promptSnippet:
+			"Mark goal as complete (achieved) or blocked (cannot proceed)",
+		promptGuidelines: [
+			"Use update_goal with status='complete' only when the current goal " +
+				"objective has been fully achieved. Do not call this for routine progress.",
+			"Use update_goal with status='blocked' only after the same blocking " +
+				"condition has persisted for at least 3 consecutive goal turns. " +
+				"Temporary obstacles do not qualify.",
+			"Most goal turns should end normally without calling update_goal. " +
+				"The runtime continues the goal automatically.",
+		],
+		parameters: UpdateGoalParams,
+
+		async execute(
+			_toolCallId: string,
+			params: Record<string, unknown>,
+			_signal: AbortSignal | undefined,
+			_onUpdate: unknown,
+			_ctx: unknown,
+		) {
+			const status = params.status as "complete" | "blocked";
+			const reason = params.reason as string | undefined;
+
+			try {
+				const mode = getMode();
+				if (status === "complete") {
+					mode.markComplete(reason);
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Goal marked as complete${reason ? `: ${reason}` : "."}`,
+							},
+						],
+						details: mode.getSnapshot() as unknown as Record<string, unknown>,
+					};
+				} else {
+					mode.markBlocked(reason || "blocked");
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Goal marked as blocked${reason ? `: ${reason}` : "."}`,
+							},
+						],
+						details: mode.getSnapshot() as unknown as Record<string, unknown>,
+					};
+				}
+			} catch (e: any) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Failed to update goal: ${e.message}`,
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	});
+}


### PR DESCRIPTION
# Add goal extension example

Add `goal/` as an example extension under `packages/coding-agent/examples/extensions/`.

## What it does

A minimal extension for multi-turn autonomous goal execution. The agent keeps working across turns until the goal is complete or blocked.

- `/goal <objective>` -- create a goal, the agent auto-continues until done
- `/goal status|pause|resume|cancel` -- lifecycle control
- `create_goal` / `update_goal` / `get_goal` -- agent-facing tools
- Esc during work pauses the goal (no lost progress)
- Goals persist across sessions via session entries

## Design choices

**No new mechanisms.** Persistence uses `pi.appendEntry` and `ctx.sessionManager.getEntries()` -- same pattern as `todo.ts`. Tools use `pi.registerTool` with TypeBox schemas and `StringEnum`. Command uses `pi.registerCommand`. Context injection uses the `context` hook. Everything runs on existing extension APIs.

**Pure state machine.** `GoalMode` (goal-mode.ts) has no pi runtime dependency. It's a standalone class testable in isolation. The extension layer (goal-extension.ts) wires it to pi hooks.

**Minimal surface.** Three agent tools, one slash command with subcommands, one context injection. The auto-continuation loop is a thin `turn_end` hook that calls `pi.sendUserMessage` with a follow-up -- same mechanism used by other extensions.

## Why an example extension

pi's core stays minimal. Autonomous multi-turn task execution is a workflow preference, not a runtime concern. Like `plan-mode/` and `subagent/`, this lives where users can copy it into their extensions directory if they need it.

I use pi daily and want it to handle long-running tasks without babysitting. This extension scratches that itch. If the implementation doesn't fit pi's extension patterns, I'm happy to adjust. If the concept itself doesn't belong in the examples directory, a close is fine too -- I'd still love to see some form of goal tracking in the extension ecosystem.

AI-generated by `/wr`, reviewed and edited by a human.
