### PR TITLE
fix(coding-agent): preserve TTY in startup benchmark

### DIFF
--- a/scripts/profile-coding-agent-node.mjs
+++ b/scripts/profile-coding-agent-node.mjs
@@ -388,7 +388,7 @@ async function runTuiBenchmarkRun({ runtime, runIndex, measuredIndex, options, p
 	const child = spawn(command.executable, command.args, {
 		cwd: packageDir,
 		env: createBenchmarkEnv(options, isolatedAgentDir),
-		stdio: ["inherit", "ignore", "pipe"],
+		stdio: ["inherit", "inherit", "pipe"],
 		shell: process.platform === "win32" && runtime === "bun",
 	});
 


### PR DESCRIPTION
fixes: [#6975](https://github.com/earendil-works/pi/issues/6619)