### PR TITLE
Support externally managed Codex subscription auth

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -273,7 +273,7 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 				throw new Error(`No API key for provider: ${model.provider}`);
 			}
 
-			const accountId = extractAccountId(apiKey);
+			const accountId = options?.headers?.["chatgpt-account-id"]?.trim() || extractAccountId(apiKey);
 			const grammarToolInputProperties = createGrammarToolInputProperties(
 				context.tools,
 				model.compat?.supportsOpenAIGrammarTools ?? false,

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -104,6 +104,7 @@ function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
 		together: "TOGETHER_API_KEY",
 		opencode: "OPENCODE_API_KEY",
 		"opencode-go": "OPENCODE_API_KEY",
+		"openai-codex": "OPENAI_CODEX_ACCESS_TOKEN",
 		"kimi-coding": "KIMI_API_KEY",
 		"cloudflare-workers-ai": "CLOUDFLARE_API_KEY",
 		"cloudflare-ai-gateway": "CLOUDFLARE_API_KEY",

--- a/packages/ai/src/providers/openai-codex.ts
+++ b/packages/ai/src/providers/openai-codex.ts
@@ -1,8 +1,32 @@
 import { openAICodexResponsesApi } from "../api/openai-codex-responses.lazy.ts";
 import { lazyOAuth } from "../auth/helpers.ts";
 import { loadOpenAICodexOAuth } from "../auth/oauth/load.ts";
+import type { ApiKeyAuth } from "../auth/types.ts";
 import { createProvider, type Provider } from "../models.ts";
 import { OPENAI_CODEX_MODELS } from "./openai-codex.models.ts";
+
+function externalCodexAuth(): ApiKeyAuth {
+	return {
+		name: "externally managed Codex access token",
+		login: async (interaction) => ({
+			type: "api_key",
+			key: await interaction.prompt({ type: "secret", message: "Enter externally managed Codex access token" }),
+		}),
+		resolve: async ({ ctx, credential }) => {
+			const apiKey = credential?.key ?? (await ctx.env("OPENAI_CODEX_ACCESS_TOKEN"));
+			if (!apiKey) return undefined;
+			const accountId = credential?.env?.OPENAI_CODEX_ACCOUNT_ID ?? (await ctx.env("OPENAI_CODEX_ACCOUNT_ID"));
+			return {
+				auth: {
+					apiKey,
+					...(accountId ? { headers: { "chatgpt-account-id": accountId } } : {}),
+				},
+				env: credential?.env,
+				source: credential?.key ? "stored credential" : "OPENAI_CODEX_ACCESS_TOKEN",
+			};
+		},
+	};
+}
 
 export function openaiCodexProvider(): Provider<"openai-codex-responses"> {
 	return createProvider({
@@ -10,6 +34,7 @@ export function openaiCodexProvider(): Provider<"openai-codex-responses"> {
 		name: "OpenAI Codex",
 		baseUrl: "https://chatgpt.com/backend-api",
 		auth: {
+			apiKey: externalCodexAuth(),
 			oauth: lazyOAuth({ name: "OpenAI (ChatGPT Plus/Pro)", load: loadOpenAICodexOAuth }),
 		},
 		models: Object.values(OPENAI_CODEX_MODELS),

--- a/packages/ai/test/env-api-keys.test.ts
+++ b/packages/ai/test/env-api-keys.test.ts
@@ -8,6 +8,7 @@ const originalZaiCodingCnApiKey = process.env.ZAI_CODING_CN_API_KEY;
 const originalAnthropicAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
 const originalAnthropicOauthToken = process.env.ANTHROPIC_OAUTH_TOKEN;
 const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+const originalOpenAICodexAccessToken = process.env.OPENAI_CODEX_ACCESS_TOKEN;
 
 afterEach(() => {
 	if (originalCopilotGitHubToken === undefined) {
@@ -51,6 +52,12 @@ afterEach(() => {
 	} else {
 		process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
 	}
+
+	if (originalOpenAICodexAccessToken === undefined) {
+		delete process.env.OPENAI_CODEX_ACCESS_TOKEN;
+	} else {
+		process.env.OPENAI_CODEX_ACCESS_TOKEN = originalOpenAICodexAccessToken;
+	}
 });
 
 describe("environment API keys", () => {
@@ -77,6 +84,13 @@ describe("environment API keys", () => {
 
 		expect(findEnvKeys("zai-coding-cn")).toEqual(["ZAI_CODING_CN_API_KEY"]);
 		expect(getEnvApiKey("zai-coding-cn")).toBe("zai-coding-cn-token");
+	});
+
+	it("resolves externally managed Codex access tokens", () => {
+		process.env.OPENAI_CODEX_ACCESS_TOKEN = "codex-access-token";
+
+		expect(findEnvKeys("openai-codex")).toEqual(["OPENAI_CODEX_ACCESS_TOKEN"]);
+		expect(getEnvApiKey("openai-codex")).toBe("codex-access-token");
 	});
 
 	it("reports ANTHROPIC_AUTH_TOKEN but preserves OAuth token API key lookup", () => {

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -10,6 +10,7 @@ import { cloudflareAIGatewayProvider } from "../src/providers/cloudflare-ai-gate
 import { cloudflareWorkersAIProvider } from "../src/providers/cloudflare-workers-ai.ts";
 import { fauxAssistantMessage, fauxProvider } from "../src/providers/faux.ts";
 import { googleVertexProvider } from "../src/providers/google-vertex.ts";
+import { openaiCodexProvider } from "../src/providers/openai-codex.ts";
 import type { Api, Context, Model, ProviderStreams } from "../src/types.ts";
 import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
 
@@ -21,6 +22,35 @@ function fakeAuthContext(env: Record<string, string>, files: string[] = []): Aut
 }
 
 const context: Context = { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] };
+
+describe("openai codex provider", () => {
+	it("accepts an externally managed access token without OAuth", async () => {
+		const models = createModels({
+			authContext: fakeAuthContext({ OPENAI_CODEX_ACCESS_TOKEN: "external-token" }),
+		});
+		models.setProvider(openaiCodexProvider());
+
+		expect(await models.getAuth("openai-codex")).toMatchObject({
+			auth: { apiKey: "external-token" },
+			source: "OPENAI_CODEX_ACCESS_TOKEN",
+		});
+	});
+
+	it("adds an externally managed account ID to request auth", async () => {
+		const models = createModels({
+			authContext: fakeAuthContext({
+				OPENAI_CODEX_ACCESS_TOKEN: "opaque-token",
+				OPENAI_CODEX_ACCOUNT_ID: "account-123",
+			}),
+		});
+		models.setProvider(openaiCodexProvider());
+
+		expect((await models.getAuth("openai-codex"))?.auth).toEqual({
+			apiKey: "opaque-token",
+			headers: { "chatgpt-account-id": "account-123" },
+		});
+	});
+});
 
 describe("builtin providers", () => {
 	it("builtinModels registers every builtin provider with models", async () => {

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -14,6 +14,26 @@ export const HTTP_IDLE_TIMEOUT_CHOICES = [
 const originalGlobalFetch = globalThis.fetch;
 let installedGlobalFetch: typeof globalThis.fetch | undefined;
 
+const UNDICI_GLOBAL_NAMES = [
+	"fetch",
+	"Headers",
+	"Response",
+	"Request",
+	"FormData",
+	"WebSocket",
+	"CloseEvent",
+	"ErrorEvent",
+	"MessageEvent",
+	"EventSource",
+] as const;
+
+function canInstallUndiciGlobals(): boolean {
+	return UNDICI_GLOBAL_NAMES.every((name) => {
+		const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+		return !descriptor || descriptor.writable === true || typeof descriptor.set === "function";
+	});
+}
+
 export function parseHttpIdleTimeoutMs(value: unknown): number | undefined {
 	if (typeof value === "string") {
 		const trimmed = value.trim();
@@ -99,7 +119,9 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 		installedGlobalFetch === undefined
 			? globalThis.fetch === originalGlobalFetch
 			: globalThis.fetch === installedGlobalFetch;
-	if (shouldInstallGlobals) {
+	// Embedded runtimes can own non-writable Web APIs. Preserve that surface
+	// instead of letting undici.install() fail partway through its assignments.
+	if (shouldInstallGlobals && canInstallUndiciGlobals()) {
 		undici.install?.();
 		installedGlobalFetch = globalThis.fetch;
 	}

--- a/packages/coding-agent/test/http-dispatcher.test.ts
+++ b/packages/coding-agent/test/http-dispatcher.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { applyHttpProxySettings } from "../src/core/http-dispatcher.ts";
+import { applyHttpProxySettings, configureHttpDispatcher } from "../src/core/http-dispatcher.ts";
 
+const originalWebSocketDescriptor = Object.getOwnPropertyDescriptor(globalThis, "WebSocket");
 const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY"] as const;
 
 describe("http proxy settings", () => {
@@ -49,5 +50,27 @@ describe("http proxy settings", () => {
 
 		expect(process.env.HTTP_PROXY).toBeUndefined();
 		expect(process.env.HTTPS_PROXY).toBeUndefined();
+	});
+});
+
+describe("configureHttpDispatcher", () => {
+	afterEach(() => {
+		if (originalWebSocketDescriptor) {
+			Object.defineProperty(globalThis, "WebSocket", originalWebSocketDescriptor);
+		} else {
+			Reflect.deleteProperty(globalThis, "WebSocket");
+		}
+	});
+
+	it("preserves a host-owned Web API surface", () => {
+		const fetchBefore = globalThis.fetch;
+		Object.defineProperty(globalThis, "WebSocket", {
+			configurable: true,
+			value: class HostWebSocket {},
+			writable: false,
+		});
+
+		expect(() => configureHttpDispatcher()).not.toThrow();
+		expect(globalThis.fetch).toBe(fetchBefore);
 	});
 });


### PR DESCRIPTION
## Summary
- resolve `OPENAI_CODEX_ACCESS_TOKEN` as non-persistent Codex API-key auth
- accept `OPENAI_CODEX_ACCOUNT_ID` for opaque access tokens and send it as `chatgpt-account-id`
- preserve host-owned read-only Web API globals in embedded runtimes

## Verification
- `npm run check`
- `npx vitest --run test/providers.test.ts test/env-api-keys.test.ts` (29 tests)
- `npx vitest --run test/http-dispatcher.test.ts` (4 tests)
- live AgentOS Pi session against `openai-codex/gpt-5.6-terra`