### PR TITLE
feat(tui): inline images under tmux via sixel

### DIFF
--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -87,7 +87,21 @@ export class Image implements Component {
 					this.imageId = result.imageId;
 				}
 
-				if (caps.images === "kitty") {
+				if (caps.images === "sixel") {
+					// tmux draws sixel downward from the cursor and leaves the
+					// cursor on the row below the image, and it frees the image
+					// as soon as anything writes to a row it covers. So: emit the
+					// blank rows of the block first, then move up and paint the
+					// image last, wrapped in DECSC/DECRC so the TUI's cursor
+					// accounting is untouched.
+					lines = [];
+					for (let i = 0; i < result.rows - 1; i++) {
+						lines.push("");
+					}
+					const rowOffset = result.rows - 1;
+					const moveUp = rowOffset > 0 ? `\x1b[${rowOffset}A` : "";
+					lines.push(`\x1b7${moveUp}${result.sequence}\x1b8`);
+				} else if (caps.images === "kitty") {
 					// For Kitty: C=1 prevents cursor movement.
 					// Don't need the cursor movement.
 					lines = [result.sequence];

--- a/packages/tui/src/sixel.ts
+++ b/packages/tui/src/sixel.ts
@@ -1,0 +1,524 @@
+/**
+ * Pure-TypeScript sixel encoding, used for inline images inside terminal
+ * multiplexers.
+ *
+ * Unlike the kitty and iTerm2 protocols, sixel data is *parsed by tmux itself*
+ * (when built with `--enable-sixel`) and stored in tmux's own grid, so tmux
+ * owns the cells the image occupies and repaints/erases them correctly. That
+ * makes it the only image protocol that survives a differentially-rendered TUI
+ * running inside a multiplexer.
+ *
+ * Deliberately dependency-free: `@earendil-works/pi-tui` ships with two runtime
+ * deps and we do not want to add a WASM image codec to that list. We therefore
+ * decode PNG ourselves (via `node:zlib`) and fall back to the textual image
+ * placeholder for formats we cannot decode.
+ */
+
+import { inflateSync } from "node:zlib";
+
+export interface RgbaImage {
+	width: number;
+	height: number;
+	/** RGBA, 8 bits per channel, row-major. */
+	data: Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// PNG decoding
+// ---------------------------------------------------------------------------
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+const CHANNELS_PER_COLOR_TYPE: Record<number, number> = {
+	0: 1, // grayscale
+	2: 3, // truecolor
+	3: 1, // palette index
+	4: 2, // grayscale + alpha
+	6: 4, // truecolor + alpha
+};
+
+function paethPredictor(a: number, b: number, c: number): number {
+	const p = a + b - c;
+	const pa = Math.abs(p - a);
+	const pb = Math.abs(p - b);
+	const pc = Math.abs(p - c);
+	if (pa <= pb && pa <= pc) return a;
+	if (pb <= pc) return b;
+	return c;
+}
+
+/**
+ * Decode a PNG into RGBA. Returns null for anything we do not handle
+ * (interlaced images, bit depths below 8), so callers can fall back.
+ */
+export function decodePng(buffer: Buffer): RgbaImage | null {
+	try {
+		if (buffer.length < 8) return null;
+		for (let i = 0; i < PNG_SIGNATURE.length; i++) {
+			if (buffer[i] !== PNG_SIGNATURE[i]) return null;
+		}
+
+		let offset = 8;
+		let width = 0;
+		let height = 0;
+		let bitDepth = 0;
+		let colorType = 0;
+		let interlace = 0;
+		let palette: Uint8Array | null = null;
+		let paletteAlpha: Uint8Array | null = null;
+		const idatChunks: Buffer[] = [];
+
+		while (offset + 8 <= buffer.length) {
+			const length = buffer.readUInt32BE(offset);
+			const type = buffer.toString("ascii", offset + 4, offset + 8);
+			const dataStart = offset + 8;
+			const dataEnd = dataStart + length;
+			if (dataEnd > buffer.length) return null;
+
+			if (type === "IHDR") {
+				width = buffer.readUInt32BE(dataStart);
+				height = buffer.readUInt32BE(dataStart + 4);
+				bitDepth = buffer[dataStart + 8];
+				colorType = buffer[dataStart + 9];
+				interlace = buffer[dataStart + 12];
+			} else if (type === "PLTE") {
+				palette = new Uint8Array(buffer.subarray(dataStart, dataEnd));
+			} else if (type === "tRNS") {
+				paletteAlpha = new Uint8Array(buffer.subarray(dataStart, dataEnd));
+			} else if (type === "IDAT") {
+				idatChunks.push(buffer.subarray(dataStart, dataEnd));
+			} else if (type === "IEND") {
+				break;
+			}
+
+			offset = dataEnd + 4; // skip CRC
+		}
+
+		if (width <= 0 || height <= 0 || idatChunks.length === 0) return null;
+		// Adam7 interlacing is rare for agent-produced images (plots, screenshots);
+		// bail out instead of carrying the deinterlacing code.
+		if (interlace !== 0) return null;
+		if (![1, 2, 4, 8, 16].includes(bitDepth)) return null;
+
+		const channels = CHANNELS_PER_COLOR_TYPE[colorType];
+		if (channels === undefined) return null;
+		if (colorType === 3 && !palette) return null;
+
+		// Filtering operates on whole bytes; for sub-byte depths the "pixel"
+		// distance used by the left/up-left predictors rounds up to one byte.
+		const bytesPerPixel = Math.max(1, Math.ceil((channels * bitDepth) / 8));
+		const stride = Math.ceil((width * channels * bitDepth) / 8);
+
+		const raw = inflateSync(Buffer.concat(idatChunks));
+		if (raw.length < (stride + 1) * height) return null;
+
+		// Un-filter scanlines in place into a contiguous buffer.
+		const pixels = new Uint8Array(stride * height);
+		let rawOffset = 0;
+		for (let y = 0; y < height; y++) {
+			const filter = raw[rawOffset++];
+			const rowStart = y * stride;
+			const prevStart = rowStart - stride;
+
+			for (let x = 0; x < stride; x++) {
+				const value = raw[rawOffset + x];
+				const left = x >= bytesPerPixel ? pixels[rowStart + x - bytesPerPixel] : 0;
+				const up = y > 0 ? pixels[prevStart + x] : 0;
+				const upLeft = y > 0 && x >= bytesPerPixel ? pixels[prevStart + x - bytesPerPixel] : 0;
+
+				let out: number;
+				switch (filter) {
+					case 0:
+						out = value;
+						break;
+					case 1:
+						out = value + left;
+						break;
+					case 2:
+						out = value + up;
+						break;
+					case 3:
+						out = value + ((left + up) >> 1);
+						break;
+					case 4:
+						out = value + paethPredictor(left, up, upLeft);
+						break;
+					default:
+						return null;
+				}
+				pixels[rowStart + x] = out & 0xff;
+			}
+			rawOffset += stride;
+		}
+
+		// Read one sample, honouring bit depth. For depths below 8 the samples are
+		// packed most-significant-bit first within each byte.
+		const maxValue = (1 << Math.min(bitDepth, 8)) - 1;
+		const readSample = (rowStart: number, sampleIndex: number): number => {
+			if (bitDepth === 8) return pixels[rowStart + sampleIndex];
+			if (bitDepth === 16) return pixels[rowStart + sampleIndex * 2]; // high byte
+			const bitOffset = sampleIndex * bitDepth;
+			const byte = pixels[rowStart + (bitOffset >> 3)];
+			const shift = 8 - bitDepth - (bitOffset & 7);
+			return (byte >> shift) & maxValue;
+		};
+		// Grayscale samples must be stretched to the full 0-255 range; palette
+		// indices must not be.
+		const scaleGray = (value: number): number => (bitDepth >= 8 ? value : Math.round((value * 255) / maxValue));
+
+		// Expand to RGBA.
+		const rgba = new Uint8Array(width * height * 4);
+		for (let y = 0; y < height; y++) {
+			const rowStart = y * stride;
+			for (let x = 0; x < width; x++) {
+				const sample = x * channels;
+				const dst = (y * width + x) * 4;
+				let r: number;
+				let g: number;
+				let b: number;
+				let a = 255;
+
+				switch (colorType) {
+					case 0:
+						r = g = b = scaleGray(readSample(rowStart, sample));
+						break;
+					case 2:
+						r = readSample(rowStart, sample);
+						g = readSample(rowStart, sample + 1);
+						b = readSample(rowStart, sample + 2);
+						break;
+					case 3: {
+						const index = readSample(rowStart, sample);
+						const p = palette as Uint8Array;
+						r = p[index * 3] ?? 0;
+						g = p[index * 3 + 1] ?? 0;
+						b = p[index * 3 + 2] ?? 0;
+						if (paletteAlpha && index < paletteAlpha.length) a = paletteAlpha[index];
+						break;
+					}
+					case 4:
+						r = g = b = scaleGray(readSample(rowStart, sample));
+						a = scaleGray(readSample(rowStart, sample + 1));
+						break;
+					default:
+						r = readSample(rowStart, sample);
+						g = readSample(rowStart, sample + 1);
+						b = readSample(rowStart, sample + 2);
+						a = readSample(rowStart, sample + 3);
+						break;
+				}
+
+				rgba[dst] = r;
+				rgba[dst + 1] = g;
+				rgba[dst + 2] = b;
+				rgba[dst + 3] = a;
+			}
+		}
+
+		return { width, height, data: rgba };
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resampling
+// ---------------------------------------------------------------------------
+
+/**
+ * Box-filter resize. Averaging (rather than nearest neighbour) matters a lot
+ * here: images are typically downscaled several-fold to fit a terminal cell
+ * grid, and nearest neighbour turns thin plot lines and text into aliased mush.
+ */
+export function resizeImage(image: RgbaImage, targetWidth: number, targetHeight: number): RgbaImage {
+	const width = Math.max(1, Math.round(targetWidth));
+	const height = Math.max(1, Math.round(targetHeight));
+	if (width === image.width && height === image.height) return image;
+
+	const out = new Uint8Array(width * height * 4);
+	const xRatio = image.width / width;
+	const yRatio = image.height / height;
+
+	for (let y = 0; y < height; y++) {
+		const srcY0 = Math.floor(y * yRatio);
+		const srcY1 = Math.max(srcY0 + 1, Math.min(image.height, Math.ceil((y + 1) * yRatio)));
+
+		for (let x = 0; x < width; x++) {
+			const srcX0 = Math.floor(x * xRatio);
+			const srcX1 = Math.max(srcX0 + 1, Math.min(image.width, Math.ceil((x + 1) * xRatio)));
+
+			let r = 0;
+			let g = 0;
+			let b = 0;
+			let a = 0;
+			let count = 0;
+
+			for (let sy = srcY0; sy < srcY1; sy++) {
+				for (let sx = srcX0; sx < srcX1; sx++) {
+					const src = (sy * image.width + sx) * 4;
+					const alpha = image.data[src + 3];
+					// Weight colour by alpha so transparent pixels do not bleed
+					// their (often black) colour into the average.
+					r += image.data[src] * alpha;
+					g += image.data[src + 1] * alpha;
+					b += image.data[src + 2] * alpha;
+					a += alpha;
+					count++;
+				}
+			}
+
+			const dst = (y * width + x) * 4;
+			if (a > 0) {
+				out[dst] = Math.round(r / a);
+				out[dst + 1] = Math.round(g / a);
+				out[dst + 2] = Math.round(b / a);
+			}
+			out[dst + 3] = count > 0 ? Math.round(a / count) : 0;
+		}
+	}
+
+	return { width, height, data: out };
+}
+
+// ---------------------------------------------------------------------------
+// Colour quantization (median cut)
+// ---------------------------------------------------------------------------
+
+export interface QuantizedImage {
+	/** Palette entries as packed 0xRRGGBB. */
+	palette: number[];
+	/** One palette index per pixel, or -1 for transparent pixels. */
+	indices: Int16Array;
+	width: number;
+	height: number;
+}
+
+interface ColorBox {
+	pixels: Uint32Array;
+	rMin: number;
+	rMax: number;
+	gMin: number;
+	gMax: number;
+	bMin: number;
+	bMax: number;
+}
+
+function makeBox(pixels: Uint32Array): ColorBox {
+	let rMin = 255;
+	let rMax = 0;
+	let gMin = 255;
+	let gMax = 0;
+	let bMin = 255;
+	let bMax = 0;
+
+	for (let i = 0; i < pixels.length; i++) {
+		const value = pixels[i];
+		const r = (value >> 16) & 0xff;
+		const g = (value >> 8) & 0xff;
+		const b = value & 0xff;
+		if (r < rMin) rMin = r;
+		if (r > rMax) rMax = r;
+		if (g < gMin) gMin = g;
+		if (g > gMax) gMax = g;
+		if (b < bMin) bMin = b;
+		if (b > bMax) bMax = b;
+	}
+
+	return { pixels, rMin, rMax, gMin, gMax, bMin, bMax };
+}
+
+function splitBox(box: ColorBox): [ColorBox, ColorBox] | null {
+	if (box.pixels.length < 2) return null;
+
+	const rRange = box.rMax - box.rMin;
+	const gRange = box.gMax - box.gMin;
+	const bRange = box.bMax - box.bMin;
+	const shift = rRange >= gRange && rRange >= bRange ? 16 : gRange >= bRange ? 8 : 0;
+
+	const sorted = Uint32Array.from(box.pixels).sort((a, b) => ((a >> shift) & 0xff) - ((b >> shift) & 0xff));
+	const mid = sorted.length >> 1;
+	if (mid === 0 || mid === sorted.length) return null;
+
+	return [makeBox(sorted.subarray(0, mid)), makeBox(sorted.subarray(mid))];
+}
+
+/**
+ * Median-cut quantization down to `maxColors`, with a 15-bit lookup cache for
+ * the nearest-colour mapping (the naive map is O(pixels * palette)).
+ */
+export function quantize(image: RgbaImage, maxColors: number, alphaThreshold = 128): QuantizedImage {
+	const pixelCount = image.width * image.height;
+	const opaque: number[] = [];
+	const indices = new Int16Array(pixelCount).fill(-1);
+
+	for (let i = 0; i < pixelCount; i++) {
+		if (image.data[i * 4 + 3] < alphaThreshold) continue;
+		opaque.push((image.data[i * 4] << 16) | (image.data[i * 4 + 1] << 8) | image.data[i * 4 + 2]);
+	}
+
+	if (opaque.length === 0) {
+		return { palette: [0], indices, width: image.width, height: image.height };
+	}
+
+	let boxes: ColorBox[] = [makeBox(Uint32Array.from(opaque))];
+	while (boxes.length < maxColors) {
+		// Split the box with the largest volume-weighted range first.
+		let bestIndex = -1;
+		let bestScore = 0;
+		for (let i = 0; i < boxes.length; i++) {
+			const box = boxes[i];
+			if (box.pixels.length < 2) continue;
+			const score =
+				Math.max(box.rMax - box.rMin, box.gMax - box.gMin, box.bMax - box.bMin) * Math.log2(box.pixels.length + 1);
+			if (score > bestScore) {
+				bestScore = score;
+				bestIndex = i;
+			}
+		}
+		if (bestIndex < 0) break;
+
+		const halves = splitBox(boxes[bestIndex]);
+		if (!halves) break;
+		boxes = [...boxes.slice(0, bestIndex), ...halves, ...boxes.slice(bestIndex + 1)];
+	}
+
+	const palette = boxes.map((box) => {
+		let r = 0;
+		let g = 0;
+		let b = 0;
+		for (let i = 0; i < box.pixels.length; i++) {
+			const value = box.pixels[i];
+			r += (value >> 16) & 0xff;
+			g += (value >> 8) & 0xff;
+			b += value & 0xff;
+		}
+		const n = box.pixels.length || 1;
+		return ((Math.round(r / n) & 0xff) << 16) | ((Math.round(g / n) & 0xff) << 8) | (Math.round(b / n) & 0xff);
+	});
+
+	// 5 bits per channel cache: 32768 entries covering the whole RGB cube.
+	const cache = new Int16Array(32768).fill(-1);
+	for (let i = 0; i < pixelCount; i++) {
+		const alpha = image.data[i * 4 + 3];
+		if (alpha < alphaThreshold) continue;
+
+		const r = image.data[i * 4];
+		const g = image.data[i * 4 + 1];
+		const b = image.data[i * 4 + 2];
+		const key = ((r >> 3) << 10) | ((g >> 3) << 5) | (b >> 3);
+
+		let best = cache[key];
+		if (best < 0) {
+			let bestDistance = Number.POSITIVE_INFINITY;
+			for (let p = 0; p < palette.length; p++) {
+				const dr = ((palette[p] >> 16) & 0xff) - r;
+				const dg = ((palette[p] >> 8) & 0xff) - g;
+				const db = (palette[p] & 0xff) - b;
+				const distance = dr * dr + dg * dg + db * db;
+				if (distance < bestDistance) {
+					bestDistance = distance;
+					best = p;
+				}
+			}
+			cache[key] = best;
+		}
+		indices[i] = best;
+	}
+
+	return { palette, indices, width: image.width, height: image.height };
+}
+
+// ---------------------------------------------------------------------------
+// Sixel encoding
+// ---------------------------------------------------------------------------
+
+export interface SixelEncodeOptions {
+	/** Maximum palette size. Most terminals expose 256 colour registers. */
+	maxColors?: number;
+}
+
+/** Run-length encode a repeated sixel character, per the DEC sixel grammar. */
+function emitRun(char: string, count: number): string {
+	if (count <= 0) return "";
+	if (count <= 3) return char.repeat(count);
+	return `!${count}${char}`;
+}
+
+/**
+ * Encode an RGBA image as a sixel DCS sequence.
+ *
+ * Uses P2=1 ("transparent background"), so pixels below the alpha threshold
+ * leave the terminal background untouched instead of being painted black.
+ */
+export function encodeSixelFromRgba(image: RgbaImage, options: SixelEncodeOptions = {}): string {
+	const maxColors = Math.max(2, Math.min(256, options.maxColors ?? 256));
+	const { palette, indices, width, height } = quantize(image, maxColors);
+
+	const parts: string[] = [`\x1bP0;1;0q"1;1;${width};${height}`];
+
+	for (let i = 0; i < palette.length; i++) {
+		// Sixel colour components are percentages (0-100), not 0-255.
+		const r = Math.round((((palette[i] >> 16) & 0xff) * 100) / 255);
+		const g = Math.round((((palette[i] >> 8) & 0xff) * 100) / 255);
+		const b = Math.round(((palette[i] & 0xff) * 100) / 255);
+		parts.push(`#${i};2;${r};${g};${b}`);
+	}
+
+	const bandCount = Math.ceil(height / 6);
+	const bits = new Uint8Array(width);
+
+	for (let band = 0; band < bandCount; band++) {
+		const y0 = band * 6;
+		const rowCount = Math.min(6, height - y0);
+
+		// Which palette entries actually appear in this band?
+		const used = new Set<number>();
+		for (let row = 0; row < rowCount; row++) {
+			const rowStart = (y0 + row) * width;
+			for (let x = 0; x < width; x++) {
+				const index = indices[rowStart + x];
+				if (index >= 0) used.add(index);
+			}
+		}
+
+		let first = true;
+		for (const colorIndex of used) {
+			bits.fill(0);
+			for (let row = 0; row < rowCount; row++) {
+				const rowStart = (y0 + row) * width;
+				const bit = 1 << row;
+				for (let x = 0; x < width; x++) {
+					if (indices[rowStart + x] === colorIndex) bits[x] |= bit;
+				}
+			}
+
+			// `$` is a carriage return within the band: it lets the next colour
+			// overprint the same six-pixel-tall strip from column zero.
+			if (!first) parts.push("$");
+			first = false;
+			parts.push(`#${colorIndex}`);
+
+			let runChar = "";
+			let runLength = 0;
+			let pending = "";
+			for (let x = 0; x < width; x++) {
+				const char = String.fromCharCode(63 + bits[x]);
+				if (char === runChar) {
+					runLength++;
+				} else {
+					pending += emitRun(runChar, runLength);
+					runChar = char;
+					runLength = 1;
+				}
+			}
+			// Trailing empty pixels need no output; the band is implicitly blank.
+			if (runChar !== "?") pending += emitRun(runChar, runLength);
+			parts.push(pending);
+		}
+
+		if (band < bandCount - 1) parts.push("-");
+	}
+
+	parts.push("\x1b\\");
+	return parts.join("");
+}

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
+import { decodePng, encodeSixelFromRgba, resizeImage } from "./sixel.ts";
 
-export type ImageProtocol = "kitty" | "iterm2" | null;
+export type ImageProtocol = "kitty" | "iterm2" | "sixel" | null;
 
 export interface TerminalCapabilities {
 	images: ImageProtocol;
@@ -46,23 +47,84 @@ export function setCellDimensions(dims: CellDimensions): void {
  * outer terminal. tmux only re-emits them when its `client_termfeatures` lists
  * `hyperlinks`, and strips them otherwise. On any error fallbacks `false`.
  */
-function probeTmuxHyperlinks(): boolean {
+function probeTmuxTermFeatures(): string[] {
 	try {
 		const termfeatures = execSync("tmux display-message -p '#{client_termfeatures}'", {
 			encoding: "utf8",
 			timeout: 250,
 			stdio: ["ignore", "pipe", "ignore"],
 		});
-		return termfeatures
-			.split(",")
-			.map((feature) => feature.trim())
-			.includes("hyperlinks");
+		return termfeatures.split(",").map((feature) => feature.trim());
 	} catch {
-		return false;
+		return [];
 	}
 }
 
-export function detectCapabilities(tmuxForwardsHyperlink: () => boolean = probeTmuxHyperlinks): TerminalCapabilities {
+/**
+ * Checks whether the attached tmux client forwards OSC 8 hyperlinks to the
+ * outer terminal. tmux only re-emits them when its `client_termfeatures` lists
+ * `hyperlinks`, and strips them otherwise. On any error fallbacks `false`.
+ */
+function probeTmuxHyperlinks(): boolean {
+	return probeTmuxTermFeatures().includes("hyperlinks");
+}
+
+/**
+ * Checks whether inline images can work under the current tmux.
+ *
+ * Two things must hold: the tmux binary was built with `--enable-sixel` (so it
+ * parses the image into its own grid instead of passing bytes through blindly),
+ * and the attached client's terminal can render sixel. tmux reports the latter
+ * in `client_termfeatures`; the former is implied, since tmux only advertises
+ * the `sixel` feature when compiled with support for it.
+ */
+function probeTmuxSixel(): boolean {
+	return probeTmuxTermFeatures().includes("sixel");
+}
+
+let cachedTmuxCellDimensions: CellDimensions | null = null;
+
+/**
+ * tmux scales and positions sixel images using *its own* idea of the cell size
+ * (`window_cell_width`/`window_cell_height`, defaulting to 16x32), which need
+ * not match what the outer terminal reports to us via XTWINOPS. Geometry has to
+ * be computed in tmux's units or the image will not land on the rows the TUI
+ * reserved for it.
+ */
+export function getTmuxCellDimensions(): CellDimensions {
+	if (cachedTmuxCellDimensions) return cachedTmuxCellDimensions;
+	try {
+		const output = execSync("tmux display-message -p '#{window_cell_width},#{window_cell_height}'", {
+			encoding: "utf8",
+			timeout: 250,
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		const [widthPx, heightPx] = output.trim().split(",").map(Number);
+		if (Number.isFinite(widthPx) && Number.isFinite(heightPx) && widthPx > 0 && heightPx > 0) {
+			cachedTmuxCellDimensions = { widthPx, heightPx };
+			return cachedTmuxCellDimensions;
+		}
+	} catch {
+		// fall through to tmux's compiled-in defaults
+	}
+	cachedTmuxCellDimensions = { widthPx: 16, heightPx: 32 };
+	return cachedTmuxCellDimensions;
+}
+
+/**
+ * Number of terminal rows tmux consumes for a sixel image of `heightPx`,
+ * mirroring `sixel_size_in_cells()`: exact division when the height is a whole
+ * number of cells, otherwise rounded up. Getting this wrong by one row shifts
+ * everything below the image.
+ */
+export function sixelRowsForHeight(heightPx: number, cellHeightPx: number): number {
+	return Math.ceil(heightPx / cellHeightPx);
+}
+
+export function detectCapabilities(
+	tmuxForwardsHyperlink: () => boolean = probeTmuxHyperlinks,
+	tmuxSupportsSixel: () => boolean = probeTmuxSixel,
+): TerminalCapabilities {
 	const termProgram = process.env.TERM_PROGRAM?.toLowerCase() || "";
 	const terminalEmulator = process.env.TERMINAL_EMULATOR?.toLowerCase() || "";
 	const term = process.env.TERM?.toLowerCase() || "";
@@ -70,9 +132,20 @@ export function detectCapabilities(tmuxForwardsHyperlink: () => boolean = probeT
 	const hasTrueColorHint = colorTerm === "truecolor" || colorTerm === "24bit";
 
 	// Emit OSC 8 hyperlinks only when tmux confirms it forwards.
-	// Image protocols are unreliable under tmux, so leave `images: null`.
+	//
+	// Images: the kitty and iTerm2 protocols are genuinely unusable here, since
+	// tmux passes those escapes through without understanding them, leaving the
+	// image in a layer the TUI's line diff cannot erase (see #4208). Sixel is
+	// different: tmux parses it and owns the resulting cells, so it repaints and
+	// clears correctly. Enable images only when tmux confirms sixel support.
+	// Caveat: tmux drops sixel images before reflow, so images scrolled into the
+	// history or surviving a resize leave blank cells behind.
 	if (process.env.TMUX || term.startsWith("tmux")) {
-		return { images: null, trueColor: hasTrueColorHint, hyperlinks: tmuxForwardsHyperlink() };
+		return {
+			images: tmuxSupportsSixel() ? "sixel" : null,
+			trueColor: hasTrueColorHint,
+			hyperlinks: tmuxForwardsHyperlink(),
+		};
 	}
 
 	// screen does not forward OSC 8 hyperlinks, so keep them off there.
@@ -133,6 +206,7 @@ export function getCapabilities(): TerminalCapabilities {
 
 export function resetCapabilitiesCache(): void {
 	cachedCapabilities = null;
+	cachedTmuxCellDimensions = null;
 }
 
 /** Override the cached capabilities. Useful in tests to exercise both code paths. */
@@ -142,6 +216,8 @@ export function setCapabilities(caps: TerminalCapabilities): void {
 
 const KITTY_PREFIX = "\x1b_G";
 const ITERM2_PREFIX = "\x1b]1337;File=";
+// Sixel data arrives as a DCS string whose parameters end with `q`.
+const SIXEL_PATTERN = /\x1bP[0-9;]*q/;
 
 export function isImageLine(line: string): boolean {
 	// Fast path: sequence at line start (single-row images)
@@ -149,7 +225,7 @@ export function isImageLine(line: string): boolean {
 		return true;
 	}
 	// Slow path: sequence elsewhere (multi-row images have cursor-up prefix)
-	return line.includes(KITTY_PREFIX) || line.includes(ITERM2_PREFIX);
+	return line.includes(KITTY_PREFIX) || line.includes(ITERM2_PREFIX) || SIXEL_PATTERN.test(line);
 }
 
 /**
@@ -460,6 +536,33 @@ export function renderImage(
 			preserveAspectRatio: options.preserveAspectRatio ?? true,
 		});
 		return { sequence, rows: size.rows };
+	}
+
+	if (caps.images === "sixel") {
+		// Sixel carries raw pixels, so we downscale here rather than asking the
+		// terminal to do it. All geometry is in tmux's cell units.
+		const cell = getTmuxCellDimensions();
+		const decoded = decodePng(Buffer.from(base64Data, "base64"));
+		if (!decoded) return null;
+
+		const cellSize = calculateImageCellSize(imageDimensions, maxWidth, options.maxHeightCells, cell);
+		const scale = Math.min(
+			(cellSize.columns * cell.widthPx) / decoded.width,
+			(cellSize.rows * cell.heightPx) / decoded.height,
+			1,
+		);
+
+		// Snap to whole cells. Any part of the final cell row/column the image does
+		// not cover is filled by the terminal with the current background colour,
+		// which shows up as a bright band along the edge of the image. Filling the
+		// cell block exactly also makes the row count unambiguous.
+		const columns = Math.max(1, Math.min(maxWidth, Math.round((decoded.width * scale) / cell.widthPx)));
+		const rows = Math.max(1, Math.round((decoded.height * scale) / cell.heightPx));
+		const targetWidth = columns * cell.widthPx;
+		const targetHeight = rows * cell.heightPx;
+
+		const sequence = encodeSixelFromRgba(resizeImage(decoded, targetWidth, targetHeight));
+		return { sequence, rows: sixelRowsForHeight(targetHeight, cell.heightPx) };
 	}
 
 	return null;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -58,6 +58,18 @@ function extractKittyImageRows(line: string): number {
 	return parseKittyImageHeader(line)?.rows ?? 1;
 }
 
+// A sixel image block is emitted as blank rows followed by a final line holding
+// an optional cursor-up jump and the DCS payload (see components/image.ts), so
+// the sequence sits at the *end* of the rows it covers.
+const SIXEL_BLOCK_PATTERN = /^\x1b7(?:\x1b\[(\d+)A)?\x1bP[0-9;]*q/;
+
+/** Rows covered by a sixel image whose sequence terminates on this line, if any. */
+export function extractSixelImageRows(line: string): number | undefined {
+	const match = SIXEL_BLOCK_PATTERN.exec(line);
+	if (!match) return undefined;
+	return match[1] ? Number(match[1]) + 1 : 1;
+}
+
 /**
  * Component interface - all components must implement this
  */
@@ -1139,15 +1151,29 @@ export class TUI extends Container {
 		return reservedRows;
 	}
 
-	private expandChangedRangeForKittyImages(
+	private expandChangedRangeForImages(
 		firstChanged: number,
 		lastChanged: number,
 		newLines: string[],
 	): { firstChanged: number; lastChanged: number } {
 		let expandedFirstChanged = firstChanged;
 		let expandedLastChanged = lastChanged;
+		const expand = (blockStart: number, blockEnd: number): void => {
+			if (blockStart > lastChanged || blockEnd < firstChanged) return;
+			expandedFirstChanged = Math.min(expandedFirstChanged, blockStart);
+			expandedLastChanged = Math.max(expandedLastChanged, blockEnd);
+		};
 		const expandForLines = (lines: string[]): void => {
 			for (let i = 0; i < lines.length; i++) {
+				// tmux frees a sixel image as soon as any row it covers is written
+				// to, and will not redraw it for us. Whenever any part of the block
+				// is repainted we must therefore repaint the sequence itself,
+				// which lives on the block's last row.
+				const sixelRows = extractSixelImageRows(lines[i]);
+				if (sixelRows !== undefined) {
+					expand(i - sixelRows + 1, i);
+					continue;
+				}
 				if (extractKittyImageIds(lines[i]).length === 0) continue;
 				const blockEnd = i + this.getKittyImageReservedRows(lines, i) - 1;
 				if (i >= firstChanged || (i <= lastChanged && blockEnd >= firstChanged)) {
@@ -1392,7 +1418,7 @@ export class TUI extends Container {
 			lastChanged = newLines.length - 1;
 		}
 		if (firstChanged !== -1) {
-			const expandedRange = this.expandChangedRangeForKittyImages(firstChanged, lastChanged, newLines);
+			const expandedRange = this.expandChangedRangeForImages(firstChanged, lastChanged, newLines);
 			firstChanged = expandedRange.firstChanged;
 			lastChanged = expandedRange.lastChanged;
 		}

--- a/packages/tui/test/sixel.test.ts
+++ b/packages/tui/test/sixel.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { test } from "node:test";
+import { decodePng, encodeSixelFromRgba, quantize, type RgbaImage, resizeImage } from "../src/sixel.ts";
+import { sixelRowsForHeight } from "../src/terminal-image.ts";
+
+/**
+ * Minimal sixel parser used to verify the encoder's output independently of the
+ * encoder's own bookkeeping. Supports the subset we emit: raster attributes,
+ * palette definitions, RLE runs, `$` (carriage return) and `-` (newline).
+ */
+function decodeSixel(sequence: string): RgbaImage {
+	const match = /^\x1bP[0-9;]*q(?:"(\d+);(\d+);(\d+);(\d+))?/.exec(sequence);
+	assert.ok(match, "sequence must start with a sixel DCS introducer");
+	const width = Number(match[3]);
+	const height = Number(match[4]);
+
+	const data = new Uint8Array(width * height * 4);
+	const palette = new Map<number, [number, number, number]>();
+	let color = 0;
+	let x = 0;
+	let bandTop = 0;
+
+	let i = match[0].length;
+	const end = sequence.indexOf("\x1b\\");
+	while (i < (end === -1 ? sequence.length : end)) {
+		const char = sequence[i];
+
+		if (char === "#") {
+			const rest = /^#(\d+)(?:;2;(\d+);(\d+);(\d+))?/.exec(sequence.slice(i));
+			assert.ok(rest, `bad colour introducer at ${i}`);
+			color = Number(rest[1]);
+			if (rest[2] !== undefined) {
+				palette.set(color, [
+					Math.round((Number(rest[2]) * 255) / 100),
+					Math.round((Number(rest[3]) * 255) / 100),
+					Math.round((Number(rest[4]) * 255) / 100),
+				]);
+			}
+			i += rest[0].length;
+			continue;
+		}
+
+		if (char === "$") {
+			x = 0;
+			i++;
+			continue;
+		}
+
+		if (char === "-") {
+			x = 0;
+			bandTop += 6;
+			i++;
+			continue;
+		}
+
+		let repeat = 1;
+		if (char === "!") {
+			const rest = /^!(\d+)/.exec(sequence.slice(i));
+			assert.ok(rest, `bad repeat at ${i}`);
+			repeat = Number(rest[1]);
+			i += rest[0].length;
+		}
+
+		const bits = sequence.charCodeAt(i) - 63;
+		assert.ok(bits >= 0 && bits < 64, `bad sixel data byte at ${i}`);
+		i++;
+
+		for (let r = 0; r < repeat; r++, x++) {
+			if (x >= width) continue;
+			for (let row = 0; row < 6; row++) {
+				if ((bits & (1 << row)) === 0) continue;
+				const y = bandTop + row;
+				if (y >= height) continue;
+				const rgb = palette.get(color) ?? [0, 0, 0];
+				const dst = (y * width + x) * 4;
+				data[dst] = rgb[0];
+				data[dst + 1] = rgb[1];
+				data[dst + 2] = rgb[2];
+				data[dst + 3] = 255;
+			}
+		}
+	}
+
+	return { width, height, data };
+}
+
+function solidImage(width: number, height: number, rgba: [number, number, number, number]): RgbaImage {
+	const data = new Uint8Array(width * height * 4);
+	for (let i = 0; i < width * height; i++) {
+		data.set(rgba, i * 4);
+	}
+	return { width, height, data };
+}
+
+test("encodes a solid image that round-trips to the same colour", () => {
+	const image = solidImage(10, 8, [200, 40, 90, 255]);
+	const decoded = decodeSixel(encodeSixelFromRgba(image));
+
+	assert.equal(decoded.width, 10);
+	assert.equal(decoded.height, 8);
+	for (let i = 0; i < decoded.width * decoded.height; i++) {
+		// Palette components are stored as percentages, so allow rounding slop.
+		assert.ok(Math.abs(decoded.data[i * 4] - 200) <= 3, `red channel at ${i}`);
+		assert.ok(Math.abs(decoded.data[i * 4 + 1] - 40) <= 3, `green channel at ${i}`);
+		assert.ok(Math.abs(decoded.data[i * 4 + 2] - 90) <= 3, `blue channel at ${i}`);
+	}
+});
+
+test("emits a DCS sequence with transparent background and raster attributes", () => {
+	const sequence = encodeSixelFromRgba(solidImage(4, 4, [1, 2, 3, 255]));
+	assert.ok(sequence.startsWith('\x1bP0;1;0q"1;1;4;4'), `unexpected header: ${JSON.stringify(sequence.slice(0, 24))}`);
+	assert.ok(sequence.endsWith("\x1b\\"));
+});
+
+test("leaves transparent pixels unpainted", () => {
+	const image = solidImage(8, 6, [255, 255, 255, 0]);
+	// One opaque pixel in the middle of a fully transparent image.
+	image.data.set([10, 220, 30, 255], (2 * 8 + 3) * 4);
+
+	const decoded = decodeSixel(encodeSixelFromRgba(image));
+	for (let y = 0; y < 6; y++) {
+		for (let x = 0; x < 8; x++) {
+			const alpha = decoded.data[(y * 8 + x) * 4 + 3];
+			assert.equal(alpha, y === 2 && x === 3 ? 255 : 0, `pixel ${x},${y}`);
+		}
+	}
+});
+
+test("round-trips a multi-band image with several colours", () => {
+	const width = 17;
+	const height = 15; // not a multiple of 6, exercises the partial last band
+	const image = solidImage(width, height, [0, 0, 0, 255]);
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			const dst = (y * width + x) * 4;
+			image.data[dst] = (x * 15) % 256;
+			image.data[dst + 1] = (y * 17) % 256;
+			image.data[dst + 2] = 128;
+		}
+	}
+
+	const decoded = decodeSixel(encodeSixelFromRgba(image));
+	assert.equal(decoded.width, width);
+	assert.equal(decoded.height, height);
+	for (let i = 0; i < width * height; i++) {
+		assert.equal(decoded.data[i * 4 + 3], 255, `pixel ${i} should be painted`);
+		assert.ok(Math.abs(decoded.data[i * 4] - image.data[i * 4]) <= 24, `red channel at ${i}`);
+		assert.ok(Math.abs(decoded.data[i * 4 + 1] - image.data[i * 4 + 1]) <= 24, `green channel at ${i}`);
+	}
+});
+
+test("run-length encodes long identical spans", () => {
+	const sequence = encodeSixelFromRgba(solidImage(200, 6, [10, 20, 30, 255]));
+	assert.match(sequence, /!\d{2,}/);
+	// A 200px band must not be spelled out one character at a time.
+	assert.ok(sequence.length < 200, `expected compact output, got ${sequence.length} bytes`);
+});
+
+test("quantizes down to the requested palette size", () => {
+	const width = 64;
+	const height = 64;
+	const image = solidImage(width, height, [0, 0, 0, 255]);
+	for (let i = 0; i < width * height; i++) {
+		image.data[i * 4] = i % 256;
+		image.data[i * 4 + 1] = (i * 7) % 256;
+		image.data[i * 4 + 2] = (i * 13) % 256;
+	}
+
+	const result = quantize(image, 16);
+	assert.ok(result.palette.length <= 16, `palette too large: ${result.palette.length}`);
+	assert.ok(result.palette.length > 1, "expected more than one colour");
+	for (let i = 0; i < result.indices.length; i++) {
+		assert.ok(result.indices[i] >= 0 && result.indices[i] < result.palette.length, `index ${i} out of range`);
+	}
+});
+
+test("resizes with a box filter and keeps colours stable", () => {
+	const resized = resizeImage(solidImage(40, 40, [90, 180, 240, 255]), 10, 10);
+	assert.equal(resized.width, 10);
+	assert.equal(resized.height, 10);
+	for (let i = 0; i < 100; i++) {
+		assert.equal(resized.data[i * 4], 90);
+		assert.equal(resized.data[i * 4 + 1], 180);
+		assert.equal(resized.data[i * 4 + 2], 240);
+		assert.equal(resized.data[i * 4 + 3], 255);
+	}
+});
+
+test("rejects images it cannot decode instead of throwing", () => {
+	assert.equal(decodePng(Buffer.from("not a png")), null);
+	assert.equal(decodePng(Buffer.alloc(0)), null);
+});
+
+// PNG decoding is verified against ImageMagick when available, so the decoder is
+// checked against a real encoder rather than only against our own fixtures.
+function makePngWithImageMagick(args: string[]): Buffer | null {
+	try {
+		return execFileSync("magick", [...args, "png:-"], { maxBuffer: 32 * 1024 * 1024 });
+	} catch {
+		return null;
+	}
+}
+
+test("decodes PNG variants produced by ImageMagick", () => {
+	const variants: Array<{ name: string; args: string[] }> = [
+		{ name: "truecolor", args: ["-size", "12x9", "gradient:red-blue", "-define", "png:color-type=2"] },
+		{ name: "truecolor-alpha", args: ["-size", "12x9", "gradient:red-blue", "-define", "png:color-type=6"] },
+		{ name: "grayscale", args: ["-size", "12x9", "gradient:black-white", "-colorspace", "gray"] },
+		{ name: "palette", args: ["-size", "12x9", "gradient:red-blue", "-colors", "8", "-define", "png:color-type=3"] },
+	];
+
+	for (const variant of variants) {
+		const png = makePngWithImageMagick(variant.args);
+		if (!png) {
+			continue; // ImageMagick unavailable; skip rather than fail the suite
+		}
+		const decoded = decodePng(png);
+		assert.ok(decoded, `${variant.name} should decode`);
+		assert.equal(decoded.width, 12, `${variant.name} width`);
+		assert.equal(decoded.height, 9, `${variant.name} height`);
+		// A gradient must not decode to a single flat colour.
+		const first = decoded.data.slice(0, 3).join(",");
+		const last = decoded.data.slice((12 * 9 - 1) * 4, (12 * 9 - 1) * 4 + 3).join(",");
+		assert.notEqual(first, last, `${variant.name} should not be flat`);
+	}
+});
+
+test("sixelRowsForHeight matches tmux's sixel_size_in_cells", () => {
+	// Exact multiples divide evenly; anything else rounds up.
+	assert.equal(sixelRowsForHeight(32, 32), 1);
+	assert.equal(sixelRowsForHeight(64, 32), 2);
+	assert.equal(sixelRowsForHeight(320, 32), 10);
+	assert.equal(sixelRowsForHeight(1, 32), 1);
+	assert.equal(sixelRowsForHeight(33, 32), 2);
+	assert.equal(sixelRowsForHeight(300, 32), 10);
+});

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -211,7 +211,10 @@ describe("detectCapabilities", () => {
 
 	it("enables hyperlinks under tmux when the client forwards them", () => {
 		withEnv({ TMUX: "/tmp/tmux-1000/default,1234,0", TERM_PROGRAM: "ghostty" }, () => {
-			const caps = detectCapabilities(() => true);
+			const caps = detectCapabilities(
+				() => true,
+				() => false,
+			);
 			assert.strictEqual(caps.hyperlinks, true);
 			assert.strictEqual(caps.images, null);
 		});
@@ -219,19 +222,50 @@ describe("detectCapabilities", () => {
 
 	it("disables hyperlinks under tmux when the client does not forward them", () => {
 		withEnv({ TMUX: "/tmp/tmux-1000/default,1234,0", TERM_PROGRAM: "ghostty" }, () => {
-			const caps = detectCapabilities(() => false);
+			const caps = detectCapabilities(
+				() => false,
+				() => false,
+			);
 			assert.strictEqual(caps.hyperlinks, false);
+			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("enables sixel images under tmux when the client supports sixel", () => {
+		withEnv({ TMUX: "/tmp/tmux-1000/default,1234,0", TERM_PROGRAM: "iterm.app" }, () => {
+			const caps = detectCapabilities(
+				() => true,
+				() => true,
+			);
+			assert.strictEqual(caps.images, "sixel");
+		});
+	});
+
+	it("keeps images disabled under tmux without sixel support", () => {
+		// The kitty/iTerm2 protocols must never be used under tmux: tmux does not
+		// understand them, so the image ends up in a layer the TUI cannot erase.
+		withEnv({ TMUX: "/tmp/tmux-1000/default,1234,0", TERM_PROGRAM: "iterm.app" }, () => {
+			const caps = detectCapabilities(
+				() => true,
+				() => false,
+			);
 			assert.strictEqual(caps.images, null);
 		});
 	});
 
 	it("checks tmux capability when TERM starts with 'tmux'", () => {
 		withEnv({ TERM: "tmux-256color", TERM_PROGRAM: "iterm.app" }, () => {
-			const caps = detectCapabilities(() => true);
+			const caps = detectCapabilities(
+				() => true,
+				() => false,
+			);
 			assert.strictEqual(caps.hyperlinks, true);
 			assert.strictEqual(caps.images, null);
 
-			const caps2 = detectCapabilities(() => false);
+			const caps2 = detectCapabilities(
+				() => false,
+				() => false,
+			);
 			assert.strictEqual(caps2.hyperlinks, false);
 		});
 	});


### PR DESCRIPTION
## Summary

Enables inline images under tmux by adding a sixel backend. Today `detectCapabilities()` returns `images: null` whenever `TMUX` is set, so image support is off for everyone in a multiplexer.

## Why the current blanket disable is too broad

Tracing the history:

- The disable arrived in 30a8a41f as a drive-by inside an **OSC 8 hyperlink** fix. The comment then read *"Image protocols are **also** unreliable under tmux/screen ... **for safety**"* — guilt by association with the hyperlink problem, not a reproduction. 9d2bceba later fixed the hyperlink half properly (it now *probes* `client_termfeatures`) and truncated the image sentence to the bald *"Image protocols are unreliable under tmux"*.
- The one documented image-corruption report, #4208, was **cmux**, not tmux (c9e87d2a). It was root-caused and fixed a day later in b8712457: kitty/iTerm2 images live in a layer the TUI's line diff does not own, so repainting text under an image does not erase it. cmux was un-blacklisted; **tmux was simply never re-tested.**

That failure mode is specific to *passthrough* protocols. Sixel is different: tmux built with `--enable-sixel` parses the DCS into its own grid and owns the resulting cells, so it repaints and clears them like any other content. Confirmed in tmux's `image.c` — `image_check_line()`/`image_check_area()` free an image whenever a cell it covers is written.

## What this does

- `detectCapabilities()` gains a **sixel probe** alongside the existing hyperlink probe, returning `images: "sixel"` only when tmux reports `sixel` in `client_termfeatures` (which tmux advertises only if compiled with sixel support *and* the attached client can render it). **kitty and iTerm2 remain disabled under tmux** — that blacklist was correct.
- New `src/sixel.ts`: a dependency-free encoder — PNG decode via `node:zlib` (colour types 0/2/3/4/6, bit depths 1–16), box-filter resize, median-cut quantization with a 15-bit nearest-colour cache. `pi-tui` ships two runtime deps and this adds none.
- Geometry is computed in **tmux's** cell units (`window_cell_width`/`window_cell_height`, default 16x32) rather than the outer terminal's XTWINOPS report, since the two need not agree — and mirrors tmux's own row arithmetic, which rounds up unconditionally (a 32px image in 32px cells still takes two rows).
- The image is painted **last** within its block and wrapped in DECSC/DECRC, so the TUI's cursor accounting is untouched. Because tmux frees an image as soon as anything writes to a row it covers, the changed-line range is expanded to cover the whole block — the same treatment b8712457 gave kitty.

## Testing

- `packages/tui/test/sixel.test.ts`: round-trips encoder output through an independent minimal sixel parser (solid, multi-band, partial final band, transparency, RLE, palette size), plus PNG decoding checked against ImageMagick-generated colour-type variants.
- `packages/tui/test/terminal-image.test.ts`: sixel-on/sixel-off capability cases; existing tmux cases now pin the sixel probe explicitly.
- Full suite: 701 passing.
- Live against tmux 3.5a: for several image sizes, the reserved block height matches tmux's actual row consumption exactly and the cursor lands where the TUI expects.

## Known limitations

- **tmux drops sixel images before reflow**, so an image scrolled into history or surviving a pane resize leaves blank cells behind. This is inherent to tmux's implementation, not something we can patch around here.
- Only PNG input is encoded; other formats fall back to the existing text placeholder.
- Quantization to 256 colours is visible on photographic content (fine for plots/diagrams/screenshots).

Draft: I am running this daily under iTerm2 → et → tmux and will report back on how it holds up.
