### PR TITLE
feat(agent): add per-session store queues

### DIFF
--- a/packages/agent/src/harness/session/jsonl-store.ts
+++ b/packages/agent/src/harness/session/jsonl-store.ts
@@ -8,9 +8,15 @@ import type {
 	SessionTreeEntry,
 } from "../types.ts";
 import { SessionError, toError } from "../types.ts";
+import { KeyedOperationQueue } from "./keyed-operation-queue.ts";
 import { createSessionId, createTimestamp, getFileSystemResultOrThrow } from "./repository.ts";
 
-export type JsonlSessionStoreOptions = { fs: JsonlSessionStoreFileSystem; sessionsRoot: string };
+export interface JsonlSessionStoreOptions {
+	fs: JsonlSessionStoreFileSystem;
+	sessionsRoot: string;
+	/** Maximum active operations across session keys. Defaults to 4. */
+	maxConcurrentOperations?: number;
+}
 export type JsonlSessionStoreFileSystem = Pick<
 	FileSystem,
 	| "absolutePath"
@@ -27,6 +33,8 @@ export type JsonlSessionStoreFileSystem = Pick<
 
 type JsonlSessionFileSystem = Pick<FileSystem, "readTextFile" | "readTextLines" | "writeFile" | "appendFile">;
 
+const DEFAULT_MAX_CONCURRENT_OPERATIONS = 4;
+
 interface SessionHeader {
 	type: "session";
 	version: 3;
@@ -35,6 +43,13 @@ interface SessionHeader {
 	cwd: string;
 	parentSession?: string;
 	metadata?: Record<string, unknown>;
+}
+
+interface SessionDocumentDescriptor {
+	id: string;
+	timestamp: string;
+	fileName: string;
+	operationKey: string;
 }
 
 function invalidSession(path: string, message: string, cause?: Error): SessionError {
@@ -154,21 +169,23 @@ function encodeCwd(cwd: string): string {
 	return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
 }
 
-class SerialOperationQueue {
-	private tail: Promise<void> = Promise.resolve();
-
-	enqueue<T>(operation: () => Promise<T> | T): Promise<T> {
-		const result = this.tail.then(operation);
-		this.tail = result.then(
-			() => undefined,
-			() => undefined,
-		);
-		return result;
+function createDocumentDescriptor(options: JsonlSessionCreateOptions): SessionDocumentDescriptor {
+	const id = options.id ?? createSessionId();
+	if (!id) throw new SessionError("invalid_session", "Session id cannot be empty");
+	let encodedId: string;
+	try {
+		encodedId = encodeURIComponent(id);
+	} catch (error) {
+		throw new SessionError("invalid_session", `Invalid session id ${JSON.stringify(id)}`, toError(error));
 	}
-
-	async drain(): Promise<void> {
-		await this.tail;
-	}
+	const timestamp = createTimestamp();
+	const fileName = `${timestamp.replace(/[:.]/g, "-")}_${encodedId}.jsonl`;
+	return {
+		id,
+		timestamp,
+		fileName,
+		operationKey: `document:${JSON.stringify([encodeCwd(options.cwd), fileName])}`,
+	};
 }
 
 class JsonlSessionStore
@@ -178,25 +195,30 @@ class JsonlSessionStore
 	private readonly sessionsRootInput: string;
 	private sessionsRoot: string | undefined;
 	private readonly entryIdsByPath = new Map<string, Set<string>>();
-	private readonly operations = new SerialOperationQueue();
+	private readonly operationKeysByPath = new Map<string, string>();
+	private readonly operations: KeyedOperationQueue<string>;
 	private disposed = false;
 	private disposePromise: Promise<void> | undefined;
 
 	constructor(options: JsonlSessionStoreOptions) {
 		this.fs = options.fs;
 		this.sessionsRootInput = options.sessionsRoot;
+		this.operations = new KeyedOperationQueue({
+			maxConcurrentOperations: options.maxConcurrentOperations ?? DEFAULT_MAX_CONCURRENT_OPERATIONS,
+		});
 	}
 
 	create(options: JsonlSessionCreateOptions): Promise<SessionSnapshot<JsonlSessionMetadata>> {
 		this.assertOpen();
-		return this.operations.enqueue(() =>
-			this.createDocument(options, options.parentSessionPath, options.metadata, []),
+		const descriptor = createDocumentDescriptor(options);
+		return this.operations.enqueue(descriptor.operationKey, () =>
+			this.createDocument(descriptor, options, options.parentSessionPath, options.metadata, []),
 		);
 	}
 
 	load(metadata: JsonlSessionMetadata): Promise<SessionSnapshot<JsonlSessionMetadata>> {
 		this.assertOpen();
-		return this.operations.enqueue(() => this.loadDocument(metadata));
+		return this.operations.enqueue(this.operationKey(metadata), () => this.loadDocument(metadata));
 	}
 
 	private async loadDocument(metadata: JsonlSessionMetadata): Promise<SessionSnapshot<JsonlSessionMetadata>> {
@@ -212,7 +234,7 @@ class JsonlSessionStore
 
 	list(options: JsonlSessionListOptions = {}): Promise<JsonlSessionMetadata[]> {
 		this.assertOpen();
-		return this.operations.enqueue(() => this.listSessions(options));
+		return this.operations.enqueueBarrier(() => this.listSessions(options));
 	}
 
 	private async listSessions(options: JsonlSessionListOptions): Promise<JsonlSessionMetadata[]> {
@@ -232,7 +254,7 @@ class JsonlSessionStore
 
 	appendEntry(metadata: JsonlSessionMetadata, entry: SessionTreeEntry): Promise<void> {
 		this.assertOpen();
-		return this.operations.enqueue(async () => {
+		return this.operations.enqueue(this.operationKey(metadata), async () => {
 			if (
 				!getFileSystemResultOrThrow(await this.fs.exists(metadata.path), `Failed to check session ${metadata.path}`)
 			) {
@@ -255,12 +277,13 @@ class JsonlSessionStore
 
 	delete(metadata: JsonlSessionMetadata): Promise<void> {
 		this.assertOpen();
-		return this.operations.enqueue(async () => {
+		return this.operations.enqueue(this.operationKey(metadata), async () => {
 			getFileSystemResultOrThrow(
 				await this.fs.remove(metadata.path, { force: true }),
 				`Failed to delete session ${metadata.path}`,
 			);
 			this.entryIdsByPath.delete(metadata.path);
+			this.operationKeysByPath.delete(metadata.path);
 		});
 	}
 
@@ -270,8 +293,10 @@ class JsonlSessionStore
 		entries: readonly SessionTreeEntry[],
 	): Promise<SessionSnapshot<JsonlSessionMetadata>> {
 		this.assertOpen();
-		return this.operations.enqueue(() =>
+		const descriptor = createDocumentDescriptor(options);
+		return this.operations.enqueue(descriptor.operationKey, () =>
 			this.createDocument(
+				descriptor,
 				options,
 				options.parentSessionPath ?? source.path,
 				options.metadata ?? source.metadata,
@@ -292,28 +317,34 @@ class JsonlSessionStore
 		if (this.disposed) throw new SessionError("storage", "JSONL session store is disposed");
 	}
 
+	private operationKey(metadata: JsonlSessionMetadata): string {
+		return this.operationKeysByPath.get(metadata.path) ?? metadata.path;
+	}
+
 	private async createDocument(
+		descriptor: SessionDocumentDescriptor,
 		options: JsonlSessionCreateOptions,
 		parentSessionPath: string | undefined,
 		metadata: Record<string, unknown> | undefined,
 		entries: readonly SessionTreeEntry[],
 	): Promise<SessionSnapshot<JsonlSessionMetadata>> {
-		const id = options.id ?? createSessionId();
-		const timestamp = createTimestamp();
 		const dir = await this.getSessionDir(options.cwd);
 		getFileSystemResultOrThrow(
 			await this.fs.createDir(dir, { recursive: true }),
 			`Failed to create session directory ${dir}`,
 		);
 		const path = getFileSystemResultOrThrow(
-			await this.fs.joinPath([dir, `${timestamp.replace(/[:.]/g, "-")}_${id}.jsonl`]),
-			`Failed to resolve session file path for ${id}`,
+			await this.fs.joinPath([dir, descriptor.fileName]),
+			`Failed to resolve session file path for ${descriptor.id}`,
 		);
+		if (getFileSystemResultOrThrow(await this.fs.exists(path), `Failed to check session ${path}`)) {
+			throw new SessionError("invalid_session", `Session already exists: ${path}`);
+		}
 		const header: SessionHeader = {
 			type: "session",
 			version: 3,
-			id,
-			timestamp,
+			id: descriptor.id,
+			timestamp: descriptor.timestamp,
 			cwd: options.cwd,
 			parentSession: parentSessionPath,
 			metadata,
@@ -321,6 +352,7 @@ class JsonlSessionStore
 		const content = [JSON.stringify(header), ...entries.map((entry) => JSON.stringify(entry)), ""].join("\n");
 		getFileSystemResultOrThrow(await this.fs.writeFile(path, content), `Failed to create session ${path}`);
 		this.entryIdsByPath.set(path, new Set(entries.map((entry) => entry.id)));
+		this.operationKeysByPath.set(path, descriptor.operationKey);
 		return { metadata: metadataFromHeader(header, path), entries: [...entries] };
 	}
 

--- a/packages/agent/src/harness/session/keyed-operation-queue.ts
+++ b/packages/agent/src/harness/session/keyed-operation-queue.ts
@@ -1,0 +1,69 @@
+export class KeyedOperationQueue<TKey> {
+	private readonly tails = new Map<TKey, Promise<void>>();
+	private readonly maxConcurrentOperations: number | undefined;
+	private readonly permitWaiters: Array<() => void> = [];
+	private activeOperations = 0;
+	private barrier: Promise<void> = Promise.resolve();
+
+	constructor(options: { maxConcurrentOperations?: number } = {}) {
+		if (
+			options.maxConcurrentOperations !== undefined &&
+			(!Number.isInteger(options.maxConcurrentOperations) || options.maxConcurrentOperations < 1)
+		) {
+			throw new RangeError("maxConcurrentOperations must be a positive integer");
+		}
+		this.maxConcurrentOperations = options.maxConcurrentOperations;
+	}
+
+	enqueue<T>(key: TKey, operation: () => Promise<T> | T): Promise<T> {
+		const previous = this.tails.get(key) ?? Promise.resolve();
+		const result = Promise.all([this.barrier, previous]).then(() => this.runOperation(operation));
+		const tail = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		this.tails.set(key, tail);
+		void tail.then(() => {
+			if (this.tails.get(key) === tail) this.tails.delete(key);
+		});
+		return result;
+	}
+
+	enqueueBarrier<T>(operation: () => Promise<T> | T): Promise<T> {
+		const result = Promise.all([this.barrier, ...this.tails.values()]).then(() => this.runOperation(operation));
+		this.barrier = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+
+	async drain(): Promise<void> {
+		await Promise.all([this.barrier, ...this.tails.values()]);
+	}
+
+	private async runOperation<T>(operation: () => Promise<T> | T): Promise<T> {
+		await this.acquirePermit();
+		try {
+			return await operation();
+		} finally {
+			this.releasePermit();
+		}
+	}
+
+	private async acquirePermit(): Promise<void> {
+		if (this.maxConcurrentOperations === undefined) return;
+		if (this.activeOperations < this.maxConcurrentOperations) {
+			this.activeOperations += 1;
+			return;
+		}
+		await new Promise<void>((resolve) => this.permitWaiters.push(resolve));
+	}
+
+	private releasePermit(): void {
+		if (this.maxConcurrentOperations === undefined) return;
+		const next = this.permitWaiters.shift();
+		if (next) next();
+		else this.activeOperations -= 1;
+	}
+}

--- a/packages/agent/src/harness/session/memory-store.ts
+++ b/packages/agent/src/harness/session/memory-store.ts
@@ -1,5 +1,6 @@
 import type { SessionMetadata, SessionSnapshot, SessionStore, SessionTreeEntry } from "../types.ts";
 import { SessionError } from "../types.ts";
+import { KeyedOperationQueue } from "./keyed-operation-queue.ts";
 import { createSessionId, createTimestamp } from "./repository.ts";
 
 export type InMemorySessionCreateOptions = { id?: string };
@@ -9,34 +10,18 @@ interface InMemorySessionState {
 	entries: SessionTreeEntry[];
 }
 
-class SerialOperationQueue {
-	private tail: Promise<void> = Promise.resolve();
-
-	enqueue<T>(operation: () => Promise<T> | T): Promise<T> {
-		const result = this.tail.then(operation);
-		this.tail = result.then(
-			() => undefined,
-			() => undefined,
-		);
-		return result;
-	}
-
-	async drain(): Promise<void> {
-		await this.tail;
-	}
-}
-
 class InMemorySessionStore implements SessionStore<SessionMetadata, InMemorySessionCreateOptions, void> {
 	private readonly sessions = new Map<string, InMemorySessionState>();
-	private readonly operations = new SerialOperationQueue();
+	private readonly operations = new KeyedOperationQueue<string>();
 	private disposed = false;
 	private disposePromise: Promise<void> | undefined;
 
 	create(options: InMemorySessionCreateOptions = {}): Promise<SessionSnapshot<SessionMetadata>> {
 		this.assertOpen();
-		return this.operations.enqueue(() => {
+		const id = options.id ?? createSessionId();
+		return this.operations.enqueue(id, () => {
 			const state: InMemorySessionState = {
-				metadata: { id: options.id ?? createSessionId(), createdAt: createTimestamp() },
+				metadata: { id, createdAt: createTimestamp() },
 				entries: [],
 			};
 			this.sessions.set(state.metadata.id, state);
@@ -46,17 +31,17 @@ class InMemorySessionStore implements SessionStore<SessionMetadata, InMemorySess
 
 	load(metadata: SessionMetadata): Promise<SessionSnapshot<SessionMetadata>> {
 		this.assertOpen();
-		return this.operations.enqueue(() => this.snapshot(this.getState(metadata)));
+		return this.operations.enqueue(metadata.id, () => this.snapshot(this.getState(metadata)));
 	}
 
 	list(): Promise<SessionMetadata[]> {
 		this.assertOpen();
-		return this.operations.enqueue(() => [...this.sessions.values()].map((state) => state.metadata));
+		return this.operations.enqueueBarrier(() => [...this.sessions.values()].map((state) => state.metadata));
 	}
 
 	appendEntry(metadata: SessionMetadata, entry: SessionTreeEntry): Promise<void> {
 		this.assertOpen();
-		return this.operations.enqueue(() => {
+		return this.operations.enqueue(metadata.id, () => {
 			const state = this.getState(metadata);
 			if (state.entries.some((existing) => existing.id === entry.id)) {
 				throw new SessionError("invalid_entry", `Entry ${entry.id} already exists`);
@@ -67,7 +52,7 @@ class InMemorySessionStore implements SessionStore<SessionMetadata, InMemorySess
 
 	delete(metadata: SessionMetadata): Promise<void> {
 		this.assertOpen();
-		return this.operations.enqueue(() => {
+		return this.operations.enqueue(metadata.id, () => {
 			this.sessions.delete(metadata.id);
 		});
 	}
@@ -78,9 +63,10 @@ class InMemorySessionStore implements SessionStore<SessionMetadata, InMemorySess
 		entries: readonly SessionTreeEntry[],
 	): Promise<SessionSnapshot<SessionMetadata>> {
 		this.assertOpen();
-		return this.operations.enqueue(() => {
+		const id = options.id ?? createSessionId();
+		return this.operations.enqueue(id, () => {
 			const state: InMemorySessionState = {
-				metadata: { id: options.id ?? createSessionId(), createdAt: createTimestamp() },
+				metadata: { id, createdAt: createTimestamp() },
 				entries: [...entries],
 			};
 			this.sessions.set(state.metadata.id, state);

--- a/packages/agent/test/harness/repo.test.ts
+++ b/packages/agent/test/harness/repo.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, writeFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
 import { createJsonlSessionStore } from "../../src/harness/session/jsonl-store.ts";
 import {
@@ -10,6 +10,10 @@ import { createSessionRepository } from "../../src/harness/session/repository.ts
 import type { SessionMetadata, SessionStore } from "../../src/harness/types.ts";
 import { createAssistantMessage, createTempDir, createUserMessage } from "./session-test-utils.ts";
 
+afterEach(() => {
+	vi.useRealTimers();
+});
+
 class CountingReadEnv extends NodeExecutionEnv {
 	readCount = 0;
 
@@ -19,12 +23,104 @@ class CountingReadEnv extends NodeExecutionEnv {
 	}
 }
 
-function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+function createDeferred(): Deferred {
 	let resolve!: () => void;
 	const promise = new Promise<void>((resolvePromise) => {
 		resolve = resolvePromise;
 	});
 	return { promise, resolve };
+}
+
+interface Deferred {
+	promise: Promise<void>;
+	resolve: () => void;
+}
+
+function settlesBeforeNextTurn(promise: Promise<unknown>): Promise<boolean> {
+	return Promise.race([
+		promise.then(() => true),
+		new Promise<boolean>((resolve) => setImmediate(() => resolve(false))),
+	]);
+}
+
+class PerPathBlockingAppendEnv extends NodeExecutionEnv {
+	private readonly appendBlocks = new Map<string, { started: Deferred; release: Deferred }>();
+	private listBlock: { started: Deferred; release: Deferred } | undefined;
+	readonly appendCounts = new Map<string, number>();
+
+	blockAppend(path: string): { started: Deferred; release: Deferred } {
+		const block = { started: createDeferred(), release: createDeferred() };
+		this.appendBlocks.set(path, block);
+		return block;
+	}
+
+	blockNextList(): { started: Deferred; release: Deferred } {
+		const block = { started: createDeferred(), release: createDeferred() };
+		this.listBlock = block;
+		return block;
+	}
+
+	override async exists(path: string) {
+		if (this.appendBlocks.has(path)) return { ok: true as const, value: true };
+		return super.exists(path);
+	}
+
+	override async appendFile(path: string, content: string | Uint8Array) {
+		this.appendCounts.set(path, (this.appendCounts.get(path) ?? 0) + 1);
+		const block = this.appendBlocks.get(path);
+		if (block) {
+			block.started.resolve();
+			await block.release.promise;
+		}
+		return super.appendFile(path, content);
+	}
+
+	override async listDir(path: string) {
+		const block = this.listBlock;
+		if (block) {
+			this.listBlock = undefined;
+			block.started.resolve();
+			await block.release.promise;
+		}
+		return super.listDir(path);
+	}
+}
+
+function createEntry(id: string) {
+	return {
+		type: "message" as const,
+		id,
+		parentId: null,
+		timestamp: "2026-01-01T00:00:00.000Z",
+		message: createUserMessage(id),
+	};
+}
+
+class BlockingCreateEnv extends NodeExecutionEnv {
+	readonly firstWriteStarted = createDeferred();
+	readonly secondWriteStarted = createDeferred();
+	readonly releaseFirstWrite = createDeferred();
+	readonly writtenPaths = new Set<string>();
+	readonly writePaths: string[] = [];
+
+	override async createDir() {
+		return { ok: true as const, value: undefined };
+	}
+
+	override async exists(path: string) {
+		return { ok: true as const, value: this.writtenPaths.has(path) };
+	}
+
+	override async writeFile(path: string) {
+		this.writePaths.push(path);
+		if (this.writePaths.length === 1) {
+			this.firstWriteStarted.resolve();
+			await this.releaseFirstWrite.promise;
+		}
+		if (this.writePaths.length === 2) this.secondWriteStarted.resolve();
+		this.writtenPaths.add(path);
+		return { ok: true as const, value: undefined };
+	}
 }
 
 class BlockingAppendEnv extends NodeExecutionEnv {
@@ -117,6 +213,228 @@ describe("InMemorySessionStore", () => {
 });
 
 describe("JsonlSessionStore", () => {
+	it.each(["create", "fork"] as const)(
+		"serializes conflicting create and %s destinations",
+		async (secondOperation) => {
+			vi.useFakeTimers({ toFake: ["Date"] });
+			vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+			const root = createTempDir();
+			const env = new BlockingCreateEnv({ cwd: root });
+			const store = createJsonlSessionStore({ fs: env, sessionsRoot: root });
+			const options = { cwd: "/tmp/target", id: "shared-id" };
+			const first = store.create(options);
+			await env.firstWriteStarted.promise;
+			const second =
+				secondOperation === "create"
+					? store.create(options)
+					: store.fork(
+							{
+								id: "source",
+								createdAt: "2025-01-01T00:00:00.000Z",
+								cwd: "/tmp/source",
+								path: "/tmp/source.jsonl",
+							},
+							options,
+							[createEntry("fork-entry")],
+						);
+			const secondStartedBeforeFirstFinished = await settlesBeforeNextTurn(env.secondWriteStarted.promise);
+
+			env.releaseFirstWrite.resolve();
+			const results = await Promise.allSettled([first, second]);
+
+			expect(secondStartedBeforeFirstFinished).toBe(false);
+			expect(env.writePaths).toHaveLength(1);
+			expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"]);
+			expect(results[1]).toMatchObject({
+				status: "rejected",
+				reason: { code: "invalid_session", message: expect.stringContaining("Session already exists") },
+			});
+		},
+	);
+
+	it("encodes custom session IDs used in filenames", async () => {
+		const root = createTempDir();
+		const store = createJsonlSessionStore({ fs: new NodeExecutionEnv({ cwd: root }), sessionsRoot: root });
+		const snapshot = await store.create({ cwd: root, id: "../unsafe\\id" });
+
+		expect(snapshot.metadata.path).toContain("..%2Funsafe%5Cid.jsonl");
+		expect(existsSync(snapshot.metadata.path)).toBe(true);
+	});
+
+	it("allows appends to different sessions to run concurrently", async () => {
+		const root = createTempDir();
+		const env = new PerPathBlockingAppendEnv({ cwd: root });
+		const store = createJsonlSessionStore({ fs: env, sessionsRoot: root });
+		const first = await store.create({ cwd: "/tmp/first", id: "first" });
+		const second = await store.create({ cwd: "/tmp/second", id: "second" });
+		const firstBlock = env.blockAppend(first.metadata.path);
+		const secondBlock = env.blockAppend(second.metadata.path);
+
+		const firstAppend = store.appendEntry(first.metadata, createEntry("first-entry"));
+		await firstBlock.started.promise;
+		const secondAppend = store.appendEntry(second.metadata, createEntry("second-entry"));
+		const secondStartedBeforeFirstFinished = await settlesBeforeNextTurn(secondBlock.started.promise);
+
+		firstBlock.release.resolve();
+		secondBlock.release.resolve();
+		await Promise.all([firstAppend, secondAppend]);
+		expect(secondStartedBeforeFirstFinished).toBe(true);
+	});
+
+	it("caps concurrent operations across JSONL sessions at four by default", async () => {
+		const root = createTempDir();
+		const env = new PerPathBlockingAppendEnv({ cwd: root });
+		const store = createJsonlSessionStore({ fs: env, sessionsRoot: root });
+		const snapshots = [];
+		for (let index = 0; index < 6; index++) {
+			snapshots.push(await store.create({ cwd: `/tmp/session-${index}`, id: `session-${index}` }));
+		}
+		const blocks = snapshots.map((snapshot) => env.blockAppend(snapshot.metadata.path));
+		const appends = snapshots.map((snapshot, index) =>
+			store.appendEntry(snapshot.metadata, createEntry(`entry-${index}`)),
+		);
+		await Promise.all(blocks.slice(0, 4).map((block) => block.started.promise));
+		const fifthStartedWithoutCapacity = await settlesBeforeNextTurn(blocks[4]!.started.promise);
+		const sixthStartedWithoutCapacity = await settlesBeforeNextTurn(blocks[5]!.started.promise);
+
+		for (const block of blocks) block.release.resolve();
+		await Promise.all(appends);
+
+		expect(fifthStartedWithoutCapacity).toBe(false);
+		expect(sixthStartedWithoutCapacity).toBe(false);
+	});
+
+	it("allows overriding the JSONL concurrency limit", async () => {
+		const root = createTempDir();
+		const env = new PerPathBlockingAppendEnv({ cwd: root });
+		const store = createJsonlSessionStore({ fs: env, sessionsRoot: root, maxConcurrentOperations: 1 });
+		const first = await store.create({ cwd: "/tmp/first", id: "first" });
+		const second = await store.create({ cwd: "/tmp/second", id: "second" });
+		const firstBlock = env.blockAppend(first.metadata.path);
+		const secondBlock = env.blockAppend(second.metadata.path);
+		const firstAppend = store.appendEntry(first.metadata, createEntry("first-entry"));
+		await firstBlock.started.promise;
+		const secondAppend = store.appendEntry(second.metadata, createEntry("second-entry"));
+		const secondStartedBeforeFirstFinished = await settlesBeforeNextTurn(secondBlock.started.promise);
+
+		firstBlock.release.resolve();
+		secondBlock.release.resolve();
+		await Promise.all([firstAppend, secondAppend]);
+		expect(secondStartedBeforeFirstFinished).toBe(false);
+	});
+
+	it.each([0, -1, 1.5, Number.POSITIVE_INFINITY])(
+		"rejects invalid JSONL concurrency limit %s",
+		(maxConcurrentOperations) => {
+			const root = createTempDir();
+			expect(() =>
+				createJsonlSessionStore({
+					fs: new NodeExecutionEnv({ cwd: root }),
+					sessionsRoot: root,
+					maxConcurrentOperations,
+				}),
+			).toThrow("maxConcurrentOperations must be a positive integer");
+		},
+	);
+
+	it("releases JSONL concurrency capacity after an operation fails", async () => {
+		const root = createTempDir();
+		const store = createJsonlSessionStore({
+			fs: new NodeExecutionEnv({ cwd: root }),
+			sessionsRoot: root,
+			maxConcurrentOperations: 1,
+		});
+		const first = await store.create({ cwd: "/tmp/first", id: "first" });
+		const second = await store.create({ cwd: "/tmp/second", id: "second" });
+		const duplicate = createEntry("duplicate-entry");
+		await store.appendEntry(first.metadata, duplicate);
+
+		const failure = store.appendEntry(first.metadata, duplicate);
+		const nextSession = store.appendEntry(second.metadata, createEntry("next-entry"));
+
+		await expect(failure).rejects.toThrow("Entry duplicate-entry already exists");
+		await expect(nextSession).resolves.toBeUndefined();
+	});
+
+	it("serializes appends to the same session", async () => {
+		const root = createTempDir();
+		const env = new PerPathBlockingAppendEnv({ cwd: root });
+		const store = createJsonlSessionStore({ fs: env, sessionsRoot: root });
+		const snapshot = await store.create({ cwd: root, id: "session" });
+		const block = env.blockAppend(snapshot.metadata.path);
+
+		const firstAppend = store.appendEntry(snapshot.metadata, createEntry("first-entry"));
+		await block.started.promise;
+		const secondAppend = store.appendEntry(snapshot.metadata, createEntry("second-entry"));
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		const appendCountWhileFirstWasBlocked = env.appendCounts.get(snapshot.metadata.path);
+
+		block.release.resolve();
+		await Promise.all([firstAppend, secondAppend]);
+		expect(appendCountWhileFirstWasBlocked).toBe(1);
+		expect((await store.load(snapshot.metadata)).entries.map((entry) => entry.id)).toEqual([
+			"first-entry",
+			"second-entry",
+		]);
+	});
+
+	it("uses listing as a barrier between accepted session operations", async () => {
+		const root = createTempDir();
+		const env = new PerPathBlockingAppendEnv({ cwd: root });
+		const store = createJsonlSessionStore({ fs: env, sessionsRoot: root });
+		const first = await store.create({ cwd: "/tmp/first", id: "first" });
+		const second = await store.create({ cwd: "/tmp/second", id: "second" });
+		const firstBlock = env.blockAppend(first.metadata.path);
+		const secondBlock = env.blockAppend(second.metadata.path);
+		const listBlock = env.blockNextList();
+
+		const firstAppend = store.appendEntry(first.metadata, createEntry("first-entry"));
+		await firstBlock.started.promise;
+		const list = store.list();
+		const secondAppend = store.appendEntry(second.metadata, createEntry("second-entry"));
+		const listStartedBeforeFirstFinished = await settlesBeforeNextTurn(listBlock.started.promise);
+
+		firstBlock.release.resolve();
+		await firstAppend;
+		await listBlock.started.promise;
+		const secondStartedBeforeListFinished = await settlesBeforeNextTurn(secondBlock.started.promise);
+		listBlock.release.resolve();
+		await list;
+		await secondBlock.started.promise;
+		secondBlock.release.resolve();
+		await secondAppend;
+
+		expect(listStartedBeforeFirstFinished).toBe(false);
+		expect(secondStartedBeforeListFinished).toBe(false);
+	});
+
+	it("waits for every accepted session operation during disposal", async () => {
+		const root = createTempDir();
+		const env = new PerPathBlockingAppendEnv({ cwd: root });
+		const store = createJsonlSessionStore({ fs: env, sessionsRoot: root });
+		const first = await store.create({ cwd: "/tmp/first", id: "first" });
+		const second = await store.create({ cwd: "/tmp/second", id: "second" });
+		const firstBlock = env.blockAppend(first.metadata.path);
+		const secondBlock = env.blockAppend(second.metadata.path);
+		const firstAppend = store.appendEntry(first.metadata, createEntry("first-entry"));
+		const secondAppend = store.appendEntry(second.metadata, createEntry("second-entry"));
+		await Promise.all([firstBlock.started.promise, secondBlock.started.promise]);
+
+		let disposed = false;
+		const dispose = store[Symbol.asyncDispose]().then(() => {
+			disposed = true;
+		});
+		firstBlock.release.resolve();
+		await firstAppend;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		const disposedWhileSecondWasBlocked = disposed;
+		secondBlock.release.resolve();
+		await Promise.all([secondAppend, dispose]);
+
+		expect(disposedWhileSecondWasBlocked).toBe(false);
+		expect(disposed).toBe(true);
+	});
+
 	it("waits for accepted appends before disposal and rejects later writes", async () => {
 		const root = createTempDir();
 		const env = new BlockingAppendEnv({ cwd: root });


### PR DESCRIPTION
## Summary

- serialize memory and JSONL operations per session while allowing unrelated sessions to progress concurrently
- preserve coherent `list()` snapshots with queue barriers and drain every accepted operation during disposal
- bound JSONL filesystem concurrency to four operations by default with a configurable override; keep memory unlimited and SQLite unchanged
- derive stable JSONL destination keys, reject same-path collisions, and encode custom IDs used in filenames

## Behavior change

JSONL custom IDs are percent-encoded in generated filenames, and empty custom IDs are rejected.

## Testing

- `npm run check`
- `./test.sh`
- 125 focused harness tests across 7 files
- `repo.test.ts` passed five consecutive runs

## Known limitation

Cross-process exclusive JSONL creation remains unavailable because `FileSystem` does not expose atomic create-if-absent semantics.
