### PR TITLE
fix(coding-agent): queue extension commands after agent runs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Extensions can explicitly schedule a registered extension command at the current agent operation's settled boundary with `pi.queueCommand()`.
+
+### Fixed
+
+- The LLM-callable reload example now uses the native control queue instead of sending model-visible slash-prefixed user text.
+
 ## [0.83.0] - 2026-07-29
 
 ### New Features

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1296,7 +1296,7 @@ Important behavior:
 
 For predictable behavior, treat reload as terminal for that handler (`await ctx.reload(); return;`).
 
-Tools run with `ExtensionContext`, so they cannot call `ctx.reload()` directly. Use a command as the reload entrypoint, then expose a tool that queues that command as a follow-up user message.
+Tools run with `ExtensionContext`, so they cannot call `ctx.reload()` directly. Use a command as the reload entrypoint, then expose a tool that explicitly queues that registered command for the current agent operation's settled boundary. `pi.queueCommand()` does not create a user message or reinterpret extension-origin text as a command.
 
 Example tool the LLM can call to trigger reload:
 
@@ -1319,9 +1319,10 @@ export default function (pi: ExtensionAPI) {
     description: "Reload extensions, skills, prompts, themes, and context files",
     parameters: Type.Object({}),
     async execute() {
-      pi.sendUserMessage("/reload-runtime", { deliverAs: "followUp" });
+      pi.queueCommand("reload-runtime");
       return {
-        content: [{ type: "text", text: "Queued /reload-runtime as a follow-up command." }],
+        content: [{ type: "text", text: "Queued native runtime reload." }],
+        terminate: true,
       };
     },
   });
@@ -1434,7 +1435,18 @@ pi.sendUserMessage("And then summarize", { deliverAs: "followUp" });
 
 When not streaming, the message is sent immediately and triggers a new turn. When streaming without `deliverAs`, throws an error.
 
-See [send-user-message.ts](../examples/extensions/send-user-message.ts) for a complete example.
+See [send-user-message.ts](../examples/extensions/send-user-message.ts) for a complete example. Slash-prefixed text sent through `sendUserMessage()` remains model-visible user data; it never invokes an extension command.
+
+### pi.queueCommand(name, args?)
+
+Queue an exact registered extension command to run after the current agent operation settles. This explicit control queue is separate from model-visible steering/follow-up messages: it appends no user message, starts no provider turn, and does not parse slash-prefixed text. The name is the command's invocation name without `/`; arguments are passed verbatim. Calls made while idle or for an unknown command throw synchronously.
+
+```typescript
+pi.queueCommand("reload-runtime");
+pi.queueCommand("handoff", "optional args");
+```
+
+Queued commands run FIFO once streaming stops, before `agent_settled` is emitted and before the originating prompt resolves. Commands from an aborted run or replaced extension runtime are discarded. Handler failures use normal extension-command error reporting and do not create a model turn. A tool that must prevent an automatic provider continuation should also return `terminate: true`; in a parallel tool batch every result must terminate.
 
 ### pi.appendEntry(customType, data?)
 
@@ -2897,7 +2909,7 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `handoff.ts` | Cross-provider model handoff | `registerCommand`, `ui.editor`, `ui.custom` |
 | `qna.ts` | Q&A with custom UI | `registerCommand`, `ui.custom`, `setEditorText` |
 | `send-user-message.ts` | Inject user messages | `registerCommand`, `sendUserMessage` |
-| `reload-runtime.ts` | Reload command and LLM tool handoff | `registerCommand`, `ctx.reload()`, `sendUserMessage` |
+| `reload-runtime.ts` | Reload command and LLM tool handoff | `registerCommand`, `ctx.reload()`, `pi.queueCommand()` |
 | `shutdown-command.ts` | Graceful shutdown command | `registerCommand`, `shutdown()` |
 | **Events & Gates** |||
 | `permission-gate.ts` | Block dangerous commands | `on("tool_call")`, `ui.confirm` |

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -75,7 +75,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `overlay-qa-tests.ts` | Comprehensive overlay QA tests: anchors, margins, stacking, overflow, animation |
 | `doom-overlay/` | DOOM game running as an overlay at 35 FPS (demonstrates real-time game rendering) |
 | `shutdown-command.ts` | Adds `/quit` command demonstrating `ctx.shutdown()` |
-| `reload-runtime.ts` | Adds `/reload-runtime` and `reload_runtime` tool showing safe reload flow |
+| `reload-runtime.ts` | Queues a native reload command from an LLM tool with `pi.queueCommand()` |
 | `interactive-shell.ts` | Run interactive commands (vim, htop) with full terminal via `user_bash` hook |
 | `inline-bash.ts` | Expands `!{command}` patterns in prompts via `input` event transformation |
 | `input-transform-streaming.ts` | Skips expensive input preprocessing for mid-stream steering via `streamingBehavior` |

--- a/packages/coding-agent/examples/extensions/reload-runtime.ts
+++ b/packages/coding-agent/examples/extensions/reload-runtime.ts
@@ -20,17 +20,18 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	// LLM-callable tool. Tools get ExtensionContext, so they cannot call ctx.reload() directly.
-	// Instead, queue a follow-up user command that executes the command above.
+	// Instead, queue the registered command for the current agent operation's settled boundary.
 	pi.registerTool({
 		name: "reload_runtime",
 		label: "Reload Runtime",
 		description: "Reload extensions, skills, prompts, themes, and context files",
 		parameters: Type.Object({}),
 		async execute() {
-			pi.sendUserMessage("/reload-runtime", { deliverAs: "followUp" });
+			pi.queueCommand("reload-runtime");
 			return {
-				content: [{ type: "text", text: "Queued /reload-runtime as a follow-up command." }],
+				content: [{ type: "text", text: "Queued native runtime reload." }],
 				details: {},
+				terminate: true,
 			};
 		},
 	});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -77,6 +77,7 @@ import {
 	type MessageStartEvent,
 	type MessageUpdateEvent,
 	type ReplacedSessionContext,
+	type ResolvedCommand,
 	type SessionBeforeCompactResult,
 	type SessionBeforeTreeResult,
 	type SessionStartEvent,
@@ -311,6 +312,9 @@ export class AgentSession {
 	private _unsubscribeAgent?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _isAgentRunActive = false;
+	private _agentRunGeneration = 0;
+	private _abortedAgentRuns = new Set<number>();
+	private _disposed = false;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
 
@@ -320,6 +324,13 @@ export class AgentSession {
 	private _followUpMessages: string[] = [];
 	/** Messages queued to be included with the next user prompt as context ("asides"). */
 	private _pendingNextTurnMessages: CustomMessage[] = [];
+	/** Extension commands queued explicitly for the current agent operation's settled boundary. */
+	private _pendingExtensionCommands: Array<{
+		command: ResolvedCommand;
+		args: string;
+		runner: ExtensionRunner;
+		generation: number;
+	}> = [];
 
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
@@ -578,12 +589,17 @@ export class AgentSession {
 		resolve();
 	}
 
-	private async _emitAgentSettled(): Promise<void> {
+	private async _emitAgentSettled(generation: number): Promise<void> {
+		if (generation !== this._agentRunGeneration) return;
 		this._isAgentRunActive = false;
 		try {
+			await this._drainExtensionCommands(generation);
+			if (this._disposed || generation !== this._agentRunGeneration) return;
 			await this._extensionRunner.emit({ type: "agent_settled" });
+			if (this._disposed || generation !== this._agentRunGeneration) return;
 			this._emit({ type: "agent_settled" });
 		} finally {
+			this._abortedAgentRuns.delete(generation);
 			this._resolveIdleWaitIfIdle();
 		}
 	}
@@ -835,6 +851,9 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	dispose(): void {
+		this._disposed = true;
+		this._abortedAgentRuns.add(this._agentRunGeneration);
+		this._pendingExtensionCommands = [];
 		try {
 			this.abortRetry();
 			this.abortCompaction();
@@ -1060,6 +1079,7 @@ export class AgentSession {
 
 	private async _runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void> {
 		this._isAgentRunActive = true;
+		const generation = ++this._agentRunGeneration;
 		try {
 			await this.agent.prompt(messages);
 			while (await this._handlePostAgentRun()) {
@@ -1068,7 +1088,7 @@ export class AgentSession {
 		} finally {
 			this._systemPromptOverride = undefined;
 			this._flushPendingBashMessages();
-			await this._emitAgentSettled();
+			await this._emitAgentSettled(generation);
 		}
 	}
 
@@ -1078,6 +1098,7 @@ export class AgentSession {
 		if (!msg) {
 			return false;
 		}
+		if (msg.stopReason === "aborted") this._abortedAgentRuns.add(this._agentRunGeneration);
 
 		if (this._isRetryableError(msg) && (await this._prepareRetry(msg))) {
 			return true;
@@ -1267,30 +1288,54 @@ export class AgentSession {
 	/**
 	 * Try to execute an extension command. Returns true if command was found and executed.
 	 */
-	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
-		// Parse command name and args
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+	private _queueExtensionCommand(runner: ExtensionRunner, name: string, args = ""): void {
+		if (!this._isAgentRunActive) {
+			throw new Error("Extension commands can only be queued during an active agent operation.");
+		}
+		const command = runner.getCommand(name);
+		if (!command) throw new Error(`Unknown extension command: /${name}`);
+		this._pendingExtensionCommands.push({ command, args, runner, generation: this._agentRunGeneration });
+	}
 
-		const command = this._extensionRunner.getCommand(commandName);
-		if (!command) return false;
+	private async _drainExtensionCommands(generation: number): Promise<void> {
+		while (!this._disposed && generation === this._agentRunGeneration) {
+			const index = this._pendingExtensionCommands.findIndex((queued) => queued.generation === generation);
+			if (index === -1) return;
+			const [queued] = this._pendingExtensionCommands.splice(index, 1);
+			if (this._abortedAgentRuns.has(generation) || queued.runner !== this._extensionRunner) continue;
+			await this._executeExtensionCommand(queued.command, queued.args, queued.runner);
+		}
+		this._pendingExtensionCommands = this._pendingExtensionCommands.filter(
+			(queued) => queued.generation !== generation,
+		);
+	}
 
-		// Get command context from extension runner (includes session control methods)
-		const ctx = this._extensionRunner.createCommandContext();
-
+	private async _executeExtensionCommand(
+		command: ResolvedCommand,
+		args: string,
+		runner: ExtensionRunner,
+	): Promise<void> {
+		const ctx = runner.createCommandContext();
 		try {
 			await command.handler(args, ctx);
-			return true;
 		} catch (err) {
-			// Emit error via extension runner
-			this._extensionRunner.emitError({
-				extensionPath: `command:${commandName}`,
+			(this._disposed ? runner : this._extensionRunner).emitError({
+				extensionPath: `command:${command.invocationName}`,
 				event: "command",
 				error: err instanceof Error ? err.message : String(err),
 			});
-			return true;
 		}
+	}
+
+	private async _tryExecuteExtensionCommand(text: string): Promise<boolean> {
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+		const runner = this._extensionRunner;
+		const command = runner.getCommand(commandName);
+		if (!command) return false;
+		await this._executeExtensionCommand(command, args, runner);
+		return true;
 	}
 
 	/**
@@ -1540,6 +1585,7 @@ export class AgentSession {
 	 * Abort current operation and wait for agent to become idle.
 	 */
 	async abort(): Promise<void> {
+		if (this._isAgentRunActive) this._abortedAgentRuns.add(this._agentRunGeneration);
 		this.abortRetry();
 		this.agent.abort();
 		await this.waitForIdle();
@@ -1928,6 +1974,9 @@ export class AgentSession {
 	 * Cancel in-progress compaction (manual or auto).
 	 */
 	abortCompaction(): void {
+		if (this._isAgentRunActive && (this._compactionAbortController || this._autoCompactionAbortController)) {
+			this._abortedAgentRuns.add(this._agentRunGeneration);
+		}
 		this._compactionAbortController?.abort();
 		this._autoCompactionAbortController?.abort();
 	}
@@ -2374,6 +2423,7 @@ export class AgentSession {
 						});
 					});
 				},
+				queueCommand: (name, args) => this._queueExtensionCommand(runner, name, args),
 				appendEntry: (customType, data) => {
 					const entryId = this.sessionManager.appendCustomEntry(customType, data);
 					const entry = this.sessionManager.getEntry(entryId);
@@ -2729,6 +2779,9 @@ export class AgentSession {
 	 * Cancel in-progress retry.
 	 */
 	abortRetry(): void {
+		if (this._isAgentRunActive && this._retryAbortController) {
+			this._abortedAgentRuns.add(this._agentRunGeneration);
+		}
 		this._retryAbortController?.abort();
 	}
 

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -181,6 +181,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 	const runtime: ExtensionRuntime = {
 		sendMessage: notInitialized,
 		sendUserMessage: notInitialized,
+		queueCommand: notInitialized,
 		appendEntry: notInitialized,
 		setSessionName: notInitialized,
 		getSessionName: notInitialized,
@@ -309,6 +310,11 @@ function createExtensionAPI(
 		sendUserMessage(content, options): void {
 			runtime.assertActive();
 			runtime.sendUserMessage(content, options);
+		},
+
+		queueCommand(name: string, args?: string): void {
+			runtime.assertActive();
+			runtime.queueCommand(name, args);
 		},
 
 		appendEntry(customType: string, data?: unknown): void {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -322,6 +322,7 @@ export class ExtensionRunner {
 		// Copy actions into the shared runtime (all extension APIs reference this)
 		this.runtime.sendMessage = actions.sendMessage;
 		this.runtime.sendUserMessage = actions.sendUserMessage;
+		this.runtime.queueCommand = actions.queueCommand;
 		this.runtime.appendEntry = actions.appendEntry;
 		this.runtime.setSessionName = actions.setSessionName;
 		this.runtime.getSessionName = actions.getSessionName;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1297,6 +1297,9 @@ export interface ExtensionAPI {
 		options?: { deliverAs?: "steer" | "followUp" },
 	): void;
 
+	/** Queue an exact registered extension command for the current agent operation's settled boundary. */
+	queueCommand(name: string, args?: string): void;
+
 	/** Append a custom entry to the session for state persistence (not sent to LLM). */
 	appendEntry<T = unknown>(customType: string, data?: T): void;
 
@@ -1540,6 +1543,8 @@ export type SendUserMessageHandler = (
 	options?: { deliverAs?: "steer" | "followUp" },
 ) => void;
 
+export type QueueCommandHandler = (name: string, args?: string) => void;
+
 export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
 
 export type SetSessionNameHandler = (name: string) => void;
@@ -1601,6 +1606,7 @@ export interface ExtensionRuntimeState {
 export interface ExtensionActions {
 	sendMessage: SendMessageHandler;
 	sendUserMessage: SendUserMessageHandler;
+	queueCommand: QueueCommandHandler;
 	appendEntry: AppendEntryHandler;
 	setSessionName: SetSessionNameHandler;
 	getSessionName: GetSessionNameHandler;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -75,6 +75,7 @@ describe("ExtensionRunner", () => {
 	const extensionActions: ExtensionActions = {
 		sendMessage: () => {},
 		sendUserMessage: () => {},
+		queueCommand: () => {},
 		appendEntry: () => {},
 		setSessionName: () => {},
 		getSessionName: () => undefined,

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -89,6 +89,244 @@ describe("AgentSession queue characterization", () => {
 		expect(harness.session.messages).toEqual([]);
 	});
 
+	it("runs an explicitly queued extension command after settling without a model-visible user message", async () => {
+		const commandRuns: string[] = [];
+		let streamingAtCommand = true;
+		let unknownCommandError = "";
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("testcmd", {
+						description: "Test command",
+						handler: async (args) => {
+							streamingAtCommand = harness.session.isStreaming;
+							commandRuns.push(args);
+						},
+					});
+					pi.registerCommand("failcmd", {
+						description: "Failing test command",
+						handler: async () => {
+							throw new Error("queued failure exactly");
+						},
+					});
+					pi.registerTool({
+						name: "queue_testcmd",
+						label: "Queue Test Command",
+						description: "Queue the test command",
+						parameters: Type.Object({}),
+						execute: async () => {
+							try {
+								pi.queueCommand("missing");
+							} catch (error) {
+								unknownCommandError = String(error);
+							}
+							pi.queueCommand("failcmd");
+							pi.queueCommand("testcmd", "queued exactly");
+							return {
+								content: [{ type: "text", text: "queued" }],
+								details: {},
+								terminate: true,
+							};
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const commandErrors: string[] = [];
+		harness.session.extensionRunner.onError((error) => commandErrors.push(`${error.event}:${error.error}`));
+		harness.setResponses([fauxAssistantMessage(fauxToolCall("queue_testcmd", {}), { stopReason: "toolUse" })]);
+
+		await harness.session.prompt("start");
+
+		expect(commandRuns).toEqual(["queued exactly"]);
+		expect(streamingAtCommand).toBe(false);
+		expect(unknownCommandError).toContain("Unknown extension command: /missing");
+		expect(commandErrors).toEqual(["command:queued failure exactly"]);
+		expect(getUserTexts(harness)).toEqual(["start"]);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("rejects extension command scheduling while idle", async () => {
+		let extensionApi: ExtensionAPI | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					extensionApi = pi;
+					pi.registerCommand("testcmd", { handler: async () => {} });
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		expect(() => extensionApi?.queueCommand("testcmd")).toThrow(
+			"Extension commands can only be queued during an active agent operation.",
+		);
+	});
+
+	it("discards commands queued by an aborted agent run", async () => {
+		let extensionApi: ExtensionAPI | undefined;
+		let commandRuns = 0;
+		const waiting = await createWaitingHarness({
+			extensionFactories: [
+				(pi) => {
+					extensionApi = pi;
+					pi.registerCommand("testcmd", {
+						handler: async () => {
+							commandRuns += 1;
+						},
+					});
+				},
+			],
+		});
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" })]);
+
+		await waitForToolStart;
+		extensionApi?.queueCommand("testcmd");
+		const abortPromise = harness.session.abort();
+		releaseToolExecution();
+		await Promise.all([promptPromise, abortPromise]);
+
+		expect(commandRuns).toBe(0);
+	});
+
+	it("drains control commands before a settled handler can start another agent run", async () => {
+		const order: string[] = [];
+		let sentNested = false;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("testcmd", {
+						handler: async () => {
+							order.push(`command:${harness.session.isStreaming}`);
+						},
+					});
+					pi.registerTool({
+						name: "queue_testcmd",
+						label: "Queue Test Command",
+						description: "Queue the test command",
+						parameters: Type.Object({}),
+						execute: async () => {
+							pi.queueCommand("testcmd");
+							return { content: [{ type: "text", text: "queued" }], details: {}, terminate: true };
+						},
+					});
+					pi.on("agent_settled", async () => {
+						if (sentNested) return;
+						sentNested = true;
+						order.push("settled");
+						pi.sendUserMessage("nested run");
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("queue_testcmd", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("nested complete"),
+		]);
+
+		await harness.session.prompt("start");
+		await harness.session.waitForIdle();
+
+		expect(order.slice(0, 2)).toEqual(["command:false", "settled"]);
+		expect(getUserTexts(harness)).toEqual(["start", "nested run"]);
+	});
+
+	it("isolates nested-run commands and discards stale commands from the outer generation", async () => {
+		let oldCommandRuns = 0;
+		let nestedCommandRuns = 0;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("start_nested", {
+						handler: async () => {
+							await harness.session.prompt("nested run");
+						},
+					});
+					pi.registerCommand("old_after", {
+						handler: async () => {
+							oldCommandRuns += 1;
+						},
+					});
+					pi.registerCommand("nested", {
+						handler: async () => {
+							nestedCommandRuns += 1;
+						},
+					});
+					pi.registerTool({
+						name: "queue_outer",
+						label: "Queue Outer Commands",
+						description: "Queue outer-generation commands",
+						parameters: Type.Object({}),
+						execute: async () => {
+							pi.queueCommand("start_nested");
+							pi.queueCommand("old_after");
+							return { content: [{ type: "text", text: "queued" }], details: {}, terminate: true };
+						},
+					});
+					pi.registerTool({
+						name: "queue_nested",
+						label: "Queue Nested Command",
+						description: "Queue a nested-generation command",
+						parameters: Type.Object({}),
+						execute: async () => {
+							pi.queueCommand("nested");
+							return { content: [{ type: "text", text: "queued" }], details: {}, terminate: true };
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("queue_outer", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage(fauxToolCall("queue_nested", {}), { stopReason: "toolUse" }),
+		]);
+
+		await harness.session.prompt("start");
+
+		expect(oldCommandRuns).toBe(0);
+		expect(nestedCommandRuns).toBe(1);
+		expect(getUserTexts(harness)).toEqual(["start", "nested run"]);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("discards remaining commands when the session is disposed", async () => {
+		let secondCommandRuns = 0;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.registerCommand("dispose", { handler: async () => harness.session.dispose() });
+					pi.registerCommand("second", {
+						handler: async () => {
+							secondCommandRuns += 1;
+						},
+					});
+					pi.registerTool({
+						name: "queue_dispose",
+						label: "Queue Dispose",
+						description: "Queue session disposal",
+						parameters: Type.Object({}),
+						execute: async () => {
+							pi.queueCommand("dispose");
+							pi.queueCommand("second");
+							return { content: [{ type: "text", text: "queued" }], details: {}, terminate: true };
+						},
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage(fauxToolCall("queue_dispose", {}), { stopReason: "toolUse" })]);
+
+		await harness.session.prompt("start");
+
+		expect(secondCommandRuns).toBe(0);
+	});
+
 	it("delivers extension-origin steering messages before the next LLM call", async () => {
 		let extensionApi: ExtensionAPI | undefined;
 		const waiting = await createWaitingHarness({


### PR DESCRIPTION
## Summary

- add explicit `pi.queueCommand(name, args?)` control-plane scheduling for registered extension commands
- dispatch captured commands only at their originating `AgentSession` operation's non-streaming settled boundary
- preserve raw/model-visible slash `sendUserMessage()` behavior from #2023
- repair the LLM-callable native reload example with `pi.queueCommand()` + `terminate: true`

This rebases the previously reviewed implementation onto current `earendil-works/pi@78465346` (`0.83.0`). It directly addresses #7277 and the broken documented reload workaround: `sendUserMessage("/reload-runtime", {deliverAs:"followUp"})` disables slash expansion and sends literal model-visible text instead of invoking the command.

## Safety semantics

- no user/custom message, provider turn, process, session, or transcript entry is created by the scheduler
- exact resolved command, args, runner, and operation generation are captured
- aborted, disposed, superseded-generation, and replaced-runner commands are discarded
- nested `AgentSession` runs drain their own generation without consuming stale outer commands
- handler failures retain normal command error reporting and FIFO continuation

## Verification

- `npx vitest --run packages/coding-agent/test/suite/agent-session-queue.test.ts packages/coding-agent/test/extensions-runner.test.ts` — 57 passed
- rebased cleanly onto current main; `git diff --check origin/main...HEAD` passes
- the earlier v0.82.1 backport passed the full coding-agent suite: 1,632 passed, 48 skipped
- independent adversarial review passed after reentrant-settlement, abort-provenance, disposal, and nested-generation fixes

The only repository-wide typecheck failures in the reused workspace are unrelated generated model-catalog drift across `packages/ai`; focused coding-agent tests and the changed surfaces pass.
