### PR TITLE
Set AI_AGENT for child process attribution

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -662,6 +662,7 @@ pi --thinking high "Solve this complex problem"
 
 | Variable | Description |
 |----------|-------------|
+| `AI_AGENT` | Set to `pi` by the CLI and RPC entry points so generic tooling can attribute child processes to Pi |
 | `PI_CODING_AGENT` | Set to `true` by the CLI and RPC entry points so child processes can detect that they run inside Pi |
 | `PI_CODING_AGENT_DIR` | Override config directory (default: `~/.pi/agent`) |
 | `PI_CODING_AGENT_SESSION_DIR` | Override session storage directory (overridden by `--session-dir`) |

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -11,6 +11,7 @@ import { main } from "./main.ts";
 
 process.title = APP_NAME;
 process.env.PI_CODING_AGENT = "true";
+process.env.AI_AGENT = "pi";
 process.emitWarning = (() => {}) as typeof process.emitWarning;
 
 // Configure undici's global dispatcher before provider SDKs issue requests.

--- a/packages/coding-agent/src/rpc-entry.ts
+++ b/packages/coding-agent/src/rpc-entry.ts
@@ -5,6 +5,7 @@ import { main } from "./main.ts";
 
 process.title = `${APP_NAME}-rpc`;
 process.env.PI_CODING_AGENT = "true";
+process.env.AI_AGENT = "pi";
 process.emitWarning = (() => {}) as typeof process.emitWarning;
 
 configureHttpDispatcher();


### PR DESCRIPTION
## Summary

Set `AI_AGENT=pi` in the CLI and RPC entry points, alongside the existing
`PI_CODING_AGENT=true` marker.

`AI_AGENT` is an emerging cross-agent convention used by Claude Code, GitHub
CLI, and Vercel's agent detection tooling. Setting it allows generic consumers
to identify Pi without Pi-specific heuristics.

## Testing

- `npm run check`
- `git diff --check`