### PR TITLE
fix(openai-codex): clamp session-id header to 64 chars like prompt_cache_key (#6630)

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -46,7 +46,7 @@ import { formatProviderError, normalizeProviderError } from "../utils/error-body
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
-import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
+import { clampOpenAIPromptCacheKey, clampSessionIdHeader } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 
@@ -1546,8 +1546,14 @@ function buildSSEHeaders(
 	headers.set("content-type", "application/json");
 
 	if (sessionId) {
-		headers.set("session-id", sessionId);
-		headers.set("x-client-request-id", sessionId);
+		// Clamp to the 64-char limit the Codex backend enforces on these header
+		// values (same rule as the body's `prompt_cache_key`); an unclamped long
+		// sessionId makes every request fail with HTTP 400 (#6630).
+		const clamped = clampSessionIdHeader(sessionId);
+		if (clamped) {
+			headers.set("session-id", clamped);
+			headers.set("x-client-request-id", clamped);
+		}
 	}
 
 	return headers;
@@ -1566,7 +1572,11 @@ function buildWebSocketHeaders(
 	headers.delete("OpenAI-Beta");
 	headers.delete("openai-beta");
 	headers.set("OpenAI-Beta", OPENAI_BETA_RESPONSES_WEBSOCKETS);
-	headers.set("x-client-request-id", requestId);
-	headers.set("session-id", requestId);
+	// Clamp to the 64-char limit the Codex backend enforces on these header
+	// values; `requestId` is `options?.sessionId || createCodexRequestId()` and
+	// an unclamped long sessionId makes every request fail with HTTP 400 (#6630).
+	const clampedRequestId = clampSessionIdHeader(requestId) ?? requestId;
+	headers.set("x-client-request-id", clampedRequestId);
+	headers.set("session-id", clampedRequestId);
 	return headers;
 }

--- a/packages/ai/src/api/openai-prompt-cache.ts
+++ b/packages/ai/src/api/openai-prompt-cache.ts
@@ -6,3 +6,23 @@ export function clampOpenAIPromptCacheKey(key: string | undefined): string | und
 	if (chars.length <= OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH) return key;
 	return chars.slice(0, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH).join("");
 }
+
+/**
+ * Clamp a session id destined for a request *header* to the same 64-char limit
+ * the ChatGPT Codex backend enforces on `prompt_cache_key` (it validates the
+ * `session-id` / `x-client-request-id` header values against the same rules).
+ *
+ * The body's `prompt_cache_key` is already clamped via
+ * {@link clampOpenAIPromptCacheKey}, but the headers were sent raw — so a long
+ * `options.sessionId` (e.g. a ~150-char Claude Code `metadata.user_id` mapped
+ * to sessionId by a proxy) made every request fail with HTTP 400
+ * `[prompt_cache_key] [string_above_max_length]` (#6630).
+ *
+ * Clamps the same way the body field does so the header and body stay
+ * consistent for a given session. (A long-prefix-collision-resistant hash would
+ * avoid collapsing distinct long-prefix sessions into one key; that's a
+ * follow-up that would have to change the body field too.)
+ */
+export function clampSessionIdHeader(sessionId: string | undefined): string | undefined {
+	return clampOpenAIPromptCacheKey(sessionId);
+}

--- a/packages/ai/test/openai-session-id-clamp.test.ts
+++ b/packages/ai/test/openai-session-id-clamp.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { clampSessionIdHeader, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH } from "../src/api/openai-prompt-cache.ts";
+
+describe("clampSessionIdHeader (#6630)", () => {
+	it("returns undefined for undefined input (no header to send)", () => {
+		expect(clampSessionIdHeader(undefined)).toBeUndefined();
+	});
+
+	it("returns a short session id unchanged", () => {
+		const short = "0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3";
+		expect(clampSessionIdHeader(short)).toBe(short);
+	});
+
+	it("returns an exactly-64-char id unchanged", () => {
+		const exact = "a".repeat(OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH);
+		expect(clampSessionIdHeader(exact)).toBe(exact);
+		expect(clampSessionIdHeader(exact)).toHaveLength(OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH);
+	});
+
+	it("clamps an id longer than 64 chars to 64 (the Codex backend's prompt_cache_key limit)", () => {
+		// A long sessionId — e.g. a ~150-char Claude Code metadata.user_id mapped
+		// to sessionId by a proxy — made every request fail with HTTP 400
+		// `[prompt_cache_key] [string_above_max_length]` because the raw value was
+		// sent in the session-id / x-client-request-id headers unclamped, while
+		// the body's prompt_cache_key was already clamped (#6630).
+		const long = "a".repeat(150);
+		const clamped = clampSessionIdHeader(long);
+		expect(clamped).not.toBe(long);
+		expect(clamped).toHaveLength(OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH);
+	});
+
+	it("clamps a multibyte id by grapheme count, matching the body clamp", () => {
+		// Array.from(...) splits by code point, the same approach the body field's
+		// clamp uses — keep them consistent so a header and body for the same
+		// session agree.
+		const long = "𝕏".repeat(80); // 80 code points, each 2 UTF-16 units
+		const clamped = clampSessionIdHeader(long);
+		expect(Array.from(clamped ?? "").length).toBe(OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #6630. For `openai-codex`, the body's `prompt_cache_key` was clamped to 64 chars via `clampOpenAIPromptCacheKey`, but the `session-id` and `x-client-request-id` **headers** carried the raw, unclamped `options.sessionId`. The ChatGPT Codex backend validates those header values against the same `prompt_cache_key` rules (max length 64), so any `sessionId` longer than 64 chars made every request fail with HTTP 400:

```
Codex error: [StringParam] [prompt_cache_key] [string_above_max_length]
Invalid 'prompt_cache_key': string too long. Expected a string with maximum length 64, but got a string with length 150 instead.
```

This started biting in the wild because Claude Code sends `metadata.user_id` values of ~150 chars, which proxies map to `sessionId`.

## Root cause

In `packages/ai/src/api/openai-codex-responses.ts`:
- `buildSSEHeaders` set `session-id` / `x-client-request-id` directly from the raw `sessionId` parameter.
- `buildWebSocketHeaders` set them from `requestId` (= `options?.sessionId || createCodexRequestId()`).

Neither path consulted `clampOpenAIPromptCacheKey`, which the body field (around line 500) already used.

## Fix

Add `clampSessionIdHeader` to `openai-prompt-cache.ts` (delegates to `clampOpenAIPromptCacheKey`, sharing the 64-char limit) and apply it in both header paths:
- `buildSSEHeaders`: clamp `sessionId` before setting `session-id` / `x-client-request-id`.
- `buildWebSocketHeaders`: clamp `requestId` before setting the headers.

The header now clamps the same way the body field does, so a given session's header and body stay consistent.

## Scope / follow-up

- This is scoped to the `openai-codex` provider (#6630 is openai-codex-specific). The non-codex `openai-responses.ts` `createClient` also sends raw session headers, but that path hits different backends with different validation (it's the subject of #6625, where the OpenCode Zen API rejects the headers outright rather than length-validating them).
- The reporter suggests hashing (instead of truncating) when over 64 chars, because long client-supplied IDs (e.g. Claude Code `user_id`s) share a long common prefix and plain truncation collapses distinct sessions into one key. That's a real improvement, but it would also change the body's `prompt_cache_key` behavior (currently truncate), so I've left it as a follow-up rather than bundling a semantics change into this fix. Happy to do that as a separate PR if you'd prefer the body+header to both hash.

## Tests

`packages/ai/test/openai-session-id-clamp.test.ts` — unit tests for `clampSessionIdHeader`: undefined passthrough, short id unchanged, exactly-64 unchanged, >64 clamped to 64, and multibyte clamp-by-code-point consistency with the body field.

Regression: the existing prompt-cache and codex-stream suites still pass (42 passed; the codex-stream / cache-affinity e2e tests skip without a codex token — skip, not fail). Biome clean on the touched files.
