### PR TITLE
feat(session-selector): add Ctrl+A archive shortcut to session picker (v0.81.0 rebase)

### DIFF
--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -40,6 +40,7 @@ export interface AppKeybindings {
 	"app.session.rename": true;
 	"app.session.delete": true;
 	"app.session.deleteNoninvasive": true;
+	"app.session.archive": true;
 	"app.models.save": true;
 	"app.models.enableAll": true;
 	"app.models.clearAll": true;
@@ -151,6 +152,10 @@ export const KEYBINDINGS = {
 	"app.session.deleteNoninvasive": {
 		defaultKeys: "ctrl+backspace",
 		description: "Delete session when query is empty",
+	},
+	"app.session.archive": {
+		defaultKeys: "ctrl+a",
+		description: "Archive session",
 	},
 	"app.models.save": {
 		defaultKeys: "ctrl+s",
@@ -266,6 +271,7 @@ const KEYBINDING_NAME_MIGRATIONS = {
 	renameSession: "app.session.rename",
 	deleteSession: "app.session.delete",
 	deleteSessionNoninvasive: "app.session.deleteNoninvasive",
+	archiveSession: "app.session.archive",
 } as const satisfies Record<string, Keybinding>;
 
 function isLegacyKeybindingName(key: string): key is keyof typeof KEYBINDING_NAME_MIGRATIONS {

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, statSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import * as os from "node:os";
+import { dirname, join } from "node:path";
 import {
 	type Component,
 	Container,
@@ -172,6 +173,7 @@ class SessionSelectorHeader implements Component {
 				keyHint("app.session.toggleSort", "sort"),
 				keyHint("app.session.toggleNamedFilter", "named"),
 				keyHint("app.session.delete", "delete"),
+				keyHint("app.session.archive", "archive"),
 				keyHint("app.session.togglePath", `path ${pathState}`),
 			];
 			if (this.showRenameHint) {
@@ -306,6 +308,7 @@ class SessionList implements Component, Focusable {
 	public onDeleteConfirmationChange?: (path: string | null) => void;
 	public onDeleteSession?: (sessionPath: string) => Promise<void>;
 	public onRenameSession?: (sessionPath: string) => void;
+	public onArchiveSession?: (sessionPath: string) => Promise<void>;
 	public onError?: (message: string) => void;
 	private maxVisible: number = 10; // Max sessions visible (one line each)
 
@@ -572,9 +575,21 @@ class SessionList implements Component, Focusable {
 			return;
 		}
 
-		// Ctrl+D: initiate delete confirmation (useful on terminals that don't distinguish Ctrl+Backspace from Backspace)
+		// Ctrl+D: initiate delete confirmation
 		if (kb.matches(keyData, "app.session.delete")) {
 			this.startDeleteConfirmationForSelectedSession();
+			return;
+		}
+
+		// Ctrl+A: archive selected session to .pi/archive/YYYY-MM/
+		if (kb.matches(keyData, "app.session.archive")) {
+			const selected = this.filteredSessions[this.selectedIndex];
+			if (!selected) return;
+			if (this.isCurrentSessionPath(selected.session.path)) {
+				this.onError?.("Cannot archive the currently active session");
+				return;
+			}
+			void this.onArchiveSession?.(selected.session.path);
 			return;
 		}
 
@@ -852,6 +867,34 @@ export class SessionSelectorComponent extends Container implements Focusable {
 				this.header.setStatusMessage({ type: "error", message: `Failed to delete: ${errorMessage}` }, 3000);
 			}
 
+			this.requestRender();
+		};
+
+		// Handle session archive
+		this.sessionList.onArchiveSession = async (sessionPath: string) => {
+			try {
+				const s = statSync(sessionPath);
+				const month = s.mtime.toISOString().slice(0, 7);
+				const archiveDir = join(dirname(sessionPath), "..", "archive", month);
+				mkdirSync(archiveDir, { recursive: true });
+				renameSync(sessionPath, join(archiveDir, sessionPath.split(/[/\\]/).pop()!));
+
+				if (this.currentSessions) {
+					this.currentSessions = this.currentSessions.filter((s) => s.path !== sessionPath);
+				}
+				if (this.allSessions) {
+					this.allSessions = this.allSessions.filter((s) => s.path !== sessionPath);
+				}
+
+				const sessions = this.scope === "all" ? (this.allSessions ?? []) : (this.currentSessions ?? []);
+				const showCwd = this.scope === "all";
+				this.sessionList.setSessions(sessions, showCwd);
+
+				this.header.setStatusMessage({ type: "info", message: "Session archived" }, 2000);
+				await this.refreshSessionsAfterMutation();
+			} catch (err) {
+				this.header.setStatusMessage({ type: "error", message: `Archive failed: ${err}` }, 3000);
+			}
 			this.requestRender();
 		};
 


### PR DESCRIPTION
## Summary

Add an "Archive" keyboard shortcut (`Ctrl+A`) to the `/resume` session selector, allowing users to archive selected session files to `.pi/archive/YYYY-MM/` with a single keystroke. Archive preserves data for future analysis while keeping the active session list clean—complementing the existing delete flow (`Ctrl+D`).

> Previous PR #6874 was closed. This is a fresh PR rebased onto **v0.81.0** with zero conflicts.

## Changes

**`packages/coding-agent/src/core/keybindings.ts`** (+3 lines):
- Register `app.session.archive` in `AppKeybindings` interface
- Add default keybinding `ctrl+a` with description "Archive session"
- Add name mapping `archiveSession` → `app.session.archive`

**`packages/coding-agent/src/modes/interactive/components/session-selector.ts`** (+48 lines):
- Add `onArchiveSession` callback to `SessionList`
- Handle `app.session.archive` keypress: guard against archiving current session, fire callback
- Display `ctrl+a archive` hint in selector footer alongside sort/named/delete hints
- Implement archive logic: stat → determine archive dir (.pi/archive/YYYY-MM/) → mkdir → rename → refresh list → show status

## Usage

1. Open `/resume` session selector
2. ↑↓ select a session
3. Press `Ctrl+A` to archive it immediately

The existing `/archive all` command remains for batch operations.

## Verification

- [x] Rebased on v0.81.0 (zero conflicts)
- [x] Full build passes (npm run build)
- [x] Archive bypasses currently active session (same guard as delete)
- [x] Archived sessions removed from in-memory list and UI refreshes
- [x] Status message shown on success
- [x] Keybinding hint in selector footer