### PR TITLE
fix(server): guard JSON.parse in RPC stdout handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5659,7 +5659,8 @@
 				"server": "dist/cli.js"
 			},
 			"devDependencies": {
-				"shx": "0.4.0"
+				"shx": "0.4.0",
+				"vitest": "4.1.9"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
 		"clean": "shx rm -rf dist",
 		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
 		"build": "tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js",
+		"test": "vitest --run",
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"keywords": [
@@ -43,6 +44,7 @@
 		"@earendil-works/pi-coding-agent": "^0.82.1"
 	},
 	"devDependencies": {
-		"shx": "0.4.0"
+		"shx": "0.4.0",
+		"vitest": "4.1.9"
 	}
 }

--- a/packages/server/src/rpc-process.ts
+++ b/packages/server/src/rpc-process.ts
@@ -22,6 +22,25 @@ function toError(error: unknown): Error {
 	return error instanceof Error ? error : new Error(String(error));
 }
 
+/**
+ * Parse a single RPC stdout line. Returns undefined when the line is not valid JSON
+ * so callers can skip malformed input instead of crashing the stdout handler.
+ */
+export function parseRpcLine(line: string): unknown {
+	try {
+		return JSON.parse(line);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Cap on the diagnostic stderr buffer. Malformed stdout lines are recorded there
+ * so exit errors carry context, but a chatty child could otherwise grow it
+ * without bound over a long-running server.
+ */
+const MAX_STDERR_BUFFER = 64 * 1024;
+
 export class RpcProcessInstance {
 	readonly process: ChildProcess;
 
@@ -47,7 +66,8 @@ export class RpcProcessInstance {
 		this.attachListeners();
 	}
 
-	private getSpawnCommand(): { command: string; args: string[] } {
+	/** Protected so tests can subclass and inject a controlled spawn target. */
+	protected getSpawnCommand(): { command: string; args: string[] } {
 		if (isBunBinary) {
 			return {
 				command: join(dirname(process.execPath), process.platform === "win32" ? "pi.exe" : "pi"),
@@ -99,29 +119,39 @@ export class RpcProcessInstance {
 	}
 
 	private handleLine(line: string): void {
-		const parsed = JSON.parse(line) as { type?: string; id?: string };
-		switch (parsed.type) {
+		const parsed = parseRpcLine(line);
+		if (!parsed || typeof parsed !== "object") {
+			// Malformed line (non-JSON log, node warning, truncated write). Preserve for
+			// diagnostics via stderrBuffer instead of crashing the stdout stream handler.
+			// Cap the buffer so a chatty child cannot grow it without bound.
+			if (this.stderrBuffer.length < MAX_STDERR_BUFFER) {
+				this.stderrBuffer += `[rpc-process] discarded malformed stdout line: ${line}\n`;
+			}
+			return;
+		}
+		const message = parsed as { type?: string; id?: string };
+		switch (message.type) {
 			case "response": {
-				if (!parsed.id) {
+				if (!message.id) {
 					return;
 				}
-				const pending = this.pendingRequests.get(parsed.id);
+				const pending = this.pendingRequests.get(message.id);
 				if (!pending) {
 					return;
 				}
-				this.pendingRequests.delete(parsed.id);
-				pending.resolve(parsed as RpcResponse);
+				this.pendingRequests.delete(message.id);
+				pending.resolve(message as RpcResponse);
 				return;
 			}
 
 			case "extension_ui_request": {
-				this.uiRequestHandler?.(parsed as RpcExtensionUIRequest);
+				this.uiRequestHandler?.(message as RpcExtensionUIRequest);
 				return;
 			}
 
 			default: {
 				for (const listener of this.eventListeners) {
-					listener(parsed as AgentSessionEvent);
+					listener(message as AgentSessionEvent);
 				}
 			}
 		}

--- a/packages/server/test/rpc-process.test.ts
+++ b/packages/server/test/rpc-process.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { parseRpcLine, RpcProcessInstance } from "../src/rpc-process.ts";
+
+// Test-only subclass that overrides the protected spawn hook so integration
+// tests can drive the real stdout parsing path without needing a built
+// @earendil-works/pi-coding-agent RPC entry on disk. The command to spawn is
+// carried through module-scoped state because the super constructor invokes
+// getSpawnCommand before the subclass body runs (fields aren't initialized
+// yet).
+//
+// NOTE: Non-reentrant. If more than one test constructs TestRpcProcessInstance,
+// serialize them or refactor.
+let pendingTestCommand: { command: string; args: string[] } | null = null;
+
+class TestRpcProcessInstance extends RpcProcessInstance {
+	constructor(options: { cwd: string; command: string; args: string[] }) {
+		pendingTestCommand = { command: options.command, args: options.args };
+		try {
+			super({ cwd: options.cwd });
+		} finally {
+			pendingTestCommand = null;
+		}
+	}
+
+	protected override getSpawnCommand(): { command: string; args: string[] } {
+		if (!pendingTestCommand) {
+			throw new Error("TestRpcProcessInstance: no pending spawn command");
+		}
+		return pendingTestCommand;
+	}
+}
+
+describe("parseRpcLine", () => {
+	it("returns the parsed value for valid JSON", () => {
+		const result = parseRpcLine('{"type":"response","id":"abc"}');
+		expect(result).toEqual({ type: "response", id: "abc" });
+	});
+
+	it("returns undefined for malformed JSON instead of throwing", () => {
+		expect(parseRpcLine("not json")).toBeUndefined();
+		expect(parseRpcLine("{unterminated")).toBeUndefined();
+		expect(parseRpcLine("")).toBeUndefined();
+	});
+});
+
+describe("RpcProcessInstance stdout handling", () => {
+	it("does not throw an uncaught exception when the child writes a non-JSON line and still dispatches valid events after", async () => {
+		const script = [
+			// A stray non-JSON line the child might emit (log line, node warning, partial line).
+			'process.stdout.write("not json\\n");',
+			// Followed by a valid event that must still reach eventListeners.
+			'process.stdout.write(JSON.stringify({ type: "custom_event", value: 42 }) + "\\n");',
+			// Keep the child alive briefly so the parent can observe both lines.
+			"setTimeout(() => process.exit(0), 200);",
+		].join("");
+
+		const uncaughtErrors: Error[] = [];
+		const onUncaught = (err: Error) => {
+			uncaughtErrors.push(err);
+		};
+		process.on("uncaughtException", onUncaught);
+
+		try {
+			let exitError: Error | undefined;
+			const rpc = new TestRpcProcessInstance({
+				cwd: process.cwd(),
+				command: process.execPath,
+				args: ["-e", script],
+			});
+
+			const events: unknown[] = [];
+			rpc.onEvent((event) => events.push(event));
+			await new Promise<void>((resolve) => {
+				rpc.onExit((err) => {
+					exitError = err;
+					resolve();
+				});
+			});
+			// Two setImmediate ticks so any uncaughtException from the (unfixed)
+			// baseline can propagate through the microtask queue and into the
+			// process-level listener registered above.
+			await new Promise((resolve) => setImmediate(resolve));
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(uncaughtErrors).toEqual([]);
+			expect(exitError?.message).toContain("discarded malformed stdout line: not json");
+			expect(events).toEqual([{ type: "custom_event", value: 42 }]);
+
+			await rpc.dispose();
+		} finally {
+			process.off("uncaughtException", onUncaught);
+		}
+	});
+});

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		testTimeout: 15000,
+		reporters: process.env.GITHUB_ACTIONS ? ["dot", "github-actions"] : ["dot"],
+		silent: "passed-only",
+	},
+});


### PR DESCRIPTION
Closes #7300.

## Summary

`RpcProcessInstance.handleLine` parsed each stdout line with a bare `JSON.parse` invoked synchronously from the child-process `'data'` handler. Any non-JSON line the spawned RPC child emitted — a stray log line, a Node deprecation warning routed to stdout, a truncated line before shutdown — threw an uncaught `SyntaxError` inside the stream event handler and crashed the server process. The SSE parsers in `packages/ai` already wrap their parses in `try/catch`; this PR aligns `rpc-process.ts` with that pattern.

## Changes

- Extract `parseRpcLine` helper that returns `undefined` on parse failure.
- In `handleLine`, skip malformed lines and record a bounded diagnostic in `stderrBuffer` instead of letting the exception escape.
- Cap the diagnostic buffer at 64 KiB so a chatty child cannot grow it without bound over a long-running server.
- Widen `getSpawnCommand` from `private` to `protected` so tests can inject a controlled child.
- Add a vitest scaffold and regression tests for `parseRpcLine` and the stdout handler.

## Testing

- `npm run check` — clean on `packages/server` (pre-existing errors elsewhere are model-catalog related and unchanged by this PR).
- `./test.sh` — `packages/server` 3/3 pass. Other packages' pre-existing failures unchanged.
- Reverting only the `handleLine` fix and rerunning the new test produces the exact `SyntaxError: Unexpected token 'o', "not json" is not valid JSON` from the issue, confirming the regression is caught.

## Notes

- No changes to public API. Only visibility widened: `getSpawnCommand` `private → protected`.
- Lockfile updated to add `vitest@4.1.9` as a devDep of `@earendil-works/pi-server` (aligned with the version already pinned in `agent`/`ai`/`coding-agent`). Committed with `PI_ALLOW_LOCKFILE_CHANGE=1` per `AGENTS.md`.
- No `CHANGELOG.md` edit per `CONTRIBUTING.md`.
