### PR TITLE
fix: persist jiti cache in agent dir to avoid cold start recompilation

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -410,6 +410,10 @@ async function loadExtensionModule(extensionPath: string, cacheToken?: Extension
 
 	const jiti = createJiti(import.meta.url, {
 		moduleCache: false,
+		// Use a persistent cache directory so jiti compiled output survives
+		// OS temp directory cleanup. Without this, cold starts recompile all
+		// TypeScript extensions via Babel (~340ms for pi-powerline-footer).
+		cache: path.join(getAgentDir(), "cache", "jiti"),
 		// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
 		// Also disable tryNative so jiti handles ALL imports (not just the entry point)
 		// In Node.js/dev: use aliases to resolve to node_modules paths


### PR DESCRIPTION
## Problem

Pi extensions written in TypeScript are compiled at runtime by jiti/Babel. The compiled output is cached to `os.tmpdir()/jiti/` (`/var/folders/.../T/jiti/` on macOS). 

macOS periodically removes unused files from temp directories (default: 3 days). When the cache is purged, every `.ts` extension must be recompiled on next startup.

## Impact

Measured with `PI_TIMING=1` on a system with pi-powerline-footer, pi-goal, and ponytail extensions:

| Phase | Cold (no jiti cache) | Warm (with cache) | Penalty |
|-------|---------------------|-------------------|---------|
| pi-powerline-footer import | 361ms | 19ms | **+342ms** |
| Extensions total | 379ms | 22ms | **+357ms** |
| createAgentSessionRuntime | 501ms | 104ms | **+397ms** |

pi-powerline-footer has a 2990-line `index.ts` + 20 helper `.ts` files (106KB total). Babel compilation of this takes ~340ms cold vs ~19ms warm.

## Fix

Configure jiti to cache in `~/.pi/agent/cache/jiti/` instead of the OS temp directory. The agent config directory is persistent and not subject to automatic cleanup.

One-line change in `packages/coding-agent/src/core/extensions/loader.ts`:
```diff
 const jiti = createJiti(import.meta.url, {
     moduleCache: false,
+    cache: path.join(getAgentDir(), "cache", "jiti"),
     ...
 });
```

jiti will create the directory automatically (`mkdirSync({ recursive: true })`).
