### PR TITLE
fix(ai): recover openai-completions tool calls emitted in content

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -42,6 +42,10 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
+import {
+	applyRecoveredToolCallsToAssistantMessage,
+	assistantMessageHasToolCalls,
+} from "../utils/recover-tool-calls-from-content.ts";
 
 /**
  * Check if conversation messages contain tool calls or tool results.
@@ -232,7 +236,9 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 						partial: output,
 					});
 				} else if (block.type === "toolCall") {
-					block.arguments = parseStreamingJson(block.partialArgs);
+					if (typeof block.partialArgs === "string") {
+						block.arguments = parseStreamingJson(block.partialArgs);
+					}
 					// Finalize in-place and strip the scratch buffers so replay only
 					// carries parsed arguments.
 					delete block.partialArgs;
@@ -437,9 +443,14 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				}
 			}
 
+			if (!assistantMessageHasToolCalls(output) && context.tools && context.tools.length > 0) {
+				applyRecoveredToolCallsToAssistantMessage(output, context.tools);
+			}
+
 			for (const block of blocks) {
 				finishBlock(block);
 			}
+
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
 			}

--- a/packages/ai/src/utils/recover-tool-calls-from-content.ts
+++ b/packages/ai/src/utils/recover-tool-calls-from-content.ts
@@ -1,0 +1,211 @@
+import type { AssistantMessage, Tool, ToolCall } from "../types.ts";
+
+export interface RecoveredToolCall {
+	id: string;
+	name: string;
+	arguments: Record<string, unknown>;
+}
+
+/**
+ * Ollama and other OpenAI-compatible local servers often return syntactically valid tool-call JSON in
+ * assistant `content` while leaving the structured `tool_calls` stream field empty. pi-agent-core only
+ * dispatches tools from `toolCall` content blocks, so this recovery pass lifts JSON-shaped tool calls
+ * out of plain text when the model was offered tools but emitted no native toolCall blocks.
+ */
+export function extractKnownToolNames(tools: Tool[] | undefined): Set<string> {
+	const names = new Set<string>();
+	if (!tools) {
+		return names;
+	}
+	for (const tool of tools) {
+		if (typeof tool.name === "string" && tool.name.trim().length > 0) {
+			names.add(tool.name.trim());
+		}
+	}
+	return names;
+}
+
+function stripToolCallWrappers(text: string): string {
+	let trimmed = text.trim();
+	const xmlMatch = trimmed.match(/^<tool_call>\s*([\s\S]*?)\s*<\/tool_call>$/i);
+	if (xmlMatch) {
+		trimmed = xmlMatch[1]!.trim();
+	}
+	const fenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+	if (fenceMatch) {
+		trimmed = fenceMatch[1]!.trim();
+	}
+	return trimmed;
+}
+
+function normalizeArguments(value: unknown): Record<string, unknown> | undefined {
+	if (value === undefined || value === null) {
+		return {};
+	}
+	if (typeof value === "string") {
+		const parsed = tryParseJson(value.trim());
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+		return undefined;
+	}
+	if (typeof value === "object" && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
+	return undefined;
+}
+
+function tryParseJson(text: string): unknown {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
+
+function coerceRecoveredToolCall(candidate: unknown, knownToolNames: Set<string>): RecoveredToolCall | undefined {
+	if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+		return undefined;
+	}
+	const row = candidate as Record<string, unknown>;
+
+	const fn = row.function;
+	if (fn && typeof fn === "object" && !Array.isArray(fn)) {
+		const fnRow = fn as Record<string, unknown>;
+		const name = typeof fnRow.name === "string" ? fnRow.name.trim() : "";
+		if (!name || !knownToolNames.has(name)) {
+			return undefined;
+		}
+		const args = normalizeArguments(fnRow.arguments);
+		if (args === undefined) {
+			return undefined;
+		}
+		const id = typeof row.id === "string" && row.id.trim().length > 0 ? row.id.trim() : createRecoveredToolCallId(name);
+		return { id, name, arguments: args };
+	}
+
+	const name = typeof row.name === "string" ? row.name.trim() : "";
+	if (!name || !knownToolNames.has(name)) {
+		return undefined;
+	}
+	const args = normalizeArguments(row.arguments ?? row.parameters ?? row.input);
+	if (args === undefined) {
+		return undefined;
+	}
+	const id = typeof row.id === "string" && row.id.trim().length > 0 ? row.id.trim() : createRecoveredToolCallId(name);
+	return { id, name, arguments: args };
+}
+
+function parseRecoveredToolCallsFromText(text: string, knownToolNames: Set<string>): RecoveredToolCall[] {
+	if (knownToolNames.size === 0) {
+		return [];
+	}
+	const normalized = stripToolCallWrappers(text);
+	if (normalized.length === 0) {
+		return [];
+	}
+
+	const parsed = tryParseJson(normalized);
+	if (parsed === undefined) {
+		return [];
+	}
+
+	if (Array.isArray(parsed)) {
+		const recovered: RecoveredToolCall[] = [];
+		for (const entry of parsed) {
+			const toolCall = coerceRecoveredToolCall(entry, knownToolNames);
+			if (toolCall) {
+				recovered.push(toolCall);
+			}
+		}
+		return recovered;
+	}
+
+	const single = coerceRecoveredToolCall(parsed, knownToolNames);
+	return single ? [single] : [];
+}
+
+export function createRecoveredToolCallId(name: string): string {
+	const suffix = Math.random().toString(36).slice(2, 10);
+	return `recovered_${name}_${suffix}`;
+}
+
+export function assistantMessageHasToolCalls(message: AssistantMessage): boolean {
+	return message.content.some((block) => block.type === "toolCall");
+}
+
+export function recoverToolCallsFromText(text: string, tools: Tool[] | undefined): RecoveredToolCall[] {
+	return parseRecoveredToolCallsFromText(text, extractKnownToolNames(tools));
+}
+
+export interface RecoverToolCallsFromContentResult {
+	recovered: RecoveredToolCall[];
+	remainingText: string;
+}
+
+export function recoverToolCallsFromContentText(
+	text: string,
+	tools: Tool[] | undefined,
+): RecoverToolCallsFromContentResult {
+	const recovered = recoverToolCallsFromText(text, tools);
+	if (recovered.length === 0) {
+		return { recovered: [], remainingText: text };
+	}
+	const normalized = stripToolCallWrappers(text.trim());
+	const parsed = tryParseJson(normalized);
+	if (parsed === undefined) {
+		return { recovered: [], remainingText: text };
+	}
+	return { recovered, remainingText: "" };
+}
+
+export function applyRecoveredToolCallsToAssistantMessage(
+	message: AssistantMessage,
+	tools: Tool[] | undefined,
+): boolean {
+	if (assistantMessageHasToolCalls(message)) {
+		return false;
+	}
+	if (!tools || tools.length === 0) {
+		return false;
+	}
+
+	const nextContent: AssistantMessage["content"] = [];
+	let recoveredAny = false;
+
+	for (const block of message.content) {
+		if (block.type !== "text") {
+			nextContent.push(block);
+			continue;
+		}
+
+		const { recovered, remainingText } = recoverToolCallsFromContentText(block.text, tools);
+		if (recovered.length === 0) {
+			nextContent.push(block);
+			continue;
+		}
+
+		recoveredAny = true;
+		if (remainingText.trim().length > 0) {
+			nextContent.push({ type: "text", text: remainingText });
+		}
+		for (const toolCall of recovered) {
+			nextContent.push({
+				type: "toolCall",
+				id: toolCall.id,
+				name: toolCall.name,
+				arguments: toolCall.arguments,
+			} satisfies ToolCall);
+		}
+	}
+
+	if (!recoveredAny) {
+		return false;
+	}
+
+	message.content.splice(0, message.content.length, ...nextContent);
+	if (message.stopReason === "stop") {
+		message.stopReason = "toolUse";
+	}
+	return true;
+}

--- a/packages/ai/test/openai-completions-content-tool-call-recovery.test.ts
+++ b/packages/ai/test/openai-completions-content-tool-call-recovery.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getModel, streamSimple } from "../src/compat.ts";
+import type { Tool } from "../src/types.ts";
+
+const mockState = vi.hoisted(() => ({
+	lastParams: undefined as unknown,
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: (params: unknown) => {
+					mockState.lastParams = params;
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							yield {
+								choices: [{
+									delta: {
+										content: '{\n  "name": "echo",\n  "arguments": {\n    "text": "hello"\n  }\n}',
+									},
+									finish_reason: "stop",
+								}],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									prompt_tokens_details: { cached_tokens: 0 },
+									completion_tokens_details: { reasoning_tokens: 0 },
+								},
+							};
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+
+	return { default: FakeOpenAI };
+});
+
+const echoTool: Tool = {
+	name: "echo",
+	description: "Echo text",
+	parameters: {
+		type: "object",
+		properties: { text: { type: "string" } },
+		required: ["text"],
+	},
+};
+
+describe("openai-completions content tool-call recovery", () => {
+	beforeEach(() => {
+		mockState.lastParams = undefined;
+	});
+
+	it("recovers tool JSON emitted in content when tool_calls is empty", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = { ...baseModel, api: "openai-completions" } as const;
+
+		const response = await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "call echo", timestamp: Date.now() }],
+				tools: [echoTool],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		expect(response.stopReason).toBe("toolUse");
+		expect(response.content).toEqual([
+			{
+				type: "toolCall",
+				id: expect.stringMatching(/^recovered_echo_/),
+				name: "echo",
+				arguments: { text: "hello" },
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

OpenAI-compatible local inference servers (Ollama `qwen2.5-coder:14b` on `/v1/chat/completions`, LM Studio, etc.) often return syntactically valid tool-call JSON in the assistant **`content`** field while leaving the structured **`tool_calls`** array empty.

pi-agent-core only dispatches tools from `toolCall` content blocks, so agents see narration / empty turns and never execute tools — even when the model produced correct tool JSON.

This adds a recovery pass in `openai-completions` that lifts tool JSON out of `content` when:
- the request included tools, and
- the assistant message has no native `toolCall` blocks after streaming completes.

Also fixes `finishBlock` to skip re-parsing `toolCall.arguments` from `partialArgs` when the scratch buffer was never populated (recovered calls already carry parsed arguments).

## Motivation / evidence

- Ollama [issue #13519](https://github.com/ollama/ollama/issues/13519) — tool JSON in content, not `tool_calls`
- Hands-on probe (Fusion executor, 2026-07-14): `qwen2.5-coder:14b` on `/v1` returns `content: {"name":"echo","arguments":{...}}`, `tool_calls: []`; `qwen3-coder:latest` returns proper `tool_calls` natively
- Same failure mode reported by Cline, opencode, Hermes-agent, etc.

## Test plan

- [x] `npm test -- test/openai-completions-content-tool-call-recovery.test.ts` (mock SSE with JSON-in-content, asserts `stopReason: toolUse` and recovered `toolCall` block)
- [ ] Manual: Ollama `qwen2.5-coder:14b` via openai-completions with a single tool — tool dispatches after merge