### PR TITLE
Fix Grok 4.5 context ceiling

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -295,11 +295,19 @@ async function streamAssistantResponse(
 	const llmMessages = await config.convertToLlm(messages);
 
 	// Build LLM context
-	const llmContext: Context = {
+	let llmContext: Context = {
 		systemPrompt: context.systemPrompt,
 		messages: llmMessages,
 		tools: context.tools,
 	};
+
+	const replacementContext = await config.beforeProviderRequest?.(
+		{ model: config.model, context: llmContext, messages },
+		signal,
+	);
+	if (replacementContext) {
+		llmContext = replacementContext;
+	}
 
 	// Resolve API key (important for expiring tokens)
 	const resolvedApiKey =

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,4 +1,5 @@
 import type {
+	Context,
 	ImageContent,
 	Message,
 	Model,
@@ -19,6 +20,7 @@ import type {
 	AgentMessage,
 	AgentState,
 	AgentTool,
+	BeforeProviderRequestContext,
 	BeforeToolCallContext,
 	BeforeToolCallResult,
 	PrepareNextTurnContext,
@@ -98,6 +100,10 @@ export interface AgentOptions {
 	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>;
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+	beforeProviderRequest?: (
+		context: BeforeProviderRequestContext,
+		signal?: AbortSignal,
+	) => Context | undefined | Promise<Context | undefined>;
 	streamFn: StreamFn;
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	onPayload?: SimpleStreamOptions["onPayload"];
@@ -176,6 +182,10 @@ export class Agent {
 
 	public convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	public transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+	public beforeProviderRequest?: (
+		context: BeforeProviderRequestContext,
+		signal?: AbortSignal,
+	) => Context | undefined | Promise<Context | undefined>;
 	public streamFunction: StreamFn;
 	public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 	public onPayload?: SimpleStreamOptions["onPayload"];
@@ -213,6 +223,7 @@ export class Agent {
 		this._state = createMutableAgentState(runtimeOptions.initialState);
 		this.convertToLlm = runtimeOptions.convertToLlm ?? defaultConvertToLlm;
 		this.transformContext = runtimeOptions.transformContext;
+		this.beforeProviderRequest = runtimeOptions.beforeProviderRequest;
 		this.streamFunction = runtimeOptions.streamFn ?? getDefaultStreamFn();
 		this.getApiKey = runtimeOptions.getApiKey;
 		this.onPayload = runtimeOptions.onPayload;
@@ -456,6 +467,7 @@ export class Agent {
 					: undefined,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
+			beforeProviderRequest: this.beforeProviderRequest,
 			getApiKey: this.getApiKey,
 			getSteeringMessages: async () => {
 				if (skipInitialSteeringPoll) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -139,6 +139,13 @@ export interface AgentLoopTurnUpdate {
 	thinkingLevel?: ThinkingLevel;
 }
 
+/** Provider input after context transformation and conversion, before dispatch. */
+export interface BeforeProviderRequestContext {
+	model: Model<any>;
+	context: Context;
+	messages: AgentMessage[];
+}
+
 export interface PrepareNextTurnContext extends ShouldStopAfterTurnContext {}
 
 export interface AgentLoopConfig extends SimpleStreamOptions {
@@ -193,6 +200,16 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * ```
 	 */
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+
+	/**
+	 * Runs after context transformation and conversion, immediately before each provider request.
+	 * Return a replacement provider context to alter the request, or undefined to preserve it.
+	 * Throw to fail closed without dispatching the provider request.
+	 */
+	beforeProviderRequest?: (
+		context: BeforeProviderRequestContext,
+		signal?: AbortSignal,
+	) => Context | undefined | Promise<Context | undefined>;
 
 	/**
 	 * Resolves an API key dynamically for each LLM call.

--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -14,13 +14,13 @@ Events are defined in [`AgentSessionEvent`](https://github.com/earendil-works/pi
 type AgentSessionEvent =
   | AgentEvent
   | { type: "queue_update"; steering: readonly string[]; followUp: readonly string[] }
-  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
-  | { type: "compaction_end"; reason: "manual" | "threshold" | "overflow"; result: CompactionResult | undefined; aborted: boolean; willRetry: boolean; errorMessage?: string }
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" | "context_ceiling" }
+  | { type: "compaction_end"; reason: "manual" | "threshold" | "overflow" | "context_ceiling"; result: CompactionResult | undefined; aborted: boolean; willRetry: boolean; errorMessage?: string }
   | { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
   | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
   | { type: "summarization_retry_scheduled"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
   | { type: "summarization_retry_attempt_start"; source: "branchSummary" }
-  | { type: "summarization_retry_attempt_start"; source: "compaction"; reason: "manual" | "threshold" | "overflow" }
+  | { type: "summarization_retry_attempt_start"; source: "compaction"; reason: "manual" | "threshold" | "overflow" | "context_ceiling" }
   | { type: "summarization_retry_finished" };
 ```
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -1033,7 +1033,7 @@ Emitted when compaction runs, whether manual or automatic.
 {"type": "compaction_start", "reason": "threshold"}
 ```
 
-The `reason` field is `"manual"`, `"threshold"`, or `"overflow"`.
+The `reason` field is `"manual"`, `"threshold"`, `"overflow"`, or `"context_ceiling"`.
 
 ```json
 {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -24,7 +24,7 @@ import type {
 	PrepareNextTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
-import { contentText } from "@earendil-works/pi-ai";
+import { type Context, contentText } from "@earendil-works/pi-ai";
 import type {
 	AssistantMessage,
 	AuthResult,
@@ -135,6 +135,21 @@ export function parseSkillBlock(text: string): ParsedSkillBlock | null {
 	};
 }
 
+const GROK_CONTEXT_CEILING_PROVIDER = "opencode";
+const GROK_CONTEXT_CEILING_MODEL_ID = "grok-4.5";
+const GROK_COMPACTION_TRIGGER_TOKENS = 180_000;
+const GROK_CONTEXT_CEILING_TOKENS = 200_000;
+const GROK_OUTPUT_RESERVATION_TOKENS = 16_384;
+
+function estimateGrokProviderRequestTokens(context: Context): number {
+	return (
+		estimateContextTokens(context.messages as AgentMessage[]).tokens +
+		Math.ceil((context.systemPrompt ?? "").length / 4) +
+		(context.tools?.length ? Math.ceil(JSON.stringify(context.tools).length / 4) : 0) +
+		GROK_OUTPUT_RESERVATION_TOKENS
+	);
+}
+
 /** Session-specific events that extend the core AgentEvent */
 export type AgentSessionEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
@@ -149,13 +164,13 @@ export type AgentSessionEvent =
 			steering: readonly string[];
 			followUp: readonly string[];
 	  }
-	| { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
+	| { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" | "context_ceiling" }
 	| { type: "entry_appended"; entry: SessionEntry }
 	| { type: "session_info_changed"; name: string | undefined }
 	| { type: "thinking_level_changed"; level: ThinkingLevel }
 	| {
 			type: "compaction_end";
-			reason: "manual" | "threshold" | "overflow";
+			reason: "manual" | "threshold" | "overflow" | "context_ceiling";
 			result: CompactionResult | undefined;
 			aborted: boolean;
 			willRetry: boolean;
@@ -174,7 +189,7 @@ export type AgentSessionEvent =
 	| {
 			type: "summarization_retry_attempt_start";
 			source: "compaction";
-			reason: "manual" | "threshold" | "overflow";
+			reason: "manual" | "threshold" | "overflow" | "context_ceiling";
 	  }
 	| { type: "summarization_retry_finished" }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
@@ -393,6 +408,7 @@ export class AgentSession {
 		this._unsubscribeAgent = this.agent.subscribe(this._handleAgentEvent);
 		this._installAgentToolHooks();
 		this._installAgentNextTurnRefresh();
+		this._installGrokContextCeilingGate();
 
 		this._buildRuntime({
 			activeToolNames: this._initialActiveToolNames,
@@ -402,6 +418,53 @@ export class AgentSession {
 
 	get modelRuntime(): ModelRuntime {
 		return this._modelRuntime;
+	}
+
+	private _grokSummarizationGuard(model: Model<any>): ((context: Context) => void) | undefined {
+		if (model.provider !== GROK_CONTEXT_CEILING_PROVIDER || model.id !== GROK_CONTEXT_CEILING_MODEL_ID) {
+			return undefined;
+		}
+		return (context) => {
+			const estimatedTokens = estimateGrokProviderRequestTokens(context);
+			if (estimatedTokens >= GROK_CONTEXT_CEILING_TOKENS) {
+				throw new Error(
+					`Grok 4.5 context ceiling reached (${estimatedTokens.toLocaleString()} tokens). Pi cannot summarize this request below ${GROK_CONTEXT_CEILING_TOKENS.toLocaleString()} tokens; start a new session or compact manually before retrying.`,
+				);
+			}
+		};
+	}
+
+	private _installGrokContextCeilingGate(): void {
+		this.agent.beforeProviderRequest = async ({ model, context }) => {
+			if (model.provider !== GROK_CONTEXT_CEILING_PROVIDER || model.id !== GROK_CONTEXT_CEILING_MODEL_ID) {
+				return undefined;
+			}
+
+			let providerContext = context;
+			let estimatedTokens = estimateGrokProviderRequestTokens(providerContext);
+			if (estimatedTokens < GROK_COMPACTION_TRIGGER_TOKENS) {
+				return undefined;
+			}
+
+			if (await this._runAutoCompaction("context_ceiling", true)) {
+				const transformedMessages = this.agent.transformContext
+					? await this.agent.transformContext(this.agent.state.messages)
+					: this.agent.state.messages;
+				providerContext = {
+					...context,
+					messages: await this.agent.convertToLlm(transformedMessages),
+				};
+				estimatedTokens = estimateGrokProviderRequestTokens(providerContext);
+			}
+
+			if (estimatedTokens >= GROK_CONTEXT_CEILING_TOKENS) {
+				throw new Error(
+					`Grok 4.5 context ceiling reached (${estimatedTokens.toLocaleString()} tokens). Pi could not compact the provider request below ${GROK_CONTEXT_CEILING_TOKENS.toLocaleString()} tokens; start a new session or compact manually before retrying.`,
+				);
+			}
+
+			return providerContext;
+		};
 	}
 
 	private async _getRequiredRequestAuth(model: Model<any>): Promise<{
@@ -1857,6 +1920,7 @@ export class AgentSession {
 					env,
 					this.settingsManager.getRetrySettings(),
 					this._summarizationRetryCallbacks({ source: "compaction", reason: "manual" }),
+					this._grokSummarizationGuard(this.model),
 				);
 				summary = result.summary;
 				firstKeptEntryId = result.firstKeptEntryId;
@@ -2044,7 +2108,10 @@ export class AgentSession {
 	/**
 	 * Internal: Run auto-compaction with events.
 	 */
-	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
+	private async _runAutoCompaction(
+		reason: "overflow" | "threshold" | "context_ceiling",
+		willRetry: boolean,
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		let started = false;
 
@@ -2118,7 +2185,8 @@ export class AgentSession {
 				usage = extensionCompaction.usage;
 				details = extensionCompaction.details;
 			} else {
-				// Generate compaction result
+				// Generate compaction result. A Grok compaction summary is itself a provider request,
+				// so it must obey the same hard ceiling as the interrupted turn.
 				const compactResult = await compact(
 					preparation,
 					this.model,
@@ -2131,6 +2199,7 @@ export class AgentSession {
 					env,
 					this.settingsManager.getRetrySettings(),
 					this._summarizationRetryCallbacks({ source: "compaction", reason }),
+					this._grokSummarizationGuard(this.model),
 				);
 				summary = compactResult.summary;
 				firstKeptEntryId = compactResult.firstKeptEntryId;
@@ -2205,7 +2274,9 @@ export class AgentSession {
 					errorMessage:
 						reason === "overflow"
 							? `Context overflow recovery failed: ${errorMessage}`
-							: `Auto-compaction failed: ${errorMessage}`,
+							: reason === "context_ceiling"
+								? `Grok 4.5 context-ceiling recovery failed: ${errorMessage}`
+								: `Auto-compaction failed: ${errorMessage}`,
 				});
 			}
 			return false;
@@ -2644,7 +2715,9 @@ export class AgentSession {
 	 * the TUI needs to render the retry and recreate the underlying indicator.
 	 */
 	private _summarizationRetryCallbacks(
-		source: { source: "branchSummary" } | { source: "compaction"; reason: "manual" | "threshold" | "overflow" },
+		source:
+			| { source: "branchSummary" }
+			| { source: "compaction"; reason: "manual" | "threshold" | "overflow" | "context_ceiling" },
 	): RetryCallbacks {
 		return {
 			onRetryScheduled: (attempt, maxAttempts, delayMs, errorMessage) => {

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -559,6 +559,8 @@ function createSummarizationOptions(
  * the whole compaction on the first attempt. Deterministic errors and aborts return
  * immediately (see {@link retryAssistantCall}).
  */
+export type SummarizationRequestGuard = (context: Context) => void;
+
 export async function completeSummarization(
 	model: Model<any>,
 	context: Context,
@@ -566,6 +568,7 @@ export async function completeSummarization(
 	streamFn?: StreamFn,
 	retry?: RetryPolicy,
 	callbacks?: RetryCallbacks,
+	guard?: SummarizationRequestGuard,
 ): Promise<AssistantMessage> {
 	// Summaries are standalone requests, so isolate routing and avoid cache writes that cannot be reused.
 	const requestOptions: SimpleStreamOptions = {
@@ -573,10 +576,12 @@ export async function completeSummarization(
 		cacheRetention: "none",
 		sessionId: uuidv7(),
 	};
-	const produce = async (): Promise<AssistantMessage> =>
-		streamFn
+	const produce = async (): Promise<AssistantMessage> => {
+		guard?.(context);
+		return streamFn
 			? (await streamFn(model, context, requestOptions)).result()
 			: completeSimple(model, context, requestOptions);
+	};
 	return retryAssistantCall(produce, retry, requestOptions.signal, callbacks);
 }
 
@@ -633,6 +638,7 @@ export async function generateSummaryWithUsage(
 	env?: Record<string, string>,
 	retry?: RetryPolicy,
 	callbacks?: RetryCallbacks,
+	guard?: SummarizationRequestGuard,
 ): Promise<{ text: string; usage: Usage }> {
 	const maxTokens = Math.min(
 		Math.floor(0.8 * reserveTokens),
@@ -674,6 +680,7 @@ export async function generateSummaryWithUsage(
 		streamFn,
 		retry,
 		callbacks,
+		guard,
 	);
 
 	if (response.stopReason === "error") {
@@ -826,6 +833,7 @@ export async function compact(
 	env?: Record<string, string>,
 	retry?: RetryPolicy,
 	callbacks?: RetryCallbacks,
+	guard?: SummarizationRequestGuard,
 ): Promise<CompactionResult> {
 	const {
 		firstKeptEntryId,
@@ -860,6 +868,7 @@ export async function compact(
 				env,
 				retry,
 				callbacks,
+				guard,
 			);
 			historyText = historyResult.text;
 			historyUsage = historyResult.usage;
@@ -876,6 +885,7 @@ export async function compact(
 			streamFn,
 			retry,
 			callbacks,
+			guard,
 		);
 		// Merge into single summary
 		summary = `${historyText}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.text}`;
@@ -896,6 +906,7 @@ export async function compact(
 			env,
 			retry,
 			callbacks,
+			guard,
 		);
 		summary = result.text;
 		summaryUsage = result.usage;
@@ -933,6 +944,7 @@ async function generateTurnPrefixSummary(
 	streamFn?: StreamFn,
 	retry?: RetryPolicy,
 	callbacks?: RetryCallbacks,
+	guard?: SummarizationRequestGuard,
 ): Promise<{ text: string; usage: Usage }> {
 	const maxTokens = Math.min(
 		Math.floor(0.5 * reserveTokens),
@@ -956,6 +968,7 @@ async function generateTurnPrefixSummary(
 		streamFn,
 		retry,
 		callbacks,
+		guard,
 	);
 
 	if (response.stopReason === "error") {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -588,9 +588,9 @@ export interface SessionBeforeCompactEvent {
 	preparation: CompactionPreparation;
 	branchEntries: SessionEntry[];
 	customInstructions?: string;
-	/** What triggered the compaction: manual /compact, the context threshold, or context overflow recovery */
-	reason: "manual" | "threshold" | "overflow";
-	/** True when the aborted turn is retried after this compaction (overflow recovery) */
+	/** What triggered the compaction: manual /compact, the context threshold, overflow recovery, or a provider-request ceiling */
+	reason: "manual" | "threshold" | "overflow" | "context_ceiling";
+	/** True when the aborted turn is retried after this compaction (overflow or context-ceiling recovery) */
 	willRetry: boolean;
 	signal: AbortSignal;
 }
@@ -600,9 +600,9 @@ export interface SessionCompactEvent {
 	type: "session_compact";
 	compactionEntry: CompactionEntry;
 	fromExtension: boolean;
-	/** What triggered the compaction: manual /compact, the context threshold, or context overflow recovery */
-	reason: "manual" | "threshold" | "overflow";
-	/** True when the aborted turn is retried after this compaction (overflow recovery) */
+	/** What triggered the compaction: manual /compact, the context threshold, overflow recovery, or a provider-request ceiling */
+	reason: "manual" | "threshold" | "overflow" | "context_ceiling";
+	/** True when the aborted turn is retried after this compaction (overflow or context-ceiling recovery) */
 	willRetry: boolean;
 }
 

--- a/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
+++ b/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
@@ -71,7 +71,7 @@ export class RetryStatusIndicator extends StatusIndicator {
 	}
 }
 
-export type CompactionStatusReason = "manual" | "threshold" | "overflow";
+export type CompactionStatusReason = "manual" | "threshold" | "overflow" | "context_ceiling";
 
 export class CompactionStatusIndicator extends StatusIndicator {
 	constructor(ui: TUI, reason: CompactionStatusReason) {
@@ -79,7 +79,7 @@ export class CompactionStatusIndicator extends StatusIndicator {
 		const label =
 			reason === "manual"
 				? `Compacting context... ${cancelHint}`
-				: `${reason === "overflow" ? "Context overflow detected, " : ""}Auto-compacting... ${cancelHint}`;
+				: `${reason === "overflow" ? "Context overflow detected, " : reason === "context_ceiling" ? "Provider-request ceiling reached, " : ""}Auto-compacting... ${cancelHint}`;
 		super(
 			"compaction",
 			ui,

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -491,6 +491,141 @@ describe("AgentSession compaction characterization", () => {
 		expect(runAutoCompactionSpy).not.toHaveBeenCalled();
 	});
 
+	it("compacts and rebuilds exact Grok 4.5 requests at the 180K pre-dispatch trigger", async () => {
+		const harness = await createHarness({
+			provider: "opencode",
+			models: [{ id: "grok-4.5", contextWindow: 200_000, maxTokens: 8_192 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "Grok ceiling summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const now = Date.now();
+		const priorUser = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "history" }],
+			timestamp: now - 2,
+		};
+		const priorAssistant = createAssistant(harness, { stopReason: "stop", totalTokens: 180_000, timestamp: now - 1 });
+		harness.sessionManager.appendMessage(priorUser);
+		harness.sessionManager.appendMessage(priorAssistant);
+		harness.session.agent.state.messages = [priorUser, priorAssistant];
+		harness.setResponses([
+			(context) => {
+				expect(
+					context.messages.some(
+						(message) =>
+							message.role === "user" &&
+							Array.isArray(message.content) &&
+							message.content.some((part) => part.type === "text" && part.text.includes("Grok ceiling summary")),
+					),
+				).toBe(true);
+				return fauxAssistantMessage("provider request after ceiling compaction");
+			},
+		]);
+
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("compaction_start").at(-1)).toEqual({
+			type: "compaction_start",
+			reason: "context_ceiling",
+		});
+	});
+
+	it("fails closed without a provider call when Grok remains at the 200K ceiling", async () => {
+		const harness = await createHarness({
+			provider: "opencode",
+			models: [{ id: "grok-4.5", contextWindow: 200_000, maxTokens: 8_192 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [(pi) => pi.on("session_before_compact", async () => ({ cancel: true }))],
+		});
+		harnesses.push(harness);
+		const now = Date.now();
+		const priorUser = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "history" }],
+			timestamp: now - 2,
+		};
+		const priorAssistant = createAssistant(harness, { stopReason: "stop", totalTokens: 200_000, timestamp: now - 1 });
+		harness.sessionManager.appendMessage(priorUser);
+		harness.sessionManager.appendMessage(priorAssistant);
+		harness.session.agent.state.messages = [priorUser, priorAssistant];
+		harness.setResponses([fauxAssistantMessage("must not be sent")]);
+
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(harness.session.agent.state.errorMessage).toContain("Grok 4.5 context ceiling");
+	});
+
+	it("blocks an oversized Grok compaction summary before it reaches the provider", async () => {
+		const harness = await createHarness({
+			provider: "opencode",
+			models: [{ id: "grok-4.5", contextWindow: 200_000, maxTokens: 8_192 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+		});
+		harnesses.push(harness);
+		const now = Date.now();
+		const oversizedHistory = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "history".repeat(150_000) }],
+			timestamp: now - 3,
+		};
+		const priorAssistant = createAssistant(harness, { stopReason: "stop", totalTokens: 1, timestamp: now - 2 });
+		const latestUser = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "recent" }],
+			timestamp: now - 1,
+		};
+		const latestAssistant = createAssistant(harness, { stopReason: "stop", totalTokens: 200_000, timestamp: now });
+		for (const message of [oversizedHistory, priorAssistant, latestUser, latestAssistant]) {
+			harness.sessionManager.appendMessage(message);
+		}
+		harness.session.agent.state.messages = [oversizedHistory, priorAssistant, latestUser, latestAssistant];
+		harness.setResponses([fauxAssistantMessage("must not be sent")]);
+
+		await expect(harness.session.compact()).rejects.toThrow("Grok 4.5 context ceiling");
+		expect(harness.faux.state.callCount).toBe(0);
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(harness.session.agent.state.errorMessage).toContain("Grok 4.5 context ceiling");
+	});
+
+	it("does not apply the Grok pre-dispatch gate to another model at the same token count", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 500_000, maxTokens: 8_192 }],
+			settings: { compaction: { enabled: false } },
+		});
+		harnesses.push(harness);
+		const now = Date.now();
+		const priorUser = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "history" }],
+			timestamp: now - 2,
+		};
+		const priorAssistant = createAssistant(harness, { stopReason: "stop", totalTokens: 200_000, timestamp: now - 1 });
+		harness.sessionManager.appendMessage(priorUser);
+		harness.sessionManager.appendMessage(priorAssistant);
+		harness.session.agent.state.messages = [priorUser, priorAssistant];
+		harness.setResponses([fauxAssistantMessage("allowed non-Grok request")]);
+
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+
 	it("does not trigger threshold compaction below the threshold or when disabled", async () => {
 		const belowThresholdHarness = await createHarness({
 			settings: { compaction: { enabled: true, reserveTokens: 1000 } },

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -61,6 +61,7 @@ export function getAssistantTexts(harness: Harness): string[] {
 }
 
 export interface HarnessOptions {
+	provider?: string;
 	models?: FauxModelDefinition[];
 	settings?: Partial<Settings>;
 	systemPrompt?: string;
@@ -101,6 +102,7 @@ function createTempDir(): string {
 export async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
 	const tempDir = createTempDir();
 	const fauxProvider: FauxProviderRegistration = registerFauxProvider({
+		provider: options.provider,
 		models: options.models,
 	});
 	fauxProvider.setResponses([]);

--- a/packages/coding-agent/test/suite/regressions/5217-compaction-reason.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5217-compaction-reason.test.ts
@@ -4,12 +4,12 @@ import type { ExtensionFactory } from "../../../src/index.ts";
 import { createHarness, type Harness } from "../harness.ts";
 
 type SessionWithCompactionInternals = {
-	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+	_runAutoCompaction: (reason: "overflow" | "threshold" | "context_ceiling", willRetry: boolean) => Promise<boolean>;
 };
 
 interface RecordedCompactionEvent {
 	type: "session_before_compact" | "session_compact";
-	reason: "manual" | "threshold" | "overflow";
+	reason: "manual" | "threshold" | "overflow" | "context_ceiling";
 	willRetry: boolean;
 }
 


### PR DESCRIPTION
## Summary
- fail closed before any `opencode/grok-4.5` provider request reaches 200K estimated tokens
- compact at 180K and guard both automatic and manual compaction summaries
- document the `context_ceiling` compaction reason and cover dispatch boundaries

## Verification
- `npm run check`
- `npm run build`
- `node ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-compaction.test.ts`
- built-runtime Grok ceiling repro (`triggerEstimate: 180000`, fail-closed at 800K)