### PR TITLE
fix(coding-agent): speed up external editor launch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slow Ctrl+G external-editor startup when the system temporary directory contains many files.
+
 ## [0.80.7] - 2026-07-14
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-editor.ts
@@ -5,8 +5,6 @@
 
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
 import {
 	Container,
 	Editor,
@@ -18,6 +16,10 @@ import {
 	type TUI,
 } from "@earendil-works/pi-tui";
 import type { KeybindingsManager } from "../../../core/keybindings.ts";
+import {
+	createExternalEditorTempFile,
+	removeExternalEditorTempFile,
+} from "../../../utils/external-editor-temp-file.ts";
 import { getEditorTheme, theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint } from "./keybinding-hints.ts";
@@ -128,10 +130,9 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 		}
 
 		const currentText = this.editor.getText();
-		const tmpFile = path.join(os.tmpdir(), `pi-extension-editor-${Date.now()}.md`);
+		const { directory: tempDir, file: tmpFile } = createExternalEditorTempFile("prompt.md", currentText);
 
 		try {
-			fs.writeFileSync(tmpFile, currentText, "utf-8");
 			this.tui.stop();
 
 			const [editor, ...editorArgs] = editorCmd.split(" ");
@@ -154,11 +155,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 				this.editor.setText(newContent);
 			}
 		} finally {
-			try {
-				fs.unlinkSync(tmpFile);
-			} catch {
-				// Ignore cleanup errors
-			}
+			removeExternalEditorTempFile(tempDir);
 			this.tui.start();
 			// Force full re-render since external editor uses alternate screen
 			this.tui.requestRender(true);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -97,6 +97,7 @@ import { hasTrustRequiringProjectResources, ProjectTrustStore } from "../../core
 import { getChangelogPath, getNewEntries, normalizeChangelogLinks, parseChangelog } from "../../utils/changelog.ts";
 import { copyToClipboard, readClipboardText } from "../../utils/clipboard.ts";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.ts";
+import { createExternalEditorTempFile, removeExternalEditorTempFile } from "../../utils/external-editor-temp-file.ts";
 import { parseGitUrl } from "../../utils/git.ts";
 import { getCwdRelativePath } from "../../utils/paths.ts";
 import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
@@ -3796,12 +3797,9 @@ export class InteractiveMode {
 		}
 
 		const currentText = this.editor.getExpandedText?.() ?? this.editor.getText();
-		const tmpFile = path.join(os.tmpdir(), `pi-editor-${Date.now()}.pi.md`);
+		const { directory: tempDir, file: tmpFile } = createExternalEditorTempFile("prompt.pi.md", currentText);
 
 		try {
-			// Write current content to temp file
-			fs.writeFileSync(tmpFile, currentText, "utf-8");
-
 			// Stop TUI to release terminal
 			this.ui.stop();
 
@@ -3829,12 +3827,7 @@ export class InteractiveMode {
 			}
 			// On non-zero exit, keep original text (no action needed)
 		} finally {
-			// Clean up temp file
-			try {
-				fs.unlinkSync(tmpFile);
-			} catch {
-				// Ignore cleanup errors
-			}
+			removeExternalEditorTempFile(tempDir);
 
 			// Restart TUI
 			this.ui.start();

--- a/packages/coding-agent/src/utils/external-editor-temp-file.ts
+++ b/packages/coding-agent/src/utils/external-editor-temp-file.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface ExternalEditorTempFile {
+	/** The private temporary directory holding the file; pass this to removeExternalEditorTempFile. */
+	directory: string;
+	/** The absolute path to the editable file inside the directory. */
+	file: string;
+}
+
+/**
+ * Create a prompt file for an external editor inside a fresh, private temporary
+ * directory. Using a dedicated `mkdtemp` directory (rather than a uniquely named
+ * file directly in `os.tmpdir()`) keeps editor startup fast even when the system
+ * temporary directory holds many entries. If writing the file fails, the
+ * directory is removed before the error propagates so no empty directory leaks.
+ */
+export function createExternalEditorTempFile(fileName: string, content: string): ExternalEditorTempFile {
+	const directory = mkdtempSync(join(tmpdir(), "pi-editor-"));
+	const file = join(directory, fileName);
+	try {
+		writeFileSync(file, content, "utf-8");
+		return { directory, file };
+	} catch (error) {
+		rmSync(directory, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+/**
+ * Recursively remove a temporary directory created by createExternalEditorTempFile.
+ * Cleanup failures are swallowed so a stale temp directory can never prevent the
+ * TUI from restarting after the editor exits.
+ */
+export function removeExternalEditorTempFile(directory: string): void {
+	try {
+		rmSync(directory, { recursive: true, force: true });
+	} catch {
+		// Cleanup must not prevent the TUI from restarting.
+	}
+}

--- a/packages/coding-agent/test/external-editor-temp-file.test.ts
+++ b/packages/coding-agent/test/external-editor-temp-file.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createExternalEditorTempFile, removeExternalEditorTempFile } from "../src/utils/external-editor-temp-file.ts";
+
+const createdDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of createdDirectories) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+	createdDirectories.length = 0;
+});
+
+describe("external editor temp files", () => {
+	it("places the prompt in a private sparse directory", () => {
+		const tempFile = createExternalEditorTempFile("prompt.pi.md", "hello");
+		createdDirectories.push(tempFile.directory);
+
+		expect(dirname(tempFile.directory)).toBe(tmpdir());
+		expect(basename(tempFile.directory)).toMatch(/^pi-editor-/);
+		expect(dirname(tempFile.file)).toBe(tempFile.directory);
+		expect(basename(tempFile.file)).toBe("prompt.pi.md");
+		expect(readFileSync(tempFile.file, "utf-8")).toBe("hello");
+		if (process.platform !== "win32") {
+			expect(statSync(tempFile.directory).mode & 0o777).toBe(0o700);
+		}
+	});
+
+	it("removes the entire temporary directory", () => {
+		const tempFile = createExternalEditorTempFile("prompt.md", "hello");
+		removeExternalEditorTempFile(tempFile.directory);
+
+		expect(existsSync(tempFile.directory)).toBe(false);
+		expect(() => removeExternalEditorTempFile(tempFile.directory)).not.toThrow();
+	});
+});


### PR DESCRIPTION
## What

Speeds up the `Ctrl+G` external-editor launch. Instead of writing the prompt to a uniquely-named file directly in `os.tmpdir()`, it creates the file inside a fresh private `mkdtemp` directory. When the system temp directory holds many entries, the previous approach could be noticeably slow to start; the dedicated directory avoids that.

The temp-file create/remove logic is extracted into a small shared util (`external-editor-temp-file.ts`) used by both the main editor (`interactive-mode.ts`) and the extension editor (`extension-editor.ts`), so the two flows stay in sync. Cleanup now removes the whole directory recursively.

## Changes

- New `src/utils/external-editor-temp-file.ts` with `createExternalEditorTempFile` / `removeExternalEditorTempFile`.
- Both editor implementations use the helper instead of hand-rolled `os.tmpdir()` + `Date.now()` paths.
- Unit tests covering directory placement, `0700` permissions, content round-trip, and idempotent cleanup.
- Changelog entry under `[Unreleased]`.

## Testing

- `npx vitest --run external-editor-temp-file` — passes (2 tests).

## Out of scope, but noticed while in here

I self-reviewed the touched functions and found a few pre-existing items adjacent to this change. I left them out to keep this PR focused on the perf fix — happy to address any of them here or in a follow-up, your call:

1. **Windows: unquoted temp path to a `shell:true` spawn.** `spawn(editor, [...editorArgs, tmpFile], { shell: process.platform === "win32" })` doesn't quote `tmpFile`; if `os.tmpdir()` contains a space, `cmd.exe` splits the path and the editor opens the wrong file. The spawn line is unchanged by this PR.
2. **Crash on an unwritable/full temp dir.** `openExternalEditor()` is called fire-and-forget at both call sites, so a throw from temp-file creation becomes an unhandled rejection. Pre-existing (the old `writeFileSync` propagated the same way).
3. **The `spawn` + read-back block is still duplicated** across both editor implementations. This PR extracted only the temp-file handling; consolidating the spawn/read-back too would remove the remaining drift risk.
