### PR TITLE
update deprecated github actions

### DIFF
--- a/.github/workflows/approve-contributor.yml
+++ b/.github/workflows/approve-contributor.yml
@@ -13,13 +13,13 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Update contributor approval
         id: update
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -146,7 +146,7 @@ jobs:
 
       - name: Comment on issue
         if: steps.update.outputs.status == 'added' || steps.update.outputs.status == 'updated' || steps.update.outputs.status == 'already'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issueAuthor = context.payload.issue.user.login;

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -33,7 +33,7 @@ jobs:
       SOURCE_REF: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
@@ -44,7 +44,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -201,13 +201,13 @@ jobs:
       SOURCE_REF: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/issue-analysis.yml
+++ b/.github/workflows/issue-analysis.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Verify sender permission
         id: verify
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ORG_READ_TOKEN: ${{ secrets.EARENDIL_ORG_READ_TOKEN }}
         with:
@@ -254,19 +254,19 @@ jobs:
     steps:
       - name: Create high-entropy working directory name
         id: workdir
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const crypto = require('crypto');
             core.setOutput('name', `pi-ci-${crypto.randomBytes(16).toString('hex')}`);
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: ${{ steps.workdir.outputs.name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -319,7 +319,7 @@ jobs:
 
       - name: Write auth.json
         id: write_auth
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PI_AUTH_JSON: ${{ secrets.PI_AUTH_JSON }}
         with:
@@ -341,7 +341,7 @@ jobs:
             }
 
       - name: Run pi /is
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-agent
           GH_TOKEN: ${{ github.token }}
@@ -404,7 +404,7 @@ jobs:
 
       - name: Persist refreshed auth.json
         if: always() && steps.write_auth.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_TOKEN: ${{ secrets.PI_AUTH_UPDATE_TOKEN }}
           PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-agent
@@ -457,7 +457,7 @@ jobs:
       - name: Export session files
         id: export_session_files
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-agent
           WORKDIR: ${{ steps.workdir.outputs.name }}
@@ -509,7 +509,7 @@ jobs:
       - name: Upload session gist
         id: gist
         if: always() && steps.export_session_files.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PI_GIST_TOKEN: ${{ secrets.PI_GIST_TOKEN }}
         with:
@@ -540,7 +540,7 @@ jobs:
 
       - name: Comment with session import instructions
         if: always() && steps.gist.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GIST_URL: ${{ steps.gist.outputs.url }}
           GIST_ID: ${{ steps.gist.outputs.id }}
@@ -619,7 +619,7 @@ jobs:
 
       - name: Remove trigger label
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             try {

--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Check issue author
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const APPROVED_FILE = '.github/APPROVED_CONTRIBUTORS';

--- a/.github/workflows/issue-triage-labels.yml
+++ b/.github/workflows/issue-triage-labels.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Update triage labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const UNTRIAGED_LABEL = 'untriaged';

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check if contributor is approved
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const APPROVED_FILE = '.github/APPROVED_CONTRIBUTORS';

--- a/.github/workflows/publish-model-catalog.yml
+++ b/.github/workflows/publish-model-catalog.yml
@@ -42,13 +42,13 @@ jobs:
       SOURCE_REF: ${{ github.event.workflow_run.head_sha || inputs.source_ref || github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: npm
@@ -87,13 +87,13 @@ jobs:
       R2_ENDPOINT: https://67c0d357268b0fca6e0b465bb9d01b84.r2.cloudflarestorage.com
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
 

--- a/.github/workflows/remove-inprogress-on-close.yml
+++ b/.github/workflows/remove-inprogress-on-close.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Remove inprogress label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const labelName = 'inprogress';


### PR DESCRIPTION
fixes #6875

AI produced summary of what changed in these versions:

 Summary of relevant changes:

 actions/checkout v4 -> v7.0.1

 Key changes:
 - Runtime moved to Node 24.
 - Requires GitHub Actions runner v2.327.1+.
 - v6 changed credential persistence:
     - credentials are persisted to a separate file instead of directly in local git config.
 - v7 added safer behavior:
     - blocks unsafe fork checkout scenarios for pull_request_target and workflow_run.
 - v7.0.1 includes fixes around unsafe PR checks, branch whitespace trimming, escaping values passed to --unset, and dependency updates.

 Risk for this repo:
 - Low.
 - Workflows use GitHub-hosted runners, so runner version should be fine.
 - Some workflows set persist-credentials: false; those are unaffected or safer.

 actions/github-script v7 -> v9.0.0

 Key changes:
 - v8 moved runtime to Node 24.
 - Requires GitHub Actions runner v2.327.1+.
 - v9 added an injected getOctokit helper for creating additional Octokit clients.
 - v9 breaking change:
     - require('@actions/github') no longer works inside scripts because @actions/github is now ESM-only.
     - declaring const getOctokit = ... or let getOctokit = ... inside a script can now conflict with the injected parameter.

 Risk for this repo:
 - Low.
 - I checked the workflows and did not find require('@actions/github') or local getOctokit declarations.
 - Existing github.rest.*, core.*, context.*, fetch, require('fs'), require('path'), etc. patterns remain valid.

 actions/setup-node v4.1.0 -> v7.0.0

 Key changes:
 - Runtime moved to Node 24 starting in v5.
 - Requires GitHub Actions runner v2.327.1+.
 - v5 introduced automatic package-manager cache detection when a valid packageManager field exists in package.json.
 - v6 limited that automatic caching behavior to npm.
 - v7 migrated internals to ESM and upgraded dependencies.
 - v7 added cache outputs:
     - cache-primary-key
     - cache-matched-key
 - v7 fixed NODE_AUTH_TOKEN and mirrorToken handling.

 Risk for this repo:
 - Low.
 - Root package.json does not have a packageManager field, and workflows already explicitly use cache: npm where needed.
 - Node installed for jobs is still controlled by node-version: 22, so this does not change the project runtime version. It only changes the
   action’s own runtime.