### PR TITLE
fix(agent): parallel tool batches persist each sibling result on its own completion

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,54 @@
+# Fix parallel tool batches losing completed results when one sibling stalls
+
+## Summary
+
+Restructure `executeToolCallsParallel` in `packages/agent/src/agent-loop.ts` so that each sibling's `toolResultMessage` is persisted (emitted) at that sibling's own completion, never gated on the batch's `Promise.all` barrier. Add an abort race so the barrier can be abandoned when the user presses Esc, synthesizing "Operation aborted" outcomes for never-settled siblings so no tool call is orphaned.
+
+## Root Cause
+
+In the previous implementation, `createToolResultMessage` + `emitToolResultMessage` ran in a sequential loop **after** `await Promise.all(...)`. This meant:
+
+1. `tool_execution_end` was emitted per sibling on completion (from #3503), but the toolResult message was not persisted until **all** siblings settled.
+2. If one tool stalled (e.g. a network socket ignoring the abort signal), the `Promise.all` barrier never resolved.
+3. While waiting, **no** toolResult was persisted to `Agent.state.messages` via `message_end` → `agent.ts::processEvents`.
+4. On the next turn, `transformMessages` synthesised `isError: true "No result provided"` for every tool in the batch.
+5. The UI appeared frozen because `turn_end`/`agent_end` were never reached.
+
+## The Fix
+
+### Per-sibling persistence
+Each prepared tool call thunk now calls `createToolResultMessage` + `emitToolResultMessage` inline on its own completion, before resolving. Completed siblings can no longer be gated by a stalled sibling.
+
+### Claim map
+A `Map<toolCallId, ToolResultMessage>` coordinates emission with the abort race. Whoever inserts an id into the map is the one to emit that result. The check-before-insert never spans an `await`, so every `toolCallId` gets exactly one emitted `toolResult` — including when a stalled sibling settles after the batch was already abandoned on abort (it sees the claim and stays silent).
+
+### Abort race
+`Promise.race([allSettled, waitForAbort(signal)])` lets the function exit even when a sibling ignores the abort signal. On abort, `synthesizeAbortedOutcomes` builds error outcomes for any sibling that never settled (or whose thunk's emission was still in-flight), emitting `tool_execution_end` + `toolResult` for each so UIs clear their "running" state.
+
+### Return-value semantics preserved
+The returned `messages` array and `turn_end.toolResults` remain in assistant source order regardless of completion order, so downstream consumers and `shouldTerminateToolBatch` are unaffected.
+
+## Behavior Change
+
+**In parallel mode, `toolResult` message events (`message_start`/`message_end`) are now emitted in tool completion order** rather than assistant source order. `turn_end.toolResults` and the messages returned from the batch remain in assistant source order (matched by `toolCallId`). This mirrors the existing `tool_execution_end` completion-order semantics from #3503. Extensions and UIs that consume `toolResult` events should be updated accordingly.
+
+## Files Changed
+
+- `packages/agent/src/agent-loop.ts` — restructured `executeToolCallsParallel`
+- `packages/agent/src/types.ts` — updated `ToolExecutionMode` and `AgentLoopConfig.toolExecution` TSDoc
+- `packages/agent/test/agent-loop.test.ts` — updated one existing test + 6 new regression tests
+- `packages/coding-agent/docs/extensions.md` — updated `tool_execution_*` and `tool_result` documentation
+
+## Test Commands
+
+```bash
+# Run agent-loop tests (21 original + 6 new = 27 passing)
+cd packages/agent && npx vitest --run test/agent-loop.test.ts
+
+# Typecheck
+cd .. && npx tsc --noEmit -p packages/agent/tsconfig.build.json
+```
+
+## Related Issues
+
+Fixes #7053. Related to the broader `Promise.all`-barrier pattern: #7113, #6665, #7153, #6755.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -494,7 +494,15 @@ async function executeToolCallsParallel(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 ): Promise<ExecutedToolCallBatch> {
-	const finalizedCalls: FinalizedToolCallEntry[] = [];
+	const entries: ParallelToolCallEntry[] = [];
+	const settledOutcomes: Array<PersistedToolCallResult | undefined> = [];
+
+	// Claim map coordinating per-sibling persistence with the abort race below.
+	// Inserting a toolCallId IS the claim: whoever inserts must be the one to
+	// emit that result, and check-then-insert never spans an await, so each
+	// toolCallId gets exactly one emitted toolResult — including when a stalled
+	// sibling settles after the batch was abandoned on abort.
+	const claimedToolResults = new Map<string, ToolResultMessage>();
 
 	for (const toolCall of toolCalls) {
 		await emit({
@@ -511,45 +519,133 @@ async function executeToolCallsParallel(
 				result: preparation.result,
 				isError: preparation.isError,
 			} satisfies FinalizedToolCallOutcome;
+
+			// Immediate outcomes complete during preflight: persist right away,
+			// exactly like executeToolCallsSequential does per iteration.
+			const toolResultMessage = createToolResultMessage(finalized);
+			claimedToolResults.set(toolCall.id, toolResultMessage);
 			await emitToolExecutionEnd(finalized, emit);
-			finalizedCalls.push(finalized);
+			await emitToolResultMessage(toolResultMessage, emit);
+			entries.push({ kind: "settled", toolCall, outcome: { finalized, toolResultMessage } });
 			if (signal?.aborted) {
 				break;
 			}
 			continue;
 		}
 
-		finalizedCalls.push(async () => {
-			const executed = await executePreparedToolCall(preparation, signal, emit);
-			const finalized = await finalizeExecutedToolCall(
-				currentContext,
-				assistantMessage,
-				preparation,
-				executed,
-				config,
-				signal,
-			);
-			await emitToolExecutionEnd(finalized, emit);
-			return finalized;
+		const index = entries.length;
+		entries.push({
+			kind: "pending",
+			toolCall,
+			run: async () => {
+				const executed = await executePreparedToolCall(preparation, signal, emit);
+				const finalized = await finalizeExecutedToolCall(
+					currentContext,
+					assistantMessage,
+					preparation,
+					executed,
+					config,
+					signal,
+				);
+
+				// Claim-or-bail. No await between the check and the insertion.
+				// If the abort race claimed this id first, the batch was abandoned
+				// and an abort error was already emitted for it: stay silent so we
+				// never emit a duplicate toolResult or post-abort events.
+				const claimed = claimedToolResults.get(toolCall.id);
+				if (claimed) {
+					return { finalized, toolResultMessage: claimed };
+				}
+
+				const toolResultMessage = createToolResultMessage(finalized);
+				claimedToolResults.set(toolCall.id, toolResultMessage);
+				const outcome: PersistedToolCallResult = { finalized, toolResultMessage };
+
+				// Record synchronously so the abort race can see this sibling is
+				// already persisted (emission in flight) and skip it.
+				settledOutcomes[index] = outcome;
+
+				// Persist THIS sibling now, on its own completion, instead of
+				// waiting for the Promise.all barrier. A stalled sibling can no
+				// longer gate the durability of already-completed ones.
+				await emitToolExecutionEnd(finalized, emit);
+				await emitToolResultMessage(toolResultMessage, emit);
+				return outcome;
+			},
 		});
 		if (signal?.aborted) {
 			break;
 		}
 	}
 
-	const orderedFinalizedCalls = await Promise.all(
-		finalizedCalls.map((entry) => (typeof entry === "function" ? entry() : Promise.resolve(entry))),
+	// Builds abort-error outcomes for siblings that never settled, emitting them
+	// so their tool calls are not orphaned and UIs clear their pending state.
+	// Each id is claimed synchronously BEFORE the first emit await, so a
+	// late-settling thunk sees the claim and stays silent.
+	const synthesizeAbortedOutcomes = async (): Promise<PersistedToolCallResult[]> => {
+		const results: PersistedToolCallResult[] = [];
+		for (let index = 0; index < entries.length; index++) {
+			const entry = entries[index];
+			if (!entry) {
+				continue;
+			}
+			const settled = entry.kind === "settled" ? entry.outcome : settledOutcomes[index];
+			if (settled) {
+				// Persisted before the abort (or claimed with emission in flight).
+				results.push(settled);
+				continue;
+			}
+
+			const finalized: FinalizedToolCallOutcome = {
+				toolCall: entry.toolCall,
+				result: createErrorToolResult("Operation aborted"),
+				isError: true,
+			};
+			const toolResultMessage = createToolResultMessage(finalized);
+			claimedToolResults.set(entry.toolCall.id, toolResultMessage);
+			const outcome: PersistedToolCallResult = { finalized, toolResultMessage };
+			settledOutcomes[index] = outcome;
+
+			// Emit tool_execution_end too, otherwise the stalled call keeps
+			// rendering as "running" until the next turn.
+			await emitToolExecutionEnd(finalized, emit);
+			await emitToolResultMessage(toolResultMessage, emit);
+			results.push(outcome);
+		}
+		return results;
+	};
+
+	// Start all prepared thunks concurrently. The barrier now only assembles
+	// the source-ordered return value; it no longer gates durability.
+	const runners = entries.map((entry) =>
+		entry.kind === "settled" ? Promise.resolve(entry.outcome) : entry.run(),
 	);
-	const messages: ToolResultMessage[] = [];
-	for (const finalized of orderedFinalizedCalls) {
-		const toolResultMessage = createToolResultMessage(finalized);
-		await emitToolResultMessage(toolResultMessage, emit);
-		messages.push(toolResultMessage);
+	const allSettled = Promise.all(runners);
+
+	// If the abort race wins, allSettled may reject later (e.g. a listener
+	// throws inside a late-settling thunk). Mark it handled so it cannot
+	// surface as an unhandled rejection after the batch has returned.
+	allSettled.catch(() => {});
+
+	let outcomes: PersistedToolCallResult[];
+	if (signal) {
+		const abort = waitForAbort(signal);
+		const winner = await Promise.race([
+			allSettled.then((values) => ({ kind: "completed" as const, values })),
+			abort.promise,
+		]);
+		abort.cancel();
+		outcomes = winner === "aborted" ? await synthesizeAbortedOutcomes() : winner.values;
+	} else {
+		outcomes = await allSettled;
 	}
 
+	// Return value keeps assistant source order regardless of completion order,
+	// so turn_end.toolResults and the next LLM call's context are unchanged
+	// from pre-fix semantics.
 	return {
-		messages,
-		terminate: shouldTerminateToolBatch(orderedFinalizedCalls),
+		messages: outcomes.map((outcome) => outcome.toolResultMessage),
+		terminate: shouldTerminateToolBatch(outcomes.map((outcome) => outcome.finalized)),
 	};
 }
 
@@ -577,7 +673,19 @@ type FinalizedToolCallOutcome = {
 	isError: boolean;
 };
 
-type FinalizedToolCallEntry = FinalizedToolCallOutcome | (() => Promise<FinalizedToolCallOutcome>);
+/** A finalized tool call plus the exact ToolResultMessage that was emitted for it. */
+type PersistedToolCallResult = { finalized: FinalizedToolCallOutcome; toolResultMessage: ToolResultMessage };
+
+/**
+ * One entry of a parallel tool batch.
+ * - "settled": outcome known during preflight (unknown tool, invalid args,
+ *   blocked call, aborted preflight). Persisted inline, in preflight order.
+ * - "pending": a prepared tool call whose thunk executes, finalizes, and
+ *   persists its own tool result before resolving.
+ */
+type ParallelToolCallEntry =
+	| { kind: "settled"; toolCall: AgentToolCall; outcome: PersistedToolCallResult }
+	| { kind: "pending"; toolCall: AgentToolCall; run: () => Promise<PersistedToolCallResult> };
 
 function shouldTerminateToolBatch(finalizedCalls: FinalizedToolCallOutcome[]): boolean {
 	return finalizedCalls.length > 0 && finalizedCalls.every((finalized) => finalized.result.terminate === true);
@@ -757,6 +865,32 @@ function createErrorToolResult(message: string): AgentToolResult<any> {
 	return {
 		content: [{ type: "text", text: message }],
 		details: {},
+	};
+}
+
+/**
+ * Promise resolving when the signal aborts. `cancel` detaches the listener once
+ * the race is decided so the signal does not retain the closure for the rest of
+ * the run.
+ */
+function waitForAbort(signal: AbortSignal): { promise: Promise<"aborted">; cancel: () => void } {
+	let onAbort: (() => void) | undefined;
+	const promise = new Promise<"aborted">((resolve) => {
+		if (signal.aborted) {
+			resolve("aborted");
+			return;
+		}
+		onAbort = () => resolve("aborted");
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	return {
+		promise,
+		cancel: () => {
+			if (onAbort) {
+				signal.removeEventListener("abort", onAbort);
+				onAbort = undefined;
+			}
+		},
 	};
 }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -36,8 +36,11 @@ export type StreamFn = (
  *
  * - "sequential": each tool call is prepared, executed, and finalized before the next one starts.
  * - "parallel": tool calls are prepared sequentially, then allowed tools execute concurrently.
- *   `tool_execution_end` is emitted in tool completion order after each tool is finalized,
- *   while tool-result message artifacts are emitted later in assistant source order.
+ *   `tool_execution_end` and the tool-result message events are emitted per tool in
+ *   completion order as each tool is finalized, so completed tools are persisted even
+ *   if a sibling stalls. The batch's returned `toolResults` (and `turn_end.toolResults`)
+ *   remain in assistant source order. On abort, siblings that never settled are
+ *   persisted as `isError` "Operation aborted" results instead of being orphaned.
  */
 export type ToolExecutionMode = "sequential" | "parallel";
 
@@ -255,8 +258,11 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * Tool execution mode.
 	 * - "sequential": execute tool calls one by one
 	 * - "parallel": preflight tool calls sequentially, then execute allowed tools concurrently;
-	 *   emit `tool_execution_end` in tool completion order after each tool is finalized,
-	 *   then emit tool-result message artifacts later in assistant source order
+	 *   `tool_execution_end` and the tool-result message events are emitted per tool in
+	 *   completion order as each tool is finalized, so completed tools are persisted even
+	 *   if a sibling stalls. The batch's returned `toolResults` (and `turn_end.toolResults`)
+	 *   remain in assistant source order. On abort, siblings that never settled are
+	 *   persisted as `isError` "Operation aborted" results instead of being orphaned.
 	 *
 	 * Default: "parallel"
 	 */

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -15,40 +15,40 @@ import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool
 // Mock stream for testing - mimics MockAssistantStream
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
 	constructor() {
-		super(
-			(event) => event.type === "done" || event.type === "error",
-			(event) => {
-				if (event.type === "done") return event.message;
-				if (event.type === "error") return event.error;
-				throw new Error("Unexpected event type");
-			},
-		);
+	super(
+		(event) => event.type === "done" || event.type === "error",
+		(event) => {
+		if (event.type === "done") return event.message;
+		if (event.type === "error") return event.error;
+		throw new Error("Unexpected event type");
+		},
+	);
 	}
 }
 
 function createUsage() {
 	return {
-		input: 0,
-		output: 0,
-		cacheRead: 0,
-		cacheWrite: 0,
-		totalTokens: 0,
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 	};
 }
 
 function createModel(): Model<"openai-responses"> {
 	return {
-		id: "mock",
-		name: "mock",
-		api: "openai-responses",
-		provider: "openai",
-		baseUrl: "https://example.invalid",
-		reasoning: false,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 8192,
-		maxTokens: 2048,
+	id: "mock",
+	name: "mock",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://example.invalid",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 8192,
+	maxTokens: 2048,
 	};
 }
 
@@ -57,22 +57,22 @@ function createAssistantMessage(
 	stopReason: AssistantMessage["stopReason"] = "stop",
 ): AssistantMessage {
 	return {
-		role: "assistant",
-		content,
-		api: "openai-responses",
-		provider: "openai",
-		model: "mock",
-		usage: createUsage(),
-		stopReason,
-		timestamp: Date.now(),
+	role: "assistant",
+	content,
+	api: "openai-responses",
+	provider: "openai",
+	model: "mock",
+	usage: createUsage(),
+	stopReason,
+	timestamp: Date.now(),
 	};
 }
 
 function createUserMessage(text: string): UserMessage {
 	return {
-		role: "user",
-		content: text,
-		timestamp: Date.now(),
+	role: "user",
+	content: text,
+	timestamp: Date.now(),
 	};
 }
 
@@ -83,1407 +83,2075 @@ function identityConverter(messages: AgentMessage[]): Message[] {
 
 describe("default stream function compatibility", () => {
 	it("uses the configured default when a legacy caller omits streamFn", async () => {
-		let calls = 0;
-		setDefaultStreamFn(() => {
-			calls++;
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				stream.push({
-					type: "done",
-					reason: "stop",
-					message: createAssistantMessage([{ type: "text", text: "fallback" }]),
-				});
-			});
-			return stream;
+	let calls = 0;
+	setDefaultStreamFn(() => {
+		calls++;
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		stream.push({
+			type: "done",
+			reason: "stop",
+			message: createAssistantMessage([{ type: "text", text: "fallback" }]),
 		});
+		});
+		return stream;
+	});
 
-		try {
-			const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
-			const config: AgentLoopConfig = { model: createModel(), convertToLlm: identityConverter };
-			const stream = Reflect.apply(agentLoop, undefined, [
-				[createUserMessage("Hello")],
-				context,
-				config,
-				undefined,
-			]) as ReturnType<typeof agentLoop>;
+	try {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = { model: createModel(), convertToLlm: identityConverter };
+		const stream = Reflect.apply(agentLoop, undefined, [
+		[createUserMessage("Hello")],
+		context,
+		config,
+		undefined,
+		]) as ReturnType<typeof agentLoop>;
 
-			await stream.result();
-			expect(calls).toBe(1);
-		} finally {
-			setDefaultStreamFn(undefined);
-		}
+		await stream.result();
+		expect(calls).toBe(1);
+	} finally {
+		setDefaultStreamFn(undefined);
+	}
 	});
 });
 
 describe("agentLoop with AgentMessage", () => {
 	it("should emit events with AgentMessage types", async () => {
-		const context: AgentContext = {
-			systemPrompt: "You are helpful.",
-			messages: [],
-			tools: [],
-		};
+	const context: AgentContext = {
+		systemPrompt: "You are helpful.",
+		messages: [],
+		tools: [],
+	};
 
-		const userPrompt: AgentMessage = createUserMessage("Hello");
+	const userPrompt: AgentMessage = createUserMessage("Hello");
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
 
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				const message = createAssistantMessage([{ type: "text", text: "Hi there!" }]);
-				stream.push({ type: "done", reason: "stop", message });
-			});
-			return stream;
-		};
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		const message = createAssistantMessage([{ type: "text", text: "Hi there!" }]);
+		stream.push({ type: "done", reason: "stop", message });
+		});
+		return stream;
+	};
 
-		const events: AgentEvent[] = [];
-		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+	const events: AgentEvent[] = [];
+	const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
 
-		for await (const event of stream) {
-			events.push(event);
-		}
+	for await (const event of stream) {
+		events.push(event);
+	}
 
-		const messages = await stream.result();
+	const messages = await stream.result();
 
-		// Should have user message and assistant message
-		expect(messages.length).toBe(2);
-		expect(messages[0].role).toBe("user");
-		expect(messages[1].role).toBe("assistant");
+	// Should have user message and assistant message
+	expect(messages.length).toBe(2);
+	expect(messages[0].role).toBe("user");
+	expect(messages[1].role).toBe("assistant");
 
-		// Verify event sequence
-		const eventTypes = events.map((e) => e.type);
-		expect(eventTypes).toContain("agent_start");
-		expect(eventTypes).toContain("turn_start");
-		expect(eventTypes).toContain("message_start");
-		expect(eventTypes).toContain("message_end");
-		expect(eventTypes).toContain("turn_end");
-		expect(eventTypes).toContain("agent_end");
+	// Verify event sequence
+	const eventTypes = events.map((e) => e.type);
+	expect(eventTypes).toContain("agent_start");
+	expect(eventTypes).toContain("turn_start");
+	expect(eventTypes).toContain("message_start");
+	expect(eventTypes).toContain("message_end");
+	expect(eventTypes).toContain("turn_end");
+	expect(eventTypes).toContain("agent_end");
 	});
 
 	it("should handle custom message types via convertToLlm", async () => {
-		// Create a custom message type
-		interface CustomNotification {
-			role: "notification";
-			text: string;
-			timestamp: number;
-		}
+	// Create a custom message type
+	interface CustomNotification {
+		role: "notification";
+		text: string;
+		timestamp: number;
+	}
 
-		const notification: CustomNotification = {
-			role: "notification",
-			text: "This is a notification",
-			timestamp: Date.now(),
-		};
+	const notification: CustomNotification = {
+		role: "notification",
+		text: "This is a notification",
+		timestamp: Date.now(),
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "You are helpful.",
-			messages: [notification as unknown as AgentMessage], // Custom message in context
-			tools: [],
-		};
+	const context: AgentContext = {
+		systemPrompt: "You are helpful.",
+		messages: [notification as unknown as AgentMessage], // Custom message in context
+		tools: [],
+	};
 
-		const userPrompt: AgentMessage = createUserMessage("Hello");
+	const userPrompt: AgentMessage = createUserMessage("Hello");
 
-		let convertedMessages: Message[] = [];
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: (messages) => {
-				// Filter out notifications, convert rest
-				convertedMessages = messages
-					.filter((m) => (m as { role: string }).role !== "notification")
-					.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
-				return convertedMessages;
-			},
-		};
+	let convertedMessages: Message[] = [];
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: (messages) => {
+		// Filter out notifications, convert rest
+		convertedMessages = messages
+			.filter((m) => (m as { role: string }).role !== "notification")
+			.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+		return convertedMessages;
+		},
+	};
 
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				const message = createAssistantMessage([{ type: "text", text: "Response" }]);
-				stream.push({ type: "done", reason: "stop", message });
-			});
-			return stream;
-		};
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		const message = createAssistantMessage([{ type: "text", text: "Response" }]);
+		stream.push({ type: "done", reason: "stop", message });
+		});
+		return stream;
+	};
 
-		const events: AgentEvent[] = [];
-		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+	const events: AgentEvent[] = [];
+	const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
 
-		for await (const event of stream) {
-			events.push(event);
-		}
+	for await (const event of stream) {
+		events.push(event);
+	}
 
-		// The notification should have been filtered out in convertToLlm
-		expect(convertedMessages.length).toBe(1); // Only user message
-		expect(convertedMessages[0].role).toBe("user");
+	// The notification should have been filtered out in convertToLlm
+	expect(convertedMessages.length).toBe(1); // Only user message
+	expect(convertedMessages[0].role).toBe("user");
 	});
 
 	it("should apply transformContext before convertToLlm", async () => {
-		const context: AgentContext = {
-			systemPrompt: "You are helpful.",
-			messages: [
-				createUserMessage("old message 1"),
-				createAssistantMessage([{ type: "text", text: "old response 1" }]),
-				createUserMessage("old message 2"),
-				createAssistantMessage([{ type: "text", text: "old response 2" }]),
-			],
-			tools: [],
-		};
+	const context: AgentContext = {
+		systemPrompt: "You are helpful.",
+		messages: [
+		createUserMessage("old message 1"),
+		createAssistantMessage([{ type: "text", text: "old response 1" }]),
+		createUserMessage("old message 2"),
+		createAssistantMessage([{ type: "text", text: "old response 2" }]),
+		],
+		tools: [],
+	};
 
-		const userPrompt: AgentMessage = createUserMessage("new message");
+	const userPrompt: AgentMessage = createUserMessage("new message");
 
-		let transformedMessages: AgentMessage[] = [];
-		let convertedMessages: Message[] = [];
+	let transformedMessages: AgentMessage[] = [];
+	let convertedMessages: Message[] = [];
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			transformContext: async (messages) => {
-				// Keep only last 2 messages (prune old ones)
-				transformedMessages = messages.slice(-2);
-				return transformedMessages;
-			},
-			convertToLlm: (messages) => {
-				convertedMessages = messages.filter(
-					(m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult",
-				) as Message[];
-				return convertedMessages;
-			},
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		transformContext: async (messages) => {
+		// Keep only last 2 messages (prune old ones)
+		transformedMessages = messages.slice(-2);
+		return transformedMessages;
+		},
+		convertToLlm: (messages) => {
+		convertedMessages = messages.filter(
+			(m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult",
+		) as Message[];
+		return convertedMessages;
+		},
+	};
 
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				const message = createAssistantMessage([{ type: "text", text: "Response" }]);
-				stream.push({ type: "done", reason: "stop", message });
-			});
-			return stream;
-		};
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		const message = createAssistantMessage([{ type: "text", text: "Response" }]);
+		stream.push({ type: "done", reason: "stop", message });
+		});
+		return stream;
+	};
 
-		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+	const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
 
-		for await (const _ of stream) {
-			// consume
-		}
+	for await (const _ of stream) {
+		// consume
+	}
 
-		// transformContext should have been called first, keeping only last 2
-		expect(transformedMessages.length).toBe(2);
-		// Then convertToLlm receives the pruned messages
-		expect(convertedMessages.length).toBe(2);
+	// transformContext should have been called first, keeping only last 2
+	expect(transformedMessages.length).toBe(2);
+	// Then convertToLlm receives the pruned messages
+	expect(convertedMessages.length).toBe(2);
 	});
 
 	it("should handle tool calls and results", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const executed: string[] = [];
-		const toolUsage = {
-			input: 1,
-			output: 2,
-			cacheRead: 3,
-			cacheWrite: 4,
-			totalTokens: 10,
-			cost: { input: 0.1, output: 0.2, cacheRead: 0.3, cacheWrite: 0.4, total: 1 },
+	const toolSchema = Type.Object({ value: Type.String() });
+	const executed: string[] = [];
+	const toolUsage = {
+		input: 1,
+		output: 2,
+		cacheRead: 3,
+		cacheWrite: 4,
+		totalTokens: 10,
+		cost: { input: 0.1, output: 0.2, cacheRead: 0.3, cacheWrite: 0.4, total: 1 },
+	};
+	const patchedToolUsage = {
+		input: 5,
+		output: 6,
+		cacheRead: 7,
+		cacheWrite: 8,
+		totalTokens: 26,
+		cost: { input: 0.5, output: 0.6, cacheRead: 0.7, cacheWrite: 0.8, total: 2.6 },
+	};
+	let observedToolUsage: typeof toolUsage | undefined;
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		executed.push(params.value);
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
+			usage: toolUsage,
 		};
-		const patchedToolUsage = {
-			input: 5,
-			output: 6,
-			cacheRead: 7,
-			cacheWrite: 8,
-			totalTokens: 26,
-			cost: { input: 0.5, output: 0.6, cacheRead: 0.7, cacheWrite: 0.8, total: 2.6 },
-		};
-		let observedToolUsage: typeof toolUsage | undefined;
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				executed.push(params.value);
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-					usage: toolUsage,
-				};
-			},
-		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		const userPrompt: AgentMessage = createUserMessage("echo something");
+	const userPrompt: AgentMessage = createUserMessage("echo something");
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			afterToolCall: async ({ result }) => {
-				observedToolUsage = result.usage;
-				return { usage: patchedToolUsage };
-			},
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		afterToolCall: async ({ result }) => {
+		observedToolUsage = result.usage;
+		return { usage: patchedToolUsage };
+		},
+	};
 
-		let callIndex = 0;
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					// First call: return tool call
-					const message = createAssistantMessage(
-						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
-						"toolUse",
-					);
-					stream.push({ type: "done", reason: "toolUse", message });
-				} else {
-					// Second call: return final response
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					stream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return stream;
-		};
-
-		const events: AgentEvent[] = [];
-		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
-
-		for await (const event of stream) {
-			events.push(event);
+	let callIndex = 0;
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			// First call: return tool call
+			const message = createAssistantMessage(
+			[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+			"toolUse",
+			);
+			stream.push({ type: "done", reason: "toolUse", message });
+		} else {
+			// Second call: return final response
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			stream.push({ type: "done", reason: "stop", message });
 		}
+		callIndex++;
+		});
+		return stream;
+	};
 
-		// Tool should have been executed
-		expect(executed).toEqual(["hello"]);
+	const events: AgentEvent[] = [];
+	const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
 
-		// Should have tool execution events
-		const toolStart = events.find((e) => e.type === "tool_execution_start");
-		const toolEnd = events.find((e) => e.type === "tool_execution_end");
-		expect(toolStart).toBeDefined();
-		expect(toolEnd).toBeDefined();
-		if (toolEnd?.type === "tool_execution_end") {
-			expect(toolEnd.isError).toBe(false);
-		}
-		expect(observedToolUsage).toEqual(toolUsage);
-		const messages = await stream.result();
-		const toolResult = messages.find((message) => message.role === "toolResult");
-		expect(toolResult?.role === "toolResult" ? toolResult.usage : undefined).toEqual(patchedToolUsage);
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	// Tool should have been executed
+	expect(executed).toEqual(["hello"]);
+
+	// Should have tool execution events
+	const toolStart = events.find((e) => e.type === "tool_execution_start");
+	const toolEnd = events.find((e) => e.type === "tool_execution_end");
+	expect(toolStart).toBeDefined();
+	expect(toolEnd).toBeDefined();
+	if (toolEnd?.type === "tool_execution_end") {
+		expect(toolEnd.isError).toBe(false);
+	}
+	expect(observedToolUsage).toEqual(toolUsage);
+	const messages = await stream.result();
+	const toolResult = messages.find((message) => message.role === "toolResult");
+	expect(toolResult?.role === "toolResult" ? toolResult.usage : undefined).toEqual(patchedToolUsage);
 	});
 
 	it("should not execute tool calls from a length-truncated assistant message", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const executed: string[] = [];
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				executed.push(params.value);
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
+	const toolSchema = Type.Object({ value: Type.String() });
+	const executed: string[] = [];
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		executed.push(params.value);
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
 
-		let callIndex = 0;
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					// Output hit the token limit mid tool call. The salvage parser can
-					// produce arguments that validate but are silently truncated, so
-					// nothing in this message may execute.
-					const message = createAssistantMessage(
-						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hel" } }],
-						"length",
-					);
-					stream.push({ type: "done", reason: "length", message });
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					stream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return stream;
-		};
-
-		const events: AgentEvent[] = [];
-		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, streamFn);
-		for await (const event of stream) {
-			events.push(event);
+	let callIndex = 0;
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			// Output hit the token limit mid tool call. The salvage parser can
+			// produce arguments that validate but are silently truncated, so
+			// nothing in this message may execute.
+			const message = createAssistantMessage(
+			[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hel" } }],
+			"length",
+			);
+			stream.push({ type: "done", reason: "length", message });
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			stream.push({ type: "done", reason: "stop", message });
 		}
+		callIndex++;
+		});
+		return stream;
+	};
 
-		// The tool must never execute with potentially truncated arguments.
-		expect(executed).toEqual([]);
+	const events: AgentEvent[] = [];
+	const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, streamFn);
+	for await (const event of stream) {
+		events.push(event);
+	}
 
-		const toolEnd = events.find((e) => e.type === "tool_execution_end");
-		expect(toolEnd).toBeDefined();
-		if (toolEnd?.type === "tool_execution_end") {
-			expect(toolEnd.isError).toBe(true);
-			const text = toolEnd.result.content.find((c: { type: string }) => c.type === "text");
-			expect(text && "text" in text ? text.text : "").toContain("output token limit");
-		}
+	// The tool must never execute with potentially truncated arguments.
+	expect(executed).toEqual([]);
 
-		// The loop continues so the model can re-issue the tool call.
-		expect(callIndex).toBe(2);
-		const messages = await stream.result();
-		expect(messages[messages.length - 1].role).toBe("assistant");
+	const toolEnd = events.find((e) => e.type === "tool_execution_end");
+	expect(toolEnd).toBeDefined();
+	if (toolEnd?.type === "tool_execution_end") {
+		expect(toolEnd.isError).toBe(true);
+		const text = toolEnd.result.content.find((c: { type: string }) => c.type === "text");
+		expect(text && "text" in text ? text.text : "").toContain("output token limit");
+	}
+
+	// The loop continues so the model can re-issue the tool call.
+	expect(callIndex).toBe(2);
+	const messages = await stream.result();
+	expect(messages[messages.length - 1].role).toBe("assistant");
 	});
 
 	it("should execute mutated beforeToolCall args without revalidation", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const executed: Array<string | number> = [];
-		const tool: AgentTool<typeof toolSchema, { value: string | number }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				executed.push(params.value as string | number);
-				return {
-					content: [{ type: "text", text: `echoed: ${String(params.value)}` }],
-					details: { value: params.value as string | number },
-				};
-			},
+	const toolSchema = Type.Object({ value: Type.String() });
+	const executed: Array<string | number> = [];
+	const tool: AgentTool<typeof toolSchema, { value: string | number }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		executed.push(params.value as string | number);
+		return {
+			content: [{ type: "text", text: `echoed: ${String(params.value)}` }],
+			details: { value: params.value as string | number },
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		const userPrompt: AgentMessage = createUserMessage("echo something");
+	const userPrompt: AgentMessage = createUserMessage("echo something");
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			beforeToolCall: async ({ args }) => {
-				const mutableArgs = args as { value: string | number };
-				mutableArgs.value = 123;
-				return undefined;
-			},
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		beforeToolCall: async ({ args }) => {
+		const mutableArgs = args as { value: string | number };
+		mutableArgs.value = 123;
+		return undefined;
+		},
+	};
 
-		let callIndex = 0;
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					const message = createAssistantMessage(
-						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
-						"toolUse",
-					);
-					stream.push({ type: "done", reason: "toolUse", message });
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					stream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return stream;
-		};
-
-		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
-		for await (const _event of stream) {
-			// consume
+	let callIndex = 0;
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			const message = createAssistantMessage(
+			[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+			"toolUse",
+			);
+			stream.push({ type: "done", reason: "toolUse", message });
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			stream.push({ type: "done", reason: "stop", message });
 		}
+		callIndex++;
+		});
+		return stream;
+	};
 
-		expect(executed).toEqual([123]);
+	const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+	for await (const _event of stream) {
+		// consume
+	}
+
+	expect(executed).toEqual([123]);
 	});
 
 	it("should prepare tool arguments for validation", async () => {
-		const replaceSchema = Type.Object({ oldText: Type.String(), newText: Type.String() });
-		const toolSchema = Type.Object({ edits: Type.Array(replaceSchema) });
-		const executed: Array<Array<{ oldText: string; newText: string }>> = [];
-		const tool: AgentTool<typeof toolSchema, { count: number }> = {
-			name: "edit",
-			label: "Edit",
-			description: "Edit tool",
-			parameters: toolSchema,
-			prepareArguments(args) {
-				if (!args || typeof args !== "object") {
-					return args as { edits: { oldText: string; newText: string }[] };
-				}
-				const input = args as {
-					edits?: Array<{ oldText: string; newText: string }>;
-					oldText?: string;
-					newText?: string;
-				};
-				if (typeof input.oldText !== "string" || typeof input.newText !== "string") {
-					return args as { edits: { oldText: string; newText: string }[] };
-				}
-				return {
-					edits: [...(input.edits ?? []), { oldText: input.oldText, newText: input.newText }],
-				};
-			},
-			async execute(_toolCallId, params) {
-				executed.push(params.edits);
-				return {
-					content: [{ type: "text", text: `edited ${params.edits.length}` }],
-					details: { count: params.edits.length },
-				};
-			},
-		};
-
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
-
-		const userPrompt: AgentMessage = createUserMessage("edit something");
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
-
-		let callIndex = 0;
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					const message = createAssistantMessage(
-						[
-							{
-								type: "toolCall",
-								id: "tool-1",
-								name: "edit",
-								arguments: { oldText: "before", newText: "after" },
-							},
-						],
-						"toolUse",
-					);
-					stream.push({ type: "done", reason: "toolUse", message });
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					stream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return stream;
-		};
-
-		const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
-		for await (const _event of stream) {
-			// consume
+	const replaceSchema = Type.Object({ oldText: Type.String(), newText: Type.String() });
+	const toolSchema = Type.Object({ edits: Type.Array(replaceSchema) });
+	const executed: Array<Array<{ oldText: string; newText: string }>> = [];
+	const tool: AgentTool<typeof toolSchema, { count: number }> = {
+		name: "edit",
+		label: "Edit",
+		description: "Edit tool",
+		parameters: toolSchema,
+		prepareArguments(args) {
+		if (!args || typeof args !== "object") {
+			return args as { edits: { oldText: string; newText: string }[] };
 		}
+		const input = args as {
+			edits?: Array<{ oldText: string; newText: string }>;
+			oldText?: string;
+			newText?: string;
+		};
+		if (typeof input.oldText !== "string" || typeof input.newText !== "string") {
+			return args as { edits: { oldText: string; newText: string }[] };
+		}
+		return {
+			edits: [...(input.edits ?? []), { oldText: input.oldText, newText: input.newText }],
+		};
+		},
+		async execute(_toolCallId, params) {
+		executed.push(params.edits);
+		return {
+			content: [{ type: "text", text: `edited ${params.edits.length}` }],
+			details: { count: params.edits.length },
+		};
+		},
+	};
 
-		expect(executed).toEqual([[{ oldText: "before", newText: "after" }]]);
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
+
+	const userPrompt: AgentMessage = createUserMessage("edit something");
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
+
+	let callIndex = 0;
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			const message = createAssistantMessage(
+			[
+				{
+				type: "toolCall",
+				id: "tool-1",
+				name: "edit",
+				arguments: { oldText: "before", newText: "after" },
+				},
+			],
+			"toolUse",
+			);
+			stream.push({ type: "done", reason: "toolUse", message });
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			stream.push({ type: "done", reason: "stop", message });
+		}
+		callIndex++;
+		});
+		return stream;
+	};
+
+	const stream = agentLoop([userPrompt], context, config, undefined, streamFn);
+	for await (const _event of stream) {
+		// consume
+	}
+
+	expect(executed).toEqual([[{ oldText: "before", newText: "after" }]]);
 	});
 
 	it("should emit tool_execution_end in completion order but persist tool results in source order", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		let firstResolved = false;
-		let parallelObserved = false;
-		let releaseFirst: (() => void) | undefined;
-		const firstDone = new Promise<void>((resolve) => {
-			releaseFirst = resolve;
-		});
+	const toolSchema = Type.Object({ value: Type.String() });
+	let firstResolved = false;
+	let parallelObserved = false;
+	let releaseFirst: (() => void) | undefined;
+	const firstDone = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
 
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				if (params.value === "first") {
-					await firstDone;
-					firstResolved = true;
-				}
-				if (params.value === "second" && !firstResolved) {
-					parallelObserved = true;
-				}
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
-		};
-
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
-
-		const userPrompt: AgentMessage = createUserMessage("echo both");
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			toolExecution: "parallel",
-		};
-
-		let callIndex = 0;
-		const stream = agentLoop([userPrompt], context, config, undefined, () => {
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					const message = createAssistantMessage(
-						[
-							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
-							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
-						],
-						"toolUse",
-					);
-					mockStream.push({ type: "done", reason: "toolUse", message });
-					setTimeout(() => releaseFirst?.(), 20);
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					mockStream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return mockStream;
-		});
-
-		const events: AgentEvent[] = [];
-		for await (const event of stream) {
-			events.push(event);
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		if (params.value === "first") {
+			await firstDone;
+			firstResolved = true;
 		}
+		if (params.value === "second" && !firstResolved) {
+			parallelObserved = true;
+		}
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
+		};
+		},
+	};
 
-		const toolExecutionEndIds = events.flatMap((event) => {
-			if (event.type !== "tool_execution_end") {
-				return [];
-			}
-			return [event.toolCallId];
-		});
-		const toolResultIds = events.flatMap((event) => {
-			if (event.type !== "message_end" || event.message.role !== "toolResult") {
-				return [];
-			}
-			return [event.message.toolCallId];
-		});
-		const turnToolResultIds = events.flatMap((event) => {
-			if (event.type !== "turn_end") {
-				return [];
-			}
-			return event.toolResults.map((toolResult) => toolResult.toolCallId);
-		});
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		expect(parallelObserved).toBe(true);
-		expect(toolExecutionEndIds).toEqual(["tool-2", "tool-1"]);
-		expect(toolResultIds).toEqual(["tool-1", "tool-2"]);
-		expect(turnToolResultIds).toEqual(["tool-1", "tool-2"]);
+	const userPrompt: AgentMessage = createUserMessage("echo both");
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
+
+	let callIndex = 0;
+	const stream = agentLoop([userPrompt], context, config, undefined, () => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			const message = createAssistantMessage(
+			[
+				{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+				{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+			],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			setTimeout(() => releaseFirst?.(), 20);
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			mockStream.push({ type: "done", reason: "stop", message });
+		}
+		callIndex++;
+		});
+		return mockStream;
+	});
+
+	const events: AgentEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	const toolExecutionEndIds = events.flatMap((event) => {
+		if (event.type !== "tool_execution_end") {
+		return [];
+		}
+		return [event.toolCallId];
+	});
+	const toolResultIds = events.flatMap((event) => {
+		if (event.type !== "message_end" || event.message.role !== "toolResult") {
+		return [];
+		}
+		return [event.message.toolCallId];
+	});
+	const turnToolResultIds = events.flatMap((event) => {
+		if (event.type !== "turn_end") {
+		return [];
+		}
+		return event.toolResults.map((toolResult) => toolResult.toolCallId);
+	});
+
+	expect(parallelObserved).toBe(true);
+	expect(toolExecutionEndIds).toEqual(["tool-2", "tool-1"]);
+	expect(toolResultIds).toEqual(["tool-2", "tool-1"]);
+	expect(turnToolResultIds).toEqual(["tool-1", "tool-2"]);
 	});
 
 	it("should inject queued messages after all tool calls complete", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const executed: string[] = [];
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				executed.push(params.value);
-				return {
-					content: [{ type: "text", text: `ok:${params.value}` }],
-					details: { value: params.value },
-				};
-			},
+	const toolSchema = Type.Object({ value: Type.String() });
+	const executed: string[] = [];
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		executed.push(params.value);
+		return {
+			content: [{ type: "text", text: `ok:${params.value}` }],
+			details: { value: params.value },
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		const userPrompt: AgentMessage = createUserMessage("start");
-		const queuedUserMessage: AgentMessage = createUserMessage("interrupt");
+	const userPrompt: AgentMessage = createUserMessage("start");
+	const queuedUserMessage: AgentMessage = createUserMessage("interrupt");
 
-		let queuedDelivered = false;
-		let callIndex = 0;
-		let sawInterruptInContext = false;
+	let queuedDelivered = false;
+	let callIndex = 0;
+	let sawInterruptInContext = false;
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			toolExecution: "sequential",
-			getSteeringMessages: async () => {
-				// Return steering message after tool execution has started.
-				if (executed.length >= 1 && !queuedDelivered) {
-					queuedDelivered = true;
-					return [queuedUserMessage];
-				}
-				return [];
-			},
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "sequential",
+		getSteeringMessages: async () => {
+		// Return steering message after tool execution has started.
+		if (executed.length >= 1 && !queuedDelivered) {
+			queuedDelivered = true;
+			return [queuedUserMessage];
+		}
+		return [];
+		},
+	};
 
-		const events: AgentEvent[] = [];
-		const stream = agentLoop([userPrompt], context, config, undefined, (_model, ctx, _options) => {
-			// Check if interrupt message is in context on second call
-			if (callIndex === 1) {
-				sawInterruptInContext = ctx.messages.some(
-					(m) => m.role === "user" && typeof m.content === "string" && m.content === "interrupt",
-				);
-			}
-
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					// First call: return two tool calls
-					const message = createAssistantMessage(
-						[
-							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
-							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
-						],
-						"toolUse",
-					);
-					mockStream.push({ type: "done", reason: "toolUse", message });
-				} else {
-					// Second call: return final response
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					mockStream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return mockStream;
-		});
-
-		for await (const event of stream) {
-			events.push(event);
+	const events: AgentEvent[] = [];
+	const stream = agentLoop([userPrompt], context, config, undefined, (_model, ctx, _options) => {
+		// Check if interrupt message is in context on second call
+		if (callIndex === 1) {
+		sawInterruptInContext = ctx.messages.some(
+			(m) => m.role === "user" && typeof m.content === "string" && m.content === "interrupt",
+		);
 		}
 
-		// Both tools should execute before steering is injected
-		expect(executed).toEqual(["first", "second"]);
-
-		const toolEnds = events.filter(
-			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
-		);
-		expect(toolEnds.length).toBe(2);
-		expect(toolEnds[0].isError).toBe(false);
-		expect(toolEnds[1].isError).toBe(false);
-
-		// Queued message should appear in events after both tool result messages
-		const eventSequence = events.flatMap((event) => {
-			if (event.type !== "message_start") return [];
-			if (event.message.role === "toolResult") return [`tool:${event.message.toolCallId}`];
-			if (event.message.role === "user" && typeof event.message.content === "string") {
-				return [event.message.content];
-			}
-			return [];
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			// First call: return two tool calls
+			const message = createAssistantMessage(
+			[
+				{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+				{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+			],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+		} else {
+			// Second call: return final response
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			mockStream.push({ type: "done", reason: "stop", message });
+		}
+		callIndex++;
 		});
-		expect(eventSequence).toContain("interrupt");
-		expect(eventSequence.indexOf("tool:tool-1")).toBeLessThan(eventSequence.indexOf("interrupt"));
-		expect(eventSequence.indexOf("tool:tool-2")).toBeLessThan(eventSequence.indexOf("interrupt"));
+		return mockStream;
+	});
 
-		// Interrupt message should be in context when second LLM call is made
-		expect(sawInterruptInContext).toBe(true);
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	// Both tools should execute before steering is injected
+	expect(executed).toEqual(["first", "second"]);
+
+	const toolEnds = events.filter(
+		(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+	);
+	expect(toolEnds.length).toBe(2);
+	expect(toolEnds[0].isError).toBe(false);
+	expect(toolEnds[1].isError).toBe(false);
+
+	// Queued message should appear in events after both tool result messages
+	const eventSequence = events.flatMap((event) => {
+		if (event.type !== "message_start") return [];
+		if (event.message.role === "toolResult") return [`tool:${event.message.toolCallId}`];
+		if (event.message.role === "user" && typeof event.message.content === "string") {
+		return [event.message.content];
+		}
+		return [];
+	});
+	expect(eventSequence).toContain("interrupt");
+	expect(eventSequence.indexOf("tool:tool-1")).toBeLessThan(eventSequence.indexOf("interrupt"));
+	expect(eventSequence.indexOf("tool:tool-2")).toBeLessThan(eventSequence.indexOf("interrupt"));
+
+	// Interrupt message should be in context when second LLM call is made
+	expect(sawInterruptInContext).toBe(true);
 	});
 
 	it("should force sequential execution when a tool has executionMode=sequential even with default parallel config", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		let firstResolved = false;
-		let parallelObserved = false;
-		let releaseFirst: (() => void) | undefined;
-		const firstDone = new Promise<void>((resolve) => {
-			releaseFirst = resolve;
-		});
+	const toolSchema = Type.Object({ value: Type.String() });
+	let firstResolved = false;
+	let parallelObserved = false;
+	let releaseFirst: (() => void) | undefined;
+	const firstDone = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
 
-		const slowTool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "slow",
-			label: "Slow",
-			description: "Slow tool",
-			parameters: toolSchema,
-			executionMode: "sequential",
-			async execute(_toolCallId, params) {
-				if (params.value === "first") {
-					await firstDone;
-					firstResolved = true;
-				}
-				if (params.value === "second" && !firstResolved) {
-					parallelObserved = true;
-				}
-				return {
-					content: [{ type: "text", text: `slow: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
-		};
-
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [slowTool],
-		};
-
-		const userPrompt: AgentMessage = createUserMessage("run both");
-		// config is parallel (default), but tool forces sequential
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
-
-		let callIndex = 0;
-		const stream = agentLoop([userPrompt], context, config, undefined, () => {
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					const message = createAssistantMessage(
-						[
-							{ type: "toolCall", id: "tool-1", name: "slow", arguments: { value: "first" } },
-							{ type: "toolCall", id: "tool-2", name: "slow", arguments: { value: "second" } },
-						],
-						"toolUse",
-					);
-					mockStream.push({ type: "done", reason: "toolUse", message });
-					setTimeout(() => releaseFirst?.(), 20);
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					mockStream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return mockStream;
-		});
-
-		const events: AgentEvent[] = [];
-		for await (const event of stream) {
-			events.push(event);
+	const slowTool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "slow",
+		label: "Slow",
+		description: "Slow tool",
+		parameters: toolSchema,
+		executionMode: "sequential",
+		async execute(_toolCallId, params) {
+		if (params.value === "first") {
+			await firstDone;
+			firstResolved = true;
 		}
+		if (params.value === "second" && !firstResolved) {
+			parallelObserved = true;
+		}
+		return {
+			content: [{ type: "text", text: `slow: ${params.value}` }],
+			details: { value: params.value },
+		};
+		},
+	};
 
-		// With sequential execution, second tool should NOT start before first finishes
-		expect(parallelObserved).toBe(false);
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [slowTool],
+	};
 
-		const toolResultIds = events.flatMap((event) => {
-			if (event.type !== "message_end" || event.message.role !== "toolResult") {
-				return [];
-			}
-			return [event.message.toolCallId];
+	const userPrompt: AgentMessage = createUserMessage("run both");
+	// config is parallel (default), but tool forces sequential
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
+
+	let callIndex = 0;
+	const stream = agentLoop([userPrompt], context, config, undefined, () => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			const message = createAssistantMessage(
+			[
+				{ type: "toolCall", id: "tool-1", name: "slow", arguments: { value: "first" } },
+				{ type: "toolCall", id: "tool-2", name: "slow", arguments: { value: "second" } },
+			],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			setTimeout(() => releaseFirst?.(), 20);
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			mockStream.push({ type: "done", reason: "stop", message });
+		}
+		callIndex++;
 		});
-		expect(toolResultIds).toEqual(["tool-1", "tool-2"]);
+		return mockStream;
+	});
+
+	const events: AgentEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	// With sequential execution, second tool should NOT start before first finishes
+	expect(parallelObserved).toBe(false);
+
+	const toolResultIds = events.flatMap((event) => {
+		if (event.type !== "message_end" || event.message.role !== "toolResult") {
+		return [];
+		}
+		return [event.message.toolCallId];
+	});
+	expect(toolResultIds).toEqual(["tool-1", "tool-2"]);
 	});
 
 	it("should force sequential execution when one of multiple tools has executionMode=sequential", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const executionOrder: string[] = [];
-		let releaseSlow: (() => void) | undefined;
-		const slowDone = new Promise<void>((resolve) => {
-			releaseSlow = resolve;
-		});
+	const toolSchema = Type.Object({ value: Type.String() });
+	const executionOrder: string[] = [];
+	let releaseSlow: (() => void) | undefined;
+	const slowDone = new Promise<void>((resolve) => {
+		releaseSlow = resolve;
+	});
 
-		const slowTool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "slow",
-			label: "Slow",
-			description: "Slow tool",
-			parameters: toolSchema,
-			executionMode: "sequential",
-			async execute(_toolCallId, params) {
-				executionOrder.push(`slow:${params.value}`);
-				if (params.value === "a") {
-					await slowDone;
-				}
-				return {
-					content: [{ type: "text", text: `slow: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
-		};
-
-		const fastTool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "fast",
-			label: "Fast",
-			description: "Fast tool",
-			parameters: toolSchema,
-			// no executionMode = defaults to parallel
-			async execute(_toolCallId, params) {
-				executionOrder.push(`fast:${params.value}`);
-				return {
-					content: [{ type: "text", text: `fast: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
-		};
-
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [slowTool, fastTool],
-		};
-
-		const userPrompt: AgentMessage = createUserMessage("run both");
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			// parallel by default, but slowTool forces sequential
-		};
-
-		let callIndex = 0;
-		const stream = agentLoop([userPrompt], context, config, undefined, () => {
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					const message = createAssistantMessage(
-						[
-							{ type: "toolCall", id: "tool-1", name: "slow", arguments: { value: "a" } },
-							{ type: "toolCall", id: "tool-2", name: "fast", arguments: { value: "b" } },
-						],
-						"toolUse",
-					);
-					mockStream.push({ type: "done", reason: "toolUse", message });
-					setTimeout(() => releaseSlow?.(), 20);
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					mockStream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return mockStream;
-		});
-
-		const events: AgentEvent[] = [];
-		for await (const event of stream) {
-			events.push(event);
+	const slowTool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "slow",
+		label: "Slow",
+		description: "Slow tool",
+		parameters: toolSchema,
+		executionMode: "sequential",
+		async execute(_toolCallId, params) {
+		executionOrder.push(`slow:${params.value}`);
+		if (params.value === "a") {
+			await slowDone;
 		}
+		return {
+			content: [{ type: "text", text: `slow: ${params.value}` }],
+			details: { value: params.value },
+		};
+		},
+	};
 
-		// Fast tool should NOT run before slow tool finishes
-		expect(executionOrder[0]).toBe("slow:a");
-		expect(executionOrder).toContain("fast:b");
+	const fastTool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "fast",
+		label: "Fast",
+		description: "Fast tool",
+		parameters: toolSchema,
+		// no executionMode = defaults to parallel
+		async execute(_toolCallId, params) {
+		executionOrder.push(`fast:${params.value}`);
+		return {
+			content: [{ type: "text", text: `fast: ${params.value}` }],
+			details: { value: params.value },
+		};
+		},
+	};
+
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [slowTool, fastTool],
+	};
+
+	const userPrompt: AgentMessage = createUserMessage("run both");
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		// parallel by default, but slowTool forces sequential
+	};
+
+	let callIndex = 0;
+	const stream = agentLoop([userPrompt], context, config, undefined, () => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			const message = createAssistantMessage(
+			[
+				{ type: "toolCall", id: "tool-1", name: "slow", arguments: { value: "a" } },
+				{ type: "toolCall", id: "tool-2", name: "fast", arguments: { value: "b" } },
+			],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			setTimeout(() => releaseSlow?.(), 20);
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			mockStream.push({ type: "done", reason: "stop", message });
+		}
+		callIndex++;
+		});
+		return mockStream;
+	});
+
+	const events: AgentEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	// Fast tool should NOT run before slow tool finishes
+	expect(executionOrder[0]).toBe("slow:a");
+	expect(executionOrder).toContain("fast:b");
 	});
 
 	it("should allow parallel execution when all tools have executionMode=parallel", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		let firstResolved = false;
-		let parallelObserved = false;
-		let releaseFirst: (() => void) | undefined;
-		const firstDone = new Promise<void>((resolve) => {
-			releaseFirst = resolve;
-		});
+	const toolSchema = Type.Object({ value: Type.String() });
+	let firstResolved = false;
+	let parallelObserved = false;
+	let releaseFirst: (() => void) | undefined;
+	const firstDone = new Promise<void>((resolve) => {
+		releaseFirst = resolve;
+	});
 
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			executionMode: "parallel",
-			async execute(_toolCallId, params) {
-				if (params.value === "first") {
-					await firstDone;
-					firstResolved = true;
-				}
-				if (params.value === "second" && !firstResolved) {
-					parallelObserved = true;
-				}
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
-		};
-
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
-
-		const userPrompt: AgentMessage = createUserMessage("echo both");
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
-
-		let callIndex = 0;
-		const stream = agentLoop([userPrompt], context, config, undefined, () => {
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					const message = createAssistantMessage(
-						[
-							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
-							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
-						],
-						"toolUse",
-					);
-					mockStream.push({ type: "done", reason: "toolUse", message });
-					setTimeout(() => releaseFirst?.(), 20);
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					mockStream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return mockStream;
-		});
-
-		const events: AgentEvent[] = [];
-		for await (const event of stream) {
-			events.push(event);
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		executionMode: "parallel",
+		async execute(_toolCallId, params) {
+		if (params.value === "first") {
+			await firstDone;
+			firstResolved = true;
 		}
+		if (params.value === "second" && !firstResolved) {
+			parallelObserved = true;
+		}
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
+		};
+		},
+	};
 
-		// With executionMode=parallel, second tool should start before first finishes
-		expect(parallelObserved).toBe(true);
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
+
+	const userPrompt: AgentMessage = createUserMessage("echo both");
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
+
+	let callIndex = 0;
+	const stream = agentLoop([userPrompt], context, config, undefined, () => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			const message = createAssistantMessage(
+			[
+				{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+				{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+			],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			setTimeout(() => releaseFirst?.(), 20);
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			mockStream.push({ type: "done", reason: "stop", message });
+		}
+		callIndex++;
+		});
+		return mockStream;
+	});
+
+	const events: AgentEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	// With executionMode=parallel, second tool should start before first finishes
+	expect(parallelObserved).toBe(true);
 	});
 
 	it("should use prepareNextTurn snapshot before continuing", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-				};
+	const toolSchema = Type.Object({ value: Type.String() });
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
+		};
+		},
+	};
+	const context: AgentContext = {
+		systemPrompt: "first prompt",
+		messages: [],
+		tools: [tool],
+	};
+	let convertedSecondTurnSystemPrompt = "";
+	let prepared = false;
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		prepareNextTurn: async ({ context: currentContext }) => {
+		if (prepared) return undefined;
+		prepared = true;
+		return {
+			context: {
+			systemPrompt: "second prompt",
+			messages: currentContext.messages.slice(),
+			tools: currentContext.tools,
 			},
 		};
-		const context: AgentContext = {
-			systemPrompt: "first prompt",
-			messages: [],
-			tools: [tool],
-		};
-		let convertedSecondTurnSystemPrompt = "";
-		let prepared = false;
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			prepareNextTurn: async ({ context: currentContext }) => {
-				if (prepared) return undefined;
-				prepared = true;
-				return {
-					context: {
-						systemPrompt: "second prompt",
-						messages: currentContext.messages.slice(),
-						tools: currentContext.tools,
-					},
-				};
-			},
-		};
+		},
+	};
 
-		let llmCalls = 0;
-		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, (_model, ctx) => {
-			llmCalls++;
-			if (llmCalls === 2) {
-				convertedSecondTurnSystemPrompt = ctx.systemPrompt ?? "";
-			}
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (llmCalls === 1) {
-					mockStream.push({
-						type: "done",
-						reason: "toolUse",
-						message: createAssistantMessage(
-							[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
-							"toolUse",
-						),
-					});
-				} else {
-					mockStream.push({
-						type: "done",
-						reason: "stop",
-						message: createAssistantMessage([{ type: "text", text: "done" }]),
-					});
-				}
-			});
-			return mockStream;
-		});
-
-		for await (const _event of stream) {
-			// consume
+	let llmCalls = 0;
+	const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, (_model, ctx) => {
+		llmCalls++;
+		if (llmCalls === 2) {
+		convertedSecondTurnSystemPrompt = ctx.systemPrompt ?? "";
 		}
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (llmCalls === 1) {
+			mockStream.push({
+			type: "done",
+			reason: "toolUse",
+			message: createAssistantMessage(
+				[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+				"toolUse",
+			),
+			});
+		} else {
+			mockStream.push({
+			type: "done",
+			reason: "stop",
+			message: createAssistantMessage([{ type: "text", text: "done" }]),
+			});
+		}
+		});
+		return mockStream;
+	});
 
-		expect(llmCalls).toBe(2);
-		expect(convertedSecondTurnSystemPrompt).toBe("second prompt");
+	for await (const _event of stream) {
+		// consume
+	}
+
+	expect(llmCalls).toBe(2);
+	expect(convertedSecondTurnSystemPrompt).toBe("second prompt");
 	});
 
 	it("should stop after the current turn when shouldStopAfterTurn returns true", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const executed: string[] = [];
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				executed.push(params.value);
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
+	const toolSchema = Type.Object({ value: Type.String() });
+	const executed: string[] = [];
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		executed.push(params.value);
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		let steeringPolls = 0;
-		let followUpPolls = 0;
-		let callbackToolResultIds: string[] = [];
-		let callbackContextRoles: string[] = [];
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			getSteeringMessages: async () => {
-				steeringPolls++;
-				return [];
-			},
-			getFollowUpMessages: async () => {
-				followUpPolls++;
-				return [createUserMessage("follow up should stay queued")];
-			},
-			shouldStopAfterTurn: async ({ message, toolResults, context }) => {
-				expect(message.role).toBe("assistant");
-				callbackToolResultIds = toolResults.map((toolResult) => toolResult.toolCallId);
-				callbackContextRoles = context.messages.map((contextMessage) => contextMessage.role);
-				return true;
-			},
-		};
+	let steeringPolls = 0;
+	let followUpPolls = 0;
+	let callbackToolResultIds: string[] = [];
+	let callbackContextRoles: string[] = [];
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		getSteeringMessages: async () => {
+		steeringPolls++;
+		return [];
+		},
+		getFollowUpMessages: async () => {
+		followUpPolls++;
+		return [createUserMessage("follow up should stay queued")];
+		},
+		shouldStopAfterTurn: async ({ message, toolResults, context }) => {
+		expect(message.role).toBe("assistant");
+		callbackToolResultIds = toolResults.map((toolResult) => toolResult.toolCallId);
+		callbackContextRoles = context.messages.map((contextMessage) => contextMessage.role);
+		return true;
+		},
+	};
 
-		let llmCalls = 0;
-		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, () => {
-			llmCalls++;
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (llmCalls === 1) {
-					const message = createAssistantMessage(
-						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
-						"toolUse",
-					);
-					mockStream.push({ type: "done", reason: "toolUse", message });
-				} else {
-					mockStream.push({
-						type: "done",
-						reason: "stop",
-						message: createAssistantMessage([{ type: "text", text: "should not run" }]),
-					});
-				}
+	let llmCalls = 0;
+	const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, () => {
+		llmCalls++;
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (llmCalls === 1) {
+			const message = createAssistantMessage(
+			[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+		} else {
+			mockStream.push({
+			type: "done",
+			reason: "stop",
+			message: createAssistantMessage([{ type: "text", text: "should not run" }]),
 			});
-			return mockStream;
-		});
-
-		const events: AgentEvent[] = [];
-		for await (const event of stream) {
-			events.push(event);
 		}
+		});
+		return mockStream;
+	});
 
-		const messages = await stream.result();
-		expect(llmCalls).toBe(1);
-		expect(executed).toEqual(["hello"]);
-		expect(steeringPolls).toBe(1);
-		expect(followUpPolls).toBe(0);
-		expect(callbackToolResultIds).toEqual(["tool-1"]);
-		expect(callbackContextRoles).toEqual(["user", "assistant", "toolResult"]);
-		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
-		expect(events.map((event) => event.type)).toEqual([
-			"agent_start",
-			"turn_start",
-			"message_start",
-			"message_end",
-			"message_start",
-			"message_end",
-			"tool_execution_start",
-			"tool_execution_end",
-			"message_start",
-			"message_end",
-			"turn_end",
-			"agent_end",
-		]);
+	const events: AgentEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	const messages = await stream.result();
+	expect(llmCalls).toBe(1);
+	expect(executed).toEqual(["hello"]);
+	expect(steeringPolls).toBe(1);
+	expect(followUpPolls).toBe(0);
+	expect(callbackToolResultIds).toEqual(["tool-1"]);
+	expect(callbackContextRoles).toEqual(["user", "assistant", "toolResult"]);
+	expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+	expect(events.map((event) => event.type)).toEqual([
+		"agent_start",
+		"turn_start",
+		"message_start",
+		"message_end",
+		"message_start",
+		"message_end",
+		"tool_execution_start",
+		"tool_execution_end",
+		"message_start",
+		"message_end",
+		"turn_end",
+		"agent_end",
+	]);
 	});
 
 	it("should stop after a tool batch when every tool result sets terminate=true", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-					terminate: true,
-				};
-			},
+	const toolSchema = Type.Object({ value: Type.String() });
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
+			terminate: true,
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
 
-		let llmCalls = 0;
-		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, () => {
-			llmCalls++;
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				const message = createAssistantMessage(
-					[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
-					"toolUse",
-				);
-				mockStream.push({ type: "done", reason: "toolUse", message });
-			});
-			return mockStream;
+	let llmCalls = 0;
+	const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, () => {
+		llmCalls++;
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		const message = createAssistantMessage(
+			[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+			"toolUse",
+		);
+		mockStream.push({ type: "done", reason: "toolUse", message });
 		});
+		return mockStream;
+	});
 
-		const events: AgentEvent[] = [];
-		for await (const event of stream) {
-			events.push(event);
-		}
+	const events: AgentEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
 
-		const messages = await stream.result();
-		expect(llmCalls).toBe(1);
-		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
-		expect(events.filter((event) => event.type === "turn_end")).toHaveLength(1);
+	const messages = await stream.result();
+	expect(llmCalls).toBe(1);
+	expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+	expect(events.filter((event) => event.type === "turn_end")).toHaveLength(1);
 	});
 
 	it("should continue after parallel tool calls when not all tool results terminate", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-					terminate: params.value === "first",
-				};
-			},
+	const toolSchema = Type.Object({ value: Type.String() });
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
+			terminate: params.value === "first",
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			toolExecution: "parallel",
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
 
-		let callIndex = 0;
-		const stream = agentLoop([createUserMessage("echo both")], context, config, undefined, () => {
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				if (callIndex === 0) {
-					const message = createAssistantMessage(
-						[
-							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
-							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
-						],
-						"toolUse",
-					);
-					mockStream.push({ type: "done", reason: "toolUse", message });
-				} else {
-					const message = createAssistantMessage([{ type: "text", text: "done" }]);
-					mockStream.push({ type: "done", reason: "stop", message });
-				}
-				callIndex++;
-			});
-			return mockStream;
-		});
-
-		for await (const _event of stream) {
-			// consume
+	let callIndex = 0;
+	const stream = agentLoop([createUserMessage("echo both")], context, config, undefined, () => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		if (callIndex === 0) {
+			const message = createAssistantMessage(
+			[
+				{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+				{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+			],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+		} else {
+			const message = createAssistantMessage([{ type: "text", text: "done" }]);
+			mockStream.push({ type: "done", reason: "stop", message });
 		}
+		callIndex++;
+		});
+		return mockStream;
+	});
 
-		const messages = await stream.result();
-		expect(callIndex).toBe(2);
-		expect(messages.map((message) => message.role)).toEqual([
-			"user",
-			"assistant",
-			"toolResult",
-			"toolResult",
-			"assistant",
-		]);
+	for await (const _event of stream) {
+		// consume
+	}
+
+	const messages = await stream.result();
+	expect(callIndex).toBe(2);
+	expect(messages.map((message) => message.role)).toEqual([
+		"user",
+		"assistant",
+		"toolResult",
+		"toolResult",
+		"assistant",
+	]);
 	});
 
 	it("should allow afterToolCall to mark a tool batch as terminating", async () => {
-		const toolSchema = Type.Object({ value: Type.String() });
-		const tool: AgentTool<typeof toolSchema, { value: string }> = {
-			name: "echo",
-			label: "Echo",
-			description: "Echo tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				return {
-					content: [{ type: "text", text: `echoed: ${params.value}` }],
-					details: { value: params.value },
-				};
-			},
+	const toolSchema = Type.Object({ value: Type.String() });
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "",
-			messages: [],
-			tools: [tool],
-		};
+	const context: AgentContext = {
+		systemPrompt: "",
+		messages: [],
+		tools: [tool],
+	};
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-			afterToolCall: async () => ({ terminate: true }),
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		afterToolCall: async () => ({ terminate: true }),
+	};
 
-		let llmCalls = 0;
-		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, () => {
-			llmCalls++;
-			const mockStream = new MockAssistantStream();
-			queueMicrotask(() => {
-				const message = createAssistantMessage(
-					[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
-					"toolUse",
-				);
-				mockStream.push({ type: "done", reason: "toolUse", message });
-			});
-			return mockStream;
+	let llmCalls = 0;
+	const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, () => {
+		llmCalls++;
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+		const message = createAssistantMessage(
+			[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+			"toolUse",
+		);
+		mockStream.push({ type: "done", reason: "toolUse", message });
 		});
+		return mockStream;
+	});
 
-		for await (const _event of stream) {
-			// consume
-		}
+	for await (const _event of stream) {
+		// consume
+	}
 
-		expect(llmCalls).toBe(1);
+	expect(llmCalls).toBe(1);
 	});
 });
 
 describe("agentLoopContinue with AgentMessage", () => {
 	it("should throw when context has no messages", () => {
-		const context: AgentContext = {
-			systemPrompt: "You are helpful.",
-			messages: [],
-			tools: [],
-		};
+	const context: AgentContext = {
+		systemPrompt: "You are helpful.",
+		messages: [],
+		tools: [],
+	};
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
 
-		expect(() =>
-			agentLoopContinue(context, config, undefined, () => {
-				throw new Error("Unexpected stream call");
-			}),
-		).toThrow("Cannot continue: no messages in context");
+	expect(() =>
+		agentLoopContinue(context, config, undefined, () => {
+		throw new Error("Unexpected stream call");
+		}),
+	).toThrow("Cannot continue: no messages in context");
 	});
 
 	it("should continue from existing context without emitting user message events", async () => {
-		const userMessage: AgentMessage = createUserMessage("Hello");
+	const userMessage: AgentMessage = createUserMessage("Hello");
 
-		const context: AgentContext = {
-			systemPrompt: "You are helpful.",
-			messages: [userMessage],
-			tools: [],
-		};
+	const context: AgentContext = {
+		systemPrompt: "You are helpful.",
+		messages: [userMessage],
+		tools: [],
+	};
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: identityConverter,
-		};
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+	};
 
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				const message = createAssistantMessage([{ type: "text", text: "Response" }]);
-				stream.push({ type: "done", reason: "stop", message });
-			});
-			return stream;
-		};
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		const message = createAssistantMessage([{ type: "text", text: "Response" }]);
+		stream.push({ type: "done", reason: "stop", message });
+		});
+		return stream;
+	};
 
-		const events: AgentEvent[] = [];
-		const stream = agentLoopContinue(context, config, undefined, streamFn);
+	const events: AgentEvent[] = [];
+	const stream = agentLoopContinue(context, config, undefined, streamFn);
 
-		for await (const event of stream) {
-			events.push(event);
-		}
+	for await (const event of stream) {
+		events.push(event);
+	}
 
-		const messages = await stream.result();
+	const messages = await stream.result();
 
-		// Should only return the new assistant message (not the existing user message)
-		expect(messages.length).toBe(1);
-		expect(messages[0].role).toBe("assistant");
+	// Should only return the new assistant message (not the existing user message)
+	expect(messages.length).toBe(1);
+	expect(messages[0].role).toBe("assistant");
 
-		// Should NOT have user message events (that's the key difference from agentLoop)
-		const messageEndEvents = events.filter((e) => e.type === "message_end");
-		expect(messageEndEvents.length).toBe(1);
-		expect((messageEndEvents[0] as any).message.role).toBe("assistant");
+	// Should NOT have user message events (that's the key difference from agentLoop)
+	const messageEndEvents = events.filter((e) => e.type === "message_end");
+	expect(messageEndEvents.length).toBe(1);
+	expect((messageEndEvents[0] as any).message.role).toBe("assistant");
 	});
 
 	it("should allow custom message types as last message (caller responsibility)", async () => {
-		// Custom message that will be converted to user message by convertToLlm
-		interface CustomMessage {
-			role: "custom";
-			text: string;
-			timestamp: number;
-		}
+	// Custom message that will be converted to user message by convertToLlm
+	interface CustomMessage {
+		role: "custom";
+		text: string;
+		timestamp: number;
+	}
 
-		const customMessage: CustomMessage = {
-			role: "custom",
-			text: "Hook content",
-			timestamp: Date.now(),
+	const customMessage: CustomMessage = {
+		role: "custom",
+		text: "Hook content",
+		timestamp: Date.now(),
+	};
+
+	const context: AgentContext = {
+		systemPrompt: "You are helpful.",
+		messages: [customMessage as unknown as AgentMessage],
+		tools: [],
+	};
+
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: (messages) => {
+		// Convert custom to user message
+		return messages
+			.map((m) => {
+			if ((m as any).role === "custom") {
+				return {
+				role: "user" as const,
+				content: (m as any).text,
+				timestamp: m.timestamp,
+				};
+			}
+			return m;
+			})
+			.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+		},
+	};
+
+	const streamFn = () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+		const message = createAssistantMessage([{ type: "text", text: "Response to custom message" }]);
+		stream.push({ type: "done", reason: "stop", message });
+		});
+		return stream;
+	};
+
+	// Should not throw - the custom message will be converted to user message
+	const stream = agentLoopContinue(context, config, undefined, streamFn);
+
+	const events: AgentEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+
+	const messages = await stream.result();
+	expect(messages.length).toBe(1);
+	expect(messages[0].role).toBe("assistant");
+	});
+});
+
+// --- Regression tests for parallel tool batch orphan fix (fix/parallel-tool-result-orphan) ---
+
+function defer<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+	resolve = res;
+	reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+/** Flush the microtask queue (and one macrotask turn) between manual resolutions. */
+async function flush(turns = 5): Promise<void> {
+	for (let i = 0; i < turns; i++) {
+	await new Promise((resolve) => setImmediate(resolve));
+	}
+}
+
+describe("parallel tool batch per-sibling persistence (fix/parallel-tool-result-orphan)", () => {
+	it("persists each tool result when its own sibling completes, not after the barrier", async () => {
+	const toolSchema = Type.Object({ value: Type.String() });
+	const resolveOrder: string[] = [];
+
+	const dA = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+	const dB = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+	const dC = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		if (params.value === "a") return dA.promise;
+		if (params.value === "b") return dB.promise;
+		if (params.value === "c") return dC.promise;
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
 		};
+		},
+	};
 
-		const context: AgentContext = {
-			systemPrompt: "You are helpful.",
-			messages: [customMessage as unknown as AgentMessage],
-			tools: [],
-		};
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [tool] };
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
 
-		const config: AgentLoopConfig = {
-			model: createModel(),
-			convertToLlm: (messages) => {
-				// Convert custom to user message
-				return messages
-					.map((m) => {
-						if ((m as any).role === "custom") {
-							return {
-								role: "user" as const,
-								content: (m as any).text,
-								timestamp: m.timestamp,
-							};
-						}
-						return m;
-					})
-					.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
-			},
-		};
-
-		const streamFn = () => {
-			const stream = new MockAssistantStream();
-			queueMicrotask(() => {
-				const message = createAssistantMessage([{ type: "text", text: "Response to custom message" }]);
-				stream.push({ type: "done", reason: "stop", message });
+	let callIndex = 0;
+	const stream = agentLoop(
+		[createUserMessage("run three")],
+		context,
+		config,
+		undefined,
+		() => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+			if (callIndex === 0) {
+			const message = createAssistantMessage(
+				[
+				{ type: "toolCall", id: "tool-a", name: "echo", arguments: { value: "a" } },
+				{ type: "toolCall", id: "tool-b", name: "echo", arguments: { value: "b" } },
+				{ type: "toolCall", id: "tool-c", name: "echo", arguments: { value: "c" } },
+				],
+				"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			} else {
+			mockStream.push({
+				type: "done",
+				reason: "stop",
+				message: createAssistantMessage([{ type: "text", text: "done" }]),
 			});
-			return stream;
-		};
+			}
+			callIndex++;
+		});
+		return mockStream;
+		},
+	);
 
-		// Should not throw - the custom message will be converted to user message
-		const stream = agentLoopContinue(context, config, undefined, streamFn);
-
-		const events: AgentEvent[] = [];
-		for await (const event of stream) {
-			events.push(event);
+	const events: AgentEvent[] = [];
+	// Start consuming events
+	const consumeEvents = async () => {
+		for await (const event of stream as AsyncIterable<AgentEvent>) {
+		events.push(event);
 		}
+	};
+	void consumeEvents();
 
-		const messages = await stream.result();
-		expect(messages.length).toBe(1);
-		expect(messages[0].role).toBe("assistant");
+	// Wait for all three tool_execution_start events
+	await new Promise<void>((resolve) => {
+		const check = () => {
+		const starts = events.filter((e) => e.type === "tool_execution_start");
+		if (starts.length >= 3) resolve();
+		else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+	});
+
+	// Resolve b only
+	dB.resolve({ content: [{ type: "text", text: "b result" }], details: { value: "b" } });
+	resolveOrder.push("b");
+
+	await flush(5);
+
+	// b's toolResult should already be emitted, not waiting for a or c
+	const toolResultIds = events
+		.filter((e) => e.type === "message_end" && (e as any).message?.role === "toolResult")
+		.map((e) => (e as any).message?.toolCallId as string);
+	expect(toolResultIds).toContain("tool-b");
+	const bIndex = toolResultIds.indexOf("tool-b");
+	expect(toolResultIds.indexOf("tool-a")).toBe(-1);
+	expect(toolResultIds.indexOf("tool-c")).toBe(-1);
+
+	// Now resolve all
+	dA.resolve({ content: [{ type: "text", text: "a result" }], details: { value: "a" } });
+	dC.resolve({ content: [{ type: "text", text: "c result" }], details: { value: "c" } });
+	resolveOrder.push("a", "c");
+
+	// Drain the stream
+	await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+	const allToolResultIds = events
+		.filter((e) => e.type === "message_end" && (e as any).message?.role === "toolResult")
+		.map((e) => (e as any).message?.toolCallId as string);
+	expect(allToolResultIds).toContain("tool-a");
+	expect(allToolResultIds).toContain("tool-b");
+	expect(allToolResultIds).toContain("tool-c");
+	});
+
+	it("abort with a never-settling sibling persists the completed one, synthesizes an abort result, and does not hang", async () => {
+	const toolSchema = Type.Object({ value: Type.String() });
+
+	// stuck never settles
+	const stuckExecute = () => new Promise<never>(() => {});
+	const stuckTool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "stuck",
+		label: "Stuck",
+		description: "Stuck tool",
+		parameters: toolSchema,
+		execute: stuckExecute,
+	};
+
+	let fastResolved = false;
+	const fastTool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "fast",
+		label: "Fast",
+		description: "Fast tool",
+		parameters: toolSchema,
+		execute: async (_id, params) => {
+		fastResolved = true;
+		return { content: [{ type: "text", text: `fast: ${params.value}` }], details: {} };
+		},
+	};
+
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [stuckTool, fastTool] };
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
+
+	const abortController = new AbortController();
+
+	let callIndex = 0;
+	const stream = agentLoop(
+		[createUserMessage("run both")],
+		context,
+		config,
+		abortController.signal,
+		() => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+			if (callIndex === 0) {
+			const message = createAssistantMessage(
+				[
+				{ type: "toolCall", id: "tool-fast", name: "fast", arguments: { value: "fast" } },
+				{ type: "toolCall", id: "tool-stuck", name: "stuck", arguments: { value: "stuck" } },
+				],
+				"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			} else {
+			mockStream.push({
+				type: "done",
+				reason: "stop",
+				message: createAssistantMessage([{ type: "text", text: "done" }]),
+			});
+			}
+			callIndex++;
+		});
+		return mockStream;
+		},
+	);
+
+	const events: AgentEvent[] = [];
+	const consumeEvents = async () => {
+		for await (const event of stream as AsyncIterable<AgentEvent>) {
+		events.push(event);
+		}
+	};
+	void consumeEvents();
+
+	// Wait for fast's toolResult message_end
+	await new Promise<void>((resolve) => {
+		const check = () => {
+		const fastResult = events.find(
+			(e) =>
+			e.type === "message_end" &&
+			(e as any).message?.role === "toolResult" &&
+			(e as any).message?.toolCallId === "tool-fast",
+		);
+		if (fastResult) resolve();
+		else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+	});
+
+	expect(fastResolved).toBe(true);
+
+	// Now abort
+	abortController.abort();
+
+	// Watchdog: if this times out, the freeze regression is back
+	const result = await Promise.race([
+		new Promise<void>((resolve) => {
+		const check = () => {
+			const turnEnd = events.find((e) => e.type === "turn_end");
+			const agentEnd = events.find((e) => e.type === "agent_end");
+			if (turnEnd && agentEnd) resolve();
+			else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+		}),
+		new Promise<"timeout">((_resolve, reject) => setTimeout(() => reject(new Error("TIMEOUT: batch still blocked on stalled sibling")), 2000)),
+	]);
+
+	// Assertions
+	const allToolResults = events
+		.filter((e) => e.type === "message_end" && (e as any).message?.role === "toolResult")
+		.map((e) => e as Extract<AgentEvent, { type: "message_end" }> & { message: any });
+
+	expect(allToolResults.length).toBe(2);
+
+	const fastResult = allToolResults.find((e) => e.message.toolCallId === "tool-fast");
+	expect(fastResult?.message.isError).toBe(false);
+	const fastText = fastResult?.message.content.find((c: any) => c.type === "text");
+	expect(fastText?.text).toContain("fast:");
+
+	const stuckResult = allToolResults.find((e) => e.message.toolCallId === "tool-stuck");
+	expect(stuckResult?.message.isError).toBe(true);
+	const stuckText = stuckResult?.message.content.find((c: any) => c.type === "text");
+	expect(stuckText?.text).toContain("Operation aborted");
+
+	// tool_execution_end was emitted for stuck
+	const stuckEnd = events.find(
+		(e) => e.type === "tool_execution_end" && (e as any).toolCallId === "tool-stuck",
+	);
+	expect(stuckEnd).toBeDefined();
+	if (stuckEnd?.type === "tool_execution_end") {
+		expect(stuckEnd.isError).toBe(true);
+	}
+
+	// turn_end and agent_end were emitted
+	expect(events.some((e) => e.type === "turn_end")).toBe(true);
+	expect(events.some((e) => e.type === "agent_end")).toBe(true);
+
+	// Each toolCallId appears exactly once
+	const ids = allToolResults.map((e) => e.message.toolCallId);
+	expect(ids).toHaveLength(new Set(ids).size);
+	});
+
+	it("does not double-emit when a stalled sibling settles after the abort", async () => {
+	const toolSchema = Type.Object({ value: Type.String() });
+
+	const stuckDeferred = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+
+	const stuckTool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "stuck",
+		label: "Stuck",
+		description: "Stuck tool",
+		parameters: toolSchema,
+		execute: () => stuckDeferred.promise,
+	};
+
+	let fastResolved = false;
+	const fastTool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "fast",
+		label: "Fast",
+		description: "Fast tool",
+		parameters: toolSchema,
+		execute: async (_id, params) => {
+		fastResolved = true;
+		return { content: [{ type: "text", text: `fast: ${params.value}` }], details: {} };
+		},
+	};
+
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [stuckTool, fastTool] };
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
+
+	const abortController = new AbortController();
+
+	let callIndex = 0;
+	const stream = agentLoop(
+		[createUserMessage("run both")],
+		context,
+		config,
+		abortController.signal,
+		() => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+			if (callIndex === 0) {
+			const message = createAssistantMessage(
+				[
+				{ type: "toolCall", id: "tool-fast", name: "fast", arguments: { value: "fast" } },
+				{ type: "toolCall", id: "tool-stuck", name: "stuck", arguments: { value: "stuck" } },
+				],
+				"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			} else {
+			mockStream.push({
+				type: "done",
+				reason: "stop",
+				message: createAssistantMessage([{ type: "text", text: "done" }]),
+				});
+			}
+			callIndex++;
+		});
+		return mockStream;
+		},
+	);
+
+	const events: AgentEvent[] = [];
+	const consumeEvents = async () => {
+		for await (const event of stream as AsyncIterable<AgentEvent>) {
+		events.push(event);
+		}
+	};
+	void consumeEvents();
+
+	// Wait for fast's toolResult
+	await new Promise<void>((resolve) => {
+		const check = () => {
+		if (events.find((e) => e.type === "message_end" && (e as any).message?.toolCallId === "tool-fast"))
+			resolve();
+		else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+	});
+
+	expect(fastResolved).toBe(true);
+
+	// Abort
+	abortController.abort();
+
+	// Wait for the batch to complete
+	await new Promise<void>((resolve) => {
+		const check = () => {
+		if (events.find((e) => e.type === "agent_end")) resolve();
+		else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+	});
+
+	const stuckResultsBeforeLate = events.filter(
+		(e) =>
+		(e.type === "message_end" || e.type === "tool_execution_end" || e.type === "message_start") &&
+		(e as any).toolCallId === "tool-stuck" || (e as any).message?.toolCallId === "tool-stuck",
+	);
+
+	// Now resolve the stuck tool after abort
+	stuckDeferred.resolve({ content: [{ type: "text", text: "should not emit" }], details: {} });
+
+	// Wait for any late events to flush
+	await flush(10);
+
+	const stuckResultsAfterLate = events.filter(
+		(e) =>
+		(e.type === "message_end" || e.type === "tool_execution_end" || e.type === "message_start") &&
+		((e as any).toolCallId === "tool-stuck" || (e as any).message?.toolCallId === "tool-stuck"),
+	);
+
+	// No additional events for stuck after the abort completion
+	expect(stuckResultsAfterLate.length).toBe(stuckResultsBeforeLate.length);
+
+	// Exactly one toolResult for stuck overall
+	const stuckToolResults = events.filter(
+		(e) =>
+		e.type === "message_end" &&
+		(e as any).message?.role === "toolResult" &&
+		(e as any).message?.toolCallId === "tool-stuck",
+	);
+	expect(stuckToolResults.length).toBe(1);
+	});
+
+	it("keeps returned messages and turn_end.toolResults in assistant source order", async () => {
+	const toolSchema = Type.Object({ value: Type.String() });
+
+	const dA = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+	const dB = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+	const dC = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		async execute(_toolCallId, params) {
+		if (params.value === "a") return dA.promise;
+		if (params.value === "b") return dB.promise;
+		if (params.value === "c") return dC.promise;
+		return {
+			content: [{ type: "text", text: `echoed: ${params.value}` }],
+			details: { value: params.value },
+		};
+		},
+	};
+
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [tool] };
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
+
+	let callIndex = 0;
+	const stream = agentLoop(
+		[createUserMessage("run three")],
+		context,
+		config,
+		undefined,
+		() => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+			if (callIndex === 0) {
+			const message = createAssistantMessage(
+				[
+				{ type: "toolCall", id: "tool-a", name: "echo", arguments: { value: "a" } },
+				{ type: "toolCall", id: "tool-b", name: "echo", arguments: { value: "b" } },
+				{ type: "toolCall", id: "tool-c", name: "echo", arguments: { value: "c" } },
+				],
+				"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			} else {
+			mockStream.push({
+				type: "done",
+				reason: "stop",
+				message: createAssistantMessage([{ type: "text", text: "done" }]),
+				});
+			}
+			callIndex++;
+		});
+		return mockStream;
+		},
+	);
+
+	const events: AgentEvent[] = [];
+	const consumeEvents = async () => {
+		for await (const event of stream as AsyncIterable<AgentEvent>) {
+		events.push(event);
+		}
+	};
+	void consumeEvents();
+
+	// Resolve in order c, a, b (different from source order a, b, c)
+	dC.resolve({ content: [{ type: "text", text: "c result" }], details: { value: "c" } });
+	await flush(2);
+	dA.resolve({ content: [{ type: "text", text: "a result" }], details: { value: "a" } });
+	await flush(2);
+	dB.resolve({ content: [{ type: "text", text: "b result" }], details: { value: "b" } });
+
+	// Wait for completion
+	await new Promise<void>((resolve) => {
+		const check = () => {
+		if (events.find((e) => e.type === "agent_end")) resolve();
+		else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+	});
+
+	// Returned messages are in source order
+	const turnEndEvent = events.find((e) => e.type === "turn_end") as Extract<AgentEvent, { type: "turn_end" }> | undefined;
+	expect(turnEndEvent?.toolResults.map((r) => r.toolCallId)).toEqual(["tool-a", "tool-b", "tool-c"]);
+
+	// tool_execution_end order reflects completion order
+	const toolExecutionEndIds = events
+		.filter((e) => e.type === "tool_execution_end")
+		.map((e) => (e as any).toolCallId);
+	expect(toolExecutionEndIds).toEqual(["tool-c", "tool-a", "tool-b"]);
+	});
+
+	it("immediate outcomes in a mixed parallel batch are persisted during preflight", async () => {
+	const toolSchema = Type.Object({ value: Type.String() });
+
+	const immediateDeferred = defer<{ content: { type: "text"; text: string }[]; details: Record<string, unknown> }>();
+
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		execute: () => immediateDeferred.promise,
+	};
+
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [tool] };
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
+
+	let callIndex = 0;
+	const stream = agentLoop(
+		[createUserMessage("run two")],
+		context,
+		config,
+		undefined,
+		() => {
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+			if (callIndex === 0) {
+			const message = createAssistantMessage(
+				[
+				{ type: "toolCall", id: "tool-err", name: "unknown_tool", arguments: { value: "x" } },
+				{ type: "toolCall", id: "tool-real", name: "echo", arguments: { value: "y" } },
+				],
+				"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+			} else {
+			mockStream.push({
+				type: "done",
+				reason: "stop",
+				message: createAssistantMessage([{ type: "text", text: "done" }]),
+				});
+			}
+			callIndex++;
+		});
+		return mockStream;
+		},
+	);
+
+	const events: AgentEvent[] = [];
+	const consumeEvents = async () => {
+		for await (const event of stream as AsyncIterable<AgentEvent>) {
+		events.push(event);
+		}
+	};
+	void consumeEvents();
+
+	// The unknown tool result should be emitted before the prepared tool resolves
+	await new Promise<void>((resolve) => {
+		const check = () => {
+		const errResult = events.find(
+			(e) =>
+			e.type === "message_end" &&
+			(e as any).message?.role === "toolResult" &&
+			(e as any).message?.toolCallId === "tool-err",
+		);
+		if (errResult) resolve();
+		else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+	});
+
+	const errResult = events.find(
+		(e) =>
+		e.type === "message_end" &&
+		(e as any).message?.role === "toolResult" &&
+		(e as any).message?.toolCallId === "tool-err",
+	);
+	expect(errResult).toBeDefined();
+	if (errResult?.type === "message_end") {
+		expect((errResult as any).message.isError).toBe(true);
+	}
+
+	// The prepared tool result should NOT be emitted yet
+	const realResultBeforeResolve = events.find(
+		(e) =>
+		e.type === "message_end" &&
+		(e as any).message?.role === "toolResult" &&
+		(e as any).message?.toolCallId === "tool-real",
+	);
+	expect(realResultBeforeResolve).toBeUndefined();
+
+	// Now resolve the prepared tool
+	immediateDeferred.resolve({ content: [{ type: "text", text: "real result" }], details: {} });
+
+	// Wait for completion
+	await new Promise<void>((resolve) => {
+		const check = () => {
+		if (events.find((e) => e.type === "agent_end")) resolve();
+		else setTimeout(check, 5);
+		};
+		setTimeout(check, 5);
+	});
+
+	// Both results should be in the final messages
+	const allToolResults = events.filter(
+		(e) =>
+		e.type === "message_end" &&
+		(e as any).message?.role === "toolResult",
+	);
+	expect(allToolResults.length).toBe(2);
+	});
+
+	it("terminate semantics are preserved for parallel batches", async () => {
+	const toolSchema = Type.Object({ value: Type.String() });
+	const tool: AgentTool<typeof toolSchema, { value: string }> = {
+		name: "echo",
+		label: "Echo",
+		description: "Echo tool",
+		parameters: toolSchema,
+		execute: async (_id, params) => ({
+		content: [{ type: "text", text: `echoed: ${params.value}` }],
+		details: { value: params.value },
+		terminate: true,
+		}),
+	};
+
+	const context: AgentContext = { systemPrompt: "", messages: [], tools: [tool] };
+	const config: AgentLoopConfig = {
+		model: createModel(),
+		convertToLlm: identityConverter,
+		toolExecution: "parallel",
+	};
+
+	let llmCalls = 0;
+	const stream = agentLoop(
+		[createUserMessage("echo both")],
+		context,
+		config,
+		undefined,
+		() => {
+		llmCalls++;
+		const mockStream = new MockAssistantStream();
+		queueMicrotask(() => {
+			const message = createAssistantMessage(
+			[
+				{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "first" } },
+				{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second" } },
+			],
+			"toolUse",
+			);
+			mockStream.push({ type: "done", reason: "toolUse", message });
+		});
+		return mockStream;
+		},
+	);
+
+	for await (const _event of stream as AsyncIterable<AgentEvent>) {
+		// consume
+	}
+
+	// Both tools set terminate: true, so no second LLM call
+	expect(llmCalls).toBe(1);
 	});
 });

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -628,8 +628,7 @@ Fired for tool execution lifecycle updates.
 In parallel tool mode:
 - `tool_execution_start` is emitted in assistant source order during the preflight phase
 - `tool_execution_update` events may interleave across tools
-- `tool_execution_end` is emitted in tool completion order after each tool is finalized
-- final `toolResult` message events are still emitted later in assistant source order
+- `tool_execution_end` and the final `toolResult` message events (`message_start`/`message_end`) are emitted per tool in completion order as each tool is finalized. `turn_end.toolResults` remains in assistant source order. If the run is aborted while a tool is still executing, its result is persisted as an `isError` "Operation aborted" tool result rather than being orphaned.
 
 ```typescript
 pi.on("tool_execution_start", async (event, ctx) => {
@@ -815,7 +814,7 @@ pi.on("tool_call", (event) => {
 
 Fired after tool execution finishes and before `tool_execution_end` plus the final tool result message events are emitted. **Can modify result.**
 
-In parallel tool mode, `tool_result` and `tool_execution_end` may interleave in tool completion order, while final `toolResult` message events are still emitted later in assistant source order.
+In parallel tool mode, `tool_result` and `tool_execution_end` may interleave in tool completion order, while final `toolResult` message events (`message_start`/`message_end`) are emitted per tool in completion order as each tool is finalized. `turn_end.toolResults` remains in assistant source order. If the run is aborted while a tool is still executing, its result is persisted as an `isError` "Operation aborted" tool result rather than being orphaned.
 
 `tool_result` handlers chain like middleware:
 - Handlers run in extension load order


### PR DESCRIPTION
# fix(agent): parallel tool batches persist each sibling result on its own completion

## Summary

Restructure `executeToolCallsParallel` in `packages/agent/src/agent-loop.ts` so that each sibling's `toolResultMessage` is persisted (emitted) at that sibling's own completion, never gated on the batch's `Promise.all` barrier. Add an abort race so the barrier can be abandoned when the user presses Esc, synthesizing "Operation aborted" outcomes for never-settled siblings so no tool call is orphaned.

## Root Cause

In the previous implementation, `createToolResultMessage` + `emitToolResultMessage` ran in a sequential loop **after** `await Promise.all(...)`. This meant:

1. `tool_execution_end` was emitted per sibling on completion (from #3503), but the toolResult message was not persisted until **all** siblings settled.
2. If one tool stalled (e.g. a network socket ignoring the abort signal), the `Promise.all` barrier never resolved.
3. While waiting, **no** toolResult was persisted to `Agent.state.messages` via `message_end` → `agent.ts::processEvents`.
4. On the next turn, `transformMessages` synthesised `isError: true "No result provided"` for every tool in the batch.
5. The UI appeared frozen because `turn_end`/`agent_end` were never reached.

## The Fix

### Per-sibling persistence
Each prepared tool call thunk now calls `createToolResultMessage` + `emitToolResultMessage` inline on its own completion, before resolving. Completed siblings can no longer be gated by a stalled sibling.

### Claim map
A `Map<toolCallId, ToolResultMessage>` coordinates emission with the abort race. Whoever inserts an id into the map is the one to emit that result. The check-before-insert never spans an `await`, so every `toolCallId` gets exactly one emitted `toolResult` — including when a stalled sibling settles after the batch was already abandoned on abort (it sees the claim and stays silent).

### Abort race
`Promise.race([allSettled, waitForAbort(signal)])` lets the function exit even when a sibling ignores the abort signal. On abort, `synthesizeAbortedOutcomes` builds error outcomes for any sibling that never settled (or whose thunk's emission was still in-flight), emitting `tool_execution_end` + `toolResult` for each so UIs clear their "running" state.

### Return-value semantics preserved
The returned `messages` array and `turn_end.toolResults` remain in assistant source order regardless of completion order, so downstream consumers and `shouldTerminateToolBatch` are unaffected.

## Behavior Change

**In parallel mode, `toolResult` message events (`message_start`/`message_end`) are now emitted in tool completion order** rather than assistant source order. `turn_end.toolResults` and the messages returned from the batch remain in assistant source order (matched by `toolCallId`). This mirrors the existing `tool_execution_end` completion-order semantics from #3503. Extensions and UIs that consume `toolResult` events should be updated accordingly.

## Files Changed

- `packages/agent/src/agent-loop.ts` — restructured `executeToolCallsParallel`
- `packages/agent/src/types.ts` — updated `ToolExecutionMode` and `AgentLoopConfig.toolExecution` TSDoc
- `packages/agent/test/agent-loop.test.ts` — updated one existing test + 6 new regression tests
- `packages/coding-agent/docs/extensions.md` — updated `tool_execution_*` and `tool_result` documentation
- **Publishing setup** (same branch): renamed all `@earendil-works/*` packages to `@bramburn/*`, added `.npmrc` with `NPM_TOKEN` to each, added `.github/workflows/publish.yml` to publish on tag push

## Test Commands

```bash
# Run agent-loop tests (21 original + 6 new = 27 passing)
cd packages/agent && npx vitest --run test/agent-loop.test.ts

# Typecheck
cd .. && npx tsc --noEmit -p packages/agent/tsconfig.build.json
```

## Related Issues

Fixes #7053. Related to the broader `Promise.all`-barrier pattern: #7113, #6665, #7153, #6755.
