### PR TITLE
feat(session-selector): add Ctrl+A archive shortcut to session picker

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -40,6 +40,7 @@ export interface AppKeybindings {
 	"app.session.rename": true;
 	"app.session.delete": true;
 	"app.session.deleteNoninvasive": true;
+	"app.session.archive": true;
 	"app.models.save": true;
 	"app.models.enableAll": true;
 	"app.models.clearAll": true;
@@ -151,6 +152,10 @@ export const KEYBINDINGS = {
 	"app.session.deleteNoninvasive": {
 		defaultKeys: "ctrl+backspace",
 		description: "Delete session when query is empty",
+	},
+	"app.session.archive": {
+		defaultKeys: "ctrl+a",
+		description: "Archive session",
 	},
 	"app.models.save": {
 		defaultKeys: "ctrl+s",
@@ -266,6 +271,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	renameSession: "app.session.rename",
 	deleteSession: "app.session.delete",
 	deleteSessionNoninvasive: "app.session.deleteNoninvasive",
+	archiveSession: "app.session.archive",
 } as const satisfies Record<string, Keybinding>;
 
 function isLegacyKeybindingName(key: string): key is keyof typeof KEYBINDING_NAME_MIGRATIONS {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, statSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import * as os from "node:os";
+import { dirname, join } from "node:path";
 import {
 	type Component,
 	Container,
@@ -172,6 +173,7 @@ class SessionSelectorHeader implements Component {
 				keyHint("app.session.toggleSort", "sort"),
 				keyHint("app.session.toggleNamedFilter", "named"),
 				keyHint("app.session.delete", "delete"),
+				keyHint("app.session.archive", "archive"),
 				keyHint("app.session.togglePath", `path ${pathState}`),
 			];
 			if (this.showRenameHint) {
@@ -306,6 +308,7 @@ class SessionList implements Component, Focusable {
 	public onDeleteConfirmationChange?: (path: string | null) => void;
 	public onDeleteSession?: (sessionPath: string) => Promise<void>;
 	public onRenameSession?: (sessionPath: string) => void;
+	public onArchiveSession?: (sessionPath: string) => Promise<void>;
 	public onError?: (message: string) => void;
 	private maxVisible: number = 10; // Max sessions visible (one line each)
 
@@ -572,9 +575,21 @@ class SessionList implements Component, Focusable {
 			return;
 		}
 
-		// Ctrl+D: initiate delete confirmation (useful on terminals that don't distinguish Ctrl+Backspace from Backspace)
+		// Ctrl+D: initiate delete confirmation
 		if (kb.matches(keyData, "app.session.delete")) {
 			this.startDeleteConfirmationForSelectedSession();
+			return;
+		}
+
+		// Ctrl+A: archive selected session to .pi/archive/YYYY-MM/
+		if (kb.matches(keyData, "app.session.archive")) {
+			const selected = this.filteredSessions[this.selectedIndex];
+			if (!selected) return;
+			if (this.isCurrentSessionPath(selected.session.path)) {
+				this.onError?.("Cannot archive the currently active session");
+				return;
+			}
+			void this.onArchiveSession?.(selected.session.path);
 			return;
 		}
 
@@ -852,6 +867,34 @@ export class SessionSelectorComponent extends Container implements Focusable {
 				this.header.setStatusMessage({ type: "error", message: `Failed to delete: ${errorMessage}` }, 3000);
 			}
 
+			this.requestRender();
+		};
+
+		// Handle session archive
+		this.sessionList.onArchiveSession = async (sessionPath: string) => {
+			try {
+				const s = statSync(sessionPath);
+				const month = s.mtime.toISOString().slice(0, 7);
+				const archiveDir = join(dirname(sessionPath), "..", "archive", month);
+				mkdirSync(archiveDir, { recursive: true });
+				renameSync(sessionPath, join(archiveDir, sessionPath.split(/[/\\]/).pop()!));
+
+				if (this.currentSessions) {
+					this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
+				}
+				if (this.allSessions) {
+					this.allSessions = this.allSessions.filter((s) => s.path !== sessionPath);
+				}
+
+				const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
+				const showCwd = this.scope === "all";
+				this.sessionList.setSessions(sessions, showCwd);
+
+				this.header.setStatusMessage({ type: "info", message: "Session archived" }, 2000);
+				await this.refreshSessionsAfterMutation();
+			} catch (err) {
+				this.header.setStatusMessage({ type: "error", message: `Archive failed: ${err}` }, 3000);
+			}
 			this.requestRender();
 		};
 


### PR DESCRIPTION
Add an 'Archive' keyboard shortcut (Ctrl+A) to the /resume session selector, allowing users to archive selected sessions to .pidot/archive/YYYY-MM/ with a single keystroke.

Changes:
- Register app.session.archive keybinding (ctrl+a) in AppKeybindings
- Add onArchiveSession callback to SessionList
- Handle Ctrl+A in SessionList.handleInput: archive selected session (preventing current-session archive, same as delete guard)
- Display archive hint in selector footer alongside sort/named/delete
- Implement archive logic in SessionSelectorComponent: move .jsonl file to archive dir, update session list, show status message

Archive preserves data for future analysis while keeping the active session list clean, complementing the existing delete (Ctrl+D) flow.