### PR TITLE
feat(coding-agent): support wildcard model overrides

### DIFF
--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -340,6 +340,27 @@ Use `modelOverrides` to customize built-in models and matching extension-registe
 
 `modelOverrides` supports these fields per model: `name`, `reasoning`, `thinkingLevelMap`, `input`, `cost` (partial), `contextWindow`, `maxTokens`, `headers`, `compat`.
 
+Use `"*"` to apply an override to every model on the provider, including models added to the catalog later. An exact model ID is applied after the wildcard and takes precedence for overlapping fields:
+
+```json
+{
+  "providers": {
+    "github-copilot": {
+      "modelOverrides": {
+        "*": {
+          "headers": {
+            "Copilot-Integration-Id": "copilot-developer-cli"
+          }
+        },
+        "claude-opus-5": {
+          "maxTokens": 32000
+        }
+      }
+    }
+  }
+}
+```
+
 Direct OpenAI GPT-5.6 Sol, Terra, and Luna default to a `272000` context window so requests remain within OpenAI's short-context pricing tier. To opt into OpenAI's 1.05M context window, increase it for each model you use:
 
 ```json
@@ -360,6 +381,7 @@ The override preserves the built-in pricing metadata. Requests with more than 27
 
 Behavior notes:
 - `modelOverrides` are applied to built-in provider models and matching extension-registered provider models.
+- The `"*"` override applies to every model on the provider; an exact model override takes precedence.
 - Unknown model IDs are ignored.
 - You can combine provider-level `baseUrl`/`headers` with `modelOverrides`.
 - Overriding `name` changes model matching and secondary detail text only; the footer and primary model lists continue to show the model `id`.

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -389,6 +389,7 @@ function rawModelHeaders(
 	const definition = config?.models?.find((entry) => entry.id === model.id);
 	const extensionModel = extension?.models?.find((entry) => entry.id === model.id);
 	const headers = {
+		...config?.modelOverrides?.["*"]?.headers,
 		...config?.modelOverrides?.[model.id]?.headers,
 		...definition?.headers,
 		...extensionModel?.headers,
@@ -432,8 +433,10 @@ export function composeModelProvider(
 			models = extension.oauth.modifyModels(models, extensionOAuthCredential);
 		}
 		return models.map((model) => {
-			const override = config?.modelOverrides?.[model.id];
-			return override ? applyModelOverride(model, override) : model;
+			const wildcardOverride = config?.modelOverrides?.["*"];
+			const modelOverride = config?.modelOverrides?.[model.id];
+			const wildcardModel = wildcardOverride ? applyModelOverride(model, wildcardOverride) : model;
+			return modelOverride ? applyModelOverride(wildcardModel, modelOverride) : wildcardModel;
 		});
 	};
 	// Validate eagerly so registration/reload reports structural errors immediately.

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -694,6 +694,40 @@ describe("ModelRegistry", () => {
 			expect(opus?.name).not.toBe("Custom Sonnet Name");
 		});
 
+		test("wildcard model override applies to every model before exact overrides", async () => {
+			writeRawModelsJson({
+				openrouter: {
+					modelOverrides: {
+						"*": {
+							name: "Wildcard Name",
+							contextWindow: 12345,
+							headers: { "X-Override-Scope": "wildcard" },
+						},
+						"anthropic/claude-sonnet-4": {
+							name: "Exact Name",
+							headers: { "X-Override-Scope": "exact" },
+						},
+					},
+				},
+			});
+
+			const registry = await createModelRegistry(authStorage, modelsJsonPath);
+			const models = getModelsForProvider(registry, "openrouter");
+			const sonnet = models.find((model) => model.id === "anthropic/claude-sonnet-4");
+			const opus = models.find((model) => model.id === "anthropic/claude-opus-4");
+
+			expect(sonnet).toMatchObject({ name: "Exact Name", contextWindow: 12345 });
+			expect(opus).toMatchObject({ name: "Wildcard Name", contextWindow: 12345 });
+			expect(await registry.getApiKeyAndHeaders(sonnet!)).toMatchObject({
+				ok: true,
+				headers: { "X-Override-Scope": "exact" },
+			});
+			expect(await registry.getApiKeyAndHeaders(opus!)).toMatchObject({
+				ok: true,
+				headers: { "X-Override-Scope": "wildcard" },
+			});
+		});
+
 		test("model override with compat.openRouterRouting", async () => {
 			writeRawModelsJson({
 				openrouter: {


### PR DESCRIPTION
## Summary
- support `"*"` in `modelOverrides` to configure every model on a provider
- apply exact model overrides after the wildcard so model-specific settings take precedence
- document wildcard usage and cover metadata and request-header precedence

This allows provider integrations to apply shared request headers to existing and future catalog models without maintaining an explicit model list.

## Test plan
- [x] `npm run check`
- [x] `node ../../node_modules/vitest/dist/cli.js --run test/model-registry.test.ts` (82 tests)
- [x] wildcard configuration smoke-tested with `github-copilot/claude-opus-5`
- [ ] `./test.sh` (all affected tests pass; unrelated `detectInstallMethod` Windows pnpm test consistently times out under the full suite and passes in isolation)
