### PR TITLE
feat(ai): preserve structured metadata for Bedrock provider errors

### DIFF
--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -372,10 +372,9 @@ function formatBedrockError(error: unknown): string {
 	return `${core}${dataRetentionHint}`;
 }
 
-/** Subset of the SDK error shape this module probes, mirroring `SdkErrorShape` in error-body.ts. */
 type SdkErrorMetadata = { $metadata?: { httpStatusCode?: unknown; requestId?: unknown } };
 
-/** Header-derived values are dropped, not truncated, above this length: a truncated request id is not a request id. */
+/** Over-long header values are dropped rather than truncated: a truncated request id is not a request id. */
 const MAX_BEDROCK_DIAGNOSTIC_VALUE_CHARS = 200;
 
 function normalizeDiagnosticValue(value: unknown): string | undefined {
@@ -386,13 +385,9 @@ function normalizeDiagnosticValue(value: unknown): string | undefined {
 }
 
 /**
- * Provider error code, e.g. `ValidationException`. The SDK puts it on `error.name`
- * for both paths that expose one: service exceptions from `client.send()`, and the
- * plain `Error` the event-stream unmarshaller throws for an unmodeled stream error
- * (named after the frame's `:error-code`), so do not gate on `instanceof
- * BedrockRuntimeServiceException`. Every modeled Bedrock error ends in `Exception`,
- * which excludes transport failures like `TimeoutError` and the SDK's `Unknown`
- * placeholder without enumerating them.
+ * The SDK puts the modeled code on `error.name` for service exceptions and unmodeled stream errors alike, so
+ * do not narrow to `BedrockRuntimeServiceException`. Modeled Bedrock errors all end in `Exception`, unlike
+ * transport names such as `TimeoutError`.
  */
 function extractBedrockErrorCode(error: unknown): string | undefined {
 	if (!(error instanceof Error) || !error.name.endsWith("Exception")) return undefined;
@@ -400,18 +395,9 @@ function extractBedrockErrorCode(error: unknown): string | undefined {
 }
 
 /**
- * Structured provider metadata for a failed turn, additive alongside `errorMessage`,
- * which must stay byte-identical because `isRetryableAssistantError` classifies
- * retries by matching it. Unknown fields are omitted, never guessed.
- *
- * Carries `details` only, no `error` block, as `pi_messages_rewrite` does: the thrown
- * value is not always an `Error`, so `extractDiagnosticError` would record
- * `"[object Object]"` plus a stack trace pointing into the SDK.
- *
- * A modeled mid-stream exception yields only `requestId`. `@smithy/core`'s
- * `getMessageUnmarshaller` throws a bare object literal, so neither a code nor a
- * status survives, and `fallbackRequestId` from the initial response is all that is
- * left to correlate on.
+ * Structured metadata alongside `errorMessage`, which stays byte-identical because `isRetryableAssistantError`
+ * matches against it. Unknown fields are omitted, never guessed: a modeled mid-stream exception reaches us as
+ * a bare object literal, leaving only `fallbackRequestId`. `details` only, as the throw is not always `Error`.
  */
 function appendBedrockFailureDiagnostic(
 	output: AssistantMessage,

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -47,6 +47,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.ts";
+import { appendAssistantMessageDiagnostic } from "../utils/diagnostics.ts";
 import { normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
@@ -219,6 +220,10 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 			config.authSchemePreference = ["httpBearerAuth"];
 		}
 
+		// Kept outside the try so the catch can still correlate a mid-stream failure:
+		// exceptions delivered as stream events carry no HTTP metadata of their own.
+		let responseRequestId: string | undefined;
+
 		try {
 			const client = new BedrockRuntimeClient(config);
 			const customHeaders = providerHeadersToRecord(options.headers);
@@ -246,6 +251,7 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 			const command = new ConverseStreamCommand(commandInput);
 
 			const response = await client.send(command, { abortSignal: options.signal });
+			responseRequestId = normalizeDiagnosticValue(response.$metadata.requestId);
 			if (response.$metadata.httpStatusCode !== undefined) {
 				const responseHeaders: Record<string, string> = {};
 				if (response.$metadata.requestId) {
@@ -308,6 +314,9 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 			}
 			output.stopReason = options.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatBedrockError(error);
+			if (output.stopReason === "error") {
+				appendBedrockFailureDiagnostic(output, error, responseRequestId);
+			}
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}
@@ -361,6 +370,68 @@ function formatBedrockError(error: unknown): string {
 		return `${prefix}: ${core}${dataRetentionHint}`;
 	}
 	return `${core}${dataRetentionHint}`;
+}
+
+/** Subset of the SDK error shape this module probes, mirroring `SdkErrorShape` in error-body.ts. */
+type SdkErrorMetadata = { $metadata?: { httpStatusCode?: unknown; requestId?: unknown } };
+
+/** Header-derived values are dropped, not truncated, above this length: a truncated request id is not a request id. */
+const MAX_BEDROCK_DIAGNOSTIC_VALUE_CHARS = 200;
+
+function normalizeDiagnosticValue(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	if (trimmed.length === 0 || trimmed.length > MAX_BEDROCK_DIAGNOSTIC_VALUE_CHARS) return undefined;
+	return trimmed;
+}
+
+/**
+ * Provider error code, e.g. `ValidationException`. The SDK puts it on `error.name`
+ * for both paths that expose one: service exceptions from `client.send()`, and the
+ * plain `Error` the event-stream unmarshaller throws for an unmodeled stream error
+ * (named after the frame's `:error-code`), so do not gate on `instanceof
+ * BedrockRuntimeServiceException`. Every modeled Bedrock error ends in `Exception`,
+ * which excludes transport failures like `TimeoutError` and the SDK's `Unknown`
+ * placeholder without enumerating them.
+ */
+function extractBedrockErrorCode(error: unknown): string | undefined {
+	if (!(error instanceof Error) || !error.name.endsWith("Exception")) return undefined;
+	return normalizeDiagnosticValue(error.name);
+}
+
+/**
+ * Structured provider metadata for a failed turn, additive alongside `errorMessage`,
+ * which must stay byte-identical because `isRetryableAssistantError` classifies
+ * retries by matching it. Unknown fields are omitted, never guessed.
+ *
+ * Carries `details` only, no `error` block, as `pi_messages_rewrite` does: the thrown
+ * value is not always an `Error`, so `extractDiagnosticError` would record
+ * `"[object Object]"` plus a stack trace pointing into the SDK.
+ *
+ * A modeled mid-stream exception yields only `requestId`. `@smithy/core`'s
+ * `getMessageUnmarshaller` throws a bare object literal, so neither a code nor a
+ * status survives, and `fallbackRequestId` from the initial response is all that is
+ * left to correlate on.
+ */
+function appendBedrockFailureDiagnostic(
+	output: AssistantMessage,
+	error: unknown,
+	fallbackRequestId: string | undefined,
+): void {
+	const metadata = (error as SdkErrorMetadata)?.$metadata;
+	const details: Record<string, unknown> = {};
+
+	if (typeof metadata?.httpStatusCode === "number") details.status = metadata.httpStatusCode;
+
+	const errorCode = extractBedrockErrorCode(error);
+	if (errorCode !== undefined) details.errorCode = errorCode;
+
+	const requestId = normalizeDiagnosticValue(metadata?.requestId) ?? fallbackRequestId;
+	if (requestId !== undefined) details.requestId = requestId;
+
+	if (Object.keys(details).length === 0) return;
+
+	appendAssistantMessageDiagnostic(output, { type: "bedrock_response_failure", timestamp: Date.now(), details });
 }
 
 /**

--- a/packages/ai/test/bedrock-error-metadata.test.ts
+++ b/packages/ai/test/bedrock-error-metadata.test.ts
@@ -4,8 +4,7 @@ type SendResult = { kind: "reject"; error: unknown } | { kind: "resolve"; respon
 
 const bedrockMock = vi.hoisted(() => ({
 	send: undefined as SendResult | undefined,
-	// Exposed so tests can build errors that are real instances of the mocked
-	// base class, which is what the provider's `instanceof` check sees.
+	// Exposed so tests can build errors that are real instances of the mocked base class.
 	ServiceException: undefined as unknown as new (message?: string) => Error,
 }));
 
@@ -66,10 +65,7 @@ function getModelFixture(): Model<"bedrock-converse-stream"> {
 	return getModel("amazon-bedrock", "us.anthropic.claude-opus-4-8");
 }
 
-/**
- * A `BedrockRuntimeServiceException`, which is what the SDK's `handleError` path
- * throws for a non-2xx HTTP response. `name` carries the modeled AWS error code.
- */
+/** What the SDK's `handleError` path throws for a non-2xx response; `name` is the modeled AWS error code. */
 function makeServiceException(name: string, extra: Record<string, unknown> = {}): Error {
 	const error = new bedrockMock.ServiceException(VALIDATION_MESSAGE) as Error & Record<string, unknown>;
 	error.name = name;
@@ -77,11 +73,7 @@ function makeServiceException(name: string, extra: Record<string, unknown> = {})
 	return error;
 }
 
-/**
- * Resolve `send()` with a stream that fails after `messageStart`. `thrown` is
- * raised from inside the async iterator, which is where `@smithy/core`'s
- * `getMessageUnmarshaller` raises stream exceptions.
- */
+/** Fails after `messageStart`, throwing from inside the iterator like `getMessageUnmarshaller` does. */
 function respondWithFailingStream(thrown: unknown): SendResult {
 	return {
 		kind: "resolve",
@@ -121,7 +113,6 @@ describe("bedrock failure diagnostics", () => {
 
 		expect(message.stopReason).toBe("error");
 		expect(diagnostic?.details).toEqual({ status: 400, errorCode: "ValidationException", requestId: REQUEST_ID });
-		// Details only: no `error` block, so no stack trace is persisted with the session.
 		expect(diagnostic?.error).toBeUndefined();
 		expect(Object.keys(diagnostic ?? {}).sort()).toEqual(["details", "timestamp", "type"]);
 	});
@@ -135,16 +126,11 @@ describe("bedrock failure diagnostics", () => {
 			}),
 		};
 
-		// `isRetryableAssistantError` matches patterns against this exact string.
 		expect((await runBedrock()).errorMessage).toBe(`Validation error: ${VALIDATION_MESSAGE}`);
 	});
 
 	it("reports only the request id for a modeled mid-stream exception", async () => {
-		// This is the shape the installed SDK actually delivers. `@smithy/core`
-		// `getMessageUnmarshaller` throws `deserializedException[code]`, and the JSON
-		// shape deserializer built that value as a bare object literal: no prototype,
-		// no `$metadata`, no `name`. The AWS error code is destroyed by the SDK before
-		// it reaches us, so reporting one here would be a fabrication.
+		// The SDK throws a bare object literal here, so the code is genuinely unavailable.
 		bedrockMock.send = respondWithFailingStream({ message: "Too many requests, please wait." });
 
 		const message = await runBedrock();
@@ -154,10 +140,7 @@ describe("bedrock failure diagnostics", () => {
 	});
 
 	it("captures the error code for an unmodeled mid-stream error", async () => {
-		// The other unmarshaller branch (a `:message-type` of `error`, or an exception
-		// type missing from the union) throws a real `Error` whose `name` is the
-		// frame's `:error-code`. That code is recoverable, and the request id still
-		// comes from the initial response.
+		// This branch throws a real `Error` named after the frame's `:error-code`.
 		const unmodeled = new Error("Model stream terminated unexpectedly.");
 		unmodeled.name = "ModelStreamErrorException";
 		bedrockMock.send = respondWithFailingStream(unmodeled);
@@ -169,9 +152,7 @@ describe("bedrock failure diagnostics", () => {
 	});
 
 	it("does not report a transport failure name as a provider error code", async () => {
-		// `@smithy/node-http-handler` throws `TimeoutError`, `@smithy/core` throws
-		// `CredentialsProviderError`. Both are real `Error`s with informative names, but
-		// neither is an AWS error code, and every modeled Bedrock error ends in "Exception".
+		// Real `Error`s with informative names, but not AWS codes; modeled ones end in "Exception".
 		const timeout = new Error("Connection timed out after 1000 ms");
 		timeout.name = "TimeoutError";
 		bedrockMock.send = respondWithFailingStream(timeout);
@@ -213,15 +194,11 @@ describe("bedrock failure diagnostics", () => {
 			}),
 		};
 
-		// A truncated request id is not a request id, so both are omitted and only
-		// the trustworthy field survives.
 		expect(findDiagnostic(await runBedrock())?.details).toEqual({ status: 400 });
 	});
 
 	it("omits the SDK's Unknown placeholder instead of reporting it as a code", async () => {
-		// `loadRestJsonErrorCode` falls back to "Unknown" when the response carried no
-		// `x-amzn-errortype`, e.g. a gateway 403 with an opaque body. It does not end in
-		// "Exception", so it is omitted rather than reported as a provider code.
+		// The SDK's fallback when the response carried no `x-amzn-errortype`.
 		bedrockMock.send = {
 			kind: "reject",
 			error: makeServiceException("Unknown", { $metadata: { httpStatusCode: 403, requestId: REQUEST_ID } }),

--- a/packages/ai/test/bedrock-error-metadata.test.ts
+++ b/packages/ai/test/bedrock-error-metadata.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type SendResult = { kind: "reject"; error: unknown } | { kind: "resolve"; response: unknown };
+
+const bedrockMock = vi.hoisted(() => ({
+	send: undefined as SendResult | undefined,
+	// Exposed so tests can build errors that are real instances of the mocked
+	// base class, which is what the provider's `instanceof` check sees.
+	ServiceException: undefined as unknown as new (message?: string) => Error,
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+	bedrockMock.ServiceException = BedrockRuntimeServiceException;
+
+	class BedrockRuntimeClient {
+		middlewareStack = { add: () => {} };
+
+		send(): Promise<unknown> {
+			const outcome = bedrockMock.send;
+			if (!outcome) return Promise.reject(new Error("test did not configure a send outcome"));
+			return outcome.kind === "reject" ? Promise.reject(outcome.error) : Promise.resolve(outcome.response);
+		}
+	}
+
+	class ConverseStreamCommand {
+		readonly input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+import { stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
+import { getModel } from "../src/compat.ts";
+import type { AssistantMessage, Context, Model } from "../src/types.ts";
+import type { AssistantMessageDiagnostic } from "../src/utils/diagnostics.ts";
+
+const DIAGNOSTIC_TYPE = "bedrock_response_failure";
+const VALIDATION_MESSAGE = "The provided model identifier is invalid.";
+const REQUEST_ID = "11111111-2222-3333-4444-555555555555";
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+
+function getModelFixture(): Model<"bedrock-converse-stream"> {
+	return getModel("amazon-bedrock", "us.anthropic.claude-opus-4-8");
+}
+
+/**
+ * A `BedrockRuntimeServiceException`, which is what the SDK's `handleError` path
+ * throws for a non-2xx HTTP response. `name` carries the modeled AWS error code.
+ */
+function makeServiceException(name: string, extra: Record<string, unknown> = {}): Error {
+	const error = new bedrockMock.ServiceException(VALIDATION_MESSAGE) as Error & Record<string, unknown>;
+	error.name = name;
+	Object.assign(error, extra);
+	return error;
+}
+
+/**
+ * Resolve `send()` with a stream that fails after `messageStart`. `thrown` is
+ * raised from inside the async iterator, which is where `@smithy/core`'s
+ * `getMessageUnmarshaller` raises stream exceptions.
+ */
+function respondWithFailingStream(thrown: unknown): SendResult {
+	return {
+		kind: "resolve",
+		response: {
+			$metadata: { httpStatusCode: 200, requestId: REQUEST_ID },
+			stream: (async function* () {
+				yield { messageStart: { role: "assistant" } };
+				throw thrown;
+			})(),
+		},
+	};
+}
+
+async function runBedrock(signal?: AbortSignal): Promise<AssistantMessage> {
+	return streamBedrock(getModelFixture(), context, { cacheRetention: "none", signal }).result();
+}
+
+function findDiagnostic(message: AssistantMessage): AssistantMessageDiagnostic | undefined {
+	return message.diagnostics?.find((d) => d.type === DIAGNOSTIC_TYPE);
+}
+
+beforeEach(() => {
+	bedrockMock.send = undefined;
+});
+
+describe("bedrock failure diagnostics", () => {
+	it("records status, error code and request id for a non-2xx from client.send()", async () => {
+		bedrockMock.send = {
+			kind: "reject",
+			error: makeServiceException("ValidationException", {
+				$metadata: { httpStatusCode: 400, requestId: REQUEST_ID },
+			}),
+		};
+
+		const message = await runBedrock();
+		const diagnostic = findDiagnostic(message);
+
+		expect(message.stopReason).toBe("error");
+		expect(diagnostic?.details).toEqual({ status: 400, errorCode: "ValidationException", requestId: REQUEST_ID });
+		// Details only: no `error` block, so no stack trace is persisted with the session.
+		expect(diagnostic?.error).toBeUndefined();
+		expect(Object.keys(diagnostic ?? {}).sort()).toEqual(["details", "timestamp", "type"]);
+	});
+
+	it("leaves errorMessage untouched so retry classification is unaffected", async () => {
+		bedrockMock.send = {
+			kind: "reject",
+			error: makeServiceException("ValidationException", {
+				$metadata: { httpStatusCode: 400, requestId: REQUEST_ID },
+				$response: { body: { pipe: () => {} } },
+			}),
+		};
+
+		// `isRetryableAssistantError` matches patterns against this exact string.
+		expect((await runBedrock()).errorMessage).toBe(`Validation error: ${VALIDATION_MESSAGE}`);
+	});
+
+	it("reports only the request id for a modeled mid-stream exception", async () => {
+		// This is the shape the installed SDK actually delivers. `@smithy/core`
+		// `getMessageUnmarshaller` throws `deserializedException[code]`, and the JSON
+		// shape deserializer built that value as a bare object literal: no prototype,
+		// no `$metadata`, no `name`. The AWS error code is destroyed by the SDK before
+		// it reaches us, so reporting one here would be a fabrication.
+		bedrockMock.send = respondWithFailingStream({ message: "Too many requests, please wait." });
+
+		const message = await runBedrock();
+
+		expect(message.stopReason).toBe("error");
+		expect(findDiagnostic(message)?.details).toEqual({ requestId: REQUEST_ID });
+	});
+
+	it("captures the error code for an unmodeled mid-stream error", async () => {
+		// The other unmarshaller branch (a `:message-type` of `error`, or an exception
+		// type missing from the union) throws a real `Error` whose `name` is the
+		// frame's `:error-code`. That code is recoverable, and the request id still
+		// comes from the initial response.
+		const unmodeled = new Error("Model stream terminated unexpectedly.");
+		unmodeled.name = "ModelStreamErrorException";
+		bedrockMock.send = respondWithFailingStream(unmodeled);
+
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			errorCode: "ModelStreamErrorException",
+			requestId: REQUEST_ID,
+		});
+	});
+
+	it("does not report a transport failure name as a provider error code", async () => {
+		// `@smithy/node-http-handler` throws `TimeoutError`, `@smithy/core` throws
+		// `CredentialsProviderError`. Both are real `Error`s with informative names, but
+		// neither is an AWS error code, and every modeled Bedrock error ends in "Exception".
+		const timeout = new Error("Connection timed out after 1000 ms");
+		timeout.name = "TimeoutError";
+		bedrockMock.send = respondWithFailingStream(timeout);
+
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({ requestId: REQUEST_ID });
+	});
+
+	it("emits no diagnostic when the failure carries no provider metadata", async () => {
+		bedrockMock.send = { kind: "reject", error: new Error("socket hang up") };
+
+		const message = await runBedrock();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toBe("socket hang up");
+		expect(findDiagnostic(message)).toBeUndefined();
+	});
+
+	it("emits no diagnostic for an aborted turn", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		bedrockMock.send = {
+			kind: "reject",
+			error: makeServiceException("ValidationException", {
+				$metadata: { httpStatusCode: 400, requestId: REQUEST_ID },
+			}),
+		};
+
+		const message = await runBedrock(controller.signal);
+
+		expect(message.stopReason).toBe("aborted");
+		expect(findDiagnostic(message)).toBeUndefined();
+	});
+
+	it("drops header-derived values that exceed the length bound", async () => {
+		bedrockMock.send = {
+			kind: "reject",
+			error: makeServiceException(`${"E".repeat(5000)}Exception`, {
+				$metadata: { httpStatusCode: 400, requestId: "R".repeat(5000) },
+			}),
+		};
+
+		// A truncated request id is not a request id, so both are omitted and only
+		// the trustworthy field survives.
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({ status: 400 });
+	});
+
+	it("omits the SDK's Unknown placeholder instead of reporting it as a code", async () => {
+		// `loadRestJsonErrorCode` falls back to "Unknown" when the response carried no
+		// `x-amzn-errortype`, e.g. a gateway 403 with an opaque body. It does not end in
+		// "Exception", so it is omitted rather than reported as a provider code.
+		bedrockMock.send = {
+			kind: "reject",
+			error: makeServiceException("Unknown", { $metadata: { httpStatusCode: 403, requestId: REQUEST_ID } }),
+		};
+
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			status: 403,
+			requestId: REQUEST_ID,
+		});
+	});
+});


### PR DESCRIPTION
Closes #7224.

## Scope

To be upfront about what this does and does not do: the noisy string in my original report (`Validation error: 400: {"_events":...}`) is **already fixed on main**. It was the serialized `ClientHttp2Stream` from `$response.body`, and #7081 fixed it in v0.82.1 by adding the unread-stream guard to `normalizeProviderError`. I filed the issue three days after that release, against an older version. Verified against current `main`:

```
errorMessage: "Validation error: The provided model identifier is invalid."
```

This PR addresses only the remaining half: the **structured metadata is still dropped**. The AWS SDK hands us everything on the thrown exception —

```
$metadata: { httpStatusCode: 400, requestId: "a0562e22-...", ... }
name: "ValidationException"
```

— but `normalizeProviderError` reports `messageCarriesBody: true`, so `formatBedrockError` uses only `norm.message` and the status, code, and request id are discarded. A failed turn ends up as a single opaque string, which is why downstream runtimes cannot classify a provider failure or correlate one with AWS support without parsing it.

## Approach

The mechanism already exists, so this adds **no new core type surface**: `AssistantMessage.diagnostics` is documented for exactly this ("Redacted provider/runtime diagnostics for failures and recoveries"). This adds `bedrock_response_failure`:

```json
{ "status": 400, "errorCode": "ValidationException", "requestId": "a0562e22-3ad5-4e0a-b403-921d53dd38e0" }
```

71 added lines in the provider, **zero existing lines changed**.

Deliberate choices:

- **`errorMessage` is byte-identical.** This was the main risk. `isRetryableAssistantError` classifies retries by regex over that string, and the `BEDROCK_ERROR_PREFIXES` comment documents the prefixes as load-bearing for it. Folding metadata into the message would have silently changed retry behavior, so the change is purely additive and a test pins the exact string.
- **`details` only, no `error` block**, as `pi_messages_rewrite` does. A modeled mid-stream exception is not an `Error` at all (see below), so routing the thrown value through `extractDiagnosticError` would persist `"[object Object]"` plus a stack trace pointing into the SDK. The readable text already lives in `errorMessage`; this diagnostic exists for the machine-readable fields.
- **`errorCode` comes from `error.name`**, which is where the SDK puts the modeled code for both paths that expose one: service exceptions from `client.send()` (via `x-amzn-errortype`), and the plain `Error` the event-stream unmarshaller throws for an unmodeled stream error (via the frame's `:error-code`). Gating on `instanceof BedrockRuntimeServiceException` would drop the latter. All 13 modeled Bedrock errors end in `Exception`, so that suffix is the gate; it excludes transport failures like `TimeoutError` and `CredentialsProviderError`, and the SDK's `Unknown` placeholder, without enumerating them.
- **A modeled mid-stream exception reports only a request id, on purpose.** `@smithy/core`'s `getMessageUnmarshaller` reads the code into a local `:exception-type` and then throws `deserializedException[code]`, which `JsonShapeDeserializer` built as a bare object literal — no prototype, no `$metadata`, no `name`. The code is destroyed by the SDK before it reaches the provider, so claiming one would be a fabrication. The request id from the initial response is threaded through as a fallback so these failures stay correlatable.
- **`details.status`** matches the key `pi_messages_response_failure` already uses.
- **Over-long header-derived values are dropped, not truncated.** A truncated request id is not a request id.
- **Aborted turns emit no diagnostic.**

Worth flagging separately, since it is pre-existing and not touched here: because the unmarshaller throws from inside the async iterator, the `else if (item.validationException)` chain in the stream loop is unreachable with `@aws-sdk/client-bedrock-runtime@3.1048.0`, so `formatBedrockError`'s comment about stream event items extending `BedrockRuntimeServiceException` is stale and mid-stream failures never get a `BEDROCK_ERROR_PREFIXES` prefix. Happy to file that separately rather than widen this diff.

## Why Bedrock only

The issue is Bedrock-specific, and `normalizeProviderError` already centralizes status/body extraction, so extending this to other providers later is cheap and needs no redesign. Doing it generically up front would touch the error path of every provider for a problem demonstrated on one, which reads like the core bloat CONTRIBUTING.md warns about. Happy to generalize it if you would rather have it that way.

## Testing

`npm run check` and `./test.sh` both pass (Node 22).

New: `packages/ai/test/bedrock-error-metadata.test.ts`, nine cases reusing the existing `vi.mock("@aws-sdk/client-bedrock-runtime")` pattern from `bedrock-custom-headers.test.ts`. The two mid-stream cases raise the failure from inside the async iterator with the value shape the installed SDK actually produces (a bare object literal for the modeled case) rather than a fabricated exception instance, so they encode real behavior instead of assumed behavior.

Beyond the unit tests I verified against real Bedrock (`us-west-2`), since a mock cannot prove the SDK exposes these fields:

| Case | status | errorCode | requestId | retryable |
|---|---|---|---|---|
| nonexistent model (the issue repro) | 400 | `ValidationException` | real | false |
| no model entitlement | 403 | `AccessDeniedException` | real | false |

And against a local HTTP/2 server so the SDK's real error deserialization runs, confirming retry classification is unchanged in both directions: 400 → not retryable, 503 `ServiceUnavailableException` → retryable.
