### PR TITLE
fix(agent,coding-agent): use absolute System32 path for taskkill/rundll32 to avoid spawn ENOENT

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -220,11 +220,15 @@ function getShellEnv(baseEnv?: NodeJS.ProcessEnv, extraEnv?: Record<string, stri
 
 function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
+		const taskkillPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe");
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const child = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
 				windowsHide: true,
+			});
+			child.on("error", () => {
+				// taskkill not found or cannot spawn — best-effort
 			});
 		} catch {
 			// Ignore errors.

--- a/packages/coding-agent/src/utils/open-browser.ts
+++ b/packages/coding-agent/src/utils/open-browser.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { join } from "node:path";
 
 /**
  * Open a URL or file in the platform browser/default handler.
@@ -12,7 +13,10 @@ export function openBrowser(target: string): void {
 		process.platform === "darwin"
 			? ["open", [target]]
 			: process.platform === "win32"
-				? ["rundll32", ["url.dll,FileProtocolHandler", target]]
+				? [
+						join(process.env.SystemRoot ?? "C:\\Windows", "System32", "rundll32.exe"),
+						["url.dll,FileProtocolHandler", target],
+					]
 				: ["xdg-open", [target]];
 
 	// spawn reports launcher failures (for example, missing xdg-open) via an

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter } from "node:path";
+import { delimiter, join } from "node:path";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
 
@@ -199,12 +199,20 @@ export function killTrackedDetachedChildren(): void {
  */
 export function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
-		// Use taskkill on Windows to kill process tree
+		// Use taskkill on Windows to kill process tree.
+		// Use absolute System32 path because spawn("taskkill") relies on PATH
+		// lookup which can fail on some environments (e.g. Node.js 24 with
+		// stripped PATH, WOW64 32-bit redirects). Also catch async ENOENT via
+		// the ChildProcess error event — spawn errors are async in newer Node.
+		const taskkillPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe");
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const child = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
 				windowsHide: true,
+			});
+			child.on("error", () => {
+				// taskkill not found or cannot spawn — best-effort
 			});
 		} catch {
 			// Ignore errors if taskkill fails


### PR DESCRIPTION
## Problem

`spawn("taskkill")` and `spawn("rundll32")` rely on PATH lookup which can fail on Node.js 24 or in environments with stripped/missing System32 in PATH. The error is emitted asynchronously via ChildProcess `error` event, so the existing `try/catch` never catches it, crashing the process.

## Fix

Use `process.env.SystemRoot\System32\...` for absolute path resolution on all three affected calls, and add `child.on("error", ...)` to handle async spawn failures gracefully.

## Changed files

- `packages/coding-agent/src/utils/shell.ts` — taskkill in `killProcessTree()`
- `packages/agent/src/harness/env/nodejs.ts` — taskkill in local `killProcessTree()`
- `packages/coding-agent/src/utils/open-browser.ts` — rundll32 in `openBrowser()`

All checks pass (`npm run check` clean).

Fixes #6596