### PR TITLE
fix: use spawnSync with absolute taskkill.exe path to prevent ENOENT on Node.js 24

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { constants, createReadStream } from "node:fs";
 import {
@@ -220,10 +220,14 @@ function getShellEnv(baseEnv?: NodeJS.ProcessEnv, extraEnv?: Record<string, stri
 
 function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
+		// Use absolute path to taskkill.exe to bypass PATH lookup, which can
+		// fail with ENOENT on Node.js 24+. spawnSync keeps the call synchronous
+		// and surfaces errors in the return object instead of emitting an async
+		// 'error' event that bypasses try/catch and crashes the process.
+		const taskkill = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe");
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			spawnSync(taskkill, ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
-				detached: true,
 				windowsHide: true,
 			});
 		} catch {

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter } from "node:path";
+import { delimiter, join } from "node:path";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
 
@@ -196,14 +196,18 @@ export function killTrackedDetachedChildren(): void {
 
 /**
  * Kill a process and all its children (cross-platform)
+ *
+ * On Windows, uses `spawnSync` with an absolute path to taskkill.exe to avoid
+ * PATH-lookup failures (ENOENT on Node.js 24+ where spawn error events are
+ * emitted asynchronously and bypass try/catch). spawnSync keeps the call
+ * synchronous and surfaces errors in the return object instead of crashing.
  */
 export function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
-		// Use taskkill on Windows to kill process tree
+		const taskkill = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe");
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			spawnSync(taskkill, ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
-				detached: true,
 				windowsHide: true,
 			});
 		} catch {


### PR DESCRIPTION
## Summary

Fixes #6596.

`killProcessTree()` in two files uses `spawn("taskkill", ...)` which crashes with `ENOENT` on Node.js 24+. The existing `try/catch` never catches the error because Node.js 24 emits it **asynchronously** via the `ChildProcess` `error` event, not as a synchronous throw.

## Root Cause Analysis

Two compounding issues:

1. **PATH lookup is unreliable**: `spawn("taskkill")` depends on PATH resolution, which can fail on some Node.js 24 builds or environments where PATH is stripped/limited.

2. **try/catch doesn't catch async spawn errors**: When `spawn()` can't find the executable, the `ENOENT` error is emitted as an `error` event on the `ChildProcess` object. Without an explicit `.on("error", ...)` handler, this becomes an **unhandled error event** that crashes the process — and the surrounding `try/catch` never fires because `spawn()` itself returns successfully (the child process object).

## Fix

| Aspect | Before | After |
|--------|--------|-------|
| Spawn mode | `spawn()` (async, fire-and-forget) | `spawnSync()` (synchronous) |
| Executable path | `"taskkill"` (PATH lookup) | `join(SystemRoot, "System32", "taskkill.exe")` (absolute) |
| Error handling | `try/catch` (never catches async errors) | `try/catch` (now works — spawnSync errors are synchronous) |
| `detached: true` | Present (unnecessary for fire-and-forget) | Removed (spawnSync doesn't need it) |

### Why `spawnSync` over `spawn` + `.on("error")`

The function signature is `killProcessTree(pid: number): void` — it's a **synchronous** function. Using `spawnSync`:

- Errors are returned in the result object (or thrown synchronously), so `try/catch` works correctly
- The process is guaranteed killed before the function returns
- No risk of unhandled async error events
- Matches the synchronous semantics expected by callers (cleanup handlers, timeout callbacks)

## Files Changed

- `packages/coding-agent/src/utils/shell.ts` — exported `killProcessTree` (added `join` import)
- `packages/agent/src/harness/env/nodejs.ts` — local `killProcessTree` (added `spawnSync` import)

## Verification

- `spawnSync` with absolute path bypasses PATH lookup entirely
- If `taskkill.exe` doesn't exist (e.g., Wine, minimal Windows), `spawnSync` returns `{ error: ENOENT }` in the result — no crash
- `process.env.SystemRoot ?? "C:\\Windows"` handles edge cases where SystemRoot is unset
- Unix path (`process.kill` with SIGKILL) is unchanged