### PR TITLE
tui: raise visibleWidth cache to 4096 entries, use LRU eviction

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -42,7 +42,7 @@ const leadingNonPrintingRegex = /^[\p{Default_Ignorable_Code_Point}\p{Control}\p
 const rgiEmojiRegex = /^\p{RGI_Emoji}$/v;
 
 // Cache for non-ASCII strings
-const WIDTH_CACHE_SIZE = 512;
+const WIDTH_CACHE_SIZE = 4096;
 const widthCache = new Map<string, number>();
 
 export const cjkBreakRegex =
@@ -223,9 +223,11 @@ export function visibleWidth(str: string): number {
 		return str.length;
 	}
 
-	// Check cache
+	// Check cache (LRU: refresh recency on hit)
 	const cached = widthCache.get(str);
 	if (cached !== undefined) {
+		widthCache.delete(str);
+		widthCache.set(str, cached);
 		return cached;
 	}
 


### PR DESCRIPTION
## Summary
- `visibleWidth`'s 512-entry cache thrashes on real agent sessions: transcripts contain many distinct non-ASCII lines (box drawing, emoji status, CJK), exceeding the cap every frame.
- Eviction was FIFO (delete first inserted key), so hot entries — powerline segments, repeated UI chrome — were evicted while cold one-off lines survived.
- Raise the cap to 4096 and refresh recency on cache hits (delete + re-set), making eviction LRU.

## Testing
- Full `packages/tui` test suite passes on the rebased branch (exit 0).
- Rebased onto current main (post v0.82.1).