### PR TITLE
fix(tui): disable terminal auto-wrap to prevent double rendering

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -144,7 +144,8 @@ export class ProcessTerminal implements Terminal {
 		process.stdin.resume();
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
-		process.stdout.write("\x1b[?2004h");
+		// Also disable terminal auto-wrap to prevent double-wrapping bugs during differential rendering.
+		process.stdout.write("\x1b[?2004h\x1b[?7l");
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -408,8 +409,8 @@ export class ProcessTerminal implements Terminal {
 			process.stdout.write(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
 		}
 
-		// Disable bracketed paste mode
-		process.stdout.write("\x1b[?2004l");
+		// Disable bracketed paste mode and restore auto-wrap
+		process.stdout.write("\x1b[?2004l\x1b[?7h");
 
 		const shouldDisableKittyProtocol = this.keyboardProtocolPushed || this._kittyProtocolActive;
 		this.clearKeyboardProtocolNegotiationBuffer();

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -33,7 +33,8 @@ export class VirtualTerminal implements Terminal {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
 		// Enable bracketed paste mode for consistency with ProcessTerminal
-		this.xterm.write("\x1b[?2004h");
+		// Also disable terminal auto-wrap
+		this.xterm.write("\x1b[?2004h\x1b[?7l");
 	}
 
 	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {
@@ -41,8 +42,8 @@ export class VirtualTerminal implements Terminal {
 	}
 
 	stop(): void {
-		// Disable bracketed paste mode
-		this.xterm.write("\x1b[?2004l");
+		// Disable bracketed paste mode and restore auto-wrap
+		this.xterm.write("\x1b[?2004l\x1b[?7h");
 		this.inputHandler = undefined;
 		this.resizeHandler = undefined;
 	}


### PR DESCRIPTION
Disables terminal auto-wrap (DECAWM) during TUI sessions to prevent double-wrapping issues and cursor/rendering desynchronization on lines matching the terminal width.