### PR TITLE
fix(coding-agent): disable undici idle timeout by default for local LLMs

### DIFF
--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -1,13 +1,25 @@
 import { EventEmitter } from "node:events";
 import * as undici from "undici";
 
-export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
+/**
+ * Default HTTP body/headers idle timeout in milliseconds.
+ *
+ * `0` disables undici's per-socket idle timeout so slow local LLM backends
+ * (vLLM, LM Studio, llama.cpp, Ollama) that may stay silent for minutes during
+ * prompt evaluation / inter-token pauses are not disconnected prematurely
+ * (see #3715).  Provider-level timeouts (retry.provider.timeoutMs) still apply
+ * and are the preferred way to bound requests.  Set a non-zero value (e.g. via
+ * `/settings`) if you need an HTTP-level safety net.
+ */
+export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 0;
 
 export const HTTP_IDLE_TIMEOUT_CHOICES = [
 	{ label: "30 sec", timeoutMs: 30_000 },
 	{ label: "1 min", timeoutMs: 60_000 },
 	{ label: "2 min", timeoutMs: 120_000 },
 	{ label: "5 min", timeoutMs: 300_000 },
+	{ label: "10 min", timeoutMs: 600_000 },
+	{ label: "30 min", timeoutMs: 1_800_000 },
 	{ label: "disabled", timeoutMs: 0 },
 ] as const;
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -332,7 +332,7 @@ describe("SettingsManager", () => {
 	});
 
 	describe("httpIdleTimeoutMs", () => {
-		it("should default to 5 minutes", () => {
+		it("should default to disabled (0)", () => {
 			const manager = SettingsManager.create(projectDir, agentDir);
 			expect(manager.getHttpIdleTimeoutMs()).toBe(DEFAULT_HTTP_IDLE_TIMEOUT_MS);
 		});


### PR DESCRIPTION
Change DEFAULT_HTTP_IDLE_TIMEOUT_MS from 300000 (5 min) to 0 (disabled) so undici's per-socket bodyTimeout/headersTimeout no longer terminates slow local LLM backends (vLLM, LM Studio, llama.cpp, Ollama) that may stay silent for minutes during prompt evaluation.

Provider-level timeouts (retry.provider.timeoutMs) still apply and remain the preferred way to bound requests.  Users who want an HTTP-level safety net can set a non-zero value via /settings (two new choices: 10 min and 30 min are also added).

## Problem

  Local LLMs can be silent for 5+ minutes during prompt evaluation / inter-token pauses. undici's default
  `bodyTimeout` kills the connection with `TypeError: terminated` / `UND_ERR_BODY_TIMEOUT`, making local models
  unusable for long-running requests.

  ## Fix

  - **Changed default:** `DEFAULT_HTTP_IDLE_TIMEOUT_MS` from `300_000` → `0` (disabled)
  - **Added choices:** "10 min" and "30 min" to the HTTP idle timeout options
  - Provider-level timeouts (`retry.provider.timeoutMs`) still apply and remain the preferred way to bound requests
  - Users who want an HTTP-level safety net can set a non-zero value via `/settings`

Closes #3715