### PR TITLE
Add setRenderedSession extension API for rendering an external AgentSession

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -246,6 +246,7 @@ const noOpUIContext: ExtensionUIContext = {
 	setHeader: () => {},
 	setTitle: () => {},
 	custom: async () => undefined as never,
+	setRenderedSession: async () => {},
 	pasteToEditor: () => {},
 	setEditorText: () => {},
 	getEditorText: () => "",

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -46,6 +46,7 @@ import type {
 } from "@earendil-works/pi-tui";
 import type { Static, TSchema } from "typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
+import type { AgentSession } from "../agent-session.ts";
 import type { BashResult } from "../bash-executor.ts";
 import type { CompactionPreparation, CompactionResult } from "../compaction/index.ts";
 import type { EventBus } from "../event-bus.ts";
@@ -207,6 +208,25 @@ export interface ExtensionUIContext {
 			onHandle?: (handle: OverlayHandle) => void;
 		},
 	): Promise<T>;
+
+	/**
+	 * Point the interactive renderer (chat transcript, footer, editor submit
+	 * routing, terminal title) at an external {@link AgentSession} — for example
+	 * an in-process subagent session — reusing the entire main render pipeline
+	 * instead of a simulated overlay. Pass `undefined` to return to the session
+	 * pi is actually running. Setting a new session while one is already rendered
+	 * switches directly.
+	 *
+	 * Unlike {@link ExtensionCommandContext.switchSession} (which loads a session
+	 * from a path and disposes the current one), this neither creates nor
+	 * destroys sessions — the running session keeps executing in the background,
+	 * and the passed session must already be a fully initialized `AgentSession`
+	 * (its extensions are NOT re-bound). A real session switch (`/new`,
+	 * `/resume`, `/fork`, `/reload`) resets this override automatically.
+	 *
+	 * TUI mode only; a no-op in non-interactive modes.
+	 */
+	setRenderedSession(session: AgentSession | undefined): Promise<void>;
 
 	/** Paste text into the editor, triggering paste handling (collapse for large content). */
 	pasteToEditor(text: string): void;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -427,8 +427,12 @@ export class InteractiveMode {
 	private themeController: InteractiveThemeController;
 
 	// Convenience accessors
+	// `session` is overridable by setRenderedSession(): the renderer follows the
+	// override while `mainSession` always reads the runtime's own (lifecycle code
+	// that must never see it).
+	private presentedSession: AgentSession | undefined = undefined;
 	private get session(): AgentSession {
-		return this.runtimeHost.session;
+		return this.presentedSession ?? this.runtimeHost.session;
 	}
 	private get agent() {
 		return this.session.agent;
@@ -445,6 +449,10 @@ export class InteractiveMode {
 		this.options = options;
 		this.autoTrustOnReloadCwd = options.autoTrustOnReloadCwd;
 		this.runtimeHost.setBeforeSessionInvalidate(() => {
+			// A real main-session replacement is starting (new/resume/fork/reload).
+			// Drop any active presentation first so rebindCurrentSession rebinds the
+			// real session, not a stale presented one.
+			this.presentedSession = undefined;
 			this.resetExtensionUI();
 		});
 		this.runtimeHost.setRebindSession(async () => {
@@ -1761,6 +1769,46 @@ export class InteractiveMode {
 	}
 
 	/**
+	 * Point the interactive renderer (transcript, footer, editor submit routing,
+	 * title) at an external {@link AgentSession}, reusing the main render
+	 * pipeline. Pass `undefined` to return to the running session. Switching
+	 * while one is already rendered replaces it.
+	 *
+	 * Unlike `switchSession(path)`, this neither creates nor destroys sessions —
+	 * the running session keeps executing in the background. `session` must be a
+	 * fully initialized `AgentSession` (its extensions are NOT re-bound). A real
+	 * session switch (/new, /resume, /fork, /reload) resets the override first.
+	 */
+	async setRenderedSession(session: AgentSession | undefined): Promise<void> {
+		const target = session ?? undefined;
+		if (this.presentedSession === target) return;
+		this.unsubscribe?.();
+		this.unsubscribe = undefined;
+		// Not resetExtensionUI(): it clears extension widgets, which would drop the
+		// caller's own fleet bar and strand the user in the presented session.
+		this.presentedSession = target;
+		this.syncSessionBoundUI();
+		this.renderCurrentSessionState();
+		this.subscribeToAgent();
+		this.ui.requestRender();
+	}
+
+	/**
+	 * Re-point the UI pieces that hold their own session reference (rather than
+	 * reading the `session` getter each frame) at the current `session`. Called
+	 * on present/restore. Deliberately narrower than applyRuntimeSettings(),
+	 * which also reconfigures global HTTP/editor state we must not touch for an
+	 * in-process presentation.
+	 */
+	private syncSessionBoundUI(): void {
+		this.footer.setSession(this.session);
+		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
+		this.footerDataProvider.setCwd(this.sessionManager.getCwd());
+		this.updateEditorBorderColor();
+		this.updateTerminalTitle();
+	}
+
+	/**
 	 * Get a registered tool definition by name (for custom rendering).
 	 */
 	private getRegisteredToolDefinition(toolName: string) {
@@ -2154,6 +2202,7 @@ export class InteractiveMode {
 			setHeader: (factory) => this.setExtensionHeader(factory),
 			setTitle: (title) => this.ui.terminal.setTitle(title),
 			custom: (factory, options) => this.showExtensionCustom(factory, options),
+			setRenderedSession: (session) => this.setRenderedSession(session),
 			pasteToEditor: (text) => this.editor.handleInput(`\x1b[200~${text}\x1b[201~`),
 			setEditorText: (text) => this.editor.setText(text),
 			getEditorText: () => this.editor.getExpandedText?.() ?? this.editor.getText(),

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -229,6 +229,10 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 			return undefined as never;
 		},
 
+		async setRenderedSession() {
+			// Session presentation not supported in RPC mode (no interactive renderer)
+		},
+
 		pasteToEditor(text: string): void {
 			// Paste handling not supported in RPC mode - falls back to setEditorText
 			this.setEditorText(text);

--- a/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
@@ -26,6 +26,7 @@ function createUiContext(
 		setHeader: () => {},
 		setTitle: () => {},
 		custom: async <T>() => undefined as T,
+		setRenderedSession: async () => {},
 		pasteToEditor: () => {},
 		setEditorText: () => {},
 		getEditorText: () => "",


### PR DESCRIPTION
Closes #7058

## Summary

Add a single `setRenderedSession(session | undefined)` method to `ExtensionUIContext`, letting an extension point pi's main interactive renderer (transcript, footer, editor submit routing, terminal title) at an externally-supplied `AgentSession` — reusing the entire main render pipeline instead of a simulated overlay.

## Motivation

Extensions like `pi-subagents` spawn in-process subagents (via `createAgentSession`) and want to let the user view and drive one in the main TUI — with identical rendering to the main session (streaming, tool calls, thinking, markdown) and the real prompt editor routing to it. There's currently no extension API for this:

- `ctx.ui.custom({ overlay: true })` renders a *separate* overlay component — it doesn't reuse the main render pipeline, can't make the prompt editor submit to the external session, and (because the overlay only covers the rows it renders) leaks main-session content into the terminal scrollback.
- `ctx.switchSession(path)` is file-based and destructive: it disposes the current session and reloads the target from disk. Ephemeral in-memory subagents have no path, and the "peek then return cheaply, keeping both alive" UX isn't possible.

The internal primitive already exists — `rebindCurrentSession` (`interactive-mode.ts`) re-points the render tree at `this.session` and rebuilds. The only gap is exposing it for an externally-supplied live session without a destructive file swap.

## Design

```ts
// ExtensionUIContext (core/extensions/types.ts)
setRenderedSession(session: AgentSession | undefined): Promise<void>;
```

- Pass a session → the renderer follows it; pass `undefined` → return to the running session.
- Matches the interface's prevailing **set-clear pattern** (`setFooter`/`setHeader`/`setWidget`/`setEditorComponent` all take `value | undefined` to set/clear) — no new `present`/`restore` verb pair, no `Main` business term baked into the API.
- The running session keeps executing in the background; nothing is disposed.
- A real session switch (`/new`, `/resume`, `/fork`, `/reload`) resets the override (via `setBeforeSessionInvalidate`).
- No-op in rpc/print mode.

Unlike `switchSession(path)`, this neither creates nor destroys sessions — the passed session must already be initialized (its extensions are NOT re-bound). Passing a live `AgentSession` object is intentional: rendering must `subscribe` to that specific instance, and the session may be ephemeral with no JSONL path.

## Implementation

- `private presentedSession: AgentSession | undefined`; `get session()` returns `presentedSession ?? runtimeHost.session`.
- `setRenderedSession(session)`: unsubscribe current → set `presentedSession` → `syncSessionBoundUI()` (re-point footer/title/editor border — narrower than `applyRuntimeSettings`, no global HTTP/editor state) → `renderCurrentSessionState()` → `subscribeToAgent()`.
- `setBeforeSessionInvalidate` clears `presentedSession` first (crash guard: a teardown must never read a stale override).
- Deliberately does **not** call `resetExtensionUI()` — it clears extension widgets, which would drop the calling extension's own UI (e.g. a fleet list) and strand the user in the presented session.
- `runner.ts`'s `noOpUIContext` and `rpc-mode.ts`'s context get no-op stubs (same as `custom`).

## Verification

Driving `pi-subagents`'s "view a subagent in the main TUI" feature end-to-end against this fork: selecting a subagent in the fleet bar swaps the whole main view to the subagent's live session (identical rendering to main — streaming/tool/markdown), the real prompt editor routes to it (running → steer, idle → continue), and selecting `main` returns. Fleet bar stays live to switch back.

All pre-commit checks pass (biome, tsc, lockfile, browser-smoke).
