### PR TITLE
feat(types): add hiddenThinkingLabel field to AssistantMessage

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -399,6 +399,8 @@ export interface AssistantMessage {
 	usage: Usage;
 	stopReason: StopReason;
 	errorMessage?: string;
+	/** Override the collapsed thinking label for this specific message. */
+	hiddenThinkingLabel?: string;
 	timestamp: number; // Unix timestamp in milliseconds
 }
 

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -127,8 +127,9 @@ export class AssistantMessageComponent extends Container {
 
 				if (this.hideThinkingBlock) {
 					// Show one static label for each run of thinking blocks when hidden.
+					const label = this.lastMessage?.hiddenThinkingLabel ?? this.hiddenThinkingLabel;
 					this.contentContainer.addChild(
-						new Text(theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel)), this.outputPad, 0),
+						new Text(theme.italic(theme.fg("thinkingText", label)), this.outputPad, 0),
 					);
 				} else {
 					// Render each run of thinking blocks as one Markdown section.


### PR DESCRIPTION
This enables per-message thinking labels (e.g. "Thought for 3s") so users can tell whether the model is still thinking or stuck, and see thinking duration at a glance.

The current setHiddenThinkingLabel API is global — all collapsed thinking blocks share a single label. Extensions cannot set per-message labels. Attempts using message_update, appendEntry, and other approaches all failed due to global state sharing or timing issues.

Changes:
1. AssistantMessage: add hiddenThinkingLabel?: string optional field
2. AssistantMessageComponent: read message.hiddenThinkingLabel first, fall back to global default via ??

Extensions can then set the label in message_end via:
  return { message: { ...event.message, hiddenThinkingLabel } }

Fully backward-compatible: unset field falls through to existing global default, no behavior change for current users.