### PR TITLE
fix(clipboard): await wl-copy exit code before claiming success

### DIFF
--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -104,15 +104,25 @@ export async function copyToClipboard(text: string): Promise<void> {
 						try {
 							// Verify wl-copy exists (spawn errors are async and won't be caught)
 							execSync("which wl-copy", { stdio: "ignore" });
-							// wl-copy with execSync hangs due to fork behavior; use spawn instead
-							const proc = spawn("wl-copy", [], { stdio: ["pipe", "ignore", "ignore"] });
-							proc.stdin.on("error", () => {
-								// Ignore EPIPE errors if wl-copy exits early
+							// wl-copy with execSync hangs due to fork behavior; use spawn instead.
+							// Await the exit code so a failed wl-copy (e.g. no compositor access
+							// in a sandbox) falls through to the xclip/xsel/OSC 52 fallbacks.
+							const wlCopyExit = await new Promise<number>((resolve) => {
+								const proc = spawn("wl-copy", [], { stdio: ["pipe", "ignore", "ignore"] });
+								proc.on("error", () => resolve(1));
+								proc.on("close", (code) => resolve(code ?? 1));
+								proc.stdin.on("error", () => {
+									// Ignore EPIPE errors if wl-copy exits early
+								});
+								proc.stdin.write(text);
+								proc.stdin.end();
 							});
-							proc.stdin.write(text);
-							proc.stdin.end();
-							proc.unref();
-							copied = true;
+							if (wlCopyExit === 0) {
+								copied = true;
+							} else if (hasX11Display) {
+								copyToX11Clipboard(options);
+								copied = true;
+							}
 						} catch {
 							if (hasX11Display) {
 								copyToX11Clipboard(options);
@@ -139,3 +149,5 @@ export async function copyToClipboard(text: string): Promise<void> {
 		throw new Error("Failed to copy to clipboard");
 	}
 }
+
+


### PR DESCRIPTION
`/copy` falsely reports success when `wl-copy` is on PATH but can't reach the Wayland compositor (sandboxed environments, bwrap, namespaces that inherit `WAYLAND_DISPLAY` but not the socket).

The spawn was fire-and-forget: `copied = true` was set immediately after `spawn()` without awaiting the exit code, so the X11/OSC 52 fallbacks never ran.

### Fix

Wrap `spawn("wl-copy")` in a Promise that resolves on the `close` event. Only set `copied = true` on exit code 0. On non-zero exit, fall through to xclip/xsel if `DISPLAY` is set, then to OSC 52.

### Testing

Reproduced with a fake `wl-copy` that exits 1:

```
# Before fix: copied = true (bug)
# After fix:  copied = false, falls through to X11 fallback
```

Fixes #6872