### PR TITLE
fix(tui): detect unmarked multiline paste

### DIFF
--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -254,6 +254,32 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 	return { sequences, remainder: "" };
 }
 
+function classifyUnmarkedPaste(sequences: string[]): "none" | "pending" | "paste" {
+	let sawNewline = false;
+	let sawTextAfterNewline = false;
+
+	for (const sequence of sequences) {
+		if (sequence === "\r" || sequence === "\n") {
+			sawNewline = true;
+			continue;
+		}
+
+		if (sequence === "\t") {
+			if (sawNewline) sawTextAfterNewline = true;
+			continue;
+		}
+
+		if (sequence.length !== 1) return "none";
+
+		const code = sequence.charCodeAt(0);
+		if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) return "none";
+		if (sawNewline) sawTextAfterNewline = true;
+	}
+
+	if (!sawNewline) return "none";
+	return sawTextAfterNewline ? "paste" : "pending";
+}
+
 export type StdinBufferOptions = {
 	/**
 	 * Maximum time to wait for sequence completion (default: 10ms)
@@ -278,6 +304,8 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	private pasteMode: boolean = false;
 	private pasteBuffer: string = "";
 	private pendingKittyPrintableCodepoint: number | undefined;
+	private pendingUnmarkedPasteSequences: string[] = [];
+	private unmarkedPasteTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
@@ -289,6 +317,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		if (this.timeout) {
 			clearTimeout(this.timeout);
 			this.timeout = null;
+		}
+		if (this.unmarkedPasteTimeout) {
+			clearTimeout(this.unmarkedPasteTimeout);
+			this.unmarkedPasteTimeout = null;
 		}
 
 		// Handle high-byte conversion (for compatibility with parseKeypress)
@@ -303,6 +335,11 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			}
 		} else {
 			str = data;
+		}
+
+		if (this.pendingUnmarkedPasteSequences.length > 0) {
+			str = this.pendingUnmarkedPasteSequences.join("") + str;
+			this.pendingUnmarkedPasteSequences = [];
 		}
 
 		if (str.length === 0 && this.buffer.length === 0) {
@@ -371,6 +408,33 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		const result = extractCompleteSequences(this.buffer);
 		this.buffer = result.remainder;
 
+		if (this.buffer.length === 0) {
+			const unmarkedPaste = classifyUnmarkedPaste(result.sequences);
+			if (unmarkedPaste === "paste") {
+				this.pendingKittyPrintableCodepoint = undefined;
+				this.emit("paste", result.sequences.join(""));
+				return;
+			}
+
+			if (unmarkedPaste === "pending") {
+				const newlineIndex = result.sequences.findIndex((sequence) => sequence === "\r" || sequence === "\n");
+				for (const sequence of result.sequences.slice(0, newlineIndex)) {
+					this.emitDataSequence(sequence);
+				}
+
+				this.pendingUnmarkedPasteSequences = result.sequences.slice(newlineIndex);
+				this.unmarkedPasteTimeout = setTimeout(() => {
+					const pending = this.pendingUnmarkedPasteSequences;
+					this.pendingUnmarkedPasteSequences = [];
+					this.unmarkedPasteTimeout = null;
+					for (const sequence of pending) {
+						this.emitDataSequence(sequence);
+					}
+				}, this.timeoutMs);
+				return;
+			}
+		}
+
 		for (const sequence of result.sequences) {
 			this.emitDataSequence(sequence);
 		}
@@ -402,13 +466,22 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			clearTimeout(this.timeout);
 			this.timeout = null;
 		}
+		if (this.unmarkedPasteTimeout) {
+			clearTimeout(this.unmarkedPasteTimeout);
+			this.unmarkedPasteTimeout = null;
+		}
 
-		if (this.buffer.length === 0) {
+		const sequences = this.pendingUnmarkedPasteSequences;
+		this.pendingUnmarkedPasteSequences = [];
+		if (this.buffer.length > 0) {
+			sequences.push(this.buffer);
+			this.buffer = "";
+		}
+
+		if (sequences.length === 0) {
 			return [];
 		}
 
-		const sequences = [this.buffer];
-		this.buffer = "";
 		this.pendingKittyPrintableCodepoint = undefined;
 		return sequences;
 	}
@@ -418,14 +491,19 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			clearTimeout(this.timeout);
 			this.timeout = null;
 		}
+		if (this.unmarkedPasteTimeout) {
+			clearTimeout(this.unmarkedPasteTimeout);
+			this.unmarkedPasteTimeout = null;
+		}
 		this.buffer = "";
 		this.pasteMode = false;
 		this.pasteBuffer = "";
 		this.pendingKittyPrintableCodepoint = undefined;
+		this.pendingUnmarkedPasteSequences = [];
 	}
 
 	getBuffer(): string {
-		return this.buffer;
+		return this.pendingUnmarkedPasteSequences.join("") + this.buffer;
 	}
 
 	destroy(): void {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -356,6 +356,18 @@ describe("StdinBuffer", () => {
 
 			assert.deepStrictEqual(emittedSequences, ["\x1b[<35"]);
 		});
+
+		it("should flush a pending unmarked newline", async () => {
+			processInput("abc\r");
+			assert.deepStrictEqual(emittedSequences, ["a", "b", "c"]);
+			assert.strictEqual(buffer.getBuffer(), "\r");
+
+			assert.deepStrictEqual(buffer.flush(), ["\r"]);
+			assert.strictEqual(buffer.getBuffer(), "");
+
+			await wait(15);
+			assert.deepStrictEqual(emittedSequences, ["a", "b", "c"]);
+		});
 	});
 
 	describe("Clear", () => {
@@ -369,7 +381,7 @@ describe("StdinBuffer", () => {
 		});
 	});
 
-	describe("Bracketed Paste", () => {
+	describe("Paste", () => {
 		let emittedPaste: string[] = [];
 
 		beforeEach(() => {
@@ -433,6 +445,73 @@ describe("StdinBuffer", () => {
 			assert.deepStrictEqual(emittedPaste, ["Hello 世界 🎉"]);
 			assert.deepStrictEqual(emittedSequences, []);
 		});
+
+		it("should detect multiline paste without bracketed paste markers", () => {
+			processInput("line one\rline two");
+
+			assert.deepStrictEqual(emittedPaste, ["line one\rline two"]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("should detect unmarked paste with CRLF newlines", () => {
+			processInput("a\r\nb");
+
+			assert.deepStrictEqual(emittedPaste, ["a\r\nb"]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("should detect unmarked paste split after a newline", () => {
+			processInput("line one");
+			processInput("\r");
+			processInput("line two");
+
+			assert.deepStrictEqual(emittedPaste, ["\rline two"]);
+			assert.deepStrictEqual(emittedSequences, ["l", "i", "n", "e", " ", "o", "n", "e"]);
+		});
+
+		it("should allow tabs in unmarked paste", () => {
+			processInput("one\r\ttwo");
+
+			assert.deepStrictEqual(emittedPaste, ["one\r\ttwo"]);
+			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("should not treat batched typing followed by enter as paste", async () => {
+			processInput("abc\r");
+
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.deepStrictEqual(emittedSequences, ["a", "b", "c"]);
+
+			await wait(15);
+
+			assert.deepStrictEqual(emittedSequences, ["a", "b", "c", "\r"]);
+		});
+
+		it("should not treat repeated trailing newlines as paste", async () => {
+			processInput("\r\r");
+
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.deepStrictEqual(emittedSequences, []);
+
+			await wait(15);
+
+			assert.deepStrictEqual(emittedSequences, ["\r", "\r"]);
+		});
+
+		it("should not treat batched escape sequences as paste", () => {
+			processInput("abc\r");
+			processInput("\x1b[A");
+
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.deepStrictEqual(emittedSequences, ["a", "b", "c", "\r", "\x1b[A"]);
+		});
+
+		it("should not treat DEL as printable paste content", () => {
+			processInput("abc\r\x7f");
+
+			assert.deepStrictEqual(emittedPaste, []);
+			assert.deepStrictEqual(emittedSequences, ["a", "b", "c", "\r", "\x7f"]);
+		});
 	});
 
 	describe("Destroy", () => {
@@ -453,6 +532,15 @@ describe("StdinBuffer", () => {
 
 			// Should not have emitted anything
 			assert.deepStrictEqual(emittedSequences, []);
+		});
+
+		it("should clear pending unmarked newlines on destroy", async () => {
+			processInput("abc\r");
+			buffer.destroy();
+
+			await wait(15);
+
+			assert.deepStrictEqual(emittedSequences, ["a", "b", "c"]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- detect multiline stdin batches when bracketed paste markers are missing
- briefly hold trailing newlines so paste split across stdin chunks is still recognized
- keep ordinary Enter input and batches containing control or escape sequences on the keyboard-input path

## Why

Some terminals, including Termux configurations, do not forward bracketed paste markers. Newlines in those batches were emitted as regular key events, causing the editor to submit before the rest of the pasted text was inserted.

## Validation

- `node --test test/stdin-buffer.test.ts` (64 tests)
- `npm run check`
- `./test.sh`

Fixes #7321
