### PR TITLE
fix: env section ignored

### DIFF
--- a/packages/ai/src/auth/helpers.ts
+++ b/packages/ai/src/auth/helpers.ts
@@ -14,7 +14,9 @@ export function envApiKeyAuth(name: string, envVars: readonly string[]): ApiKeyA
 			return { type: "api_key", key };
 		},
 		resolve: async ({ ctx, credential }) => {
-			if (credential?.key) return { auth: { apiKey: credential.key }, source: "stored credential" };
+			if (credential?.key) {
+				return { auth: { apiKey: credential.key }, env: credential.env, source: "stored credential" };
+			}
 			for (const envVar of envVars) {
 				const value = await ctx.env(envVar);
 				if (value) return { auth: { apiKey: value }, source: envVar };

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -50,7 +50,9 @@ const bedrockAuth: ApiKeyAuth = {
 		return { type: "api_key" };
 	},
 	resolve: async ({ ctx, credential }) => {
-		if (credential?.key) return { auth: { apiKey: credential.key }, source: "stored credential" };
+		if (credential?.key) {
+			return { auth: { apiKey: credential.key }, env: credential.env, source: "stored credential" };
+		}
 		if (await ctx.env("AWS_BEARER_TOKEN_BEDROCK")) return { auth: {}, source: "AWS_BEARER_TOKEN_BEDROCK" };
 		if (credential?.env?.AWS_PROFILE ?? (await ctx.env("AWS_PROFILE"))) {
 			return {


### PR DESCRIPTION
Fixes #6799.

`envApiKeyAuth.resolve()` dropped `credential.env` on the stored-key branch, so `AuthResult.env` was `undefined` and `getProviderEnvValue` fell back to `process.env`.

Reproduced: an azure credential with `env.AZURE_OPENAI_BASE_URL` and no ambient env threw the issue's error through both `auth.resolve(...)` and `Models.getAuth(...)`. Fixed and re-tested ✅ .

2 providers needed fixing, Azure and Bedrock.

For Azure: added the env value in the helper, which covers 34 `envApiKeyAuth` providers. Most consume `options.env` via `resolveCacheRetention` (`PI_CACHE_RETENTION`), Azure only via `AZURE_OPENAI_*`. Useless for some helper consumers but kept per the documented per-field contract: google (Generative AI), mistral, and openrouter-images.

For Bedrock: added to Bedrock (for `AWS_REGION, HTTP(S)_PROXY`, `AWS_BEDROCK_FORCE_HTTP1`, `PI_CACHE_RETENTION`).

Only remaining providers where env is not threaded: google-vertex api-key (`createClientWithApiKey` ignores project/location/options.env, ADC already does). `cloudflare-workers-ai` and `cloudflare-ai-gateway` intentionally only thread the two documented keys.
