### PR TITLE
Add manual redirect URL fallback to OpenRouter OAuth login

### DIFF
--- a/packages/ai/src/auth/oauth/openrouter.ts
+++ b/packages/ai/src/auth/oauth/openrouter.ts
@@ -3,7 +3,9 @@
  *
  * OpenRouter exchanges an authorization code for a permanent, user-controlled
  * API key rather than an expiring access/refresh token pair. The callback is
- * handled by a one-shot loopback server on an ephemeral port.
+ * handled by a one-shot loopback server on an ephemeral port, raced against a
+ * manual prompt so remote/headless sessions can paste the redirect URL when
+ * the browser cannot reach the loopback server.
  *
  * NOTE: This module uses Node.js http.createServer for the OAuth callback server.
  * It is only intended for CLI use, not browser environments.
@@ -28,8 +30,16 @@ type JsonObject = Record<string, unknown>;
 
 type OpenRouterCallbackServer = {
 	callbackUrl: string;
-	credential: Promise<OAuthCredential>;
-	close(): void;
+	/** Stop listening and release timers without settling `waitForCredential`. */
+	close: () => void;
+	/** Hand the login over to manual code entry unless a callback already claimed the exchange. */
+	cancelWait: () => void;
+	/**
+	 * Resolves with the credential once a browser callback completes the key
+	 * exchange, or with null once `cancelWait` hands the login over to manual
+	 * code entry. Rejects on timeout, cancellation, or a failed exchange.
+	 */
+	waitForCredential: () => Promise<OAuthCredential | null>;
 };
 
 function sendHtml(response: ServerResponse, status: number, html: string): void {
@@ -37,6 +47,23 @@ function sendHtml(response: ServerResponse, status: number, html: string): void 
 	response.setHeader("content-type", "text/html; charset=utf-8");
 	response.setHeader("cache-control", "no-store");
 	response.end(html);
+}
+
+function parseAuthorizationInput(input: string): string | undefined {
+	const value = input.trim();
+	if (!value) return undefined;
+
+	try {
+		return new URL(value).searchParams.get("code") ?? undefined;
+	} catch {
+		// not a URL
+	}
+
+	if (value.includes("code=")) {
+		return new URLSearchParams(value).get("code") ?? undefined;
+	}
+
+	return value;
 }
 
 function errorDetail(body: JsonObject): string | undefined {
@@ -112,9 +139,9 @@ async function startCallbackServer(
 ): Promise<OpenRouterCallbackServer> {
 	if (signal?.aborted) throw new Error("Login cancelled");
 	const callbackHost = getCallbackHost();
-	let resolveCredential: (credential: OAuthCredential) => void = () => {};
+	let resolveCredential: (credential: OAuthCredential | null) => void = () => {};
 	let rejectCredential: (error: Error) => void = () => {};
-	const credential = new Promise<OAuthCredential>((resolve, reject) => {
+	const credential = new Promise<OAuthCredential | null>((resolve, reject) => {
 		resolveCredential = resolve;
 		rejectCredential = reject;
 	});
@@ -125,12 +152,16 @@ async function startCallbackServer(
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 	let onAbort: (() => void) | undefined;
 
-	const finish = (result: { credential: OAuthCredential } | { error: Error }): void => {
-		if (settled) return;
-		settled = true;
+	const close = (): void => {
 		if (timeout) clearTimeout(timeout);
 		if (onAbort) signal?.removeEventListener("abort", onAbort);
 		server.close();
+	};
+
+	const finish = (result: { credential: OAuthCredential | null } | { error: Error }): void => {
+		if (settled) return;
+		settled = true;
+		close();
 		if ("credential" in result) resolveCredential(result.credential);
 		else rejectCredential(result.error);
 	};
@@ -186,22 +217,25 @@ async function startCallbackServer(
 	onAbort = () => finish({ error: new Error("Login cancelled") });
 	signal?.addEventListener("abort", onAbort, { once: true });
 	if (signal?.aborted) {
-		signal.removeEventListener("abort", onAbort);
-		server.close();
+		close();
 		throw new Error("Login cancelled");
 	}
 	timeout = setTimeout(() => finish({ error: new Error("OpenRouter OAuth login timed out") }), LOGIN_TIMEOUT_MS);
 
 	const address = server.address();
 	if (!address || typeof address === "string") {
-		finish({ error: new Error("Could not determine the OpenRouter OAuth callback port") });
+		close();
 		throw new Error("Could not determine the OpenRouter OAuth callback port");
 	}
 
 	return {
 		callbackUrl: `http://${callbackHost}:${address.port}${callbackPath}`,
-		credential,
-		close: () => finish({ error: new Error("Login cancelled") }),
+		close,
+		// A claimed callback is already exchanging its code; let that exchange settle the login.
+		cancelWait: () => {
+			if (!claimed) finish({ credential: null });
+		},
+		waitForCredential: () => credential,
 	};
 }
 
@@ -209,26 +243,57 @@ async function loginOpenRouter(interaction: AuthInteraction): Promise<OAuthCrede
 	const { verifier, challenge } = await generatePKCE();
 	const callbackPath = `/oauth/callback/${crypto.randomUUID()}`;
 	const callback = await startCallbackServer(callbackPath, verifier, interaction.signal);
-	const authorizeUrl = new URL(AUTHORIZE_URL);
-	authorizeUrl.search = new URLSearchParams({
-		callback_url: callback.callbackUrl,
-		code_challenge: challenge,
-		code_challenge_method: "S256",
-	}).toString();
-
-	interaction.notify({
-		type: "progress",
-		message: `Listening for OpenRouter OAuth callback on ${callback.callbackUrl}`,
-	});
-	interaction.notify({
-		type: "auth_url",
-		url: authorizeUrl.toString(),
-		instructions: "Complete sign-in in your browser.",
-	});
+	const manualAbort = new AbortController();
+	let manualInput: string | undefined;
+	let manualError: Error | undefined;
 
 	try {
-		return await callback.credential;
+		const authorizeUrl = new URL(AUTHORIZE_URL);
+		authorizeUrl.search = new URLSearchParams({
+			callback_url: callback.callbackUrl,
+			code_challenge: challenge,
+			code_challenge_method: "S256",
+		}).toString();
+
+		interaction.notify({
+			type: "progress",
+			message: `Listening for OpenRouter OAuth callback on ${callback.callbackUrl}`,
+		});
+		interaction.notify({
+			type: "auth_url",
+			url: authorizeUrl.toString(),
+			instructions:
+				"Complete sign-in in your browser. If the browser is on another machine, paste the final redirect URL here.",
+		});
+
+		const manualPromise = interaction
+			.prompt({
+				type: "manual_code",
+				message: "Complete sign-in in your browser, or paste the authorization code / redirect URL here:",
+				placeholder: callback.callbackUrl,
+				signal: manualAbort.signal,
+			})
+			.then((input) => {
+				manualInput = input;
+				callback.cancelWait();
+			})
+			.catch((error) => {
+				manualError = error instanceof Error ? error : new Error(String(error));
+				callback.cancelWait();
+			});
+
+		const credential = await callback.waitForCredential();
+		if (manualError) throw manualError;
+		if (credential) return credential;
+
+		await manualPromise;
+		if (manualError) throw manualError;
+		const code = manualInput ? parseAuthorizationInput(manualInput) : undefined;
+		if (!code) throw new Error("Missing authorization code");
+		interaction.notify({ type: "progress", message: "Exchanging authorization code for an API key..." });
+		return await exchangeAuthorizationCode(code, verifier, interaction.signal);
 	} finally {
+		manualAbort.abort();
 		callback.close();
 	}
 }

--- a/packages/ai/test/openrouter-oauth.test.ts
+++ b/packages/ai/test/openrouter-oauth.test.ts
@@ -63,9 +63,11 @@ describe.sequential("OpenRouter OAuth", () => {
 
 		let authorizeUrl: URL | undefined;
 		let callbackResponse: Promise<Response> | undefined;
+		let manualSignal: AbortSignal | undefined;
 		const credential = await openRouterOAuth.login({
-			prompt: async () => {
-				throw new Error("OpenRouter login must not prompt for a code");
+			prompt: (prompt) => {
+				manualSignal = prompt.signal;
+				return new Promise<string>(() => {});
 			},
 			notify: (event) => {
 				if (event.type !== "auth_url") return;
@@ -83,6 +85,7 @@ describe.sequential("OpenRouter OAuth", () => {
 			expires: Number.MAX_SAFE_INTEGER,
 		});
 		expect((await callbackResponse)?.status).toBe(200);
+		expect(manualSignal?.aborted).toBe(true);
 		expect(authorizeUrl?.origin).toBe("https://openrouter.ai");
 		expect(authorizeUrl?.pathname).toBe("/auth");
 		expect(authorizeUrl?.searchParams.get("code_challenge_method")).toBe("S256");
@@ -110,7 +113,7 @@ describe.sequential("OpenRouter OAuth", () => {
 
 		let callbackResponse: Promise<Response> | undefined;
 		const login = openRouterOAuth.login({
-			prompt: async () => "",
+			prompt: () => new Promise<string>(() => {}),
 			notify: (event) => {
 				if (event.type !== "auth_url") return;
 				const callbackUrl = new URL(new URL(event.url).searchParams.get("callback_url") ?? "");
@@ -138,7 +141,7 @@ describe.sequential("OpenRouter OAuth", () => {
 		let callbackUrl: URL | undefined;
 		let firstCallback: Promise<Response> | undefined;
 		const login = openRouterOAuth.login({
-			prompt: async () => "",
+			prompt: () => new Promise<string>(() => {}),
 			notify: (event) => {
 				if (event.type !== "auth_url") return;
 				callbackUrl = new URL(new URL(event.url).searchParams.get("callback_url") ?? "");
@@ -165,7 +168,7 @@ describe.sequential("OpenRouter OAuth", () => {
 
 		let callbackResponse: Promise<Response> | undefined;
 		const login = openRouterOAuth.login({
-			prompt: async () => "",
+			prompt: () => new Promise<string>(() => {}),
 			notify: (event) => {
 				if (event.type !== "auth_url") return;
 				const callbackUrl = new URL(new URL(event.url).searchParams.get("callback_url") ?? "");
@@ -178,12 +181,91 @@ describe.sequential("OpenRouter OAuth", () => {
 		expect((await callbackResponse)?.status).toBe(502);
 	});
 
+	it("mints a key from a pasted redirect URL when the loopback callback never arrives", async () => {
+		let exchangeBody: Record<string, unknown> | undefined;
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input instanceof Request ? input.url : String(input);
+			if (url !== TOKEN_URL) return nativeFetch(input, init);
+			exchangeBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return jsonResponse({ key: "sk-or-manual" });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		let callbackUrl: string | undefined;
+		const credential = await openRouterOAuth.login({
+			prompt: async (prompt) => {
+				if (prompt.type !== "manual_code") throw new Error(`Unexpected prompt: ${prompt.type}`);
+				return `${callbackUrl}?code=manual-code`;
+			},
+			notify: (event) => {
+				if (event.type !== "auth_url") return;
+				callbackUrl = new URL(event.url).searchParams.get("callback_url") ?? undefined;
+			},
+		});
+
+		expect(credential).toEqual({
+			type: "oauth",
+			access: "sk-or-manual",
+			refresh: "",
+			expires: Number.MAX_SAFE_INTEGER,
+		});
+		expect(exchangeBody).toMatchObject({ code: "manual-code", code_challenge_method: "S256" });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("accepts a bare authorization code from the manual prompt", async () => {
+		let exchangeBody: Record<string, unknown> | undefined;
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = input instanceof Request ? input.url : String(input);
+			if (url !== TOKEN_URL) return nativeFetch(input, init);
+			exchangeBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return jsonResponse({ key: "sk-or-manual" });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const credential = await openRouterOAuth.login({
+			prompt: async () => "  manual-code  ",
+			notify: () => {},
+		});
+
+		expect(credential).toMatchObject({ access: "sk-or-manual" });
+		expect(exchangeBody).toMatchObject({ code: "manual-code" });
+	});
+
+	it("fails login when the manual prompt is cancelled", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ key: "sk-or-unexpected" }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			openRouterOAuth.login({
+				prompt: async () => {
+					throw new Error("Login cancelled");
+				},
+				notify: () => {},
+			}),
+		).rejects.toThrow("Login cancelled");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects empty manual input without exchanging a code", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ key: "sk-or-unexpected" }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			openRouterOAuth.login({
+				prompt: async () => "   ",
+				notify: () => {},
+			}),
+		).rejects.toThrow("Missing authorization code");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("closes the pending callback when login is cancelled", async () => {
 		const controller = new AbortController();
 		let callbackUrl: URL | undefined;
 		const login = openRouterOAuth.login({
 			signal: controller.signal,
-			prompt: async () => "",
+			prompt: () => new Promise<string>(() => {}),
 			notify: (event) => {
 				if (event.type !== "auth_url") return;
 				callbackUrl = new URL(new URL(event.url).searchParams.get("callback_url") ?? "");
@@ -217,7 +299,7 @@ describe.sequential("OpenRouter OAuth", () => {
 		let callbackUrl: URL | undefined;
 		const login = openRouterOAuth.login({
 			signal: controller.signal,
-			prompt: async () => "",
+			prompt: () => new Promise<string>(() => {}),
 			notify: (event) => {
 				if (event.type !== "auth_url") return;
 				callbackUrl = new URL(new URL(event.url).searchParams.get("callback_url") ?? "");

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -48,6 +48,7 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 
 - Run `/login openrouter`, then select **Sign in with OpenRouter** to open the OpenRouter PKCE authorization flow
 - The authorization creates a user-controlled OpenRouter API key billed from your OpenRouter credits
+- On remote/headless machines (e.g. over SSH) the browser cannot reach the loopback callback; paste the final redirect URL (or the authorization code) into the login prompt instead
 - `OPENROUTER_API_KEY` remains available through **Use an API key**
 
 ### Radius


### PR DESCRIPTION
## Summary

`/login openrouter` only completes through the loopback callback server, so it can't finish on remote/headless machines (SSH, containers) — the browser runs elsewhere and can't reach 127.0.0.1 on the host running pi.

This races the callback server against a `manual_code` prompt, same as the Anthropic and OpenAI Codex flows: paste the final redirect URL (or the bare code) and it's exchanged with the same PKCE verifier. A claimed callback keeps priority, so a paste can't interrupt an in-flight exchange. The server object now follows the Codex `OAuthServerInfo` shape (`waitForCredential` / `cancelWait` / `close`).

No UI changes — the login dialog already handles `manual_code` prompts.

## Testing

- `npm run check` and `./test.sh`
- 4 new tests: pasted redirect URL, bare code, cancelled prompt, empty input
- Manual e2e over SSH: pasted redirect URL mints a working key; callback path still works (verified via port forward); cancel leaves no credential and frees the port

Closes #7078