### PR TITLE
fix(coding-agent): do not highlight read errors

### DIFF
--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -176,7 +176,7 @@ function formatReadResult(
 
 	const rawPath = str(args?.file_path ?? args?.path);
 	const output = getTextOutput(result, showImages);
-	const lang = rawPath ? getLanguageFromPath(rawPath) : undefined;
+	const lang = !isError && rawPath ? getLanguageFromPath(rawPath) : undefined;
 	const renderedLines = lang ? highlightCode(replaceTabs(output), lang) : output.split("\n");
 	const lines = trimTrailingEmptyLines(renderedLines);
 	const maxLines = options.expanded ? lines.length : 10;

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -8,7 +8,7 @@ import { type BashOperations, createBashToolDefinition } from "../src/core/tools
 import { createReadTool, createReadToolDefinition } from "../src/core/tools/read.ts";
 import { createWriteToolDefinition } from "../src/core/tools/write.ts";
 import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
-import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../src/utils/ansi.ts";
 
 function createBaseToolDefinition(name = "custom_tool"): ToolDefinition {
@@ -399,6 +399,24 @@ describe("ToolExecutionComponent parity", () => {
 		expect(rendered).toContain("one");
 		expect(rendered).toContain("two");
 		expect(rendered).not.toContain("two\n\n");
+	});
+
+	test("does not syntax-highlight read errors based on the requested file path", () => {
+		const component = new ToolExecutionComponent(
+			"read",
+			"tool-read-error-highlighting",
+			{ path: "config.exs", offset: 120, limit: 130 },
+			{},
+			createReadToolDefinition(process.cwd()),
+			createFakeTui(),
+			process.cwd(),
+		);
+		const error = "Offset 120 is beyond end of file (96 lines total)";
+		component.updateResult({ content: [{ type: "text", text: error }], details: undefined, isError: true }, false);
+
+		const rendered = component.render(120).join("\n");
+		expect(stripAnsi(rendered)).toContain(error);
+		expect(rendered).toContain(theme.fg("toolOutput", error));
 	});
 
 	test("collapses ordinary read results until expanded", () => {


### PR DESCRIPTION
## Summary

- skip file-language syntax highlighting for failed `read` results
- keep successful file contents syntax-highlighted as before
- add regression coverage using an Elixir path and the out-of-range offset error

## Root cause

The read renderer derived a language solely from the requested file path. Error text therefore passed through that file's syntax highlighter; for example, an error reading `config.exs` was highlighted as Elixir.

## Tests

- `npm run check`
- `./test.sh`
