### PR TITLE
feat(coding-agent): support shared auth file

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -663,6 +663,7 @@ pi --thinking high "Solve this complex problem"
 | Variable | Description |
 |----------|-------------|
 | `PI_CODING_AGENT_DIR` | Override config directory (default: `~/.pi/agent`) |
+| `PI_CODING_AGENT_AUTH_FILE` | Override only the credential file (default: `<PI_CODING_AGENT_DIR>/auth.json`). Processes using the same literal path share Pi's cross-process OAuth refresh lock while keeping other config state separate |
 | `PI_CODING_AGENT_SESSION_DIR` | Override session storage directory (overridden by `--session-dir`) |
 | `PI_PACKAGE_DIR` | Override package directory (useful for Nix/Guix where store paths tokenize poorly) |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
@@ -670,6 +671,8 @@ pi --thinking high "Solve this complex problem"
 | `PI_TELEMETRY` | Override install/update telemetry and provider attribution headers. Use `1`/`true`/`yes` to enable or `0`/`false`/`no` to disable. This does not disable update checks |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache (Anthropic: 1h, OpenAI: 24h) |
 | `VISUAL`, `EDITOR` | Fallback external editor for Ctrl+G when `externalEditor` is unset; defaults to Notepad on Windows and `nano` elsewhere |
+
+`PI_CODING_AGENT_AUTH_FILE` is an explicit credential authority: login, logout, OAuth refresh, request auth, and model-catalog refresh all use it. Pi does not migrate legacy credentials from a different `PI_CODING_AGENT_DIR` into an explicit auth file. Protect the file as a secret and grant access only to processes that should share provider credentials.
 
 ---
 

--- a/packages/coding-agent/docs/security.md
+++ b/packages/coding-agent/docs/security.md
@@ -36,6 +36,12 @@ This is intentional. Pi is designed to operate on local source trees, invoke pro
 
 Project trust is only an input-loading guard. It prevents a repository from silently changing pi's settings or extensions before you approve it. It does not make untrusted code, untrusted prompts, or untrusted model output safe. Prompt injection from repository files, comments, documentation, context files, or build output is expected local-agent risk and cannot be reliably prevented by pi.
 
+## Shared Credential Files
+
+`PI_CODING_AGENT_AUTH_FILE` can place credentials outside `PI_CODING_AGENT_DIR`. Pi uses the same file for login, logout, request auth, model-catalog refresh, and OAuth token rotation. Multiple processes using the same literal path share the file's cross-process lock, which avoids concurrent refresh of one rotating token while allowing their remaining config state to stay separate.
+
+The override does not create a security boundary. Every process that can access the file can use or replace all credentials stored in it. Keep it on a trusted local filesystem, preserve restrictive permissions, and do not share it with containers, users, or agents that should have separate provider identities. Pi does not import legacy credentials from another agent directory into an explicit auth file.
+
 ## Running Untrusted or Unmonitored Work
 
 For untrusted repositories, generated code you do not intend to monitor closely, or unattended automation, run pi in a contained environment. Use a container, VM, micro-VM, remote sandbox, or policy-controlled sandbox with only the files and credentials required for the task.

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -294,6 +294,7 @@ pi --exclude-tools ask_question
 | Variable | Description |
 |----------|-------------|
 | `PI_CODING_AGENT_DIR` | Override config directory; default is `~/.pi/agent` |
+| `PI_CODING_AGENT_AUTH_FILE` | Override only the credential file; default is `<PI_CODING_AGENT_DIR>/auth.json`. The same literal path gives multiple Pi processes one cross-process OAuth refresh lock |
 | `PI_CODING_AGENT_SESSION_DIR` | Override session storage directory; overridden by `--session-dir` |
 | `PI_PACKAGE_DIR` | Override package directory, useful for Nix/Guix store paths |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package update checks, and install/update telemetry |
@@ -301,6 +302,8 @@ pi --exclude-tools ask_question
 | `PI_TELEMETRY` | Override install/update telemetry and provider attribution headers: `1`/`true`/`yes` or `0`/`false`/`no`. This does not disable update checks |
 | `PI_CACHE_RETENTION` | Set to `long` for extended prompt cache where supported |
 | `VISUAL`, `EDITOR` | Fallback external editor for Ctrl+G when `externalEditor` is unset; defaults to Notepad on Windows and `nano` elsewhere |
+
+An explicit `PI_CODING_AGENT_AUTH_FILE` is used by login, logout, OAuth refresh, request auth, and model-catalog refresh. Pi does not migrate legacy credentials from a separate agent directory into it. Treat it as secret-bearing shared state and expose it only to processes that should share provider credentials.
 
 ## Design Principles
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -4,7 +4,7 @@
 
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import chalk from "chalk";
-import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_SESSION_DIR } from "../config.ts";
+import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_AUTH_FILE, ENV_SESSION_DIR } from "../config.ts";
 import type { ExtensionFlag } from "../core/extensions/types.ts";
 
 export type Mode = "text" | "json" | "rpc";
@@ -372,6 +372,7 @@ ${chalk.bold("Environment Variables:")}
   AWS_BEARER_TOKEN_BEDROCK         - Bedrock API key (bearer token)
   AWS_REGION                       - AWS region for Amazon Bedrock (e.g., us-east-1)
   ${ENV_AGENT_DIR.padEnd(32)} - Config directory (default: ~/${CONFIG_DIR_NAME}/agent)
+  ${ENV_AUTH_FILE.padEnd(32)} - Credential file (default: <config directory>/auth.json)
   ${ENV_SESSION_DIR.padEnd(32)} - Session storage directory (overridden by --session-dir)
   PI_PACKAGE_DIR                   - Override package directory (for Nix/Guix store paths)
   PI_OFFLINE                       - Disable startup network operations when set to 1/true/yes

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -493,6 +493,7 @@ export const VERSION: string = pkg.version || "0.0.0";
 
 // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
 export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+export const ENV_AUTH_FILE = `${APP_NAME.toUpperCase()}_CODING_AGENT_AUTH_FILE`;
 export const ENV_SESSION_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_SESSION_DIR`;
 
 export function expandTildePath(path: string): string {
@@ -530,8 +531,12 @@ export function getModelsPath(): string {
 	return join(getAgentDir(), "models.json");
 }
 
-/** Get path to auth.json */
+/** Get path to auth.json, optionally independent from the agent config directory. */
 export function getAuthPath(): string {
+	const envPath = process.env[ENV_AUTH_FILE];
+	if (envPath) {
+		return expandTildePath(envPath);
+	}
 	return join(getAgentDir(), "auth.json");
 }
 

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -37,6 +37,8 @@ export interface AgentSessionRuntimeDiagnostic {
 export interface CreateAgentSessionServicesOptions {
 	cwd: string;
 	agentDir?: string;
+	/** Credential file path. Defaults to agentDir/auth.json. */
+	authPath?: string;
 	settingsManager?: SettingsManager;
 	modelRuntime?: ModelRuntime;
 	extensionFlagValues?: Map<string, boolean | string>;
@@ -139,7 +141,7 @@ export async function createAgentSessionServices(
 	const modelRuntime =
 		options.modelRuntime ??
 		(await ModelRuntime.create({
-			authPath: join(agentDir, "auth.json"),
+			authPath: options.authPath ? resolvePath(options.authPath) : join(agentDir, "auth.json"),
 			modelsPath: join(agentDir, "models.json"),
 		}));
 	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -5,9 +5,9 @@
 
 import type { Credential, CredentialInfo, CredentialStore } from "@earendil-works/pi-ai";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
+import { dirname } from "path";
 import lockfile from "proper-lockfile";
-import { getAgentDir } from "../config.ts";
+import { getAuthPath } from "../config.ts";
 import { normalizePath } from "../utils/paths.ts";
 import { resolveConfigValue } from "./resolve-config-value.ts";
 
@@ -28,7 +28,7 @@ export interface AuthStorageBackend {
 export class FileAuthStorageBackend implements AuthStorageBackend {
 	private authPath: string;
 
-	constructor(authPath: string = join(getAgentDir(), "auth.json")) {
+	constructor(authPath: string = getAuthPath()) {
 		this.authPath = normalizePath(authPath);
 	}
 
@@ -178,7 +178,7 @@ export class AuthStorage implements CredentialStore {
 	}
 
 	static create(authPath?: string): AuthStorage {
-		return new AuthStorage(new FileAuthStorageBackend(authPath ?? join(getAgentDir(), "auth.json")));
+		return new AuthStorage(new FileAuthStorageBackend(authPath ?? getAuthPath()));
 	}
 
 	static fromStorage(storage: AuthStorageBackend): AuthStorage {
@@ -258,10 +258,7 @@ export class AuthStorage implements CredentialStore {
  * One-off synchronous read of a stored credential from an auth.json file,
  * without instantiating a store or resolving configured key values.
  */
-export function readStoredCredential(
-	providerId: string,
-	authPath: string = join(getAgentDir(), "auth.json"),
-): Credential | undefined {
+export function readStoredCredential(providerId: string, authPath: string = getAuthPath()): Credential | undefined {
 	try {
 		const data = JSON.parse(readFileSync(normalizePath(authPath), "utf-8")) as AuthStorageData;
 		return data[providerId];

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -35,8 +35,10 @@ export interface CreateAgentSessionOptions {
 	cwd?: string;
 	/** Global config directory. Default: ~/.pi/agent */
 	agentDir?: string;
+	/** Credential file path. Defaults to agentDir/auth.json (or the configured default when agentDir is omitted). */
+	authPath?: string;
 
-	/** Canonical model/auth runtime. Defaults to a runtime using agentDir/auth.json and models.json. */
+	/** Canonical model/auth runtime. Defaults to a runtime using authPath and agentDir/models.json. */
 	modelRuntime?: ModelRuntime;
 
 	/** Model to use. Default: from settings, else first available */
@@ -166,7 +168,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const agentDir = options.agentDir ? resolvePath(options.agentDir) : getDefaultAgentDir();
 	let resourceLoader = options.resourceLoader;
 
-	const authPath = options.agentDir ? join(agentDir, "auth.json") : undefined;
+	const authPath = options.authPath
+		? resolvePath(options.authPath)
+		: options.agentDir
+			? join(agentDir, "auth.json")
+			: undefined;
 	const modelsPath = options.agentDir ? join(agentDir, "models.json") : undefined;
 	const modelRuntime = options.modelRuntime ?? (await ModelRuntime.create({ authPath, modelsPath }));
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -15,7 +15,7 @@ import { listModels } from "./cli/list-models.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import { selectSession } from "./cli/session-picker.ts";
 import { shouldRunFirstTimeSetup, showFirstTimeSetup, showStartupSelector } from "./cli/startup-ui.ts";
-import { ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir, VERSION } from "./config.ts";
+import { ENV_SESSION_DIR, expandTildePath, getAgentDir, getAuthPath, getPackageDir, VERSION } from "./config.ts";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.ts";
 import {
 	type AgentSessionRuntimeDiagnostic,
@@ -634,6 +634,7 @@ export async function main(args: string[], options?: MainOptions) {
 		const services = await createAgentSessionServices({
 			cwd,
 			agentDir,
+			authPath: getAuthPath(),
 			settingsManager: runtimeSettingsManager,
 			extensionFlagValues: parsed.unknownFlags,
 			resourceLoaderReloadOptions: shouldResolveProjectTrust

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -5,7 +5,7 @@
 import chalk from "chalk";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { CONFIG_DIR_NAME, getAgentDir, getBinDir } from "./config.ts";
+import { CONFIG_DIR_NAME, getAgentDir, getAuthPath, getBinDir } from "./config.ts";
 import { migrateKeybindingsConfig } from "./core/keybindings.ts";
 
 const MIGRATION_GUIDE_URL =
@@ -20,9 +20,14 @@ const EXTENSIONS_DOC_URL =
  */
 export function migrateAuthToAuthJson(): string[] {
 	const agentDir = getAgentDir();
-	const authPath = join(agentDir, "auth.json");
+	const defaultAuthPath = join(agentDir, "auth.json");
+	const authPath = getAuthPath();
 	const oauthPath = join(agentDir, "oauth.json");
 	const settingsPath = join(agentDir, "settings.json");
+
+	// An explicit auth authority is independent from this agent directory. Never
+	// move legacy private credentials into it implicitly; normal login/storage owns it.
+	if (authPath !== defaultAuthPath) return [];
 
 	// Skip if auth.json already exists
 	if (existsSync(authPath)) return [];

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -8,6 +8,7 @@ import {
 	CONFIG_DIR_NAME,
 	detectInstallMethod,
 	getAgentDir,
+	getAuthPath,
 	getPackageDir,
 	getSelfUpdateCommand,
 	getSelfUpdateUnavailableInstruction,
@@ -396,7 +397,7 @@ function updateTargetIncludesExtensions(target: UpdateTarget): boolean {
 
 async function refreshModelCatalogs(agentDir: string): Promise<void> {
 	const modelRuntime = await ModelRuntime.create({
-		authPath: join(agentDir, "auth.json"),
+		authPath: getAuthPath(),
 		modelsPath: join(agentDir, "models.json"),
 		allowModelNetwork: false,
 	});

--- a/packages/coding-agent/test/auth-path.test.ts
+++ b/packages/coding-agent/test/auth-path.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { printHelp } from "../src/cli/args.ts";
+import { ENV_AGENT_DIR, ENV_AUTH_FILE, getAuthPath } from "../src/config.ts";
+import { migrateAuthToAuthJson } from "../src/migrations.ts";
+
+const originalAgentDir = process.env[ENV_AGENT_DIR];
+const originalAuthFile = process.env[ENV_AUTH_FILE];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	if (originalAgentDir === undefined) delete process.env[ENV_AGENT_DIR];
+	else process.env[ENV_AGENT_DIR] = originalAgentDir;
+	if (originalAuthFile === undefined) delete process.env[ENV_AUTH_FILE];
+	else process.env[ENV_AUTH_FILE] = originalAuthFile;
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+	vi.restoreAllMocks();
+});
+
+describe("getAuthPath", () => {
+	test("defaults to auth.json in the configured agent directory", () => {
+		process.env[ENV_AGENT_DIR] = "/tmp/pi-private-home";
+		delete process.env[ENV_AUTH_FILE];
+		expect(getAuthPath()).toBe(join("/tmp/pi-private-home", "auth.json"));
+	});
+
+	test("uses an auth-file override independently from the agent directory", () => {
+		process.env[ENV_AGENT_DIR] = "/tmp/pi-private-home";
+		process.env[ENV_AUTH_FILE] = "/tmp/pi-shared/auth.json";
+		expect(getAuthPath()).toBe("/tmp/pi-shared/auth.json");
+	});
+
+	test("expands a tilde in the auth-file override", () => {
+		process.env[ENV_AUTH_FILE] = "~/.pi/shared-auth.json";
+		expect(getAuthPath()).toBe(join(homedir(), ".pi", "shared-auth.json"));
+	});
+
+	test("lists the branded auth-file variable in CLI help", () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		printHelp();
+		expect(log).toHaveBeenCalledWith(expect.stringContaining(ENV_AUTH_FILE));
+	});
+
+	test("does not migrate private legacy credentials into an explicit auth file", () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-auth-path-"));
+		tempDirs.push(root);
+		const agentDir = join(root, "private-agent");
+		const authFile = join(root, "shared", "auth.json");
+		process.env[ENV_AGENT_DIR] = agentDir;
+		process.env[ENV_AUTH_FILE] = authFile;
+		// The agent directory exists in real startup before migrations run.
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			join(agentDir, "oauth.json"),
+			JSON.stringify({ anthropic: { access: "access", refresh: "refresh", expires: 1 } }),
+		);
+
+		expect(migrateAuthToAuthJson()).toEqual([]);
+		expect(existsSync(authFile)).toBe(false);
+		expect(existsSync(join(agentDir, "oauth.json"))).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/auth-storage-process.test.ts
+++ b/packages/coding-agent/test/auth-storage-process.test.ts
@@ -1,0 +1,100 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+const childFixture = fileURLToPath(new URL("./fixtures/shared-auth-refresh-child.ts", import.meta.url));
+
+describe("shared auth-file refresh", () => {
+	let cleanup: () => void;
+	let authPath: string;
+
+	beforeEach(() => {
+		const temp = mkdtempSync(join(tmpdir(), "pi-shared-auth-process-"));
+		cleanup = () => rmSync(temp, { recursive: true, force: true });
+		authPath = join(temp, "auth.json");
+		writeFileSync(
+			authPath,
+			JSON.stringify({
+				"rotating-oauth": {
+					type: "oauth",
+					access: "expired-access",
+					refresh: "refresh-1",
+					expires: 0,
+				},
+			}),
+		);
+	});
+
+	afterEach(() => cleanup());
+
+	test("performs one rotating refresh across two Node processes using the same literal path", async () => {
+		let refreshCount = 0;
+		const readyResponses: ServerResponse[] = [];
+		const server = createServer(async (request, response) => {
+			request.resume();
+			if (request.url === "/ready") {
+				readyResponses.push(response);
+				if (readyResponses.length === 2) {
+					for (const ready of readyResponses) ready.end("ready");
+				}
+				return;
+			}
+			if (request.url === "/refresh") {
+				refreshCount++;
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				response.setHeader("content-type", "application/json");
+				response.end(
+					JSON.stringify({
+						type: "oauth",
+						access: "fresh-access",
+						refresh: "refresh-2",
+						expires: Date.now() + 60_000,
+					}),
+				);
+				return;
+			}
+			response.statusCode = 404;
+			response.end();
+		});
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		try {
+			const address = server.address();
+			if (!address || typeof address === "string") throw new Error("Refresh fixture did not bind a TCP port");
+			const endpoint = `http://127.0.0.1:${address.port}`;
+			const runChild = () =>
+				new Promise<string>((resolve, reject) => {
+					const child = spawn(process.execPath, ["--import", "tsx", childFixture], {
+						cwd: fileURLToPath(new URL("..", import.meta.url)),
+						env: {
+							...process.env,
+							TEST_SHARED_AUTH_PATH: authPath,
+							TEST_SHARED_AUTH_ENDPOINT: endpoint,
+						},
+						stdio: ["ignore", "pipe", "pipe"],
+					});
+					let stdout = "";
+					let stderr = "";
+					child.stdout.setEncoding("utf8").on("data", (chunk) => {
+						stdout += chunk;
+					});
+					child.stderr.setEncoding("utf8").on("data", (chunk) => {
+						stderr += chunk;
+					});
+					child.on("error", reject);
+					child.on("close", (code) => {
+						if (code === 0) resolve(stdout.trim());
+						else reject(new Error(`Shared-auth child exited ${code}: ${stderr.trim()}`));
+					});
+				});
+
+			await expect(Promise.all([runChild(), runChild()])).resolves.toEqual(["ok", "ok"]);
+			expect(refreshCount).toBe(1);
+		} finally {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+		}
+	}, 15_000);
+});

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -107,6 +107,67 @@ describe("AuthStorage", () => {
 		});
 	});
 
+	test("serializes rotating OAuth refresh across stores sharing one auth path", async () => {
+		const providerId = "rotating-oauth";
+		writeAuthJson({
+			[providerId]: {
+				type: "oauth",
+				access: "expired-access",
+				refresh: "refresh-1",
+				expires: 0,
+			},
+		});
+		let refreshCount = 0;
+		const provider: Provider = {
+			id: providerId,
+			name: "Rotating OAuth",
+			auth: {
+				oauth: {
+					name: "OAuth",
+					login: async () => {
+						throw new Error("not used");
+					},
+					refresh: async () => {
+						refreshCount++;
+						await new Promise((resolve) => setTimeout(resolve, 25));
+						return {
+							type: "oauth" as const,
+							access: "fresh-access",
+							refresh: "refresh-2",
+							expires: Date.now() + 60_000,
+						};
+					},
+					toAuth: async (credential) => ({ apiKey: credential.access }),
+				},
+			},
+			getModels: () => [],
+			stream: () => {
+				throw new Error("not used");
+			},
+			streamSimple: () => {
+				throw new Error("not used");
+			},
+		};
+		const first = createModels({ credentials: AuthStorage.create(authJsonPath) });
+		const second = createModels({ credentials: AuthStorage.create(authJsonPath) });
+		first.setProvider(provider);
+		second.setProvider(provider);
+
+		const [firstAuth, secondAuth] = await Promise.all([first.getAuth(providerId), second.getAuth(providerId)]);
+
+		expect(refreshCount).toBe(1);
+		expect(firstAuth).toMatchObject({ auth: { apiKey: "fresh-access" } });
+		expect(secondAuth).toMatchObject({ auth: { apiKey: "fresh-access" } });
+		expect(JSON.parse(readFileSync(authJsonPath, "utf8"))).toEqual({
+			[providerId]: {
+				type: "oauth",
+				access: "fresh-access",
+				refresh: "refresh-2",
+				expires: expect.any(Number),
+			},
+		});
+	});
+
 	test("delete removes one credential while preserving others", async () => {
 		writeAuthJson({
 			anthropic: { type: "api_key", key: "anthropic-key" },

--- a/packages/coding-agent/test/fixtures/shared-auth-refresh-child.ts
+++ b/packages/coding-agent/test/fixtures/shared-auth-refresh-child.ts
@@ -1,0 +1,45 @@
+import { createModels, type Provider } from "@earendil-works/pi-ai";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+
+const authPath = process.env.TEST_SHARED_AUTH_PATH;
+const endpoint = process.env.TEST_SHARED_AUTH_ENDPOINT;
+if (!authPath || !endpoint) throw new Error("Missing shared-auth test configuration");
+
+const providerId = "rotating-oauth";
+const provider: Provider = {
+	id: providerId,
+	name: "Rotating OAuth",
+	auth: {
+		oauth: {
+			name: "OAuth",
+			login: async () => {
+				throw new Error("not used");
+			},
+			refresh: async () => {
+				const response = await fetch(`${endpoint}/refresh`, { method: "POST" });
+				if (!response.ok) throw new Error(`Refresh fixture failed: ${response.status}`);
+				return (await response.json()) as {
+					type: "oauth";
+					access: string;
+					refresh: string;
+					expires: number;
+				};
+			},
+			toAuth: async (credential) => ({ apiKey: credential.access }),
+		},
+	},
+	getModels: () => [],
+	stream: () => {
+		throw new Error("not used");
+	},
+	streamSimple: () => {
+		throw new Error("not used");
+	},
+};
+
+await fetch(`${endpoint}/ready`, { method: "POST" });
+const models = createModels({ credentials: AuthStorage.create(authPath) });
+models.setProvider(provider);
+const auth = await models.getAuth(providerId);
+if (auth?.auth.apiKey !== "fresh-access") throw new Error("Did not resolve the shared replacement credential");
+process.stdout.write("ok\n");


### PR DESCRIPTION
## Summary

Add an official credential-file override independent from the Pi agent config directory:

- introduce the branded `${APP_NAME}_CODING_AGENT_AUTH_FILE` environment variable (`PI_CODING_AGENT_AUTH_FILE` by default)
- route CLI request auth, login/logout, OAuth refresh, model-catalog refresh, status text, migrations, and default auth-storage helpers through the same path
- add explicit `authPath` options to SDK/session-service construction while preserving existing precedence and defaults
- keep legacy credential migration scoped to the default agent-directory auth file
- document shared-file locking and the security boundary

## Motivation

Processes may need isolated settings, sessions, and resources while sharing one OAuth credential authority. Independent copies of `auth.json` have independent lock domains and can concurrently exchange the same rotating refresh token. Using the same literal auth-file path lets Pi's existing cross-process lock and double-checked refresh serialize that exchange without sharing the rest of `PI_CODING_AGENT_DIR`.

## Verification

- `npm run check`
- 19 focused tests covering path/default behavior, migration suppression, CLI help, storage behavior, and rotating OAuth refresh
- the cross-process test barriers two independent Node children on one expired credential and asserts exactly one refresh request plus convergence on the persisted replacement

No provider credentials or network OAuth accounts are used by the tests.
