### PR TITLE
fix: validateToolArguments() coerces nullable union

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed tool argument validation to preserve values that already match an `anyOf`/`oneOf` union arm before attempting coercion, avoiding nullable unions converting `null` to another primitive value ([#7328](https://github.com/earendil-works/pi/issues/7328)).
 - Updated GPT-5.6 Terra and Luna pricing across OpenAI and passthrough model catalogs.
 
 ## [0.83.0] - 2026-07-29

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -173,6 +173,13 @@ function applySchemaArrayCoercion(value: unknown[], schema: JsonSchemaObject): v
 
 function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unknown {
 	for (const schema of schemas) {
+		const validator = getSubSchemaValidator(schema);
+		if (validator?.Check(value)) {
+			return value;
+		}
+	}
+
+	for (const schema of schemas) {
 		const candidate = structuredClone(value);
 		const coerced = coerceWithJsonSchema(candidate, schema);
 		const validator = getSubSchemaValidator(schema);

--- a/packages/ai/test/validation.test.ts
+++ b/packages/ai/test/validation.test.ts
@@ -98,6 +98,42 @@ describe("validateToolArguments", () => {
 		}
 	});
 
+	it("preserves a value that already matches a nullable union arm", () => {
+		const tool: Tool = {
+			name: "echo",
+			description: "Echo tool",
+			parameters: Type.Object({
+				value: Type.Union([Type.Number(), Type.Null()]),
+			}),
+		};
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tool-1",
+			name: "echo",
+			arguments: { value: null },
+		};
+
+		expect(validateToolArguments(tool, toolCall)).toEqual({ value: null });
+	});
+
+	it("preserves a value that already matches a oneOf nullable union arm", () => {
+		const { tool, toolCall } = createToolCallWithPlainSchema(
+			{ oneOf: [{ type: "number" }, { type: "null" }] } as Tool["parameters"],
+			null,
+		);
+
+		expect(validateToolArguments(tool, toolCall)).toEqual({ value: null });
+	});
+
+	it("still coerces nullable unions when the original value does not match any arm", () => {
+		const { tool, toolCall } = createToolCallWithPlainSchema(
+			{ anyOf: [{ type: "number" }, { type: "null" }] } as Tool["parameters"],
+			"42",
+		);
+
+		expect(validateToolArguments(tool, toolCall)).toEqual({ value: 42 });
+	});
+
 	it("accepts null for nullable array schemas with items", () => {
 		const { tool, toolCall } = createToolCallWithPlainSchema(
 			{ type: ["array", "null"], items: { type: "string" } } as Tool["parameters"],


### PR DESCRIPTION
Addresses #7328.

Reproduced the issue where `validateToolArguments()` coerced null in a nullable union like `Type.Union([Type.Number(), Type.Null()])` into `0`, because union coercion tried coercing each arm before checking whether the original value was already valid.

Fixed this by making `anyOf`/`oneOf` coercion first preserve values that already validate against any union member, and only fall back to existing coercion when no member accepts the original value.

Re-ran the repro test from the issue to verify fix. It now preserves `{ value: null }`.