### PR TITLE
fix(coding-agent): enable streaming usage for llama.cpp provider

### DIFF
--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -43,7 +43,7 @@ function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-comp
 			supportsStore: false,
 			supportsDeveloperRole: false,
 			supportsReasoningEffort: false,
-			supportsUsageInStreaming: false,
+			supportsUsageInStreaming: true,
 			supportsStrictMode: false,
 			maxTokensField: "max_tokens",
 		},


### PR DESCRIPTION
## Problem

The built-in llama.cpp provider hardcodes `supportsUsageInStreaming` to false. Because of this, pi never sends `stream_options.include_usage` and llama-server omits the final usage chunk. Streamed responses record 0 tokens, so `/session` stats also report 0 token usage.

## Fix

Set `supportsUsageInStreaming` to true.

llama-server supports the standard OpenAI `include_usage` option. Since September 2025 (ggml-org/llama.cpp#16052) the server only includes usage when the client asks for it. Router mode, which the llama.cpp provider requires, only exists in newer builds, so any compatible server already supports the option.

## Verification

Tested against llama-server b10094 through a logging proxy, driving the provider's own catalog and stream path.

- Before the fix pi sent no `stream_options` and recorded zero usage.
- After the fix pi sent `stream_options` with `include_usage` and recorded real counts, including cached tokens from `prompt_tokens_details`.

Before:

```
hello

Hello! How can I help you today?

Session Info

File: /home/steve/.pi/agent/sessions/--home-steve--/2026-07-29T06-38-09-886Z_019fac98-4bde-76a8-bcbb-07ed13bcba21.jsonl
ID: 019fac98-4bde-76a8-bcbb-07ed13bcba21

Messages
Total: 2
User: 1
Assistant: 1
Tools: 0 calls, 0 results

Tokens
Input: 0
Output: 0
Total: 0
```

After:

```
hello

Hello! How can I help you today?

Session Info

File: /home/steve/.pi/agent/sessions/--home-steve--/2026-07-29T06-36-46-635Z_019fac97-06ab-7305-ba07-ba84588e1794.jsonl
ID: 019fac97-06ab-7305-ba07-ba84588e1794

Messages
Total: 2
User: 1
Assistant: 1
Tools: 0 calls, 0 results

Tokens
Input: 1,442
Output: 14
Total: 1,456
```

## Note for existing setups

Users who set up the llama.cpp provider before this fix should delete `~/.pi/agent/models-store.json` and redo the configuration.
