### PR TITLE
fix(ai): strip multimodal media markers from tool results to prevent tokenizer crashes

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -124,6 +124,28 @@ function isImageContentBlock(block: { type: string }): block is ImageContent {
 	return block.type === "image";
 }
 
+/**
+ * Strip multimodal media markers from text content to prevent tokenizer crashes.
+ *
+ * When tool results contain media markers like `|image|` or `<|image|>` but no actual
+ * image data is attached, the model's multimodal tokenizer can crash with errors like
+ * "number of media markers in text (N) exceeds number of bitmaps (0)". This happens
+ * when tool output includes chat templates (e.g., from llama.cpp's /props endpoint)
+ * that contain these markers as template strings.
+ *
+ * This function replaces such markers with safe placeholders before sending to the model.
+ */
+function stripMediaMarkers(text: string): string {
+	// Match both `|image|` and `<|image|>` patterns (order matters: <|...|> first)
+	return text
+		.replace(/<\|\s*image\s*\|>/g, "[image]")
+		.replace(/\|\s*image\s*\|/g, "[image]")
+		.replace(/<\|\s*img\s*\|>/g, "[img]")
+		.replace(/\|\s*img\s*\|/g, "[img]")
+		.replace(/<\|\s*video\s*\|>/g, "[video]")
+		.replace(/\|\s*video\s*\|/g, "[video]");
+}
+
 function isEncryptedReasoningDetail(detail: unknown): detail is OpenAIEncryptedReasoningDetail {
 	if (typeof detail !== "object" || detail === null) {
 		return false;
@@ -1199,10 +1221,14 @@ export function convertMessages(
 				// Always send tool result with text (or placeholder if only images)
 				const hasText = textResult.length > 0;
 				const toolResultText = hasText ? textResult : hasImages ? "(see attached image)" : "(no tool output)";
+				// Strip media markers from tool results to prevent tokenizer crashes.
+				// Markers like `|image|` may appear in tool output (e.g., chat templates
+				// from llama.cpp /props) but without actual image data, causing crashes.
+				const sanitizedToolResult = stripMediaMarkers(sanitizeSurrogates(toolResultText));
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {
 					role: "tool",
-					content: sanitizeSurrogates(toolResultText),
+					content: sanitizedToolResult,
 					tool_call_id: toolMsg.toolCallId,
 				};
 				if (compat.requiresToolResultName && toolMsg.toolName) {

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -32,6 +32,28 @@ import type { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+
+/**
+ * Strip multimodal media markers from text content to prevent tokenizer crashes.
+ *
+ * When tool results contain media markers like `|image|` or `<|image|>` but no actual
+ * image data is attached, the model's multimodal tokenizer can crash with errors like
+ * "number of media markers in text (N) exceeds number of bitmaps (0)". This happens
+ * when tool output includes chat templates (e.g., from llama.cpp's /props endpoint)
+ * that contain these markers as template strings.
+ *
+ * This function replaces such markers with safe placeholders before sending to the model.
+ */
+function stripMediaMarkers(text: string): string {
+	// Match both `|image|` and `<|image|>` patterns (order matters: <|...|> first)
+	return text
+		.replace(/<\|\s*image\s*\|>/g, "[image]")
+		.replace(/\|\s*image\s*\|/g, "[image]")
+		.replace(/<\|\s*img\s*\|>/g, "[img]")
+		.replace(/\|\s*img\s*\|/g, "[img]")
+		.replace(/<\|\s*video\s*\|>/g, "[video]")
+		.replace(/\|\s*video\s*\|/g, "[video]");
+}
 import {
 	appendGrammarToolInputJsonDelta,
 	type GrammarToolInputJsonBuffer,
@@ -85,12 +107,15 @@ function convertToolResultOutput<TApi extends Api>(
 	const hasText = textResult.length > 0;
 
 	if (images.length === 0 || !model.input.includes("image")) {
-		return sanitizeSurrogates(hasText ? textResult : images.length > 0 ? "(see attached image)" : "(no tool output)");
+		// Strip media markers to prevent tokenizer crashes.
+		// Markers like `|image|` may appear in tool output (e.g., chat templates
+		// from llama.cpp /props) but without actual image data, causing crashes.
+		return stripMediaMarkers(sanitizeSurrogates(hasText ? textResult : images.length > 0 ? "(see attached image)" : "(no tool output)"));
 	}
 
 	const output: ToolResultOutputContent = [];
 	if (hasText) {
-		output.push({ type: "input_text", text: sanitizeSurrogates(textResult) });
+		output.push({ type: "input_text", text: stripMediaMarkers(sanitizeSurrogates(textResult)) });
 	}
 	for (const image of images) {
 		output.push({

--- a/packages/ai/test/openai-completions-media-marker-stripping.test.ts
+++ b/packages/ai/test/openai-completions-media-marker-stripping.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/api/openai-completions.ts";
+import { getModel } from "../src/compat.ts";
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	OpenAICompletionsCompat,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.ts";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const compat: Omit<Required<OpenAICompletionsCompat>, "deferredToolsMode"> & {
+	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+} = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	chatTemplateKwargs: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+	supportsOpenAIGrammarTools: false,
+	cacheControlFormat: "anthropic",
+	sendSessionAffinityHeaders: false,
+	sessionAffinityFormat: "openai",
+	supportsLongCacheRetention: true,
+};
+
+function buildToolResult(toolCallId: string, timestamp: number, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "bash",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	};
+}
+
+describe("openai-completions stripMediaMarkers", () => {
+	it("strips |image| markers from tool results", () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text"],
+		};
+
+		const now = Date.now();
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "curl /props" } }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Check props", timestamp: now - 2 },
+				assistantMessage,
+				buildToolResult("tool-1", now + 1, "Chat template with |image| marker"),
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const toolMessage = messages.find((m) => m.role === "tool") as { role: "tool"; content: string } | undefined;
+		expect(toolMessage).toBeTruthy();
+		expect(toolMessage?.content).toContain("[image]");
+		expect(toolMessage?.content).not.toContain("|image|");
+	});
+
+	it("strips <|image|> markers from tool results", () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text"],
+		};
+
+		const now = Date.now();
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "curl /props" } }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Check props", timestamp: now - 2 },
+				assistantMessage,
+				buildToolResult("tool-1", now + 1, "Jinja: {{- '<|image|>' }}"),
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const toolMessage = messages.find((m) => m.role === "tool") as { role: "tool"; content: string } | undefined;
+		expect(toolMessage).toBeTruthy();
+		expect(toolMessage?.content).toContain("[image]");
+		expect(toolMessage?.content).not.toContain("<|image|>");
+	});
+
+	it("strips |img| and |video| markers from tool results", () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text"],
+		};
+
+		const now = Date.now();
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "curl /props" } }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Check props", timestamp: now - 2 },
+				assistantMessage,
+				buildToolResult("tool-1", now + 1, "Multiple |img| and |video| markers"),
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const toolMessage = messages.find((m) => m.role === "tool") as { role: "tool"; content: string } | undefined;
+		expect(toolMessage).toBeTruthy();
+		expect(toolMessage?.content).toContain("[img]");
+		expect(toolMessage?.content).toContain("[video]");
+		expect(toolMessage?.content).not.toContain("|img|");
+		expect(toolMessage?.content).not.toContain("|video|");
+	});
+
+	it("preserves normal tool results without markers", () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text"],
+		};
+
+		const now = Date.now();
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "ls" } }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "List files", timestamp: now - 2 },
+				assistantMessage,
+				buildToolResult("tool-1", now + 1, "file1.txt\nfile2.txt"),
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const toolMessage = messages.find((m) => m.role === "tool") as { role: "tool"; content: string } | undefined;
+		expect(toolMessage).toBeTruthy();
+		expect(toolMessage?.content).toBe("file1.txt\nfile2.txt");
+	});
+});


### PR DESCRIPTION
## Problem

When tool results contain multimodal media markers like `|image|` or `<|image|>` but no actual image data is attached, the model's multimodal tokenizer can crash with errors like:

```
mtmd_tokenize: error: number of media markers in text (N) exceeds number of bitmaps (0)
```

This happens when tool output includes chat templates (e.g., from llama.cpp's /props endpoint) that contain these markers as template strings.

## Solution

Added `stripMediaMarkers()` function that replaces media markers with safe placeholders ([image], [img], [video]) before sending tool result text to the model. Applied in both `openai-completions.ts` and `openai-responses-shared.ts`.

## Testing

- Added 4 unit tests covering |image|, <|image|>, |img|, |video| markers
- Verified normal tool results still work correctly
- All existing tests pass