### PR TITLE
fix(coding-agent): reject overlapping user bash commands

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2770,6 +2770,10 @@ export class AgentSession {
 		onChunk?: (chunk: string) => void,
 		options?: { excludeFromContext?: boolean; id?: string; operations?: BashOperations },
 	): Promise<BashResult> {
+		if (this._bashAbortController !== undefined) {
+			throw new Error("A user bash command is already running");
+		}
+
 		this._bashAbortController = new AbortController();
 
 		// Apply command prefix if configured (e.g., "shopt -s expand_aliases" for alias support)

--- a/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-bash-persistence.test.ts
@@ -132,6 +132,52 @@ describe("AgentSession bash and persistence characterization", () => {
 		expect(harness.session.isBashRunning).toBe(false);
 	});
 
+	it("rejects overlapping user bash commands", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		let execCalls = 0;
+		let finishFirst: (() => void) | undefined;
+		const operations: BashOperations = {
+			exec: async () => {
+				execCalls++;
+				if (execCalls > 1) return { exitCode: 0 };
+
+				return await new Promise<{ exitCode: number | null }>((resolve) => {
+					finishFirst = () => resolve({ exitCode: 0 });
+				});
+			},
+		};
+
+		const firstBash = harness.session.executeBash("first", undefined, { operations });
+		let secondOutcome: { status: "pending" | "fulfilled" | "rejected"; error?: unknown } = {
+			status: "pending",
+		};
+		const secondBash = harness.session.executeBash("second", undefined, { operations }).then(
+			() => {
+				secondOutcome = { status: "fulfilled" };
+			},
+			(error: unknown) => {
+				secondOutcome = { status: "rejected", error };
+			},
+		);
+		await Promise.resolve();
+		const secondOutcomeBeforeFirstSettles = secondOutcome;
+		const startedCommandsBeforeFirstSettles = execCalls;
+		const runningBeforeFirstSettles = harness.session.isBashRunning;
+
+		finishFirst?.();
+		await Promise.all([firstBash, secondBash]);
+
+		expect(secondOutcomeBeforeFirstSettles).toMatchObject({
+			status: "rejected",
+			error: { message: "A user bash command is already running" },
+		});
+		expect(startedCommandsBeforeFirstSettles).toBe(1);
+		expect(runningBeforeFirstSettles).toBe(true);
+		expect(harness.session.isBashRunning).toBe(false);
+	});
+
 	it("persists user, assistant, toolResult, and custom messages in order", async () => {
 		const echoTool: AgentTool = {
 			name: "echo",


### PR DESCRIPTION
## Summary                                                                                                                                      
                                                                                                                                                   
RPC and SDK permit concurrent bash calls, allowing `AgentSession.executeBash()` to be invoked while another user-bash command is active. Because the session stores a single abort controller, an overlapping call can overwrite its cancellation state.                                               
                                                                                                                                                   
Reject overlapping user-bash executions within the same session until the active command settles. This aligns with the existing behavior of interactive mode bash execution handling.                                      
                                                                                                                                                   
## Testing                                                                                                                                      
                                                                                                                                                   
Added a regression test verifying that only the first command starts and the overlapping call rejects.                                                          