### PR TITLE
fix(ai): route Fireworks Kimi K3 through openai-completions

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -2114,6 +2114,22 @@ async function generateModels() {
 			candidate.baseUrl = "https://api.fireworks.ai/inference/v1";
 			candidate.compat = { supportsStore: false, supportsDeveloperRole: false };
 		}
+		// Kimi K3 on Fireworks uses the OpenAI-compatible API with the same
+		// reasoning_content interleaving and deferred-tools behavior as Moonshot K3.
+		// The Anthropic-compatible Fireworks endpoint does not expose K3's effort/
+		// budget reasoning controls, so route it through openai-completions.
+		if (candidate.provider === "fireworks" && candidate.id.includes("kimi-k3")) {
+			candidate.api = "openai-completions";
+			candidate.baseUrl = "https://api.fireworks.ai/inference/v1";
+			candidate.compat = {
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: true,
+				requiresReasoningContentOnAssistantMessages: true,
+				deferredToolsMode: "kimi",
+				thinkingFormat: "openai",
+			};
+		}
 	}
 
 

--- a/packages/ai/test/fireworks-models.test.ts
+++ b/packages/ai/test/fireworks-models.test.ts
@@ -58,6 +58,44 @@ describe("Fireworks models", () => {
 		expect(fast.thinkingLevelMap).toEqual(base.thinkingLevelMap);
 	});
 
+	it("routes Kimi K3 through the OpenAI-compatible API with kimi deferred-tools compat", () => {
+		const base = getModel("fireworks", "accounts/fireworks/models/kimi-k3");
+		const fast = getModel("fireworks", "accounts/fireworks/routers/kimi-k3-fast");
+
+		expect(base).toBeDefined();
+		expect(base.api).toBe("openai-completions");
+		expect(base.baseUrl).toBe("https://api.fireworks.ai/inference/v1");
+		expect(base.provider).toBe("fireworks");
+		expect(base.reasoning).toBe(true);
+		expect(base.input).toEqual(["text", "image"]);
+		expect(base.contextWindow).toBe(1048576);
+		expect(base.maxTokens).toBe(131072);
+		expect(base.cost).toEqual({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 });
+		expect(base.compat).toEqual({
+			supportsStore: false,
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: true,
+			requiresReasoningContentOnAssistantMessages: true,
+			deferredToolsMode: "kimi",
+			thinkingFormat: "openai",
+		});
+		expect(base.thinkingLevelMap).toEqual({
+			off: null,
+			minimal: null,
+			low: "low",
+			medium: "medium",
+			high: "high",
+			xhigh: null,
+			max: "max",
+		});
+
+		expect(fast.api).toBe(base.api);
+		expect(fast.baseUrl).toBe(base.baseUrl);
+		expect(fast.compat).toEqual(base.compat);
+		expect(fast.thinkingLevelMap).toEqual(base.thinkingLevelMap);
+		expect(fast.cost).toEqual({ input: 4.5, output: 22.5, cacheRead: 0.45, cacheWrite: 0 });
+	});
+
 	it("resolves FIREWORKS_API_KEY from the environment", () => {
 		process.env.FIREWORKS_API_KEY = "test-fireworks-key";
 


### PR DESCRIPTION
Closes #7199.

## What

Adds a Fireworks kimi-k3 branch in `generate-models.ts` (next to the GLM-5.2 Fireworks exception) routing both `accounts/fireworks/models/kimi-k3` and `accounts/fireworks/routers/kimi-k3-fast` to `openai-completions` at `https://api.fireworks.ai/inference/v1`, with the same compat Moonshot K3 gets: `supportsReasoningEffort`, `requiresReasoningContentOnAssistantMessages`, `deferredToolsMode: "kimi"`, `thinkingFormat: "openai"`. The `thinkingLevelMap` (low/medium/high/max) is auto-derived from models.dev `reasoning_options`.

## Why

K3's reasoning controls are OpenAI-style: `reasoning_effort` (low/medium/high/max), reasoning returned as `reasoning_content` ([Fireworks reasoning guide](https://docs.fireworks.ai/guides/reasoning)). On the anthropic-messages route pi only sends budget-based thinking for generic-compat models (`output_config.effort` requires `compat.forceAdaptiveThinking`), so the thinking-level selector has no effect for K3. Fireworks also maps `max` → `high` on the Anthropic surface ([reasoning effort mapping](https://docs.fireworks.ai/tools-sdks/anthropic-compatibility#reasoning-effort-mapping)), making the top effort level unreachable there.

Verified live against the Fireworks API: the OpenAI endpoint accepts `reasoning_effort` and returns `reasoning_content`; the Anthropic endpoint accepts `thinking` but exposes no usable effort control on pi's path.

## Testing

- New regression test in `packages/ai/test/fireworks-models.test.ts` asserting API route, baseUrl, compat block, and derived thinkingLevelMap for both the model and the fast router — 13/13 pass
- `npm run generate-models` regenerates cleanly with both K3 entries under `openai-completions`
- `npm run check` clean
