### PR TITLE
***WIP it's a PoC *** fix(coding-agent): guard tree navigation during responses

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -165,6 +165,9 @@ export class AgentSessionRuntime {
 	}
 
 	private async teardownCurrent(reason: SessionShutdownEvent["reason"], targetSessionFile?: string): Promise<void> {
+		// Settle any active response first so the aborted turn (including tool
+		// results) is persisted to the outgoing session before it is replaced.
+		await this.session.abort();
 		await emitSessionShutdownEvent(this.session.extensionRunner, {
 			type: "session_shutdown",
 			reason,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2896,6 +2896,10 @@ export class AgentSession {
 		targetId: string,
 		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string } = {},
 	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
+		if (this.isStreaming) {
+			throw new Error("Wait for the current response to finish before navigating the session tree.");
+		}
+
 		const oldLeafId = this.sessionManager.getLeafId();
 
 		// No-op if already at target

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4655,15 +4655,8 @@ export class InteractiveMode {
 						}
 					}
 
+					// The user committed to navigating: stop the active response first.
 					if (this.session.isStreaming) {
-						const interruptChoice = await this.showExtensionSelector(
-							"Stop the current response to navigate the session tree?",
-							["Stop and navigate", "Cancel"],
-						);
-						if (interruptChoice !== "Stop and navigate") {
-							this.showTreeSelector(entryId);
-							return;
-						}
 						this.restoreQueuedMessagesToEditor();
 						await this.session.abort();
 					}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4612,7 +4612,7 @@ export class InteractiveMode {
 				this.ui.terminal.rows,
 				async (entryId) => {
 					// Selecting the current leaf is a no-op (already there)
-					if (entryId === realLeafId) {
+					if (entryId === this.sessionManager.getLeafId()) {
 						done();
 						this.showStatus("Already at this point");
 						return;
@@ -4653,6 +4653,19 @@ export class InteractiveMode {
 							// User made a complete choice
 							break;
 						}
+					}
+
+					if (this.session.isStreaming) {
+						const interruptChoice = await this.showExtensionSelector(
+							"Stop the current response to navigate the session tree?",
+							["Stop and navigate", "Cancel"],
+						);
+						if (interruptChoice !== "Stop and navigate") {
+							this.showTreeSelector(entryId);
+							return;
+						}
+						this.restoreQueuedMessagesToEditor();
+						await this.session.abort();
 					}
 
 					// Set up escape handler and status indicator if summarizing

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, parse } from "node:path";
-import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	type CreateAgentSessionRuntimeFactory,
@@ -12,6 +13,7 @@ import {
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 import type {
+	AgentToolResult,
 	ExtensionAPI,
 	ExtensionFactory,
 	SessionBeforeForkEvent,
@@ -159,6 +161,55 @@ describe("AgentSessionRuntime characterization", () => {
 			throw new Error("missing persisted assistant message");
 		}
 		expect(persistedAssistant.usage.cost.total).toBe(0.123);
+	});
+
+	it("settles the active response before session replacement", async () => {
+		let toolStarted!: () => void;
+		const toolStartedPromise = new Promise<void>((resolve) => {
+			toolStarted = resolve;
+		});
+		const { runtime, faux } = await createRuntimeForTest((pi: ExtensionAPI) => {
+			pi.registerTool({
+				name: "block",
+				label: "Block",
+				description: "Blocks until aborted",
+				parameters: Type.Object({}),
+				execute: (_toolCallId, _params, signal) =>
+					new Promise<AgentToolResult<unknown>>((resolve) => {
+						toolStarted();
+						signal?.addEventListener("abort", () =>
+							resolve({ content: [{ type: "text", text: "tool aborted" }], details: {} }),
+						);
+					}),
+			});
+		});
+
+		await runtime.session.prompt("hello");
+		const firstSessionFile = runtime.session.sessionFile!;
+		await runtime.newSession();
+		await runtime.session.bindExtensions({});
+
+		faux.setResponses([fauxAssistantMessage(fauxToolCall("block", {}), { stopReason: "toolUse" })]);
+		const outgoingSession = runtime.session;
+		const promptPromise = outgoingSession.prompt("start blocking tool");
+		await toolStartedPromise;
+
+		const switchResult = await runtime.switchSession(firstSessionFile);
+		await promptPromise;
+
+		expect(switchResult.cancelled).toBe(false);
+		expect(runtime.session.sessionFile).toBe(firstSessionFile);
+		// The outgoing session settled before replacement: the interrupted tool
+		// call has a persisted tool result instead of dangling forever.
+		const outgoingEntries = SessionManager.open(outgoingSession.sessionFile!)
+			.getEntries()
+			.filter((entry) => entry.type === "message");
+		expect(outgoingEntries.map((entry) => entry.message.role)).toEqual([
+			"user",
+			"assistant",
+			"toolResult",
+			"assistant",
+		]);
 	});
 
 	it("emits session_before_switch and session_start for new and resume flows", async () => {

--- a/packages/coding-agent/test/suite/regressions/tree-during-streaming.test.ts
+++ b/packages/coding-agent/test/suite/regressions/tree-during-streaming.test.ts
@@ -1,33 +1,21 @@
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
-import { userMsg } from "../../utilities.ts";
+import { assistantMsg, userMsg } from "../../utilities.ts";
 import { createHarness } from "../harness.ts";
 
-describe("tree navigation during streaming", () => {
+describe("tree navigation during an active response", () => {
 	it("rejects navigation without changing the active leaf", async () => {
 		const harness = await createHarness();
-		let releaseResponse = () => {};
-		const responseRelease = new Promise<void>((resolve) => {
-			releaseResponse = resolve;
-		});
 
 		try {
 			const targetId = harness.sessionManager.appendMessage(userMsg("first"));
-			harness.setResponses([() => responseRelease.then(() => fauxAssistantMessage("response"))]);
-
-			const promptPromise = harness.session.prompt("second");
-			await vi.waitFor(() => expect(harness.sessionManager.getLeafId()).not.toBe(targetId));
-			const activeLeafId = harness.sessionManager.getLeafId();
+			const activeLeafId = harness.sessionManager.appendMessage(assistantMsg("response"));
+			vi.spyOn(harness.session, "isStreaming", "get").mockReturnValue(true);
 
 			await expect(harness.session.navigateTree(targetId, { summarize: false })).rejects.toThrow(
 				"Wait for the current response to finish before navigating the session tree.",
 			);
 			expect(harness.sessionManager.getLeafId()).toBe(activeLeafId);
-
-			releaseResponse();
-			await promptPromise;
 		} finally {
-			releaseResponse();
 			harness.cleanup();
 		}
 	});

--- a/packages/coding-agent/test/suite/regressions/tree-during-streaming.test.ts
+++ b/packages/coding-agent/test/suite/regressions/tree-during-streaming.test.ts
@@ -1,0 +1,34 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { userMsg } from "../../utilities.ts";
+import { createHarness } from "../harness.ts";
+
+describe("tree navigation during streaming", () => {
+	it("rejects navigation without changing the active leaf", async () => {
+		const harness = await createHarness();
+		let releaseResponse = () => {};
+		const responseRelease = new Promise<void>((resolve) => {
+			releaseResponse = resolve;
+		});
+
+		try {
+			const targetId = harness.sessionManager.appendMessage(userMsg("first"));
+			harness.setResponses([() => responseRelease.then(() => fauxAssistantMessage("response"))]);
+
+			const promptPromise = harness.session.prompt("second");
+			await vi.waitFor(() => expect(harness.sessionManager.getLeafId()).not.toBe(targetId));
+			const activeLeafId = harness.sessionManager.getLeafId();
+
+			await expect(harness.session.navigateTree(targetId, { summarize: false })).rejects.toThrow(
+				"Wait for the current response to finish before navigating the session tree.",
+			);
+			expect(harness.sessionManager.getLeafId()).toBe(activeLeafId);
+
+			releaseResponse();
+			await promptPromise;
+		} finally {
+			releaseResponse();
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/tree-during-streaming.test.ts
+++ b/packages/coding-agent/test/suite/regressions/tree-during-streaming.test.ts
@@ -1,20 +1,33 @@
-import { describe, expect, it, vi } from "vitest";
-import { assistantMsg, userMsg } from "../../utilities.ts";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { userMsg } from "../../utilities.ts";
 import { createHarness } from "../harness.ts";
 
 describe("tree navigation during an active response", () => {
 	it("rejects navigation without changing the active leaf", async () => {
 		const harness = await createHarness();
+		const targetId = harness.sessionManager.appendMessage(userMsg("first"));
+		let navigationResult: unknown;
+		let leafUnchanged = false;
 
 		try {
-			const targetId = harness.sessionManager.appendMessage(userMsg("first"));
-			const activeLeafId = harness.sessionManager.appendMessage(assistantMsg("response"));
-			vi.spyOn(harness.session, "isStreaming", "get").mockReturnValue(true);
+			// Navigate from inside the response factory, while the run is active.
+			harness.setResponses([
+				async () => {
+					const activeLeafId = harness.sessionManager.getLeafId();
+					navigationResult = await harness.session
+						.navigateTree(targetId, { summarize: false })
+						.catch((error) => error);
+					leafUnchanged = activeLeafId !== targetId && harness.sessionManager.getLeafId() === activeLeafId;
+					return fauxAssistantMessage("response");
+				},
+			]);
+			await harness.session.prompt("second");
 
-			await expect(harness.session.navigateTree(targetId, { summarize: false })).rejects.toThrow(
-				"Wait for the current response to finish before navigating the session tree.",
+			expect(navigationResult).toEqual(
+				new Error("Wait for the current response to finish before navigating the session tree."),
 			);
-			expect(harness.sessionManager.getLeafId()).toBe(activeLeafId);
+			expect(leafUnchanged).toBe(true);
 		} finally {
 			harness.cleanup();
 		}


### PR DESCRIPTION
WIP WIP WIP
Will add an issue as the other ones were auto-closed but never deliberately rejected by a maintainer. 

Thinking of solutions to the bug where if you /tree while the agent is streaming and go somewhere else, weird stuff happens. 

We *could* just block /tree entirely during streaming, but that would mean not being able to read the /tree anymore which I personally find v helpful when I'm planning my next move.

So instead this:
- lets you /tree
- but when you select a checkpoint during active agent, opens a dialogue (do you want to interrupt the agent)
- still shows you the branch summarization dialogue
- If you click through that, it interrupts the session and proceeds with your chosen branch summarization option

See the video!

## BEFORE

https://github.com/user-attachments/assets/24663f77-cea4-4d12-a5d6-78d9dc168e0c

## AFTER

https://github.com/user-attachments/assets/dbce6fb6-adfb-4ff2-b8e6-ef7fc3485e0e


---
## Summary

- keep `/tree` available for read-only inspection while a response is active
- require explicit confirmation before aborting the response and committing tree navigation
- reject non-interactive tree navigation while a response is active
- cover rejection and leaf preservation with a regression test

## Testing

- `npm run check`
- `node node_modules/vitest/dist/cli.js --run test/suite/regressions/tree-during-streaming.test.ts` from `packages/coding-agent`
- manually exercised active tool abortion and navigation in tmux
- `./test.sh` attempted in the isolated worktree: 1,530 tests passed and 85 extension/CLI resolution tests failed because `packages/ai/dist` and `packages/tui/dist` were not built

Fixes #5096.
Related to #6558.
