### PR TITLE
fix(coding-agent): compact during long tool runs

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `Agent.shouldStopAfterTurn` so hosts can end a run safely between completed tool turns before another provider request ([#6879](https://github.com/earendil-works/pi/issues/6879)).
+
 ## [0.81.1] - 2026-07-21
 
 ### Added

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -23,6 +23,7 @@ import type {
 	BeforeToolCallResult,
 	PrepareNextTurnContext,
 	QueueMode,
+	ShouldStopAfterTurnContext,
 	StreamFn,
 	ToolExecutionMode,
 } from "./types.ts";
@@ -118,6 +119,15 @@ export interface AgentOptions {
 	transport?: Transport;
 	maxRetryDelayMs?: number;
 	toolExecution?: ToolExecutionMode;
+	/**
+	 * Called after each turn fully completes and `turn_end` has been emitted.
+	 *
+	 * If it returns true, the loop emits `agent_end` and exits before polling steering or follow-up queues,
+	 * without starting another LLM call. The current assistant response and any tool executions finish normally.
+	 *
+	 * Use this to request a graceful stop after the current turn, e.g. before context gets too full.
+	 */
+	shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 }
 
 class PendingMessageQueue {
@@ -206,6 +216,8 @@ export class Agent {
 	public maxRetryDelayMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
+	/** Hook to stop the agent loop after the current turn completes. */
+	public shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 
 	constructor(options: AgentOptions) {
 		// Older compiled consumers may omit options or streamFn even though the current API requires them.
@@ -228,6 +240,7 @@ export class Agent {
 		this.transport = runtimeOptions.transport ?? "auto";
 		this.maxRetryDelayMs = runtimeOptions.maxRetryDelayMs;
 		this.toolExecution = runtimeOptions.toolExecution ?? "parallel";
+		this.shouldStopAfterTurn = runtimeOptions.shouldStopAfterTurn;
 	}
 
 	/**
@@ -443,6 +456,7 @@ export class Agent {
 			thinkingBudgets: this.thinkingBudgets,
 			maxRetryDelayMs: this.maxRetryDelayMs,
 			toolExecution: this.toolExecution,
+			shouldStopAfterTurn: this.shouldStopAfterTurn,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
 			prepareNextTurn:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed long tool-calling runs bypassing the auto-compaction threshold until provider context overflow; Pi now compacts and resumes between completed tool turns ([#6879](https://github.com/earendil-works/pi/issues/6879)).
+
 ## [0.81.1] - 2026-07-21
 
 ### New Features

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -34,6 +34,8 @@ contextTokens > contextWindow - reserveTokens
 
 By default, `reserveTokens` is 16384 tokens (configurable in `~/.pi/agent/settings.json` or `<project-dir>/.pi/settings.json`). This leaves room for the LLM's response.
 
+Pi checks the threshold after each completed tool turn. If a tool result crosses it during a long agent run, Pi stops before the next provider request, compacts, and resumes from the retained tool results. Final assistant responses still compact without starting an extra turn.
+
 You can also trigger manually with `/compact [instructions]`, where optional instructions focus the summary.
 
 ### How It Works

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -22,6 +22,7 @@ import type {
 	AgentState,
 	AgentTool,
 	PrepareNextTurnContext,
+	ShouldStopAfterTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import { contentText } from "@earendil-works/pi-ai";
@@ -323,6 +324,8 @@ export class AgentSession {
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
 	private _overflowRecoveryAttempted = false;
+	/** Whether the active tool loop stopped so threshold compaction can run and resume it. */
+	private _midTurnCompactionNeeded = false;
 
 	// Branch summarization state
 	private _branchSummaryAbortController: AbortController | undefined = undefined;
@@ -391,6 +394,7 @@ export class AgentSession {
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
 		this._installAgentToolHooks();
 		this._installAgentNextTurnRefresh();
+		this._installMidTurnCompactionHook();
 
 		this._buildRuntime({
 			activeToolNames: this._initialActiveToolNames,
@@ -536,6 +540,41 @@ export class AgentSession {
 				thinkingLevel: this.agent.state.thinkingLevel,
 			};
 		};
+	}
+
+	/**
+	 * Install a shouldStopAfterTurn hook that triggers mid-turn compaction when
+	 * tool results push context over the threshold. Composes with any existing
+	 * shouldStopAfterTurn set on the Agent.
+	 */
+	private _installMidTurnCompactionHook(): void {
+		const previousShouldStop = this.agent.shouldStopAfterTurn;
+		this.agent.shouldStopAfterTurn = async (context: ShouldStopAfterTurnContext) => {
+			if (await previousShouldStop?.(context)) return true;
+			return this._midTurnShouldStop(context);
+		};
+	}
+
+	/**
+	 * Check whether the context after a completed tool turn exceeds the compaction
+	 * threshold. Only triggers when tool results are present (safe boundary).
+	 */
+	private _midTurnShouldStop(context: ShouldStopAfterTurnContext): boolean {
+		if (context.toolResults.length === 0) return false;
+
+		const settings = this.settingsManager.getCompactionSettings();
+		if (!settings.enabled) return false;
+
+		const contextWindow = this.model?.contextWindow ?? 0;
+		if (contextWindow === 0) return false;
+
+		const estimate = estimateContextTokens(context.context.messages);
+		if (shouldCompact(estimate.tokens, contextWindow, settings)) {
+			this._midTurnCompactionNeeded = "threshold";
+			return true;
+		}
+
+		return false;
 	}
 
 	// =========================================================================
@@ -1071,6 +1110,15 @@ export class AgentSession {
 	}
 
 	private async _handlePostAgentRun(): Promise<boolean> {
+		// Handle mid-turn threshold compaction first - stop was triggered between
+		// tool batches so we must continue after compaction to process pending results.
+		if (this._midTurnCompactionNeeded) {
+			this._midTurnCompactionNeeded = false;
+			// Continue only if compaction succeeds; otherwise another request would
+			// send the same oversized context.
+			return await this._runAutoCompaction("threshold", true);
+		}
+
 		const msg = this._lastAssistantMessage;
 		this._lastAssistantMessage = undefined;
 		if (!msg) {
@@ -2008,30 +2056,30 @@ export class AgentSession {
 			return await this._runAutoCompaction("overflow", willRetry);
 		}
 
-		// Case 2: Threshold - context is getting large
-		// For error messages or all-zero usage messages, estimate from the last valid response.
-		// This ensures sessions that hit persistent API errors (e.g. 529) or malformed zero-usage
-		// responses can still compact and do not reset context accounting.
-		let contextTokens: number;
-		const directContextTokens = assistantMessage.usage ? calculateContextTokens(assistantMessage.usage) : 0;
-		if (assistantMessage.stopReason === "error" || directContextTokens === 0) {
-			const messages = this.agent.state.messages;
-			const estimate = estimateContextTokens(messages);
-			if (estimate.lastUsageIndex === null) return false; // No usage data at all
-			// Verify the usage source is post-compaction. Kept pre-compaction messages
-			// have stale usage reflecting the old (larger) context and would falsely
-			// trigger compaction right after one just finished.
+		// Case 2: Threshold - context is getting large. Include messages appended
+		// after the latest provider usage, notably tool results produced mid-run.
+		const messages = this.agent.state.messages;
+		const estimate = estimateContextTokens(messages);
+		let estimatedContextTokens: number | undefined;
+		if (estimate.lastUsageIndex !== null) {
+			// Kept pre-compaction messages retain stale usage from the larger context.
 			const usageMsg = messages[estimate.lastUsageIndex];
-			if (
+			const usageIsStale =
 				compactionEntry &&
 				usageMsg.role === "assistant" &&
-				(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime()
-			) {
-				return false;
+				(usageMsg as AssistantMessage).timestamp <= new Date(compactionEntry.timestamp).getTime();
+			if (!usageIsStale) {
+				estimatedContextTokens = estimate.tokens;
 			}
-			contextTokens = estimate.tokens;
+		}
+
+		const directContextTokens = assistantMessage.usage ? calculateContextTokens(assistantMessage.usage) : 0;
+		let contextTokens: number;
+		if (assistantMessage.stopReason === "error" || directContextTokens === 0) {
+			if (estimatedContextTokens === undefined) return false;
+			contextTokens = estimatedContextTokens;
 		} else {
-			contextTokens = directContextTokens;
+			contextTokens = Math.max(directContextTokens, estimatedContextTokens ?? 0);
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			return await this._runAutoCompaction("threshold", false);

--- a/packages/coding-agent/test/suite/regressions/6879-mid-turn-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6879-mid-turn-compaction.test.ts
@@ -1,0 +1,70 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("#6879 mid-turn compaction", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("compacts after a large tool result and resumes before another provider request", async () => {
+		const toolResult = `large-result-marker:${"A".repeat(2000)}`;
+		const largeTool: AgentTool = {
+			name: "big_result",
+			label: "Big Result",
+			description: "Returns a large result",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text", text: toolResult }],
+				details: {},
+			}),
+		};
+		const harness = await createHarness({
+			settings: { compaction: { enabled: true, reserveTokens: 100, keepRecentTokens: 200 } },
+			models: [{ id: "faux-1", contextWindow: 1000, maxTokens: 100 }],
+			tools: [largeTool],
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", (event) => ({
+						compaction: {
+							summary: "compacted history",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		let resumedRequest = "";
+		harness.setResponses([
+			fauxAssistantMessage("old-history-marker"),
+			fauxAssistantMessage(fauxToolCall("big_result", {}), { stopReason: "toolUse" }),
+			(context) => {
+				resumedRequest = JSON.stringify(context.messages);
+				return fauxAssistantMessage("done after compaction");
+			},
+		]);
+
+		await harness.session.prompt("seed old history");
+		await harness.session.prompt("run the big tool");
+
+		expect(harness.eventsOfType("compaction_start")).toContainEqual({
+			type: "compaction_start",
+			reason: "threshold",
+		});
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(resumedRequest).toContain("large-result-marker");
+		expect(resumedRequest).not.toContain("old-history-marker");
+		expect(harness.session.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [{ type: "text", text: "done after compaction" }],
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- expose `Agent.shouldStopAfterTurn` through agent-core
- stop long tool loops at safe completed-tool boundaries
- compact threshold-crossing context and resume retained tool results
- account for trailing tool results in threshold estimates
- document behavior and add regression coverage

Fixes #6879.

## Verification FAILED

**What failed:** The new faux-provider regression still did not observe a threshold `compaction_start` after a large tool result.

**Why:** The test initially supplied synthetic usage, but the faux provider replaces it with actual prompt usage. After adapting the test to actual accounting and increasing the tool result, the expected compaction event still did not fire. The remaining cause is not verified.

**What I tried:** One bounded fix pass removed synthetic usage and increased the tool result from 800 to 2,000 characters, then reran the same targeted test.

**What you need to decide:** Continue debugging the hook/test interaction in a follow-up pass, or wait for another upstream implementation. This draft must not merge in its current state.

```text
FAIL  test/suite/regressions/6879-mid-turn-compaction.test.ts
AssertionError: expected [] to deep equally contain { type: 'compaction_start', …(1) }
Test Files  1 failed (1)
Tests       1 failed (1)
```

## Checks

- `git diff --check` — passed before commit
- targeted regression — **failed** as documented above
- `npm run check` — not run after blocking targeted failure
- `npm run build:offline` — not run after blocking targeted failure
- live Pi install/runtime verification — not performed

This pull request was prepared with AI assistance and is intentionally draft-only because verification is red.
