### PR TITLE
perf(coding-agent): cut Node CLI startup cost

### DIFF
--- a/packages/coding-agent/src/bun/cli.ts
+++ b/packages/coding-agent/src/bun/cli.ts
@@ -9,4 +9,5 @@ import { restoreSandboxEnv } from "./restore-sandbox-env.ts";
 restoreSandboxEnv();
 
 await import("./register-bedrock.ts");
+await import("./register-extension-virtual-modules.ts");
 await import("../cli.ts");

--- a/packages/coding-agent/src/bun/register-extension-virtual-modules.ts
+++ b/packages/coding-agent/src/bun/register-extension-virtual-modules.ts
@@ -1,0 +1,8 @@
+/**
+ * Register extension virtual modules for the Bun compiled binary.
+ * Imported only from bun/cli.ts so the Node.js CLI never pays for these imports.
+ */
+import { registerExtensionVirtualModules } from "../core/extensions/loader.ts";
+import { EXTENSION_VIRTUAL_MODULES } from "../core/extensions/virtual-modules.ts";
+
+registerExtensionVirtualModules(EXTENSION_VIRTUAL_MODULES);

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,16 +5,30 @@
  *
  * Test with: npx tsx src/cli-new.ts [args...]
  */
-import { APP_NAME } from "./config.ts";
-import { configureHttpDispatcher } from "./core/http-dispatcher.ts";
-import { main } from "./main.ts";
+import { APP_NAME, VERSION } from "./config.ts";
 
 process.title = APP_NAME;
 process.env.PI_CODING_AGENT = "true";
 process.emitWarning = (() => {}) as typeof process.emitWarning;
 
+const args = process.argv.slice(2);
+
+// Fast path: --version / -v must not load the agent session graph.
+// Package subcommands are handled later in main (their flags are not version).
+const PACKAGE_COMMANDS = new Set(["install", "remove", "uninstall", "update", "list", "config"]);
+const firstArg = args[0];
+const isPackageCommand = firstArg !== undefined && PACKAGE_COMMANDS.has(firstArg);
+if (!isPackageCommand && (args.includes("--version") || args.includes("-v"))) {
+	console.log(VERSION);
+	process.exit(0);
+}
+
+// Deferred load: keep metadata flags cheap; full CLI graph is large.
+const { configureHttpDispatcher } = await import("./core/http-dispatcher.ts");
+const { main } = await import("./main.ts");
+
 // Configure undici's global dispatcher before provider SDKs issue requests.
 // Runtime settings are applied once SettingsManager has loaded global/project settings.
 configureHttpDispatcher();
 
-main(process.argv.slice(2));
+void main(args);

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -7,22 +7,9 @@ import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import * as _bundledPiAgentCore from "@earendil-works/pi-agent-core";
-import * as _bundledPiAiCompat from "@earendil-works/pi-ai/compat";
-import * as _bundledPiAiOauth from "@earendil-works/pi-ai/oauth";
 import type { KeyId } from "@earendil-works/pi-tui";
-import * as _bundledPiTui from "@earendil-works/pi-tui";
 import { createJiti } from "jiti/static";
-// Static imports of packages that extensions may use.
-// These MUST be static so Bun bundles them into the compiled binary.
-// The virtualModules option then makes them available to extensions.
-import * as _bundledTypebox from "typebox";
-import * as _bundledTypeboxCompile from "typebox/compile";
-import * as _bundledTypeboxValue from "typebox/value";
 import { CONFIG_DIR_NAME, getAgentDir, isBunBinary } from "../../config.ts";
-// NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
-// avoiding a circular dependency. Extensions can import from @earendil-works/pi-coding-agent.
-import * as _bundledPiCodingAgent from "../../index.ts";
 import { resolvePath } from "../../utils/paths.ts";
 import { createEventBus, type EventBus } from "../event-bus.ts";
 import type { ExecOptions } from "../exec.ts";
@@ -42,30 +29,27 @@ import type {
 	ToolDefinition,
 } from "./types.ts";
 
-/** Modules available to extensions via virtualModules (for compiled Bun binary) */
-const VIRTUAL_MODULES: Record<string, unknown> = {
-	typebox: _bundledTypebox,
-	"typebox/compile": _bundledTypeboxCompile,
-	"typebox/value": _bundledTypeboxValue,
-	"@sinclair/typebox": _bundledTypebox,
-	"@sinclair/typebox/compile": _bundledTypeboxCompile,
-	"@sinclair/typebox/value": _bundledTypeboxValue,
-	"@earendil-works/pi-agent-core": _bundledPiAgentCore,
-	"@earendil-works/pi-tui": _bundledPiTui,
-	// Extensions resolve the pi-ai root to the compat entrypoint (a strict
-	// superset of the core entrypoint): existing extensions using the old
-	// global API keep working at runtime until compat is removed.
-	"@earendil-works/pi-ai": _bundledPiAiCompat,
-	"@earendil-works/pi-ai/compat": _bundledPiAiCompat,
-	"@earendil-works/pi-ai/oauth": _bundledPiAiOauth,
-	"@earendil-works/pi-coding-agent": _bundledPiCodingAgent,
-	"@mariozechner/pi-agent-core": _bundledPiAgentCore,
-	"@mariozechner/pi-tui": _bundledPiTui,
-	"@mariozechner/pi-ai": _bundledPiAiCompat,
-	"@mariozechner/pi-ai/compat": _bundledPiAiCompat,
-	"@mariozechner/pi-ai/oauth": _bundledPiAiOauth,
-	"@mariozechner/pi-coding-agent": _bundledPiCodingAgent,
-};
+/**
+ * Bun binary virtual modules for extension imports.
+ * Registered from bun/cli.ts via registerExtensionVirtualModules() so the Node.js
+ * CLI does not pay for loading the full package graph when the extension loader is
+ * imported. Node.js uses getAliases() path resolution instead.
+ */
+let extensionVirtualModules: Record<string, unknown> | undefined;
+
+/** Register packages exposed to extensions under the Bun compiled binary. */
+export function registerExtensionVirtualModules(modules: Record<string, unknown>): void {
+	extensionVirtualModules = modules;
+}
+
+function getExtensionVirtualModules(): Record<string, unknown> {
+	if (!extensionVirtualModules) {
+		throw new Error(
+			"Extension virtual modules are not registered. The Bun binary entrypoint must call registerExtensionVirtualModules().",
+		);
+	}
+	return extensionVirtualModules;
+}
 
 const require = createRequire(import.meta.url);
 
@@ -391,7 +375,7 @@ async function loadExtensionModule(extensionPath: string, cacheToken?: Extension
 		// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
 		// Also disable tryNative so jiti handles ALL imports (not just the entry point)
 		// In Node.js/dev: use aliases to resolve to node_modules paths
-		...(isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() }),
+		...(isBunBinary ? { virtualModules: getExtensionVirtualModules(), tryNative: false } : { alias: getAliases() }),
 	});
 
 	const module = await jiti.import(extensionPath, { default: true });

--- a/packages/coding-agent/src/core/extensions/virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/virtual-modules.ts
@@ -1,0 +1,42 @@
+/**
+ * Packages exposed to extensions under the Bun compiled binary.
+ *
+ * These MUST be static imports so Bun includes them in the binary. They are only
+ * registered from the Bun entrypoint; the Node.js CLI uses jiti path aliases
+ * instead and must not load this module at startup.
+ */
+import * as bundledPiAgentCore from "@earendil-works/pi-agent-core";
+import * as bundledPiAiCompat from "@earendil-works/pi-ai/compat";
+import * as bundledPiAiOauth from "@earendil-works/pi-ai/oauth";
+import * as bundledPiTui from "@earendil-works/pi-tui";
+import * as bundledTypebox from "typebox";
+import * as bundledTypeboxCompile from "typebox/compile";
+import * as bundledTypeboxValue from "typebox/value";
+// NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
+// avoiding a circular dependency. Extensions can import from @earendil-works/pi-coding-agent.
+import * as bundledPiCodingAgent from "../../index.ts";
+
+/** Modules available to extensions via jiti virtualModules (Bun binary only). */
+export const EXTENSION_VIRTUAL_MODULES: Record<string, unknown> = {
+	typebox: bundledTypebox,
+	"typebox/compile": bundledTypeboxCompile,
+	"typebox/value": bundledTypeboxValue,
+	"@sinclair/typebox": bundledTypebox,
+	"@sinclair/typebox/compile": bundledTypeboxCompile,
+	"@sinclair/typebox/value": bundledTypeboxValue,
+	"@earendil-works/pi-agent-core": bundledPiAgentCore,
+	"@earendil-works/pi-tui": bundledPiTui,
+	// Extensions resolve the pi-ai root to the compat entrypoint (a strict
+	// superset of the core entrypoint): existing extensions using the old
+	// global API keep working at runtime until compat is removed.
+	"@earendil-works/pi-ai": bundledPiAiCompat,
+	"@earendil-works/pi-ai/compat": bundledPiAiCompat,
+	"@earendil-works/pi-ai/oauth": bundledPiAiOauth,
+	"@earendil-works/pi-coding-agent": bundledPiCodingAgent,
+	"@mariozechner/pi-agent-core": bundledPiAgentCore,
+	"@mariozechner/pi-tui": bundledPiTui,
+	"@mariozechner/pi-ai": bundledPiAiCompat,
+	"@mariozechner/pi-ai/compat": bundledPiAiCompat,
+	"@mariozechner/pi-ai/oauth": bundledPiAiOauth,
+	"@mariozechner/pi-coding-agent": bundledPiCodingAgent,
+};

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -1,44 +1,16 @@
 import { EventEmitter } from "node:events";
 import * as undici from "undici";
+import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-timeout.ts";
 
-export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
-
-export const HTTP_IDLE_TIMEOUT_CHOICES = [
-	{ label: "30 sec", timeoutMs: 30_000 },
-	{ label: "1 min", timeoutMs: 60_000 },
-	{ label: "2 min", timeoutMs: 120_000 },
-	{ label: "5 min", timeoutMs: 300_000 },
-	{ label: "disabled", timeoutMs: 0 },
-] as const;
+export {
+	DEFAULT_HTTP_IDLE_TIMEOUT_MS,
+	formatHttpIdleTimeoutMs,
+	HTTP_IDLE_TIMEOUT_CHOICES,
+	parseHttpIdleTimeoutMs,
+} from "./http-timeout.ts";
 
 const originalGlobalFetch = globalThis.fetch;
 let installedGlobalFetch: typeof globalThis.fetch | undefined;
-
-export function parseHttpIdleTimeoutMs(value: unknown): number | undefined {
-	if (typeof value === "string") {
-		const trimmed = value.trim();
-		if (trimmed.toLowerCase() === "disabled") {
-			return 0;
-		}
-		if (trimmed.length === 0) {
-			return undefined;
-		}
-		return parseHttpIdleTimeoutMs(Number(trimmed));
-	}
-
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-		return undefined;
-	}
-	return Math.floor(value);
-}
-
-export function formatHttpIdleTimeoutMs(timeoutMs: number): string {
-	const choice = HTTP_IDLE_TIMEOUT_CHOICES.find((item) => item.timeoutMs === timeoutMs);
-	if (choice) {
-		return choice.label;
-	}
-	return `${timeoutMs / 1000} sec`;
-}
 
 export function applyHttpProxySettings(httpProxy: string | undefined): void {
 	const proxy = httpProxy?.trim();

--- a/packages/coding-agent/src/core/http-timeout.ts
+++ b/packages/coding-agent/src/core/http-timeout.ts
@@ -1,0 +1,35 @@
+export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
+
+export const HTTP_IDLE_TIMEOUT_CHOICES = [
+	{ label: "30 sec", timeoutMs: 30_000 },
+	{ label: "1 min", timeoutMs: 60_000 },
+	{ label: "2 min", timeoutMs: 120_000 },
+	{ label: "5 min", timeoutMs: 300_000 },
+	{ label: "disabled", timeoutMs: 0 },
+] as const;
+
+export function parseHttpIdleTimeoutMs(value: unknown): number | undefined {
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (trimmed.toLowerCase() === "disabled") {
+			return 0;
+		}
+		if (trimmed.length === 0) {
+			return undefined;
+		}
+		return parseHttpIdleTimeoutMs(Number(trimmed));
+	}
+
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+		return undefined;
+	}
+	return Math.floor(value);
+}
+
+export function formatHttpIdleTimeoutMs(timeoutMs: number): string {
+	const choice = HTTP_IDLE_TIMEOUT_CHOICES.find((item) => item.timeoutMs === timeoutMs);
+	if (choice) {
+		return choice.label;
+	}
+	return `${timeoutMs / 1000} sec`;
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -6,7 +6,7 @@ import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
-import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
+import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-timeout.ts";
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -12,7 +12,7 @@ import {
 	Spacer,
 	Text,
 } from "@earendil-works/pi-tui";
-import { formatHttpIdleTimeoutMs, HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-dispatcher.ts";
+import { formatHttpIdleTimeoutMs, HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-timeout.ts";
 import type { DefaultProjectTrust, WarningSettings } from "../../../core/settings-manager.ts";
 import {
 	getSelectListTheme,

--- a/packages/coding-agent/src/utils/syntax-highlight.ts
+++ b/packages/coding-agent/src/utils/syntax-highlight.ts
@@ -1,4 +1,4 @@
-import hljs from "highlight.js/lib/index.js";
+import { createRequire } from "node:module";
 import { decodeHtmlEntityAt } from "./html.ts";
 
 export type HighlightFormatter = (text: string) => string;
@@ -9,6 +9,19 @@ export interface HighlightOptions {
 	ignoreIllegals?: boolean;
 	languageSubset?: string[];
 	theme?: HighlightTheme;
+}
+
+// Lazy-load highlight.js (~35ms) — only needed when rendering code, not at CLI startup.
+type HighlightJs = typeof import("highlight.js/lib/index.js")["default"];
+const require = createRequire(import.meta.url);
+let hljsModule: HighlightJs | undefined;
+
+function getHljs(): HighlightJs {
+	if (!hljsModule) {
+		// CJS interop: require() returns the default export object directly.
+		hljsModule = require("highlight.js/lib/index.js") as HighlightJs;
+	}
+	return hljsModule;
 }
 
 const SPAN_CLOSE = "</span>";
@@ -132,6 +145,7 @@ export function renderHighlightedHtml(html: string, theme: HighlightTheme = {}):
 }
 
 export function highlight(code: string, options: HighlightOptions = {}): string {
+	const hljs = getHljs();
 	const html = options.language
 		? hljs.highlight(code, {
 				language: options.language,
@@ -142,5 +156,5 @@ export function highlight(code: string, options: HighlightOptions = {}): string 
 }
 
 export function supportsLanguage(name: string): boolean {
-	return hljs.getLanguage(name) !== undefined;
+	return getHljs().getLanguage(name) !== undefined;
 }


### PR DESCRIPTION
## Summary

Node CLI startup was dominated by static module loading, including Bun-only extension virtual module imports that ran on every Node start.

- Fast-path `--version` / `-v` in `cli.ts` before loading `main` / undici
- Move extension `virtualModules` static imports to the Bun entry only; Node keeps jiti path aliases
- Lazy-load `highlight.js` on first `highlight()` call
- Split HTTP timeout helpers out of the undici dispatcher so settings load does not pull the HTTP stack

## Benchmarks (this machine)

| Path | Before | After |
|------|--------|-------|
| `pi --version` | ~430ms median | ~40ms |
| RPC ready (`get_state`) | ~376ms | ~344ms |

## Test plan

- [x] `npm run check`
- [x] `vitest` for `stdout-cleanliness`, `syntax-highlight`, `args`, `config`, `extensions-discovery`, `extensions-runner`
- [x] `node scripts/profile-coding-agent-node.mjs --mode rpc --runs 5 --skip-build --isolated-agent-dir`
- [ ] Bun binary still registers extension virtual modules and can load extensions that import `@earendil-works/pi-coding-agent`
- [ ] `pi update` / package commands unchanged