### PR TITLE
fix(ai): support OpenCode Go Responses models

### DIFF
--- a/packages/ai/src/providers/opencode-go.ts
+++ b/packages/ai/src/providers/opencode-go.ts
@@ -1,11 +1,14 @@
 import { anthropicMessagesApi } from "../api/anthropic-messages.lazy.ts";
 import { openAICompletionsApi } from "../api/openai-completions.lazy.ts";
+import { openAIResponsesApi } from "../api/openai-responses.lazy.ts";
 import { envApiKeyAuth } from "../auth/helpers.ts";
 import { createProvider, type Provider } from "../models.ts";
 import { OPENCODE_GO_MODELS } from "./opencode-go.models.ts";
 
-export function opencodeGoProvider(): Provider<"anthropic-messages" | "openai-completions"> {
-	return createProvider({
+type OpenCodeGoApi = "anthropic-messages" | "openai-completions" | "openai-responses";
+
+export function opencodeGoProvider(): Provider<OpenCodeGoApi> {
+	return createProvider<OpenCodeGoApi>({
 		id: "opencode-go",
 		name: "OpenCode Zen Go",
 		auth: { apiKey: envApiKeyAuth("OpenCode API key", ["OPENCODE_API_KEY"]) },
@@ -13,6 +16,7 @@ export function opencodeGoProvider(): Provider<"anthropic-messages" | "openai-co
 		api: {
 			"anthropic-messages": anthropicMessagesApi(),
 			"openai-completions": openAICompletionsApi(),
+			"openai-responses": openAIResponsesApi(),
 		},
 	});
 }


### PR DESCRIPTION
## Summary

- register the OpenAI Responses API implementation for OpenCode Zen Go
- declare the provider's supported API union explicitly so it type-checks both before and after live model catalog generation

## Background

`models.dev` now maps OpenCode Go's Grok 4.5 model through `@ai-sdk/openai`, which Pi generates as `openai-responses`. The generated catalog therefore includes `Model<"openai-responses">`, but the provider only registered Anthropic Messages and OpenAI Completions, causing `npm run build` to fail with TS2322.

## Validation

- `npm run check`
- `cd packages/ai && npm run build`

The package build includes live model generation and verifies the updated catalog state.
