### PR TITLE
ai: OpenAI and Codex forced tool calls

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added cache-friendly dynamic tool loading. `ToolResultMessage.addedToolNames` marks where tools from `Context.tools` became available; Anthropic and OpenAI Responses use native deferred loading so late tools stay out of the cached prefix, while other providers continue using `Context.tools` normally ([#6474](https://github.com/earendil-works/pi-mono/pull/6474)).
 - Added native `xhigh` and `max` thinking levels for Claude Fable 5 across all generated provider catalogs ([#6490](https://github.com/earendil-works/pi-mono/pull/6490) by [@davidbrai](https://github.com/davidbrai)).
+- Added `toolChoice` support to OpenAI Codex Responses, including `"required"` to force a tool call.
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added cache-friendly dynamic tool loading. `ToolResultMessage.addedToolNames` marks where tools from `Context.tools` became available; Anthropic and OpenAI Responses use native deferred loading so late tools stay out of the cached prefix, while other providers continue using `Context.tools` normally ([#6474](https://github.com/earendil-works/pi-mono/pull/6474)).
 - Added native `xhigh` and `max` thinking levels for Claude Fable 5 across all generated provider catalogs ([#6490](https://github.com/earendil-works/pi-mono/pull/6490) by [@davidbrai](https://github.com/davidbrai)).
 - Added `toolChoice` support to OpenAI Codex Responses, including `"required"` to force a tool call.
+- Added `toolChoice` support to OpenAI Responses, including required and named tool selection.
 
 ### Fixed
 

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -85,6 +85,7 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	textVerbosity?: "low" | "medium" | "high";
+	toolChoice?: "auto" | "none" | "required";
 }
 
 type CodexResponseStatus = "completed" | "incomplete" | "failed" | "cancelled" | "queued" | "in_progress";
@@ -97,7 +98,7 @@ interface RequestBody {
 	previous_response_id?: string;
 	input?: ResponseInput;
 	tools?: OpenAITool[];
-	tool_choice?: "auto";
+	tool_choice?: OpenAICodexResponsesOptions["toolChoice"];
 	parallel_tool_calls?: boolean;
 	temperature?: number;
 	reasoning?: { effort?: string; summary?: string };
@@ -497,7 +498,7 @@ function buildRequestBody(
 		text: { verbosity: options?.textVerbosity || "low" },
 		include: ["reasoning.encrypted_content"],
 		prompt_cache_key: clampOpenAIPromptCacheKey(options?.sessionId),
-		tool_choice: "auto",
+		tool_choice: options?.toolChoice ?? "auto",
 		parallel_tool_calls: true,
 	};
 

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -83,6 +83,7 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
+	toolChoice?: ResponseCreateParamsStreaming["tool_choice"];
 }
 
 /**
@@ -252,6 +253,10 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 
 	if (toolPlacement.immediate.length > 0) {
 		params.tools = convertResponsesTools(toolPlacement.immediate);
+	}
+
+	if (options?.toolChoice !== undefined) {
+		params.tool_choice = options.toolChoice;
 	}
 
 	if (model.reasoning) {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { zstdDecompressSync } from "node:zlib";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	closeOpenAICodexWebSocketSessions,
@@ -698,6 +699,61 @@ describe("openai-codex streaming", () => {
 		}).result();
 
 		expect(requestedReasoning).toEqual({ effort: "xhigh", summary: "auto" });
+	});
+
+	it("forwards required tool choice", async () => {
+		const token = mockToken();
+		const encoder = new TextEncoder();
+		const sse = buildSSEPayload({ status: "completed" });
+		let requestedToolChoice: unknown;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL, init?: RequestInit) => {
+				requestedToolChoice = decodeCodexRequestBody(init?.body)?.tool_choice;
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(encoder.encode(sse));
+							controller.close();
+						},
+					}),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}),
+		);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		await streamOpenAICodexResponses(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Do not call ping. Respond with text instead.", timestamp: Date.now() },
+				],
+				tools: [
+					{
+						name: "ping",
+						description: "Ping",
+						parameters: Type.Object({ value: Type.String() }),
+					},
+				],
+			},
+			{ apiKey: token, transport: "sse", toolChoice: "required" },
+		).result();
+
+		expect(requestedToolChoice).toBe("required");
 	});
 
 	it.each(["gpt-5.3-codex", "gpt-5.4", "gpt-5.5"])("clamps %s minimal reasoning effort to low", async (modelId) => {

--- a/packages/ai/test/openai-responses-copilot-provider.test.ts
+++ b/packages/ai/test/openai-responses-copilot-provider.test.ts
@@ -1,3 +1,4 @@
+import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { stream as streamOpenAIResponses } from "../src/api/openai-responses.ts";
 import { getModel } from "../src/compat.ts";
@@ -88,6 +89,53 @@ describe("openai-responses provider defaults", () => {
 		expect(capturedPayload).not.toBeNull();
 		expect(capturedPayload).not.toMatchObject({
 			reasoning: expect.anything(),
+		});
+	});
+
+	it("forwards required tool choice", async () => {
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			getModel("openai", "gpt-5.4"),
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Do not call ping. Respond with text instead.",
+						timestamp: Date.now(),
+					},
+				],
+				tools: [
+					{
+						name: "ping",
+						description: "Ping",
+						parameters: Type.Object({ value: Type.String() }),
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				toolChoice: "required",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).toMatchObject({
+			tool_choice: "required",
+			tools: [expect.objectContaining({ name: "ping" })],
 		});
 	});
 


### PR DESCRIPTION
closes #6585

Tested with live test that forced tool calls despite asking the model to not call tools:

```ts
import { Type } from "typebox";
import { stream as streamCodex } from "./packages/ai/src/api/openai-codex-responses.ts";
import { stream as streamOpenAI } from "./packages/ai/src/api/openai-responses.ts";
import { getModel } from "./packages/ai/src/compat.ts";
import type { AssistantMessage, Context } from "./packages/ai/src/types.ts";
import { resolveApiKey } from "./packages/ai/test/oauth.ts";

const tool = {
	name: "report_probe",
	description: "Report a probe value.",
	parameters: Type.Object({ value: Type.String() }, { additionalProperties: false }),
};

const context: Context = {
	messages: [
		{
			role: "user",
			content: "Do not call report_probe. Respond with plain text instead.",
			timestamp: Date.now(),
		},
	],
	tools: [tool],
};

function assertToolCall(label: string, result: AssistantMessage): void {
	const call = result.content.find((part) => part.type === "toolCall");
	if (!call) throw new Error(`${label}: response did not contain a tool call (stopReason=${result.stopReason})`);
	if (call.name !== tool.name) throw new Error(`${label}: called ${call.name} instead of ${tool.name}`);
	console.log(`${label}: PASS (${call.name}, stopReason=${result.stopReason})`);
}

const openAIKey = process.env.OPENAI_API_KEY;
if (!openAIKey) throw new Error("OPENAI_API_KEY is not available from .env");

const openAIModel = getModel("openai", "gpt-5.4");
if (!openAIModel) throw new Error("openai/gpt-5.4 model not found");

assertToolCall(
	"openai",
	await streamOpenAI(openAIModel, context, {
		apiKey: openAIKey,
		toolChoice: "required",
		maxTokens: 128,
	}).result(),
);

const codexKey = await resolveApiKey("openai-codex");
if (!codexKey) throw new Error("OpenAI Codex auth is not available from ~/.pi/agent/auth.json");

const codexModel = getModel("openai-codex", "gpt-5.5");
if (!codexModel) throw new Error("openai-codex/gpt-5.5 model not found");

assertToolCall(
	"openai-codex",
	await streamCodex(codexModel, context, {
		apiKey: codexKey,
		toolChoice: "required",
		maxTokens: 128,
		transport: "sse",
	}).result(),
);
```

```
 $ node --env-file=.env pi-live-tool-choice.ts (timeout 180s)

 openai: PASS (report_probe, stopReason=toolUse)
 openai-codex: PASS (report_probe, stopReason=toolUse)
```
