### PR TITLE
fix(ai): send max_tokens for Z.AI providers

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -578,7 +578,7 @@ function detectOpenAICompletionsCompat(model: Model<"openai-completions">): Open
 		isAntLing;
 
 	const useMaxTokens =
-		baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isNvidia || isAntLing;
+		baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isNvidia || isAntLing || isZai;
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
 	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1417,7 +1417,13 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		isAntLing;
 
 	const useMaxTokens =
-		baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isNvidia || isAntLing;
+		baseUrl.includes("chutes.ai") ||
+		isMoonshot ||
+		isCloudflareAiGateway ||
+		isTogether ||
+		isNvidia ||
+		isAntLing ||
+		isZai;
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
 	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1390,10 +1390,10 @@ describe("openai-completions tool_choice", () => {
 	});
 
 	it("sends max_tokens for Z.AI completions models", async () => {
-		// Z.AI resolves maxTokensField via detectCompat (isZai), not per-model compat like OpenCode.
 		const cases = [getModel("zai", "glm-5.1")!, getModel("zai", "glm-5.2")!] as const;
 
 		for (const model of cases) {
+			expect(model.compat?.maxTokensField).toBe("max_tokens");
 			let payload: unknown;
 
 			await streamSimple(

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1389,6 +1389,33 @@ describe("openai-completions tool_choice", () => {
 		}
 	});
 
+	it("sends max_tokens for Z.AI completions models", async () => {
+		// Z.AI resolves maxTokensField via detectCompat (isZai), not per-model compat like OpenCode.
+		const cases = [getModel("zai", "glm-5.1")!, getModel("zai", "glm-5.2")!] as const;
+
+		for (const model of cases) {
+			let payload: unknown;
+
+			await streamSimple(
+				model,
+				{
+					messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+				},
+				{
+					apiKey: "test",
+					maxTokens: 123,
+					onPayload: (params: unknown) => {
+						payload = params;
+					},
+				},
+			).result();
+
+			const params = (payload ?? mockState.lastParams) as { max_tokens?: number; max_completion_tokens?: number };
+			expect(params.max_tokens).toBe(123);
+			expect(params.max_completion_tokens).toBeUndefined();
+		}
+	});
+
 	it("omits reasoning effort for OpenCode Grok Build", async () => {
 		const model = getModel("opencode", "grok-build-0.1")!;
 		let payload: unknown;


### PR DESCRIPTION
Refs #7143.

Z.AI (`zai`, `zai-coding-cn`, `api.z.ai`, `open.bigmodel.cn`) ignores `max_completion_tokens` and only honors `max_tokens`, so the output cap pi sent never applied and Z.AI fell back to its 65536 default, truncating long reasoning turns mid-tool-call (`finish_reason: length`).

Adds `isZai` to `useMaxTokens` in `detectCompat()`, mirroring moonshot/together/nvidia/etc. I used `detectCompat()` rather than per-model `compat.maxTokensField` (the approach taken for OpenCode in #5331) so it also covers custom/self-hosted Z.AI base URLs and future Z.AI models. Happy to switch to per-model entries if preferred.

A live GLM-5.2 API check confirmed `max_tokens` is honored while `max_completion_tokens` is ignored. Adds a test that Z.AI models send `max_tokens`; passes locally with biome and vitest.
