### PR TITLE
fix: custom-compaction through provider via new model runtime complete

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed `setToolsExpanded(false)` to be a no-op when tool output is already collapsed, avoiding redundant `Tool output: collapsed` startup notices from extensions ([#7292](https://github.com/earendil-works/pi/issues/7292)).
+- Fixed extension-driven model calls in custom compaction, handoff, and Q&A examples to dispatch through the coding-agent model runtime so custom providers and resolved auth options are preserved ([#7325](https://github.com/earendil-works/pi/pull/7325)).
 
 ## [0.83.0] - 2026-07-29
 

--- a/packages/coding-agent/examples/extensions/custom-compaction.ts
+++ b/packages/coding-agent/examples/extensions/custom-compaction.ts
@@ -14,7 +14,6 @@
  */
 
 import { uuidv7 } from "@earendil-works/pi-ai";
-import { complete } from "@earendil-works/pi-ai/compat";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { convertToLlm, serializeConversation } from "@earendil-works/pi-coding-agent";
 
@@ -88,7 +87,7 @@ ${conversationText}
 
 		try {
 			// Pass signal to honor abort requests (e.g., user cancels compaction)
-			const response = await complete(
+			const response = await ctx.modelRegistry.complete(
 				model,
 				{ messages: summaryMessages },
 				{

--- a/packages/coding-agent/examples/extensions/handoff.ts
+++ b/packages/coding-agent/examples/extensions/handoff.ts
@@ -13,8 +13,7 @@
  */
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { uuidv7 } from "@earendil-works/pi-ai";
-import { complete, type Message } from "@earendil-works/pi-ai/compat";
+import { type Message, uuidv7 } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, SessionEntry } from "@earendil-works/pi-coding-agent";
 import { BorderedLoader, convertToLlm, serializeConversation } from "@earendil-works/pi-coding-agent";
 
@@ -134,7 +133,7 @@ export default function (pi: ExtensionAPI) {
 						timestamp: Date.now(),
 					};
 
-					const response = await complete(
+					const response = await ctx.modelRegistry.complete(
 						ctx.model!,
 						{ systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
 						{

--- a/packages/coding-agent/examples/extensions/qna.ts
+++ b/packages/coding-agent/examples/extensions/qna.ts
@@ -7,7 +7,7 @@
  * 3. Loads the result into the editor for user to fill in answers
  */
 
-import { complete, type UserMessage } from "@earendil-works/pi-ai/compat";
+import type { UserMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { BorderedLoader } from "@earendil-works/pi-coding-agent";
 
@@ -87,7 +87,7 @@ export default function (pi: ExtensionAPI) {
 						timestamp: Date.now(),
 					};
 
-					const response = await complete(
+					const response = await ctx.modelRegistry.complete(
 						ctx.model!,
 						{ systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
 						{ apiKey: auth.apiKey, headers: auth.headers, env: auth.env, signal: loader.signal },

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -1,4 +1,12 @@
-import type { Api, AuthResult, Model, Provider } from "@earendil-works/pi-ai";
+import type {
+	Api,
+	AssistantMessage,
+	AuthResult,
+	Context,
+	Model,
+	ModelsApiStreamOptions,
+	Provider,
+} from "@earendil-works/pi-ai";
 import type { ModelRuntime } from "./model-runtime.ts";
 import type { AuthStatus, ProviderConfigInput } from "./provider-composer.ts";
 
@@ -94,6 +102,14 @@ export class ModelRegistry {
 
 	getProvider(provider: string): Provider | undefined {
 		return this.runtime.getProvider(provider);
+	}
+
+	complete<TApi extends Api>(
+		model: Model<TApi>,
+		context: Context,
+		options?: ModelsApiStreamOptions<TApi>,
+	): Promise<AssistantMessage> {
+		return this.runtime.complete(model, context, options);
 	}
 
 	getProviderDisplayName(provider: string): string {

--- a/packages/coding-agent/test/compaction-extensions-example.test.ts
+++ b/packages/coding-agent/test/compaction-extensions-example.test.ts
@@ -2,8 +2,15 @@
  * Verify the documentation example from extensions.md compiles and works.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ExtensionAPI, SessionBeforeCompactEvent, SessionCompactEvent } from "../src/core/extensions/index.ts";
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	convertToLlm: (messages: unknown) => messages,
+	serializeConversation: () => "conversation",
+}));
+
+const { default: customCompactionExtension } = await import("../examples/extensions/custom-compaction.ts");
 
 describe("Documentation example", () => {
 	it("custom compaction example should type-check correctly", () => {
@@ -45,6 +52,81 @@ describe("Documentation example", () => {
 
 		// Just verify the function exists and is callable
 		expect(typeof exampleExtension).toBe("function");
+	});
+
+	it("custom compaction example dispatches through modelRegistry.complete", async () => {
+		let handler: ((event: any, ctx: any) => Promise<any>) | undefined;
+		customCompactionExtension({
+			on(event, fn) {
+				if (event === "session_before_compact") handler = fn as typeof handler;
+			},
+		} as ExtensionAPI);
+
+		expect(handler).toBeDefined();
+
+		const complete = vi.fn(async () => ({
+			role: "assistant",
+			content: [{ type: "text", text: "custom provider summary" }],
+			provider: "example-custom",
+			api: "example-custom-api",
+			model: "summary-model",
+			stopReason: "stop",
+			usage: {
+				input: 1,
+				output: 2,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 3,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		}));
+		const model = {
+			provider: "example-custom",
+			api: "example-custom-api",
+			id: "summary-model",
+			name: "Summary Model",
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1000,
+			maxTokens: 100,
+		};
+
+		const result = await handler!(
+			{
+				preparation: {
+					messagesToSummarize: [
+						{ role: "user", content: [{ type: "text", text: "please remember this" }], timestamp: Date.now() },
+					],
+					turnPrefixMessages: [],
+					tokensBefore: 42,
+					firstKeptEntryId: "entry-1",
+				},
+				branchEntries: [],
+				signal: new AbortController().signal,
+			},
+			{
+				ui: { notify: vi.fn() },
+				modelRegistry: {
+					find: vi.fn(() => model),
+					getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "fake-key" })),
+					complete,
+				},
+			},
+		);
+
+		expect(complete).toHaveBeenCalledWith(
+			model,
+			expect.objectContaining({ messages: expect.any(Array) }),
+			expect.objectContaining({ apiKey: "fake-key", maxTokens: 8192 }),
+		);
+		expect(result).toMatchObject({
+			compaction: {
+				summary: "custom provider summary",
+				firstKeptEntryId: "entry-1",
+				tokensBefore: 42,
+			},
+		});
 	});
 
 	it("compact event should have correct fields", () => {


### PR DESCRIPTION
 Addresses #7273.
 
The issue was that a model registered via `pi.registerProvider()` was visible to Pi’s runtime provider registry, but compat `complete()` could not dispatch its custom `api` id. This was because extension examples mixed runtime models from `ctx.modelRegistry` with the separate legacy compat API registry.

- Added `ctx.modelRegistry.complete()` as the provider-aware completion path for extensions, delegating through `ModelRuntime.complete()`.
- Updated runtime-model examples to use that path so custom providers and provider overrides are honored without mutating compat global state.
- Verified the repro now succeeds with compat still unaware of `gitlab-duo-api`, and the compaction extension test passes.

The issue’s failing path was:

```ts
   custom-compaction.ts
     -> model = ctx.modelRegistry.find("gitlab-duo", ...)
     -> compat complete(model, ...)
     -> getApiProvider("gitlab-duo-api")
     -> undefined
     -> throw
```

The patch changes that path to:

 ```ts
   custom-compaction.ts
     -> model = ctx.modelRegistry.find("gitlab-duo", ...)
     -> ctx.modelRegistry.complete(model, ...)
     -> ModelRuntime.complete(...)
     -> runtime provider registered by pi.registerProvider()
     -> succeeds
```