### PR TITLE
Expose extension context clear callback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ctx.clear()` to extension contexts so extensions can clear the active session without generating a compaction summary.
+
 ## [0.82.1] - 2026-07-25
 
 ### New Features

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1060,6 +1060,21 @@ ctx.compact({
 });
 ```
 
+### ctx.clear()
+
+Clear the active session without generating a compaction summary. Use `onComplete` and `onError` for follow-up actions.
+
+```typescript
+ctx.clear({
+  onComplete: () => {
+    ctx.ui.notify("Context cleared", "info");
+  },
+  onError: (error) => {
+    ctx.ui.notify(`Clear failed: ${error.message}`, "error");
+  },
+});
+```
+
 ### ctx.getSystemPrompt()
 
 Returns Pi's current system prompt string.

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -4,6 +4,7 @@ import { resolvePath } from "../utils/paths.ts";
 import type { AgentSession } from "./agent-session.ts";
 import type { AgentSessionRuntimeDiagnostic, AgentSessionServices } from "./agent-session-services.ts";
 import type {
+	ClearResult,
 	ProjectTrustContext,
 	ReplacedSessionContext,
 	SessionShutdownEvent,
@@ -218,6 +219,10 @@ export class AgentSessionRuntime {
 		);
 		await this.finishSessionReplacement(options?.withSession);
 		return { cancelled: false };
+	}
+
+	async clear(): Promise<ClearResult> {
+		return this.session.clear();
 	}
 
 	async newSession(options?: {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -66,6 +66,8 @@ import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
 import {
+	type ClearOptions,
+	type ClearResult,
 	type ContextUsage,
 	type ExtensionCommandContextActions,
 	type ExtensionErrorListener,
@@ -152,6 +154,7 @@ export type AgentSessionEvent =
 	| { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
 	| { type: "entry_appended"; entry: SessionEntry }
 	| { type: "session_info_changed"; name: string | undefined }
+	| { type: "session_cleared"; previousSessionFile: string | undefined; sessionFile: string | undefined }
 	| { type: "thinking_level_changed"; level: ThinkingLevel }
 	| {
 			type: "compaction_end";
@@ -229,6 +232,7 @@ export interface ExtensionBindings {
 	uiContext?: ExtensionUIContext;
 	mode?: ExtensionMode;
 	commandContextActions?: ExtensionCommandContextActions;
+	clearHandler?: (options?: ClearOptions) => void;
 	abortHandler?: () => void;
 	shutdownHandler?: ShutdownHandler;
 	onError?: ExtensionErrorListener;
@@ -354,6 +358,7 @@ export class AgentSession {
 	private _extensionUIContext?: ExtensionUIContext;
 	private _extensionMode: ExtensionMode = "print";
 	private _extensionCommandContextActions?: ExtensionCommandContextActions;
+	private _extensionClearHandler?: (options?: ClearOptions) => void;
 	private _extensionAbortHandler?: () => void;
 	private _extensionShutdownHandler?: ShutdownHandler;
 	private _extensionErrorListener?: ExtensionErrorListener;
@@ -1925,6 +1930,24 @@ export class AgentSession {
 	}
 
 	/**
+	 * Clear the session context without generating a summary.
+	 */
+	async clear(): Promise<ClearResult> {
+		const usage = this.getContextUsage();
+		const previousSessionFile = this.sessionFile;
+		this.sessionManager.newSession({ parentSession: previousSessionFile });
+		this.agent.reset();
+		this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+		this.clearQueue();
+		this._emit({
+			type: "session_cleared",
+			previousSessionFile,
+			sessionFile: this.sessionFile,
+		});
+		return { tokensBefore: usage?.tokens ?? undefined, estimatedTokensAfter: 0 };
+	}
+
+	/**
 	 * Cancel in-progress compaction (manual or auto).
 	 */
 	abortCompaction(): void {
@@ -2236,6 +2259,9 @@ export class AgentSession {
 		if (bindings.commandContextActions !== undefined) {
 			this._extensionCommandContextActions = bindings.commandContextActions;
 		}
+		if (bindings.clearHandler !== undefined) {
+			this._extensionClearHandler = bindings.clearHandler;
+		}
 		if (bindings.abortHandler !== undefined) {
 			this._extensionAbortHandler = bindings.abortHandler;
 		}
@@ -2430,6 +2456,13 @@ export class AgentSession {
 							options?.onError?.(err);
 						}
 					})();
+				},
+				clear: (options) => {
+					if (this._extensionClearHandler) {
+						this._extensionClearHandler(options);
+						return;
+					}
+					options?.onError?.(new Error("Clear is unavailable in this context"));
 				},
 				getSystemPrompt: () => this.systemPrompt,
 				getSystemPromptOptions: () => this._baseSystemPromptOptions,

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -41,6 +41,8 @@ export type {
 	BeforeProviderRequestEventResult,
 	BuildSystemPromptOptions,
 	// Context
+	ClearOptions,
+	ClearResult,
 	CompactOptions,
 	// Events - Agent
 	ContextEvent,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -16,6 +16,7 @@ import type {
 	BeforeAgentStartEventResult,
 	BeforeProviderHeadersEvent,
 	BeforeProviderRequestEvent,
+	ClearOptions,
 	CompactOptions,
 	ContextEvent,
 	ContextEventResult,
@@ -281,6 +282,7 @@ export class ExtensionRunner {
 	private hasPendingMessagesFn: () => boolean = () => false;
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
+	private clearFn: (options?: ClearOptions) => void = () => {};
 	private getSystemPromptFn: () => string = () => "";
 	private getSystemPromptOptionsFn: () => BuildSystemPromptOptions = () => ({ cwd: this.cwd });
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
@@ -343,6 +345,7 @@ export class ExtensionRunner {
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
+		this.clearFn = contextActions.clear;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
 		this.getSystemPromptOptionsFn = contextActions.getSystemPromptOptions ?? (() => ({ cwd: this.cwd }));
 
@@ -729,6 +732,10 @@ export class ExtensionRunner {
 			compact: (options) => {
 				runner.assertActive();
 				runner.compactFn(options);
+			},
+			clear: (options) => {
+				runner.assertActive();
+				runner.clearFn(options);
 			},
 			getSystemPrompt: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -298,6 +298,16 @@ export interface CompactOptions {
 	onError?: (error: Error) => void;
 }
 
+export interface ClearResult {
+	tokensBefore?: number;
+	estimatedTokensAfter: number;
+}
+
+export interface ClearOptions {
+	onComplete?: (result: ClearResult) => void;
+	onError?: (error: Error) => void;
+}
+
 /**
  * Context passed to extension event handlers.
  */
@@ -336,6 +346,8 @@ export interface ExtensionContext {
 	getContextUsage(): ContextUsage | undefined;
 	/** Trigger compaction without awaiting completion. */
 	compact(options?: CompactOptions): void;
+	/** Clear the active session without generating a summary and without awaiting completion. */
+	clear(options?: ClearOptions): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
 }
@@ -1623,6 +1635,7 @@ export interface ExtensionContextActions {
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
+	clear: (options?: ClearOptions) => void;
 	getSystemPrompt: () => string;
 	getSystemPromptOptions?: () => BuildSystemPromptOptions;
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1634,6 +1634,18 @@ export class InteractiveMode {
 		await this.session.bindExtensions({
 			uiContext,
 			mode: "tui",
+			clearHandler: (options) => {
+				void (async () => {
+					try {
+						this.clearStatusIndicator();
+						const result = await this.runtimeHost.clear();
+						options?.onComplete?.(result);
+					} catch (error) {
+						const err = error instanceof Error ? error : new Error(String(error));
+						options?.onError?.(err);
+					}
+				})();
+			},
 			abortHandler: () => {
 				this.restoreQueuedMessagesToEditor({ abort: true });
 			},
@@ -1804,6 +1816,17 @@ export class InteractiveMode {
 				void (async () => {
 					try {
 						const result = await this.session.compact(options?.customInstructions);
+						options?.onComplete?.(result);
+					} catch (error) {
+						const err = error instanceof Error ? error : new Error(String(error));
+						options?.onError?.(err);
+					}
+				})();
+			},
+			clear: (options) => {
+				void (async () => {
+					try {
+						const result = await this.runtimeHost.clear();
 						options?.onComplete?.(result);
 					} catch (error) {
 						const err = error instanceof Error ? error : new Error(String(error));
@@ -2884,6 +2907,13 @@ export class InteractiveMode {
 			case "session_info_changed":
 				this.updateTerminalTitle();
 				this.footer.invalidate();
+				this.ui.requestRender();
+				break;
+
+			case "session_cleared":
+				this.renderCurrentSessionState();
+				this.updateTerminalTitle();
+				this.showStatus("Context cleared");
 				this.ui.requestRender();
 				break;
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -72,6 +72,17 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 		session = runtimeHost.session;
 		await session.bindExtensions({
 			mode: mode === "json" ? "json" : "print",
+			clearHandler: (options) => {
+				void (async () => {
+					try {
+						const result = await runtimeHost.clear();
+						options?.onComplete?.(result);
+					} catch (error) {
+						const err = error instanceof Error ? error : new Error(String(error));
+						options?.onError?.(err);
+					}
+				})();
+			},
 			commandContextActions: {
 				waitForIdle: () => session.waitForIdle(),
 				newSession: async (newSessionOptions) => runtimeHost.newSession(newSessionOptions),

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -318,6 +318,17 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 		await session.bindExtensions({
 			uiContext: createExtensionUIContext(),
 			mode: "rpc",
+			clearHandler: (options) => {
+				void (async () => {
+					try {
+						const result = await runtimeHost.clear();
+						options?.onComplete?.(result);
+					} catch (error) {
+						const err = error instanceof Error ? error : new Error(String(error));
+						options?.onError?.(err);
+					}
+				})();
+			},
 			commandContextActions: {
 				waitForIdle: () => session.waitForIdle(),
 				newSession: async (options) => runtimeHost.newSession(options),

--- a/packages/coding-agent/test/agent-session-runtime-events.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-events.test.ts
@@ -156,6 +156,35 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		]);
 	});
 
+	it("clears the active session without compacting", async () => {
+		const sessionEvents: Array<{ previousSessionFile: string | undefined; sessionFile: string | undefined }> = [];
+		let compacted = false;
+		const { runtimeHost } = await createRuntimeHost((pi) => {
+			pi.on("session_compact", () => {
+				compacted = true;
+			});
+		});
+		runtimeHost.session.subscribe((event) => {
+			if (event.type === "session_cleared") {
+				sessionEvents.push({ previousSessionFile: event.previousSessionFile, sessionFile: event.sessionFile });
+			}
+		});
+
+		await runtimeHost.session.prompt("hello");
+		const previousSessionFile = runtimeHost.session.sessionFile;
+		expect(previousSessionFile).toBeTruthy();
+
+		const result = await runtimeHost.clear();
+		expect("summary" in result).toBe(false);
+		expect(result.estimatedTokensAfter).toBe(0);
+
+		expect(compacted).toBe(false);
+		expect(runtimeHost.session.sessionFile).not.toBe(previousSessionFile);
+		expect(runtimeHost.session.messages).toEqual([]);
+		expect(runtimeHost.session.sessionManager.getHeader()?.parentSession).toBe(previousSessionFile);
+		expect(sessionEvents).toEqual([{ previousSessionFile, sessionFile: runtimeHost.session.sessionFile }]);
+	});
+
 	it("honors session_before_switch cancellation", async () => {
 		const events: RecordedSessionEvent[] = [];
 		const { runtimeHost } = await createRuntimeHost((pi) => {

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -98,6 +98,7 @@ describe("ExtensionRunner", () => {
 		shutdown: () => {},
 		getContextUsage: () => undefined,
 		compact: () => {},
+		clear: () => {},
 		getSystemPrompt: () => "",
 	};
 
@@ -522,6 +523,21 @@ describe("ExtensionRunner", () => {
 
 			const ctx = runner.createContext();
 			expect(ctx.isProjectTrusted()).toBe(false);
+		});
+
+		it("routes ExtensionContext clear requests through the bound clear action", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const clear = vi.fn();
+			runner.bindCore(extensionActions, {
+				...extensionContextActions,
+				clear,
+			});
+
+			const options = { onComplete: vi.fn(), onError: vi.fn() };
+			runner.createContext().clear(options);
+
+			expect(clear).toHaveBeenCalledWith(options);
 		});
 
 		it("exposes rpc mode with hasUI true when an RPC UI context is provided", async () => {

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -19,6 +19,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		shutdown: vi.fn(),
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,
+		clear: vi.fn(),
 		getSystemPrompt: () => "",
 	};
 }


### PR DESCRIPTION
Extensions can already request compaction, but there was no runtime-owned way to clear context without generating a summary. This adds the matching clear callback so tools like Mecha can safely hand off and reset the active session.
