### PR TITLE
feat: get_available_thinking_levels rpc

### DIFF
--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -313,6 +313,26 @@ Response:
 }
 ```
 
+#### get_available_thinking_levels
+
+List the thinking levels supported by the current model. Returns `["off"]` for a model without reasoning support.
+
+```json
+{"type": "get_available_thinking_levels"}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "get_available_thinking_levels",
+  "success": true,
+  "data": {
+    "levels": ["off", "minimal", "low", "medium", "high"]
+  }
+}
+```
+
 ### Queue Modes
 
 #### set_steering_mode

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -281,6 +281,14 @@ export class RpcClient {
 	}
 
 	/**
+	 * Get list of available thinking levels for the current model.
+	 */
+	async getAvailableThinkingLevels(): Promise<ThinkingLevel[]> {
+		const response = await this.send({ type: "get_available_thinking_levels" });
+		return this.getData<{ levels: ThinkingLevel[] }>(response).levels;
+	}
+
+	/**
 	 * Set steering mode.
 	 */
 	async setSteeringMode(mode: "all" | "one-at-a-time"): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -504,6 +504,11 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				return success(id, "cycle_thinking_level", { level });
 			}
 
+			case "get_available_thinking_levels": {
+				const levels = session.getAvailableThinkingLevels();
+				return success(id, "get_available_thinking_levels", { levels });
+			}
+
 			// =================================================================
 			// Queue Modes
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -36,6 +36,7 @@ export type RpcCommand =
 	// Thinking
 	| { id?: string; type: "set_thinking_level"; level: ThinkingLevel }
 	| { id?: string; type: "cycle_thinking_level" }
+	| { id?: string; type: "get_available_thinking_levels" }
 
 	// Queue modes
 	| { id?: string; type: "set_steering_mode"; mode: "all" | "one-at-a-time" }
@@ -153,6 +154,13 @@ export type RpcResponse =
 			command: "cycle_thinking_level";
 			success: true;
 			data: { level: ThinkingLevel } | null;
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "get_available_thinking_levels";
+			success: true;
+			data: { levels: ThinkingLevel[] };
 	  }
 
 	// Queue modes

--- a/packages/coding-agent/test/rpc.test.ts
+++ b/packages/coding-agent/test/rpc.test.ts
@@ -209,6 +209,28 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY && !process.env.ANTHROPIC_OAUTH_T
 		expect(newState.thinkingLevel).toBe(result!.level);
 	}, 30000);
 
+	test("should get available thinking levels", async () => {
+		await client.start();
+
+		const levels = await client.getAvailableThinkingLevels();
+		expect(levels.length).toBeGreaterThan(0);
+
+		// The current level reported by get_state must be in the available list
+		const state = await client.getState();
+		expect(levels).toContain(state.thinkingLevel);
+
+		// cycle_thinking_level must only ever land on levels from get_available_thinking_levels
+		const initialLevel = state.thinkingLevel;
+		const cycled = await client.cycleThinkingLevel();
+		if (cycled) {
+			expect(levels).toContain(cycled.level);
+			// distinct cycle step (unless only one level)
+			if (levels.length > 1) {
+				expect(cycled.level).not.toBe(initialLevel);
+			}
+		}
+	}, 30000);
+
 	test("should get available models", async () => {
 		await client.start();
 


### PR DESCRIPTION
To make use that requested #6773 happy.

Adds `get_available_thinking_levels` RPC command, modeled after existing ones.