### PR TITLE
fix(coding-agent): replace deprecated getModel in SDK example

### DIFF
--- a/packages/coding-agent/examples/sdk/02-custom-model.ts
+++ b/packages/coding-agent/examples/sdk/02-custom-model.ts
@@ -4,13 +4,12 @@
  * Shows how to select a specific model and thinking level.
  */
 
-import { getModel } from "@earendil-works/pi-ai/compat";
 import { createAgentSession, ModelRuntime } from "@earendil-works/pi-coding-agent";
 
 const modelRuntime = await ModelRuntime.create();
 
 // Option 1: Find a specific built-in model by provider/id
-const opus = getModel("anthropic", "claude-opus-4-5");
+const opus = modelRuntime.getModel("anthropic", "claude-opus-4-5");
 if (opus) {
 	console.log(`Found model: ${opus.provider}/${opus.id}`);
 }


### PR DESCRIPTION
Replace the deprecated `getModel` import from `@earendil-works/pi-ai/compat` with `ModelRuntime.getModel()` in the custom model SDK example.

Approved in #7271. Supersedes #7268.

Tests:
- `npm run check`
- `./test.sh`

AI disclosure: The PR wording was lightly edited by an AI assistant based on my description.