### PR TITLE
feat(tui): pin chat input and support mouse caret

### DIFF
--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -14,6 +14,7 @@ All components implement:
 interface Component {
   render(width: number): string[];
   handleInput?(data: string): void;
+  handleMouse?(event: TuiMouseEvent): boolean;
   wantsKeyRelease?: boolean;
   invalidate(): void;
 }
@@ -23,6 +24,7 @@ interface Component {
 |--------|-------------|
 | `render(width)` | Return array of strings (one per line). Each line **must not exceed `width`**. |
 | `handleInput?(data)` | Receive keyboard input when component has focus. |
+| `handleMouse?(event)` | Receive mouse input with coordinates local to the component. Return `true` when handled. |
 | `wantsKeyRelease?` | If true, component receives key release events (Kitty protocol). Default: false. |
 | `invalidate()` | Clear cached render state. Called on theme changes. |
 
@@ -204,7 +206,7 @@ See [overlay-qa-tests.ts](../examples/extensions/overlay-qa-tests.ts) for compre
 Import from `@earendil-works/pi-tui`:
 
 ```typescript
-import { Text, Box, Container, Spacer, Markdown } from "@earendil-works/pi-tui";
+import { Text, Box, Container, Spacer, Markdown, Viewport } from "@earendil-works/pi-tui";
 ```
 
 ### Text
@@ -245,6 +247,24 @@ container.addChild(component1);
 container.addChild(component2);
 container.removeChild(component1);
 ```
+
+### Viewport
+
+Keeps one region pinned at the bottom while the preceding content scrolls independently.
+
+```typescript
+const viewport = new Viewport({
+  content: historyContainer,
+  fixed: composerContainer,
+  getHeight: () => tui.terminal.rows,
+  scrollStep: 3, // optional; defaults to 3 lines per wheel event
+});
+
+tui.addChild(viewport);
+tui.setMouseTracking(true);
+```
+
+`Viewport` follows new content while it is at the bottom. After the user scrolls up, incoming content does not change the reviewed position. Scrolling back to the bottom resumes following new content.
 
 ### Spacer
 
@@ -306,6 +326,27 @@ handleInput(data: string) {
 - Arrow keys: `Key.up`, `Key.down`, `Key.left`, `Key.right`
 - With modifiers: `Key.ctrl("c")`, `Key.shift("tab")`, `Key.alt("left")`, `Key.ctrlShift("p")`
 - String format also works: `"enter"`, `"ctrl+c"`, `"shift+tab"`, `"ctrl+shift+p"`
+
+## Mouse Input
+
+Enable SGR mouse tracking on the TUI, then implement `handleMouse()` on components that need it:
+
+```typescript
+import type { TuiMouseEvent } from "@earendil-works/pi-tui";
+
+tui.setMouseTracking(true);
+
+class ClickableComponent implements Component {
+  handleMouse(event: TuiMouseEvent): boolean {
+    if (event.type !== "press" || event.button !== "left") return false;
+    // event.x and event.y are zero-based and local to this component.
+    this.selectAt(event.x, event.y);
+    return true;
+  }
+}
+```
+
+Mouse tracking sends press, release, and wheel events to the TUI instead of the terminal's native mouse handling. Hold `Shift` while dragging when you need to select terminal text. `Container` and `Viewport` translate coordinates before forwarding events to their children.
 
 ## Line Width
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -36,6 +36,7 @@ import {
 	Text,
 	TruncatedText,
 	TUI,
+	Viewport,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import chalk from "chalk";
@@ -334,6 +335,9 @@ export class InteractiveMode {
 	private autocompleteProviderWrappers: AutocompleteProviderFactory[] = [];
 	private fdPath: string | undefined;
 	private editorContainer: Container;
+	private historyContainer: Container;
+	private fixedContainer: Container;
+	private viewport: Viewport;
 	private footer: FooterComponent;
 	private footerDataProvider: FooterDataProvider;
 	// Stored so the same manager can be injected into custom editors, selectors, and extension UI.
@@ -479,6 +483,13 @@ export class InteractiveMode {
 		this.footerDataProvider = new FooterDataProvider(this.sessionManager.getCwd());
 		this.footer = new FooterComponent(this.session, this.footerDataProvider);
 		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
+		this.historyContainer = new Container();
+		this.fixedContainer = new Container();
+		this.viewport = new Viewport({
+			content: this.historyContainer,
+			fixed: this.fixedContainer,
+			getHeight: () => this.ui.terminal.rows,
+		});
 
 		// Load hide thinking block setting
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
@@ -704,19 +715,23 @@ export class InteractiveMode {
 			console.log(theme.fg("dim", `Model scope: ${modelList}${cycleHint}`));
 		}
 
-		// Add header container as first child. Populate it after applying theme settings.
-		// Keep loaded resources before chat so restored session messages never precede them.
-		this.ui.addChild(this.headerContainer);
-		this.ui.addChild(this.loadedResourcesContainer);
+		// Keep startup and chat content scrollable while the composer stays pinned.
+		this.historyContainer.clear();
+		this.historyContainer.addChild(this.headerContainer);
+		this.historyContainer.addChild(this.loadedResourcesContainer);
+		this.historyContainer.addChild(this.chatContainer);
 
-		this.ui.addChild(this.chatContainer);
-		this.ui.addChild(this.pendingMessagesContainer);
-		this.ui.addChild(this.statusContainer);
 		this.renderWidgets(); // Initialize with default spacer
-		this.ui.addChild(this.widgetContainerAbove);
-		this.ui.addChild(this.editorContainer);
-		this.ui.addChild(this.widgetContainerBelow);
-		this.ui.addChild(this.footer);
+		this.fixedContainer.clear();
+		this.fixedContainer.addChild(this.pendingMessagesContainer);
+		this.fixedContainer.addChild(this.statusContainer);
+		this.fixedContainer.addChild(this.widgetContainerAbove);
+		this.fixedContainer.addChild(this.editorContainer);
+		this.fixedContainer.addChild(this.widgetContainerBelow);
+		this.fixedContainer.addChild(this.customFooter ?? this.footer);
+
+		this.ui.addChild(this.viewport);
+		this.ui.setMouseTracking(true);
 		this.ui.setFocus(this.editor);
 
 		this.setupKeyHandlers();
@@ -2048,21 +2063,21 @@ export class InteractiveMode {
 			this.customFooter.dispose();
 		}
 
-		// Remove current footer from UI
+		// Remove current footer from the pinned region.
 		if (this.customFooter) {
-			this.ui.removeChild(this.customFooter);
+			this.fixedContainer.removeChild(this.customFooter);
 		} else {
-			this.ui.removeChild(this.footer);
+			this.fixedContainer.removeChild(this.footer);
 		}
 
 		if (factory) {
 			// Create and add custom footer, passing the data provider
 			this.customFooter = factory(this.ui, theme, this.footerDataProvider);
-			this.ui.addChild(this.customFooter);
+			this.fixedContainer.addChild(this.customFooter);
 		} else {
 			// Restore built-in footer
 			this.customFooter = undefined;
-			this.ui.addChild(this.footer);
+			this.fixedContainer.addChild(this.footer);
 		}
 
 		this.ui.requestRender();

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2,6 +2,7 @@ import type { AutocompleteProvider, AutocompleteSuggestions } from "../autocompl
 import { getKeybindings } from "../keybindings.ts";
 import { decodePrintableKey, matchesKey } from "../keys.ts";
 import { KillRing } from "../kill-ring.ts";
+import type { TuiMouseEvent } from "../mouse.ts";
 import { type Component, CURSOR_MARKER, type Focusable, type TUI } from "../tui.ts";
 import { UndoStack } from "../undo-stack.ts";
 import {
@@ -281,8 +282,9 @@ export class Editor implements Component, Focusable {
 	private theme: EditorTheme;
 	private paddingX: number = 0;
 
-	// Store last render width for cursor navigation
+	// Store last render dimensions for cursor navigation and mouse positioning
 	private lastWidth: number = 80;
+	private lastPaddingX: number = 0;
 
 	// Vertical scrolling support
 	private scrollOffset: number = 0;
@@ -488,8 +490,9 @@ export class Editor implements Component, Focusable {
 		// without padding we reserve 1 column for the cursor.
 		const layoutWidth = Math.max(1, contentWidth - (paddingX ? 0 : 1));
 
-		// Store for cursor navigation (must match wrapping width)
+		// Store for cursor navigation and mouse positioning (must match wrapping width)
 		this.lastWidth = layoutWidth;
+		this.lastPaddingX = paddingX;
 
 		const horizontal = this.borderColor("─");
 
@@ -598,6 +601,49 @@ export class Editor implements Component, Focusable {
 		}
 
 		return result;
+	}
+
+	handleMouse(event: TuiMouseEvent): boolean {
+		if (event.type !== "press" || event.button !== "left") return false;
+
+		const localVisualRow = event.y - 1; // Top border occupies row zero.
+		const visualLines = this.buildVisualLineMap(this.lastWidth);
+		const visibleLineCount = Math.min(
+			Math.max(5, Math.floor(this.tui.terminal.rows * 0.3)),
+			visualLines.length - this.scrollOffset,
+		);
+		if (localVisualRow < 0 || localVisualRow >= visibleLineCount) return false;
+
+		const visualLineIndex = this.scrollOffset + localVisualRow;
+		const visualLine = visualLines[visualLineIndex];
+		if (!visualLine) return false;
+
+		const logicalText = this.state.lines[visualLine.logicalLine] ?? "";
+		const visualText = logicalText.slice(visualLine.startCol, visualLine.startCol + visualLine.length);
+		const clickedColumn = Math.max(0, event.x - this.lastPaddingX);
+		let visualWidth = 0;
+		let offset = 0;
+		const segments = [...this.segment(visualText, "grapheme")];
+		for (const segment of segments) {
+			if (visualWidth >= clickedColumn) break;
+			visualWidth += visibleWidth(segment.segment);
+			offset = segment.index + segment.segment.length;
+		}
+
+		const isLastVisualLine =
+			visualLineIndex === visualLines.length - 1 ||
+			visualLines[visualLineIndex + 1]?.logicalLine !== visualLine.logicalLine;
+		if (!isLastVisualLine && offset >= visualLine.length) {
+			offset = segments[segments.length - 1]?.index ?? 0;
+		}
+
+		this.lastAction = null;
+		this.exitHistoryBrowsing();
+		this.state.cursorLine = visualLine.logicalLine;
+		this.setCursorCol(Math.min(logicalText.length, visualLine.startCol + offset));
+		this.tui.setFocus(this);
+		if (this.autocompleteState) this.updateAutocomplete();
+		return true;
 	}
 
 	handleInput(data: string): void {

--- a/packages/tui/src/components/viewport.ts
+++ b/packages/tui/src/components/viewport.ts
@@ -1,0 +1,89 @@
+import type { TuiMouseEvent } from "../mouse.ts";
+import type { Component } from "../tui.ts";
+
+export interface ViewportOptions {
+	content: Component;
+	fixed: Component;
+	getHeight: () => number;
+	scrollStep?: number;
+}
+
+/**
+ * Keeps one region fixed at the bottom while exposing a scrollable viewport
+ * over the preceding content.
+ */
+export class Viewport implements Component {
+	private readonly content: Component;
+	private readonly fixed: Component;
+	private readonly getHeight: () => number;
+	private readonly scrollStep: number;
+	private viewportStart = 0;
+	private followBottom = true;
+	private lastContentLength = 0;
+	private lastHistoryHeight = 0;
+	private lastFixedOffset = 0;
+
+	constructor(options: ViewportOptions) {
+		this.content = options.content;
+		this.fixed = options.fixed;
+		this.getHeight = options.getHeight;
+		this.scrollStep = Math.max(1, Math.floor(options.scrollStep ?? 3));
+	}
+
+	render(width: number): string[] {
+		const height = Math.max(1, Math.floor(this.getHeight()));
+		const fixedLines = this.fixed.render(width);
+		if (fixedLines.length >= height) {
+			this.lastContentLength = 0;
+			this.lastHistoryHeight = 0;
+			this.lastFixedOffset = fixedLines.length - height;
+			return fixedLines.slice(-height);
+		}
+
+		const contentLines = this.content.render(width);
+		const historyHeight = height - fixedLines.length;
+		const maxStart = Math.max(0, contentLines.length - historyHeight);
+		this.viewportStart = this.followBottom ? maxStart : Math.min(this.viewportStart, maxStart);
+		this.lastContentLength = contentLines.length;
+		this.lastHistoryHeight = historyHeight;
+		this.lastFixedOffset = 0;
+
+		const visible = contentLines.slice(this.viewportStart, this.viewportStart + historyHeight);
+		while (visible.length < historyHeight) visible.push("");
+		return [...visible, ...fixedLines];
+	}
+
+	handleMouse(event: TuiMouseEvent): boolean {
+		if (event.type === "wheel") {
+			const maxStart = Math.max(0, this.lastContentLength - this.lastHistoryHeight);
+			if (event.direction === "up") {
+				if (this.followBottom) this.viewportStart = maxStart;
+				this.followBottom = false;
+				this.viewportStart = Math.max(0, this.viewportStart - this.scrollStep);
+			} else {
+				this.viewportStart = Math.min(maxStart, this.viewportStart + this.scrollStep);
+				this.followBottom = this.viewportStart >= maxStart;
+			}
+			return true;
+		}
+
+		if (event.y < this.lastHistoryHeight) {
+			return this.content.handleMouse?.({ ...event, y: event.y + this.viewportStart }) ?? false;
+		}
+		return (
+			this.fixed.handleMouse?.({
+				...event,
+				y: event.y - this.lastHistoryHeight + this.lastFixedOffset,
+			}) ?? false
+		);
+	}
+
+	scrollToBottom(): void {
+		this.followBottom = true;
+	}
+
+	invalidate(): void {
+		this.content.invalidate();
+		this.fixed.invalidate();
+	}
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -27,6 +27,7 @@ export { type SettingItem, SettingsList, type SettingsListTheme } from "./compon
 export { Spacer } from "./components/spacer.ts";
 export { Text } from "./components/text.ts";
 export { TruncatedText } from "./components/truncated-text.ts";
+export { Viewport, type ViewportOptions } from "./components/viewport.ts";
 // Editor component interface (for custom editors)
 export type { EditorComponent } from "./editor-component.ts";
 // Fuzzy matching
@@ -57,6 +58,8 @@ export {
 	parseKey,
 	setKittyProtocolActive,
 } from "./keys.ts";
+// Mouse input handling
+export { type MouseButton, parseMouseInput, type TuiMouseEvent } from "./mouse.ts";
 // Input buffering for batch splitting
 export { StdinBuffer, type StdinBufferEventMap, type StdinBufferOptions } from "./stdin-buffer.ts";
 // Terminal interface and implementations

--- a/packages/tui/src/mouse.ts
+++ b/packages/tui/src/mouse.ts
@@ -1,0 +1,43 @@
+export type MouseButton = "left" | "middle" | "right";
+
+type MouseModifiers = {
+	x: number;
+	y: number;
+	shift: boolean;
+	alt: boolean;
+	ctrl: boolean;
+};
+
+export type TuiMouseEvent =
+	| (MouseModifiers & { type: "press" | "release" | "move"; button: MouseButton })
+	| (MouseModifiers & { type: "wheel"; direction: "up" | "down" });
+
+const BUTTONS: readonly MouseButton[] = ["left", "middle", "right"];
+
+/** Parse an SGR mouse sequence into a zero-based terminal event. */
+export function parseMouseInput(data: string): TuiMouseEvent | undefined {
+	const match = data.match(/^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/);
+	if (!match) return undefined;
+
+	const code = Number.parseInt(match[1]!, 10);
+	const x = Math.max(0, Number.parseInt(match[2]!, 10) - 1);
+	const y = Math.max(0, Number.parseInt(match[3]!, 10) - 1);
+	const modifiers = {
+		x,
+		y,
+		shift: (code & 4) !== 0,
+		alt: (code & 8) !== 0,
+		ctrl: (code & 16) !== 0,
+	};
+
+	const buttonCode = code & 3;
+	if ((code & 64) !== 0) {
+		if (buttonCode > 1) return undefined;
+		return { ...modifiers, type: "wheel", direction: buttonCode === 0 ? "up" : "down" };
+	}
+
+	const button = BUTTONS[buttonCode];
+	if (!button) return undefined;
+	if (match[4] === "m") return { ...modifiers, type: "release", button };
+	return { ...modifiers, type: (code & 32) !== 0 ? "move" : "press", button };
+}

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -15,6 +15,8 @@ const APPLE_TERMINAL_SHIFT_ENTER_SEQUENCE = "\x1b[13;2u";
 const DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS = 7;
 const KEYBOARD_PROTOCOL_RESPONSE_FRAGMENT_TIMEOUT_MS = 150;
 const KITTY_KEYBOARD_PROTOCOL_QUERY = `\x1b[>${DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS}u\x1b[?u\x1b[c`;
+const MOUSE_TRACKING_ENABLE_SEQUENCE = "\x1b[?1000h\x1b[?1006h";
+const MOUSE_TRACKING_DISABLE_SEQUENCE = "\x1b[?1000l\x1b[?1006l";
 
 export type KeyboardProtocolNegotiationSequence =
 	| { type: "kitty-flags"; flags: number }
@@ -77,6 +79,9 @@ export interface Terminal {
 	// Cursor positioning (relative to current position)
 	moveBy(lines: number): void; // Move cursor up (negative) or down (positive) by N lines
 
+	// Mouse input (optional for custom terminal implementations)
+	setMouseTracking?(enabled: boolean): void;
+
 	// Cursor visibility
 	hideCursor(): void; // Hide the cursor
 	showCursor(): void; // Show the cursor
@@ -108,6 +113,8 @@ export class ProcessTerminal implements Terminal {
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string) => void;
 	private progressInterval?: ReturnType<typeof setInterval>;
+	private started = false;
+	private mouseTracking = false;
 	private writeLogPath = (() => {
 		const env = process.env.PI_TUI_WRITE_LOG || "";
 		if (!env) return "";
@@ -134,6 +141,7 @@ export class ProcessTerminal implements Terminal {
 	start(onInput: (data: string) => void, onResize: () => void): void {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
+		this.started = true;
 
 		// Save previous state and enable raw mode
 		this.wasRaw = process.stdin.isRaw || false;
@@ -145,6 +153,9 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		process.stdout.write("\x1b[?2004h");
+		if (this.mouseTracking) {
+			process.stdout.write(MOUSE_TRACKING_ENABLE_SEQUENCE);
+		}
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.resizeHandler);
@@ -404,6 +415,11 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	stop(): void {
+		if (this.mouseTracking && this.started) {
+			process.stdout.write(MOUSE_TRACKING_DISABLE_SEQUENCE);
+		}
+		this.started = false;
+
 		if (this.clearProgressInterval()) {
 			process.stdout.write(TERMINAL_PROGRESS_CLEAR_SEQUENCE);
 		}
@@ -449,6 +465,13 @@ export class ProcessTerminal implements Terminal {
 		if (process.stdin.setRawMode) {
 			process.stdin.setRawMode(this.wasRaw);
 		}
+	}
+
+	setMouseTracking(enabled: boolean): void {
+		if (this.mouseTracking === enabled) return;
+		this.mouseTracking = enabled;
+		if (!this.started) return;
+		process.stdout.write(enabled ? MOUSE_TRACKING_ENABLE_SEQUENCE : MOUSE_TRACKING_DISABLE_SEQUENCE);
 	}
 
 	write(data: string): void {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -7,6 +7,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { isKeyRelease, matchesKey } from "./keys.ts";
+import { parseMouseInput, type TuiMouseEvent } from "./mouse.ts";
 import type { Terminal } from "./terminal.ts";
 import {
 	isOsc11BackgroundColorResponse,
@@ -73,6 +74,9 @@ export interface Component {
 	 * Optional handler for keyboard input when component has focus
 	 */
 	handleInput?(data: string): void;
+
+	/** Optional handler for mouse input using coordinates local to the component. */
+	handleMouse?(event: TuiMouseEvent): boolean;
 
 	/**
 	 * If true, component receives key release events (Kitty protocol).
@@ -255,20 +259,24 @@ type OverlayFocusRestorePolicy = "clear" | "preserve";
  */
 export class Container implements Component {
 	children: Component[] = [];
+	private childLayouts: Array<{ component: Component; startRow: number; height: number }> = [];
 
 	addChild(component: Component): void {
 		this.children.push(component);
+		this.childLayouts = [];
 	}
 
 	removeChild(component: Component): void {
 		const index = this.children.indexOf(component);
 		if (index !== -1) {
 			this.children.splice(index, 1);
+			this.childLayouts = [];
 		}
 	}
 
 	clear(): void {
 		this.children = [];
+		this.childLayouts = [];
 	}
 
 	invalidate(): void {
@@ -279,13 +287,24 @@ export class Container implements Component {
 
 	render(width: number): string[] {
 		const lines: string[] = [];
+		this.childLayouts = [];
 		for (const child of this.children) {
 			const childLines = child.render(width);
+			this.childLayouts.push({ component: child, startRow: lines.length, height: childLines.length });
 			for (const line of childLines) {
 				lines.push(line);
 			}
 		}
 		return lines;
+	}
+
+	handleMouse(event: TuiMouseEvent): boolean {
+		for (let index = this.childLayouts.length - 1; index >= 0; index--) {
+			const layout = this.childLayouts[index]!;
+			if (event.y < layout.startRow || event.y >= layout.startRow + layout.height) continue;
+			return layout.component.handleMouse?.({ ...event, y: event.y - layout.startRow }) ?? false;
+		}
+		return false;
 	}
 }
 
@@ -310,6 +329,7 @@ export class TUI extends Container {
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
+	private mouseTracking = false;
 	private clearOnShrink = process.env.PI_CLEAR_ON_SHRINK === "1"; // Clear empty rows when content shrinks (default: off)
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves
@@ -350,6 +370,12 @@ export class TUI extends Container {
 			this.terminal.hideCursor();
 		}
 		this.requestRender();
+	}
+
+	setMouseTracking(enabled: boolean): void {
+		if (this.mouseTracking === enabled) return;
+		this.mouseTracking = enabled;
+		this.terminal.setMouseTracking?.(enabled);
 	}
 
 	getClearOnShrink(): boolean {
@@ -789,6 +815,16 @@ export class TUI extends Container {
 
 		// Consume terminal cell size responses without blocking unrelated input.
 		if (this.consumeCellSizeResponse(data)) {
+			return;
+		}
+
+		const mouseEvent = parseMouseInput(data);
+		if (mouseEvent) {
+			// Existing overlays are keyboard-driven. Consume mouse input while one is visible
+			// so a click cannot mutate the editor underneath it.
+			if (!this.hasOverlay() && super.handleMouse(mouseEvent)) {
+				this.requestRender();
+			}
 			return;
 		}
 

--- a/packages/tui/test/editor-mouse.test.ts
+++ b/packages/tui/test/editor-mouse.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Editor } from "../src/components/editor.ts";
+import { TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+const theme = {
+	borderColor: (value: string) => value,
+	selectList: {
+		selectedPrefix: (value: string) => value,
+		selectedText: (value: string) => value,
+		description: (value: string) => value,
+		scrollInfo: (value: string) => value,
+		noMatch: (value: string) => value,
+	},
+};
+
+const leftClick = (x: number, y: number) => ({
+	type: "press" as const,
+	button: "left" as const,
+	x,
+	y,
+	shift: false,
+	alt: false,
+	ctrl: false,
+});
+
+describe("Editor mouse positioning", () => {
+	it("places the caret at the clicked text column", () => {
+		const tui = new TUI(new VirtualTerminal(20, 10));
+		const editor = new Editor(tui, theme);
+		editor.setText("hello world");
+		editor.render(20);
+
+		assert.strictEqual(editor.handleMouse(leftClick(5, 1)), true);
+		assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 5 });
+	});
+
+	it("accounts for editor padding", () => {
+		const tui = new TUI(new VirtualTerminal(20, 10));
+		const editor = new Editor(tui, theme, { paddingX: 2 });
+		editor.setText("hello");
+		editor.render(20);
+
+		editor.handleMouse(leftClick(4, 1));
+		assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 2 });
+	});
+
+	it("maps clicks on wrapped visual lines back to the logical line", () => {
+		const tui = new TUI(new VirtualTerminal(6, 10));
+		const editor = new Editor(tui, theme);
+		editor.setText("abcdefgh");
+		editor.render(6);
+
+		editor.handleMouse(leftClick(2, 2));
+		assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 7 });
+	});
+
+	it("places the caret after a wide grapheme when its second cell is clicked", () => {
+		const tui = new TUI(new VirtualTerminal(20, 10));
+		const editor = new Editor(tui, theme);
+		editor.setText("a🙂b");
+		editor.render(20);
+
+		editor.handleMouse(leftClick(2, 1));
+		assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 3 });
+	});
+
+	it("accounts for the editor's internal vertical scroll", () => {
+		const tui = new TUI(new VirtualTerminal(20, 10));
+		const editor = new Editor(tui, theme);
+		editor.setText(Array.from({ length: 7 }, (_, index) => `line ${index}`).join("\n"));
+		editor.render(20);
+
+		editor.handleMouse(leftClick(2, 1));
+		assert.deepStrictEqual(editor.getCursor(), { line: 2, col: 2 });
+	});
+
+	it("ignores clicks on the border", () => {
+		const tui = new TUI(new VirtualTerminal(20, 10));
+		const editor = new Editor(tui, theme);
+		editor.setText("hello");
+		editor.render(20);
+
+		assert.strictEqual(editor.handleMouse(leftClick(2, 0)), false);
+		assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 5 });
+	});
+});

--- a/packages/tui/test/mouse-interaction.test.ts
+++ b/packages/tui/test/mouse-interaction.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Editor } from "../src/components/editor.ts";
+import { Viewport } from "../src/components/viewport.ts";
+import { type Component, Container, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class TestComponent implements Component {
+	lines: string[];
+
+	constructor(lines: string[]) {
+		this.lines = lines;
+	}
+
+	render(): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+const theme = {
+	borderColor: (value: string) => value,
+	selectList: {
+		selectedPrefix: (value: string) => value,
+		selectedText: (value: string) => value,
+		description: (value: string) => value,
+		scrollInfo: (value: string) => value,
+		noMatch: (value: string) => value,
+	},
+};
+
+describe("TUI mouse interaction", () => {
+	it("routes a terminal click through a fixed viewport into the editor", async () => {
+		const terminal = new VirtualTerminal(20, 6);
+		const tui = new TUI(terminal);
+		const editor = new Editor(tui, theme);
+		editor.setText("abcdef");
+		const fixed = new Container();
+		fixed.addChild(editor);
+		const viewport = new Viewport({
+			content: new TestComponent(Array.from({ length: 8 }, (_, index) => `history ${index}`)),
+			fixed,
+			getHeight: () => terminal.rows,
+		});
+		tui.addChild(viewport);
+		tui.setFocus(editor);
+		tui.setMouseTracking(true);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;4;5M");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 3 });
+		tui.stop();
+	});
+});

--- a/packages/tui/test/mouse.test.ts
+++ b/packages/tui/test/mouse.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { parseMouseInput } from "../src/mouse.ts";
+
+describe("parseMouseInput", () => {
+	it("parses left-button presses with zero-based coordinates", () => {
+		assert.deepStrictEqual(parseMouseInput("\x1b[<0;4;3M"), {
+			type: "press",
+			button: "left",
+			x: 3,
+			y: 2,
+			shift: false,
+			alt: false,
+			ctrl: false,
+		});
+	});
+
+	it("parses releases and modifiers", () => {
+		assert.deepStrictEqual(parseMouseInput("\x1b[<28;7;9m"), {
+			type: "release",
+			button: "left",
+			x: 6,
+			y: 8,
+			shift: true,
+			alt: true,
+			ctrl: true,
+		});
+	});
+
+	it("parses wheel directions", () => {
+		assert.deepStrictEqual(parseMouseInput("\x1b[<64;2;5M"), {
+			type: "wheel",
+			direction: "up",
+			x: 1,
+			y: 4,
+			shift: false,
+			alt: false,
+			ctrl: false,
+		});
+		const wheelDown = parseMouseInput("\x1b[<65;2;5M");
+		assert.strictEqual(wheelDown?.type, "wheel");
+		if (wheelDown?.type === "wheel") assert.strictEqual(wheelDown.direction, "down");
+	});
+
+	it("ignores unsupported horizontal wheel input", () => {
+		assert.strictEqual(parseMouseInput("\x1b[<66;2;5M"), undefined);
+		assert.strictEqual(parseMouseInput("\x1b[<67;2;5M"), undefined);
+	});
+
+	it("ignores non-mouse input", () => {
+		assert.strictEqual(parseMouseInput("hello"), undefined);
+	});
+});

--- a/packages/tui/test/viewport.test.ts
+++ b/packages/tui/test/viewport.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Viewport } from "../src/components/viewport.ts";
+import type { Component } from "../src/tui.ts";
+
+class TestComponent implements Component {
+	lines: string[];
+	mouseRows: number[] = [];
+
+	constructor(lines: string[]) {
+		this.lines = lines;
+	}
+
+	render(): string[] {
+		return this.lines;
+	}
+	handleMouse(event: { y: number }): boolean {
+		this.mouseRows.push(event.y);
+		return true;
+	}
+	invalidate(): void {}
+}
+
+const wheel = (direction: "up" | "down") => ({
+	type: "wheel" as const,
+	direction,
+	x: 0,
+	y: 0,
+	shift: false,
+	alt: false,
+	ctrl: false,
+});
+
+describe("Viewport", () => {
+	it("keeps the fixed region at the bottom and shows the latest history", () => {
+		const content = new TestComponent(Array.from({ length: 8 }, (_, index) => `history ${index}`));
+		const fixed = new TestComponent(["input", "footer"]);
+		const viewport = new Viewport({ content, fixed, getHeight: () => 6, scrollStep: 2 });
+
+		assert.deepStrictEqual(viewport.render(20), [
+			"history 4",
+			"history 5",
+			"history 6",
+			"history 7",
+			"input",
+			"footer",
+		]);
+	});
+
+	it("scrolls only history while the fixed region stays visible", () => {
+		const content = new TestComponent(Array.from({ length: 8 }, (_, index) => `history ${index}`));
+		const fixed = new TestComponent(["input", "footer"]);
+		const viewport = new Viewport({ content, fixed, getHeight: () => 6, scrollStep: 2 });
+
+		viewport.render(20);
+		assert.strictEqual(viewport.handleMouse(wheel("up")), true);
+		assert.deepStrictEqual(viewport.render(20), [
+			"history 2",
+			"history 3",
+			"history 4",
+			"history 5",
+			"input",
+			"footer",
+		]);
+	});
+
+	it("preserves the reviewed lines when new history arrives", () => {
+		const content = new TestComponent(Array.from({ length: 8 }, (_, index) => `history ${index}`));
+		const fixed = new TestComponent(["input", "footer"]);
+		const viewport = new Viewport({ content, fixed, getHeight: () => 6, scrollStep: 2 });
+
+		viewport.render(20);
+		viewport.handleMouse(wheel("up"));
+		viewport.render(20);
+		content.lines.push("history 8", "history 9");
+
+		assert.deepStrictEqual(viewport.render(20).slice(0, 4), ["history 2", "history 3", "history 4", "history 5"]);
+	});
+
+	it("resumes following the latest history after scrollToBottom", () => {
+		const content = new TestComponent(Array.from({ length: 8 }, (_, index) => `history ${index}`));
+		const viewport = new Viewport({
+			content,
+			fixed: new TestComponent(["input", "footer"]),
+			getHeight: () => 6,
+			scrollStep: 2,
+		});
+
+		viewport.render(20);
+		viewport.handleMouse(wheel("up"));
+		viewport.scrollToBottom();
+		assert.deepStrictEqual(viewport.render(20).slice(0, 4), ["history 4", "history 5", "history 6", "history 7"]);
+	});
+
+	it("routes fixed-region coordinates after clipping an oversized fixed region", () => {
+		const fixed = new TestComponent(["fixed 0", "fixed 1", "fixed 2", "fixed 3", "fixed 4"]);
+		const viewport = new Viewport({
+			content: new TestComponent(["history"]),
+			fixed,
+			getHeight: () => 3,
+		});
+
+		assert.deepStrictEqual(viewport.render(20), ["fixed 2", "fixed 3", "fixed 4"]);
+		viewport.handleMouse({
+			type: "press",
+			button: "left",
+			x: 0,
+			y: 1,
+			shift: false,
+			alt: false,
+			ctrl: false,
+		});
+		assert.deepStrictEqual(fixed.mouseRows, [3]);
+	});
+
+	it("pads short history so the fixed region remains at the bottom", () => {
+		const viewport = new Viewport({
+			content: new TestComponent(["history 0"]),
+			fixed: new TestComponent(["input", "footer"]),
+			getHeight: () => 6,
+		});
+
+		assert.deepStrictEqual(viewport.render(20), ["history 0", "", "", "", "input", "footer"]);
+	});
+});

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -14,6 +14,8 @@ export class VirtualTerminal implements Terminal {
 	private resizeHandler?: () => void;
 	private _columns: number;
 	private _rows: number;
+	private started = false;
+	private mouseTracking = false;
 
 	constructor(columns = 80, rows = 24) {
 		this._columns = columns;
@@ -32,8 +34,10 @@ export class VirtualTerminal implements Terminal {
 	start(onInput: (data: string) => void, onResize: () => void): void {
 		this.inputHandler = onInput;
 		this.resizeHandler = onResize;
+		this.started = true;
 		// Enable bracketed paste mode for consistency with ProcessTerminal
 		this.xterm.write("\x1b[?2004h");
+		if (this.mouseTracking) this.xterm.write("\x1b[?1000h\x1b[?1006h");
 	}
 
 	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {
@@ -41,6 +45,8 @@ export class VirtualTerminal implements Terminal {
 	}
 
 	stop(): void {
+		if (this.mouseTracking && this.started) this.xterm.write("\x1b[?1000l\x1b[?1006l");
+		this.started = false;
 		// Disable bracketed paste mode
 		this.xterm.write("\x1b[?2004l");
 		this.inputHandler = undefined;
@@ -73,6 +79,13 @@ export class VirtualTerminal implements Terminal {
 			this.xterm.write(`\x1b[${-lines}A`);
 		}
 		// lines === 0: no movement
+	}
+
+	setMouseTracking(enabled: boolean): void {
+		if (this.mouseTracking === enabled) return;
+		this.mouseTracking = enabled;
+		if (!this.started) return;
+		this.xterm.write(enabled ? "\x1b[?1000h\x1b[?1006h" : "\x1b[?1000l\x1b[?1006l");
 	}
 
 	hideCursor(): void {


### PR DESCRIPTION
## Summary

- add SGR mouse tracking and component-local mouse event routing to `pi-tui`
- add a `Viewport` component that keeps the composer/footer pinned while conversation history scrolls independently
- preserve the reviewed history position when new content arrives and resume following at the bottom
- move the editor caret to left-clicked positions, including padding, wrapped lines, wide graphemes, and internally scrolled input
- integrate the viewport into coding-agent interactive mode and document the public TUI APIs

## Compatibility

- `Terminal.setMouseTracking` is optional, so existing custom terminal implementations remain source-compatible
- mouse tracking is restored on terminal stop; terminal text selection remains available with Shift+drag
- custom footers stay inside the pinned region

## Validation

- `npm run check`
- full `packages/tui` Node test suite except `autocomplete.test.ts` (its three symlink cases require Windows Developer Mode and fail with `EPERM` on this machine)
- targeted mouse, viewport, editor, terminal, render, and stdin-buffer regressions
- coding-agent regressions: 3 files, 36 tests passed
- Pi from this checkout started successfully in an Orca-managed terminal
