### PR TITLE
fix(coding-agent): isolate autoload-disabled package test from real home directory

### DIFF
--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -1715,20 +1715,31 @@ Content`,
 		});
 
 		it("should resolve autoload-disabled package entries as positive-only without a global package", async () => {
-			const pkgDir = join(tempDir, "positive-only-pkg");
-			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
-			mkdirSync(join(pkgDir, "skills", "foo"), { recursive: true });
-			writeFileSync(join(pkgDir, "extensions", "foo.ts"), "export default function() {}");
-			writeFileSync(join(pkgDir, "extensions", "bar.ts"), "export default function() {}");
-			writeFileSync(join(pkgDir, "skills", "foo", "SKILL.md"), "# Foo\n");
-			settingsManager.setProjectPackages([
-				{ source: relative(join(tempDir, ".pi"), pkgDir), autoload: false, extensions: ["+extensions/foo.ts"] },
-			]);
+			const previousHome = process.env.HOME;
+			process.env.HOME = tempDir;
 
-			const result = await packageManager.resolve();
+			try {
+				const pkgDir = join(tempDir, "positive-only-pkg");
+				mkdirSync(join(pkgDir, "extensions"), { recursive: true });
+				mkdirSync(join(pkgDir, "skills", "foo"), { recursive: true });
+				writeFileSync(join(pkgDir, "extensions", "foo.ts"), "export default function() {}");
+				writeFileSync(join(pkgDir, "extensions", "bar.ts"), "export default function() {}");
+				writeFileSync(join(pkgDir, "skills", "foo", "SKILL.md"), "# Foo\n");
+				settingsManager.setProjectPackages([
+					{ source: relative(join(tempDir, ".pi"), pkgDir), autoload: false, extensions: ["+extensions/foo.ts"] },
+				]);
 
-			expect(result.extensions.map((resource) => resource.path)).toEqual([join(pkgDir, "extensions", "foo.ts")]);
-			expect(result.skills).toEqual([]);
+				const result = await packageManager.resolve();
+
+				expect(result.extensions.map((resource) => resource.path)).toEqual([join(pkgDir, "extensions", "foo.ts")]);
+				expect(result.skills).toEqual([]);
+			} finally {
+				if (previousHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = previousHome;
+				}
+			}
 		});
 	});
 

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -97,7 +97,6 @@ describe("DefaultPackageManager", () => {
 		}
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
-		vi.unstubAllEnvs();
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
@@ -1717,9 +1716,6 @@ Content`,
 
 		it("should resolve autoload-disabled package entries as positive-only without a global package", async () => {
 			vi.stubEnv("HOME", tempDir);
-			const decoySkill = join(tempDir, ".agents", "skills", "decoy", "SKILL.md");
-			mkdirSync(join(tempDir, ".agents", "skills", "decoy"), { recursive: true });
-			writeFileSync(decoySkill, "---\nname: decoy\ndescription: user-scope decoy\n---\n");
 			const pkgDir = join(tempDir, "positive-only-pkg");
 			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
 			mkdirSync(join(pkgDir, "skills", "foo"), { recursive: true });
@@ -1733,7 +1729,7 @@ Content`,
 			const result = await packageManager.resolve();
 
 			expect(result.extensions.map((resource) => resource.path)).toEqual([join(pkgDir, "extensions", "foo.ts")]);
-			expect(result.skills.map((resource) => resource.path)).toEqual([decoySkill]);
+			expect(result.skills).toEqual([]);
 		});
 	});
 

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -1717,6 +1717,9 @@ Content`,
 
 		it("should resolve autoload-disabled package entries as positive-only without a global package", async () => {
 			vi.stubEnv("HOME", tempDir);
+			const decoySkill = join(tempDir, ".agents", "skills", "decoy", "SKILL.md");
+			mkdirSync(join(tempDir, ".agents", "skills", "decoy"), { recursive: true });
+			writeFileSync(decoySkill, "---\nname: decoy\ndescription: user-scope decoy\n---\n");
 			const pkgDir = join(tempDir, "positive-only-pkg");
 			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
 			mkdirSync(join(pkgDir, "skills", "foo"), { recursive: true });
@@ -1730,7 +1733,7 @@ Content`,
 			const result = await packageManager.resolve();
 
 			expect(result.extensions.map((resource) => resource.path)).toEqual([join(pkgDir, "extensions", "foo.ts")]);
-			expect(result.skills).toEqual([]);
+			expect(result.skills.map((resource) => resource.path)).toEqual([decoySkill]);
 		});
 	});
 

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -97,6 +97,7 @@ describe("DefaultPackageManager", () => {
 		}
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
@@ -1715,31 +1716,21 @@ Content`,
 		});
 
 		it("should resolve autoload-disabled package entries as positive-only without a global package", async () => {
-			const previousHome = process.env.HOME;
-			process.env.HOME = tempDir;
+			vi.stubEnv("HOME", tempDir);
+			const pkgDir = join(tempDir, "positive-only-pkg");
+			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
+			mkdirSync(join(pkgDir, "skills", "foo"), { recursive: true });
+			writeFileSync(join(pkgDir, "extensions", "foo.ts"), "export default function() {}");
+			writeFileSync(join(pkgDir, "extensions", "bar.ts"), "export default function() {}");
+			writeFileSync(join(pkgDir, "skills", "foo", "SKILL.md"), "# Foo\n");
+			settingsManager.setProjectPackages([
+				{ source: relative(join(tempDir, ".pi"), pkgDir), autoload: false, extensions: ["+extensions/foo.ts"] },
+			]);
 
-			try {
-				const pkgDir = join(tempDir, "positive-only-pkg");
-				mkdirSync(join(pkgDir, "extensions"), { recursive: true });
-				mkdirSync(join(pkgDir, "skills", "foo"), { recursive: true });
-				writeFileSync(join(pkgDir, "extensions", "foo.ts"), "export default function() {}");
-				writeFileSync(join(pkgDir, "extensions", "bar.ts"), "export default function() {}");
-				writeFileSync(join(pkgDir, "skills", "foo", "SKILL.md"), "# Foo\n");
-				settingsManager.setProjectPackages([
-					{ source: relative(join(tempDir, ".pi"), pkgDir), autoload: false, extensions: ["+extensions/foo.ts"] },
-				]);
+			const result = await packageManager.resolve();
 
-				const result = await packageManager.resolve();
-
-				expect(result.extensions.map((resource) => resource.path)).toEqual([join(pkgDir, "extensions", "foo.ts")]);
-				expect(result.skills).toEqual([]);
-			} finally {
-				if (previousHome === undefined) {
-					delete process.env.HOME;
-				} else {
-					process.env.HOME = previousHome;
-				}
-			}
+			expect(result.extensions.map((resource) => resource.path)).toEqual([join(pkgDir, "extensions", "foo.ts")]);
+			expect(result.skills).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
Hello, small fix:

When running tests locally, if you have `~/.agents/skills` with at least one skill in it, this test fails incorrectly (this is not an issue in CI as runners lack this directory, but happened to me). Doesn't seem to happen anywhere else

This is because `resolve` also scans `~/.agents/skills`, and as a result `expect(result.skills).toEqual([])` fails.

Suggested fix is to `vi.stubEnv("HOME", tempDir)` just for the test