### PR TITLE
feat(coding-agent): expose opt-in session flush

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1012,6 +1012,27 @@ export class SessionManager {
 		return this.sessionFile;
 	}
 
+	/**
+	 * Flush all in-memory session entries to disk immediately.
+	 *
+	 * New sessions normally defer creating their file until the first assistant
+	 * response, avoiding empty sessions in history. Integrations that advertise a
+	 * session path for external resume (for example, terminal workspace managers)
+	 * can opt in here so the initial model and thinking state is resumable before
+	 * any response exists. Once flushed, later entries append normally.
+	 *
+	 * Returns true when the session is persisted and has a backing file; false for
+	 * in-memory sessions.
+	 */
+	flush(): boolean {
+		if (!this.persist || !this.sessionFile) return false;
+		if (!this.flushed) {
+			this._rewriteFile();
+			this.flushed = true;
+		}
+		return true;
+	}
+
 	_persist(entry: SessionEntry): void {
 		if (!this.persist || !this.sessionFile) return;
 

--- a/packages/coding-agent/test/session-manager/custom-session-id.test.ts
+++ b/packages/coding-agent/test/session-manager/custom-session-id.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { SessionManager } from "../../src/core/session-manager.ts";
+import { loadEntriesFromFile, SessionManager } from "../../src/core/session-manager.ts";
 
 const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
@@ -80,6 +80,41 @@ describe("SessionManager.newSession with custom id", () => {
 		expect(sessionFile).toContain("created-session-id");
 		expect(basename(sessionFile)).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z_created-session-id\.jsonl$/);
 		expect(existsSync(sessionFile)).toBe(false);
+	});
+
+	it("flushes initial runtime state before an assistant response and remains appendable", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-session-manager-"));
+		const session = SessionManager.create(tempDir, tempDir, { id: "resumable-idle-session" });
+		const sessionFile = session.getSessionFile()!;
+
+		session.appendModelChange("test-provider", "profile-model");
+		session.appendThinkingLevelChange("high");
+		expect(existsSync(sessionFile)).toBe(false);
+
+		expect(session.flush()).toBe(true);
+		expect(existsSync(sessionFile)).toBe(true);
+		expect(loadEntriesFromFile(sessionFile).map((entry) => entry.type)).toEqual([
+			"session",
+			"model_change",
+			"thinking_level_change",
+		]);
+
+		const flushedContents = readFileSync(sessionFile, "utf8");
+		expect(session.flush()).toBe(true);
+		expect(readFileSync(sessionFile, "utf8")).toBe(flushedContents);
+
+		session.appendModelChange("test-provider", "last-used-model");
+		const entries = loadEntriesFromFile(sessionFile);
+		expect(entries.at(-1)).toMatchObject({
+			type: "model_change",
+			provider: "test-provider",
+			modelId: "last-used-model",
+		});
+	});
+
+	it("returns false when flushing an in-memory session", () => {
+		const session = SessionManager.inMemory();
+		expect(session.flush()).toBe(false);
 	});
 
 	it("generates a UUIDv7 id when creating a branched session", () => {


### PR DESCRIPTION
## Why

New persisted sessions intentionally delay creating their JSONL file until the first assistant response. Integrations that advertise a session path to an external workspace/session manager can therefore publish a path that does not exist yet. If the workspace restarts while the agent is still idle, external resume creates a fresh session and loses the initial model/thinking state.

There is a second idle-session edge: even when runtime entries are flushed, `createAgentSession()` previously classified a session as resumable only when it contained messages, so model/thinking-only sessions were ignored.

## What

- Add an idempotent `SessionManager.flush()` API that writes the current in-memory entries immediately.
- Preserve the existing deferred-persistence default unless an integration explicitly opts in.
- Treat persisted model/thinking entries as existing session state even before any messages exist.
- Restore the saved runtime instead of the current global default and avoid duplicate runtime entries.
- Fill missing model/thinking entries for partial legacy session state.
- Return `false` for in-memory sessions and `true` for persisted sessions with a backing path.

## Tests

- `npm run build`
- focused flush + SDK idle-resume tests (19/19)
- full session-manager suite (99/99)
- repository pre-commit check (format, lint, typecheck, shrinkwrap/install-lock, browser smoke)

The intended consumer is Herdr's Pi integration, which reports `sessionManager.getSessionFile()` during `session_start` and can call `flush()` before reporting it.