### PR TITLE
fix(coding-agent): normalize path separators in footer for cross-platform display

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -40,7 +40,7 @@ export function formatCwdForFooter(cwd: string, home: string | undefined): strin
 		(relativeToHome !== ".." && !relativeToHome.startsWith(`..${sep}`) && !isAbsolute(relativeToHome));
 
 	if (!isInsideHome) return cwd;
-	return relativeToHome === "" ? "~" : `~${sep}${relativeToHome}`;
+	return relativeToHome === "" ? "~" : `~/${relativeToHome.replaceAll("\\", "/")}`;
 }
 
 /**

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -101,6 +101,10 @@ function createFooterData(providerCount: number): ReadonlyFooterDataProvider {
 }
 
 describe("formatCwdForFooter", () => {
+	it("returns the cwd unchanged when home is undefined", () => {
+		expect(formatCwdForFooter("/some/path", undefined)).toBe("/some/path");
+	});
+
 	it("does not abbreviate sibling paths that share the home prefix", () => {
 		expect(formatCwdForFooter("/home/user2", "/home/user")).toBe("/home/user2");
 	});
@@ -108,6 +112,18 @@ describe("formatCwdForFooter", () => {
 	it("abbreviates the home directory and descendants", () => {
 		expect(formatCwdForFooter("/home/user", "/home/user")).toBe("~");
 		expect(formatCwdForFooter("/home/user/project", "/home/user")).toBe("~/project");
+	});
+
+	it("normalizes path separators for home-relative paths on Windows-style paths", () => {
+		// regression: on Windows path.sep is \\, which caused output like ~\\project
+		expect(formatCwdForFooter("C:\\Users\\user\\project", "C:\\Users\\user")).toBe("~/project");
+	});
+
+	it("normalizes nested subdirectory paths to forward slashes", () => {
+		// regression: path.relative() on Windows returns \\ separators for subdirectories
+		expect(formatCwdForFooter("C:\\Users\\user\\project\\sub\\dir", "C:\\Users\\user")).toBe(
+			"~/project/sub/dir",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

`formatCwdForFooter` in `footer.ts` used `path.sep` (OS-native separator) to construct the cwd display. On Windows this produces `~\project` instead of `~/project`.

## Changes

- **footer.ts**: Always use forward slash `/` for the display path, normalize backslashes from `path.relative()`
- **footer-width.test.ts**: +3 regression tests (Windows-style paths, nested subdirs, undefined home)

## Verification

- `footer-width.test.ts`: 10/10 passed (was 7, +3 new)
- `npm run check`: no new errors

## Related Issue

#7123

(Previously #7112, auto-closed due to new contributor policy.)