### PR TITLE
rpc: sanitize unpaired UTF-16 surrogates in JSONL output

### DIFF
--- a/packages/coding-agent/src/modes/rpc/jsonl.ts
+++ b/packages/coding-agent/src/modes/rpc/jsonl.ts
@@ -2,13 +2,25 @@ import type { Readable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 
 /**
+ * Replace unpaired UTF-16 surrogates in string values with U+FFFD.
+ *
+ * JavaScript strings tolerate lone surrogates (e.g. an emoji split across
+ * streaming chunks), and well-formed JSON.stringify serializes them as lone
+ * `\udXXX` escapes. Strict JSON parsers (e.g. Emacs' native json-parse)
+ * reject such records, so sanitize before serializing.
+ */
+function wellFormedReplacer(_key: string, value: unknown): unknown {
+	return typeof value === "string" ? value.toWellFormed() : value;
+}
+
+/**
  * Serialize a single strict JSONL record.
  *
  * Framing is LF-only. Payload strings may contain other Unicode separators such as
  * U+2028 and U+2029. Clients must split records on `\n` only.
  */
 export function serializeJsonLine(value: unknown): string {
-	return `${JSON.stringify(value)}\n`;
+	return `${JSON.stringify(value, wellFormedReplacer)}\n`;
 }
 
 /**

--- a/packages/coding-agent/test/rpc-jsonl.test.ts
+++ b/packages/coding-agent/test/rpc-jsonl.test.ts
@@ -11,6 +11,21 @@ describe("RPC JSONL framing", () => {
 		expect(JSON.parse(line.trim())).toEqual({ text: "a\u2028b\u2029c" });
 	});
 
+	test("replaces unpaired surrogates so strict parsers accept the record", () => {
+		// A high surrogate without its low half, as produced when an emoji is
+		// split across streaming chunks.
+		const line = serializeJsonLine({ text: "hi \ud83d", nested: ["\ude00 bye"] });
+
+		expect(line).not.toMatch(/\\ud[89ab]/i);
+		expect(JSON.parse(line.trim())).toEqual({ text: "hi \ufffd", nested: ["\ufffd bye"] });
+	});
+
+	test("preserves well-formed astral characters", () => {
+		const line = serializeJsonLine({ text: "hi \u{1f600}" });
+
+		expect(JSON.parse(line.trim())).toEqual({ text: "hi \u{1f600}" });
+	});
+
 	test("splits on LF only and preserves U+2028/U+2029 inside payloads", async () => {
 		const lines: string[] = [];
 		const stream = Readable.from([serializeJsonLine({ text: "a\u2028b\u2029c" })]);


### PR DESCRIPTION
## Problem

JavaScript strings tolerate lone UTF-16 surrogates (e.g. an emoji split across streaming chunks), and well-formed `JSON.stringify` (ES2019) serializes them as lone `\udXXX` escape sequences. The resulting JSONL record is rejected by strict JSON parsers.

Concretely, Emacs' native `json-parse-buffer` — used by the pimacs.el RPC client — fails with:

```
error in process filter: invalid surrogate pair: 1, 1539, 1539
```

which (before defensive handling on the client side) permanently wedged the RPC stream.

## Fix

`serializeJsonLine` now passes a replacer to `JSON.stringify` that applies `String.prototype.toWellFormed()` (Node ≥ 20; engines require ≥ 22.19) to string values, replacing unpaired surrogates with U+FFFD. Valid surrogate pairs, astral characters, and U+2028/U+2029 handling are unaffected.

## Tests

- new: lone high/low surrogates replaced, output contains no lone `\ud8xx-\udbxx` escapes, parses cleanly
- new: well-formed astral characters round-trip unchanged
- existing JSONL framing tests still pass (6/6)

Related client-side hardening: ananthakumaran/pimacs.el#6

Marked draft for review.