### PR TITLE
MAV-62 Add stable session entry IDs

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -150,8 +150,10 @@ class PendingMessageQueue {
 		return [first];
 	}
 
-	clear(): void {
+	clear(): AgentMessage[] {
+		const cleared = this.messages;
 		this.messages = [];
+		return cleared;
 	}
 }
 
@@ -279,20 +281,22 @@ export class Agent {
 		this.followUpQueue.enqueue(message);
 	}
 
-	/** Remove all queued steering messages. */
-	clearSteeringQueue(): void {
-		this.steeringQueue.clear();
+	/** Remove and return all queued steering messages. */
+	clearSteeringQueue(): AgentMessage[] {
+		return this.steeringQueue.clear();
 	}
 
-	/** Remove all queued follow-up messages. */
-	clearFollowUpQueue(): void {
-		this.followUpQueue.clear();
+	/** Remove and return all queued follow-up messages. */
+	clearFollowUpQueue(): AgentMessage[] {
+		return this.followUpQueue.clear();
 	}
 
-	/** Remove all queued steering and follow-up messages. */
-	clearAllQueues(): void {
-		this.clearSteeringQueue();
-		this.clearFollowUpQueue();
+	/** Remove and return all queued steering and follow-up messages. */
+	clearAllQueues(): { steering: AgentMessage[]; followUp: AgentMessage[] } {
+		return {
+			steering: this.clearSteeringQueue(),
+			followUp: this.clearFollowUpQueue(),
+		};
 	}
 
 	/** Returns true when either queue still contains pending messages. */

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -227,6 +227,8 @@ export interface PromptOptions {
 	streamingBehavior?: "steer" | "followUp";
 	/** Source of input for extension input event handlers. Defaults to "interactive". */
 	source?: InputSource;
+	/** ID returned by sessionManager.reserveEntryId(). The user entry is flushed before provider execution. */
+	userEntryId?: string;
 	/** Internal hook used by RPC mode to observe prompt preflight acceptance or rejection. */
 	preflightResult?: (success: boolean) => void;
 }
@@ -303,6 +305,8 @@ export class AgentSession {
 	private _followUpMessages: string[] = [];
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
+	/** Reserved session entry IDs keyed by provider-facing user message object identity. */
+	private _userEntryIds = new WeakMap<AgentMessage, string>();
 
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
@@ -534,6 +538,13 @@ export class AgentSession {
 		}
 	}
 
+	private _emitEntryAppended(entryId: string): void {
+		const entry = this.sessionManager.getEntry(entryId);
+		if (entry) {
+			this._emit({ type: "entry_appended", entry });
+		}
+	}
+
 	private _emitQueueUpdate(): void {
 		this._emit({
 			type: "queue_update",
@@ -609,19 +620,28 @@ export class AgentSession {
 			// Check if this is a custom message from extensions
 			if (event.message.role === "custom") {
 				// Persist as CustomMessageEntry
-				this.sessionManager.appendCustomMessageEntry(
+				const entryId = this.sessionManager.appendCustomMessageEntry(
 					event.message.customType,
 					event.message.content,
 					event.message.display,
 					event.message.details,
 				);
+				this._emitEntryAppended(entryId);
 			} else if (
 				event.message.role === "user" ||
 				event.message.role === "assistant" ||
 				event.message.role === "toolResult"
 			) {
 				// Regular LLM message - persist as SessionMessageEntry
-				this.sessionManager.appendMessage(event.message);
+				const userEntryId = event.message.role === "user" ? this._userEntryIds.get(event.message) : undefined;
+				const entryId = this.sessionManager.appendMessage(
+					event.message,
+					userEntryId ? { id: userEntryId, flush: true } : undefined,
+				);
+				if (event.message.role === "user") {
+					this._userEntryIds.delete(event.message);
+				}
+				this._emitEntryAppended(entryId);
 			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 
@@ -1105,6 +1125,10 @@ export class AgentSession {
 			if (expandPromptTemplates && text.startsWith("/")) {
 				const handled = await this._tryExecuteExtensionCommand(text);
 				if (handled) {
+					if (options?.userEntryId) {
+						this.sessionManager.releaseEntryId(options.userEntryId);
+						throw new Error("Prompt was handled as an extension command and did not create a user entry");
+					}
 					// Extension command executed, no prompt to send
 					preflightResult?.(true);
 					return;
@@ -1122,6 +1146,10 @@ export class AgentSession {
 					this.isStreaming ? options?.streamingBehavior : undefined,
 				);
 				if (inputResult.action === "handled") {
+					if (options?.userEntryId) {
+						this.sessionManager.releaseEntryId(options.userEntryId);
+						throw new Error("Prompt was handled by an input extension and did not create a user entry");
+					}
 					preflightResult?.(true);
 					return;
 				}
@@ -1146,9 +1174,9 @@ export class AgentSession {
 					);
 				}
 				if (options.streamingBehavior === "followUp") {
-					await this._queueFollowUp(expandedText, currentImages);
+					await this._queueFollowUp(expandedText, currentImages, options.userEntryId);
 				} else {
-					await this._queueSteer(expandedText, currentImages);
+					await this._queueSteer(expandedText, currentImages, options.userEntryId);
 				}
 				preflightResult?.(true);
 				return;
@@ -1192,11 +1220,15 @@ export class AgentSession {
 			if (currentImages) {
 				userContent.push(...currentImages);
 			}
-			messages.push({
+			const userMessage = {
 				role: "user",
 				content: userContent,
 				timestamp: Date.now(),
-			});
+			} satisfies AgentMessage;
+			if (options?.userEntryId) {
+				this._userEntryIds.set(userMessage, options.userEntryId);
+			}
+			messages.push(userMessage);
 
 			// Inject any pending "nextTurn" messages as context alongside the user message
 			for (const msg of this._pendingNextTurnMessages) {
@@ -1351,35 +1383,43 @@ export class AgentSession {
 	/**
 	 * Internal: Queue a steering message (already expanded, no extension command check).
 	 */
-	private async _queueSteer(text: string, images?: ImageContent[]): Promise<void> {
+	private async _queueSteer(text: string, images?: ImageContent[], userEntryId?: string): Promise<void> {
 		this._steeringMessages.push(text);
 		this._emitQueueUpdate();
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images) {
 			content.push(...images);
 		}
-		this.agent.steer({
+		const userMessage = {
 			role: "user",
 			content,
 			timestamp: Date.now(),
-		});
+		} satisfies AgentMessage;
+		if (userEntryId) {
+			this._userEntryIds.set(userMessage, userEntryId);
+		}
+		this.agent.steer(userMessage);
 	}
 
 	/**
 	 * Internal: Queue a follow-up message (already expanded, no extension command check).
 	 */
-	private async _queueFollowUp(text: string, images?: ImageContent[]): Promise<void> {
+	private async _queueFollowUp(text: string, images?: ImageContent[], userEntryId?: string): Promise<void> {
 		this._followUpMessages.push(text);
 		this._emitQueueUpdate();
 		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
 		if (images) {
 			content.push(...images);
 		}
-		this.agent.followUp({
+		const userMessage = {
 			role: "user",
 			content,
 			timestamp: Date.now(),
-		});
+		} satisfies AgentMessage;
+		if (userEntryId) {
+			this._userEntryIds.set(userMessage, userEntryId);
+		}
+		this.agent.followUp(userMessage);
 	}
 
 	/**
@@ -1488,16 +1528,26 @@ export class AgentSession {
 	/**
 	 * Clear all queued messages and return them.
 	 * Useful for restoring to editor when user aborts.
-	 * @returns Object with steering and followUp arrays
+	 * @returns Queued display text plus native entry IDs whose reservations were released
 	 */
-	clearQueue(): { steering: string[]; followUp: string[] } {
+	clearQueue(): { steering: string[]; followUp: string[]; cancelledEntryIds: string[] } {
 		const steering = [...this._steeringMessages];
 		const followUp = [...this._followUpMessages];
 		this._steeringMessages = [];
 		this._followUpMessages = [];
-		this.agent.clearAllQueues();
+		const cleared = this.agent.clearAllQueues();
+		const cancelledEntryIds: string[] = [];
+		for (const message of [...cleared.steering, ...cleared.followUp]) {
+			const entryId = this._userEntryIds.get(message);
+			if (entryId) {
+				this._userEntryIds.delete(message);
+				if (this.sessionManager.releaseEntryId(entryId)) {
+					cancelledEntryIds.push(entryId);
+				}
+			}
+		}
 		this._emitQueueUpdate();
-		return { steering, followUp };
+		return { steering, followUp, cancelledEntryIds };
 	}
 
 	/** Number of pending messages (includes both steering and follow-up) */
@@ -2359,10 +2409,7 @@ export class AgentSession {
 				},
 				appendEntry: (customType, data) => {
 					const entryId = this.sessionManager.appendCustomEntry(customType, data);
-					const entry = this.sessionManager.getEntry(entryId);
-					if (entry) {
-						this._emit({ type: "entry_appended", entry });
-					}
+					this._emitEntryAppended(entryId);
 				},
 				setSessionName: (name) => {
 					this.setSessionName(name);

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -43,6 +43,13 @@ export interface NewSessionOptions {
 	parentSession?: string;
 }
 
+export interface AppendMessageOptions {
+	/** Entry ID previously returned by reserveEntryId(). */
+	id?: string;
+	/** Write the entry immediately, even before the first assistant message. */
+	flush?: boolean;
+}
+
 export interface SessionEntryBase {
 	type: string;
 	id: string;
@@ -213,6 +220,14 @@ export function assertValidSessionId(id: string): void {
 	if (!/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/.test(id)) {
 		throw new Error(
 			"Session id must be non-empty, contain only alphanumeric characters, '-', '_', and '.', and start and end with an alphanumeric character",
+		);
+	}
+}
+
+function assertValidEntryId(id: string): void {
+	if (!/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/.test(id)) {
+		throw new Error(
+			"Session entry id must be non-empty, contain only alphanumeric characters, '-', '_', and '.', and start and end with an alphanumeric character",
 		);
 	}
 }
@@ -863,6 +878,7 @@ export class SessionManager {
 	private byId: Map<string, SessionEntry> = new Map();
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
+	private reservedEntryIds: Set<string> = new Set();
 	private leafId: string | null = null;
 
 	private constructor(
@@ -945,6 +961,7 @@ export class SessionManager {
 		this.byId.clear();
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
+		this.reservedEntryIds.clear();
 		this.leafId = null;
 		this.flushed = false;
 
@@ -959,6 +976,7 @@ export class SessionManager {
 		this.byId.clear();
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
+		this.reservedEntryIds.clear();
 		this.leafId = null;
 		for (const entry of this.fileEntries) {
 			if (entry.type === "session") continue;
@@ -1012,11 +1030,12 @@ export class SessionManager {
 		return this.sessionFile;
 	}
 
-	_persist(entry: SessionEntry): void {
+	_persist(entry: SessionEntry, flush = false): void {
 		if (!this.persist || !this.sessionFile) return;
 
-		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
-		if (!hasAssistant) {
+		const nextFileEntries = [...this.fileEntries, entry];
+		const hasAssistant = nextFileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
+		if (!hasAssistant && !flush) {
 			if (this.flushed) {
 				appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
 			} else {
@@ -1029,7 +1048,7 @@ export class SessionManager {
 		if (!this.flushed) {
 			const fd = openSync(this.sessionFile, "wx");
 			try {
-				for (const e of this.fileEntries) {
+				for (const e of nextFileEntries) {
 					writeFileSync(fd, `${JSON.stringify(e)}\n`);
 				}
 			} finally {
@@ -1041,11 +1060,42 @@ export class SessionManager {
 		}
 	}
 
-	private _appendEntry(entry: SessionEntry): void {
+	private _appendEntry(entry: SessionEntry, flush = false): void {
+		this._persist(entry, flush);
 		this.fileEntries.push(entry);
 		this.byId.set(entry.id, entry);
 		this.leafId = entry.id;
-		this._persist(entry);
+	}
+
+	private _generateEntryId(): string {
+		return generateId({
+			has: (id) => this.byId.has(id) || this.reservedEntryIds.has(id),
+		});
+	}
+
+	/**
+	 * Reserve a session entry ID without appending an entry or advancing the leaf.
+	 * Pass an existing candidate to re-establish an unconsumed reservation after restart.
+	 */
+	reserveEntryId(candidate?: string): string {
+		if (candidate !== undefined) {
+			assertValidEntryId(candidate);
+			if (this.byId.has(candidate)) {
+				throw new Error(`Session entry ID already exists: ${candidate}`);
+			}
+			if (this.reservedEntryIds.has(candidate)) {
+				throw new Error(`Session entry ID is already reserved: ${candidate}`);
+			}
+		}
+
+		const id = candidate ?? this._generateEntryId();
+		this.reservedEntryIds.add(id);
+		return id;
+	}
+
+	/** Release an unconsumed entry ID reservation. */
+	releaseEntryId(id: string): boolean {
+		return this.reservedEntryIds.delete(id);
 	}
 
 	/** Append a message as child of current leaf, then advance leaf. Returns entry id.
@@ -1054,15 +1104,34 @@ export class SessionManager {
 	 * so it is easier to find them.
 	 * These need to be appended via appendCompaction() and appendBranchSummary() methods.
 	 */
-	appendMessage(message: Message | CustomMessage | BashExecutionMessage): string {
+	appendMessage(message: Message | CustomMessage | BashExecutionMessage, options?: AppendMessageOptions): string {
+		let id: string;
+		if (options?.id !== undefined) {
+			if (this.byId.has(options.id)) {
+				throw new Error(`Session entry ID already exists: ${options.id}`);
+			}
+			if (!this.reservedEntryIds.delete(options.id)) {
+				throw new Error(`Session entry ID was not reserved: ${options.id}`);
+			}
+			id = options.id;
+		} else {
+			id = this._generateEntryId();
+		}
 		const entry: SessionMessageEntry = {
 			type: "message",
-			id: generateId(this.byId),
+			id,
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			message,
 		};
-		this._appendEntry(entry);
+		try {
+			this._appendEntry(entry, options?.flush);
+		} catch (error) {
+			if (options?.id !== undefined) {
+				this.reservedEntryIds.add(options.id);
+			}
+			throw error;
+		}
 		return entry.id;
 	}
 
@@ -1070,7 +1139,7 @@ export class SessionManager {
 	appendThinkingLevelChange(thinkingLevel: string): string {
 		const entry: ThinkingLevelChangeEntry = {
 			type: "thinking_level_change",
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			thinkingLevel,
@@ -1083,7 +1152,7 @@ export class SessionManager {
 	appendModelChange(provider: string, modelId: string): string {
 		const entry: ModelChangeEntry = {
 			type: "model_change",
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			provider,
@@ -1104,7 +1173,7 @@ export class SessionManager {
 	): string {
 		const entry: CompactionEntry<T> = {
 			type: "compaction",
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			summary,
@@ -1124,7 +1193,7 @@ export class SessionManager {
 			type: "custom",
 			customType,
 			data,
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 		};
@@ -1137,7 +1206,7 @@ export class SessionManager {
 		const sanitizedName = name.replace(/[\r\n]+/g, " ").trim();
 		const entry: SessionInfoEntry = {
 			type: "session_info",
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			name: sanitizedName,
@@ -1180,7 +1249,7 @@ export class SessionManager {
 			content,
 			display,
 			details,
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 		};
@@ -1235,7 +1304,7 @@ export class SessionManager {
 		}
 		const entry: LabelEntry = {
 			type: "label",
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			targetId,
@@ -1391,7 +1460,7 @@ export class SessionManager {
 		this.leafId = branchFromId;
 		const entry: BranchSummaryEntry = {
 			type: "branch_summary",
-			id: generateId(this.byId),
+			id: this._generateEntryId(),
 			parentId: branchFromId,
 			timestamp: new Date().toISOString(),
 			fromId: branchFromId ?? "root",

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -220,6 +220,7 @@ export {
 	type PromptTemplate,
 } from "./core/sdk.ts";
 export {
+	type AppendMessageOptions,
 	type BranchSummaryEntry,
 	buildContextEntries,
 	buildSessionContext,

--- a/packages/coding-agent/test/session-manager/entry-id-reservation.test.ts
+++ b/packages/coding-agent/test/session-manager/entry-id-reservation.test.ts
@@ -1,0 +1,138 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+describe("SessionManager entry ID reservations", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		while (tempDirs.length > 0) {
+			const tempDir = tempDirs.pop();
+			if (tempDir) {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("reserves IDs without appending entries or advancing the leaf", () => {
+		const session = SessionManager.inMemory();
+
+		const first = session.reserveEntryId();
+		const second = session.reserveEntryId();
+
+		expect(first).not.toBe(second);
+		expect(session.getEntries()).toEqual([]);
+		expect(session.getEntry(first)).toBeUndefined();
+		expect(session.getLeafId()).toBeNull();
+	});
+
+	it("appends a message with its reserved ID", () => {
+		const session = SessionManager.inMemory();
+		const parentId = session.appendCustomEntry("parent");
+		const reservedId = session.reserveEntryId("maverick-entry-1");
+
+		const entryId = session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: reservedId });
+
+		expect(entryId).toBe(reservedId);
+		expect(session.getEntry(reservedId)).toMatchObject({
+			type: "message",
+			id: reservedId,
+			parentId,
+		});
+	});
+
+	it("rejects unreserved, duplicate, and invalid IDs without mutating the session", () => {
+		const session = SessionManager.inMemory();
+
+		expect(() =>
+			session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: "not-reserved" }),
+		).toThrow("Session entry ID was not reserved: not-reserved");
+		expect(session.getEntries()).toEqual([]);
+
+		const reservedId = session.reserveEntryId("reserved-once");
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: reservedId });
+		expect(() => session.appendMessage({ role: "user", content: "again", timestamp: 2 }, { id: reservedId })).toThrow(
+			"Session entry ID already exists: reserved-once",
+		);
+		expect(session.getEntries()).toHaveLength(1);
+
+		expect(() => session.reserveEntryId("not valid")).toThrow("Session entry id must be non-empty");
+	});
+
+	it("releases unconsumed reservations and clears them with the session", () => {
+		const session = SessionManager.inMemory();
+		const releasedId = session.reserveEntryId("released-entry");
+
+		expect(session.releaseEntryId(releasedId)).toBe(true);
+		expect(session.releaseEntryId(releasedId)).toBe(false);
+		expect(() => session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: releasedId })).toThrow(
+			"Session entry ID was not reserved: released-entry",
+		);
+
+		const previousSessionId = session.getSessionId();
+		const clearedId = session.reserveEntryId("cleared-entry");
+		session.newSession();
+
+		expect(session.getSessionId()).not.toBe(previousSessionId);
+		expect(() => session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: clearedId })).toThrow(
+			"Session entry ID was not reserved: cleared-entry",
+		);
+	});
+
+	it("flushes a reserved user entry before the first assistant message", () => {
+		const tempDir = join(tmpdir(), `pi-entry-id-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		tempDirs.push(tempDir);
+
+		const session = SessionManager.create(tempDir, tempDir);
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persistent session file");
+		const reservedId = session.reserveEntryId("durable-user-entry");
+
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: reservedId, flush: true });
+
+		expect(existsSync(sessionFile)).toBe(true);
+		const reopened = SessionManager.open(sessionFile, tempDir);
+		expect(reopened.getEntry(reservedId)).toMatchObject({
+			type: "message",
+			id: reservedId,
+			message: { role: "user", content: "hello" },
+		});
+	});
+
+	it("keeps the default first-user persistence behavior without flush", () => {
+		const tempDir = join(tmpdir(), `pi-entry-id-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		tempDirs.push(tempDir);
+
+		const session = SessionManager.create(tempDir, tempDir);
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected a persistent session file");
+
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+
+		expect(existsSync(sessionFile)).toBe(false);
+	});
+
+	it("keeps the tree unchanged and restores the reservation when persistence fails", () => {
+		const tempDir = join(tmpdir(), `pi-entry-id-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		tempDirs.push(tempDir);
+		const session = SessionManager.create(tempDir, tempDir);
+		const reservedId = session.reserveEntryId("retryable-user-entry");
+		rmSync(tempDir, { recursive: true, force: true });
+
+		expect(() =>
+			session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: reservedId, flush: true }),
+		).toThrow();
+		expect(session.getEntries()).toEqual([]);
+		expect(session.getLeafId()).toBeNull();
+
+		mkdirSync(tempDir, { recursive: true });
+		expect(
+			session.appendMessage({ role: "user", content: "hello", timestamp: 1 }, { id: reservedId, flush: true }),
+		).toBe(reservedId);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-entry-ids.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-entry-ids.test.ts
@@ -1,0 +1,297 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PromptTemplate } from "../../src/core/prompt-templates.ts";
+import { createSyntheticSourceInfo } from "../../src/core/source-info.ts";
+import { createTestResourceLoader } from "../utilities.ts";
+import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+describe("AgentSession entry IDs", () => {
+	const harnesses: Harness[] = [];
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+		while (tempDirs.length > 0) {
+			const tempDir = tempDirs.pop();
+			if (tempDir) {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("persists a reserved user ID and emits stable entries after message_end", async () => {
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async (_toolCallId, params) => {
+				const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+				return {
+					content: [{ type: "text", text }],
+					details: {},
+				};
+			},
+		};
+		const harness = await createHarness({ tools: [echoTool] });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("echo", { text: "hello" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+		const userEntryId = harness.sessionManager.reserveEntryId("maverick-user-entry");
+
+		await harness.session.prompt("use the tool", { userEntryId });
+
+		const appendedEntries = harness.eventsOfType("entry_appended").map((event) => event.entry);
+		const messageEntries = appendedEntries.filter((entry) => entry.type === "message");
+		expect(messageEntries.map((entry) => entry.message.role)).toEqual([
+			"user",
+			"assistant",
+			"toolResult",
+			"assistant",
+		]);
+		expect(messageEntries[0]?.id).toBe(userEntryId);
+		expect(new Set(messageEntries.map((entry) => entry.id)).size).toBe(messageEntries.length);
+		for (const entry of messageEntries) {
+			expect(harness.sessionManager.getEntry(entry.id)).toBe(entry);
+		}
+
+		const userMessageEndIndex = harness.events.findIndex(
+			(event) => event.type === "message_end" && event.message.role === "user",
+		);
+		const userEntryIndex = harness.events.findIndex(
+			(event) => event.type === "entry_appended" && event.entry.id === userEntryId,
+		);
+		expect(userMessageEndIndex).toBeGreaterThanOrEqual(0);
+		expect(userEntryIndex).toBeGreaterThan(userMessageEndIndex);
+	});
+
+	it("preserves reserved IDs through skill and prompt-template expansion without provider metadata", async () => {
+		const tempDir = join(tmpdir(), `pi-entry-id-expansion-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		tempDirs.push(tempDir);
+		const skillPath = join(tempDir, "test-skill.md");
+		writeFileSync(skillPath, "# Test Skill\n\nUse the skill body.");
+		const template: PromptTemplate = {
+			name: "review",
+			description: "Review template",
+			content: "Review this code: $1",
+			filePath: join(tempDir, "review.md"),
+			sourceInfo: createSyntheticSourceInfo(join(tempDir, "review.md"), {
+				source: "local",
+				scope: "temporary",
+				origin: "top-level",
+			}),
+		};
+		const resourceLoader = {
+			...createTestResourceLoader(),
+			getSkills: () => ({
+				skills: [
+					{
+						name: "test",
+						description: "Test skill",
+						filePath: skillPath,
+						disableModelInvocation: false,
+						baseDir: tempDir,
+						sourceInfo: createSyntheticSourceInfo(skillPath, {
+							source: "local",
+							scope: "project",
+							origin: "top-level",
+							baseDir: tempDir,
+						}),
+					},
+				],
+				diagnostics: [],
+			}),
+			getPrompts: () => ({ prompts: [template], diagnostics: [] }),
+		};
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		const providerUsers: unknown[] = [];
+		harness.setResponses([
+			(context) => {
+				providerUsers.push(context.messages.find((message) => message.role === "user"));
+				return fauxAssistantMessage("skill done");
+			},
+			(context) => {
+				providerUsers.push(context.messages.filter((message) => message.role === "user").at(-1));
+				return fauxAssistantMessage("template done");
+			},
+		]);
+		const skillEntryId = harness.sessionManager.reserveEntryId("skill-user-entry");
+		const templateEntryId = harness.sessionManager.reserveEntryId("template-user-entry");
+
+		await harness.session.prompt("/skill:test explain this", { userEntryId: skillEntryId });
+		await harness.session.prompt("/review src/index.ts", { userEntryId: templateEntryId });
+
+		const skillEntry = harness.sessionManager.getEntry(skillEntryId);
+		const templateEntry = harness.sessionManager.getEntry(templateEntryId);
+		expect(skillEntry?.type).toBe("message");
+		expect(templateEntry?.type).toBe("message");
+		if (skillEntry?.type === "message") {
+			expect(getMessageText(skillEntry.message)).toContain('<skill name="test" location="');
+			expect(getMessageText(skillEntry.message)).toContain("explain this");
+		}
+		if (templateEntry?.type === "message") {
+			expect(getMessageText(templateEntry.message)).toBe("Review this code: src/index.ts");
+		}
+		expect(providerUsers).toHaveLength(2);
+		for (const user of providerUsers) {
+			expect(user).not.toHaveProperty("id");
+		}
+	});
+
+	it("preserves distinct reserved IDs for identical queued messages", async () => {
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
+		harnesses.push(harness);
+		harness.session.setFollowUpMode("all");
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("original turn complete"),
+			fauxAssistantMessage("follow-ups complete"),
+		]);
+		const sawToolStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("start");
+		await sawToolStart;
+		const firstEntryId = harness.sessionManager.reserveEntryId("queued-user-1");
+		const secondEntryId = harness.sessionManager.reserveEntryId("queued-user-2");
+
+		await harness.session.prompt("same", { streamingBehavior: "followUp", userEntryId: firstEntryId });
+		await harness.session.prompt("same", { streamingBehavior: "followUp", userEntryId: secondEntryId });
+		releaseToolExecution?.();
+		await promptPromise;
+
+		const queuedEntries = harness
+			.eventsOfType("entry_appended")
+			.map((event) => event.entry)
+			.filter(
+				(entry) =>
+					entry.type === "message" && entry.message.role === "user" && getMessageText(entry.message) === "same",
+			);
+		expect(queuedEntries.map((entry) => entry.id)).toEqual([firstEntryId, secondEntryId]);
+	});
+
+	it("releases reserved IDs when an extension command handles the prompt", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("handled", {
+						description: "Handle without a user message",
+						handler: async () => {},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const entryId = harness.sessionManager.reserveEntryId("handled-command-entry");
+
+		await expect(harness.session.prompt("/handled", { userEntryId: entryId })).rejects.toThrow(
+			"Prompt was handled as an extension command and did not create a user entry",
+		);
+		expect(harness.sessionManager.getEntries()).toEqual([]);
+		expect(harness.sessionManager.reserveEntryId(entryId)).toBe(entryId);
+	});
+
+	it("releases reserved IDs when an input extension handles the prompt", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("input", () => ({ action: "handled" }));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const entryId = harness.sessionManager.reserveEntryId("handled-input-entry");
+
+		await expect(harness.session.prompt("handled", { userEntryId: entryId })).rejects.toThrow(
+			"Prompt was handled by an input extension and did not create a user entry",
+		);
+		expect(harness.sessionManager.getEntries()).toEqual([]);
+		expect(harness.sessionManager.reserveEntryId(entryId)).toBe(entryId);
+	});
+
+	it("releases the exact reserved IDs for queued messages that are cleared", async () => {
+		let releaseToolExecution: (() => void) | undefined;
+		const toolRelease = new Promise<void>((resolve) => {
+			releaseToolExecution = resolve;
+		});
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await toolRelease;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({ tools: [waitTool] });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+		const sawToolStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "tool_execution_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("start");
+		await sawToolStart;
+		const firstEntryId = harness.sessionManager.reserveEntryId("cancelled-user-1");
+		const secondEntryId = harness.sessionManager.reserveEntryId("cancelled-user-2");
+		await harness.session.prompt("same", { streamingBehavior: "followUp", userEntryId: firstEntryId });
+		await harness.session.prompt("same", { streamingBehavior: "followUp", userEntryId: secondEntryId });
+
+		expect(harness.session.clearQueue()).toEqual({
+			steering: [],
+			followUp: ["same", "same"],
+			cancelledEntryIds: [firstEntryId, secondEntryId],
+		});
+		expect(harness.sessionManager.reserveEntryId(firstEntryId)).toBe(firstEntryId);
+		expect(harness.sessionManager.reserveEntryId(secondEntryId)).toBe(secondEntryId);
+		releaseToolExecution?.();
+		await promptPromise;
+
+		const deliveredUserTexts = harness
+			.eventsOfType("entry_appended")
+			.flatMap((event) =>
+				event.entry.type === "message" && event.entry.message.role === "user"
+					? [getMessageText(event.entry.message)]
+					: [],
+			);
+		expect(deliveredUserTexts).toEqual(["start"]);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -10,9 +10,11 @@ function normalizeEventOrder(events: Harness["events"]): string[] {
 		const label =
 			event.type === "message_start" || event.type === "message_end"
 				? `${event.type}:${event.message.role}`
-				: event.type === "tool_execution_start" || event.type === "tool_execution_end"
-					? `${event.type}:${event.toolName}`
-					: event.type;
+				: event.type === "entry_appended" && event.entry.type === "message"
+					? `${event.type}:${event.entry.message.role}`
+					: event.type === "tool_execution_start" || event.type === "tool_execution_end"
+						? `${event.type}:${event.toolName}`
+						: event.type;
 		if (label === "message_update" && normalized[normalized.length - 1] === "message_update") {
 			continue;
 		}
@@ -248,9 +250,11 @@ describe("AgentSession retry and event characterization", () => {
 			"turn_start",
 			"message_start:user",
 			"message_end:user",
+			"entry_appended:user",
 			"message_start:assistant",
 			"message_update",
 			"message_end:assistant",
+			"entry_appended:assistant",
 			"turn_end",
 			"agent_end",
 			"agent_settled",
@@ -285,18 +289,22 @@ describe("AgentSession retry and event characterization", () => {
 			"turn_start",
 			"message_start:user",
 			"message_end:user",
+			"entry_appended:user",
 			"message_start:assistant",
 			"message_update",
 			"message_end:assistant",
+			"entry_appended:assistant",
 			"tool_execution_start:echo",
 			"tool_execution_end:echo",
 			"message_start:toolResult",
 			"message_end:toolResult",
+			"entry_appended:toolResult",
 			"turn_end",
 			"turn_start",
 			"message_start:assistant",
 			"message_update",
 			"message_end:assistant",
+			"entry_appended:assistant",
 			"turn_end",
 			"agent_end",
 			"agent_settled",


### PR DESCRIPTION
## Summary

- add caller-reserved session entry IDs with collision and restart handling
- propagate reserved user IDs through prompt expansion and queued delivery without adding provider-visible metadata
- emit stable post-append entries for user, assistant, and tool-result messages
- flush reserved first-user entries before provider execution and preserve reservation state across failures or cancellation

## MAV-62

Maverick needs a durable native entry identity before delivering a canonical user element to Pi. This lets it correlate exact Pi entries without matching message text, timestamps, or timeline position.

## Verification

- `npm run check`
- coding-agent focused suite: 12 files, 151 tests passed
- agent core: 19 tests passed

The broader coding-agent suite has five environment-only failures on the local Node 22.16 runtime; this repository requires Node 22.19 or newer. The failures are `.mts` loading and extension-factory cache tests unrelated to this change.
