### PR TITLE
fix(ai,agent,coding-agent): prevent retry on tool validation errors

### DIFF
--- a/packages/agent/src/harness/tools/edit.ts
+++ b/packages/agent/src/harness/tools/edit.ts
@@ -51,7 +51,17 @@ function prepareEditArguments(input: unknown): EditToolInput {
 	if (typeof args.edits === "string") {
 		try {
 			const parsed: unknown = JSON.parse(args.edits);
-			if (Array.isArray(parsed)) args.edits = parsed;
+			if (Array.isArray(parsed)) {
+				// Validate each element has required oldText and newText as strings
+				const valid = parsed.every(
+					(item) =>
+						item &&
+						typeof item === "object" &&
+						typeof (item as Record<string, unknown>).oldText === "string" &&
+						typeof (item as Record<string, unknown>).newText === "string",
+				);
+				if (valid) args.edits = parsed;
+			}
 		} catch {}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2638,6 +2638,11 @@ export class AgentSession {
 	private _isRetryableError(message: AssistantMessage): boolean {
 		// Context overflow is handled by compaction, not retry.
 		if (isContextOverflow(message, this.model?.contextWindow ?? 0)) return false;
+
+		// Don't retry tool validation errors - they indicate the LLM sent malformed tool arguments
+		// which won't be fixed by retrying the same provider call.
+		if (message.errorMessage?.includes("Validation failed for tool")) return false;
+
 		return isRetryableAssistantError(message);
 	}
 

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -102,7 +102,17 @@ function prepareEditArguments(input: unknown): EditToolInput {
 	if (typeof args.edits === "string") {
 		try {
 			const parsed = JSON.parse(args.edits);
-			if (Array.isArray(parsed)) args.edits = parsed;
+			if (Array.isArray(parsed)) {
+				// Validate each element has required oldText and newText as strings
+				const valid = parsed.every(
+					(item) =>
+						item &&
+						typeof item === "object" &&
+						typeof (item as Record<string, unknown>).oldText === "string" &&
+						typeof (item as Record<string, unknown>).newText === "string",
+				);
+				if (valid) args.edits = parsed;
+			}
 		} catch {}
 	}
 


### PR DESCRIPTION

## Problem
When LLM sends malformed tool arguments (e.g., `edits` as JSON string with duplicate/invalid keys), validation fails with 'edits.0: must be object'. The error message contains '429' from JSON payload, which incorrectly triggers agent-level retry. On retry, LLM produces completely different response (using `write` instead of `edit`), destroying user's code.

## Root Cause
1. `RETRYABLE_PROVIDER_ERROR_PATTERN` regex '429' matches inside JSON-stringified tool args in validation errors
2. Tool validation errors not filtered from retry logic

## Fix
1. **packages/ai/src/utils/retry.ts**: Change '429' to precise patterns (`\b429\b`, `status.*429`, `http.*429`)
2. **packages/agent/src/harness/tools/edit.ts** & **packages/coding-agent/src/core/tools/edit.ts**: Validate parsed JSON edits have required `oldText`/`newText` strings
3. **packages/coding-agent/src/core/agent-session.ts**: Guard `_isRetryableError` to exclude 'Validation failed for tool' errors
