### PR TITLE
feat(coding-agent): expose scoped models to extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added cache-friendly dynamic tool loading for extension tools activated by tool results. Supported Anthropic and OpenAI Responses models load definitions where they become available, preserving the cached prompt prefix. See [Dynamic Tool Loading](docs/extensions.md#dynamic-tool-loading) ([#6474](https://github.com/earendil-works/pi-mono/pull/6474)).
 - Added inherited native `xhigh` and `max` thinking levels for Claude Fable 5 across all generated provider catalogs ([#6490](https://github.com/earendil-works/pi-mono/pull/6490) by [@davidbrai](https://github.com/davidbrai)).
 - Added `Ctrl+X` to copy the last assistant message, or the selected message in `/tree`.
+- Added `pi.getScopedModels()` so extensions can inspect the current session's model cycle scope.
 
 ### Fixed
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1639,6 +1639,15 @@ Typical `sourceInfo.source` values:
 - `sdk` for tools passed via `createAgentSession({ customTools })`
 - extension source metadata for tools registered by extensions
 
+### pi.getScopedModels()
+
+Get a snapshot of the current session's scoped model list in cycle order. Returns an empty array when no model scope is configured. Each entry contains `model` and an optional `thinkingLevel`; mutating the returned array or its entries does not change the session scope.
+
+```typescript
+const scopedModels = pi.getScopedModels();
+const scopedIds = scopedModels.map(({ model }) => `${model.provider}/${model.id}`);
+```
+
 ### pi.setModel(model)
 
 Set the current model. Returns `false` if no API key is available for the model. See [models.md](models.md) for configuring custom models.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2342,6 +2342,7 @@ export class AgentSession {
 				setActiveTools: (toolNames) => this.setActiveToolsByName(toolNames),
 				refreshTools: () => this._refreshToolRegistry(),
 				getCommands,
+				getScopedModels: () => this.scopedModels.map((scopedModel) => ({ ...scopedModel })),
 				setModel: async (model) => {
 					if (!this.modelRegistry.hasConfiguredAuth(model)) return false;
 					await this.setModel(model);

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -181,6 +181,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		// registerTool() is valid during extension load; refresh is only needed post-bind.
 		refreshTools: () => {},
 		getCommands: notInitialized,
+		getScopedModels: notInitialized,
 		setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
 		getThinkingLevel: notInitialized,
 		setThinkingLevel: notInitialized,
@@ -337,6 +338,11 @@ function createExtensionAPI(
 		getCommands() {
 			runtime.assertActive();
 			return runtime.getCommands();
+		},
+
+		getScopedModels() {
+			runtime.assertActive();
+			return runtime.getScopedModels();
 		},
 
 		setModel(model) {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -328,6 +328,7 @@ export class ExtensionRunner {
 		this.runtime.setActiveTools = actions.setActiveTools;
 		this.runtime.refreshTools = actions.refreshTools;
 		this.runtime.getCommands = actions.getCommands;
+		this.runtime.getScopedModels = actions.getScopedModels;
 		this.runtime.setModel = actions.setModel;
 		this.runtime.getThinkingLevel = actions.getThinkingLevel;
 		this.runtime.setThinkingLevel = actions.setThinkingLevel;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -50,6 +50,7 @@ import type { ReadonlyFooterDataProvider } from "../footer-data-provider.ts";
 import type { KeybindingsManager } from "../keybindings.ts";
 import type { CustomMessage } from "../messages.ts";
 import type { ModelRegistry } from "../model-registry.ts";
+import type { ScopedModel } from "../model-resolver.ts";
 import type {
 	BranchSummaryEntry,
 	CompactionEntry,
@@ -1312,6 +1313,9 @@ export interface ExtensionAPI {
 	// Model and Thinking Level
 	// =========================================================================
 
+	/** Get the models currently configured for scoped cycling. */
+	getScopedModels(): ScopedModel[];
+
 	/** Set the current model. Returns false if no API key available. */
 	setModel(model: Model<any>): Promise<boolean>;
 
@@ -1531,6 +1535,8 @@ export type SetActiveToolsHandler = (toolNames: string[]) => void;
 
 export type RefreshToolsHandler = () => void;
 
+export type GetScopedModelsHandler = () => ScopedModel[];
+
 export type SetModelHandler = (model: Model<any>) => Promise<boolean>;
 
 export type GetThinkingLevelHandler = () => ThinkingLevel;
@@ -1577,6 +1583,7 @@ export interface ExtensionActions {
 	setActiveTools: SetActiveToolsHandler;
 	refreshTools: RefreshToolsHandler;
 	getCommands: GetCommandsHandler;
+	getScopedModels: GetScopedModelsHandler;
 	setModel: SetModelHandler;
 	getThinkingLevel: GetThinkingLevelHandler;
 	setThinkingLevel: SetThinkingLevelHandler;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -82,6 +82,7 @@ describe("ExtensionRunner", () => {
 		setActiveTools: () => {},
 		refreshTools: () => {},
 		getCommands: () => [],
+		getScopedModels: () => [],
 		setModel: async () => false,
 		getThinkingLevel: () => "off",
 		setThinkingLevel: () => {},

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -44,6 +44,35 @@ describe("AgentSession model and extension characterization", () => {
 		).toEqual([`${nextModel.provider}/${nextModel.id}`]);
 	});
 
+	it("exposes live scoped models to extensions without exposing mutable session state", async () => {
+		let extensionApi: ExtensionAPI | undefined;
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: false },
+			],
+			extensionFactories: [
+				(pi) => {
+					extensionApi = pi;
+				},
+			],
+		});
+		harnesses.push(harness);
+		const modelOne = harness.getModel("faux-1")!;
+		const modelTwo = harness.getModel("faux-2")!;
+		harness.session.setScopedModels([{ model: modelOne, thinkingLevel: "high" }, { model: modelTwo }]);
+
+		const scopedModels = extensionApi?.getScopedModels();
+		expect(scopedModels).toEqual([{ model: modelOne, thinkingLevel: "high" }, { model: modelTwo }]);
+
+		scopedModels?.pop();
+		if (scopedModels?.[0]) scopedModels[0].thinkingLevel = "low";
+		expect(extensionApi?.getScopedModels()).toEqual([
+			{ model: modelOne, thinkingLevel: "high" },
+			{ model: modelTwo },
+		]);
+	});
+
 	it("cycles through scoped models and preserves the scoped thinking preference", async () => {
 		const harness = await createHarness({
 			models: [


### PR DESCRIPTION
## Summary

- add `pi.getScopedModels()` to expose the current session model-cycle scope
- return a snapshot so extensions cannot mutate session state through the result
- document the API and cover the AgentSession extension boundary

This lets extensions align delegated work with the models already scoped for the active session instead of maintaining a separate model list.

## Validation

- `cd packages/coding-agent && npm test -- test/suite/agent-session-model-extension.test.ts` (13 passed)
- `npm run check`

Related to #3535; this PR adds the read side only.