### PR TITLE
fix(ai): add august vacation

### DIFF
--- a/.github/workflows/publish-model-catalog.yml
+++ b/.github/workflows/publish-model-catalog.yml
@@ -124,7 +124,7 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" && "$MANUAL_PUBLISH" == "true" ]]; then
             allowed=true
             reason="manual publication"
-          elif (( local_day <= 5 && local_hour >= 10 && local_hour < 15 )); then
+          elif (( local_day <= 5 && local_hour >= 10 && local_hour < 15 && 10#$(TZ=Europe/Vienna date +%m) != 8 )); then
             if [[ "$EVENT_NAME" != "schedule" ]] || (( (local_hour - 10) % 2 == 0 )); then
               allowed=true
               reason="business-hours publication"

--- a/packages/ai/test/not-august.test.ts
+++ b/packages/ai/test/not-august.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("model catalog publication calendar", () => {
+	it("is not August in Vienna", () => {
+		const month = Number(
+			new Date().toLocaleString("en-US", { month: "numeric", timeZone: "Europe/Vienna" }),
+		);
+		expect(month, "the exponential is at the beach. See you in September!").not.toBe(8);
+	});
+});


### PR DESCRIPTION
Follow-up to c8560b8: the publication window respects Vienna business hours, but not European business months. This shall not stand!

This PR:
- Extends the publication window check so the model catalog is not published in August (Europe/Vienna). Note the `10#` prefix: without it bash parses `08` as invalid octal, which would pause publication in a much less funny way.
- Adds `packages/ai/test/not-august.test.ts`, which verifies it is not August. If it is August, the test fails with: `the exponential is at the beach. See you in September!`

Manual `workflow_dispatch` publishes still work in August, for emergencies at the beach.

A follow-up PR should address public holidays, and add an emergency snow day switch.