### PR TITLE
Remove "./" from pi-ai bin path so lockfiles stop flip-flopping

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -41,7 +41,7 @@
 		}
 	},
 	"bin": {
-		"pi-ai": "./dist/cli.js"
+		"pi-ai": "dist/cli.js"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
Fixes #6811

> [!WARNING]
> *edit*: Sorry, I should have read CONTRIBUTING.md before publishing this PR.
I fully acknowledge my mistake opening it without an lgtm. 😢

One line change:

    -  "pi-ai": "./dist/cli.js"
    +  "pi-ai": "dist/cli.js"

package-lock.json in my project won't stay put. One line keeps toggling:

    "pi-ai": "dist/cli.js"  <->  "pi-ai": "./dist/cli.js"


Details in #6811
