### PR TITLE
fix(ai): route GitHub Copilot MAI-Code models through /responses endp…

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the GitHub Copilot `mai-code-1-flash-picker` model to route through the `/responses` endpoint.
 - Fixed Amazon Bedrock requests to use the generic `apiKey` stream option as a Bedrock bearer token.
 
 ## [0.80.6] - 2026-07-09

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1437,8 +1437,11 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 
 				// Claude 4.x and 5.x models route to Anthropic Messages API
 				const isCopilotClaude = /^claude-(haiku|sonnet|opus)-[45]([.\-]|$)/.test(modelId);
-				// gpt-5 models require responses API, others use completions
-				const needsResponsesApi = modelId.startsWith("gpt-5") || modelId.startsWith("oswe");
+				// gpt-5, oswe, and MAI-Code models are only served through the
+				// Copilot /responses endpoint; they reject /chat/completions with
+				// "model is not accessible via the /chat/completions endpoint".
+				const needsResponsesApi =
+					modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
 
 				const api: Api = isCopilotClaude
 					? "anthropic-messages"

--- a/packages/ai/src/providers/github-copilot.models.ts
+++ b/packages/ai/src/providers/github-copilot.models.ts
@@ -468,11 +468,10 @@ export const GITHUB_COPILOT_MODELS = {
 	"mai-code-1-flash-picker": {
 		id: "mai-code-1-flash-picker",
 		name: "MAI-Code-1-Flash",
-		api: "openai-completions",
+		api: "openai-responses",
 		provider: "github-copilot",
 		baseUrl: "https://api.individual.githubcopilot.com",
 		headers: {"User-Agent":"GitHubCopilotChat/0.35.0","Editor-Version":"vscode/1.107.0","Editor-Plugin-Version":"copilot-chat/0.35.0","Copilot-Integration-Id":"vscode-chat"},
-		compat: {"supportsStore":false,"supportsDeveloperRole":false,"supportsReasoningEffort":false},
 		reasoning: true,
 		input: ["text"],
 		cost: {
@@ -483,5 +482,5 @@ export const GITHUB_COPILOT_MODELS = {
 		},
 		contextWindow: 256000,
 		maxTokens: 128000,
-	} satisfies Model<"openai-completions">,
+	} satisfies Model<"openai-responses">,
 } as const;


### PR DESCRIPTION
…oint

mai-code-1-flash-picker is not accessible via /chat/completions and must use the Copilot /responses endpoint. Update generate-models.ts to send mai-* models to the responses API and regenerate the affected model entry.