### PR TITLE
feat(extensions): expose ctx.scopedModels to extensions

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -982,9 +982,11 @@ ctx.sessionManager.buildContextEntries()    // Active branch entries with compac
 ctx.sessionManager.getLeafId()              // Current leaf entry ID
 ```
 
-### ctx.modelRegistry / ctx.model / ctx.thinkingLevel
+### ctx.modelRegistry / ctx.model / ctx.thinkingLevel / ctx.scopedModels
 
 Access to models, providers, and resolved authentication. `ctx.modelRegistry.getProvider(id)` returns the effective pi-ai provider, while `getProviderAuth(id)` resolves its current API key, headers, base URL, and provider-scoped environment without requiring a loaded model. `ctx.model` is the active model, and `ctx.thinkingLevel` is its current effective thinking level.
+
+`ctx.scopedModels` is the read-only list of models scoped to the current session — the same set the `/scoped-models` command shows. It is resolved at session start from the `--models` CLI flag and the `enabledModels` setting (matched against the available catalogue with minimatch on `provider/modelId` or a bare `modelId`). It is empty when no scoping is configured, meaning every available model is usable. Each entry is `{ model, thinkingLevel? }`, where `thinkingLevel` is set only when a pattern pinned it (e.g. `anthropic/*:high`). Use it to populate a model picker that mirrors the built-in one instead of enumerating the whole catalogue via `ctx.modelRegistry.getAvailable()`.
 
 ### ctx.signal
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2405,6 +2405,7 @@ export class AgentSession {
 			},
 			{
 				getModel: () => this.model,
+				getScopedModels: () => this._scopedModels,
 				isIdle: () => this.isIdle,
 				isProjectTrusted: () => this.settingsManager.isProjectTrusted(),
 				getSignal: () => this.agent.signal,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -9,6 +9,7 @@ import { type Theme, theme } from "../../modes/interactive/theme/theme.ts";
 import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
 import type { ModelRegistry } from "../model-registry.ts";
+import type { ScopedModel } from "../model-resolver.ts";
 import type { SessionManager } from "../session-manager.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import type {
@@ -273,6 +274,7 @@ export class ExtensionRunner {
 	private modelRegistry: ModelRegistry;
 	private errorListeners: Set<ExtensionErrorListener> = new Set();
 	private getModel: () => Model<any> | undefined = () => undefined;
+	private getScopedModels: () => readonly ScopedModel[] = () => [];
 	private isIdleFn: () => boolean = () => true;
 	private isProjectTrustedFn: () => boolean = () => true;
 	private getSignalFn: () => AbortSignal | undefined = () => undefined;
@@ -335,6 +337,7 @@ export class ExtensionRunner {
 
 		// Context actions (required)
 		this.getModel = contextActions.getModel;
+		this.getScopedModels = contextActions.getScopedModels;
 		this.isIdleFn = contextActions.isIdle;
 		this.isProjectTrustedFn = contextActions.isProjectTrusted;
 		this.getSignalFn = contextActions.getSignal;
@@ -665,6 +668,7 @@ export class ExtensionRunner {
 	createContext(): ExtensionContext {
 		const runner = this;
 		const getModel = this.getModel;
+		const getScopedModels = this.getScopedModels;
 		return {
 			get ui() {
 				runner.assertActive();
@@ -693,6 +697,10 @@ export class ExtensionRunner {
 			get model() {
 				runner.assertActive();
 				return getModel();
+			},
+			get scopedModels() {
+				runner.assertActive();
+				return getScopedModels();
 			},
 			get thinkingLevel() {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -54,6 +54,7 @@ import type { ReadonlyFooterDataProvider } from "../footer-data-provider.ts";
 import type { KeybindingsManager } from "../keybindings.ts";
 import type { CustomMessage } from "../messages.ts";
 import type { ModelRegistry } from "../model-registry.ts";
+import type { ScopedModel } from "../model-resolver.ts";
 import type {
 	BranchSummaryEntry,
 	CompactionEntry,
@@ -318,6 +319,11 @@ export interface ExtensionContext {
 	modelRegistry: ModelRegistry;
 	/** Current model (may be undefined) */
 	model: Model<any> | undefined;
+	/** Models scoped to this session (resolved from `--models` /
+	 *  `enabledModels` settings against the available catalogue). Same set
+	 *  the `/scoped-models` command shows. Empty when no scoping is
+	 *  configured (all available models are usable). Read-only snapshot. */
+	scopedModels: readonly ScopedModel[];
 	/** Current thinking level, when provided by the session runtime. */
 	thinkingLevel?: ThinkingLevel;
 	/** Whether the agent is idle (not streaming) */
@@ -1615,6 +1621,7 @@ export interface ExtensionActions {
  */
 export interface ExtensionContextActions {
 	getModel: () => Model<any> | undefined;
+	getScopedModels: () => readonly ScopedModel[];
 	isIdle: () => boolean;
 	isProjectTrusted: () => boolean;
 	getSignal: () => AbortSignal | undefined;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -18,6 +18,7 @@ import type {
 } from "../src/core/extensions/types.ts";
 import { KeybindingsManager, type KeyId } from "../src/core/keybindings.ts";
 import type { ModelRegistry } from "../src/core/model-registry.ts";
+import type { ScopedModel } from "../src/core/model-resolver.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 
 describe("ExtensionRunner", () => {
@@ -99,7 +100,24 @@ describe("ExtensionRunner", () => {
 		getContextUsage: () => undefined,
 		compact: () => {},
 		getSystemPrompt: () => "",
+		getScopedModels: () => [],
 	};
+
+	describe("scopedModels", () => {
+		it("reflects the getScopedModels context action on ctx.scopedModels", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			// Before bindCore the default is an empty list (never undefined).
+			expect(runner.createContext().scopedModels).toEqual([]);
+
+			// After bindCore wires a getScopedModels action, ctx.scopedModels
+			// returns it live (same reference, lazy getter).
+			const scoped = [{ model: { id: "scoped-test" }, thinkingLevel: "high" }] as unknown as ScopedModel[];
+			runner.bindCore(extensionActions, { ...extensionContextActions, getScopedModels: () => scoped });
+			expect(runner.createContext().scopedModels).toBe(scoped);
+		});
+	});
 
 	describe("project_trust", () => {
 		it("continues past undecided handlers and returns the first yes/no decision", async () => {


### PR DESCRIPTION
## Problem

Extensions have no way to read the session's **scoped model set** — the models resolved from `--models` / `enabledModels` against the available catalogue (the same list the built-in `/scoped-models` command shows).

The only model surfaces on `ExtensionContext` today are:
- `ctx.model` — the single active model
- `ctx.modelRegistry.getAvailable()` — the **entire catalogue, unfiltered**

So an extension that wants a scoped model picker (e.g. a mobile/web companion, a model-switcher) must either enumerate every model or **re-implement pi's scope resolution from disk** — minimatch on `provider/modelId` (or a bare `modelId`), the `enabledModels` setting, the `--models` CLI flag, plus the `:thinking` suffix parsing. That logic already lives in the core (`resolveModelScope`); duplicating it is fragile.

## Solution

Expose the already-computed scoped list on `ExtensionContext`, mirroring exactly how `ctx.model` is exposed:

```ts
interface ExtensionContext {
  // ...existing...
  /** Same set /scoped-models shows. Empty when no scoping is configured. */
  scopedModels: readonly ScopedModel[];
}
```

Each entry is `{ model, thinkingLevel? }`, where `thinkingLevel` is set only when a pattern pinned it (e.g. `anthropic/*:high`). Empty array = no scoping (all available models usable).

### Consumer example

```ts
// An extension building a scoped model picker — no catalogue filtering,
// no config reading, no glob matching:
const scoped = ctx.scopedModels;              // ScopedModel[]
const models = scoped.map(s => s.model);      // Model<Api>[]
const pick   = models.length > 0 ? models : ctx.modelRegistry.getAvailable();
```

## Changes

| File | Change |
|------|--------|
| `extensions/types.ts` | `ExtensionContext.scopedModels` + `ExtensionContextActions.getScopedModels` (+ `ScopedModel` import) |
| `extensions/runner.ts` | private field, `bindCore` wiring, lazy `scopedModels` getter in `createContext()` |
| `agent-session.ts` | provide `getScopedModels: () => this._scopedModels` in the context actions |
| `test/extensions-runner.test.ts` | assert `ctx.scopedModels` defaults to `[]` then reflects the action (live ref) |
| `docs/extensions.md` | document the new field |

## Design notes

- **Mirrors `ctx.model`** (field → `bindCore` → lazy getter), so it inherits the same stale-instance/lazy semantics for free.
- **Additive + backward compatible**: a new required field on `ExtensionContextActions`, but the only in-tree implementor is `AgentSession` (updated). The default getter returns `[]` until `bindCore` wires it.
- **Read-only snapshot** — scoped models are resolved at session start; exposing them as a getter (not a setter) matches their lifecycle. Mutating scope still goes through the existing session APIs.

## Testing

Added a unit test in `extensions-runner.test.ts`. Local full typecheck/test was not run (monorepo `npm install` is heavy on Windows); relying on CI. The change is mechanical — it follows the `getModel` wiring line-for-line.

## Checklist

- [x] Additive, no breaking change to existing extension APIs
- [x] Mirrors an existing, proven pattern (`ctx.model`)
- [x] Unit test included
- [x] Docs updated