### PR TITLE
fix(ai): send x-client-request-id on anthropic-messages

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -907,8 +907,16 @@ function createClient(
 	}
 
 	// API key or header-owned auth.
-	const sessionAffinityHeaders: ProviderHeaders =
-		sessionId && getAnthropicCompat(model).sendSessionAffinityHeaders ? { "x-session-affinity": sessionId } : {};
+	// Always send x-client-request-id when sessionId is present (matches openai-responses /
+	// openai-completions / openai-codex-responses) so gateways can key session affinity.
+	// x-session-affinity remains behind the Fireworks-style compat flag.
+	const sessionAffinityHeaders: ProviderHeaders = {};
+	if (sessionId) {
+		sessionAffinityHeaders["x-client-request-id"] = sessionId;
+		if (getAnthropicCompat(model).sendSessionAffinityHeaders) {
+			sessionAffinityHeaders["x-session-affinity"] = sessionId;
+		}
+	}
 	const defaultHeaders = mergeHeaders(
 		{
 			accept: "application/json",

--- a/packages/ai/test/fireworks-models.test.ts
+++ b/packages/ai/test/fireworks-models.test.ts
@@ -208,25 +208,28 @@ describe("Fireworks Anthropic session affinity and tool compat", () => {
 			sessionId: "fireworks-session-1",
 		});
 
+		expect(request.headers["x-client-request-id"]).toBe("fireworks-session-1");
 		expect(request.headers["x-session-affinity"]).toBe("fireworks-session-1");
 	});
 
-	it("omits x-session-affinity header for native Anthropic models", async () => {
+	it("sends x-client-request-id but omits x-session-affinity for native Anthropic models", async () => {
 		const model = createAnthropicModel();
 		const request = await captureAnthropicRequest(model, createContext(), {
 			sessionId: "anthropic-session-1",
 		});
 
+		expect(request.headers["x-client-request-id"]).toBe("anthropic-session-1");
 		expect(request.headers["x-session-affinity"]).toBeUndefined();
 	});
 
-	it("omits x-session-affinity header when cacheRetention is none", async () => {
+	it("omits session-affinity headers when cacheRetention is none", async () => {
 		const model = createFireworksModel();
 		const request = await captureAnthropicRequest(model, createContext(), {
 			sessionId: "fireworks-session-2",
 			cacheRetention: "none",
 		});
 
+		expect(request.headers["x-client-request-id"]).toBeUndefined();
 		expect(request.headers["x-session-affinity"]).toBeUndefined();
 	});
 


### PR DESCRIPTION
### Summary
- Send `x-client-request-id` from `options.sessionId` on the `anthropic-messages` path whenever a session id is present (same as openai-responses / openai-completions / openai-codex-responses).
- Keep `x-session-affinity` behind `compat.sendSessionAffinityHeaders` (Fireworks-style).

### Validation
- `npx vitest --run test/fireworks-models.test.ts` (12 passed)

Fixes #7161

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.

Made with [Cursor](https://cursor.com)