### PR TITLE
fix(coding-agent): use llama context for output limit

### DIFF
--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -12,8 +12,6 @@ import { LlamaClient, type LlamaModelInfo, llamaInferenceUrl, normalizeLlamaServ
 
 export const LLAMA_PROVIDER_ID = "llama.cpp";
 export const DEFAULT_LLAMA_SERVER_URL = "http://127.0.0.1:8080";
-const DEFAULT_MAX_TOKENS = 16384;
-
 function credentialServerUrl(credential: ApiKeyCredential | undefined): string | undefined {
 	const value = credential?.env?.LLAMA_BASE_URL;
 	return typeof value === "string" && value.trim() ? normalizeLlamaServerUrl(value) : undefined;
@@ -40,7 +38,7 @@ function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-comp
 		input: model.architecture?.input_modalities?.includes("image") ? ["text", "image"] : ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
-		maxTokens: Math.min(DEFAULT_MAX_TOKENS, contextWindow),
+		maxTokens: contextWindow,
 		compat: {
 			supportsStore: false,
 			supportsDeveloperRole: false,

--- a/packages/coding-agent/test/llama-extension.test.ts
+++ b/packages/coding-agent/test/llama-extension.test.ts
@@ -67,7 +67,7 @@ describe("llama.cpp extension", () => {
 					id: "loaded",
 					status: { value: "loaded", args: ["llama-server", "--n-gpu-layers", "999"] },
 					architecture: { input_modalities: ["text", "image"] },
-					meta: { n_ctx: 16384, n_ctx_train: 131072 },
+					meta: { n_ctx: 65536, n_ctx_train: 131072 },
 				},
 				{ id: "unloaded", status: { value: "unloaded" } },
 				{ id: "loading", status: { value: "loading" } },
@@ -79,8 +79,8 @@ describe("llama.cpp extension", () => {
 			expect.objectContaining({
 				id: "loaded",
 				baseUrl: "http://localhost:8080/v1",
-				contextWindow: 16384,
-				maxTokens: 16384,
+				contextWindow: 65536,
+				maxTokens: 65536,
 				input: ["text", "image"],
 			}),
 		]);


### PR DESCRIPTION
## Summary

- derive llama.cpp output limits from each loaded model's context window
- remove the fixed 16,384-token cap
- cover context windows above 16,384 in the llama extension test

Fixes #6994.

## Validation

- `npm run check`
- `./test.sh`
