### PR TITLE
fix(ai): stop Responses streams at terminal event

### DIFF
--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -572,6 +572,11 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 		} else if (event.type === "response.completed" || event.type === "response.incomplete") {
 			finalizeResponse(event.response);
+			// A terminal response event is the semantic end of a Responses stream. Some compatible
+			// gateways keep the HTTP body open for seconds after this event (and may omit [DONE]);
+			// returning here lets AsyncIteratorClose abort that idle tail instead of delaying the
+			// assistant result and any tool dispatch until transport EOF.
+			return;
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}` || "Unknown error");
 		} else if (event.type === "response.failed") {

--- a/packages/ai/test/openai-responses-terminal-event.test.ts
+++ b/packages/ai/test/openai-responses-terminal-event.test.ts
@@ -107,8 +107,8 @@ async function* createEarlyEofEvents(): AsyncIterable<ResponseStreamEvent> {
 	} as ResponseStreamEvent;
 }
 
-async function* createCompletedEvents(): AsyncIterable<ResponseStreamEvent> {
-	yield {
+function createCompletedEvent(): ResponseStreamEvent {
+	return {
 		type: "response.completed",
 		sequence_number: 0,
 		response: {
@@ -122,6 +122,10 @@ async function* createCompletedEvents(): AsyncIterable<ResponseStreamEvent> {
 			},
 		},
 	} as unknown as ResponseStreamEvent;
+}
+
+async function* createCompletedEvents(): AsyncIterable<ResponseStreamEvent> {
+	yield createCompletedEvent();
 }
 
 async function* createIncompleteEvents(): AsyncIterable<ResponseStreamEvent> {
@@ -151,6 +155,32 @@ async function* createFailedEvents(): AsyncIterable<ResponseStreamEvent> {
 			error: { code: "server_error", message: "boom" },
 		},
 	} as ResponseStreamEvent;
+}
+
+function createOpenAfterCompletedEvents(): {
+	events: AsyncIterable<ResponseStreamEvent>;
+	wasClosed: () => boolean;
+} {
+	let closed = false;
+	let emitted = false;
+	const events: AsyncIterable<ResponseStreamEvent> = {
+		[Symbol.asyncIterator]() {
+			return {
+				async next() {
+					if (!emitted) {
+						emitted = true;
+						return { done: false as const, value: createCompletedEvent() };
+					}
+					return new Promise<IteratorResult<ResponseStreamEvent>>(() => {});
+				},
+				async return() {
+					closed = true;
+					return { done: true as const, value: undefined };
+				},
+			};
+		},
+	};
+	return { events, wasClosed: () => closed };
 }
 
 describe("OpenAI Responses terminal event handling", () => {
@@ -201,6 +231,22 @@ describe("OpenAI Responses terminal event handling", () => {
 			cacheWrite: 3,
 			totalTokens: 27,
 		});
+	});
+
+	it("returns at response.completed without waiting for transport EOF", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const { events, wasClosed } = createOpenAfterCompletedEvents();
+
+		await expect(
+			Promise.race([
+				processResponsesStream(events, output, stream, model),
+				new Promise((_, reject) => setTimeout(() => reject(new Error("waited for transport EOF")), 100)),
+			]),
+		).resolves.toBeUndefined();
+		expect(wasClosed()).toBe(true);
+		expect(output.stopReason).toBe("stop");
 	});
 
 	it("finalizes incomplete terminal events as length stops", async () => {


### PR DESCRIPTION
## Investigation status

This can be a Provider or gateway transport issue. The observed Provider emitted response.completed, then delayed HTTP EOF and omitted [DONE]. That trace does not prove pi caused the transport tail. I am continuing to compare Providers and request paths.

The proposed change is defensive parser behavior. It prevents a Provider-specific tail from delaying a semantically complete response.

## Problem

processResponsesStream() finalizes response.completed and response.incomplete but keeps iterating the OpenAI SDK stream until transport EOF. A Responses-compatible gateway may emit the authoritative terminal event and then keep the HTTP body open. That tail delays the assistant result and tool dispatch.

Codex uses the terminal protocol event as this boundary. Meaningful response data is already present on that event.

## Fix

Return after finalizing response.completed or response.incomplete. Iterator cleanup stops the irrelevant body tail. response.failed and pre-terminal EOF behavior remain unchanged.

## Regression coverage

The test yields a valid response.completed, then leaves the iterator pending. It verifies that:

- processing resolves without transport EOF;
- iterator cleanup runs; and
- the completed response remains a normal stop result.

## Verification

- npm run check
- package regression: 6/6 passed
