### PR TITLE
fix(ai): support GPT-5.6 prompt cache options

### DIFF
--- a/packages/ai/src/api/openai-prompt-cache.ts
+++ b/packages/ai/src/api/openai-prompt-cache.ts
@@ -1,8 +1,25 @@
 export const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
+export const OPENAI_GPT_56_PROMPT_CACHE_OPTIONS = { mode: "implicit", ttl: "30m" } as const;
+
+export interface OpenAIPromptCacheOptions {
+	mode?: "implicit" | "explicit";
+	ttl?: "30m";
+}
 
 export function clampOpenAIPromptCacheKey(key: string | undefined): string | undefined {
 	if (key === undefined) return undefined;
 	const chars = Array.from(key);
 	if (chars.length <= OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH) return key;
 	return chars.slice(0, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH).join("");
+}
+
+export function isOpenAIGPT56Family(modelId: string): boolean {
+	return /(?:^|[/.])gpt-5\.6(?:$|[-_/.])/.test(modelId.toLowerCase());
+}
+
+export function getOpenAIGPT56PromptCacheOptions(
+	modelId: string,
+	enabled: boolean,
+): OpenAIPromptCacheOptions | undefined {
+	return enabled && isOpenAIGPT56Family(modelId) ? OPENAI_GPT_56_PROMPT_CACHE_OPTIONS : undefined;
 }

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -21,13 +21,21 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
-import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
+import {
+	clampOpenAIPromptCacheKey,
+	getOpenAIGPT56PromptCacheOptions,
+	type OpenAIPromptCacheOptions,
+} from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 // OpenAI Responses rejects max_output_tokens below 16: https://github.com/earendil-works/pi/issues/6265
 const OPENAI_RESPONSES_MIN_OUTPUT_TOKENS = 16;
+
+type OpenAIResponsesCreateParamsStreaming = ResponseCreateParamsStreaming & {
+	prompt_cache_options?: OpenAIPromptCacheOptions;
+};
 
 function hasHeader(headers: ProviderHeaders | undefined, name: string): boolean {
 	if (!headers) return false;
@@ -229,12 +237,14 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 	});
 
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env);
-	const params: ResponseCreateParamsStreaming = {
+	const promptCacheOptions = getOpenAIGPT56PromptCacheOptions(model.id, cacheRetention !== "none");
+	const params: OpenAIResponsesCreateParamsStreaming = {
 		model: model.id,
 		input: messages,
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : clampOpenAIPromptCacheKey(options?.sessionId),
-		prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
+		prompt_cache_options: promptCacheOptions,
+		prompt_cache_retention: promptCacheOptions ? undefined : getPromptCacheRetention(compat, cacheRetention),
 		store: false,
 	};
 

--- a/packages/ai/test/cache-retention.test.ts
+++ b/packages/ai/test/cache-retention.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
 import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import { isOpenAIGPT56Family } from "../src/api/openai-prompt-cache.ts";
 import { stream as streamOpenAIResponses } from "../src/api/openai-responses.ts";
 import { getModel, stream } from "../src/compat.ts";
 import { MODELS } from "../src/models.generated.ts";
@@ -16,6 +17,12 @@ class PayloadCaptured extends Error {
 interface OpenAICompletionsCachePayload {
 	prompt_cache_key?: string;
 	prompt_cache_retention?: string;
+}
+
+interface OpenAIResponsesCachePayload {
+	prompt_cache_key?: string;
+	prompt_cache_retention?: string;
+	prompt_cache_options?: { mode?: "implicit" | "explicit"; ttl?: "30m" };
 }
 
 function stopAfterPayload<TPayload>(capture: (payload: TPayload) => void): (payload: unknown) => never {
@@ -391,6 +398,68 @@ describe("Cache Retention (PI_CACHE_RETENTION)", () => {
 			expect(capturedPayload).not.toBeNull();
 			expect(capturedPayload.prompt_cache_key).toBe("session-2");
 			expect(capturedPayload.prompt_cache_retention).toBe("24h");
+		});
+
+		it.each(["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-fast"])(
+			"should detect %s as a GPT-5.6 cache-options model",
+			(modelId) => {
+				expect(isOpenAIGPT56Family(modelId)).toBe(true);
+				expect(isOpenAIGPT56Family(`openai/${modelId}`)).toBe(true);
+			},
+		);
+
+		it("should keep GPT-5.5 on legacy prompt cache retention", async () => {
+			const model = getModel("openai", "gpt-5.5");
+			let capturedPayload: OpenAIResponsesCachePayload | undefined;
+
+			try {
+				const s = streamOpenAIResponses(model, context, {
+					apiKey: "fake-key",
+					cacheRetention: "long",
+					sessionId: "session-gpt-55",
+					onPayload: stopAfterPayload<OpenAIResponsesCachePayload>((payload) => {
+						capturedPayload = payload;
+					}),
+				});
+
+				for await (const event of s) {
+					if (event.type === "error") break;
+				}
+			} catch {
+				// Expected to fail
+			}
+
+			expect(capturedPayload).toBeDefined();
+			expect(capturedPayload?.prompt_cache_key).toBe("session-gpt-55");
+			expect(capturedPayload?.prompt_cache_options).toBeUndefined();
+			expect(capturedPayload?.prompt_cache_retention).toBe("24h");
+		});
+
+		it("should use prompt_cache_options for GPT-5.6 prompt caching", async () => {
+			const model = getModel("openai", "gpt-5.6-luna");
+			let capturedPayload: OpenAIResponsesCachePayload | undefined;
+
+			try {
+				const s = streamOpenAIResponses(model, context, {
+					apiKey: "fake-key",
+					cacheRetention: "long",
+					sessionId: "session-gpt-56",
+					onPayload: stopAfterPayload<OpenAIResponsesCachePayload>((payload) => {
+						capturedPayload = payload;
+					}),
+				});
+
+				for await (const event of s) {
+					if (event.type === "error") break;
+				}
+			} catch {
+				// Expected to fail
+			}
+
+			expect(capturedPayload).toBeDefined();
+			expect(capturedPayload?.prompt_cache_key).toBe("session-gpt-56");
+			expect(capturedPayload?.prompt_cache_options).toEqual({ mode: "implicit", ttl: "30m" });
+			expect(capturedPayload?.prompt_cache_retention).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
### What changed

Adds GPT-5.6-aware prompt caching for the OpenAI Responses API.

GPT-5.6 models now send `prompt_cache_options: { mode: "implicit", ttl: "30m" }` with the existing `prompt_cache_key`. For GPT-5.6, the legacy `prompt_cache_retention` field is omitted.

Older models, including GPT-5.5, keep the existing `prompt_cache_retention` behavior.

### Why

OpenAI documents `prompt_cache_options` for controlling prompt caching behavior, and GPT-5.6 needs that newer field while older models should keep the current request shape.

Docs: https://developers.openai.com/api/docs/guides/prompt-caching

### Verification

Ran from `packages/ai`:

```sh
node node_modules/vitest/vitest.mjs --run test/cache-retention.test.ts
```

Result: 1 test file passed, 24 passed, 4 skipped.

Ran from the repo root:

```sh
npm run check
```

Result: passed.