### PR TITLE
feat(ai): honor compat.forceAdaptiveThinking in bedrock-converse-stream

### DIFF
--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -400,7 +400,7 @@ export const streamSimple: StreamFunction<"bedrock-converse-stream", SimpleStrea
 	}
 
 	if (isAnthropicClaudeModel(model)) {
-		if (supportsAdaptiveThinking(model.id, model.name)) {
+		if (usesAdaptiveThinking(model)) {
 			return stream(model, context, {
 				...base,
 				reasoning: options.reasoning,
@@ -585,6 +585,16 @@ function supportsAdaptiveThinking(modelId: string, modelName?: string): boolean 
 			s.includes("sonnet-5") ||
 			s.includes("fable-5"),
 	);
+}
+
+/**
+ * Whether requests for this model should use the adaptive thinking format.
+ * `compat.forceAdaptiveThinking` overrides the id/name-based detection, which
+ * cannot know about Claude models released after this package version or
+ * application inference profiles whose ARN and name both hide the model.
+ */
+function usesAdaptiveThinking(model: Model<"bedrock-converse-stream">): boolean {
+	return model.compat?.forceAdaptiveThinking ?? supportsAdaptiveThinking(model.id, model.name);
 }
 
 function supportsNativeXhighEffort(model: Model<"bedrock-converse-stream">): boolean {
@@ -1023,7 +1033,7 @@ function buildAdditionalModelRequestFields(
 		// GovCloud Bedrock currently rejects the Claude thinking.display field.
 		// Omit it there until the GovCloud Converse schema catches up.
 		const display = isGovCloudBedrockTarget(model, options) ? undefined : (options.thinkingDisplay ?? "summarized");
-		const result: Record<string, any> = supportsAdaptiveThinking(model.id, model.name)
+		const result: Record<string, any> = usesAdaptiveThinking(model)
 			? {
 					thinking: { type: "adaptive", ...(display !== undefined ? { display } : {}) },
 					output_config: { effort: mapThinkingLevelToEffort(model, options.reasoning) },
@@ -1051,7 +1061,7 @@ function buildAdditionalModelRequestFields(
 					};
 				})();
 
-		if (!supportsAdaptiveThinking(model.id, model.name) && (options.interleavedThinking ?? true)) {
+		if (!usesAdaptiveThinking(model) && (options.interleavedThinking ?? true)) {
 			result.anthropic_beta = ["interleaved-thinking-2025-05-14"];
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -602,6 +602,20 @@ export interface AnthropicMessagesCompat {
 	supportsToolReferences?: boolean;
 }
 
+/** Compatibility settings for the Bedrock Converse API. */
+export interface BedrockConverseCompat {
+	/**
+	 * Whether to force adaptive thinking (`thinking.type: "adaptive"` plus
+	 * `output_config.effort`) regardless of the model id. Overrides the
+	 * id/name-based detection, which cannot know about Claude models released
+	 * after this package version, or application inference profiles whose ARN
+	 * and name both hide the model. Set to `false` to force fixed-budget
+	 * thinking on a model the detection would enable.
+	 * Default: unset (id/name-based detection).
+	 */
+	forceAdaptiveThinking?: boolean;
+}
+
 /**
  * OpenRouter provider routing preferences.
  * Controls which upstream providers OpenRouter routes requests to.
@@ -731,7 +745,9 @@ export interface Model<TApi extends Api> {
 			? OpenAIResponsesCompat
 			: TApi extends "anthropic-messages"
 				? AnthropicMessagesCompat
-				: never;
+				: TApi extends "bedrock-converse-stream"
+					? BedrockConverseCompat
+					: never;
 }
 
 export interface ImagesModel<TApi extends ImagesApi>

--- a/packages/ai/test/bedrock-thinking-payload.test.ts
+++ b/packages/ai/test/bedrock-thinking-payload.test.ts
@@ -142,6 +142,41 @@ describe("Bedrock thinking payload", () => {
 	});
 });
 
+describe("compat.forceAdaptiveThinking", () => {
+	it("forces adaptive thinking on a model the id/name detection does not match", async () => {
+		const baseModel = getModel("amazon-bedrock", "us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+		const model: Model<"bedrock-converse-stream"> = {
+			...baseModel,
+			compat: { forceAdaptiveThinking: true },
+		};
+
+		const payload = await capturePayload(model);
+
+		expect(payload.additionalModelRequestFields?.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.additionalModelRequestFields?.output_config).toEqual({ effort: "high" });
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toBeUndefined();
+	});
+
+	it("opts out of adaptive thinking on a model the detection matches", async () => {
+		const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-opus-4-6-v1");
+		const model: Model<"bedrock-converse-stream"> = {
+			...baseModel,
+			id: "global.anthropic.claude-opus-4-8-v1",
+			name: "Claude Opus 4.8 (Global)",
+			compat: { forceAdaptiveThinking: false },
+		};
+
+		const payload = await capturePayload(model);
+
+		expect(payload.additionalModelRequestFields?.thinking).toEqual({
+			type: "enabled",
+			budget_tokens: 16384,
+			display: "summarized",
+		});
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toEqual(["interleaved-thinking-2025-05-14"]);
+	});
+});
+
 describe.skipIf(!hasBedrockCredentials())("Bedrock Claude max tokens E2E", () => {
 	it(
 		"uses the model maxTokens cap instead of Bedrock's 4096-token default for adaptive Claude models",


### PR DESCRIPTION
The Bedrock provider decides the thinking wire shape purely from an id/name match (`supportsAdaptiveThinking`). A Claude model that requires the adaptive format but is not in the list gets `thinking: {type: "enabled", budget_tokens}` and the request dies with a ValidationException. sonnet-5 hit exactly this until 0.81.1 added it to the list; we ate the breakage in production on 0.79.10 behind a Bedrock-compatible gateway. Application inference profiles whose ARN and name both hide the model have no recourse even on current HEAD.

This adds `BedrockConverseCompat` (previously `compat` was typed `never` for this api) and honors `compat.forceAdaptiveThinking` at the three decision sites, matching the escape hatch `anthropic-messages` already has. Unset preserves existing behavior byte-for-byte; `false` opts a detected model out.

- `npm run check` passes.
- `./test.sh`: packages/ai fully green (85 files, incl. 2 new payload tests). 3 pre-existing coding-agent failures on my machine come from the suite reading my real `~/.agents` dir; unrelated to this change.

Disclosure per CONTRIBUTING: implemented with AI assistance (Claude Code), reviewed and understood by me. I'm aware of the lgtm gate for new contributors — happy to take this through an issue first if that's preferred; opening the PR since the diff is small enough to be its own explanation.