### PR TITLE
fix: erase entire turn on abort/error, not just the assistant message

### DIFF
--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -160,6 +160,10 @@ export function transformMessages<TApi extends Api>(
 	const result: Message[] = [];
 	let pendingToolCalls: ToolCall[] = [];
 	let existingToolResultIds = new Set<string>();
+	// Index in `result` where the current turn's user message was pushed. Used to
+	// erase an entire incomplete turn (not just the aborted assistant message) when
+	// that turn ends in error/abort. See rationale below.
+	let turnStartIndex: number | null = null;
 	const insertSyntheticToolResults = () => {
 		if (pendingToolCalls.length > 0) {
 			for (const tc of pendingToolCalls) {
@@ -186,13 +190,19 @@ export function transformMessages<TApi extends Api>(
 			// If we have pending orphaned tool calls from a previous assistant, insert synthetic results now
 			insertSyntheticToolResults();
 
-			// Skip errored/aborted assistant messages entirely.
-			// These are incomplete turns that shouldn't be replayed:
+			// Skip errored/aborted turns entirely, including the user message that
+			// started them. These are incomplete turns that shouldn't be replayed:
 			// - May have partial content (reasoning without message, incomplete tool calls)
 			// - Replaying them can cause API errors (e.g., OpenAI "reasoning without following item")
 			// - The model should retry from the last valid state
 			const assistantMsg = msg as AssistantMessage;
 			if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
+				if (turnStartIndex !== null) {
+					result.length = turnStartIndex;
+				}
+				pendingToolCalls = [];
+				existingToolResultIds = new Set();
+				turnStartIndex = null;
 				continue;
 			}
 
@@ -210,6 +220,7 @@ export function transformMessages<TApi extends Api>(
 		} else if (msg.role === "user") {
 			// User message interrupts tool flow - insert synthetic results for orphaned calls
 			insertSyntheticToolResults();
+			turnStartIndex = result.length;
 			result.push(msg);
 		} else {
 			result.push(msg);


### PR DESCRIPTION
In `transformMessages`, assistant messages with `stopReason === "aborted"` or `"error"` are filtered out, which can result in two consecutive user messages in the output. This change drops the user message as well when the response was aborted.

Example of the old behavior:

```
User: hello, reply with some long text because I want to test something
Model: Definitely, I can generate a long [Operation aborted]
User: Hello, is this the first message in our conversation? If it is, cite this message verbatim
Model: Yes — this is the first message in our conversation. No prior context, files read, or commands run before this exchange. Your message, verbatim, was:

 "hello, reply with some long text because I want to test something

 Hello, is this the first message in our conversation? If it is, cite this message verbatim"
```