### PR TITLE
feat(ai): use provider-reported cost when responses include it

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -225,6 +225,8 @@ for (const block of response.content) {
 
 Snippets in the rest of this README assume a `models` collection set up like this (with the relevant providers registered).
 
+`usage.cost` is computed from the model's catalog rates. When an API reports the billed cost in the response (Vercel AI Gateway, OpenRouter with usage accounting), the reported total is used instead and catalog rates only serve as the fallback, cost components are scaled so they keep summing to the total.
+
 ## Providers and Models
 
 A **provider** is the runtime unit: it owns its model catalog, its auth (API key resolution, OAuth flows), and its stream behavior. A `Models` collection holds providers and routes every request to the provider that owns the model.

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -7,7 +7,7 @@ import type {
 	RawMessageStreamEvent,
 	RefusalStopDetails,
 } from "@anthropic-ai/sdk/resources/messages.js";
-import { calculateCost } from "../models.ts";
+import { applyReportedCost, calculateCost } from "../models.ts";
 import type {
 	AnthropicMessagesCompat,
 	Api,
@@ -729,6 +729,12 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
 					calculateCost(model, output.usage);
+					// Vercel AI Gateway attaches the billed total to the final message_delta
+					const reportedCost = (event as { provider_metadata?: { gateway?: { cost?: string | number } } })
+						.provider_metadata?.gateway?.cost;
+					if (reportedCost != null) {
+						applyReportedCost(output.usage, Number(reportedCost));
+					}
 				}
 			}
 

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -10,7 +10,7 @@ import type {
 	ChatCompletionSystemMessageParam,
 	ChatCompletionToolMessageParam,
 } from "openai/resources/chat/completions.js";
-import { calculateCost, clampThinkingLevel } from "../models.ts";
+import { applyReportedCost, calculateCost, clampThinkingLevel } from "../models.ts";
 import type {
 	AssistantMessage,
 	CacheRetention,
@@ -1184,6 +1184,8 @@ function parseChunkUsage(
 		prompt_cache_hit_tokens?: number;
 		prompt_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
 		completion_tokens_details?: { reasoning_tokens?: number };
+		cost?: number;
+		cost_details?: { upstream_inference_cost?: number | null };
 	},
 	model: Model<"openai-completions">,
 ): AssistantMessage["usage"] {
@@ -1212,6 +1214,10 @@ function parseChunkUsage(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 	calculateCost(model, usage);
+	if (typeof rawUsage.cost === "number") {
+		// BYOK requests bill inference upstream, upstream_inference_cost carries that share (Vercel AI Gateway)
+		applyReportedCost(usage, rawUsage.cost + (rawUsage.cost_details?.upstream_inference_cost ?? 0));
+	}
 	return usage;
 }
 

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1185,6 +1185,7 @@ function parseChunkUsage(
 		prompt_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
 		completion_tokens_details?: { reasoning_tokens?: number };
 		cost?: number;
+		is_byok?: boolean;
 		cost_details?: { upstream_inference_cost?: number | null };
 	},
 	model: Model<"openai-completions">,
@@ -1215,8 +1216,9 @@ function parseChunkUsage(
 	};
 	calculateCost(model, usage);
 	if (typeof rawUsage.cost === "number") {
-		// BYOK requests bill inference upstream, upstream_inference_cost carries that share (Vercel AI Gateway)
-		applyReportedCost(usage, rawUsage.cost + (rawUsage.cost_details?.upstream_inference_cost ?? 0));
+		// BYOK responses bill inference upstream, upstream_inference_cost carries that share (Vercel AI Gateway, OpenRouter)
+		const upstreamCost = rawUsage.is_byok === true ? (rawUsage.cost_details?.upstream_inference_cost ?? 0) : 0;
+		applyReportedCost(usage, rawUsage.cost + upstreamCost);
 	}
 	return usage;
 }

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -658,6 +658,21 @@ export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage
 	return usage.cost;
 }
 
+// A provider-reported total is the billed amount and wins over catalog math, components are scaled to keep summing to it
+export function applyReportedCost(usage: Usage, reportedTotal: number): Usage["cost"] {
+	if (!Number.isFinite(reportedTotal) || reportedTotal < 0) return usage.cost;
+	const local = usage.cost.total;
+	if (local > 0) {
+		const scale = reportedTotal / local;
+		usage.cost.input *= scale;
+		usage.cost.output *= scale;
+		usage.cost.cacheRead *= scale;
+		usage.cost.cacheWrite *= scale;
+	}
+	usage.cost.total = reportedTotal;
+	return usage.cost;
+}
+
 const EXTENDED_THINKING_LEVELS: ModelThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 export function getSupportedThinkingLevels<TApi extends Api>(model: Model<TApi>): ModelThinkingLevel[] {

--- a/packages/ai/test/reported-cost.test.ts
+++ b/packages/ai/test/reported-cost.test.ts
@@ -1,0 +1,315 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import { applyReportedCost } from "../src/models.ts";
+import type { Model, Usage } from "../src/types.ts";
+
+const mockState = vi.hoisted(() => ({
+	chunkSets: [] as unknown[][],
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: () => {
+					const chunks = mockState.chunkSets.shift() ?? [];
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							for (const chunk of chunks) {
+								yield chunk;
+							}
+						},
+					};
+					const result = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{ data: typeof stream; response: { status: number; headers: Headers } }>;
+					};
+					result.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return result;
+				},
+			},
+		};
+	}
+	return { default: FakeOpenAI };
+});
+
+function makeUsage(cost: Usage["cost"]): Usage {
+	return {
+		input: 100,
+		output: 50,
+		cacheRead: 200,
+		cacheWrite: 0,
+		totalTokens: 350,
+		cost,
+	};
+}
+
+describe("applyReportedCost", () => {
+	it("scales components so they keep summing to the reported total", () => {
+		const usage = makeUsage({ input: 0.5, output: 0.25, cacheRead: 0.25, cacheWrite: 0, total: 1 });
+		applyReportedCost(usage, 2);
+		expect(usage.cost.input).toBeCloseTo(1);
+		expect(usage.cost.output).toBeCloseTo(0.5);
+		expect(usage.cost.cacheRead).toBeCloseTo(0.5);
+		expect(usage.cost.total).toBe(2);
+	});
+
+	it("sets only the total when local rates are all zero", () => {
+		const usage = makeUsage({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+		applyReportedCost(usage, 0.0042);
+		expect(usage.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.0042 });
+	});
+
+	it("zeroes everything when the reported total is zero (BYOK)", () => {
+		const usage = makeUsage({ input: 0.5, output: 0.25, cacheRead: 0.25, cacheWrite: 0, total: 1 });
+		applyReportedCost(usage, 0);
+		expect(usage.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+	});
+
+	it("ignores non-finite and negative values", () => {
+		const usage = makeUsage({ input: 0.5, output: 0.25, cacheRead: 0.25, cacheWrite: 0, total: 1 });
+		applyReportedCost(usage, Number.NaN);
+		applyReportedCost(usage, -1);
+		expect(usage.cost.total).toBe(1);
+	});
+});
+
+function gatewayCompletionsModel(cost: Model<"openai-completions">["cost"]): Model<"openai-completions"> {
+	return {
+		id: "moonshotai/kimi-k3",
+		name: "Kimi K3",
+		api: "openai-completions",
+		provider: "vercel-ai-gateway",
+		baseUrl: "https://ai-gateway.vercel.sh/v1",
+		reasoning: true,
+		input: ["text"],
+		cost,
+		contextWindow: 262144,
+		maxTokens: 131072,
+	};
+}
+
+describe("openai-completions reported cost", () => {
+	beforeEach(() => {
+		mockState.chunkSets = [];
+	});
+
+	it("uses usage.cost from the final chunk on a model without catalog rates", async () => {
+		mockState.chunkSets = [
+			[
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [{ index: 0, delta: { content: "hi" }, finish_reason: "stop" }],
+				},
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [],
+					usage: {
+						prompt_tokens: 91,
+						completion_tokens: 38,
+						prompt_tokens_details: { cached_tokens: 91 },
+						cost: 0.0005973,
+					},
+				},
+			],
+		];
+
+		const model = gatewayCompletionsModel({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		const message = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test" },
+		).result();
+
+		expect(message.usage.cost.total).toBe(0.0005973);
+	});
+
+	it("scales catalog-derived components to the reported total", async () => {
+		mockState.chunkSets = [
+			[
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [{ index: 0, delta: { content: "hi" }, finish_reason: "stop" }],
+				},
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [],
+					usage: { prompt_tokens: 1000, completion_tokens: 1000, cost: 0.036 },
+				},
+			],
+		];
+
+		// Local calc: 1000 * 3/M + 1000 * 15/M = 0.018, half the reported total.
+		const model = gatewayCompletionsModel({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 });
+		const message = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test" },
+		).result();
+
+		expect(message.usage.cost.total).toBe(0.036);
+		expect(message.usage.cost.input).toBeCloseTo(0.006);
+		expect(message.usage.cost.output).toBeCloseTo(0.03);
+	});
+
+	it("adds upstream_inference_cost for BYOK requests", async () => {
+		mockState.chunkSets = [
+			[
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [{ index: 0, delta: { content: "hi" }, finish_reason: "stop" }],
+				},
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [],
+					usage: {
+						prompt_tokens: 1000,
+						completion_tokens: 1000,
+						cost: 0,
+						is_byok: true,
+						cost_details: { upstream_inference_cost: 0.012 },
+					},
+				},
+			],
+		];
+
+		const model = gatewayCompletionsModel({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		const message = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test" },
+		).result();
+
+		expect(message.usage.cost.total).toBe(0.012);
+	});
+
+	it("keeps the local calculation when no cost is reported", async () => {
+		mockState.chunkSets = [
+			[
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [{ index: 0, delta: { content: "hi" }, finish_reason: "stop" }],
+				},
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [],
+					usage: { prompt_tokens: 1000, completion_tokens: 1000 },
+				},
+			],
+		];
+
+		const model = gatewayCompletionsModel({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 });
+		const message = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test" },
+		).result();
+
+		expect(message.usage.cost.total).toBeCloseTo(0.018);
+	});
+});
+
+function createSseResponse(events: Array<{ event: string; data: string }>): Response {
+	const body = events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n");
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createFakeAnthropicClient(response: Response): Anthropic {
+	return {
+		messages: {
+			create: () => ({
+				asResponse: async () => response,
+			}),
+		},
+	} as unknown as Anthropic;
+}
+
+function gatewayAnthropicModel(cost: Model<"anthropic-messages">["cost"]): Model<"anthropic-messages"> {
+	return {
+		id: "moonshotai/kimi-k3",
+		name: "Kimi K3",
+		api: "anthropic-messages",
+		provider: "vercel-ai-gateway",
+		baseUrl: "https://ai-gateway.vercel.sh",
+		reasoning: true,
+		input: ["text"],
+		cost,
+		contextWindow: 262144,
+		maxTokens: 131072,
+	};
+}
+
+describe("anthropic-messages reported cost", () => {
+	it("uses provider_metadata.gateway.cost from the final message_delta", async () => {
+		const response = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "gen_test",
+						usage: {
+							input_tokens: 0,
+							output_tokens: 0,
+							cache_read_input_tokens: 91,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "text_delta", text: "hi" },
+				}),
+			},
+			{
+				event: "content_block_stop",
+				data: JSON.stringify({ type: "content_block_stop", index: 0 }),
+			},
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: { output_tokens: 100 },
+					provider_metadata: { gateway: { cost: "0.0015273" } },
+				}),
+			},
+			{
+				event: "message_stop",
+				data: JSON.stringify({ type: "message_stop" }),
+			},
+		]);
+
+		const model = gatewayAnthropicModel({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		const message = await streamAnthropic(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ client: createFakeAnthropicClient(response) },
+		).result();
+
+		expect(message.usage.cost.total).toBe(0.0015273);
+	});
+});

--- a/packages/ai/test/reported-cost.test.ts
+++ b/packages/ai/test/reported-cost.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
 import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
 import { applyReportedCost } from "../src/models.ts";
-import type { Model, Usage } from "../src/types.ts";
+import type { AssistantMessage, Model, Usage } from "../src/types.ts";
 
 const mockState = vi.hoisted(() => ({
 	chunkSets: [] as unknown[][],
@@ -193,6 +193,39 @@ describe("openai-completions reported cost", () => {
 		expect(message.usage.cost.total).toBe(0.012);
 	});
 
+	it("ignores upstream_inference_cost for non-BYOK responses", async () => {
+		mockState.chunkSets = [
+			[
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [{ index: 0, delta: { content: "hi" }, finish_reason: "stop" }],
+				},
+				{
+					id: "gen_test",
+					model: "moonshotai/kimi-k3",
+					choices: [],
+					usage: {
+						prompt_tokens: 1000,
+						completion_tokens: 1000,
+						cost: 0.018,
+						is_byok: false,
+						cost_details: { upstream_inference_cost: 0.018 },
+					},
+				},
+			],
+		];
+
+		const model = gatewayCompletionsModel({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		const message = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test" },
+		).result();
+
+		expect(message.usage.cost.total).toBe(0.018);
+	});
+
 	it("keeps the local calculation when no cost is reported", async () => {
 		mockState.chunkSets = [
 			[
@@ -254,62 +287,82 @@ function gatewayAnthropicModel(cost: Model<"anthropic-messages">["cost"]): Model
 	};
 }
 
+function kimiSseEvents(gatewayCost: string): Array<{ event: string; data: string }> {
+	return [
+		{
+			event: "message_start",
+			data: JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "gen_test",
+					usage: {
+						input_tokens: 0,
+						output_tokens: 0,
+						cache_read_input_tokens: 91,
+						cache_creation_input_tokens: 0,
+					},
+				},
+			}),
+		},
+		{
+			event: "content_block_start",
+			data: JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+		},
+		{
+			event: "content_block_delta",
+			data: JSON.stringify({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "hi" },
+			}),
+		},
+		{
+			event: "content_block_stop",
+			data: JSON.stringify({ type: "content_block_stop", index: 0 }),
+		},
+		{
+			event: "message_delta",
+			data: JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 100 },
+				provider_metadata: { gateway: { cost: gatewayCost } },
+			}),
+		},
+		{
+			event: "message_stop",
+			data: JSON.stringify({ type: "message_stop" }),
+		},
+	];
+}
+
+async function runAnthropicStream(model: Model<"anthropic-messages">, gatewayCost: string): Promise<AssistantMessage> {
+	return await streamAnthropic(
+		model,
+		{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+		{ client: createFakeAnthropicClient(createSseResponse(kimiSseEvents(gatewayCost))) },
+	).result();
+}
+
 describe("anthropic-messages reported cost", () => {
 	it("uses provider_metadata.gateway.cost from the final message_delta", async () => {
-		const response = createSseResponse([
-			{
-				event: "message_start",
-				data: JSON.stringify({
-					type: "message_start",
-					message: {
-						id: "gen_test",
-						usage: {
-							input_tokens: 0,
-							output_tokens: 0,
-							cache_read_input_tokens: 91,
-							cache_creation_input_tokens: 0,
-						},
-					},
-				}),
-			},
-			{
-				event: "content_block_start",
-				data: JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
-			},
-			{
-				event: "content_block_delta",
-				data: JSON.stringify({
-					type: "content_block_delta",
-					index: 0,
-					delta: { type: "text_delta", text: "hi" },
-				}),
-			},
-			{
-				event: "content_block_stop",
-				data: JSON.stringify({ type: "content_block_stop", index: 0 }),
-			},
-			{
-				event: "message_delta",
-				data: JSON.stringify({
-					type: "message_delta",
-					delta: { stop_reason: "end_turn" },
-					usage: { output_tokens: 100 },
-					provider_metadata: { gateway: { cost: "0.0015273" } },
-				}),
-			},
-			{
-				event: "message_stop",
-				data: JSON.stringify({ type: "message_stop" }),
-			},
-		]);
-
 		const model = gatewayAnthropicModel({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
-		const message = await streamAnthropic(
-			model,
-			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
-			{ client: createFakeAnthropicClient(response) },
-		).result();
-
+		const message = await runAnthropicStream(model, "0.0015273");
 		expect(message.usage.cost.total).toBe(0.0015273);
+	});
+
+	it("scales catalog-derived components to the reported total", async () => {
+		// Local calc: 91 cacheRead * 0.3/M + 100 output * 15/M = 0.0015273, half the reported total.
+		const model = gatewayAnthropicModel({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 });
+		const message = await runAnthropicStream(model, "0.0030546");
+		expect(message.usage.cost.total).toBe(0.0030546);
+		expect(message.usage.cost.cacheRead).toBeCloseTo(0.0000546);
+		expect(message.usage.cost.output).toBeCloseTo(0.003);
+	});
+
+	it("keeps the local calculation when the reported value is invalid", async () => {
+		const model = gatewayAnthropicModel({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 });
+		const message = await runAnthropicStream(model, "not-a-number");
+		expect(message.usage.cost.total).toBeCloseTo(0.0015273);
 	});
 });

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -558,6 +558,15 @@ output.usage.totalTokens = output.usage.input + output.usage.output +
 calculateCost(model, output.usage);
 ```
 
+When the API reports the billed cost in the response, prefer it over catalog math with the exported `applyReportedCost(usage, reportedTotal)`. It sets `cost.total` to the reported value and scales the components so they keep summing to it, invalid values (negative, non-finite) are ignored:
+
+```typescript
+calculateCost(model, output.usage);
+if (typeof response.usage.cost === "number") {
+  applyReportedCost(output.usage, response.usage.cost);
+}
+```
+
 ### Context Overflow Errors
 
 When a request exceeds the model's context window, pi can recover automatically by compacting the conversation and retrying. This recovery only kicks in if pi recognizes the failure as an overflow.

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -211,6 +211,8 @@ If your command is slow, expensive, rate-limited, or should keep using a previou
 
 A cost tier supplies a complete alternate rate set and applies to the full request when total input usage (`input + cacheRead + cacheWrite`) exceeds `inputTokensAbove`. When multiple tiers match, the highest threshold wins.
 
+Catalog rates are a fallback. When an API reports the billed cost in the response (Vercel AI Gateway, OpenRouter with usage accounting), pi uses the reported total and scales the cost components so they keep summing to it, so a custom model without `cost` still shows real spend on those providers.
+
 ```json
 {
   "cost": {


### PR DESCRIPTION
When a response includes the billed cost, use it as `usage.cost.total` instead of relying on catalog rates. Falls back to `calculateCost` unchanged when nothing is reported.

- `openai-completions`: reads `usage.cost` plus `cost_details.upstream_inference_cost` (the BYOK upstream share; Vercel AI Gateway sends these on every response, OpenRouter uses the same fields when usage accounting is on)
- `anthropic-messages`: reads `provider_metadata.gateway.cost` from the final `message_delta` (Vercel AI Gateway)
- `applyReportedCost` scales the cost components so they keep summing to the reported total; when catalog rates are all zero, only the total is set

Why: models missing from the baked catalog, and custom models.json entries without `cost`, display $0.00 even though the response carried the billed amount (hit last week with moonshotai/kimi-k3 through the Vercel AI Gateway). The reported total also stays correct across provider price changes, tiered pricing, and BYOK.

Tests in `packages/ai/test/reported-cost.test.ts` cover the helper and both adapters, including the zero-rate catalog and BYOK cases. `npm run check` and `./test.sh` pass.

I work on the AI Gateway team at Vercel. Discussed with Mario in Slack before opening this.
