### PR TITLE
fix(ai): request fine-grained tool streaming on AWS for Anthropic

### DIFF
--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -221,6 +221,11 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 			}
 			const cacheRetention = resolveCacheRetention(options.cacheRetention, options.env);
 			const inferenceMaxTokens = options.maxTokens ?? (isAnthropicClaudeModel(model) ? model.maxTokens : undefined);
+			const toolConfig = convertToolConfig(
+				context.tools,
+				options.toolChoice,
+				model.compat?.supportsStrictMode ?? false,
+			);
 			let commandInput = {
 				modelId: model.id,
 				messages: convertMessages(context, model, cacheRetention, options.env),
@@ -229,8 +234,8 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 					...(inferenceMaxTokens !== undefined && { maxTokens: inferenceMaxTokens }),
 					...(options.temperature !== undefined && { temperature: options.temperature }),
 				},
-				toolConfig: convertToolConfig(context.tools, options.toolChoice, model.compat?.supportsStrictMode ?? false),
-				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
+				toolConfig,
+				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options, toolConfig !== undefined),
 				...(options.requestMetadata !== undefined && { requestMetadata: options.requestMetadata }),
 			};
 			const nextCommandInput = await options?.onPayload?.(commandInput, model);
@@ -1027,54 +1032,73 @@ function isGovCloudBedrockTarget(model: Model<"bedrock-converse-stream">, option
 	return modelId.startsWith("us-gov.") || modelId.startsWith("arn:aws-us-gov:");
 }
 
+/**
+ * Anthropic buffers the entire toolUse input block server-side by default and
+ * flushes it only when the block completes — a large tool call (tens of
+ * thousands of tokens) then produces minutes of zero stream events followed by
+ * one burst, which downstream idle watchdogs read as a dead stream. This beta
+ * streams tool input as it is generated, matching the eager input streaming
+ * the Anthropic Messages provider already requests. The tradeoff (input JSON
+ * may arrive incomplete on early termination, since server-side validation is
+ * skipped) is already handled: tool arguments go through the tolerant
+ * `parseStreamingJson` on every delta and at block stop.
+ */
+const FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
+
 function buildAdditionalModelRequestFields(
 	model: Model<"bedrock-converse-stream">,
 	options: BedrockOptions,
+	hasTools: boolean,
 ): Record<string, any> | undefined {
-	if (!options.reasoning || !model.reasoning) {
+	if (!isAnthropicClaudeModel(model)) {
 		return undefined;
 	}
 
-	if (isAnthropicClaudeModel(model)) {
+	const result: Record<string, any> = {};
+	const betas: string[] = [];
+
+	if (options.reasoning && model.reasoning) {
 		// GovCloud Bedrock currently rejects the Claude thinking.display field.
 		// Omit it there until the GovCloud Converse schema catches up.
 		const display = isGovCloudBedrockTarget(model, options) ? undefined : (options.thinkingDisplay ?? "summarized");
-		const result: Record<string, any> = supportsAdaptiveThinking(model.id, model.name)
-			? {
-					thinking: { type: "adaptive", ...(display !== undefined ? { display } : {}) },
-					output_config: { effort: mapThinkingLevelToEffort(model, options.reasoning) },
-				}
-			: (() => {
-					const defaultBudgets: Record<ThinkingLevel, number> = {
-						minimal: 1024,
-						low: 2048,
-						medium: 8192,
-						high: 16384,
-						xhigh: 16384, // Budget-based Claude clamps extended levels to high
-						max: 16384,
-					};
+		if (supportsAdaptiveThinking(model.id, model.name)) {
+			result.thinking = { type: "adaptive", ...(display !== undefined ? { display } : {}) };
+			result.output_config = { effort: mapThinkingLevelToEffort(model, options.reasoning) };
+		} else {
+			const defaultBudgets: Record<ThinkingLevel, number> = {
+				minimal: 1024,
+				low: 2048,
+				medium: 8192,
+				high: 16384,
+				xhigh: 16384, // Budget-based Claude clamps extended levels to high
+				max: 16384,
+			};
 
-					// Custom budgets only cover token-based levels through high.
-					const level = options.reasoning === "xhigh" || options.reasoning === "max" ? "high" : options.reasoning;
-					const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[options.reasoning];
+			// Custom budgets only cover token-based levels through high.
+			const level = options.reasoning === "xhigh" || options.reasoning === "max" ? "high" : options.reasoning;
+			const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[options.reasoning];
 
-					return {
-						thinking: {
-							type: "enabled",
-							budget_tokens: budget,
-							...(display !== undefined ? { display } : {}),
-						},
-					};
-				})();
+			result.thinking = {
+				type: "enabled",
+				budget_tokens: budget,
+				...(display !== undefined ? { display } : {}),
+			};
 
-		if (!supportsAdaptiveThinking(model.id, model.name) && (options.interleavedThinking ?? true)) {
-			result.anthropic_beta = ["interleaved-thinking-2025-05-14"];
+			if (options.interleavedThinking ?? true) {
+				betas.push("interleaved-thinking-2025-05-14");
+			}
 		}
-
-		return result;
 	}
 
-	return undefined;
+	if (hasTools && (model.compat?.supportsEagerToolInputStreaming ?? true)) {
+		betas.push(FINE_GRAINED_TOOL_STREAMING_BETA);
+	}
+
+	if (betas.length > 0) {
+		result.anthropic_beta = betas;
+	}
+
+	return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function createImageBlock(mimeType: string, data: string) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -639,6 +639,15 @@ export interface AnthropicMessagesCompat {
 export interface BedrockCompat {
 	/** Whether the model supports Bedrock strict tool schemas. Default: false. */
 	supportsStrictMode?: boolean;
+	/**
+	 * Whether to request eager toolUse input streaming for Anthropic models
+	 * (the `fine-grained-tool-streaming-2025-05-14` beta, passed through
+	 * `additionalModelRequestFields.anthropic_beta`). Without it, Anthropic
+	 * buffers the entire toolUse input block server-side and flushes it only on
+	 * completion — a large tool call means minutes of zero stream events.
+	 * Default: true.
+	 */
+	supportsEagerToolInputStreaming?: boolean;
 }
 
 /**

--- a/packages/ai/test/bedrock-eager-tool-input.test.ts
+++ b/packages/ai/test/bedrock-eager-tool-input.test.ts
@@ -1,0 +1,146 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { type BedrockOptions, stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
+import { getModel } from "../src/compat.ts";
+import type { Context, Model, Tool } from "../src/types.ts";
+
+// Anthropic buffers the entire toolUse input block server-side by default:
+// a large tool call produces minutes of zero stream events, then one burst.
+// The fine-grained tool streaming beta streams input as generated. These pin
+// that the Bedrock provider requests it for Anthropic models with tools —
+// mirroring the eager input streaming the Anthropic Messages provider sends.
+const FINE_GRAINED_BETA = "fine-grained-tool-streaming-2025-05-14";
+const INTERLEAVED_BETA = "interleaved-thinking-2025-05-14";
+
+interface CapturedPayload {
+	toolConfig?: unknown;
+	additionalModelRequestFields?: {
+		thinking?: { type: string };
+		anthropic_beta?: string[];
+	};
+}
+
+class PayloadCaptured extends Error {
+	constructor() {
+		super("payload captured");
+		this.name = "PayloadCaptured";
+	}
+}
+
+const tool: Tool = {
+	name: "lookup",
+	description: "Look up a value",
+	parameters: Type.Object({ value: Type.String() }),
+};
+
+function makeContext(tools: Tool[] = [tool]): Context {
+	return {
+		messages: [{ role: "user", content: "Use the tool", timestamp: Date.now() }],
+		...(tools.length > 0 ? { tools } : {}),
+	};
+}
+
+async function capturePayload(
+	model: Model<"bedrock-converse-stream">,
+	context: Context,
+	options?: BedrockOptions,
+): Promise<CapturedPayload> {
+	let capturedPayload: CapturedPayload | undefined;
+	const s = streamBedrock(model, context, {
+		...options,
+		onPayload: (payload) => {
+			capturedPayload = payload as CapturedPayload;
+			throw new PayloadCaptured();
+		},
+	});
+
+	for await (const event of s) {
+		if (event.type === "error") {
+			break;
+		}
+	}
+
+	if (!capturedPayload) {
+		throw new Error("Expected Bedrock payload to be captured before request abort");
+	}
+
+	return capturedPayload;
+}
+
+function opus48(): Model<"bedrock-converse-stream"> {
+	const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-opus-4-6-v1");
+	return {
+		...baseModel,
+		id: "global.anthropic.claude-opus-4-8-v1",
+		name: "Claude Opus 4.8 (Global)",
+	};
+}
+
+describe("Bedrock eager tool input streaming", () => {
+	it("requests the fine-grained tool streaming beta for an Anthropic model with tools", async () => {
+		const payload = await capturePayload(opus48(), makeContext());
+
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toEqual([FINE_GRAINED_BETA]);
+	});
+
+	it("does not request the beta without tools", async () => {
+		const payload = await capturePayload(opus48(), makeContext([]));
+
+		expect(payload.additionalModelRequestFields).toBeUndefined();
+	});
+
+	it("does not request the beta when toolChoice is none (tools are dropped)", async () => {
+		const payload = await capturePayload(opus48(), makeContext(), { toolChoice: "none" });
+
+		expect(payload.toolConfig).toBeUndefined();
+		expect(payload.additionalModelRequestFields).toBeUndefined();
+	});
+
+	it("honors compat.supportsEagerToolInputStreaming: false", async () => {
+		const model: Model<"bedrock-converse-stream"> = {
+			...opus48(),
+			compat: { supportsEagerToolInputStreaming: false },
+		};
+		const payload = await capturePayload(model, makeContext());
+
+		expect(payload.additionalModelRequestFields).toBeUndefined();
+	});
+
+	it("appends to the interleaved-thinking beta on non-adaptive models instead of replacing it", async () => {
+		const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-opus-4-6-v1");
+		const model: Model<"bedrock-converse-stream"> = {
+			...baseModel,
+			id: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+			name: "Claude Sonnet 4",
+		};
+		const payload = await capturePayload(model, makeContext(), { reasoning: "high" });
+
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toEqual([INTERLEAVED_BETA, FINE_GRAINED_BETA]);
+	});
+
+	it("keeps reasoning-only payloads unchanged on non-adaptive models (interleaved beta only)", async () => {
+		const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-opus-4-6-v1");
+		const model: Model<"bedrock-converse-stream"> = {
+			...baseModel,
+			id: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+			name: "Claude Sonnet 4",
+		};
+		const payload = await capturePayload(model, makeContext([]), { reasoning: "high" });
+
+		expect(payload.additionalModelRequestFields?.anthropic_beta).toEqual([INTERLEAVED_BETA]);
+		expect(payload.additionalModelRequestFields?.thinking).toBeDefined();
+	});
+
+	it("sends no additionalModelRequestFields for non-Anthropic models even with tools", async () => {
+		const baseModel = getModel("amazon-bedrock", "global.anthropic.claude-opus-4-6-v1");
+		const model: Model<"bedrock-converse-stream"> = {
+			...baseModel,
+			id: "us.meta.llama3-3-70b-instruct-v1:0",
+			name: "Llama 3.3 70B",
+			reasoning: false,
+		};
+		const payload = await capturePayload(model, makeContext());
+
+		expect(payload.additionalModelRequestFields).toBeUndefined();
+	});
+});


### PR DESCRIPTION
This is a fix to make the Anthropic models behave the same way in AWS Bedrock as they do when accessed directly from Anthropic.
The current difference is that Anthropic streams data, whereas AWS Bedrock buffers them. This tripped us up when switching backends since our code made the assumption that Bedrock also would stream our Opus, Sonnet and Haiku requests.

This PR just makes sure that AWS Bedrock also streams it, in parity with Anthropic.
Do note that this change is made with the assumption that this was an oversight in the PI project. It could also be deliberate, which make this PR moot.


Claude wrote all code, this is Claude's description:

Anthropic buffers the entire toolUse input block server-side by default and flushes it only when the block completes. A large tool call (tens of thousands of tokens) then produces minutes of zero stream events followed by one burst - downstream idle watchdogs read this as a dead stream. Measured against a real 52k-token tool call on Bedrock opus-4-8: max inter-event gap 368s without the beta, 2.0s with it.

The Anthropic Messages provider already requests eager tool input streaming; the Bedrock provider never did. Add the fine-grained-tool-streaming-2025-05-14 beta to additionalModelRequestFields for Anthropic Claude models when tools are configured, appended to the interleaved-thinking beta where that applies. Opt out per model via compat.supportsEagerToolInputStreaming: false.

Incomplete input JSON on early termination (the tradeoff of skipping server-side buffering) is already handled: tool arguments go through the tolerant parseStreamingJson on every delta and at block stop.