### PR TITLE
fix: rpc bash no longer bypass user_bash

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -556,9 +556,24 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 			// =================================================================
 
 			case "bash": {
+				const eventResult = await session.extensionRunner.emitUserBash({
+					type: "user_bash",
+					command: command.command,
+					excludeFromContext: command.excludeFromContext ?? false,
+					cwd: session.sessionManager.getCwd(),
+				});
+
+				if (eventResult?.result) {
+					session.recordBashResult(command.command, eventResult.result, {
+						excludeFromContext: command.excludeFromContext,
+					});
+					return success(id, "bash", eventResult.result);
+				}
+
 				const result = await session.executeBash(command.command, undefined, {
 					excludeFromContext: command.excludeFromContext,
 					id,
+					operations: eventResult?.operations,
 				});
 				return success(id, "bash", result);
 			}


### PR DESCRIPTION
Addresses #7063. 

This PR fixes an RPC-only gap where bash commands bypassed the `user_bash` extension event, unlike interactive `!` commands. I reproduced it locally with a minimal guard extension, updated RPC bash handling to emit `user_bash` and honor intercepted results/operations, and the regression tests passed.