### PR TITLE
fix: preserve extension provider auth during availability refresh

### DIFF
--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -246,11 +246,31 @@ export class ModelRuntime implements Models {
 			this.credentials.list(),
 		]);
 		const auth = new Map(checks);
+
+		// Preserve auth entries for extension providers that have apiKey configured
+		// This prevents race condition where async refresh clears provisional auth entries
+		for (const [providerId, config] of this.extensionProviders.entries()) {
+			if (config.apiKey && !auth.has(providerId)) {
+				auth.set(providerId, {
+					type: config.oauth && !config.apiKey ? "oauth" : "api_key",
+					source: "configured provider",
+				});
+			}
+		}
+
 		const configuredProviders = new Set(
 			checks
 				.filter((entry): entry is [string, AuthCheck] => entry[1] !== undefined)
 				.map(([providerId]) => providerId),
 		);
+
+		// Add extension providers with apiKey to configured providers
+		for (const [providerId, config] of this.extensionProviders.entries()) {
+			if (config.apiKey) {
+				configuredProviders.add(providerId);
+			}
+		}
+
 		this.snapshot = {
 			all: [...this.models.getModels()],
 			available: [...available],


### PR DESCRIPTION
## Problem

Extension providers registered via `pi.registerProvider()` encounter `Error: Provider is not configured` after startup, `/new`, or provider switching.

## Root Cause

`runAvailabilityRefresh()` rebuilds the auth map from `checkAuth()` results, which clears the provisional auth entry created by `registerProvider()`. This creates a race condition:

1. `registerProvider()` creates provisional auth entry
2. `void this.refresh()` triggers async `runAvailabilityRefresh()`
3. `runAvailabilityRefresh()` rebuilds auth map, clearing the provisional entry
4. Provider becomes unconfigured

## Solution

Preserve auth entries for extension providers that have `apiKey` configured during `runAvailabilityRefresh()`. This prevents the race condition by ensuring extension providers with valid credentials maintain their auth state.

## Changes

- Modified `runAvailabilityRefresh()` in `packages/coding-agent/src/core/model-runtime.ts`
- Added logic to preserve auth entries for extension providers with `apiKey`
- Added extension providers to `configuredProviders` set

Fixes: #6776