### PR TITLE
fix(tui): clear inverted cursor on exit to avoid dual cursor appearance

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -695,6 +695,8 @@ export class TUI extends Container {
 		}
 		// Move cursor to the end of the content to prevent overwriting/artifacts on exit
 		if (this.previousLines.length > 0) {
+			// Overwrite the inverted cursor with a normal space to clear the artifact
+			this.terminal.write(" ");
 			const targetRow = this.previousLines.length; // Line after the last content
 			const lineDiff = targetRow - this.hardwareCursorRow;
 			if (lineDiff > 0) {


### PR DESCRIPTION
When pi exits, the reverse-video cursor character remains visible on the editor prompt line. Combined with the terminal's own cursor below, this creates the appearance of two cursors, which is confusing.

Overwrite the inverted cursor with a normal space before exiting.