### PR TITLE
feat: add configurable auto-update on new session

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -126,6 +126,7 @@ export interface Settings {
 	httpProxy?: string; // Proxy URL applied as HTTP_PROXY and HTTPS_PROXY for Pi-managed HTTP clients
 	httpIdleTimeoutMs?: number; // HTTP header/body idle timeout in milliseconds; 0 disables it
 	websocketConnectTimeoutMs?: number; // WebSocket connect/open handshake timeout in milliseconds; 0 disables it
+	autoUpdateOnNewSession?: boolean; // default: false - automatically run 'pi update --all' when starting a new session
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -575,6 +575,9 @@ export async function main(args: string[], options?: MainOptions) {
 		(envSessionDir ? expandTildePath(envSessionDir) : undefined) ??
 		startupSettingsManager.getSessionDir();
 	let sessionManager = await createSessionManager(parsed, cwd, sessionDir, startupSettingsManager);
+	if (sessionManager.fileEntries.length === 1 && startupSettingsManager.getGlobalSettings().autoUpdateOnNewSession) {
+		await handlePackageCommand(["update", "--all"], { extensionFactories: options?.extensionFactories });
+	}
 	const missingSessionCwdIssue = getMissingSessionCwdIssue(sessionManager, cwd);
 	if (missingSessionCwdIssue) {
 		if (appMode === "interactive") {


### PR DESCRIPTION
Adds a new configurable setting `autoUpdateOnNewSession` to automatically run `pi update --all` when starting a new session. This is disabled by default to avoid startup latency for most users but can be enabled by power users who always want the latest tools.