### PR TITLE
fix(agent): make SQLite session operations linear

### DIFF
--- a/packages/agent/test/harness/session.test.ts
+++ b/packages/agent/test/harness/session.test.ts
@@ -64,9 +64,9 @@ async function runSessionSuite(name: string, createFixture: () => Promise<Sessio
 			const assistant1 = await session.appendMessage(createAssistantMessage("two"));
 			await session.appendMessage(createUserMessage("three"));
 			await session.moveTo(user1);
-			await session.appendMessage(createAssistantMessage("branched"));
+			const branched = await session.appendMessage(createAssistantMessage("branched"));
 			const branch = await session.getBranch();
-			expect(branch.map((entry) => entry.id)).toContain(user1);
+			expect(branch.map((entry) => entry.id)).toEqual([user1, branched]);
 			expect(branch.map((entry) => entry.id)).not.toContain(assistant1);
 			const context = await session.buildContext();
 			expect(context.messages.map((message) => message.role)).toEqual(["user", "assistant"]);

--- a/packages/agent/test/harness/sqlite-migrations.test.ts
+++ b/packages/agent/test/harness/sqlite-migrations.test.ts
@@ -440,7 +440,7 @@ END;
 		await expect(reopened.getEntries()).rejects.toMatchObject({ code: "invalid_entry" });
 	});
 
-	it("rolls back state when appendEntry fails after mutating caches", async () => {
+	it("does not publish connection state when an append transaction fails", async () => {
 		const root = createTempDir();
 		const databasePath = join(root, "sessions.sqlite");
 		const sqlite = createNodeSqliteFactory();
@@ -452,28 +452,40 @@ END;
 		});
 		const originalPrepare = db.prepare.bind(db);
 		db.prepare = (sql: string) => {
-			if (sql.startsWith("UPDATE sessions SET active_leaf_id = ?")) {
+			if (sql.startsWith("INSERT INTO branch_entries")) {
 				return new ThrowingStatement(async () => {
-					throw new Error("active leaf update failed");
+					throw new Error("branch insert failed");
 				});
 			}
 			return originalPrepare(sql);
 		};
 
-		await expect(
-			storage.appendEntry({
-				type: "message",
-				id: "root",
-				parentId: null,
-				timestamp: new Date().toISOString(),
-				message: createUserMessage("root"),
-			}),
-		).rejects.toMatchObject({ code: "storage" });
+		const rootEntry = {
+			type: "message" as const,
+			id: "root",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+			message: createUserMessage("root"),
+		};
+		await expect(storage.appendEntry(rootEntry)).rejects.toMatchObject({ code: "storage" });
+		db.prepare = originalPrepare;
 		const sessionRow = await db
 			.prepare("SELECT active_leaf_id FROM sessions WHERE id = ?")
 			.get<{ active_leaf_id: string | null }>("session-1");
 		expect(sessionRow?.active_leaf_id).toBeNull();
 		expect(await storage.readEntries()).toEqual([]);
+		await expect(
+			storage.appendEntry({
+				type: "leaf",
+				id: "leaf",
+				parentId: null,
+				timestamp: new Date().toISOString(),
+				targetId: rootEntry.id,
+			}),
+		).rejects.toMatchObject({ code: "not_found" });
+		expect(await storage.readEntries()).toEqual([]);
+		await storage.appendEntry(rootEntry);
+		expect(await storage.readEntries()).toEqual([rootEntry]);
 		await db.close();
 	});
 

--- a/packages/agent/test/harness/sqlite-migrations.test.ts
+++ b/packages/agent/test/harness/sqlite-migrations.test.ts
@@ -450,15 +450,13 @@ END;
 			cwd: root,
 			sessionId: "session-1",
 		});
-		const originalPrepare = db.prepare.bind(db);
-		db.prepare = (sql: string) => {
-			if (sql.startsWith("INSERT INTO branch_entries")) {
-				return new ThrowingStatement(async () => {
-					throw new Error("branch insert failed");
-				});
-			}
-			return originalPrepare(sql);
-		};
+		await db.exec(`
+			CREATE TEMP TRIGGER fail_branch_entry_insert
+			BEFORE INSERT ON branch_entries
+			BEGIN
+				SELECT RAISE(ABORT, 'branch insert failed');
+			END;
+		`);
 
 		const rootEntry = {
 			type: "message" as const,
@@ -467,8 +465,11 @@ END;
 			timestamp: new Date().toISOString(),
 			message: createUserMessage("root"),
 		};
-		await expect(storage.appendEntry(rootEntry)).rejects.toMatchObject({ code: "storage" });
-		db.prepare = originalPrepare;
+		try {
+			await expect(storage.appendEntry(rootEntry)).rejects.toMatchObject({ code: "storage" });
+		} finally {
+			await db.exec("DROP TRIGGER fail_branch_entry_insert");
+		}
 		const sessionRow = await db
 			.prepare("SELECT active_leaf_id FROM sessions WHERE id = ?")
 			.get<{ active_leaf_id: string | null }>("session-1");

--- a/packages/storage/sqlite-node/src/sqlite/storage/index.ts
+++ b/packages/storage/sqlite-node/src/sqlite/storage/index.ts
@@ -153,9 +153,9 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 		activeBranchId: string | null,
 	): Promise<string> {
 		let branchId = activeBranchId;
+		// Reuse the staged active branch when available. Otherwise materialize
+		// the parent path once, then add only the new tip entry below.
 		if (!branchId) branchId = await this.materializeBranch(parentId);
-		// After a branch is materialized/resynced, subsequent linear appends only add the
-		// new tip entry. We do not rebuild the full branch on every append.
 		const entryRow = await this.db
 			.prepare("SELECT entry_seq FROM session_entries WHERE session_id = ? AND id = ?")
 			.get<{ entry_seq: number }>(this.metadata.id, entryId);

--- a/packages/storage/sqlite-node/src/sqlite/storage/index.ts
+++ b/packages/storage/sqlite-node/src/sqlite/storage/index.ts
@@ -74,7 +74,6 @@ async function loadSqliteSession(
 	sessionId: string,
 ): Promise<{
 	row: SessionRow;
-	leafId: string | null;
 	activeBranchId: string | null;
 	materializedState: SessionMaterializedState;
 }> {
@@ -83,7 +82,6 @@ async function loadSqliteSession(
 		.get<SessionRow>(sessionId);
 	if (!row) throw new SessionError("not_found", `Session not found: ${sessionId}`);
 
-	const leafId = row.active_leaf_id;
 	const materializedRow = await db
 		.prepare("SELECT session_id, payload FROM session_materialized WHERE session_id = ?")
 		.get<SessionMaterializedRow>(sessionId);
@@ -95,7 +93,6 @@ async function loadSqliteSession(
 		.all<EntryMaterializedRow>(sessionId);
 	return {
 		row,
-		leafId,
 		activeBranchId: await loadActiveBranchId(db, sessionId),
 		materializedState: materializedStateFromRows(materializedRow, entryMaterializedRows),
 	};
@@ -105,7 +102,6 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 	private readonly db: SqliteDatabase;
 	readonly metadata: SqliteSessionMetadata;
 	private byId: Map<string, SessionTreeEntry>;
-	private currentLeafId: string | null;
 	private activeBranchId: string | null;
 	private materializedState: SessionMaterializedState;
 
@@ -116,7 +112,7 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 		let current = await this.readEntry(leafId);
 		if (!current) throw new SessionError("not_found", `Entry ${leafId} not found`);
 		while (current) {
-			path.unshift(current);
+			path.push(current);
 			if (stopAtEntryId !== null && current.id === stopAtEntryId) break;
 			if (current.type === "compaction") {
 				if (current.retainedTail) break;
@@ -127,10 +123,10 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 			if (!parent) throw new SessionError("invalid_session", `Entry ${current.parentId} not found`);
 			current = parent;
 		}
-		return path;
+		return path.reverse();
 	}
 
-	private async materializeBranch(leafId: string | null): Promise<void> {
+	private async materializeBranch(leafId: string | null): Promise<string> {
 		const branchId = uuidv7();
 		// Rebuild the branch path only when branch membership changes: branch switch
 		// (leaf navigation) or a new fork from a parent that already has a child.
@@ -148,31 +144,31 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 				.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
 				.run(this.metadata.id, branchId, entry.id, entryRow.entry_seq);
 		}
-		this.activeBranchId = branchId;
+		return branchId;
 	}
 
-	private async appendToActiveBranch(entryId: string, parentId: string | null): Promise<void> {
-		if (!this.activeBranchId) {
-			await this.materializeBranch(parentId);
-		}
+	private async appendToActiveBranch(
+		entryId: string,
+		parentId: string | null,
+		activeBranchId: string | null,
+	): Promise<string> {
+		let branchId = activeBranchId;
+		if (!branchId) branchId = await this.materializeBranch(parentId);
 		// After a branch is materialized/resynced, subsequent linear appends only add the
 		// new tip entry. We do not rebuild the full branch on every append.
-		if (!this.activeBranchId) {
-			throw invalidSession(`active branch missing for session ${this.metadata.id}`);
-		}
 		const entryRow = await this.db
 			.prepare("SELECT entry_seq FROM session_entries WHERE session_id = ? AND id = ?")
 			.get<{ entry_seq: number }>(this.metadata.id, entryId);
 		if (!entryRow) throw invalidSession(`missing entry row for session ${this.metadata.id} entry ${entryId}`);
 		await this.db
 			.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
-			.run(this.metadata.id, this.activeBranchId, entryId, entryRow.entry_seq);
+			.run(this.metadata.id, branchId, entryId, entryRow.entry_seq);
+		return branchId;
 	}
 
 	private constructor(
 		db: SqliteDatabase,
 		metadata: SqliteSessionMetadata,
-		leafId: string | null,
 		activeBranchId: string | null,
 		materializedState: SessionMaterializedState,
 	) {
@@ -180,7 +176,6 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 		this.metadata = metadata;
 		this.byId = new Map<string, SessionTreeEntry>();
 		this.materializedState = materializedState;
-		this.currentLeafId = leafId;
 		this.activeBranchId = activeBranchId;
 	}
 
@@ -189,7 +184,6 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 		return new SqliteSessionConnection(
 			db,
 			rowToMetadata(loaded.row, metadata.path),
-			loaded.leafId,
 			loaded.activeBranchId,
 			loaded.materializedState,
 		);
@@ -233,7 +227,6 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 				metadata: options.metadata,
 			},
 			null,
-			null,
 			createEmptyMaterializedState(),
 		);
 	}
@@ -259,17 +252,16 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 
 	async appendEntry(entry: SessionTreeEntry, options: { transaction?: boolean } = {}): Promise<void> {
 		const encoded = encodeEntry(entry);
-		const previousMaterializedState: SessionMaterializedState = {
+		const nextMaterializedState: SessionMaterializedState = {
 			...this.materializedState,
 			labelsById: new Map(this.materializedState.labelsById),
 			modelThinkingConfigs: [...this.materializedState.modelThinkingConfigs],
 			currentModel: this.materializedState.currentModel ? { ...this.materializedState.currentModel } : null,
 		};
-		const previousById = new Map(this.byId);
-		const previousLeafId = this.currentLeafId;
-		const previousActiveBranchId = this.activeBranchId;
+		const nextLeafId = leafIdAfterEntry(entry);
+		let nextActiveBranchId = this.activeBranchId;
 		try {
-			applyEntryToMaterializedState(this.materializedState, entry);
+			applyEntryToMaterializedState(nextMaterializedState, entry);
 			const write = async () => {
 				const parentHadExistingChild = await hasExistingChild(this.db, this.metadata.id, entry.parentId);
 				const nextSeq = await getNextSequence(this.db, this.metadata.id);
@@ -281,35 +273,31 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 				await advanceSequence(this.db, this.metadata.id, nextSeq);
 				await this.db
 					.prepare("UPDATE session_materialized SET payload = ? WHERE session_id = ?")
-					.run(serializeSummary(this.materializedState), this.metadata.id);
+					.run(serializeSummary(nextMaterializedState), this.metadata.id);
 				for (const materializedEntry of entryMaterializedValues(entry)) {
 					await this.db
 						.prepare("INSERT INTO entry_materialized (session_id, entry_seq, type, payload) VALUES (?, ?, ?, ?)")
 						.run(this.metadata.id, nextSeq, materializedEntry.type, materializedEntry.payload);
 				}
-				this.byId.set(entry.id, entry);
-				this.currentLeafId = leafIdAfterEntry(entry);
 				await this.db
 					.prepare("UPDATE sessions SET active_leaf_id = ? WHERE id = ?")
-					.run(this.currentLeafId, this.metadata.id);
+					.run(nextLeafId, this.metadata.id);
 				if (entry.type === "leaf") {
-					this.activeBranchId = null;
-					await this.materializeBranch(entry.targetId);
-					await this.appendToActiveBranch(entry.id, entry.parentId);
+					nextActiveBranchId = await this.materializeBranch(entry.targetId);
+					nextActiveBranchId = await this.appendToActiveBranch(entry.id, entry.parentId, nextActiveBranchId);
 				} else {
 					if (parentHadExistingChild) {
-						await this.materializeBranch(entry.parentId);
+						nextActiveBranchId = await this.materializeBranch(entry.parentId);
 					}
-					await this.appendToActiveBranch(entry.id, entry.parentId);
+					nextActiveBranchId = await this.appendToActiveBranch(entry.id, entry.parentId, nextActiveBranchId);
 				}
 			};
 			if (options.transaction === false) await write();
 			else await this.db.transaction(write);
+			this.materializedState = nextMaterializedState;
+			this.byId.set(entry.id, entry);
+			this.activeBranchId = nextActiveBranchId;
 		} catch (error) {
-			this.materializedState = previousMaterializedState;
-			this.byId = previousById;
-			this.currentLeafId = previousLeafId;
-			this.activeBranchId = previousActiveBranchId;
 			if (error instanceof SessionError) throw error;
 			throw new SessionError("storage", `Failed to append SQLite session entry ${entry.id}`, toError(error));
 		}


### PR DESCRIPTION
## Summary

- stage SQLite connection cache and projection state until append transactions succeed
- stop cloning the complete entry cache on every append
- build SQLite branch paths with `push()` plus `reverse()` instead of repeated `unshift()`
- strengthen branch-order and failed-transaction cache-publication regressions

In the local 100,000-entry benchmark, bulk persistence improved from roughly 343 seconds to 5 seconds, and branch reconstruction improved from roughly 912 ms to 32 ms.

## Testing

- `npm install --ignore-scripts`
- `npm run build`
- `npm run check`
- 129 focused session and SQLite tests passed
- issue #5303 regression: 2 tests passed in isolation

Repeated local `./test.sh` runs hit the unrelated, load-sensitive issue #5303 detached-output regression. The test passes in isolation; all session and SQLite tests pass.
