### PR TITLE
fix(ai): expose Kimi Coding K3 effort levels

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -251,6 +251,15 @@ const KIMI_K3_THINKING_LEVEL_MAP = {
 	xhigh: null,
 	max: "max",
 } as const;
+const KIMI_CODING_K3_THINKING_LEVEL_MAP = {
+	off: null,
+	minimal: null,
+	low: "low",
+	medium: null,
+	high: "high",
+	xhigh: null,
+	max: "max",
+} as const;
 const KIMI_K3_MAX_TOKENS = 131072;
 const KIMI_K3_COST = {
 	input: 3,
@@ -1702,7 +1711,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						forceAdaptiveThinking: true,
 					},
 					reasoning: isKimiK3 || m.reasoning === true,
-					...(isKimiK3 ? { thinkingLevelMap: KIMI_K3_THINKING_LEVEL_MAP } : {}),
+					...(isKimiK3 ? { thinkingLevelMap: KIMI_CODING_K3_THINKING_LEVEL_MAP } : {}),
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {
 						input: m.cost?.input || impliedCost?.input || 0,

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -110,8 +110,14 @@ describe("getSupportedThinkingLevels", () => {
 		}
 	});
 
-	it("includes only max for Kimi Coding K3", () => {
+	it("includes low, high, and max for Kimi Coding K3", () => {
 		const model = getModel("kimi-coding", "k3");
+		expect(model).toBeDefined();
+		expect(getSupportedThinkingLevels(model!)).toEqual(["low", "high", "max"]);
+	});
+
+	it.each(["moonshotai", "moonshotai-cn"] as const)("includes only max for %s Kimi K3", (provider) => {
+		const model = getModel(provider, "kimi-k3");
 		expect(model).toBeDefined();
 		expect(getSupportedThinkingLevels(model!)).toEqual(["max"]);
 	});


### PR DESCRIPTION
## Summary

- expose `low`, `high`, and `max` thinking levels for Kimi Coding K3
- keep direct Moonshot K3 on its separate max-only contract
- update thinking-level regression coverage for both endpoints

Kimi Code now documents `low`, `high`, and `max` for `k3`: https://www.kimi.com/code/docs/en/kimi-code/models.html#model-overview

This is a follow-up to #6737. The max-only metadata added there matched Kimi Code's documented capability at the time, but the subscription endpoint has since added `low` and `high`.

## Tests

- `node node_modules/vitest/dist/cli.js --run test/supports-xhigh.test.ts` from `packages/ai`
- `npm run check`
- `./test.sh`
