### PR TITLE
fix(ai): make provider retries abortable

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed OpenAI and Anthropic provider retry waits to honor abort signals and configured delay limits ([#6911](https://github.com/earendil-works/pi/issues/6911)).
 - Fixed OpenRouter Anthropic cache breakpoints to advance through tool results and enabled cache control for `~anthropic/*-latest` aliases ([#6941](https://github.com/earendil-works/pi/pull/6941) by [@mteam88](https://github.com/mteam88)).
 
 ## [0.81.1] - 2026-07-21

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -34,6 +34,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
@@ -550,9 +551,16 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				maxRetries: 0,
 			};
-			const response = await client.messages.create({ ...params, stream: true }, requestOptions).asResponse();
+			const response = await retryProviderRequest(
+				() => client.messages.create({ ...params, stream: true }, requestOptions).asResponse(),
+				{
+					maxRetries: options?.maxRetries,
+					maxRetryDelayMs: options?.maxRetryDelayMs,
+					signal: options?.signal,
+				},
+			);
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 

--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -14,6 +14,7 @@ import { formatProviderError, normalizeProviderError } from "../utils/error-body
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -107,9 +108,16 @@ export const stream: StreamFunction<"azure-openai-responses", AzureOpenAIRespons
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				maxRetries: 0,
 			};
-			const { data: openaiStream, response } = await client.responses.create(params, requestOptions).withResponse();
+			const { data: openaiStream, response } = await retryProviderRequest(
+				() => client.responses.create(params, requestOptions).withResponse(),
+				{
+					maxRetries: options?.maxRetries,
+					maxRetryDelayMs: options?.maxRetryDelayMs,
+					signal: options?.signal,
+				},
+			);
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -158,9 +158,16 @@ function getRetryAfterDelayMs(headers: Headers): number | undefined {
 	return undefined;
 }
 
-function capRetryDelayMs(delayMs: number, options?: StreamOptions): number {
+class RetryDelayExceededError extends Error {}
+
+function validateRetryDelayMs(delayMs: number, options?: StreamOptions): number {
 	const maxRetryDelayMs = options?.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
-	return maxRetryDelayMs > 0 ? Math.min(delayMs, maxRetryDelayMs) : delayMs;
+	if (maxRetryDelayMs > 0 && delayMs > maxRetryDelayMs) {
+		throw new RetryDelayExceededError(
+			`Server requested ${Math.ceil(delayMs / 1000)}s retry delay (max: ${Math.ceil(maxRetryDelayMs / 1000)}s)`,
+		);
+	}
+	return delayMs;
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
@@ -404,9 +411,7 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 						const delayMs =
 							retryAfterDelayMs === undefined
 								? BASE_DELAY_MS * 2 ** attempt
-								: response.status === 429
-									? capRetryDelayMs(retryAfterDelayMs, options)
-									: retryAfterDelayMs;
+								: validateRetryDelayMs(retryAfterDelayMs, options);
 
 						await sleep(delayMs, options?.signal);
 						continue;
@@ -427,7 +432,11 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 					}
 					lastError = error instanceof Error ? error : new Error(String(error));
 					// Network errors are retryable
-					if (attempt < maxRetries && !lastError.message.includes("usage limit")) {
+					if (
+						attempt < maxRetries &&
+						!(lastError instanceof RetryDelayExceededError) &&
+						!lastError.message.includes("usage limit")
+					) {
 						const delayMs = BASE_DELAY_MS * 2 ** attempt;
 						await sleep(delayMs, options?.signal);
 						continue;

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -38,6 +38,7 @@ import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
@@ -219,11 +220,16 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				maxRetries: 0,
 			};
-			const { data: openaiStream, response } = await client.chat.completions
-				.create(params, requestOptions)
-				.withResponse();
+			const { data: openaiStream, response } = await retryProviderRequest(
+				() => client.chat.completions.create(params, requestOptions).withResponse(),
+				{
+					maxRetries: options?.maxRetries,
+					maxRetryDelayMs: options?.maxRetryDelayMs,
+					signal: options?.signal,
+				},
+			);
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -20,6 +20,7 @@ import { formatProviderError, normalizeProviderError } from "../utils/error-body
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.ts";
@@ -134,9 +135,16 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 			const requestOptions = {
 				...(options?.signal ? { signal: options.signal } : {}),
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-				maxRetries: options?.maxRetries ?? 0,
+				maxRetries: 0,
 			};
-			const { data: openaiStream, response } = await client.responses.create(params, requestOptions).withResponse();
+			const { data: openaiStream, response } = await retryProviderRequest(
+				() => client.responses.create(params, requestOptions).withResponse(),
+				{
+					maxRetries: options?.maxRetries,
+					maxRetryDelayMs: options?.maxRetryDelayMs,
+					signal: options?.signal,
+				},
+			);
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 

--- a/packages/ai/src/api/openrouter-images.ts
+++ b/packages/ai/src/api/openrouter-images.ts
@@ -18,6 +18,7 @@ import type {
 } from "../types.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { headersToRecord, providerHeadersToRecord } from "../utils/headers.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 
 interface OpenRouterGeneratedImage {
@@ -64,11 +65,19 @@ export const generateImages: ImagesFunction<"openrouter-images", ImagesOptions> 
 		const requestOptions = {
 			...(options?.signal ? { signal: options.signal } : {}),
 			...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-			maxRetries: options?.maxRetries ?? 0,
+			maxRetries: 0,
 		};
-		const { data: response, response: rawResponse } = await client.chat.completions
-			.create(params as unknown as ChatCompletionCreateParamsNonStreaming, requestOptions)
-			.withResponse();
+		const { data: response, response: rawResponse } = await retryProviderRequest(
+			() =>
+				client.chat.completions
+					.create(params as unknown as ChatCompletionCreateParamsNonStreaming, requestOptions)
+					.withResponse(),
+			{
+				maxRetries: options?.maxRetries,
+				maxRetryDelayMs: options?.maxRetryDelayMs,
+				signal: options?.signal,
+			},
+		);
 		await options?.onResponse?.({ status: rawResponse.status, headers: headersToRecord(rawResponse.headers) }, model);
 
 		const imageResponse = response as OpenRouterImageGenerationResponse;

--- a/packages/ai/src/utils/provider-retry.ts
+++ b/packages/ai/src/utils/provider-retry.ts
@@ -1,0 +1,125 @@
+const DEFAULT_MAX_RETRY_DELAY_MS = 60_000;
+
+interface ProviderRetryOptions {
+	maxRetries?: number;
+	maxRetryDelayMs?: number;
+	signal?: AbortSignal;
+}
+
+interface ProviderError extends Error {
+	status: number | undefined;
+	headers: Headers | undefined;
+}
+
+function isProviderError(error: unknown): error is ProviderError {
+	if (!(error instanceof Error) || !("status" in error) || !("headers" in error)) return false;
+	return (
+		(error.status === undefined || typeof error.status === "number") &&
+		(error.headers === undefined || error.headers instanceof Headers)
+	);
+}
+
+/** Mirrors the pinned OpenAI/Anthropic SDK retry policy; review when either SDK is upgraded. */
+function isRetryableProviderError(error: ProviderError): boolean {
+	const shouldRetry = error.headers?.get("x-should-retry");
+	if (shouldRetry === "true") return true;
+	if (shouldRetry === "false") return false;
+
+	if (error.status === undefined) return true;
+	return (
+		error.status === 408 ||
+		error.status === 409 ||
+		error.status === 429 ||
+		(typeof error.status === "number" && error.status >= 500)
+	);
+}
+
+function validateServerRetryDelayMs(
+	delayMs: number,
+	maxRetryDelayMs: number | undefined,
+	providerErrorMessage: string,
+): number {
+	const maxDelayMs = maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+	if (maxDelayMs > 0 && delayMs > maxDelayMs) {
+		throw new Error(
+			`Server requested ${Math.ceil(delayMs / 1000)}s retry delay (max: ${Math.ceil(maxDelayMs / 1000)}s). ${providerErrorMessage}`,
+		);
+	}
+	return delayMs;
+}
+
+function getRetryDelayMs(error: ProviderError, retryIndex: number, maxRetryDelayMs: number | undefined): number {
+	const retryAfterMs = error.headers?.get("retry-after-ms");
+	if (retryAfterMs) {
+		const value = Number.parseFloat(retryAfterMs);
+		if (!Number.isNaN(value)) return validateServerRetryDelayMs(value, maxRetryDelayMs, error.message);
+	}
+
+	const retryAfter = error.headers?.get("retry-after");
+	if (retryAfter) {
+		const seconds = Number.parseFloat(retryAfter);
+		const delayMs = Number.isNaN(seconds) ? Date.parse(retryAfter) - Date.now() : seconds * 1000;
+		return validateServerRetryDelayMs(delayMs, maxRetryDelayMs, error.message);
+	}
+
+	const exponentialDelay = Math.min(0.5 * 2 ** retryIndex, 8) * 1000;
+	return exponentialDelay * (1 - Math.random() * 0.25);
+}
+
+function createAbortError(): Error {
+	const error = new Error("Request aborted");
+	error.name = "AbortError";
+	return error;
+}
+
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(createAbortError());
+			return;
+		}
+
+		const onAbort = () => {
+			clearTimeout(timeout);
+			reject(createAbortError());
+		};
+		const timeout = setTimeout(
+			() => {
+				signal?.removeEventListener("abort", onAbort);
+				resolve();
+			},
+			Math.max(0, ms),
+		);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+/**
+ * Reproduce the retry behavior used by the OpenAI and Anthropic SDKs while making
+ * their backoff sleep interruptible. Their built-in retry timers ignore the
+ * request AbortSignal, so callers must invoke the SDK with `maxRetries: 0` and
+ * wrap the request with this helper. Provider-requested delays above
+ * `maxRetryDelayMs` fail immediately (60 seconds by default); set it to zero to
+ * disable the limit.
+ */
+export async function retryProviderRequest<T>(
+	request: () => Promise<T>,
+	options: ProviderRetryOptions = {},
+): Promise<T> {
+	const maxRetries = options.maxRetries ?? 0;
+	let retriesRemaining = maxRetries;
+
+	for (;;) {
+		try {
+			// Each retry is a fresh SDK request, so X-Stainless-Retry-Count remains zero.
+			return await request();
+		} catch (error) {
+			if (options.signal?.aborted) throw createAbortError();
+			if (retriesRemaining <= 0 || !isProviderError(error) || !isRetryableProviderError(error)) throw error;
+
+			const retryIndex = maxRetries - retriesRemaining;
+			retriesRemaining--;
+			await abortableSleep(getRetryDelayMs(error, retryIndex, options.maxRetryDelayMs), options.signal);
+		}
+	}
+}

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -2094,6 +2094,46 @@ describe("openai-codex streaming", () => {
 		expect(codexRequests).toBe(2);
 	});
 
+	it.each([429, 503])("fails immediately when a %i retry delay exceeds the limit", async (status) => {
+		const token = mockToken();
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ error: { code: "temporarily_unavailable", message: "retry later" } }), {
+					status,
+					headers: { "content-type": "application/json", "retry-after": "2" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+			maxRetries: 3,
+			maxRetryDelayMs: 1000,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Server requested 2s retry delay (max: 1s)");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("zstd-compresses SSE request bodies", async () => {
 		const token = mockToken();
 		const encoder = new TextEncoder();

--- a/packages/ai/test/openai-completions-retry.test.ts
+++ b/packages/ai/test/openai-completions-retry.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
 import type { Context, Model } from "../src/types.ts";
 
 const mockState = vi.hoisted(() => ({
 	requestOptions: [] as unknown[],
+	requestErrors: [] as Error[],
 }));
 
 vi.mock("openai", () => {
@@ -30,10 +31,14 @@ vi.mock("openai", () => {
 							response: { status: number; headers: Headers };
 						}>;
 					};
-					promise.withResponse = async () => ({
-						data: stream,
-						response: { status: 200, headers: new Headers() },
-					});
+					promise.withResponse = async () => {
+						const error = mockState.requestErrors.shift();
+						if (error) throw error;
+						return {
+							data: stream,
+							response: { status: 200, headers: new Headers() },
+						};
+					};
 					return promise;
 				},
 			},
@@ -61,7 +66,7 @@ const context: Context = {
 	tools: [],
 };
 
-async function consume(options?: { maxRetries?: number }) {
+async function consume(options?: { maxRetries?: number; maxRetryDelayMs?: number }) {
 	const stream = streamOpenAICompletions(model, context, { apiKey: "test", ...options });
 	for await (const _event of stream) {
 		void _event;
@@ -72,6 +77,11 @@ async function consume(options?: { maxRetries?: number }) {
 describe("openai-completions provider retries", () => {
 	beforeEach(() => {
 		mockState.requestOptions = [];
+		mockState.requestErrors = [];
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it("disables SDK retries by default", async () => {
@@ -79,8 +89,51 @@ describe("openai-completions provider retries", () => {
 		expect(mockState.requestOptions).toEqual([expect.objectContaining({ maxRetries: 0 })]);
 	});
 
-	it("honors explicit provider retry settings", async () => {
-		await consume({ maxRetries: 2 });
-		expect(mockState.requestOptions).toEqual([expect.objectContaining({ maxRetries: 2 })]);
+	it("honors provider retries while keeping SDK retries disabled", async () => {
+		vi.useFakeTimers();
+		mockState.requestErrors = [
+			Object.assign(new Error("rate limited"), {
+				status: 429,
+				headers: new Headers({ "retry-after-ms": "100" }),
+			}),
+			Object.assign(new Error("server error"), {
+				status: 500,
+				headers: new Headers({ "retry-after-ms": "100" }),
+			}),
+		];
+
+		const result = consume({ maxRetries: 2, maxRetryDelayMs: 100 });
+		await vi.advanceTimersByTimeAsync(0);
+		expect(mockState.requestOptions).toHaveLength(1);
+		await vi.advanceTimersByTimeAsync(99);
+		expect(mockState.requestOptions).toHaveLength(1);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(mockState.requestOptions).toHaveLength(2);
+		await vi.advanceTimersByTimeAsync(99);
+		expect(mockState.requestOptions).toHaveLength(2);
+		await vi.advanceTimersByTimeAsync(1);
+		await result;
+
+		expect(mockState.requestOptions).toEqual([
+			expect.objectContaining({ maxRetries: 0 }),
+			expect.objectContaining({ maxRetries: 0 }),
+			expect.objectContaining({ maxRetries: 0 }),
+		]);
+	});
+
+	it("fails immediately when a provider-requested retry delay exceeds the limit", async () => {
+		mockState.requestErrors = [
+			Object.assign(new Error("rate limited"), {
+				status: 429,
+				headers: new Headers({ "retry-after": "277403" }),
+			}),
+		];
+
+		const result = await consume({ maxRetries: 2, maxRetryDelayMs: 1000 });
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Server requested 277403s retry delay (max: 1s)");
+		expect(result.errorMessage).toContain("rate limited");
+		expect(mockState.requestOptions).toEqual([expect.objectContaining({ maxRetries: 0 })]);
 	});
 });

--- a/packages/ai/test/provider-retry.test.ts
+++ b/packages/ai/test/provider-retry.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { retryProviderRequest } from "../src/utils/provider-retry.ts";
+
+function providerError(status: number | undefined, headers?: Record<string, string>): Error {
+	return Object.assign(new Error(`Provider error: ${status}`), {
+		status,
+		headers: new Headers(headers),
+	});
+}
+
+describe("provider request retries", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("retries retryable provider errors", async () => {
+		vi.useFakeTimers();
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(429, { "retry-after-ms": "1000" }))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		await vi.advanceTimersByTimeAsync(999);
+		expect(request).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(1);
+
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not retry errors the provider marks as non-retryable", async () => {
+		const error = providerError(429, { "x-should-retry": "false" });
+		const request = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+
+		await expect(retryProviderRequest(request, { maxRetries: 2 })).rejects.toBe(error);
+		expect(request).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects a provider-requested retry delay above the limit", async () => {
+		const request = vi.fn<() => Promise<string>>().mockRejectedValue(providerError(429, { "retry-after": "277403" }));
+
+		await expect(retryProviderRequest(request, { maxRetries: 1, maxRetryDelayMs: 1000 })).rejects.toThrow(
+			"Server requested 277403s retry delay (max: 1s)",
+		);
+		expect(request).toHaveBeenCalledTimes(1);
+	});
+
+	it("allows disabling the provider-requested retry delay cap", async () => {
+		vi.useFakeTimers();
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(429, { "retry-after": "2" }))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1, maxRetryDelayMs: 0 });
+		await vi.advanceTimersByTimeAsync(1999);
+		expect(request).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(1);
+
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("aborts a provider-requested retry delay", async () => {
+		vi.useFakeTimers();
+		const controller = new AbortController();
+		const request = vi.fn<() => Promise<string>>().mockRejectedValue(providerError(429, { "retry-after": "277403" }));
+
+		const result = retryProviderRequest(request, { maxRetries: 2, maxRetryDelayMs: 0, signal: controller.signal });
+		await vi.advanceTimersByTimeAsync(0);
+		expect(request).toHaveBeenCalledTimes(1);
+		expect(vi.getTimerCount()).toBe(1);
+
+		controller.abort();
+
+		await expect(result).rejects.toMatchObject({ name: "AbortError" });
+		expect(request).toHaveBeenCalledTimes(1);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -142,7 +142,7 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 | `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
 
-When a provider requests a retry delay longer than `retry.provider.maxRetryDelayMs` (e.g., Google's "quota will reset after 5h"), the request fails immediately with an informative error instead of waiting silently. Set to `0` to disable the cap.
+When a provider requests a retry delay longer than `retry.provider.maxRetryDelayMs`, the request fails immediately with an informative error instead of waiting silently. Set it to `0` to disable the limit.
 
 Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explicitly needed. Setting it above `0` can make SDK/provider retries handle out-of-usage-limit errors before Pi sees them, which may block the agent until the provider quota resets in some circumstances.
 

--- a/packages/coding-agent/test/sdk-stream-options.test.ts
+++ b/packages/coding-agent/test/sdk-stream-options.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { createAgentSession } from "../src/core/sdk.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
-import { SettingsManager } from "../src/core/settings-manager.ts";
+import { type Settings, SettingsManager } from "../src/core/settings-manager.ts";
 
 import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 
@@ -76,7 +76,7 @@ describe("createAgentSession stream options", () => {
 
 	async function captureStreamOptions(
 		api: Api,
-		settings: { httpIdleTimeoutMs?: number; websocketConnectTimeoutMs?: number },
+		settings: Partial<Settings>,
 		requestOptions: SimpleStreamOptions = {},
 		extensionSource?: string,
 	): Promise<SimpleStreamOptions | undefined> {
@@ -159,6 +159,15 @@ describe("createAgentSession stream options", () => {
 		);
 
 		expect(options?.websocketConnectTimeoutMs).toBe(0);
+	});
+
+	it("forwards provider retry settings", async () => {
+		const options = await captureStreamOptions("openai-completions", {
+			retry: { provider: { maxRetries: 2, maxRetryDelayMs: 3000 } },
+		});
+
+		expect(options?.maxRetries).toBe(2);
+		expect(options?.maxRetryDelayMs).toBe(3000);
 	});
 
 	it("runs before_provider_headers on assembled headers without forwarding the transform", async () => {


### PR DESCRIPTION
Fixes #6911

It replaces Antrhopic and OpenAI SDK inner retries with common helper that preserves configured provider retry counts (the native also did), enforces maxRetrayDelayMS (didn't), and makes retry interruptible through abortsignal (didn't).

I've considered few alternatives s.a.:
- patching the providers: clearly brittle and bad idea
- simply race the provider call with abort signal: would work, but wouldn't easily allow honoring maxRetrayDelayMS and since I was fixing stuff, I also wanted to fix that.

On the note of `maxRetrayDelayMS`. This was presumably originally created for google models, but nowdays seemed to *only* be used by custom openai codex endpoints (custom retry handling), where it was enforced *in a wrong* (at least given docs) way as just a cap, not hard threshold. So fixed that. I didn't also bring codex to the common helper as it seemed as unnecessary change.

I'm aware the codebase doesn't really do cross-providers helpers s.a. this one and prefers duplicating stuff in each rather but this seemed such a simple thing it felt right, happy to adjust tho.

