### PR TITLE
feat: support durable external tool results

### DIFF
--- a/docs/design/durable-external-tool-result.md
+++ b/docs/design/durable-external-tool-result.md
@@ -1,0 +1,64 @@
+# Durable External Tool Result
+
+## Goal
+
+Allow a custom tool to suspend an `AgentSession` while an external controller collects a typed
+result, then resume the same Pi session after JSONL export/open without synthesizing a user prompt.
+
+This is a general Pi capability. It has no cloud, approval UI, database, or provider-specific
+concepts.
+
+## Public API
+
+```ts
+type ExternalToolResultInput = {
+  toolCallId: string
+  content: AgentToolResult<unknown>["content"]
+  details: unknown
+  isError?: boolean
+}
+
+session.listPendingExternalToolCalls(): PendingExternalToolCall[]
+await session.submitExternalToolResult(result): SubmitExternalToolResultOutcome
+```
+
+`submitExternalToolResult()` is idempotent. A duplicate submission for an already resolved call
+returns `already_resolved`; it never executes a tool twice.
+
+## Session Semantics
+
+1. A custom tool opts in by returning `defer: true` instead of `terminate: true`.
+2. Pi persists the assistant tool call normally, then appends a `custom` JSONL entry with
+   `customType: "pi.pending_external_tool"`. It does not append a tool-result message for that call.
+3. The current agent turn settles without a synthetic result or continuation prompt.
+4. `SessionManager.open()` rebuilds the pending call from JSONL.
+5. The host submits a typed tool result for the original `toolCallId`.
+6. Pi appends the native tool-result message and a `pi.external_tool_result` audit entry, removes the
+   pending state, and schedules continuation through Pi's native turn machinery.
+
+If several calls are deferred in one assistant response, Pi persists all of them but waits until
+every outstanding deferred call has a native result. Earlier submissions return
+`pending_external_results`; only the final submission continues the model turn.
+
+## Invariants
+
+- Pending and resolved state live in Pi JSONL, never in a host transcript reconstruction.
+- Only a tool call already present on the active Pi branch can be resumed.
+- A pending result may be submitted only while the session is idle.
+- The result is appended once; duplicate submission is a no-op result, not an error or replay.
+- Pi owns subsequent model/tool scheduling, retry, compaction, and cancellation.
+- Existing `terminate: true` behavior remains unchanged.
+
+## Initial Scope
+
+The first change adds durable state and typed result persistence. It deliberately does not make
+automatic model continuation policy configurable: the session exposes the result to Pi's native
+next-turn path. Follow-up policy and UI remain host responsibilities.
+
+## Required Tests
+
+- defer -> export -> open -> list pending -> submit -> tool result persisted
+- duplicate submit is idempotent
+- unknown and non-pending tool call rejection
+- submission while an agent run is active rejection
+- regular `terminate: true` regression

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -470,6 +470,11 @@ async function executeToolCallsSequential(
 		}
 
 		await emitToolExecutionEnd(finalized, emit);
+		if (finalized.result.defer) {
+			await emitToolExecutionDeferred(finalized, emit);
+			finalizedCalls.push(finalized);
+			break;
+		}
 		const toolResultMessage = createToolResultMessage(finalized);
 		await emitToolResultMessage(toolResultMessage, emit);
 		finalizedCalls.push(finalized);
@@ -482,7 +487,9 @@ async function executeToolCallsSequential(
 
 	return {
 		messages,
-		terminate: shouldTerminateToolBatch(finalizedCalls),
+		terminate:
+			shouldTerminateToolBatch(finalizedCalls) ||
+			finalizedCalls.some((finalized) => finalized.result.defer === true),
 	};
 }
 
@@ -542,6 +549,10 @@ async function executeToolCallsParallel(
 	);
 	const messages: ToolResultMessage[] = [];
 	for (const finalized of orderedFinalizedCalls) {
+		if (finalized.result.defer) {
+			await emitToolExecutionDeferred(finalized, emit);
+			continue;
+		}
 		const toolResultMessage = createToolResultMessage(finalized);
 		await emitToolResultMessage(toolResultMessage, emit);
 		messages.push(toolResultMessage);
@@ -549,7 +560,9 @@ async function executeToolCallsParallel(
 
 	return {
 		messages,
-		terminate: shouldTerminateToolBatch(orderedFinalizedCalls),
+		terminate:
+			shouldTerminateToolBatch(orderedFinalizedCalls) ||
+			orderedFinalizedCalls.some((finalized) => finalized.result.defer === true),
 	};
 }
 
@@ -737,6 +750,7 @@ async function finalizeExecutedToolCall(
 					details: afterResult.details ?? result.details,
 					usage: afterResult.usage ?? result.usage,
 					terminate: afterResult.terminate ?? result.terminate,
+					defer: afterResult.defer ?? result.defer,
 				};
 				isError = afterResult.isError ?? isError;
 			}
@@ -765,6 +779,17 @@ async function emitToolExecutionEnd(finalized: FinalizedToolCallOutcome, emit: A
 		type: "tool_execution_end",
 		toolCallId: finalized.toolCall.id,
 		toolName: finalized.toolCall.name,
+		result: finalized.result,
+		isError: finalized.isError,
+	});
+}
+
+async function emitToolExecutionDeferred(finalized: FinalizedToolCallOutcome, emit: AgentEventSink): Promise<void> {
+	await emit({
+		type: "tool_execution_deferred",
+		toolCallId: finalized.toolCall.id,
+		toolName: finalized.toolCall.name,
+		args: finalized.toolCall.arguments,
 		result: finalized.result,
 		isError: finalized.isError,
 	});

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -376,6 +376,19 @@ export class Agent {
 		await this.runContinuation();
 	}
 
+	/**
+	 * Append an externally resolved message without creating a user prompt.
+	 *
+	 * This is intended for durable tool calls whose final result is supplied by a
+	 * session host after the original agent turn has settled.
+	 */
+	async appendExternalMessage(message: AgentMessage): Promise<void> {
+		await this.runWithLifecycle(async () => {
+			await this.processEvents({ type: "message_start", message });
+			await this.processEvents({ type: "message_end", message });
+		});
+	}
+
 	private normalizePromptInput(
 		input: string | AgentMessage | AgentMessage[],
 		images?: ImageContent[],

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -87,6 +87,14 @@ export interface AfterToolCallResult {
 	 * Early termination only happens when every finalized tool result in the batch sets this to true.
 	 */
 	terminate?: boolean;
+	/**
+	 * Suspend this tool call until an external host submits its final tool result.
+	 *
+	 * A deferred result is emitted to observers, but no `toolResult` message is added to
+	 * the transcript. The session host must later provide a native result for the same
+	 * tool-call id before continuing the agent.
+	 */
+	defer?: boolean;
 }
 
 /** Context passed to `beforeToolCall`. */
@@ -366,6 +374,14 @@ export interface AgentToolResult<T> {
 	 * Early termination only happens when every finalized tool result in the batch sets this to true.
 	 */
 	terminate?: boolean;
+	/**
+	 * Suspend this tool call until an external host submits its final tool result.
+	 *
+	 * A deferred result is emitted to observers, but no `toolResult` message is added to
+	 * the transcript. The session host must later provide a native result for the same
+	 * tool-call id before continuing the agent.
+	 */
+	defer?: boolean;
 }
 
 /**
@@ -434,4 +450,12 @@ export type AgentEvent =
 	// Tool execution lifecycle
 	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any }
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
-	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean };
+	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean }
+	| {
+			type: "tool_execution_deferred";
+			toolCallId: string;
+			toolName: string;
+			args: any;
+			result: any;
+			isError: boolean;
+	  };

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -368,6 +368,61 @@ describe("agentLoop with AgentMessage", () => {
 		expect(toolResult?.role === "toolResult" ? toolResult.usage : undefined).toEqual(patchedToolUsage);
 	});
 
+	it("defers an external tool result without adding a synthetic tool result message", async () => {
+		const toolSchema = Type.Object({ question: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { question: string }> = {
+			name: "ask_external",
+			label: "Ask external host",
+			description: "Wait for an answer from an external host",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return {
+					content: [{ type: "text", text: params.question }],
+					details: { question: params.question },
+					defer: true,
+				};
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(
+			[createUserMessage("ask for approval")],
+			{ systemPrompt: "", messages: [], tools: [tool] },
+			{ model: createModel(), convertToLlm: identityConverter, toolExecution: "sequential" },
+			undefined,
+			() => {
+				const response = new MockAssistantStream();
+				queueMicrotask(() => {
+					response.push({
+						type: "done",
+						reason: "toolUse",
+						message: createAssistantMessage(
+							[
+								{
+									type: "toolCall",
+									id: "external-1",
+									name: "ask_external",
+									arguments: { question: "Continue?" },
+								},
+							],
+							"toolUse",
+						),
+					});
+				});
+				return response;
+			},
+		);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const messages = await stream.result();
+
+		expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+		expect(events.some((event) => event.type === "tool_execution_deferred")).toBe(true);
+		expect(events.some((event) => event.type === "message_end" && event.message.role === "toolResult")).toBe(false);
+	});
+
 	it("should not execute tool calls from a length-truncated assistant message", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: string[] = [];

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -32,6 +32,7 @@ import type {
 	Model,
 	ProviderHeaders,
 	TextContent,
+	ToolResultMessage,
 	Usage,
 } from "@earendil-works/pi-ai/compat";
 import {
@@ -119,6 +120,29 @@ export interface ParsedSkillBlock {
 	content: string;
 	userMessage: string | undefined;
 }
+
+/** A tool call whose final result must be supplied by the session host later. */
+export interface PendingExternalToolCall {
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+	pendingEntryId: string;
+}
+
+/** Native result supplied by a host for a previously deferred tool call. */
+export interface ExternalToolResultInput {
+	toolCallId: string;
+	content: (TextContent | ImageContent)[];
+	details: unknown;
+	isError?: boolean;
+	usage?: Usage;
+	addedToolNames?: string[];
+}
+
+export type SubmitExternalToolResultOutcome =
+	| { status: "resumed" }
+	| { status: "pending_external_results"; remaining: number }
+	| { status: "already_resolved" };
 
 /**
  * Parse a skill block from message text.
@@ -593,6 +617,14 @@ export class AgentSession {
 
 	/** Internal handler for agent events - shared by subscribe and reconnect */
 	private _handleAgentEvent = async (event: AgentEvent): Promise<void> => {
+		if (event.type === "tool_execution_deferred") {
+			this.sessionManager.appendCustomEntry("pi.pending_external_tool", {
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				args: event.args,
+			});
+		}
+
 		// When a user message starts, check if it's from either queue and remove it BEFORE emitting
 		// This ensures the UI sees the updated queue state
 		if (event.type === "message_start" && event.message.role === "user") {
@@ -1072,6 +1104,13 @@ export class AgentSession {
 		}
 	}
 
+	private async _continueAgentRun(): Promise<void> {
+		await this.agent.continue();
+		while (await this._handlePostAgentRun()) {
+			await this.agent.continue();
+		}
+	}
+
 	private async _handlePostAgentRun(): Promise<boolean> {
 		const msg = this._lastAssistantMessage;
 		this._lastAssistantMessage = undefined;
@@ -1100,6 +1139,104 @@ export class AgentSession {
 		// The agent loop drains both queues before emitting agent_end. Any messages
 		// here were queued by agent_end extension handlers and need a continuation.
 		return this.agent.hasQueuedMessages();
+	}
+
+	/** Return unresolved tool calls whose final result must be supplied by an external host. */
+	listPendingExternalToolCalls(): PendingExternalToolCall[] {
+		const resolvedToolCallIds = new Set<string>();
+		const pending = new Map<string, PendingExternalToolCall>();
+
+		for (const entry of this.sessionManager.getBranch()) {
+			if (entry.type === "message" && entry.message.role === "toolResult") {
+				resolvedToolCallIds.add(entry.message.toolCallId);
+				continue;
+			}
+			if (entry.type !== "custom" || entry.customType !== "pi.pending_external_tool") {
+				continue;
+			}
+			const data = entry.data as Partial<PendingExternalToolCall> | undefined;
+			if (typeof data?.toolCallId !== "string" || typeof data.toolName !== "string") {
+				continue;
+			}
+			pending.set(data.toolCallId, {
+				toolCallId: data.toolCallId,
+				toolName: data.toolName,
+				args: data.args,
+				pendingEntryId: entry.id,
+			});
+		}
+
+		return [...pending.values()].filter((call) => !resolvedToolCallIds.has(call.toolCallId));
+	}
+
+	/**
+	 * Persist the native result for a deferred tool call and continue using Pi's normal agent loop.
+	 * The original tool is never executed again.
+	 */
+	async submitExternalToolResult(input: ExternalToolResultInput): Promise<SubmitExternalToolResultOutcome> {
+		if (this.isStreaming) {
+			throw new Error(
+				"Agent is already processing. Wait for the session to become idle before resolving an external tool call.",
+			);
+		}
+
+		const pendingCall = this.listPendingExternalToolCalls().find((call) => call.toolCallId === input.toolCallId);
+		if (!pendingCall) {
+			const hasResolvedResult = this.sessionManager
+				.getBranch()
+				.some(
+					(entry) =>
+						entry.type === "message" &&
+						entry.message.role === "toolResult" &&
+						entry.message.toolCallId === input.toolCallId,
+				);
+			if (hasResolvedResult) {
+				return { status: "already_resolved" };
+			}
+			throw new Error(`No pending external tool call found for id: ${input.toolCallId}`);
+		}
+		const hasMatchingToolCall = this.sessionManager.getBranch().some((entry) => {
+			if (entry.type !== "message" || entry.message.role !== "assistant") {
+				return false;
+			}
+			return entry.message.content.some(
+				(block) =>
+					block.type === "toolCall" && block.id === pendingCall.toolCallId && block.name === pendingCall.toolName,
+			);
+		});
+		if (!hasMatchingToolCall) {
+			throw new Error(
+				`The pending external tool call ${input.toolCallId} has no matching assistant tool call in this branch.`,
+			);
+		}
+
+		const result: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: pendingCall.toolCallId,
+			toolName: pendingCall.toolName,
+			content: input.content,
+			details: input.details,
+			usage: input.usage,
+			...(input.addedToolNames?.length ? { addedToolNames: input.addedToolNames } : {}),
+			isError: input.isError ?? false,
+			timestamp: Date.now(),
+		};
+
+		this._isAgentRunActive = true;
+		try {
+			await this.agent.appendExternalMessage(result);
+			this.sessionManager.appendCustomEntry("pi.external_tool_result", { toolCallId: input.toolCallId });
+			const remaining = this.listPendingExternalToolCalls().length;
+			if (remaining > 0) {
+				return { status: "pending_external_results", remaining };
+			}
+			await this._continueAgentRun();
+			return { status: "resumed" };
+		} finally {
+			this._systemPromptOverride = undefined;
+			this._flushPendingBashMessages();
+			await this._emitAgentSettled();
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -7,9 +7,12 @@ export {
 	type AgentSessionConfig,
 	type AgentSessionEvent,
 	type AgentSessionEventListener,
+	type ExternalToolResultInput,
 	type ModelCycleResult,
+	type PendingExternalToolCall,
 	type PromptOptions,
 	type SessionStats,
+	type SubmitExternalToolResultOutcome,
 } from "./agent-session.ts";
 export {
 	AgentSessionRuntime,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -17,11 +17,14 @@ export {
 	type AgentSessionConfig,
 	type AgentSessionEvent,
 	type AgentSessionEventListener,
+	type ExternalToolResultInput,
 	type ModelCycleResult,
 	type ParsedSkillBlock,
+	type PendingExternalToolCall,
 	type PromptOptions,
 	parseSkillBlock,
 	type SessionStats,
+	type SubmitExternalToolResultOutcome,
 } from "./core/agent-session.ts";
 export { readStoredCredential } from "./core/auth-storage.ts";
 // Compaction

--- a/packages/coding-agent/test/agent-session-external-tool-result.test.ts
+++ b/packages/coding-agent/test/agent-session-external-tool-result.test.ts
@@ -1,0 +1,197 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function assistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+describe("AgentSession external tool results", () => {
+	let tempDir: string | undefined;
+	let session: AgentSession | undefined;
+
+	afterEach(() => {
+		session?.dispose();
+		session = undefined;
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+		tempDir = undefined;
+	});
+
+	it("persists, resumes, and idempotently resolves a deferred external tool call", async () => {
+		tempDir = join(tmpdir(), `pi-external-tool-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		let responseIndex = 0;
+		const agent = new Agent({
+			initialState: { model, systemPrompt: "test", thinkingLevel: "off", tools: [] },
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const message =
+						responseIndex++ === 0
+							? assistantMessage(
+									[
+										{
+											type: "toolCall",
+											id: "approval-1",
+											name: "wait_for_approval",
+											arguments: { action: "deploy" },
+										},
+									],
+									"toolUse",
+								)
+							: assistantMessage([{ type: "text", text: "Deployment approved." }], "stop");
+					stream.push({ type: "done", reason: responseIndex === 1 ? "toolUse" : "stop", message });
+				});
+				return stream;
+			},
+		});
+
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createModelRegistry(authStorage, tempDir);
+		const sessionDir = join(tempDir, "sessions");
+		const sessionManager = SessionManager.create(tempDir, sessionDir, { id: "external-tool-result" });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager: SettingsManager.create(tempDir, tempDir),
+			cwd: tempDir,
+			modelRuntime: getModelRuntime(modelRegistry),
+			resourceLoader: createTestResourceLoader(),
+			customTools: [
+				{
+					name: "wait_for_approval",
+					label: "Wait for approval",
+					description: "Wait for an external approval.",
+					parameters: Type.Object({ action: Type.String() }),
+					execute: async () => ({
+						content: [{ type: "text", text: "Waiting for approval." }],
+						details: {},
+						defer: true,
+					}),
+				},
+			],
+		});
+
+		await session.prompt("Deploy the service.");
+		expect(session.listPendingExternalToolCalls()).toEqual([
+			expect.objectContaining({
+				toolCallId: "approval-1",
+				toolName: "wait_for_approval",
+				args: { action: "deploy" },
+			}),
+		]);
+		expect(session.state.messages.some((message) => message.role === "toolResult")).toBe(false);
+		const sessionFile = sessionManager.getSessionFile();
+		expect(sessionFile).toBeTruthy();
+
+		session.dispose();
+		const restoredManager = SessionManager.open(sessionFile!, sessionDir);
+		const restoredContext = restoredManager.buildSessionContext();
+		const restoredAgent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: "test",
+				thinkingLevel: "off",
+				tools: [],
+				messages: restoredContext.messages,
+			},
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const message = assistantMessage([{ type: "text", text: "Deployment approved." }], "stop");
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent: restoredAgent,
+			sessionManager: restoredManager,
+			settingsManager: SettingsManager.create(tempDir, tempDir),
+			cwd: tempDir,
+			modelRuntime: getModelRuntime(modelRegistry),
+			resourceLoader: createTestResourceLoader(),
+		});
+		expect(session.listPendingExternalToolCalls()).toEqual([
+			expect.objectContaining({
+				toolCallId: "approval-1",
+				toolName: "wait_for_approval",
+				args: { action: "deploy" },
+			}),
+		]);
+		await expect(
+			session.submitExternalToolResult({
+				toolCallId: "not-pending",
+				content: [{ type: "text", text: "Nope." }],
+				details: {},
+			}),
+		).rejects.toThrow("No pending external tool call found");
+
+		await expect(
+			session.submitExternalToolResult({
+				toolCallId: "approval-1",
+				content: [{ type: "text", text: "Approved by the project owner." }],
+				details: { approved: true },
+			}),
+		).resolves.toEqual({ status: "resumed" });
+
+		expect(session.listPendingExternalToolCalls()).toEqual([]);
+		expect(
+			session.state.messages.some((message) => message.role === "toolResult" && message.toolCallId === "approval-1"),
+		).toBe(true);
+		expect(session.state.messages.at(-1)).toMatchObject({ role: "assistant" });
+		await expect(
+			session.submitExternalToolResult({
+				toolCallId: "approval-1",
+				content: [{ type: "text", text: "Duplicate." }],
+				details: {},
+			}),
+		).resolves.toEqual({ status: "already_resolved" });
+	});
+});


### PR DESCRIPTION
## Summary

Adds a generic durable external-tool-result flow for any session host that must wait for a typed result outside the running agent process.

- A tool can return `defer: true`.
- Pi persists the assistant tool call and a JSONL pending marker, without fabricating a tool-result message.
- `AgentSession.listPendingExternalToolCalls()` reconstructs unresolved calls after JSONL reopen.
- `AgentSession.submitExternalToolResult()` writes a native tool result for the original `toolCallId` and resumes through Pi's normal continuation path.
- Duplicate submissions are idempotent and never run the original tool again.
- If an assistant response defers several calls, Pi waits for every outstanding result before continuing, so providers never receive an incomplete tool-result sequence.

The feature is limited to the existing session, tool-call, and tool-result model. Existing `terminate: true` behavior is unchanged.

## Validation

- `npm run check`
- `npx vitest --run packages/agent/test/agent-loop.test.ts packages/coding-agent/test/agent-session-external-tool-result.test.ts`
- Built `@earendil-works/pi-agent-core` and `@earendil-works/pi-coding-agent`.

A focused design note is included in the diff as supporting context, rather than being required to understand this PR.