### PR TITLE
fix(coding-agent): clean up extension event bus listeners

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Added a status line when the tool output expansion is toggled ([#7180](https://github.com/earendil-works/pi/issues/7180)).
+- Removed extension event-bus listeners when their session reloads or is disposed ([#7193](https://github.com/earendil-works/pi/issues/7193)).
 
 ## [0.82.1] - 2026-07-25
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2600,8 +2600,10 @@ export class AgentSession {
 	}
 
 	async reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<void> {
-		const previousFlagValues = this._extensionRunner.getFlagValues();
-		await emitSessionShutdownEvent(this._extensionRunner, { type: "session_shutdown", reason: "reload" });
+		const previousRunner = this._extensionRunner;
+		const previousFlagValues = previousRunner.getFlagValues();
+		await emitSessionShutdownEvent(previousRunner, { type: "session_shutdown", reason: "reload" });
+		previousRunner.invalidate();
 		await this.settingsManager.reload();
 		this.syncQueueModesFromSettings();
 		resetApiProviders();

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -172,6 +172,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
 	};
 	const state: { staleMessage?: string } = {};
+	const eventBusUnsubscribers = new Set<() => void>();
 	const assertActive = () => {
 		if (state.staleMessage) {
 			throw new Error(state.staleMessage);
@@ -198,10 +199,26 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		pendingProviderRegistrations: [],
 		pendingNativeProviderRegistrations: [],
 		assertActive,
+		trackEventBusSubscription: (unsubscribe) => {
+			let active = true;
+			const trackedUnsubscribe = () => {
+				if (!active) return;
+				active = false;
+				eventBusUnsubscribers.delete(trackedUnsubscribe);
+				unsubscribe();
+			};
+			eventBusUnsubscribers.add(trackedUnsubscribe);
+			return trackedUnsubscribe;
+		},
 		invalidate: (message) => {
-			state.staleMessage ??=
+			if (state.staleMessage) return;
+			state.staleMessage =
 				message ??
 				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
+			for (const unsubscribe of eventBusUnsubscribers) {
+				unsubscribe();
+			}
+			eventBusUnsubscribers.clear();
 		},
 		// Pre-bind: queue registrations so bindCore() can flush them once the
 		// model registry is available. bindCore() replaces both with direct calls.
@@ -386,7 +403,16 @@ function createExtensionAPI(
 			runtime.unregisterProvider(name, extension.path);
 		},
 
-		events: eventBus,
+		events: {
+			emit(channel, data) {
+				runtime.assertActive();
+				eventBus.emit(channel, data);
+			},
+			on(channel, handler) {
+				runtime.assertActive();
+				return runtime.trackEventBusSubscription(eventBus.on(channel, handler));
+			},
+		},
 	} as ExtensionAPI;
 
 	return api;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1581,6 +1581,8 @@ export interface ExtensionRuntimeState {
 	pendingNativeProviderRegistrations: Array<{ provider: Provider; extensionPath: string }>;
 	/** Throws when this extension instance is stale after runtime replacement. */
 	assertActive: () => void;
+	/** Tracks an event-bus subscription so runtime invalidation can remove it. */
+	trackEventBusSubscription: (unsubscribe: () => void) => () => void;
 	/** Marks this extension instance as stale after runtime replacement or reload. */
 	invalidate: (message?: string) => void;
 	/**

--- a/packages/coding-agent/test/suite/regressions/7193-event-bus-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7193-event-bus-lifecycle.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEventBus } from "../../../src/core/event-bus.ts";
+import type { ExtensionAPI, LoadExtensionsResult } from "../../../src/core/extensions/index.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../../src/core/extensions/loader.ts";
+import type { ResourceLoader } from "../../../src/core/resource-loader.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("issue #7193 extension event-bus lifecycle", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("removes only stale extension listeners on reload and dispose", async () => {
+		const eventBus = createEventBus();
+		const extensionApis: ExtensionAPI[] = [];
+		const extensionCalls: number[] = [];
+		let hostCalls = 0;
+		let generation = 0;
+
+		eventBus.on("issue-7193", () => {
+			hostCalls++;
+		});
+
+		const loadExtensions = async (): Promise<LoadExtensionsResult> => {
+			const runtime = createExtensionRuntime();
+			const currentGeneration = generation++;
+			const extension = await loadExtensionFromFactory(
+				(pi) => {
+					extensionApis.push(pi);
+					extensionCalls[currentGeneration] = 0;
+					pi.events.on("issue-7193", () => {
+						extensionCalls[currentGeneration] = (extensionCalls[currentGeneration] ?? 0) + 1;
+					});
+				},
+				process.cwd(),
+				eventBus,
+				runtime,
+				`<issue-7193:${currentGeneration}>`,
+			);
+			return { extensions: [extension], errors: [], runtime };
+		};
+
+		let extensionsResult = await loadExtensions();
+		const resourceLoader: ResourceLoader = {
+			getExtensions: () => extensionsResult,
+			getSkills: () => ({ skills: [], diagnostics: [] }),
+			getPrompts: () => ({ prompts: [], diagnostics: [] }),
+			getThemes: () => ({ themes: [], diagnostics: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			getSystemPrompt: () => undefined,
+			getAppendSystemPrompt: () => [],
+			extendResources: () => {},
+			reload: async () => {
+				extensionsResult = await loadExtensions();
+			},
+		};
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+
+		eventBus.emit("issue-7193", undefined);
+		expect(extensionCalls).toEqual([1]);
+		expect(hostCalls).toBe(1);
+
+		const initialApi = extensionApis[0]!;
+		await harness.session.reload();
+		expect(() => initialApi.events.emit("issue-7193", undefined)).toThrow(/stale/);
+
+		eventBus.emit("issue-7193", undefined);
+		expect(extensionCalls).toEqual([1, 1]);
+		expect(hostCalls).toBe(2);
+
+		await harness.session.reload();
+		eventBus.emit("issue-7193", undefined);
+		expect(extensionCalls).toEqual([1, 1, 1]);
+		expect(hostCalls).toBe(3);
+
+		harness.session.dispose();
+		eventBus.emit("issue-7193", undefined);
+		expect(extensionCalls).toEqual([1, 1, 1]);
+		expect(hostCalls).toBe(4);
+	});
+});


### PR DESCRIPTION
## Summary

- scope `pi.events.on()` subscriptions to the extension runtime that registered them
- invalidate the previous runtime after `session_shutdown` and before rebuilding extensions on reload
- add regression coverage for repeated reloads, disposal, stale APIs, and host-owned listeners

## Root cause

`ExtensionAPI.events` exposed the shared event bus directly, so the runtime did not own the unsubscribe callbacks created by extensions. Reloading replaced the runner without invalidating it, and disposal could not remove listeners it did not track.

## Impact

Reloaded or disposed extension runtimes no longer receive shared event-bus events. Listeners registered directly by the embedding host remain active.

## Checks

- `node ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/7193-event-bus-lifecycle.test.ts`
- `npm run check`

Fixes #7193
