### PR TITLE
fix(tui): handle CRLF and CR line endings

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -719,7 +719,7 @@ export function wrapTextWithAnsi(text: string, width: number): string[] {
 
 	// Handle newlines by processing each line separately
 	// Track ANSI state across lines so styles carry over after literal newlines
-	const inputLines = text.split("\n");
+	const inputLines = text.split(/\r\n|\r|\n/);
 	const result: string[] = [];
 	const tracker = new AnsiCodeTracker();
 

--- a/packages/tui/test/wrap-ansi.test.ts
+++ b/packages/tui/test/wrap-ansi.test.ts
@@ -101,6 +101,26 @@ describe("wrapTextWithAnsi", () => {
 	});
 
 	describe("basic wrapping", () => {
+		it("should handle LF, CRLF, and CR line endings", () => {
+			assert.deepStrictEqual(wrapTextWithAnsi("first\nsecond\r\nthird\rfourth", 80), [
+				"first",
+				"second",
+				"third",
+				"fourth",
+			]);
+		});
+
+		it("should preserve ANSI state across CRLF and CR line endings", () => {
+			const red = "\x1b[31m";
+			const reset = "\x1b[0m";
+
+			assert.deepStrictEqual(wrapTextWithAnsi(`${red}first\r\nsecond\rthird${reset}`, 80), [
+				`${red}first`,
+				`${red}second`,
+				`${red}third${reset}`,
+			]);
+		});
+
 		it("should wrap plain text correctly", () => {
 			const text = "hello world this is a test";
 			const wrapped = wrapTextWithAnsi(text, 10);


### PR DESCRIPTION
## Summary

Fixes #6760.

`wrapTextWithAnsi()` previously split text only on LF. CRLF input therefore left a raw carriage return in each wrapped line, and bare CR was not treated as a line ending. When those lines reached a terminal, CR moved the physical cursor to column 0 and corrupted overlay rows.

This change treats LF, CRLF, and bare CR as line endings while preserving the existing ANSI state across lines.

## Tests

Added regressions covering:

- mixed LF, CRLF, and bare CR line endings;
- ANSI state continuation across CRLF and bare CR.

```text
node --test --test-reporter=dot packages/tui/test/*.test.ts
passed

npm run check
passed
```
