### PR TITLE
feat(ai): add GitHub Copilot Claude Opus 5 support

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Claude Opus 5 support for the GitHub Copilot provider, routing through the Anthropic Messages API with adaptive thinking, 1M context, and the Copilot `minimal` thinking-level override.
+
 ## [0.82.1] - 2026-07-25
 
 ### Added

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -380,6 +380,7 @@ const GITHUB_COPILOT_EXTENDED_CONTEXT_MODELS = new Set([
 	"claude-opus-4.6",
 	"claude-opus-4.7",
 	"claude-opus-4.8",
+	"claude-opus-5",
 	"claude-sonnet-4.6",
 	"claude-sonnet-5",
 	"gpt-5.3-codex",
@@ -392,6 +393,7 @@ const GITHUB_COPILOT_EXTENDED_CONTEXT_MODELS = new Set([
 const GITHUB_COPILOT_THINKING_LEVEL_OVERRIDES = {
 	"claude-opus-4.7": { minimal: "low" },
 	"claude-opus-4.8": { minimal: "low" },
+	"claude-opus-5": { minimal: "low" },
 	"claude-sonnet-4.6": { minimal: "low", max: "max" },
 } satisfies Record<string, NonNullable<Model<Api>["thinkingLevelMap"]>>;
 

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -61,6 +61,13 @@ describe("Copilot Claude via Anthropic Messages", () => {
 		expect(getSupportedThinkingLevels(opus47)).toContain("xhigh");
 		expect(getSupportedThinkingLevels(opus47)).toContain("max");
 
+		const opus5 = getModel("github-copilot", "claude-opus-5");
+		expect(opus5.api).toBe("anthropic-messages");
+		expect(opus5.contextWindow).toBe(1000000);
+		expect(opus5.thinkingLevelMap).toMatchObject({ minimal: "low", xhigh: "xhigh", max: "max" });
+		expect(getSupportedThinkingLevels(opus5)).toContain("xhigh");
+		expect(getSupportedThinkingLevels(opus5)).toContain("max");
+
 		const sonnet46 = getModel("github-copilot", "claude-sonnet-4.6");
 		expect(sonnet46.thinkingLevelMap).toMatchObject({ minimal: "low", max: "max" });
 		expect(getSupportedThinkingLevels(sonnet46)).toContain("max");


### PR DESCRIPTION
## Summary

Adds GitHub Copilot Claude Opus 5 support:

- Adds the Copilot `minimal` thinking-level override (`{ minimal: "low" }`) for `claude-opus-5`, matching `claude-opus-4.7`/`4.8`.
- Pins `claude-opus-5` into `GITHUB_COPILOT_EXTENDED_CONTEXT_MODELS` so its 1M context window is enforced by our override rather than relying on upstream models.dev metadata, consistent with the other Copilot Opus models.

Model routes through the Anthropic Messages API with adaptive thinking, 1M context, and the Copilot `minimal` thinking-level override.

## Testing

- `node ../../node_modules/vitest/dist/cli.js --run test/github-copilot-anthropic.test.ts` (3 passed)
- `npm run check` (clean)
