### PR TITLE
feat(coding-agent): add get_sessions RPC command

### DIFF
--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -528,6 +528,32 @@ Response:
 
 ### Session
 
+#### get_sessions
+
+Get saved sessions for the current working directory or configured session storage.
+
+```json
+{"type": "get_sessions", "scope": "cwd"}
+```
+
+Scopes:
+- `"cwd"`: List sessions for the current working directory
+- `"all"`: List all sessions in the configured session storage
+
+Both scopes respect `--session-dir`.
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "get_sessions",
+  "success": true,
+  "data": {"sessions": []}
+}
+```
+
+Session objects match `SessionInfo`; `created` and `modified` are ISO 8601 strings.
+
 #### get_session_stats
 
 Get token usage, cost statistics, and current context window usage.

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -12,7 +12,7 @@ import type { BashResult } from "../../core/bash-executor.ts";
 import type { CompactionResult } from "../../core/compaction/index.ts";
 import type { SessionEntry, SessionTreeNode } from "../../core/session-manager.ts";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.ts";
-import type { RpcCommand, RpcResponse, RpcSessionState, RpcSlashCommand } from "./rpc-types.ts";
+import type { RpcCommand, RpcResponse, RpcSessionInfo, RpcSessionState, RpcSlashCommand } from "./rpc-types.ts";
 
 // ============================================================================
 // Types
@@ -344,6 +344,14 @@ export class RpcClient {
 	 */
 	async abortBash(): Promise<void> {
 		await this.send({ type: "abort_bash" });
+	}
+
+	/**
+	 * Get sessions for the current working directory or configured session storage.
+	 */
+	async getSessions(scope: "cwd" | "all"): Promise<RpcSessionInfo[]> {
+		const response = await this.send({ type: "get_sessions", scope });
+		return this.getData<{ sessions: RpcSessionInfo[] }>(response).sessions;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -25,6 +25,7 @@ import {
 	waitForRawStdoutBackpressure,
 	writeRawStdout,
 } from "../../core/output-guard.ts";
+import { SessionManager } from "../../core/session-manager.ts";
 import { killTrackedDetachedChildren } from "../../utils/shell.ts";
 import { type Theme, theme } from "../interactive/theme/theme.ts";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.ts";
@@ -571,6 +572,20 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 			// =================================================================
 			// Session
 			// =================================================================
+
+			case "get_sessions": {
+				const sessionManager = session.sessionManager;
+				if (command.scope === "all") {
+					if (!sessionManager.usesDefaultSessionDir()) {
+						const sessions = await SessionManager.listAll(sessionManager.getSessionDir());
+						return success(id, "get_sessions", { sessions });
+					}
+					const sessions = await SessionManager.listAll();
+					return success(id, "get_sessions", { sessions });
+				}
+				const sessions = await SessionManager.list(sessionManager.getCwd(), sessionManager.getSessionDir());
+				return success(id, "get_sessions", { sessions });
+			}
 
 			case "get_session_stats": {
 				const stats = session.getSessionStats();

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -10,7 +10,7 @@ import type { ImageContent, Model } from "@earendil-works/pi-ai";
 import type { SessionStats } from "../../core/agent-session.ts";
 import type { BashResult } from "../../core/bash-executor.ts";
 import type { CompactionResult } from "../../core/compaction/index.ts";
-import type { SessionEntry, SessionTreeNode } from "../../core/session-manager.ts";
+import type { SessionEntry, SessionInfo, SessionTreeNode } from "../../core/session-manager.ts";
 import type { SourceInfo } from "../../core/source-info.ts";
 
 // ============================================================================
@@ -55,6 +55,7 @@ export type RpcCommand =
 	| { id?: string; type: "abort_bash" }
 
 	// Session
+	| { id?: string; type: "get_sessions"; scope: "cwd" | "all" }
 	| { id?: string; type: "get_session_stats" }
 	| { id?: string; type: "export_html"; outputPath?: string }
 	| { id?: string; type: "switch_session"; sessionPath: string }
@@ -106,6 +107,11 @@ export interface RpcSessionState {
 	messageCount: number;
 	pendingMessageCount: number;
 }
+
+export type RpcSessionInfo = Omit<SessionInfo, "created" | "modified"> & {
+	created: string;
+	modified: string;
+};
 
 // ============================================================================
 // RPC Responses (stdout)
@@ -180,6 +186,7 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "abort_bash"; success: true }
 
 	// Session
+	| { id?: string; type: "response"; command: "get_sessions"; success: true; data: { sessions: RpcSessionInfo[] } }
 	| { id?: string; type: "response"; command: "get_session_stats"; success: true; data: SessionStats }
 	| { id?: string; type: "response"; command: "export_html"; success: true; data: { path: string } }
 	| { id?: string; type: "response"; command: "switch_session"; success: true; data: { cancelled: boolean } }

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -172,6 +172,7 @@ async function createRuntimeHost(options: { withAuth: boolean; responseDelayMs: 
 
 async function startRpcMode(options: { withAuth: boolean; responseDelayMs: number; model?: Model<any> }): Promise<{
 	lineHandler: (line: string) => void;
+	sessionManager: SessionManager;
 	cleanup: () => Promise<void>;
 }> {
 	rpcIo.outputLines = [];
@@ -181,7 +182,7 @@ async function startRpcMode(options: { withAuth: boolean; responseDelayMs: numbe
 	void runRpcMode(runtimeHost);
 	await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
 
-	return { lineHandler: rpcIo.lineHandler!, cleanup };
+	return { lineHandler: rpcIo.lineHandler!, sessionManager: runtimeHost.session.sessionManager, cleanup };
 }
 
 describe("RPC prompt response semantics", () => {
@@ -282,6 +283,47 @@ describe("RPC prompt response semantics", () => {
 
 			await sleep(150);
 		} finally {
+			await cleanup();
+		}
+	});
+});
+
+describe("RPC get_sessions", () => {
+	afterEach(() => {
+		rpcIo.outputLines = [];
+		rpcIo.lineHandler = undefined;
+	});
+
+	it("uses the configured session storage for each scope", async () => {
+		const { lineHandler, sessionManager, cleanup } = await startRpcMode({ withAuth: false, responseDelayMs: 0 });
+		const cwd = "/current/project";
+		const sessionDir = "/custom/sessions";
+		const data = { sessions: [] };
+		vi.spyOn(sessionManager, "getCwd").mockReturnValue(cwd);
+		vi.spyOn(sessionManager, "getSessionDir").mockReturnValue(sessionDir);
+		vi.spyOn(sessionManager, "usesDefaultSessionDir").mockReturnValueOnce(false).mockReturnValueOnce(true);
+		const list = vi.spyOn(SessionManager, "list").mockResolvedValue([]);
+		const listAll = vi.spyOn(SessionManager, "listAll").mockResolvedValue([]);
+
+		try {
+			lineHandler(JSON.stringify({ id: "cwd", type: "get_sessions", scope: "cwd" }));
+			lineHandler(JSON.stringify({ id: "all-custom", type: "get_sessions", scope: "all" }));
+			lineHandler(JSON.stringify({ id: "all-default", type: "get_sessions", scope: "all" }));
+
+			await vi.waitFor(() => {
+				const responses = parseOutputLines(rpcIo.outputLines).filter(
+					(record) => record.type === "response" && record.command === "get_sessions",
+				);
+				expect(responses).toHaveLength(3);
+				for (const id of ["cwd", "all-custom", "all-default"]) {
+					expect(responses).toContainEqual({ id, type: "response", command: "get_sessions", success: true, data });
+				}
+			});
+			expect(list).toHaveBeenCalledOnce();
+			expect(list).toHaveBeenCalledWith(cwd, sessionDir);
+			expect(listAll.mock.calls).toEqual([[sessionDir], []]);
+		} finally {
+			vi.restoreAllMocks();
 			await cleanup();
 		}
 	});


### PR DESCRIPTION
This adds a read-only `get_sessions` RPC command exposing existing `SessionManager` reads:
    - `cwd`: sessions for the current working directory.
    - `all`: all sessions in configured storage, including custom session directories.

This lets RPC clients discover sessions before `switch_session` without reproducing Pi's session storage layout. Search, grouping, picker, rename, and delete behaviour remain outside RPC.