### PR TITLE
fix(coding-agent): accept colon-qualified skill names

### DIFF
--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -140,7 +140,7 @@ Per the [Agent Skills specification](https://agentskills.io/specification#frontm
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Max 64 chars. Lowercase a-z, 0-9, hyphens. Unlike the standard, Pi does not require this to match the parent directory because that standard requirement is suboptimal for shared skill directories. |
+| `name` | Yes | Max 64 chars. Lowercase a-z, 0-9, hyphens, with an optional namespace in `<namespace>:<name>` form. Unlike the standard, Pi does not require this to match the parent directory because that standard requirement is suboptimal for shared skill directories. |
 | `description` | Yes | Max 1024 chars. What the skill does and when to use it. |
 | `license` | No | License name or reference to bundled file. |
 | `compatibility` | No | Max 500 chars. Environment requirements. |
@@ -151,13 +151,14 @@ Per the [Agent Skills specification](https://agentskills.io/specification#frontm
 ### Name Rules
 
 - 1-64 characters
-- Lowercase letters, numbers, hyphens only
-- No leading/trailing hyphens
-- No consecutive hyphens
+- Lowercase letters, numbers, hyphens, and at most one namespace colon
+- Namespaced skills use `<namespace>:<name>`, with non-empty segments on both sides of the colon
+- No leading/trailing hyphens in any segment
+- No consecutive hyphens in any segment
 Pi does not require the name to match the parent directory. The Agent Skills standard does, but that requirement is suboptimal for shared skill directories used by multiple tools.
 
-Valid: `pdf-processing`, `data-analysis`, `code-review`
-Invalid: `PDF-Processing`, `-pdf`, `pdf--processing`
+Valid: `pdf-processing`, `data-analysis`, `code-review`, `inc:ship-it`
+Invalid: `PDF-Processing`, `-pdf`, `pdf--processing`, `inc:`, `inc::ship-it`
 
 ### Description Best Practices
 
@@ -178,7 +179,8 @@ description: Helps with PDFs.
 Pi validates skills against the Agent Skills standard. Most issues produce warnings but still load the skill:
 
 - Name exceeds 64 characters or contains invalid characters
-- Name starts/ends with hyphen or has consecutive hyphens
+- Name contains more than one colon or has an empty namespace/name segment
+- Name starts/ends with hyphen or has consecutive hyphens in any segment
 - Description exceeds 1024 characters
 
 Unknown frontmatter fields are ignored.

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -14,6 +14,8 @@ const MAX_NAME_LENGTH = 64;
 const MAX_DESCRIPTION_LENGTH = 1024;
 
 const IGNORE_FILE_NAMES = [".gitignore", ".ignore", ".fdignore"];
+const SKILL_NAME_SEGMENT_REGEX = /^[a-z0-9-]+$/;
+const SKILL_NAME_RULES = "must be lowercase a-z, 0-9, hyphens, and at most one namespace colon";
 
 type IgnoreMatcher = ReturnType<typeof ignore>;
 
@@ -96,16 +98,31 @@ function validateName(name: string): string[] {
 		errors.push(`name exceeds ${MAX_NAME_LENGTH} characters (${name.length})`);
 	}
 
-	if (!/^[a-z0-9-]+$/.test(name)) {
-		errors.push(`name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)`);
+	const segments = name.split(":");
+	if (segments.length > 2) {
+		errors.push("name must contain at most one colon");
 	}
 
-	if (name.startsWith("-") || name.endsWith("-")) {
-		errors.push(`name must not start or end with a hyphen`);
-	}
+	for (let i = 0; i < segments.length; i++) {
+		const segment = segments[i] ?? "";
+		const label = segments.length === 1 ? "name" : i === 0 ? "namespace" : i === 1 ? "name" : `name segment ${i + 1}`;
 
-	if (name.includes("--")) {
-		errors.push(`name must not contain consecutive hyphens`);
+		if (segment.length === 0) {
+			errors.push(`${label} must not be empty`);
+			continue;
+		}
+
+		if (!SKILL_NAME_SEGMENT_REGEX.test(segment)) {
+			errors.push(`name contains invalid characters (${SKILL_NAME_RULES})`);
+		}
+
+		if (segment.startsWith("-") || segment.endsWith("-")) {
+			errors.push(`${label} must not start or end with a hyphen`);
+		}
+
+		if (segment.includes("--")) {
+			errors.push(`${label} must not contain consecutive hyphens`);
+		}
 	}
 
 	return errors;

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -1,4 +1,5 @@
-import { homedir } from "os";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
 import { join, resolve } from "path";
 import { describe, expect, it } from "vitest";
 import type { ResourceDiagnostic } from "../src/core/diagnostics.ts";
@@ -7,6 +8,16 @@ import { createSyntheticSourceInfo } from "../src/core/source-info.ts";
 
 const fixturesDir = resolve(__dirname, "fixtures/skills");
 const collisionFixturesDir = resolve(__dirname, "fixtures/skills-collision");
+
+function writeSkill(root: string, dirName: string, name: string): string {
+	const skillDir = join(root, dirName);
+	mkdirSync(skillDir, { recursive: true });
+	writeFileSync(
+		join(skillDir, "SKILL.md"),
+		`---\nname: ${JSON.stringify(name)}\ndescription: Test skill.\n---\n\n# Test\n`,
+	);
+	return skillDir;
+}
 
 function createTestSkill(options: {
 	name: string;
@@ -62,6 +73,49 @@ describe("skills", () => {
 
 			expect(skills).toHaveLength(1);
 			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("invalid characters"))).toBe(true);
+		});
+
+		it("should allow colon-qualified names with one namespace segment", () => {
+			const root = mkdtempSync(join(tmpdir(), "pi-skill-name-"));
+			try {
+				const skillDir = writeSkill(root, "inc:ship-it", "inc:ship-it");
+				const { skills, diagnostics } = loadSkillsFromDir({
+					dir: skillDir,
+					source: "test",
+				});
+
+				expect(skills).toHaveLength(1);
+				expect(skills[0].name).toBe("inc:ship-it");
+				expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("invalid characters"))).toBe(false);
+			} finally {
+				rmSync(root, { recursive: true, force: true });
+			}
+		});
+
+		it("should warn for malformed colon-qualified names", () => {
+			const cases = [
+				{ name: ":ship-it", message: "namespace must not be empty" },
+				{ name: "inc:", message: "name must not be empty" },
+				{ name: "inc::ship-it", message: "name must contain at most one colon" },
+				{ name: "inc:ship:it", message: "name must contain at most one colon" },
+				{ name: "inc:Ship-it", message: "invalid characters" },
+				{ name: "inc:-ship-it", message: "name must not start or end with a hyphen" },
+			];
+			const root = mkdtempSync(join(tmpdir(), "pi-skill-name-"));
+			try {
+				for (const [index, testCase] of cases.entries()) {
+					const skillDir = writeSkill(root, `skill-${index}`, testCase.name);
+					const { skills, diagnostics } = loadSkillsFromDir({
+						dir: skillDir,
+						source: "test",
+					});
+
+					expect(skills).toHaveLength(1);
+					expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes(testCase.message))).toBe(true);
+				}
+			} finally {
+				rmSync(root, { recursive: true, force: true });
+			}
 		});
 
 		it("should warn when name exceeds 64 characters", () => {

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -144,7 +144,7 @@ describe("AgentSession prompt characterization", () => {
 		expect(sawImage).toBe(true);
 	});
 
-	it("expands skill commands before sending the prompt", async () => {
+	it("expands colon-qualified skill commands before sending the prompt", async () => {
 		const tempDir = join(tmpdir(), `pi-skill-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(tempDir, { recursive: true });
 		tempDirs.push(tempDir);
@@ -156,7 +156,7 @@ describe("AgentSession prompt characterization", () => {
 			getSkills: () => ({
 				skills: [
 					{
-						name: "test",
+						name: "inc:ship-it",
 						description: "Test skill",
 						filePath: skillPath,
 						disableModelInvocation: false,
@@ -184,9 +184,9 @@ describe("AgentSession prompt characterization", () => {
 			},
 		]);
 
-		await harness.session.prompt("/skill:test explain this");
+		await harness.session.prompt("/skill:inc:ship-it explain this");
 
-		expect(expandedPrompt).toContain('<skill name="test" location="');
+		expect(expandedPrompt).toContain('<skill name="inc:ship-it" location="');
 		expect(expandedPrompt).toContain("Use the skill body.");
 		expect(expandedPrompt).toContain("explain this");
 	});


### PR DESCRIPTION
### Problem

Pi currently loads plugin-namespaced skills like `inc:ship-it`, but startup reports them under `[Skill conflicts]` because the skill-name validator only accepts a single unqualified lowercase segment.

That makes valid plugin skill names look broken even though they still load, and it pushes users toward renaming skills instead of fixing the loader.

### Isolated Reproduction

From a clean checkout, using only scratch directories:

```bash
tmp_root="$(mktemp -d)"
mkdir -p "$tmp_root/agent/skills/inc:ship-it" "$tmp_root/cwd"
cat > "$tmp_root/agent/skills/inc:ship-it/SKILL.md" <<'EOF'
---
name: inc:ship-it
description: Ship work through the deployment checklist.
---

# Ship It

Use the deployment checklist.
EOF

cd "$tmp_root/cwd"
PI_CODING_AGENT_DIR="$tmp_root/agent" PI_OFFLINE=1 \
  pi --no-extensions --no-skills --skill "$tmp_root/agent/skills" \
  --no-prompt-templates --no-themes --no-context-files --no-session --offline
```

Before this change, startup showed:

```text
[Skills]
  inc:ship-it

[Skill conflicts]
  auto (user) <scratch>/agent/skills/inc:ship-it/SKILL.md
    name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)
```

After this change, startup shows the skill without the warning:

```text
[Skills]
  inc:ship-it
```

### Fix Rationale

The fix belongs in the skill loader validation, not in skill frontmatter renames. Namespaced plugin skills are already used as skill names and are safe downstream:

- Skill dedupe/collision handling uses the full name as a `Map` key.
- Interactive/RPC commands expose the full name as `skill:<name>`.
- Skill command expansion already parses everything after `/skill:` up to whitespace, so `/skill:inc:ship-it` resolves correctly.
- File paths are based on the loaded `SKILL.md` path, not derived from the skill name.

### Edge-Case Rules

The validator now accepts either:

- `name`
- `namespace:name`

Each segment must follow the existing segment rules:

- lowercase `a-z`, `0-9`, and hyphens only
- no empty namespace or name segment
- no leading or trailing hyphen in any segment
- no consecutive hyphens in any segment
- at most one colon
- still capped at 64 total characters

Still rejected with warnings:

- `:ship-it`
- `inc:`
- `inc::ship-it`
- `inc:ship:it`
- `inc:Ship-it`
- `inc:-ship-it`

### Tests Run

```bash
node node_modules/vitest/vitest.mjs --run test/skills.test.ts test/suite/agent-session-prompt.test.ts
PATH="$HOME/.nvm/versions/node/v22.19.0/bin:$PATH" npm run check
PATH="$HOME/.nvm/versions/node/v22.19.0/bin:$PATH" npm run build
```

Also reran the isolated startup reproduction against the built local CLI and confirmed the `[Skill conflicts]` warning is gone.
