### PR TITLE
fix: add retry logic to compaction summarization for transient stream failures

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -8,8 +8,9 @@
 import type { AgentMessage, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { contentText } from "@earendil-works/pi-ai";
 import type { AssistantMessage, Context, Model, SimpleStreamOptions, Usage } from "@earendil-works/pi-ai/compat";
-import { completeSimple } from "@earendil-works/pi-ai/compat";
+import { completeSimple, isRetryableAssistantError } from "@earendil-works/pi-ai/compat";
 import { convertToLlm } from "../messages.ts";
+import { sleep } from "../../utils/sleep.ts";
 import {
 	buildSessionContext,
 	type CompactionEntry,
@@ -527,17 +528,60 @@ function createSummarizationOptions(
 	return options;
 }
 
+// ============================================================================
+// Summarization retry configuration
+// ============================================================================
+
+/** Maximum number of retry attempts for transient summarization failures. */
+const SUMMARIZATION_MAX_RETRIES = 3;
+
+/** Base delay in ms for exponential backoff between summarization retries. */
+const SUMMARIZATION_RETRY_BASE_DELAY_MS = 1000;
+
+/**
+ * Complete a summarization call with bounded retry for transient errors.
+ *
+ * Normal assistant turns retry transient stream failures (socket drops,
+ * timeouts, provider overloads) via `isRetryableAssistantError` in the
+ * agent session loop. The compaction path previously made a single
+ * non-retried call, so one transient mid-stream failure would fail the
+ * entire compaction. This wrapper applies the same retryable-error
+ * classification with exponential backoff so that transient failures
+ * are recovered automatically while deterministic errors still fail fast.
+ */
 async function completeSummarization(
 	model: Model<any>,
 	context: Context,
 	options: SimpleStreamOptions,
 	streamFn?: StreamFn,
 ): Promise<AssistantMessage> {
-	if (!streamFn) {
-		return completeSimple(model, context, options);
+	let lastResponse: AssistantMessage | undefined;
+
+	for (let attempt = 0; attempt <= SUMMARIZATION_MAX_RETRIES; attempt++) {
+		// Wait with exponential backoff before retrying (skip delay on first attempt)
+		if (attempt > 0) {
+			const delayMs = SUMMARIZATION_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+			await sleep(delayMs, options.signal);
+		}
+
+		const response = streamFn
+			? await (await streamFn(model, context, options)).result()
+			: await completeSimple(model, context, options);
+
+		// If the response is not a retryable error, return immediately.
+		// This covers both successful responses and deterministic errors
+		// (e.g. content policy violations) that should fail fast.
+		if (response.stopReason !== "error" || !isRetryableAssistantError(response)) {
+			return response;
+		}
+
+		// Transient error — retry if attempts remain
+		lastResponse = response;
 	}
-	const stream = await streamFn(model, context, options);
-	return stream.result();
+
+	// All retry attempts exhausted; return the last failed response so the
+	// caller can inspect stopReason/errorMessage and throw appropriately.
+	return lastResponse!;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds bounded retry with exponential backoff to `completeSummarization()` in the compaction path, so that a single transient mid-stream socket death no longer fails the entire compaction.

Fixes #6647

## Root Cause Analysis

`completeSummarization()` in `packages/coding-agent/src/core/compaction/compaction.ts` made a **single, non-retried** LLM call for summarization. When the stream died mid-flight (e.g. `"terminated"`, `"socket hang up"`, `"connection reset"`), the function returned an error response and `generateSummary()` threw immediately:

```
Compaction failed: Summarization failed: terminated
```

Normal assistant turns already handle this class of transient error via `isRetryableAssistantError` (defined in `packages/ai/src/utils/retry.ts`) with exponential backoff in the agent session loop. However, the compaction path — which is the **shared choke point** for compaction, split-turn summary, and branch summary — bypassed that retry infrastructure entirely.

Large sessions are the most exposed because they produce the longest streams, making them the most likely to encounter a transient network interruption. This is exactly the failure mode users reported in #6647.

## Fix

The fix wraps the existing `completeSummarization()` call in a bounded retry loop that:

1. **Reuses the existing `isRetryableAssistantError` classifier** — the same function used by normal assistant turns — to determine whether a failed response is transient (socket drops, timeouts, provider overloads, rate limits) vs. deterministic (content policy violations, invalid requests).

2. **Applies exponential backoff** (1s, 2s, 4s) between retry attempts, respecting the caller's `AbortSignal` so cancellation still works cleanly.

3. **Caps at 3 retry attempts** to avoid unbounded retry loops while giving transient network issues ample time to recover.

4. **Fails fast on deterministic errors** — if `isRetryableAssistantError` returns `false`, the error response is returned immediately without retrying, preserving existing behavior for non-transient failures.

### Why this works

- The retry is at the **lowest shared choke point** (`completeSummarization`), so all three callers — `generateSummary()`, `generateTurnPrefixSummary()`, and branch summarization — benefit automatically.
- By gating on `isRetryableAssistantError`, we only retry errors that are genuinely transient. Deterministic errors (quota exhaustion, content policy) still fail immediately.
- The exponential backoff matches the pattern already used in the agent session's `_prepareRetry()`, keeping behavior consistent across the codebase.
- The `AbortSignal` is passed through to `sleep()`, so if the user cancels compaction mid-retry, the wait is interrupted immediately.

## Files Changed

| File | Change |
|------|--------|
| `packages/coding-agent/src/core/compaction/compaction.ts` | Added retry loop to `completeSummarization()` with `isRetryableAssistantError` gate and exponential backoff |

## Verification

- **Transient errors are retried**: A response with `stopReason: "error"` and `errorMessage: "terminated"` (or any pattern matched by `RETRYABLE_PROVIDER_ERROR_PATTERN`) will be retried up to 3 times with 1s/2s/4s backoff.
- **Deterministic errors fail fast**: A response with `errorMessage: "insufficient_quota"` returns immediately without retry.
- **Successful responses pass through**: Non-error responses are returned on the first attempt with zero overhead.
- **Abort signal respected**: If `options.signal` is aborted during backoff sleep, the retry loop terminates immediately via the `sleep()` rejection.
- **All callers benefit**: `generateSummary()`, `generateTurnPrefixSummary()`, and branch summarization all flow through `completeSummarization()`, so the fix covers compaction, split-turn, and branch summary paths.
- **No behavioral change for non-stream paths**: The `completeSimple` (non-stream) path also benefits from retry, which is correct since it can also encounter transient HTTP errors.