### PR TITLE
fix: guard against undefined assistant.usage in context token calculations

### DIFF
--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -116,6 +116,7 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 
 /** Calculate total context tokens from provider usage. */
 export function calculateContextTokens(usage: Usage): number {
+	if (!usage) return 0;
 	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
 }
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {

--- a/packages/ai/src/utils/estimate.ts
+++ b/packages/ai/src/utils/estimate.ts
@@ -15,6 +15,7 @@ const CHARS_PER_TOKEN = 4;
 const ESTIMATED_IMAGE_CHARS = 4800;
 
 export function calculateContextTokens(usage: Usage): number {
+	if (!usage) return 0;
 	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
 }
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3084,11 +3084,13 @@ export class AgentSession {
 					toolCalls += assistantMsg.content.filter((c) => c.type === "toolCall").length;
 				}
 				const usage = assistantMsg.usage;
-				totalInput += usage.input;
-				totalOutput += usage.output;
-				totalCacheRead += usage.cacheRead;
-				totalCacheWrite += usage.cacheWrite;
-				totalCost += usage.cost.total;
+				if (usage) {
+					totalInput += usage.input;
+					totalOutput += usage.output;
+					totalCacheRead += usage.cacheRead;
+					totalCacheWrite += usage.cacheWrite;
+					totalCost += usage.cost?.total ?? 0;
+				}
 			}
 		}
 
@@ -3133,7 +3135,7 @@ export class AgentSession {
 				const entry = branchEntries[i];
 				if (entry.type === "message" && entry.message.role === "assistant") {
 					const assistant = entry.message;
-					if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error") {
+					if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error" && assistant.usage) {
 						const contextTokens = calculateContextTokens(assistant.usage);
 						if (contextTokens > 0) {
 							hasPostCompactionUsage = true;

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -118,6 +118,7 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
  * Uses the native totalTokens field when available, falls back to computing from components.
  */
 export function calculateContextTokens(usage: Usage): number {
+	if (!usage) return 0;
 	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
 }
 


### PR DESCRIPTION
Multiple functions assume `assistant.usage` is always present, but some LLM providers (e.g., DeepSeek V4) may not return usage data in streaming responses. This causes crashes that brick the session:

- `Cannot read properties of undefined (reading 'totalTokens')`
- `Cannot read properties of undefined (reading 'length')`

## Changes

- **`calculateContextTokens`** (3 copies across packages): return 0 when usage is undefined
- **`getContextUsage`**: skip assistants without usage data  
- **`getSessionStats`**: guard `usage` and `usage.cost` with null checks

## Related

- Closes #6311
- Closes #6312