### PR TITLE
fix(ai): honor auth.json env block in envApiKeyAuth (fixes #6799)

### DIFF
--- a/packages/ai/src/auth/helpers.ts
+++ b/packages/ai/src/auth/helpers.ts
@@ -14,10 +14,15 @@ export function envApiKeyAuth(name: string, envVars: readonly string[]): ApiKeyA
 			return { type: "api_key", key };
 		},
 		resolve: async ({ ctx, credential }) => {
-			if (credential?.key) return { auth: { apiKey: credential.key }, source: "stored credential" };
+			// Surface provider-scoped env from the stored credential (auth.json `env`)
+			// so provider config such as AZURE_OPENAI_BASE_URL resolves before process
+			// env. Per-field: prefer the credential value, fall back to ambient env.
+			const env = credential?.env;
+			if (credential?.key) return { auth: { apiKey: credential.key }, env, source: "stored credential" };
 			for (const envVar of envVars) {
-				const value = await ctx.env(envVar);
-				if (value) return { auth: { apiKey: value }, source: envVar };
+				const fromCredential = env?.[envVar];
+				const value = fromCredential ?? (await ctx.env(envVar));
+				if (value) return { auth: { apiKey: value }, env, source: fromCredential ? "stored credential" : envVar };
 			}
 			return undefined;
 		},

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -254,6 +254,37 @@ describe("envApiKeyAuth", () => {
 		expect(await auth.resolve({ ctx: fakeAuthContext({}) })).toBeUndefined();
 	});
 
+	it("surfaces provider-scoped credential env in the auth result (#6799)", async () => {
+		const auth = envApiKeyAuth("Azure OpenAI API key", ["AZURE_OPENAI_API_KEY"]);
+
+		const withStoredKey = await auth.resolve({
+			ctx: fakeAuthContext({}),
+			credential: {
+				type: "api_key",
+				key: "stored",
+				env: { AZURE_OPENAI_BASE_URL: "https://example.openai.azure.com" },
+			},
+		});
+		expect(withStoredKey?.auth.apiKey).toBe("stored");
+		expect(withStoredKey?.env).toEqual({ AZURE_OPENAI_BASE_URL: "https://example.openai.azure.com" });
+
+		// The api key itself may live in the credential env block, and the scoped
+		// env still flows through instead of the ambient environment.
+		const fromCredentialEnv = await auth.resolve({
+			ctx: fakeAuthContext({ AZURE_OPENAI_API_KEY: "ambient" }),
+			credential: {
+				type: "api_key",
+				env: { AZURE_OPENAI_API_KEY: "scoped", AZURE_OPENAI_BASE_URL: "https://example.openai.azure.com" },
+			},
+		});
+		expect(fromCredentialEnv?.auth.apiKey).toBe("scoped");
+		expect(fromCredentialEnv?.source).toBe("stored credential");
+		expect(fromCredentialEnv?.env).toEqual({
+			AZURE_OPENAI_API_KEY: "scoped",
+			AZURE_OPENAI_BASE_URL: "https://example.openai.azure.com",
+		});
+	});
+
 	it("login prompts for a secret and returns an api-key credential", async () => {
 		const auth = envApiKeyAuth("Test key", ["TEST_KEY"]);
 		const credential = await auth.login?.({


### PR DESCRIPTION
envApiKeyAuth dropped the credential's provider-scoped env, so config such as AZURE_OPENAI_BASE_URL set in auth.json was ignored and only the process environment was consulted. Thread credential.env through the resolved AuthResult and prefer it per-field over ambient env, matching the documented ApiKeyAuth.resolve contract and the cloudflare provider. Fixes Azure OpenAI and every other provider built on this helper.