### PR TITLE
fix: tool_call_id error when switching

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -34,6 +34,7 @@ import type {
 } from "../types.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
+import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
@@ -895,10 +896,21 @@ export function convertMessages(
 		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
 		// These come from providers like github-copilot, openai-codex, opencode
 		// Extract just the call_id part and normalize it
+		// Multiple tool calls in the same turn can share call_id but differ by item_id.
+		// Preserve item-level uniqueness when replaying into Chat Completions, which
+		// requires distinct tool call ids.
 		if (id.includes("|")) {
-			const [callId] = id.split("|");
 			// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
-			return callId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
+			const separatorIndex = id.indexOf("|");
+			const callId = id.slice(0, separatorIndex).replace(/[^a-zA-Z0-9_-]/g, "_");
+			const itemId = id.slice(separatorIndex + 1).replace(/[^a-zA-Z0-9_-]/g, "_");
+			const combinedId = itemId.length > 0 ? `${callId}_${itemId}` : callId;
+			if (combinedId.length <= 40) {
+				return combinedId;
+			}
+			const hash = shortHash(id).slice(0, 8);
+			const prefix = callId.slice(0, Math.max(1, 40 - hash.length - 1));
+			return `${prefix}_${hash}`;
 		}
 
 		if (model.provider === "openai") return id.length > 40 ? id.slice(0, 40) : id;


### PR DESCRIPTION
Addresses #6796.

When a session started on an OpenAI Responses-style model is switched to an openai-completions model, Pi normalizes replayed tool call IDs by stripping the `|<item-id>` suffix and keeping only the shared `call_id`. If two replayed tool calls came from the same Responses `call_id`, they collapse to the same `tool_calls[].id`/`tool_call_id,` and the next request fails with a duplicate-ID 400.

Reproduced it by running a cross-provider session containing two Responses-style tool calls like `call-...|fc_1` and `call-...|fc_2` plus their tool results, output contained duplicate assistant tool call IDs and duplicate tool-result `tool_call_ids` (matching the reported failure).

This fix normalizes pipe-separated cross-provider tool call IDs before replaying them into Chat Completions, so IDs shaped like `{call_id}|{item_id}` (for example `call_abc123|fc_abc123…`) become a valid unique tool-call ID instead of leaking provider-specific long/special-character forms. I ran the reported session with the fix applied, and tool-call replay now works correctly.