### PR TITLE
fix(ai): align GPT-5.6 Codex context with official client

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -2113,10 +2113,9 @@ async function generateModels() {
 
 	// OpenAI Codex (ChatGPT OAuth) models
 	// NOTE: These are not fetched from models.dev; we keep a small, explicit list to avoid aliases.
-	// Older model limits are based on observed server behavior; GPT-5.6 follows Codex's 372k catalog limit.
+	// Keep Codex requests in the short-context pricing tier by default.
 	const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 	const CODEX_CONTEXT = 272000;
-	const CODEX_GPT_56_CONTEXT = 372000;
 	const CODEX_SPARK_CONTEXT = 128000;
 	const CODEX_MAX_TOKENS = 128000;
 	const codexModels: Model<"openai-codex-responses">[] = [
@@ -2177,7 +2176,7 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: withOpenAiLongContextPricing({ input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 }),
-			contextWindow: CODEX_GPT_56_CONTEXT,
+			contextWindow: CODEX_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{
@@ -2189,7 +2188,7 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: withOpenAiLongContextPricing({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 }),
-			contextWindow: CODEX_GPT_56_CONTEXT,
+			contextWindow: CODEX_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{
@@ -2201,7 +2200,7 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: withOpenAiLongContextPricing({ input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 3.125 }),
-			contextWindow: CODEX_GPT_56_CONTEXT,
+			contextWindow: CODEX_CONTEXT,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 	];


### PR DESCRIPTION
## Summary

Resolves https://github.com/earendil-works/pi/issues/6838

- Set the GPT-5.6 Sol, Terra, and Luna context window to 272K for the `openai-codex` provider.
- Keep the existing long-context pricing tiers so explicit model overrides still account for the higher rates.

## Why

Pi previously raised these models to 372K based on older Codex metadata ([pi#6471](https://github.com/earendil-works/pi/pull/6471)). The official Codex client has since set both `context_window` and `max_context_window` to 272K for all three GPT-5.6 variants ([openai/codex#33961](https://github.com/openai/codex/pull/33961)), with the same change backported to the stable release line ([openai/codex#33972](https://github.com/openai/codex/pull/33972)).

The model still supports a 1.05M physical context window, but OpenAI prices requests above 272K at 2x input and 1.5x output for the full request; cache writes cost 1.25x the uncached input rate ([GPT-5.6 Sol documentation](https://developers.openai.com/api/docs/models/gpt-5.6-sol)). Using 272K as the Codex default avoids crossing that pricing boundary automatically while preserving long-context cost metadata for explicit overrides.

## Validation

- `npm run check`
- `cd packages/ai && node node_modules/vitest/dist/cli.js --run test/models-runtime.test.ts` (25 passed)
- `npm --prefix packages/ai run generate-models` (confirmed all three Codex GPT-5.6 variants generate with `contextWindow: 272000`)

`./test.sh` was attempted but could not complete in this checkout because generated provider JSON and built workspace `dist` artifacts were absent after an `--ignore-scripts` dependency install. The relevant targeted tests pass.
