### PR TITLE
fix(tui): guard null children in Box and Container render/invalidate

### DIFF
--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -65,6 +65,7 @@ export class Box implements Component {
 	}
 
 	invalidate(): void {
+		this.children = this.children.filter((c) => c != null);
 		this.invalidateCache();
 		for (const child of this.children) {
 			child.invalidate?.();
@@ -82,6 +83,7 @@ export class Box implements Component {
 		// Render all children
 		const childLines: string[] = [];
 		for (const child of this.children) {
+			if (child == null) continue;
 			const lines = child.render(contentWidth);
 			for (const line of lines) {
 				childLines.push(leftPad + line);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -272,6 +272,7 @@ export class Container implements Component {
 	}
 
 	invalidate(): void {
+		this.children = this.children.filter((c) => c != null);
 		for (const child of this.children) {
 			child.invalidate?.();
 		}
@@ -280,6 +281,7 @@ export class Container implements Component {
 	render(width: number): string[] {
 		const lines: string[] = [];
 		for (const child of this.children) {
+			if (child == null) continue;
 			const childLines = child.render(width);
 			for (const line of childLines) {
 				lines.push(line);


### PR DESCRIPTION
After extension install/remove, stale component references can remain in children arrays. Adding null guards in render loops and filtering in invalidate() prevents：
```
pi exiting due to uncaughtException:
TypeError: Cannot read properties of undefined (reading 'render')
    at Box.render (file:///Users/xxxx/.npm/_npx/4dddf6712fa995c9/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui/dist/components/box.js:62:33)
```

- Box.invalidate: filter null entries before propagating invalidation
- Box.render: skip null children in render loop
- Container.invalidate: filter null entries before propagating
- Container.render: skip null children in render loop