### PR TITLE
Use bun info for package update checks

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -1499,13 +1499,14 @@ export class DefaultPackageManager implements PackageManager {
 
 	private async getLatestNpmVersion(packageSpec: string, range?: string): Promise<string> {
 		const npmCommand = this.getNpmCommand();
+		const metadataCommand = this.getPackageManagerName() === "bun" ? "info" : "view";
 		const stdout = await this.runCommandCapture(
 			npmCommand.command,
-			[...npmCommand.args, "view", packageSpec, "version", "--json"],
+			[...npmCommand.args, metadataCommand, packageSpec, "version", "--json"],
 			{ cwd: this.cwd, timeoutMs: NETWORK_TIMEOUT_MS },
 		);
 		const raw = stdout.trim();
-		if (!raw) throw new Error("Empty response from npm view");
+		if (!raw) throw new Error(`Empty response from ${metadataCommand}`);
 		const parsed = JSON.parse(raw) as unknown;
 		if (typeof parsed === "string") {
 			return parsed;
@@ -1515,7 +1516,7 @@ export class DefaultPackageManager implements PackageManager {
 			const latest = range ? maxSatisfying(versions, range) : [...versions].sort(rcompare)[0];
 			if (latest) return latest;
 		}
-		throw new Error("Unexpected response from npm view");
+		throw new Error(`Unexpected response from ${metadataCommand}`);
 	}
 
 	private async gitHasAvailableUpdate(installedPath: string): Promise<boolean> {

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -2476,6 +2476,25 @@ export default function(api) { api.registerTool({ name: "test", description: "te
 			);
 		});
 
+		it("should use bun info for npm update checks", async () => {
+			settingsManager = SettingsManager.inMemory({ npmCommand: ["bun"] });
+			packageManager = new DefaultPackageManager({
+				cwd: tempDir,
+				agentDir,
+				settingsManager,
+			});
+
+			const runCommandCaptureSpy = vi.spyOn(packageManager as any, "runCommandCapture").mockResolvedValue('"1.2.3"');
+
+			const latest = await (packageManager as any).getLatestNpmVersion("@scope/pkg");
+			expect(latest).toBe("1.2.3");
+			expect(runCommandCaptureSpy).toHaveBeenCalledWith(
+				"bun",
+				["info", "@scope/pkg", "version", "--json"],
+				expect.objectContaining({ cwd: tempDir }),
+			);
+		});
+
 		it("should wait for close before resolving captured stdout", async () => {
 			const managerWithInternals = packageManager as unknown as {
 				spawnCaptureCommand(


### PR DESCRIPTION
This is a small qol pr that fixes extensions update checks when bun is used as npm package manager.

With `"npmCommand": ["bun"]`, Pi runs `bun view`, which bun treats as a missing script. The error is swallowed, so startup package update notifications never appear.

This fix uses `bun info` for bun while keeping `view` for other package managers.