### PR TITLE
feat(coding-agent): add rendering mode setting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `--alt` to run interactive mode with the alternate-screen TUI ([#7304](https://github.com/earendil-works/pi/issues/7304)).
 - Added a sticky editor, status, widget, and footer dock to `--alt` mode while keeping the transcript independently scrollable.
 - Added a transient draggable transcript scrollbar to `--alt` mode.
+- Added a persistent rendering mode preference to `/settings`; `--alt` remains a per-run override.
 
 ### Fixed
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -178,6 +178,7 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
 | `terminal.showImages` | boolean | `true` | Show images in terminal (if supported) |
 | `terminal.imageWidthCells` | number | `60` | Preferred inline image width in terminal cells |
 | `terminal.clearOnShrink` | boolean | `false` | Clear empty rows when content shrinks (can cause flicker) |
+| `terminal.renderingMode` | string | `"main"` | Interactive renderer: `"main"` or experimental `"alternate"`. Changes from `/settings` apply after restart; `--alt` overrides this setting for one run |
 | `images.autoResize` | boolean | `true` | Resize images to 2000x2000 max |
 | `images.blockImages` | boolean | `false` | Block all images from being sent to LLM |
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -248,6 +248,8 @@ pi --no-extensions -e ./my-extension.ts
 
 When `--alt` is active, the transcript scrolls inside the terminal viewport while queued messages, working status, extension widgets, editor, and footer remain fixed at the bottom. Mouse/trackpad input scrolls the region under the pointer; keyboard viewport actions always remain available. Inline images work in terminals that support the Kitty graphics protocol, including Kitty and Ghostty. In iTerm2 they render as text placeholders because its inline-image protocol cannot delete or crop placements during application-owned scrolling. Without `--alt`, pi uses the main screen and terminal-owned scrollback, and iTerm2 inline images continue to render normally.
 
+To use alternate-screen mode by default, set **Rendering mode** to `alternate` in `/settings`. The change applies after restarting pi. `--alt` remains a per-run override.
+
 ### File Arguments
 
 Prefix files with `@` to include them in the message:

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -32,11 +32,14 @@ export interface RetrySettings {
 	provider?: ProviderRetrySettings;
 }
 
+export type RenderingMode = "main" | "alternate";
+
 export interface TerminalSettings {
 	showImages?: boolean; // default: true (only relevant if terminal supports images)
 	imageWidthCells?: number; // default: 60 (preferred inline image width in terminal cells)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 	showTerminalProgress?: boolean; // default: false (OSC 9;4 terminal progress indicators)
+	renderingMode?: RenderingMode; // default: "main"
 }
 
 export interface ImageSettings {
@@ -1117,6 +1120,19 @@ export class SettingsManager {
 		}
 		this.globalSettings.terminal.showTerminalProgress = enabled;
 		this.markModified("terminal", "showTerminalProgress");
+		this.save();
+	}
+
+	getRenderingMode(): RenderingMode {
+		return this.settings.terminal?.renderingMode === "alternate" ? "alternate" : "main";
+	}
+
+	setRenderingMode(mode: RenderingMode): void {
+		if (!this.globalSettings.terminal) {
+			this.globalSettings.terminal = {};
+		}
+		this.globalSettings.terminal.renderingMode = mode;
+		this.markModified("terminal", "renderingMode");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -252,6 +252,7 @@ export {
 	type DefaultProjectTrust,
 	type ImageSettings,
 	type PackageSource,
+	type RenderingMode,
 	type RetrySettings,
 	SettingsManager,
 	type SettingsManagerCreateOptions,

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -13,7 +13,7 @@ import {
 	Text,
 } from "@earendil-works/pi-tui";
 import { formatHttpIdleTimeoutMs, HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-dispatcher.ts";
-import type { DefaultProjectTrust, WarningSettings } from "../../../core/settings-manager.ts";
+import type { DefaultProjectTrust, RenderingMode, WarningSettings } from "../../../core/settings-manager.ts";
 import {
 	getSelectListTheme,
 	getSettingsListTheme,
@@ -79,6 +79,7 @@ export interface SettingsConfig {
 	defaultProjectTrust: DefaultProjectTrust;
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
+	renderingMode: RenderingMode;
 	warnings: WarningSettings;
 }
 
@@ -110,6 +111,7 @@ export interface SettingsCallbacks {
 	onDefaultProjectTrustChange: (defaultProjectTrust: DefaultProjectTrust) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
+	onRenderingModeChange: (mode: RenderingMode) => void;
 	onWarningsChange: (warnings: WarningSettings) => void;
 	onCancel: () => void;
 }
@@ -611,6 +613,13 @@ export class SettingsSelectorComponent extends Container {
 					),
 			},
 			{
+				id: "rendering-mode",
+				label: "Rendering mode",
+				description: "Terminal renderer used, either main or alternate (experimental)",
+				currentValue: config.renderingMode,
+				values: ["main", "alternate"],
+			},
+			{
 				id: "theme",
 				label: "Theme",
 				description: "Color theme for the interface",
@@ -818,6 +827,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "terminal-progress":
 						callbacks.onShowTerminalProgressChange(newValue === "true");
+						break;
+					case "rendering-mode":
+						callbacks.onRenderingModeChange(newValue as RenderingMode);
 						break;
 					case "theme":
 						callbacks.onThemeChange(newValue);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -91,6 +91,7 @@ import { DefaultPackageManager } from "../../core/package-manager.ts";
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
 import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.ts";
 import { type SessionEntry, SessionManager, sessionEntryToContextMessages } from "../../core/session-manager.ts";
+import type { RenderingMode } from "../../core/settings-manager.ts";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.ts";
 import type { SourceInfo } from "../../core/source-info.ts";
 import { isInstallTelemetryEnabled } from "../../core/telemetry.ts";
@@ -329,7 +330,7 @@ export interface InteractiveModeOptions {
 }
 
 interface InteractiveTuiOptions {
-	alt: boolean;
+	renderingMode: RenderingMode;
 	showHardwareCursor: boolean;
 	logDirectory: string;
 	terminal?: Terminal;
@@ -338,7 +339,7 @@ interface InteractiveTuiOptions {
 /** Composition root for selecting the interactive terminal renderer. */
 export function createInteractiveTui(options: InteractiveTuiOptions): TUI {
 	const terminal = options.terminal ?? new ProcessTerminal();
-	if (options.alt) {
+	if (options.renderingMode === "alternate") {
 		return new TuiAltScreen(terminal, options.showHardwareCursor, options.logDirectory, { openUrl: openBrowser });
 	}
 	return new TuiMainScreen(terminal, options.showHardwareCursor, options.logDirectory);
@@ -473,7 +474,9 @@ export class InteractiveMode {
 
 	constructor(runtimeHost: AgentSessionRuntime, options: InteractiveModeOptions = {}) {
 		this.runtimeHost = runtimeHost;
-		this.options = options;
+		const renderingMode: RenderingMode =
+			options.alt === undefined ? this.settingsManager.getRenderingMode() : options.alt ? "alternate" : "main";
+		this.options = { ...options, alt: renderingMode === "alternate" };
 		this.autoTrustOnReloadCwd = options.autoTrustOnReloadCwd;
 		this.runtimeHost.setBeforeSessionInvalidate(() => {
 			this.resetExtensionUI();
@@ -483,7 +486,7 @@ export class InteractiveMode {
 		});
 		this.version = VERSION;
 		this.ui = createInteractiveTui({
-			alt: options.alt ?? false,
+			renderingMode,
 			showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
 			logDirectory: getAgentDir(),
 		});
@@ -4234,6 +4237,7 @@ export class InteractiveMode {
 					quietStartup: this.settingsManager.getQuietStartup(),
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 					showTerminalProgress: this.settingsManager.getShowTerminalProgress(),
+					renderingMode: this.settingsManager.getRenderingMode(),
 					warnings: this.settingsManager.getWarnings(),
 				},
 				{
@@ -4373,6 +4377,10 @@ export class InteractiveMode {
 					},
 					onShowTerminalProgressChange: (enabled) => {
 						this.settingsManager.setShowTerminalProgress(enabled);
+					},
+					onRenderingModeChange: (mode) => {
+						this.settingsManager.setRenderingMode(mode);
+						this.showStatus(`Rendering mode: ${mode} (restart required)`);
 					},
 					onWarningsChange: (warnings) => {
 						this.settingsManager.setWarnings(warnings);

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -17,7 +17,7 @@ describe("createInteractiveTui", () => {
 	it("selects the alternate-screen renderer only when requested", async () => {
 		const mainTerminal = new RecordingTerminal();
 		const mainTui = createInteractiveTui({
-			alt: false,
+			renderingMode: "main",
 			showHardwareCursor: false,
 			logDirectory: "/tmp",
 			terminal: mainTerminal,
@@ -30,7 +30,7 @@ describe("createInteractiveTui", () => {
 
 		const altTerminal = new RecordingTerminal();
 		const altTui = createInteractiveTui({
-			alt: true,
+			renderingMode: "alternate",
 			showHardwareCursor: false,
 			logDirectory: "/tmp",
 			terminal: altTerminal,

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -397,6 +397,29 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("rendering mode", () => {
+		it("defaults to main and persists alternate mode", async () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getRenderingMode()).toBe("main");
+
+			manager.setRenderingMode("alternate");
+			await manager.flush();
+
+			expect(manager.getRenderingMode()).toBe("alternate");
+			const savedSettings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8"));
+			expect(savedSettings.terminal.renderingMode).toBe("alternate");
+		});
+
+		it("falls back to main for unsupported values", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ terminal: { renderingMode: "other" } }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getRenderingMode()).toBe("main");
+		});
+	});
+
 	describe("outputPad", () => {
 		it("should default to 1 and persist binary values", async () => {
 			const manager = SettingsManager.create(projectDir, agentDir);


### PR DESCRIPTION
Make it possible to configure in settings whether to use the new alternate screen TUI or not.