### PR TITLE
feat(coding-agent): Experimental loadout management

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -254,6 +254,16 @@ export class Agent {
 		return this._state;
 	}
 
+	/** @internal Whether a model has been selected for future turns. */
+	get hasModel(): boolean {
+		return this._state.model !== DEFAULT_MODEL;
+	}
+
+	/** @internal Clear the selected model while retaining the agent's internal sentinel. */
+	clearModel(): void {
+		this._state.model = DEFAULT_MODEL;
+	}
+
 	/** Controls how queued steering messages are drained. */
 	set steeringMode(mode: QueueMode) {
 		this.steeringQueue.mode = mode;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added persistent resource management through `pi loadout` (`pi config` remains an alias) and interactive `/loadout` session overrides with staged reloads, append-only session persistence, best-effort resume restoration, and safe extension unloading.
+
 ## [0.82.1] - 2026-07-25
 
 ### New Features

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -180,6 +180,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/model` | Switch models |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
+| `/loadout` | Stage session-only extensions, skills, prompts, and themes, then reload |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
 | `/name <name>` | Set session display name |
@@ -268,6 +269,12 @@ Use `/session` in interactive mode to see the current session ID before reusing 
 
 **`--fork <path|id>`** - Fork an existing session file or partial session UUID directly from the CLI. This copies the full source session into a new session file in the current project.
 
+### Session Loadouts
+
+Use `/loadout` to stage session-only overrides for extensions, skills, prompt templates, and themes. Space toggles a resource, Enter applies the staged set with one reload, and Escape discards it. These overrides do not change global or project settings, and ordinary `/reload` preserves them.
+
+A deliberate non-empty loadout is saved as session metadata. Clearing a previously saved loadout writes a reset marker; opening the selector or reloading does not create duplicate entries. When an existing session has a saved non-empty loadout, interactive mode asks before restoring it. Missing or no-longer-trusted resources are skipped with warnings. Print, JSON, and RPC modes do not restore or prompt for saved loadouts.
+
 ### Compaction
 
 Long sessions can exhaust context windows. Compaction summarizes older messages while keeping recent ones.
@@ -301,7 +308,7 @@ Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trus
 
 If no extension or saved decision applies, `defaultProjectTrust` controls the fallback behavior. Set it to `"ask"`, `"always"`, or `"never"` in `~/.pi/agent/settings.json`, or change it with `/settings`.
 
-`pi config` and package commands use the same project trust flow, except `pi update` never prompts. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
+`pi loadout` and package commands use the same project trust flow, except `pi update` never prompts. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
 
 Use `/trust` in interactive mode to save a project trust decision for future sessions, including trust for the immediate parent folder. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
@@ -428,7 +435,7 @@ pi update --models                      # refresh model catalogs only
 pi update --self                        # update pi only
 pi update --self --force                # reinstall pi even if current
 pi update npm:@foo/pi-tools             # update one package
-pi config                               # enable/disable extensions, skills, prompts, themes
+pi loadout                              # persistently enable/disable extensions, skills, prompts, themes
 ```
 
 Packages install to `~/.pi/agent/git/` (git) or `~/.pi/agent/npm/` (npm). Use `-l` for project-local installs (`.pi/git/`, `.pi/npm/`). Git `@ref` values are pinned tags or commits; pinned packages are skipped by `pi update --extensions` and `pi update --all`, so use `pi install git:host/user/repo@new-ref` to move an existing package to a new ref. Git packages install dependencies with `npm install --omit=dev` by default, so runtime deps must be listed under `dependencies`; when `npmCommand` is configured, git packages use plain `install` for compatibility with wrappers. If you use a Node version manager and want package installs to reuse a stable npm context, set `npmCommand` in `settings.json`, for example `["mise", "exec", "node@20", "--", "npm"]`.
@@ -528,10 +535,10 @@ pi update --self             # Update pi only
 pi update --self --force     # Reinstall pi even if current
 pi update --extension <src>  # Update one package
 pi list                      # List installed packages
-pi config                    # Enable/disable package resources
+pi loadout                   # Persistently enable/disable package resources
 ```
 
-`pi config` and project package commands accept `--approve`/`--no-approve` to trust or ignore project-local settings for one command. `pi update` never prompts for project trust.
+`pi config` remains accepted as a backwards-compatible alias for `pi loadout`. `pi loadout` and project package commands accept `--approve`/`--no-approve` to trust or ignore project-local settings for one command. `pi update` never prompts for project trust.
 
 ### Modes
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -223,6 +223,8 @@ Extension factories may run in invocations that never start a session. Do not st
 
 Defer background resource startup until `session_start` or the command/tool/event that needs the resource. Register an idempotent `session_shutdown` handler to close any session-scoped resources you start.
 
+`/reload` and interactive `/loadout` can unload an extension. Pi emits `session_shutdown` before removing the old runtime, then invalidates captured `pi` and context APIs; using them after reload throws. Event-bus subscriptions made through `pi.events.on()` are removed with that runtime. Pi cannot clean up arbitrary timers, processes, sockets, or file watchers, so extensions remain responsible for releasing those in `session_shutdown`. Commands, tools, hooks, shortcuts, renderers, UI, and provider registrations owned by an unloaded extension are removed.
+
 ### Extension Styles
 
 **Single file** - simplest, for small extensions:
@@ -1286,7 +1288,7 @@ pi.registerCommand("reload-runtime", {
 
 Important behavior:
 - `await ctx.reload()` emits `session_shutdown` for the current extension runtime
-- It then reloads resources and emits `session_start` with `reason: "reload"` and `resources_discover` with reason `"reload"`
+- It then invalidates that runtime, removes runtime-owned UI and event-bus subscriptions, reloads resources, and emits `session_start` with `reason: "reload"` and `resources_discover` with reason `"reload"`
 - The currently running command handler still continues in the old call frame
 - Code after `await ctx.reload()` still runs from the pre-reload version
 - Code after `await ctx.reload()` must not assume old in-memory extension state is still valid

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -36,6 +36,7 @@ pi update --self            # update pi only
 pi update --self --force    # reinstall pi even if current
 pi update npm:@foo/bar      # update one package
 pi update --extension npm:@foo/bar
+pi loadout                  # persistently enable or disable resources
 ```
 
 These commands manage pi packages and `pi update` can update the pi CLI installation. To uninstall pi itself, see [Quickstart](quickstart.md#uninstall).
@@ -217,7 +218,9 @@ Filter what a package loads using the object form in settings:
 
 ## Enable and Disable Resources
 
-Use `pi config` to enable or disable extensions, skills, prompt templates, and themes from installed packages and local directories. `pi config` starts in global settings (`~/.pi/agent/settings.json`); press Tab to switch between global and project-local modes. Use `pi config -l` to start in project overrides (`.pi/settings.json`) with inherited global resources dimmed.
+Use `pi loadout` to persistently enable or disable extensions, skills, prompt templates, and themes from installed packages and local directories. It starts in global settings (`~/.pi/agent/settings.json`); press Tab to switch between global and project-local modes. Use `pi loadout -l` to start in project overrides (`.pi/settings.json`) with inherited global resources dimmed. `pi config` remains accepted as a backwards-compatible alias.
+
+Inside interactive mode, `/loadout` instead stages overrides for the current session. It never writes either settings file. Enter applies the staged set and reloads resources once; Escape discards it. Ordinary `/reload` preserves active session overrides. Deliberate non-empty overrides are stored in the session, and interactive resume asks before restoring them. Restoration matches only currently discovered resources, so it cannot install packages, introduce paths from session data, or bypass project trust; unavailable resources are skipped with warnings.
 
 ## Scope and Deduplication
 

--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -134,7 +134,7 @@ interface BashExecutionMessage {
 
 interface CustomMessage {
   role: "custom";
-  customType: string;            // Extension identifier
+  customType: string;            // Extension or built-in identifier
   content: string | (TextContent | ImageContent)[];
   display: boolean;              // Show in TUI
   details?: any;                 // Extension-specific metadata
@@ -267,6 +267,14 @@ Extension state persistence. Does NOT participate in LLM context.
 ```
 
 Use `customType` to identify your extension's entries on reload. Interactive mode can render custom entries via `pi.registerEntryRenderer(customType, renderer)`, but they still do not participate in LLM context.
+
+Pi also uses namespaced custom entries for built-in session metadata. Session loadouts use `customType: "pi.loadout"` with a versioned payload:
+
+```json
+{"type":"custom","id":"l8i9j0k1","parentId":"h8i9j0k1","timestamp":"2024-12-03T14:22:00.000Z","customType":"pi.loadout","data":{"version":1,"overrides":[{"reference":{"type":"skill","origin":"top-level","scope":"user","relativePath":"skills/review/SKILL.md"},"enabled":false}]}}
+```
+
+Loadout entries are session-wide metadata, not conversation context. Pi reads the latest valid entry in physical file order rather than following the current `/tree` branch. Non-empty entries represent deliberate `/loadout` changes; an empty `overrides` array is a reset marker written only when clearing an earlier saved loadout. Forked or extracted session files retain only loadout entries copied into their retained path.
 
 ### CustomMessageEntry
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -17,7 +17,7 @@ Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trus
 
 If no extension or saved decision applies, `defaultProjectTrust` controls the fallback behavior. Set it to `"ask"`, `"always"`, or `"never"` in `~/.pi/agent/settings.json`, or change it with `/settings`.
 
-`pi config` and package commands use the same project trust flow, except `pi update` never prompts. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
+`pi loadout` and package commands use the same project trust flow, except `pi update` never prompts. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them. `pi config` is an alias for `pi loadout`.
 
 Use `/trust` in interactive mode to save a project trust decision for future sessions, including trust for the immediate parent folder. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
@@ -229,7 +229,9 @@ When multiple sources specify a session directory, precedence is `--session-dir`
 
 ### Resources
 
-These settings define where to load extensions, skills, prompts, and themes from.
+These settings define where to load extensions, skills, prompts, and themes from. Use `pi loadout` to edit their persistent global or project selection.
+
+Interactive `/loadout` is separate: it applies session-only overrides and never writes either settings file. A normal `/reload` keeps those active overrides.
 
 Paths in `~/.pi/agent/settings.json` resolve relative to `~/.pi/agent`. Paths in `.pi/settings.json` resolve relative to `.pi`. Absolute paths and `~` are supported.
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -41,6 +41,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/model` | Switch models |
 | `/scoped-models` | Enable/disable models for Ctrl+P cycling |
 | `/settings` | Thinking level, theme, message delivery, transport |
+| `/loadout` | Stage session-only extensions, skills, prompts, and themes, then reload |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
 | `/name <name>` | Set session display name |
@@ -95,6 +96,12 @@ Useful session commands:
 
 See [Sessions](sessions.md) and [Compaction](compaction.md) for details.
 
+### Session Loadouts
+
+`/loadout` changes the current session's effective extensions, skills, prompt templates, and themes without writing global or project settings. Changes are staged: Space toggles, Enter applies and reloads once, and Escape discards. Ordinary `/reload` keeps the active session overrides.
+
+Pi saves only deliberate loadout changes as non-context session metadata. A non-empty loadout is offered for restoration when that existing session is opened interactively; declining leaves normal settings active and may prompt again on a future resume. Missing resources are skipped with warnings, and saved data cannot install packages or bypass project trust. Print, JSON, and RPC modes ignore saved loadouts.
+
 ## Context Files
 
 Pi loads `AGENTS.md` or `CLAUDE.md` at startup from:
@@ -124,7 +131,7 @@ Non-interactive modes (`-p`, `--mode json`, and `--mode rpc`) do not show a trus
 
 If no extension or saved decision applies, `defaultProjectTrust` controls the fallback behavior. Set it to `"ask"`, `"always"`, or `"never"` in `~/.pi/agent/settings.json`, or change it with `/settings`.
 
-`pi config` and package commands use the same project trust flow, except `pi update` never prompts. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
+`pi loadout` and package commands use the same project trust flow, except `pi update` never prompts. Pass `--approve` to trust project-local settings for one command or `--no-approve` to ignore them.
 
 Use `/trust` in interactive mode to save a project trust decision for future sessions, including trust for the immediate parent folder. It writes `~/.pi/agent/trust.json` only; the current session is not reloaded, so restart pi for changes to take effect.
 
@@ -156,10 +163,10 @@ pi update --models           # Refresh model catalogs only
 pi update --self             # Update pi only
 pi update --extension <src>  # Update one package
 pi list                      # List installed packages
-pi config                    # Enable/disable package resources
+pi loadout                   # Persistently enable/disable package resources
 ```
 
-These commands manage pi packages and `pi update` can update the pi CLI installation. To uninstall pi itself, see [Quickstart](quickstart.md#uninstall). `pi config` and project package commands accept `--approve`/`--no-approve` to trust or ignore project-local settings for one command. `pi update` never prompts for project trust.
+These commands manage pi packages and `pi update` can update the pi CLI installation. To uninstall pi itself, see [Quickstart](quickstart.md#uninstall). `pi config` remains accepted as an alias for `pi loadout`. `pi loadout` and project package commands accept `--approve`/`--no-approve` to trust or ignore project-local settings for one command. `pi update` never prompts for project trust.
 
 See [Pi Packages](packages.md) for package sources and security notes.
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -231,8 +231,8 @@ ${chalk.bold("Commands:")}
   ${APP_NAME} uninstall <source> [-l]   Alias for remove
   ${APP_NAME} update [source|self|pi]   Update pi, extensions, or model catalogs
   ${APP_NAME} list                      List installed extensions from settings
-  ${APP_NAME} config [-l]               Open TUI to enable/disable package resources (Tab switches scope)
-  ${APP_NAME} <command> --help          Show help for install/remove/uninstall/update/list/config
+  ${APP_NAME} loadout [-l]              Open TUI to enable/disable package resources (config is an alias)
+  ${APP_NAME} <command> --help          Show help for install/remove/uninstall/update/list/loadout
 
 ${chalk.bold("Options:")}
   --provider <name>              Provider name (default: google)

--- a/packages/coding-agent/src/cli/loadout-selector.ts
+++ b/packages/coding-agent/src/cli/loadout-selector.ts
@@ -1,13 +1,16 @@
 /**
- * TUI config selector for `pi config` command
+ * TUI loadout selector for `pi loadout` command
  */
 
 import { ProcessTerminal, TUI } from "@earendil-works/pi-tui";
 import type { SettingsManager } from "../core/settings-manager.ts";
-import { ConfigSelectorComponent, type ScopedResolvedPaths } from "../modes/interactive/components/config-selector.ts";
+import {
+	LoadoutSelectorComponent,
+	type ScopedResolvedPaths,
+} from "../modes/interactive/components/loadout-selector.ts";
 import { initTheme, stopThemeWatcher } from "../modes/interactive/theme/theme.ts";
 
-export interface ConfigSelectorOptions {
+export interface LoadoutSelectorOptions {
 	resolvedPaths: ScopedResolvedPaths;
 	settingsManager: SettingsManager;
 	cwd: string;
@@ -16,8 +19,8 @@ export interface ConfigSelectorOptions {
 	projectModeAvailable: boolean;
 }
 
-/** Show TUI config selector and return when closed */
-export async function selectConfig(options: ConfigSelectorOptions): Promise<void> {
+/** Show TUI loadout selector and return when closed */
+export async function selectLoadout(options: LoadoutSelectorOptions): Promise<void> {
 	// Initialize theme before showing TUI
 	initTheme(options.settingsManager.getTheme(), true);
 
@@ -25,7 +28,7 @@ export async function selectConfig(options: ConfigSelectorOptions): Promise<void
 		const ui = new TUI(new ProcessTerminal(), undefined, options.agentDir);
 		let resolved = false;
 
-		const selector = new ConfigSelectorComponent(
+		const selector = new LoadoutSelectorComponent(
 			options.resolvedPaths,
 			options.settingsManager,
 			options.cwd,

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -153,9 +153,10 @@ export async function createAgentSessionServices(
 
 	const diagnostics: AgentSessionRuntimeDiagnostic[] = [];
 	const extensionsResult = resourceLoader.getExtensions();
+	modelRuntime.resetSessionExtensionProviders();
 	for (const { name, config, extensionPath } of extensionsResult.runtime.pendingProviderRegistrations) {
 		try {
-			modelRuntime.registerProvider(name, config);
+			modelRuntime.registerSessionExtensionProvider(name, config);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			diagnostics.push({
@@ -167,7 +168,7 @@ export async function createAgentSessionServices(
 	extensionsResult.runtime.pendingProviderRegistrations = [];
 	for (const { provider, extensionPath } of extensionsResult.runtime.pendingNativeProviderRegistrations) {
 		try {
-			modelRuntime.registerNativeProvider(provider);
+			modelRuntime.registerSessionNativeExtensionProvider(provider);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			diagnostics.push({

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -256,6 +256,11 @@ export interface ModelCycleResult {
 	isScoped: boolean;
 }
 
+export interface ReloadResult {
+	/** User-facing diagnostic when reload removed the active model. */
+	modelFallbackMessage?: string;
+}
+
 /** Session statistics for /session command */
 export interface SessionStats {
 	sessionFile: string | undefined;
@@ -2316,16 +2321,45 @@ export class AgentSession {
 
 	private _refreshCurrentModelFromRegistry(): void {
 		const currentModel = this.model;
-		if (!currentModel) {
-			return;
-		}
-
+		if (!currentModel) return;
 		const refreshedModel = this._modelRuntime.getModel(currentModel.provider, currentModel.id);
-		if (!refreshedModel || refreshedModel === currentModel) {
-			return;
+		if (refreshedModel && refreshedModel !== currentModel) this.agent.state.model = refreshedModel;
+	}
+
+	private _reconcileModelAfterReload(previousModel: Model<any> | undefined): string | undefined {
+		this._scopedModels = this._scopedModels.flatMap((scoped) => {
+			const model = this._modelRuntime.getModel(scoped.model.provider, scoped.model.id);
+			return model ? [{ ...scoped, model }] : [];
+		});
+		if (!previousModel) return undefined;
+
+		const refreshedModel = this._modelRuntime.getModel(previousModel.provider, previousModel.id);
+		if (refreshedModel) {
+			this.agent.state.model = refreshedModel;
+			return undefined;
 		}
 
-		this.agent.state.model = refreshedModel;
+		const fallback = this._modelRuntime.getAvailableSnapshot()[0];
+		if (fallback) {
+			this.agent.state.model = fallback;
+			this.agent.state.thinkingLevel = clampThinkingLevel(fallback, this.thinkingLevel) as ThinkingLevel;
+			return `Active model "${previousModel.provider}/${previousModel.id}" is no longer available after reload. Switched to "${fallback.provider}/${fallback.id}".`;
+		}
+
+		this.agent.state.model = {
+			...previousModel,
+			id: "unknown",
+			name: "unknown",
+			api: "unknown",
+			provider: "unknown",
+			baseUrl: "",
+			reasoning: false,
+			input: [],
+			contextWindow: 0,
+			maxTokens: 0,
+		};
+		this.agent.state.thinkingLevel = "off";
+		return `Active model "${previousModel.provider}/${previousModel.id}" is no longer available after reload. No configured model is available; use /model or /login to select one.`;
 	}
 
 	private _bindExtensionCore(runner: ExtensionRunner): void {
@@ -2436,15 +2470,15 @@ export class AgentSession {
 			},
 			{
 				registerProvider: (name, config) => {
-					this._modelRuntime.registerProvider(name, config);
+					this._modelRuntime.registerSessionExtensionProvider(name, config);
 					this._refreshCurrentModelFromRegistry();
 				},
 				registerNativeProvider: (provider) => {
-					this._modelRuntime.registerNativeProvider(provider);
+					this._modelRuntime.registerSessionNativeExtensionProvider(provider);
 					this._refreshCurrentModelFromRegistry();
 				},
 				unregisterProvider: (name) => {
-					this._modelRuntime.unregisterProvider(name);
+					this._modelRuntime.unregisterSessionExtensionProvider(name);
 					this._refreshCurrentModelFromRegistry();
 				},
 			},
@@ -2598,15 +2632,28 @@ export class AgentSession {
 		});
 	}
 
-	async reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<void> {
-		const previousFlagValues = this._extensionRunner.getFlagValues();
-		await emitSessionShutdownEvent(this._extensionRunner, { type: "session_shutdown", reason: "reload" });
+	async reload(options?: {
+		beforeExtensionInvalidate?: () => void;
+		beforeSessionStart?: () => void | Promise<void>;
+	}): Promise<ReloadResult> {
+		const oldRunner = this._extensionRunner;
+		const previousFlagValues = oldRunner.getFlagValues();
+		const previousActiveToolNames = this.getActiveToolNames();
+		const previousModel = this.model;
+		await emitSessionShutdownEvent(oldRunner, { type: "session_shutdown", reason: "reload" });
+		try {
+			options?.beforeExtensionInvalidate?.();
+		} finally {
+			oldRunner.invalidate();
+		}
+
 		await this.settingsManager.reload();
 		this.syncQueueModesFromSettings();
 		resetApiProviders();
+		this._modelRuntime.resetSessionExtensionProviders();
 		await this._resourceLoader.reload();
 		this._buildRuntime({
-			activeToolNames: this.getActiveToolNames(),
+			activeToolNames: previousActiveToolNames,
 			flagValues: previousFlagValues,
 			includeAllExtensionTools: true,
 		});
@@ -2621,6 +2668,8 @@ export class AgentSession {
 			await this._extensionRunner.emit({ type: "session_start", reason: "reload" });
 			await this.extendResourcesFromExtensions("reload");
 		}
+		await this._modelRuntime.refresh({ allowNetwork: false });
+		return { modelFallbackMessage: this._reconcileModelAfterReload(previousModel) };
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -869,7 +869,7 @@ export class AgentSession {
 
 	/** Current model (may be undefined if not yet selected) */
 	get model(): Model<any> | undefined {
-		return this.agent.state.model;
+		return this.agent.hasModel ? this.agent.state.model : undefined;
 	}
 
 	/** Current thinking level */
@@ -2346,18 +2346,7 @@ export class AgentSession {
 			return `Active model "${previousModel.provider}/${previousModel.id}" is no longer available after reload. Switched to "${fallback.provider}/${fallback.id}".`;
 		}
 
-		this.agent.state.model = {
-			...previousModel,
-			id: "unknown",
-			name: "unknown",
-			api: "unknown",
-			provider: "unknown",
-			baseUrl: "",
-			reasoning: false,
-			input: [],
-			contextWindow: 0,
-			maxTokens: 0,
-		};
+		this.agent.clearModel();
 		this.agent.state.thinkingLevel = "off";
 		return `Active model "${previousModel.provider}/${previousModel.id}" is no longer available after reload. No configured model is available; use /model or /login to select one.`;
 	}

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -172,6 +172,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
 	};
 	const state: { staleMessage?: string } = {};
+	const eventBusUnsubscribers = new Set<() => void>();
 	const assertActive = () => {
 		if (state.staleMessage) {
 			throw new Error(state.staleMessage);
@@ -199,9 +200,23 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		pendingNativeProviderRegistrations: [],
 		assertActive,
 		invalidate: (message) => {
-			state.staleMessage ??=
+			if (state.staleMessage) return;
+			state.staleMessage =
 				message ??
 				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
+			for (const unsubscribe of eventBusUnsubscribers) unsubscribe();
+			eventBusUnsubscribers.clear();
+		},
+		trackEventBusSubscription: (unsubscribe) => {
+			let active = true;
+			const trackedUnsubscribe = () => {
+				if (!active) return;
+				active = false;
+				eventBusUnsubscribers.delete(trackedUnsubscribe);
+				unsubscribe();
+			};
+			eventBusUnsubscribers.add(trackedUnsubscribe);
+			return trackedUnsubscribe;
 		},
 		// Pre-bind: queue registrations so bindCore() can flush them once the
 		// model registry is available. bindCore() replaces both with direct calls.
@@ -386,7 +401,16 @@ function createExtensionAPI(
 			runtime.unregisterProvider(name, extension.path);
 		},
 
-		events: eventBus,
+		events: {
+			emit(channel, data) {
+				runtime.assertActive();
+				eventBus.emit(channel, data);
+			},
+			on(channel, handler) {
+				runtime.assertActive();
+				return runtime.trackEventBusSubscription(eventBus.on(channel, handler));
+			},
+		},
 	} as ExtensionAPI;
 
 	return api;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1577,6 +1577,8 @@ export interface ExtensionRuntimeState {
 	assertActive: () => void;
 	/** Marks this extension instance as stale after runtime replacement or reload. */
 	invalidate: (message?: string) => void;
+	/** Track an event-bus subscription so invalidating this runtime removes it. */
+	trackEventBusSubscription: (unsubscribe: () => void) => () => void;
 	/**
 	 * Register or unregister a provider.
 	 *

--- a/packages/coding-agent/src/core/loadout.ts
+++ b/packages/coding-agent/src/core/loadout.ts
@@ -1,0 +1,362 @@
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { CONFIG_DIR_NAME } from "../config.ts";
+import { parseGitUrl } from "../utils/git.ts";
+import { canonicalizePath, isLocalPath, resolvePath } from "../utils/paths.ts";
+import type { ResourceDiagnostic } from "./diagnostics.ts";
+import type { PathMetadata, ResolvedPaths, ResolvedResource } from "./package-manager.ts";
+import type { SessionEntry, SessionManager } from "./session-manager.ts";
+
+export const LOADOUT_CUSTOM_TYPE = "pi.loadout";
+export const LOADOUT_ENTRY_VERSION = 1;
+
+export type LoadoutResourceType = "extension" | "skill" | "prompt" | "theme";
+export type LoadoutResourceScope = "user" | "project";
+
+export interface PackageLoadoutResourceReference {
+	type: LoadoutResourceType;
+	origin: "package";
+	/** Canonical package identity without an npm version or git ref. */
+	source: string;
+	/** POSIX-style path relative to the package root. */
+	relativePath: string;
+}
+
+export interface TopLevelLoadoutResourceReference {
+	type: LoadoutResourceType;
+	origin: "top-level";
+	scope: LoadoutResourceScope;
+	/** Path relative to the standard user or project resource root. */
+	relativePath?: string;
+	/** Canonical local fallback for resources outside the standard roots. */
+	path?: string;
+}
+
+export type LoadoutResourceReference = PackageLoadoutResourceReference | TopLevelLoadoutResourceReference;
+
+export interface LoadoutOverride {
+	reference: LoadoutResourceReference;
+	enabled: boolean;
+}
+
+export interface LoadoutEntryPayload {
+	version: 1;
+	overrides: LoadoutOverride[];
+}
+
+export interface SelectableLoadoutResource {
+	reference: LoadoutResourceReference;
+	path: string;
+	/** Enabled state after the session overlay. */
+	enabled: boolean;
+	/** Enabled state from package/settings resolution before the session overlay. */
+	defaultEnabled: boolean;
+	metadata: PathMetadata;
+}
+
+export interface LoadoutSnapshot {
+	resources: SelectableLoadoutResource[];
+	overrides: LoadoutOverride[];
+	diagnostics: ResourceDiagnostic[];
+}
+
+export interface LoadoutResourceLoader {
+	getLoadoutSnapshot(): LoadoutSnapshot;
+	setLoadoutOverrides(overrides: readonly LoadoutOverride[]): void;
+}
+
+export interface ResolveLoadoutOverlayOptions {
+	cwd: string;
+	agentDir: string;
+}
+
+export interface ResolvedLoadoutOverlay {
+	resolvedPaths: ResolvedPaths;
+	snapshot: LoadoutSnapshot;
+}
+
+const RESOURCE_COLLECTIONS = [
+	["extensions", "extension"],
+	["skills", "skill"],
+	["prompts", "prompt"],
+	["themes", "theme"],
+] as const satisfies ReadonlyArray<readonly [keyof ResolvedPaths, LoadoutResourceType]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+	const allowedKeys = new Set(allowed);
+	return Object.keys(value).every((key) => allowedKeys.has(key));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0 && !value.includes("\0");
+}
+
+function isLoadoutResourceType(value: unknown): value is LoadoutResourceType {
+	return value === "extension" || value === "skill" || value === "prompt" || value === "theme";
+}
+
+function isSafeRelativePath(value: unknown): value is string {
+	if (!isNonEmptyString(value) || isAbsolute(value)) return false;
+	const segments = value.replace(/\\/g, "/").split("/");
+	return !segments.includes("..");
+}
+
+function parseReference(value: unknown): LoadoutResourceReference | undefined {
+	if (!isRecord(value) || !isLoadoutResourceType(value.type)) return undefined;
+	if (value.origin === "package") {
+		if (!hasOnlyKeys(value, ["type", "origin", "source", "relativePath"])) return undefined;
+		if (!isNonEmptyString(value.source) || !isSafeRelativePath(value.relativePath)) return undefined;
+		return {
+			type: value.type,
+			origin: "package",
+			source: value.source,
+			relativePath: value.relativePath.replace(/\\/g, "/"),
+		};
+	}
+	if (value.origin !== "top-level") return undefined;
+	if (!hasOnlyKeys(value, ["type", "origin", "scope", "relativePath", "path"])) return undefined;
+	if (value.scope !== "user" && value.scope !== "project") return undefined;
+	if (value.relativePath !== undefined) {
+		if (value.path !== undefined || !isSafeRelativePath(value.relativePath)) return undefined;
+		return {
+			type: value.type,
+			origin: "top-level",
+			scope: value.scope,
+			relativePath: value.relativePath.replace(/\\/g, "/"),
+		};
+	}
+	if (!isNonEmptyString(value.path)) return undefined;
+	return { type: value.type, origin: "top-level", scope: value.scope, path: value.path };
+}
+
+/** Parse and defensively copy a versioned loadout payload. */
+export function parseLoadoutEntryPayload(value: unknown): LoadoutEntryPayload | undefined {
+	if (!isRecord(value) || !hasOnlyKeys(value, ["version", "overrides"])) return undefined;
+	if (value.version !== LOADOUT_ENTRY_VERSION || !Array.isArray(value.overrides)) return undefined;
+	const overrides: LoadoutOverride[] = [];
+	const seen = new Set<string>();
+	for (const candidate of value.overrides) {
+		if (!isRecord(candidate) || !hasOnlyKeys(candidate, ["reference", "enabled"])) return undefined;
+		if (typeof candidate.enabled !== "boolean") return undefined;
+		const reference = parseReference(candidate.reference);
+		if (!reference) return undefined;
+		const key = getLoadoutResourceReferenceKey(reference);
+		if (seen.has(key)) return undefined;
+		seen.add(key);
+		overrides.push({ reference, enabled: candidate.enabled });
+	}
+	return { version: LOADOUT_ENTRY_VERSION, overrides };
+}
+
+export function getLoadoutResourceReferenceKey(reference: LoadoutResourceReference): string {
+	return reference.origin === "package"
+		? JSON.stringify([reference.type, reference.origin, reference.source, reference.relativePath])
+		: JSON.stringify([
+				reference.type,
+				reference.origin,
+				reference.scope,
+				reference.relativePath !== undefined ? "relative" : "path",
+				reference.relativePath ?? reference.path,
+			]);
+}
+
+function parseNpmPackageName(source: string): string | undefined {
+	if (!source.startsWith("npm:")) return undefined;
+	const spec = source.slice(4).trim();
+	const match = spec.match(/^(@[^/]+\/[^@]+|[^@]+)(?:@.+)?$/);
+	return match?.[1];
+}
+
+function canonicalPackageSource(
+	source: string,
+	scope: LoadoutResourceScope,
+	options: ResolveLoadoutOverlayOptions,
+): string {
+	const npmName = parseNpmPackageName(source);
+	if (npmName) return `npm:${npmName}`;
+	const git = parseGitUrl(source);
+	if (git) return `git:${git.host.toLowerCase()}/${git.path}`;
+	if (!isLocalPath(source)) return source.trim();
+	const baseDir = scope === "project" ? join(options.cwd, CONFIG_DIR_NAME) : options.agentDir;
+	return `local:${canonicalizePath(resolvePath(source, baseDir, { trim: true }))}`;
+}
+
+function isPathWithin(target: string, root: string): boolean {
+	const relativePath = relative(root, target);
+	return (
+		relativePath === "" ||
+		(relativePath !== ".." && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath))
+	);
+}
+
+function toRelativeResourcePath(target: string, root: string): string {
+	const value = relative(root, target);
+	return (value || ".").split(sep).join("/");
+}
+
+/** Build a logical reference from a resource already discovered by package/settings resolution. */
+export function createLoadoutResourceReference(
+	resourceType: LoadoutResourceType,
+	resource: ResolvedResource,
+	options: ResolveLoadoutOverlayOptions,
+): LoadoutResourceReference | undefined {
+	const scope = resource.metadata.scope;
+	if (scope !== "user" && scope !== "project") return undefined;
+	const resourcePath = resolve(resource.path);
+	if (resource.metadata.origin === "package") {
+		const baseDir = resource.metadata.baseDir ? resolve(resource.metadata.baseDir) : resolve(resource.path, "..");
+		if (!isPathWithin(resourcePath, baseDir)) return undefined;
+		return {
+			type: resourceType,
+			origin: "package",
+			source: canonicalPackageSource(resource.metadata.source, scope, options),
+			relativePath: toRelativeResourcePath(resourcePath, baseDir),
+		};
+	}
+	const standardRoot = resolve(scope === "project" ? join(options.cwd, CONFIG_DIR_NAME) : options.agentDir);
+	if (isPathWithin(resourcePath, standardRoot)) {
+		return {
+			type: resourceType,
+			origin: "top-level",
+			scope,
+			relativePath: toRelativeResourcePath(resourcePath, standardRoot),
+		};
+	}
+	return {
+		type: resourceType,
+		origin: "top-level",
+		scope,
+		path: canonicalizePath(resourcePath),
+	};
+}
+
+function cloneReference(reference: LoadoutResourceReference): LoadoutResourceReference {
+	return reference.origin === "package"
+		? { ...reference }
+		: reference.relativePath !== undefined
+			? { type: reference.type, origin: "top-level", scope: reference.scope, relativePath: reference.relativePath }
+			: { type: reference.type, origin: "top-level", scope: reference.scope, path: reference.path };
+}
+
+export function cloneLoadoutOverrides(overrides: readonly LoadoutOverride[]): LoadoutOverride[] {
+	return overrides.map((override) => ({ reference: cloneReference(override.reference), enabled: override.enabled }));
+}
+
+export function cloneLoadoutSnapshot(snapshot: LoadoutSnapshot): LoadoutSnapshot {
+	return {
+		resources: snapshot.resources.map((resource) => ({
+			...resource,
+			reference: cloneReference(resource.reference),
+			metadata: { ...resource.metadata },
+		})),
+		overrides: cloneLoadoutOverrides(snapshot.overrides),
+		diagnostics: snapshot.diagnostics.map((diagnostic) => ({
+			...diagnostic,
+			collision: diagnostic.collision ? { ...diagnostic.collision } : undefined,
+		})),
+	};
+}
+
+function describeReference(reference: LoadoutResourceReference): string {
+	if (reference.origin === "package") return `${reference.source}/${reference.relativePath}`;
+	return reference.relativePath ?? reference.path ?? "unknown";
+}
+
+/** Apply session overrides only to currently discovered resources. */
+export function resolveLoadoutOverlay(
+	resolvedPaths: ResolvedPaths,
+	overrides: readonly LoadoutOverride[],
+	options: ResolveLoadoutOverlayOptions,
+): ResolvedLoadoutOverlay {
+	const parsed = parseLoadoutEntryPayload({ version: LOADOUT_ENTRY_VERSION, overrides });
+	if (!parsed) throw new Error("Invalid loadout overrides");
+	const overridesByKey = new Map(
+		parsed.overrides.map((override) => [getLoadoutResourceReferenceKey(override.reference), override] as const),
+	);
+	const unmatchedKeys = new Set(overridesByKey.keys());
+	const resources: SelectableLoadoutResource[] = [];
+	const overlaid: ResolvedPaths = { extensions: [], skills: [], prompts: [], themes: [] };
+
+	for (const [collection, resourceType] of RESOURCE_COLLECTIONS) {
+		for (const resource of resolvedPaths[collection]) {
+			const reference = createLoadoutResourceReference(resourceType, resource, options);
+			if (!reference) {
+				overlaid[collection].push({ ...resource, metadata: { ...resource.metadata } });
+				continue;
+			}
+			const key = getLoadoutResourceReferenceKey(reference);
+			const override = overridesByKey.get(key);
+			const enabled = override?.enabled ?? resource.enabled;
+			if (override) unmatchedKeys.delete(key);
+			const metadata = { ...resource.metadata };
+			overlaid[collection].push({ path: resource.path, enabled, metadata });
+			resources.push({
+				reference,
+				path: resource.path,
+				enabled,
+				defaultEnabled: resource.enabled,
+				metadata: { ...metadata },
+			});
+		}
+	}
+
+	const diagnostics: ResourceDiagnostic[] = [];
+	for (const key of unmatchedKeys) {
+		const override = overridesByKey.get(key)!;
+		diagnostics.push({
+			type: "warning",
+			message: `Saved loadout ${override.reference.type} is unavailable: ${describeReference(override.reference)}`,
+		});
+	}
+	return {
+		resolvedPaths: overlaid,
+		snapshot: { resources, overrides: cloneLoadoutOverrides(parsed.overrides), diagnostics },
+	};
+}
+
+/** Recover the latest valid loadout entry in physical session-file order. */
+export function getLatestLoadoutEntry(entries: readonly SessionEntry[]): LoadoutEntryPayload | undefined {
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry.type !== "custom" || entry.customType !== LOADOUT_CUSTOM_TYPE) continue;
+		const payload = parseLoadoutEntryPayload(entry.data);
+		if (payload) return payload;
+	}
+	return undefined;
+}
+
+export function getSessionLoadout(sessionManager: Pick<SessionManager, "getEntries">): LoadoutEntryPayload | undefined {
+	return getLatestLoadoutEntry(sessionManager.getEntries());
+}
+
+function overrideSetsEqual(left: readonly LoadoutOverride[], right: readonly LoadoutOverride[]): boolean {
+	if (left.length !== right.length) return false;
+	const rightByKey = new Map(
+		right.map((override) => [getLoadoutResourceReferenceKey(override.reference), override.enabled]),
+	);
+	return left.every(
+		(override) => rightByKey.get(getLoadoutResourceReferenceKey(override.reference)) === override.enabled,
+	);
+}
+
+/**
+ * Append a deliberate session loadout change.
+ * Empty state is written only as a reset marker after a prior non-empty state.
+ */
+export function appendSessionLoadout(
+	sessionManager: Pick<SessionManager, "appendCustomEntry" | "getEntries">,
+	overrides: readonly LoadoutOverride[],
+): string | undefined {
+	const payload = parseLoadoutEntryPayload({ version: LOADOUT_ENTRY_VERSION, overrides });
+	if (!payload) throw new Error("Invalid loadout overrides");
+	const latest = getLatestLoadoutEntry(sessionManager.getEntries());
+	if (payload.overrides.length === 0) {
+		if (!latest || latest.overrides.length === 0) return undefined;
+	} else if (latest && overrideSetsEqual(latest.overrides, payload.overrides)) {
+		return undefined;
+	}
+	return sessionManager.appendCustomEntry(LOADOUT_CUSTOM_TYPE, payload);
+}

--- a/packages/coding-agent/src/core/loadout.ts
+++ b/packages/coding-agent/src/core/loadout.ts
@@ -332,7 +332,7 @@ export function getSessionLoadout(sessionManager: Pick<SessionManager, "getEntri
 	return getLatestLoadoutEntry(sessionManager.getEntries());
 }
 
-function overrideSetsEqual(left: readonly LoadoutOverride[], right: readonly LoadoutOverride[]): boolean {
+export function loadoutOverridesEqual(left: readonly LoadoutOverride[], right: readonly LoadoutOverride[]): boolean {
 	if (left.length !== right.length) return false;
 	const rightByKey = new Map(
 		right.map((override) => [getLoadoutResourceReferenceKey(override.reference), override.enabled]),
@@ -355,7 +355,7 @@ export function appendSessionLoadout(
 	const latest = getLatestLoadoutEntry(sessionManager.getEntries());
 	if (payload.overrides.length === 0) {
 		if (!latest || latest.overrides.length === 0) return undefined;
-	} else if (latest && overrideSetsEqual(latest.overrides, payload.overrides)) {
+	} else if (latest && loadoutOverridesEqual(latest.overrides, payload.overrides)) {
 		return undefined;
 	}
 	return sessionManager.appendCustomEntry(LOADOUT_CUSTOM_TYPE, payload);

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -98,6 +98,10 @@ export class ModelRuntime implements Models {
 	private readonly builtins = new Map<string, Provider>();
 	private readonly nativeExtensionProviders = new Map<string, Provider>();
 	private readonly extensionProviders = new Map<string, ProviderConfigInput>();
+	private readonly sessionExtensionProviders = new Map<
+		string,
+		{ nativeProvider?: Provider; config?: ProviderConfigInput }
+	>();
 	private readonly compositionErrors = new Map<string, string>();
 	private readonly modelsPath: string | undefined;
 	private readonly modelNetworkEnabled: boolean;
@@ -194,12 +198,26 @@ export class ModelRuntime implements Models {
 			...this.nativeExtensionProviders.keys(),
 			...this.config.getProviderIds(),
 			...this.extensionProviders.keys(),
+			...this.sessionExtensionProviders.keys(),
 		]);
 	}
 
+	private getEffectiveRegisteredProvider(providerId: string): {
+		nativeProvider?: Provider;
+		config?: ProviderConfigInput;
+	} {
+		const sessionProvider = this.sessionExtensionProviders.get(providerId);
+		if (sessionProvider) return sessionProvider;
+		return {
+			nativeProvider: this.nativeExtensionProviders.get(providerId),
+			config: this.extensionProviders.get(providerId),
+		};
+	}
+
 	private recomposeProvider(providerId: string): void {
-		const base = this.nativeExtensionProviders.get(providerId) ?? this.builtins.get(providerId);
-		const extension = this.extensionProviders.get(providerId);
+		const registered = this.getEffectiveRegisteredProvider(providerId);
+		const base = registered.nativeProvider ?? this.builtins.get(providerId);
+		const extension = registered.config;
 		if (!base && !this.config.getProvider(providerId) && !extension) {
 			this.models.deleteProvider(providerId);
 			this.compositionErrors.delete(providerId);
@@ -343,15 +361,18 @@ export class ModelRuntime implements Models {
 	}
 
 	getRegisteredProviderConfig(providerId: string): ProviderConfigInput | undefined {
-		return this.extensionProviders.get(providerId);
+		return this.getEffectiveRegisteredProvider(providerId).config;
 	}
 
 	getRegisteredProviderIds(): readonly string[] {
-		return [...new Set([...this.extensionProviders.keys(), ...this.nativeExtensionProviders.keys()])];
+		return [...this.providerIds()].filter((providerId) => {
+			const registered = this.getEffectiveRegisteredProvider(providerId);
+			return registered.config !== undefined || registered.nativeProvider !== undefined;
+		});
 	}
 
 	getRegisteredNativeProvider(providerId: string): Provider | undefined {
-		return this.nativeExtensionProviders.get(providerId);
+		return this.getEffectiveRegisteredProvider(providerId).nativeProvider;
 	}
 
 	/** @internal Compatibility fallback for ModelRegistry when provider auth is unconfigured. */
@@ -359,7 +380,7 @@ export class ModelRuntime implements Models {
 		return resolveCompatibilityRequestConfig(
 			model,
 			this.config.getProvider(model.provider),
-			this.extensionProviders.get(model.provider),
+			this.getEffectiveRegisteredProvider(model.provider).config,
 		);
 	}
 
@@ -383,7 +404,7 @@ export class ModelRuntime implements Models {
 		const configuredHeaders = resolveConfiguredModelHeaders(
 			providerOrModel,
 			this.config.getProvider(providerOrModel.provider),
-			this.extensionProviders.get(providerOrModel.provider),
+			this.getEffectiveRegisteredProvider(providerOrModel.provider).config,
 			{ ...(resolution.env ?? {}), ...(overrides.env ?? {}) },
 		);
 		return {
@@ -428,7 +449,7 @@ export class ModelRuntime implements Models {
 		if (this.snapshot.storedProviders.has(providerId)) return { configured: true, source: "stored" };
 		const configured = configuredRequestAuthStatus(
 			this.config.getProvider(providerId),
-			this.extensionProviders.get(providerId),
+			this.getEffectiveRegisteredProvider(providerId).config,
 		);
 		if (configured) return configured;
 		const check = this.snapshot.auth.get(providerId);
@@ -586,6 +607,50 @@ export class ModelRuntime implements Models {
 	unregisterProvider(providerId: string): void {
 		this.extensionProviders.delete(providerId);
 		this.nativeExtensionProviders.delete(providerId);
+		this.recomposeProvider(providerId);
+		this.updateModelSnapshot();
+		void this.refresh({ allowNetwork: false });
+	}
+
+	/** Clear provider registrations owned by the current extension runtime. */
+	resetSessionExtensionProviders(): void {
+		const providerIds = [...this.sessionExtensionProviders.keys()];
+		this.sessionExtensionProviders.clear();
+		for (const providerId of providerIds) this.recomposeProvider(providerId);
+		this.updateModelSnapshot();
+	}
+
+	/** Register a provider in the current extension-runtime layer. */
+	registerSessionExtensionProvider(providerId: string, config: ProviderConfigInput): void {
+		const previous = this.getEffectiveRegisteredProvider(providerId).config;
+		validateExtensionProvider(
+			providerId,
+			this.getEffectiveRegisteredProvider(providerId).nativeProvider ?? this.builtins.get(providerId),
+			this.config.getProvider(providerId),
+			config,
+		);
+		const effective: ProviderConfigInput = { ...previous };
+		for (const [key, value] of Object.entries(config)) {
+			if (value !== undefined) (effective as Record<string, unknown>)[key] = value;
+		}
+		this.sessionExtensionProviders.set(providerId, { config: effective });
+		this.recomposeProvider(providerId);
+		this.updateModelSnapshot();
+		void this.refresh({ allowNetwork: false });
+	}
+
+	/** Register a native provider in the current extension-runtime layer. */
+	registerSessionNativeExtensionProvider(provider: Provider): void {
+		if (!provider.id.trim()) throw new Error("Provider id must not be empty.");
+		this.sessionExtensionProviders.set(provider.id, { nativeProvider: provider });
+		this.recomposeProvider(provider.id);
+		this.updateModelSnapshot();
+		void this.refresh({ allowNetwork: false });
+	}
+
+	/** Unregister a provider from the current extension-runtime layer. */
+	unregisterSessionExtensionProvider(providerId: string): void {
+		this.sessionExtensionProviders.set(providerId, {});
 		this.recomposeProvider(providerId);
 		this.updateModelSnapshot();
 		void this.refresh({ allowNetwork: false });

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -16,6 +16,15 @@ import {
 	loadExtensionsCached,
 } from "./extensions/loader.ts";
 import type { Extension, ExtensionRuntime, InlineExtension, LoadExtensionsResult } from "./extensions/types.ts";
+import {
+	cloneLoadoutOverrides,
+	cloneLoadoutSnapshot,
+	LOADOUT_ENTRY_VERSION,
+	type LoadoutOverride,
+	type LoadoutSnapshot,
+	parseLoadoutEntryPayload,
+	resolveLoadoutOverlay,
+} from "./loadout.ts";
 import { DefaultPackageManager, type PathMetadata, type ResolvedResource } from "./package-manager.ts";
 import type { PromptTemplate } from "./prompt-templates.ts";
 import { loadPromptTemplates } from "./prompt-templates.ts";
@@ -45,6 +54,10 @@ export interface ResourceLoader {
 	getAppendSystemPrompt(): string[];
 	extendResources(paths: ResourceExtensionPaths): void;
 	reload(options?: ResourceLoaderReloadOptions): Promise<void>;
+	/** Optional capability implemented by DefaultResourceLoader for session loadout overlays. */
+	getLoadoutSnapshot?(): LoadoutSnapshot;
+	/** Optional capability implemented by DefaultResourceLoader for session loadout overlays. */
+	setLoadoutOverrides?(overrides: readonly LoadoutOverride[]): void;
 }
 
 function resolvePromptInput(input: string | undefined, description: string): string | undefined {
@@ -212,6 +225,8 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private extensionThemeSourceInfos: Map<string, SourceInfo>;
 	private lastPromptPaths: string[];
 	private lastThemePaths: string[];
+	private loadoutOverrides: LoadoutOverride[];
+	private loadoutSnapshot: LoadoutSnapshot;
 	private loaded: boolean;
 
 	constructor(options: DefaultResourceLoaderOptions) {
@@ -259,6 +274,8 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.extensionThemeSourceInfos = new Map();
 		this.lastPromptPaths = [];
 		this.lastThemePaths = [];
+		this.loadoutOverrides = [];
+		this.loadoutSnapshot = { resources: [], overrides: [], diagnostics: [] };
 		this.loaded = false;
 	}
 
@@ -288,6 +305,16 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	getAppendSystemPrompt(): string[] {
 		return this.appendSystemPrompt;
+	}
+
+	getLoadoutSnapshot(): LoadoutSnapshot {
+		return cloneLoadoutSnapshot(this.loadoutSnapshot);
+	}
+
+	setLoadoutOverrides(overrides: readonly LoadoutOverride[]): void {
+		const payload = parseLoadoutEntryPayload({ version: LOADOUT_ENTRY_VERSION, overrides });
+		if (!payload) throw new Error("Invalid loadout overrides");
+		this.loadoutOverrides = cloneLoadoutOverrides(payload.overrides);
 	}
 
 	extendResources(paths: ResourceExtensionPaths): void {
@@ -354,7 +381,13 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 		// reload() preserves SettingsManager.projectTrusted and reloads settings for that trust state.
 		await this.settingsManager.reload();
-		const resolvedPaths = await this.packageManager.resolve();
+		const baseResolvedPaths = await this.packageManager.resolve();
+		const overlay = resolveLoadoutOverlay(baseResolvedPaths, this.loadoutOverrides, {
+			cwd: this.cwd,
+			agentDir: this.agentDir,
+		});
+		const resolvedPaths = overlay.resolvedPaths;
+		this.loadoutSnapshot = overlay.snapshot;
 		const cliExtensionPaths = await this.packageManager.resolveExtensionSources(this.additionalExtensionPaths, {
 			temporary: true,
 		});
@@ -493,7 +526,11 @@ export class DefaultResourceLoader implements ResourceLoader {
 	}
 
 	private async loadCurrentExtensionSet(options: { includeInlineFactories: boolean }): Promise<LoadExtensionsResult> {
-		const resolvedPaths = await this.packageManager.resolve();
+		const baseResolvedPaths = await this.packageManager.resolve();
+		const resolvedPaths = resolveLoadoutOverlay(baseResolvedPaths, this.loadoutOverrides, {
+			cwd: this.cwd,
+			agentDir: this.agentDir,
+		}).resolvedPaths;
 		const cliExtensionPaths = await this.packageManager.resolveExtensionSources(this.additionalExtensionPaths, {
 			temporary: true,
 		});

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -18,6 +18,7 @@ export interface BuiltinSlashCommand {
 
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
+	{ name: "loadout", description: "Change session extensions, skills, prompts, and themes" },
 	{ name: "model", description: "Select model (opens selector UI)", argumentHint: "<provider/model>" },
 	{ name: "scoped-models", description: "Enable/disable models for Ctrl+P cycling" },
 	{ name: "export", description: "Export session (HTML default, or specify path: .html/.jsonl)" },

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -165,6 +165,31 @@ export {
 } from "./core/extensions/index.ts";
 // Footer data provider (git branch + extension statuses - data not otherwise available to extensions)
 export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.ts";
+export {
+	appendSessionLoadout,
+	cloneLoadoutOverrides,
+	cloneLoadoutSnapshot,
+	createLoadoutResourceReference,
+	getLatestLoadoutEntry,
+	getLoadoutResourceReferenceKey,
+	getSessionLoadout,
+	LOADOUT_CUSTOM_TYPE,
+	LOADOUT_ENTRY_VERSION,
+	type LoadoutEntryPayload,
+	type LoadoutOverride,
+	type LoadoutResourceLoader,
+	type LoadoutResourceReference,
+	type LoadoutResourceScope,
+	type LoadoutResourceType,
+	type LoadoutSnapshot,
+	type PackageLoadoutResourceReference,
+	parseLoadoutEntryPayload,
+	type ResolvedLoadoutOverlay,
+	type ResolveLoadoutOverlayOptions,
+	resolveLoadoutOverlay,
+	type SelectableLoadoutResource,
+	type TopLevelLoadoutResourceReference,
+} from "./core/loadout.ts";
 export { convertToLlm } from "./core/messages.ts";
 export { ModelRegistry } from "./core/model-registry.ts";
 export {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -182,6 +182,7 @@ export {
 	type LoadoutResourceScope,
 	type LoadoutResourceType,
 	type LoadoutSnapshot,
+	loadoutOverridesEqual,
 	type PackageLoadoutResourceReference,
 	parseLoadoutEntryPayload,
 	type ResolvedLoadoutOverlay,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -45,7 +45,7 @@ import { builtInExtensions } from "./extensions/index.ts";
 import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
 import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.ts";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.ts";
-import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
+import { handleLoadoutCommand, handlePackageCommand } from "./package-manager-cli.ts";
 import { isLocalPath, normalizePath, resolvePath } from "./utils/paths.ts";
 import { cleanupWindowsSelfUpdateQuarantine } from "./utils/windows-self-update.ts";
 
@@ -502,7 +502,7 @@ export async function main(args: string[], options?: MainOptions) {
 		return;
 	}
 
-	if (await handleConfigCommand(args, { extensionFactories })) {
+	if (await handleLoadoutCommand(args, { extensionFactories })) {
 		return;
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -825,6 +825,7 @@ export async function main(args: string[], options?: MainOptions) {
 			initialImages,
 			initialMessages: parsed.messages,
 			verbose: parsed.verbose,
+			promptForSavedLoadout: parsed.fork === undefined,
 		});
 		if (startupBenchmark) {
 			await interactiveMode.init();

--- a/packages/coding-agent/src/modes/interactive/components/loadout-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/loadout-selector.ts
@@ -38,7 +38,7 @@ const RESOURCE_TYPE_LABELS: Record<ResourceType, string> = {
 	themes: "Themes",
 };
 
-interface ResourceItem {
+export interface LoadoutResourceItem {
 	path: string;
 	enabled: boolean;
 	metadata: PathMetadata;
@@ -48,19 +48,19 @@ interface ResourceItem {
 	subgroupKey: string;
 }
 
-interface ResourceSubgroup {
+export interface LoadoutResourceSubgroup {
 	type: ResourceType;
 	label: string;
-	items: ResourceItem[];
+	items: LoadoutResourceItem[];
 }
 
-interface ResourceGroup {
+export interface LoadoutResourceGroup {
 	key: string;
 	label: string;
 	scope: "user" | "project" | "temporary";
 	origin: "package" | "top-level";
 	source: string;
-	subgroups: ResourceSubgroup[];
+	subgroups: LoadoutResourceSubgroup[];
 }
 
 function formatBaseDir(baseDir: string): string {
@@ -96,8 +96,8 @@ function getGroupLabel(metadata: PathMetadata, agentDir: string): string {
 	return metadata.scope === "user" ? "User settings" : "Project settings";
 }
 
-function buildGroups(resolved: ResolvedPaths, agentDir: string): ResourceGroup[] {
-	const groupMap = new Map<string, ResourceGroup>();
+export function buildLoadoutResourceGroups(resolved: ResolvedPaths, agentDir: string): LoadoutResourceGroup[] {
+	const groupMap = new Map<string, LoadoutResourceGroup>();
 
 	const addToGroup = (resources: ResolvedResource[], resourceType: ResourceType) => {
 		for (const res of resources) {
@@ -180,9 +180,9 @@ function buildGroups(resolved: ResolvedPaths, agentDir: string): ResourceGroup[]
 }
 
 type FlatEntry =
-	| { type: "group"; group: ResourceGroup }
-	| { type: "subgroup"; subgroup: ResourceSubgroup; group: ResourceGroup }
-	| { type: "item"; item: ResourceItem };
+	| { type: "group"; group: LoadoutResourceGroup }
+	| { type: "subgroup"; subgroup: LoadoutResourceSubgroup; group: LoadoutResourceGroup }
+	| { type: "item"; item: LoadoutResourceItem };
 
 class LoadoutSelectorHeader implements Component {
 	private writeScope: LoadoutWriteScope;
@@ -220,7 +220,7 @@ class LoadoutSelectorHeader implements Component {
 }
 
 class ResourceList implements Component, Focusable {
-	private groupsByScope: Record<LoadoutWriteScope, ResourceGroup[]>;
+	private groupsByScope: Record<LoadoutWriteScope, LoadoutResourceGroup[]>;
 	private flatItems: FlatEntry[] = [];
 	private filteredItems: FlatEntry[] = [];
 	private selectedIndex = 0;
@@ -234,7 +234,7 @@ class ResourceList implements Component, Focusable {
 
 	public onCancel?: () => void;
 	public onExit?: () => void;
-	public onToggle?: (item: ResourceItem, newEnabled: boolean) => void;
+	public onToggle?: (item: LoadoutResourceItem, newEnabled: boolean) => void;
 	public onSwitchMode?: () => void;
 
 	private _focused = false;
@@ -247,7 +247,7 @@ class ResourceList implements Component, Focusable {
 	}
 
 	constructor(
-		groupsByScope: Record<LoadoutWriteScope, ResourceGroup[]>,
+		groupsByScope: Record<LoadoutWriteScope, LoadoutResourceGroup[]>,
 		settingsManager: SettingsManager,
 		cwd: string,
 		agentDir: string,
@@ -274,11 +274,11 @@ class ResourceList implements Component, Focusable {
 		this.filterItems(this.searchInput.getValue());
 	}
 
-	private get groups(): ResourceGroup[] {
+	private get groups(): LoadoutResourceGroup[] {
 		return this.groupsByScope[this.writeScope];
 	}
 
-	private buildInheritedEnabledMap(groups: ResourceGroup[]): Map<string, boolean> {
+	private buildInheritedEnabledMap(groups: LoadoutResourceGroup[]): Map<string, boolean> {
 		const result = new Map<string, boolean>();
 		for (const group of groups) {
 			for (const subgroup of group.subgroups) {
@@ -325,9 +325,9 @@ class ResourceList implements Component, Focusable {
 		}
 
 		const lowerQuery = query.toLowerCase();
-		const matchingItems = new Set<ResourceItem>();
-		const matchingSubgroups = new Set<ResourceSubgroup>();
-		const matchingGroups = new Set<ResourceGroup>();
+		const matchingItems = new Set<LoadoutResourceItem>();
+		const matchingSubgroups = new Set<LoadoutResourceSubgroup>();
+		const matchingGroups = new Set<LoadoutResourceGroup>();
 
 		for (const entry of this.flatItems) {
 			if (entry.type === "item") {
@@ -373,7 +373,7 @@ class ResourceList implements Component, Focusable {
 		this.selectedIndex = firstItemIndex >= 0 ? firstItemIndex : 0;
 	}
 
-	updateItem(item: ResourceItem, enabled: boolean): void {
+	updateItem(item: LoadoutResourceItem, enabled: boolean): void {
 		item.enabled = enabled;
 		// Update in groups too
 		for (const group of this.groups) {
@@ -513,7 +513,7 @@ class ResourceList implements Component, Focusable {
 		this.filterItems(this.searchInput.getValue());
 	}
 
-	private toggleResource(item: ResourceItem): boolean | undefined {
+	private toggleResource(item: LoadoutResourceItem): boolean | undefined {
 		if (this.writeScope === "project") {
 			const state = this.getNextOverrideState(item);
 			if (!this.setProjectResourceOverride(item, state)) return undefined;
@@ -529,7 +529,7 @@ class ResourceList implements Component, Focusable {
 		return enabled;
 	}
 
-	private toggleTopLevelResource(item: ResourceItem, enabled: boolean): void {
+	private toggleTopLevelResource(item: LoadoutResourceItem, enabled: boolean): void {
 		const scope = item.metadata.scope as "user" | "project";
 		const settings =
 			scope === "project" ? this.settingsManager.getProjectSettings() : this.settingsManager.getGlobalSettings();
@@ -577,7 +577,7 @@ class ResourceList implements Component, Focusable {
 		}
 	}
 
-	private togglePackageResource(item: ResourceItem, enabled: boolean): void {
+	private togglePackageResource(item: LoadoutResourceItem, enabled: boolean): void {
 		const scope = item.metadata.scope as "user" | "project";
 		const settings =
 			scope === "project" ? this.settingsManager.getProjectSettings() : this.settingsManager.getGlobalSettings();
@@ -636,7 +636,7 @@ class ResourceList implements Component, Focusable {
 		}
 	}
 
-	private renderCheckbox(item: ResourceItem): string {
+	private renderCheckbox(item: LoadoutResourceItem): string {
 		if (this.writeScope === "project") {
 			const state = this.getProjectOverrideState(item);
 			if (state === "load") return theme.fg("success", "[+]");
@@ -646,7 +646,7 @@ class ResourceList implements Component, Focusable {
 		return item.enabled ? theme.fg("success", "[x]") : theme.fg("dim", "[ ]");
 	}
 
-	private getItemSuffix(item: ResourceItem): string {
+	private getItemSuffix(item: LoadoutResourceItem): string {
 		if (this.writeScope !== "project") return "";
 		const state = this.getProjectOverrideState(item);
 		if (state === "load") return theme.fg("muted", "  project load");
@@ -654,7 +654,7 @@ class ResourceList implements Component, Focusable {
 		return this.isInheritedGlobalItem(item) ? theme.fg("dim", "  inherited global") : "";
 	}
 
-	private isDimmedItem(item: ResourceItem): boolean {
+	private isDimmedItem(item: LoadoutResourceItem): boolean {
 		return (
 			this.writeScope === "project" &&
 			this.isInheritedGlobalItem(item) &&
@@ -662,13 +662,13 @@ class ResourceList implements Component, Focusable {
 		);
 	}
 
-	private setProjectResourceOverride(item: ResourceItem, state: ProjectOverrideState): boolean {
+	private setProjectResourceOverride(item: LoadoutResourceItem, state: ProjectOverrideState): boolean {
 		return item.metadata.origin === "top-level"
 			? this.setProjectTopLevelOverride(item, state)
 			: this.setProjectPackageOverride(item, state);
 	}
 
-	private setProjectTopLevelOverride(item: ResourceItem, state: ProjectOverrideState): boolean {
+	private setProjectTopLevelOverride(item: LoadoutResourceItem, state: ProjectOverrideState): boolean {
 		const current = (this.settingsManager.getProjectSettings()[item.resourceType] ?? []) as string[];
 		const pattern = this.isInheritedGlobalItem(item) ? item.path : this.getResourcePatternForScope(item, "project");
 		const patterns = this.getTopLevelOverridePatterns(item, "project");
@@ -693,7 +693,7 @@ class ResourceList implements Component, Focusable {
 		else this.settingsManager.setProjectThemePaths(paths);
 	}
 
-	private setProjectPackageOverride(item: ResourceItem, state: ProjectOverrideState): boolean {
+	private setProjectPackageOverride(item: LoadoutResourceItem, state: ProjectOverrideState): boolean {
 		const packages = [...(this.settingsManager.getProjectSettings().packages ?? [])] as PackageSource[];
 		let pkgIndex = packages.findIndex((pkg) =>
 			this.packageSourceStringMatches(
@@ -728,7 +728,7 @@ class ResourceList implements Component, Focusable {
 		return true;
 	}
 
-	private getNextOverrideState(item: ResourceItem): ProjectOverrideState {
+	private getNextOverrideState(item: LoadoutResourceItem): ProjectOverrideState {
 		const state = this.getProjectOverrideState(item);
 		const inheritedEnabled = this.getInheritedEnabled(item);
 		if (state === "inherit") return inheritedEnabled ? "unload" : "load";
@@ -736,7 +736,7 @@ class ResourceList implements Component, Focusable {
 		return inheritedEnabled ? "inherit" : "unload";
 	}
 
-	private getProjectOverrideState(item: ResourceItem): ProjectOverrideState {
+	private getProjectOverrideState(item: LoadoutResourceItem): ProjectOverrideState {
 		if (this.writeScope !== "project") return "inherit";
 		if (item.metadata.origin === "top-level") {
 			return this.getOverrideStateFromEntries(
@@ -771,18 +771,18 @@ class ResourceList implements Component, Focusable {
 		return state;
 	}
 
-	private getInheritedEnabled(item: ResourceItem): boolean {
+	private getInheritedEnabled(item: LoadoutResourceItem): boolean {
 		return (
 			this.inheritedEnabledByKey.get(this.getResourceItemKey(item)) ??
 			(this.getItemScope(item) === "user" ? item.enabled : true)
 		);
 	}
 
-	private isInheritedGlobalItem(item: ResourceItem): boolean {
+	private isInheritedGlobalItem(item: LoadoutResourceItem): boolean {
 		return this.getItemScope(item) === "user" || this.inheritedEnabledByKey.has(this.getResourceItemKey(item));
 	}
 
-	private getTopLevelOverridePatterns(item: ResourceItem, scope: SettingsScope): Set<string> {
+	private getTopLevelOverridePatterns(item: LoadoutResourceItem, scope: SettingsScope): Set<string> {
 		const baseDir = this.getTopLevelBaseDir(scope);
 		const patterns = new Set<string>([
 			this.getResourcePatternForScope(item, scope),
@@ -793,14 +793,14 @@ class ResourceList implements Component, Focusable {
 		return patterns;
 	}
 
-	private getResourcePatternForScope(item: ResourceItem, scope: SettingsScope): string {
+	private getResourcePatternForScope(item: LoadoutResourceItem, scope: SettingsScope): string {
 		const sourceScope = this.getItemScope(item);
 		if (scope !== sourceScope) return item.path;
 		const baseDir = item.metadata.baseDir ?? this.getTopLevelBaseDir(sourceScope);
 		return relative(baseDir, item.path);
 	}
 
-	private createPackageOverrideSource(item: ResourceItem): PackageSource {
+	private createPackageOverrideSource(item: LoadoutResourceItem): PackageSource {
 		const source = item.metadata.source;
 		if (!isLocalPath(source)) return { source, autoload: false };
 		const sourcePath = resolvePath(source, this.getTopLevelBaseDir(this.getItemScope(item)), { trim: true });
@@ -820,7 +820,7 @@ class ResourceList implements Component, Focusable {
 		return left === right;
 	}
 
-	private findMatchingPackageSource(item: ResourceItem, targetScope: SettingsScope): PackageSource | undefined {
+	private findMatchingPackageSource(item: LoadoutResourceItem, targetScope: SettingsScope): PackageSource | undefined {
 		const settings =
 			targetScope === "project"
 				? this.settingsManager.getProjectSettings()
@@ -839,11 +839,11 @@ class ResourceList implements Component, Focusable {
 		return entry.startsWith("!") || entry.startsWith("+") || entry.startsWith("-") ? entry.slice(1) : entry;
 	}
 
-	private getResourceItemKey(item: ResourceItem): string {
+	private getResourceItemKey(item: LoadoutResourceItem): string {
 		return `${item.resourceType}:${canonicalizePath(item.path)}`;
 	}
 
-	private getItemScope(item: ResourceItem): SettingsScope {
+	private getItemScope(item: LoadoutResourceItem): SettingsScope {
 		return item.metadata.scope === "project" ? "project" : "user";
 	}
 
@@ -851,13 +851,13 @@ class ResourceList implements Component, Focusable {
 		return scope === "project" ? join(this.cwd, CONFIG_DIR_NAME) : this.agentDir;
 	}
 
-	private getResourcePattern(item: ResourceItem): string {
+	private getResourcePattern(item: LoadoutResourceItem): string {
 		const scope = item.metadata.scope as "user" | "project";
 		const baseDir = item.metadata.baseDir ?? this.getTopLevelBaseDir(scope);
 		return relative(baseDir, item.path);
 	}
 
-	private getPackageResourcePattern(item: ResourceItem): string {
+	private getPackageResourcePattern(item: LoadoutResourceItem): string {
 		const baseDir = item.metadata.baseDir ?? dirname(item.path);
 		return relative(baseDir, item.path);
 	}
@@ -893,8 +893,8 @@ export class LoadoutSelectorComponent extends Container implements Focusable {
 
 		this.writeScope = writeScope;
 		const groupsByScope = {
-			global: buildGroups(resolvedPaths.global, agentDir),
-			project: buildGroups(resolvedPaths.project, agentDir),
+			global: buildLoadoutResourceGroups(resolvedPaths.global, agentDir),
+			project: buildLoadoutResourceGroups(resolvedPaths.project, agentDir),
 		};
 
 		// Add header

--- a/packages/coding-agent/src/modes/interactive/components/loadout-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/loadout-selector.ts
@@ -24,10 +24,10 @@ import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint, rawKeyHint } from "./keybinding-hints.ts";
 
 type ResourceType = "extensions" | "skills" | "prompts" | "themes";
-type ConfigWriteScope = "global" | "project";
+type LoadoutWriteScope = "global" | "project";
 type SettingsScope = "user" | "project";
 type ProjectOverrideState = "inherit" | "load" | "unload";
-export type ScopedResolvedPaths = Record<ConfigWriteScope, ResolvedPaths>;
+export type ScopedResolvedPaths = Record<LoadoutWriteScope, ResolvedPaths>;
 
 const RESOURCE_TYPES = ["extensions", "skills", "prompts", "themes"] as const satisfies readonly ResourceType[];
 
@@ -184,16 +184,16 @@ type FlatEntry =
 	| { type: "subgroup"; subgroup: ResourceSubgroup; group: ResourceGroup }
 	| { type: "item"; item: ResourceItem };
 
-class ConfigSelectorHeader implements Component {
-	private writeScope: ConfigWriteScope;
+class LoadoutSelectorHeader implements Component {
+	private writeScope: LoadoutWriteScope;
 	private projectModeAvailable: boolean;
 
-	constructor(writeScope: ConfigWriteScope, projectModeAvailable: boolean) {
+	constructor(writeScope: LoadoutWriteScope, projectModeAvailable: boolean) {
 		this.writeScope = writeScope;
 		this.projectModeAvailable = projectModeAvailable;
 	}
 
-	setWriteScope(writeScope: ConfigWriteScope): void {
+	setWriteScope(writeScope: LoadoutWriteScope): void {
 		this.writeScope = writeScope;
 	}
 
@@ -220,7 +220,7 @@ class ConfigSelectorHeader implements Component {
 }
 
 class ResourceList implements Component, Focusable {
-	private groupsByScope: Record<ConfigWriteScope, ResourceGroup[]>;
+	private groupsByScope: Record<LoadoutWriteScope, ResourceGroup[]>;
 	private flatItems: FlatEntry[] = [];
 	private filteredItems: FlatEntry[] = [];
 	private selectedIndex = 0;
@@ -229,7 +229,7 @@ class ResourceList implements Component, Focusable {
 	private settingsManager: SettingsManager;
 	private cwd: string;
 	private agentDir: string;
-	private writeScope: ConfigWriteScope;
+	private writeScope: LoadoutWriteScope;
 	private inheritedEnabledByKey: Map<string, boolean>;
 
 	public onCancel?: () => void;
@@ -247,12 +247,12 @@ class ResourceList implements Component, Focusable {
 	}
 
 	constructor(
-		groupsByScope: Record<ConfigWriteScope, ResourceGroup[]>,
+		groupsByScope: Record<LoadoutWriteScope, ResourceGroup[]>,
 		settingsManager: SettingsManager,
 		cwd: string,
 		agentDir: string,
 		terminalHeight?: number,
-		writeScope: ConfigWriteScope = "global",
+		writeScope: LoadoutWriteScope = "global",
 	) {
 		this.groupsByScope = groupsByScope;
 		this.settingsManager = settingsManager;
@@ -268,7 +268,7 @@ class ResourceList implements Component, Focusable {
 		this.filteredItems = [...this.flatItems];
 	}
 
-	setWriteScope(writeScope: ConfigWriteScope): void {
+	setWriteScope(writeScope: LoadoutWriteScope): void {
 		this.writeScope = writeScope;
 		this.buildFlatList();
 		this.filterItems(this.searchInput.getValue());
@@ -863,10 +863,10 @@ class ResourceList implements Component, Focusable {
 	}
 }
 
-export class ConfigSelectorComponent extends Container implements Focusable {
-	private header: ConfigSelectorHeader;
+export class LoadoutSelectorComponent extends Container implements Focusable {
+	private header: LoadoutSelectorHeader;
 	private resourceList: ResourceList;
-	private writeScope: ConfigWriteScope;
+	private writeScope: LoadoutWriteScope;
 
 	private _focused = false;
 	get focused(): boolean {
@@ -886,7 +886,7 @@ export class ConfigSelectorComponent extends Container implements Focusable {
 		onExit: () => void,
 		requestRender: () => void,
 		terminalHeight?: number,
-		writeScope: ConfigWriteScope = "global",
+		writeScope: LoadoutWriteScope = "global",
 		projectModeAvailable = true,
 	) {
 		super();
@@ -901,7 +901,7 @@ export class ConfigSelectorComponent extends Container implements Focusable {
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
-		this.header = new ConfigSelectorHeader(this.writeScope, projectModeAvailable);
+		this.header = new LoadoutSelectorHeader(this.writeScope, projectModeAvailable);
 		this.addChild(this.header);
 		this.addChild(new Spacer(1));
 

--- a/packages/coding-agent/src/modes/interactive/components/session-loadout-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-loadout-selector.ts
@@ -28,6 +28,11 @@ import {
 
 type ResourceCollection = keyof ResolvedPaths;
 
+export interface SessionLoadoutSelection {
+	overrides: LoadoutOverride[];
+	explicitReset: boolean;
+}
+
 type FlatEntry =
 	| { type: "reset" }
 	| { type: "group"; group: LoadoutResourceGroup }
@@ -107,7 +112,7 @@ class SessionLoadoutList implements Component, Focusable {
 	private resetSelected = false;
 	private _focused = false;
 
-	onApply?: (overrides: LoadoutOverride[]) => void;
+	onApply?: (selection: SessionLoadoutSelection) => void;
 	onCancel?: () => void;
 	onChange?: () => void;
 
@@ -253,9 +258,14 @@ class SessionLoadoutList implements Component, Focusable {
 			return;
 		}
 		if (keybindings.matches(data, "tui.select.confirm")) {
-			this.onApply?.(
-				buildSessionLoadoutOverrides(this.snapshot, this.enabledByReference, this.clearExistingOverrides),
-			);
+			this.onApply?.({
+				overrides: buildSessionLoadoutOverrides(
+					this.snapshot,
+					this.enabledByReference,
+					this.clearExistingOverrides,
+				),
+				explicitReset: this.clearExistingOverrides,
+			});
 			return;
 		}
 		if (data === " ") {
@@ -330,7 +340,7 @@ export class SessionLoadoutSelectorComponent extends Container implements Focusa
 		snapshot: LoadoutSnapshot;
 		agentDir: string;
 		terminalHeight?: number;
-		onApply: (overrides: LoadoutOverride[]) => void;
+		onApply: (selection: SessionLoadoutSelection) => void;
 		onCancel: () => void;
 		requestRender: () => void;
 	}) {

--- a/packages/coding-agent/src/modes/interactive/components/session-loadout-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-loadout-selector.ts
@@ -1,0 +1,355 @@
+import {
+	type Component,
+	Container,
+	type Focusable,
+	getKeybindings,
+	Input,
+	Spacer,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import {
+	cloneLoadoutOverrides,
+	getLoadoutResourceReferenceKey,
+	type LoadoutOverride,
+	type LoadoutSnapshot,
+	type SelectableLoadoutResource,
+} from "../../../core/loadout.ts";
+import type { ResolvedPaths } from "../../../core/package-manager.ts";
+import { theme } from "../theme/theme.ts";
+import { DynamicBorder } from "./dynamic-border.ts";
+import { keyHint, rawKeyHint } from "./keybinding-hints.ts";
+import {
+	buildLoadoutResourceGroups,
+	type LoadoutResourceGroup,
+	type LoadoutResourceItem,
+	type LoadoutResourceSubgroup,
+} from "./loadout-selector.ts";
+
+type ResourceCollection = keyof ResolvedPaths;
+
+type FlatEntry =
+	| { type: "reset" }
+	| { type: "group"; group: LoadoutResourceGroup }
+	| { type: "subgroup"; subgroup: LoadoutResourceSubgroup }
+	| { type: "item"; item: LoadoutResourceItem; resource: SelectableLoadoutResource };
+
+function resourceLookupKey(collection: ResourceCollection, path: string): string {
+	return `${collection}:${path}`;
+}
+
+function toResolvedPaths(snapshot: LoadoutSnapshot): ResolvedPaths {
+	const resolved: ResolvedPaths = { extensions: [], skills: [], prompts: [], themes: [] };
+	for (const resource of snapshot.resources) {
+		const collection = `${resource.reference.type}s` as ResourceCollection;
+		resolved[collection].push({ path: resource.path, enabled: resource.enabled, metadata: { ...resource.metadata } });
+	}
+	return resolved;
+}
+
+export function buildSessionLoadoutOverrides(
+	snapshot: LoadoutSnapshot,
+	enabledByReference: ReadonlyMap<string, boolean>,
+	clearExistingOverrides: boolean,
+): LoadoutOverride[] {
+	const visibleKeys = new Set(
+		snapshot.resources.map((resource) => getLoadoutResourceReferenceKey(resource.reference)),
+	);
+	const overrides = clearExistingOverrides
+		? []
+		: cloneLoadoutOverrides(
+				snapshot.overrides.filter(
+					(override) => !visibleKeys.has(getLoadoutResourceReferenceKey(override.reference)),
+				),
+			);
+	for (const resource of snapshot.resources) {
+		const key = getLoadoutResourceReferenceKey(resource.reference);
+		const enabled = enabledByReference.get(key) ?? resource.enabled;
+		if (enabled !== resource.defaultEnabled) {
+			overrides.push({ reference: resource.reference, enabled });
+		}
+	}
+	return cloneLoadoutOverrides(overrides);
+}
+
+class SessionLoadoutHeader implements Component {
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const title = theme.bold("Session Loadout");
+		const separator = theme.fg("muted", " · ");
+		const hints = [
+			rawKeyHint("space", "toggle/reset"),
+			keyHint("tui.select.confirm", "apply"),
+			keyHint("tui.select.cancel", "discard"),
+		].join(separator);
+		const spacing = Math.max(1, width - visibleWidth(title) - visibleWidth(hints));
+		return [
+			truncateToWidth(`${title}${" ".repeat(spacing)}${hints}`, width, ""),
+			truncateToWidth(
+				theme.fg("muted", "Session only · staged until apply · global/project settings unchanged"),
+				width,
+				"",
+			),
+		];
+	}
+}
+
+class SessionLoadoutList implements Component, Focusable {
+	private flatEntries: FlatEntry[];
+	private filteredEntries: FlatEntry[];
+	private selectedIndex = 0;
+	private searchInput = new Input();
+	private maxVisible: number;
+	private snapshot: LoadoutSnapshot;
+	private enabledByReference: Map<string, boolean>;
+	private clearExistingOverrides = false;
+	private resetSelected = false;
+	private _focused = false;
+
+	onApply?: (overrides: LoadoutOverride[]) => void;
+	onCancel?: () => void;
+	onChange?: () => void;
+
+	get focused(): boolean {
+		return this._focused;
+	}
+	set focused(value: boolean) {
+		this._focused = value;
+		this.searchInput.focused = value;
+	}
+
+	constructor(snapshot: LoadoutSnapshot, agentDir: string, terminalHeight?: number) {
+		this.snapshot = snapshot;
+		this.enabledByReference = new Map(
+			snapshot.resources.map((resource) => [getLoadoutResourceReferenceKey(resource.reference), resource.enabled]),
+		);
+		this.maxVisible = Math.max(5, (terminalHeight ?? 24) - 8);
+		this.flatEntries = this.buildFlatEntries(agentDir);
+		this.filteredEntries = [...this.flatEntries];
+	}
+
+	private buildFlatEntries(agentDir: string): FlatEntry[] {
+		const resourcesByPath = new Map<string, SelectableLoadoutResource>();
+		for (const resource of this.snapshot.resources) {
+			resourcesByPath.set(
+				resourceLookupKey(`${resource.reference.type}s` as ResourceCollection, resource.path),
+				resource,
+			);
+		}
+
+		const entries: FlatEntry[] = [{ type: "reset" }];
+		for (const group of buildLoadoutResourceGroups(toResolvedPaths(this.snapshot), agentDir)) {
+			entries.push({ type: "group", group });
+			for (const subgroup of group.subgroups) {
+				entries.push({ type: "subgroup", subgroup });
+				for (const item of subgroup.items) {
+					const resource = resourcesByPath.get(resourceLookupKey(item.resourceType, item.path));
+					if (resource) entries.push({ type: "item", item, resource });
+				}
+			}
+		}
+		return entries;
+	}
+
+	private isSelectable(entry: FlatEntry): boolean {
+		return entry.type === "reset" || entry.type === "item";
+	}
+
+	private findNextSelectable(fromIndex: number, direction: 1 | -1): number {
+		let index = fromIndex + direction;
+		while (index >= 0 && index < this.filteredEntries.length) {
+			if (this.isSelectable(this.filteredEntries[index]!)) return index;
+			index += direction;
+		}
+		return fromIndex;
+	}
+
+	private filter(query: string): void {
+		const normalized = query.trim().toLowerCase();
+		if (!normalized) {
+			this.filteredEntries = [...this.flatEntries];
+			this.selectedIndex = 0;
+			return;
+		}
+
+		const matchingItems = new Set<LoadoutResourceItem>();
+		const matchingSubgroups = new Set<LoadoutResourceSubgroup>();
+		const matchingGroups = new Set<LoadoutResourceGroup>();
+		for (const entry of this.flatEntries) {
+			if (
+				entry.type === "item" &&
+				(entry.item.displayName.toLowerCase().includes(normalized) ||
+					entry.item.resourceType.toLowerCase().includes(normalized) ||
+					entry.item.path.toLowerCase().includes(normalized))
+			) {
+				matchingItems.add(entry.item);
+			}
+		}
+		for (const entry of this.flatEntries) {
+			if (entry.type !== "group") continue;
+			for (const subgroup of entry.group.subgroups) {
+				if (subgroup.items.some((item) => matchingItems.has(item))) {
+					matchingSubgroups.add(subgroup);
+					matchingGroups.add(entry.group);
+				}
+			}
+		}
+		this.filteredEntries = this.flatEntries.filter((entry) => {
+			if (entry.type === "reset") return "reset persistent settings clear overrides".includes(normalized);
+			if (entry.type === "group") return matchingGroups.has(entry.group);
+			if (entry.type === "subgroup") return matchingSubgroups.has(entry.subgroup);
+			return matchingItems.has(entry.item);
+		});
+		this.selectedIndex = Math.max(
+			0,
+			this.filteredEntries.findIndex((entry) => this.isSelectable(entry)),
+		);
+	}
+
+	private toggleSelected(): void {
+		const entry = this.filteredEntries[this.selectedIndex];
+		if (!entry) return;
+		if (entry.type === "reset") {
+			this.clearExistingOverrides = true;
+			this.resetSelected = true;
+			for (const resource of this.snapshot.resources) {
+				this.enabledByReference.set(getLoadoutResourceReferenceKey(resource.reference), resource.defaultEnabled);
+			}
+			this.onChange?.();
+			return;
+		}
+		if (entry.type !== "item") return;
+		const key = getLoadoutResourceReferenceKey(entry.resource.reference);
+		this.enabledByReference.set(key, !(this.enabledByReference.get(key) ?? entry.resource.enabled));
+		this.resetSelected = false;
+		this.onChange?.();
+	}
+
+	handleInput(data: string): void {
+		const keybindings = getKeybindings();
+		if (keybindings.matches(data, "tui.select.up")) {
+			this.selectedIndex = this.findNextSelectable(this.selectedIndex, -1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.down")) {
+			this.selectedIndex = this.findNextSelectable(this.selectedIndex, 1);
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.pageUp")) {
+			for (let count = 0; count < this.maxVisible; count++) {
+				this.selectedIndex = this.findNextSelectable(this.selectedIndex, -1);
+			}
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.pageDown")) {
+			for (let count = 0; count < this.maxVisible; count++) {
+				this.selectedIndex = this.findNextSelectable(this.selectedIndex, 1);
+			}
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.cancel")) {
+			this.onCancel?.();
+			return;
+		}
+		if (keybindings.matches(data, "tui.select.confirm")) {
+			this.onApply?.(
+				buildSessionLoadoutOverrides(this.snapshot, this.enabledByReference, this.clearExistingOverrides),
+			);
+			return;
+		}
+		if (data === " ") {
+			this.toggleSelected();
+			return;
+		}
+		this.searchInput.handleInput(data);
+		this.filter(this.searchInput.getValue());
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const lines = [...this.searchInput.render(width), ""];
+		if (this.filteredEntries.length === 0) {
+			lines.push(theme.fg("muted", "  No resources found"));
+			return lines;
+		}
+		const startIndex = Math.max(
+			0,
+			Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.filteredEntries.length - this.maxVisible),
+		);
+		const endIndex = Math.min(startIndex + this.maxVisible, this.filteredEntries.length);
+		for (let index = startIndex; index < endIndex; index++) {
+			const entry = this.filteredEntries[index]!;
+			const cursor = index === this.selectedIndex ? "> " : "  ";
+			if (entry.type === "reset") {
+				const marker = this.resetSelected ? theme.fg("success", "[x]") : theme.fg("dim", "[ ]");
+				lines.push(
+					truncateToWidth(
+						`${cursor}${marker} ${theme.bold("Use persistent settings")} ${theme.fg("muted", "(clear session overrides)")}`,
+						width,
+						"...",
+					),
+				);
+			} else if (entry.type === "group") {
+				lines.push(truncateToWidth(`  ${theme.fg("accent", theme.bold(entry.group.label))}`, width, ""));
+			} else if (entry.type === "subgroup") {
+				lines.push(truncateToWidth(`    ${theme.fg("muted", entry.subgroup.label)}`, width, ""));
+			} else {
+				const key = getLoadoutResourceReferenceKey(entry.resource.reference);
+				const enabled = this.enabledByReference.get(key) ?? entry.resource.enabled;
+				const marker = enabled ? theme.fg("success", "[x]") : theme.fg("dim", "[ ]");
+				const label = index === this.selectedIndex ? theme.bold(entry.item.displayName) : entry.item.displayName;
+				lines.push(truncateToWidth(`${cursor}    ${marker} ${label}`, width, "..."));
+			}
+		}
+		if (startIndex > 0 || endIndex < this.filteredEntries.length) {
+			const selectable = this.filteredEntries.filter((entry) => this.isSelectable(entry));
+			const current = this.filteredEntries
+				.slice(0, this.selectedIndex + 1)
+				.filter((entry) => this.isSelectable(entry)).length;
+			lines.push(theme.fg("dim", `  (${current}/${selectable.length})`));
+		}
+		return lines;
+	}
+}
+
+export class SessionLoadoutSelectorComponent extends Container implements Focusable {
+	private resourceList: SessionLoadoutList;
+	private _focused = false;
+
+	get focused(): boolean {
+		return this._focused;
+	}
+	set focused(value: boolean) {
+		this._focused = value;
+		this.resourceList.focused = value;
+	}
+
+	constructor(options: {
+		snapshot: LoadoutSnapshot;
+		agentDir: string;
+		terminalHeight?: number;
+		onApply: (overrides: LoadoutOverride[]) => void;
+		onCancel: () => void;
+		requestRender: () => void;
+	}) {
+		super();
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(new SessionLoadoutHeader());
+		this.addChild(new Spacer(1));
+		this.resourceList = new SessionLoadoutList(options.snapshot, options.agentDir, options.terminalHeight);
+		this.resourceList.onApply = options.onApply;
+		this.resourceList.onCancel = options.onCancel;
+		this.resourceList.onChange = options.requestRender;
+		this.addChild(this.resourceList);
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+	}
+
+	getResourceList(): Component & Focusable {
+		return this.resourceList;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -75,12 +75,7 @@ import type {
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.ts";
 import { configureHttpDispatcher, formatHttpIdleTimeoutMs } from "../../core/http-dispatcher.ts";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.ts";
-import {
-	appendSessionLoadout,
-	getSessionLoadout,
-	type LoadoutOverride,
-	loadoutOverridesEqual,
-} from "../../core/loadout.ts";
+import { appendSessionLoadout, getSessionLoadout, loadoutOverridesEqual } from "../../core/loadout.ts";
 import { createCompactionSummaryMessage } from "../../core/messages.ts";
 import {
 	defaultModelPerProvider,
@@ -132,7 +127,10 @@ import {
 	OAuthSelectorComponent,
 } from "./components/oauth-selector.ts";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.ts";
-import { SessionLoadoutSelectorComponent } from "./components/session-loadout-selector.ts";
+import {
+	type SessionLoadoutSelection,
+	SessionLoadoutSelectorComponent,
+} from "./components/session-loadout-selector.ts";
 import { SessionSelectorComponent } from "./components/session-selector.ts";
 import { SettingsSelectorComponent } from "./components/settings-selector.ts";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.ts";
@@ -4179,7 +4177,7 @@ export class InteractiveMode {
 		}
 	}
 
-	private async applySessionLoadout(overrides: LoadoutOverride[], persist: boolean): Promise<void> {
+	private async applySessionLoadout(selection: SessionLoadoutSelection, persist: boolean): Promise<void> {
 		if (this.loadoutActionBlocked("applying")) return;
 		const loader = this.getLoadoutLoader();
 		if (!loader) {
@@ -4187,13 +4185,13 @@ export class InteractiveMode {
 			return;
 		}
 		const previousOverrides = loader.getLoadoutSnapshot().overrides;
-		loader.setLoadoutOverrides(overrides);
+		loader.setLoadoutOverrides(selection.overrides);
 		if (!(await this.handleReloadCommand())) {
 			loader.setLoadoutOverrides(previousOverrides);
 			return;
 		}
-		if (persist && !loadoutOverridesEqual(previousOverrides, overrides)) {
-			appendSessionLoadout(this.sessionManager, overrides);
+		if (persist && (selection.explicitReset || !loadoutOverridesEqual(previousOverrides, selection.overrides))) {
+			appendSessionLoadout(this.sessionManager, selection.overrides);
 		}
 		this.showLoadoutDiagnostics();
 	}
@@ -4210,10 +4208,10 @@ export class InteractiveMode {
 				snapshot: loader.getLoadoutSnapshot(),
 				agentDir: this.runtimeHost.services.agentDir,
 				terminalHeight: this.ui.terminal.rows,
-				onApply: (overrides) => {
+				onApply: (selection) => {
 					if (this.loadoutActionBlocked("applying")) return;
 					done();
-					void this.applySessionLoadout(overrides, true);
+					void this.applySessionLoadout(selection, true);
 				},
 				onCancel: () => {
 					done();
@@ -4241,7 +4239,7 @@ export class InteractiveMode {
 			"Continue with the last session's extensions, skills, prompts, and themes? Missing resources will be skipped.",
 		);
 		if (!accepted) return;
-		await this.applySessionLoadout(saved.overrides, false);
+		await this.applySessionLoadout({ overrides: saved.overrides, explicitReset: false }, false);
 	}
 
 	private showSettingsSelector(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2380,10 +2380,10 @@ export class InteractiveMode {
 	private setCustomEditorComponent(factory: EditorFactory | undefined): void {
 		this.editorComponentFactory = factory;
 
-		// Save text from current editor before switching
-		const currentText = this.editor.getText();
-
-		this.editorContainer.clear();
+		const previousEditor = this.editor;
+		const editorIsDisplayed =
+			this.editorContainer.children.length === 1 && this.editorContainer.children[0] === previousEditor;
+		const currentText = previousEditor.getText();
 
 		if (factory) {
 			// Create the custom editor with tui, theme, and keybindings
@@ -2438,8 +2438,11 @@ export class InteractiveMode {
 			this.editor = this.defaultEditor;
 		}
 
-		this.editorContainer.addChild(this.editor as Component);
-		this.ui.setFocus(this.editor as Component);
+		if (editorIsDisplayed) {
+			this.editorContainer.clear();
+			this.editorContainer.addChild(this.editor as Component);
+			this.ui.setFocus(this.editor as Component);
+		}
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -75,7 +75,12 @@ import type {
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.ts";
 import { configureHttpDispatcher, formatHttpIdleTimeoutMs } from "../../core/http-dispatcher.ts";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.ts";
-import { appendSessionLoadout, getSessionLoadout, type LoadoutOverride } from "../../core/loadout.ts";
+import {
+	appendSessionLoadout,
+	getSessionLoadout,
+	type LoadoutOverride,
+	loadoutOverridesEqual,
+} from "../../core/loadout.ts";
 import { createCompactionSummaryMessage } from "../../core/messages.ts";
 import {
 	defaultModelPerProvider,
@@ -4181,9 +4186,15 @@ export class InteractiveMode {
 			this.showWarning("Session loadouts are unavailable with the configured resource loader.");
 			return;
 		}
+		const previousOverrides = loader.getLoadoutSnapshot().overrides;
 		loader.setLoadoutOverrides(overrides);
-		if (persist) appendSessionLoadout(this.sessionManager, overrides);
-		await this.handleReloadCommand();
+		if (!(await this.handleReloadCommand())) {
+			loader.setLoadoutOverrides(previousOverrides);
+			return;
+		}
+		if (persist && !loadoutOverridesEqual(previousOverrides, overrides)) {
+			appendSessionLoadout(this.sessionManager, overrides);
+		}
 		this.showLoadoutDiagnostics();
 	}
 
@@ -5195,7 +5206,7 @@ export class InteractiveMode {
 
 		let selectedModel: Model<any> | undefined;
 		let selectionError: string | undefined;
-		if (isUnknownModel(previousModel)) {
+		if (!previousModel || isUnknownModel(previousModel)) {
 			const availableModels = await this.session.modelRuntime.getAvailable();
 			const providerModels = availableModels.filter((model) => model.provider === providerId);
 			if (!hasDefaultModelProvider(providerId)) {
@@ -5418,18 +5429,18 @@ export class InteractiveMode {
 	// Command handlers
 	// =========================================================================
 
-	private async handleReloadCommand(): Promise<void> {
+	private async handleReloadCommand(): Promise<boolean> {
 		if (this.session.isStreaming) {
 			this.showWarning("Wait for the current response to finish before reloading.");
-			return;
+			return false;
 		}
 		if (this.session.isCompacting) {
 			this.showWarning("Wait for compaction to finish before reloading.");
-			return;
+			return false;
 		}
 		if (this.session.isBashRunning) {
 			this.showWarning("Wait for the bash command to finish before reloading.");
-			return;
+			return false;
 		}
 
 		const reloadBox = new Container();
@@ -5527,11 +5538,13 @@ export class InteractiveMode {
 			);
 			dismissReloadBox(this.editor as Component);
 			reloadBoxDismissed = true;
+			return true;
 		} catch (error) {
 			if (!reloadBoxDismissed) {
 				dismissReloadBox(this.editor as Component);
 			}
 			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
+			return false;
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -75,6 +75,7 @@ import type {
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.ts";
 import { configureHttpDispatcher, formatHttpIdleTimeoutMs } from "../../core/http-dispatcher.ts";
 import { type AppKeybinding, KeybindingsManager } from "../../core/keybindings.ts";
+import { appendSessionLoadout, getSessionLoadout, type LoadoutOverride } from "../../core/loadout.ts";
 import { createCompactionSummaryMessage } from "../../core/messages.ts";
 import {
 	defaultModelPerProvider,
@@ -126,6 +127,7 @@ import {
 	OAuthSelectorComponent,
 } from "./components/oauth-selector.ts";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.ts";
+import { SessionLoadoutSelectorComponent } from "./components/session-loadout-selector.ts";
 import { SessionSelectorComponent } from "./components/session-selector.ts";
 import { SettingsSelectorComponent } from "./components/settings-selector.ts";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.ts";
@@ -318,6 +320,8 @@ export interface InteractiveModeOptions {
 	initialMessages?: string[];
 	/** Force verbose startup (overrides quietStartup setting) */
 	verbose?: boolean;
+	/** Whether an existing initial session may offer to restore its saved loadout. */
+	promptForSavedLoadout?: boolean;
 }
 
 export class InteractiveMode {
@@ -356,6 +360,7 @@ export class InteractiveMode {
 	private changelogMarkdown: string | undefined = undefined;
 	private startupNoticesShown = false;
 	private anthropicSubscriptionWarningShown = false;
+	private loadoutRestoreDecisions = new Set<string>();
 
 	// Status line tracking (for mutating immediately-sequential status updates)
 	private lastStatusSpacer: Spacer | undefined = undefined;
@@ -795,6 +800,10 @@ export class InteractiveMode {
 
 		// Render initial messages AFTER showing loaded resources
 		this.renderInitialMessages();
+
+		if (this.options.promptForSavedLoadout !== false) {
+			await this.maybeRestoreSavedLoadout();
+		}
 
 		// Set up theme file watcher
 		onThemeChange(() => {
@@ -2652,6 +2661,11 @@ export class InteractiveMode {
 				this.editor.setText("");
 				return;
 			}
+			if (text === "/loadout") {
+				this.editor.setText("");
+				this.showLoadoutSelector();
+				return;
+			}
 			if (text === "/scoped-models") {
 				this.editor.setText("");
 				await this.showModelsSelector();
@@ -4122,6 +4136,103 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private loadoutActionBlocked(action: "opening" | "applying"): boolean {
+		if (this.session.isStreaming) {
+			this.showWarning(`Wait for the current response to finish before ${action} a session loadout.`);
+			return true;
+		}
+		if (this.session.isCompacting) {
+			this.showWarning(`Wait for compaction to finish before ${action} a session loadout.`);
+			return true;
+		}
+		if (this.session.isBashRunning) {
+			this.showWarning(`Wait for the bash command to finish before ${action} a session loadout.`);
+			return true;
+		}
+		return false;
+	}
+
+	private getLoadoutLoader():
+		| {
+				getLoadoutSnapshot: NonNullable<AgentSession["resourceLoader"]["getLoadoutSnapshot"]>;
+				setLoadoutOverrides: NonNullable<AgentSession["resourceLoader"]["setLoadoutOverrides"]>;
+		  }
+		| undefined {
+		const loader = this.session.resourceLoader;
+		if (!loader.getLoadoutSnapshot || !loader.setLoadoutOverrides) return undefined;
+		return {
+			getLoadoutSnapshot: loader.getLoadoutSnapshot.bind(loader),
+			setLoadoutOverrides: loader.setLoadoutOverrides.bind(loader),
+		};
+	}
+
+	private showLoadoutDiagnostics(): void {
+		const loader = this.getLoadoutLoader();
+		if (!loader) return;
+		for (const diagnostic of loader.getLoadoutSnapshot().diagnostics) {
+			this.showWarning(diagnostic.message);
+		}
+	}
+
+	private async applySessionLoadout(overrides: LoadoutOverride[], persist: boolean): Promise<void> {
+		if (this.loadoutActionBlocked("applying")) return;
+		const loader = this.getLoadoutLoader();
+		if (!loader) {
+			this.showWarning("Session loadouts are unavailable with the configured resource loader.");
+			return;
+		}
+		loader.setLoadoutOverrides(overrides);
+		if (persist) appendSessionLoadout(this.sessionManager, overrides);
+		await this.handleReloadCommand();
+		this.showLoadoutDiagnostics();
+	}
+
+	private showLoadoutSelector(): void {
+		if (this.loadoutActionBlocked("opening")) return;
+		const loader = this.getLoadoutLoader();
+		if (!loader) {
+			this.showWarning("Session loadouts are unavailable with the configured resource loader.");
+			return;
+		}
+		this.showSelector((done) => {
+			const selector = new SessionLoadoutSelectorComponent({
+				snapshot: loader.getLoadoutSnapshot(),
+				agentDir: this.runtimeHost.services.agentDir,
+				terminalHeight: this.ui.terminal.rows,
+				onApply: (overrides) => {
+					if (this.loadoutActionBlocked("applying")) return;
+					done();
+					void this.applySessionLoadout(overrides, true);
+				},
+				onCancel: () => {
+					done();
+					this.ui.requestRender();
+				},
+				requestRender: () => this.ui.requestRender(),
+			});
+			return { component: selector, focus: selector.getResourceList() };
+		});
+	}
+
+	private getLoadoutRestoreDecisionKey(): string {
+		return this.sessionManager.getSessionFile() ?? this.sessionManager.getSessionId();
+	}
+
+	private async maybeRestoreSavedLoadout(): Promise<void> {
+		const key = this.getLoadoutRestoreDecisionKey();
+		if (this.loadoutRestoreDecisions.has(key)) return;
+		const saved = getSessionLoadout(this.sessionManager);
+		if (!saved || saved.overrides.length === 0) return;
+		this.loadoutRestoreDecisions.add(key);
+
+		const accepted = await this.showExtensionConfirm(
+			"Restore session loadout?",
+			"Continue with the last session's extensions, skills, prompts, and themes? Missing resources will be skipped.",
+		);
+		if (!accepted) return;
+		await this.applySessionLoadout(saved.overrides, false);
+	}
+
 	private showSettingsSelector(): void {
 		this.showSelector((done) => {
 			const selector = new SettingsSelectorComponent(
@@ -4808,6 +4919,7 @@ export class InteractiveMode {
 			if (result.cancelled) {
 				return result;
 			}
+			await this.maybeRestoreSavedLoadout();
 			this.showStatus("Resumed session");
 			return result;
 		} catch (error: unknown) {
@@ -4825,6 +4937,7 @@ export class InteractiveMode {
 				if (result.cancelled) {
 					return result;
 				}
+				await this.maybeRestoreSavedLoadout();
 				this.showStatus("Resumed session in current cwd");
 				return result;
 			}
@@ -5474,6 +5587,7 @@ export class InteractiveMode {
 				this.showStatus("Import cancelled");
 				return;
 			}
+			await this.maybeRestoreSavedLoadout();
 			this.showStatus(`Session imported from: ${inputPath}`);
 		} catch (error: unknown) {
 			if (error instanceof MissingSessionCwdError) {
@@ -5487,6 +5601,7 @@ export class InteractiveMode {
 					this.showStatus("Import cancelled");
 					return;
 				}
+				await this.maybeRestoreSavedLoadout();
 				this.showStatus(`Session imported from: ${inputPath}`);
 				return;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5427,8 +5427,10 @@ export class InteractiveMode {
 			this.showWarning("Wait for compaction to finish before reloading.");
 			return;
 		}
-
-		this.resetExtensionUI();
+		if (this.session.isBashRunning) {
+			this.showWarning("Wait for the bash command to finish before reloading.");
+			return;
+		}
 
 		const reloadBox = new Container();
 		const borderColor = (s: string) => theme.fg("border", s);
@@ -5444,7 +5446,6 @@ export class InteractiveMode {
 		reloadBox.addChild(new Spacer(1));
 		reloadBox.addChild(new DynamicBorder(borderColor));
 
-		const previousEditor = this.editor;
 		this.editorContainer.clear();
 		this.editorContainer.addChild(reloadBox);
 		this.ui.setFocus(reloadBox);
@@ -5471,7 +5472,16 @@ export class InteractiveMode {
 		};
 
 		try {
-			await this.session.reload({ beforeSessionStart: restoreChatBeforeSessionStart });
+			const reloadResult = await this.session.reload({
+				beforeExtensionInvalidate: () => {
+					this.resetExtensionUI();
+					this.editorContainer.clear();
+					this.editorContainer.addChild(reloadBox);
+					this.ui.setFocus(reloadBox);
+					this.ui.requestRender();
+				},
+				beforeSessionStart: restoreChatBeforeSessionStart,
+			});
 			restoreChatBeforeSessionStart();
 			configureHttpDispatcher(this.settingsManager.getHttpIdleTimeoutMs());
 			this.keybindings.reload();
@@ -5507,6 +5517,9 @@ export class InteractiveMode {
 			if (modelsJsonError) {
 				this.showError(`models.json error: ${modelsJsonError}`);
 			}
+			if (reloadResult.modelFallbackMessage) {
+				this.showWarning(reloadResult.modelFallbackMessage);
+			}
 			this.showStatus(
 				savedImplicitProjectTrust
 					? "Reloaded keybindings, extensions, skills, prompts, themes, and context files; saved project trust"
@@ -5516,7 +5529,7 @@ export class InteractiveMode {
 			reloadBoxDismissed = true;
 		} catch (error) {
 			if (!reloadBoxDismissed) {
-				dismissReloadBox(previousEditor as Component);
+				dismissReloadBox(this.editor as Component);
 			}
 			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
 		}

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
 import chalk from "chalk";
-import { selectConfig } from "./cli/config-selector.ts";
+import { selectLoadout } from "./cli/loadout-selector.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import {
 	APP_NAME,
@@ -89,13 +89,14 @@ function getPackageCommandUsage(command: PackageCommand): string {
 	}
 }
 
-const CONFIG_COMMAND_USAGE = `${APP_NAME} config [-l] [--approve|--no-approve]`;
+const LOADOUT_COMMAND_USAGE = `${APP_NAME} loadout [-l] [--approve|--no-approve]`;
 
-function printConfigCommandHelp(): void {
+function printLoadoutCommandHelp(): void {
 	console.log(`${chalk.bold("Usage:")}
-  ${CONFIG_COMMAND_USAGE}
+  ${LOADOUT_COMMAND_USAGE}
 
-Open the resource configuration TUI to enable or disable package resources.
+Open the resource loadout TUI to enable or disable package resources.
+Alias: ${APP_NAME} config
 Without -l, starts in global settings (~/${CONFIG_DIR_NAME}/agent/settings.json).
 Press Tab in the TUI to switch between global and project-local modes.
 
@@ -600,17 +601,17 @@ async function createCommandSettingsManager(options: {
 	return { settingsManager, projectTrustWarnings };
 }
 
-export async function handleConfigCommand(
+export async function handleLoadoutCommand(
 	args: string[],
 	runtimeOptions: PackageCommandRuntimeOptions = {},
 ): Promise<boolean> {
 	const [command, ...rest] = args;
-	if (command !== "config") {
+	if (command !== "loadout" && command !== "config") {
 		return false;
 	}
 
 	if (rest.includes("-h") || rest.includes("--help")) {
-		printConfigCommandHelp();
+		printLoadoutCommandHelp();
 		return true;
 	}
 
@@ -624,13 +625,13 @@ export async function handleConfigCommand(
 		} else if (arg === "-na" || arg === "--no-approve") {
 			projectTrustOverride = false;
 		} else if (arg.startsWith("-")) {
-			console.error(chalk.red(`Unknown option ${arg} for "config".`));
-			console.error(chalk.dim(`Use "${APP_NAME} --help" or "${CONFIG_COMMAND_USAGE}".`));
+			console.error(chalk.red(`Unknown option ${arg} for "loadout".`));
+			console.error(chalk.dim(`Use "${APP_NAME} --help" or "${LOADOUT_COMMAND_USAGE}".`));
 			process.exitCode = 1;
 			return true;
 		} else {
 			console.error(chalk.red(`Unexpected argument ${arg}.`));
-			console.error(chalk.dim(`Usage: ${CONFIG_COMMAND_USAGE}`));
+			console.error(chalk.dim(`Usage: ${LOADOUT_COMMAND_USAGE}`));
 			process.exitCode = 1;
 			return true;
 		}
@@ -646,11 +647,11 @@ export async function handleConfigCommand(
 	});
 	reportProjectTrustWarnings(projectTrustWarnings);
 	if (local && !settingsManager.isProjectTrusted()) {
-		console.error(chalk.red("Project is not trusted. Use --approve to modify local resource config."));
+		console.error(chalk.red("Project is not trusted. Use --approve to modify the local resource loadout."));
 		process.exitCode = 1;
 		return true;
 	}
-	reportSettingsErrors(settingsManager, "config command");
+	reportSettingsErrors(settingsManager, "loadout command");
 	const globalSettingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: false });
 	const globalResolvedPaths = await new DefaultPackageManager({
 		cwd,
@@ -661,7 +662,7 @@ export async function handleConfigCommand(
 		? await new DefaultPackageManager({ cwd, agentDir, settingsManager }).resolve()
 		: globalResolvedPaths;
 
-	await selectConfig({
+	await selectLoadout({
 		resolvedPaths: { global: globalResolvedPaths, project: projectResolvedPaths },
 		settingsManager,
 		cwd,

--- a/packages/coding-agent/test/agent-session-dynamic-provider.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-provider.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Provider } from "@earendil-works/pi-ai";
 import { getModel } from "@earendil-works/pi-ai/compat";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { ModelRuntime } from "../src/core/model-runtime.ts";
 import { DefaultResourceLoader } from "../src/core/resource-loader.ts";
@@ -261,6 +261,42 @@ describe("AgentSession dynamic provider registration", () => {
 		expect(result.modelFallbackMessage).toContain(
 			'Active model "temporary-provider/temporary-model" is no longer available after reload.',
 		);
+		session.dispose();
+	});
+
+	it("clears a removed active model when reload has no fallback", async () => {
+		let enabled = true;
+		const session = await createSession([
+			(pi) => {
+				if (!enabled) return;
+				pi.registerProvider("temporary-provider", {
+					baseUrl: "https://temporary.test",
+					apiKey: "test-key",
+					api: "openai-completions",
+					models: [
+						{
+							id: "temporary-model",
+							name: "Temporary Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 4096,
+						},
+					],
+				});
+			},
+		]);
+		await session.modelRuntime.refresh({ allowNetwork: false });
+		await session.setModel(session.modelRuntime.getModel("temporary-provider", "temporary-model")!);
+		vi.spyOn(session.modelRuntime, "getAvailableSnapshot").mockReturnValue([]);
+
+		enabled = false;
+		const result = await session.reload();
+
+		expect(session.model).toBeUndefined();
+		expect(session.thinkingLevel).toBe("off");
+		expect(result.modelFallbackMessage).toContain("No configured model is available");
 		session.dispose();
 	});
 });

--- a/packages/coding-agent/test/agent-session-dynamic-provider.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-provider.test.ts
@@ -176,4 +176,91 @@ describe("AgentSession dynamic provider registration", () => {
 
 		session.dispose();
 	});
+
+	it("replays duplicate provider registrations from a clean extension layer", async () => {
+		let generation = 1;
+		const session = await createSession([
+			(pi) => {
+				pi.registerProvider("reload-provider", {
+					baseUrl: `https://generation-${generation}.test`,
+					apiKey: "test-key",
+					api: "openai-completions",
+					...(generation === 1 ? { headers: { "x-stale": "yes" } } : {}),
+					models: [
+						{
+							id: `model-${generation}`,
+							name: `Model ${generation}`,
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 4096,
+						},
+					],
+				});
+			},
+			(pi) => {
+				pi.registerProvider("reload-provider", { name: `Winner ${generation}` });
+			},
+		]);
+		await session.modelRuntime.refresh({ allowNetwork: false });
+
+		expect(session.modelRuntime.getRegisteredProviderConfig("reload-provider")).toMatchObject({
+			name: "Winner 1",
+			headers: { "x-stale": "yes" },
+		});
+		expect(session.modelRuntime.getModel("reload-provider", "model-1")).toBeDefined();
+
+		generation = 2;
+		await session.reload();
+
+		expect(session.modelRuntime.getRegisteredProviderConfig("reload-provider")).toMatchObject({
+			name: "Winner 2",
+			baseUrl: "https://generation-2.test",
+		});
+		expect(session.modelRuntime.getRegisteredProviderConfig("reload-provider")?.headers).toBeUndefined();
+		expect(session.modelRuntime.getModel("reload-provider", "model-1")).toBeUndefined();
+		expect(session.modelRuntime.getModel("reload-provider", "model-2")).toBeDefined();
+		session.dispose();
+	});
+
+	it("removes disabled providers and falls back when their model was active", async () => {
+		let enabled = true;
+		const session = await createSession([
+			(pi) => {
+				if (!enabled) return;
+				pi.registerProvider("temporary-provider", {
+					baseUrl: "https://temporary.test",
+					apiKey: "test-key",
+					api: "openai-completions",
+					models: [
+						{
+							id: "temporary-model",
+							name: "Temporary Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 4096,
+						},
+					],
+				});
+			},
+		]);
+		await session.modelRuntime.refresh({ allowNetwork: false });
+		const temporaryModel = session.modelRuntime.getModel("temporary-provider", "temporary-model")!;
+		await session.setModel(temporaryModel);
+
+		enabled = false;
+		const result = await session.reload();
+
+		expect(session.modelRuntime.getProvider("temporary-provider")).toBeUndefined();
+		expect(session.modelRuntime.getModel("temporary-provider", "temporary-model")).toBeUndefined();
+		expect(session.model).toBeDefined();
+		expect(session.model?.provider).not.toBe("temporary-provider");
+		expect(result.modelFallbackMessage).toContain(
+			'Active model "temporary-provider/temporary-model" is no longer available after reload.',
+		);
+		session.dispose();
+	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -8,7 +8,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
-import { createExtensionRuntime, discoverAndLoadExtensions, loadExtensions } from "../src/core/extensions/loader.ts";
+import { createEventBus } from "../src/core/event-bus.ts";
+import {
+	createExtensionRuntime,
+	discoverAndLoadExtensions,
+	loadExtensionFromFactory,
+	loadExtensions,
+} from "../src/core/extensions/loader.ts";
 import { ExtensionRunner, emitProjectTrustEvent } from "../src/core/extensions/runner.ts";
 import type {
 	ExtensionActions,
@@ -814,6 +820,60 @@ describe("ExtensionRunner", () => {
 				details: { source: "ext1" },
 				isError: true,
 			});
+		});
+	});
+
+	describe("shared event bus", () => {
+		it("removes listeners owned by an invalidated runtime without breaking replacement communication", async () => {
+			const eventBus = createEventBus();
+			const oldRuntime = createExtensionRuntime();
+			let oldApi: Parameters<Parameters<typeof loadExtensionFromFactory>[0]>[0] | undefined;
+			let peerApi: Parameters<Parameters<typeof loadExtensionFromFactory>[0]>[0] | undefined;
+			let oldCalls = 0;
+			const oldExtension = await loadExtensionFromFactory(
+				(pi) => {
+					oldApi = pi;
+					pi.events.on("reload:test", () => oldCalls++);
+				},
+				tempDir,
+				eventBus,
+				oldRuntime,
+				"<old>",
+			);
+			await loadExtensionFromFactory(
+				(pi) => {
+					peerApi = pi;
+				},
+				tempDir,
+				eventBus,
+				oldRuntime,
+				"<peer>",
+			);
+			const oldRunner = new ExtensionRunner([oldExtension], oldRuntime, tempDir, sessionManager, modelRegistry);
+
+			peerApi!.events.emit("reload:test", undefined);
+			expect(oldCalls).toBe(1);
+			oldRunner.invalidate();
+			expect(() => oldApi!.events.emit("reload:test", undefined)).toThrow(
+				"stale after session replacement or reload",
+			);
+
+			const newRuntime = createExtensionRuntime();
+			let newApi: typeof oldApi;
+			let newCalls = 0;
+			await loadExtensionFromFactory(
+				(pi) => {
+					newApi = pi;
+					pi.events.on("reload:test", () => newCalls++);
+				},
+				tempDir,
+				eventBus,
+				newRuntime,
+				"<new>",
+			);
+			newApi!.events.emit("reload:test", undefined);
+			expect(oldCalls).toBe(1);
+			expect(newCalls).toBe(1);
 		});
 	});
 

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -1,0 +1,133 @@
+import type { Component, EditorComponent } from "@earendil-works/pi-tui";
+import { Container } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { EditorFactory } from "../src/core/extensions/types.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+class TestEditor implements EditorComponent {
+	onSubmit?: (text: string) => void;
+	onChange?: (text: string) => void;
+	borderColor?: (text: string) => string;
+	private text = "";
+	readonly label: string;
+
+	constructor(label: string) {
+		this.label = label;
+	}
+
+	getText(): string {
+		return this.text;
+	}
+
+	setText(text: string): void {
+		this.text = text;
+	}
+
+	handleInput(): void {}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return [this.label];
+	}
+}
+
+class TestDefaultEditor extends TestEditor {
+	getPaddingX(): number {
+		return 1;
+	}
+}
+
+class TestDialog implements Component {
+	readonly dispose = vi.fn();
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return ["dialog"];
+	}
+}
+
+type EditorContext = {
+	editorComponentFactory: EditorFactory | undefined;
+	defaultEditor: TestDefaultEditor;
+	editor: EditorComponent;
+	editorContainer: Container;
+	ui: {
+		setFocus: (component: Component) => void;
+		requestRender: () => void;
+	};
+	keybindings: object;
+	autocompleteProvider: undefined;
+	extensionSelector?: TestDialog;
+};
+
+type InteractiveModePrivate = {
+	setCustomEditorComponent(this: EditorContext, factory: EditorFactory | undefined): void;
+	hideExtensionSelector(this: EditorContext): void;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
+
+function createContext(editorContainer: Container, defaultEditor: TestDefaultEditor): EditorContext {
+	return {
+		editorComponentFactory: undefined,
+		defaultEditor,
+		editor: defaultEditor,
+		editorContainer,
+		ui: {
+			setFocus: vi.fn(),
+			requestRender: vi.fn(),
+		},
+		keybindings: {},
+		autocompleteProvider: undefined,
+	};
+}
+
+describe("InteractiveMode custom editor replacement", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("keeps an active selector visible and restores the delayed custom editor when it closes", () => {
+		const defaultEditor = new TestDefaultEditor("default editor");
+		defaultEditor.setText("draft");
+		const selector = new TestDialog();
+		const editorContainer = new Container();
+		editorContainer.addChild(selector);
+		const context = createContext(editorContainer, defaultEditor);
+		context.extensionSelector = selector;
+		const customEditor = new TestEditor("custom editor");
+		const factory: EditorFactory = () => customEditor;
+
+		interactiveModePrototype.setCustomEditorComponent.call(context, factory);
+
+		expect(context.editor).toBe(customEditor);
+		expect(customEditor.getText()).toBe("draft");
+		expect(editorContainer.children).toEqual([selector]);
+		expect(context.ui.setFocus).not.toHaveBeenCalled();
+
+		interactiveModePrototype.hideExtensionSelector.call(context);
+
+		expect(selector.dispose).toHaveBeenCalledOnce();
+		expect(editorContainer.children).toEqual([customEditor]);
+		expect(context.ui.setFocus).toHaveBeenCalledWith(customEditor);
+	});
+
+	it("replaces and focuses the editor immediately when the old editor is displayed", () => {
+		const defaultEditor = new TestDefaultEditor("default editor");
+		defaultEditor.setText("draft");
+		const editorContainer = new Container();
+		editorContainer.addChild(defaultEditor);
+		const context = createContext(editorContainer, defaultEditor);
+		const customEditor = new TestEditor("custom editor");
+
+		interactiveModePrototype.setCustomEditorComponent.call(context, () => customEditor);
+
+		expect(context.editor).toBe(customEditor);
+		expect(customEditor.getText()).toBe("draft");
+		expect(editorContainer.children).toEqual([customEditor]);
+		expect(context.ui.setFocus).toHaveBeenCalledWith(customEditor);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-import-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-import-command.test.ts
@@ -19,6 +19,7 @@ type ImportCommandContext = {
 	renderCurrentSessionState: () => void;
 	handleFatalRuntimeError: (prefix: string, error: unknown) => Promise<never>;
 	promptForMissingSessionCwd: (error: unknown) => Promise<string | undefined>;
+	maybeRestoreSavedLoadout: () => Promise<void>;
 	getPathCommandArgument: (text: string, command: PathCommand) => string | undefined;
 };
 
@@ -55,6 +56,7 @@ describe("InteractiveMode /import parsing", () => {
 		const showExtensionConfirm = vi.fn(async () => true);
 		const showStatus = vi.fn();
 		const showError = vi.fn();
+		const maybeRestoreSavedLoadout = vi.fn(async () => {});
 
 		const context: ImportCommandContext = {
 			clearStatusIndicator: vi.fn(),
@@ -68,6 +70,7 @@ describe("InteractiveMode /import parsing", () => {
 				throw new Error("unexpected fatal error");
 			}),
 			promptForMissingSessionCwd: vi.fn(async () => undefined),
+			maybeRestoreSavedLoadout,
 			getPathCommandArgument: interactiveModePrototype.getPathCommandArgument,
 		};
 
@@ -78,6 +81,7 @@ describe("InteractiveMode /import parsing", () => {
 			"Replace current session with path/to/session.jsonl?",
 		);
 		expect(importFromJsonl).toHaveBeenCalledWith("path/to/session.jsonl");
+		expect(maybeRestoreSavedLoadout).toHaveBeenCalledOnce();
 		expect(showError).not.toHaveBeenCalled();
 		expect(showStatus).toHaveBeenCalledWith("Session imported from: path/to/session.jsonl");
 	});
@@ -87,6 +91,7 @@ describe("InteractiveMode /import parsing", () => {
 		const showExtensionConfirm = vi.fn(async () => true);
 		const showStatus = vi.fn();
 		const showError = vi.fn();
+		const maybeRestoreSavedLoadout = vi.fn(async () => {});
 
 		const context: ImportCommandContext = {
 			clearStatusIndicator: vi.fn(),
@@ -100,12 +105,14 @@ describe("InteractiveMode /import parsing", () => {
 				throw new Error("unexpected fatal error");
 			}),
 			promptForMissingSessionCwd: vi.fn(async () => undefined),
+			maybeRestoreSavedLoadout,
 			getPathCommandArgument: interactiveModePrototype.getPathCommandArgument,
 		};
 
 		await interactiveModePrototype.handleImportCommand.call(context, "/import john's/session.jsonl");
 
 		expect(importFromJsonl).toHaveBeenCalledWith("john's/session.jsonl");
+		expect(maybeRestoreSavedLoadout).toHaveBeenCalledOnce();
 		expect(showError).not.toHaveBeenCalled();
 		expect(showStatus).toHaveBeenCalledWith("Session imported from: john's/session.jsonl");
 	});
@@ -131,6 +138,7 @@ describe("InteractiveMode /import parsing", () => {
 			renderCurrentSessionState: vi.fn(),
 			handleFatalRuntimeError,
 			promptForMissingSessionCwd: vi.fn(async () => undefined),
+			maybeRestoreSavedLoadout: vi.fn(async () => {}),
 			getPathCommandArgument: interactiveModePrototype.getPathCommandArgument,
 		};
 

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -16,6 +16,7 @@ type SubmitContext = {
 	flushPendingBashComponents: () => void;
 	onInputCallback?: (text: string) => void;
 	pendingUserInputs: string[];
+	showLoadoutSelector: () => void;
 };
 
 type InputContext = {
@@ -45,6 +46,7 @@ function createSubmitContext(): SubmitContext {
 		},
 		flushPendingBashComponents: vi.fn(),
 		pendingUserInputs: [],
+		showLoadoutSelector: vi.fn(),
 	};
 }
 
@@ -58,6 +60,17 @@ describe("InteractiveMode startup input", () => {
 		expect(context.pendingUserInputs).toEqual(["early prompt"]);
 		expect(context.flushPendingBashComponents).toHaveBeenCalledTimes(1);
 		expect(context.editor.addToHistory).toHaveBeenCalledWith("early prompt");
+	});
+
+	it("opens /loadout without forwarding it as a prompt", async () => {
+		const context = createSubmitContext();
+		interactiveModePrototype.setupEditorSubmitHandler.call(context);
+
+		await context.defaultEditor.onSubmit?.("/loadout");
+
+		expect(context.showLoadoutSelector).toHaveBeenCalledOnce();
+		expect(context.session.prompt).not.toHaveBeenCalled();
+		expect(context.editor.setText).toHaveBeenCalledWith("");
 	});
 
 	it("returns queued startup input before installing a new input callback", async () => {

--- a/packages/coding-agent/test/loadout.test.ts
+++ b/packages/coding-agent/test/loadout.test.ts
@@ -1,0 +1,294 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	appendSessionLoadout,
+	createLoadoutResourceReference,
+	getLatestLoadoutEntry,
+	getLoadoutResourceReferenceKey,
+	getSessionLoadout,
+	LOADOUT_CUSTOM_TYPE,
+	type LoadoutOverride,
+	type LoadoutResourceReference,
+	parseLoadoutEntryPayload,
+	resolveLoadoutOverlay,
+} from "../src/core/loadout.ts";
+import type { ResolvedPaths, ResolvedResource } from "../src/core/package-manager.ts";
+import { DefaultResourceLoader } from "../src/core/resource-loader.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+
+const packageReference: LoadoutResourceReference = {
+	type: "extension",
+	origin: "package",
+	source: "npm:test-package",
+	relativePath: "extensions/test.ts",
+};
+
+function override(reference: LoadoutResourceReference, enabled: boolean): LoadoutOverride {
+	return { reference, enabled };
+}
+
+describe("loadout session entries", () => {
+	it("parses and validates versioned payloads defensively", () => {
+		const input = {
+			version: 1,
+			overrides: [
+				override(packageReference, true),
+				override(
+					{
+						type: "skill",
+						origin: "top-level",
+						scope: "project",
+						relativePath: "skills/review/SKILL.md",
+					},
+					false,
+				),
+			],
+		};
+
+		const parsed = parseLoadoutEntryPayload(input);
+		expect(parsed).toEqual(input);
+		expect(parsed).not.toBe(input);
+		expect(parsed?.overrides[0].reference).not.toBe(input.overrides[0].reference);
+
+		expect(parseLoadoutEntryPayload({ ...input, version: 2 })).toBeUndefined();
+		expect(parseLoadoutEntryPayload({ version: 1, overrides: [{ reference: packageReference }] })).toBeUndefined();
+		expect(
+			parseLoadoutEntryPayload({
+				version: 1,
+				overrides: [
+					override(
+						{
+							type: "prompt",
+							origin: "top-level",
+							scope: "user",
+							relativePath: "../outside.md",
+						},
+						true,
+					),
+				],
+			}),
+		).toBeUndefined();
+		expect(
+			parseLoadoutEntryPayload({
+				version: 1,
+				overrides: [override(packageReference, true), override(packageReference, false)],
+			}),
+		).toBeUndefined();
+	});
+
+	it("uses the latest valid entry in file order, including reset markers", () => {
+		const session = SessionManager.inMemory();
+		session.appendCustomEntry(LOADOUT_CUSTOM_TYPE, { version: 1, overrides: [override(packageReference, true)] });
+		const firstEntryId = session.getLeafId()!;
+		session.appendCustomEntry(LOADOUT_CUSTOM_TYPE, { version: 99, overrides: [] });
+
+		expect(getSessionLoadout(session)?.overrides).toEqual([override(packageReference, true)]);
+
+		session.branch(firstEntryId);
+		session.appendCustomEntry(LOADOUT_CUSTOM_TYPE, { version: 1, overrides: [] });
+		session.branch(firstEntryId);
+
+		expect(getSessionLoadout(session)).toEqual({ version: 1, overrides: [] });
+		expect(getLatestLoadoutEntry(session.getEntries())).toEqual({ version: 1, overrides: [] });
+	});
+
+	it("writes non-empty changes and only the necessary reset tombstone", () => {
+		const session = SessionManager.inMemory();
+		expect(appendSessionLoadout(session, [])).toBeUndefined();
+		expect(session.getEntries()).toHaveLength(0);
+
+		expect(appendSessionLoadout(session, [override(packageReference, true)])).toBeTypeOf("string");
+		expect(appendSessionLoadout(session, [override(packageReference, true)])).toBeUndefined();
+		expect(session.getEntries()).toHaveLength(1);
+
+		expect(appendSessionLoadout(session, [])).toBeTypeOf("string");
+		expect(appendSessionLoadout(session, [])).toBeUndefined();
+		expect(session.getEntries()).toHaveLength(2);
+		expect(getSessionLoadout(session)).toEqual({ version: 1, overrides: [] });
+	});
+});
+
+describe("loadout resource matching", () => {
+	const options = { cwd: "/workspace/project", agentDir: "/home/test/.pi/agent" };
+
+	it("matches package identity across versions and includes resource type", () => {
+		const extension: ResolvedResource = {
+			path: "/packages/test/extensions/shared.md",
+			enabled: false,
+			metadata: {
+				source: "npm:test-package@2.0.0",
+				scope: "user",
+				origin: "package",
+				baseDir: "/packages/test",
+			},
+		};
+		const prompt: ResolvedResource = { ...extension };
+		const oldReference = createLoadoutResourceReference(
+			"extension",
+			{ ...extension, metadata: { ...extension.metadata, source: "npm:test-package@1.0.0" } },
+			options,
+		)!;
+		const resolved: ResolvedPaths = {
+			extensions: [extension],
+			skills: [],
+			prompts: [prompt],
+			themes: [],
+		};
+
+		const result = resolveLoadoutOverlay(resolved, [override(oldReference, true)], options);
+		expect(result.resolvedPaths.extensions[0].enabled).toBe(true);
+		expect(result.resolvedPaths.prompts[0].enabled).toBe(false);
+		expect(getLoadoutResourceReferenceKey(oldReference)).not.toBe(
+			getLoadoutResourceReferenceKey(createLoadoutResourceReference("prompt", prompt, options)!),
+		);
+		expect(result.snapshot.diagnostics).toEqual([]);
+	});
+});
+
+describe("DefaultResourceLoader loadout overlay", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let cwd: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `loadout-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		agentDir = join(tempDir, "agent");
+		cwd = join(tempDir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function createResources(): void {
+		mkdirSync(join(agentDir, "extensions"), { recursive: true });
+		writeFileSync(join(agentDir, "extensions", "toggle.ts"), "export default function() {}");
+		mkdirSync(join(agentDir, "skills", "toggle"), { recursive: true });
+		writeFileSync(
+			join(agentDir, "skills", "toggle", "SKILL.md"),
+			"---\nname: toggle\ndescription: Toggle skill\n---\nSkill content",
+		);
+		mkdirSync(join(agentDir, "prompts"), { recursive: true });
+		writeFileSync(join(agentDir, "prompts", "toggle.md"), "Toggle prompt");
+		mkdirSync(join(agentDir, "themes"), { recursive: true });
+		const theme = JSON.parse(
+			readFileSync(join(process.cwd(), "src", "modes", "interactive", "theme", "dark.json"), "utf-8"),
+		) as { name: string };
+		theme.name = "toggle-theme";
+		writeFileSync(join(agentDir, "themes", "toggle.json"), JSON.stringify(theme));
+	}
+
+	function allResourceOverrides(loader: DefaultResourceLoader, enabled: boolean): LoadoutOverride[] {
+		return loader.getLoadoutSnapshot().resources.map((resource) => override(resource.reference, enabled));
+	}
+
+	function expectAllLoaded(loader: DefaultResourceLoader, loaded: boolean): void {
+		expect(loader.getExtensions().extensions.some((extension) => extension.path.endsWith("toggle.ts"))).toBe(loaded);
+		expect(loader.getSkills().skills.some((skill) => skill.name === "toggle")).toBe(loaded);
+		expect(loader.getPrompts().prompts.some((prompt) => prompt.name === "toggle")).toBe(loaded);
+		expect(loader.getThemes().themes.some((theme) => theme.name === "toggle-theme")).toBe(loaded);
+	}
+
+	it("turns disabled resources on for all four resource types", async () => {
+		createResources();
+		const settingsManager = SettingsManager.inMemory();
+		settingsManager.setExtensionPaths(["-extensions/toggle.ts"]);
+		settingsManager.setSkillPaths(["-skills/toggle"]);
+		settingsManager.setPromptTemplatePaths(["-prompts/toggle.md"]);
+		settingsManager.setThemePaths(["-themes/toggle.json"]);
+		const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager });
+		await loader.reload();
+
+		expect(loader.getLoadoutSnapshot().resources).toHaveLength(4);
+		expect(loader.getLoadoutSnapshot().resources.every((resource) => !resource.defaultEnabled)).toBe(true);
+		expectAllLoaded(loader, false);
+
+		loader.setLoadoutOverrides(allResourceOverrides(loader, true));
+		await loader.reload();
+
+		expectAllLoaded(loader, true);
+		expect(loader.getLoadoutSnapshot().resources.every((resource) => resource.enabled)).toBe(true);
+	});
+
+	it("turns enabled resources off and preserves the overlay across ordinary reloads", async () => {
+		createResources();
+		const loader = new DefaultResourceLoader({ cwd, agentDir });
+		await loader.reload();
+		expectAllLoaded(loader, true);
+
+		loader.setLoadoutOverrides(allResourceOverrides(loader, false));
+		await loader.reload();
+		expectAllLoaded(loader, false);
+		await loader.reload();
+		expectAllLoaded(loader, false);
+		expect(loader.getLoadoutSnapshot().overrides).toHaveLength(4);
+	});
+
+	it("preserves unmatched overrides and restores them if a resource returns", async () => {
+		const loader = new DefaultResourceLoader({ cwd, agentDir });
+		const promptReference: LoadoutResourceReference = {
+			type: "prompt",
+			origin: "top-level",
+			scope: "user",
+			relativePath: "prompts/later.md",
+		};
+		loader.setLoadoutOverrides([override(promptReference, false)]);
+		await loader.reload();
+
+		expect(loader.getLoadoutSnapshot().overrides).toEqual([override(promptReference, false)]);
+		expect(loader.getLoadoutSnapshot().diagnostics[0]?.message).toContain("is unavailable");
+
+		mkdirSync(join(agentDir, "prompts"), { recursive: true });
+		writeFileSync(join(agentDir, "prompts", "later.md"), "Later prompt");
+		await loader.reload();
+
+		expect(loader.getPrompts().prompts.some((prompt) => prompt.name === "later")).toBe(false);
+		expect(loader.getLoadoutSnapshot().diagnostics).toEqual([]);
+	});
+
+	it("does not treat session references as path, package, or trust authority", async () => {
+		const projectExtension = join(cwd, ".pi", "extensions", "untrusted.ts");
+		const externalExtension = join(tempDir, "external.ts");
+		mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
+		writeFileSync(projectExtension, "export default function() {}");
+		writeFileSync(externalExtension, "export default function() {}");
+		const settingsManager = SettingsManager.create(cwd, agentDir, { projectTrusted: false });
+		const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager });
+		const payload = parseLoadoutEntryPayload({
+			version: 1,
+			overrides: [
+				override(
+					{
+						type: "extension",
+						origin: "top-level",
+						scope: "project",
+						relativePath: "extensions/untrusted.ts",
+					},
+					true,
+				),
+				override({ type: "extension", origin: "top-level", scope: "user", path: externalExtension }, true),
+				override(
+					{
+						type: "extension",
+						origin: "package",
+						source: "npm:not-installed-by-loadout",
+						relativePath: "extensions/index.ts",
+					},
+					true,
+				),
+			],
+		})!;
+
+		loader.setLoadoutOverrides(payload.overrides);
+		await loader.reload();
+
+		expect(loader.getExtensions().extensions).toEqual([]);
+		expect(loader.getLoadoutSnapshot().diagnostics).toHaveLength(3);
+		expect(loader.getLoadoutSnapshot().resources).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -8,7 +8,7 @@ import type { ResolvedPaths } from "../src/core/package-manager.ts";
 import { InMemorySettingsStorage, SettingsManager } from "../src/core/settings-manager.ts";
 import { ProjectTrustStore } from "../src/core/trust-manager.ts";
 import { main } from "../src/main.ts";
-import { ConfigSelectorComponent } from "../src/modes/interactive/components/config-selector.ts";
+import { LoadoutSelectorComponent } from "../src/modes/interactive/components/loadout-selector.ts";
 import { handlePackageCommand } from "../src/package-manager-cli.ts";
 
 describe("package commands", () => {
@@ -372,6 +372,40 @@ describe("package commands", () => {
 		}
 	});
 
+	it("shows canonical loadout command help", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await expect(main(["loadout", "--help"])).resolves.toBeUndefined();
+
+		const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+		expect(stdout).toContain("pi loadout [-l]");
+		expect(stdout).toContain("Alias: pi config");
+		expect(stdout).not.toContain("pi config [-l]");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("keeps config as a silent alias for loadout", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await expect(main(["config", "--help"])).resolves.toBeUndefined();
+
+		const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+		expect(stdout).toContain("pi loadout [-l]");
+		expect(stdout).toContain("Alias: pi config");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("uses canonical loadout terminology in command errors", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await expect(main(["config", "--unknown"])).resolves.toBeUndefined();
+
+		const stderr = errorSpy.mock.calls.map(([message]) => String(message)).join("\n");
+		expect(stderr).toContain('Unknown option --unknown for "loadout".');
+		expect(stderr).toContain("pi loadout [-l] [--approve|--no-approve]");
+		expect(process.exitCode).toBe(1);
+	});
+
 	it("refreshes only model catalogs with update --models", async () => {
 		const refresh = vi.fn(async () => ({ aborted: false, errors: new Map<string, Error>() }));
 		const create = vi.spyOn(ModelRuntime, "create").mockResolvedValue({ refresh } as unknown as ModelRuntime);
@@ -408,12 +442,12 @@ describe("package commands", () => {
 		expect(process.exitCode).toBe(1);
 	});
 
-	it("cycles project package overrides in config local mode", async () => {
+	it("cycles project package overrides in loadout local mode", async () => {
 		const storage = new InMemorySettingsStorage();
 		storage.withLock("global", () => JSON.stringify({ packages: ["npm:pi-tools"] }));
 		const settingsManager = SettingsManager.fromStorage(storage, { projectTrusted: true });
 		const resolvedPaths = extensionPaths(join(tempDir, "pkg"), "npm:pi-tools", "user", ["bar.ts"]);
-		const selector = new ConfigSelectorComponent(
+		const selector = new LoadoutSelectorComponent(
 			{ global: resolvedPaths, project: resolvedPaths },
 			settingsManager,
 			projectDir,

--- a/packages/coding-agent/test/session-loadout-selector.test.ts
+++ b/packages/coding-agent/test/session-loadout-selector.test.ts
@@ -1,0 +1,158 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.ts";
+import { getLoadoutResourceReferenceKey, type LoadoutSnapshot } from "../src/core/loadout.ts";
+import {
+	buildSessionLoadoutOverrides,
+	SessionLoadoutSelectorComponent,
+} from "../src/modes/interactive/components/session-loadout-selector.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+const extensionReference = {
+	type: "extension" as const,
+	origin: "top-level" as const,
+	scope: "user" as const,
+	relativePath: "extensions/example.ts",
+};
+
+const missingPromptReference = {
+	type: "prompt" as const,
+	origin: "top-level" as const,
+	scope: "user" as const,
+	relativePath: "prompts/missing.md",
+};
+
+function createSnapshot(): LoadoutSnapshot {
+	return {
+		resources: [
+			{
+				reference: extensionReference,
+				path: "/agent/extensions/example.ts",
+				enabled: true,
+				defaultEnabled: true,
+				metadata: {
+					source: "auto",
+					scope: "user",
+					origin: "top-level",
+					baseDir: "/agent/extensions",
+				},
+			},
+		],
+		overrides: [{ reference: missingPromptReference, enabled: true }],
+		diagnostics: [],
+	};
+}
+
+describe("SessionLoadoutSelectorComponent", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		setKeybindings(new KeybindingsManager());
+	});
+
+	it("stages toggles until Enter and identifies session-only behavior", () => {
+		const onApply = vi.fn();
+		const selector = new SessionLoadoutSelectorComponent({
+			snapshot: createSnapshot(),
+			agentDir: "/agent",
+			onApply,
+			onCancel: () => {},
+			requestRender: () => {},
+		});
+		const list = selector.getResourceList();
+
+		const rendered = stripAnsi(selector.render(100).join("\n"));
+		expect(rendered).toContain("Session Loadout");
+		expect(rendered).toContain("staged until apply");
+		expect(rendered).toContain("global/project settings unchanged");
+		expect(rendered).toContain("example.ts");
+
+		list.handleInput!("\u001b[B");
+		list.handleInput!(" ");
+		expect(onApply).not.toHaveBeenCalled();
+		list.handleInput!("\n");
+
+		expect(onApply).toHaveBeenCalledOnce();
+		expect(onApply.mock.calls[0]?.[0]).toEqual([
+			{ reference: missingPromptReference, enabled: true },
+			{ reference: extensionReference, enabled: false },
+		]);
+	});
+
+	it("discards with Escape and emits no staged changes", () => {
+		const onApply = vi.fn();
+		const onCancel = vi.fn();
+		const selector = new SessionLoadoutSelectorComponent({
+			snapshot: createSnapshot(),
+			agentDir: "/agent",
+			onApply,
+			onCancel,
+			requestRender: () => {},
+		});
+		const list = selector.getResourceList();
+
+		list.handleInput!("\u001b[B");
+		list.handleInput!(" ");
+		list.handleInput!("\u001b");
+
+		expect(onCancel).toHaveBeenCalledOnce();
+		expect(onApply).not.toHaveBeenCalled();
+	});
+
+	it("clears visible and unmatched overrides through the reset row", () => {
+		const snapshot = createSnapshot();
+		snapshot.resources[0]!.enabled = false;
+		snapshot.overrides.push({ reference: extensionReference, enabled: false });
+		const onApply = vi.fn();
+		const selector = new SessionLoadoutSelectorComponent({
+			snapshot,
+			agentDir: "/agent",
+			onApply,
+			onCancel: () => {},
+			requestRender: () => {},
+		});
+		const list = selector.getResourceList();
+
+		list.handleInput!(" ");
+		list.handleInput!("\n");
+
+		expect(onApply).toHaveBeenCalledWith([]);
+		expect(stripAnsi(selector.render(100).join("\n"))).toContain("[x] Use persistent settings");
+	});
+
+	it("keeps unavailable overrides cleared when adjusting a resource after reset", () => {
+		const snapshot = createSnapshot();
+		snapshot.resources[0]!.enabled = false;
+		snapshot.overrides.push({ reference: extensionReference, enabled: false });
+		const onApply = vi.fn();
+		const selector = new SessionLoadoutSelectorComponent({
+			snapshot,
+			agentDir: "/agent",
+			onApply,
+			onCancel: () => {},
+			requestRender: () => {},
+		});
+		const list = selector.getResourceList();
+
+		list.handleInput!(" ");
+		list.handleInput!("\u001b[B");
+		list.handleInput!(" ");
+		list.handleInput!("\n");
+
+		expect(onApply).toHaveBeenCalledWith([{ reference: extensionReference, enabled: false }]);
+	});
+});
+
+describe("buildSessionLoadoutOverrides", () => {
+	it("drops visible states matching defaults while retaining unavailable references", () => {
+		const snapshot = createSnapshot();
+		const enabled = new Map([[getLoadoutResourceReferenceKey(extensionReference), true]]);
+
+		expect(buildSessionLoadoutOverrides(snapshot, enabled, false)).toEqual([
+			{ reference: missingPromptReference, enabled: true },
+		]);
+	});
+});

--- a/packages/coding-agent/test/session-loadout-selector.test.ts
+++ b/packages/coding-agent/test/session-loadout-selector.test.ts
@@ -76,10 +76,13 @@ describe("SessionLoadoutSelectorComponent", () => {
 		list.handleInput!("\n");
 
 		expect(onApply).toHaveBeenCalledOnce();
-		expect(onApply.mock.calls[0]?.[0]).toEqual([
-			{ reference: missingPromptReference, enabled: true },
-			{ reference: extensionReference, enabled: false },
-		]);
+		expect(onApply.mock.calls[0]?.[0]).toEqual({
+			overrides: [
+				{ reference: missingPromptReference, enabled: true },
+				{ reference: extensionReference, enabled: false },
+			],
+			explicitReset: false,
+		});
 	});
 
 	it("discards with Escape and emits no staged changes", () => {
@@ -119,7 +122,7 @@ describe("SessionLoadoutSelectorComponent", () => {
 		list.handleInput!(" ");
 		list.handleInput!("\n");
 
-		expect(onApply).toHaveBeenCalledWith([]);
+		expect(onApply).toHaveBeenCalledWith({ overrides: [], explicitReset: true });
 		expect(stripAnsi(selector.render(100).join("\n"))).toContain("[x] Use persistent settings");
 	});
 
@@ -142,7 +145,27 @@ describe("SessionLoadoutSelectorComponent", () => {
 		list.handleInput!(" ");
 		list.handleInput!("\n");
 
-		expect(onApply).toHaveBeenCalledWith([{ reference: extensionReference, enabled: false }]);
+		expect(onApply).toHaveBeenCalledWith({
+			overrides: [{ reference: extensionReference, enabled: false }],
+			explicitReset: true,
+		});
+	});
+
+	it("distinguishes applying an unchanged empty loadout from an explicit reset", () => {
+		const snapshot = createSnapshot();
+		snapshot.overrides = [];
+		const onApply = vi.fn();
+		const selector = new SessionLoadoutSelectorComponent({
+			snapshot,
+			agentDir: "/agent",
+			onApply,
+			onCancel: () => {},
+			requestRender: () => {},
+		});
+
+		selector.getResourceList().handleInput!("\n");
+
+		expect(onApply).toHaveBeenCalledWith({ overrides: [], explicitReset: false });
 	});
 });
 

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -2,7 +2,8 @@ import type { AgentTool, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type Model, type Usage } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
-import type { BuildSystemPromptOptions, ExtensionAPI } from "../../src/index.ts";
+import type { BuildSystemPromptOptions, ExtensionAPI, ExtensionFactory, ResourceLoader } from "../../src/index.ts";
+import { createTestExtensionsResult } from "../utilities.ts";
 import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
 
 describe("AgentSession model and extension characterization", () => {
@@ -393,5 +394,71 @@ describe("AgentSession model and extension characterization", () => {
 		await harness.session.reload();
 
 		expect(lifecycleEvents).toEqual(["start:startup", "shutdown:reload", "start:reload"]);
+	});
+
+	it("invalidates the old runtime after host cleanup and removes disabled extension resources", async () => {
+		let enabled = true;
+		const phases: string[] = [];
+		const factory: ExtensionFactory = (pi) => {
+			if (!enabled) return;
+			pi.on("session_shutdown", () => {
+				phases.push("shutdown");
+			});
+			pi.on("input", () => ({ action: "continue" }));
+			pi.registerCommand("removed-command", { handler: async () => {} });
+			pi.registerShortcut("ctrl+shift+y", { handler: () => {} });
+			pi.registerMessageRenderer("removed-message", () => undefined);
+			pi.registerEntryRenderer("removed-entry", () => undefined);
+			pi.registerTool({
+				name: "removed_tool",
+				label: "Removed Tool",
+				description: "Removed on reload",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+			});
+		};
+		let extensionsResult = await createTestExtensionsResult([factory]);
+		const resourceLoader: ResourceLoader = {
+			getExtensions: () => extensionsResult,
+			getSkills: () => ({ skills: [], diagnostics: [] }),
+			getPrompts: () => ({ prompts: [], diagnostics: [] }),
+			getThemes: () => ({ themes: [], diagnostics: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			getSystemPrompt: () => undefined,
+			getAppendSystemPrompt: () => [],
+			extendResources: () => {},
+			reload: async () => {
+				extensionsResult = await createTestExtensionsResult([factory]);
+			},
+		};
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ shutdownHandler: () => {} });
+		const oldRunner = harness.session.extensionRunner;
+		const oldContext = oldRunner.createContext();
+
+		expect(oldRunner.getCommand("removed-command")).toBeDefined();
+		expect(harness.session.getAllTools().map((tool) => tool.name)).toContain("removed_tool");
+		expect(oldRunner.hasHandlers("input")).toBe(true);
+		expect(oldRunner.getMessageRenderer("removed-message")).toBeDefined();
+		expect(oldRunner.getEntryRenderer("removed-entry")).toBeDefined();
+
+		enabled = false;
+		await harness.session.reload({
+			beforeExtensionInvalidate: () => {
+				phases.push("host-ui-cleanup");
+				expect(oldContext.cwd).toBe(harness.tempDir);
+			},
+		});
+
+		expect(phases).toEqual(["shutdown", "host-ui-cleanup"]);
+		expect(() => oldContext.cwd).toThrow("stale after session replacement or reload");
+		expect(harness.session.extensionRunner.getCommand("removed-command")).toBeUndefined();
+		expect(harness.session.getAllTools().map((tool) => tool.name)).not.toContain("removed_tool");
+		expect(harness.session.getActiveToolNames()).not.toContain("removed_tool");
+		expect(harness.session.extensionRunner.hasHandlers("input")).toBe(false);
+		expect(harness.session.extensionRunner.getShortcuts({}).size).toBe(0);
+		expect(harness.session.extensionRunner.getMessageRenderer("removed-message")).toBeUndefined();
+		expect(harness.session.extensionRunner.getEntryRenderer("removed-entry")).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
+++ b/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
@@ -5,6 +5,7 @@ import {
 	type LoadoutOverride,
 	type LoadoutSnapshot,
 } from "../../src/core/loadout.ts";
+import type { SessionLoadoutSelection } from "../../src/modes/interactive/components/session-loadout-selector.ts";
 import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
 import { createHarness, type Harness } from "./harness.ts";
 
@@ -21,7 +22,7 @@ type RestoreContext = {
 	sessionManager: Harness["sessionManager"];
 	getLoadoutRestoreDecisionKey: () => string;
 	showExtensionConfirm: (title: string, message: string) => Promise<boolean>;
-	applySessionLoadout: (overrides: LoadoutOverride[], persist: boolean) => Promise<void>;
+	applySessionLoadout: (selection: SessionLoadoutSelection, persist: boolean) => Promise<void>;
 };
 
 type ApplyContext = {
@@ -44,7 +45,7 @@ type ReloadBlockedContext = {
 
 type InteractiveModePrivate = {
 	maybeRestoreSavedLoadout(this: RestoreContext): Promise<void>;
-	applySessionLoadout(this: ApplyContext, overrides: LoadoutOverride[], persist: boolean): Promise<void>;
+	applySessionLoadout(this: ApplyContext, selection: SessionLoadoutSelection, persist: boolean): Promise<void>;
 	loadoutActionBlocked(this: Pick<ApplyContext, "session" | "showWarning">, action: "opening" | "applying"): boolean;
 	handleReloadCommand(this: ReloadBlockedContext): Promise<boolean>;
 };
@@ -81,7 +82,7 @@ describe("interactive session loadout restore", () => {
 		await interactiveModePrototype.maybeRestoreSavedLoadout.call(context);
 
 		expect(showExtensionConfirm).toHaveBeenCalledOnce();
-		expect(applySessionLoadout).toHaveBeenCalledWith(overrides, false);
+		expect(applySessionLoadout).toHaveBeenCalledWith({ overrides, explicitReset: false }, false);
 		expect(harness.sessionManager.getEntries()).toHaveLength(entryCount);
 	});
 
@@ -165,7 +166,7 @@ describe("interactive /loadout application", () => {
 			showWarning,
 		};
 
-		await interactiveModePrototype.applySessionLoadout.call(context, overrides, true);
+		await interactiveModePrototype.applySessionLoadout.call(context, { overrides, explicitReset: false }, true);
 
 		expect(setLoadoutOverrides).toHaveBeenCalledWith(overrides);
 		expect(handleReloadCommand).toHaveBeenCalledOnce();
@@ -173,9 +174,10 @@ describe("interactive /loadout application", () => {
 		expect(showWarning).toHaveBeenCalledWith("Saved loadout skill is unavailable");
 	});
 
-	it("does not write a reset marker when the declined saved loadout is already inactive", async () => {
+	it("writes a reset tombstone when reset is explicit after a declined restore", async () => {
 		const harness = await createTestHarness();
 		appendSessionLoadout(harness.sessionManager, overrides);
+		const entryCount = harness.sessionManager.getEntries().length;
 		const setLoadoutOverrides = vi.fn();
 		const context: ApplyContext = {
 			session: { isStreaming: false, isCompacting: false, isBashRunning: false },
@@ -190,9 +192,35 @@ describe("interactive /loadout application", () => {
 			showWarning: vi.fn(),
 		};
 
-		await interactiveModePrototype.applySessionLoadout.call(context, [], true);
+		await interactiveModePrototype.applySessionLoadout.call(context, { overrides: [], explicitReset: true }, true);
 
-		expect(setLoadoutOverrides).toHaveBeenCalledOnce();
+		expect(setLoadoutOverrides).toHaveBeenCalledWith([]);
+		expect(harness.sessionManager.getEntries()).toHaveLength(entryCount + 1);
+		expect(getSessionLoadout(harness.sessionManager)?.overrides).toEqual([]);
+	});
+
+	it("does not write a reset tombstone for an unchanged apply after a declined restore", async () => {
+		const harness = await createTestHarness();
+		appendSessionLoadout(harness.sessionManager, overrides);
+		const entryCount = harness.sessionManager.getEntries().length;
+		const setLoadoutOverrides = vi.fn();
+		const context: ApplyContext = {
+			session: { isStreaming: false, isCompacting: false, isBashRunning: false },
+			sessionManager: harness.sessionManager,
+			getLoadoutLoader: () => ({
+				getLoadoutSnapshot: () => ({ resources: [], overrides: [], diagnostics: [] }),
+				setLoadoutOverrides,
+			}),
+			loadoutActionBlocked: () => false,
+			handleReloadCommand: async () => true,
+			showLoadoutDiagnostics: () => {},
+			showWarning: vi.fn(),
+		};
+
+		await interactiveModePrototype.applySessionLoadout.call(context, { overrides: [], explicitReset: false }, true);
+
+		expect(setLoadoutOverrides).toHaveBeenCalledWith([]);
+		expect(harness.sessionManager.getEntries()).toHaveLength(entryCount);
 		expect(getSessionLoadout(harness.sessionManager)?.overrides).toEqual(overrides);
 	});
 
@@ -212,7 +240,7 @@ describe("interactive /loadout application", () => {
 			showWarning: vi.fn(),
 		};
 
-		await interactiveModePrototype.applySessionLoadout.call(context, overrides, true);
+		await interactiveModePrototype.applySessionLoadout.call(context, { overrides, explicitReset: false }, true);
 
 		expect(setLoadoutOverrides).toHaveBeenNthCalledWith(1, overrides);
 		expect(setLoadoutOverrides).toHaveBeenNthCalledWith(2, []);
@@ -244,7 +272,7 @@ describe("interactive /loadout application", () => {
 			showWarning,
 		};
 
-		await interactiveModePrototype.applySessionLoadout.call(context, overrides, true);
+		await interactiveModePrototype.applySessionLoadout.call(context, { overrides, explicitReset: false }, true);
 
 		expect(setLoadoutOverrides).not.toHaveBeenCalled();
 		expect(handleReloadCommand).not.toHaveBeenCalled();

--- a/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
+++ b/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
@@ -32,7 +32,7 @@ type ApplyContext = {
 		setLoadoutOverrides: (overrides: readonly LoadoutOverride[]) => void;
 	};
 	loadoutActionBlocked: (action: "opening" | "applying") => boolean;
-	handleReloadCommand: () => Promise<void>;
+	handleReloadCommand: () => Promise<boolean>;
 	showLoadoutDiagnostics: () => void;
 	showWarning: (message: string) => void;
 };
@@ -46,7 +46,7 @@ type InteractiveModePrivate = {
 	maybeRestoreSavedLoadout(this: RestoreContext): Promise<void>;
 	applySessionLoadout(this: ApplyContext, overrides: LoadoutOverride[], persist: boolean): Promise<void>;
 	loadoutActionBlocked(this: Pick<ApplyContext, "session" | "showWarning">, action: "opening" | "applying"): boolean;
-	handleReloadCommand(this: ReloadBlockedContext): Promise<void>;
+	handleReloadCommand(this: ReloadBlockedContext): Promise<boolean>;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
@@ -144,11 +144,11 @@ describe("interactive /loadout application", () => {
 	it("persists a deliberate change, reloads once, and reports unmatched resources", async () => {
 		const harness = await createTestHarness();
 		const setLoadoutOverrides = vi.fn();
-		const handleReloadCommand = vi.fn(async () => {});
+		const handleReloadCommand = vi.fn(async () => true);
 		const showWarning = vi.fn();
 		const snapshot: LoadoutSnapshot = {
 			resources: [],
-			overrides,
+			overrides: [],
 			diagnostics: [{ type: "warning", message: "Saved loadout skill is unavailable" }],
 		};
 		const context: ApplyContext = {
@@ -173,6 +173,53 @@ describe("interactive /loadout application", () => {
 		expect(showWarning).toHaveBeenCalledWith("Saved loadout skill is unavailable");
 	});
 
+	it("does not write a reset marker when the declined saved loadout is already inactive", async () => {
+		const harness = await createTestHarness();
+		appendSessionLoadout(harness.sessionManager, overrides);
+		const setLoadoutOverrides = vi.fn();
+		const context: ApplyContext = {
+			session: { isStreaming: false, isCompacting: false, isBashRunning: false },
+			sessionManager: harness.sessionManager,
+			getLoadoutLoader: () => ({
+				getLoadoutSnapshot: () => ({ resources: [], overrides: [], diagnostics: [] }),
+				setLoadoutOverrides,
+			}),
+			loadoutActionBlocked: () => false,
+			handleReloadCommand: async () => true,
+			showLoadoutDiagnostics: () => {},
+			showWarning: vi.fn(),
+		};
+
+		await interactiveModePrototype.applySessionLoadout.call(context, [], true);
+
+		expect(setLoadoutOverrides).toHaveBeenCalledOnce();
+		expect(getSessionLoadout(harness.sessionManager)?.overrides).toEqual(overrides);
+	});
+
+	it("rolls back in-memory overrides and persistence when reload fails", async () => {
+		const harness = await createTestHarness();
+		const setLoadoutOverrides = vi.fn();
+		const context: ApplyContext = {
+			session: { isStreaming: false, isCompacting: false, isBashRunning: false },
+			sessionManager: harness.sessionManager,
+			getLoadoutLoader: () => ({
+				getLoadoutSnapshot: () => ({ resources: [], overrides: [], diagnostics: [] }),
+				setLoadoutOverrides,
+			}),
+			loadoutActionBlocked: () => false,
+			handleReloadCommand: async () => false,
+			showLoadoutDiagnostics: vi.fn(),
+			showWarning: vi.fn(),
+		};
+
+		await interactiveModePrototype.applySessionLoadout.call(context, overrides, true);
+
+		expect(setLoadoutOverrides).toHaveBeenNthCalledWith(1, overrides);
+		expect(setLoadoutOverrides).toHaveBeenNthCalledWith(2, []);
+		expect(getSessionLoadout(harness.sessionManager)).toBeUndefined();
+		expect(context.showLoadoutDiagnostics).not.toHaveBeenCalled();
+	});
+
 	it.each([
 		["streaming", { isStreaming: true, isCompacting: false, isBashRunning: false }],
 		["compaction", { isStreaming: false, isCompacting: true, isBashRunning: false }],
@@ -180,7 +227,7 @@ describe("interactive /loadout application", () => {
 	])("blocks application during %s", async (_name, session) => {
 		const harness = await createTestHarness();
 		const setLoadoutOverrides = vi.fn();
-		const handleReloadCommand = vi.fn(async () => {});
+		const handleReloadCommand = vi.fn(async () => true);
 		const showWarning = vi.fn();
 		const context: ApplyContext = {
 			session,

--- a/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
+++ b/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	appendSessionLoadout,
+	getSessionLoadout,
+	type LoadoutOverride,
+	type LoadoutSnapshot,
+} from "../../src/core/loadout.ts";
+import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const reference = {
+	type: "skill" as const,
+	origin: "top-level" as const,
+	scope: "user" as const,
+	relativePath: "skills/review/SKILL.md",
+};
+const overrides: LoadoutOverride[] = [{ reference, enabled: false }];
+
+type RestoreContext = {
+	loadoutRestoreDecisions: Set<string>;
+	sessionManager: Harness["sessionManager"];
+	getLoadoutRestoreDecisionKey: () => string;
+	showExtensionConfirm: (title: string, message: string) => Promise<boolean>;
+	applySessionLoadout: (overrides: LoadoutOverride[], persist: boolean) => Promise<void>;
+};
+
+type ApplyContext = {
+	session: { isStreaming: boolean; isCompacting: boolean; isBashRunning: boolean };
+	sessionManager: Harness["sessionManager"];
+	getLoadoutLoader: () => {
+		getLoadoutSnapshot: () => LoadoutSnapshot;
+		setLoadoutOverrides: (overrides: readonly LoadoutOverride[]) => void;
+	};
+	loadoutActionBlocked: (action: "opening" | "applying") => boolean;
+	handleReloadCommand: () => Promise<void>;
+	showLoadoutDiagnostics: () => void;
+	showWarning: (message: string) => void;
+};
+
+type InteractiveModePrivate = {
+	maybeRestoreSavedLoadout(this: RestoreContext): Promise<void>;
+	applySessionLoadout(this: ApplyContext, overrides: LoadoutOverride[], persist: boolean): Promise<void>;
+	loadoutActionBlocked(this: Pick<ApplyContext, "session" | "showWarning">, action: "opening" | "applying"): boolean;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
+const harnesses: Harness[] = [];
+
+async function createTestHarness(): Promise<Harness> {
+	const harness = await createHarness();
+	harnesses.push(harness);
+	return harness;
+}
+
+afterEach(() => {
+	for (const harness of harnesses.splice(0)) harness.cleanup();
+});
+
+describe("interactive session loadout restore", () => {
+	it("accepts a saved loadout once per live runtime without appending", async () => {
+		const harness = await createTestHarness();
+		appendSessionLoadout(harness.sessionManager, overrides);
+		const entryCount = harness.sessionManager.getEntries().length;
+		const showExtensionConfirm = vi.fn(async () => true);
+		const applySessionLoadout = vi.fn(async () => {});
+		const context: RestoreContext = {
+			loadoutRestoreDecisions: new Set(),
+			sessionManager: harness.sessionManager,
+			getLoadoutRestoreDecisionKey: () => harness.sessionManager.getSessionId(),
+			showExtensionConfirm,
+			applySessionLoadout,
+		};
+
+		await interactiveModePrototype.maybeRestoreSavedLoadout.call(context);
+		await interactiveModePrototype.maybeRestoreSavedLoadout.call(context);
+
+		expect(showExtensionConfirm).toHaveBeenCalledOnce();
+		expect(applySessionLoadout).toHaveBeenCalledWith(overrides, false);
+		expect(harness.sessionManager.getEntries()).toHaveLength(entryCount);
+	});
+
+	it("remembers a declined restore and ignores reset or fresh sessions", async () => {
+		const declinedHarness = await createTestHarness();
+		appendSessionLoadout(declinedHarness.sessionManager, overrides);
+		const showExtensionConfirm = vi.fn(async () => false);
+		const applySessionLoadout = vi.fn(async () => {});
+		const declined: RestoreContext = {
+			loadoutRestoreDecisions: new Set(),
+			sessionManager: declinedHarness.sessionManager,
+			getLoadoutRestoreDecisionKey: () => declinedHarness.sessionManager.getSessionId(),
+			showExtensionConfirm,
+			applySessionLoadout,
+		};
+		await interactiveModePrototype.maybeRestoreSavedLoadout.call(declined);
+		await interactiveModePrototype.maybeRestoreSavedLoadout.call(declined);
+		expect(showExtensionConfirm).toHaveBeenCalledOnce();
+		expect(applySessionLoadout).not.toHaveBeenCalled();
+
+		const resetHarness = await createTestHarness();
+		appendSessionLoadout(resetHarness.sessionManager, overrides);
+		appendSessionLoadout(resetHarness.sessionManager, []);
+		const ignoredConfirm = vi.fn(async () => true);
+		const reset: RestoreContext = {
+			loadoutRestoreDecisions: new Set(),
+			sessionManager: resetHarness.sessionManager,
+			getLoadoutRestoreDecisionKey: () => resetHarness.sessionManager.getSessionId(),
+			showExtensionConfirm: ignoredConfirm,
+			applySessionLoadout,
+		};
+		await interactiveModePrototype.maybeRestoreSavedLoadout.call(reset);
+		expect(ignoredConfirm).not.toHaveBeenCalled();
+
+		const freshHarness = await createTestHarness();
+		const fresh: RestoreContext = {
+			loadoutRestoreDecisions: new Set(),
+			sessionManager: freshHarness.sessionManager,
+			getLoadoutRestoreDecisionKey: () => freshHarness.sessionManager.getSessionId(),
+			showExtensionConfirm: ignoredConfirm,
+			applySessionLoadout,
+		};
+		await interactiveModePrototype.maybeRestoreSavedLoadout.call(fresh);
+		expect(ignoredConfirm).not.toHaveBeenCalled();
+	});
+});
+
+describe("interactive /loadout application", () => {
+	it("persists a deliberate change, reloads once, and reports unmatched resources", async () => {
+		const harness = await createTestHarness();
+		const setLoadoutOverrides = vi.fn();
+		const handleReloadCommand = vi.fn(async () => {});
+		const showWarning = vi.fn();
+		const snapshot: LoadoutSnapshot = {
+			resources: [],
+			overrides,
+			diagnostics: [{ type: "warning", message: "Saved loadout skill is unavailable" }],
+		};
+		const context: ApplyContext = {
+			session: { isStreaming: false, isCompacting: false, isBashRunning: false },
+			sessionManager: harness.sessionManager,
+			getLoadoutLoader: () => ({ getLoadoutSnapshot: () => snapshot, setLoadoutOverrides }),
+			loadoutActionBlocked(action) {
+				return interactiveModePrototype.loadoutActionBlocked.call(this, action);
+			},
+			handleReloadCommand,
+			showLoadoutDiagnostics() {
+				for (const diagnostic of snapshot.diagnostics) this.showWarning(diagnostic.message);
+			},
+			showWarning,
+		};
+
+		await interactiveModePrototype.applySessionLoadout.call(context, overrides, true);
+
+		expect(setLoadoutOverrides).toHaveBeenCalledWith(overrides);
+		expect(handleReloadCommand).toHaveBeenCalledOnce();
+		expect(getSessionLoadout(harness.sessionManager)?.overrides).toEqual(overrides);
+		expect(showWarning).toHaveBeenCalledWith("Saved loadout skill is unavailable");
+	});
+
+	it.each([
+		["streaming", { isStreaming: true, isCompacting: false, isBashRunning: false }],
+		["compaction", { isStreaming: false, isCompacting: true, isBashRunning: false }],
+		["bash", { isStreaming: false, isCompacting: false, isBashRunning: true }],
+	])("blocks application during %s", async (_name, session) => {
+		const harness = await createTestHarness();
+		const setLoadoutOverrides = vi.fn();
+		const handleReloadCommand = vi.fn(async () => {});
+		const showWarning = vi.fn();
+		const context: ApplyContext = {
+			session,
+			sessionManager: harness.sessionManager,
+			getLoadoutLoader: () => ({
+				getLoadoutSnapshot: () => ({ resources: [], overrides: [], diagnostics: [] }),
+				setLoadoutOverrides,
+			}),
+			loadoutActionBlocked(action) {
+				return interactiveModePrototype.loadoutActionBlocked.call(this, action);
+			},
+			handleReloadCommand,
+			showLoadoutDiagnostics: () => {},
+			showWarning,
+		};
+
+		await interactiveModePrototype.applySessionLoadout.call(context, overrides, true);
+
+		expect(setLoadoutOverrides).not.toHaveBeenCalled();
+		expect(handleReloadCommand).not.toHaveBeenCalled();
+		expect(getSessionLoadout(harness.sessionManager)).toBeUndefined();
+		expect(showWarning).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
+++ b/packages/coding-agent/test/suite/session-loadout-interactive.test.ts
@@ -37,10 +37,16 @@ type ApplyContext = {
 	showWarning: (message: string) => void;
 };
 
+type ReloadBlockedContext = {
+	session: { isStreaming: boolean; isCompacting: boolean; isBashRunning: boolean };
+	showWarning: (message: string) => void;
+};
+
 type InteractiveModePrivate = {
 	maybeRestoreSavedLoadout(this: RestoreContext): Promise<void>;
 	applySessionLoadout(this: ApplyContext, overrides: LoadoutOverride[], persist: boolean): Promise<void>;
 	loadoutActionBlocked(this: Pick<ApplyContext, "session" | "showWarning">, action: "opening" | "applying"): boolean;
+	handleReloadCommand(this: ReloadBlockedContext): Promise<void>;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
@@ -120,6 +126,17 @@ describe("interactive session loadout restore", () => {
 		};
 		await interactiveModePrototype.maybeRestoreSavedLoadout.call(fresh);
 		expect(ignoredConfirm).not.toHaveBeenCalled();
+	});
+});
+
+describe("interactive reload blocking", () => {
+	it("blocks ordinary reload while direct user bash is running", async () => {
+		const showWarning = vi.fn();
+		await interactiveModePrototype.handleReloadCommand.call({
+			session: { isStreaming: false, isCompacting: false, isBashRunning: true },
+			showWarning,
+		});
+		expect(showWarning).toHaveBeenCalledWith("Wait for the bash command to finish before reloading.");
 	});
 });
 


### PR DESCRIPTION
This is a draft of a feature that allows you to hit `/loadout` to enable or disable extensions in the middle of a session.

The session loadout overrides are also persisted in the session which makes it possible to restore on resumption.  This needs user confirmation.

Careful: this PR is not for merging.  It's 100% over-engineered clanker slop.