### PR TITLE
fix(coding-agent): read clipboard via wl-paste on Wayland, xclip/xsel on X11

### DIFF
--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -268,8 +268,11 @@ export async function readClipboardImage(options?: {
 		const wsl = isWSL(env);
 		const wayland = isWaylandSession(env);
 
-		if (wayland || wsl) {
+		if (wsl) {
 			image = readClipboardImageViaWlPaste() ?? readClipboardImageViaXclip();
+		} else if (wayland) {
+			// wl-paste is authoritative on Wayland; the X11 clipboard may be stale.
+			image = readClipboardImageViaWlPaste();
 		}
 
 		if (!image && wsl) {

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from "child_process";
+import { type ExecSyncOptionsWithStringEncoding, execSync, spawn } from "child_process";
 import { platform } from "os";
 import { isWaylandSession } from "./clipboard-image.ts";
 import { clipboard } from "./clipboard-native.ts";
@@ -32,8 +32,45 @@ function emitOsc52(text: string): boolean {
 	return true;
 }
 
-/** Read plain text from the system clipboard, if native clipboard access is available. */
+const READ_CLIPBOARD_CLI_OPTIONS: ExecSyncOptionsWithStringEncoding = {
+	encoding: "utf8",
+	timeout: 5000,
+	maxBuffer: 50 * 1024 * 1024,
+};
+
+function readClipboardTextViaCli(command: string): string | null {
+	try {
+		return execSync(command, READ_CLIPBOARD_CLI_OPTIONS) || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Read plain text from the system clipboard.
+ *
+ * On Linux the native addon is X11-only, so prefer CLI tools there, mirroring
+ * the copy path which also bypasses the native addon on Linux.
+ */
 export async function readClipboardText(): Promise<string | null> {
+	if (platform() === "linux") {
+		const wayland = isWaylandSession() && Boolean(process.env.WAYLAND_DISPLAY);
+		if (wayland) {
+			// wl-paste is authoritative on Wayland; the X11 clipboard may be stale.
+			const text = readClipboardTextViaCli("wl-paste --no-newline --type text");
+			if (text) {
+				return text;
+			}
+		} else if (process.env.DISPLAY) {
+			const text =
+				readClipboardTextViaCli("xclip -selection clipboard -o") ??
+				readClipboardTextViaCli("xsel --clipboard --output");
+			if (text) {
+				return text;
+			}
+		}
+	}
+
 	if (!clipboard) {
 		return null;
 	}

--- a/packages/coding-agent/test/clipboard-image.test.ts
+++ b/packages/coding-agent/test/clipboard-image.test.ts
@@ -35,18 +35,6 @@ function spawnOk(stdout: Buffer): SpawnSyncReturns<Buffer> {
 	};
 }
 
-function spawnError(error: Error): SpawnSyncReturns<Buffer> {
-	return {
-		pid: 123,
-		output: [Buffer.alloc(0), Buffer.alloc(0), Buffer.alloc(0)],
-		stdout: Buffer.alloc(0),
-		stderr: Buffer.alloc(0),
-		status: null,
-		signal: null,
-		error,
-	};
-}
-
 describe("readClipboardImage", () => {
 	beforeEach(() => {
 		vi.resetModules();
@@ -77,35 +65,24 @@ describe("readClipboardImage", () => {
 		expect(Array.from(result?.bytes ?? [])).toEqual([1, 2, 3]);
 	});
 
-	test("Wayland: falls back to xclip when wl-paste is missing", async () => {
+	test("Wayland: does not fall back to xclip when wl-paste has no image", async () => {
 		mocks.clipboard.hasImage.mockImplementation(() => {
 			throw new Error("clipboard.hasImage should not be called on Wayland");
 		});
 
-		const enoent = new Error("spawn ENOENT");
-		(enoent as { code?: string }).code = "ENOENT";
-
 		mocks.spawnSync.mockImplementation((command, args, _options) => {
-			if (command === "wl-paste") {
-				return spawnError(enoent);
+			if (command === "wl-paste" && args[0] === "--list-types") {
+				return spawnOk(Buffer.from("text/plain\n", "utf-8"));
 			}
-
-			if (command === "xclip" && args.includes("TARGETS")) {
-				return spawnOk(Buffer.from("image/png\n", "utf-8"));
+			if (command === "xclip") {
+				throw new Error("xclip should not be called on Wayland: the X11 clipboard may be stale");
 			}
-
-			if (command === "xclip" && args.includes("image/png")) {
-				return spawnOk(Buffer.from([9, 8]));
-			}
-
-			return spawnOk(Buffer.alloc(0));
+			throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
 		});
 
 		const { readClipboardImage } = await import("../src/utils/clipboard-image.ts");
 		const result = await readClipboardImage({ platform: "linux", env: { XDG_SESSION_TYPE: "wayland" } });
-		expect(result).not.toBeNull();
-		expect(result?.mimeType).toBe("image/png");
-		expect(Array.from(result?.bytes ?? [])).toEqual([9, 8]);
+		expect(result).toBeNull();
 	});
 
 	test("WSL: passes PowerShell path directly instead of through a custom env var", async () => {


### PR DESCRIPTION
Closes #7248

## Problem

`readClipboardText()` only used the native clipboard-rs addon, which is X11-only. On Wayland the X11/XWayland clipboard it reads is empty or stale, so Ctrl+V text paste silently no-ops.

## Fix

On Linux, prefer CLI tools mirroring the copy path:

- Wayland: `wl-paste --no-newline --type text` (authoritative; the X11 clipboard may be stale)
- X11: `xclip -selection clipboard -o`, then `xsel --clipboard --output`
- Native addon remains as last resort on all platforms

Also treats `wl-paste` as authoritative for image reads on Wayland so image paste can't return a stale X11 image.

Verified on KDE Plasma 6 Wayland (Konsole): text copied via `wl-copy` from a Wayland app now pastes with Ctrl+V.
