### PR TITLE
fix(coding-agent): make model refresh state consistent

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -19,6 +19,10 @@
 			"types": "./dist/compat.d.ts",
 			"import": "./dist/compat.js"
 		},
+		"./internal/refresh-queue": {
+			"types": "./dist/refresh-queue.d.ts",
+			"import": "./dist/refresh-queue.js"
+		},
 		"./providers/*": {
 			"types": "./dist/providers/*.d.ts",
 			"import": "./dist/providers/*.js"

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -13,6 +13,7 @@ import type {
 	ProviderAuth,
 } from "./auth/types.ts";
 import { InMemoryModelsStore, type ModelsStore, type ProviderModelsStore } from "./models-store.ts";
+import { createRefreshQueue } from "./refresh-queue.ts";
 import type {
 	Api,
 	ApiStreamOptions,
@@ -556,7 +557,6 @@ export interface CreateProviderOptions<TApi extends Api = Api> {
 export function createProvider<TApi extends Api = Api>(input: CreateProviderOptions<TApi>): Provider<TApi> {
 	const baselineModels = input.models;
 	let dynamicModels: readonly Model<TApi>[] = [];
-	let inflightRefresh: Promise<void> | undefined;
 	const fetchModels = input.fetchModels;
 	const currentModels = (): readonly Model<TApi>[] => {
 		const merged = [...baselineModels];
@@ -594,26 +594,20 @@ export function createProvider<TApi extends Api = Api>(input: CreateProviderOpti
 		auth: input.auth,
 		getModels: currentModels,
 		refreshModels: fetchModels
-			? (context) => {
-					inflightRefresh ??= (async () => {
-						try {
-							const stored = await context.store.read();
-							if (stored) {
-								dynamicModels = stored.models
-									.filter((model) => model.provider === input.id)
-									.map((model) => model as Model<TApi>);
-							}
-							if (!context.allowNetwork || context.signal?.aborted) return;
-							const refreshed = await fetchModels(context);
-							if (context.signal?.aborted) return;
-							dynamicModels = refreshed;
-							await context.store.write({ models: refreshed, checkedAt: Date.now() });
-						} finally {
-							inflightRefresh = undefined;
-						}
-					})();
-					return inflightRefresh;
-				}
+			? createRefreshQueue(async (context: RefreshModelsContext) => {
+					if (context.signal?.aborted) return;
+					const stored = await context.store.read();
+					if (stored) {
+						dynamicModels = stored.models
+							.filter((model) => model.provider === input.id)
+							.map((model) => model as Model<TApi>);
+					}
+					if (!context.allowNetwork || context.signal?.aborted) return;
+					const refreshed = await fetchModels(context);
+					if (context.signal?.aborted) return;
+					dynamicModels = refreshed;
+					await context.store.write({ models: refreshed, checkedAt: Date.now() });
+				})
 			: undefined,
 		filterModels: input.filterModels,
 		stream: (model, context, options) => dispatch(model, (streams) => streams.stream(model, context, options)),

--- a/packages/ai/src/providers/radius.ts
+++ b/packages/ai/src/providers/radius.ts
@@ -1,7 +1,8 @@
 import { piMessagesApi } from "../api/pi-messages.lazy.ts";
 import { envApiKeyAuth, lazyOAuth } from "../auth/helpers.ts";
 import { loadRadiusOAuth } from "../auth/oauth/load.ts";
-import type { Provider } from "../models.ts";
+import type { Provider, RefreshModelsContext } from "../models.ts";
+import { createRefreshQueue } from "../refresh-queue.ts";
 import {
 	DEFAULT_RADIUS_GATEWAY,
 	getRadiusModels,
@@ -22,7 +23,6 @@ export function radiusProvider(options: RadiusProviderOptions = {}): Provider<"p
 	const name = options.name ?? "Radius";
 	const gateway = normalizeRadiusGatewayUrl(options.gateway ?? DEFAULT_RADIUS_GATEWAY);
 	let models = getRadiusModels(id, undefined);
-	let inflightRefresh: Promise<void> | undefined;
 	const streams = piMessagesApi();
 
 	return {
@@ -33,34 +33,27 @@ export function radiusProvider(options: RadiusProviderOptions = {}): Provider<"p
 			oauth: lazyOAuth({ name, load: () => loadRadiusOAuth({ name, gateway }) }),
 		},
 		getModels: () => models,
-		refreshModels: (context) => {
-			inflightRefresh ??= (async () => {
-				try {
-					const stored = await context.store.read();
-					if (stored) models = stored.models.filter((model) => model.provider === id) as typeof models;
+		refreshModels: createRefreshQueue(async (context: RefreshModelsContext) => {
+			if (context.signal?.aborted) return;
+			const stored = await context.store.read();
+			if (stored) models = stored.models.filter((model) => model.provider === id) as typeof models;
 
-					// Import catalogs cached by the pre-ModelsStore Radius implementation.
-					if (!stored && context.credential?.type === "oauth") {
-						const legacy = getRadiusModels(id, context.credential);
-						if (legacy.length > 0) {
-							models = legacy;
-							await context.store.write({ models: legacy, checkedAt: Date.now() });
-						}
-					}
-
-					if (!context.allowNetwork || context.signal?.aborted) return;
-					const apiKey =
-						context.credential?.type === "oauth" ? context.credential.access : context.credential?.key;
-					const config = await loadRadiusGatewayConfig(gateway, apiKey, context.signal);
-					if (context.signal?.aborted) return;
-					models = getRadiusModelsFromConfig(id, config);
-					await context.store.write({ models, checkedAt: Date.now() });
-				} finally {
-					inflightRefresh = undefined;
+			// Import catalogs cached by the pre-ModelsStore Radius implementation.
+			if (!stored && context.credential?.type === "oauth") {
+				const legacy = getRadiusModels(id, context.credential);
+				if (legacy.length > 0) {
+					models = legacy;
+					await context.store.write({ models: legacy, checkedAt: Date.now() });
 				}
-			})();
-			return inflightRefresh;
-		},
+			}
+
+			if (!context.allowNetwork || context.signal?.aborted) return;
+			const apiKey = context.credential?.type === "oauth" ? context.credential.access : context.credential?.key;
+			const config = await loadRadiusGatewayConfig(gateway, apiKey, context.signal);
+			if (context.signal?.aborted) return;
+			models = getRadiusModelsFromConfig(id, config);
+			await context.store.write({ models, checkedAt: Date.now() });
+		}),
 		stream: (model, context, streamOptions) => streams.stream(model, context, streamOptions),
 		streamSimple: (model, context, streamOptions) => streams.streamSimple(model, context, streamOptions),
 	};

--- a/packages/ai/src/refresh-queue.ts
+++ b/packages/ai/src/refresh-queue.ts
@@ -1,0 +1,80 @@
+/** Instance-local FIFO: one owner at a time; same context identity coalesces; queued abort settles without fetch. */
+export function createRefreshQueue<TContext extends { signal?: AbortSignal }>(
+	refresh: (context: TContext) => Promise<void>,
+): (context: TContext) => Promise<void> {
+	type Job = {
+		context: TContext | undefined;
+		resolve: () => void;
+		reject: (error: unknown) => void;
+		onAbort?: () => void;
+	};
+
+	const queued: Job[] = [];
+	let active: Job | undefined;
+	const pending = new WeakMap<TContext, Promise<void>>();
+
+	const detachListener = (job: Job) => {
+		const context = job.context;
+		if (context && job.onAbort) context.signal?.removeEventListener("abort", job.onAbort);
+		job.onAbort = undefined;
+	};
+
+	const forget = (job: Job) => {
+		detachListener(job);
+		const context = job.context;
+		if (context) pending.delete(context);
+		job.context = undefined;
+	};
+
+	const runNext = () => {
+		if (active) return;
+		const job = queued.shift();
+		if (!job) return;
+		active = job;
+		const context = job.context!;
+		// Owner keeps pending for same-context coalescing; signal is observed by the refresh body.
+		detachListener(job);
+
+		void (async () => {
+			try {
+				await refresh(context);
+				job.resolve();
+			} catch (error) {
+				job.reject(error);
+			} finally {
+				pending.delete(context);
+				job.context = undefined;
+				active = undefined;
+				runNext();
+			}
+		})();
+	};
+
+	return (context) => {
+		const existing = pending.get(context);
+		if (existing) return existing;
+
+		let resolve!: () => void;
+		let reject!: (error: unknown) => void;
+		const promise = new Promise<void>((res, rej) => {
+			resolve = res;
+			reject = rej;
+		});
+		const job: Job = { context, resolve, reject };
+		pending.set(context, promise);
+
+		const cancel = () => {
+			if (job === active || !job.context) return;
+			const index = queued.indexOf(job);
+			if (index >= 0) queued.splice(index, 1);
+			forget(job);
+			job.resolve();
+		};
+		job.onAbort = cancel;
+		queued.push(job);
+		if (context.signal?.aborted) cancel();
+		else context.signal?.addEventListener("abort", cancel, { once: true });
+		if (job.context) runNext();
+		return promise;
+	};
+}

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { envApiKeyAuth } from "../src/auth/helpers.ts";
 import type { AuthContext, AuthEvent } from "../src/auth/types.ts";
-import { createModels, createProvider } from "../src/models.ts";
-import { InMemoryModelsStore, type ModelsStoreEntry } from "../src/models-store.ts";
+import { createModels, createProvider, type RefreshModelsContext } from "../src/models.ts";
 import { builtinModels, builtinProviders, getBuiltinModel } from "../src/providers/all.ts";
 import { amazonBedrockProvider } from "../src/providers/amazon-bedrock.ts";
 import { anthropicProvider } from "../src/providers/anthropic.ts";
@@ -10,6 +9,8 @@ import { cloudflareAIGatewayProvider } from "../src/providers/cloudflare-ai-gate
 import { cloudflareWorkersAIProvider } from "../src/providers/cloudflare-workers-ai.ts";
 import { fauxAssistantMessage, fauxProvider } from "../src/providers/faux.ts";
 import { googleVertexProvider } from "../src/providers/google-vertex.ts";
+import { radiusProvider } from "../src/providers/radius.ts";
+import { createRefreshQueue } from "../src/refresh-queue.ts";
 import type { Api, Context, Model, ProviderStreams } from "../src/types.ts";
 import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
 
@@ -293,6 +294,41 @@ describe("envApiKeyAuth", () => {
 	});
 });
 
+describe("createRefreshQueue", () => {
+	it("coalesces context identity, preserves FIFO context, skips queued aborts, and continues after rejection", async () => {
+		const ownerController = new AbortController();
+		const queuedController = new AbortController();
+		let markOwnerStarted: (() => void) | undefined;
+		const ownerStarted = new Promise<void>((resolve) => {
+			markOwnerStarted = resolve;
+		});
+		const starts: string[] = [];
+		const refresh = createRefreshQueue(async (context: { id: string; fail?: boolean; signal?: AbortSignal }) => {
+			starts.push(context.id);
+			if (context.id === "owner") {
+				markOwnerStarted?.();
+				await new Promise<void>((resolve) =>
+					ownerController.signal.addEventListener("abort", () => resolve(), { once: true }),
+				);
+			}
+			if (context.fail) throw new Error("owner failed");
+		});
+		const ownerContext = { id: "owner", fail: true, signal: ownerController.signal };
+		const owner = refresh(ownerContext);
+		expect(refresh(ownerContext)).toBe(owner);
+		await ownerStarted;
+		const queued = refresh({ id: "queued", signal: queuedController.signal });
+		const final = refresh({ id: "final" });
+		queuedController.abort();
+		await expect(queued).resolves.toBeUndefined();
+		expect(starts).toEqual(["owner"]);
+		ownerController.abort();
+		await expect(owner).rejects.toThrow("owner failed");
+		await expect(final).resolves.toBeUndefined();
+		expect(starts).toEqual(["owner", "final"]);
+	});
+});
+
 describe("createProvider", () => {
 	function recordingStreams(label: string, calls: string[]): ProviderStreams {
 		const respond = (model: Model<Api>) => {
@@ -391,38 +427,128 @@ describe("createProvider", () => {
 		expect(result.errorMessage).toContain("no API implementation");
 	});
 
-	it("supports dynamic providers: empty until refreshed, in-flight refreshes deduped", async () => {
-		let fetches = 0;
+	it("does not publish an aborted refresh", async () => {
+		const ownerController = new AbortController();
+		let releaseOwner: (() => void) | undefined;
+		const ownerStarted = new Promise<void>((resolve) => {
+			releaseOwner = resolve;
+		});
+		const starts: string[] = [];
+		const writes: string[] = [];
+		const model = (id: string): Model<Api> => ({ ...testModel("api-a", id), provider: "dynamic" });
 		const provider = createProvider({
 			id: "dynamic",
 			auth: { apiKey: { name: "Test", resolve: async () => ({ auth: {} }) } },
 			models: [],
-			fetchModels: async () => {
-				fetches++;
-				await new Promise((resolve) => setTimeout(resolve, 5));
-				return [testModel("api-a", "listed")];
+			fetchModels: async (refreshContext) => {
+				const key = refreshContext.credential?.type === "api_key" ? refreshContext.credential.key! : "missing";
+				starts.push(key);
+				if (key === "owner") {
+					releaseOwner?.();
+					await new Promise<void>((resolve) =>
+						ownerController.signal.addEventListener("abort", () => resolve(), { once: true }),
+					);
+				}
+				return [model(key)];
 			},
 			api: recordingStreams("a", []),
 		});
-
-		const store = new InMemoryModelsStore();
-		const refreshContext = {
-			credential: { type: "api_key" as const },
+		const refresh = (key: string, signal?: AbortSignal): RefreshModelsContext => ({
+			credential: { type: "api_key", key },
 			store: {
-				read: () => store.read("dynamic"),
-				write: (entry: ModelsStoreEntry) => store.write("dynamic", entry),
-				delete: () => store.delete("dynamic"),
+				read: async () => undefined,
+				write: async () => {
+					writes.push(key);
+				},
+				delete: async () => {},
 			},
 			allowNetwork: true,
-		};
+			signal,
+		});
+		const owner = provider.refreshModels!(refresh("owner", ownerController.signal));
+		await ownerStarted;
+		ownerController.abort();
+		await owner;
+		expect(starts).toEqual(["owner"]);
+		expect(writes).toEqual([]);
 		expect(provider.getModels()).toEqual([]);
-		await Promise.all([provider.refreshModels?.(refreshContext), provider.refreshModels?.(refreshContext)]);
-		expect(fetches).toBe(1);
-		expect(provider.getModels().map((m) => m.id)).toEqual(["listed"]);
+	});
 
-		// a later refresh fetches again
-		await provider.refreshModels?.(refreshContext);
-		expect(fetches).toBe(2);
+	it("applies each caller's context when dynamic refreshes are serialized", async () => {
+		let releaseOwner: (() => void) | undefined;
+		const ownerStarted = new Promise<void>((resolve) => {
+			releaseOwner = resolve;
+		});
+		let markOwnerFetching: (() => void) | undefined;
+		const ownerFetching = new Promise<void>((resolve) => {
+			markOwnerFetching = resolve;
+		});
+		const provider = createProvider({
+			id: "dynamic",
+			auth: { apiKey: { name: "Test", resolve: async () => ({ auth: {} }) } },
+			models: [],
+			fetchModels: async (context) => {
+				const key = context.credential?.type === "api_key" ? (context.credential.key ?? "missing") : "missing";
+				if (key === "owner") {
+					markOwnerFetching?.();
+					await ownerStarted;
+				}
+				return [{ ...testModel("api-a", key), provider: "dynamic" }];
+			},
+			api: recordingStreams("a", []),
+		});
+		const context = (key: string): RefreshModelsContext => ({
+			credential: { type: "api_key", key },
+			store: { read: async () => undefined, write: async () => {}, delete: async () => {} },
+			allowNetwork: true,
+		});
+
+		const owner = provider.refreshModels!(context("owner"));
+		await ownerFetching;
+		const final = provider.refreshModels!(context("final"));
+		releaseOwner?.();
+		await Promise.all([owner, final]);
+
+		expect(provider.getModels().map((entry) => entry.id)).toEqual(["final"]);
+	});
+});
+
+describe("radiusProvider", () => {
+	it("uses each refresh caller's credential", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: URL | string, init?: RequestInit) => {
+				const authorization = new Headers(init?.headers).get("authorization");
+				return Response.json({
+					baseUrl: "https://radius.example.test/v1",
+					models: [
+						{
+							id: authorization === "Bearer owner" ? "owner" : "final",
+							name: "Model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 1000,
+							maxTokens: 100,
+						},
+					],
+				});
+			}),
+		);
+		const provider = radiusProvider({ gateway: "https://radius.example.test" });
+		const context = (key: string): RefreshModelsContext => ({
+			credential: { type: "api_key", key },
+			store: { read: async () => undefined, write: async () => {}, delete: async () => {} },
+			allowNetwork: true,
+		});
+
+		try {
+			await provider.refreshModels!(context("owner"));
+			await provider.refreshModels!(context("final"));
+			expect(provider.getModels().map((model) => model.id)).toEqual(["final"]);
+		} finally {
+			vi.unstubAllGlobals();
+		}
 	});
 });
 

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -51,8 +51,46 @@ interface ModelRuntimeSnapshot {
 	all: readonly Model<Api>[];
 	available: readonly Model<Api>[];
 	configuredProviders: ReadonlySet<string>;
-	storedProviders: ReadonlySet<string>;
+	storedCredentialTypes: ReadonlyMap<string, Credential["type"]>;
+	runtimeProviders: ReadonlySet<string>;
 	auth: ReadonlyMap<string, AuthCheck | undefined>;
+}
+
+interface RegistrationSources {
+	native: ReadonlyMap<string, Provider>;
+	extensions: ReadonlyMap<string, ProviderConfigInput>;
+	revision: number;
+}
+
+interface ComposedModels {
+	models: MutableModels;
+	compositionErrors: ReadonlyMap<string, string>;
+}
+
+interface PublishedState {
+	models: MutableModels;
+	config: ModelConfig;
+	extensions: ReadonlyMap<string, ProviderConfigInput>;
+	compositionErrors: ReadonlyMap<string, string>;
+	snapshot: ModelRuntimeSnapshot;
+}
+
+interface ConvergenceState {
+	target: number;
+	scheduled: boolean;
+	progress: number;
+	suppressedAt: number;
+	error?: string;
+}
+
+interface AvailabilityReadState {
+	reads: WeakMap<PublishedState, Promise<readonly Model<Api>[]>>;
+	error?: string;
+}
+
+interface TransactionResult<T> {
+	refresh: ModelsRefreshResult;
+	value: T;
 }
 
 export interface CreateModelRuntimeOptions {
@@ -92,27 +130,49 @@ function mergeHeaders(
 	return merged;
 }
 
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function supportsCredentialType(provider: Provider, type: Credential["type"]): boolean {
+	return type === "api_key" ? provider.auth.apiKey !== undefined : provider.auth.oauth !== undefined;
+}
+
+function abortedResult(): ModelsRefreshResult {
+	return { aborted: true, errors: new Map() };
+}
+
 /** Configured pi-ai Models collection used by coding-agent and SDK consumers. */
 export class ModelRuntime implements Models {
-	private readonly models: MutableModels;
 	private readonly credentials: RuntimeCredentials;
+	private readonly modelsStore: ModelsStore;
 	private readonly defaultBuiltins: ReadonlyMap<string, Provider>;
-	private readonly builtins = new Map<string, Provider>();
 	private readonly nativeExtensionProviders = new Map<string, Provider>();
 	private readonly extensionProviders = new Map<string, ProviderConfigInput>();
-	private readonly compositionErrors = new Map<string, string>();
 	private readonly modelsPath: string | undefined;
 	private readonly modelNetworkEnabled: boolean;
-	private config: ModelConfig;
-	private snapshot: ModelRuntimeSnapshot = {
-		all: [],
-		available: [],
-		configuredProviders: new Set(),
-		storedProviders: new Set(),
-		auth: new Map(),
+	private published: PublishedState;
+	private sourceRevision = 0;
+	private transactionTail: Promise<void> = Promise.resolve();
+	private readonly convergence: ConvergenceState = {
+		target: 0,
+		scheduled: false,
+		progress: 0,
+		suppressedAt: 0,
 	};
-	private availabilityRefresh: Promise<void> | undefined;
-	private availabilityError: string | undefined;
+	private readonly availability: AvailabilityReadState = { reads: new WeakMap() };
+
+	private get models(): MutableModels {
+		return this.published.models;
+	}
+
+	private get config(): ModelConfig {
+		return this.published.config;
+	}
+
+	private get snapshot(): ModelRuntimeSnapshot {
+		return this.published.snapshot;
+	}
 
 	private constructor(
 		credentials: RuntimeCredentials,
@@ -123,13 +183,28 @@ export class ModelRuntime implements Models {
 		modelNetworkEnabled: boolean,
 	) {
 		this.credentials = credentials;
-		this.config = config;
+		this.modelsStore = modelsStore;
 		this.modelsPath = modelsPath;
 		this.modelNetworkEnabled = modelNetworkEnabled;
 		this.defaultBuiltins = new Map(providers.map((provider) => [provider.id, provider]));
-		for (const [providerId, provider] of this.defaultBuiltins) this.builtins.set(providerId, provider);
-		this.models = createModels({ credentials, modelsStore });
-		this.rebuildProviders();
+		const initialSources = this.captureSources();
+		const composed = this.composeModels(config, initialSources);
+		const models = this.materializeModels(composed.models, initialSources);
+		const all = [...models.getModels()];
+		this.published = {
+			models,
+			config,
+			extensions: new Map(),
+			compositionErrors: composed.compositionErrors,
+			snapshot: {
+				all,
+				available: [],
+				configuredProviders: new Set(),
+				storedCredentialTypes: new Map(),
+				runtimeProviders: new Set(),
+				auth: new Map(),
+			},
+		};
 	}
 
 	static async create(options: CreateModelRuntimeOptions = {}): Promise<ModelRuntime> {
@@ -158,8 +233,6 @@ export class ModelRuntime implements Models {
 			providers,
 			process.env.PI_OFFLINE === undefined,
 		);
-		runtime.configureRadiusProviders();
-		runtime.rebuildProviders();
 		const refreshFromNetwork = runtime.modelNetworkEnabled && options.allowModelNetwork === true;
 		const controller = refreshFromNetwork ? new AbortController() : undefined;
 		const timeout = controller
@@ -173,123 +246,351 @@ export class ModelRuntime implements Models {
 		return runtime;
 	}
 
-	private configureRadiusProviders(): void {
-		this.builtins.clear();
-		for (const [providerId, provider] of this.defaultBuiltins) this.builtins.set(providerId, provider);
-		for (const providerId of this.config.getProviderIds()) {
-			const config = this.config.getProvider(providerId);
-			if (config?.oauth !== "radius" || !config.baseUrl) continue;
-			this.builtins.set(
+	private captureSources(): RegistrationSources {
+		return {
+			native: new Map(this.nativeExtensionProviders),
+			extensions: new Map(this.extensionProviders),
+			revision: this.sourceRevision,
+		};
+	}
+
+	private configuredBuiltins(config: ModelConfig): Map<string, Provider> {
+		const builtins = new Map(this.defaultBuiltins);
+		for (const providerId of config.getProviderIds()) {
+			const providerConfig = config.getProvider(providerId);
+			if (providerConfig?.oauth !== "radius" || !providerConfig.baseUrl) continue;
+			builtins.set(
 				providerId,
 				builtinProviderCatalog.radiusProvider({
 					id: providerId,
-					name: config.name ?? providerId,
-					gateway: config.baseUrl.replace(/\/v1\/?$/u, ""),
+					name: providerConfig.name ?? providerId,
+					gateway: providerConfig.baseUrl.replace(/\/v1\/?$/u, ""),
 				}),
 			);
 		}
+		return builtins;
 	}
 
-	private providerIds(): Set<string> {
-		return new Set([
-			...this.builtins.keys(),
-			...this.nativeExtensionProviders.keys(),
-			...this.config.getProviderIds(),
-			...this.extensionProviders.keys(),
+	private composeModels(
+		config: ModelConfig,
+		sources: RegistrationSources,
+		credentials: CredentialStore = this.credentials,
+	): ComposedModels {
+		const models = createModels({ credentials, modelsStore: this.modelsStore });
+		const errors = new Map<string, string>();
+		const builtins = this.configuredBuiltins(config);
+		const providerIds = new Set([
+			...builtins.keys(),
+			...sources.native.keys(),
+			...config.getProviderIds(),
+			...sources.extensions.keys(),
 		]);
+		for (const providerId of providerIds) {
+			const base = sources.native.get(providerId) ?? builtins.get(providerId);
+			const extension = sources.extensions.get(providerId);
+			if (base && !config.getProvider(providerId) && !extension) {
+				models.setProvider(base);
+				continue;
+			}
+			try {
+				models.setProvider(composeModelProvider(providerId, base, config, extension));
+			} catch (error) {
+				errors.set(providerId, errorMessage(error));
+				if (base) models.setProvider(base);
+			}
+		}
+		return { models, compositionErrors: errors };
 	}
 
-	private recomposeProvider(providerId: string): void {
-		const base = this.nativeExtensionProviders.get(providerId) ?? this.builtins.get(providerId);
-		const extension = this.extensionProviders.get(providerId);
-		if (!base && !this.config.getProvider(providerId) && !extension) {
-			this.models.deleteProvider(providerId);
-			this.compositionErrors.delete(providerId);
-			return;
+	private materializeModels(working: Models, sources: RegistrationSources): MutableModels {
+		const stable = createModels({ credentials: this.credentials, modelsStore: this.modelsStore });
+		for (const provider of working.getProviders()) {
+			const capturedModels = [...working.getModels(provider.id)];
+			const view: Provider = {
+				...provider,
+				getModels: () => capturedModels,
+				refreshModels: provider.refreshModels
+					? async (context) => {
+							await this.enqueue(
+								context.signal,
+								() => undefined,
+								async () => {
+									await this.runTransaction(
+										{
+											allowNetwork: context.allowNetwork,
+											force: context.force,
+											signal: context.signal,
+										},
+										async (candidate) => {
+											await candidate.getProvider(provider.id)?.refreshModels?.(context);
+										},
+										undefined,
+										sources,
+										new Set([provider.id]),
+									);
+								},
+							);
+						}
+					: undefined,
+				filterModels: provider.filterModels
+					? (models, credential) => provider.filterModels!(models, credential)
+					: undefined,
+				// Keep explicit method call so class/prototype stream handlers retain their receiver.
+				stream: (model, context, options) => provider.stream(model, context, options),
+				streamSimple: (model, context, options) => provider.streamSimple(model, context, options),
+			};
+			stable.setProvider(view);
 		}
-		if (base && !this.config.getProvider(providerId) && !extension) {
-			// No overlays: use the builtin untouched so its auth/login/stream behavior is exact.
-			this.models.setProvider(base);
-			this.compositionErrors.delete(providerId);
-			return;
-		}
-		try {
-			this.models.setProvider(composeModelProvider(providerId, base, this.config, extension));
-			this.compositionErrors.delete(providerId);
-		} catch (error) {
-			this.compositionErrors.set(providerId, error instanceof Error ? error.message : String(error));
-			if (base) this.models.setProvider(base);
-			else this.models.deleteProvider(providerId);
-		}
+		return stable;
 	}
 
-	private rebuildProviders(): void {
-		this.models.clearProviders();
-		this.compositionErrors.clear();
-		for (const providerId of this.providerIds()) this.recomposeProvider(providerId);
-		this.updateModelSnapshot();
-	}
-
-	private updateModelSnapshot(): void {
-		const all = [...this.models.getModels()];
-		this.snapshot = {
-			...this.snapshot,
-			all,
-			available: all.filter((model) => this.snapshot.configuredProviders.has(model.provider)),
+	/** Memoize credential reads for one transaction/inspection; optionally drop cache after mutate. */
+	private memoizedCredentialStore(store: CredentialStore, invalidateOnMutate: boolean): CredentialStore {
+		const reads = new Map<string, Promise<Credential | undefined>>();
+		return {
+			read: (providerId) => {
+				const existing = reads.get(providerId);
+				if (existing) return existing;
+				const pending = store.read(providerId);
+				reads.set(providerId, pending);
+				return pending;
+			},
+			list: () => store.list(),
+			modify: async (providerId, fn) => {
+				const result = await store.modify(providerId, fn);
+				if (invalidateOnMutate) reads.delete(providerId);
+				return result;
+			},
+			delete: async (providerId) => {
+				await store.delete(providerId);
+				if (invalidateOnMutate) reads.delete(providerId);
+			},
 		};
 	}
 
-	private async runAvailabilityRefresh(): Promise<void> {
-		const providers = this.models.getProviders();
-		const [available, checks, credentials] = await Promise.all([
-			this.models.getAvailable(),
+	private async inspectCandidate(
+		models: Models,
+		transactionCredentials: CredentialStore = this.credentials,
+	): Promise<ModelRuntimeSnapshot> {
+		const providers = models.getProviders();
+		const inspection = createModels({ credentials: transactionCredentials, modelsStore: this.modelsStore });
+		for (const provider of providers) inspection.setProvider(provider);
+		const [checks, available, credentials] = await Promise.all([
 			Promise.all(
 				providers.map(
-					async (provider): Promise<[string, AuthCheck | undefined]> => [
+					async (provider): Promise<readonly [string, AuthCheck | undefined]> => [
 						provider.id,
-						await this.models.checkAuth(provider.id),
+						await inspection.checkAuth(provider.id),
 					],
 				),
 			),
+			inspection.getAvailable(),
 			this.credentials.list(),
 		]);
 		const auth = new Map(checks);
-		const configuredProviders = new Set(
-			checks
-				.filter((entry): entry is [string, AuthCheck] => entry[1] !== undefined)
-				.map(([providerId]) => providerId),
-		);
-		this.snapshot = {
-			all: [...this.models.getModels()],
+		const providersById = new Map(providers.map((provider) => [provider.id, provider]));
+		return {
+			all: [...models.getModels()],
 			available: [...available],
-			configuredProviders,
-			storedProviders: new Set(credentials.map((entry) => entry.providerId)),
+			configuredProviders: new Set(
+				checks.filter((entry): entry is readonly [string, AuthCheck] => entry[1] !== undefined).map(([id]) => id),
+			),
+			storedCredentialTypes: new Map(
+				credentials.flatMap((entry) =>
+					providersById.has(entry.providerId) ? [[entry.providerId, entry.type] as const] : [],
+				),
+			),
+			runtimeProviders: new Set(
+				providers
+					.filter(
+						(provider) => provider.auth.apiKey !== undefined && this.credentials.hasRuntimeApiKey(provider.id),
+					)
+					.map((provider) => provider.id),
+			),
 			auth,
 		};
-		this.availabilityError = undefined;
 	}
 
-	private queueAvailabilityRefresh(after: Promise<void> | undefined): Promise<void> {
-		const refresh = (after ?? Promise.resolve()).catch(() => {}).then(() => this.runAvailabilityRefresh());
-		const recorded = refresh.catch((error) => {
-			this.availabilityError = error instanceof Error ? error.message : String(error);
-			throw error;
+	private enqueue<T>(signal: AbortSignal | undefined, canceled: () => T, operation: () => Promise<T>): Promise<T> {
+		if (signal?.aborted) return Promise.resolve(canceled());
+		let started = false;
+		let resolveCanceled: ((value: T) => void) | undefined;
+		const canceledWhileQueued = new Promise<T>((resolve) => {
+			resolveCanceled = resolve;
 		});
-		const tracked = recorded.finally(() => {
-			if (this.availabilityRefresh === tracked) this.availabilityRefresh = undefined;
+		const onAbort = () => {
+			if (!started) resolveCanceled?.(canceled());
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+		const execution = this.transactionTail
+			.catch(() => {})
+			.then(async () => {
+				if (signal?.aborted) return canceled();
+				started = true;
+				signal?.removeEventListener("abort", onAbort);
+				return operation();
+			});
+		this.transactionTail = execution.then(
+			() => {},
+			() => {},
+		);
+		return Promise.race([execution, canceledWhileQueued]).finally(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolveCanceled = undefined;
 		});
-		this.availabilityRefresh = tracked;
-		return tracked;
 	}
 
-	/** Coalesce concurrent readers onto the pending refresh. */
-	private refreshAvailability(): Promise<void> {
-		return this.availabilityRefresh ?? this.queueAvailabilityRefresh(undefined);
+	private async runTransaction<T>(
+		options: ModelsRefreshOptions,
+		mutate: ((models: MutableModels) => Promise<T>) | undefined,
+		defaultValue: T,
+		sources = this.captureSources(),
+		alreadyRefreshedProviders?: ReadonlySet<string>,
+	): Promise<TransactionResult<T>> {
+		const config = await ModelConfig.load(this.modelsPath);
+		if (options.signal?.aborted) return { refresh: abortedResult(), value: defaultValue };
+		const transactionCredentials = this.memoizedCredentialStore(this.credentials, true);
+		const composed = this.composeModels(config, sources, transactionCredentials);
+		const value = mutate ? await mutate(composed.models) : defaultValue;
+		const refreshOptions = {
+			...options,
+			allowNetwork: options.allowNetwork ?? this.modelNetworkEnabled,
+		};
+		const refreshModels = alreadyRefreshedProviders
+			? createModels({ credentials: this.credentials, modelsStore: this.modelsStore })
+			: composed.models;
+		if (alreadyRefreshedProviders) {
+			for (const provider of composed.models.getProviders()) {
+				refreshModels.setProvider(
+					alreadyRefreshedProviders.has(provider.id) ? { ...provider, refreshModels: undefined } : provider,
+				);
+			}
+		}
+		const refresh = ((await refreshModels.refresh(refreshOptions)) as ModelsRefreshResult | undefined) ?? {
+			aborted: refreshOptions.signal?.aborted ?? false,
+			errors: new Map(),
+		};
+		if (refresh.aborted || options.signal?.aborted || sources.revision !== this.sourceRevision) {
+			return { refresh: { ...refresh, aborted: true }, value };
+		}
+		const snapshot = await this.inspectCandidate(composed.models, transactionCredentials);
+		if (options.signal?.aborted || sources.revision !== this.sourceRevision) {
+			return { refresh: { ...refresh, aborted: true }, value };
+		}
+		this.published = {
+			models: this.materializeModels(composed.models, sources),
+			config,
+			extensions: sources.extensions,
+			compositionErrors: composed.compositionErrors,
+			snapshot,
+		};
+		this.availability.error = undefined;
+		this.convergence.error = undefined;
+		return { refresh, value };
 	}
 
-	/** Mutations must not observe an in-flight refresh started before them. */
-	private forceRefreshAvailability(): Promise<void> {
-		return this.queueAvailabilityRefresh(this.availabilityRefresh);
+	private publishSourcesSynchronously(): void {
+		const sources = this.captureSources();
+		const config = this.config;
+		const composed = this.composeModels(config, sources);
+		const models = this.materializeModels(composed.models, sources);
+		const all = [...models.getModels()];
+		const previous = this.snapshot;
+		const auth = new Map<string, AuthCheck | undefined>();
+		const configuredProviders = new Set<string>();
+		const storedCredentialTypes = new Map<string, Credential["type"]>();
+		const runtimeProviders = new Set<string>();
+		for (const provider of models.getProviders()) {
+			const supportsApiKey = provider.auth.apiKey !== undefined;
+			const supportsOAuth = provider.auth.oauth !== undefined;
+			const storedType = previous.storedCredentialTypes.get(provider.id);
+			const compatibleStored = storedType !== undefined && supportsCredentialType(provider, storedType);
+			const incompatibleStored = storedType !== undefined && !compatibleStored;
+			if (storedType !== undefined) storedCredentialTypes.set(provider.id, storedType);
+			const compatibleRuntime = previous.runtimeProviders.has(provider.id) && supportsApiKey;
+			if (compatibleRuntime) runtimeProviders.add(provider.id);
+
+			const oldCheck = previous.auth.get(provider.id);
+			const compatibleOldCheck =
+				!incompatibleStored &&
+				(oldCheck?.type === "api_key" ? supportsApiKey : oldCheck?.type === "oauth" ? supportsOAuth : false);
+			if (compatibleOldCheck && oldCheck) auth.set(provider.id, oldCheck);
+
+			const configured = configuredRequestAuthStatus(
+				config.getProvider(provider.id),
+				sources.extensions.get(provider.id),
+			);
+			const compatibleConfigured = configured?.configured === true && supportsApiKey && !incompatibleStored;
+			const projectedType = compatibleStored
+				? storedType
+				: compatibleRuntime || compatibleConfigured
+					? "api_key"
+					: compatibleOldCheck
+						? oldCheck?.type
+						: undefined;
+			if (compatibleStored || compatibleRuntime || compatibleConfigured || compatibleOldCheck) {
+				configuredProviders.add(provider.id);
+				if (!auth.has(provider.id) && projectedType) {
+					auth.set(provider.id, { type: projectedType, source: "configured provider" });
+				}
+			}
+		}
+		this.published = {
+			models,
+			config,
+			extensions: sources.extensions,
+			compositionErrors: composed.compositionErrors,
+			snapshot: {
+				all,
+				available: all.filter((entry) => configuredProviders.has(entry.provider)),
+				configuredProviders,
+				storedCredentialTypes,
+				runtimeProviders,
+				auth,
+			},
+		};
+		this.availability.error = undefined;
+	}
+
+	private requestConvergence(): void {
+		this.convergence.target = this.sourceRevision;
+		if (this.convergence.scheduled) return;
+		if (this.convergence.target <= this.convergence.suppressedAt) this.convergence.suppressedAt = 0;
+		this.convergence.scheduled = true;
+		const scheduledFor = this.convergence.target;
+		queueMicrotask(() => {
+			void this.enqueue(
+				undefined,
+				() => undefined,
+				async () => {
+					// Bound self-triggered registration churn; a later external registration re-requests.
+					let attempts = 0;
+					try {
+						while (this.convergence.progress < this.convergence.target && attempts < 8) {
+							attempts++;
+							const target = this.sourceRevision;
+							const result = await this.runTransaction({ allowNetwork: false }, undefined, undefined);
+							if (!result.refresh.aborted) this.convergence.progress = target;
+						}
+						if (this.convergence.progress < this.convergence.target) {
+							this.convergence.suppressedAt = this.convergence.target;
+							this.convergence.error = "Provider registration convergence did not stabilize after 8 attempts.";
+						}
+					} catch (error) {
+						this.convergence.suppressedAt = scheduledFor;
+						this.convergence.error = `Provider registration convergence failed: ${errorMessage(error)}`;
+					} finally {
+						this.convergence.scheduled = false;
+						if (
+							this.convergence.target > this.convergence.progress &&
+							this.convergence.target > this.convergence.suppressedAt
+						) {
+							this.requestConvergence();
+						}
+					}
+				},
+			);
+		});
 	}
 
 	getProviders(): readonly Provider[] {
@@ -312,21 +613,44 @@ export class ModelRuntime implements Models {
 		return this.models.checkAuth(providerId);
 	}
 
+	private availabilityFor(state: PublishedState): Promise<readonly Model<Api>[]> {
+		const existing = this.availability.reads.get(state);
+		if (existing) return existing;
+		const pending = state.models.getAvailable();
+		this.availability.reads.set(state, pending);
+		void pending
+			.finally(() => {
+				if (this.availability.reads.get(state) === pending) this.availability.reads.delete(state);
+			})
+			.catch(() => {});
+		return pending;
+	}
+
 	async getAvailable(providerId?: string): Promise<readonly Model<Api>[]> {
 		if (providerId) {
-			if (this.availabilityRefresh) {
-				await this.availabilityRefresh;
-				return this.snapshot.available.filter((model) => model.provider === providerId);
-			}
+			const state = this.published;
 			try {
-				return await this.models.getAvailable(providerId);
+				const available = await state.models.getAvailable(providerId);
+				if (state === this.published) this.availability.error = undefined;
+				return available;
 			} catch (error) {
-				this.availabilityError = error instanceof Error ? error.message : String(error);
+				if (state === this.published) this.availability.error = errorMessage(error);
 				throw error;
 			}
 		}
-		await this.refreshAvailability();
-		return this.snapshot.available;
+		for (;;) {
+			const state = this.published;
+			try {
+				const available = await this.availabilityFor(state);
+				if (state !== this.published) continue;
+				this.availability.error = undefined;
+				return available;
+			} catch (error) {
+				if (state !== this.published) continue;
+				this.availability.error = errorMessage(error);
+				throw error;
+			}
+		}
 	}
 
 	getAvailableSnapshot(): readonly Model<Api>[] {
@@ -337,10 +661,11 @@ export class ModelRuntime implements Models {
 		const errors: string[] = [];
 		const configError = this.config.getError();
 		if (configError) errors.push(configError);
-		for (const [providerId, error] of this.compositionErrors) {
+		for (const [providerId, error] of this.published.compositionErrors) {
 			errors.push(`Provider "${providerId}": ${error}`);
 		}
-		if (this.availabilityError) errors.push(`Availability refresh: ${this.availabilityError}`);
+		if (this.availability.error) errors.push(`Availability refresh: ${this.availability.error}`);
+		if (this.convergence.error) errors.push(this.convergence.error);
 		return errors.length > 0 ? errors.join("\n\n") : undefined;
 	}
 
@@ -361,7 +686,7 @@ export class ModelRuntime implements Models {
 		return resolveCompatibilityRequestConfig(
 			model,
 			this.config.getProvider(model.provider),
-			this.extensionProviders.get(model.provider),
+			this.published.extensions.get(model.provider),
 		);
 	}
 
@@ -379,13 +704,14 @@ export class ModelRuntime implements Models {
 		providerOrModel: string | Model<Api>,
 		overrides: ModelRuntimeAuthOverrides = {},
 	): Promise<AuthResult | undefined> {
-		if (typeof providerOrModel === "string") return this.models.getAuth(providerOrModel, overrides);
-		const resolution = await this.models.getAuth(providerOrModel, overrides);
+		const state = this.published;
+		if (typeof providerOrModel === "string") return state.models.getAuth(providerOrModel, overrides);
+		const resolution = await state.models.getAuth(providerOrModel, overrides);
 		if (!resolution) return undefined;
 		const configuredHeaders = resolveConfiguredModelHeaders(
 			providerOrModel,
-			this.config.getProvider(providerOrModel.provider),
-			this.extensionProviders.get(providerOrModel.provider),
+			state.config.getProvider(providerOrModel.provider),
+			state.extensions.get(providerOrModel.provider),
 			{ ...(resolution.env ?? {}), ...(overrides.env ?? {}) },
 		);
 		return {
@@ -402,23 +728,25 @@ export class ModelRuntime implements Models {
 		apiKey: string,
 		refreshOptions: ModelsRefreshOptions = {},
 	): Promise<void> {
-		this.credentials.setRuntimeApiKey(providerId, apiKey);
-		const auth = new Map(this.snapshot.auth).set(providerId, { type: "api_key", source: "runtime API key" });
-		const configuredProviders = new Set(this.snapshot.configuredProviders).add(providerId);
-		const storedProviders = new Set(this.snapshot.storedProviders).add(providerId);
-		this.snapshot = {
-			...this.snapshot,
-			auth,
-			configuredProviders,
-			storedProviders,
-			available: this.snapshot.all.filter((model) => configuredProviders.has(model.provider)),
-		};
-		await this.refresh(refreshOptions);
+		await this.enqueue(
+			refreshOptions.signal,
+			() => undefined,
+			async () => {
+				this.credentials.setRuntimeApiKey(providerId, apiKey);
+				await this.runTransaction(refreshOptions, undefined, undefined);
+			},
+		);
 	}
 
 	async removeRuntimeApiKey(providerId: string): Promise<void> {
-		this.credentials.removeRuntimeApiKey(providerId);
-		await this.refresh({ allowNetwork: this.modelNetworkEnabled });
+		await this.enqueue(
+			undefined,
+			() => undefined,
+			async () => {
+				this.credentials.removeRuntimeApiKey(providerId);
+				await this.runTransaction({ allowNetwork: this.modelNetworkEnabled }, undefined, undefined);
+			},
+		);
 	}
 
 	listCredentials(): Promise<readonly CredentialInfo[]> {
@@ -426,11 +754,12 @@ export class ModelRuntime implements Models {
 	}
 
 	getProviderAuthStatus(providerId: string): AuthStatus {
-		if (this.credentials.hasRuntimeApiKey(providerId)) return { configured: true, source: "runtime" };
-		if (this.snapshot.storedProviders.has(providerId)) return { configured: true, source: "stored" };
+		if (this.snapshot.runtimeProviders.has(providerId)) return { configured: true, source: "runtime" };
+		if (!this.snapshot.configuredProviders.has(providerId)) return { configured: false };
+		if (this.snapshot.storedCredentialTypes.has(providerId)) return { configured: true, source: "stored" };
 		const configured = configuredRequestAuthStatus(
 			this.config.getProvider(providerId),
-			this.extensionProviders.get(providerId),
+			this.published.extensions.get(providerId),
 		);
 		if (configured) return configured;
 		const check = this.snapshot.auth.get(providerId);
@@ -441,11 +770,11 @@ export class ModelRuntime implements Models {
 		model: Model<Api>,
 		options: (StreamOptions & ModelsStreamTransforms) | undefined,
 	): Promise<{ provider: Provider; model: Model<Api>; options: StreamOptions }> {
-		const provider = this.models.getProvider(model.provider);
+		const state = this.published;
+		const provider = state.models.getProvider(model.provider);
 		if (!provider) throw new ModelsError("provider", `Unknown provider: ${model.provider}`);
 		const resolution = await this.getAuth(model, { apiKey: options?.apiKey, env: options?.env });
 		if (!resolution) throw new ModelsError("auth", `Provider is not configured: ${model.provider}`);
-
 		const { transformHeaders, ...providerOptions } = options ?? {};
 		let headers = mergeHeaders(resolution.auth.headers, providerOptions.headers);
 		if (transformHeaders) headers = await transformHeaders(headers ?? {});
@@ -503,93 +832,79 @@ export class ModelRuntime implements Models {
 	}
 
 	async login(providerId: string, type: AuthType, interaction: AuthInteraction): Promise<Credential> {
-		const credential = await this.models.login(providerId, type, interaction);
-		await this.refresh({ allowNetwork: this.modelNetworkEnabled });
-		return credential;
+		return this.enqueue(
+			undefined,
+			() => {
+				throw new ModelsError("auth", `Login canceled for ${providerId}`);
+			},
+			async () => {
+				const result = await this.runTransaction(
+					{ allowNetwork: this.modelNetworkEnabled },
+					(models) => models.login(providerId, type, interaction),
+					undefined as never,
+				);
+				return result.value;
+			},
+		);
 	}
 
 	async logout(providerId: string): Promise<void> {
-		await this.models.logout(providerId);
-		// Reset credential-dependent compatibility projections before the unconfigured provider is skipped by refresh.
-		this.recomposeProvider(providerId);
-		await this.refresh({ allowNetwork: this.modelNetworkEnabled });
+		await this.enqueue(
+			undefined,
+			() => undefined,
+			async () => {
+				await this.runTransaction(
+					{ allowNetwork: this.modelNetworkEnabled },
+					async (models) => {
+						await models.logout(providerId);
+					},
+					undefined,
+				);
+			},
+		);
 	}
 
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {
-		this.config = await ModelConfig.load(this.modelsPath);
-		this.configureRadiusProviders();
-		this.rebuildProviders();
-		const refreshOptions = {
-			...options,
-			allowNetwork: options.allowNetwork ?? this.modelNetworkEnabled,
-		};
-		// Published pi-ai builds before ModelsStore returned void and accepted a provider ID.
-		// The fallback keeps source-mode CLI tests working without rebuilding workspace dependencies.
-		const result = ((await this.models.refresh(refreshOptions)) as ModelsRefreshResult | undefined) ?? {
-			aborted: refreshOptions.signal?.aborted ?? false,
-			errors: new Map(),
-		};
-		this.updateModelSnapshot();
-		try {
-			await this.forceRefreshAvailability();
-		} catch {
-			// Availability errors are recorded by forceRefreshAvailability; refreshed models remain usable.
-		}
-		return result;
+		const sources = this.captureSources();
+		return this.enqueue(options.signal, abortedResult, async () => {
+			try {
+				return (await this.runTransaction(options, undefined, undefined, sources)).refresh;
+			} catch (error) {
+				this.availability.error = errorMessage(error);
+				throw error;
+			}
+		});
 	}
 
 	registerNativeProvider(provider: Provider): void {
 		if (!provider.id.trim()) throw new Error("Provider id must not be empty.");
 		this.extensionProviders.delete(provider.id);
 		this.nativeExtensionProviders.set(provider.id, provider);
-		this.recomposeProvider(provider.id);
-		this.updateModelSnapshot();
-		void this.refresh({ allowNetwork: false });
+		this.sourceRevision++;
+		this.publishSourcesSynchronously();
+		this.requestConvergence();
 	}
 
 	registerProvider(providerId: string, config: ProviderConfigInput): void {
-		// Validate the incoming registration on its own, like the legacy registry:
-		// a broken re-registration must throw without touching the stored config.
-		validateExtensionProvider(providerId, this.builtins.get(providerId), this.config.getProvider(providerId), config);
+		const builtin = this.configuredBuiltins(this.config).get(providerId);
+		validateExtensionProvider(providerId, builtin, this.config.getProvider(providerId), config);
 		this.nativeExtensionProviders.delete(providerId);
-		// Re-registration merges defined values over the previous registration and
-		// preserves undefined ones, matching the legacy ModelRegistry contract.
 		const previous = this.extensionProviders.get(providerId);
 		const effective: ProviderConfigInput = { ...previous };
 		for (const [key, value] of Object.entries(config)) {
 			if (value !== undefined) (effective as Record<string, unknown>)[key] = value;
 		}
 		this.extensionProviders.set(providerId, effective);
-		this.recomposeProvider(providerId);
-		this.updateModelSnapshot();
-		if (
-			this.snapshot.storedProviders.has(providerId) ||
-			configuredRequestAuthStatus(this.config.getProvider(providerId), effective)?.configured
-		) {
-			const configuredProviders = new Set(this.snapshot.configuredProviders).add(providerId);
-			const auth = new Map(this.snapshot.auth);
-			// Provisional entry until the async refresh lands; never clobber a real check result.
-			if (!auth.get(providerId)) {
-				auth.set(providerId, {
-					type: effective.oauth && !effective.apiKey ? "oauth" : "api_key",
-					source: "configured provider",
-				});
-			}
-			this.snapshot = {
-				...this.snapshot,
-				auth,
-				configuredProviders,
-				available: this.snapshot.all.filter((model) => configuredProviders.has(model.provider)),
-			};
-		}
-		void this.refresh({ allowNetwork: false });
+		this.sourceRevision++;
+		this.publishSourcesSynchronously();
+		this.requestConvergence();
 	}
 
 	unregisterProvider(providerId: string): void {
 		this.extensionProviders.delete(providerId);
 		this.nativeExtensionProviders.delete(providerId);
-		this.recomposeProvider(providerId);
-		this.updateModelSnapshot();
-		void this.refresh({ allowNetwork: false });
+		this.sourceRevision++;
+		this.publishSourcesSynchronously();
+		this.requestConvergence();
 	}
 }

--- a/packages/coding-agent/src/core/remote-catalog-provider.ts
+++ b/packages/coding-agent/src/core/remote-catalog-provider.ts
@@ -1,4 +1,5 @@
 import type { Api, Model, ModelsStoreEntry, Provider } from "@earendil-works/pi-ai";
+import { createRefreshQueue } from "@earendil-works/pi-ai/internal/refresh-queue";
 import { VERSION } from "../config.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 
@@ -47,77 +48,69 @@ export function withRemoteCatalog(
 	localGeneratedAt?: number,
 ): Provider {
 	let dynamicModels: readonly Model<Api>[] = [];
-	let inflightRefresh: Promise<void> | undefined;
 
 	return {
 		...provider,
 		getModels: () => mergeModels(provider.getModels(), dynamicModels),
-		refreshModels: (context) => {
-			inflightRefresh ??= (async () => {
-				try {
-					const stored = await context.store.read();
-					dynamicModels = remoteModels(stored, localGeneratedAt).filter((model) => model.provider === provider.id);
-					if (!context.allowNetwork || context.signal?.aborted) return;
-					if (
-						!context.force &&
-						stored?.checkedAt !== undefined &&
-						stored.lastModified !== undefined &&
-						Date.now() - stored.checkedAt < REMOTE_CATALOG_REFRESH_INTERVAL_MS
-					) {
-						return;
-					}
+		refreshModels: createRefreshQueue(async (context) => {
+			const stored = await context.store.read();
+			dynamicModels = remoteModels(stored, localGeneratedAt).filter((model) => model.provider === provider.id);
+			if (!context.allowNetwork || context.signal?.aborted) return;
+			if (
+				!context.force &&
+				stored?.checkedAt !== undefined &&
+				stored.lastModified !== undefined &&
+				Date.now() - stored.checkedAt < REMOTE_CATALOG_REFRESH_INTERVAL_MS
+			) {
+				return;
+			}
 
-					// Only revalidate when a cached body backs the validator, so a 304 can never
-					// leave the overlay empty.
-					const validator = stored?.models.length ? stored.etag : undefined;
-					const url = new URL(`/api/models/providers/${encodeURIComponent(provider.id)}`, catalogBaseUrl);
-					const response = await fetch(url, {
-						headers: {
-							accept: "application/json",
-							"User-Agent": getPiUserAgent(VERSION),
-							...(validator ? { "if-none-match": validator } : {}),
-						},
-						signal: context.signal,
-					});
-					if (context.signal?.aborted) return;
-					const checkedAt = Date.now();
-					// Unchanged: dynamicModels already holds the stored overlay, so only the
-					// freshness window moves.
-					if (response.status === 304 && stored) {
-						await context.store.write({ ...stored, checkedAt });
-						return;
-					}
-					if (response.status === 404 || response.status === 501) {
-						await context.store.write({
-							...(stored ?? { models: [] }),
-							checkedAt,
-							lastModified: 0,
-							etag: undefined,
-						});
-						return;
-					}
-					if (!response.ok) {
-						// Transient failure: the cached body and its validator stay valid, so keep the
-						// etag and let the next refresh revalidate instead of downloading the catalog.
-						await context.store.write({ ...(stored ?? { models: [] }), checkedAt });
-						throw new Error(`Model catalog request failed for ${provider.id}: ${response.status}`);
-					}
-					const refreshed = parseCatalog(provider.id, await response.json());
-					const lastModified = Date.parse(response.headers.get("last-modified") ?? "");
-					if (context.signal?.aborted) return;
-					const entry = {
-						models: refreshed,
-						checkedAt,
-						lastModified: Number.isNaN(lastModified) ? 0 : lastModified,
-						etag: response.headers.get("etag") ?? undefined,
-					};
-					dynamicModels = remoteModels(entry, localGeneratedAt);
-					await context.store.write(entry);
-				} finally {
-					inflightRefresh = undefined;
-				}
-			})();
-			return inflightRefresh;
-		},
+			// Only revalidate when a cached body backs the validator, so a 304 can never
+			// leave the overlay empty.
+			const validator = stored?.models.length ? stored.etag : undefined;
+			const url = new URL(`/api/models/providers/${encodeURIComponent(provider.id)}`, catalogBaseUrl);
+			const response = await fetch(url, {
+				headers: {
+					accept: "application/json",
+					"User-Agent": getPiUserAgent(VERSION),
+					...(validator ? { "if-none-match": validator } : {}),
+				},
+				signal: context.signal,
+			});
+			if (context.signal?.aborted) return;
+			const checkedAt = Date.now();
+			// Unchanged: dynamicModels already holds the stored overlay, so only the
+			// freshness window moves.
+			if (response.status === 304 && stored) {
+				await context.store.write({ ...stored, checkedAt });
+				return;
+			}
+			if (response.status === 404 || response.status === 501) {
+				await context.store.write({
+					...(stored ?? { models: [] }),
+					checkedAt,
+					lastModified: 0,
+					etag: undefined,
+				});
+				return;
+			}
+			if (!response.ok) {
+				// Transient failure: the cached body and its validator stay valid, so keep the
+				// etag and let the next refresh revalidate instead of downloading the catalog.
+				await context.store.write({ ...(stored ?? { models: [] }), checkedAt });
+				throw new Error(`Model catalog request failed for ${provider.id}: ${response.status}`);
+			}
+			const refreshed = parseCatalog(provider.id, await response.json());
+			const lastModified = Date.parse(response.headers.get("last-modified") ?? "");
+			if (context.signal?.aborted) return;
+			const entry = {
+				models: refreshed,
+				checkedAt,
+				lastModified: Number.isNaN(lastModified) ? 0 : lastModified,
+				etag: response.headers.get("etag") ?? undefined,
+			};
+			dynamicModels = remoteModels(entry, localGeneratedAt);
+			await context.store.write(entry);
+		}),
 	};
 }

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -191,9 +191,13 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		}
 	}
 
-	private close(): void {
+	dispose(): void {
+		if (this.closed) return;
 		this.closed = true;
-		if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+		if (this.refreshTimeout) {
+			clearTimeout(this.refreshTimeout);
+			this.refreshTimeout = undefined;
+		}
 		this.refreshAbortController.abort();
 	}
 
@@ -341,7 +345,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		}
 		// Escape or Ctrl+C
 		else if (kb.matches(keyData, "tui.select.cancel")) {
-			this.close();
+			this.dispose();
 			this.onCancelCallback();
 		}
 		// Pass everything else to search input
@@ -352,7 +356,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private handleSelect(model: Model<any>): void {
-		this.close();
+		this.dispose();
 		// Save as new default
 		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 		this.onSelectCallback(model);

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -1,4 +1,4 @@
-import { type Model, modelsAreEqual } from "@earendil-works/pi-ai";
+import { type Api, type Model, modelsAreEqual } from "@earendil-works/pi-ai";
 import {
 	Container,
 	type Focusable,
@@ -19,11 +19,11 @@ import { keyHint } from "./keybinding-hints.ts";
 interface ModelItem {
 	provider: string;
 	id: string;
-	model: Model<any>;
+	model: Model<Api>;
 }
 
 interface ScopedModelItem {
-	model: Model<any>;
+	model: Model<Api>;
 	thinkingLevel?: string;
 }
 
@@ -50,10 +50,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private activeModels: ModelItem[] = [];
 	private filteredModels: ModelItem[] = [];
 	private selectedIndex: number = 0;
-	private currentModel?: Model<any>;
+	private currentModel?: Model<Api>;
 	private settingsManager: SettingsManager;
 	private modelRuntime: ModelRuntime;
-	private onSelectCallback: (model: Model<any>) => void;
+	private onSelectCallback: (model: Model<Api>) => void;
 	private onCancelCallback: () => void;
 	private errorMessage?: string;
 	private refreshStatusMessage = "Refreshing model catalogs…";
@@ -69,11 +69,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	constructor(
 		tui: TUI,
-		currentModel: Model<any> | undefined,
+		currentModel: Model<Api> | undefined,
 		settingsManager: SettingsManager,
 		modelRuntime: ModelRuntime,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
-		onSelect: (model: Model<any>) => void,
+		onSelect: (model: Model<Api>) => void,
 		onCancel: () => void,
 		initialSearchInput?: string,
 	) {
@@ -137,7 +137,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private loadModelsFromSnapshot(): void {
-		const models = this.modelRuntime.getAvailableSnapshot().map((model: Model<any>) => ({
+		const models = this.modelRuntime.getAvailableSnapshot().map((model: Model<Api>) => ({
 			provider: model.provider,
 			id: model.id,
 			model,
@@ -161,18 +161,24 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	private async refreshModels(): Promise<void> {
 		const timeoutMs = 15_000;
-		let timedOut = false;
-		this.refreshTimeout = setTimeout(() => {
-			timedOut = true;
+		let settled = false;
+		const applyTimeout = (): void => {
+			if (settled || this.closed) return;
+			settled = true;
+			this.refreshTimeout = undefined;
+			this.refreshStatusMessage = "";
+			this.errorMessage = "Model refresh timed out; showing cached models.";
 			this.refreshAbortController.abort();
-		}, timeoutMs);
+			this.updateList();
+			this.tui.requestRender();
+		};
+		this.refreshTimeout = setTimeout(applyTimeout, timeoutMs);
 		try {
 			const result = await this.modelRuntime.refresh({ signal: this.refreshAbortController.signal });
-			if (this.closed) return;
+			if (settled || this.closed) return;
+			settled = true;
 			this.refreshStatusMessage = "";
-			if (result.aborted && timedOut) {
-				this.errorMessage = "Model refresh timed out; showing cached models.";
-			} else if (result.errors.size === 1) {
+			if (result.errors.size === 1) {
 				this.errorMessage = `Could not refresh ${result.errors.keys().next().value}; showing cached models.`;
 			} else if (result.errors.size > 1) {
 				this.errorMessage = `Could not refresh ${result.errors.size} model catalogs; showing cached models.`;
@@ -183,11 +189,24 @@ export class ModelSelectorComponent extends Container implements Focusable {
 					this.refreshStatusSuccess = true;
 				}
 			}
+			const selectedModel = this.filteredModels[this.selectedIndex];
+			const previousFilteredIndex = this.selectedIndex;
 			this.loadModelsFromSnapshot();
-			this.filterModels(this.searchInput.getValue());
+			this.refreshFilteredModels(this.searchInput.getValue(), selectedModel, previousFilteredIndex);
+			this.tui.requestRender();
+		} catch {
+			// Consume all refresh rejections. After timeout/dispose, leave UI alone.
+			if (settled || this.closed) return;
+			settled = true;
+			this.refreshStatusMessage = "";
+			this.errorMessage = "Could not refresh model catalogs; showing cached models.";
+			this.updateList();
 			this.tui.requestRender();
 		} finally {
-			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+			if (this.refreshTimeout) {
+				clearTimeout(this.refreshTimeout);
+				this.refreshTimeout = undefined;
+			}
 		}
 	}
 
@@ -237,16 +256,38 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private filterModels(query: string): void {
-		this.filteredModels = query
-			? fuzzyFilter(this.activeModels, query, ({ id, provider, model }) =>
-					getModelSelectorSearchText({ id, provider, name: model.name }),
-				)
-			: this.activeModels;
+		this.filteredModels = this.getFilteredModels(query);
 		// When filtering by a query, move the selector to the top row so the best
 		// match is highlighted. When the query is cleared, keep the current position
 		// clamped to the (restored) list length.
 		this.selectedIndex = query ? 0 : Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
 		this.updateList();
+	}
+
+	private refreshFilteredModels(
+		query: string,
+		selectedModel: ModelItem | undefined,
+		previousFilteredIndex: number,
+	): void {
+		this.filteredModels = this.getFilteredModels(query);
+		const selectedIndex = selectedModel
+			? this.filteredModels.findIndex(
+					(item) => item.provider === selectedModel.provider && item.id === selectedModel.id,
+				)
+			: -1;
+		this.selectedIndex =
+			selectedIndex >= 0
+				? selectedIndex
+				: Math.min(previousFilteredIndex, Math.max(0, this.filteredModels.length - 1));
+		this.updateList();
+	}
+
+	private getFilteredModels(query: string): ModelItem[] {
+		return query
+			? fuzzyFilter(this.activeModels, query, ({ id, provider, model }) =>
+					getModelSelectorSearchText({ id, provider, name: model.name }),
+				)
+			: this.activeModels;
 	}
 
 	private updateList(): void {
@@ -298,7 +339,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
 				this.listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
 			}
 		} else if (this.filteredModels.length === 0) {
-			this.listContainer.addChild(new Text(theme.fg("muted", "  No matching models"), 0, 0));
+			const emptyMessage =
+				this.scope === "all" && this.allModels.length === 0 && this.searchInput.getValue() === ""
+					? "No cached models yet."
+					: "No matching models";
+			this.listContainer.addChild(new Text(theme.fg("muted", `  ${emptyMessage}`), 0, 0));
 		} else {
 			const selected = this.filteredModels[this.selectedIndex];
 			this.listContainer.addChild(new Spacer(1));
@@ -355,7 +400,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		}
 	}
 
-	private handleSelect(model: Model<any>): void {
+	private handleSelect(model: Model<Api>): void {
 		this.dispose();
 		// Save as new default
 		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);

--- a/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
@@ -1,4 +1,4 @@
-import type { Model } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import {
 	Container,
 	type Focusable,
@@ -67,20 +67,28 @@ function getSortedIds(enabledIds: EnabledIds, allIds: string[]): string[] {
 
 interface ModelItem {
 	fullId: string;
-	model: Model<any> | undefined;
+	model: Model<Api> | undefined;
 	enabled: boolean;
 }
 
 export interface ModelsConfig {
-	allModels: Model<any>[];
+	allModels: Model<Api>[];
 	enabledModelIds: string[] | null;
 }
 
 export interface ModelsCallbacks {
-	/** Called whenever the enabled model set or order changes (session-only, no persist) */
-	onChange: (enabledModelIds: string[] | null) => void | Promise<void>;
-	/** Called when user wants to persist current selection to settings */
-	onPersist: (enabledModelIds: string[] | null) => void | Promise<void>;
+	/** Called whenever the enabled model set or order changes (session-only, no persist). */
+	onChange: (
+		enabledModelIds: string[] | null,
+		allModels: readonly Model<Api>[],
+		isDirty: boolean,
+	) => void | Promise<void>;
+	/** Called when user wants to persist the current selection to settings. */
+	onPersist: (
+		enabledModelIds: string[] | null,
+		allModels: readonly Model<Api>[],
+		isDirty: boolean,
+	) => void | Promise<void>;
 	onCancel: () => void;
 }
 
@@ -89,7 +97,7 @@ export interface ModelsCallbacks {
  * Changes are session-only until explicitly persisted with Ctrl+S.
  */
 export class ScopedModelsSelectorComponent extends Container implements Focusable {
-	private modelsById: Map<string, Model<any>> = new Map();
+	private modelsById: Map<string, Model<Api>> = new Map();
 	private allIds: string[] = [];
 	private enabledIds: EnabledIds = null;
 	private filteredItems: ModelItem[] = [];
@@ -110,17 +118,16 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 	private callbacks: ModelsCallbacks;
 	private maxVisible = 8;
 	private isDirty = false;
+	private refreshStatusMessage: string | undefined;
+	private refreshStatusSuccess = false;
+	private refreshErrorMessage: string | undefined;
+	private readonly refreshAbortController = new AbortController();
+	private closed = false;
 
 	constructor(config: ModelsConfig, callbacks: ModelsCallbacks) {
 		super();
 		this.callbacks = callbacks;
-
-		for (const model of config.allModels) {
-			const fullId = `${model.provider}/${model.id}`;
-			this.modelsById.set(fullId, model);
-			this.allIds.push(fullId);
-		}
-
+		this.replaceModels(config.allModels);
 		this.enabledIds = config.enabledModelIds === null ? null : [...config.enabledModelIds];
 		this.filteredItems = this.buildItems();
 
@@ -149,6 +156,80 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 
 		this.addChild(new DynamicBorder());
 		this.updateList();
+	}
+
+	get refreshSignal(): AbortSignal {
+		return this.refreshAbortController.signal;
+	}
+
+	get disposed(): boolean {
+		return this.closed;
+	}
+
+	abortRefresh(): void {
+		this.refreshAbortController.abort();
+	}
+
+	dispose(): void {
+		if (this.closed) return;
+		this.closed = true;
+		this.abortRefresh();
+	}
+
+	beginRefresh(): void {
+		if (this.closed) return;
+		this.refreshStatusMessage = "Refreshing model catalogs…";
+		this.refreshStatusSuccess = false;
+		this.refreshErrorMessage = undefined;
+		this.updateList();
+	}
+
+	/** Replace the catalog displayed by this mounted selector without resetting user state. */
+	applyCatalogRefresh(allModels: readonly Model<Api>[], errorMessage?: string): void {
+		if (this.closed) return;
+		const selectedId = this.filteredItems[this.selectedIndex]?.fullId;
+		const previousFilteredIndex = this.selectedIndex;
+		this.replaceModels(allModels);
+		this.refreshStatusMessage = errorMessage === undefined ? "Model catalogs refreshed." : undefined;
+		this.refreshStatusSuccess = errorMessage === undefined;
+		this.refreshErrorMessage = errorMessage;
+		this.rebuild(selectedId, previousFilteredIndex);
+	}
+
+	setRefreshError(errorMessage: string): void {
+		if (this.closed) return;
+		this.refreshStatusMessage = undefined;
+		this.refreshStatusSuccess = false;
+		this.refreshErrorMessage = this.refreshErrorMessage
+			? `${this.refreshErrorMessage} ${errorMessage}`
+			: errorMessage;
+		this.updateList();
+	}
+
+	/**
+	 * Replace the preliminary raw-pattern rows with a catalog-resolved scope.
+	 * User edits always win over the asynchronous resolution.
+	 */
+	applyResolvedEnabledModelIds(enabledModelIds: string[] | null): void {
+		if (this.closed || this.isDirty) return;
+		const selectedId = this.filteredItems[this.selectedIndex]?.fullId;
+		const previousFilteredIndex = this.selectedIndex;
+		this.enabledIds = enabledModelIds === null ? null : [...enabledModelIds];
+		this.rebuild(selectedId, previousFilteredIndex);
+	}
+
+	private replaceModels(models: readonly Model<Api>[]): void {
+		this.modelsById.clear();
+		this.allIds = [];
+		for (const model of models) {
+			const fullId = `${model.provider}/${model.id}`;
+			this.modelsById.set(fullId, model);
+			this.allIds.push(fullId);
+		}
+	}
+
+	private getAllModels(): readonly Model<Api>[] {
+		return this.allIds.map((id) => this.modelsById.get(id)!);
 	}
 
 	private buildItems(): ModelItem[] {
@@ -181,6 +262,10 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 	}
 
 	private refresh(): void {
+		this.rebuild(undefined, this.selectedIndex);
+	}
+
+	private rebuild(selectedId: string | undefined, previousFilteredIndex: number): void {
 		const query = this.searchInput.getValue();
 		const items = this.buildItems();
 		this.filteredItems = query
@@ -190,63 +275,93 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 						: item.fullId,
 				)
 			: items;
-		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredItems.length - 1));
+		const selectedIndex = selectedId ? this.filteredItems.findIndex((item) => item.fullId === selectedId) : -1;
+		this.selectedIndex =
+			selectedIndex >= 0
+				? selectedIndex
+				: Math.min(previousFilteredIndex, Math.max(0, this.filteredItems.length - 1));
 		this.updateList();
 		this.footerText.setText(this.getFooterText());
 	}
 
 	private notifyChange(): void {
-		this.callbacks.onChange(this.enabledIds === null ? null : [...this.enabledIds]);
+		const result = this.callbacks.onChange(
+			this.enabledIds === null ? null : [...this.enabledIds],
+			this.getAllModels(),
+			this.isDirty,
+		);
+		if (result && typeof (result as Promise<void>).then === "function") {
+			void (result as Promise<void>).catch((error) => {
+				console.error("Could not apply scoped model selection:", error);
+			});
+		}
 	}
 
 	private updateList(): void {
 		this.listContainer.clear();
+		const noCachedModels = this.allIds.length === 0 && this.searchInput.getValue() === "";
 
 		if (this.filteredItems.length === 0) {
-			this.listContainer.addChild(new Text(theme.fg("muted", "  No matching models"), 0, 0));
-			return;
-		}
-
-		const startIndex = Math.max(
-			0,
-			Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.filteredItems.length - this.maxVisible),
-		);
-		const endIndex = Math.min(startIndex + this.maxVisible, this.filteredItems.length);
-		const allEnabled = this.enabledIds === null;
-
-		for (let i = startIndex; i < endIndex; i++) {
-			const item = this.filteredItems[i]!;
-			const isSelected = i === this.selectedIndex;
-			const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
-			const id = item.model?.id ?? item.fullId;
-			const modelText = isSelected ? theme.fg("accent", id) : id;
-			const providerBadge = theme.fg("muted", item.model ? ` [${item.model.provider}]` : " [unavailable]");
-			const status = item.model
-				? allEnabled
-					? ""
-					: item.enabled
-						? theme.fg("success", " ✓")
-						: theme.fg("dim", " ✗")
-				: theme.fg("dim", " ✗");
-			this.listContainer.addChild(new Text(`${prefix}${modelText}${providerBadge}${status}`, 0, 0));
-		}
-
-		// Add scroll indicator if needed
-		if (startIndex > 0 || endIndex < this.filteredItems.length) {
 			this.listContainer.addChild(
-				new Text(theme.fg("muted", `  (${this.selectedIndex + 1}/${this.filteredItems.length})`), 0, 0),
+				new Text(theme.fg("muted", noCachedModels ? "  No cached models yet." : "  No matching models"), 0, 0),
 			);
+		} else {
+			const startIndex = Math.max(
+				0,
+				Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.filteredItems.length - this.maxVisible),
+			);
+			const endIndex = Math.min(startIndex + this.maxVisible, this.filteredItems.length);
+			const allEnabled = this.enabledIds === null;
+
+			for (let i = startIndex; i < endIndex; i++) {
+				const item = this.filteredItems[i]!;
+				const isSelected = i === this.selectedIndex;
+				const prefix = isSelected ? theme.fg("accent", "→ ") : "  ";
+				const id = item.model?.id ?? item.fullId;
+				const modelText = isSelected ? theme.fg("accent", id) : id;
+				const providerBadge = theme.fg("muted", item.model ? ` [${item.model.provider}]` : " [unavailable]");
+				const status = item.model
+					? allEnabled
+						? ""
+						: item.enabled
+							? theme.fg("success", " ✓")
+							: theme.fg("dim", " ✗")
+					: theme.fg("dim", " ✗");
+				this.listContainer.addChild(new Text(`${prefix}${modelText}${providerBadge}${status}`, 0, 0));
+			}
+
+			// Add scroll indicator if needed
+			if (startIndex > 0 || endIndex < this.filteredItems.length) {
+				this.listContainer.addChild(
+					new Text(theme.fg("muted", `  (${this.selectedIndex + 1}/${this.filteredItems.length})`), 0, 0),
+				);
+			}
+
+			if (this.filteredItems.length > 0) {
+				const selected = this.filteredItems[this.selectedIndex];
+				this.listContainer.addChild(new Spacer(1));
+				this.listContainer.addChild(
+					new Text(
+						theme.fg("muted", `  ${selected.model ? `Model Name: ${selected.model.name}` : "Model unavailable"}`),
+						0,
+						0,
+					),
+				);
+			}
 		}
 
-		if (this.filteredItems.length > 0) {
-			const selected = this.filteredItems[this.selectedIndex];
+		if (noCachedModels && this.filteredItems.length > 0) {
+			this.listContainer.addChild(new Spacer(1));
+			this.listContainer.addChild(new Text(theme.fg("muted", "  No cached models yet."), 0, 0));
+		}
+		if (this.refreshErrorMessage) {
+			this.listContainer.addChild(new Spacer(1));
+			this.listContainer.addChild(new Text(theme.fg("error", `  ${this.refreshErrorMessage}`), 0, 0));
+		}
+		if (this.refreshStatusMessage) {
 			this.listContainer.addChild(new Spacer(1));
 			this.listContainer.addChild(
-				new Text(
-					theme.fg("muted", `  ${selected.model ? `Model Name: ${selected.model.name}` : "Model unavailable"}`),
-					0,
-					0,
-				),
+				new Text(theme.fg(this.refreshStatusSuccess ? "success" : "muted", `  ${this.refreshStatusMessage}`), 0, 0),
 			);
 		}
 	}
@@ -341,7 +456,16 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 
 		// Save/persist to settings
 		if (kb.matches(data, "app.models.save")) {
-			this.callbacks.onPersist(this.enabledIds === null ? null : [...this.enabledIds]);
+			const result = this.callbacks.onPersist(
+				this.enabledIds === null ? null : [...this.enabledIds],
+				this.getAllModels(),
+				this.isDirty,
+			);
+			if (result && typeof (result as Promise<void>).then === "function") {
+				void (result as Promise<void>).catch((error) => {
+					console.error("Could not persist scoped model selection:", error);
+				});
+			}
 			this.isDirty = false;
 			this.footerText.setText(this.getFooterText());
 			return;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -151,6 +151,7 @@ import { UserMessageComponent } from "./components/user-message.ts";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.ts";
 import { editInExternalEditor } from "./external-editor.ts";
 import { getModelSearchText } from "./model-search.ts";
+import { SelectorOwnership, type SelectorView } from "./selector-ownership.ts";
 import {
 	getAvailableThemes,
 	getAvailableThemesWithPaths,
@@ -361,6 +362,7 @@ export class InteractiveMode {
 	private autocompleteProviderWrappers: AutocompleteProviderFactory[] = [];
 	private fdPath: string | undefined;
 	private editorContainer: Container;
+	private selectorOwnership!: SelectorOwnership;
 	private footer: FooterComponent;
 	private footerContainer: Container;
 	private footerDataProvider: FooterDataProvider;
@@ -513,6 +515,20 @@ export class InteractiveMode {
 		this.editor = this.defaultEditor;
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor as Component);
+		this.selectorOwnership = new SelectorOwnership(
+			(component, focus) => {
+				this.editorContainer.clear();
+				this.editorContainer.addChild(component);
+				this.ui.setFocus(focus);
+				this.ui.requestRender();
+			},
+			() => {
+				this.editorContainer.clear();
+				this.editorContainer.addChild(this.editor);
+				this.ui.setFocus(this.editor);
+				this.ui.requestRender();
+			},
+		);
 		this.footerDataProvider = new FooterDataProvider(this.sessionManager.getCwd());
 		this.footer = new FooterComponent(this.session, this.footerDataProvider);
 		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
@@ -4196,17 +4212,8 @@ export class InteractiveMode {
 	 * Shows a selector component in place of the editor.
 	 * @param create Factory that receives a `done` callback and returns the component and focus target
 	 */
-	private showSelector(create: (done: () => void) => { component: Component; focus: Component }): void {
-		const done = () => {
-			this.editorContainer.clear();
-			this.editorContainer.addChild(this.editor);
-			this.ui.setFocus(this.editor);
-		};
-		const { component, focus } = create(done);
-		this.editorContainer.clear();
-		this.editorContainer.addChild(component);
-		this.ui.setFocus(focus);
-		this.ui.requestRender();
+	private showSelector(create: (done: () => void) => SelectorView): void {
+		this.selectorOwnership.show(create);
 	}
 
 	private showSettingsSelector(): void {
@@ -4566,7 +4573,7 @@ export class InteractiveMode {
 				},
 				initialSearchInput,
 			);
-			return { component: selector, focus: selector };
+			return { component: selector, focus: selector, dispose: () => selector.dispose() };
 		});
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AuthEvent, AuthPrompt } from "@earendil-works/pi-ai";
+import type { Api, AuthEvent, AuthPrompt } from "@earendil-works/pi-ai";
 import type { AssistantMessage, ImageContent, Message, Model } from "@earendil-works/pi-ai/compat";
 import type {
 	AutocompleteItem,
@@ -84,7 +84,6 @@ import { createCompactionSummaryMessage } from "../../core/messages.ts";
 import {
 	defaultModelPerProvider,
 	findExactModelReferenceMatch,
-	resolveModelScope,
 	resolveModelScopeWithDiagnostics,
 } from "../../core/model-resolver.ts";
 import { DefaultPackageManager } from "../../core/package-manager.ts";
@@ -4212,8 +4211,8 @@ export class InteractiveMode {
 	 * Shows a selector component in place of the editor.
 	 * @param create Factory that receives a `done` callback and returns the component and focus target
 	 */
-	private showSelector(create: (done: () => void) => SelectorView): void {
-		this.selectorOwnership.show(create);
+	private showSelector(create: (done: () => void) => SelectorView): boolean {
+		return this.selectorOwnership.show(create);
 	}
 
 	private showSettingsSelector(): void {
@@ -4573,87 +4572,175 @@ export class InteractiveMode {
 				},
 				initialSearchInput,
 			);
-			return { component: selector, focus: selector, dispose: () => selector.dispose() };
+			return {
+				component: selector,
+				focus: selector,
+				dispose: () => selector.dispose(),
+			};
 		});
 	}
 
-	private async showModelsSelector(): Promise<void> {
-		// Get all available models
-		await this.session.modelRuntime.refresh();
-		const allModels = [...(await this.session.modelRuntime.getAvailable())];
-		const allModelIds = new Set(allModels.map((model) => `${model.provider}/${model.id}`));
+	private showModelsSelector(): void {
+		const cachedModels = [...this.session.modelRuntime.getAvailableSnapshot()];
 		const configuredPatterns = this.settingsManager.getEnabledModels();
 		const sessionScopedModels = this.session.scopedModels;
-
-		if (allModels.length === 0 && !configuredPatterns?.length && sessionScopedModels.length === 0) {
-			this.showStatus("No models available");
-			return;
-		}
-
-		const configuredScope = configuredPatterns?.length
-			? await resolveModelScopeWithDiagnostics(configuredPatterns, this.session.modelRuntime)
-			: undefined;
-
-		// Check if session has scoped models (from previous session-only changes or CLI --models)
 		const hasSessionScope = sessionScopedModels.length > 0;
-
-		// Build enabled model IDs from session state or settings
-		let currentEnabledIds: string[] | null = null;
-
-		if (hasSessionScope) {
-			// Use current session's scoped models
-			currentEnabledIds = sessionScopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`);
-		} else if (configuredScope) {
-			currentEnabledIds = configuredScope.scopedModels.map(
-				(scoped) => `${scoped.model.provider}/${scoped.model.id}`,
-			);
-		}
-
-		for (const diagnostic of configuredScope?.diagnostics ?? []) {
-			if (diagnostic.code !== "no-match") continue;
-			currentEnabledIds ??= [];
-			if (!currentEnabledIds.includes(diagnostic.pattern)) currentEnabledIds.push(diagnostic.pattern);
-		}
-
-		// Helper to update session's scoped models (session-only, no persist)
-		const updateSessionModels = async (enabledIds: string[] | null) => {
-			currentEnabledIds = enabledIds === null ? null : [...enabledIds];
-			const hasEnabledAvailableModel = enabledIds?.some((id) => allModelIds.has(id)) ?? false;
-			const allAvailableModelsEnabled =
-				enabledIds !== null && [...allModelIds].every((id) => enabledIds.includes(id));
-			if (enabledIds && hasEnabledAvailableModel && !allAvailableModelsEnabled) {
-				const newScopedModels = await resolveModelScope(enabledIds, this.session.modelRuntime);
-				this.session.setScopedModels(
-					newScopedModels.map((sm) => ({
-						model: sm.model,
-						thinkingLevel: sm.thinkingLevel,
-					})),
-				);
-			} else {
-				// All enabled or none enabled = no filter
-				this.session.setScopedModels([]);
+		const currentEnabledIds = hasSessionScope
+			? sessionScopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`)
+			: configuredPatterns?.length
+				? [...configuredPatterns]
+				: null;
+		const thinkingLevelsByModelId = new Map<string, string>();
+		for (const scoped of sessionScopedModels) {
+			if (scoped.thinkingLevel) {
+				thinkingLevelsByModelId.set(`${scoped.model.provider}/${scoped.model.id}`, scoped.thinkingLevel);
 			}
-			await this.updateAvailableProviderCount();
+		}
+		const configuredThinkingLevelsByModelId = new Map<string, string>();
+		const getThinkingLevel = (id: string): string | undefined =>
+			thinkingLevelsByModelId.get(id) ?? configuredThinkingLevelsByModelId.get(id);
+
+		const resolveAgainstCatalog = (patterns: string[], models: readonly Model<Api>[]) => {
+			// Keep the selector's session update bound to the catalog it rendered, not a later runtime publication.
+			const catalogRuntime = {
+				getAvailable: async () => models,
+			} as Parameters<typeof resolveModelScopeWithDiagnostics>[1];
+			return resolveModelScopeWithDiagnostics(patterns, catalogRuntime);
+		};
+		const patternsForSelection = (enabledIds: string[]): string[] =>
+			enabledIds.map((id) => {
+				const thinkingLevel = getThinkingLevel(id);
+				return thinkingLevel ? `${id}:${thinkingLevel}` : id;
+			});
+		const recordThinkingLevels = (
+			scopedModels: { model: Model<Api>; thinkingLevel?: string }[],
+			target = thinkingLevelsByModelId,
+		) => {
+			for (const scoped of scopedModels) {
+				const id = `${scoped.model.provider}/${scoped.model.id}`;
+				if (scoped.thinkingLevel) target.set(id, scoped.thinkingLevel);
+			}
+		};
+		const isExactAllEnabled = (enabledIds: string[], currentModels: readonly Model<Api>[]): boolean => {
+			const allModelIds = new Set(currentModels.map((model) => `${model.provider}/${model.id}`));
+			return (
+				enabledIds.length === allModelIds.size &&
+				enabledIds.every((id) => allModelIds.has(id) && !getThinkingLevel(id))
+			);
+		};
+
+		let selector: ScopedModelsSelectorComponent | undefined;
+		let lifecycleGeneration = 0;
+		let configuredResolutionGeneration = 0;
+		const isActive = (generation: number, expectedSelector = selector): boolean =>
+			lifecycleGeneration === generation &&
+			expectedSelector !== undefined &&
+			selector === expectedSelector &&
+			!expectedSelector.disposed;
+
+		const updateSessionModels = async (
+			enabledIds: string[] | null,
+			currentModels: readonly Model<Api>[],
+			generation: number,
+		) => {
+			if (!isActive(generation) || currentModels.length === 0) {
+				// An empty catalog cannot prove that an existing session scope should broaden.
+				return;
+			}
+			if (enabledIds === null) {
+				this.session.setScopedModels([]);
+			} else if (enabledIds.length === 0) {
+				// Retain the established no-filter behavior only when the catalog can prove the selection is empty.
+				this.session.setScopedModels([]);
+			} else if (isExactAllEnabled(enabledIds, currentModels)) {
+				// No unresolved extras: this is the one explicit-list form that means no filter.
+				this.session.setScopedModels([]);
+			} else {
+				const resolved = await resolveAgainstCatalog(patternsForSelection(enabledIds), currentModels);
+				if (!isActive(generation)) return;
+				recordThinkingLevels(resolved.scopedModels);
+				if (resolved.scopedModels.length > 0) {
+					this.session.setScopedModels(resolved.scopedModels);
+				}
+			}
+			// An empty catalog or an unresolved-only selection must not clear/broaden an existing session scope.
+			if (!isActive(generation)) return;
+			this.updateAvailableProviderCount();
+			if (!isActive(generation)) return;
 			this.ui.requestRender();
 		};
 
-		this.showSelector((done) => {
-			const selector = new ScopedModelsSelectorComponent(
+		let sessionUpdate = Promise.resolve();
+		const enqueueSessionUpdate = (enabledIds: string[] | null, currentModels: readonly Model<Api>[]) => {
+			const capturedIds = enabledIds === null ? null : [...enabledIds];
+			const capturedModels = [...currentModels];
+			const generation = lifecycleGeneration;
+			const update = sessionUpdate.then(async () => {
+				if (!isActive(generation)) return;
+				await updateSessionModels(capturedIds, capturedModels, generation);
+			});
+			sessionUpdate = update.catch((error) => {
+				console.error("Could not update scoped models:", error);
+			});
+			return update;
+		};
+		const applyConfiguredScope = async (models: readonly Model<Api>[]): Promise<boolean> => {
+			const configuredResolutionRevision = ++configuredResolutionGeneration;
+			const generation = lifecycleGeneration;
+			const selectorAtStart = selector;
+			const isCurrentConfiguredResolution = (): boolean =>
+				configuredResolutionRevision === configuredResolutionGeneration && isActive(generation, selectorAtStart);
+			// A newer invocation owns every configured-resolution side effect, including errors.
+			if (
+				hasSessionScope ||
+				!configuredPatterns?.length ||
+				selectorAtStart === undefined ||
+				!isCurrentConfiguredResolution()
+			) {
+				return false;
+			}
+			let resolved: Awaited<ReturnType<typeof resolveAgainstCatalog>>;
+			try {
+				resolved = await resolveAgainstCatalog(configuredPatterns, models);
+			} catch (error) {
+				if (!isCurrentConfiguredResolution()) return false;
+				throw error;
+			}
+			if (!isCurrentConfiguredResolution()) return false;
+			recordThinkingLevels(resolved.scopedModels, configuredThinkingLevelsByModelId);
+			if (!isCurrentConfiguredResolution()) return false;
+			const enabledIds = [
+				...resolved.scopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`),
+				...resolved.diagnostics
+					.filter((diagnostic) => diagnostic.code === "no-match")
+					.map((diagnostic) => diagnostic.pattern),
+			];
+			selectorAtStart.applyResolvedEnabledModelIds(enabledIds);
+			if (!isCurrentConfiguredResolution()) return false;
+			this.ui.requestRender();
+			return true;
+		};
+
+		const shown = this.showSelector((done) => {
+			selector = new ScopedModelsSelectorComponent(
 				{
-					allModels,
+					allModels: cachedModels,
 					enabledModelIds: currentEnabledIds,
 				},
 				{
-					onChange: async (enabledIds) => {
-						await updateSessionModels(enabledIds);
-					},
-					onPersist: (enabledIds) => {
-						// Persist to settings
-						const allEnabled =
-							enabledIds !== null &&
-							enabledIds.length === allModels.length &&
-							enabledIds.every((id) => allModelIds.has(id));
-						const newPatterns = enabledIds === null || allEnabled ? undefined : enabledIds;
+					onChange: (enabledIds, currentModels) => enqueueSessionUpdate(enabledIds, currentModels),
+					onPersist: (enabledIds, currentModels, isDirty) => {
+						const generation = lifecycleGeneration;
+						if (!isActive(generation)) return;
+						const newPatterns =
+							!hasSessionScope && !isDirty && configuredPatterns !== undefined
+								? configuredPatterns
+								: enabledIds === null || (enabledIds !== null && isExactAllEnabled(enabledIds, currentModels))
+									? undefined
+									: enabledIds.map((id) => {
+											const thinkingLevel = getThinkingLevel(id);
+											return thinkingLevel ? `${id}:${thinkingLevel}` : id;
+										});
 						this.settingsManager.setEnabledModels(newPatterns ? [...newPatterns] : undefined);
 						this.showStatus("Model selection saved to settings");
 					},
@@ -4663,8 +4750,78 @@ export class InteractiveMode {
 					},
 				},
 			);
-			return { component: selector, focus: selector };
+			return {
+				component: selector,
+				focus: selector,
+				dispose: () => {
+					lifecycleGeneration++;
+					configuredResolutionGeneration++;
+					selector?.dispose();
+				},
+			};
 		});
+		if (shown && selector) {
+			void applyConfiguredScope(cachedModels).catch(() => {
+				// Keep diagnostics free of raw provider/resolver exception text (may contain secrets).
+				console.error("Could not resolve configured model scope from cached catalog.");
+			});
+			void this.refreshScopedModelsSelector(selector, applyConfiguredScope);
+		}
+	}
+
+	private async refreshScopedModelsSelector(
+		selector: ScopedModelsSelectorComponent,
+		applyConfiguredScope: (models: readonly Model<Api>[]) => Promise<boolean>,
+	): Promise<void> {
+		const timeoutMs = 15_000;
+		let settled = false;
+		const applyResult = async (errorMessage?: string): Promise<void> => {
+			if (settled || selector.disposed) return;
+			settled = true;
+			const models = this.session.modelRuntime.getAvailableSnapshot();
+			selector.applyCatalogRefresh(models, errorMessage);
+			if (selector.disposed) return;
+			this.ui.requestRender();
+			try {
+				const applied = await applyConfiguredScope(models);
+				if (!applied || selector.disposed) return;
+				this.ui.requestRender();
+			} catch {
+				if (selector.disposed) return;
+				// Stable generic text only: raw resolver errors may contain secrets.
+				console.error("Could not resolve configured model scope from refreshed catalog.");
+				selector.setRefreshError("Could not resolve configured model scope; showing current models.");
+				if (selector.disposed) return;
+				this.ui.requestRender();
+			}
+		};
+		selector.beginRefresh();
+		const timeout = setTimeout(() => {
+			if (selector.disposed || settled) return;
+			selector.abortRefresh();
+			void applyResult("Model refresh timed out; showing cached models.");
+		}, timeoutMs);
+		let errorMessage: string | undefined;
+		try {
+			const result = await this.session.modelRuntime.refresh({
+				signal: selector.refreshSignal,
+			});
+			if (settled || selector.disposed) return;
+			if (result.errors.size === 1) {
+				errorMessage = `Could not refresh ${result.errors.keys().next().value}; showing cached models.`;
+			} else if (result.errors.size > 1) {
+				errorMessage = `Could not refresh ${result.errors.size} model catalogs; showing cached models.`;
+			} else {
+				errorMessage = this.session.modelRuntime.getError();
+			}
+		} catch {
+			// Stable generic text only: raw refresh exceptions may contain secrets.
+			if (settled || selector.disposed) return;
+			errorMessage = "Could not refresh model catalogs; showing cached models.";
+		} finally {
+			clearTimeout(timeout);
+		}
+		await applyResult(errorMessage);
 	}
 
 	private showUserMessageSelector(): void {

--- a/packages/coding-agent/src/modes/interactive/selector-ownership.ts
+++ b/packages/coding-agent/src/modes/interactive/selector-ownership.ts
@@ -1,0 +1,75 @@
+import type { Component } from "@earendil-works/pi-tui";
+
+export interface SelectorView {
+	component: Component;
+	focus: Component;
+	dispose?: () => void;
+}
+
+type SelectorEntry = {
+	dispose?: () => void;
+	disposed: boolean;
+};
+
+/**
+ * Owns the single interactive editor-slot selector.
+ *
+ * - Replacement and close dispose the previous entry once.
+ * - A stale `done` cannot close a newer selector.
+ * - Factories that complete synchronously before mount never become current.
+ */
+export class SelectorOwnership {
+	private current: SelectorEntry | undefined;
+	private readonly mount: (component: Component, focus: Component) => void;
+	private readonly restore: () => void;
+
+	constructor(mount: (component: Component, focus: Component) => void, restore: () => void) {
+		this.mount = mount;
+		this.restore = restore;
+	}
+
+	show(create: (done: () => void) => SelectorView): boolean {
+		const entry: SelectorEntry = { disposed: false };
+		let creating = true;
+		let canceled = false;
+		const done = () => {
+			if (creating) {
+				canceled = true;
+				return;
+			}
+			this.close(entry);
+		};
+
+		const view = create(done);
+		creating = false;
+		entry.dispose = view.dispose;
+
+		if (canceled) {
+			this.dispose(entry);
+			return false;
+		}
+
+		const previous = this.current;
+		this.current = undefined;
+		if (previous) this.dispose(previous);
+
+		this.current = entry;
+		this.mount(view.component, view.focus);
+		return true;
+	}
+
+	private close(entry: SelectorEntry): void {
+		if (this.current !== entry) return;
+		this.current = undefined;
+		this.dispose(entry);
+		this.restore();
+	}
+
+	private dispose(entry: SelectorEntry): void {
+		if (entry.disposed) return;
+		entry.disposed = true;
+		const dispose = entry.dispose;
+		entry.dispose = undefined;
+		dispose?.();
+	}
+}

--- a/packages/coding-agent/test/interactive-mode-selector-dispose.test.ts
+++ b/packages/coding-agent/test/interactive-mode-selector-dispose.test.ts
@@ -1,0 +1,91 @@
+import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
+import type { TUI } from "@earendil-works/pi-tui";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { ModelSelectorComponent } from "../src/modes/interactive/components/model-selector.ts";
+import { SelectorOwnership } from "../src/modes/interactive/selector-ownership.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function createFakeTui(requestRender: () => void): TUI {
+	return { requestRender } as unknown as TUI;
+}
+
+describe("ModelSelectorComponent.dispose", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	afterAll(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("aborts only its own refresh and ignores a late completion", async () => {
+		const harness = await createHarness({ models: [{ id: "model", name: "Model", reasoning: true }] });
+		harnesses.push(harness);
+		const refreshes: Array<{ signal: AbortSignal | undefined; completion: Deferred<ModelsRefreshResult> }> = [];
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation((options: ModelsRefreshOptions = {}) => {
+			const completion = deferred<ModelsRefreshResult>();
+			refreshes.push({ signal: options.signal, completion });
+			return completion.promise;
+		});
+		const firstRender = vi.fn();
+		const secondRender = vi.fn();
+		const currentModel = harness.getModel();
+		const first = new ModelSelectorComponent(
+			createFakeTui(firstRender),
+			currentModel,
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+		const second = new ModelSelectorComponent(
+			createFakeTui(secondRender),
+			currentModel,
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+		const ownership = new SelectorOwnership(
+			() => {},
+			() => {},
+		);
+		ownership.show(() => ({ component: first, focus: first, dispose: () => first.dispose() }));
+		ownership.show(() => ({ component: second, focus: second, dispose: () => second.dispose() }));
+		await vi.waitFor(() => expect(refreshes).toHaveLength(2));
+		firstRender.mockClear();
+		secondRender.mockClear();
+
+		expect(refreshes[0].signal?.aborted).toBe(true);
+		expect(refreshes[1].signal?.aborted).toBe(false);
+
+		refreshes[0].completion.resolve({ aborted: true, errors: new Map() });
+		await refreshes[0].completion.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(firstRender).not.toHaveBeenCalled();
+		expect(secondRender).not.toHaveBeenCalled();
+
+		second.dispose();
+		second.dispose();
+		expect(refreshes[1].signal?.aborted).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-selector-dispose.test.ts
+++ b/packages/coding-agent/test/interactive-mode-selector-dispose.test.ts
@@ -1,26 +1,34 @@
 import type { ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
 import type { TUI } from "@earendil-works/pi-tui";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ModelSelectorComponent } from "../src/modes/interactive/components/model-selector.ts";
 import { SelectorOwnership } from "../src/modes/interactive/selector-ownership.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
 import { createHarness, type Harness } from "./suite/harness.ts";
 
 interface Deferred<T> {
 	promise: Promise<T>;
 	resolve(value: T): void;
+	reject(reason?: unknown): void;
 }
 
 function deferred<T>(): Deferred<T> {
 	let resolve!: (value: T) => void;
-	const promise = new Promise<T>((resolvePromise) => {
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
 		resolve = resolvePromise;
+		reject = rejectPromise;
 	});
-	return { promise, resolve };
+	return { promise, resolve, reject };
 }
 
 function createFakeTui(requestRender: () => void): TUI {
 	return { requestRender } as unknown as TUI;
+}
+
+function render(selector: ModelSelectorComponent): string {
+	return stripAnsi(selector.render(120).join("\n"));
 }
 
 describe("ModelSelectorComponent.dispose", () => {
@@ -87,5 +95,196 @@ describe("ModelSelectorComponent.dispose", () => {
 		second.dispose();
 		second.dispose();
 		expect(refreshes[1].signal?.aborted).toBe(true);
+	});
+});
+
+describe("ModelSelectorComponent refresh deadline", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("stops waiting at 15s, shows timeout with cached models, and ignores late completion", async () => {
+		const harness = await createHarness({ models: [{ id: "cached", name: "Cached Model", reasoning: true }] });
+		harnesses.push(harness);
+		const completion = deferred<ModelsRefreshResult>();
+		let refreshSignal: AbortSignal | undefined;
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation((options: ModelsRefreshOptions = {}) => {
+			refreshSignal = options.signal;
+			return completion.promise;
+		});
+		const requestRender = vi.fn();
+		const selector = new ModelSelectorComponent(
+			createFakeTui(requestRender),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+
+		expect(render(selector)).toContain("Refreshing model catalogs…");
+		expect(render(selector)).toContain("cached");
+		expect(refreshSignal?.aborted).toBe(false);
+		requestRender.mockClear();
+
+		await vi.advanceTimersByTimeAsync(15_000);
+		await Promise.resolve();
+
+		const afterTimeout = render(selector);
+		expect(afterTimeout).toContain("Model refresh timed out; showing cached models.");
+		expect(afterTimeout).toContain("cached");
+		expect(afterTimeout).not.toContain("Refreshing model catalogs…");
+		expect(refreshSignal?.aborted).toBe(true);
+		expect(requestRender).toHaveBeenCalled();
+
+		// Late success must not overwrite the timeout UI.
+		requestRender.mockClear();
+		completion.resolve({ aborted: false, errors: new Map() });
+		await completion.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(render(selector)).toContain("Model refresh timed out; showing cached models.");
+		expect(render(selector)).not.toContain("Model catalogs refreshed.");
+		expect(render(selector)).not.toContain("Refreshing model catalogs…");
+		expect(requestRender).not.toHaveBeenCalled();
+
+		selector.dispose();
+	});
+
+	it("does not mutate after dispose even if the deadline fires later", async () => {
+		const harness = await createHarness({ models: [{ id: "cached", name: "Cached Model", reasoning: true }] });
+		harnesses.push(harness);
+		const completion = deferred<ModelsRefreshResult>();
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(() => completion.promise);
+		const requestRender = vi.fn();
+		const selector = new ModelSelectorComponent(
+			createFakeTui(requestRender),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+		const before = render(selector);
+		requestRender.mockClear();
+		selector.dispose();
+		await vi.advanceTimersByTimeAsync(15_000);
+		completion.resolve({ aborted: false, errors: new Map() });
+		await completion.promise;
+		await Promise.resolve();
+
+		expect(render(selector)).toBe(before);
+		expect(requestRender).not.toHaveBeenCalled();
+	});
+
+	it("clears refreshing and shows a stable cached-model error when refresh rejects early", async () => {
+		const harness = await createHarness({ models: [{ id: "cached", name: "Cached Model", reasoning: true }] });
+		harnesses.push(harness);
+		const completion = deferred<ModelsRefreshResult>();
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(() => completion.promise);
+		const requestRender = vi.fn();
+		const selector = new ModelSelectorComponent(
+			createFakeTui(requestRender),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+
+		expect(render(selector)).toContain("Refreshing model catalogs…");
+		requestRender.mockClear();
+
+		completion.reject(new Error("provider network blew up with secrets"));
+		await completion.promise.catch(() => {});
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const afterReject = render(selector);
+		expect(afterReject).toContain("Could not refresh model catalogs; showing cached models.");
+		expect(afterReject).toContain("cached");
+		expect(afterReject).not.toContain("Refreshing model catalogs…");
+		expect(afterReject).not.toContain("provider network blew up with secrets");
+		expect(requestRender).toHaveBeenCalled();
+
+		selector.dispose();
+	});
+
+	it("consumes a late rejection after timeout without mutating UI", async () => {
+		const harness = await createHarness({ models: [{ id: "cached", name: "Cached Model", reasoning: true }] });
+		harnesses.push(harness);
+		const completion = deferred<ModelsRefreshResult>();
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(() => completion.promise);
+		const requestRender = vi.fn();
+		const selector = new ModelSelectorComponent(
+			createFakeTui(requestRender),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+
+		await vi.advanceTimersByTimeAsync(15_000);
+		await Promise.resolve();
+		const afterTimeout = render(selector);
+		expect(afterTimeout).toContain("Model refresh timed out; showing cached models.");
+		requestRender.mockClear();
+
+		completion.reject(new Error("late provider failure"));
+		await completion.promise.catch(() => {});
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(render(selector)).toBe(afterTimeout);
+		expect(render(selector)).toContain("Model refresh timed out; showing cached models.");
+		expect(render(selector)).not.toContain("Could not refresh model catalogs; showing cached models.");
+		expect(requestRender).not.toHaveBeenCalled();
+
+		selector.dispose();
+	});
+
+	it("consumes a late rejection after dispose without mutating UI", async () => {
+		const harness = await createHarness({ models: [{ id: "cached", name: "Cached Model", reasoning: true }] });
+		harnesses.push(harness);
+		const completion = deferred<ModelsRefreshResult>();
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(() => completion.promise);
+		const requestRender = vi.fn();
+		const selector = new ModelSelectorComponent(
+			createFakeTui(requestRender),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+		const before = render(selector);
+		requestRender.mockClear();
+		selector.dispose();
+
+		completion.reject(new Error("late after dispose"));
+		await completion.promise.catch(() => {});
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(render(selector)).toBe(before);
+		expect(requestRender).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/model-runtime-concurrency.test.ts
+++ b/packages/coding-agent/test/model-runtime-concurrency.test.ts
@@ -1,0 +1,839 @@
+import {
+	type CredentialStore,
+	InMemoryCredentialStore,
+	InMemoryModelsStore,
+	type Model,
+	type Provider,
+} from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRuntime } from "../src/core/model-runtime.ts";
+
+interface Deferred<T = void> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+	reject(error: unknown): void;
+}
+
+function deferred<T = void>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function model(provider: string, id: string): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: `https://${provider}.test/v1`,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000,
+		maxTokens: 100,
+	};
+}
+
+function nativeProvider(
+	id: string,
+	models: () => readonly Model<"openai-completions">[],
+	overrides: Partial<Provider<"openai-completions">> = {},
+): Provider<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		auth: {
+			apiKey: {
+				name: `${id} key`,
+				check: async ({ credential }) =>
+					credential?.key ? { type: "api_key", source: `${id}:${credential.key}` } : undefined,
+				resolve: async ({ credential }) =>
+					credential?.key ? { auth: { apiKey: credential.key }, source: `${id}:${credential.key}` } : undefined,
+			},
+		},
+		getModels: models,
+		stream: () => {
+			throw new Error("unused");
+		},
+		streamSimple: () => {
+			throw new Error("unused");
+		},
+		...overrides,
+	};
+}
+
+function nativeOAuthProvider(
+	id: string,
+	models: () => readonly Model<"openai-completions">[],
+): Provider<"openai-completions"> {
+	return nativeProvider(id, models, {
+		auth: {
+			oauth: {
+				name: `${id} OAuth`,
+				login: async () => {
+					throw new Error("unused");
+				},
+				refresh: async (credential) => credential,
+				toAuth: async (credential) => ({ apiKey: credential.access }),
+			},
+		},
+	});
+}
+
+async function runtime(credentials: CredentialStore = AuthStorage.inMemory()): Promise<ModelRuntime> {
+	return ModelRuntime.create({
+		credentials,
+		modelsStore: new InMemoryModelsStore(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+}
+
+async function waitFor(assertion: () => void | Promise<void>): Promise<void> {
+	await vi.waitFor(assertion, { timeout: 2_000, interval: 5 });
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("ModelRuntime atomic publication", () => {
+	it("serializes refresh owners, preserves options, and promptly skips queued and pre-aborted work", async () => {
+		const modelRuntime = await runtime(AuthStorage.inMemory({ fifo: { type: "api_key", key: "key" } }));
+		let active = 0;
+		let maxActive = 0;
+		const seen: Array<boolean | undefined> = [];
+		let gate: Deferred | undefined;
+		let started: Deferred | undefined;
+		modelRuntime.registerNativeProvider(
+			nativeProvider("fifo", () => [model("fifo", "one")], {
+				refreshModels: async ({ force }) => {
+					active++;
+					maxActive = Math.max(maxActive, active);
+					seen.push(force);
+					started?.resolve();
+					try {
+						await gate?.promise;
+					} finally {
+						active--;
+					}
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		await modelRuntime.refresh({ allowNetwork: false });
+		await waitFor(() => expect(active).toBe(0));
+		seen.length = 0;
+		gate = deferred();
+		started = deferred();
+
+		const first = modelRuntime.refresh({ allowNetwork: false, force: true });
+		await started.promise;
+		const queuedAbort = new AbortController();
+		const second = modelRuntime.refresh({ allowNetwork: false, force: false, signal: queuedAbort.signal });
+		const third = modelRuntime.refresh({ allowNetwork: false, force: false });
+		queuedAbort.abort();
+		await expect(second).resolves.toMatchObject({ aborted: true });
+		expect(active).toBe(1);
+
+		const preAborted = new AbortController();
+		preAborted.abort();
+		await expect(modelRuntime.refresh({ allowNetwork: false, signal: preAborted.signal })).resolves.toMatchObject({
+			aborted: true,
+		});
+		expect(active).toBe(1);
+		gate.resolve();
+		await Promise.all([first, third]);
+
+		expect(maxActive).toBe(1);
+		expect(seen).toEqual([true, false]);
+	});
+
+	it("continues FIFO work after an owner rejects", async () => {
+		const modelRuntime = await runtime();
+		modelRuntime.registerNativeProvider(
+			nativeProvider("owner-failure", () => [model("owner-failure", "one")], {
+				auth: {
+					apiKey: {
+						name: "failing login",
+						login: async () => {
+							throw new Error("owner failed");
+						},
+						resolve: async () => undefined,
+					},
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		const first = modelRuntime.login("owner-failure", "api_key", { prompt: async () => "unused", notify: () => {} });
+		const second = modelRuntime.refresh({ allowNetwork: false });
+		await expect(first).rejects.toThrow("owner failed");
+		await expect(second).resolves.toMatchObject({ aborted: false });
+	});
+
+	it("reads each provider credential once while inspecting a refresh candidate", async () => {
+		const base = new InMemoryCredentialStore();
+		await base.modify("read-once", async () => ({ type: "api_key", key: "key" }));
+		let reads = 0;
+		const credentials: CredentialStore = {
+			read: async (providerId) => {
+				if (providerId === "read-once") reads++;
+				return base.read(providerId);
+			},
+			list: () => base.list(),
+			modify: (providerId, fn) => base.modify(providerId, fn),
+			delete: (providerId) => base.delete(providerId),
+		};
+		const modelRuntime = await runtime(credentials);
+		modelRuntime.registerNativeProvider(nativeProvider("read-once", () => [model("read-once", "one")]));
+		await modelRuntime.refresh({ allowNetwork: false });
+		await modelRuntime.refresh({ allowNetwork: false });
+		reads = 0;
+
+		await modelRuntime.refresh({ allowNetwork: false });
+
+		expect(reads).toBe(1);
+	});
+
+	it("resolves request auth live without running request-time auth during refresh or availability reads", async () => {
+		const modelRuntime = await runtime();
+		let key = "first";
+		let resolutions = 0;
+		modelRuntime.registerNativeProvider(
+			nativeProvider("live-auth", () => [model("live-auth", "one")], {
+				auth: {
+					apiKey: {
+						name: "live key",
+						check: async () => ({ type: "api_key", source: "available" }),
+						resolve: async () => {
+							resolutions++;
+							return { auth: { apiKey: key }, source: key };
+						},
+					},
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		await modelRuntime.getAvailable();
+		expect(modelRuntime.getProviderAuthStatus("live-auth")).toMatchObject({ configured: true });
+		expect(resolutions).toBe(0);
+
+		expect((await modelRuntime.getAuth("live-auth"))?.auth.apiKey).toBe("first");
+		key = "second";
+		expect((await modelRuntime.getAuth("live-auth"))?.auth.apiKey).toBe("second");
+		expect(resolutions).toBe(2);
+	});
+
+	it("reads externally mutated credentials live against one published provider view", async () => {
+		const credentials = AuthStorage.inMemory();
+		const modelRuntime = await runtime(credentials);
+		modelRuntime.registerNativeProvider(nativeProvider("external-auth", () => [model("external-auth", "one")]));
+
+		expect(modelRuntime.hasConfiguredAuth("external-auth")).toBe(false);
+		expect(modelRuntime.getProviderAuthStatus("external-auth")).toEqual({ configured: false });
+		expect(await modelRuntime.checkAuth("external-auth")).toBeUndefined();
+
+		await credentials.modify("external-auth", async () => ({ type: "api_key", key: "live" }));
+
+		expect(modelRuntime.hasConfiguredAuth("external-auth")).toBe(false);
+		expect(modelRuntime.getProviderAuthStatus("external-auth")).toEqual({ configured: false });
+		expect(await modelRuntime.checkAuth("external-auth")).toEqual({
+			type: "api_key",
+			source: "external-auth:live",
+		});
+
+		await credentials.delete("external-auth");
+
+		expect(modelRuntime.hasConfiguredAuth("external-auth")).toBe(false);
+		expect(modelRuntime.getProviderAuthStatus("external-auth")).toEqual({ configured: false });
+		expect(await modelRuntime.checkAuth("external-auth")).toBeUndefined();
+	});
+
+	it("keeps a complete old catalog view through refresh while checkAuth reads credentials live", async () => {
+		const credentials = AuthStorage.inMemory({ staged: { type: "api_key", key: "A" } });
+		const modelRuntime = await runtime(credentials);
+		let version = "A";
+		let refreshGate: Deferred | undefined;
+		modelRuntime.registerNativeProvider(
+			nativeProvider("staged", () => [model("staged", version)], {
+				refreshModels: async () => {
+					if (refreshGate) {
+						version = "B";
+						await refreshGate.promise;
+					}
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		await modelRuntime.refresh({ allowNetwork: false });
+		const oldProvider = modelRuntime.getProvider("staged");
+		expect(oldProvider?.getModels().map((entry) => entry.id)).toEqual(["A"]);
+		expect((await modelRuntime.checkAuth("staged"))?.source).toBe("staged:A");
+
+		await credentials.modify("staged", async () => ({ type: "api_key", key: "B" }));
+		refreshGate = deferred();
+		const refreshing = modelRuntime.refresh({ allowNetwork: false });
+		await waitFor(() => expect(version).toBe("B"));
+
+		// Published catalog stays on the pre-refresh snapshot while work is in flight.
+		expect(modelRuntime.getModels("staged").map((entry) => entry.id)).toEqual(["A"]);
+		expect(modelRuntime.getModel("staged", "A")).toBeDefined();
+		expect(modelRuntime.getModel("staged", "B")).toBeUndefined();
+		expect(oldProvider?.getModels().map((entry) => entry.id)).toEqual(["A"]);
+		expect((await modelRuntime.checkAuth("staged"))?.source).toBe("staged:B");
+
+		refreshGate.resolve();
+		await refreshing;
+		expect(modelRuntime.getModels("staged").map((entry) => entry.id)).toEqual(["B"]);
+		expect(
+			modelRuntime
+				.getProvider("staged")
+				?.getModels()
+				.map((entry) => entry.id),
+		).toEqual(["B"]);
+		expect((await modelRuntime.checkAuth("staged"))?.source).toBe("staged:B");
+		// Captured pre-refresh provider views remain frozen; object identity is not promised.
+		expect(oldProvider?.getModels().map((entry) => entry.id)).toEqual(["A"]);
+	});
+
+	it("publishes a direct Provider.refreshModels call without mutating its captured view", async () => {
+		const modelRuntime = await runtime(AuthStorage.inMemory({ direct: { type: "api_key", key: "key" } }));
+		let current = [model("direct", "A")];
+		let publishB = false;
+		modelRuntime.registerNativeProvider(
+			nativeProvider("direct", () => current, {
+				refreshModels: async () => {
+					if (publishB) current = [model("direct", "B")];
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		const captured = modelRuntime.getProvider("direct");
+		expect(captured?.getModels().map((entry) => entry.id)).toEqual(["A"]);
+		publishB = true;
+
+		await captured?.refreshModels?.({
+			allowNetwork: false,
+			credential: { type: "api_key", key: "key" },
+			store: { read: async () => undefined, write: async () => {}, delete: async () => {} },
+		});
+
+		expect(modelRuntime.getModels("direct").map((entry) => entry.id)).toEqual(["B"]);
+		expect(captured?.getModels().map((entry) => entry.id)).toEqual(["A"]);
+	});
+
+	it("publishes successful catalogs and a failed provider's restored cache as one candidate", async () => {
+		const credentials = AuthStorage.inMemory({
+			success: { type: "api_key", key: "key" },
+			failure: { type: "api_key", key: "key" },
+		});
+		const stores = new InMemoryModelsStore();
+		await stores.write("failure", { models: [model("failure", "cached-A")] });
+		const modelRuntime = await ModelRuntime.create({
+			credentials,
+			modelsStore: stores,
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		let successModels = [model("success", "old")];
+		let failureModels = [model("failure", "old")];
+		modelRuntime.registerNativeProvider(
+			nativeProvider("success", () => successModels, {
+				refreshModels: async ({ allowNetwork }) => {
+					if (allowNetwork) successModels = [model("success", "new-B")];
+				},
+			}),
+		);
+		modelRuntime.registerNativeProvider(
+			nativeProvider("failure", () => failureModels, {
+				refreshModels: async ({ allowNetwork, store }) => {
+					if (allowNetwork) {
+						failureModels = [model("failure", "unpublished-X")];
+						throw new Error("network failed");
+					}
+					failureModels = [...((await store.read())?.models ?? [])] as Array<Model<"openai-completions">>;
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+
+		const result = await modelRuntime.refresh({ allowNetwork: true });
+
+		expect(result.errors.get("failure")?.message).toBe("network failed");
+		expect(modelRuntime.getModels("success").map((entry) => entry.id)).toEqual(["new-B"]);
+		expect(modelRuntime.getModels("failure").map((entry) => entry.id)).toEqual(["cached-A"]);
+		expect(
+			modelRuntime
+				.getProvider("success")
+				?.getModels()
+				.map((entry) => entry.id),
+		).toEqual(["new-B"]);
+		expect(
+			modelRuntime
+				.getProvider("failure")
+				?.getModels()
+				.map((entry) => entry.id),
+		).toEqual(["cached-A"]);
+	});
+
+	it("discards an aborted candidate even when its provider and store already changed", async () => {
+		const credentials = AuthStorage.inMemory({ abortable: { type: "api_key", key: "key" } });
+		const stores = new InMemoryModelsStore();
+		const modelRuntime = await ModelRuntime.create({
+			credentials,
+			modelsStore: stores,
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		let current = [model("abortable", "A")];
+		let abortDuringRefresh: AbortController | undefined;
+		modelRuntime.registerNativeProvider(
+			nativeProvider("abortable", () => current, {
+				refreshModels: async ({ store }) => {
+					if (!abortDuringRefresh) return;
+					current = [model("abortable", "B")];
+					await store.write({ models: current });
+					abortDuringRefresh.abort();
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		const oldProvider = modelRuntime.getProvider("abortable");
+		abortDuringRefresh = new AbortController();
+
+		const result = await modelRuntime.refresh({ allowNetwork: true, signal: abortDuringRefresh.signal });
+
+		expect(result.aborted).toBe(true);
+		// Aborted candidates must not publish; store side effects may already exist.
+		expect(modelRuntime.getModels("abortable").map((entry) => entry.id)).toEqual(["A"]);
+		expect(
+			modelRuntime
+				.getProvider("abortable")
+				?.getModels()
+				.map((entry) => entry.id),
+		).toEqual(["A"]);
+		expect(oldProvider?.getModels().map((entry) => entry.id)).toEqual(["A"]);
+		expect((await stores.read("abortable"))?.models.map((entry) => entry.id)).toEqual(["B"]);
+	});
+
+	it("publishes synchronous registration immediately and prevents an older refresh from overwriting it", async () => {
+		const modelRuntime = await runtime(AuthStorage.inMemory({ slow: { type: "api_key", key: "key" } }));
+		const gate = deferred();
+		let block = false;
+		modelRuntime.registerNativeProvider(
+			nativeProvider("slow", () => [model("slow", "A")], {
+				refreshModels: async () => {
+					if (block) await gate.promise;
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		await modelRuntime.refresh({ allowNetwork: false });
+		block = true;
+		const stale = modelRuntime.refresh({ allowNetwork: false });
+		await Promise.resolve();
+		modelRuntime.registerProvider("instant", {
+			baseUrl: "https://instant.test/v1",
+			apiKey: "key",
+			api: "openai-completions",
+			models: [model("instant", "B")],
+		});
+
+		expect(modelRuntime.getModel("instant", "B")).toBeDefined();
+		expect(
+			modelRuntime
+				.getProvider("instant")
+				?.getModels()
+				.map((entry) => entry.id),
+		).toEqual(["B"]);
+		expect(modelRuntime.hasConfiguredAuth("instant")).toBe(true);
+		gate.resolve();
+		await expect(stale).resolves.toMatchObject({ aborted: true });
+		await waitFor(() => expect(modelRuntime.getModel("instant", "B")).toBeDefined());
+		expect(modelRuntime.getModels("instant").map((entry) => entry.id)).toEqual(["B"]);
+	});
+
+	it("merges model headers with configured headers", async () => {
+		const modelRuntime = await runtime();
+		modelRuntime.registerProvider("configured-headers", {
+			baseUrl: "https://configured-headers.test/v1",
+			apiKey: "key",
+			api: "openai-completions",
+			models: [
+				{
+					...model("configured-headers", "model"),
+					headers: { "x-configured": "configured", "x-shared": "configured" },
+				},
+			],
+		});
+		const configured = modelRuntime.getModel("configured-headers", "model");
+		expect(configured).toBeDefined();
+
+		const auth = await modelRuntime.getAuth({
+			...configured!,
+			headers: { "x-model": "model", "x-shared": "model" },
+		});
+
+		expect(auth?.auth.headers).toEqual({
+			"x-model": "model",
+			"x-shared": "configured",
+			"x-configured": "configured",
+		});
+	});
+
+	it("recovers convergence after a transient owner failure when a newer registration arrives", async () => {
+		const base = new InMemoryCredentialStore();
+		let failNextList = false;
+		const failedListStarted = deferred();
+		const releaseFailedList = deferred();
+		const credentials: CredentialStore = {
+			read: (providerId) => base.read(providerId),
+			list: async () => {
+				if (failNextList) {
+					failNextList = false;
+					failedListStarted.resolve();
+					await releaseFailedList.promise;
+					throw new Error("transient convergence failure");
+				}
+				return base.list();
+			},
+			modify: (providerId, fn) => base.modify(providerId, fn),
+			delete: (providerId) => base.delete(providerId),
+		};
+		const modelRuntime = await runtime(credentials);
+		failNextList = true;
+		modelRuntime.registerProvider("first", {
+			baseUrl: "https://first.test/v1",
+			apiKey: "key",
+			api: "openai-completions",
+			models: [model("first", "one")],
+		});
+		await failedListStarted.promise;
+		modelRuntime.registerProvider("second", {
+			baseUrl: "https://second.test/v1",
+			apiKey: "key",
+			api: "openai-completions",
+			models: [model("second", "two")],
+		});
+		releaseFailedList.resolve();
+		await waitFor(() => expect(modelRuntime.getError() ?? "").not.toContain("transient convergence failure"));
+		expect(modelRuntime.getModel("first", "one")).toBeDefined();
+		expect(modelRuntime.getModel("second", "two")).toBeDefined();
+	});
+
+	it("bounds self-triggered convergence churn and accepts a later recovery registration", async () => {
+		const modelRuntime = await runtime(AuthStorage.inMemory({ churn: { type: "api_key", key: "key" } }));
+		let churn = true;
+		let refreshes = 0;
+		const churnProvider = nativeProvider("churn", () => [model("churn", "stable")], {
+			refreshModels: async () => {
+				refreshes++;
+				if (churn) modelRuntime.registerNativeProvider(churnProvider);
+			},
+		});
+
+		modelRuntime.registerNativeProvider(churnProvider);
+		await waitFor(() => expect(modelRuntime.getError()).toContain("convergence"));
+		// Public contract: self-triggered churn is bounded; exact attempt count is private.
+		expect(refreshes).toBeGreaterThan(0);
+		expect(refreshes).toBeLessThan(50);
+		churn = false;
+		modelRuntime.registerProvider("recovery", {
+			baseUrl: "https://recovery.test/v1",
+			apiKey: "key",
+			api: "openai-completions",
+			models: [model("recovery", "works")],
+		});
+		await waitFor(() => expect(modelRuntime.getError() ?? "").not.toContain("convergence"));
+		expect(modelRuntime.getModel("recovery", "works")).toBeDefined();
+	});
+
+	it("retries a failed global availability read for the same published state", async () => {
+		const base = new InMemoryCredentialStore();
+		await base.modify("retry", async () => ({ type: "api_key", key: "key" }));
+		let failNextRead = false;
+		const credentials: CredentialStore = {
+			read: async (providerId) => {
+				if (providerId === "retry" && failNextRead) {
+					failNextRead = false;
+					throw new Error("transient availability read");
+				}
+				return base.read(providerId);
+			},
+			list: () => base.list(),
+			modify: (providerId, fn) => base.modify(providerId, fn),
+			delete: (providerId) => base.delete(providerId),
+		};
+		const modelRuntime = await runtime(credentials);
+		modelRuntime.registerNativeProvider(nativeProvider("retry", () => [model("retry", "ready")]));
+		await modelRuntime.refresh({ allowNetwork: false });
+		failNextRead = true;
+
+		await expect(modelRuntime.getAvailable()).rejects.toThrow("transient availability read");
+		await expect(modelRuntime.getAvailable()).resolves.toContainEqual(model("retry", "ready"));
+		expect(modelRuntime.getError()).toBeUndefined();
+	});
+
+	it("preserves stored API-key auth through a compatible same-provider overlay", async () => {
+		const modelRuntime = await runtime(
+			AuthStorage.inMemory({ anthropic: { type: "api_key", key: "stored-anthropic" } }),
+		);
+		const original = modelRuntime.getModels("anthropic");
+		expect(original.length).toBeGreaterThan(0);
+
+		modelRuntime.registerProvider("anthropic", { baseUrl: "https://proxy.test/v1" });
+
+		expect(modelRuntime.getProviderAuthStatus("anthropic")).toEqual({ configured: true, source: "stored" });
+		expect(modelRuntime.hasConfiguredAuth("anthropic")).toBe(true);
+		expect((await modelRuntime.checkAuth("anthropic"))?.type).toBe("api_key");
+		expect(modelRuntime.getAvailableSnapshot()).toHaveLength(original.length);
+		expect((await modelRuntime.getAuth("anthropic"))?.auth.apiKey).toBe("stored-anthropic");
+	});
+
+	it("preserves an unchanged configured provider when another provider is registered", async () => {
+		const modelRuntime = await runtime(
+			AuthStorage.inMemory({ anthropic: { type: "api_key", key: "stored-anthropic" } }),
+		);
+		modelRuntime.registerProvider("anthropic", { baseUrl: "https://first-proxy.test/v1" });
+		await modelRuntime.refresh({ allowNetwork: false });
+		const available = modelRuntime.getAvailableSnapshot().filter((entry) => entry.provider === "anthropic");
+
+		modelRuntime.registerProvider("unrelated", {
+			baseUrl: "https://unrelated.test/v1",
+			apiKey: "unrelated-key",
+			api: "openai-completions",
+			models: [model("unrelated", "one")],
+		});
+
+		expect(modelRuntime.getProviderAuthStatus("anthropic")).toEqual({ configured: true, source: "stored" });
+		expect((await modelRuntime.checkAuth("anthropic"))?.type).toBe("api_key");
+		expect(modelRuntime.getAvailableSnapshot().filter((entry) => entry.provider === "anthropic")).toEqual(available);
+		expect((await modelRuntime.getAuth("anthropic"))?.auth.apiKey).toBe("stored-anthropic");
+	});
+
+	it("immediately projects compatible stored credentials onto native provider replacements", async () => {
+		const credentials = AuthStorage.inMemory({
+			"native-api-key": { type: "api_key", key: "native-key" },
+			"native-oauth": {
+				type: "oauth",
+				access: "oauth-access",
+				refresh: "oauth-refresh",
+				expires: Date.now() + 60_000,
+			},
+		});
+		const modelRuntime = await runtime(credentials);
+		modelRuntime.registerNativeProvider(nativeProvider("native-api-key", () => [model("native-api-key", "first")]));
+		modelRuntime.registerNativeProvider(nativeOAuthProvider("native-oauth", () => [model("native-oauth", "first")]));
+		await modelRuntime.refresh({ allowNetwork: false });
+
+		modelRuntime.registerNativeProvider(
+			nativeProvider("native-api-key", () => [model("native-api-key", "replacement")]),
+		);
+		modelRuntime.registerNativeProvider(
+			nativeOAuthProvider("native-oauth", () => [model("native-oauth", "replacement")]),
+		);
+
+		expect(modelRuntime.getProviderAuthStatus("native-api-key")).toEqual({ configured: true, source: "stored" });
+		expect(modelRuntime.getProviderAuthStatus("native-oauth")).toEqual({ configured: true, source: "stored" });
+		expect((await modelRuntime.checkAuth("native-api-key"))?.type).toBe("api_key");
+		expect((await modelRuntime.checkAuth("native-oauth"))?.type).toBe("oauth");
+		expect((await modelRuntime.getAuth("native-api-key"))?.auth.apiKey).toBe("native-key");
+		expect((await modelRuntime.getAuth("native-oauth"))?.auth.apiKey).toBe("oauth-access");
+	});
+
+	it("immediately fails closed when configured API-key auth replaces stored OAuth", async () => {
+		const modelRuntime = await runtime(
+			AuthStorage.inMemory({
+				"oauth-to-configured-key": {
+					type: "oauth",
+					access: "oauth-access",
+					refresh: "oauth-refresh",
+					expires: Date.now() + 60_000,
+				},
+				"refresh-owner": { type: "api_key", key: "owner-key" },
+			}),
+		);
+		const refreshStarted = deferred();
+		const releaseRefresh = deferred();
+		let blockRefresh = false;
+		modelRuntime.registerNativeProvider(
+			nativeOAuthProvider("oauth-to-configured-key", () => [model("oauth-to-configured-key", "oauth")]),
+		);
+		modelRuntime.registerNativeProvider(
+			nativeProvider("refresh-owner", () => [model("refresh-owner", "owner")], {
+				refreshModels: async () => {
+					if (!blockRefresh) return;
+					refreshStarted.resolve();
+					await releaseRefresh.promise;
+				},
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		await modelRuntime.refresh({ allowNetwork: false });
+		blockRefresh = true;
+		const staleRefresh = modelRuntime.refresh({ allowNetwork: false });
+		await refreshStarted.promise;
+
+		modelRuntime.registerProvider("oauth-to-configured-key", {
+			baseUrl: "https://oauth-to-configured-key.test/v1",
+			apiKey: "configured-key",
+			api: "openai-completions",
+			models: [model("oauth-to-configured-key", "api-key")],
+		});
+
+		expect(modelRuntime.hasConfiguredAuth("oauth-to-configured-key")).toBe(false);
+		expect(await modelRuntime.checkAuth("oauth-to-configured-key")).toBeUndefined();
+		expect(modelRuntime.getProviderAuthStatus("oauth-to-configured-key")).toEqual({ configured: false });
+		expect(modelRuntime.getAvailableSnapshot().some((entry) => entry.provider === "oauth-to-configured-key")).toBe(
+			false,
+		);
+		expect(await modelRuntime.getAuth("oauth-to-configured-key")).toBeUndefined();
+
+		releaseRefresh.resolve();
+		await expect(staleRefresh).resolves.toMatchObject({ aborted: true });
+		await modelRuntime.refresh({ allowNetwork: false });
+
+		modelRuntime.registerProvider("unrelated-after-convergence", {
+			baseUrl: "https://unrelated-after-convergence.test/v1",
+			apiKey: "unrelated-key",
+			api: "openai-completions",
+			models: [model("unrelated-after-convergence", "one")],
+		});
+
+		expect(modelRuntime.hasConfiguredAuth("oauth-to-configured-key")).toBe(false);
+		expect(await modelRuntime.checkAuth("oauth-to-configured-key")).toBeUndefined();
+		expect(modelRuntime.getProviderAuthStatus("oauth-to-configured-key")).toEqual({ configured: false });
+		expect(modelRuntime.getAvailableSnapshot().some((entry) => entry.provider === "oauth-to-configured-key")).toBe(
+			false,
+		);
+		expect(await modelRuntime.getAuth("oauth-to-configured-key")).toBeUndefined();
+	});
+
+	it("fails closed across incompatible provider replacements and removal", async () => {
+		const credentials = AuthStorage.inMemory({
+			"oauth-to-key": {
+				type: "oauth",
+				access: "access",
+				refresh: "refresh",
+				expires: Date.now() + 60_000,
+			},
+			"key-to-oauth": { type: "api_key", key: "stored-key" },
+		});
+		const modelRuntime = await runtime(credentials);
+		modelRuntime.registerNativeProvider(nativeOAuthProvider("oauth-to-key", () => [model("oauth-to-key", "oauth")]));
+		modelRuntime.registerNativeProvider(nativeProvider("key-to-oauth", () => [model("key-to-oauth", "api-key")]));
+		await modelRuntime.refresh({ allowNetwork: false });
+		expect(modelRuntime.isUsingOAuth("oauth-to-key")).toBe(true);
+		expect(modelRuntime.isUsingOAuth("key-to-oauth")).toBe(false);
+
+		modelRuntime.registerNativeProvider(nativeProvider("oauth-to-key", () => [model("oauth-to-key", "api-key")]));
+		modelRuntime.registerNativeProvider(nativeOAuthProvider("key-to-oauth", () => [model("key-to-oauth", "oauth")]));
+		for (const providerId of ["oauth-to-key", "key-to-oauth"]) {
+			expect(modelRuntime.hasConfiguredAuth(providerId)).toBe(false);
+			expect(modelRuntime.getProviderAuthStatus(providerId)).toEqual({ configured: false });
+			expect(await modelRuntime.checkAuth(providerId)).toBeUndefined();
+			expect(await modelRuntime.getAuth(providerId)).toBeUndefined();
+		}
+		expect(modelRuntime.getAvailableSnapshot().some((entry) => entry.provider === "oauth-to-key")).toBe(false);
+		expect(modelRuntime.getAvailableSnapshot().some((entry) => entry.provider === "key-to-oauth")).toBe(false);
+
+		modelRuntime.unregisterProvider("oauth-to-key");
+		expect(modelRuntime.getProvider("oauth-to-key")).toBeUndefined();
+		expect(modelRuntime.hasConfiguredAuth("oauth-to-key")).toBe(false);
+		expect(modelRuntime.getProviderAuthStatus("oauth-to-key")).toEqual({ configured: false });
+		expect(await modelRuntime.checkAuth("oauth-to-key")).toBeUndefined();
+		expect(modelRuntime.getAvailableSnapshot().some((entry) => entry.provider === "oauth-to-key")).toBe(false);
+	});
+
+	it("keeps scoped availability independent from an unrelated blocked global read", async () => {
+		const base = new InMemoryCredentialStore();
+		await base.modify("scoped", async () => ({ type: "api_key", key: "key" }));
+		await base.modify("blocked", async () => ({ type: "api_key", key: "key" }));
+		const blocked = deferred<Awaited<ReturnType<CredentialStore["read"]>>>();
+		let blockGlobal = false;
+		const credentials: CredentialStore = {
+			read: (providerId) => (blockGlobal && providerId === "blocked" ? blocked.promise : base.read(providerId)),
+			list: () => base.list(),
+			modify: (providerId, fn) => base.modify(providerId, fn),
+			delete: (providerId) => base.delete(providerId),
+		};
+		const modelRuntime = await runtime(credentials);
+		modelRuntime.registerNativeProvider(nativeProvider("scoped", () => [model("scoped", "ready")]));
+		modelRuntime.registerNativeProvider(nativeProvider("blocked", () => [model("blocked", "wait")]));
+		await modelRuntime.refresh({ allowNetwork: false });
+		await modelRuntime.refresh({ allowNetwork: false });
+		blockGlobal = true;
+		const globalReadStarted = deferred();
+		const originalRead = credentials.read;
+		credentials.read = async (providerId) => {
+			if (providerId === "blocked") globalReadStarted.resolve();
+			return originalRead(providerId);
+		};
+		const global = modelRuntime.getAvailable();
+		await globalReadStarted.promise;
+
+		await expect(modelRuntime.getAvailable("scoped")).resolves.toEqual([model("scoped", "ready")]);
+		blocked.reject(new Error("unrelated failure"));
+		await expect(global).rejects.toThrow("unrelated failure");
+		await expect(modelRuntime.getAvailable("scoped")).resolves.toEqual([model("scoped", "ready")]);
+	});
+
+	it("publishes login, logout, and runtime API-key changes only with their refresh transaction", async () => {
+		const modelRuntime = await runtime();
+		let gate: Deferred | undefined;
+		modelRuntime.registerNativeProvider(
+			nativeProvider("mutations", () => [model("mutations", "one")], {
+				auth: {
+					apiKey: {
+						name: "mutation key",
+						login: async () => ({ type: "api_key", key: "login-key" }),
+						check: async ({ credential }) =>
+							credential?.key ? { type: "api_key", source: credential.key } : undefined,
+						resolve: async ({ credential }) =>
+							credential?.key ? { auth: { apiKey: credential.key }, source: credential.key } : undefined,
+					},
+				},
+				refreshModels: async () => gate?.promise,
+			}),
+		);
+		await modelRuntime.refresh({ allowNetwork: false });
+		gate = deferred();
+
+		const login = modelRuntime.login("mutations", "api_key", { prompt: async () => "unused", notify: () => {} });
+		await Promise.resolve();
+		expect(modelRuntime.hasConfiguredAuth("mutations")).toBe(false);
+		gate.resolve();
+		await login;
+		expect((await modelRuntime.checkAuth("mutations"))?.source).toBe("login-key");
+
+		gate = deferred();
+		const logout = modelRuntime.logout("mutations");
+		await Promise.resolve();
+		expect(modelRuntime.hasConfiguredAuth("mutations")).toBe(true);
+		gate.resolve();
+		await logout;
+		expect(modelRuntime.hasConfiguredAuth("mutations")).toBe(false);
+
+		gate = deferred();
+		const setKey = modelRuntime.setRuntimeApiKey("mutations", "runtime-key", { allowNetwork: false });
+		await Promise.resolve();
+		expect(modelRuntime.hasConfiguredAuth("mutations")).toBe(false);
+		gate.resolve();
+		await setKey;
+		expect((await modelRuntime.checkAuth("mutations"))?.source).toBe("runtime-key");
+
+		gate = deferred();
+		const removeKey = modelRuntime.removeRuntimeApiKey("mutations");
+		await Promise.resolve();
+		expect(modelRuntime.hasConfiguredAuth("mutations")).toBe(true);
+		gate.resolve();
+		await removeKey;
+		expect(modelRuntime.hasConfiguredAuth("mutations")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/model-runtime-modify-models-compat.test.ts
+++ b/packages/coding-agent/test/model-runtime-modify-models-compat.test.ts
@@ -67,7 +67,8 @@ describe("extension provider model lifecycle", () => {
 
 		runtime.registerNativeProvider(provider);
 		const registry = new ModelRegistry(runtime);
-		expect(registry.getProvider("extension-native")).toBe(provider);
+		expect(registry.getProvider("extension-native")).not.toBe(provider);
+		expect(registry.getProvider("extension-native")).toMatchObject({ id: provider.id, name: provider.name });
 		expect(registry.getRegisteredNativeProvider("extension-native")).toBe(provider);
 		expect(registry.getRegisteredProviderIds()).toContain("extension-native");
 		expect(registry.find("extension-native", "native")).toBeDefined();

--- a/packages/coding-agent/test/scoped-models-refresh.test.ts
+++ b/packages/coding-agent/test/scoped-models-refresh.test.ts
@@ -1,0 +1,677 @@
+import type { Api, Model, ModelsRefreshOptions, ModelsRefreshResult } from "@earendil-works/pi-ai";
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as ModelResolver from "../src/core/model-resolver.ts";
+
+const { resolveModelScopeWithDiagnosticsMock } = vi.hoisted(() => ({
+	resolveModelScopeWithDiagnosticsMock: vi.fn(),
+}));
+
+vi.mock("../src/core/model-resolver.ts", async (importOriginal) => {
+	const actual = await importOriginal<typeof ModelResolver>();
+	return {
+		...actual,
+		resolveModelScopeWithDiagnostics: resolveModelScopeWithDiagnosticsMock,
+	};
+});
+
+import { KeybindingsManager } from "../src/core/keybindings.ts";
+import type { ScopedModelsSelectorComponent } from "../src/modes/interactive/components/scoped-models-selector.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function model(id: string, name = id): Model<Api> {
+	return {
+		provider: "faux",
+		id,
+		name,
+		api: "openai-completions",
+	} as Model<Api>;
+}
+
+function fullId(model: Model<Api>): string {
+	return `${model.provider}/${model.id}`;
+}
+
+function render(selector: ScopedModelsSelectorComponent): string {
+	return stripAnsi(selector.render(120).join("\n"));
+}
+
+function openScopedModelsSelector(context: object): void {
+	Reflect.set(
+		context,
+		"refreshScopedModelsSelector",
+		Reflect.get(InteractiveMode.prototype, "refreshScopedModelsSelector"),
+	);
+	const show = Reflect.get(InteractiveMode.prototype, "showModelsSelector") as (this: object) => void;
+	show.call(context);
+}
+
+function createContext(options: {
+	snapshot: () => readonly Model<Api>[];
+	refresh: (options?: ModelsRefreshOptions) => Promise<ModelsRefreshResult>;
+	configuredPatterns?: string[];
+	scopedModels?: Array<{
+		model: Model<Api>;
+		thinkingLevel?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+	}>;
+}) {
+	let selector: ScopedModelsSelectorComponent | undefined;
+	let disposeSelector: (() => void) | undefined;
+	const session = {
+		modelRuntime: {
+			getAvailableSnapshot: options.snapshot,
+			refresh: vi.fn(options.refresh),
+			// The selector must not use this moving global runtime view when it applies a callback.
+			getAvailable: vi.fn(async () => [model("wrong", "Wrong runtime model")]),
+			getError: () => undefined,
+		},
+		scopedModels: options.scopedModels ?? [],
+		setScopedModels: vi.fn(),
+	};
+	const context = {
+		session,
+		settingsManager: {
+			getEnabledModels: () => options.configuredPatterns,
+			setEnabledModels: vi.fn(),
+		},
+		showStatus: vi.fn(),
+		showSelector: (
+			factory: (done: () => void) => {
+				component: ScopedModelsSelectorComponent;
+				dispose?: () => void;
+			},
+		) => {
+			const view = factory(() => {});
+			selector = view.component;
+			disposeSelector = view.dispose;
+			return true;
+		},
+		updateAvailableProviderCount: vi.fn(async () => {}),
+		ui: { requestRender: vi.fn() },
+	};
+	return {
+		context,
+		session,
+		getSelector: () => selector,
+		disposeSelector: () => disposeSelector?.(),
+	};
+}
+
+describe("/scoped-models cache-first refresh", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(async () => {
+		setKeybindings(new KeybindingsManager());
+		const { resolveModelScopeWithDiagnostics } = await vi.importActual<typeof ModelResolver>(
+			"../src/core/model-resolver.ts",
+		);
+		resolveModelScopeWithDiagnosticsMock.mockReset();
+		resolveModelScopeWithDiagnosticsMock.mockImplementation(resolveModelScopeWithDiagnostics);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("keeps raw wildcard settings until an edit, then combines their resolved models and no-match rows", async () => {
+		const alpha = model("alpha", "Alpha cached");
+		const refresh = deferred<ModelsRefreshResult>();
+		const patterns = ["faux/*:high", "faux/missing"];
+		const { context, getSelector } = createContext({
+			snapshot: () => [alpha],
+			refresh: () => refresh.promise,
+			configuredPatterns: patterns,
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		// The mounting view is synchronous and represents the raw settings rather than prematurely materializing a glob.
+		expect(render(selector)).toContain("faux/*:high [unavailable]");
+		await vi.waitFor(() => {
+			expect(render(selector)).toContain("alpha [faux] ✓");
+			expect(render(selector)).toContain("faux/missing [unavailable] ✗");
+		});
+		selector.handleInput("\x13");
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(patterns);
+		selector.handleInput("\x1b[1;3B");
+		selector.handleInput("\x13");
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(["faux/missing", "faux/alpha:high"]);
+		refresh.resolve({ aborted: true, errors: new Map() });
+	});
+
+	it("keeps wildcard thinking levels through a resolved edit without broadening the session scope", async () => {
+		const alpha = model("alpha");
+		const beta = model("beta");
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, session, getSelector } = createContext({
+			snapshot: () => [alpha, beta],
+			refresh: () => refresh.promise,
+			configuredPatterns: ["faux/*:high"],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		await vi.waitFor(() => {
+			expect(render(selector)).toContain("alpha [faux] ✓");
+			expect(render(selector)).toContain("beta [faux] ✓");
+		});
+
+		selector.handleInput("\x1b[1;3B");
+		await vi.waitFor(() => {
+			expect(session.setScopedModels).toHaveBeenLastCalledWith([
+				{ model: beta, thinkingLevel: "high" },
+				{ model: alpha, thinkingLevel: "high" },
+			]);
+		});
+		expect(session.setScopedModels).not.toHaveBeenLastCalledWith([]);
+
+		selector.handleInput("\x13");
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(["faux/beta:high", "faux/alpha:high"]);
+		refresh.resolve({ aborted: true, errors: new Map() });
+	});
+
+	it("saves an untouched session scope with its thinking level instead of configured settings", async () => {
+		const configured = model("configured");
+		const session = model("session");
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, getSelector } = createContext({
+			snapshot: () => [configured, session],
+			refresh: () => refresh.promise,
+			configuredPatterns: [fullId(configured)],
+			scopedModels: [{ model: session, thinkingLevel: "high" }],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		selector.handleInput("\x13");
+
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(["faux/session:high"]);
+		refresh.resolve({ aborted: true, errors: new Map() });
+	});
+
+	it("does not clear an existing session scope for an empty catalog or an unresolved-only selection", async () => {
+		const prior = model("prior");
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, session, getSelector } = createContext({
+			snapshot: () => [],
+			refresh: () => refresh.promise,
+			configuredPatterns: ["faux/missing"],
+			scopedModels: [{ model: prior }],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		expect(render(selector)).toContain("faux/prior [unavailable] ✗");
+		selector.handleInput("\r");
+		await Promise.resolve();
+		expect(session.setScopedModels).not.toHaveBeenCalled();
+		refresh.resolve({ aborted: false, errors: new Map() });
+		await Promise.resolve();
+		expect(session.setScopedModels).not.toHaveBeenCalled();
+	});
+
+	it("keeps a scope containing every available model plus an unresolved pattern", async () => {
+		const alpha = model("alpha");
+		const refresh = deferred<ModelsRefreshResult>();
+		const patterns = [fullId(alpha), "faux/missing"];
+		const { context, session, getSelector } = createContext({
+			snapshot: () => [alpha],
+			refresh: () => refresh.promise,
+			configuredPatterns: patterns,
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		await vi.waitFor(() => expect(render(selector)).toContain("faux/missing [unavailable] ✗"));
+		// Reordering is an intentional edit, so the wildcard/ID representation may materialize but the unresolved row remains.
+		selector.handleInput("\x1b[1;3B");
+		await vi.waitFor(() => expect(session.setScopedModels).toHaveBeenLastCalledWith([{ model: alpha }]));
+		selector.handleInput("\x13");
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(["faux/missing", fullId(alpha)]);
+		refresh.resolve({ aborted: true, errors: new Map() });
+	});
+
+	it("preserves thinking level when a callback uses refreshed model objects", async () => {
+		const alpha = model("alpha", "Alpha cached");
+		const beta = model("beta", "Beta cached");
+		const refreshedAlpha = model("alpha", "Alpha refreshed");
+		const refreshedBeta = model("beta", "Beta refreshed");
+		const gamma = model("gamma", "Gamma refreshed");
+		let snapshot: readonly Model<Api>[] = [alpha, beta];
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, session, getSelector } = createContext({
+			snapshot: () => snapshot,
+			refresh: () => refresh.promise,
+			scopedModels: [
+				{ model: alpha, thinkingLevel: "high" },
+				{ model: beta, thinkingLevel: "low" },
+			],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		snapshot = [refreshedAlpha, refreshedBeta, gamma];
+		refresh.resolve({ aborted: false, errors: new Map() });
+		await vi.waitFor(() => expect(render(selector)).toContain("Model Name: Alpha refreshed"));
+		selector.handleInput("\x1b[1;3B");
+		await vi.waitFor(() => {
+			expect(session.setScopedModels).toHaveBeenLastCalledWith([
+				{ model: refreshedBeta, thinkingLevel: "low" },
+				{ model: refreshedAlpha, thinkingLevel: "high" },
+			]);
+		});
+		selector.handleInput("\x13");
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(["faux/beta:low", "faux/alpha:high"]);
+	});
+
+	it("uses the refreshed selector catalog rather than a newer runtime catalog in callbacks", async () => {
+		const alpha = model("alpha", "Alpha cached");
+		const beta = model("beta", "Beta cached");
+		const refreshedAlpha = model("alpha", "Alpha refreshed");
+		const refreshedBeta = model("beta", "Beta refreshed");
+		const gamma = model("gamma", "Gamma refreshed");
+		let snapshot: readonly Model<Api>[] = [alpha, beta];
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, session, getSelector } = createContext({
+			snapshot: () => snapshot,
+			refresh: () => refresh.promise,
+			scopedModels: [{ model: alpha }],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		snapshot = [refreshedAlpha, refreshedBeta, gamma];
+		refresh.resolve({ aborted: false, errors: new Map() });
+		await vi.waitFor(() => expect(render(selector)).toContain("Model Name: Alpha refreshed"));
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\r");
+		await vi.waitFor(() => {
+			expect(session.setScopedModels).toHaveBeenLastCalledWith([
+				{ model: refreshedAlpha },
+				{ model: refreshedBeta },
+			]);
+		});
+		expect(session.modelRuntime.getAvailable).not.toHaveBeenCalled();
+	});
+
+	it("serializes rapid changes so the latest reordered scope wins", async () => {
+		const alpha = model("alpha");
+		const beta = model("beta");
+		const gamma = model("gamma");
+		const delta = model("delta");
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, session, getSelector } = createContext({
+			snapshot: () => [alpha, beta, gamma, delta],
+			refresh: () => refresh.promise,
+			scopedModels: [{ model: alpha }, { model: beta }, { model: gamma }],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		selector.handleInput("\x1b[1;3B");
+		selector.handleInput("\x1b[1;3B");
+		await vi.waitFor(() => {
+			expect(session.setScopedModels).toHaveBeenLastCalledWith([
+				{ model: beta },
+				{ model: gamma },
+				{ model: alpha },
+			]);
+		});
+		refresh.resolve({ aborted: true, errors: new Map() });
+	});
+
+	it("keeps the refreshed configured resolution when the cached resolution finishes last", async () => {
+		const alpha = model("alpha", "Alpha cached");
+		const beta = model("beta", "Beta refreshed");
+		let snapshot: readonly Model<Api>[] = [alpha];
+		const cachedResolution = deferred<{
+			scopedModels: Array<{ model: Model<Api>; thinkingLevel?: "high" }>;
+			diagnostics: [];
+		}>();
+		const refreshedResolution = deferred<{
+			scopedModels: Array<{ model: Model<Api>; thinkingLevel?: "high" }>;
+			diagnostics: [];
+		}>();
+		resolveModelScopeWithDiagnosticsMock
+			.mockReturnValueOnce(cachedResolution.promise)
+			.mockReturnValueOnce(refreshedResolution.promise);
+		const { context, session, getSelector } = createContext({
+			snapshot: () => snapshot,
+			refresh: async () => {
+				snapshot = [beta];
+				return { aborted: false, errors: new Map() };
+			},
+			configuredPatterns: ["faux/*:high"],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		await vi.waitFor(() => expect(resolveModelScopeWithDiagnosticsMock).toHaveBeenCalledTimes(2));
+
+		refreshedResolution.resolve({
+			scopedModels: [{ model: beta, thinkingLevel: "high" }],
+			diagnostics: [],
+		});
+		await vi.waitFor(() => expect(render(selector)).toContain("→ beta [faux] ✓"));
+		cachedResolution.resolve({
+			scopedModels: [{ model: alpha, thinkingLevel: "high" }],
+			diagnostics: [],
+		});
+		await cachedResolution.promise;
+		await Promise.resolve();
+
+		expect(render(selector)).toContain("→ beta [faux] ✓");
+		expect(render(selector)).not.toContain("alpha [unavailable] ✓");
+		selector.handleInput("\r");
+		selector.handleInput("\r");
+		await vi.waitFor(() =>
+			expect(session.setScopedModels).toHaveBeenLastCalledWith([{ model: beta, thinkingLevel: "high" }]),
+		);
+		selector.handleInput("\x13");
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(["faux/beta:high"]);
+	});
+
+	it("applies cached resolution before the refreshed resolution replaces it", async () => {
+		const alpha = model("alpha", "Alpha cached");
+		const beta = model("beta", "Beta refreshed");
+		let snapshot: readonly Model<Api>[] = [alpha];
+		const catalogRefresh = deferred<ModelsRefreshResult>();
+		const cachedResolution = deferred<{
+			scopedModels: Array<{ model: Model<Api>; thinkingLevel?: "high" }>;
+			diagnostics: [];
+		}>();
+		const refreshedResolution = deferred<{
+			scopedModels: Array<{ model: Model<Api>; thinkingLevel?: "high" }>;
+			diagnostics: [];
+		}>();
+		resolveModelScopeWithDiagnosticsMock
+			.mockReturnValueOnce(cachedResolution.promise)
+			.mockReturnValueOnce(refreshedResolution.promise);
+		const { context, session, getSelector } = createContext({
+			snapshot: () => snapshot,
+			refresh: () => catalogRefresh.promise,
+			configuredPatterns: ["faux/*:high"],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		await vi.waitFor(() => expect(resolveModelScopeWithDiagnosticsMock).toHaveBeenCalledTimes(1));
+
+		cachedResolution.resolve({
+			scopedModels: [{ model: alpha, thinkingLevel: "high" }],
+			diagnostics: [],
+		});
+		await vi.waitFor(() => expect(render(selector)).toContain("→ alpha [faux] ✓"));
+		snapshot = [beta];
+		catalogRefresh.resolve({ aborted: false, errors: new Map() });
+		await vi.waitFor(() => expect(resolveModelScopeWithDiagnosticsMock).toHaveBeenCalledTimes(2));
+		refreshedResolution.resolve({
+			scopedModels: [{ model: beta, thinkingLevel: "high" }],
+			diagnostics: [],
+		});
+		await vi.waitFor(() => expect(render(selector)).toContain("→ beta [faux] ✓"));
+
+		expect(render(selector)).not.toContain("alpha [unavailable] ✓");
+		selector.handleInput("\r");
+		selector.handleInput("\r");
+		await vi.waitFor(() =>
+			expect(session.setScopedModels).toHaveBeenLastCalledWith([{ model: beta, thinkingLevel: "high" }]),
+		);
+		selector.handleInput("\x13");
+		expect(context.settingsManager.setEnabledModels).toHaveBeenLastCalledWith(["faux/beta:high"]);
+	});
+
+	it("shows a stable TUI error without secret-bearing refresh exception text", async () => {
+		const alpha = model("alpha");
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const unhandledRejection = vi.fn();
+		const onUnhandledRejection = (reason: unknown) => unhandledRejection(reason);
+		process.on("unhandledRejection", onUnhandledRejection);
+		const { context, getSelector } = createContext({
+			snapshot: () => [alpha],
+			refresh: async () => {
+				throw new Error("secret-token-refresh");
+			},
+		});
+
+		try {
+			openScopedModelsSelector(context);
+			const selector = getSelector();
+			if (!selector) throw new Error("Expected selector");
+			await vi.waitFor(() => {
+				expect(render(selector)).toContain("Could not refresh model catalogs; showing cached models.");
+			});
+			const view = render(selector);
+			expect(view).not.toContain("secret-token-refresh");
+			expect(view).not.toContain("Refreshing model catalogs\u2026");
+			expect(context.ui.requestRender).toHaveBeenCalled();
+			for (const call of consoleError.mock.calls) {
+				expect(call.join(" ")).not.toContain("secret-token-refresh");
+			}
+			expect(unhandledRejection).not.toHaveBeenCalled();
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("keeps the refreshed selector usable when configured scope resolution fails", async () => {
+		const alpha = model("alpha");
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const unhandledRejection = vi.fn();
+		const onUnhandledRejection = (reason: unknown) => unhandledRejection(reason);
+		process.on("unhandledRejection", onUnhandledRejection);
+		const { resolveModelScopeWithDiagnostics } = await vi.importActual<typeof ModelResolver>(
+			"../src/core/model-resolver.ts",
+		);
+		resolveModelScopeWithDiagnosticsMock
+			.mockImplementationOnce(resolveModelScopeWithDiagnostics)
+			.mockRejectedValueOnce(new Error("secret-token-resolver"));
+		const { context, session, getSelector } = createContext({
+			snapshot: () => [alpha],
+			refresh: async () => ({ aborted: false, errors: new Map() }),
+			configuredPatterns: [fullId(alpha)],
+		});
+
+		try {
+			openScopedModelsSelector(context);
+			const selector = getSelector();
+			if (!selector) throw new Error("Expected selector");
+			await vi.waitFor(() => {
+				expect(render(selector)).toContain("Could not resolve configured model scope; showing current models.");
+			});
+			const view = render(selector);
+			expect(view).not.toContain("secret-token-resolver");
+			expect(view).not.toContain("Refreshing model catalogs\u2026");
+			expect(context.ui.requestRender).toHaveBeenCalled();
+			expect(consoleError).toHaveBeenCalledWith("Could not resolve configured model scope from refreshed catalog.");
+			for (const call of consoleError.mock.calls) {
+				expect(call.join(" ")).not.toContain("secret-token-resolver");
+			}
+			expect(unhandledRejection).not.toHaveBeenCalled();
+
+			selector.handleInput("\r");
+			await vi.waitFor(() => expect(session.setScopedModels).toHaveBeenLastCalledWith([]));
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("handles configured scope resolution failure after timeout without an unhandled rejection", async () => {
+		vi.useFakeTimers();
+		const alpha = model("alpha");
+		const completion = deferred<ModelsRefreshResult>();
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const unhandledRejection = vi.fn();
+		const onUnhandledRejection = (reason: unknown) => unhandledRejection(reason);
+		process.on("unhandledRejection", onUnhandledRejection);
+		try {
+			const { resolveModelScopeWithDiagnostics } = await vi.importActual<typeof ModelResolver>(
+				"../src/core/model-resolver.ts",
+			);
+			resolveModelScopeWithDiagnosticsMock
+				.mockImplementationOnce(resolveModelScopeWithDiagnostics)
+				.mockRejectedValueOnce(new Error("secret-token-resolver"));
+			const { context, session, getSelector } = createContext({
+				snapshot: () => [alpha],
+				refresh: () => completion.promise,
+				configuredPatterns: [fullId(alpha)],
+			});
+
+			openScopedModelsSelector(context);
+			const selector = getSelector();
+			if (!selector) throw new Error("Expected selector");
+			await vi.advanceTimersByTimeAsync(15_000);
+			await Promise.resolve();
+
+			const view = render(selector);
+			expect(view).toContain("Model refresh timed out; showing cached models.");
+			expect(view).toContain("Could not resolve configured model scope; showing current models.");
+			expect(view).not.toContain("secret-token-resolver");
+			expect(view).not.toContain("Refreshing model catalogs\u2026");
+			expect(context.ui.requestRender).toHaveBeenCalled();
+			expect(consoleError).toHaveBeenCalledWith("Could not resolve configured model scope from refreshed catalog.");
+			for (const call of consoleError.mock.calls) {
+				expect(call.join(" ")).not.toContain("secret-token-resolver");
+			}
+			expect(unhandledRejection).not.toHaveBeenCalled();
+
+			selector.handleInput("\r");
+			await vi.waitFor(() => expect(session.setScopedModels).toHaveBeenLastCalledWith([]));
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
+	});
+
+	it("does not apply configured resolution after selector disposal", async () => {
+		const alpha = model("alpha");
+		const configuredResolution = deferred<{
+			scopedModels: Array<{ model: Model<Api>; thinkingLevel?: "high" }>;
+			diagnostics: [];
+		}>();
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, getSelector, disposeSelector } = createContext({
+			snapshot: () => [alpha],
+			refresh: () => refresh.promise,
+			configuredPatterns: ["faux/*:high"],
+		});
+		resolveModelScopeWithDiagnosticsMock.mockReturnValueOnce(configuredResolution.promise);
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		const applyResolved = vi.spyOn(selector, "applyResolvedEnabledModelIds");
+		context.ui.requestRender.mockClear();
+		disposeSelector();
+		configuredResolution.resolve({
+			scopedModels: [{ model: alpha, thinkingLevel: "high" }],
+			diagnostics: [],
+		});
+		await configuredResolution.promise;
+		await Promise.resolve();
+
+		expect(applyResolved).not.toHaveBeenCalled();
+		expect(context.ui.requestRender).not.toHaveBeenCalled();
+		refresh.resolve({ aborted: true, errors: new Map() });
+	});
+
+	it("does not update the session after a queued selection resolution is disposed", async () => {
+		const alpha = model("alpha");
+		const beta = model("beta");
+		const gamma = model("gamma");
+		const selectionResolution = deferred<{
+			scopedModels: Array<{ model: Model<Api> }>;
+			diagnostics: [];
+		}>();
+		const refresh = deferred<ModelsRefreshResult>();
+		const { context, session, getSelector, disposeSelector } = createContext({
+			snapshot: () => [alpha, beta, gamma],
+			refresh: () => refresh.promise,
+			scopedModels: [{ model: alpha }, { model: beta }],
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		resolveModelScopeWithDiagnosticsMock.mockReturnValueOnce(selectionResolution.promise);
+		context.ui.requestRender.mockClear();
+		selector.handleInput("\x1b[1;3B");
+		await vi.waitFor(() => expect(resolveModelScopeWithDiagnosticsMock).toHaveBeenCalled());
+		disposeSelector();
+		selectionResolution.resolve({
+			scopedModels: [{ model: beta }, { model: alpha }],
+			diagnostics: [],
+		});
+		await selectionResolution.promise;
+		await Promise.resolve();
+
+		expect(session.setScopedModels).not.toHaveBeenCalled();
+		expect(context.ui.requestRender).not.toHaveBeenCalled();
+		refresh.resolve({ aborted: true, errors: new Map() });
+	});
+
+	it("applies a timeout exactly once and ignores a late completion or a disposed selector", async () => {
+		vi.useFakeTimers();
+		const cached = model("cached");
+		const late = model("late");
+		let snapshot: readonly Model<Api>[] = [cached];
+		const completion = deferred<ModelsRefreshResult>();
+		const { context, getSelector } = createContext({
+			snapshot: () => snapshot,
+			refresh: () => completion.promise,
+		});
+
+		openScopedModelsSelector(context);
+		const selector = getSelector();
+		if (!selector) throw new Error("Expected selector");
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(render(selector)).toContain("Model refresh timed out; showing cached models.");
+		snapshot = [late];
+		completion.resolve({ aborted: false, errors: new Map() });
+		await Promise.resolve();
+		expect(render(selector)).toContain("Model refresh timed out; showing cached models.");
+
+		const lateAfterDispose = deferred<ModelsRefreshResult>();
+		const disposedContext = createContext({
+			snapshot: () => [cached],
+			refresh: () => lateAfterDispose.promise,
+		});
+		openScopedModelsSelector(disposedContext.context);
+		const disposed = disposedContext.getSelector();
+		if (!disposed) throw new Error("Expected selector");
+		const renderedBeforeDispose = render(disposed);
+		disposed.dispose();
+		await vi.advanceTimersByTimeAsync(15_000);
+		lateAfterDispose.resolve({ aborted: false, errors: new Map() });
+		await Promise.resolve();
+		expect(render(disposed)).toBe(renderedBeforeDispose);
+		expect(disposedContext.context.ui.requestRender).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/selector-ownership.test.ts
+++ b/packages/coding-agent/test/selector-ownership.test.ts
@@ -1,0 +1,122 @@
+import { Container } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { SelectorOwnership } from "../src/modes/interactive/selector-ownership.ts";
+
+describe("InteractiveMode selector ownership", () => {
+	it("replaces the previous selector and disposes it once", () => {
+		const first = new Container();
+		const second = new Container();
+		const firstDispose = vi.fn();
+		const secondDispose = vi.fn();
+		const mount = vi.fn();
+		const restore = vi.fn();
+		const ownership = new SelectorOwnership(mount, restore);
+		let firstDone!: () => void;
+		let secondDone!: () => void;
+
+		expect(
+			ownership.show((done) => {
+				firstDone = done;
+				return { component: first, focus: first, dispose: firstDispose };
+			}),
+		).toBe(true);
+		expect(
+			ownership.show((done) => {
+				secondDone = done;
+				return { component: second, focus: second, dispose: secondDispose };
+			}),
+		).toBe(true);
+
+		expect(firstDispose).toHaveBeenCalledTimes(1);
+		expect(mount).toHaveBeenLastCalledWith(second, second);
+
+		firstDone();
+		secondDone();
+		secondDone();
+		expect(firstDispose).toHaveBeenCalledTimes(1);
+		expect(secondDispose).toHaveBeenCalledTimes(1);
+		expect(restore).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not replace the current selector when the factory finishes synchronously", () => {
+		const active = new Container();
+		const canceled = new Container();
+		const activeDispose = vi.fn();
+		const canceledDispose = vi.fn();
+		const mount = vi.fn();
+		const restore = vi.fn();
+		const ownership = new SelectorOwnership(mount, restore);
+		let activeDone!: () => void;
+
+		expect(
+			ownership.show((done) => {
+				activeDone = done;
+				return { component: active, focus: active, dispose: activeDispose };
+			}),
+		).toBe(true);
+		expect(
+			ownership.show((done) => {
+				done();
+				return { component: canceled, focus: canceled, dispose: canceledDispose };
+			}),
+		).toBe(false);
+
+		expect(activeDispose).not.toHaveBeenCalled();
+		expect(canceledDispose).toHaveBeenCalledTimes(1);
+		expect(mount).toHaveBeenCalledTimes(1);
+		expect(mount).toHaveBeenCalledWith(active, active);
+		expect(restore).not.toHaveBeenCalled();
+
+		activeDone();
+		expect(activeDispose).toHaveBeenCalledTimes(1);
+		expect(restore).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves the editor in place when a synchronously completed first selector is returned", () => {
+		const mount = vi.fn();
+		const restore = vi.fn();
+		const dispose = vi.fn();
+		const ownership = new SelectorOwnership(mount, restore);
+		const component = new Container();
+
+		expect(
+			ownership.show((done) => {
+				done();
+				return { component, focus: component, dispose };
+			}),
+		).toBe(false);
+
+		expect(dispose).toHaveBeenCalledTimes(1);
+		expect(mount).not.toHaveBeenCalled();
+		expect(restore).not.toHaveBeenCalled();
+	});
+
+	it("ignores a stale done callback after a newer selector is shown", () => {
+		const first = new Container();
+		const second = new Container();
+		const firstDispose = vi.fn();
+		const secondDispose = vi.fn();
+		const mount = vi.fn();
+		const restore = vi.fn();
+		const ownership = new SelectorOwnership(mount, restore);
+		let firstDone!: () => void;
+		let secondDone!: () => void;
+
+		ownership.show((done) => {
+			firstDone = done;
+			return { component: first, focus: first, dispose: firstDispose };
+		});
+		ownership.show((done) => {
+			secondDone = done;
+			return { component: second, focus: second, dispose: secondDispose };
+		});
+
+		firstDone();
+		expect(secondDispose).not.toHaveBeenCalled();
+		expect(restore).not.toHaveBeenCalled();
+
+		secondDone();
+		expect(secondDispose).toHaveBeenCalledTimes(1);
+		expect(restore).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/6949-unavailable-scoped-model.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6949-unavailable-scoped-model.test.ts
@@ -19,8 +19,10 @@ function createInteractiveContext(options: {
 	const context = {
 		session: {
 			modelRuntime: {
-				refresh: vi.fn(),
+				refresh: vi.fn().mockResolvedValue({ aborted: false, errors: new Map() }),
+				getAvailableSnapshot: () => options.allModels,
 				getAvailable,
+				getError: () => undefined,
 			},
 			scopedModels: options.scopedModels ?? [],
 			setScopedModels,
@@ -32,6 +34,7 @@ function createInteractiveContext(options: {
 		showStatus: vi.fn(),
 		showSelector: (factory: (done: () => void) => { component: ScopedModelsSelectorComponent }) => {
 			selector = factory(() => {}).component;
+			return true;
 		},
 		updateAvailableProviderCount: vi.fn(),
 		ui: { requestRender: vi.fn() },
@@ -40,6 +43,11 @@ function createInteractiveContext(options: {
 }
 
 async function showModelsSelector(context: object): Promise<void> {
+	Reflect.set(
+		context,
+		"refreshScopedModelsSelector",
+		Reflect.get(InteractiveMode.prototype, "refreshScopedModelsSelector"),
+	);
 	const show = Reflect.get(InteractiveMode.prototype, "showModelsSelector") as (this: object) => Promise<void>;
 	await show.call(context);
 }
@@ -89,28 +97,35 @@ describe("issue #6949 unavailable scoped models", () => {
 		expect(persisted).toEqual([[availableId]]);
 	});
 
-	it("passes unmatched settings patterns to the selector with one combined resolution", async () => {
+	it("combines resolved settings patterns with unavailable pattern rows after cache-first mount", async () => {
 		const harness = await createHarness({ models: [{ id: "available", name: "Available" }] });
 		harnesses.push(harness);
-		const unavailableIds = ["unavailable-one", "unavailable-two"].map((id) => `${harness.models[0].provider}/${id}`);
+		const [available] = harness.models;
+		const unavailableIds = ["unavailable-one", "unavailable-two"].map((id) => `${available.provider}/${id}`);
 		const { context, getAvailable, getSelector } = createInteractiveContext({
-			allModels: [],
-			enabledModelIds: unavailableIds,
+			allModels: [available],
+			enabledModelIds: [`${available.provider}/*`, ...unavailableIds],
 		});
 
 		await showModelsSelector(context);
 
 		const selector = getSelector();
 		if (!selector) throw new Error("Expected scoped-model selector to open");
-		const rendered = stripAnsi(selector.render(100).join("\n"));
-		for (const unavailableId of unavailableIds) {
-			expect(rendered).toContain(`${unavailableId} [unavailable] ✗`);
-		}
-		expect(getAvailable).toHaveBeenCalledTimes(2);
+		await vi.waitFor(() => {
+			const rendered = stripAnsi(selector.render(100).join("\n"));
+			expect(rendered).toContain(`${available.id} [${available.provider}] ✓`);
+			for (const unavailableId of unavailableIds) {
+				expect(rendered).toContain(`${unavailableId} [unavailable] ✗`);
+			}
+		});
+		// Resolution uses the captured catalog snapshot, not the moving global runtime view.
+		expect(getAvailable).not.toHaveBeenCalled();
 	});
 
 	it("opens when only a session-scoped model is unavailable", async () => {
-		const harness = await createHarness({ models: [{ id: "unavailable", name: "Unavailable" }] });
+		const harness = await createHarness({
+			models: [{ id: "unavailable", name: "Unavailable" }],
+		});
 		harnesses.push(harness);
 		const model = harness.models[0];
 		const fullId = `${model.provider}/${model.id}`;

--- a/packages/coding-agent/test/suite/regressions/7209-model-selector-filter-resets-selection.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7209-model-selector-filter-resets-selection.test.ts
@@ -1,3 +1,6 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ModelsRefreshOptions } from "@earendil-works/pi-ai";
 import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../../../src/core/keybindings.ts";
@@ -17,6 +20,51 @@ function selectedModelId(rendered: string): string | undefined {
 	const rest = line.replace(/^→\s*/, "");
 	const id = rest.split(" [")[0];
 	return id?.trim() || undefined;
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+interface CatalogModel {
+	id: string;
+	name: string;
+}
+
+function modelsJson(models: CatalogModel[]): Record<string, unknown> {
+	return {
+		providers: {
+			stable: {
+				baseUrl: "https://example.test/v1",
+				api: "openai-completions",
+				apiKey: "test-key",
+				models,
+			},
+		},
+	};
+}
+
+function writeModelsJson(harness: Harness, models: CatalogModel[]): void {
+	writeFileSync(join(harness.tempDir, "models.json"), JSON.stringify(modelsJson(models)));
+}
+
+function delayRefresh(harness: Harness): Deferred<void> {
+	const refresh = harness.session.modelRuntime.refresh.bind(harness.session.modelRuntime);
+	const completion = deferred<void>();
+	vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(async (options: ModelsRefreshOptions = {}) => {
+		await completion.promise;
+		return refresh(options);
+	});
+	return completion;
 }
 
 describe("model selector filter resets selection to top", () => {
@@ -124,5 +172,124 @@ describe("model selector filter resets selection to top", () => {
 		}
 
 		expect(selectedModelId(stripAnsi(selector.render(120).join("\n")))).toBe("alpha-2");
+	});
+
+	it("keeps the highlighted model across a reordered background refresh", async () => {
+		const harness = await createHarness({
+			modelsJson: modelsJson([
+				{ id: "alpha-1", name: "Alpha One" },
+				{ id: "alpha-2", name: "Alpha Two" },
+				{ id: "alpha-3", name: "Alpha Three" },
+			]),
+		});
+		harnesses.push(harness);
+		const refreshCompletion = delayRefresh(harness);
+		const onSelect = vi.fn();
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			onSelect,
+			() => {},
+		);
+
+		for (const char of "alpha") {
+			selector.handleInput(char);
+		}
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		expect(selectedModelId(stripAnsi(selector.render(120).join("\n")))).toBe("alpha-3");
+
+		writeModelsJson(harness, [
+			{ id: "alpha-2", name: "Alpha Two (replaced)" },
+			{ id: "alpha-3", name: "Alpha Three (replaced)" },
+			{ id: "alpha-1", name: "Alpha One (replaced)" },
+		]);
+		refreshCompletion.resolve();
+
+		await vi.waitFor(() => {
+			const rendered = stripAnsi(selector.render(120).join("\n"));
+			expect(rendered).toContain("Model catalogs refreshed.");
+			expect(rendered).toContain("Model Name: Alpha Three (replaced)");
+			expect(selectedModelId(rendered)).toBe("alpha-3");
+			expect(selector.getSearchInput().getValue()).toBe("alpha");
+		});
+
+		selector.handleInput("\r");
+		expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ provider: "stable", id: "alpha-3" }));
+	});
+
+	it("uses the previous filtered position when a background refresh removes the highlighted model", async () => {
+		const harness = await createHarness({
+			modelsJson: modelsJson([
+				{ id: "alpha-1", name: "Alpha One" },
+				{ id: "alpha-2", name: "Alpha Two" },
+				{ id: "alpha-3", name: "Alpha Three" },
+			]),
+		});
+		harnesses.push(harness);
+		const refreshCompletion = delayRefresh(harness);
+		const onSelect = vi.fn();
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			onSelect,
+			() => {},
+		);
+
+		for (const char of "alpha") {
+			selector.handleInput(char);
+		}
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		expect(selectedModelId(stripAnsi(selector.render(120).join("\n")))).toBe("alpha-3");
+
+		writeModelsJson(harness, [
+			{ id: "alpha-1", name: "Alpha One (replaced)" },
+			{ id: "alpha-2", name: "Alpha Two (replaced)" },
+		]);
+		refreshCompletion.resolve();
+
+		await vi.waitFor(() => {
+			const rendered = stripAnsi(selector.render(120).join("\n"));
+			expect(rendered).toContain("Model catalogs refreshed.");
+			expect(selectedModelId(rendered)).toBe("alpha-2");
+			expect(selector.getSearchInput().getValue()).toBe("alpha");
+		});
+
+		// A user query edit still returns to the top filtered row.
+		selector.handleInput("\x7f");
+		expect(selectedModelId(stripAnsi(selector.render(120).join("\n")))).toBe("alpha-1");
+		selector.handleInput("\r");
+		expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ provider: "stable", id: "alpha-1" }));
+	});
+
+	it("shows both the refresh state and empty cached state immediately", async () => {
+		const harness = await createHarness({
+			modelsJson: { providers: {} },
+			withConfiguredAuth: false,
+		});
+		harnesses.push(harness);
+		const refreshCompletion = delayRefresh(harness);
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			harness.getModel(),
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		expect(rendered).toContain("No cached models yet.");
+		expect(rendered).toContain("Refreshing model catalogs…");
+		selector.dispose();
+		refreshCompletion.resolve();
 	});
 });


### PR DESCRIPTION
### Problem

Model catalog refreshes currently cross several ownership boundaries without one consistent publication boundary.

A provider can already be refreshing when `/model`, `/scoped-models`, login/logout, a runtime API-key change, or extension registration starts another refresh. The existing shared in-flight promises can make a later caller inherit the first caller's credentials, model store, network policy, or cancellation lifetime. At the runtime layer, model, authentication, and availability state can then be observed from different refresh generations. At the UI layer, a replaced selector can still receive a late result, and both model selectors can lose in-progress interaction state while waiting for a stalled provider.

The common root cause is missing ownership boundaries for refresh work and published state. It appears at three layers: provider execution, runtime publication, and selector lifetime.

### Changes

#### Provider refresh ownership

- Serialize dynamic provider refreshes per provider while preserving each caller's context.
- Let a queued caller time out or abort without cancelling the active owner.
- Preserve FIFO ordering, same-context coalescing, failure recovery, and the final caller's catalog result.
- Apply the same behavior to generated providers, Radius, and remote catalogs without adding a public package API or dependency.

#### Atomic runtime publication

- Build refreshes as serialized candidate transactions.
- Publish models, provider views, authentication projection, and availability as one coherent state.
- Keep the previous published state readable until the candidate is complete.
- On a partial provider failure, restore that provider from cache where possible, publish one coherent candidate, and report the provider errors.
- Discard a candidate if its caller aborts before publication.
- Publish extension registration and unregistration to the catalog synchronously, then converge authentication and availability in order; stale refreshes cannot overwrite newer registration state.
- Route login, logout, and runtime API-key changes through the same transaction ordering.

#### Selector lifecycle and interaction state

- Render cached models immediately and refresh in the background.
- Give the active selector explicit ownership so replacement disposes it once and stale callbacks cannot close or update a newer selector.
- Keep `/model` search and highlighted `provider/id` stable when refreshed models reorder. If the model disappears, select the nearest surviving row. User query edits still select the best match.
- Refresh `/scoped-models` in place while preserving query, selection, enabled order, toggles, dirty state, persisted patterns, unavailable scoped models, and thinking levels.
- Enforce the 15-second selector deadline even when a provider ignores `AbortSignal`: keep cached models visible, show a stable timeout, and ignore late completion.
- Consume rejected refreshes without unhandled rejections or exposing raw provider or resolver error text in the TUI.

The commits separate these layers for review, but the behavior is verified cumulatively because provider ownership, runtime publication, and selector lifetime form one consistency boundary.

### Related

Related: #7027, #7113, #7153, #7301

These reports cover overlapping refresh paths. The focused tests exercise the provider, runtime-publication, and selector-lifecycle invariants addressed here; they do not reproduce every reported environment end to end.

### Limitations

Cancellation prevents an aborted candidate from being published, but it cannot roll back provider or `ModelsStore` side effects already performed. Permanently non-cooperative provider work can still occupy the runtime transaction queue; the 15-second selector deadlines only unblock the UI and ignore late completion.

### Verification

- Focused package-root matrix: 13 test files, 104 tests passed.
- `npm run check`: Biome checked 939 files with no fixes; pinned dependency/import, shrinkwrap/install-lock, `tsgo --noEmit`, and browser-smoke checks passed.
- `git diff --check upstream/main`
- Diff: 18 files, +3915/-533.
- Local `./test.sh` is not authoritative in this worktree because CLI subprocess tests require built workspace `dist` artifacts and this environment has known clipboard/permission failures. The Draft PR's GitHub Actions build/check/test job is the required full-suite gate.
- Not run locally: `npm run build`; GitHub Actions runs build before the full test job.

### Commit order

1. isolate provider refresh contexts;
2. serialize runtime transactions and publish one coherent state;
3. establish selector ownership;
4. preserve `/model` interaction state;
5. refresh `/scoped-models` in place.
