### PR TITLE
fix(ai): never enable OpenAI/Anthropic SDK Retry-After sleeps

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -39,6 +39,7 @@ import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampMaxTokensToContext } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
+import { PROVIDER_SDK_MAX_RETRIES } from "../utils/sdk-retries.ts";
 
 /**
  * Resolve cache retention preference.
@@ -550,7 +551,7 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				maxRetries: PROVIDER_SDK_MAX_RETRIES,
 			};
 			const response = await client.messages.create({ ...params, stream: true }, requestOptions).asResponse();
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);

--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -17,6 +17,7 @@ import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
+import { PROVIDER_SDK_MAX_RETRIES } from "../utils/sdk-retries.ts";
 
 const DEFAULT_AZURE_API_VERSION = "v1";
 const AZURE_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode", "azure-openai-responses"]);
@@ -107,7 +108,7 @@ export const stream: StreamFunction<"azure-openai-responses", AzureOpenAIRespons
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				maxRetries: PROVIDER_SDK_MAX_RETRIES,
 			};
 			const { data: openaiStream, response } = await client.responses.create(params, requestOptions).withResponse();
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -33,6 +33,7 @@ import type {
 	ToolResultMessage,
 } from "../types.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
+import { PROVIDER_SDK_MAX_RETRIES } from "../utils/sdk-retries.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
@@ -219,7 +220,9 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				// Never enable the OpenAI SDK's own retries: they sleep the full
+				// Retry-After without a cap and without honoring AbortSignal.
+				maxRetries: PROVIDER_SDK_MAX_RETRIES,
 			};
 			const { data: openaiStream, response } = await client.chat.completions
 				.create(params, requestOptions)

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -24,6 +24,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
+import { PROVIDER_SDK_MAX_RETRIES } from "../utils/sdk-retries.ts";
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 // OpenAI Responses rejects max_output_tokens below 16: https://github.com/earendil-works/pi/issues/6265
@@ -134,7 +135,7 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				maxRetries: PROVIDER_SDK_MAX_RETRIES,
 			};
 			const { data: openaiStream, response } = await client.responses.create(params, requestOptions).withResponse();
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);

--- a/packages/ai/src/api/openrouter-images.ts
+++ b/packages/ai/src/api/openrouter-images.ts
@@ -19,6 +19,7 @@ import type {
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { headersToRecord, providerHeadersToRecord } from "../utils/headers.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { PROVIDER_SDK_MAX_RETRIES } from "../utils/sdk-retries.ts";
 
 interface OpenRouterGeneratedImage {
 	image_url?: string | { url?: string };
@@ -64,7 +65,7 @@ export const generateImages: ImagesFunction<"openrouter-images", ImagesOptions> 
 		const requestOptions = {
 			...(options?.signal ? { signal: options.signal } : {}),
 			...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-			maxRetries: options?.maxRetries ?? 0,
+			maxRetries: PROVIDER_SDK_MAX_RETRIES,
 		};
 		const { data: response, response: rawResponse } = await client.chat.completions
 			.create(params as unknown as ChatCompletionCreateParamsNonStreaming, requestOptions)

--- a/packages/ai/src/utils/sdk-retries.ts
+++ b/packages/ai/src/utils/sdk-retries.ts
@@ -1,0 +1,14 @@
+/**
+ * Provider SDK retry policy for OpenAI/Anthropic clients.
+ *
+ * Those SDKs honor `Retry-After` without a delay cap and sleep with a plain
+ * `setTimeout` that ignores AbortSignal. When a provider returns a multi-hour
+ * or multi-day `Retry-After` (for example OpenCode `GoUsageLimitError` with
+ * `retry-after: ~3 days`), the agent stays in "working" until that sleep ends
+ * and Escape cannot interrupt it.
+ *
+ * Always pass this value as the SDK `maxRetries` option. Pi's agent-level
+ * retry remains abortable and treats terminal usage/quota/billing errors as
+ * non-retryable via {@link isRetryableAssistantError}.
+ */
+export const PROVIDER_SDK_MAX_RETRIES = 0 as const;

--- a/packages/ai/test/openai-completions-retry.test.ts
+++ b/packages/ai/test/openai-completions-retry.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
 import type { Context, Model } from "../src/types.ts";
+import { PROVIDER_SDK_MAX_RETRIES } from "../src/utils/sdk-retries.ts";
 
 const mockState = vi.hoisted(() => ({
 	requestOptions: [] as unknown[],
@@ -74,13 +75,21 @@ describe("openai-completions provider retries", () => {
 		mockState.requestOptions = [];
 	});
 
-	it("disables SDK retries by default", async () => {
+	it("disables OpenAI SDK retries by default", async () => {
 		await consume();
-		expect(mockState.requestOptions).toEqual([expect.objectContaining({ maxRetries: 0 })]);
+		expect(mockState.requestOptions).toEqual([
+			expect.objectContaining({ maxRetries: PROVIDER_SDK_MAX_RETRIES }),
+		]);
 	});
 
-	it("honors explicit provider retry settings", async () => {
+	it("keeps OpenAI SDK retries disabled even when caller requests provider retries", async () => {
+		// OpenAI's client sleeps the full Retry-After without a cap and without
+		// honoring AbortSignal. Passing maxRetries through would freeze the UI
+		// (and Escape) on usage-limit 429s such as OpenCode GoUsageLimitError.
 		await consume({ maxRetries: 2 });
-		expect(mockState.requestOptions).toEqual([expect.objectContaining({ maxRetries: 2 })]);
+		expect(mockState.requestOptions).toEqual([
+			expect.objectContaining({ maxRetries: PROVIDER_SDK_MAX_RETRIES }),
+		]);
+		expect(PROVIDER_SDK_MAX_RETRIES).toBe(0);
 	});
 });

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -144,7 +144,7 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 
 When a provider requests a retry delay longer than `retry.provider.maxRetryDelayMs` (e.g., Google's "quota will reset after 5h"), the request fails immediately with an informative error instead of waiting silently. Set to `0` to disable the cap.
 
-Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explicitly needed. Setting it above `0` can make SDK/provider retries handle out-of-usage-limit errors before Pi sees them, which may block the agent until the provider quota resets in some circumstances.
+Keep `retry.provider.maxRetries` at `0`. OpenAI/Anthropic SDK retries are forced off in pi-ai because those clients sleep the full `Retry-After` without a delay cap and without honoring Escape/AbortSignal. A usage-limit 429 with a multi-day `Retry-After` (for example OpenCode `GoUsageLimitError`) would otherwise leave the UI stuck on "working". Transient failures are retried by the agent-level policy instead, which is abortable and treats terminal quota/billing limits as non-retryable.
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Force OpenAI/Anthropic SDK `maxRetries` to `0` so providers cannot freeze Pi by returning multi-hour/day `Retry-After` values.
- Keeps Escape/abort usable: SDK retry sleep is non-abortable; agent-level retry remains abortable and already treats terminal usage/quota/billing limits as non-retryable.
- Documents the footgun in settings and locks the openai-completions regression test so explicit `maxRetries: 2` can no longer re-enable SDK sleeps.

Fixes https://github.com/earendil-works/pi/issues/6911

## Context

OpenCode Go returned:

```text
429 GoUsageLimitError
retry-after: ~277403s (~3.2 days)
```

With `retry.provider.maxRetries: 2`, pi-ai forwarded that into the OpenAI client. The client slept the full Retry-After with a plain `setTimeout`, so the UI stayed on **working** and Escape did nothing.

This continues the intent of #4991: SDK retries must not hide/block usage-limit failures. That PR defaulted to 0 but still allowed settings to turn the unsafe path back on.

## Test plan

- [x] `npx vitest --run openai-completions-retry.test.ts retry.test.ts` in `packages/ai`
- [x] Direct OpenCode curl shows immediate 429 + long Retry-After
- [x] OpenAI client with `maxRetries: 0` fails in <1s; with `maxRetries: 2` begins multi-day sleep
- [ ] Reviewer: confirm no intentional callers depend on SDK-level retries for openai-completions / responses / anthropic
