### PR TITLE
fix(ai): rename OpenCode Zen Go display name to OpenCode Go

### DIFF
--- a/packages/ai/src/providers/opencode-go.ts
+++ b/packages/ai/src/providers/opencode-go.ts
@@ -8,7 +8,7 @@ import { OPENCODE_GO_MODELS } from "./opencode-go.models.ts";
 export function opencodeGoProvider(): Provider<"anthropic-messages" | "openai-completions" | "openai-responses"> {
 	return createProvider<"anthropic-messages" | "openai-completions" | "openai-responses">({
 		id: "opencode-go",
-		name: "OpenCode Zen Go",
+		name: "OpenCode Go",
 		auth: { apiKey: envApiKeyAuth("OpenCode API key", ["OPENCODE_API_KEY"]) },
 		models: Object.values(OPENCODE_GO_MODELS),
 		api: {

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -28,6 +28,7 @@ describe("builtin providers", () => {
 		const providers = models.getProviders();
 		expect(providers.length).toBe(builtinProviders().length);
 		expect(providers.map((p) => p.id)).toContain("anthropic");
+		expect(providers.find((p) => p.id === "opencode-go")?.name).toBe("OpenCode Go");
 
 		const anthropic = models.getModel("anthropic", "claude-haiku-4-5");
 		expect(anthropic?.api).toBe("anthropic-messages");


### PR DESCRIPTION
### Summary
- Rename the `opencode-go` provider display name from `OpenCode Zen Go` to `OpenCode Go` so `pi --list-models` matches the provider.

### Validation
- `npx vitest --run test/providers.test.ts -t "builtinModels registers every builtin provider"` (1 passed)

Fixes #7157

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.

Made with [Cursor](https://cursor.com)