### PR TITLE
feat(coding-agent): add deferred extension reload requests

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1026,6 +1026,24 @@ pi.on("tool_call", (event, ctx) => {
 });
 ```
 
+### ctx.requestReload()
+
+Request the canonical resource reload flow after the current runtime becomes idle.
+
+- **Interactive mode:** Runs the same guarded reload flow as `/reload`, including UI restoration and keybinding/theme refresh.
+- **RPC mode:** Reloads the bound session runtime after the current agent run or RPC command settles.
+- **Print/JSON modes:** No-op.
+
+The reload emits `session_shutdown` with reason `"reload"`, rebuilds the extension runtime, then emits `session_start` and `resources_discover` with reason `"reload"`. Available in all contexts, including event handlers and tools.
+
+```typescript
+pi.on("agent_settled", (_event, ctx) => {
+  if (shouldReloadResources()) {
+    ctx.requestReload();
+  }
+});
+```
+
 ### ctx.getContextUsage()
 
 Returns current context usage for the active model. Uses last assistant usage when available, then estimates tokens for trailing messages.
@@ -1287,37 +1305,7 @@ Important behavior:
 
 For predictable behavior, treat reload as terminal for that handler (`await ctx.reload(); return;`).
 
-Tools run with `ExtensionContext`, so they cannot call `ctx.reload()` directly. Use a command as the reload entrypoint, then expose a tool that queues that command as a follow-up user message.
-
-Example tool the LLM can call to trigger reload:
-
-```typescript
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
-
-export default function (pi: ExtensionAPI) {
-  pi.registerCommand("reload-runtime", {
-    description: "Reload extensions, skills, prompts, themes, and context files",
-    handler: async (_args, ctx) => {
-      await ctx.reload();
-      return;
-    },
-  });
-
-  pi.registerTool({
-    name: "reload_runtime",
-    label: "Reload Runtime",
-    description: "Reload extensions, skills, prompts, themes, and context files",
-    parameters: Type.Object({}),
-    async execute() {
-      pi.sendUserMessage("/reload-runtime", { deliverAs: "followUp" });
-      return {
-        content: [{ type: "text", text: "Queued /reload-runtime as a follow-up command." }],
-      };
-    },
-  });
-}
-```
+Tools and event handlers use `ExtensionContext`, so they cannot call `ctx.reload()` directly. Use `ctx.requestReload()` to defer the same canonical reload until the runtime is idle.
 
 ## ExtensionAPI Methods
 
@@ -2824,7 +2812,7 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `handoff.ts` | Cross-provider model handoff | `registerCommand`, `ui.editor`, `ui.custom` |
 | `qna.ts` | Q&A with custom UI | `registerCommand`, `ui.custom`, `setEditorText` |
 | `send-user-message.ts` | Inject user messages | `registerCommand`, `sendUserMessage` |
-| `reload-runtime.ts` | Reload command and LLM tool handoff | `registerCommand`, `ctx.reload()`, `sendUserMessage` |
+| `reload-runtime.ts` | Immediate and deferred canonical reload | `registerCommand`, `ctx.reload()`, `ctx.requestReload()` |
 | `shutdown-command.ts` | Graceful shutdown command | `registerCommand`, `shutdown()` |
 | **Events & Gates** |||
 | `permission-gate.ts` | Block dangerous commands | `on("tool_call")`, `ui.confirm` |

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -74,7 +74,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `overlay-qa-tests.ts` | Comprehensive overlay QA tests: anchors, margins, stacking, overflow, animation |
 | `doom-overlay/` | DOOM game running as an overlay at 35 FPS (demonstrates real-time game rendering) |
 | `shutdown-command.ts` | Adds `/quit` command demonstrating `ctx.shutdown()` |
-| `reload-runtime.ts` | Adds `/reload-runtime` and `reload_runtime` tool showing safe reload flow |
+| `reload-runtime.ts` | Shows immediate `ctx.reload()` and idle-safe `ctx.requestReload()` flows |
 | `interactive-shell.ts` | Run interactive commands (vim, htop) with full terminal via `user_bash` hook |
 | `inline-bash.ts` | Expands `!{command}` patterns in prompts via `input` event transformation |
 | `input-transform-streaming.ts` | Skips expensive input preprocessing for mid-stream steering via `streamingBehavior` |

--- a/packages/coding-agent/examples/extensions/reload-runtime.ts
+++ b/packages/coding-agent/examples/extensions/reload-runtime.ts
@@ -1,8 +1,8 @@
 /**
  * Reload Runtime Extension
  *
- * Demonstrates ctx.reload() from ExtensionCommandContext and an LLM-callable
- * tool that queues a follow-up command to trigger reload.
+ * Demonstrates immediate ctx.reload() from ExtensionCommandContext and
+ * deferred ctx.requestReload() from a tool's ExtensionContext.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -19,17 +19,16 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	// LLM-callable tool. Tools get ExtensionContext, so they cannot call ctx.reload() directly.
-	// Instead, queue a follow-up user command that executes the command above.
+	// LLM-callable tool. The host defers the canonical reload until the runtime is idle.
 	pi.registerTool({
 		name: "reload_runtime",
 		label: "Reload Runtime",
 		description: "Reload extensions, skills, prompts, themes, and context files",
 		parameters: Type.Object({}),
-		async execute() {
-			pi.sendUserMessage("/reload-runtime", { deliverAs: "followUp" });
+		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+			ctx.requestReload();
 			return {
-				content: [{ type: "text", text: "Queued /reload-runtime as a follow-up command." }],
+				content: [{ type: "text", text: "Reload requested for the next idle state." }],
 				details: {},
 			};
 		},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -66,6 +66,7 @@ import {
 	type MessageEndEvent,
 	type MessageStartEvent,
 	type MessageUpdateEvent,
+	type ReloadRequestHandler,
 	type ReplacedSessionContext,
 	type SessionBeforeCompactResult,
 	type SessionBeforeTreeResult,
@@ -197,6 +198,7 @@ export interface ExtensionBindings {
 	commandContextActions?: ExtensionCommandContextActions;
 	abortHandler?: () => void;
 	shutdownHandler?: ShutdownHandler;
+	reloadRequestHandler?: ReloadRequestHandler;
 	onError?: ExtensionErrorListener;
 }
 
@@ -322,6 +324,7 @@ export class AgentSession {
 	private _extensionCommandContextActions?: ExtensionCommandContextActions;
 	private _extensionAbortHandler?: () => void;
 	private _extensionShutdownHandler?: ShutdownHandler;
+	private _extensionReloadRequestHandler?: ReloadRequestHandler;
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
 
@@ -2189,6 +2192,9 @@ export class AgentSession {
 		if (bindings.shutdownHandler !== undefined) {
 			this._extensionShutdownHandler = bindings.shutdownHandler;
 		}
+		if (bindings.reloadRequestHandler !== undefined) {
+			this._extensionReloadRequestHandler = bindings.reloadRequestHandler;
+		}
 		if (bindings.onError !== undefined) {
 			this._extensionErrorListener = bindings.onError;
 		}
@@ -2365,6 +2371,9 @@ export class AgentSession {
 				hasPendingMessages: () => this.pendingMessageCount > 0,
 				shutdown: () => {
 					this._extensionShutdownHandler?.();
+				},
+				requestReload: () => {
+					this._extensionReloadRequestHandler?.();
 				},
 				getContextUsage: () => this.getContextUsage(),
 				compact: (options) => {
@@ -2558,6 +2567,7 @@ export class AgentSession {
 			this._extensionUIContext ||
 			this._extensionCommandContextActions ||
 			this._extensionShutdownHandler ||
+			this._extensionReloadRequestHandler ||
 			this._extensionErrorListener;
 		if (hasBindings) {
 			await options?.beforeSessionStart?.();

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -15,6 +15,7 @@ export type {
 	ForkHandler,
 	NavigateTreeHandler,
 	NewSessionHandler,
+	ReloadRequestHandler,
 	ShutdownHandler,
 	SwitchSessionHandler,
 } from "./runner.ts";

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -181,6 +181,8 @@ export type SwitchSessionHandler = (
 
 export type ReloadHandler = () => Promise<void>;
 
+export type ReloadRequestHandler = () => void;
+
 export type ShutdownHandler = () => void;
 
 /**
@@ -288,6 +290,7 @@ export class ExtensionRunner {
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private reloadHandler: ReloadHandler = async () => {};
+	private reloadRequestHandler: ReloadRequestHandler = () => {};
 	private shutdownHandler: ShutdownHandler = () => {};
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
@@ -340,6 +343,7 @@ export class ExtensionRunner {
 		this.abortFn = contextActions.abort;
 		this.hasPendingMessagesFn = contextActions.hasPendingMessages;
 		this.shutdownHandler = contextActions.shutdown;
+		this.reloadRequestHandler = contextActions.requestReload;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
@@ -624,6 +628,11 @@ export class ExtensionRunner {
 		this.shutdownHandler();
 	}
 
+	/** Request a canonical resource reload after the current runtime becomes idle. */
+	requestReload(): void {
+		this.reloadRequestHandler();
+	}
+
 	getActiveTools(): string[] {
 		this.assertActive();
 		return this.runtime.getActiveTools();
@@ -688,6 +697,10 @@ export class ExtensionRunner {
 			shutdown: () => {
 				runner.assertActive();
 				runner.shutdownHandler();
+			},
+			requestReload: () => {
+				runner.assertActive();
+				runner.reloadRequestHandler();
 			},
 			getContextUsage: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -326,6 +326,8 @@ export interface ExtensionContext {
 	hasPendingMessages(): boolean;
 	/** Gracefully shutdown pi and exit. Available in all contexts. */
 	shutdown(): void;
+	/** Request a canonical resource reload once the current runtime becomes idle. */
+	requestReload(): void;
 	/** Get current context usage for the active model. */
 	getContextUsage(): ContextUsage | undefined;
 	/** Trigger compaction without awaiting completion. */
@@ -1594,6 +1596,7 @@ export interface ExtensionContextActions {
 	abort: () => void;
 	hasPendingMessages: () => boolean;
 	shutdown: () => void;
+	requestReload: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -417,8 +417,10 @@ export class InteractiveMode {
 	// Messages queued while compaction is running
 	private compactionQueuedMessages: CompactionQueuedMessage[] = [];
 
-	// Shutdown state
+	// Deferred runtime actions
 	private shutdownRequested = false;
+	private reloadRequested = false;
+	private reloadInProgress = false;
 
 	// Extension UI state
 	private extensionSelector: ExtensionSelectorComponent | undefined = undefined;
@@ -1683,6 +1685,9 @@ export class InteractiveMode {
 					void this.shutdown();
 				}
 			},
+			reloadRequestHandler: () => {
+				this.requestReload();
+			},
 			onError: (error) => {
 				this.showExtensionError(error.extensionPath, error.error, error.stack);
 			},
@@ -1788,6 +1793,9 @@ export class InteractiveMode {
 			hasPendingMessages: () => this.session.pendingMessageCount > 0,
 			shutdown: () => {
 				this.shutdownRequested = true;
+			},
+			requestReload: () => {
+				this.requestReload();
 			},
 			getContextUsage: () => this.session.getContextUsage(),
 			compact: (options) => {
@@ -3040,6 +3048,7 @@ export class InteractiveMode {
 
 			case "agent_settled":
 				await this.checkShutdownRequested();
+				await this.checkReloadRequested();
 				break;
 
 			case "compaction_start": {
@@ -3090,7 +3099,10 @@ export class InteractiveMode {
 						this.chatContainer.addChild(new Text(theme.fg("error", event.errorMessage), 1, 0));
 					}
 				}
-				void this.flushCompactionQueue({ willRetry: event.willRetry });
+				void this.flushCompactionQueue({ willRetry: event.willRetry }).finally(async () => {
+					await this.checkShutdownRequested();
+					await this.checkReloadRequested();
+				});
 				this.ui.requestRender();
 				break;
 			}
@@ -3583,6 +3595,27 @@ export class InteractiveMode {
 	private async checkShutdownRequested(): Promise<void> {
 		if (!this.shutdownRequested) return;
 		await this.shutdown();
+	}
+
+	private requestReload(): void {
+		if (this.reloadInProgress) return;
+		this.reloadRequested = true;
+		if (this.session.isIdle && !this.session.isCompacting) {
+			queueMicrotask(() => void this.checkReloadRequested());
+		}
+	}
+
+	private async checkReloadRequested(): Promise<void> {
+		if (
+			this.shutdownRequested ||
+			this.reloadInProgress ||
+			!this.reloadRequested ||
+			!this.session.isIdle ||
+			this.session.isCompacting
+		)
+			return;
+		this.reloadRequested = false;
+		await this.handleReloadCommand();
 	}
 
 	private registerSignalHandlers(): void {
@@ -5277,6 +5310,7 @@ export class InteractiveMode {
 	// =========================================================================
 
 	private async handleReloadCommand(): Promise<void> {
+		if (this.reloadInProgress) return;
 		if (this.session.isStreaming) {
 			this.showWarning("Wait for the current response to finish before reloading.");
 			return;
@@ -5286,6 +5320,8 @@ export class InteractiveMode {
 			return;
 		}
 
+		this.reloadRequested = false;
+		this.reloadInProgress = true;
 		this.resetExtensionUI();
 
 		const reloadBox = new Container();
@@ -5377,6 +5413,8 @@ export class InteractiveMode {
 				dismissReloadBox(previousEditor as Component);
 			}
 			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
+		} finally {
+			this.reloadInProgress = false;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -81,8 +81,10 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		{ resolve: (value: any) => void; reject: (error: Error) => void }
 	>();
 
-	// Shutdown request flag
+	// Deferred runtime action flags
 	let shutdownRequested = false;
+	let reloadRequested = false;
+	let reloadInProgress = false;
 	let shuttingDown = false;
 	const signalCleanupHandlers: Array<() => void> = [];
 
@@ -344,6 +346,9 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 			shutdownHandler: () => {
 				shutdownRequested = true;
 			},
+			reloadRequestHandler: () => {
+				requestReload();
+			},
 			onError: (err) => {
 				output({ type: "extension_error", extensionPath: err.extensionPath, event: err.event, error: err.error });
 			},
@@ -353,8 +358,9 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		unsubscribeBackpressure?.();
 		unsubscribe = session.subscribe((event) => {
 			output(event);
-			if (event.type === "agent_settled") {
+			if (event.type === "agent_settled" || event.type === "compaction_end") {
 				void checkShutdownRequested();
+				void checkReloadRequested();
 			}
 		});
 		unsubscribeBackpressure = session.agent.subscribe(async () => {
@@ -723,6 +729,32 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		await shutdown();
 	}
 
+	function requestReload(): void {
+		if (reloadInProgress) return;
+		reloadRequested = true;
+		if (session.isIdle && !session.isCompacting) {
+			setTimeout(() => void checkReloadRequested(), 0).unref();
+		}
+	}
+
+	async function checkReloadRequested(): Promise<void> {
+		if (shutdownRequested || reloadInProgress || !reloadRequested || !session.isIdle || session.isCompacting) return;
+		reloadRequested = false;
+		reloadInProgress = true;
+		try {
+			await session.reload();
+		} catch (reloadError: unknown) {
+			output({
+				type: "extension_error",
+				extensionPath: "<runtime>",
+				event: "request_reload",
+				error: reloadError instanceof Error ? reloadError.message : String(reloadError),
+			});
+		} finally {
+			reloadInProgress = false;
+		}
+	}
+
 	const handleInputLine = async (line: string) => {
 		let parsed: unknown;
 		try {
@@ -763,6 +795,7 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				await waitForRawStdoutBackpressure();
 			}
 			await checkShutdownRequested();
+			await checkReloadRequested();
 		} catch (commandError: unknown) {
 			output(
 				error(

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -95,6 +95,7 @@ describe("ExtensionRunner", () => {
 		abort: () => {},
 		hasPendingMessages: () => false,
 		shutdown: () => {},
+		requestReload: () => {},
 		getContextUsage: () => undefined,
 		compact: () => {},
 		getSystemPrompt: () => "",
@@ -509,6 +510,22 @@ describe("ExtensionRunner", () => {
 			const ctx = runner.createContext();
 			expect(ctx.mode).toBe("print");
 			expect(ctx.hasUI).toBe(false);
+		});
+
+		it("routes reload requests from ExtensionContext", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			let requested = false;
+			runner.bindCore(extensionActions, {
+				...extensionContextActions,
+				requestReload: () => {
+					requested = true;
+				},
+			});
+
+			const ctx = runner.createContext();
+			ctx.requestReload();
+			expect(requested).toBe(true);
 		});
 
 		it("exposes project trust state on ExtensionContext", async () => {

--- a/packages/coding-agent/test/interactive-mode-request-reload.test.ts
+++ b/packages/coding-agent/test/interactive-mode-request-reload.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+const prototype = InteractiveMode.prototype as unknown as {
+	requestReload(this: RuntimeFixture): void;
+	checkReloadRequested(this: RuntimeFixture): Promise<void>;
+};
+
+type RuntimeFixture = {
+	shutdownRequested: boolean;
+	reloadRequested: boolean;
+	reloadInProgress: boolean;
+	session: { isIdle: boolean; isCompacting: boolean };
+	handleReloadCommand: ReturnType<typeof vi.fn>;
+	checkReloadRequested: ReturnType<typeof vi.fn>;
+};
+
+function createFixture(isIdle: boolean): RuntimeFixture {
+	return {
+		shutdownRequested: false,
+		reloadRequested: false,
+		reloadInProgress: false,
+		session: { isIdle, isCompacting: false },
+		handleReloadCommand: vi.fn(async () => {}),
+		checkReloadRequested: vi.fn(async () => {}),
+	};
+}
+
+describe("InteractiveMode extension reload requests", () => {
+	it("schedules a canonical reload when already idle", async () => {
+		const fixture = createFixture(true);
+
+		prototype.requestReload.call(fixture);
+		await Promise.resolve();
+
+		expect(fixture.reloadRequested).toBe(true);
+		expect(fixture.checkReloadRequested).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers until idle and then uses the built-in reload handler", async () => {
+		const fixture = createFixture(false);
+		prototype.requestReload.call(fixture);
+		expect(fixture.checkReloadRequested).not.toHaveBeenCalled();
+
+		fixture.session.isIdle = true;
+		await prototype.checkReloadRequested.call(fixture);
+
+		expect(fixture.reloadRequested).toBe(false);
+		expect(fixture.handleReloadCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers across compaction and runs after compaction ends", async () => {
+		const fixture = createFixture(true);
+		fixture.session.isCompacting = true;
+		prototype.requestReload.call(fixture);
+		expect(fixture.checkReloadRequested).not.toHaveBeenCalled();
+
+		fixture.session.isCompacting = false;
+		await prototype.checkReloadRequested.call(fixture);
+
+		expect(fixture.handleReloadCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it("gives shutdown precedence over a queued reload", async () => {
+		const fixture = createFixture(true);
+		fixture.reloadRequested = true;
+		fixture.shutdownRequested = true;
+
+		await prototype.checkReloadRequested.call(fixture);
+
+		expect(fixture.handleReloadCommand).not.toHaveBeenCalled();
+	});
+
+	it("coalesces requests while a reload is already running", () => {
+		const fixture = createFixture(true);
+		fixture.reloadInProgress = true;
+
+		prototype.requestReload.call(fixture);
+
+		expect(fixture.reloadRequested).toBe(false);
+		expect(fixture.checkReloadRequested).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -172,6 +172,7 @@ function createRuntimeHost(options: { withAuth: boolean; responseDelayMs: number
 
 async function startRpcMode(options: { withAuth: boolean; responseDelayMs: number; model?: Model<any> }): Promise<{
 	lineHandler: (line: string) => void;
+	runtimeHost: AgentSessionRuntime;
 	cleanup: () => Promise<void>;
 }> {
 	rpcIo.outputLines = [];
@@ -181,13 +182,42 @@ async function startRpcMode(options: { withAuth: boolean; responseDelayMs: numbe
 	void runRpcMode(runtimeHost);
 	await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
 
-	return { lineHandler: rpcIo.lineHandler!, cleanup };
+	return { lineHandler: rpcIo.lineHandler!, runtimeHost, cleanup };
 }
 
 describe("RPC prompt response semantics", () => {
 	afterEach(() => {
 		rpcIo.outputLines = [];
 		rpcIo.lineHandler = undefined;
+	});
+
+	it("reloads from an idle ExtensionContext request", async () => {
+		const { runtimeHost, cleanup } = await startRpcMode({ withAuth: true, responseDelayMs: 0 });
+		const reload = vi.spyOn(runtimeHost.session, "reload");
+
+		try {
+			runtimeHost.session.extensionRunner.createContext().requestReload();
+			await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("defers ExtensionContext reload requests until the agent settles", async () => {
+		const { lineHandler, runtimeHost, cleanup } = await startRpcMode({ withAuth: true, responseDelayMs: 100 });
+		const reload = vi.spyOn(runtimeHost.session, "reload");
+
+		try {
+			lineHandler(JSON.stringify({ id: "reload-busy", type: "prompt", message: "Start" }));
+			await vi.waitFor(() => {
+				expect(getPromptResponses(rpcIo.outputLines, "reload-busy")).toHaveLength(1);
+			});
+			runtimeHost.session.extensionRunner.createContext().requestReload();
+			expect(reload).not.toHaveBeenCalled();
+			await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+		} finally {
+			await cleanup();
+		}
 	});
 
 	it("emits one failure response when prompt preflight rejects", async () => {

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -2,7 +2,7 @@ import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
-import type { BuildSystemPromptOptions, ExtensionAPI } from "../../src/index.ts";
+import type { BuildSystemPromptOptions, ExtensionAPI, ExtensionContext } from "../../src/index.ts";
 import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
 
 describe("AgentSession model and extension characterization", () => {
@@ -347,6 +347,30 @@ describe("AgentSession model and extension characterization", () => {
 		expect(
 			harness.session.messages.some((message) => message.role === "custom" && message.customType === "before-start"),
 		).toBe(true);
+	});
+
+	it("routes ExtensionContext reload requests through AgentSession bindings", async () => {
+		let context: ExtensionContext | undefined;
+		let reloadRequests = 0;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async (_event, ctx) => {
+						context = ctx;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.bindExtensions({
+			reloadRequestHandler: () => {
+				reloadRequests += 1;
+			},
+		});
+		context?.requestReload();
+
+		expect(reloadRequests).toBe(1);
 	});
 
 	it("bindExtensions emits session_start and reload emits session_shutdown then session_start", async () => {

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -17,6 +17,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		abort: vi.fn(),
 		hasPendingMessages: () => false,
 		shutdown: vi.fn(),
+		requestReload: vi.fn(),
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,
 		getSystemPrompt: () => "",


### PR DESCRIPTION
## Summary
- add `ExtensionContext.requestReload()` for event handlers and tools
- defer and coalesce canonical reloads in interactive and RPC modes
- preserve streaming, compaction, shutdown, lifecycle, UI, and failure behavior by routing through existing host reload flows
- update the reload example and extension documentation

## Validation
- `npm run check`
- focused ExtensionRunner and AgentSession binding tests
- interactive idle/busy/compaction/coalescing/shutdown tests
- RPC idle and streaming deferral tests
- real two-runtime RPC and tmux TUI reload validation with the `.pi` coordinator