### PR TITLE
fix(coding-agent): retry self-update on transient version fetch failures

### DIFF
--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -24,7 +24,12 @@ import { DefaultResourceLoader } from "./core/resource-loader.ts";
 import { SettingsManager } from "./core/settings-manager.ts";
 import { hasTrustRequiringProjectResources, ProjectTrustStore } from "./core/trust-manager.ts";
 import { spawnProcess } from "./utils/child-process.ts";
-import { getLatestPiRelease, isNewerPackageVersion } from "./utils/version-check.ts";
+import {
+	formatNetworkErrorDetails,
+	getLatestPiRelease,
+	isNewerPackageVersion,
+	isTransientNetworkError,
+} from "./utils/version-check.ts";
 import {
 	cleanupWindowsSelfUpdateQuarantine,
 	quarantineWindowsNativeDependencies,
@@ -475,10 +480,18 @@ interface SelfUpdatePlan {
 async function getSelfUpdatePlan(force: boolean): Promise<SelfUpdatePlan> {
 	let latestRelease: Awaited<ReturnType<typeof getLatestPiRelease>>;
 	try {
-		latestRelease = await getLatestPiRelease(VERSION);
+		try {
+			latestRelease = await getLatestPiRelease(VERSION);
+		} catch (error: unknown) {
+			// One immediate retry for transient connection races (dual-stack ETIMEDOUT, etc.).
+			// Startup checkForNewPiVersion stays fail-soft and does not retry.
+			if (!isTransientNetworkError(error)) {
+				throw error;
+			}
+			latestRelease = await getLatestPiRelease(VERSION);
+		}
 	} catch (error: unknown) {
-		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`Could not determine latest ${APP_NAME} version: ${message}`);
+		throw new Error(`Could not determine latest ${APP_NAME} version: ${formatNetworkErrorDetails(error)}`);
 	}
 	if (!latestRelease) {
 		throw new Error(`Could not determine latest ${APP_NAME} version.`);

--- a/packages/coding-agent/src/utils/version-check.ts
+++ b/packages/coding-agent/src/utils/version-check.ts
@@ -4,10 +4,82 @@ import { getPiUserAgent } from "./pi-user-agent.ts";
 const LATEST_VERSION_URL = "https://pi.dev/api/latest-version";
 const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 10000;
 
+/** Network error codes that are usually worth a single immediate retry. */
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+	"EAI_AGAIN",
+	"ECONNABORTED",
+	"ECONNREFUSED",
+	"ECONNRESET",
+	"EHOSTUNREACH",
+	"ENETUNREACH",
+	"EPIPE",
+	"ETIMEDOUT",
+	"UND_ERR_CONNECT_TIMEOUT",
+	"UND_ERR_HEADERS_TIMEOUT",
+	"UND_ERR_SOCKET",
+]);
+
 export interface LatestPiRelease {
 	version: string;
 	packageName?: string;
 	note?: string;
+}
+
+function collectErrorCodes(error: unknown, depth = 0, codes: string[] = []): string[] {
+	if (depth > 4 || error === undefined || error === null) {
+		return codes;
+	}
+	if (typeof error === "object" && error !== null && "code" in error && typeof error.code === "string") {
+		codes.push(error.code);
+	}
+	if (error instanceof AggregateError) {
+		for (const nested of error.errors) {
+			collectErrorCodes(nested, depth + 1, codes);
+		}
+	}
+	if (error instanceof Error && error.cause !== undefined) {
+		collectErrorCodes(error.cause, depth + 1, codes);
+	}
+	return codes;
+}
+
+/**
+ * True for connection-setup / transport failures that often succeed on an immediate retry.
+ * Used by self-update; startup version checks stay fail-soft and do not retry.
+ */
+export function isTransientNetworkError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+	if (error.name === "TimeoutError" || error.name === "AbortError") {
+		return true;
+	}
+	if (error.message === "fetch failed" || /\b(ETIMEDOUT|ECONNRESET|ENETUNREACH|EAI_AGAIN)\b/.test(error.message)) {
+		return true;
+	}
+	return collectErrorCodes(error).some((code) => TRANSIENT_NETWORK_ERROR_CODES.has(code));
+}
+
+/** Flatten message + errno codes + cause chain for user-facing update errors. */
+export function formatNetworkErrorDetails(error: unknown, depth = 0): string {
+	if (depth > 4) {
+		return "...";
+	}
+	if (!(error instanceof Error)) {
+		return String(error);
+	}
+
+	const parts: string[] = [error.message];
+	if ("code" in error && typeof error.code === "string" && error.code) {
+		parts.push(`code=${error.code}`);
+	}
+	if (error instanceof AggregateError && error.errors.length > 0) {
+		const nested = error.errors.map((nestedError) => formatNetworkErrorDetails(nestedError, depth + 1)).join("; ");
+		parts.push(`errors=[${nested}]`);
+	} else if (error.cause !== undefined) {
+		parts.push(`cause=${formatNetworkErrorDetails(error.cause, depth + 1)}`);
+	}
+	return parts.join("; ");
 }
 
 export function comparePackageVersions(leftVersion: string, rightVersion: string): number | undefined {

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -664,6 +664,80 @@ else {
 		}
 	});
 
+	it("retries latest-version lookup once on transient connection failures during self-update", async () => {
+		const globalPrefix = join(tempDir, "global-prefix");
+		const selfPackageDir = join(globalPrefix, "lib", "node_modules", "@earendil-works", "pi-coding-agent");
+		const fakeNpmPath = join(tempDir, "fake-npm-retry.cjs");
+		const recordPath = join(tempDir, "self-update-retry.json");
+		mkdirSync(selfPackageDir, { recursive: true });
+		writeFileSync(
+			fakeNpmPath,
+			`const fs=require("node:fs"),path=require("node:path"),args=process.argv.slice(2),prefix=args[args.indexOf("--prefix")+1];
+if(args.includes("root")) console.log(path.join(prefix,"lib","node_modules"));
+else fs.writeFileSync(${JSON.stringify(recordPath)},JSON.stringify(args));
+`,
+		);
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ npmCommand: [originalExecPath, fakeNpmPath, "--prefix", globalPrefix] }, null, 2),
+		);
+		process.env.PI_PACKAGE_DIR = selfPackageDir;
+		Object.defineProperty(process, "execPath", {
+			value: join(selfPackageDir, "dist", "cli.js"),
+			configurable: true,
+		});
+		const targetVersion = getNewerPatchVersion();
+		const timedOut = Object.assign(new Error("connect ETIMEDOUT 1.2.3.4:443"), { code: "ETIMEDOUT" });
+		const fetchMock = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("fetch failed", { cause: timedOut }))
+			.mockResolvedValueOnce(Response.json({ version: targetVersion }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			await expect(runPackageCommandDirectly(["update", "--self"])).resolves.toBeUndefined();
+
+			expect(process.exitCode).toBeUndefined();
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+			const recordedArgs = JSON.parse(readFileSync(recordPath, "utf-8")) as string[];
+			expect(recordedArgs).toContain(`${PACKAGE_NAME}@${targetVersion}`);
+			expect(stdout).toContain(`Updated pi from ${VERSION} to ${targetVersion}`);
+		} finally {
+			logSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("surfaces nested network causes when latest-version lookup fails after retry", async () => {
+		const timedOut = Object.assign(new Error("connect ETIMEDOUT 1.2.3.4:443"), { code: "ETIMEDOUT" });
+		const fetchMock = vi.fn(async () => {
+			throw new Error("fetch failed", { cause: timedOut });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			await expect(runPackageCommandDirectly(["update", "--self"])).resolves.toBeUndefined();
+
+			expect(process.exitCode).toBe(1);
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			const stderr = errorSpy.mock.calls.map(([message]) => String(message)).join("\n");
+			expect(stderr).toContain("Could not determine latest pi version: fetch failed");
+			expect(stderr).toContain("cause=connect ETIMEDOUT 1.2.3.4:443");
+			expect(stderr).toContain("code=ETIMEDOUT");
+		} finally {
+			logSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("fails self-update when renamed npm package installation fails", async () => {
 		const globalPrefix = join(tempDir, "global-prefix");
 		const selfPackageDir = join(globalPrefix, "lib", "node_modules", "@mariozechner", "pi-coding-agent");

--- a/packages/coding-agent/test/version-check.test.ts
+++ b/packages/coding-agent/test/version-check.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	checkForNewPiVersion,
 	comparePackageVersions,
+	formatNetworkErrorDetails,
 	getLatestPiRelease,
 	getLatestPiVersion,
 	isNewerPackageVersion,
+	isTransientNetworkError,
 } from "../src/utils/version-check.ts";
 
 const originalSkipVersionCheck = process.env.PI_SKIP_VERSION_CHECK;
@@ -87,5 +89,24 @@ describe("version checks", () => {
 
 		await expect(getLatestPiVersion("1.2.3")).resolves.toBeUndefined();
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("detects transient network errors including dual-stack AggregateError causes", () => {
+		const timedOut = Object.assign(new Error("connect ETIMEDOUT 1.2.3.4:443"), { code: "ETIMEDOUT" });
+		const unreachable = Object.assign(new Error("connect ENETUNREACH ::1:443"), { code: "ENETUNREACH" });
+		const aggregate = new AggregateError([timedOut, unreachable], "");
+		const fetchFailed = new Error("fetch failed", { cause: aggregate });
+
+		expect(isTransientNetworkError(fetchFailed)).toBe(true);
+		expect(isTransientNetworkError(new Error("invalid json"))).toBe(false);
+	});
+
+	it("formats nested network error causes for user-facing messages", () => {
+		const timedOut = Object.assign(new Error("connect ETIMEDOUT 1.2.3.4:443"), { code: "ETIMEDOUT" });
+		const fetchFailed = new Error("fetch failed", { cause: timedOut });
+
+		expect(formatNetworkErrorDetails(fetchFailed)).toBe(
+			"fetch failed; cause=connect ETIMEDOUT 1.2.3.4:443; code=ETIMEDOUT",
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- Retry `getLatestPiRelease()` once in `getSelfUpdatePlan` when the latest-version request fails with a transient network error (`ETIMEDOUT`, `ECONNRESET`, dual-stack `AggregateError`, etc.).
- Surface nested `error.cause` / errno codes in the final `Could not determine latest pi version` message so dual-stack races are diagnosable.
- Leave startup `checkForNewPiVersion()` fail-soft behavior unchanged (no retry).

Fixes #6675

## Test plan
- [x] `packages/coding-agent` vitest: `test/version-check.test.ts` + `test/package-command-paths.test.ts` (35 passed)
- [x] New coverage: transient detection (incl. AggregateError cause chain), retry-once success path, final failure with nested cause details
- [ ] `npm run check` / full suite on CI

Note: I do not currently have contributor `lgtm` rights on this repo. Happy to iterate if maintainers want a different retry scope.