### PR TITLE
fix(coding-agent): share host modules with native esm extensions

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -4,9 +4,8 @@
  */
 
 import * as fs from "node:fs";
-import { createRequire } from "node:module";
+import { createRequire, type RegisterHooksOptions } from "node:module";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import * as _bundledPiAgentCore from "@earendil-works/pi-agent-core";
 import type { Provider } from "@earendil-works/pi-ai";
 import * as _bundledPiAiCompat from "@earendil-works/pi-ai/compat";
@@ -21,7 +20,7 @@ import { createJiti } from "jiti/static";
 import * as _bundledTypebox from "typebox";
 import * as _bundledTypeboxCompile from "typebox/compile";
 import * as _bundledTypeboxValue from "typebox/value";
-import { CONFIG_DIR_NAME, getAgentDir, isBunBinary } from "../../config.ts";
+import { CONFIG_DIR_NAME, getAgentDir, isBunBinary, isBunRuntime } from "../../config.ts";
 // NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 // avoiding a circular dependency. Extensions can import from @earendil-works/pi-coding-agent.
 import * as _bundledPiCodingAgent from "../../index.ts";
@@ -44,7 +43,7 @@ import type {
 	ToolDefinition,
 } from "./types.ts";
 
-/** Modules available to extensions via virtualModules (for compiled Bun binary) */
+/** Host module objects supplied to Jiti and the Bun native-module bridge. */
 const VIRTUAL_MODULES: Record<string, unknown> = {
 	typebox: _bundledTypebox,
 	"typebox/compile": _bundledTypeboxCompile,
@@ -71,70 +70,84 @@ const VIRTUAL_MODULES: Record<string, unknown> = {
 	"@mariozechner/pi-coding-agent": _bundledPiCodingAgent,
 };
 
-const require = createRequire(import.meta.url);
+const hostCodingAgentUrl = new URL(
+	import.meta.url.endsWith(".ts") ? "../../index.ts" : "../../index.js",
+	import.meta.url,
+).href;
 
 /**
- * Get aliases for jiti (used in Node.js/development mode).
- * In Bun binary mode, virtualModules is used instead.
+ * Node resolve hooks cannot return module objects like Bun's builder.module().
+ * Map every extension-visible name to the canonical specifier loaded by the host instead.
  */
-let _aliases: Record<string, string> | null = null;
+const HOST_MODULE_SPECIFIERS: Record<string, string> = {
+	typebox: "typebox",
+	"typebox/compile": "typebox/compile",
+	"typebox/value": "typebox/value",
+	"@sinclair/typebox": "typebox",
+	"@sinclair/typebox/compile": "typebox/compile",
+	"@sinclair/typebox/value": "typebox/value",
+	"@earendil-works/pi-agent-core": "@earendil-works/pi-agent-core",
+	"@earendil-works/pi-tui": "@earendil-works/pi-tui",
+	"@earendil-works/pi-ai": "@earendil-works/pi-ai/compat",
+	"@earendil-works/pi-ai/compat": "@earendil-works/pi-ai/compat",
+	"@earendil-works/pi-ai/oauth": "@earendil-works/pi-ai/oauth",
+	"@earendil-works/pi-ai/providers/all": "@earendil-works/pi-ai/providers/all",
+	"@earendil-works/pi-coding-agent": hostCodingAgentUrl,
+	"@mariozechner/pi-agent-core": "@earendil-works/pi-agent-core",
+	"@mariozechner/pi-tui": "@earendil-works/pi-tui",
+	"@mariozechner/pi-ai": "@earendil-works/pi-ai/compat",
+	"@mariozechner/pi-ai/compat": "@earendil-works/pi-ai/compat",
+	"@mariozechner/pi-ai/oauth": "@earendil-works/pi-ai/oauth",
+	"@mariozechner/pi-ai/providers/all": "@earendil-works/pi-ai/providers/all",
+	"@mariozechner/pi-coding-agent": hostCodingAgentUrl,
+};
 
-function getAliases(): Record<string, string> {
-	if (_aliases) return _aliases;
+interface BunPluginBuilder {
+	module(specifier: string, callback: () => { exports: unknown; loader: "object" }): void;
+}
 
-	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	const packageIndex = path.resolve(__dirname, "../..", "index.js");
+interface BunRuntime {
+	plugin(options: { name: string; setup(builder: BunPluginBuilder): void }): void;
+}
 
-	const typeboxEntry = require.resolve("typebox");
-	const typeboxCompileEntry = require.resolve("typebox/compile");
-	const typeboxValueEntry = require.resolve("typebox/value");
+interface NodeModuleWithHooks {
+	registerHooks(options: RegisterHooksOptions): void;
+}
 
-	const packagesRoot = path.resolve(__dirname, "../../../../");
-	const resolveWorkspaceOrImport = (workspaceRelativePath: string, specifier: string): string => {
-		const workspacePath = path.join(packagesRoot, workspaceRelativePath);
-		if (fs.existsSync(workspacePath)) {
-			return workspacePath;
+const require = createRequire(import.meta.url);
+let nativeModuleHooksRegistered = false;
+
+function ensureNativeModuleHooks(): void {
+	if (nativeModuleHooksRegistered) return;
+
+	if (isBunRuntime) {
+		const bun = (globalThis as typeof globalThis & { Bun?: BunRuntime }).Bun;
+		if (!bun) {
+			throw new Error("Bun runtime does not expose Bun.plugin()");
 		}
-		return fileURLToPath(import.meta.resolve(specifier));
-	};
+		bun.plugin({
+			name: "pi-extension-host-modules",
+			setup(builder) {
+				for (const [specifier, exports] of Object.entries(VIRTUAL_MODULES)) {
+					builder.module(specifier, () => ({ exports, loader: "object" }));
+				}
+			},
+		});
+	} else {
+		// Bun does not export registerHooks from node:module, so resolve it only in the Node branch.
+		const { registerHooks } = require("node:module") as NodeModuleWithHooks;
+		registerHooks({
+			resolve(specifier, context, nextResolve) {
+				const hostSpecifier = HOST_MODULE_SPECIFIERS[specifier];
+				if (!hostSpecifier) {
+					return nextResolve(specifier, context);
+				}
+				return nextResolve(hostSpecifier, { ...context, parentURL: import.meta.url });
+			},
+		});
+	}
 
-	const piCodingAgentEntry = packageIndex;
-	const piAgentCoreEntry = resolveWorkspaceOrImport("agent/dist/index.js", "@earendil-works/pi-agent-core");
-	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "@earendil-works/pi-tui");
-	// Extensions resolve the pi-ai root to the compat entrypoint (a strict
-	// superset of the core entrypoint): existing extensions using the old
-	// global API keep working at runtime until compat is removed.
-	const piAiCompatEntry = resolveWorkspaceOrImport("ai/dist/compat.js", "@earendil-works/pi-ai/compat");
-	const piAiOauthEntry = resolveWorkspaceOrImport("ai/dist/oauth.js", "@earendil-works/pi-ai/oauth");
-	const piAiProvidersEntry = resolveWorkspaceOrImport(
-		"ai/dist/providers/all.js",
-		"@earendil-works/pi-ai/providers/all",
-	);
-
-	_aliases = {
-		"@earendil-works/pi-coding-agent": piCodingAgentEntry,
-		"@earendil-works/pi-agent-core": piAgentCoreEntry,
-		"@earendil-works/pi-tui": piTuiEntry,
-		"@earendil-works/pi-ai/providers/all": piAiProvidersEntry,
-		"@earendil-works/pi-ai/compat": piAiCompatEntry,
-		"@earendil-works/pi-ai/oauth": piAiOauthEntry,
-		"@earendil-works/pi-ai": piAiCompatEntry,
-		"@mariozechner/pi-coding-agent": piCodingAgentEntry,
-		"@mariozechner/pi-agent-core": piAgentCoreEntry,
-		"@mariozechner/pi-tui": piTuiEntry,
-		"@mariozechner/pi-ai/providers/all": piAiProvidersEntry,
-		"@mariozechner/pi-ai/compat": piAiCompatEntry,
-		"@mariozechner/pi-ai/oauth": piAiOauthEntry,
-		"@mariozechner/pi-ai": piAiCompatEntry,
-		typebox: typeboxEntry,
-		"typebox/compile": typeboxCompileEntry,
-		"typebox/value": typeboxValueEntry,
-		"@sinclair/typebox": typeboxEntry,
-		"@sinclair/typebox/compile": typeboxCompileEntry,
-		"@sinclair/typebox/value": typeboxValueEntry,
-	};
-
-	return _aliases;
+	nativeModuleHooksRegistered = true;
 }
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
@@ -408,12 +421,18 @@ async function loadExtensionModule(extensionPath: string, cacheToken?: Extension
 		}
 	}
 
+	// jiti.import() may delegate ESM to the native runtime, bypassing Jiti's virtualModules
+	// and alias resolution. Register native hooks first so those imports resolve from the
+	// host instead of an extension's node_modules and therefore share global module state.
+	ensureNativeModuleHooks();
+
 	const jiti = createJiti(import.meta.url, {
 		moduleCache: false,
-		// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
-		// Also disable tryNative so jiti handles ALL imports (not just the entry point)
-		// In Node.js/dev: use aliases to resolve to node_modules paths
-		...(isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() }),
+		// Jiti resolves imports in transpiled modules before the native runtime sees
+		// the original bare specifier. Native hooks only cover imports Jiti delegates.
+		virtualModules: VIRTUAL_MODULES,
+		// In Bun binary, disable native loading because bundled packages have no filesystem entries.
+		...(isBunBinary ? { tryNative: false } : {}),
 	});
 
 	const module = await jiti.import(extensionPath, { default: true });

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -6,6 +6,7 @@
 import * as fs from "node:fs";
 import { createRequire, type RegisterHooksOptions } from "node:module";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import * as _bundledPiAgentCore from "@earendil-works/pi-agent-core";
 import type { Provider } from "@earendil-works/pi-ai";
 import * as _bundledPiAiCompat from "@earendil-works/pi-ai/compat";
@@ -115,12 +116,62 @@ interface NodeModuleWithHooks {
 }
 
 const require = createRequire(import.meta.url);
+const nodeExtensionRootRefCounts = new Map<string, number>();
 let nativeModuleHooksRegistered = false;
+
+function registerNodeExtensionRoot(extensionPath: string): () => void {
+	if (isBunRuntime) return () => {};
+
+	// Treat the containing directory as the shared module boundary so extensions,
+	// sibling helpers, private dependencies, and colocated SDK code reuse Pi's modules.
+	const lexicalRoot = path.dirname(path.resolve(extensionPath));
+	const roots = new Set([lexicalRoot]);
+	try {
+		roots.add(fs.realpathSync(lexicalRoot));
+	} catch {
+		// The lexical root still scopes resolution when realpath is unavailable.
+	}
+	for (const root of roots) nodeExtensionRootRefCounts.set(root, (nodeExtensionRootRefCounts.get(root) ?? 0) + 1);
+
+	let registered = true;
+	return () => {
+		if (!registered) return;
+		registered = false;
+		for (const root of roots) {
+			const nextCount = (nodeExtensionRootRefCounts.get(root) ?? 0) - 1;
+			if (nextCount === 0) nodeExtensionRootRefCounts.delete(root);
+			else nodeExtensionRootRefCounts.set(root, nextCount);
+		}
+	};
+}
+
+function isNodeExtensionImporter(parentURL: string | undefined): boolean {
+	if (parentURL === undefined || !parentURL.startsWith("file:")) return false;
+
+	let importerPath: string;
+	try {
+		importerPath = fileURLToPath(parentURL);
+	} catch {
+		return false;
+	}
+	for (const root of nodeExtensionRootRefCounts.keys()) {
+		const relative = path.relative(root, importerPath);
+		if (
+			relative === "" ||
+			(!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`))
+		) {
+			return true;
+		}
+	}
+	return false;
+}
 
 function ensureNativeModuleHooks(): void {
 	if (nativeModuleHooksRegistered) return;
 
 	if (isBunRuntime) {
+		// Bun's builder.module() does not expose the importer, so its existing bridge remains process-wide.
+		// TODO: Use registerHooks() here too once https://github.com/oven-sh/bun/issues/27369 is resolved.
 		const bun = (globalThis as typeof globalThis & { Bun?: BunRuntime }).Bun;
 		if (!bun) {
 			throw new Error("Bun runtime does not expose Bun.plugin()");
@@ -138,8 +189,9 @@ function ensureNativeModuleHooks(): void {
 		const { registerHooks } = require("node:module") as NodeModuleWithHooks;
 		registerHooks({
 			resolve(specifier, context, nextResolve) {
+				// The hook is process-wide, but only imports originating under a loaded extension root are redirected.
 				const hostSpecifier = HOST_MODULE_SPECIFIERS[specifier];
-				if (!hostSpecifier) {
+				if (!hostSpecifier || !isNodeExtensionImporter(context.parentURL)) {
 					return nextResolve(specifier, context);
 				}
 				return nextResolve(hostSpecifier, { ...context, parentURL: import.meta.url });
@@ -478,11 +530,14 @@ async function loadExtension(
 	cacheToken?: ExtensionCacheToken,
 ): Promise<{ extension: Extension | null; error: string | null }> {
 	const resolvedPath = resolvePath(extensionPath, cwd, { normalizeUnicodeSpaces: true });
+	// Keep the root registered after success because extension handlers can use dynamic imports later.
+	const unregisterNodeExtensionRoot = registerNodeExtensionRoot(resolvedPath);
 
 	try {
 		const factory = await loadExtensionModule(resolvedPath, cacheToken);
 		time(`${extensionPath} module import`, "extensions");
 		if (!factory) {
+			unregisterNodeExtensionRoot();
 			return { extension: null, error: `Extension does not export a valid factory function: ${extensionPath}` };
 		}
 
@@ -493,6 +548,7 @@ async function loadExtension(
 
 		return { extension, error: null };
 	} catch (err) {
+		unregisterNodeExtensionRoot();
 		const message = err instanceof Error ? err.message : String(err);
 		return { extension: null, error: `Failed to load extension: ${message}` };
 	}

--- a/packages/coding-agent/test/extensions-shared-module-state.test.ts
+++ b/packages/coding-agent/test/extensions-shared-module-state.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+const fixtureSourceDir = path.join(__dirname, "fixtures", "extension-shared-module-state");
+const runnerPath = path.join(fixtureSourceDir, "runner.ts");
+const bunAvailable = spawnSync("bun", ["--version"], { stdio: "ignore" }).status === 0;
+
+interface KittyAndKeybindingState {
+	kittyActive: boolean;
+	keyText: string;
+	keybindingKeys: string[];
+}
+
+interface SharedModuleStateProbeResult {
+	runtime: "Node" | "Bun";
+	errors: Array<{ path: string; error: string }>;
+	extensionCount: number;
+	expectedKittyAndKeybindingState: KittyAndKeybindingState;
+	kittyAndKeybindingStatesByExtension: Record<"ts" | "mjs" | "cjs", KittyAndKeybindingState[]>;
+	kittySettersShareState: Record<"ts" | "mjs" | "cjs", boolean>;
+	keybindingsShared: Record<"ts" | "mjs" | "cjs", boolean>;
+	queuesShared: Record<"ts" | "mjs" | "cjs", boolean>;
+}
+
+describe("extension shared module state", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-extension-shared-module-state-"));
+		for (const extension of ["extension.ts", "extension.mjs", "extension.cjs"]) {
+			fs.copyFileSync(path.join(fixtureSourceDir, extension), path.join(tempDir, extension));
+		}
+
+		// Place private Pi package copies next to the extensions. The loader must intercept
+		// their imports and return host modules instead of resolving these copies.
+		const privateModulesDir = path.join(fixtureSourceDir, "private-modules");
+		const privateScopeDir = path.join(tempDir, "node_modules", "@earendil-works");
+		fs.mkdirSync(privateScopeDir, { recursive: true });
+		fs.cpSync(path.join(privateModulesDir, "pi-coding-agent"), path.join(privateScopeDir, "pi-coding-agent"), {
+			recursive: true,
+		});
+		fs.cpSync(path.join(privateModulesDir, "pi-tui"), path.join(privateScopeDir, "pi-tui"), {
+			recursive: true,
+		});
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	// Exercise the plain Node, tsx, and Bun resolver chains in isolated runtime processes.
+	function runSharedModuleStateProbe(command: string, args: string[]): SharedModuleStateProbeResult {
+		const result = spawnSync(command, args, { cwd: repoRoot, encoding: "utf8" });
+		if (result.status !== 0) {
+			throw new Error(result.error?.message || result.stderr || `Probe exited with status ${result.status}`);
+		}
+		return JSON.parse(result.stdout.trim()) as SharedModuleStateProbeResult;
+	}
+
+	function expectSharedHostModules(result: SharedModuleStateProbeResult, runtime: "Node" | "Bun"): void {
+		// Report every shared-state failure from a probe instead of hiding queue or keybinding
+		// failures behind the first Kitty state mismatch.
+		expect.soft(result.runtime).toBe(runtime);
+		expect.soft(result.errors).toEqual([]);
+		expect.soft(result.extensionCount).toBe(3);
+		for (const states of Object.values(result.kittyAndKeybindingStatesByExtension)) {
+			expect.soft(states.length).toBeGreaterThan(0);
+			for (const state of states) expect.soft(state).toEqual(result.expectedKittyAndKeybindingState);
+		}
+		expect.soft(result.kittySettersShareState).toEqual({ ts: true, mjs: true, cjs: true });
+		expect.soft(result.keybindingsShared).toEqual({ ts: true, mjs: true, cjs: true });
+		expect.soft(result.queuesShared).toEqual({ ts: true, mjs: true, cjs: true });
+	}
+
+	it("shares real host APIs with TS, ESM, and CommonJS extensions under plain Node", () => {
+		// process.execPath is the Node executable running Vitest. Node 22.19+ executes this
+		// erasable runner.ts directly, without tsx or another transform hook.
+		const result = runSharedModuleStateProbe(process.execPath, [runnerPath, tempDir]);
+		expectSharedHostModules(result, "Node");
+	}, 30_000);
+
+	it("shares real host APIs with TS, ESM, and CommonJS extensions under Node and tsx", () => {
+		const result = runSharedModuleStateProbe(process.execPath, ["--import", "tsx", runnerPath, tempDir]);
+		expectSharedHostModules(result, "Node");
+	}, 30_000);
+
+	it.skipIf(!bunAvailable)(
+		"shares real host APIs with TS, ESM, and CommonJS extensions under Bun",
+		() => {
+			const result = runSharedModuleStateProbe("bun", [runnerPath, tempDir]);
+			expectSharedHostModules(result, "Bun");
+		},
+		30_000,
+	);
+});

--- a/packages/coding-agent/test/extensions-shared-module-state.test.ts
+++ b/packages/coding-agent/test/extensions-shared-module-state.test.ts
@@ -26,28 +26,55 @@ interface SharedModuleStateProbeResult {
 	kittySettersShareState: Record<"ts" | "mjs" | "cjs", boolean>;
 	keybindingsShared: Record<"ts" | "mjs" | "cjs", boolean>;
 	queuesShared: Record<"ts" | "mjs" | "cjs", boolean>;
+	sdkHostModuleOrigins: {
+		beforeExtensionLoad: string;
+		afterFailedExtensionLoad: string;
+		afterExtensionLoad: string;
+	};
 }
 
 describe("extension shared module state", () => {
 	let tempDir: string;
+	let extensionDir: string;
+	let sdkHostDir: string;
 
 	beforeEach(() => {
+		// tempDir/
+		// ├── extensions/  successful extensions + private Pi package copies
+		// └── sdk-host/    host importer + failing extension + separate private Pi copies
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-extension-shared-module-state-"));
+		extensionDir = path.join(tempDir, "extensions");
+		sdkHostDir = path.join(tempDir, "sdk-host");
+		fs.mkdirSync(extensionDir, { recursive: true });
+		fs.mkdirSync(sdkHostDir, { recursive: true });
 		for (const extension of ["extension.ts", "extension.mjs", "extension.cjs"]) {
-			fs.copyFileSync(path.join(fixtureSourceDir, extension), path.join(tempDir, extension));
+			fs.copyFileSync(path.join(fixtureSourceDir, extension), path.join(extensionDir, extension));
 		}
+		fs.copyFileSync(path.join(fixtureSourceDir, "host-importer.mjs"), path.join(sdkHostDir, "host-importer.mjs"));
+		fs.copyFileSync(
+			path.join(fixtureSourceDir, "failing-extension.mjs"),
+			path.join(sdkHostDir, "failing-extension.mjs"),
+		);
 
-		// Place private Pi package copies next to the extensions. The loader must intercept
-		// their imports and return host modules instead of resolving these copies.
 		const privateModulesDir = path.join(fixtureSourceDir, "private-modules");
-		const privateScopeDir = path.join(tempDir, "node_modules", "@earendil-works");
-		fs.mkdirSync(privateScopeDir, { recursive: true });
-		fs.cpSync(path.join(privateModulesDir, "pi-coding-agent"), path.join(privateScopeDir, "pi-coding-agent"), {
-			recursive: true,
-		});
-		fs.cpSync(path.join(privateModulesDir, "pi-tui"), path.join(privateScopeDir, "pi-tui"), {
-			recursive: true,
-		});
+		for (const moduleOwnerDir of [extensionDir, sdkHostDir]) {
+			const privateScopeDir = path.join(moduleOwnerDir, "node_modules", "@earendil-works");
+			fs.mkdirSync(privateScopeDir, { recursive: true });
+			fs.cpSync(path.join(privateModulesDir, "pi-coding-agent"), path.join(privateScopeDir, "pi-coding-agent"), {
+				recursive: true,
+			});
+			fs.cpSync(path.join(privateModulesDir, "pi-tui"), path.join(privateScopeDir, "pi-tui"), {
+				recursive: true,
+			});
+
+			// The SDK host probe uses the legacy name so tsx workspace path aliases do not
+			// bypass this private copy before the extension hook is installed.
+			const privateLegacyScopeDir = path.join(moduleOwnerDir, "node_modules", "@mariozechner");
+			fs.mkdirSync(privateLegacyScopeDir, { recursive: true });
+			fs.cpSync(path.join(privateModulesDir, "pi-tui"), path.join(privateLegacyScopeDir, "pi-tui"), {
+				recursive: true,
+			});
+		}
 	});
 
 	afterEach(() => {
@@ -76,24 +103,45 @@ describe("extension shared module state", () => {
 		expect.soft(result.kittySettersShareState).toEqual({ ts: true, mjs: true, cjs: true });
 		expect.soft(result.keybindingsShared).toEqual({ ts: true, mjs: true, cjs: true });
 		expect.soft(result.queuesShared).toEqual({ ts: true, mjs: true, cjs: true });
+		if (runtime === "Node") {
+			expect.soft(result.sdkHostModuleOrigins).toEqual({
+				beforeExtensionLoad: "private-copy",
+				afterFailedExtensionLoad: "private-copy",
+				afterExtensionLoad: "private-copy",
+			});
+		}
 	}
 
 	it("shares real host APIs with TS, ESM, and CommonJS extensions under plain Node", () => {
 		// process.execPath is the Node executable running Vitest. Node 22.19+ executes this
 		// erasable runner.ts directly, without tsx or another transform hook.
-		const result = runSharedModuleStateProbe(process.execPath, [runnerPath, tempDir]);
+		const result = runSharedModuleStateProbe(process.execPath, [
+			runnerPath,
+			extensionDir,
+			path.join(sdkHostDir, "host-importer.mjs"),
+		]);
 		expectSharedHostModules(result, "Node");
 	}, 30_000);
 
 	it("shares real host APIs with TS, ESM, and CommonJS extensions under Node and tsx", () => {
-		const result = runSharedModuleStateProbe(process.execPath, ["--import", "tsx", runnerPath, tempDir]);
+		const result = runSharedModuleStateProbe(process.execPath, [
+			"--import",
+			"tsx",
+			runnerPath,
+			extensionDir,
+			path.join(sdkHostDir, "host-importer.mjs"),
+		]);
 		expectSharedHostModules(result, "Node");
 	}, 30_000);
 
 	it.skipIf(!bunAvailable)(
 		"shares real host APIs with TS, ESM, and CommonJS extensions under Bun",
 		() => {
-			const result = runSharedModuleStateProbe("bun", [runnerPath, tempDir]);
+			const result = runSharedModuleStateProbe("bun", [
+				runnerPath,
+				extensionDir,
+				path.join(sdkHostDir, "host-importer.mjs"),
+			]);
 			expectSharedHostModules(result, "Bun");
 		},
 		30_000,

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/extension.cjs
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/extension.cjs
@@ -1,0 +1,47 @@
+const ENTER_SECTION_KEY = Symbol.for("pi-extension-shared-module-state.enter-section");
+
+module.exports = async function (pi) {
+	const { keyText, withFileMutationQueue } = await import("@earendil-works/pi-coding-agent");
+	const { getKeybindings, isKittyProtocolActive, KeybindingsManager, setKeybindings, setKittyProtocolActive } =
+		await import("@earendil-works/pi-tui");
+	const keybindingDefinitions = { "app.tools.expand": { defaultKeys: "ctrl+o" } };
+
+	pi.registerCommand("module-state:get:cjs", {
+		description: "Read shared module state from a CommonJS extension",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(
+				JSON.stringify([
+					{
+						kittyActive: isKittyProtocolActive(),
+						keyText: keyText("app.tools.expand"),
+						keybindingKeys: getKeybindings().getKeys("app.tools.expand"),
+					},
+				]),
+				"info",
+			);
+		},
+	});
+
+	pi.registerCommand("kitty-protocol:set:cjs", {
+		description: "Update shared Kitty protocol state from a CommonJS extension",
+		handler: async (args) => {
+			setKittyProtocolActive(args === "true");
+		},
+	});
+
+	pi.registerCommand("module-keybindings:set:cjs", {
+		description: "Update shared keybindings from a CommonJS extension",
+		handler: async (args) => {
+			setKeybindings(new KeybindingsManager(keybindingDefinitions, { "app.tools.expand": args }));
+		},
+	});
+
+	pi.registerCommand("module-state:queue:cjs", {
+		description: "Enter the shared file mutation queue from a CommonJS extension",
+		handler: async (args) => {
+			const enterSection = globalThis[ENTER_SECTION_KEY];
+			if (typeof enterSection !== "function") throw new Error("Queue probe callback is not registered");
+			await withFileMutationQueue(args, enterSection);
+		},
+	});
+};

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/extension.mjs
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/extension.mjs
@@ -1,0 +1,66 @@
+import { keyText, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import {
+	getKeybindings,
+	isKittyProtocolActive,
+	KeybindingsManager,
+	setKeybindings,
+	setKittyProtocolActive,
+} from "@earendil-works/pi-tui";
+
+const KEYBINDING_DEFINITIONS = { "app.tools.expand": { defaultKeys: "ctrl+o" } };
+const topLevelCodingAgent = await import("@earendil-works/pi-coding-agent");
+const topLevelTui = await import("@earendil-works/pi-tui");
+const ENTER_SECTION_KEY = Symbol.for("pi-extension-shared-module-state.enter-section");
+
+export default function (pi) {
+	pi.registerCommand("module-state:get:mjs", {
+		description: "Read shared module state from an ESM extension",
+		handler: async (_args, ctx) => {
+			const dynamicCodingAgent = await import("@earendil-works/pi-coding-agent");
+			const dynamicTui = await import("@earendil-works/pi-tui");
+			ctx.ui.notify(
+				JSON.stringify([
+					{
+						kittyActive: isKittyProtocolActive(),
+						keyText: keyText("app.tools.expand"),
+						keybindingKeys: getKeybindings().getKeys("app.tools.expand"),
+					},
+					{
+						kittyActive: topLevelTui.isKittyProtocolActive(),
+						keyText: topLevelCodingAgent.keyText("app.tools.expand"),
+						keybindingKeys: topLevelTui.getKeybindings().getKeys("app.tools.expand"),
+					},
+					{
+						kittyActive: dynamicTui.isKittyProtocolActive(),
+						keyText: dynamicCodingAgent.keyText("app.tools.expand"),
+						keybindingKeys: dynamicTui.getKeybindings().getKeys("app.tools.expand"),
+					},
+				]),
+				"info",
+			);
+		},
+	});
+
+	pi.registerCommand("kitty-protocol:set:mjs", {
+		description: "Update shared Kitty protocol state from an ESM extension",
+		handler: async (args) => {
+			setKittyProtocolActive(args === "true");
+		},
+	});
+
+	pi.registerCommand("module-keybindings:set:mjs", {
+		description: "Update shared keybindings from an ESM extension",
+		handler: async (args) => {
+			setKeybindings(new KeybindingsManager(KEYBINDING_DEFINITIONS, { "app.tools.expand": args }));
+		},
+	});
+
+	pi.registerCommand("module-state:queue:mjs", {
+		description: "Enter the shared file mutation queue from an ESM extension",
+		handler: async (args) => {
+			const enterSection = globalThis[ENTER_SECTION_KEY];
+			if (typeof enterSection !== "function") throw new Error("Queue probe callback is not registered");
+			await withFileMutationQueue(args, enterSection);
+		},
+	});
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/extension.ts
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/extension.ts
@@ -1,0 +1,54 @@
+import { type ExtensionAPI, keyText, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import {
+	getKeybindings,
+	isKittyProtocolActive,
+	KeybindingsManager,
+	type KeyId,
+	setKeybindings,
+	setKittyProtocolActive,
+} from "@earendil-works/pi-tui";
+
+const KEYBINDING_DEFINITIONS = { "app.tools.expand": { defaultKeys: "ctrl+o" } } as const;
+const ENTER_SECTION_KEY = Symbol.for("pi-extension-shared-module-state.enter-section");
+
+export default function (pi: ExtensionAPI): void {
+	pi.registerCommand("module-state:get:ts", {
+		description: "Read shared module state from a TypeScript extension",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(
+				JSON.stringify([
+					{
+						kittyActive: isKittyProtocolActive(),
+						keyText: keyText("app.tools.expand"),
+						keybindingKeys: getKeybindings().getKeys("app.tools.expand"),
+					},
+				]),
+				"info",
+			);
+		},
+	});
+
+	pi.registerCommand("kitty-protocol:set:ts", {
+		description: "Update shared Kitty protocol state from a TypeScript extension",
+		handler: async (args) => {
+			setKittyProtocolActive(args === "true");
+		},
+	});
+
+	pi.registerCommand("module-keybindings:set:ts", {
+		description: "Update shared keybindings from a TypeScript extension",
+		handler: async (args) => {
+			setKeybindings(new KeybindingsManager(KEYBINDING_DEFINITIONS, { "app.tools.expand": args as KeyId }));
+		},
+	});
+
+	pi.registerCommand("module-state:queue:ts", {
+		description: "Enter the shared file mutation queue from a TypeScript extension",
+		handler: async (args) => {
+			const globals = globalThis as typeof globalThis & Record<symbol, unknown>;
+			const enterSection = globals[ENTER_SECTION_KEY];
+			if (typeof enterSection !== "function") throw new Error("Queue probe callback is not registered");
+			await withFileMutationQueue(args, enterSection as () => Promise<void>);
+		},
+	});
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/failing-extension.mjs
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/failing-extension.mjs
@@ -1,0 +1,3 @@
+export default function () {
+	throw new Error("intentional extension load failure");
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/host-importer.mjs
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/host-importer.mjs
@@ -1,0 +1,4 @@
+export async function readTuiModuleOrigin() {
+	const tui = await import("@mariozechner/pi-tui");
+	return tui.moduleOrigin ?? "pi-host";
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-coding-agent/index.js
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-coding-agent/index.js
@@ -1,0 +1,7 @@
+export function keyText(id) {
+	return `private:${id}`;
+}
+
+export async function withFileMutationQueue(_path, fn) {
+	return fn();
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-coding-agent/package.json
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-coding-agent/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "@earendil-works/pi-coding-agent",
+	"type": "module",
+	"exports": "./index.js"
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-tui/index.js
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-tui/index.js
@@ -1,0 +1,34 @@
+let active = false;
+
+export class KeybindingsManager {
+	constructor(_definitions, userBindings = { "app.tools.expand": "private" }) {
+		this.userBindings = userBindings;
+	}
+
+	getKeys(keybinding) {
+		const keys = this.userBindings[keybinding];
+		return keys === undefined ? [] : Array.isArray(keys) ? [...keys] : [keys];
+	}
+
+	setUserBindings(userBindings) {
+		this.userBindings = { ...userBindings };
+	}
+}
+
+let keybindings = new KeybindingsManager({});
+
+export function getKeybindings() {
+	return keybindings;
+}
+
+export function setKeybindings(nextKeybindings) {
+	keybindings = nextKeybindings;
+}
+
+export function isKittyProtocolActive() {
+	return active;
+}
+
+export function setKittyProtocolActive(value) {
+	active = value;
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-tui/index.js
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-tui/index.js
@@ -1,3 +1,5 @@
+export const moduleOrigin = "private-copy";
+
 let active = false;
 
 export class KeybindingsManager {

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-tui/package.json
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/private-modules/pi-tui/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "@earendil-works/pi-tui",
+	"type": "module",
+	"exports": "./index.js"
+}

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/runner.ts
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/runner.ts
@@ -1,6 +1,7 @@
 import { rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
 	getKeybindings,
 	isKittyProtocolActive,
@@ -13,12 +14,27 @@ import { keyText, withFileMutationQueue } from "../../../src/index.ts";
 
 const fixtureDir = process.argv[2];
 if (!fixtureDir) throw new Error("Fixture directory argument is required");
+const sdkHostImporterPath = process.argv[3];
+if (!sdkHostImporterPath) throw new Error("SDK host importer path argument is required");
 
+const sdkHostImporter = (await import(pathToFileURL(sdkHostImporterPath).href)) as {
+	readTuiModuleOrigin(): Promise<string>;
+};
+// The SDK host helper resolves its own private pi-tui copy before extension hooks are installed.
+// A failed extension is deliberately colocated with that helper: if its pending Node scope leaks,
+// the next helper import changes from the private copy to Pi's host module.
+const sdkHostModuleOriginBeforeExtensionLoad = await sdkHostImporter.readTuiModuleOrigin();
+await loadExtensions([path.join(path.dirname(sdkHostImporterPath), "failing-extension.mjs")], fixtureDir);
+const sdkHostModuleOriginAfterFailedExtensionLoad = await sdkHostImporter.readTuiModuleOrigin();
+
+// Successful extensions live in a sibling directory. Under Node, every SDK host observation must
+// remain equal to the original private-copy marker.
 const extensionTypes = ["ts", "mjs", "cjs"] as const;
 const result = await loadExtensions(
 	extensionTypes.map((extension) => path.join(fixtureDir, `extension.${extension}`)),
 	fixtureDir,
 );
+const sdkHostModuleOriginAfterExtensionLoad = await sdkHostImporter.readTuiModuleOrigin();
 const commands = new Map(
 	result.extensions.flatMap((extension) => [...extension.commands.values()]).map((command) => [command.name, command]),
 );
@@ -143,5 +159,10 @@ console.log(
 		kittySettersShareState,
 		keybindingsShared,
 		queuesShared,
+		sdkHostModuleOrigins: {
+			beforeExtensionLoad: sdkHostModuleOriginBeforeExtensionLoad,
+			afterFailedExtensionLoad: sdkHostModuleOriginAfterFailedExtensionLoad,
+			afterExtensionLoad: sdkHostModuleOriginAfterExtensionLoad,
+		},
 	}),
 );

--- a/packages/coding-agent/test/fixtures/extension-shared-module-state/runner.ts
+++ b/packages/coding-agent/test/fixtures/extension-shared-module-state/runner.ts
@@ -1,0 +1,147 @@
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+	getKeybindings,
+	isKittyProtocolActive,
+	KeybindingsManager,
+	setKeybindings,
+	setKittyProtocolActive,
+} from "@earendil-works/pi-tui";
+import { loadExtensions } from "../../../src/core/extensions/loader.ts";
+import { keyText, withFileMutationQueue } from "../../../src/index.ts";
+
+const fixtureDir = process.argv[2];
+if (!fixtureDir) throw new Error("Fixture directory argument is required");
+
+const extensionTypes = ["ts", "mjs", "cjs"] as const;
+const result = await loadExtensions(
+	extensionTypes.map((extension) => path.join(fixtureDir, `extension.${extension}`)),
+	fixtureDir,
+);
+const commands = new Map(
+	result.extensions.flatMap((extension) => [...extension.commands.values()]).map((command) => [command.name, command]),
+);
+
+const invokeCommand = async (name: string, args = ""): Promise<unknown> => {
+	const command = commands.get(name);
+	if (!command) throw new Error(`${name} command was not registered`);
+	let notification: string | undefined;
+	await command.handler(args, {
+		ui: {
+			notify(message: string) {
+				notification = message;
+			},
+		},
+	} as never);
+	return notification === undefined ? undefined : JSON.parse(notification);
+};
+
+// Establish host state before asking each extension to report what its imported modules observe.
+const keybindingDefinitions = { "app.tools.expand": { defaultKeys: "ctrl+o" } } as const;
+setKittyProtocolActive(true);
+setKeybindings(new KeybindingsManager(keybindingDefinitions, { "app.tools.expand": "ctrl+e" }));
+const expectedKittyAndKeybindingState = {
+	kittyActive: isKittyProtocolActive(),
+	keyText: keyText("app.tools.expand"),
+	keybindingKeys: getKeybindings().getKeys("app.tools.expand"),
+};
+const kittyAndKeybindingStatesByExtension = Object.fromEntries(
+	await Promise.all(
+		extensionTypes.map(async (extension) => [extension, await invokeCommand(`module-state:get:${extension}`)]),
+	),
+);
+
+const kittySettersShareState: Record<string, boolean> = {};
+for (const extension of extensionTypes) {
+	setKittyProtocolActive(false);
+	await invokeCommand(`kitty-protocol:set:${extension}`, "true");
+	kittySettersShareState[extension] = isKittyProtocolActive();
+}
+
+const keybindingsShared: Record<string, boolean> = {};
+for (const extension of extensionTypes) {
+	setKeybindings(new KeybindingsManager(keybindingDefinitions, { "app.tools.expand": "ctrl+e" }));
+	await invokeCommand(`module-keybindings:set:${extension}`, "ctrl+g");
+	keybindingsShared[extension] =
+		getKeybindings().getKeys("app.tools.expand").join(",") === "ctrl+g" && keyText("app.tools.expand") === "ctrl+g";
+}
+
+// Start each extension queue first and hold its callback open. The host queue then attempts
+// to enter the same file section: a private queue overlaps, while the shared queue must wait.
+const queuesShared: Record<string, boolean> = {};
+const globals = globalThis as typeof globalThis & Record<symbol, unknown>;
+const enterSectionKey = Symbol.for("pi-extension-shared-module-state.enter-section");
+for (const extension of extensionTypes) {
+	const queuePath = path.join(tmpdir(), `pi-extension-shared-module-state-${process.pid}-${extension}.tmp`);
+	await writeFile(queuePath, "fixture", "utf8");
+	let activeSections = 0;
+	let queuesOverlapped = false;
+	let firstSectionEntered = false;
+	let resolveFirstSectionEntered!: () => void;
+	const firstSectionEnteredPromise = new Promise<void>((resolve) => {
+		resolveFirstSectionEntered = resolve;
+	});
+	let resolveConcurrentSectionEntered!: () => void;
+	const concurrentSectionEnteredPromise = new Promise<void>((resolve) => {
+		resolveConcurrentSectionEntered = resolve;
+	});
+	globals[enterSectionKey] = async () => {
+		activeSections++;
+		if (activeSections > 1) {
+			queuesOverlapped = true;
+			resolveConcurrentSectionEntered();
+		}
+		if (!firstSectionEntered) {
+			firstSectionEntered = true;
+			resolveFirstSectionEntered();
+			let timeout: ReturnType<typeof setTimeout> | undefined;
+			try {
+				// Release immediately if a second queue overlaps; otherwise release after the
+				// timeout so a correctly serialized host queue can proceed without deadlocking.
+				await Promise.race([
+					concurrentSectionEnteredPromise,
+					new Promise<void>((resolve) => {
+						timeout = setTimeout(resolve, 250);
+					}),
+				]);
+			} finally {
+				if (timeout) clearTimeout(timeout);
+			}
+		}
+		activeSections--;
+	};
+	try {
+		const extensionQueue = invokeCommand(`module-state:queue:${extension}`, queuePath);
+		// Do not start the host operation until the extension owns the first section.
+		// This removes extension loading and queue registration timing from the overlap check.
+		await Promise.race([
+			firstSectionEnteredPromise,
+			extensionQueue.then(() => {
+				throw new Error(`${extension} extension queue completed without entering its callback`);
+			}),
+		]);
+		await Promise.all([
+			extensionQueue,
+			withFileMutationQueue(queuePath, globals[enterSectionKey] as () => Promise<void>),
+		]);
+		queuesShared[extension] = !queuesOverlapped;
+	} finally {
+		delete globals[enterSectionKey];
+		await rm(queuePath, { force: true });
+	}
+}
+setKittyProtocolActive(false);
+
+console.log(
+	JSON.stringify({
+		runtime: process.versions.bun ? "Bun" : "Node",
+		errors: result.errors,
+		extensionCount: result.extensions.length,
+		expectedKittyAndKeybindingState,
+		kittyAndKeybindingStatesByExtension,
+		kittySettersShareState,
+		keybindingsShared,
+		queuesShared,
+	}),
+);


### PR DESCRIPTION
Jiti uses native import for esm moduels, bypassing alias and virtualModules handling. As a result, extensions can resolve private copies of Pi packages, causing module state to diverge between the host and extensions.

This PR intercepts native imports so extensions reuse the host's pi modules.

Fixes #4748