### PR TITLE
fix(server): enforce protocol adapter invariants

### DIFF
--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Restricted assistant and tool transcript lifecycle schemas to valid state combinations and terminal items.
+
 ### Added
 
 - Added transport-neutral CBOR protocol schemas, codecs, and length-prefixed framing for remote pi sessions.

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -123,32 +123,43 @@ export const UserTranscriptItemSchema = StrictObject({
 	content: Type.Array(UserContentSchema),
 	timestamp: TimestampSchema,
 });
-export const AssistantTranscriptItemSchema = StrictObject({
+const AssistantTranscriptItemProperties = {
 	id: IdSchema,
 	role: Type.Literal("assistant"),
 	content: Type.Array(AssistantContentSchema),
-	status: Type.Union([
-		Type.Literal("streaming"),
-		Type.Literal("complete"),
-		Type.Literal("error"),
-		Type.Literal("aborted"),
-	]),
 	model: ModelRefSchema,
 	responseModel: Type.Optional(Type.String({ minLength: 1 })),
 	usage: Type.Optional(UsageSchema),
-	stopReason: Type.Optional(
-		Type.Union([
-			Type.Literal("stop"),
-			Type.Literal("length"),
-			Type.Literal("toolUse"),
-			Type.Literal("error"),
-			Type.Literal("aborted"),
-		]),
-	),
-	errorMessage: Type.Optional(Type.String()),
 	timestamp: TimestampSchema,
+} as const;
+const StreamingAssistantTranscriptItemSchema = StrictObject({
+	...AssistantTranscriptItemProperties,
+	status: Type.Literal("streaming"),
 });
-export const ToolTranscriptItemSchema = StrictObject({
+const CompleteAssistantTranscriptItemSchema = StrictObject({
+	...AssistantTranscriptItemProperties,
+	status: Type.Literal("complete"),
+	stopReason: Type.Union([Type.Literal("stop"), Type.Literal("length"), Type.Literal("toolUse")]),
+});
+const ErrorAssistantTranscriptItemSchema = StrictObject({
+	...AssistantTranscriptItemProperties,
+	status: Type.Literal("error"),
+	stopReason: Type.Literal("error"),
+	errorMessage: Type.Optional(Type.String({ minLength: 1 })),
+});
+const AbortedAssistantTranscriptItemSchema = StrictObject({
+	...AssistantTranscriptItemProperties,
+	status: Type.Literal("aborted"),
+	stopReason: Type.Literal("aborted"),
+	errorMessage: Type.Optional(Type.String()),
+});
+export const AssistantTranscriptItemSchema = Type.Union([
+	StreamingAssistantTranscriptItemSchema,
+	CompleteAssistantTranscriptItemSchema,
+	ErrorAssistantTranscriptItemSchema,
+	AbortedAssistantTranscriptItemSchema,
+]);
+const ToolTranscriptItemProperties = {
 	id: IdSchema,
 	role: Type.Literal("tool"),
 	toolCallId: IdSchema,
@@ -156,11 +167,29 @@ export const ToolTranscriptItemSchema = StrictObject({
 	input: JsonValueSchema,
 	content: Type.Array(ToolContentSchema),
 	details: Type.Optional(JsonValueSchema),
-	status: Type.Union([Type.Literal("running"), Type.Literal("complete"), Type.Literal("error")]),
-	isError: Type.Boolean(),
 	usage: Type.Optional(UsageSchema),
 	timestamp: TimestampSchema,
+} as const;
+const RunningToolTranscriptItemSchema = StrictObject({
+	...ToolTranscriptItemProperties,
+	status: Type.Literal("running"),
+	isError: Type.Literal(false),
 });
+const CompleteToolTranscriptItemSchema = StrictObject({
+	...ToolTranscriptItemProperties,
+	status: Type.Literal("complete"),
+	isError: Type.Literal(false),
+});
+const ErrorToolTranscriptItemSchema = StrictObject({
+	...ToolTranscriptItemProperties,
+	status: Type.Literal("error"),
+	isError: Type.Literal(true),
+});
+export const ToolTranscriptItemSchema = Type.Union([
+	RunningToolTranscriptItemSchema,
+	CompleteToolTranscriptItemSchema,
+	ErrorToolTranscriptItemSchema,
+]);
 export const TranscriptItemSchema = Type.Union([
 	UserTranscriptItemSchema,
 	AssistantTranscriptItemSchema,
@@ -190,7 +219,13 @@ export const TranscriptProgressSchema = Type.Union([
 	}),
 	StrictObject({
 		type: Type.Literal("item_finished"),
-		item: Type.Union([AssistantTranscriptItemSchema, ToolTranscriptItemSchema]),
+		item: Type.Union([
+			CompleteAssistantTranscriptItemSchema,
+			ErrorAssistantTranscriptItemSchema,
+			AbortedAssistantTranscriptItemSchema,
+			CompleteToolTranscriptItemSchema,
+			ErrorToolTranscriptItemSchema,
+		]),
 	}),
 ]);
 export type TranscriptProgress = Static<typeof TranscriptProgressSchema>;

--- a/packages/protocol/test/protocol.test.ts
+++ b/packages/protocol/test/protocol.test.ts
@@ -41,6 +41,17 @@ const serverHello: ServerHello = {
 	snapshot: emptyServerSnapshot,
 };
 
+function itemMessage(item: unknown, type: "item_updated" | "item_finished" = "item_finished") {
+	return {
+		type: "event",
+		event: {
+			type: "session_progress",
+			sessionId: "session-1",
+			progress: { type, item },
+		},
+	};
+}
+
 describe("protocol validation", () => {
 	test("uses protocol version 2", () => {
 		expect(PROTOCOL_VERSION).toBe(2);
@@ -119,6 +130,115 @@ describe("protocol validation", () => {
 			},
 		};
 		expect(parseServerMessage(message)).toEqual(message);
+	});
+
+	test.each([
+		{ status: "streaming" },
+		{ status: "complete", stopReason: "stop" },
+		{ status: "error", stopReason: "error" },
+		{ status: "error", stopReason: "error", errorMessage: "failed" },
+		{ status: "aborted", stopReason: "aborted" },
+	])("accepts a consistent $status assistant item", (state) => {
+		const message = itemMessage(
+			{
+				id: "assistant-1",
+				role: "assistant",
+				content: [{ type: "text", text: "hello" }],
+				model: { provider: "test", id: "model" },
+				timestamp: 1,
+				...state,
+			},
+			state.status === "streaming" ? "item_updated" : "item_finished",
+		);
+		expect(parseServerMessage(message)).toEqual(message);
+	});
+
+	test.each([
+		{ status: "streaming", stopReason: "stop" },
+		{ status: "complete" },
+		{ status: "complete", stopReason: "error" },
+		{ status: "error", stopReason: "error", errorMessage: "" },
+		{ status: "aborted", stopReason: "stop" },
+	])("rejects an inconsistent $status assistant item", (state) => {
+		expect(() =>
+			parseServerMessage(
+				itemMessage({
+					id: "assistant-1",
+					role: "assistant",
+					content: [{ type: "text", text: "hello" }],
+					model: { provider: "test", id: "model" },
+					timestamp: 1,
+					...state,
+				}),
+			),
+		).toThrow(ProtocolValidationError);
+	});
+
+	test.each([
+		{ status: "running", isError: false },
+		{ status: "complete", isError: false },
+		{ status: "error", isError: true },
+	])("accepts a consistent $status tool item", (state) => {
+		const message = itemMessage(
+			{
+				id: "tool-1",
+				role: "tool",
+				toolCallId: "call-1",
+				toolName: "read",
+				input: {},
+				content: [],
+				timestamp: 1,
+				...state,
+			},
+			state.status === "running" ? "item_updated" : "item_finished",
+		);
+		expect(parseServerMessage(message)).toEqual(message);
+	});
+
+	test("rejects nonterminal items reported as finished", () => {
+		const assistant = {
+			id: "assistant-1",
+			role: "assistant",
+			content: [],
+			model: { provider: "test", id: "model" },
+			status: "streaming",
+			timestamp: 1,
+		};
+		const tool = {
+			id: "tool-1",
+			role: "tool",
+			toolCallId: "call-1",
+			toolName: "read",
+			input: {},
+			content: [],
+			status: "running",
+			isError: false,
+			timestamp: 1,
+		};
+
+		expect(() => parseServerMessage(itemMessage(assistant))).toThrow(ProtocolValidationError);
+		expect(() => parseServerMessage(itemMessage(tool))).toThrow(ProtocolValidationError);
+	});
+
+	test.each([
+		{ status: "running", isError: true },
+		{ status: "complete", isError: true },
+		{ status: "error", isError: false },
+	])("rejects an inconsistent $status tool item", (state) => {
+		expect(() =>
+			parseServerMessage(
+				itemMessage({
+					id: "tool-1",
+					role: "tool",
+					toolCallId: "call-1",
+					toolName: "read",
+					input: {},
+					content: [],
+					timestamp: 1,
+					...state,
+				}),
+			),
+		).toThrow(ProtocolValidationError);
 	});
 
 	test("rejects cyclic protocol values with a protocol validation error", () => {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Changed `toProtocolToolResultMessage()` to require the original `ToolCall` and verify tool result association.
+
+### Fixed
+
+- Hardened protocol adapters against contradictory lifecycle states, invalid identifiers and timestamps, sparse execution arrays, and additive `pi-ai` contract drift.
+
 ## [0.83.0] - 2026-07-29
 
 ## [0.82.1] - 2026-07-25

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -50,7 +50,7 @@ Custom transports can use `@earendil-works/pi-server/testing` for deterministic 
 
 `@earendil-works/pi-ai` domain objects and `@earendil-works/pi-protocol` wire DTOs remain independent. This package owns their boundary and exports `toProtocolModelMetadata()`, `toProtocolAssistantMessage()`, `toProtocolUserMessage()`, and `toProtocolToolResultMessage()`.
 
-The adapters reject invalid tool inputs, explicitly sanitize diagnostic details, and exhaustively handle closed `pi-ai` unions. The protocol mirrors `pi-ai` vocabulary such as `toolCall` and `toolUse` where the semantics are identical. Compile-time assertions cover shared thinking-level and model-input vocabularies. Tests encode adapter output through the protocol runtime schemas so incompatible changes fail in the bridging package.
+The adapters reject invalid tool inputs, identifiers, timestamps, and mismatched tool results; `toProtocolToolResultMessage()` requires the original `ToolCall` so it can verify the association and convert its arguments itself. Diagnostic details are explicitly sanitized. Closed `pi-ai` unions are mapped exhaustively, and compile-time field manifests enumerate current `pi-ai` properties so additions require an explicit review. The protocol mirrors `pi-ai` vocabulary such as `toolCall` and `toolUse` where the semantics are identical. Protocol schemas enforce consistent lifecycle states, and tests encode adapter output through the runtime schemas so incompatible changes fail in the bridging package.
 
 ## Legacy server migration
 

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -7,6 +7,7 @@ import {
 	getSupportedThinkingLevels,
 	type Model,
 	type ModelThinkingLevel,
+	type ToolCall,
 	type ToolResultMessage,
 	type UserMessage,
 } from "@earendil-works/pi-ai";
@@ -21,12 +22,84 @@ import type {
 } from "@earendil-works/pi-protocol";
 
 type Assert<T extends true> = T;
+type ExactKeys<T, Keys extends keyof T> = keyof T extends Keys ? true : false;
 type _AiThinkingLevelsFitProtocol = Assert<ModelThinkingLevel extends ThinkingLevel ? true : false>;
 type _ProtocolThinkingLevelsFitAi = Assert<ThinkingLevel extends ModelThinkingLevel ? true : false>;
 type AiModelInput = Model<Api>["input"][number];
 type ProtocolModelInput = ModelMetadata["input"][number];
 type _AiModelInputsFitProtocol = Assert<AiModelInput extends ProtocolModelInput ? true : false>;
 type _ProtocolModelInputsFitAi = Assert<ProtocolModelInput extends AiModelInput ? true : false>;
+/**
+ * Enumerate mapped and intentionally omitted pi-ai fields so additions fail compilation here.
+ * Provider replay metadata, diagnostics, cache-write retention splits, model transport settings,
+ * pricing tiers, and deferred-tool availability remain intentionally server-side.
+ */
+type _AiTextContentFieldsAccountedFor = Assert<ExactKeys<AiTextContent, "type" | "text" | "textSignature">>;
+type _AiThinkingContentFieldsAccountedFor = Assert<
+	ExactKeys<
+		Extract<AssistantMessage["content"][number], { type: "thinking" }>,
+		"type" | "thinking" | "thinkingSignature" | "redacted"
+	>
+>;
+type _AiImageContentFieldsAccountedFor = Assert<ExactKeys<AiImageContent, "type" | "data" | "mimeType">>;
+type _AiToolCallFieldsAccountedFor = Assert<
+	ExactKeys<ToolCall, "type" | "id" | "name" | "arguments" | "thoughtSignature">
+>;
+type _AiUsageFieldsAccountedFor = Assert<
+	ExactKeys<
+		AiUsage,
+		"input" | "output" | "cacheRead" | "cacheWrite" | "cacheWrite1h" | "reasoning" | "totalTokens" | "cost"
+	>
+>;
+type _AiUsageCostFieldsAccountedFor = Assert<
+	ExactKeys<AiUsage["cost"], "input" | "output" | "cacheRead" | "cacheWrite" | "total">
+>;
+type _AiModelFieldsAccountedFor = Assert<
+	ExactKeys<
+		Model<Api>,
+		| "id"
+		| "name"
+		| "api"
+		| "provider"
+		| "baseUrl"
+		| "reasoning"
+		| "thinkingLevelMap"
+		| "input"
+		| "cost"
+		| "contextWindow"
+		| "maxTokens"
+		| "headers"
+		| "compat"
+	>
+>;
+type _AiModelCostFieldsAccountedFor = Assert<
+	ExactKeys<Model<Api>["cost"], "input" | "output" | "cacheRead" | "cacheWrite" | "tiers">
+>;
+type _AiUserMessageFieldsAccountedFor = Assert<ExactKeys<UserMessage, "role" | "content" | "timestamp">>;
+type _AiAssistantMessageFieldsAccountedFor = Assert<
+	ExactKeys<
+		AssistantMessage,
+		| "role"
+		| "content"
+		| "api"
+		| "provider"
+		| "model"
+		| "responseModel"
+		| "responseId"
+		| "diagnostics"
+		| "usage"
+		| "stopReason"
+		| "errorMessage"
+		| "rawStopReason"
+		| "timestamp"
+	>
+>;
+type _AiToolResultMessageFieldsAccountedFor = Assert<
+	ExactKeys<
+		ToolResultMessage,
+		"role" | "toolCallId" | "toolName" | "content" | "details" | "usage" | "addedToolNames" | "isError" | "timestamp"
+	>
+>;
 
 export interface AssistantTranscriptOptions {
 	id: string;
@@ -36,14 +109,9 @@ export interface UserTranscriptOptions {
 	id: string;
 }
 
-export interface ToolCallMetadata {
-	toolName: string;
-	input: JsonValue;
-}
-
 export interface ToolTranscriptOptions {
 	id: string;
-	call: ToolCallMetadata;
+	call: ToolCall;
 }
 
 function nonNegativeInteger(value: number | undefined): number | undefined {
@@ -55,8 +123,15 @@ function nonNegativeNumber(value: number): number {
 	return Number.isFinite(value) ? Math.max(0, value) : 0;
 }
 
+function identifier(value: string, label: string): string {
+	if (typeof value !== "string" || value.length === 0) throw new TypeError(`${label} must be a non-empty string`);
+	return value;
+}
+
 function timestamp(value: number): number {
-	return Number.isFinite(value) && value >= 0 ? Math.floor(value) : Date.now();
+	if (!Number.isSafeInteger(value) || value < 0)
+		throw new TypeError("Protocol timestamps must be non-negative integers");
+	return value;
 }
 
 /** Validate and copy a value from an execution boundary into the protocol's JSON-compatible subset. */
@@ -74,7 +149,7 @@ export function toProtocolJsonValue(value: unknown, seen = new Set<object>()): J
 	}
 	seen.add(value);
 	try {
-		if (Array.isArray(value)) return value.map((entry) => toProtocolJsonValue(entry, seen));
+		if (Array.isArray(value)) return Array.from(value, (entry) => toProtocolJsonValue(entry, seen));
 		const result: Record<string, JsonValue> = {};
 		for (const [key, entry] of Object.entries(value)) result[key] = toProtocolJsonValue(entry, seen);
 		return result;
@@ -94,7 +169,7 @@ export function sanitizeProtocolDetails(value: unknown, seen = new Set<object>()
 	if (seen.has(value)) return "[Circular]";
 	seen.add(value);
 	try {
-		if (Array.isArray(value)) return value.map((entry) => sanitizeProtocolDetails(entry, seen) ?? null);
+		if (Array.isArray(value)) return Array.from(value, (entry) => sanitizeProtocolDetails(entry, seen) ?? null);
 		const result: Record<string, JsonValue> = {};
 		for (const [key, entry] of Object.entries(value)) {
 			const normalized = sanitizeProtocolDetails(entry, seen);
@@ -129,10 +204,10 @@ export function toProtocolUsage(usage: AiUsage | undefined): Usage | undefined {
 
 export function toProtocolModelMetadata(model: Model<Api>, authenticated: boolean): ModelMetadata {
 	const result = {
-		provider: model.provider,
-		id: model.id,
-		name: model.name || model.id,
-		api: model.api,
+		provider: identifier(model.provider, "Model provider"),
+		id: identifier(model.id, "Model id"),
+		name: identifier(model.name, "Model name"),
+		api: identifier(model.api, "Model API"),
 		reasoning: model.reasoning,
 		input: [...model.input],
 		contextWindow: Math.max(1, Math.floor(model.contextWindow)),
@@ -151,16 +226,23 @@ export function toProtocolModelMetadata(model: Model<Api>, authenticated: boolea
 
 function toProtocolUserContent(content: UserMessage["content"]): UserTranscriptItem["content"] {
 	if (typeof content === "string") return [{ type: "text", text: content }];
-	return content.map((part) =>
-		part.type === "image"
-			? { type: "image", data: part.data, mimeType: part.mimeType }
-			: { type: "text", text: part.text },
-	);
+	return content.map((part) => {
+		switch (part.type) {
+			case "text":
+				return { type: "text", text: part.text };
+			case "image":
+				return { type: "image", data: part.data, mimeType: part.mimeType };
+			default: {
+				const exhaustive: never = part;
+				return exhaustive;
+			}
+		}
+	});
 }
 
 export function toProtocolUserMessage(message: UserMessage, options: UserTranscriptOptions): UserTranscriptItem {
 	const result = {
-		id: options.id,
+		id: identifier(options.id, "Transcript item id"),
 		role: "user",
 		content: toProtocolUserContent(message.content),
 		timestamp: timestamp(message.timestamp),
@@ -182,8 +264,8 @@ function toProtocolAssistantContent(message: AssistantMessage): AssistantTranscr
 			case "toolCall":
 				return {
 					type: "toolCall",
-					toolCallId: part.id || `tool-${message.timestamp}`,
-					toolName: part.name || "unknown",
+					toolCallId: identifier(part.id, "Tool call id"),
+					toolName: identifier(part.name, "Tool call name"),
 					input: toProtocolJsonValue(part.arguments),
 				};
 			default: {
@@ -194,79 +276,101 @@ function toProtocolAssistantContent(message: AssistantMessage): AssistantTranscr
 	});
 }
 
-function toProtocolStopReason(
-	stopReason: AssistantMessage["stopReason"],
-): AssistantTranscriptItem["stopReason"] | undefined {
-	switch (stopReason) {
+export function toProtocolAssistantMessage(
+	message: AssistantMessage,
+	options: AssistantTranscriptOptions,
+): AssistantTranscriptItem {
+	const usage = toProtocolUsage(message.usage);
+	const common = {
+		id: identifier(options.id, "Transcript item id"),
+		role: "assistant",
+		content: toProtocolAssistantContent(message),
+		model: {
+			provider: identifier(message.provider, "Assistant provider"),
+			id: identifier(message.model, "Assistant model"),
+		},
+		...(message.responseModel === undefined
+			? {}
+			: { responseModel: identifier(message.responseModel, "Assistant response model") }),
+		...(usage ? { usage } : {}),
+		timestamp: timestamp(message.timestamp),
+	} as const;
+	switch (message.stopReason) {
 		case "pending":
-			return undefined;
+			return { ...common, status: "streaming" } satisfies AssistantTranscriptItem;
 		case "stop":
 		case "length":
 		case "toolUse":
+			return {
+				...common,
+				status: "complete",
+				stopReason: message.stopReason,
+			} satisfies AssistantTranscriptItem;
 		case "error":
+			if (message.errorMessage?.length === 0) {
+				throw new TypeError("Assistant error messages must not be empty");
+			}
+			return {
+				...common,
+				status: "error",
+				stopReason: "error",
+				...(message.errorMessage === undefined ? {} : { errorMessage: message.errorMessage }),
+			} satisfies AssistantTranscriptItem;
 		case "aborted":
-			return stopReason;
+			return {
+				...common,
+				status: "aborted",
+				stopReason: "aborted",
+				...(message.errorMessage === undefined ? {} : { errorMessage: message.errorMessage }),
+			} satisfies AssistantTranscriptItem;
 		default: {
-			const exhaustive: never = stopReason;
+			const exhaustive: never = message.stopReason;
 			return exhaustive;
 		}
 	}
 }
 
-export function toProtocolAssistantMessage(
-	message: AssistantMessage,
-	options: AssistantTranscriptOptions,
-): AssistantTranscriptItem {
-	const streaming = message.stopReason === "pending";
-	const stopReason = streaming ? undefined : toProtocolStopReason(message.stopReason);
-	const usage = toProtocolUsage(message.usage);
-	const result = {
-		id: options.id,
-		role: "assistant",
-		content: toProtocolAssistantContent(message),
-		status: streaming
-			? "streaming"
-			: message.stopReason === "error"
-				? "error"
-				: message.stopReason === "aborted"
-					? "aborted"
-					: "complete",
-		model: { provider: message.provider, id: message.model },
-		...(message.responseModel ? { responseModel: message.responseModel } : {}),
-		...(usage ? { usage } : {}),
-		...(stopReason ? { stopReason } : {}),
-		...(message.errorMessage === undefined ? {} : { errorMessage: message.errorMessage }),
-		timestamp: timestamp(message.timestamp),
-	} satisfies AssistantTranscriptItem;
-	return result;
-}
-
 function toProtocolToolContent(content: Array<AiTextContent | AiImageContent>): ToolTranscriptItem["content"] {
-	return content.map((part) =>
-		part.type === "image"
-			? { type: "image", data: part.data, mimeType: part.mimeType }
-			: { type: "text", text: part.text },
-	);
+	return content.map((part) => {
+		switch (part.type) {
+			case "text":
+				return { type: "text", text: part.text };
+			case "image":
+				return { type: "image", data: part.data, mimeType: part.mimeType };
+			default: {
+				const exhaustive: never = part;
+				return exhaustive;
+			}
+		}
+	});
 }
 
 export function toProtocolToolResultMessage(
 	message: ToolResultMessage,
 	options: ToolTranscriptOptions,
 ): ToolTranscriptItem {
+	const callId = identifier(options.call.id, "Tool call id");
+	const callName = identifier(options.call.name, "Tool call name");
+	if (identifier(message.toolCallId, "Tool result call id") !== callId) {
+		throw new TypeError(`Tool result ${message.toolCallId} does not match tool call ${callId}`);
+	}
+	if (identifier(message.toolName, "Tool result name") !== callName) {
+		throw new TypeError(`Tool result ${message.toolName} does not match tool call ${callName}`);
+	}
 	const details = sanitizeProtocolDetails(message.details);
 	const usage = toProtocolUsage(message.usage);
-	const result = {
-		id: options.id,
+	const common = {
+		id: identifier(options.id, "Transcript item id"),
 		role: "tool",
-		toolCallId: message.toolCallId || `tool-${message.timestamp}`,
-		toolName: options.call.toolName,
-		input: options.call.input,
+		toolCallId: callId,
+		toolName: callName,
+		input: toProtocolJsonValue(options.call.arguments),
 		content: toProtocolToolContent(message.content),
 		...(details === undefined ? {} : { details }),
-		status: message.isError ? "error" : "complete",
-		isError: message.isError,
 		...(usage ? { usage } : {}),
 		timestamp: timestamp(message.timestamp),
-	} satisfies ToolTranscriptItem;
-	return result;
+	} as const;
+	return message.isError
+		? ({ ...common, status: "error", isError: true } satisfies ToolTranscriptItem)
+		: ({ ...common, status: "complete", isError: false } satisfies ToolTranscriptItem);
 }

--- a/packages/server/src/testing/backend.ts
+++ b/packages/server/src/testing/backend.ts
@@ -89,20 +89,29 @@ export class TestSessionRuntime implements PiSessionRuntime {
 			],
 		});
 		const outcome = await done.promise;
+		const assistant =
+			outcome === "complete"
+				? {
+						id: `assistant-${this.stored.snapshot.revision + 1}`,
+						role: "assistant" as const,
+						content: [{ type: "text" as const, text: `reply:${input.text}` }],
+						status: "complete" as const,
+						model: this.stored.snapshot.model,
+						stopReason: "stop" as const,
+						timestamp: this.stored.snapshot.revision + 1,
+					}
+				: {
+						id: `assistant-${this.stored.snapshot.revision + 1}`,
+						role: "assistant" as const,
+						content: [{ type: "text" as const, text: "" }],
+						status: "aborted" as const,
+						model: this.stored.snapshot.model,
+						stopReason: "aborted" as const,
+						timestamp: this.stored.snapshot.revision + 1,
+					};
 		this.update({
 			phase: "idle",
-			transcript: [
-				...this.stored.snapshot.transcript,
-				{
-					id: `assistant-${this.stored.snapshot.revision + 1}`,
-					role: "assistant",
-					content: [{ type: "text", text: outcome === "complete" ? `reply:${input.text}` : "" }],
-					status: outcome === "complete" ? "complete" : "aborted",
-					model: this.stored.snapshot.model,
-					stopReason: outcome === "complete" ? "stop" : "aborted",
-					timestamp: this.stored.snapshot.revision + 1,
-				},
-			],
+			transcript: [...this.stored.snapshot.transcript, assistant],
 		});
 		this.pendingPrompt = undefined;
 	}

--- a/packages/server/test/protocol.test.ts
+++ b/packages/server/test/protocol.test.ts
@@ -1,7 +1,8 @@
-import type { Api, AssistantMessage, Model, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Model, ToolCall, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai";
 import { encodeServerMessage, PROTOCOL_VERSION } from "@earendil-works/pi-protocol";
 import { describe, expect, test } from "vitest";
 import {
+	sanitizeProtocolDetails,
 	toProtocolAssistantMessage,
 	toProtocolJsonValue,
 	toProtocolModelMetadata,
@@ -150,6 +151,12 @@ describe("pi-ai protocol bridge", () => {
 			isError: false,
 			timestamp: 2,
 		} satisfies ToolResultMessage;
+		const call = {
+			type: "toolCall",
+			id: "call-1",
+			name: "read",
+			arguments: { path: "README.md" },
+		} satisfies ToolCall;
 
 		const userResult = toProtocolUserMessage(user, { id: "user-1" });
 		expect(userResult).toMatchObject({
@@ -160,7 +167,7 @@ describe("pi-ai protocol bridge", () => {
 
 		const toolResult = toProtocolToolResultMessage(tool, {
 			id: "tool-1",
-			call: { toolName: "read", input: { path: "README.md" } },
+			call,
 		});
 		expect(toolResult).toMatchObject({
 			id: "tool-1",
@@ -170,6 +177,28 @@ describe("pi-ai protocol bridge", () => {
 			status: "complete",
 		});
 		assertValidServerPayload(toolResult);
+	});
+
+	test("rejects tool results associated with a different call", () => {
+		const call = {
+			type: "toolCall",
+			id: "call-1",
+			name: "read",
+			arguments: { path: "README.md" },
+		} satisfies ToolCall;
+		const result = {
+			role: "toolResult",
+			toolCallId: "call-2",
+			toolName: "read",
+			content: [{ type: "text", text: "result" }],
+			isError: false,
+			timestamp: 2,
+		} satisfies ToolResultMessage;
+
+		expect(() => toProtocolToolResultMessage(result, { id: "tool-1", call })).toThrow(/tool call/i);
+		expect(() =>
+			toProtocolToolResultMessage({ ...result, toolCallId: "call-1", toolName: "write" }, { id: "tool-1", call }),
+		).toThrow(/tool call/i);
 	});
 
 	test("derives streaming status from a pending stop reason", () => {
@@ -197,6 +226,65 @@ describe("pi-ai protocol bridge", () => {
 		assertValidServerPayload(result);
 	});
 
+	test("preserves optional non-empty assistant error messages", () => {
+		const message = {
+			role: "assistant",
+			content: [],
+			api: "test-api",
+			provider: "test-provider",
+			model: "model-1",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			timestamp: 123,
+		} satisfies AssistantMessage;
+
+		const resultWithoutMessage = toProtocolAssistantMessage(message, { id: "message-error" });
+		expect(resultWithoutMessage).toMatchObject({ status: "error", stopReason: "error" });
+		expect(resultWithoutMessage).not.toHaveProperty("errorMessage");
+		assertValidServerPayload(resultWithoutMessage);
+		expect(() => toProtocolAssistantMessage({ ...message, errorMessage: "" }, { id: "message-error" })).toThrow(
+			TypeError,
+		);
+		const resultWithMessage = toProtocolAssistantMessage(
+			{ ...message, errorMessage: "failed" },
+			{ id: "message-error" },
+		);
+		expect(resultWithMessage).toMatchObject({ status: "error", stopReason: "error", errorMessage: "failed" });
+		assertValidServerPayload(resultWithMessage);
+	});
+
+	test("rejects invalid source identifiers and timestamps", () => {
+		const message = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "", name: "read", arguments: {} }],
+			api: "test-api",
+			provider: "test-provider",
+			model: "model-1",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: 1,
+		} satisfies AssistantMessage;
+
+		expect(() => toProtocolAssistantMessage(message, { id: "assistant-1" })).toThrow(/tool call id/i);
+		expect(() =>
+			toProtocolUserMessage({ role: "user", content: "hello", timestamp: Number.NaN }, { id: "user-1" }),
+		).toThrow(/timestamp/i);
+	});
+
 	test("rejects lossy tool input conversions", () => {
 		const circular: Record<string, unknown> = {};
 		circular.self = circular;
@@ -205,5 +293,13 @@ describe("pi-ai protocol bridge", () => {
 		expect(() => toProtocolJsonValue(1n)).toThrow(TypeError);
 		expect(() => toProtocolJsonValue(undefined)).toThrow(TypeError);
 		expect(() => toProtocolJsonValue(circular)).toThrow(TypeError);
+	});
+
+	test("rejects sparse execution data and normalizes sparse diagnostic arrays", () => {
+		const sparse = new Array<unknown>(2);
+		sparse[1] = "value";
+
+		expect(() => toProtocolJsonValue(sparse)).toThrow(/undefined/i);
+		expect(sanitizeProtocolDetails(sparse)).toEqual([null, "value"]);
 	});
 });


### PR DESCRIPTION
## Summary

- model assistant and tool transcript items as valid lifecycle-state unions
- verify tool results against the originating `ToolCall` and reject invalid source identifiers, timestamps, and execution values
- add exhaustive bridge mappings and compile-time `pi-ai` field manifests
- normalize sparse diagnostic arrays while rejecting sparse execution arrays

## Breaking changes

- `item_finished` now accepts terminal assistant and tool states only
- `toProtocolToolResultMessage()` now requires the original `ToolCall`

## Verification

- `npm run check`
- protocol tests: 143 passed
- server runnable suites: 28 passed
- client tests: 27 passed

The full `./test.sh` run also reached these packages, but unrelated suites failed because generated Fireworks model metadata disagreed with its test, local package `dist` artifacts were absent, and two coding-agent timing tests failed.
