### PR TITLE
fix(ai): expose low/high thinking levels for Kimi K3

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -228,9 +228,9 @@ const DEEPSEEK_V4_THINKING_LEVEL_MAP = {
 const KIMI_K3_THINKING_LEVEL_MAP = {
 	off: null,
 	minimal: null,
-	low: null,
+	low: "low",
 	medium: null,
-	high: null,
+	high: "high",
 	xhigh: null,
 	max: "max",
 } as const;

--- a/packages/ai/test/anthropic-force-adaptive-thinking.test.ts
+++ b/packages/ai/test/anthropic-force-adaptive-thinking.test.ts
@@ -91,6 +91,8 @@ describe("Anthropic forceAdaptiveThinking compat override", () => {
 
 	it.each([
 		["k2p7", "medium", "medium"],
+		["k3", "low", "low"],
+		["k3", "high", "high"],
 		["k3", "max", "max"],
 		["kimi-for-coding", "medium", "medium"],
 		["kimi-for-coding-highspeed", "medium", "medium"],

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -110,10 +110,17 @@ describe("getSupportedThinkingLevels", () => {
 		}
 	});
 
-	it("includes only max for Kimi Coding K3", () => {
-		const model = getModel("kimi-coding", "k3");
-		expect(model).toBeDefined();
-		expect(getSupportedThinkingLevels(model!)).toEqual(["max"]);
+	it("includes only low/high/max for Kimi K3", () => {
+		const cases = [
+			getModel("kimi-coding", "k3"),
+			getModel("moonshotai", "kimi-k3"),
+			getModel("moonshotai-cn", "kimi-k3"),
+		];
+
+		for (const model of cases) {
+			expect(model).toBeDefined();
+			expect(getSupportedThinkingLevels(model!)).toEqual(["low", "high", "max"]);
+		}
 	});
 
 	it("includes only high for OpenCode Grok Build", () => {


### PR DESCRIPTION
Closes #6769

## Summary

Kimi K3 now exposes three thinking effort levels: `low`, `high`, and `max` (previously `max` only, refs #6737).

- `kimi-coding/k3`, `moonshotai/kimi-k3`, and `moonshotai-cn/kimi-k3` now report `["low", "high", "max"]` from `getSupportedThinkingLevels`.
- On the Kimi Coding Anthropic-compatible endpoint the levels map to `output_config.effort` values `low` / `high` / `max` via adaptive thinking.

## Tests

- Extended `test/supports-xhigh.test.ts` to assert the `["low", "high", "max"]` level set across all three providers.
- Extended `test/anthropic-force-adaptive-thinking.test.ts` to assert `k3` sends adaptive-thinking effort for `low` and `high` in addition to `max`.
- `npm run check` and `./test.sh` pass.
