### PR TITLE
feat(coding-agent): support checkpoint-free context recovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a terminal `session_before_compact` handled result so extensions can replace automatic context pressure without appending a compaction checkpoint, including same-operation retry after interrupted overflow recovery.
+- Added `summaryCheckpoints.enabled` so lossless context extensions can disable native and extension-provided compaction and branch-summary checkpoints while retaining pressure events and unsummarized tree navigation.
+
+### Fixed
+
+- Run automatic compaction handlers before summary credential resolution and make ordinary session abort cancel in-flight compaction handlers.
+
 ## [0.83.0] - 2026-07-29
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Fixed
 
-- Run automatic compaction handlers before summary credential resolution and make ordinary session abort cancel in-flight compaction handlers.
+- Run automatic compaction handlers before summary credential resolution; make abort/disposal settle pre-prompt compaction before any provider request; and advertise overflow retry only when the caller continues that same operation.
+- Represent unavailable native compaction preparation as an explicit discriminated event state instead of a structurally valid empty checkpoint sentinel.
 
 ## [0.83.0] - 2026-07-29
 

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -22,6 +22,13 @@ Pi has two summarization mechanisms:
 
 Both use the same structured summary format and track file operations cumulatively. Compaction and branch-summary requests use fresh routing session IDs and, where supported by the provider, disable prompt-cache writes because these one-off prompts are unlikely to be reused.
 
+Set `summaryCheckpoints.enabled` to `false` when an extension owns lossless context projection. Pi still
+emits automatic compaction events—even when no native checkpoint cut can be prepared—and an extension
+may handle pressure checkpoint-free or cancel it,
+but Pi refuses native and extension-provided `CompactionEntry` or `BranchSummaryEntry` summaries.
+Manual `/compact` and summarized `/tree` navigation then fail explicitly; unsummarized navigation is
+unchanged.
+
 ## Compaction
 
 ### When It Triggers
@@ -294,7 +301,13 @@ pi.on("session_before_compact", async (event, ctx) => {
   // signal - AbortSignal (pass to LLM calls)
 
   // Cancel:
-  return { cancel: true };
+  return { action: "cancel", errorMessage: "Optional reason" };
+  // Legacy `{ cancel: true }` remains supported.
+
+  // Or handle automatic pressure with an extension-owned context projection and
+  // no compaction checkpoint. For a retrying overflow only, `retry: true` tells
+  // Pi to continue the same interrupted operation through its existing loop.
+  return { action: "handled", retry: reason === "overflow" && willRetry };
 
   // Custom summary:
   return {
@@ -308,6 +321,8 @@ pi.on("session_before_compact", async (event, ctx) => {
   };
 });
 ```
+
+For automatic compaction, the hook runs before Pi resolves summarization credentials. A handled or cancelled event therefore does not require summary-model authentication. `action: "handled"` is terminal for the event: later extensions are not run, no `CompactionEntry` or `session_compact` event is created, and `retry: true` is rejected outside an interrupted overflow recovery.
 
 #### Converting Messages to Text
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -454,13 +454,24 @@ Fired on compaction. See [compaction.md](compaction.md) for details.
 
 ```typescript
 pi.on("session_before_compact", async (event, ctx) => {
-  const { preparation, branchEntries, customInstructions, reason, willRetry, signal } = event;
+  const {
+    preparation, preparationAvailable, tokensBefore, settings,
+    branchEntries, customInstructions, reason, willRetry, signal,
+  } = event;
 
   // reason - "manual" (/compact), "threshold", or "overflow"
   // willRetry - whether the aborted turn is retried after compaction (overflow recovery)
+  // preparationAvailable - false when native summary cutting is impossible; accounting and
+  // terminal handled/cancel outcomes remain available. Do not return `compaction` in that case.
 
   // Cancel:
-  return { cancel: true };
+  return { action: "cancel", errorMessage: "Optional reason" };
+  // Legacy `{ cancel: true }` remains supported.
+
+  // Handle automatic context pressure without appending a compaction checkpoint.
+  // `retry: true` is valid only for reason="overflow", willRetry=true; Pi then
+  // continues the same interrupted agent operation without adding a user message.
+  return { action: "handled", retry: reason === "overflow" && willRetry };
 
   // Custom summary:
   return {
@@ -480,6 +491,8 @@ pi.on("session_compact", async (event, ctx) => {
   // event.willRetry - whether the aborted turn is retried after compaction (overflow recovery)
 });
 ```
+
+`action: "handled"` and `action: "cancel"` are terminal: later handlers do not overwrite them. A handled event appends no `CompactionEntry` and emits no `session_compact`; automatic handling also runs before Pi resolves summarization credentials. With `summaryCheckpoints.enabled: false`, Pi rejects both native and extension-provided compaction summaries while still permitting these terminal checkpoint-free outcomes.
 
 #### session_before_tree / session_tree
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -461,8 +461,9 @@ pi.on("session_before_compact", async (event, ctx) => {
 
   // reason - "manual" (/compact), "threshold", or "overflow"
   // willRetry - whether the aborted turn is retried after compaction (overflow recovery)
-  // preparationAvailable - false when native summary cutting is impossible; accounting and
-  // terminal handled/cancel outcomes remain available. Do not return `compaction` in that case.
+  // preparationAvailable - false when native summary cutting is impossible; `preparation`
+  // is then undefined while accounting and terminal handled/cancel outcomes remain available.
+  // Do not return `compaction` in that case.
 
   // Cancel:
   return { action: "cancel", errorMessage: "Optional reason" };

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -106,6 +106,17 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 }
 ```
 
+### Summary Checkpoints
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `summaryCheckpoints.enabled` | boolean | `true` | Permit compaction and branch-summary checkpoint entries |
+
+Set this to `false` when an extension owns lossless context projection. Automatic compaction events
+still fire so an extension can return `{ action: "handled" }` or `{ action: "cancel" }`, but Pi will
+not generate or accept a compaction summary. `/compact` and `/tree` navigation with summarization fail
+explicitly; tree navigation without summarization remains available.
+
 ### Compaction
 
 | Setting | Type | Default | Description |

--- a/packages/coding-agent/examples/extensions/custom-compaction.ts
+++ b/packages/coding-agent/examples/extensions/custom-compaction.ts
@@ -21,6 +21,9 @@ import { convertToLlm, serializeConversation } from "@earendil-works/pi-coding-a
 export default function (pi: ExtensionAPI) {
 	pi.on("session_before_compact", async (event, ctx) => {
 		ctx.ui.notify("Custom compaction extension triggered", "info");
+		if (!event.preparationAvailable) {
+			return { action: "cancel", errorMessage: "Custom compaction requires a native preparation cut" };
+		}
 
 		const { preparation, branchEntries: _, signal } = event;
 		const { messagesToSummarize, turnPrefixMessages, tokensBefore, firstKeptEntryId, previousSummary } = preparation;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -56,6 +56,7 @@ import {
 	calculateContextTokens,
 	collectEntriesForBranchSummary,
 	compact,
+	createFileOps,
 	estimateContextTokens,
 	estimateTokens,
 	generateBranchSummary,
@@ -135,6 +136,15 @@ export function parseSkillBlock(text: string): ParsedSkillBlock | null {
 	};
 }
 
+const isArrayIntrinsic = Array.isArray;
+const getOwnPropertyDescriptorIntrinsic = Object.getOwnPropertyDescriptor;
+
+function ownDataProperty(value: unknown, key: string): unknown {
+	if (!value || typeof value !== "object" || isArrayIntrinsic(value)) return undefined;
+	const descriptor = getOwnPropertyDescriptorIntrinsic(value, key);
+	return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
 /** Session-specific events that extend the core AgentEvent */
 export type AgentSessionEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
@@ -160,6 +170,7 @@ export type AgentSessionEvent =
 			aborted: boolean;
 			willRetry: boolean;
 			errorMessage?: string;
+			handledByExtension?: boolean;
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
@@ -1541,6 +1552,7 @@ export class AgentSession {
 	 */
 	async abort(): Promise<void> {
 		this.abortRetry();
+		this.abortCompaction();
 		this.agent.abort();
 		await this.waitForIdle();
 	}
@@ -1791,8 +1803,6 @@ export class AgentSession {
 				throw new Error(formatNoModelSelectedMessage());
 			}
 
-			const { apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model);
-
 			const pathEntries = this.sessionManager.getBranch();
 			const settings = this.settingsManager.getCompactionSettings();
 
@@ -1813,6 +1823,9 @@ export class AgentSession {
 				const result = (await this._extensionRunner.emit({
 					type: "session_before_compact",
 					preparation,
+					preparationAvailable: true,
+					tokensBefore: preparation.tokensBefore,
+					settings,
 					branchEntries: pathEntries,
 					customInstructions,
 					reason: "manual",
@@ -1820,15 +1833,36 @@ export class AgentSession {
 					signal: this._compactionAbortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
-				if (result?.cancel) {
-					throw new Error("Compaction cancelled");
+				const action = ownDataProperty(result, "action");
+				if (action === "handled") {
+					throw new Error(
+						"Extensions may handle automatic context pressure only; manual compaction was not performed",
+					);
 				}
+				if (action === "cancel" || ownDataProperty(result, "cancel") === true) {
+					const message = ownDataProperty(result, "errorMessage");
+					throw new Error(typeof message === "string" && message ? message : "Compaction cancelled");
+				}
+				if (action !== undefined) throw new Error("Unknown session_before_compact action");
 
-				if (result?.compaction) {
-					extensionCompaction = result.compaction;
+				const compaction = ownDataProperty(result, "compaction");
+				if (compaction) {
+					extensionCompaction = compaction as CompactionResult;
 					fromExtension = true;
 				}
 			}
+
+			if (!this.settingsManager.getSummaryCheckpointsEnabled()) {
+				throw new Error("Summary checkpoints are disabled; use extension-owned lossless context management");
+			}
+			if (this._compactionAbortController.signal.aborted) throw new Error("Compaction cancelled");
+			let apiKey: string | undefined;
+			let headers: Record<string, string> | undefined;
+			let env: Record<string, string> | undefined;
+			if (!extensionCompaction) {
+				({ apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model));
+			}
+			if (this._compactionAbortController.signal.aborted) throw new Error("Compaction cancelled");
 
 			let summary: string;
 			let firstKeptEntryId: string;
@@ -2001,12 +2035,22 @@ export class AgentSession {
 			}
 
 			this._overflowRecoveryAttempted = true;
-			// Remove the error message from agent state (it IS saved to session for history,
-			// but we don't want it in context for the retry)
+			// Remove only the exact rejected response from live retry context. It remains
+			// persisted in the append-only session history for diagnostics.
 			const messages = this.agent.state.messages;
-			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
-				this.agent.state.messages = messages.slice(0, -1);
+			if (messages[messages.length - 1] !== assistantMessage) {
+				this._emit({
+					type: "compaction_end",
+					reason: "overflow",
+					result: undefined,
+					aborted: false,
+					willRetry: false,
+					errorMessage:
+						"Context overflow recovery stopped because the rejected response was not the live context tail.",
+				});
+				return false;
 			}
+			this.agent.state.messages = messages.slice(0, -1);
 			return await this._runAutoCompaction("overflow", willRetry);
 		}
 
@@ -2053,21 +2097,19 @@ export class AgentSession {
 				return false;
 			}
 
-			let apiKey: string | undefined;
-			let headers: Record<string, string> | undefined;
-			let env: Record<string, string> | undefined;
-			if (this.agent.streamFunction === streamSimple) {
-				({ apiKey, headers, env } = await this._getRequiredRequestAuth(this.model));
-			} else {
-				({ apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model));
-			}
-
 			const pathEntries = this.sessionManager.getBranch();
-
-			const preparation = prepareCompaction(pathEntries, settings);
-			if (!preparation) {
-				return false;
-			}
+			const nativePreparation = prepareCompaction(pathEntries, settings);
+			const estimatedTokensBefore =
+				nativePreparation?.tokensBefore ?? estimateMessagesTokens(this.agent.state.messages);
+			const preparation = nativePreparation ?? {
+				firstKeptEntryId: "",
+				messagesToSummarize: [],
+				turnPrefixMessages: [],
+				isSplitTurn: false,
+				tokensBefore: estimatedTokensBefore,
+				fileOps: createFileOps(),
+				settings,
+			};
 
 			this._emit({ type: "compaction_start", reason });
 			this._autoCompactionAbortController = new AbortController();
@@ -2080,6 +2122,9 @@ export class AgentSession {
 				const extensionResult = (await this._extensionRunner.emit({
 					type: "session_before_compact",
 					preparation,
+					preparationAvailable: nativePreparation !== undefined,
+					tokensBefore: estimatedTokensBefore,
+					settings,
 					branchEntries: pathEntries,
 					customInstructions: undefined,
 					reason,
@@ -2087,21 +2132,69 @@ export class AgentSession {
 					signal: this._autoCompactionAbortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
-				if (extensionResult?.cancel) {
+				if (this._autoCompactionAbortController.signal.aborted) {
+					this._emit({ type: "compaction_end", reason, result: undefined, aborted: true, willRetry: false });
+					return false;
+				}
+
+				const action = ownDataProperty(extensionResult, "action");
+				if (action === "handled") {
+					const retry = ownDataProperty(extensionResult, "retry") === true;
+					if (retry && (reason !== "overflow" || !willRetry)) {
+						throw new Error("An extension may retry only an interrupted overflow recovery");
+					}
 					this._emit({
 						type: "compaction_end",
 						reason,
 						result: undefined,
-						aborted: true,
+						aborted: false,
+						willRetry: retry,
+						handledByExtension: true,
+					});
+					return retry;
+				}
+				if (action === "cancel" || ownDataProperty(extensionResult, "cancel") === true) {
+					const message = ownDataProperty(extensionResult, "errorMessage");
+					this._emit({
+						type: "compaction_end",
+						reason,
+						result: undefined,
+						aborted: typeof message !== "string" || !message,
 						willRetry: false,
+						...(typeof message === "string" && message ? { errorMessage: message } : {}),
 					});
 					return false;
 				}
+				if (action !== undefined) throw new Error("Unknown session_before_compact action");
 
-				if (extensionResult?.compaction) {
-					extensionCompaction = extensionResult.compaction;
+				const compaction = ownDataProperty(extensionResult, "compaction");
+				if (compaction) {
+					extensionCompaction = compaction as CompactionResult;
 					fromExtension = true;
 				}
+			}
+
+			if (!nativePreparation) {
+				throw new Error(
+					"Native compaction cannot select a safe checkpoint cut; an extension must handle or cancel",
+				);
+			}
+			if (!this.settingsManager.getSummaryCheckpointsEnabled()) {
+				throw new Error("Summary checkpoints are disabled; extension did not handle context pressure");
+			}
+			let apiKey: string | undefined;
+			let headers: Record<string, string> | undefined;
+			let env: Record<string, string> | undefined;
+			if (!extensionCompaction) {
+				if (this.agent.streamFunction === streamSimple) {
+					({ apiKey, headers, env } = await this._getRequiredRequestAuth(this.model));
+				} else {
+					({ apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model));
+				}
+			}
+			if (this._autoCompactionAbortController.signal.aborted) {
+				this._emit({ type: "compaction_end", reason, result: undefined, aborted: true, willRetry: false });
+				return false;
 			}
 
 			let summary: string;
@@ -2898,6 +2991,9 @@ export class AgentSession {
 	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
 		if (this.isStreaming) {
 			throw new Error("Wait for the current response to finish before navigating the session tree.");
+		}
+		if (options.summarize && !this.settingsManager.getSummaryCheckpointsEnabled()) {
+			throw new Error("Summary checkpoints are disabled; navigate without summarizing the abandoned branch");
 		}
 
 		const oldLeafId = this.sessionManager.getLeafId();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -56,7 +56,6 @@ import {
 	calculateContextTokens,
 	collectEntriesForBranchSummary,
 	compact,
-	createFileOps,
 	estimateContextTokens,
 	estimateTokens,
 	generateBranchSummary,
@@ -322,6 +321,8 @@ export class AgentSession {
 	private _unsubscribeAgent?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _isAgentRunActive = false;
+	private _abortEpoch = 0;
+	private _disposed = false;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
 
@@ -580,7 +581,7 @@ export class AgentSession {
 	}
 
 	private _resolveIdleWaitIfIdle(): void {
-		if (this._isAgentRunActive || !this._resolveIdleWait) {
+		if (!this.isIdle || !this._resolveIdleWait) {
 			return;
 		}
 		const resolve = this._resolveIdleWait;
@@ -846,6 +847,8 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	dispose(): void {
+		this._disposed = true;
+		this._abortEpoch++;
 		try {
 			this.abortRetry();
 			this.abortCompaction();
@@ -890,7 +893,13 @@ export class AgentSession {
 
 	/** Whether the session has no active agent run, retry, auto-compaction, or queued continuation. */
 	get isIdle(): boolean {
-		return !this._isAgentRunActive;
+		return (
+			!this._isAgentRunActive &&
+			this._retryAbortController === undefined &&
+			this._autoCompactionAbortController === undefined &&
+			this._compactionAbortController === undefined &&
+			this._branchSummaryAbortController === undefined
+		);
 	}
 
 	/** Current effective system prompt (includes any per-turn extension modifications) */
@@ -1123,6 +1132,8 @@ export class AgentSession {
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<void> {
+		if (this._disposed) throw new Error("Agent session is disposed");
+		const abortEpoch = this._abortEpoch;
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
 		let messages: AgentMessage[] | undefined;
@@ -1209,7 +1220,11 @@ export class AgentSession {
 			// The user's new prompt is sent below, so do not call agent.continue() here.
 			const lastAssistant = this._findLastAssistantMessage();
 			if (lastAssistant) {
-				await this._checkCompaction(lastAssistant, false);
+				await this._checkCompaction(lastAssistant, false, false);
+			}
+			if (this._disposed || this._abortEpoch !== abortEpoch) {
+				preflightResult?.(true);
+				return;
 			}
 
 			// Build messages array (custom message if any, then user message)
@@ -1271,6 +1286,10 @@ export class AgentSession {
 			return;
 		}
 
+		if (this._disposed || this._abortEpoch !== abortEpoch) {
+			preflightResult?.(true);
+			return;
+		}
 		preflightResult?.(true);
 		await this._runAgentPrompt(messages);
 	}
@@ -1551,6 +1570,7 @@ export class AgentSession {
 	 * Abort current operation and wait for agent to become idle.
 	 */
 	async abort(): Promise<void> {
+		this._abortEpoch++;
 		this.abortRetry();
 		this.abortCompaction();
 		this.agent.abort();
@@ -1954,6 +1974,7 @@ export class AgentSession {
 			throw error;
 		} finally {
 			this._compactionAbortController = undefined;
+			this._resolveIdleWaitIfIdle();
 			this._reconnectToAgent();
 		}
 	}
@@ -1983,8 +2004,13 @@ export class AgentSession {
 	 *
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
+	 * @param allowOverflowRetry Whether the caller will consume a true result by continuing the interrupted operation
 	 */
-	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
+	private async _checkCompaction(
+		assistantMessage: AssistantMessage,
+		skipAbortedCheck = true,
+		allowOverflowRetry = true,
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled) return false;
 
@@ -2015,9 +2041,15 @@ export class AgentSession {
 		// but must not retry: the assistant answer already completed and agent.continue() cannot
 		// continue from an assistant message.
 		if (sameModel && isContextOverflow(assistantMessage, contextWindow)) {
-			const willRetry = assistantMessage.stopReason !== "stop";
+			const willRetry = allowOverflowRetry && assistantMessage.stopReason !== "stop";
 
 			if (!willRetry) {
+				if (assistantMessage.stopReason !== "stop") {
+					const messages = this.agent.state.messages;
+					if (messages[messages.length - 1] === assistantMessage) {
+						this.agent.state.messages = messages.slice(0, -1);
+					}
+				}
 				return await this._runAutoCompaction("overflow", false);
 			}
 
@@ -2089,50 +2121,49 @@ export class AgentSession {
 	 * Internal: Run auto-compaction with events.
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
-		const settings = this.settingsManager.getCompactionSettings();
 		let started = false;
+		let controller: AbortController | undefined;
 
 		try {
 			if (!this.model) {
 				return false;
 			}
 
+			controller = new AbortController();
+			this._autoCompactionAbortController = controller;
+			started = true;
+			this._emit({ type: "compaction_start", reason });
+			if (controller.signal.aborted) {
+				this._emit({ type: "compaction_end", reason, result: undefined, aborted: true, willRetry: false });
+				return false;
+			}
+
+			const settings = this.settingsManager.getCompactionSettings();
 			const pathEntries = this.sessionManager.getBranch();
 			const nativePreparation = prepareCompaction(pathEntries, settings);
 			const estimatedTokensBefore =
 				nativePreparation?.tokensBefore ?? estimateMessagesTokens(this.agent.state.messages);
-			const preparation = nativePreparation ?? {
-				firstKeptEntryId: "",
-				messagesToSummarize: [],
-				turnPrefixMessages: [],
-				isSplitTurn: false,
-				tokensBefore: estimatedTokensBefore,
-				fileOps: createFileOps(),
-				settings,
-			};
-
-			this._emit({ type: "compaction_start", reason });
-			this._autoCompactionAbortController = new AbortController();
-			started = true;
 
 			let extensionCompaction: CompactionResult | undefined;
 			let fromExtension = false;
 
 			if (this._extensionRunner.hasHandlers("session_before_compact")) {
+				const preparationFields = nativePreparation
+					? { preparationAvailable: true as const, preparation: nativePreparation }
+					: { preparationAvailable: false as const, preparation: undefined };
 				const extensionResult = (await this._extensionRunner.emit({
 					type: "session_before_compact",
-					preparation,
-					preparationAvailable: nativePreparation !== undefined,
+					...preparationFields,
 					tokensBefore: estimatedTokensBefore,
 					settings,
 					branchEntries: pathEntries,
 					customInstructions: undefined,
 					reason,
 					willRetry,
-					signal: this._autoCompactionAbortController.signal,
+					signal: controller.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
-				if (this._autoCompactionAbortController.signal.aborted) {
+				if (controller.signal.aborted) {
 					this._emit({ type: "compaction_end", reason, result: undefined, aborted: true, willRetry: false });
 					return false;
 				}
@@ -2192,7 +2223,7 @@ export class AgentSession {
 					({ apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model));
 				}
 			}
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (controller.signal.aborted) {
 				this._emit({ type: "compaction_end", reason, result: undefined, aborted: true, willRetry: false });
 				return false;
 			}
@@ -2213,12 +2244,12 @@ export class AgentSession {
 			} else {
 				// Generate compaction result
 				const compactResult = await compact(
-					preparation,
+					nativePreparation,
 					this.model,
 					apiKey,
 					headers,
 					undefined,
-					this._autoCompactionAbortController.signal,
+					controller.signal,
 					this.thinkingLevel,
 					this.agent.streamFunction,
 					env,
@@ -2232,7 +2263,7 @@ export class AgentSession {
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (controller.signal.aborted) {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -2303,7 +2334,10 @@ export class AgentSession {
 			}
 			return false;
 		} finally {
-			this._autoCompactionAbortController = undefined;
+			if (this._autoCompactionAbortController === controller) {
+				this._autoCompactionAbortController = undefined;
+			}
+			this._resolveIdleWaitIfIdle();
 		}
 	}
 
@@ -2813,6 +2847,7 @@ export class AgentSession {
 			return false;
 		} finally {
 			this._retryAbortController = undefined;
+			this._resolveIdleWaitIfIdle();
 		}
 
 		return true;
@@ -3177,6 +3212,7 @@ export class AgentSession {
 			return { editorText, cancelled: false, summaryEntry };
 		} finally {
 			this._branchSummaryAbortController = undefined;
+			this._resolveIdleWaitIfIdle();
 		}
 	}
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -157,6 +157,15 @@ type RunnerEmitResult<TEvent extends RunnerEmitEvent> = TEvent extends { type: "
 				? SessionBeforeTreeResult | undefined
 				: undefined;
 
+const isArrayIntrinsic = Array.isArray;
+const getOwnPropertyDescriptorIntrinsic = Object.getOwnPropertyDescriptor;
+
+function ownDataProperty(value: unknown, key: string): unknown {
+	if (!value || typeof value !== "object" || isArrayIntrinsic(value)) return undefined;
+	const descriptor = getOwnPropertyDescriptorIntrinsic(value, key);
+	return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
 export type ExtensionErrorListener = (error: ExtensionError) => void;
 
 export type NewSessionHandler = (options?: {
@@ -807,7 +816,11 @@ export class ExtensionRunner {
 
 					if (this.isSessionBeforeEvent(event) && handlerResult) {
 						result = handlerResult as SessionBeforeEventResult;
-						if (result.cancel) {
+						const action = ownDataProperty(result, "action");
+						if (
+							ownDataProperty(result, "cancel") === true ||
+							(event.type === "session_before_compact" && (action === "handled" || action === "cancel"))
+						) {
 							return result as RunnerEmitResult<TEvent>;
 						}
 					}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -47,7 +47,7 @@ import type {
 import type { Static, TSchema } from "typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
 import type { BashResult } from "../bash-executor.ts";
-import type { CompactionPreparation, CompactionResult } from "../compaction/index.ts";
+import type { CompactionPreparation, CompactionResult, CompactionSettings } from "../compaction/index.ts";
 import type { EventBus } from "../event-bus.ts";
 import type { ExecOptions, ExecResult } from "../exec.ts";
 import type { ReadonlyFooterDataProvider } from "../footer-data-provider.ts";
@@ -591,7 +591,13 @@ export interface SessionBeforeForkEvent {
 /** Fired before context compaction (can be cancelled or customized) */
 export interface SessionBeforeCompactEvent {
 	type: "session_before_compact";
+	/** Native summary preparation. Fields are empty sentinels when preparationAvailable is false. */
 	preparation: CompactionPreparation;
+	/** False when no valid native summary cut exists; terminal extension outcomes may still handle pressure. */
+	preparationAvailable: boolean;
+	/** Native accounting is available even when summary preparation is not. */
+	tokensBefore: number;
+	settings: CompactionSettings;
 	branchEntries: SessionEntry[];
 	customInstructions?: string;
 	/** What triggered the compaction: manual /compact, the context threshold, or context overflow recovery */
@@ -1109,10 +1115,32 @@ export interface SessionBeforeForkResult {
 	skipConversationRestore?: boolean;
 }
 
-export interface SessionBeforeCompactResult {
-	cancel?: boolean;
-	compaction?: CompactionResult;
-}
+export type SessionBeforeCompactResult =
+	| {
+			/** The extension fully handled automatic context pressure without creating a compaction checkpoint. */
+			action: "handled";
+			/** Continue the interrupted agent operation. Valid only for retrying overflow recovery. */
+			retry?: boolean;
+			cancel?: never;
+			compaction?: never;
+			errorMessage?: never;
+	  }
+	| {
+			/** Cancel compaction without claiming that the context pressure was handled. */
+			action: "cancel";
+			errorMessage?: string;
+			retry?: never;
+			cancel?: never;
+			compaction?: never;
+	  }
+	| {
+			/** Backward-compatible cancellation or custom checkpoint result. */
+			action?: never;
+			cancel?: boolean;
+			compaction?: CompactionResult;
+			retry?: never;
+			errorMessage?: never;
+	  };
 
 export interface SessionBeforeTreeResult {
 	cancel?: boolean;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -588,13 +588,9 @@ export interface SessionBeforeForkEvent {
 	position: "before" | "at";
 }
 
-/** Fired before context compaction (can be cancelled or customized) */
-export interface SessionBeforeCompactEvent {
+/** Fields common to every context-pressure event. */
+interface SessionBeforeCompactEventBase {
 	type: "session_before_compact";
-	/** Native summary preparation. Fields are empty sentinels when preparationAvailable is false. */
-	preparation: CompactionPreparation;
-	/** False when no valid native summary cut exists; terminal extension outcomes may still handle pressure. */
-	preparationAvailable: boolean;
 	/** Native accounting is available even when summary preparation is not. */
 	tokensBefore: number;
 	settings: CompactionSettings;
@@ -606,6 +602,21 @@ export interface SessionBeforeCompactEvent {
 	willRetry: boolean;
 	signal: AbortSignal;
 }
+
+/** Fired before context compaction (can be cancelled, customized, or handled without a checkpoint). */
+export type SessionBeforeCompactEvent = SessionBeforeCompactEventBase &
+	(
+		| {
+				/** A valid native summary cut is available. */
+				preparationAvailable: true;
+				preparation: CompactionPreparation;
+		  }
+		| {
+				/** No valid native summary cut exists; terminal extension outcomes may still handle pressure. */
+				preparationAvailable: false;
+				preparation: undefined;
+		  }
+	);
 
 /** Fired after context compaction */
 export interface SessionCompactEvent {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -14,6 +14,10 @@ export interface CompactionSettings {
 	keepRecentTokens?: number; // default: 20000
 }
 
+export interface SummaryCheckpointSettings {
+	enabled?: boolean; // default: true
+}
+
 export interface BranchSummarySettings {
 	reserveTokens?: number; // default: 16384 (tokens reserved for prompt + LLM response)
 	skipPrompt?: boolean; // default: false - when true, skips "Summarize branch?" prompt and defaults to no summary
@@ -90,6 +94,7 @@ export interface Settings {
 	followUpMode?: "all" | "one-at-a-time";
 	theme?: string;
 	compaction?: CompactionSettings;
+	summaryCheckpoints?: SummaryCheckpointSettings;
 	branchSummary?: BranchSummarySettings;
 	retry?: RetrySettings;
 	hideThinkingBlock?: boolean;
@@ -784,6 +789,10 @@ export class SettingsManager {
 			reserveTokens: this.getCompactionReserveTokens(),
 			keepRecentTokens: this.getCompactionKeepRecentTokens(),
 		};
+	}
+
+	getSummaryCheckpointsEnabled(): boolean {
+		return this.settings.summaryCheckpoints?.enabled ?? true;
 	}
 
 	getBranchSummarySettings(): { reserveTokens: number; skipPrompt: boolean } {

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -169,6 +169,7 @@ describe("AgentSession auto-compaction queue resume", () => {
 			}
 		});
 
+		session.agent.state.messages.push(overflowMessage);
 		const checkCompaction = (
 			session as unknown as {
 				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;

--- a/packages/coding-agent/test/branch-summary-extensions.test.ts
+++ b/packages/coding-agent/test/branch-summary-extensions.test.ts
@@ -12,6 +12,34 @@ describe("Branch summary extensions", () => {
 		}
 	});
 
+	it("rejects native and extension branch summaries when summary checkpoints are disabled", async () => {
+		let extensionCalls = 0;
+		const harness = await createHarness({
+			settings: { summaryCheckpoints: { enabled: false } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_tree", () => {
+						extensionCalls++;
+						return { summary: { summary: "forbidden branch checkpoint" } };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const targetId = harness.sessionManager.appendMessage(userMsg("first branch"));
+		harness.sessionManager.appendMessage(assistantMsg("first reply"));
+		harness.sessionManager.appendMessage(userMsg("abandoned branch work"));
+		const leafBefore = harness.sessionManager.appendMessage(assistantMsg("abandoned reply"));
+
+		await expect(harness.session.navigateTree(targetId, { summarize: true })).rejects.toThrow(
+			"Summary checkpoints are disabled",
+		);
+		expect(extensionCalls).toBe(0);
+		expect(harness.sessionManager.getLeafId()).toBe(leafBefore);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "branch_summary")).toHaveLength(0);
+	});
+
 	it("persists extension-provided summary usage in session totals", async () => {
 		const usage: Usage = {
 			input: 10,

--- a/packages/coding-agent/test/compaction-extensions-example.test.ts
+++ b/packages/coding-agent/test/compaction-extensions-example.test.ts
@@ -10,6 +10,7 @@ describe("Documentation example", () => {
 		// This is the example from extensions.md - verify it compiles
 		const exampleExtension = (pi: ExtensionAPI) => {
 			pi.on("session_before_compact", async (event: SessionBeforeCompactEvent, ctx) => {
+				if (!event.preparationAvailable) return { action: "cancel" };
 				// All these should be accessible on the event
 				const { preparation, branchEntries } = event;
 				// sessionManager, modelRegistry, and model come from ctx

--- a/packages/coding-agent/test/compaction-extensions.test.ts
+++ b/packages/coding-agent/test/compaction-extensions.test.ts
@@ -142,11 +142,12 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 		expect(compactEvents.length).toBe(1);
 
 		const beforeEvent = beforeCompactEvents[0];
-		expect(beforeEvent.preparation).toBeDefined();
-		expect(beforeEvent.preparation.messagesToSummarize).toBeDefined();
-		expect(beforeEvent.preparation.turnPrefixMessages).toBeDefined();
-		expect(beforeEvent.preparation.tokensBefore).toBeGreaterThanOrEqual(0);
-		expect(typeof beforeEvent.preparation.isSplitTurn).toBe("boolean");
+		expect(beforeEvent.preparationAvailable).toBe(true);
+		const preparation = beforeEvent.preparation!;
+		expect(preparation.messagesToSummarize).toBeDefined();
+		expect(preparation.turnPrefixMessages).toBeDefined();
+		expect(preparation.tokensBefore).toBeGreaterThanOrEqual(0);
+		expect(typeof preparation.isSplitTurn).toBe("boolean");
 		expect(beforeEvent.branchEntries).toBeDefined();
 		// sessionManager, modelRegistry, and model are now on ctx, not event
 
@@ -174,7 +175,7 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 		const customSummary = "Custom summary from extension";
 
 		const extension = createExtension((event) => {
-			if (event.type === "session_before_compact") {
+			if (event.type === "session_before_compact" && event.preparationAvailable) {
 				return {
 					compaction: {
 						summary: customSummary,
@@ -369,13 +370,15 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 
 		expect(capturedBeforeEvent).not.toBeNull();
 		const event = capturedBeforeEvent!;
-		expect(typeof event.preparation.isSplitTurn).toBe("boolean");
-		expect(event.preparation.firstKeptEntryId).toBeDefined();
+		expect(event.preparationAvailable).toBe(true);
+		const preparation = event.preparation!;
+		expect(typeof preparation.isSplitTurn).toBe("boolean");
+		expect(preparation.firstKeptEntryId).toBeDefined();
 
-		expect(Array.isArray(event.preparation.messagesToSummarize)).toBe(true);
-		expect(Array.isArray(event.preparation.turnPrefixMessages)).toBe(true);
+		expect(Array.isArray(preparation.messagesToSummarize)).toBe(true);
+		expect(Array.isArray(preparation.turnPrefixMessages)).toBe(true);
 
-		expect(typeof event.preparation.tokensBefore).toBe("number");
+		expect(typeof preparation.tokensBefore).toBe("number");
 
 		expect(Array.isArray(event.branchEntries)).toBe(true);
 
@@ -392,7 +395,7 @@ describe.skipIf(!API_KEY)("Compaction extensions", () => {
 		const customSummary = "Custom summary with modified values";
 
 		const extension = createExtension((event) => {
-			if (event.type === "session_before_compact") {
+			if (event.type === "session_before_compact" && event.preparationAvailable) {
 				return {
 					compaction: {
 						summary: customSummary,

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -109,15 +109,18 @@ describe("AgentSession compaction characterization", () => {
 			settings: { compaction: { keepRecentTokens: 1 } },
 			extensionFactories: [
 				(pi) => {
-					pi.on("session_before_compact", async (event) => ({
-						compaction: {
-							summary: "summary from extension",
-							firstKeptEntryId: event.preparation.firstKeptEntryId,
-							tokensBefore: event.preparation.tokensBefore,
-							usage: summaryUsage,
-							details: { source: "extension" },
-						},
-					}));
+					pi.on("session_before_compact", async (event) => {
+						if (!event.preparationAvailable) return { action: "cancel" };
+						return {
+							compaction: {
+								summary: "summary from extension",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								usage: summaryUsage,
+								details: { source: "extension" },
+							},
+						};
+					});
 				},
 			],
 		});
@@ -286,13 +289,16 @@ describe("AgentSession compaction characterization", () => {
 			},
 			extensionFactories: [
 				(pi) => {
-					pi.on("session_before_compact", async (event) => ({
-						compaction: {
-							summary: "forbidden extension checkpoint",
-							firstKeptEntryId: event.preparation.firstKeptEntryId,
-							tokensBefore: event.preparation.tokensBefore,
-						},
-					}));
+					pi.on("session_before_compact", async (event) => {
+						if (!event.preparationAvailable) return { action: "cancel" };
+						return {
+							compaction: {
+								summary: "forbidden extension checkpoint",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+							},
+						};
+					});
 				},
 			],
 		});
@@ -327,7 +333,7 @@ describe("AgentSession compaction characterization", () => {
 	});
 
 	it("emits automatic pressure to extensions even when no native checkpoint cut exists", async () => {
-		let observed: { available: boolean; firstKeptEntryId: string; tokensBefore: number } | undefined;
+		let observed: { available: boolean; preparation: unknown; tokensBefore: number } | undefined;
 		const harness = await createHarness({
 			settings: { summaryCheckpoints: { enabled: false } },
 			extensionFactories: [
@@ -335,7 +341,7 @@ describe("AgentSession compaction characterization", () => {
 					pi.on("session_before_compact", async (event) => {
 						observed = {
 							available: event.preparationAvailable,
-							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							preparation: event.preparation,
 							tokensBefore: event.tokensBefore,
 						};
 						return { action: "cancel", errorMessage: "No safe lossless projection" };
@@ -347,7 +353,7 @@ describe("AgentSession compaction characterization", () => {
 		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
 
 		await expect(sessionInternals._runAutoCompaction("overflow", true)).resolves.toBe(false);
-		expect(observed).toEqual({ available: false, firstKeptEntryId: "", tokensBefore: 0 });
+		expect(observed).toEqual({ available: false, preparation: undefined, tokensBefore: 0 });
 		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
 			reason: "overflow",
 			errorMessage: "No safe lossless projection",
@@ -386,14 +392,17 @@ describe("AgentSession compaction characterization", () => {
 			settings: { compaction: { keepRecentTokens: 1 } },
 			extensionFactories: [
 				(pi) => {
-					pi.on("session_before_compact", async (event) => ({
-						compaction: {
-							summary: "auto compacted",
-							firstKeptEntryId: event.preparation.firstKeptEntryId,
-							tokensBefore: event.preparation.tokensBefore,
-							details: {},
-						},
-					}));
+					pi.on("session_before_compact", async (event) => {
+						if (!event.preparationAvailable) return { action: "cancel" };
+						return {
+							compaction: {
+								summary: "auto compacted",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
 				},
 			],
 		});
@@ -541,6 +550,42 @@ describe("AgentSession compaction characterization", () => {
 		});
 	});
 
+	it("honors synchronous abort and disposal from compaction_start before running handlers", async () => {
+		for (const dispose of [false, true]) {
+			let handlerCalls = 0;
+			const harness = await createHarness({
+				settings: { compaction: { keepRecentTokens: 1 } },
+				extensionFactories: [
+					(pi) => {
+						pi.on("session_before_compact", async () => {
+							handlerCalls++;
+							return { action: "handled", retry: true };
+						});
+					},
+				],
+			});
+			harnesses.push(harness);
+			seedCompactableSession(harness);
+			const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type !== "compaction_start") return;
+				if (dispose) harness.session.dispose();
+				else harness.session.abortCompaction();
+			});
+
+			await expect(sessionInternals._runAutoCompaction("overflow", true)).resolves.toBe(false);
+			unsubscribe();
+			expect(handlerCalls).toBe(0);
+			expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+			if (!dispose) {
+				expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+					aborted: true,
+					willRetry: false,
+				});
+			}
+		}
+	});
+
 	it("aborts an in-flight handled overflow before it can retry or checkpoint", async () => {
 		let entered!: () => void;
 		const started = new Promise<void>((resolve) => {
@@ -683,14 +728,17 @@ describe("AgentSession compaction characterization", () => {
 			models: [{ id: "faux-1", contextWindow: 1, maxTokens: 100 }],
 			extensionFactories: [
 				(pi) => {
-					pi.on("session_before_compact", async (event) => ({
-						compaction: {
-							summary: "successful overflow compacted",
-							firstKeptEntryId: event.preparation.firstKeptEntryId,
-							tokensBefore: event.preparation.tokensBefore,
-							details: {},
-						},
-					}));
+					pi.on("session_before_compact", async (event) => {
+						if (!event.preparationAvailable) return { action: "cancel" };
+						return {
+							compaction: {
+								summary: "successful overflow compacted",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
 				},
 			],
 		});

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -148,6 +148,26 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.messages[0]?.role).toBe("compactionSummary");
 	});
 
+	it("runs a terminal manual compaction handler before summary auth", async () => {
+		const harness = await createHarness({
+			withConfiguredAuth: false,
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						action: "cancel",
+						errorMessage: "Native summaries are disabled; use the reversible context projection",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+
+		await expect(harness.session.compact()).rejects.toThrow("Native summaries are disabled");
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+	});
+
 	it("throws when compacting without a model", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -156,9 +176,10 @@ describe("AgentSession compaction characterization", () => {
 		await expect(harness.session.compact()).rejects.toThrow("No model selected");
 	});
 
-	it("throws when compacting without configured auth", async () => {
+	it("throws when compacting compactable context without configured auth", async () => {
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);
+		seedCompactableSession(harness);
 
 		await expect(harness.session.compact()).rejects.toThrow(`No API key found for ${harness.getModel().provider}.`);
 	});
@@ -242,6 +263,98 @@ describe("AgentSession compaction characterization", () => {
 		expect(getStreamCallCount()).toBe(1);
 	});
 
+	it("disables every native or extension-provided compaction checkpoint while preserving handled pressure", async () => {
+		const nativeHarness = await createHarness({
+			withConfiguredAuth: false,
+			settings: {
+				compaction: { keepRecentTokens: 1 },
+				summaryCheckpoints: { enabled: false },
+			},
+		});
+		harnesses.push(nativeHarness);
+		seedCompactableSession(nativeHarness);
+		const nativeInternals = nativeHarness.session as unknown as SessionWithCompactionInternals;
+		await expect(nativeInternals._runAutoCompaction("threshold", false)).resolves.toBe(false);
+		await expect(nativeHarness.session.compact()).rejects.toThrow("Summary checkpoints are disabled");
+		expect(nativeHarness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+
+		const extensionHarness = await createHarness({
+			withConfiguredAuth: false,
+			settings: {
+				compaction: { keepRecentTokens: 1 },
+				summaryCheckpoints: { enabled: false },
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "forbidden extension checkpoint",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(extensionHarness);
+		seedCompactableSession(extensionHarness);
+		const extensionInternals = extensionHarness.session as unknown as SessionWithCompactionInternals;
+		await expect(extensionInternals._runAutoCompaction("threshold", false)).resolves.toBe(false);
+		expect(extensionHarness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(
+			0,
+		);
+
+		const handledHarness = await createHarness({
+			withConfiguredAuth: false,
+			settings: {
+				compaction: { keepRecentTokens: 1 },
+				summaryCheckpoints: { enabled: false },
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({ action: "handled", retry: false }));
+				},
+			],
+		});
+		harnesses.push(handledHarness);
+		seedCompactableSession(handledHarness);
+		const handledInternals = handledHarness.session as unknown as SessionWithCompactionInternals;
+		await expect(handledInternals._runAutoCompaction("threshold", false)).resolves.toBe(false);
+		expect(handledHarness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			handledByExtension: true,
+			aborted: false,
+		});
+	});
+
+	it("emits automatic pressure to extensions even when no native checkpoint cut exists", async () => {
+		let observed: { available: boolean; firstKeptEntryId: string; tokensBefore: number } | undefined;
+		const harness = await createHarness({
+			settings: { summaryCheckpoints: { enabled: false } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						observed = {
+							available: event.preparationAvailable,
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.tokensBefore,
+						};
+						return { action: "cancel", errorMessage: "No safe lossless projection" };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		await expect(sessionInternals._runAutoCompaction("overflow", true)).resolves.toBe(false);
+		expect(observed).toEqual({ available: false, firstKeptEntryId: "", tokensBefore: 0 });
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			reason: "overflow",
+			errorMessage: "No safe lossless projection",
+			willRetry: false,
+		});
+	});
+
 	it("cancels in-progress manual compaction when abortCompaction is called", async () => {
 		const harness = await createHarness({
 			settings: { compaction: { keepRecentTokens: 1 } },
@@ -302,6 +415,223 @@ describe("AgentSession compaction characterization", () => {
 		await expect(sessionInternals._runAutoCompaction("threshold", false)).resolves.toBe(true);
 	});
 
+	it("lets an extension handle overflow and retry without a compaction checkpoint or summary auth", async () => {
+		const harness = await createHarness({
+			withConfiguredAuth: false,
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) =>
+						event.reason === "overflow" && event.willRetry ? { action: "handled", retry: true } : undefined,
+					);
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		await expect(sessionInternals._runAutoCompaction("overflow", true)).resolves.toBe(true);
+
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			reason: "overflow",
+			aborted: false,
+			willRetry: true,
+			handledByExtension: true,
+			result: undefined,
+		});
+	});
+
+	it("handles a completed over-window response without retry or checkpoint", async () => {
+		const harness = await createHarness({
+			withConfiguredAuth: false,
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) =>
+						event.reason === "overflow" && !event.willRetry ? { action: "handled", retry: false } : undefined,
+					);
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		await expect(sessionInternals._runAutoCompaction("overflow", false)).resolves.toBe(false);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			reason: "overflow",
+			aborted: false,
+			willRetry: false,
+			handledByExtension: true,
+		});
+	});
+
+	it("treats handled compaction as terminal across extension handlers", async () => {
+		let laterCalls = 0;
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({ action: "handled", retry: true }));
+				},
+				(pi) => {
+					pi.on("session_before_compact", async () => {
+						laterCalls++;
+						return undefined;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		await expect(sessionInternals._runAutoCompaction("overflow", true)).resolves.toBe(true);
+		expect(laterCalls).toBe(0);
+	});
+
+	it("does not dispatch mutable globals or action coercion at the extension result boundary", async () => {
+		let result: object;
+		let descriptorCalls = 0;
+		let arrayCalls = 0;
+		let coercions = 0;
+		const unknownAction = {
+			toString: () => {
+				coercions++;
+				return "handled";
+			},
+		};
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => {
+						result = { action: unknownAction };
+						return result as never;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const originalDescriptor = Object.getOwnPropertyDescriptor;
+		const originalArray = Array.isArray;
+		Object.getOwnPropertyDescriptor = ((value: object, key: PropertyKey) => {
+			if (value === result) descriptorCalls++;
+			return originalDescriptor(value, key);
+		}) as typeof Object.getOwnPropertyDescriptor;
+		Array.isArray = ((value: unknown) => {
+			if (value === result) arrayCalls++;
+			return originalArray(value);
+		}) as typeof Array.isArray;
+		try {
+			await expect(sessionInternals._runAutoCompaction("threshold", false)).resolves.toBe(false);
+		} finally {
+			Object.getOwnPropertyDescriptor = originalDescriptor;
+			Array.isArray = originalArray;
+		}
+		expect({ descriptorCalls, arrayCalls, coercions }).toEqual({
+			descriptorCalls: 0,
+			arrayCalls: 0,
+			coercions: 0,
+		});
+	});
+
+	it("aborts an in-flight handled overflow before it can retry or checkpoint", async () => {
+		let entered!: () => void;
+		const started = new Promise<void>((resolve) => {
+			entered = resolve;
+		});
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						entered();
+						await new Promise<void>((resolve) =>
+							event.signal.addEventListener("abort", () => resolve(), { once: true }),
+						);
+						return { action: "handled", retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		const recovery = sessionInternals._runAutoCompaction("overflow", true);
+		await started;
+		await harness.session.abort();
+		await expect(recovery).resolves.toBe(false);
+
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({ aborted: true, willRetry: false });
+	});
+
+	it("continues the same agent operation after extension-handled overflow", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) =>
+						event.reason === "overflow" && event.willRetry ? { action: "handled", retry: true } : undefined,
+					);
+				},
+			],
+		});
+		harnesses.push(harness);
+		const rejected = createAssistant(harness, {
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+			timestamp: Date.now(),
+		});
+		harness.setResponses([fauxAssistantMessage("seed"), rejected, fauxAssistantMessage("recovered")]);
+		let settled = 0;
+		harness.session.subscribe((event) => {
+			if (event.type === "agent_settled") settled++;
+		});
+
+		await harness.session.prompt("seed turn");
+		settled = 0;
+		await harness.session.prompt("overflow turn");
+
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(settled).toBe(1);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		expect(
+			harness.sessionManager
+				.getEntries()
+				.filter((entry) => entry.type === "message" && entry.message.role === "user"),
+		).toHaveLength(2);
+		expect(harness.session.messages.some((message) => message === rejected)).toBe(false);
+	});
+
+	it("rejects handled retry outside interrupted overflow without falling through to native compaction", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({ action: "handled", retry: true }));
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		await expect(sessionInternals._runAutoCompaction("threshold", false)).resolves.toBe(false);
+
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end").at(-1)?.errorMessage).toContain(
+			"retry only an interrupted overflow recovery",
+		);
+	});
+
 	it("does not retry overflow recovery more than once", async () => {
 		const harness = await createHarness();
 		harnesses.push(harness);
@@ -311,6 +641,7 @@ describe("AgentSession compaction characterization", () => {
 			errorMessage: "prompt is too long",
 			timestamp: Date.now(),
 		});
+		harness.session.agent.state.messages = [overflowMessage];
 		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
 		const compactionErrors: string[] = [];
 		harness.session.subscribe((event) => {
@@ -326,6 +657,24 @@ describe("AgentSession compaction characterization", () => {
 		expect(compactionErrors).toContain(
 			"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
 		);
+	});
+
+	it("stops overflow recovery when the rejected response is not the exact live tail", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const overflowMessage = createAssistant(harness, {
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+			timestamp: Date.now(),
+		});
+		harness.session.agent.state.messages = [{ ...overflowMessage }];
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction");
+
+		await expect(sessionInternals._checkCompaction(overflowMessage)).resolves.toBe(false);
+
+		expect(runAutoCompactionSpy).not.toHaveBeenCalled();
+		expect(harness.eventsOfType("compaction_end").at(-1)?.errorMessage).toContain("not the live context tail");
 	});
 
 	it("compacts successful overflow responses without retrying", async () => {

--- a/packages/coding-agent/test/suite/regressions/5217-compaction-reason.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5217-compaction-reason.test.ts
@@ -17,6 +17,7 @@ function recordingExtension(recorded: RecordedCompactionEvent[]): ExtensionFacto
 	return (pi) => {
 		pi.on("session_before_compact", async (event) => {
 			recorded.push({ type: event.type, reason: event.reason, willRetry: event.willRetry });
+			if (!event.preparationAvailable) return { action: "cancel" };
 			return {
 				compaction: {
 					summary: "summary from extension",

--- a/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
+++ b/packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts
@@ -23,20 +23,25 @@ describe("pre-prompt compaction regression", () => {
 		}
 	});
 
-	it("compacts length-stop overflow before a new prompt without continuing from an assistant message", async () => {
+	it("compacts length-stop overflow before a new prompt without promising an ignored retry", async () => {
+		let observedWillRetry: boolean | undefined;
 		const harness = await createHarness({
 			models: [{ id: "faux-1", contextWindow: 100, maxTokens: 100 }],
 			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
 			extensionFactories: [
 				(pi) => {
-					pi.on("session_before_compact", async (event) => ({
-						compaction: {
-							summary: "pre-prompt summary",
-							firstKeptEntryId: event.preparation.firstKeptEntryId,
-							tokensBefore: event.preparation.tokensBefore,
-							details: {},
-						},
-					}));
+					pi.on("session_before_compact", async (event) => {
+						observedWillRetry = event.willRetry;
+						if (!event.preparationAvailable) return { action: "cancel" };
+						return {
+							compaction: {
+								summary: "pre-prompt summary",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
 				},
 			],
 		});
@@ -64,12 +69,65 @@ describe("pre-prompt compaction regression", () => {
 		await expect(harness.session.prompt("next prompt")).resolves.toBeUndefined();
 
 		expect(continueSpy).not.toHaveBeenCalled();
+		expect(observedWillRetry).toBe(false);
 		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
 			reason: "overflow",
 			aborted: false,
-			willRetry: true,
+			willRetry: false,
 		});
 		expect(getUserTexts(harness)).toContain("next prompt");
 		expect(harness.faux.state.callCount).toBe(1);
+	});
+
+	it("settles an aborted pre-prompt handler without starting a provider request", async () => {
+		let enterHandler!: () => void;
+		const handlerEntered = new Promise<void>((resolve) => {
+			enterHandler = resolve;
+		});
+		let handlerSettled = false;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 100, maxTokens: 100 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						enterHandler();
+						await new Promise<void>((resolve) => {
+							if (event.signal.aborted) resolve();
+							else event.signal.addEventListener("abort", () => resolve(), { once: true });
+						});
+						handlerSettled = true;
+						return { action: "handled", retry: false };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const model = harness.getModel();
+		const overflowAssistant: AssistantMessage = {
+			...fauxAssistantMessage("overflow", { stopReason: "length" }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(100),
+		};
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "previous prompt" }],
+			timestamp: Date.now() - 1,
+		});
+		harness.sessionManager.appendMessage(overflowAssistant);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		const prompt = harness.session.prompt("must not be sent");
+		await handlerEntered;
+		await harness.session.abort();
+		await expect(prompt).resolves.toBeUndefined();
+
+		expect(handlerSettled).toBe(true);
+		expect(harness.session.isIdle).toBe(true);
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(getUserTexts(harness)).not.toContain("must not be sent");
 	});
 });


### PR DESCRIPTION
## Summary

Adds a narrow core contract for extension-owned, checkpoint-free context-pressure recovery while preserving Pi's ownership of request acceptance, accounting, retry, abort, and session lifecycle.

- `session_before_compact` may terminate automatic pressure handling with `{ action: "handled", retry? }` or `{ action: "cancel", errorMessage? }`.
- Automatic pressure events still fire when no native summary cut is available; `preparationAvailable` is a discriminated state and exact accounting remains available.
- `summaryCheckpoints.enabled` (default `true`) can prohibit native and extension-provided compaction/branch-summary checkpoints without disabling pressure events or unsummarized tree navigation.
- Interrupted overflow may retry the same Agent operation once; settled threshold and completed overflow never retry.
- Pre-prompt checks no longer promise a retry their caller will discard, and rejected assistant tails are removed by exact object identity.
- Abort/disposal settles pre-prompt compaction before any provider request; the abort controller exists before `compaction_start` listeners run.
- Terminal result parsing uses captured intrinsics and own data properties, without getters/coercion/iterators.

The setting defaults on, so this is capability-only unless an extension deliberately opts into checkpoint-free ownership.

## Validation

- `tsgo --noEmit`
- focused compaction/queue/tree suite: 94 passed, 18 skipped
- full `packages/coding-agent` suite: **1,673 passed, 48 skipped**
- Biome and `git diff --check`

## Related

The native settled-boundary command queue used by one downstream reload extension is proposed separately in #7293; this PR does not depend on it.
