### PR TITLE
fix: bold markdown text invisible on light terminal backgrounds

### DIFF
--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -1239,7 +1239,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 		quoteBorder: (text: string) => theme.fg("mdQuoteBorder", text),
 		hr: (text: string) => theme.fg("mdHr", text),
 		listBullet: (text: string) => theme.fg("mdListBullet", text),
-		bold: (text: string) => theme.bold(text),
+		bold: (text: string) => theme.fg("text", theme.bold(text)),
 		italic: (text: string) => theme.italic(text),
 		underline: (text: string) => theme.underline(text),
 		strikethrough: (text: string) => chalk.strikethrough(text),


### PR DESCRIPTION
On terminals with light backgrounds that interpret ANSI bold (\x1b[1m) as "bright" (bold-as-bright), bold markdown text renders as white-on-white and becomes invisible.

Root cause: `getMarkdownTheme()`'s `bold` function only applies `theme.bold()` (ANSI bold) without setting an explicit foreground color. When no foreground color is set, terminals with bold-as-bright behavior shift the text to a brighter variant, turning dark default text into white on light backgrounds.

Fix: wrap bold text in `theme.fg("text", ...)` so the foreground color is explicitly locked to the theme's text color, preventing the bright shift.

Change: one line in `packages/coding-agent/src/modes/interactive/theme/theme.ts`:

    - bold: (text: string) => theme.bold(text),
    + bold: (text: string) => theme.fg("text", theme.bold(text)),

Tested on both light theme (#1f2328 text) and dark theme (#d4d4d4 text) with a white-background terminal.