### PR TITLE
feat(agent): allow message_end hooks of AgentHarness to replace the finalized message before persistence

### DIFF
--- a/packages/agent/docs/hooks.md
+++ b/packages/agent/docs/hooks.md
@@ -45,7 +45,7 @@ interface ToolCallEvent extends HookEvent<"tool_call", { block?: boolean; reason
 	input: Record<string, unknown>;
 }
 
-interface MessageEndEvent extends HookEvent<"message_end"> {
+interface MessageEndEvent extends HookEvent<"message_end", { message?: AgentMessage }> {
 	type: "message_end";
 	message: AgentMessage;
 }
@@ -139,6 +139,8 @@ class DefaultAgentHarnessHooks<E extends HookEvent<string, unknown>, Ctx>
 				return this.emitToolCall(event, signal);
 			case "tool_result":
 				return this.emitToolResult(event, signal);
+			case "message_end":
+				return this.emitMessageEnd(event, signal);
 			case "session_before_compact":
 			case "session_before_tree":
 				return this.emitFirstCancelOrLast(event, signal);
@@ -157,10 +159,10 @@ Internal casts are acceptable inside the implementation because `Map<string, ...
 ### Observation
 
 ```ts
-await hooks.emit({ type: "message_end", message }, signal);
+await hooks.emit({ type: "after_provider_response", status, headers }, signal);
 ```
 
-Observers run. `message_end` handlers run. Return ignored unless that event later gets a result type.
+Observers run. `after_provider_response` handlers run. Return ignored because the event defines no result type.
 
 ### Context transform
 
@@ -251,6 +253,23 @@ for (const handler of handlers("tool_result")) {
 return modified
 	? { content: current.content, details: current.details, isError: current.isError }
 	: undefined;
+```
+
+### Message end
+
+Sequential transform before persistence. Each handler sees the previous replacement. Replacements must keep the original message role and get missing/`null` content normalized; invalid replacements throw and nothing is persisted. Implemented in the current harness as `emitMessageEnd()`.
+
+```ts
+let current = event;
+
+for (const handler of handlers("message_end")) {
+	const result = await handler(current, ctx, signal);
+	if (result?.message !== undefined) {
+		current = { ...current, message: normalizeReplacement(current.message, result.message) };
+	}
+}
+
+return current.message === event.message ? undefined : { message: current.message };
 ```
 
 ### Session-before events

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -69,6 +69,36 @@ function cloneStreamOptions(streamOptions?: AgentHarnessStreamOptions): AgentHar
 	};
 }
 
+function normalizeMessageEndReplacement(original: AgentMessage, replacement: AgentMessage): AgentMessage {
+	if (typeof replacement !== "object" || replacement === null) {
+		throw new AgentHarnessError("hook", "message_end hook returned a non-object message replacement");
+	}
+	const originalRole = (original as { role?: unknown }).role;
+	const replacementRole = (replacement as { role?: unknown }).role;
+	if (replacementRole !== originalRole) {
+		throw new AgentHarnessError(
+			"hook",
+			`message_end hook must keep the message role "${String(originalRole)}", got "${String(replacementRole)}"`,
+		);
+	}
+	if (
+		(replacementRole === "user" || replacementRole === "assistant" || replacementRole === "toolResult") &&
+		(replacement as { content?: unknown }).content == null
+	) {
+		return { ...replacement, content: [] } as AgentMessage;
+	}
+	return replacement;
+}
+
+function replaceMessageInPlace(target: AgentMessage, replacement: AgentMessage): void {
+	if (target === replacement) return;
+	const targetRecord = target as unknown as Record<string, unknown>;
+	for (const key of Object.keys(targetRecord)) {
+		delete targetRecord[key];
+	}
+	Object.assign(targetRecord, replacement);
+}
+
 function findDuplicateNames(names: string[]): string[] {
 	const seen = new Set<string>();
 	const duplicates = new Set<string>();
@@ -291,6 +321,23 @@ export class AgentHarness<
 		return current;
 	}
 
+	private async emitMessageEnd(message: AgentMessage): Promise<AgentMessage> {
+		const handlers = this.getHandlers("message_end");
+		let current = message;
+		if (!handlers || handlers.size === 0) return current;
+		for (const handler of handlers) {
+			try {
+				const result = await handler({ type: "message_end", message: current });
+				if (result?.message !== undefined) {
+					current = normalizeMessageEndReplacement(current, result.message);
+				}
+			} catch (error) {
+				throw normalizeHookError(error);
+			}
+		}
+		return current;
+	}
+
 	private async emitQueueUpdate(): Promise<void> {
 		await this.emitOwn({
 			type: "queue_update",
@@ -487,6 +534,8 @@ export class AgentHarness<
 
 	private async handleAgentEvent(event: AgentEvent, signal?: AbortSignal): Promise<void> {
 		if (event.type === "message_end") {
+			const finalMessage = await this.emitMessageEnd(event.message);
+			replaceMessageInPlace(event.message, finalMessage);
 			await this.session.appendMessage(event.message);
 			await this.emitAny(event, signal);
 			return;

--- a/packages/agent/src/harness/types.ts
+++ b/packages/agent/src/harness/types.ts
@@ -538,6 +538,11 @@ export interface ContextEvent {
 	messages: AgentMessage[];
 }
 
+export interface MessageEndEvent {
+	type: "message_end";
+	message: AgentMessage;
+}
+
 export interface BeforeProviderRequestEvent {
 	type: "before_provider_request";
 	model: Model<any>;
@@ -643,6 +648,7 @@ export type AgentHarnessOwnEvent<
 	| SettledEvent
 	| BeforeAgentStartEvent<TSkill, TPromptTemplate>
 	| ContextEvent
+	| MessageEndEvent
 	| BeforeProviderRequestEvent
 	| BeforeProviderPayloadEvent
 	| AfterProviderResponseEvent
@@ -668,6 +674,10 @@ export interface BeforeAgentStartResult {
 
 export interface ContextResult {
 	messages: AgentMessage[];
+}
+
+export interface MessageEndResult {
+	message?: AgentMessage;
 }
 
 export interface BeforeProviderRequestResult {
@@ -706,6 +716,7 @@ export interface SessionBeforeTreeResult {
 export type AgentHarnessEventResultMap = {
 	before_agent_start: BeforeAgentStartResult | undefined;
 	context: ContextResult | undefined;
+	message_end: MessageEndResult | undefined;
 	before_provider_request: BeforeProviderRequestResult | undefined;
 	before_provider_payload: BeforeProviderPayloadResult | undefined;
 	after_provider_response: undefined;

--- a/packages/agent/test/harness/agent-harness.test.ts
+++ b/packages/agent/test/harness/agent-harness.test.ts
@@ -465,6 +465,101 @@ describe("AgentHarness", () => {
 		});
 	});
 
+	it("runs message_end hooks as an ordered pipeline before persistence", async () => {
+		const registration = newFaux();
+		registration.setResponses([() => fauxAssistantMessage("secret")]);
+		const session = new Session(new InMemorySessionStorage());
+		const harness = new AgentHarness({
+			models,
+			env: new NodeExecutionEnv({ cwd: process.cwd() }),
+			session,
+			model: registration.getModel(),
+		});
+		const hookRoles: string[] = [];
+		harness.on("message_end", (event) => {
+			hookRoles.push(event.message.role);
+			if (event.message.role !== "assistant") return undefined;
+			return { message: { ...event.message, content: [{ type: "text", text: "one" }] } };
+		});
+		harness.on("message_end", (event) => {
+			if (event.message.role !== "assistant") return undefined;
+			const first = event.message.content[0];
+			const text = first?.type === "text" ? first.text : "";
+			return { message: { ...event.message, content: [{ type: "text", text: `${text}-two` }] } };
+		});
+		const observedTexts: string[] = [];
+		harness.subscribe((event) => {
+			if (event.type === "message_end" && event.message.role === "assistant") {
+				const first = event.message.content[0];
+				observedTexts.push(first?.type === "text" ? first.text : "");
+			}
+		});
+
+		const response = await harness.prompt("hello");
+
+		expect(hookRoles).toEqual(["user", "assistant"]);
+		expect(response.content).toEqual([{ type: "text", text: "one-two" }]);
+		expect(observedTexts).toEqual(["one-two"]);
+		const persisted = (await session.getEntries()).flatMap((entry) =>
+			entry.type === "message" && entry.message.role === "assistant" ? [entry.message] : [],
+		);
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0]).toMatchObject({ content: [{ type: "text", text: "one-two" }] });
+	});
+
+	it("rejects message_end replacements that change the message role", async () => {
+		const registration = newFaux();
+		registration.setResponses([() => fauxAssistantMessage("secret")]);
+		const session = new Session(new InMemorySessionStorage());
+		const harness = new AgentHarness({
+			models,
+			env: new NodeExecutionEnv({ cwd: process.cwd() }),
+			session,
+			model: registration.getModel(),
+		});
+		let replaced = false;
+		harness.on("message_end", (event) => {
+			if (replaced || event.message.role !== "assistant") return undefined;
+			replaced = true;
+			return { message: { ...event.message, role: "user" } as AgentMessage };
+		});
+
+		const response = await harness.prompt("hello");
+
+		expect(response.stopReason).toBe("error");
+		expect(response.errorMessage).toMatch(/message_end hook must keep the message role "assistant"/);
+		const persistedTexts = (await session.getEntries()).flatMap((entry) => {
+			if (entry.type !== "message" || entry.message.role !== "assistant") return [];
+			const first = entry.message.content[0];
+			return first?.type === "text" ? [first.text] : [];
+		});
+		expect(persistedTexts).not.toContain("secret");
+	});
+
+	it("normalizes null content on message_end replacements", async () => {
+		const registration = newFaux();
+		registration.setResponses([() => fauxAssistantMessage("secret")]);
+		const session = new Session(new InMemorySessionStorage());
+		const harness = new AgentHarness({
+			models,
+			env: new NodeExecutionEnv({ cwd: process.cwd() }),
+			session,
+			model: registration.getModel(),
+		});
+		harness.on("message_end", (event) => {
+			if (event.message.role !== "assistant") return undefined;
+			return { message: { ...event.message, content: null } as unknown as AgentMessage };
+		});
+
+		const response = await harness.prompt("hello");
+
+		expect(response.content).toEqual([]);
+		const persisted = (await session.getEntries()).flatMap((entry) =>
+			entry.type === "message" && entry.message.role === "assistant" ? [entry.message] : [],
+		);
+		expect(persisted[0]).toMatchObject({ content: [] });
+	});
+
 	it("preserves app tool types for getters and update events", async () => {
 		const session = new Session(new InMemorySessionStorage());
 		const env = new NodeExecutionEnv({ cwd: process.cwd() });


### PR DESCRIPTION
## Motivation

pi-coding-agent's `AgentSession` lets extensions replace a finalized message on `message_end`: `_emitExtensionEvent` collects a replacement from the extension runner and applies it via `_replaceMessageInPlace` before the message is persisted, so extensions can redact PII/secrets, normalize final assistant output, or fix up final message fields.

`AgentHarness` had no equivalent. It persisted `event.message` first and notified subscribers afterwards, so by the time any listener saw the message, session storage already contained the original content. Replacing it after the fact desyncs disk vs agent state vs downstream events, and behaves differently between in-memory and JSONL storage (object references make in-memory look like it worked). This PR brings the harness up to the same freedom `AgentSession` extensions already have, with the replacement happening at the only point where all consumers stay consistent: before persistence.

## Change

- New result-producing hook `on("message_end")` with `MessageEndResult { message?: AgentMessage }`.
- `handleAgentEvent` order for `message_end` is now: run the hook pipeline, replace the finalized message object in place, `session.appendMessage`, then notify subscribers. Subscribers only ever observe the final message.
- Handlers run in registration order and each receives the current message, including replacements from earlier handlers; returning `undefined` leaves the message unchanged. Same chaining pattern as `emitBeforeProviderPayload`.
- The in-place replacement (delete keys + `Object.assign`, mirroring `AgentSession._replaceMessageInPlace`) keeps agent-loop state, references held by other listeners, and the persisted entry pointing at one consistent object.

## Validation

`AgentMessage` is an open union (`CustomAgentMessages` via declaration merging), so the harness cannot validate a replacement against the union at runtime. Instead it enforces the structural invariants the harness itself depends on:

- the replacement must be a non-null object;
- the replacement must keep the original message `role` — `role` is what the harness branches on afterwards (assistant-result lookup in `executeTurn`, `convertToLlm`, session replay). For messages without a `role` field (downstream custom messages), the replacement must not add one; internal consistency of custom shapes remains the responsibility of the app that declared them;
- missing or `null` `content` on user/assistant/toolResult replacements is normalized to `[]`, matching the coding-agent behavior for untyped handlers;
- failure semantics are fail-closed: a handler error or invalid replacement throws `AgentHarnessError("hook")` before persistence, so original content never reaches session storage; the run settles through the normal failure path with an assistant error message.

## Tests and docs

- Three new tests in `agent-harness.test.ts`: ordered pipeline with persistence and subscriber visibility, fail-closed role-mismatch rejection (original content is not persisted), and null-content normalization.
- `docs/hooks.md`: `MessageEndEvent` now carries a result type, added the "Message end" mutation semantics section, and the `emit()` dispatch example includes `message_end`.