### PR TITLE
fix: redundancy in setToolsExpanded

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `setToolsExpanded(false)` to be a no-op when tool output is already collapsed, avoiding redundant `Tool output: collapsed` startup notices from extensions ([#7292](https://github.com/earendil-works/pi/issues/7292)).
+
 ## [0.83.0] - 2026-07-29
 
 ### New Features

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3816,6 +3816,8 @@ export class InteractiveMode {
 	}
 
 	private setToolsExpanded(expanded: boolean): void {
+		if (expanded === this.toolOutputExpanded) return;
+
 		this.toolOutputExpanded = expanded;
 		const activeHeader = this.customHeader ?? this.builtInHeader;
 		if (isExpandable(activeHeader)) {


### PR DESCRIPTION
Addresses #7292.

`setToolsExpanded(false)` was emitting a redundant `“Tool output: collapsed”` status even when tool output was already collapsed. Reproduced.

Fixed by making `setToolsExpanded()` return early when the requested state matches the current state, so startup extensions can safely enforce collapsed tools without noisy UI updates.

The repro/regression test now passes.