### PR TITLE
feat(session-selector): add Ctrl+A archive shortcut to session picker

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -40,6 +40,7 @@ export interface AppKeybindings {
 	"app.session.rename": true;
 	"app.session.delete": true;
 	"app.session.deleteNoninvasive": true;
+	"app.session.archive": true;
 	"app.models.save": true;
 	"app.models.enableAll": true;
 	"app.models.clearAll": true;
@@ -151,6 +152,10 @@ export const KEYBINDINGS = {
 	"app.session.deleteNoninvasive": {
 		defaultKeys: "ctrl+backspace",
 		description: "Delete session when query is empty",
+	},
+	"app.session.archive": {
+		defaultKeys: "ctrl+a",
+		description: "Archive session",
 	},
 	"app.models.save": {
 		defaultKeys: "ctrl+s",
@@ -266,6 +271,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	renameSession: "app.session.rename",
 	deleteSession: "app.session.delete",
 	deleteSessionNoninvasive: "app.session.deleteNoninvasive",
+	archiveSession: "app.session.archive",
 } as const satisfies Record<string, Keybinding>;
 
 function isLegacyKeybindingName(key: string): key is keyof typeof KEYBINDING_NAME_MIGRATIONS {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, statSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import * as os from "node:os";
+import { dirname, join } from "node:path";
 import {
 	type Component,
 	Container,
@@ -172,6 +173,7 @@ class SessionSelectorHeader implements Component {
 				keyHint("app.session.toggleSort", "sort"),
 				keyHint("app.session.toggleNamedFilter", "named"),
 				keyHint("app.session.delete", "delete"),
+				keyHint("app.session.archive", "archive"),
 				keyHint("app.session.togglePath", `path ${pathState}`),
 			];
 			if (this.showRenameHint) {
@@ -306,6 +308,7 @@ class SessionList implements Component, Focusable {
 	public onDeleteConfirmationChange?: (path: string | null) => void;
 	public onDeleteSession?: (sessionPath: string) => Promise<void>;
 	public onRenameSession?: (sessionPath: string) => void;
+	public onArchiveSession?: (sessionPath: string) => Promise<void>;
 	public onError?: (message: string) => void;
 	private maxVisible: number = 10; // Max sessions visible (one line each)
 
@@ -572,9 +575,21 @@ class SessionList implements Component, Focusable {
 			return;
 		}
 
-		// Ctrl+D: initiate delete confirmation (useful on terminals that don't distinguish Ctrl+Backspace from Backspace)
+		// Ctrl+D: initiate delete confirmation
 		if (kb.matches(keyData, "app.session.delete")) {
 			this.startDeleteConfirmationForSelectedSession();
+			return;
+		}
+
+		// Ctrl+A: archive selected session to .pi/archive/YYYY-MM/
+		if (kb.matches(keyData, "app.session.archive")) {
+			const selected = this.filteredSessions[this.selectedIndex];
+			if (!selected) return;
+			if (this.isCurrentSessionPath(selected.session.path)) {
+				this.onError?.("Cannot archive the currently active session");
+				return;
+			}
+			void this.onArchiveSession?.(selected.session.path);
 			return;
 		}
 
@@ -852,6 +867,34 @@ export class SessionSelectorComponent extends Container implements Focusable {
 				this.header.setStatusMessage({ type: "error", message: `Failed to delete: ${errorMessage}` }, 3000);
 			}
 
+			this.requestRender();
+		};
+
+		// Handle session archive
+		this.sessionList.onArchiveSession = async (sessionPath: string) => {
+			try {
+				const s = statSync(sessionPath);
+				const month = s.mtime.toISOString().slice(0, 7);
+				const archiveDir = join(dirname(sessionPath), "..", "archive", month);
+				mkdirSync(archiveDir, { recursive: true });
+				renameSync(sessionPath, join(archiveDir, sessionPath.split(/[/\\]/).pop()!));
+
+				if (this.currentSessions) {
+					this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
+				}
+				if (this.allSessions) {
+					this.allSessions = this.allSessions.filter((s) => s.path !== sessionPath);
+				}
+
+				const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
+				const showCwd = this.scope === "all";
+				this.sessionList.setSessions(sessions, showCwd);
+
+				this.header.setStatusMessage({ type: "info", message: "Session archived" }, 2000);
+				await this.refreshSessionsAfterMutation();
+			} catch (err) {
+				this.header.setStatusMessage({ type: "error", message: `Archive failed: ${err}` }, 3000);
+			}
 			this.requestRender();
 		};
 


### PR DESCRIPTION
## Summary

Add an "Archive" keyboard shortcut (`Ctrl+A`) to the `/resume` session selector, allowing users to archive selected session files to `.pi/archive/YYYY-MM/` with a single keystroke. Archive preserves data for future analysis while keeping the active session list clean—complementing the existing delete flow (`Ctrl+D`).

## Changes

**`packages/coding-agent/src/core/keybindings.ts`**:
- Register `app.session.archive` in the `AppKeybindings` interface
- Add default keybinding `ctrl+a` with description "Archive session"
- Add name mapping `archiveSession` → `app.session.archive`

**`packages/coding-agent/src/modes/interactive/components/session-selector.ts`**:
- Add `mkdirSync`, `renameSync`, `statSync` from `node:fs` and `dirname`, `join` from `node:path`
- Add `onArchiveSession?: (sessionPath: string) => Promise<void>` callback to `SessionList`
- Handle `app.session.archive` in `SessionList.handleInput`: verify selected session exists, guard against archiving the currently active session (mirrors the delete guard), then fire the callback
- Display archive hint (`Ctrl+A archive`) in the selector footer alongside sort/named/delete/path hints
- Implement archive callback in `SessionSelectorComponent`: determine archive directory from the file mtime (`.pi/archive/YYYY-MM/`), create it, move the file via `renameSync`, update in-memory session lists, show status message, and refresh from disk

## Usage

1. Open `/resume` session selector
2. Navigate to a session with ↑↓
3. Press `Ctrl+A` to archive it immediately (no confirmation dialog needed—archive is reversible via manual restore)
4. The session is moved to `.pi/archive/2026-07/` and the list updates instantly

The existing `/archive` command remains available for batch operations (`/archive all`).

## Testing

- [x] TypeScript compiles cleanly (`tsgo -p tsconfig.build.json`)
- [x] Archive bypasses currently active session (same guard as delete)
- [x] Archived sessions removed from in-memory list and UI refreshes
- [x] Status message "Session archived" displayed on success
- [x] Error message shown on failure (e.g., permissions)
- [x] Keybinding hint shown in selector footer
- [x] Users can customize or disable via `~/.pi/agent/keybindings.json`