### PR TITLE
ignore: my agent tried committing a fix into the wrong repo lmao

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Auto-append Co-Authored-By for Punch commits
+CO_AUTHOR="Co-Authored-By: Punch <punch@orb.gay>"
+
+# Only add if not already present
+if ! grep -q "$CO_AUTHOR" "$1"; then
+    echo "" >> "$1"
+    echo "$CO_AUTHOR" >> "$1"
+fi


### PR DESCRIPTION
adds a husky prepare-commit-msg hook that automatically appends `Co-Authored-By: Punch <punch@orb.gay>` to all commits

this ensures consistent co-author attribution across all commit methods (interactive, automated, etc.)

the hook checks if the co-author line already exists before adding it, so it won't duplicate if someone manually adds it.