### PR TITLE
Fix/tree navigation pending tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- Fixed session-tree navigation from racing active agent/tool runs and attaching asynchronous messages to the wrong branch.
+- Fixed session-tree navigation from racing active agent/tool runs and attaching asynchronous messages to the wrong branch. Interactive navigation now offers to abort the active run before switching branches.
 - Fixed inherited OpenRouter model context windows to use the top provider's actual context length ([#6481](https://github.com/earendil-works/pi-mono/pull/6481) by [@davidbrai](https://github.com/davidbrai)).
 - Fixed `Ctrl+V` to paste clipboard text when the pasteboard does not contain an image.
 - Fixed `/login amazon-bedrock` to prompt for and save a Bedrock API key instead of only displaying ambient AWS credential setup instructions.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed session-tree navigation from racing active agent/tool runs and attaching asynchronous messages to the wrong branch.
 - Fixed inherited OpenRouter model context windows to use the top provider's actual context length ([#6481](https://github.com/earendil-works/pi-mono/pull/6481) by [@davidbrai](https://github.com/davidbrai)).
 - Fixed `Ctrl+V` to paste clipboard text when the pasteboard does not contain an image.
 - Fixed `/login amazon-bedrock` to prompt for and save a Bedrock API key instead of only displaying ambient AWS credential setup instructions.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2800,17 +2800,17 @@ export class AgentSession {
 		targetId: string,
 		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string } = {},
 	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
-		if (this._isAgentRunActive) {
-			throw new Error(
-				"Cannot navigate the session tree while an agent run is active. Wait for the agent to become idle.",
-			);
-		}
-
 		const oldLeafId = this.sessionManager.getLeafId();
 
 		// No-op if already at target
 		if (targetId === oldLeafId) {
 			return { cancelled: false };
+		}
+
+		if (this._isAgentRunActive) {
+			throw new Error(
+				"Cannot navigate the session tree while an agent run is active. Wait for the agent to become idle.",
+			);
 		}
 
 		// Model required for summarization

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2800,6 +2800,12 @@ export class AgentSession {
 		targetId: string,
 		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string } = {},
 	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
+		if (this._isAgentRunActive) {
+			throw new Error(
+				"Cannot navigate the session tree while an agent run is active. Wait for the agent to become idle.",
+			);
+		}
+
 		const oldLeafId = this.sessionManager.getLeafId();
 
 		// No-op if already at target

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4594,6 +4594,21 @@ export class InteractiveMode {
 		}
 	}
 
+	private async confirmAbortForTreeNavigation(): Promise<boolean> {
+		if (this.session.isIdle) {
+			return true;
+		}
+
+		const choice = await this.showExtensionSelector("Agent is running", ["Abort and navigate", "Cancel"]);
+		if (choice !== "Abort and navigate") {
+			return false;
+		}
+
+		this.restoreQueuedMessagesToEditor();
+		await this.session.abort();
+		return true;
+	}
+
 	private showTreeSelector(initialSelectedId?: string): void {
 		const tree = this.sessionManager.getTree();
 		const realLeafId = this.sessionManager.getLeafId();
@@ -4617,8 +4632,13 @@ export class InteractiveMode {
 						return;
 					}
 
-					// Ask about summarization
-					done(); // Close selector first
+					// Close the tree selector before showing any follow-up choices.
+					done();
+
+					if (!(await this.confirmAbortForTreeNavigation())) {
+						this.showStatus("Navigation cancelled");
+						return;
+					}
 
 					// Loop until user makes a complete choice or cancels to tree
 					let wantsSummary = false;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4594,13 +4594,14 @@ export class InteractiveMode {
 		}
 	}
 
-	private async confirmAbortForTreeNavigation(): Promise<boolean> {
+	private async promptForTreeNavigationAbort(): Promise<boolean> {
 		if (this.session.isIdle) {
 			return true;
 		}
 
-		const choice = await this.showExtensionSelector("Agent is running", ["Abort and navigate", "Cancel"]);
-		if (choice !== "Abort and navigate") {
+		const confirmationMessage = "Abort and navigate";
+		const choice = await this.showExtensionSelector("Agent is running", [confirmationMessage, "Cancel"]);
+		if (choice !== confirmationMessage) {
 			return false;
 		}
 
@@ -4632,10 +4633,10 @@ export class InteractiveMode {
 						return;
 					}
 
-					// Close the tree selector before showing any follow-up choices.
-					done();
+					// Ask about summarization
+					done(); // Close selector first
 
-					if (!(await this.confirmAbortForTreeNavigation())) {
+					if (!(await this.promptForTreeNavigationAbort())) {
 						this.showStatus("Navigation cancelled");
 						return;
 					}

--- a/packages/coding-agent/test/interactive-mode-tree-navigation.test.ts
+++ b/packages/coding-agent/test/interactive-mode-tree-navigation.test.ts
@@ -10,13 +10,11 @@ type TreeNavigationPromptFixture = {
 	restoreQueuedMessagesToEditor: () => number;
 };
 
-const confirmAbortForTreeNavigation = (
-	InteractiveMode as unknown as {
-		prototype: {
-			confirmAbortForTreeNavigation(this: TreeNavigationPromptFixture): Promise<boolean>;
-		};
-	}
-).prototype.confirmAbortForTreeNavigation;
+type InteractiveModePrototype = {
+	promptForTreeNavigationAbort(this: TreeNavigationPromptFixture): Promise<boolean>;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
 
 describe("InteractiveMode active-run tree navigation", () => {
 	it("continues immediately when the session is idle", async () => {
@@ -26,7 +24,7 @@ describe("InteractiveMode active-run tree navigation", () => {
 			restoreQueuedMessagesToEditor: vi.fn(() => 0),
 		};
 
-		await expect(confirmAbortForTreeNavigation.call(fixture)).resolves.toBe(true);
+		await expect(interactiveModePrototype.promptForTreeNavigationAbort.call(fixture)).resolves.toBe(true);
 		expect(fixture.showExtensionSelector).not.toHaveBeenCalled();
 		expect(fixture.session.abort).not.toHaveBeenCalled();
 	});
@@ -38,7 +36,7 @@ describe("InteractiveMode active-run tree navigation", () => {
 			restoreQueuedMessagesToEditor: vi.fn(() => 0),
 		};
 
-		await expect(confirmAbortForTreeNavigation.call(fixture)).resolves.toBe(false);
+		await expect(interactiveModePrototype.promptForTreeNavigationAbort.call(fixture)).resolves.toBe(false);
 		expect(fixture.showExtensionSelector).toHaveBeenCalledWith("Agent is running", ["Abort and navigate", "Cancel"]);
 		expect(fixture.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
 		expect(fixture.session.abort).not.toHaveBeenCalled();
@@ -60,7 +58,7 @@ describe("InteractiveMode active-run tree navigation", () => {
 			}),
 		};
 
-		await expect(confirmAbortForTreeNavigation.call(fixture)).resolves.toBe(true);
+		await expect(interactiveModePrototype.promptForTreeNavigationAbort.call(fixture)).resolves.toBe(true);
 		expect(calls).toEqual(["restore", "abort"]);
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-tree-navigation.test.ts
+++ b/packages/coding-agent/test/interactive-mode-tree-navigation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type TreeNavigationPromptFixture = {
+	session: {
+		isIdle: boolean;
+		abort: () => Promise<void>;
+	};
+	showExtensionSelector: (title: string, options: string[]) => Promise<string | undefined>;
+	restoreQueuedMessagesToEditor: () => number;
+};
+
+const confirmAbortForTreeNavigation = (
+	InteractiveMode as unknown as {
+		prototype: {
+			confirmAbortForTreeNavigation(this: TreeNavigationPromptFixture): Promise<boolean>;
+		};
+	}
+).prototype.confirmAbortForTreeNavigation;
+
+describe("InteractiveMode active-run tree navigation", () => {
+	it("continues immediately when the session is idle", async () => {
+		const fixture: TreeNavigationPromptFixture = {
+			session: { isIdle: true, abort: vi.fn(async () => {}) },
+			showExtensionSelector: vi.fn(async () => "Cancel"),
+			restoreQueuedMessagesToEditor: vi.fn(() => 0),
+		};
+
+		await expect(confirmAbortForTreeNavigation.call(fixture)).resolves.toBe(true);
+		expect(fixture.showExtensionSelector).not.toHaveBeenCalled();
+		expect(fixture.session.abort).not.toHaveBeenCalled();
+	});
+
+	it("leaves the active run untouched when navigation is cancelled", async () => {
+		const fixture: TreeNavigationPromptFixture = {
+			session: { isIdle: false, abort: vi.fn(async () => {}) },
+			showExtensionSelector: vi.fn(async () => "Cancel"),
+			restoreQueuedMessagesToEditor: vi.fn(() => 0),
+		};
+
+		await expect(confirmAbortForTreeNavigation.call(fixture)).resolves.toBe(false);
+		expect(fixture.showExtensionSelector).toHaveBeenCalledWith("Agent is running", ["Abort and navigate", "Cancel"]);
+		expect(fixture.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
+		expect(fixture.session.abort).not.toHaveBeenCalled();
+	});
+
+	it("restores queued input and waits for abort before navigation continues", async () => {
+		const calls: string[] = [];
+		const fixture: TreeNavigationPromptFixture = {
+			session: {
+				isIdle: false,
+				abort: vi.fn(async () => {
+					calls.push("abort");
+				}),
+			},
+			showExtensionSelector: vi.fn(async () => "Abort and navigate"),
+			restoreQueuedMessagesToEditor: vi.fn(() => {
+				calls.push("restore");
+				return 1;
+			}),
+		};
+
+		await expect(confirmAbortForTreeNavigation.call(fixture)).resolves.toBe(true);
+		expect(calls).toEqual(["restore", "abort"]);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-tree-navigation-active-run.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-tree-navigation-active-run.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+function expectValidToolPairing(messages: AgentMessage[]): void {
+	const pendingToolCalls = new Set<string>();
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			for (const part of message.content) {
+				if (part.type === "toolCall") {
+					pendingToolCalls.add(part.id);
+				}
+			}
+		} else if (message.role === "toolResult") {
+			expect(pendingToolCalls.has(message.toolCallId)).toBe(true);
+			pendingToolCalls.delete(message.toolCallId);
+		}
+	}
+	expect(pendingToolCalls.size).toBe(0);
+}
+
+describe("AgentSession active-run tree navigation", () => {
+	const harnesses: Harness[] = [];
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+		while (tempDirs.length > 0) {
+			const tempDir = tempDirs.pop();
+			if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects navigation until a deferred tool run settles without corrupting persisted context", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-tree-navigation-"));
+		tempDirs.push(tempDir);
+		const sessionDir = join(tempDir, "sessions");
+		const sessionManager = SessionManager.create(tempDir, sessionDir);
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait until the test releases the tool",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ sessionManager, tools: [waitTool] });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("seed reply"),
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("tool run complete"),
+		]);
+
+		await harness.session.prompt("seed");
+		const seedUserEntry = sessionManager
+			.getEntries()
+			.find((entry) => entry.type === "message" && entry.message.role === "user");
+		expect(seedUserEntry).toBeDefined();
+
+		const sawToolStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("run deferred tool");
+		await sawToolStart;
+		const originatingLeafId = sessionManager.getLeafId();
+
+		try {
+			await expect(harness.session.navigateTree(seedUserEntry!.id)).rejects.toThrow(
+				"Cannot navigate the session tree while an agent run is active",
+			);
+			expect(sessionManager.getLeafId()).toBe(originatingLeafId);
+		} finally {
+			releaseToolExecution?.();
+		}
+		await promptPromise;
+
+		const persistedPath = sessionManager.getSessionFile();
+		expect(persistedPath).toBeDefined();
+		const reopened = SessionManager.open(persistedPath!, sessionDir, tempDir);
+		const reopenedContext = reopened.buildSessionContext().messages;
+		expectValidToolPairing(reopenedContext);
+		expect(reopened.getLeafId()).toBe(sessionManager.getLeafId());
+		expect(reopenedContext.filter((message) => message.role === "toolResult")).toHaveLength(1);
+
+		harness.setResponses([
+			(context) => {
+				expectValidToolPairing(context.messages);
+				return fauxAssistantMessage("context valid");
+			},
+		]);
+		await harness.session.prompt("verify context");
+		expect(getMessageText(harness.session.messages.at(-1))).toBe("context valid");
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-tree-navigation-active-run.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-tree-navigation-active-run.test.ts
@@ -85,6 +85,7 @@ describe("AgentSession active-run tree navigation", () => {
 		const originatingLeafId = sessionManager.getLeafId();
 
 		try {
+			await expect(harness.session.navigateTree(originatingLeafId!)).resolves.toEqual({ cancelled: false });
 			await expect(harness.session.navigateTree(seedUserEntry!.id)).rejects.toThrow(
 				"Cannot navigate the session tree while an agent run is active",
 			);

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -69,6 +69,7 @@ export interface HarnessOptions {
 	allowedToolNames?: string[];
 	excludedToolNames?: string[];
 	resourceLoader?: ResourceLoader;
+	sessionManager?: SessionManager;
 	extensionFactories?: Array<InlineExtension | CreateTestExtensionsResultInput>;
 	withConfiguredAuth?: boolean;
 }
@@ -108,7 +109,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	const withConfiguredAuth = options.withConfiguredAuth ?? true;
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
 
-	const sessionManager = SessionManager.inMemory();
+	const sessionManager = options.sessionManager ?? SessionManager.inMemory();
 	const settingsManager = SettingsManager.inMemory(options.settings);
 
 	const authStorage = AuthStorage.inMemory();


### PR DESCRIPTION
Prevent /tree from switching branches while an agent or tool is running. Users can either cancel navigation or abort
the active run before navigating, preventing tool results from attaching to the wrong branch.

Includes regression coverage for idle, cancel, and abort flows.

Fixes [#6558](https://github.com/earendil-works/pi/issues/6558).