### PR TITLE
fix(ai): respect forceAdaptiveThinking for Bedrock models

### DIFF
--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -219,7 +219,8 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 				addCustomHeadersMiddleware(client, customHeaders);
 			}
 			const cacheRetention = resolveCacheRetention(options.cacheRetention, options.env);
-			const inferenceMaxTokens = options.maxTokens ?? (isAnthropicClaudeModel(model) ? model.maxTokens : undefined);
+			const inferenceMaxTokens =
+				options.maxTokens ?? (usesAnthropicClaudeProtocol(model) ? model.maxTokens : undefined);
 			let commandInput = {
 				modelId: model.id,
 				messages: convertMessages(context, model, cacheRetention, options.env),
@@ -395,8 +396,8 @@ export const streamSimple: StreamFunction<"bedrock-converse-stream", SimpleStrea
 		return stream(model, context, { ...base, reasoning: undefined } satisfies BedrockOptions);
 	}
 
-	if (isAnthropicClaudeModel(model)) {
-		if (supportsAdaptiveThinking(model.id, model.name)) {
+	if (usesAnthropicClaudeProtocol(model)) {
+		if (supportsAdaptiveThinking(model)) {
 			return stream(model, context, {
 				...base,
 				reasoning: options.reasoning,
@@ -570,8 +571,11 @@ function getModelMatchCandidates(modelId: string, modelName?: string): string[] 
 	});
 }
 
-function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean {
-	const candidates = getModelMatchCandidates(modelId, modelName);
+function supportsAdaptiveThinking(model: Model<"bedrock-converse-stream">): boolean {
+	const configured = model.compat?.forceAdaptiveThinking;
+	if (typeof configured === "boolean") return configured;
+
+	const candidates = getModelMatchCandidates(model.id, model.name);
 	return candidates.some(
 		(s) =>
 			s.includes("opus-4-6") ||
@@ -643,6 +647,10 @@ function isAnthropicClaudeModel(model: Model<"bedrock-converse-stream">): boolea
 	);
 }
 
+function usesAnthropicClaudeProtocol(model: Model<"bedrock-converse-stream">): boolean {
+	return typeof model.compat?.forceAdaptiveThinking === "boolean" || isAnthropicClaudeModel(model);
+}
+
 /**
  * Check if the model supports prompt caching.
  * Supported: Claude 3.5 Haiku, Claude 3.7 Sonnet, Claude 4.x models, Claude 5 models
@@ -685,7 +693,7 @@ function supportsPromptCaching(model: Model<"bedrock-converse-stream">, env?: Pr
  * Checks both model ID and model name to support application inference profiles.
  */
 function supportsThinkingSignature(model: Model<"bedrock-converse-stream">): boolean {
-	return isAnthropicClaudeModel(model);
+	return usesAnthropicClaudeProtocol(model);
 }
 
 function buildSystemPrompt(
@@ -1015,11 +1023,12 @@ function buildAdditionalModelRequestFields(
 		return undefined;
 	}
 
-	if (isAnthropicClaudeModel(model)) {
+	if (usesAnthropicClaudeProtocol(model)) {
 		// GovCloud Bedrock currently rejects the Claude thinking.display field.
 		// Omit it there until the GovCloud Converse schema catches up.
 		const display = isGovCloudBedrockTarget(model, options) ? undefined : (options.thinkingDisplay ?? "summarized");
-		const result: Record<string, any> = supportsAdaptiveThinking(model.id, model.name)
+		const adaptiveThinking = supportsAdaptiveThinking(model);
+		const result: Record<string, any> = adaptiveThinking
 			? {
 					thinking: { type: "adaptive", ...(display !== undefined ? { display } : {}) },
 					output_config: { effort: mapThinkingLevelToEffort(model, options.reasoning) },
@@ -1047,7 +1056,7 @@ function buildAdditionalModelRequestFields(
 					};
 				})();
 
-		if (!supportsAdaptiveThinking(model.id, model.name) && (options.interleavedThinking ?? true)) {
+		if (!adaptiveThinking && (options.interleavedThinking ?? true)) {
 			result.anthropic_beta = ["interleaved-thinking-2025-05-14"];
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -535,6 +535,16 @@ export interface OpenAIResponsesCompat {
 	supportsToolSearch?: boolean;
 }
 
+/** Compatibility settings for Bedrock Converse models. */
+export interface BedrockConverseCompat {
+	/**
+	 * Overrides adaptive-thinking detection. `true` uses `thinking.type:
+	 * "adaptive"` plus `output_config.effort`; `false` uses budget-based
+	 * thinking. When omitted, Bedrock falls back to model ID/name detection.
+	 */
+	forceAdaptiveThinking?: boolean;
+}
+
 /** Compatibility settings for Anthropic Messages-compatible APIs. */
 export interface AnthropicMessagesCompat {
 	/**
@@ -711,14 +721,16 @@ export interface Model<TApi extends Api> {
 	contextWindow: number;
 	maxTokens: number;
 	headers?: Record<string, string>;
-	/** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
+	/** API-specific compatibility overrides. */
 	compat?: TApi extends "openai-completions"
 		? OpenAICompletionsCompat
 		: TApi extends "openai-responses" | "openai-codex-responses"
 			? OpenAIResponsesCompat
 			: TApi extends "anthropic-messages"
 				? AnthropicMessagesCompat
-				: never;
+				: TApi extends "bedrock-converse-stream"
+					? BedrockConverseCompat
+					: never;
 }
 
 export interface ImagesModel<TApi extends ImagesApi>

--- a/packages/ai/test/bedrock-thinking-payload.test.ts
+++ b/packages/ai/test/bedrock-thinking-payload.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { type BedrockOptions, stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
+import {
+	type BedrockOptions,
+	stream as streamBedrock,
+	streamSimple as streamSimpleBedrock,
+} from "../src/api/bedrock-converse-stream.ts";
 import { getModel } from "../src/compat.ts";
-import type { Context, Model } from "../src/types.ts";
+import type { Context, Model, SimpleStreamOptions } from "../src/types.ts";
 import { hasBedrockCredentials } from "./bedrock-utils.ts";
 
 interface BedrockThinkingPayload {
+	inferenceConfig?: { maxTokens?: number };
 	additionalModelRequestFields?: {
 		thinking?: { type: string; budget_tokens?: number; display?: string };
 		output_config?: { effort?: string };
@@ -52,7 +57,62 @@ async function capturePayload(
 	return capturedPayload;
 }
 
+async function captureSimplePayload(
+	model: Model<"bedrock-converse-stream">,
+	options: SimpleStreamOptions,
+): Promise<BedrockThinkingPayload> {
+	let capturedPayload: BedrockThinkingPayload | undefined;
+	const s = streamSimpleBedrock(model, makeContext(), {
+		...options,
+		onPayload: (payload) => {
+			capturedPayload = payload as BedrockThinkingPayload;
+			throw new PayloadCaptured();
+		},
+	});
+
+	for await (const event of s) {
+		if (event.type === "error") break;
+	}
+
+	if (!capturedPayload) throw new Error("Expected Bedrock payload to be captured before request abort");
+	return capturedPayload;
+}
+
 describe("Bedrock thinking payload", () => {
+	it("honors compat.forceAdaptiveThinking for opaque Claude profiles", async () => {
+		const model: Model<"bedrock-converse-stream"> = {
+			...getModel("amazon-bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+			id: "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/custom-profile",
+			name: "Opus 5 profile",
+			compat: { forceAdaptiveThinking: true },
+		};
+
+		const payload = await captureSimplePayload(model, { reasoning: "medium", maxTokens: 4096 });
+
+		expect(payload.inferenceConfig?.maxTokens).toBe(4096);
+		expect(payload.additionalModelRequestFields?.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.additionalModelRequestFields?.output_config).toEqual({ effort: "medium" });
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toBeUndefined();
+	});
+
+	it("allows compat.forceAdaptiveThinking=false to opt out", async () => {
+		const model: Model<"bedrock-converse-stream"> = {
+			...getModel("amazon-bedrock", "global.anthropic.claude-opus-4-6-v1"),
+			compat: { forceAdaptiveThinking: false },
+		};
+
+		const payload = await captureSimplePayload(model, { reasoning: "medium", maxTokens: 4096 });
+
+		expect(payload.inferenceConfig?.maxTokens).toBe(12288);
+		expect(payload.additionalModelRequestFields?.thinking).toEqual({
+			type: "enabled",
+			budget_tokens: 8192,
+			display: "summarized",
+		});
+		expect(payload.additionalModelRequestFields?.output_config).toBeUndefined();
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toEqual(["interleaved-thinking-2025-05-14"]);
+	});
+
 	it("uses adaptive thinking for Claude Opus 4.8 when reasoning is enabled", async () => {
 		const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-opus-4-6-v1");
 		const model: Model<"bedrock-converse-stream"> = {

--- a/packages/ai/test/bedrock-thinking-payload.test.ts
+++ b/packages/ai/test/bedrock-thinking-payload.test.ts
@@ -83,7 +83,7 @@ describe("Bedrock thinking payload", () => {
 		const model: Model<"bedrock-converse-stream"> = {
 			...getModel("amazon-bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
 			id: "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/custom-profile",
-			name: "Opus 5 profile",
+			name: "Custom profile",
 			compat: { forceAdaptiveThinking: true },
 		};
 

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -12,6 +12,7 @@ Add custom providers and models (Ollama, vLLM, LM Studio, proxies) via `~/.pi/ag
 - [Overriding Built-in Providers](#overriding-built-in-providers)
 - [Per-model Overrides](#per-model-overrides)
 - [Anthropic Messages Compatibility](#anthropic-messages-compatibility)
+- [Amazon Bedrock Compatibility](#amazon-bedrock-compatibility)
 - [OpenAI Compatibility](#openai-compatibility)
 
 ## Minimal Example
@@ -407,6 +408,10 @@ Some Anthropic-compatible providers emit thinking blocks with empty signatures a
 | `supportsCacheControlOnTools` | Whether the provider accepts Anthropic-style `cache_control` markers on tool definitions. Default: `true`. |
 | `forceAdaptiveThinking` | Whether to send adaptive thinking (`thinking.type: "adaptive"` plus `output_config.effort`) for this model. Built-in adaptive models set this automatically. Default: `false`. |
 | `allowEmptySignature` | Whether to replay empty thinking signatures as `signature: ""` instead of converting thinking to text. Default: `false`. |
+
+## Amazon Bedrock Compatibility
+
+For custom Claude models using `api: "bedrock-converse-stream"`, set model-level `compat.forceAdaptiveThinking` in the model definition or `modelOverrides`. `true` forces `thinking.type: "adaptive"` plus `output_config.effort`, `false` forces budget-based thinking, and an omitted value keeps the existing model ID/name fallback. Setting either boolean also opts opaque profile IDs and generic model names into Claude-specific thinking, max-token, and signature handling.
 
 ## OpenAI Compatibility
 


### PR DESCRIPTION
Fixes #6212

I ran into this on v0.79.8 while registering Claude Sonnet 5 for Bedrock through `models.json`. The model had `compat.forceAdaptiveThinking: true`, but the Bedrock path ignored it and relied only on a hardcoded model ID/name list. Because the model was not in that list, pi sent `thinking.type: "enabled"`, which Bedrock rejected because the model required adaptive thinking.

This change makes the explicit model setting take precedence for `bedrock-converse-stream`:

- `true` sends adaptive thinking with `output_config.effort`.
- `false` keeps budget-based thinking.
- An omitted value keeps the existing ID/name detection for built-in models.

Tests cover both explicit values:

- `true` makes an opaque profile use adaptive thinking and effort, without the legacy beta field.
- `false` makes an adaptive model use budget-based thinking and the legacy beta field.

Tested with:

- `npm run check`
- `./test.sh`
- `bedrock-thinking-payload.test.ts`