### PR TITLE
fix(tui): disambiguate Zed Shift+Enter on macOS

### DIFF
--- a/packages/coding-agent/docs/terminal-setup.md
+++ b/packages/coding-agent/docs/terminal-setup.md
@@ -75,6 +75,25 @@ chars = "\u001b[13;3u"
 
 Restart Alacritty after changing the config.
 
+## Zed (Integrated Terminal)
+
+Current Zed versions work out of the box. Zed sends a linefeed for `Shift+Enter`, which pi handles through its default `Ctrl+J` newline alias.
+
+If your Zed keymap has a legacy mapping that sends `\u001b\r`, remove it or replace it with an unambiguous CSI-u sequence:
+
+```json
+[
+  {
+    "context": "Terminal",
+    "bindings": {
+      "shift-enter": ["terminal::SendText", "\u001b[13;2u"]
+    }
+  }
+]
+```
+
+On macOS, pi also uses the local modifier state to distinguish the legacy `\u001b\r` mapping from a real `Alt+Enter`. As with the Apple Terminal fallback, native modifier detection does not work over remote SSH.
+
 ## VS Code (Integrated Terminal)
 
 VS Code 1.109.5 and newer enable Kitty keyboard protocol in the integrated terminal by default, so `Shift+Enter` should work out of the box.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Shift+Enter` in Zed's macOS integrated terminal when a legacy keymap sends `ESC` + `Return`, while preserving real `Alt+Enter` input.
+
 ## [0.82.1] - 2026-07-25
 
 ## [0.82.0] - 2026-07-24

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -11,7 +11,7 @@ const cjsRequire = createRequire(import.meta.url);
 const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
 const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
-const APPLE_TERMINAL_SHIFT_ENTER_SEQUENCE = "\x1b[13;2u";
+const CSI_U_SHIFT_ENTER_SEQUENCE = "\x1b[13;2u";
 const DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS = 7;
 const KEYBOARD_PROTOCOL_RESPONSE_FRAGMENT_TIMEOUT_MS = 150;
 const KITTY_KEYBOARD_PROTOCOL_QUERY = `\x1b[>${DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS}u\x1b[?u\x1b[c`;
@@ -37,12 +37,24 @@ function isKeyboardProtocolNegotiationSequencePrefix(sequence: string): boolean 
 	return sequence === "\x1b[" || /^\x1b\[\?[\d;]*$/.test(sequence);
 }
 
-export function isAppleTerminalSession(): boolean {
-	return process.platform === "darwin" && process.env.TERM_PROGRAM === "Apple_Terminal";
+export function shouldUseNativeShiftEnterFallback(
+	data: string,
+	platform: NodeJS.Platform = process.platform,
+	termProgram: string | undefined = process.env.TERM_PROGRAM,
+): boolean {
+	if (platform !== "darwin") return false;
+	return (termProgram === "Apple_Terminal" && data === "\r") || (termProgram === "zed" && data === "\x1b\r");
 }
 
-export function normalizeAppleTerminalInput(data: string, isAppleTerminal: boolean, isShiftPressed: boolean): string {
-	if (isAppleTerminal && data === "\r" && isShiftPressed) return APPLE_TERMINAL_SHIFT_ENTER_SEQUENCE;
+export function normalizeNativeShiftEnterInput(
+	data: string,
+	isShiftPressed: boolean,
+	platform: NodeJS.Platform = process.platform,
+	termProgram: string | undefined = process.env.TERM_PROGRAM,
+): string {
+	if (isShiftPressed && shouldUseNativeShiftEnterFallback(data, platform, termProgram)) {
+		return CSI_U_SHIFT_ENTER_SEQUENCE;
+	}
 	return data;
 }
 
@@ -308,11 +320,10 @@ export class ProcessTerminal implements Terminal {
 
 	private forwardInputSequence(sequence: string): void {
 		if (!this.inputHandler) return;
-		const isAppleTerminal = sequence === "\r" && isAppleTerminalSession();
-		const input = normalizeAppleTerminalInput(
+		const shouldCheckNativeModifiers = shouldUseNativeShiftEnterFallback(sequence);
+		const input = normalizeNativeShiftEnterInput(
 			sequence,
-			isAppleTerminal,
-			isAppleTerminal && isNativeModifierPressed("shift"),
+			shouldCheckNativeModifiers && isNativeModifierPressed("shift"),
 		);
 		this.inputHandler(input);
 	}

--- a/packages/tui/test/terminal.test.ts
+++ b/packages/tui/test/terminal.test.ts
@@ -1,24 +1,36 @@
 import assert from "node:assert";
 import { describe, it, mock } from "node:test";
 import { setKittyProtocolActive } from "../src/keys.ts";
-import { normalizeAppleTerminalInput, ProcessTerminal } from "../src/terminal.ts";
+import { normalizeNativeShiftEnterInput, ProcessTerminal, shouldUseNativeShiftEnterFallback } from "../src/terminal.ts";
 
-describe("normalizeAppleTerminalInput", () => {
-	it("rewrites Apple Terminal Return to CSI-u Shift+Enter when Shift is pressed", () => {
-		assert.equal(normalizeAppleTerminalInput("\r", true, true), "\x1b[13;2u");
+describe("native Shift+Enter fallback", () => {
+	it("recognizes ambiguous input from supported local macOS terminals", () => {
+		assert.equal(shouldUseNativeShiftEnterFallback("\r", "darwin", "Apple_Terminal"), true);
+		assert.equal(shouldUseNativeShiftEnterFallback("\x1b\r", "darwin", "zed"), true);
 	});
 
-	it("leaves Apple Terminal Return unchanged when Shift is not pressed", () => {
-		assert.equal(normalizeAppleTerminalInput("\r", true, false), "\r");
+	it("ignores other sequences, terminals, and platforms", () => {
+		assert.equal(shouldUseNativeShiftEnterFallback("\x1b\r", "darwin", "Apple_Terminal"), false);
+		assert.equal(shouldUseNativeShiftEnterFallback("\r", "darwin", "zed"), false);
+		assert.equal(shouldUseNativeShiftEnterFallback("\x1b\r", "linux", "zed"), false);
+		assert.equal(shouldUseNativeShiftEnterFallback("\x1b\r", "darwin", "iTerm.app"), false);
 	});
 
-	it("leaves non-Apple Terminal Return unchanged when Shift is pressed", () => {
-		assert.equal(normalizeAppleTerminalInput("\r", false, true), "\r");
+	it("rewrites Apple Terminal Return when Shift is pressed", () => {
+		assert.equal(normalizeNativeShiftEnterInput("\r", true, "darwin", "Apple_Terminal"), "\x1b[13;2u");
 	});
 
-	it("leaves non-Return input unchanged", () => {
-		assert.equal(normalizeAppleTerminalInput("\x1b[13;2u", true, true), "\x1b[13;2u");
-		assert.equal(normalizeAppleTerminalInput("a", true, true), "a");
+	it("rewrites Zed's legacy ESC+Return mapping when Shift is pressed", () => {
+		assert.equal(normalizeNativeShiftEnterInput("\x1b\r", true, "darwin", "zed"), "\x1b[13;2u");
+	});
+
+	it("preserves real Alt+Enter in Zed when Shift is not pressed", () => {
+		assert.equal(normalizeNativeShiftEnterInput("\x1b\r", false, "darwin", "zed"), "\x1b\r");
+	});
+
+	it("leaves unrelated input unchanged", () => {
+		assert.equal(normalizeNativeShiftEnterInput("\x1b[13;2u", true, "darwin", "zed"), "\x1b[13;2u");
+		assert.equal(normalizeNativeShiftEnterInput("a", true, "darwin", "zed"), "a");
 	});
 });
 


### PR DESCRIPTION
## Summary

Extend the existing macOS native-modifier fallback to handle `Shift+Enter` in Zed's integrated terminal when a legacy keymap emits `ESC` + `Return`.

- Normalize confirmed `Shift+Enter` to CSI-u (`\x1b[13;2u`)
- Preserve real `Alt+Enter` input
- Document Zed's preferred, unambiguous configuration
- Add regression coverage for both behaviors

## Motivation

Current Zed versions work out of the box, but some users have a global legacy mapping—also installed by Claude Code's terminal setup—that sends:

```json
"shift-enter": ["terminal::SendText", "\u001b\r"]
```

`ESC` + `Return` is indistinguishable on the wire from `Alt+Enter`. Pi therefore interprets the sequence as `Alt+Enter` and invokes `app.message.followUp` instead of inserting a newline.

## Implementation

This generalizes the native modifier fallback already used for Apple Terminal.

On local macOS sessions, Pi checks the physical Shift state only for these ambiguous inputs:

- `Apple_Terminal` + `Return`
- `zed` + `ESC` + `Return`

When Shift is pressed, the input is normalized to CSI-u `Shift+Enter`. Otherwise, the original input is left unchanged, preserving genuine `Alt+Enter`.

Other terminals, platforms, and input sequences are unaffected.

## Documentation

The terminal setup guide now recommends removing the legacy Zed mapping or replacing it with the unambiguous CSI-u sequence:

```json
"shift-enter": ["terminal::SendText", "\u001b[13;2u"]
```

CSI-u is also the recommended solution for remote sessions because native modifier detection only observes the machine where Pi is running and does not work across SSH.

## Testing

Added tests covering:

- Apple Terminal's existing fallback
- Zed `ESC` + `Return` with physical Shift
- Preservation of real `Alt+Enter`
- Unsupported terminals, sequences, and platforms

Also verified the TUI test suite, monorepo build, formatting, linting, type checks, and browser smoke checks.
