### PR TITLE
feat(coding-agent): show status when toggling tool-output expansion

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3807,6 +3807,7 @@ export class InteractiveMode {
 
 	private toggleToolOutputExpansion(): void {
 		this.setToolsExpanded(!this.toolOutputExpanded);
+		this.showStatus(`Tool output: ${this.toolOutputExpanded ? "expanded" : "collapsed"}`);
 	}
 
 	private setToolsExpanded(expanded: boolean): void {


### PR DESCRIPTION
## What

Show a transient status line when toggling tool-output expansion (`app.tools.expand`, Ctrl+O by default) — mirroring the existing feedback for the thinking-block toggle.

## Why

`toggleThinkingBlockVisibility()` ends with `this.showStatus(\`Thinking blocks: ${... ? "hidden" : "visible"}\`)`, so pressing the thinking toggle gives clear feedback. The sibling tool-output toggle, `toggleToolOutputExpansion()`, flips state and re-renders silently. When rows are already collapsed (or collapsed by an extension), there's no cue that the keypress did anything, or which state you're now in. This is a one-line asymmetry, not a capability gap.

## Change

```ts
private toggleToolOutputExpansion(): void {
    this.setToolsExpanded(!this.toolOutputExpanded);
    this.showStatus(`Tool output: ${this.toolOutputExpanded ? "expanded" : "collapsed"}`);
}
```

Uses the same `showStatus()` helper and phrasing pattern as the thinking toggle, so the two behave consistently.

## Notes

An extension can't provide this itself: `app.tools.expand` is a reserved keybinding (extensions can't bind a handler to detect the press) and `setToolsExpanded()` emits no event (extensions can't observe the toggle). The display primitive (`ui.notify`/`setStatus`) is exposed, but there's no trigger to attach it to — so the feedback has to live in core.
