### PR TITLE
fix: Codex compaction returns "Model not found" for gpt-5.6-luna

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -1527,6 +1527,7 @@ function buildBaseCodexHeaders(
 	headers.set("Authorization", `Bearer ${token}`);
 	headers.set("chatgpt-account-id", accountId);
 	headers.set("originator", "pi");
+	headers.set("OAI-Product-Sku", "codex");
 	const userAgent = _os ? `pi (${_os.platform()} ${_os.release()}; ${_os.arch()})` : "pi (browser)";
 	headers.set("User-Agent", userAgent);
 	return headers;

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -511,6 +511,8 @@ function buildRequestBody(
 
 	if (toolPlacement.immediate.length > 0) {
 		body.tools = convertResponsesTools(toolPlacement.immediate, { strict: null });
+	} else {
+		body.tools = [];
 	}
 
 	if (options?.reasoningEffort !== undefined) {

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -5,6 +5,7 @@
  * a summary of the branch being left so context isn't lost.
  */
 
+import { randomUUID } from "node:crypto";
 import type { AgentMessage, StreamFn } from "@earendil-works/pi-agent-core";
 import type { Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
@@ -344,7 +345,7 @@ export async function generateBranchSummary(
 		env,
 		signal,
 		maxTokens: 2048,
-		sessionId: globalThis.crypto?.randomUUID?.() ?? `__anon_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+		sessionId: randomUUID(),
 	};
 	const response = streamFn
 		? await (await streamFn(model, context, requestOptions)).result()

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -338,7 +338,14 @@ export async function generateBranchSummary(
 	// request behavior (timeouts, retries, attribution headers) stays consistent
 	// without running through agent state/events.
 	const context = { systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages };
-	const requestOptions: SimpleStreamOptions = { apiKey, headers, env, signal, maxTokens: 2048 };
+	const requestOptions: SimpleStreamOptions = {
+		apiKey,
+		headers,
+		env,
+		signal,
+		maxTokens: 2048,
+		sessionId: globalThis.crypto?.randomUUID?.() ?? `__anon_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+	};
 	const response = streamFn
 		? await (await streamFn(model, context, requestOptions)).result()
 		: await completeSimple(model, context, requestOptions);

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -5,8 +5,7 @@
  * a summary of the branch being left so context isn't lost.
  */
 
-import { randomUUID } from "node:crypto";
-import type { AgentMessage, StreamFn } from "@earendil-works/pi-agent-core";
+import { type AgentMessage, type StreamFn, uuidv7 } from "@earendil-works/pi-agent-core";
 import type { Model, SimpleStreamOptions } from "@earendil-works/pi-ai/compat";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
 import {
@@ -345,7 +344,7 @@ export async function generateBranchSummary(
 		env,
 		signal,
 		maxTokens: 2048,
-		sessionId: randomUUID(),
+		sessionId: uuidv7(),
 	};
 	const response = streamFn
 		? await (await streamFn(model, context, requestOptions)).result()

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -5,8 +5,7 @@
  * and after compaction the session is reloaded.
  */
 
-import { randomUUID } from "node:crypto";
-import type { AgentMessage, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { type AgentMessage, type StreamFn, type ThinkingLevel, uuidv7 } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@earendil-works/pi-ai/compat";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { convertToLlm } from "../messages.ts";
@@ -526,7 +525,7 @@ function createSummarizationOptions(
 		apiKey,
 		headers,
 		env,
-		sessionId: randomUUID(),
+		sessionId: uuidv7(),
 	};
 	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
 		options.reasoning = thinkingLevel;

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -5,6 +5,7 @@
  * and after compaction the session is reloaded.
  */
 
+import { randomUUID } from "node:crypto";
 import type { AgentMessage, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@earendil-works/pi-ai/compat";
 import { completeSimple } from "@earendil-works/pi-ai/compat";
@@ -525,7 +526,7 @@ function createSummarizationOptions(
 		apiKey,
 		headers,
 		env,
-		sessionId: globalThis.crypto?.randomUUID?.() ?? `__anon_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+		sessionId: randomUUID(),
 	};
 	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
 		options.reasoning = thinkingLevel;

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -519,7 +519,14 @@ function createSummarizationOptions(
 	signal: AbortSignal | undefined,
 	thinkingLevel: ThinkingLevel | undefined,
 ): SimpleStreamOptions {
-	const options: SimpleStreamOptions = { maxTokens, signal, apiKey, headers, env };
+	const options: SimpleStreamOptions = {
+		maxTokens,
+		signal,
+		apiKey,
+		headers,
+		env,
+		sessionId: globalThis.crypto?.randomUUID?.() ?? `__anon_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+	};
 	if (model.reasoning && thinkingLevel && thinkingLevel !== "off") {
 		options.reasoning = thinkingLevel;
 	}


### PR DESCRIPTION
Compaction (manual `/compact`, auto-compaction, and branch summarization)
through the OpenAI Codex API fails with a 404 for gpt-5.6-luna. The API
internally maps the model ID to a tier-suffixed slug that its no-tools
registry does not recognize. Regular chat with the same model works because
the tools-equipped request path resolves correctly.

Three changes were required, confirmed via bisection on a live Codex Plus
subscription — omitting any one still reproduces the 404:

1. Send `"tools": []` instead of omitting the key when no tools are present.
2. Add the `OAI-Product-Sku: codex` header, matching the official Codex CLI.
3. Generate an ad-hoc session ID for compaction requests so that
   `session-id`/`x-client-request-id` headers are always present, matching
   regular chat behavior.at behavior.

Other GPT-5.6 models (sol, terra) and older models (gpt-5.5) are unaffected.

Manually tested with gpt-5.6-luna, gpt-5.5, gpt-5.6-sol, and gpt-5.6-terra
through the Codex backend. 

AI-assisted investigation, bisection, and implementation.

fixes #6477 