### PR TITLE
Markdown transformer api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5788,6 +5788,7 @@
 				"hosted-git-info": "9.0.3",
 				"ignore": "7.0.5",
 				"jiti": "2.7.0",
+				"marked": "18.0.5",
 				"minimatch": "10.2.5",
 				"proper-lockfile": "4.1.2",
 				"semver": "7.8.0",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added chainable `pi.registerAssistantMarkdownTransformer()` hooks for display-only transformation of streaming and restored assistant Markdown.
+- Exposed the bundled `marked` parser to extensions.
 
 ## [0.80.10] - 2026-07-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added chainable `pi.registerAssistantMarkdownTransformer()` hooks for display-only transformation of streaming and restored assistant Markdown.
+
 ## [0.80.10] - 2026-07-16
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added chainable `pi.registerAssistantMarkdownTransformer()` hooks for display-only transformation of streaming and restored assistant Markdown.
 - Exposed the bundled `marked` parser to extensions.
+- Added a Unicode formula-rendering example extension.
 
 ## [0.80.10] - 2026-07-16
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2923,6 +2923,7 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `custom-provider-gitlab-duo/` | GitLab Duo integration | `registerProvider` with OAuth |
 | **Messages & Communication** |||
 | `message-renderer.ts` | Custom message rendering | `registerMessageRenderer`, `sendMessage` |
+| `unicode-math.ts` | Display-only TeX-to-Unicode transformation for assistant Markdown | `registerAssistantMarkdownTransformer` |
 | `entry-renderer.ts` | TUI-only custom entry rendering | `registerEntryRenderer`, `appendEntry` |
 | `event-bus.ts` | Inter-extension events | `pi.events` |
 | **Session Metadata** |||

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1553,6 +1553,26 @@ mode and would not execute if sent via `prompt`.
 
 Register a custom TUI renderer for custom messages with your `customType`. Custom messages are created with `pi.sendMessage()` and participate in LLM context. See [Custom UI](#custom-ui).
 
+### pi.registerAssistantMarkdownTransformer(transformer)
+
+Register a transformer for the Markdown in normal assistant text and thinking blocks. Transformers run in extension load order, and each transformer receives the Markdown returned by the previous transformer. After the chain finishes, Pi renders the transformed content with its built-in renderer.
+
+The transformer receives the Markdown string and a context with:
+
+- `contentType` — `"text"` or `"thinking"`
+
+Return the transformed Markdown:
+
+```typescript
+pi.registerAssistantMarkdownTransformer((markdown, { contentType }) => {
+  return contentType === "text"
+    ? markdown.replaceAll("-->", "→")
+    : markdown;
+});
+```
+
+If a transformer throws, Pi keeps the Markdown produced so far and continues with the next transformer. The hook is display-only: the original assistant message remains unchanged in the session and model context. It runs for both streaming updates and restored session messages, so transformers should remain synchronous and inexpensive.
+
 ### pi.registerEntryRenderer(customType, renderer)
 
 Register a custom TUI renderer for custom entries with your `customType`. Custom entries are created with `pi.appendEntry()` and do not participate in LLM context.
@@ -2734,6 +2754,8 @@ ctx.ui.setEditorComponent((tui, theme, keybindings) =>
 See [tui.md](tui.md) Pattern 7 for a complete example with mode indicator.
 
 ### Message and Entry Rendering
+
+For display-only customization of normal assistant Markdown, see [`pi.registerAssistantMarkdownTransformer()`](#piregisterassistantmarkdowntransformertransformer).
 
 Register a custom renderer for messages with your `customType`. Use message renderers for content that should participate in LLM context:
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -142,6 +142,7 @@ To share extensions via npm or git as pi packages, see [packages.md](packages.md
 |---------|---------|
 | `@earendil-works/pi-coding-agent` | Extension types (`ExtensionAPI`, `ExtensionContext`, events) |
 | `typebox` | Schema definitions for tool parameters |
+| `marked` | Markdown lexer and parser |
 | `@earendil-works/pi-ai` | AI utilities (`StringEnum` for Google-compatible enums) |
 | `@earendil-works/pi-tui` | TUI components for custom rendering |
 

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -113,6 +113,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | Extension | Description |
 |-----------|-------------|
 | `message-renderer.ts` | Custom message rendering with colors and expandable details via `registerMessageRenderer` |
+| `unicode-math.ts` | Transforms common TeX formulas in assistant Markdown into Unicode via `registerAssistantMarkdownTransformer` |
 | `entry-renderer.ts` | TUI-only session entry rendering via `appendEntry` and `registerEntryRenderer` |
 | `event-bus.ts` | Inter-extension communication via `pi.events` |
 

--- a/packages/coding-agent/examples/extensions/unicode-math.ts
+++ b/packages/coding-agent/examples/extensions/unicode-math.ts
@@ -1,0 +1,414 @@
+/**
+ * Unicode formula rendering for assistant messages.
+ *
+ * Converts common TeX notation inside \(...\), \[...\], $...$, and $$...$$
+ * to readable Unicode before Pi's built-in assistant renderer runs.
+ * Code spans and fenced code blocks are left unchanged. Unsupported TeX
+ * remains visible.
+ *
+ * Usage:
+ *   pi -e examples/extensions/unicode-math.ts
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Marked, type Token } from "marked";
+
+const markdownParser = new Marked();
+
+const TEX_SYMBOLS: Record<string, string> = {
+	alpha: "α",
+	beta: "β",
+	gamma: "γ",
+	delta: "δ",
+	epsilon: "ε",
+	varepsilon: "ϵ",
+	zeta: "ζ",
+	eta: "η",
+	theta: "θ",
+	vartheta: "ϑ",
+	iota: "ι",
+	kappa: "κ",
+	lambda: "λ",
+	mu: "μ",
+	nu: "ν",
+	xi: "ξ",
+	pi: "π",
+	varpi: "ϖ",
+	rho: "ρ",
+	sigma: "σ",
+	tau: "τ",
+	upsilon: "υ",
+	phi: "φ",
+	varphi: "ϕ",
+	chi: "χ",
+	psi: "ψ",
+	omega: "ω",
+	Gamma: "Γ",
+	Delta: "Δ",
+	Theta: "Θ",
+	Lambda: "Λ",
+	Xi: "Ξ",
+	Pi: "Π",
+	Sigma: "Σ",
+	Upsilon: "Υ",
+	Phi: "Φ",
+	Psi: "Ψ",
+	Omega: "Ω",
+	infty: "∞",
+	partial: "∂",
+	nabla: "∇",
+	forall: "∀",
+	exists: "∃",
+	in: "∈",
+	notin: "∉",
+	ni: "∋",
+	sum: "∑",
+	prod: "∏",
+	int: "∫",
+	iint: "∬",
+	iiint: "∭",
+	oint: "∮",
+	pm: "±",
+	mp: "∓",
+	times: "×",
+	cdot: "·",
+	div: "÷",
+	ast: "∗",
+	circ: "∘",
+	bullet: "•",
+	le: "≤",
+	leq: "≤",
+	ge: "≥",
+	geq: "≥",
+	ne: "≠",
+	neq: "≠",
+	approx: "≈",
+	equiv: "≡",
+	propto: "∝",
+	sim: "∼",
+	simeq: "≃",
+	cong: "≅",
+	ll: "≪",
+	gg: "≫",
+	subset: "⊂",
+	supset: "⊃",
+	subseteq: "⊆",
+	supseteq: "⊇",
+	cup: "∪",
+	cap: "∩",
+	setminus: "∖",
+	emptyset: "∅",
+	land: "∧",
+	lor: "∨",
+	neg: "¬",
+	oplus: "⊕",
+	otimes: "⊗",
+	perp: "⊥",
+	parallel: "∥",
+	angle: "∠",
+	therefore: "∴",
+	because: "∵",
+	to: "→",
+	rightarrow: "→",
+	leftarrow: "←",
+	leftrightarrow: "↔",
+	Rightarrow: "⇒",
+	Leftarrow: "⇐",
+	Leftrightarrow: "⇔",
+	mapsto: "↦",
+	ldots: "…",
+	cdots: "⋯",
+	vdots: "⋮",
+	ddots: "⋱",
+};
+
+const BLACKBOARD_SYMBOLS: Record<string, string> = {
+	C: "ℂ",
+	H: "ℍ",
+	N: "ℕ",
+	P: "ℙ",
+	Q: "ℚ",
+	R: "ℝ",
+	Z: "ℤ",
+};
+
+function createCharacterMap(...groups: Array<readonly [plain: string, mapped: string]>): Record<string, string> {
+	const entries: Array<[string, string]> = [];
+	for (const [plain, mapped] of groups) {
+		const plainCharacters = Array.from(plain);
+		const mappedCharacters = Array.from(mapped);
+		if (plainCharacters.length !== mappedCharacters.length) {
+			throw new Error(`Character map length mismatch: ${plain} -> ${mapped}`);
+		}
+		entries.push(
+			...plainCharacters.map((character, index): [string, string] => [character, mappedCharacters[index]!]),
+		);
+	}
+	return Object.fromEntries(entries);
+}
+
+const SUPERSCRIPT = createCharacterMap(
+	["0123456789+-=()", "⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾"],
+	["abcdefghijklmnopqrstuvwxyz", "ᵃᵇᶜᵈᵉᶠᵍʰⁱʲᵏˡᵐⁿᵒᵖ𐞥ʳˢᵗᵘᵛʷˣʸᶻ"],
+	["ABCDEFGHIJKLMNOPQRSTUVW", "ᴬᴮꟲᴰᴱꟳᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾꟴᴿ꟱ᵀᵁⱽᵂ"],
+	["αβγδεθφχ", "ᵅᵝᵞᵟᵋᶿᵠᵡ"],
+);
+
+const SUBSCRIPT = createCharacterMap(
+	["0123456789+-=()", "₀₁₂₃₄₅₆₇₈₉₊₋₌₍₎"],
+	["aehijklmnoprstuvx", "ₐₑₕᵢⱼₖₗₘₙₒₚᵣₛₜᵤᵥₓ"],
+	["βγρφχ", "ᵦᵧᵨᵩᵪ"],
+);
+
+function mapScript(value: string, table: Record<string, string>, marker: string): string {
+	const mapped = Array.from(value, (character) => table[character]);
+	return mapped.every((character) => character !== undefined) ? mapped.join("") : `${marker}${value}`;
+}
+
+function replaceSimpleCommands(tex: string): string {
+	return tex.replace(/\\([A-Za-z]+)/g, (match, name: string) => TEX_SYMBOLS[name] ?? match);
+}
+
+function renderEnvironment(name: string, body: string): string {
+	const rows = body
+		.trim()
+		.split(/\\\\/)
+		.map((row) => row.trim())
+		.filter(Boolean)
+		.map((row) => row.split("&").map((cell) => texToUnicode(cell)));
+
+	if (name === "aligned") {
+		return rows.map((cells) => cells.join(" ")).join("\n");
+	}
+	if (name === "pmatrix") {
+		return rows
+			.map((cells, index) => {
+				const left = rows.length === 1 ? "(" : index === 0 ? "⎛" : index === rows.length - 1 ? "⎝" : "⎜";
+				const right = rows.length === 1 ? ")" : index === 0 ? "⎞" : index === rows.length - 1 ? "⎠" : "⎟";
+				return `${left}${cells.join(" ")}${right}`;
+			})
+			.join("\n");
+	}
+	return rows
+		.map((cells, index) => {
+			const brace = rows.length === 1 ? "{" : index === 0 ? "⎧" : index === rows.length - 1 ? "⎩" : "⎪";
+			return `${brace} ${cells.join(" ")}`;
+		})
+		.join("\n");
+}
+
+/** Convert a useful subset of TeX notation to Unicode. */
+export function texToUnicode(source: string): string {
+	let text = source
+		.trim()
+		.replace(
+			/(^|\n)(?:([^\n]*=)[ \t]*\n[ \t]*)?\\begin\{(aligned|pmatrix|cases)\}([\s\S]*?)\\end\{\3\}/g,
+			(_match, lineStart: string, prefix: string | undefined, name: string, body: string) => {
+				const rendered = renderEnvironment(name, body);
+				if (prefix === undefined) return lineStart + rendered;
+				const label = `${texToUnicode(prefix)} `;
+				return lineStart + label + rendered.replace(/\n/g, `\n${" ".repeat(Array.from(label).length)}`);
+			},
+		);
+
+	while (true) {
+		const next = text
+			.replace(/\\frac\{([^{}]*)\}\{([^{}]*)\}/g, "($1)⁄($2)")
+			.replace(/\\sqrt\[([^{}]*)\]\{([^{}]*)\}/g, (_match, degree: string, value: string) => {
+				return `${mapScript(degree, SUPERSCRIPT, "^")}√(${value})`;
+			})
+			.replace(/\\sqrt\{([^{}]*)\}/g, "√($1)");
+		if (next === text) break;
+		text = next;
+	}
+
+	text = text
+		.replace(/\\mathbb\{([^{}])\}/g, (_match, symbol: string) => BLACKBOARD_SYMBOLS[symbol] ?? symbol)
+		.replace(/\\(?:mathrm|mathbf|mathit|mathsf|mathtt|text|operatorname)\{([^{}]*)\}/g, "$1")
+		.replace(/\\(?:left|right)\b/g, "")
+		.replace(/\\(?:quad|qquad)\b/g, " ")
+		.replace(/\\[,;:!]/g, " ")
+		.replace(/\\\\/g, "\n");
+
+	text = replaceSimpleCommands(text);
+	text = text
+		.replace(
+			/([∑∏∫∬∭∮])\s*_(?:\{([^{}]+)\}|([^\s^_]))\s*\^(?:\{([^{}]+)\}|([^\s^_]))/g,
+			(_match, operator: string, lowerGroup: string, lowerSingle: string, upperGroup: string, upperSingle: string) =>
+				`${operator}[${lowerGroup ?? lowerSingle}…${upperGroup ?? upperSingle}]`,
+		)
+		.replace(
+			/([∑∏∫∬∭∮])\s*\^(?:\{([^{}]+)\}|([^\s^_]))\s*_(?:\{([^{}]+)\}|([^\s^_]))/g,
+			(_match, operator: string, upperGroup: string, upperSingle: string, lowerGroup: string, lowerSingle: string) =>
+				`${operator}[${lowerGroup ?? lowerSingle}…${upperGroup ?? upperSingle}]`,
+		)
+		.replace(
+			/([∑∏∫∬∭∮])\s*_(?:\{([^{}]+)\}|([^\s^_]))/g,
+			(_match, operator: string, group: string, single: string) => `${operator}[${group ?? single}]`,
+		)
+		.replace(
+			/([∑∏∫∬∭∮])\s*\^(?:\{([^{}]+)\}|([^\s^_]))/g,
+			(_match, operator: string, group: string, single: string) => `${operator}[…${group ?? single}]`,
+		);
+	text = text.replace(/([_^])(?:\{([^{}]+)\}|([^\s{}_^]))/g, (_match, marker, group, single) => {
+		const value = marker === "^" ? (group ?? single).replace(/\^/g, "") : (group ?? single);
+		return marker === "^" ? mapScript(value, SUPERSCRIPT, "^") : mapScript(value, SUBSCRIPT, "_");
+	});
+
+	return text
+		.replace(/~/g, " ")
+		.replace(/(?<=\S)[ \t]+/g, " ")
+		.trim();
+}
+
+function isEscaped(text: string, index: number): boolean {
+	let backslashes = 0;
+	for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) backslashes++;
+	return backslashes % 2 === 1;
+}
+
+function findClosingDelimiter(text: string, start: number, delimiter: "$" | "$$"): number {
+	for (let index = text.indexOf(delimiter, start); index !== -1; index = text.indexOf(delimiter, index + 1)) {
+		if (isEscaped(text, index)) continue;
+		if (delimiter === "$" && text[index + 1] === "$") continue;
+		return index;
+	}
+	return -1;
+}
+
+function escapeMarkdown(text: string): string {
+	return text.replace(/[\\`*_[\]<>#]/g, "\\$&");
+}
+
+function renderUnicodeMathText(text: string): string {
+	let result = "";
+	let index = 0;
+
+	while (index < text.length) {
+		if (text[index] === "$" && !isEscaped(text, index)) {
+			const display = text[index + 1] === "$";
+			const delimiter = display ? "$$" : "$";
+			const contentStart = index + delimiter.length;
+			const close = findClosingDelimiter(text, contentStart, delimiter);
+			if (close !== -1) {
+				const content = text.slice(contentStart, close);
+				const validInline =
+					display ||
+					(!content.includes("\n") &&
+						content.length > 0 &&
+						!/^\s/.test(content) &&
+						!/^\d+(?:[.,]\d+)?$/.test(content) &&
+						!(/\s$/.test(content) || /\d/.test(text[close + 1] ?? "")));
+				if (validInline) {
+					const rendered = escapeMarkdown(texToUnicode(content));
+					result += display ? `\n\n${rendered}\n\n` : rendered;
+					index = close + delimiter.length;
+					continue;
+				}
+			}
+		}
+
+		const bracketDelimiter = text.slice(index, index + 2);
+		if ((bracketDelimiter === "\\(" || bracketDelimiter === "\\[") && !isEscaped(text, index)) {
+			const closingDelimiter = bracketDelimiter === "\\(" ? "\\)" : "\\]";
+			const contentStart = index + bracketDelimiter.length;
+			const close = text.indexOf(closingDelimiter, contentStart);
+			if (close !== -1) {
+				const content = text.slice(contentStart, close);
+				if (bracketDelimiter === "\\[" || !content.includes("\n")) {
+					const rendered = escapeMarkdown(texToUnicode(content));
+					result += bracketDelimiter === "\\[" ? `\n\n${rendered}\n\n` : rendered;
+					index = close + closingDelimiter.length;
+					continue;
+				}
+			}
+		}
+
+		result += text[index];
+		index++;
+	}
+
+	return result;
+}
+
+function getChildTokens(token: Token): Token[] {
+	if (token.type === "list") {
+		return token.items;
+	}
+	if (token.type === "table") {
+		return [...token.header, ...token.rows.flat()].flatMap((cell) => cell.tokens);
+	}
+	if ("tokens" in token && Array.isArray(token.tokens)) {
+		return token.tokens;
+	}
+	return [];
+}
+
+function renderTokenChildren(source: string, tokens: readonly Token[]): string {
+	let result = "";
+	let searchOffset = 0;
+	let outputOffset = 0;
+	for (const token of tokens) {
+		const index = source.indexOf(token.raw, searchOffset);
+		if (index === -1) return source;
+		searchOffset = index + token.raw.length;
+		if (token.type === "text" || token.type === "escape" || token.type === "br") {
+			continue;
+		}
+		result += renderUnicodeMathText(source.slice(outputOffset, index)) + renderUnicodeMathToken(token);
+		outputOffset = searchOffset;
+	}
+	return result + renderUnicodeMathText(source.slice(outputOffset));
+}
+
+function renderLinkText(raw: string, tokens: readonly Token[]): string {
+	const firstChild = tokens[0];
+	if (!firstChild) return raw;
+
+	let searchOffset = 0;
+	let textStart = -1;
+	let textEnd = -1;
+	for (const child of tokens) {
+		const index = raw.indexOf(child.raw, searchOffset);
+		if (index === -1) return raw;
+		if (textStart === -1) textStart = index;
+		textEnd = index + child.raw.length;
+		searchOffset = textEnd;
+	}
+
+	return raw.slice(0, textStart) + renderTokenChildren(raw.slice(textStart, textEnd), tokens) + raw.slice(textEnd);
+}
+
+function renderUnicodeMathToken(token: Token): string {
+	if (token.type === "code" || token.type === "codespan" || token.type === "html" || token.type === "def") {
+		return token.raw;
+	}
+
+	// Autolinks and bare URLs use the same source text for their label and destination,
+	// so changing their child text would also change the link target.
+	if (token.type === "link" && !token.raw.startsWith("[")) {
+		return token.raw;
+	}
+	if ((token.type === "link" || token.type === "image") && "tokens" in token && Array.isArray(token.tokens)) {
+		return renderLinkText(token.raw, token.tokens);
+	}
+
+	const childTokens = getChildTokens(token);
+	if (childTokens.length > 0) {
+		return renderTokenChildren(token.raw, childTokens);
+	}
+	return token.type === "text" || token.type === "escape" || token.type === "br"
+		? renderUnicodeMathText(token.raw)
+		: token.raw;
+}
+
+/** Replace formulas in Markdown text while preserving code, links, and raw HTML. */
+export function renderUnicodeMath(markdown: string): string {
+	return markdownParser.lexer(markdown).map(renderUnicodeMathToken).join("");
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerAssistantMarkdownTransformer((markdown, { contentType }) => {
+		return contentType === "text" ? renderUnicodeMath(markdown) : markdown;
+	});
+}

--- a/packages/coding-agent/install-lock/package-lock.json
+++ b/packages/coding-agent/install-lock/package-lock.json
@@ -504,6 +504,7 @@
 				"hosted-git-info": "9.0.3",
 				"ignore": "7.0.5",
 				"jiti": "2.7.0",
+				"marked": "18.0.5",
 				"minimatch": "10.2.5",
 				"proper-lockfile": "4.1.2",
 				"semver": "7.8.0",

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -21,6 +21,7 @@
 				"hosted-git-info": "9.0.3",
 				"ignore": "7.0.5",
 				"jiti": "2.7.0",
+				"marked": "18.0.5",
 				"minimatch": "10.2.5",
 				"proper-lockfile": "4.1.2",
 				"semver": "7.8.0",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -51,6 +51,7 @@
 		"hosted-git-info": "9.0.3",
 		"ignore": "7.0.5",
 		"jiti": "2.7.0",
+		"marked": "18.0.5",
 		"minimatch": "10.2.5",
 		"proper-lockfile": "4.1.2",
 		"semver": "7.8.0",

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -30,6 +30,7 @@ export type {
 	AppendEntryHandler,
 	// App keybindings (for custom editors)
 	AppKeybinding,
+	AssistantMarkdownTransformer,
 	AutocompleteProviderFactory,
 	// Events - Tool (ToolCallEvent types)
 	BashToolCallEvent,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -17,6 +17,7 @@ import { createJiti } from "jiti/static";
 // Static imports of packages that extensions may use.
 // These MUST be static so Bun bundles them into the compiled binary.
 // The virtualModules option then makes them available to extensions.
+import * as _bundledMarked from "marked";
 import * as _bundledTypebox from "typebox";
 import * as _bundledTypeboxCompile from "typebox/compile";
 import * as _bundledTypeboxValue from "typebox/value";
@@ -46,6 +47,7 @@ import type {
 
 /** Modules available to extensions via virtualModules (for compiled Bun binary) */
 const VIRTUAL_MODULES: Record<string, unknown> = {
+	marked: _bundledMarked,
 	typebox: _bundledTypebox,
 	"typebox/compile": _bundledTypeboxCompile,
 	"typebox/value": _bundledTypeboxValue,
@@ -85,6 +87,7 @@ function getAliases(): Record<string, string> {
 	const __dirname = path.dirname(fileURLToPath(import.meta.url));
 	const packageIndex = path.resolve(__dirname, "../..", "index.js");
 
+	const markedEntry = require.resolve("marked");
 	const typeboxEntry = require.resolve("typebox");
 	const typeboxCompileEntry = require.resolve("typebox/compile");
 	const typeboxValueEntry = require.resolve("typebox/value");
@@ -126,6 +129,7 @@ function getAliases(): Record<string, string> {
 		"@mariozechner/pi-ai/compat": piAiCompatEntry,
 		"@mariozechner/pi-ai/oauth": piAiOauthEntry,
 		"@mariozechner/pi-ai": piAiCompatEntry,
+		marked: markedEntry,
 		typebox: typeboxEntry,
 		"typebox/compile": typeboxCompileEntry,
 		"typebox/value": typeboxValueEntry,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -31,6 +31,7 @@ import { execCommand } from "../exec.ts";
 import { createSyntheticSourceInfo } from "../source-info.ts";
 import { time } from "../timings.ts";
 import type {
+	AssistantMarkdownTransformer,
 	EntryRenderer,
 	Extension,
 	ExtensionAPI,
@@ -277,6 +278,11 @@ function createExtensionAPI(
 		registerMessageRenderer<T>(customType: string, renderer: MessageRenderer<T>): void {
 			runtime.assertActive();
 			extension.messageRenderers.set(customType, renderer as MessageRenderer);
+		},
+
+		registerAssistantMarkdownTransformer(transformer: AssistantMarkdownTransformer): void {
+			runtime.assertActive();
+			extension.assistantMarkdownTransformer = transformer;
 		},
 
 		registerEntryRenderer<T>(customType: string, renderer: EntryRenderer<T>): void {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -12,6 +12,7 @@ import type { ModelRegistry } from "../model-registry.ts";
 import type { SessionManager } from "../session-manager.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import type {
+	AssistantMarkdownTransformer,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	BeforeProviderHeadersEvent,
@@ -555,6 +556,12 @@ export class ExtensionRunner {
 			}
 		}
 		return undefined;
+	}
+
+	getAssistantMarkdownTransformers(): AssistantMarkdownTransformer[] {
+		return this.extensions.flatMap((ext) =>
+			ext.assistantMarkdownTransformer ? [ext.assistantMarkdownTransformer] : [],
+		);
 	}
 
 	getEntryRenderer(customType: string): EntryRenderer | undefined {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1120,6 +1120,8 @@ export interface MessageRenderOptions {
 	expanded: boolean;
 }
 
+export type AssistantMarkdownTransformer = (markdown: string, context: { contentType: "text" | "thinking" }) => string;
+
 export interface EntryRenderOptions {
 	expanded: boolean;
 }
@@ -1255,6 +1257,9 @@ export interface ExtensionAPI {
 
 	/** Register a custom renderer for CustomMessageEntry. */
 	registerMessageRenderer<T = unknown>(customType: string, renderer: MessageRenderer<T>): void;
+
+	/** Register a transformer for assistant Markdown before Pi renders it in the interactive transcript. */
+	registerAssistantMarkdownTransformer(transformer: AssistantMarkdownTransformer): void;
 
 	/** Register a custom renderer for CustomEntry. Custom entries do not participate in LLM context. */
 	registerEntryRenderer<T = unknown>(customType: string, renderer: EntryRenderer<T>): void;
@@ -1648,6 +1653,7 @@ export interface Extension {
 	handlers: Map<string, HandlerFn[]>;
 	tools: Map<string, RegisteredTool>;
 	messageRenderers: Map<string, MessageRenderer>;
+	assistantMarkdownTransformer?: AssistantMarkdownTransformer;
 	entryRenderers?: Map<string, EntryRenderer>;
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -56,6 +56,7 @@ export type {
 	AgentToolResult,
 	AgentToolUpdateCallback,
 	AppKeybinding,
+	AssistantMarkdownTransformer,
 	AutocompleteProviderFactory,
 	BashToolCallEvent,
 	BeforeAgentStartEvent,

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
+import type { AssistantMarkdownTransformer } from "../../../core/extensions/types.ts";
 import { getMarkdownTheme, theme } from "../theme/theme.ts";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -15,6 +16,7 @@ export class AssistantMessageComponent extends Container {
 	private markdownTheme: MarkdownTheme;
 	private hiddenThinkingLabel: string;
 	private outputPad: number;
+	private markdownTransformers: readonly AssistantMarkdownTransformer[];
 	private lastMessage?: AssistantMessage;
 	private hasToolCalls = false;
 
@@ -24,6 +26,7 @@ export class AssistantMessageComponent extends Container {
 		markdownTheme: MarkdownTheme = getMarkdownTheme(),
 		hiddenThinkingLabel = "Thinking...",
 		outputPad = 1,
+		markdownTransformers: readonly AssistantMarkdownTransformer[] = [],
 	) {
 		super();
 
@@ -31,6 +34,7 @@ export class AssistantMessageComponent extends Container {
 		this.markdownTheme = markdownTheme;
 		this.hiddenThinkingLabel = hiddenThinkingLabel;
 		this.outputPad = outputPad;
+		this.markdownTransformers = markdownTransformers;
 
 		// Container for text/thinking content
 		this.contentContainer = new Container();
@@ -85,6 +89,7 @@ export class AssistantMessageComponent extends Container {
 
 		// Clear content container
 		this.contentContainer.clear();
+		message = this.transformMarkdown(message);
 
 		const hasVisibleContent = message.content.some(
 			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
@@ -176,5 +181,36 @@ export class AssistantMessageComponent extends Container {
 				this.contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), this.outputPad, 0));
 			}
 		}
+	}
+
+	private transformMarkdown(message: AssistantMessage): AssistantMessage {
+		if (this.markdownTransformers.length === 0) {
+			return message;
+		}
+
+		return {
+			...message,
+			content: message.content.map((content) => {
+				if (content.type !== "text" && content.type !== "thinking") {
+					return content;
+				}
+
+				let markdown = content.type === "text" ? content.text : content.thinking;
+				for (const transformer of this.markdownTransformers) {
+					try {
+						const transformed = transformer(markdown, {
+							contentType: content.type,
+						});
+						if (typeof transformed === "string") {
+							markdown = transformed;
+						}
+					} catch {
+						// Keep the current Markdown and continue with the next transformer.
+					}
+				}
+
+				return content.type === "text" ? { ...content, text: markdown } : { ...content, thinking: markdown };
+			}),
+		};
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -61,6 +61,7 @@ import {
 	detectCacheMiss,
 } from "../../core/cache-stats.ts";
 import type {
+	AssistantMarkdownTransformer,
 	AutocompleteProviderFactory,
 	EditorFactory,
 	ExtensionCommandContext,
@@ -1747,6 +1748,10 @@ export class InteractiveMode {
 		return this.session.getToolDefinition(toolName);
 	}
 
+	private getAssistantMarkdownTransformers(): AssistantMarkdownTransformer[] {
+		return this.session.extensionRunner.getAssistantMarkdownTransformers();
+	}
+
 	/**
 	 * Set up keyboard shortcuts registered by extensions.
 	 */
@@ -2881,6 +2886,7 @@ export class InteractiveMode {
 						this.getMarkdownThemeWithSettings(),
 						this.hiddenThinkingLabel,
 						this.outputPad,
+						this.getAssistantMarkdownTransformers(),
 					);
 					this.streamingMessage = event.message;
 					this.chatContainer.addChild(this.streamingComponent);
@@ -3252,6 +3258,7 @@ export class InteractiveMode {
 					this.getMarkdownThemeWithSettings(),
 					this.hiddenThinkingLabel,
 					this.outputPad,
+					this.getAssistantMarkdownTransformers(),
 				);
 				this.chatContainer.addChild(assistantComponent);
 				break;

--- a/packages/coding-agent/test/assistant-message.test.ts
+++ b/packages/coding-agent/test/assistant-message.test.ts
@@ -116,6 +116,77 @@ describe("AssistantMessageComponent", () => {
 		expect(updatedLines.some((line) => line.startsWith("reasoning"))).toBe(true);
 	});
 
+	test("chains Markdown transformers in registration order", () => {
+		initTheme("dark");
+		const calls: string[] = [];
+		const message = createAssistantMessage([{ type: "text", text: "The result is $x^2$." }]);
+		const component = new AssistantMessageComponent(message, false, undefined, "Thinking...", 1, [
+			(markdown, context) => {
+				calls.push("formula");
+				expect(context.contentType).toBe("text");
+				return markdown.replace("$x^2$", "x²");
+			},
+			(markdown) => {
+				calls.push("suffix");
+				return `${markdown} Done.`;
+			},
+		]);
+
+		expect(stripAnsi(component.render(80).join("\n"))).toContain("The result is x². Done.");
+		expect(calls).toEqual(["formula", "suffix"]);
+		component.updateContent(message);
+	});
+
+	test("continues the Markdown transformer chain when a transformer throws", () => {
+		initTheme("dark");
+		const calls: string[] = [];
+		const component = new AssistantMessageComponent(
+			createAssistantMessage([{ type: "text", text: "still visible" }]),
+			false,
+			undefined,
+			"Thinking...",
+			1,
+			[
+				(markdown) => {
+					calls.push("first");
+					return markdown.replace("still", "remains");
+				},
+				() => {
+					calls.push("throw");
+					throw new Error("broken transformer");
+				},
+				(markdown) => {
+					calls.push("last");
+					return `${markdown} after error`;
+				},
+			],
+		);
+
+		expect(stripAnsi(component.render(80).join("\n"))).toContain("remains visible after error");
+		expect(calls).toEqual(["first", "throw", "last"]);
+	});
+
+	test("transforms text and thinking Markdown without mutating the original message", () => {
+		initTheme("dark");
+		const message = createAssistantMessage([
+			{ type: "text", text: "answer" },
+			{ type: "thinking", thinking: "reasoning" },
+		]);
+		const component = new AssistantMessageComponent(message, false, undefined, "Thinking...", 1, [
+			(markdown, { contentType }) => {
+				return `${contentType}:${markdown}`;
+			},
+		]);
+
+		const rendered = stripAnsi(component.render(80).join("\n"));
+		expect(rendered).toContain("text:answer");
+		expect(rendered).toContain("thinking:reasoning");
+		expect(message.content).toEqual([
+			{ type: "text", text: "answer" },
+			{ type: "thinking", thinking: "reasoning" },
+		]);
+	});
+
 	test("uses configured output padding for user messages", () => {
 		initTheme("dark");
 

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -374,6 +374,9 @@ describe("extensions discovery", () => {
 	it("registers message and entry renderers", async () => {
 		const extCode = `
 			export default function(pi) {
+				pi.registerAssistantMarkdownTransformer((markdown) => {
+					return markdown;
+				});
 				pi.registerMessageRenderer("my-custom-type", (message, options, theme) => {
 					return null; // Use default rendering
 				});
@@ -388,6 +391,7 @@ describe("extensions discovery", () => {
 
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].assistantMarkdownTransformer).toBeDefined();
 		expect(result.extensions[0].messageRenderers.has("my-custom-type")).toBe(true);
 		expect(result.extensions[0].entryRenderers?.has("my-entry-type")).toBe(true);
 	});

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -69,6 +69,28 @@ describe("extensions discovery", () => {
 		expect(result.extensions).toHaveLength(1);
 	});
 
+	it("loads the bundled marked parser", async () => {
+		fs.writeFileSync(
+			path.join(extensionsDir, "marked-import.ts"),
+			`
+				import { Marked } from "marked";
+				export default function(pi) {
+					const parser = new Marked();
+					pi.registerAssistantMarkdownTransformer((markdown) => {
+						parser.lexer(markdown);
+						return markdown;
+					});
+				}
+			`,
+		);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+
+		expect(result.errors).toEqual([]);
+		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].assistantMarkdownTransformer).toBeDefined();
+	});
+
 	it("keeps the type-only pi-ai OAuth compatibility barrel resolvable", async () => {
 		fs.writeFileSync(
 			path.join(extensionsDir, "oauth-import.ts"),

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -576,6 +576,21 @@ describe("ExtensionRunner", () => {
 	});
 
 	describe("message and entry renderers", () => {
+		it("gets assistant Markdown transformers in extension load order", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.registerAssistantMarkdownTransformer((markdown) => markdown);
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "assistant-renderer-a.ts"), extCode);
+			fs.writeFileSync(path.join(extensionsDir, "assistant-renderer-b.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			expect(runner.getAssistantMarkdownTransformers()).toHaveLength(2);
+		});
+
 		it("gets message renderer by type", async () => {
 			const extCode = `
 				export default function(pi) {

--- a/packages/coding-agent/test/unicode-math-extension.test.ts
+++ b/packages/coding-agent/test/unicode-math-extension.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { renderUnicodeMath, texToUnicode } from "../examples/extensions/unicode-math.ts";
+
+describe("unicode math extension", () => {
+	test("converts common TeX notation", () => {
+		expect(texToUnicode("E = mc^2")).toBe("E = mc²");
+		expect(texToUnicode("\\frac{\\alpha + 1}{\\sqrt{x_2}} \\leq \\mathbb{R}")).toBe("(α + 1)⁄(√(x₂)) ≤ ℝ");
+		expect(texToUnicode("x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}")).toBe("x = (-b ± √(b² - 4ac))⁄(2a)");
+		expect(texToUnicode("\\sum_{k=1}^{n} k = \\frac{n(n+1)}{2}")).toBe("∑[k=1…n] k = (n(n+1))⁄(2)");
+	});
+
+	test("uses the available Unicode superscript and subscript alphabets", () => {
+		expect(texToUnicode("x^{abcdefghijklmnopqrstuvwxyz}")).toBe("xᵃᵇᶜᵈᵉᶠᵍʰⁱʲᵏˡᵐⁿᵒᵖ𐞥ʳˢᵗᵘᵛʷˣʸᶻ");
+		expect(texToUnicode("x^{ABCDEFGHIJKLMNOPQRSTUVW}")).toBe("xᴬᴮꟲᴰᴱꟳᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾꟴᴿ꟱ᵀᵁⱽᵂ");
+		expect(texToUnicode("x^{\\alpha\\beta}_\\gamma")).toBe("xᵅᵝᵧ");
+		expect(texToUnicode("x^{XYZ}")).toBe("x^XYZ");
+	});
+
+	test("renders inline and display formulas", () => {
+		const rendered = renderUnicodeMath("Inline $x_1^2 + \\pi$ and display:\n\n$$\\sum_{i=1}^n i$$");
+
+		expect(rendered).toContain("Inline x₁² + π");
+		expect(rendered).toContain("∑\\[i=1…n\\] i");
+		expect(rendered).not.toContain("$$");
+	});
+
+	test("renders bracket-delimited inline and display formulas", () => {
+		const rendered = renderUnicodeMath("Inline \\(x_1^2 + \\pi\\) and display:\n\n\\[\\sum_{i=1}^n i\\]");
+
+		expect(rendered).toContain("Inline x₁² + π");
+		expect(rendered).toContain("∑\\[i=1…n\\] i");
+		expect(rendered).not.toContain("\\(");
+		expect(rendered).not.toContain("\\sum");
+	});
+
+	test("renders large-operator bounds as linear ranges", () => {
+		expect(texToUnicode("\\sum_{i=1}^n i")).toBe("∑[i=1…n] i");
+		expect(texToUnicode("\\int_0^\\infty e^{-x}\\,dx")).toBe("∫[0…∞] e⁻ˣ dx");
+		expect(texToUnicode("\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}")).toBe("∫[-∞…∞] e⁻ˣ² dx = √(π)");
+		expect(texToUnicode("\\prod^n_{k=1} k")).toBe("∏[k=1…n] k");
+		expect(texToUnicode("\\sum_i a_i")).toBe("∑[i] aᵢ");
+		expect(texToUnicode("\\int^b f(x) dx")).toBe("∫[…b] f(x) dx");
+	});
+
+	test("renders aligned, matrix, and cases environments", () => {
+		expect(
+			texToUnicode(String.raw`\begin{aligned}
+(a+b)^2 &= a^2 + 2ab + b^2 \\
+(a-b)^2 &= a^2 - 2ab + b^2
+\end{aligned}`),
+		).toBe("(a+b)² = a² + 2ab + b²\n(a-b)² = a² - 2ab + b²");
+
+		expect(
+			texToUnicode(String.raw`A =
+\begin{pmatrix}
+1 & 2 \\
+3 & 4
+\end{pmatrix}`),
+		).toBe("A = ⎛1 2⎞\n    ⎝3 4⎠");
+
+		expect(
+			texToUnicode(String.raw`f(x) =
+\begin{cases}
+x^2, & x \ge 0 \\
+-x, & x < 0
+\end{cases}`),
+		).toBe("f(x) = ⎧ x², x ≥ 0\n       ⎩ -x, x < 0");
+	});
+
+	test("leaves formulas in code spans and fenced code blocks unchanged", () => {
+		const markdown = "`$x^2$` and $y^2$\n\n```tex\n$x^2$\n```\n\nBut $z^2$ changes.";
+		const rendered = renderUnicodeMath(markdown);
+
+		expect(rendered).toContain("`$x^2$` and y²");
+		expect(rendered).toContain("```tex\n$x^2$\n```");
+		expect(rendered).toContain("But z² changes.");
+	});
+
+	test("preserves link destinations and raw HTML", () => {
+		const markdown = [
+			"[formula $x^2$](https://example.com/$x$)",
+			"<https://example.com/$y$>",
+			"https://example.com/$q$",
+			'<span title="$z$">body $w$</span>',
+			"<div>$v$</div>",
+		].join("\n\n");
+		const rendered = renderUnicodeMath(markdown);
+
+		expect(rendered).toContain("[formula x²](https://example.com/$x$)");
+		expect(rendered).toContain("<https://example.com/$y$>");
+		expect(rendered).toContain("https://example.com/$q$");
+		expect(rendered).toContain('<span title="$z$">body w</span>');
+		expect(rendered).toContain("<div>$v$</div>");
+	});
+
+	test("uses CommonMark backtick-run semantics", () => {
+		const markdown = "``before```x` $y^2$ ``";
+		expect(renderUnicodeMath(markdown)).toBe(markdown);
+	});
+
+	test("preserves currency, escaped delimiters, and unsupported TeX", () => {
+		expect(renderUnicodeMath("Cost is $5$ today")).toBe("Cost is $5$ today");
+		expect(renderUnicodeMath("Literal \\\\(x^2\\\\)")).toBe("Literal \\\\(x^2\\\\)");
+		expect(texToUnicode("\\unknown{x}")).toBe("\\unknown{x}");
+	});
+});


### PR DESCRIPTION
Closes #6747

I made 3 commits:

The first one adds the API, pretty minimal.

The second one exports marked, because realistically, extensions will need it when parsing markdown.

The third adds an example extension that does a decent job at converting markdown formulas to unicode.
The last one is slop, feel free to ignore it.