### PR TITLE
fix(coding-agent): dedupe byte-identical context files

### DIFF
--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -94,11 +94,13 @@ export function loadProjectContextFiles(options: {
 
 	const contextFiles: Array<{ path: string; content: string }> = [];
 	const seenPaths = new Set<string>();
+	const seenContent = new Set<string>();
 
 	const globalContext = loadContextFileFromDir(resolvedAgentDir);
-	if (globalContext) {
+	if (globalContext && !seenContent.has(globalContext.content)) {
 		contextFiles.push(globalContext);
 		seenPaths.add(globalContext.path);
+		seenContent.add(globalContext.content);
 	}
 
 	const ancestorContextFiles: Array<{ path: string; content: string }> = [];
@@ -107,9 +109,10 @@ export function loadProjectContextFiles(options: {
 
 	while (true) {
 		const contextFile = loadContextFileFromDir(currentDir);
-		if (contextFile && !seenPaths.has(contextFile.path)) {
+		if (contextFile && !seenPaths.has(contextFile.path) && !seenContent.has(contextFile.content)) {
 			ancestorContextFiles.unshift(contextFile);
 			seenPaths.add(contextFile.path);
+			seenContent.add(contextFile.content);
 		}
 
 		const parentDir = dirname(currentDir);

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -345,6 +345,42 @@ Content`,
 			expect(themes.some((t) => t.sourcePath?.endsWith("skip.json"))).toBe(false);
 		});
 
+		it("should skip byte-identical context files discovered at multiple paths", async () => {
+			// cwd is nested under a parent that holds an identical AGENTS.md, which
+			// happens when a worktree lives inside the repo root. Both files have the
+			// same content; only the closest-to-cwd copy should be loaded.
+			const parentDir = join(tempDir, "parent");
+			const nestedCwd = join(parentDir, "worktree");
+			mkdirSync(nestedCwd, { recursive: true });
+
+			const sharedContent = "# Shared Guidelines\n\nBe concise.";
+			writeFileSync(join(parentDir, "AGENTS.md"), sharedContent);
+			writeFileSync(join(nestedCwd, "AGENTS.md"), sharedContent);
+
+			const loader = new DefaultResourceLoader({ cwd: nestedCwd, agentDir });
+			await loader.reload();
+
+			const { agentsFiles } = loader.getAgentsFiles();
+			const agentsMdFiles = agentsFiles.filter((f) => f.path.endsWith("AGENTS.md"));
+			expect(agentsMdFiles).toHaveLength(1);
+			expect(agentsMdFiles[0]?.path).toBe(join(nestedCwd, "AGENTS.md"));
+		});
+
+		it("should keep distinct context files with different content", async () => {
+			const parentDir = join(tempDir, "parent-distinct");
+			const nestedCwd = join(parentDir, "worktree");
+			mkdirSync(nestedCwd, { recursive: true });
+
+			writeFileSync(join(parentDir, "AGENTS.md"), "# Parent Guidelines");
+			writeFileSync(join(nestedCwd, "AGENTS.md"), "# Nested Guidelines");
+
+			const loader = new DefaultResourceLoader({ cwd: nestedCwd, agentDir });
+			await loader.reload();
+
+			const { agentsFiles } = loader.getAgentsFiles();
+			expect(agentsFiles.filter((f) => f.path.endsWith("AGENTS.md"))).toHaveLength(2);
+		});
+
 		it("should discover AGENTS.md context files", async () => {
 			writeFileSync(join(cwd, "AGENTS.md"), "# Project Guidelines\n\nBe helpful.");
 


### PR DESCRIPTION
## Problem

`loadProjectContextFiles` walks cwd → filesystem root collecting `AGENTS.md` / `CLAUDE.md` and dedupes by **path** only. When a worktree lives inside the repo root (e.g. `.claude/worktrees/<name>/`), the worktree's context file and the repo root's are **byte-identical but at different paths**, so both get loaded into the system prompt — duplicating the entire project-instructions block and wasting context tokens.

This also affects any monorepo layout where the same `CLAUDE.md` is symlinked or checked in at multiple parent levels.

Same byte-identical content loaded twice in the prompt:
```
[Context]
  ~/repo/.claude/worktrees/telemetry/CLAUDE.md, CLAUDE.md
```

## Fix

Track `seenContent` (a `Set<string>`) alongside `seenPaths` and skip any context file whose bytes already match one loaded earlier. First-seen (closest-to-cwd) copy wins.

```diff
+ const seenContent = new Set<string>();
  ...
- if (globalContext) {
+ if (globalContext && !seenContent.has(globalContext.content)) {
    contextFiles.push(globalContext);
    seenPaths.add(globalContext.path);
+   seenContent.add(globalContext.content);
  }
```

Applied symmetrically to the ancestor walk.

## Scope / non-goals

- **Byte-identical only.** Wholly-ignores near-identical files (e.g. a trailing-newline difference or symlinked-but-edited copies). Fuzzy matching risks dropping intentionally-different instructions; the lazy fix dedupes only exact dups where no information is lost.
- **System-prompt cost only.** No behavioural change to tool discovery / skill loading.
- Minimal 7-line diff in the shared loader, not patched per-caller.

## Tests

Two regression tests in `resource-loader.test.ts` (both pass; the 5 unrelated extension-import failures in this file pre-exist on a clean checkout — they need a TS loader that isn't wired in the raw repo):

- `should skip byte-identical context files discovered at multiple paths` — nested-cwd + parent with identical `AGENTS.md` → only the cwd copy loads.
- `should keep distinct context files with different content` — different content at nested + parent → both load.

## Verification

```
$ vitest run test/resource-loader.test.ts -t "byte-identical"
 Test Files  1 passed (1)
      Tests  1 passed | 24 skipped (25)

$ vitest run test/resource-loader.test.ts -t "distinct context"
 Test Files  1 passed (1)
      Tests  1 passed | 24 skipped (25)
```

Pre-existing run (clean checkout) confirms the 5 other failures are environment, not this change.
