### PR TITLE
Add native prompt API for extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `pi.prompt()` for extensions to submit native prompt input with command handling, skill/template expansion, images, and streaming queue behavior.
 - Added chainable `pi.registerMarkdownTransformer()` hooks for display-only transformation of user and assistant Markdown.
 - Added an experimental fullscreen UI mode, selectable through `--ui-mode fullscreen` or `/settings` ([#7304](https://github.com/earendil-works/pi/issues/7304)).
 - Added a sticky editor, status, widget, and footer dock to fullscreen mode while keeping the transcript independently scrollable.

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1408,6 +1408,26 @@ pi.sendMessage({
   - `"nextTurn"` - Queued for next user prompt. Does not interrupt or trigger anything.
 - `triggerTurn: true` - If agent is idle, trigger an LLM response immediately. Only applies to `"steer"` and `"followUp"` modes (ignored for `"nextTurn"`).
 
+### pi.prompt(text, options?)
+
+Submit input through the same native prompt pipeline as interactive and RPC input. This executes extension commands, emits the `input` event with `source: "extension"`, expands skill commands and prompt templates, preserves image attachments, and starts or queues the agent turn.
+
+```typescript
+await pi.prompt("/review src/index.ts", {
+  images: [{ type: "image", mimeType: "image/png", data: "..." }],
+});
+
+// During streaming, select the native queue behavior:
+await pi.prompt("Focus on error handling", { streamingBehavior: "steer" });
+await pi.prompt("Then summarize", { streamingBehavior: "followUp" });
+```
+
+**Options:**
+- `images` - Image attachments to include with the prompt.
+- `streamingBehavior` - Required while the agent is streaming: `"steer"` interrupts after the current tool batch; `"followUp"` waits until the current run finishes.
+
+Unlike `sendUserMessage()`, `prompt()` preserves command handling and skill/template expansion. It returns a promise and reports prompt validation or queueing errors to the caller.
+
 ### pi.sendUserMessage(content, options?)
 
 Send a user message to the agent. Unlike `sendMessage()` which sends custom messages, this sends an actual user message that appears as if typed by the user. Always triggers a turn.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2365,6 +2365,11 @@ export class AgentSession {
 						});
 					});
 				},
+				prompt: (text, options) =>
+					this.prompt(text, {
+						...options,
+						source: "extension",
+					}),
 				sendUserMessage: (content, options) => {
 					this.sendUserMessage(content, options).catch((err) => {
 						runner.emitError({

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -72,6 +72,7 @@ export type {
 	ExtensionFlag,
 	ExtensionHandler,
 	ExtensionMode,
+	ExtensionPromptOptions,
 	// Runtime
 	ExtensionRuntime,
 	ExtensionShortcut,
@@ -110,6 +111,7 @@ export type {
 	ProjectTrustEventDecision,
 	ProjectTrustEventResult,
 	ProjectTrustHandler,
+	PromptHandler,
 	// Provider Registration
 	ProviderConfig,
 	ProviderModelConfig,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -184,6 +184,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 
 	const runtime: ExtensionRuntime = {
 		sendMessage: notInitialized,
+		prompt: notInitialized,
 		sendUserMessage: notInitialized,
 		appendEntry: notInitialized,
 		setSessionName: notInitialized,
@@ -313,6 +314,11 @@ function createExtensionAPI(
 		sendMessage(message, options): void {
 			runtime.assertActive();
 			runtime.sendMessage(message, options);
+		},
+
+		prompt(text, options) {
+			runtime.assertActive();
+			return runtime.prompt(text, options);
 		},
 
 		sendUserMessage(content, options): void {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -322,6 +322,7 @@ export class ExtensionRunner {
 	): void {
 		// Copy actions into the shared runtime (all extension APIs reference this)
 		this.runtime.sendMessage = actions.sendMessage;
+		this.runtime.prompt = actions.prompt;
 		this.runtime.sendUserMessage = actions.sendUserMessage;
 		this.runtime.appendEntry = actions.appendEntry;
 		this.runtime.setSessionName = actions.setSessionName;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1300,6 +1300,12 @@ export interface ExtensionAPI {
 	): void;
 
 	/**
+	 * Submit native prompt input. Runs extension commands, input handlers, and skill/template expansion.
+	 * When the agent is streaming, use streamingBehavior to specify how to queue the prompt.
+	 */
+	prompt(text: string, options?: ExtensionPromptOptions): Promise<void>;
+
+	/**
 	 * Send a user message to the agent. Always triggers a turn.
 	 * When the agent is streaming, use deliverAs to specify how to queue the message.
 	 */
@@ -1546,6 +1552,15 @@ export type SendMessageHandler = <T = unknown>(
 	options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
 ) => void;
 
+export interface ExtensionPromptOptions {
+	/** Image attachments. */
+	images?: ImageContent[];
+	/** When streaming, queue as steering input or a follow-up. Required while streaming. */
+	streamingBehavior?: "steer" | "followUp";
+}
+
+export type PromptHandler = (text: string, options?: ExtensionPromptOptions) => Promise<void>;
+
 export type SendUserMessageHandler = (
 	content: string | (TextContent | ImageContent)[],
 	options?: { deliverAs?: "steer" | "followUp" },
@@ -1611,6 +1626,7 @@ export interface ExtensionRuntimeState {
  */
 export interface ExtensionActions {
 	sendMessage: SendMessageHandler;
+	prompt: PromptHandler;
 	sendUserMessage: SendUserMessageHandler;
 	appendEntry: AppendEntryHandler;
 	setSessionName: SetSessionNameHandler;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -86,6 +86,7 @@ export type {
 	ExtensionFactory,
 	ExtensionFlag,
 	ExtensionHandler,
+	ExtensionPromptOptions,
 	ExtensionRuntime,
 	ExtensionShortcut,
 	ExtensionUIContext,

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -74,6 +74,7 @@ describe("ExtensionRunner", () => {
 
 	const extensionActions: ExtensionActions = {
 		sendMessage: () => {},
+		prompt: async () => {},
 		sendUserMessage: () => {},
 		appendEntry: () => {},
 		setSessionName: () => {},

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -5,10 +5,10 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { fauxAssistantMessage, fauxToolCall, type Model } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
-import type { InputEvent } from "../../src/core/extensions/index.ts";
+import type { ExtensionAPI, InputEvent } from "../../src/core/extensions/index.ts";
 import type { PromptTemplate } from "../../src/core/prompt-templates.ts";
 import { createSyntheticSourceInfo } from "../../src/core/source-info.ts";
-import { createTestResourceLoader } from "../utilities.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
 import { createHarness, getMessageText, type Harness } from "./harness.ts";
 
 describe("AgentSession prompt characterization", () => {
@@ -222,6 +222,104 @@ describe("AgentSession prompt characterization", () => {
 		await harness.session.prompt("/review src/index.ts");
 
 		expect(expandedPrompt).toBe("Review this code: src/index.ts");
+	});
+
+	it("lets extensions submit native prompts with commands, expansion, images, and extension input source", async () => {
+		const tempDir = join(tmpdir(), `pi-extension-prompt-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		tempDirs.push(tempDir);
+		const skillPath = join(tempDir, "test-skill.md");
+		writeFileSync(skillPath, "# Test Skill\n\nUse the extension prompt skill.");
+
+		let extensionApi: ExtensionAPI | undefined;
+		const commandRuns: string[] = [];
+		const inputEvents: InputEvent[] = [];
+		const extensionsResult = await createTestExtensionsResult(
+			[
+				(pi) => {
+					extensionApi = pi;
+					pi.registerCommand("testcmd", {
+						description: "Test command",
+						handler: async (args) => {
+							commandRuns.push(args);
+						},
+					});
+					pi.on("input", (event) => {
+						inputEvents.push(event);
+					});
+				},
+			],
+			tempDir,
+		);
+		const template: PromptTemplate = {
+			name: "review",
+			description: "Review template",
+			content: "Review this code: $1",
+			filePath: join(tempDir, "review.md"),
+			sourceInfo: createSyntheticSourceInfo(join(tempDir, "review.md"), {
+				source: "local",
+				scope: "temporary",
+				origin: "top-level",
+			}),
+		};
+		const resourceLoader = {
+			...createTestResourceLoader({ extensionsResult }),
+			getSkills: () => ({
+				skills: [
+					{
+						name: "test",
+						description: "Test skill",
+						filePath: skillPath,
+						disableModelInvocation: false,
+						baseDir: tempDir,
+						sourceInfo: createSyntheticSourceInfo(skillPath, {
+							source: "local",
+							scope: "project",
+							origin: "top-level",
+							baseDir: tempDir,
+						}),
+					},
+				],
+				diagnostics: [],
+			}),
+			getPrompts: () => ({ prompts: [template], diagnostics: [] }),
+		};
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		if (!extensionApi) throw new Error("Extension API was not initialized");
+
+		let skillPrompt = "";
+		let templatePrompt = "";
+		let sawImage = false;
+		harness.setResponses([
+			(context) => {
+				const user = [...context.messages].reverse().find((message) => message.role === "user");
+				skillPrompt = user ? getMessageText(user) : "";
+				return fauxAssistantMessage("skill ok");
+			},
+			(context) => {
+				const user = [...context.messages].reverse().find((message) => message.role === "user");
+				templatePrompt = user ? getMessageText(user) : "";
+				sawImage =
+					user?.role === "user" &&
+					typeof user.content !== "string" &&
+					user.content.some((part) => part.type === "image");
+				return fauxAssistantMessage("template ok");
+			},
+		]);
+
+		await extensionApi.prompt("/testcmd hello world");
+		await extensionApi.prompt("/skill:test explain this");
+		await extensionApi.prompt("/review src/index.ts", {
+			images: [{ type: "image", mimeType: "image/png", data: "ZmFrZQ==" }],
+		});
+
+		expect(commandRuns).toEqual(["hello world"]);
+		expect(skillPrompt).toContain("Use the extension prompt skill.");
+		expect(skillPrompt).toContain("explain this");
+		expect(templatePrompt).toBe("Review this code: src/index.ts");
+		expect(sawImage).toBe(true);
+		expect(inputEvents.map((event) => event.source)).toEqual(["extension", "extension"]);
 	});
 
 	it("dispatches extension commands without consuming a provider response", async () => {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -89,6 +89,34 @@ describe("AgentSession queue characterization", () => {
 		expect(harness.session.messages).toEqual([]);
 	});
 
+	it("queues extension prompts with native steer and follow-up behavior", async () => {
+		let extensionApi: ExtensionAPI | undefined;
+		const waiting = await createWaitingHarness({
+			extensionFactories: [
+				(pi) => {
+					extensionApi = pi;
+				},
+			],
+		});
+		const { harness, waitForToolStart, promptPromise, releaseToolExecution } = waiting;
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("handled steer"),
+			fauxAssistantMessage("handled follow-up"),
+		]);
+
+		await waitForToolStart;
+		if (!extensionApi) throw new Error("Extension API was not initialized");
+		await extensionApi.prompt("steer from prompt", { streamingBehavior: "steer" });
+		await extensionApi.prompt("follow-up from prompt", { streamingBehavior: "followUp" });
+		releaseToolExecution();
+		await promptPromise;
+
+		expect(getUserTexts(harness)).toEqual(["start", "steer from prompt", "follow-up from prompt"]);
+		expect(getAssistantTexts(harness)).toEqual(["", "handled steer", "handled follow-up"]);
+	});
+
 	it("delivers extension-origin steering messages before the next LLM call", async () => {
 		let extensionApi: ExtensionAPI | undefined;
 		const waiting = await createWaitingHarness({


### PR DESCRIPTION
## Summary
- expose `pi.prompt()` to extensions
- route extension-submitted input through native command, skill, and prompt-template handling
- preserve images and streaming steer/follow-up behavior
- document and test the extension API

## Verification
- `npm run check`
- focused prompt and queue suites (29 tests)