### PR TITLE
fix: flaky model-registry test

### DIFF
--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -652,7 +652,7 @@ describe("ModelRegistry", () => {
 			expect(anthropicModels.some((m) => m.id === "claude-custom")).toBe(false);
 			expect(anthropicModels.some((m) => m.id === "claude-custom-2")).toBe(true);
 			expect(anthropicModels.some((m) => m.id.includes("claude"))).toBe(true);
-		});
+		}, 60_000);
 
 		test("removing custom models from models.json keeps built-in provider models", async () => {
 			writeModelsJson({


### PR DESCRIPTION
We had a flaky test for the `model-registry`, which tests changing `models.json` on disk and calling `registry.refresh()`.

The failure was a Vitest timeout (default 30s budget in CI). This test is intentionally exercising real `refresh()` behavior, which includes full registry creation, provider rebuild/composition, and the follow-up `registry.refresh()` path, so a “cleaner” fix that skips or narrows that work would stop testing the intended behavior. So just raised only this test’s timeout from 30s to 60s rather than change runtime semantics. Tested in loop, it passed 100/100 runs.