### PR TITLE
fix(coding-agent): keep /resume unfiltered after a resume (nested self-reference)

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1544,8 +1544,28 @@ export class SessionManager {
 			}
 		}
 		const cwd = cwdOverride ?? (header ? getSessionHeaderCwd(header) : undefined) ?? process.cwd();
-		// If no sessionDir provided, derive from file's parent directory
-		const dir = sessionDir ? normalizePath(sessionDir) : resolve(resolvedPath, "..");
+		// When no sessionDir is provided, prefer the cwd's DEFAULT session directory when it
+		// already exists, falling back to the file's parent directory otherwise.
+		//
+		// This restores the `sessionDir === getDefaultSessionDirPath(cwd)` invariant that
+		// `list()`'s filterCwd heuristic and `usesDefaultSessionDir()` rely on. Without it,
+		// resuming (open()) a session whose stored cwd differs from the "native" cwd of the
+		// directory the file happens to live in — a project dir that aggregates sessions from
+		// multiple cwds (git worktrees, a shared --session-dir, a relocated/renamed project) —
+		// leaves sessionDir pointing at that aggregate dir while cwd is the resumed session's
+		// own cwd. The next /resume then arms the cwd filter (`dir !== getDefaultSessionDirPath(cwd)`)
+		// and collapses the picker to same-cwd sessions only — frequently a single self-reference.
+		// Defaulting to the cwd's own default dir (when present) keeps /resume showing the full
+		// project list after a resume, matching the fresh-launch picker. The existsSync guard
+		// preserves prior behavior for ad-hoc paths and projects whose default dir was never
+		// created, and avoids creating a stray directory as a side effect of opening a file.
+		let dir: string;
+		if (sessionDir) {
+			dir = normalizePath(sessionDir);
+		} else {
+			const defaultDir = getDefaultSessionDirPath(cwd);
+			dir = existsSync(defaultDir) ? defaultDir : resolve(resolvedPath, "..");
+		}
 		return new SessionManager(cwd, dir, resolvedPath, true, undefined, preloadedFileEntries);
 	}
 

--- a/packages/coding-agent/test/session-manager/resume-invariant.test.ts
+++ b/packages/coding-agent/test/session-manager/resume-invariant.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../../src/config.ts";
+import { getDefaultSessionDir, SessionManager } from "../../src/core/session-manager.ts";
+
+// Regression for: running /resume inside a session that was itself opened via /resume
+// collapses the picker to a single self-reference (same-cwd sessions only).
+//
+// Root cause: SessionManager.open(path) derived `sessionDir` from the file's *parent*
+// directory. After resuming a session whose stored `cwd` differs from the "native" cwd
+// of the directory the file lives in (a project dir aggregating sessions from multiple
+// cwds — git worktrees, a shared `--session-dir`, a relocated/renamed project), the
+// post-resume (cwd, sessionDir) pair violates `sessionDir === getDefaultSessionDirPath(cwd)`.
+// `list()`'s `filterCwd` heuristic (`dir !== getDefaultSessionDirPath(cwd)`) then arms and
+// filters the picker down to same-cwd sessions — frequently just the resumed session itself.
+//
+// Fix: when no sessionDir is passed, `open()` defaults `sessionDir` to the cwd's own
+// default session dir when that dir already exists, restoring the invariant. These tests
+// pin that behavior and its fallback.
+
+function createPersistedSessionInDir(dir: string, cwd: string): string {
+	// SessionManager only flushes to disk once an assistant message is appended
+	// (see _persist()), so mirror the real two-turn shape to materialize the file.
+	const session = SessionManager.create(cwd, dir);
+	session.appendMessage({ role: "user", content: `from ${cwd}`, timestamp: Date.now() });
+	session.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text: `reply from ${cwd}` }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	});
+	const sessionFile = session.getSessionFile();
+	if (!sessionFile) {
+		throw new Error("Expected persisted session file");
+	}
+	return sessionFile;
+}
+
+describe("SessionManager.open — sessionDir invariant after resume (regression)", () => {
+	let agentDir: string;
+	let aggregateDir: string;
+	let savedAgentDir: string | undefined;
+	let projectADefaultDir: string;
+	const projectA = join(tmpdir(), `pi-resume-projA-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const projectB = join(tmpdir(), `pi-resume-projB-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+	beforeEach(() => {
+		// Isolate the agent dir so getDefaultSessionDirPath() resolves under a temp tree,
+		// never the real ~/.pi/agent.
+		agentDir = mkdtempSync(join(tmpdir(), "pi-resume-agent-"));
+		aggregateDir = mkdtempSync(join(tmpdir(), "pi-resume-agg-"));
+		savedAgentDir = process.env[ENV_AGENT_DIR];
+		process.env[ENV_AGENT_DIR] = agentDir;
+		// The fix keys off the cwd's DEFAULT session dir *existing*. Pre-create projectA's
+		// (getDefaultSessionDir() mkdirs it) so the "exists" branch is taken.
+		projectADefaultDir = getDefaultSessionDir(projectA);
+	});
+
+	afterEach(() => {
+		if (savedAgentDir === undefined) {
+			delete process.env[ENV_AGENT_DIR];
+		} else {
+			process.env[ENV_AGENT_DIR] = savedAgentDir;
+		}
+		rmSync(agentDir, { recursive: true, force: true });
+		rmSync(aggregateDir, { recursive: true, force: true });
+	});
+
+	it("resolves sessionDir to the cwd's default dir (not the file's parent) when it exists", () => {
+		// An aggregate dir holds sessions from two different cwds — the git-worktree /
+		// shared --session-dir shape.
+		const fileA = createPersistedSessionInDir(aggregateDir, projectA);
+		createPersistedSessionInDir(aggregateDir, projectB);
+
+		// The aggregate dir is NOT projectA's default dir.
+		expect(aggregateDir).not.toBe(projectADefaultDir);
+
+		// Resuming sessionA: its file lives in the aggregate dir, its cwd is projectA, and
+		// projectA's default dir exists. The fix must resolve sessionDir to projectA's
+		// default dir, restoring usesDefaultSessionDir() (which gates BOTH the picker cwd
+		// filter and the "All" scope in showSessionSelector).
+		const mgr = SessionManager.open(fileA);
+		expect(mgr.usesDefaultSessionDir()).toBe(true);
+		expect(mgr.getSessionDir()).toBe(projectADefaultDir);
+	});
+
+	it("does not collapse the /resume picker to same-cwd sessions after a resume", async () => {
+		// projectA's default dir holds a prior projectA-cwd session (the rest of the
+		// project history a fresh-launch /resume would show).
+		const inDefault = createPersistedSessionInDir(projectADefaultDir, projectA);
+		// The aggregate dir holds a projectA-cwd session and an unrelated projectB session.
+		const fileA = createPersistedSessionInDir(aggregateDir, projectA);
+		createPersistedSessionInDir(aggregateDir, projectB);
+
+		// Simulate the in-session /resume picker AFTER resuming sessionA.
+		const mgr = SessionManager.open(fileA);
+		const listed = await SessionManager.list(mgr.getCwd(), mgr.getSessionDir());
+
+		// With the fix, mgr.getSessionDir() === projectA's default dir, so list() does NOT
+		// arm the cwd filter and returns the project's default-dir contents (incl. the
+		// prior session) — NOT a single self-reference to the just-resumed session.
+		expect(listed.map((s) => s.path)).toContain(inDefault);
+		expect(listed.map((s) => s.path)).not.toContain(fileA);
+	});
+
+	it("falls back to the file's parent dir when the cwd's default dir does not exist", () => {
+		// projectC's default dir is never created — the existsSync guard must fall back to
+		// the parent dir, preserving prior behavior (no stray dir creation, no change for
+		// ad-hoc paths / projects with no session history).
+		const projectC = join(tmpdir(), `pi-resume-projC-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		const fileC = createPersistedSessionInDir(aggregateDir, projectC);
+		const mgr = SessionManager.open(fileC);
+		expect(mgr.getSessionDir()).toBe(aggregateDir);
+		expect(mgr.usesDefaultSessionDir()).toBe(false);
+	});
+});


### PR DESCRIPTION
# fix(coding-agent): keep `/resume` unfiltered after a resume (nested self-reference)

## Summary

Running `/resume` inside a session that was itself opened via `/resume` collapses the picker to a single result — a self-reference to the just-resumed session. Repeated `/resume` should be idempotent (the same list every time); instead it silently narrows. This is the same class of bug as anthropics/claude-code #46522 ("/resume picker hides sessions with mixed cwd history") and the related worktree cwd-scoping issues (#45402, #57860, #46853, #60759).

## Problem

`SessionManager.list(cwd, sessionDir)` arms a cwd filter whenever the passed `sessionDir` is not the default dir for `cwd`:

```js
const filterCwd = sessionDir !== undefined && dir !== getDefaultSessionDirPath(cwd);
const sessions = (await listSessionsFromDir(dir, onProgress))
    .filter((session) => !filterCwd || sessionCwdMatches(session.cwd, resolvedCwd));
```

That filter is **intentional** for an explicit custom `--session-dir` that aggregates sessions from multiple projects (the existing test *"scopes current-folder APIs by cwd while listing all flat sessions"*) — but it **misfires after a `/resume`**.

`switchSession` opens the resumed file with `SessionManager.open(sessionPath, undefined)`, and `open()` derived `sessionDir` from the file's **parent** directory, while `cwd` became the resumed session's header cwd:

```js
// before
const dir = sessionDir ? normalizePath(sessionDir) : resolve(resolvedPath, "..");
```

So after resuming a session whose stored `cwd` differs from the "native" cwd of the directory the file happens to live in, the post-resume `(cwd, sessionDir)` pair violates `sessionDir === getDefaultSessionDirPath(cwd)`, arming the filter. The next `/resume` then keeps only same-cwd sessions — collapsing to **1** (the self-reference) when the resumed session's cwd is unique within that directory.

This happens whenever a single session directory legitimately aggregates sessions from multiple cwds:

- a project that uses **git worktrees** whose per-worktree session dirs are unified to one shared directory (e.g. via a symlink), so the shared dir holds sessions from many worktree cwds;
- a shared **`--session-dir`** used across projects;
- a project that was **relocated/renamed**, leaving older sessions with a stale cwd in the same directory.

The picker's "All" scope is also degraded: `showSessionSelector` branches `listAll()` vs `listAll(sessionDir)` on `usesDefaultSessionDir()`, which flips `false` after such a resume.

## Reproduction (against real session data)

A shared project session directory held 90 sessions across **28 distinct `cwd`s** (a main checkout + 27 one-off worktree cwds, 1 session each):

| Step | `list(...)` result |
|---|---|
| Fresh launch in a worktree `Wy` → `/resume` | **90** (`filterCwd` = false → full list) |
| Resume an offshoot worktree session `S2` (unique cwd), then `/resume` again | **1** ← the self-reference (`usesDefaultSessionDir()` = false, filter armed) |
| Resume a session whose cwd matches the dir's native cwd, then `/resume` | 90 (no narrowing — the cwd's default dir IS this dir) |

## Root cause

`SessionManager.open(path)` derives `sessionDir` from `parent(path)` rather than from the resumed session's own project, breaking the `sessionDir === getDefaultSessionDirPath(cwd)` invariant that `list()`'s `filterCwd` heuristic and `usesDefaultSessionDir()` both rely on.

## The fix

When no `sessionDir` is provided, `open()` now defaults it to the cwd's **own** default session directory when that directory already exists, falling back to the file's parent directory otherwise:

```js
let dir;
if (sessionDir) {
    dir = normalizePath(sessionDir);
} else {
    const defaultDir = getDefaultSessionDirPath(cwd);
    dir = existsSync(defaultDir) ? defaultDir : resolve(resolvedPath, "..");
}
```

This restores the invariant, so the post-resume `/resume` picker stays unfiltered (the full project list, matching the fresh-launch picker), and `usesDefaultSessionDir()` stays `true` so the "All" scope widens to every project again.

### Why the `existsSync` fallback

- **No stray directory creation as a side effect of merely opening a file.** `open()` must not `mkdir` a new default dir (e.g. for an ad-hoc path like `/tmp/foo.jsonl`, or a project whose default dir was never created).
- **Preserves prior behavior** for those ad-hoc / no-history cases (`sessionDir = parent(file)`, `usesDefaultSessionDir() = false` — identical to before).
- `/new` after a resume now creates the new session in the resumed project's own dir (correct) rather than in whatever directory the resumed file happened to be sitting in.

The `existsSync` check is what makes the fix safe and minimal: it only changes behavior for the case that was already broken (a default dir that exists and is the resumed session's natural home), and is a pure no-op for every case that already worked.

## Testing

- New regression tests: `test/session-manager/resume-invariant.test.ts`
  - resolves `sessionDir` to the cwd's default dir (not the file's parent) when it exists → `usesDefaultSessionDir()` is `true`;
  - the `/resume` picker does not collapse to same-cwd sessions after a resume (lists the project's prior sessions, not a single self-reference);
  - falls back to the file's parent dir when the cwd's default dir does not exist (no stray dir, prior behavior).
- All **94** session-manager unit tests pass, including the existing `filterCwd` contract test (*"scopes current-folder APIs by cwd while listing all flat sessions"*).
- End-to-end repro against the real session store above: after the fix, both the 1st and 2nd `/resume` return the full list (was 1 after a resume).

## Checklist

- [x] Root cause identified and explained (`open()` parent-derivation vs `list()` filterCwd invariant)
- [x] Fix is minimal and guarded (`existsSync` fallback; no behavior change for working cases)
- [x] Regression tests added
- [x] Existing `filterCwd` contract test still passes (custom `--session-dir` aggregation still scopes by cwd)
- [x] `biome check` clean on changed files
