### PR TITLE
fix(ai): preserve MiniMax M3 video input capability

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1815,7 +1815,11 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						// MiniMax's Anthropic-compatible API - SDK appends /v1/messages
 						baseUrl,
 						reasoning: m.reasoning === true,
-						input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
+						input: m.modalities?.input?.includes("video")
+							? ["text", "image", "video"]
+							: m.modalities?.input?.includes("image")
+								? ["text", "image"]
+								: ["text"],
 						cost: {
 							input: m.cost?.input || 0,
 							output: m.cost?.output || 0,

--- a/packages/ai/scripts/model-data.ts
+++ b/packages/ai/scripts/model-data.ts
@@ -155,7 +155,7 @@ function validateModelValue(
 	if (
 		!Array.isArray(value.input) ||
 		value.input.length === 0 ||
-		value.input.some((entry) => entry !== "text" && entry !== "image")
+		value.input.some((entry) => entry !== "text" && entry !== "image" && entry !== "video")
 	) {
 		errors.push(`${label} has invalid input modalities`);
 	}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -768,7 +768,7 @@ export interface Model<TApi extends Api> {
 	 * Missing keys use provider defaults. null marks a level as unsupported.
 	 */
 	thinkingLevelMap?: ThinkingLevelMap;
-	input: ("text" | "image")[];
+	input: ("text" | "image" | "video")[];
 	cost: ModelCost;
 	contextWindow: number;
 	maxTokens: number;

--- a/packages/ai/test/model-data-validation.test.ts
+++ b/packages/ai/test/model-data-validation.test.ts
@@ -153,6 +153,22 @@ describe("generated model data validation", () => {
 		expect(() => validateModelDataDirectory(fixture.structure, fixture.dataDir)).toThrow("generation timestamp");
 	});
 
+	it("accepts video as a supported input modality", () => {
+		const fixture = createFixture();
+		const model = fixture.values["model-a"] as Record<string, unknown>;
+		model.input = ["text", "image", "video"];
+		writeFixtureData(fixture.dataDir, fixture.structure, fixture.values);
+		expect(() => validateModelDataDirectory(fixture.structure, fixture.dataDir)).not.toThrow();
+	});
+
+	it("rejects an unsupported input modality", () => {
+		const fixture = createFixture();
+		const model = fixture.values["model-a"] as Record<string, unknown>;
+		model.input = ["text", "audio"];
+		writeFixtureData(fixture.dataDir, fixture.structure, fixture.values);
+		expect(() => validateModelDataDirectory(fixture.structure, fixture.dataDir)).toThrow("invalid input modalities");
+	});
+
 	it("rejects missing provider shards imported by the aggregator", () => {
 		const { packageRoot } = createFixture();
 		writeFileSync(


### PR DESCRIPTION
Reason: MiniMax M3 supports text, image, and video inputs, but the MiniMax model generator and runtime schema only preserved text and image, dropping the target model's video input capability.

## Changes
- `packages/ai/scripts/generate-models.ts`: extend the MiniMax input modality mapping so a model whose `models.dev` input modalities include `video` keeps `["text", "image", "video"]` instead of being collapsed to text/image.
- `packages/ai/src/types.ts`: widen `Model.input` to `("text" | "image" | "video")[]`.
- `packages/ai/scripts/model-data.ts`: accept `video` as a valid input modality in the generated model-data validator.
- `packages/ai/test/model-data-validation.test.ts`: add tests that a `video` input modality validates and that an unsupported modality is rejected.

## Verification
- Regenerated model data with `node_modules/.bin/tsx packages/ai/scripts/generate-models.ts --strict --data-only`; `MiniMax-M3` now reports `input: ["text","image","video"]` for both `minimax` and `minimax-cn`, while `MiniMax-M2.7` stays `["text"]`.
- `node_modules/.bin/tsx packages/ai/scripts/check-model-data.ts` -> "Generated model data is valid."
- `node_modules/.bin/vitest --run packages/ai/test/model-data-validation.test.ts` -> 13 passed.
- `node_modules/.bin/vitest --run packages/ai/test/together-models.test.ts packages/ai/test/xiaomi-models.test.ts packages/ai/test/model-catalog-types.test.ts` -> all pass.

The generated `packages/ai/src/providers/data/*.json` catalog is gitignored and not included; it is regenerated locally from `generate-models.ts` and validated by `check:model-data`.
