### PR TITLE
fix(coding-agent): show actual extended context size in footer indicator 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ out.html
 packages/coding-agent/binaries/
 todo.md
 plans/
+docs/superpowers/
 .pi/hf-sessions/
 .pi/hf-sessions-backup/
 collect.sh

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `extendedContextWindow` field to `Model` and derived default/extended context window values for GitHub Copilot models with extended-capability support (Claude Sonnet 5, Opus 4.6/4.7/4.8, Sonnet 4.6, Fable 5, GPT-5.3-Codex, GPT-5.4/5.5/5.6, Gemini 3.1 Pro).
+
 ### Fixed
 
 - Fixed GitHub Copilot long-context pricing tiers in generated model metadata ([#6668](https://github.com/earendil-works/pi/issues/6668)).

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -359,18 +359,20 @@ const OPENCODE_OPENAI_COMPLETIONS_LONG_CACHE_RETENTION_UNSUPPORTED_MODELS = new 
 ]);
 
 // GitHub's "Models with extended capabilities" table lists these Copilot models as supporting
-// the extended 1 million token context window.
-const GITHUB_COPILOT_EXTENDED_CONTEXT_MODELS = new Set([
-	"claude-fable-5",
-	"claude-opus-4.6",
-	"claude-opus-4.7",
-	"claude-opus-4.8",
-	"claude-sonnet-4.6",
-	"claude-sonnet-5",
-	"gpt-5.3-codex",
-	"gpt-5.4",
-	"gpt-5.5",
-]);
+// the extended 1 million token context window. These have flat pricing regardless of context
+// size, so models.dev has no tier signal for their default (non-extended) context window --
+// the default value here matches each model's non-extended sibling model (200000 for the Claude
+// family, matching Opus 4.5/Sonnet 4.5/Haiku 4.5; 400000 for GPT-5.3-Codex, matching GPT-5.2-Codex).
+const GITHUB_COPILOT_FLAT_PRICED_EXTENDED_CONTEXT_MODELS: Record<string, number> = {
+	"claude-fable-5": 200000,
+	"claude-opus-4.6": 200000,
+	"claude-opus-4.7": 200000,
+	"claude-opus-4.8": 200000,
+	"claude-sonnet-4.6": 200000,
+	"claude-sonnet-5": 200000,
+	"gpt-5.3-codex": 400000,
+};
+const GITHUB_COPILOT_FLAT_PRICED_EXTENDED_CONTEXT_WINDOW = 1000000;
 
 // Checked manually against the authenticated GitHub Copilot /models endpoint on 2026-06-15.
 // Keep this to narrow corrections over models.dev metadata instead of snapshotting Copilot's catalog.
@@ -1853,8 +1855,18 @@ async function generateModels() {
 
 	// Temporary overrides until upstream model metadata is corrected.
 	for (const candidate of allModels) {
-		if (candidate.provider === "github-copilot" && GITHUB_COPILOT_EXTENDED_CONTEXT_MODELS.has(candidate.id)) {
-			candidate.contextWindow = 1000000;
+		if (candidate.provider === "github-copilot") {
+			const flatPricedDefault = GITHUB_COPILOT_FLAT_PRICED_EXTENDED_CONTEXT_MODELS[candidate.id];
+			if (flatPricedDefault !== undefined) {
+				candidate.extendedContextWindow = GITHUB_COPILOT_FLAT_PRICED_EXTENDED_CONTEXT_WINDOW;
+				candidate.contextWindow = flatPricedDefault;
+			} else {
+				const tierThreshold = candidate.cost.tiers?.[0]?.inputTokensAbove;
+				if (tierThreshold !== undefined && tierThreshold < candidate.contextWindow) {
+					candidate.extendedContextWindow = candidate.contextWindow;
+					candidate.contextWindow = tierThreshold;
+				}
+			}
 		}
 
 		if (

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -718,6 +718,12 @@ export interface Model<TApi extends Api> {
 	input: ("text" | "image")[];
 	cost: ModelCost;
 	contextWindow: number;
+	/**
+	 * Maximum context window when the model is switched into its extended/long-context mode.
+	 * Only present for models that support a distinct extended context tier (e.g. GitHub Copilot's
+	 * "extended 1M context" models). When absent, the model only has a single context window size.
+	 */
+	extendedContextWindow?: number;
 	maxTokens: number;
 	headers?: Record<string, string>;
 	/** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */

--- a/packages/ai/test/github-copilot-context-window.test.ts
+++ b/packages/ai/test/github-copilot-context-window.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/compat.ts";
+
+describe("github-copilot extended context window", () => {
+	it("gives Claude Sonnet 5 a smaller default and a 1M extended context window", () => {
+		const model = getModel("github-copilot", "claude-sonnet-5");
+
+		expect(model.contextWindow).toBe(200000);
+		expect(model.extendedContextWindow).toBe(1000000);
+	});
+
+	it("derives GPT-5.4's default context window from its pricing tier threshold", () => {
+		const model = getModel("github-copilot", "gpt-5.4");
+
+		expect(model.cost.tiers?.[0]?.inputTokensAbove).toBe(model.contextWindow);
+		expect(model.extendedContextWindow).toBeGreaterThan(model.contextWindow);
+	});
+
+	it("derives GPT-5.6 Sol's default context window from its pricing tier threshold", () => {
+		const model = getModel("github-copilot", "gpt-5.6-sol");
+
+		expect(model.contextWindow).toBe(272000);
+		expect(model.extendedContextWindow).toBe(1050000);
+	});
+
+	it("leaves models without extended capability unset", () => {
+		const model = getModel("github-copilot", "claude-haiku-4.5");
+
+		expect(model.extendedContextWindow).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `/exit` command that quits pi and prints the command to resume the session.
 - Added built-in llama.cpp router support with `/login` connection setup and `/llama` Hugging Face model search and downloads, explicit loading, unloading, and live progress. See [llama.cpp](docs/llama-cpp.md).
 - Added extension registration for complete pi-ai providers, including native authentication, model refresh, filtering, and streaming behavior.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added `/exit` command that quits pi and prints the command to resume the session.
 - Added built-in llama.cpp router support with `/login` connection setup and `/llama` Hugging Face model search and downloads, explicit loading, unloading, and live progress. See [llama.cpp](docs/llama-cpp.md).
 - Added extension registration for complete pi-ai providers, including native authentication, model refresh, filtering, and streaming behavior.
-- Added a context size step (default vs extended) and a thinking level step to the `/model` picker for GitHub Copilot models that support them, plus a `[1M]` footer indicator and an extended context column in `--list-models`.
+- Added a context size step (default vs extended) and a thinking level step to the `/model` picker for GitHub Copilot models that support them, plus a footer indicator showing the active extended context size and an extended context column in `--list-models`.
 
 ### Fixed
 
@@ -15,6 +15,7 @@
 - Fixed obsolete custom UI, custom tool, and custom editor examples in the extension documentation ([#6735](https://github.com/earendil-works/pi/issues/6735)).
 - Fixed Kimi Coding sessions to show API-equivalent implied costs with the subscription indicator.
 - Fixed OpenAI Responses early stream endings to trigger automatic retry instead of ending the agent run ([#6727](https://github.com/earendil-works/pi/issues/6727)).
+- Fixed the footer's extended-context indicator to show the model's actual extended context window size instead of a hardcoded `[1M]`.
 
 ## [0.80.10] - 2026-07-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `/exit` command that quits pi and prints the command to resume the session.
 - Added built-in llama.cpp router support with `/login` connection setup and `/llama` Hugging Face model search and downloads, explicit loading, unloading, and live progress. See [llama.cpp](docs/llama-cpp.md).
 - Added extension registration for complete pi-ai providers, including native authentication, model refresh, filtering, and streaming behavior.
+- Added a context size step (default vs extended) and a thinking level step to the `/model` picker for GitHub Copilot models that support them, plus a `[1M]` footer indicator and an extended context column in `--list-models`.
 
 ### Fixed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -197,6 +197,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/hotkeys` | Show all keyboard shortcuts |
 | `/changelog` | Display version history |
 | `/quit` | Quit pi |
+| `/exit` | Quit pi and print the command to resume this session |
 
 ### Keyboard Shortcuts
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -38,7 +38,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 |---------|-------------|
 | `/login`, `/logout` | Manage OAuth or API-key credentials |
 | [`/llama`](llama-cpp.md) | Download, load, and unload llama.cpp router models |
-| `/model` | Switch models |
+| `/model` | Switch models. For GitHub Copilot models with an extended context option, also prompts to choose the context window size (default or extended) and thinking level |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
 | `/resume` | Pick from previous sessions |

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -58,6 +58,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/hotkeys` | Show all keyboard shortcuts |
 | `/changelog` | Display version history |
 | `/quit` | Quit pi |
+| `/exit` | Quit pi and print the command to resume this session |
 
 ## Message Queue
 

--- a/packages/coding-agent/src/cli/list-models.ts
+++ b/packages/coding-agent/src/cli/list-models.ts
@@ -61,7 +61,10 @@ export async function listModels(modelRuntime: ModelRuntime, searchPattern?: str
 	const rows = filteredModels.map((m) => ({
 		provider: m.provider,
 		model: m.id,
-		context: formatTokenCount(m.contextWindow),
+		context:
+			m.extendedContextWindow !== undefined
+				? `${formatTokenCount(m.contextWindow)}->${formatTokenCount(m.extendedContextWindow)}`
+				: formatTokenCount(m.contextWindow),
 		maxOut: formatTokenCount(m.maxTokens),
 		thinking: m.reasoning ? "yes" : "no",
 		images: m.input.includes("image") ? "yes" : "no",

--- a/packages/coding-agent/src/core/remote-catalog-provider.ts
+++ b/packages/coding-agent/src/core/remote-catalog-provider.ts
@@ -9,8 +9,19 @@ function mergeModels(baseline: readonly Model<Api>[], dynamic: readonly Model<Ap
 	const merged = [...baseline];
 	for (const model of dynamic) {
 		const index = merged.findIndex((entry) => entry.id === model.id);
-		if (index >= 0) merged[index] = model;
-		else merged.push(model);
+		if (index < 0) {
+			merged.push(model);
+			continue;
+		}
+		const existing = merged[index];
+		// The remote catalog predates the default/extended context window split and reports
+		// a single (already-extended) contextWindow with no extendedContextWindow field, which
+		// would otherwise collapse the locally curated choice. Keep the local split, but still
+		// take every other field (pricing, headers, thinkingLevelMap, etc.) from the fresh entry.
+		merged[index] =
+			existing.extendedContextWindow !== undefined
+				? { ...model, contextWindow: existing.contextWindow, extendedContextWindow: existing.extendedContextWindow }
+				: model;
 	}
 	return merged;
 }

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -39,4 +39,5 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, themes, and context files" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
+	{ name: "exit", description: `Quit ${APP_NAME} and print the command to resume this session` },
 ];

--- a/packages/coding-agent/src/modes/interactive/components/context-size-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/context-size-selector.ts
@@ -1,0 +1,75 @@
+import { Container, type SelectItem, SelectList, type SelectListLayoutOptions } from "@earendil-works/pi-tui";
+import { getSelectListTheme } from "../theme/theme.ts";
+import { DynamicBorder } from "./dynamic-border.ts";
+import { formatTokens } from "./footer.ts";
+
+const CONTEXT_SIZE_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
+	minPrimaryColumnWidth: 12,
+	maxPrimaryColumnWidth: 32,
+};
+
+export interface ContextSizeChoice {
+	contextWindow: number;
+	extended: boolean;
+}
+
+/**
+ * Component that lets the user choose between a Copilot model's default and extended
+ * context window sizes, rendered with the same borders/theme as ThinkingSelectorComponent.
+ */
+export class ContextSizeSelectorComponent extends Container {
+	private selectList: SelectList;
+
+	constructor(
+		defaultContextWindow: number,
+		extendedContextWindow: number,
+		isCurrentlyExtended: boolean,
+		onSelect: (choice: ContextSizeChoice) => void,
+		onCancel: () => void,
+	) {
+		super();
+
+		const items: SelectItem[] = [
+			{
+				value: "default",
+				label: `Default (${formatTokens(defaultContextWindow)} context)`,
+				description: "Standard context window",
+			},
+			{
+				value: "extended",
+				label: `Extended (${formatTokens(extendedContextWindow)} context)`,
+				description: "Larger context window for big codebases or long conversations",
+			},
+		];
+
+		// Add top border
+		this.addChild(new DynamicBorder());
+
+		this.selectList = new SelectList(items, items.length, getSelectListTheme(), CONTEXT_SIZE_SELECT_LIST_LAYOUT);
+
+		// Preselect the currently active choice
+		const currentIndex = isCurrentlyExtended ? 1 : 0;
+		this.selectList.setSelectedIndex(currentIndex);
+
+		this.selectList.onSelect = (item) => {
+			onSelect(
+				item.value === "extended"
+					? { contextWindow: extendedContextWindow, extended: true }
+					: { contextWindow: defaultContextWindow, extended: false },
+			);
+		};
+
+		this.selectList.onCancel = () => {
+			onCancel();
+		};
+
+		this.addChild(this.selectList);
+
+		// Add bottom border
+		this.addChild(new DynamicBorder());
+	}
+
+	getSelectList(): SelectList {
+		return this.selectList;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -168,7 +168,13 @@ export class FooterComponent implements Component {
 		let statsLeft = statsParts.join(" ");
 
 		// Add model name on the right side, plus thinking level if model supports it
-		const modelName = state.model?.id || "no-model";
+		let modelName = state.model?.id || "no-model";
+		if (
+			state.model?.extendedContextWindow !== undefined &&
+			state.model.contextWindow === state.model.extendedContextWindow
+		) {
+			modelName += " [1M]";
+		}
 
 		let statsLeftWidth = visibleWidth(statsLeft);
 

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -173,7 +173,7 @@ export class FooterComponent implements Component {
 			state.model?.extendedContextWindow !== undefined &&
 			state.model.contextWindow === state.model.extendedContextWindow
 		) {
-			modelName += " [1M]";
+			modelName += ` [${formatTokens(state.model.extendedContextWindow)}]`;
 		}
 
 		let statsLeftWidth = visibleWidth(statsLeft);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2747,7 +2747,7 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
-			if (text === "/quit") {
+			if (text === "/quit" || text === "/exit") {
 				this.editor.setText("");
 				await this.shutdown();
 				return;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,8 +7,9 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AuthEvent, AuthPrompt } from "@earendil-works/pi-ai";
+import { getSupportedThinkingLevels, modelsAreEqual } from "@earendil-works/pi-ai";
 import type { AssistantMessage, ImageContent, Message, Model } from "@earendil-works/pi-ai/compat";
 import type {
 	AutocompleteItem,
@@ -101,6 +102,7 @@ import { BashExecutionComponent } from "./components/bash-execution.ts";
 import { BorderedLoader } from "./components/bordered-loader.ts";
 import { BranchSummaryMessageComponent } from "./components/branch-summary-message.ts";
 import { CompactionSummaryMessageComponent } from "./components/compaction-summary-message.ts";
+import { ContextSizeSelectorComponent } from "./components/context-size-selector.ts";
 import { CustomEditor } from "./components/custom-editor.ts";
 import { CustomEntryComponent } from "./components/custom-entry.ts";
 import { CustomMessageComponent } from "./components/custom-message.ts";
@@ -131,6 +133,7 @@ import {
 	type StatusIndicator,
 	WorkingStatusIndicator,
 } from "./components/status-indicator.ts";
+import { ThinkingSelectorComponent } from "./components/thinking-selector.ts";
 import { ToolExecutionComponent } from "./components/tool-execution.ts";
 import { TreeSelectorComponent } from "./components/tree-selector.ts";
 import { TrustSelectorComponent } from "./components/trust-selector.ts";
@@ -4413,6 +4416,62 @@ export class InteractiveMode {
 		});
 	}
 
+	/**
+	 * Finalizes a model selection: applies the model (and optional thinking level override),
+	 * updates the UI, and shows the resulting status. Used as the last step of the chained
+	 * model -> context size -> thinking level picker flow in showModelSelector.
+	 */
+	private async finalizeModelSelection(
+		model: Model<any>,
+		done: () => void,
+		thinkingLevel?: ThinkingLevel,
+	): Promise<void> {
+		try {
+			await this.session.setModel(model);
+			if (thinkingLevel !== undefined) {
+				this.session.setThinkingLevel(thinkingLevel);
+			}
+			this.footer.invalidate();
+			this.updateEditorBorderColor();
+			done();
+			const contextSuffix =
+				model.extendedContextWindow !== undefined && model.contextWindow === model.extendedContextWindow
+					? " (extended context)"
+					: "";
+			this.showStatus(`Model: ${model.id}${contextSuffix}`);
+			void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
+			this.checkDaxnutsEasterEgg(model);
+		} catch (error) {
+			done();
+			this.showError(error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	/**
+	 * Shows the thinking level step of the model picker chain if the model supports reasoning,
+	 * otherwise finalizes the selection immediately.
+	 */
+	private showThinkingLevelStep(model: Model<any>, done: () => void): void {
+		if (!model.reasoning) {
+			void this.finalizeModelSelection(model, done);
+			return;
+		}
+		this.showSelector((thinkingDone) => {
+			const availableLevels = getSupportedThinkingLevels(model) as ThinkingLevel[];
+			const thinkingSelector = new ThinkingSelectorComponent(
+				this.session.thinkingLevel,
+				availableLevels,
+				(level) => {
+					void this.finalizeModelSelection(model, thinkingDone, level);
+				},
+				() => {
+					void this.finalizeModelSelection(model, thinkingDone);
+				},
+			);
+			return { component: thinkingSelector, focus: thinkingSelector.getSelectList() };
+		});
+	}
+
 	private showModelSelector(initialSearchInput?: string): void {
 		this.showSelector((done) => {
 			const selector = new ModelSelectorComponent(
@@ -4421,19 +4480,29 @@ export class InteractiveMode {
 				this.settingsManager,
 				this.session.modelRuntime,
 				this.session.scopedModels,
-				async (model) => {
-					try {
-						await this.session.setModel(model);
-						this.footer.invalidate();
-						this.updateEditorBorderColor();
-						done();
-						this.showStatus(`Model: ${model.id}`);
-						void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
-						this.checkDaxnutsEasterEgg(model);
-					} catch (error) {
-						done();
-						this.showError(error instanceof Error ? error.message : String(error));
+				(model) => {
+					if (model.extendedContextWindow === undefined) {
+						this.showThinkingLevelStep(model, done);
+						return;
 					}
+					const extendedContextWindow = model.extendedContextWindow;
+					this.showSelector((contextDone) => {
+						const isCurrentlyExtended =
+							modelsAreEqual(this.session.model, model) &&
+							this.session.model?.contextWindow === extendedContextWindow;
+						const contextSelector = new ContextSizeSelectorComponent(
+							model.contextWindow,
+							extendedContextWindow,
+							isCurrentlyExtended,
+							(choice) => {
+								this.showThinkingLevelStep({ ...model, contextWindow: choice.contextWindow }, contextDone);
+							},
+							() => {
+								this.showThinkingLevelStep(model, contextDone);
+							},
+						);
+						return { component: contextSelector, focus: contextSelector.getSelectList() };
+					});
 				},
 				() => {
 					done();

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -162,7 +162,7 @@ describe("FooterComponent width handling", () => {
 		expect(stripAnsi(footer.render(120)[1])).toContain("$1.234 (sub)");
 	});
 
-	it("shows a [1M] indicator when the model is switched into extended context mode", () => {
+	it("shows a dynamic extended-context indicator when the model is switched into extended context mode", () => {
 		const session = createSession({
 			sessionName: "",
 			contextWindow: 1_000_000,
@@ -170,10 +170,21 @@ describe("FooterComponent width handling", () => {
 		});
 		const footer = new FooterComponent(session, createFooterData(1));
 
-		expect(stripAnsi(footer.render(120)[1])).toContain("test-model [1M]");
+		expect(stripAnsi(footer.render(120)[1])).toContain("test-model [1.0M]");
 	});
 
-	it("omits the [1M] indicator when the model is using its default context window", () => {
+	it("shows the actual extended context window size, not a hardcoded 1M", () => {
+		const session = createSession({
+			sessionName: "",
+			contextWindow: 1_050_000,
+			extendedContextWindow: 1_050_000,
+		});
+		const footer = new FooterComponent(session, createFooterData(1));
+
+		expect(stripAnsi(footer.render(120)[1])).toContain("test-model [1.1M]");
+	});
+
+	it("omits the extended-context indicator when the model is using its default context window", () => {
 		const session = createSession({
 			sessionName: "",
 			contextWindow: 200_000,
@@ -181,6 +192,6 @@ describe("FooterComponent width handling", () => {
 		});
 		const footer = new FooterComponent(session, createFooterData(1));
 
-		expect(stripAnsi(footer.render(120)[1])).not.toContain("[1M]");
+		expect(stripAnsi(footer.render(120)[1])).not.toContain("[1.0M]");
 	});
 });

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -21,6 +21,8 @@ function createSession(options: {
 	reasoning?: boolean;
 	thinkingLevel?: string;
 	usage?: AssistantUsage;
+	contextWindow?: number;
+	extendedContextWindow?: number;
 }): AgentSession {
 	const usage = options.usage;
 	const entries =
@@ -41,7 +43,8 @@ function createSession(options: {
 			model: {
 				id: options.modelId ?? "test-model",
 				provider: options.provider ?? "test",
-				contextWindow: 200_000,
+				contextWindow: options.contextWindow ?? 200_000,
+				extendedContextWindow: options.extendedContextWindow,
 				reasoning: options.reasoning ?? false,
 			},
 			thinkingLevel: options.thinkingLevel ?? "off",
@@ -51,7 +54,7 @@ function createSession(options: {
 			getSessionName: () => options.sessionName,
 			getCwd: () => "/tmp/project",
 		},
-		getContextUsage: () => ({ contextWindow: 200_000, percent: 12.3 }),
+		getContextUsage: () => ({ contextWindow: options.contextWindow ?? 200_000, percent: 12.3 }),
 		modelRuntime: {
 			isUsingOAuth: () => false,
 		},
@@ -157,5 +160,27 @@ describe("FooterComponent width handling", () => {
 		const footer = new FooterComponent(session, createFooterData(1));
 
 		expect(stripAnsi(footer.render(120)[1])).toContain("$1.234 (sub)");
+	});
+
+	it("shows a [1M] indicator when the model is switched into extended context mode", () => {
+		const session = createSession({
+			sessionName: "",
+			contextWindow: 1_000_000,
+			extendedContextWindow: 1_000_000,
+		});
+		const footer = new FooterComponent(session, createFooterData(1));
+
+		expect(stripAnsi(footer.render(120)[1])).toContain("test-model [1M]");
+	});
+
+	it("omits the [1M] indicator when the model is using its default context window", () => {
+		const session = createSession({
+			sessionName: "",
+			contextWindow: 200_000,
+			extendedContextWindow: 1_000_000,
+		});
+		const footer = new FooterComponent(session, createFooterData(1));
+
+		expect(stripAnsi(footer.render(120)[1])).not.toContain("[1M]");
 	});
 });

--- a/packages/coding-agent/test/list-models.test.ts
+++ b/packages/coding-agent/test/list-models.test.ts
@@ -1,0 +1,69 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listModels } from "../src/cli/list-models.ts";
+import type { ModelRuntime } from "../src/core/model-runtime.ts";
+
+function createFauxModel(overrides: Partial<Model<Api>> & Pick<Model<Api>, "id" | "provider">): Model<Api> {
+	return {
+		name: overrides.id,
+		api: "openai-completions",
+		baseUrl: "https://example.test",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		...overrides,
+	} as Model<Api>;
+}
+
+function createFakeModelRuntime(models: Model<Api>[]): ModelRuntime {
+	return {
+		getError: () => undefined,
+		getAvailable: async () => models,
+	} as unknown as ModelRuntime;
+}
+
+describe("listModels", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let output: string[];
+
+	beforeEach(() => {
+		output = [];
+		logSpy = vi.spyOn(console, "log").mockImplementation((line: string) => {
+			output.push(line);
+		});
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it("shows a default->extended context range for models with an extended context window", async () => {
+		const runtime = createFakeModelRuntime([
+			createFauxModel({
+				id: "claude-sonnet-5",
+				provider: "github-copilot",
+				contextWindow: 200000,
+				extendedContextWindow: 1000000,
+			}),
+		]);
+
+		await listModels(runtime);
+
+		const row = output.find((line) => line.includes("claude-sonnet-5"));
+		expect(row).toContain("200K->1M");
+	});
+
+	it("shows a plain context size for models without an extended context window", async () => {
+		const runtime = createFakeModelRuntime([
+			createFauxModel({ id: "gpt-4.1", provider: "github-copilot", contextWindow: 128000 }),
+		]);
+
+		await listModels(runtime);
+
+		const row = output.find((line) => line.includes("gpt-4.1"));
+		expect(row).toContain("128K");
+		expect(row).not.toContain("->");
+	});
+});

--- a/packages/coding-agent/test/remote-catalog-provider.test.ts
+++ b/packages/coding-agent/test/remote-catalog-provider.test.ts
@@ -82,6 +82,59 @@ describe("remote catalog provider", () => {
 		});
 	});
 
+	it("preserves the locally curated default/extended context window split when overlaying a matching remote model", async () => {
+		const baselineModel: Model<"openai-completions"> = {
+			...model("copilot-model"),
+			contextWindow: 200000,
+			extendedContextWindow: 1000000,
+			cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		};
+		// Simulates the pi.dev catalog: predates the context-window split, reports a single
+		// already-extended contextWindow, and updates pricing (which should still take effect).
+		const remoteModel: Model<"openai-completions"> = {
+			...model("copilot-model"),
+			contextWindow: 1000000,
+			cost: { input: 5, output: 10, cacheRead: 0, cacheWrite: 0 },
+		};
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify([remoteModel]), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		const provider = withRemoteCatalog(
+			createProvider({
+				id: "test-provider",
+				auth: { apiKey: { name: "Test", resolve: async () => ({ auth: {} }) } },
+				models: [baselineModel],
+				api: {
+					stream: () => {
+						throw new Error("not used");
+					},
+					streamSimple: () => {
+						throw new Error("not used");
+					},
+				},
+			}),
+		);
+		const store = new InMemoryModelsStore();
+
+		await provider.refreshModels?.({
+			credential: { type: "api_key" },
+			store: {
+				read: () => store.read(provider.id),
+				write: (entry) => store.write(provider.id, entry),
+				delete: () => store.delete(provider.id),
+			},
+			allowNetwork: true,
+		});
+
+		const merged = provider.getModels().find((entry) => entry.id === "copilot-model");
+		expect(merged?.contextWindow).toBe(200000);
+		expect(merged?.extendedContextWindow).toBe(1000000);
+		expect(merged?.cost).toEqual({ input: 5, output: 10, cacheRead: 0, cacheWrite: 0 });
+	});
+
 	it("treats unimplemented pi.dev catalog routes as an unavailable overlay", async () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("not implemented", { status: 501 }));
 		const provider = withRemoteCatalog(

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { APP_NAME } from "../src/config.ts";
+import { BUILTIN_SLASH_COMMANDS } from "../src/core/slash-commands.ts";
+
+describe("BUILTIN_SLASH_COMMANDS", () => {
+	it("includes distinct quit and exit commands", () => {
+		const quit = BUILTIN_SLASH_COMMANDS.find((command) => command.name === "quit");
+		const exit = BUILTIN_SLASH_COMMANDS.find((command) => command.name === "exit");
+
+		expect(quit).toEqual({ name: "quit", description: `Quit ${APP_NAME}` });
+		expect(exit).toEqual({
+			name: "exit",
+			description: `Quit ${APP_NAME} and print the command to resume this session`,
+		});
+	});
+
+	it("has unique command names", () => {
+		const names = BUILTIN_SLASH_COMMANDS.map((command) => command.name);
+		expect(new Set(names).size).toBe(names.length);
+	});
+});

--- a/packages/coding-agent/test/suite/model-context-size-selector.test.ts
+++ b/packages/coding-agent/test/suite/model-context-size-selector.test.ts
@@ -1,0 +1,113 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { KeybindingsManager } from "../../src/core/keybindings.ts";
+import { ContextSizeSelectorComponent } from "../../src/modes/interactive/components/context-size-selector.ts";
+import { initTheme } from "../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../src/utils/ansi.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+describe("ContextSizeSelectorComponent", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		// Ensure test isolation: keybindings are a global singleton
+		setKeybindings(new KeybindingsManager());
+	});
+
+	it("renders default and extended context choices with formatted token counts", () => {
+		let selected: unknown;
+		const selector = new ContextSizeSelectorComponent(
+			200000,
+			1000000,
+			false,
+			(choice) => {
+				selected = choice;
+			},
+			() => {},
+		);
+
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		expect(rendered).toContain("Default");
+		expect(rendered).toContain("200k");
+		expect(rendered).toContain("Extended");
+		expect(rendered).toContain("1.0M");
+		expect(selected).toBeUndefined();
+	});
+
+	it("preselects the extended option when the model is currently in extended mode", () => {
+		const selector = new ContextSizeSelectorComponent(
+			200000,
+			1000000,
+			true,
+			() => {},
+			() => {},
+		);
+
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		const extendedLine = rendered.split("\n").find((line) => line.includes("Extended"));
+		expect(extendedLine).toBeDefined();
+		expect(extendedLine).toMatch(/^→/);
+	});
+
+	it("invokes onSelect with the extended context window when the extended option is chosen", () => {
+		let selected: { contextWindow: number; extended: boolean } | undefined;
+		const selector = new ContextSizeSelectorComponent(
+			200000,
+			1000000,
+			false,
+			(choice) => {
+				selected = choice;
+			},
+			() => {},
+		);
+
+		selector.getSelectList().handleInput("\x1b[B"); // move down to "Extended"
+		selector.getSelectList().handleInput("\r"); // select
+
+		expect(selected).toEqual({ contextWindow: 1000000, extended: true });
+	});
+
+	it("invokes onCancel when escape is pressed", () => {
+		let cancelled = false;
+		const selector = new ContextSizeSelectorComponent(
+			200000,
+			1000000,
+			false,
+			() => {},
+			() => {
+				cancelled = true;
+			},
+		);
+
+		selector.getSelectList().handleInput("\x1b");
+
+		expect(cancelled).toBe(true);
+	});
+});
+
+describe("AgentSession extended context window override", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("applies an overridden contextWindow when switching to an extended-context model choice", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", name: "One", reasoning: true, contextWindow: 200000 }],
+		});
+		harnesses.push(harness);
+
+		const baseModel = harness.getModel("faux-1")!;
+		const extendedModel = { ...baseModel, contextWindow: 1000000, extendedContextWindow: 1000000 };
+
+		await harness.session.setModel(extendedModel);
+
+		expect(harness.session.model?.contextWindow).toBe(1000000);
+		expect(harness.session.model?.extendedContextWindow).toBe(1000000);
+	});
+});


### PR DESCRIPTION
## Summary
The footer's extended-context indicator was hardcoded to `[1M]`, which is incorrect for models whose extended context window isn't exactly 1M (e.g. GPT-5.4/5.5/5.6 at 1,050,000). This now renders the model's actual `extendedContextWindow` value via `formatTokens()`.

## Changes
- `footer.ts`: replace hardcoded `[1M]` suffix with `[${formatTokens(state.model.extendedContextWindow)}]`.
- `footer-width.test.ts`: update existing test to expect `[1.0M]`, add a new test asserting `[1.1M]` for a 1,050,000 extended context window, and rename tests to reflect dynamic behavior.
- `CHANGELOG.md`: update "Added" and "Fixed" entries to describe the dynamic footer indicator instead of the hardcoded `[1M]`.

## Testing
Existing and new unit tests in `footer-width.test.ts` cover both the 1M and 1.05M cases.
