### PR TITLE
fix(coding-agent): prevent duplicate messages after startup session switch

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1730,17 +1730,27 @@ export class InteractiveMode {
 	}
 
 	private async rebindCurrentSession(options: { renderBeforeBind?: boolean } = {}): Promise<void> {
+		const session = this.session;
+
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
 		this.applyRuntimeSettings();
+
 		if (options.renderBeforeBind) {
 			this.renderCurrentSessionState();
 			this.subscribeToAgent();
-			await this.bindCurrentSessionExtensions();
-		} else {
-			await this.bindCurrentSessionExtensions();
+		}
+
+		await this.bindCurrentSessionExtensions();
+
+		if (this.session !== session) {
+			return;
+		}
+
+		if (!options.renderBeforeBind) {
 			this.subscribeToAgent();
 		}
+
 		await this.updateAvailableProviderCount();
 		this.updateEditorBorderColor();
 		this.updateTerminalTitle();

--- a/packages/coding-agent/test/suite/regressions/startup-session-rebind-duplicate-subscription.test.ts
+++ b/packages/coding-agent/test/suite/regressions/startup-session-rebind-duplicate-subscription.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+
+type RebindContext = {
+	session: object;
+	unsubscribe?: () => void;
+	applyRuntimeSettings: () => void;
+	renderCurrentSessionState: () => void;
+	bindCurrentSessionExtensions: () => Promise<void>;
+	subscribeToAgent: () => void;
+	updateAvailableProviderCount: () => Promise<void>;
+	updateEditorBorderColor: () => void;
+	updateTerminalTitle: () => void;
+};
+
+type InteractiveModePrototype = {
+	rebindCurrentSession(this: RebindContext, options?: { renderBeforeBind?: boolean }): Promise<void>;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
+
+describe("overlapping startup and replacement session rebinds", () => {
+	it("does not subscribe from the stale startup rebind", async () => {
+		const startupSession = {};
+		const replacementSession = {};
+		let resolveStartupBind!: () => void;
+		let resolveReplacementBind!: () => void;
+
+		const startupBind = new Promise<void>((resolve) => {
+			resolveStartupBind = resolve;
+		});
+		const replacementBind = new Promise<void>((resolve) => {
+			resolveReplacementBind = resolve;
+		});
+
+		const subscribeToAgent = vi.fn();
+		const updateTerminalTitle = vi.fn();
+		let bindCount = 0;
+
+		const context: RebindContext = {
+			session: startupSession,
+			applyRuntimeSettings: () => {},
+			renderCurrentSessionState: () => {},
+			bindCurrentSessionExtensions: () => {
+				bindCount += 1;
+				return bindCount === 1 ? startupBind : replacementBind;
+			},
+			subscribeToAgent,
+			updateAvailableProviderCount: async () => {},
+			updateEditorBorderColor: () => {},
+			updateTerminalTitle,
+		};
+
+		const startupRebind = interactiveModePrototype.rebindCurrentSession.call(context);
+		expect(bindCount).toBe(1);
+
+		context.session = replacementSession;
+		const replacementRebind = interactiveModePrototype.rebindCurrentSession.call(context, {
+			renderBeforeBind: true,
+		});
+
+		expect(bindCount).toBe(2);
+		expect(subscribeToAgent).toHaveBeenCalledTimes(1);
+
+		resolveStartupBind();
+		await startupRebind;
+
+		expect(subscribeToAgent).toHaveBeenCalledTimes(1);
+		expect(updateTerminalTitle).not.toHaveBeenCalled();
+
+		resolveReplacementBind();
+		await replacementRebind;
+
+		expect(subscribeToAgent).toHaveBeenCalledTimes(1);
+		expect(updateTerminalTitle).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary                                                                                                                                      
                                                                                                                                                   
Fix user prompts being displayed twice after switching sessions during startup.                                                                 
                                                                                                                                                   
Pi starts the TUI before startup `session_start` handlers have finished. If the user runs `/resume` while a handler is still pending, the startup and replacement rebinds can overlap.                                                                                                      
                                                                                                                                                   
When the startup rebind later finishes, it subscribes to the replacement session a second time. From that point onward, every user prompt is added to the TUI twice, even though it is persisted and processed only once.                                                                      
                                                                                                                                                   
The rebind now captures its original session and stops after extension binding if that session has been replaced.                               
                                                                                                                                                   
Added a deterministic regression test covering the overlapping rebind sequence.                                                                 
                                                                                                                                                   
## Verification                                                                                                                                 
                                                                                                                                                   
- Focused startup and replacement session-rebind regressions               