### PR TITLE
fix(coding-agent): coerce numeric read ranges

### DIFF
--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -568,18 +568,22 @@
         return p;
       }
 
+      function formatReadLineRange(offset, limit) {
+        if (offset === undefined && limit === undefined) return '';
+        const start = offset ?? 1;
+        const numericStart = Number(start);
+        const numericLimit = Number(limit);
+        const end = limit !== undefined && Number.isFinite(numericStart) && Number.isFinite(numericLimit)
+          ? numericStart + numericLimit - 1
+          : '';
+        return `:${start}${end ? `-${end}` : ''}`;
+      }
+
       function formatToolCall(name, args) {
         switch (name) {
           case 'read': {
             const path = shortenPath(String(args.path || args.file_path || ''));
-            const offset = args.offset;
-            const limit = args.limit;
-            let display = path;
-            if (offset !== undefined || limit !== undefined) {
-              const start = offset ?? 1;
-              const end = limit !== undefined ? start + limit - 1 : '';
-              display += `:${start}${end ? `-${end}` : ''}`;
-            }
+            const display = path + formatReadLineRange(args.offset, args.limit);
             return `[read: ${display}]`;
           }
           case 'write':
@@ -945,14 +949,11 @@
           }
           case 'read': {
             const filePath = str(args.file_path ?? args.path);
-            const offset = args.offset;
-            const limit = args.limit;
 
             let pathHtml = filePath === null ? invalidArg : escapeHtml(shortenPath(filePath || ''));
-            if (filePath !== null && (offset !== undefined || limit !== undefined)) {
-              const startLine = offset ?? 1;
-              const endLine = limit !== undefined ? startLine + limit - 1 : '';
-              pathHtml += `<span class="line-numbers">:${startLine}${endLine ? '-' + endLine : ''}</span>`;
+            const lineRange = formatReadLineRange(args.offset, args.limit);
+            if (filePath !== null && lineRange) {
+              pathHtml += `<span class="line-numbers">${escapeHtml(lineRange)}</span>`;
             }
 
             html += `<div class="tool-header"><span class="tool-name">read</span> <span class="tool-path">${pathHtml}</span></div>`;

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -62,12 +62,22 @@ export interface ReadToolOptions {
 	operations?: ReadOperations;
 }
 
-type ReadRenderArgs = { path?: string; file_path?: string; offset?: number; limit?: number };
+type ReadRenderArgs = {
+	path?: string;
+	file_path?: string;
+	offset?: number | string;
+	limit?: number | string;
+};
 
 function formatReadLineRange(args: ReadRenderArgs | undefined, theme: Theme): string {
 	if (args?.offset === undefined && args?.limit === undefined) return "";
 	const startLine = args.offset ?? 1;
-	const endLine = args.limit !== undefined ? startLine + args.limit - 1 : "";
+	const numericStartLine = Number(startLine);
+	const numericLimit = Number(args.limit);
+	const endLine =
+		args.limit !== undefined && Number.isFinite(numericStartLine) && Number.isFinite(numericLimit)
+			? numericStartLine + numericLimit - 1
+			: "";
 	return theme.fg("warning", `:${startLine}${endLine ? `-${endLine}` : ""}`);
 }
 

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -945,12 +945,17 @@ class TreeList implements Component {
 		switch (name) {
 			case "read": {
 				const path = shortenPath(String(args.path || args.file_path || ""));
-				const offset = args.offset as number | undefined;
-				const limit = args.limit as number | undefined;
+				const offset = args.offset as number | string | undefined;
+				const limit = args.limit as number | string | undefined;
 				let display = path;
 				if (offset !== undefined || limit !== undefined) {
 					const start = offset ?? 1;
-					const end = limit !== undefined ? start + limit - 1 : "";
+					const numericStart = Number(start);
+					const numericLimit = Number(limit);
+					const end =
+						limit !== undefined && Number.isFinite(numericStart) && Number.isFinite(numericLimit)
+							? numericStart + numericLimit - 1
+							: "";
 					display += `:${start}${end ? `-${end}` : ""}`;
 				}
 				return `[read: ${display}]`;

--- a/packages/coding-agent/test/export-html-read-range.test.ts
+++ b/packages/coding-agent/test/export-html-read-range.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("export HTML read ranges", () => {
+	const templateJs = readFileSync(new URL("../src/core/export-html/template.js", import.meta.url), "utf-8");
+	const helperSource = templateJs.match(/function formatReadLineRange\(offset, limit\) \{[\s\S]*?^ {6}\}/m)?.[0];
+	if (!helperSource) throw new Error("formatReadLineRange helper not found in export template");
+	const formatReadLineRange = new Function(`${helperSource}; return formatReadLineRange;`)() as (
+		offset: unknown,
+		limit: unknown,
+	) => string;
+
+	it("renders numeric string arguments as an arithmetic range", () => {
+		expect(formatReadLineRange("380", "50")).toBe(":380-429");
+		expect(formatReadLineRange("580", "50")).toBe(":580-629");
+	});
+
+	it("preserves numeric arguments", () => {
+		expect(formatReadLineRange(380, 50)).toBe(":380-429");
+	});
+});

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -134,6 +134,21 @@ describe("ToolExecutionComponent parity", () => {
 		expect(rendered).toContain("README.md");
 	});
 
+	test("renders numeric string read ranges without concatenating them", () => {
+		const component = new ToolExecutionComponent(
+			"read",
+			"tool-string-range",
+			{ path: "README.md", offset: "380", limit: "50" },
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("README.md:380-429");
+		expect(rendered).not.toContain("38049");
+	});
+
 	test("bash execute emits an initial empty partial update before output arrives", async () => {
 		const updates: Array<{ content: Array<{ type: string; text?: string }>; details?: unknown }> = [];
 		const operations: BashOperations = {

--- a/packages/coding-agent/test/tree-selector.test.ts
+++ b/packages/coding-agent/test/tree-selector.test.ts
@@ -59,7 +59,11 @@ function assistantMessage(id: string, parentId: string | null, text: string): Se
 }
 
 // Helper to create a tool-call-only assistant message (filtered out in default mode)
-function toolCallOnlyAssistant(id: string, parentId: string | null): SessionMessageEntry {
+function toolCallOnlyAssistant(
+	id: string,
+	parentId: string | null,
+	args: Record<string, unknown> = { path: "test.ts" },
+): SessionMessageEntry {
 	return {
 		type: "message",
 		id,
@@ -67,7 +71,7 @@ function toolCallOnlyAssistant(id: string, parentId: string | null): SessionMess
 		timestamp: new Date().toISOString(),
 		message: {
 			role: "assistant",
-			content: [{ type: "toolCall", id: `tc-${id}`, name: "read", arguments: { path: "test.ts" } }],
+			content: [{ type: "toolCall", id: `tc-${id}`, name: "read", arguments: args }],
 			api: "anthropic-messages",
 			provider: "anthropic",
 			model: "claude-sonnet-4",
@@ -126,6 +130,44 @@ function buildTree(entries: Array<SessionEntry>): SessionTreeNode[] {
 }
 
 describe("TreeSelectorComponent", () => {
+	test("renders numeric string read ranges without concatenating them", () => {
+		const entries = [
+			userMessage("user-1", null, "inspect"),
+			toolCallOnlyAssistant("tool-asst-1", "user-1", {
+				path: "test.ts",
+				offset: "380",
+				limit: "50",
+			}),
+			{
+				type: "message" as const,
+				id: "tool-result-1",
+				parentId: "tool-asst-1",
+				timestamp: new Date().toISOString(),
+				message: {
+					role: "toolResult" as const,
+					toolCallId: "tc-tool-asst-1",
+					toolName: "read",
+					content: [{ type: "text" as const, text: "contents" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			},
+		];
+		const selector = new TreeSelectorComponent(
+			buildTree(entries),
+			"tool-result-1",
+			24,
+			() => {},
+			() => {},
+			undefined,
+			undefined,
+			"all",
+		);
+		const rendered = selector.render(120).map(stripVTControlCharacters).join("\n");
+		expect(rendered).toContain("[read: test.ts:380-429]");
+		expect(rendered).not.toContain("38049");
+	});
+
 	describe("initial selection with metadata entries", () => {
 		test("focuses nearest visible ancestor when currentLeafId is a model_change with sibling branch", () => {
 			// Tree structure:


### PR DESCRIPTION
## Summary

- coerce numeric-string read offsets and limits before calculating displayed line ranges
- apply the same range formatting to interactive tool cards, session tree history, and HTML exports
- add regressions for the observed `offset: "380"`, `limit: "50"` case

## Root cause

Tool arguments can remain strings in the raw tool call used by renderers even though execution converts them through the tool schema. JavaScript addition therefore concatenated the start and limit before subtracting one, rendering `380-38049` instead of `380-429`.

## Verification

- `npm run check`
- `npm run build`
- `./test.sh` with an isolated HOME: agent 180 passed; AI 494 passed and 733 skipped; coding-agent 1539 passed and 47 skipped; TUI passed
- focused renderer regressions: 44 passed
