### PR TITLE
fix(ai): keep signed empty text/thinking blocks in google history

### DIFF
--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -131,26 +131,32 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 
 			for (const block of msg.content) {
 				if (block.type === "text") {
-					// Skip empty text blocks
-					if (!block.text || block.text.trim() === "") continue;
 					const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.textSignature);
+					// Skip empty text blocks — unless they carry a thought signature. Gemini can attach
+					// the signature to a part whose visible text is empty and requires it echoed back;
+					// dropping it breaks the reasoning chain and the model intermittently ends mid-task
+					// turns with a thought-only STOP (empty completion, no tool call).
+					if ((!block.text || block.text.trim() === "") && !thoughtSignature) continue;
 					parts.push({
 						text: sanitizeSurrogates(block.text),
 						...(thoughtSignature && { thoughtSignature }),
 					});
 				} else if (block.type === "thinking") {
-					// Skip empty thinking blocks
-					if (!block.thinking || block.thinking.trim() === "") continue;
 					// Only keep as thinking block if same provider AND same model
 					// Otherwise convert to plain text (no tags to avoid model mimicking them)
 					if (isSameProviderAndModel) {
 						const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thinkingSignature);
+						// Same rule as text blocks: an empty thinking block is dropped only when it
+						// carries no signature (mirrors the anthropic converter's handling).
+						if ((!block.thinking || block.thinking.trim() === "") && !thoughtSignature) continue;
 						parts.push({
 							thought: true,
 							text: sanitizeSurrogates(block.thinking),
 							...(thoughtSignature && { thoughtSignature }),
 						});
 					} else {
+						// Cross-provider/model: the signature is unusable, empty blocks stay dropped.
+						if (!block.thinking || block.thinking.trim() === "") continue;
 						parts.push({
 							text: sanitizeSurrogates(block.thinking),
 						});

--- a/packages/ai/test/google-shared-signed-empty-blocks.test.ts
+++ b/packages/ai/test/google-shared-signed-empty-blocks.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/api/google-shared.ts";
+import type { AssistantMessage, Context, Model } from "../src/types.ts";
+
+// Gemini can attach `thoughtSignature` to a response part whose visible text is empty (e.g. a
+// thought burst preceding a function call) and requires the signature echoed back on the next
+// request. Dropping such blocks while rebuilding history silently breaks the reasoning chain:
+// the model then intermittently ends a mid-task turn with a thought-only STOP and no tool call.
+// These tests pin the rule: an empty text/thinking block is skipped only when it is UNSIGNED.
+
+function makeModel(id = "gemini-3-pro-preview"): Model<"google-generative-ai"> {
+	return {
+		id,
+		name: id,
+		api: "google-generative-ai",
+		provider: "google",
+		baseUrl: "https://example.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+}
+
+const VALID_SIG = "AAAAAAAAAAAAAAAAAAAAAA==";
+
+function makeContext(
+	model: { api: string; provider: string; id: string },
+	content: AssistantMessage["content"],
+): Context {
+	const now = Date.now();
+	return {
+		messages: [
+			{ role: "user", content: "Hi", timestamp: now },
+			{
+				role: "assistant",
+				content,
+				api: model.api as AssistantMessage["api"],
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: now,
+			},
+		],
+	};
+}
+
+describe("google-shared convertMessages — signed empty blocks", () => {
+	it("keeps a signed empty thinking block so its signature is echoed back", () => {
+		const model = makeModel();
+		const contents = convertMessages(
+			model,
+			makeContext(model, [
+				{ type: "thinking", thinking: "", thinkingSignature: VALID_SIG },
+				{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+			]),
+		);
+		const modelTurn = contents.find((c) => c.role === "model");
+		const signed = modelTurn?.parts?.filter((p) => p.thoughtSignature === VALID_SIG) ?? [];
+		expect(signed).toHaveLength(1);
+		expect(signed[0]?.thought).toBe(true);
+	});
+
+	it("keeps a signed empty text block the same way", () => {
+		const model = makeModel();
+		const contents = convertMessages(
+			model,
+			makeContext(model, [
+				{ type: "text", text: "", textSignature: VALID_SIG },
+				{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+			]),
+		);
+		const modelTurn = contents.find((c) => c.role === "model");
+		const signed = modelTurn?.parts?.filter((p) => p.thoughtSignature === VALID_SIG) ?? [];
+		expect(signed).toHaveLength(1);
+	});
+
+	it("still drops unsigned empty blocks", () => {
+		const model = makeModel();
+		const contents = convertMessages(
+			model,
+			makeContext(model, [
+				{ type: "thinking", thinking: "" },
+				{ type: "text", text: "   " },
+				{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+			]),
+		);
+		const modelTurn = contents.find((c) => c.role === "model");
+		expect(modelTurn?.parts).toHaveLength(1);
+		expect(modelTurn?.parts?.[0]?.functionCall).toBeTruthy();
+	});
+
+	it("still drops signed empty blocks from a different provider/model (signature unusable)", () => {
+		const model = makeModel();
+		const contents = convertMessages(
+			model,
+			makeContext({ ...model, id: "other-model" }, [
+				{ type: "thinking", thinking: "", thinkingSignature: VALID_SIG },
+				{ type: "text", text: "", textSignature: VALID_SIG },
+				{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+			]),
+		);
+		const modelTurn = contents.find((c) => c.role === "model");
+		expect(modelTurn?.parts).toHaveLength(1);
+		expect(modelTurn?.parts?.[0]?.functionCall).toBeTruthy();
+		expect(JSON.stringify(modelTurn)).not.toContain(VALID_SIG);
+	});
+});


### PR DESCRIPTION
Fixes #7356.

`convertMessages` drops empty text/thinking blocks when rebuilding history — including their `thoughtSignature`. Gemini puts signatures on empty parts too and expects them echoed back. With the chain broken, gemini flash intermittently ends a mid-task turn with a thought-only STOP (no content, no tool call), which the agent loop reads as done. This silently killed 16 of 34 batch runs in one day for us, on byte-identical inputs.

Fix: drop an empty block only when it is unsigned — the rule the anthropic converter already uses. Cross-provider/model history is unchanged (signature unusable there). Covers `google` and `google-vertex` (shared converter).

Tests in `test/google-shared-signed-empty-blocks.test.ts`; `npm run check` and `./test.sh` pass.
