### PR TITLE
fix(openai-completions): handle array content and missing finish_reason

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -471,14 +471,26 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 						choice.delta.content !== undefined &&
 						choice.delta.content.length > 0
 					) {
-						const block = ensureTextBlock();
-						block.text += choice.delta.content;
-						stream.push({
-							type: "text_delta",
-							contentIndex: getContentIndex(block),
-							delta: choice.delta.content,
-							partial: output,
-						});
+						// Some providers (e.g. Databricks Qwen3, gpt-oss) return content as a
+						// typed array [{type:'reasoning',...},{type:'text',text:'...'}] when tools
+						// are present. Extract only the text blocks; ignore reasoning blocks.
+						const rawContent = choice.delta.content;
+						const textContent = Array.isArray(rawContent)
+							? (rawContent as Array<{ type?: string; text?: string }>)
+									.filter((b) => b?.type === "text")
+									.map((b) => b?.text ?? "")
+									.join("")
+							: rawContent;
+						if (textContent.length > 0) {
+							const block = ensureTextBlock();
+							block.text += textContent;
+							stream.push({
+								type: "text_delta",
+								contentIndex: getContentIndex(block),
+								delta: textContent,
+								partial: output,
+							});
+						}
 					}
 
 					// Some endpoints return reasoning in reasoning_content (llama.cpp),
@@ -574,7 +586,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			if (output.stopReason === "error") {
 				throw new Error(output.errorMessage || "Provider returned an error stop reason");
 			}
-			if (!hasFinishReason) {
+			if (!hasFinishReason && compat.supportsFinishReason !== false) {
 				throw new Error("Stream ended without finish_reason");
 			}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -525,6 +525,8 @@ export interface OpenAICompletionsCompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether all replayed assistant messages must include an empty reasoning_content field when reasoning is enabled. Default: auto-detected from URL. */
 	requiresReasoningContentOnAssistantMessages?: boolean;
+	/** Whether the provider sends a `finish_reason` in the stream. Some providers (e.g. Kimi, inkling) never set finish_reason; set to false to suppress the "Stream ended without finish_reason" error. Default: true. */
+	supportsFinishReason?: boolean;
 	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort when supported, "together" uses reasoning: { enabled } plus reasoning_effort when supported, "zai" uses thinking: { type }, "qwen" uses top-level enable_thinking: boolean, "qwen-chat-template" uses chat_template_kwargs.enable_thinking and preserve_thinking, "chat-template" uses configurable chat_template_kwargs, "string-thinking" uses top-level thinking: string, and "ant-ling" uses reasoning: { effort } only when the mapped effort is non-null. Default: "openai". */
 	thinkingFormat?:
 		| "openai"


### PR DESCRIPTION
## Problem

Two bugs affecting providers that return non-standard streaming responses:

### 1. Array content (`[object Object],[object Object]`)

Some Databricks models (Qwen3, gpt-oss reasoning models) return `choice.delta.content` as a **typed array** when tools are present:

```json
[{"type": "reasoning", "summary": [...]}, {"type": "text", "text": "Hello!"}]
```

The current code does:
```typescript
block.text += choice.delta.content; // array + string = "[object Object],[object Object]"
```

This produces garbled output instead of the actual response text.

### 2. Missing `finish_reason` (`Stream ended without finish_reason`)

Some providers (Databricks Kimi `kimi-k2-7-code`, `inkling`) never set `finish_reason` in any streaming chunk. The stream completes successfully with `[DONE]` but no chunk ever has `finish_reason`, causing Pi to throw an error even though the response content was received successfully.

## Fix

**Fix 1**: Before accumulating text, check if `content` is an array and extract only `type: "text"` blocks, ignoring `type: "reasoning"` blocks:

```typescript
const rawContent = choice.delta.content;
const textContent = Array.isArray(rawContent)
    ? rawContent.filter(b => b?.type === "text").map(b => b?.text ?? "").join("")
    : rawContent;
```

**Fix 2**: Add a `supportsFinishReason?: boolean` compat flag (default: `true`). Set to `false` to skip the finish_reason check for providers that don't send it:

```typescript
if (!hasFinishReason && compat.supportsFinishReason !== false) {
    throw new Error("Stream ended without finish_reason");
}
```

## Usage (Fix 2)

For providers that don't send `finish_reason`, add to their provider config in `models.json`:

```json
{
  "compat": {
    "supportsFinishReason": false
  }
}
```