### PR TITLE
feat(coding-agent): show SYSTEM.md and APPEND_SYSTEM.md in startup [Context] banner

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1039,7 +1039,7 @@ export class AgentSession {
 		const appendSystemPrompt =
 			loaderAppendSystemPrompt.length > 0 ? loaderAppendSystemPrompt.join("\n\n") : undefined;
 		const loadedSkills = this._resourceLoader.getSkills().skills;
-		const loadedContextFiles = this._resourceLoader.getAgentsFiles().agentsFiles;
+		const loadedContextFiles = this._resourceLoader.getAgentsFiles().agentsFiles.filter((f) => f.content !== "");
 
 		this._baseSystemPromptOptions = {
 			cwd: this._cwd,

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -205,7 +205,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private themeDiagnostics: ResourceDiagnostic[];
 	private agentsFiles: Array<{ path: string; content: string }>;
 	private systemPrompt?: string;
+	private systemPromptPath?: string;
 	private appendSystemPrompt: string[];
+	private appendSystemPromptPaths: string[];
 	private lastSkillPaths: string[];
 	private extensionSkillSourceInfos: Map<string, SourceInfo>;
 	private extensionPromptSourceInfos: Map<string, SourceInfo>;
@@ -252,7 +254,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.themes = [];
 		this.themeDiagnostics = [];
 		this.agentsFiles = [];
+		this.systemPromptPath = undefined;
 		this.appendSystemPrompt = [];
+		this.appendSystemPromptPaths = [];
 		this.lastSkillPaths = [];
 		this.extensionSkillSourceInfos = new Map();
 		this.extensionPromptSourceInfos = new Map();
@@ -280,6 +284,14 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	getAgentsFiles(): { agentsFiles: Array<{ path: string; content: string }> } {
 		return { agentsFiles: this.agentsFiles };
+	}
+
+	getSystemPromptPath(): string | undefined {
+		return this.systemPromptPath;
+	}
+
+	getAppendSystemPromptPaths(): string[] {
+		return this.appendSystemPromptPaths;
 	}
 
 	getSystemPrompt(): string | undefined {
@@ -474,21 +486,38 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;
 		this.agentsFiles = resolvedAgentsFiles.agentsFiles;
 
-		const baseSystemPrompt = resolvePromptInput(
-			this.systemPromptSource ?? this.discoverSystemPromptFile(),
-			"system prompt",
-		);
+		// Track SYSTEM.md / APPEND_SYSTEM.md file paths for context banner visibility (#7096)
+		this.systemPromptPath =
+			this.systemPromptSource !== undefined ? undefined : (this.discoverSystemPromptFile() ?? undefined);
+		this.appendSystemPromptPaths =
+			this.appendSystemPromptSource !== undefined
+				? []
+				: this.discoverAppendSystemPromptFile()
+					? [this.discoverAppendSystemPromptFile()!]
+					: [];
+
+		const baseSystemPrompt = resolvePromptInput(this.systemPromptSource ?? this.systemPromptPath, "system prompt");
 		this.systemPrompt = this.systemPromptOverride ? this.systemPromptOverride(baseSystemPrompt) : baseSystemPrompt;
 
 		const appendSources =
-			this.appendSystemPromptSource ??
-			(this.discoverAppendSystemPromptFile() ? [this.discoverAppendSystemPromptFile()!] : []);
+			this.appendSystemPromptSource ?? (this.appendSystemPromptPaths.length > 0 ? this.appendSystemPromptPaths : []);
 		const baseAppend = appendSources
 			.map((s) => resolvePromptInput(s, "append system prompt"))
 			.filter((s): s is string => s !== undefined);
 		this.appendSystemPrompt = this.appendSystemPromptOverride
 			? this.appendSystemPromptOverride(baseAppend)
 			: baseAppend;
+
+		// Append SYSTEM.md / APPEND_SYSTEM.md entries for startup [Context] banner visibility.
+		// Content is intentionally empty so they are not double-injected into the system prompt
+		// (they are already applied as customPrompt / appendSystemPrompt).
+		if (this.systemPromptPath) {
+			this.agentsFiles.push({ path: this.systemPromptPath, content: "" });
+		}
+		for (const p of this.appendSystemPromptPaths) {
+			this.agentsFiles.push({ path: p, content: "" });
+		}
+
 		this.loaded = true;
 	}
 


### PR DESCRIPTION
## Summary

`SYSTEM.md` and `APPEND_SYSTEM.md` silently alter agent behavior—`SYSTEM.md` replaces the entire system prompt, and `APPEND_SYSTEM.md` appends to it—yet neither file appears in the startup `[Context]` banner. Users have no visibility into whether these files are active in their session.

This PR makes `SYSTEM.md` and `APPEND_SYSTEM.md` visible in the startup `[Context]` banner alongside `AGENTS.md` / `CLAUDE.md`.

Closes #7096

## Background

Three files affect the system prompt, but they take different code paths:

| File | Loaded by | Applied as | Shows in `[Context]`? |
|------|-----------|------------|----------------------|
| `AGENTS.md` | `loadProjectContextFiles()` | `<project_instructions>` in prompt | Yes |
| `SYSTEM.md` | `discoverSystemPromptFile()` | `customPrompt` (full replacement) | **No** |
| `APPEND_SYSTEM.md` | `discoverAppendSystemPromptFile()` | `appendSystemPrompt` | **No** |

The `[Context]` banner in `interactive-mode.ts` only queries `resourceLoader.getAgentsFiles()` — which only covers `AGENTS.md` / `CLAUDE.md`. The `SYSTEM.md` and `APPEND_SYSTEM.md` paths were never tracked after discovery, so they had no path back to the UI.

## Changes

### `packages/coding-agent/src/core/resource-loader.ts`

- Added `systemPromptPath` and `appendSystemPromptPaths` private fields to `DefaultResourceLoader` to track the discovered file paths.
- In `reload()`, save the discovered paths before resolving content, then append marker entries to `agentsFiles` with empty content for banner visibility.
- Added `getSystemPromptPath()` and `getAppendSystemPromptPaths()` getters.

### `packages/coding-agent/src/core/agent-session.ts`

- In `_rebuildSystemPrompt()`, filter context files with empty content before passing them to `buildSystemPrompt()`. The display-only entries carry no content, so they are naturally excluded from prompt injection.

### Design Decision: Empty Content Markers

`SYSTEM.md` / `APPEND_SYSTEM.md` are already applied to the system prompt through separate channels (`customPrompt` / `appendSystemPrompt`). If we added them to `agentsFiles` with their full content, `buildSystemPrompt()` would inject them a second time inside `<project_instructions>`, duplicating their effect.

By using empty-content entries, we avoid this without modifying the `ResourceLoader` interface or `buildSystemPrompt()` signature — both are public APIs used by extensions and SDK consumers.

## Behavior

| Before | After |
|--------|-------|
| `[Context]` shows only `AGENTS.md` / `CLAUDE.md` | `[Context]` also shows `SYSTEM.md` / `APPEND_SYSTEM.md` when discovered from disk |
| `--system-prompt "text"` — no path shown | Unchanged (no file → no path) |
| `--append-system-prompt "text"` — no path shown | Unchanged (no file → no path) |
| `noContextFiles: true` — only blocks AGENTS.md discovery | `SYSTEM.md` / `APPEND_SYSTEM.md` still appear (they are controlled separately) |

## Verification

- `npm run check` — passes with zero errors
- `test/resource-loader.test.ts` — all 5 context-file tests pass:
  - `should discover AGENTS.md context files`
  - `should ignore context file candidates that are directories`
  - `should skip AGENTS.md and CLAUDE.md discovery when noContextFiles is true`
  - `should discover SYSTEM.md from cwd/.pi`
  - `should discover APPEND_SYSTEM.md`
- No new test failures introduced
