### PR TITLE
fix(tui): truncate over-width lines instead of crashing

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -16,7 +16,14 @@ import {
 	type TerminalColorScheme,
 } from "./terminal-colors.ts";
 import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.ts";
-import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.ts";
+import {
+	extractSegments,
+	normalizeTerminalOutput,
+	sliceByColumn,
+	sliceWithWidth,
+	truncateToWidth,
+	visibleWidth,
+} from "./utils.ts";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
@@ -1497,7 +1504,7 @@ export class TUI extends Container {
 		const renderEnd = Math.min(lastChanged, newLines.length - 1);
 		for (let i = firstChanged; i <= renderEnd; i++) {
 			if (i > firstChanged) buffer += "\r\n";
-			const line = newLines[i];
+			let line = newLines[i];
 			const isImage = isImageLine(line);
 			const imageReservedRows = isImage ? this.getKittyImageReservedRows(newLines, i, renderEnd) : 1;
 			if (imageReservedRows > 1) {
@@ -1523,32 +1530,7 @@ export class TUI extends Container {
 
 			buffer += "\x1b[2K"; // Clear current line
 			if (!isImage && visibleWidth(line) > width) {
-				// Log all lines to crash file for debugging
-				const crashLogPath = path.join(this.logDirectory, "pi-crash.log");
-				const crashData = [
-					`Crash at ${new Date().toISOString()}`,
-					`Terminal width: ${width}`,
-					`Line ${i} visible width: ${visibleWidth(line)}`,
-					"",
-					"=== All rendered lines ===",
-					...newLines.map((l, idx) => `[${idx}] (w=${visibleWidth(l)}) ${l}`),
-					"",
-				].join("\n");
-				fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-				fs.writeFileSync(crashLogPath, crashData);
-
-				// Clean up terminal state before throwing
-				this.stop();
-
-				const errorMsg = [
-					`Rendered line ${i} exceeds terminal width (${visibleWidth(line)} > ${width}).`,
-					"",
-					"This is likely caused by a custom TUI component not truncating its output.",
-					"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
-					"",
-					`Debug log written to: ${crashLogPath}`,
-				].join("\n");
-				throw new Error(errorMsg);
+				line = truncateToWidth(line, width - 1);
 			}
 			buffer += line;
 		}


### PR DESCRIPTION
## Problem

When a rendered line exceeds the terminal width, `doRender()` throws an unhandled error that kills the entire session. This is triggered by any component outputting a line wider than the terminal — most visibly by `@gotgenes/pi-permission-system` when long tool input JSON produces permission prompt lines exceeding terminal width.

Crash log example from a user report:
- Terminal width: 213
- Offending line width: 279 (a permission prompt for `ctx_batch_execute` with a long embedded `grep` command)

## Root cause

At line 1516, the code checks `if (!isImage && visibleWidth(line) > width)` and responds by:
1. Writing a crash debug log
2. Calling `this.stop()` to tear down the TUI
3. Throwing an `Error` — which propagates unhandled and kills the session

## Fix

Replace the crash with truncation using `truncateToWidth()` from the same `utils.ts` module (which already handles ANSI escape sequences and wide characters correctly). Lines that exceed terminal width are now safely truncated with an ellipsis instead of crashing.

Also changed `const line` to `let line` since the variable is now reassigned.

## Testing

- All 700 TUI tests pass
- Existing `bug-regression-isimageline-startswith-bug` tests still pass (image lines continue to bypass width checking)