### PR TITLE
Normalize OpenAI tool schema required arrays

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -52,6 +52,7 @@ import {
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.ts";
 import { buildBaseOptions } from "./simple-options.ts";
+import { normalizeOpenAIToolParameters } from "./tool-schema.ts";
 import { transformMessages } from "./transform-messages.ts";
 
 /**
@@ -1304,7 +1305,7 @@ function convertTools(
 			function: {
 				name: tool.name,
 				description: tool.description,
-				parameters: tool.parameters as Record<string, unknown>, // TypeBox already generates JSON Schema
+				parameters: normalizeOpenAIToolParameters(tool.parameters),
 				// Only include strict if provider supports it. Some reject unknown fields.
 				...(compat.supportsStrictMode !== false && { strict: strict ?? false }),
 			},

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -39,6 +39,7 @@ import {
 	resolveGrammarConstrainedSampling,
 	resolveJsonSchemaStrictSampling,
 } from "./constrained-sampling.ts";
+import { normalizeOpenAIToolParameters } from "./tool-schema.ts";
 import { transformMessages } from "./transform-messages.ts";
 
 // =============================================================================
@@ -369,7 +370,7 @@ export function convertResponsesTools(tools: readonly Tool[], options?: ConvertR
 			type: "function",
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters as Record<string, unknown>, // TypeBox already generates JSON Schema
+			parameters: normalizeOpenAIToolParameters(tool.parameters),
 			...(options?.deferLoading ? { defer_loading: true } : {}),
 		};
 		if (supportsStrictMode) {

--- a/packages/ai/src/api/tool-schema.ts
+++ b/packages/ai/src/api/tool-schema.ts
@@ -1,0 +1,57 @@
+import type { TSchema } from "typebox";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function visitJsonSchema(schema: unknown): void {
+	if (!isRecord(schema)) return;
+
+	const properties = schema.properties;
+	if (schema.type === "object" || isRecord(properties)) {
+		if (!Array.isArray(schema.required)) {
+			schema.required = [];
+		}
+	}
+
+	if (isRecord(properties)) {
+		for (const value of Object.values(properties)) {
+			visitJsonSchema(value);
+		}
+	}
+
+	for (const key of ["items", "additionalProperties", "contains", "not", "if", "then", "else"] as const) {
+		visitJsonSchema(schema[key]);
+	}
+
+	for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+		const variants = schema[key];
+		if (!Array.isArray(variants)) continue;
+		for (const variant of variants) {
+			visitJsonSchema(variant);
+		}
+	}
+
+	for (const key of ["$defs", "definitions"] as const) {
+		const definitions = schema[key];
+		if (!isRecord(definitions)) continue;
+		for (const value of Object.values(definitions)) {
+			visitJsonSchema(value);
+		}
+	}
+}
+
+/**
+ * Normalize JSON Schema object `required` fields for OpenAI-compatible tool schemas.
+ *
+ * TypeBox omits `required` when every property is optional. Some OpenAI-compatible
+ * gateways serialize or validate that missing field as `null`, while the OpenAI
+ * function schema shape expects `required` to be an array. Missing and empty
+ * `required` are equivalent in JSON Schema, so emit an explicit empty array for
+ * object schemas without required properties.
+ */
+export function normalizeOpenAIToolParameters(parameters: TSchema): Record<string, unknown> {
+	const normalized = structuredClone(parameters) as Record<string, unknown>;
+	visitJsonSchema(normalized);
+	return normalized;
+}

--- a/packages/ai/test/openai-tool-schema.test.ts
+++ b/packages/ai/test/openai-tool-schema.test.ts
@@ -1,0 +1,86 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { normalizeOpenAIToolParameters } from "../src/api/tool-schema.ts";
+
+describe("normalizeOpenAIToolParameters", () => {
+	it("adds empty required arrays for all-optional object schemas", () => {
+		const schema = Type.Object({
+			action: Type.Optional(Type.Union([Type.Literal("read"), Type.Literal("write")])),
+			content: Type.Optional(Type.String()),
+		});
+
+		const normalized = normalizeOpenAIToolParameters(schema);
+
+		expect(normalized.required).toEqual([]);
+		expect(schema).not.toHaveProperty("required");
+	});
+
+	it("preserves existing required arrays", () => {
+		const schema = Type.Object({
+			path: Type.String(),
+			limit: Type.Optional(Type.Number()),
+		});
+
+		const normalized = normalizeOpenAIToolParameters(schema);
+
+		expect(normalized.required).toEqual(["path"]);
+	});
+
+	it("normalizes nested object schemas in properties, unions, arrays, and definitions", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				child: {
+					type: "object",
+					properties: {
+						name: { type: "string" },
+					},
+				},
+				union: {
+					anyOf: [
+						{
+							type: "object",
+							properties: {
+								value: { type: "string" },
+							},
+							required: null,
+						},
+					],
+				},
+				list: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: {
+							id: { type: "string" },
+						},
+					},
+				},
+			},
+			$defs: {
+				Metadata: {
+					type: "object",
+					properties: {
+						label: { type: "string" },
+					},
+				},
+			},
+		} as unknown as Parameters<typeof normalizeOpenAIToolParameters>[0];
+
+		const normalized = normalizeOpenAIToolParameters(schema) as {
+			required?: unknown;
+			properties: {
+				child: { required?: unknown };
+				union: { anyOf: Array<{ required?: unknown }> };
+				list: { items: { required?: unknown } };
+			};
+			$defs: { Metadata: { required?: unknown } };
+		};
+
+		expect(normalized.required).toEqual([]);
+		expect(normalized.properties.child.required).toEqual([]);
+		expect(normalized.properties.union.anyOf[0].required).toEqual([]);
+		expect(normalized.properties.list.items.required).toEqual([]);
+		expect(normalized.$defs.Metadata.required).toEqual([]);
+	});
+});


### PR DESCRIPTION
This fixes DeepSeek/strict OpenAI-compatible providers rejecting tools whose JSON Schema serialized `required` as null.

What changed:
- Added a small helper to normalize OpenAI tool parameters before sending them.
- Explicitly emits `required: []` for object schemas that have no required properties.
- Applied the same normalization in both chat completions and responses tool conversion paths.
- Added unit coverage for all-optional, nested, union, array, and definitions cases.

Verification:
- `npm --prefix packages/ai test -- openai-tool-schema.test.ts` ✅
- Broader targeted suite hit unrelated repo-wide typecheck issues in this checkout's test environment, but the new unit test passes.