### PR TITLE
fix(ai): normalize optional object tool schemas for OpenAI-compatible providers

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -38,6 +38,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
+import { normalizeToolSchemaForOpenAI } from "../utils/normalize-json-schema.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
@@ -1315,7 +1316,9 @@ function convertTools(
 			function: {
 				name: tool.name,
 				description: tool.description,
-				parameters: tool.parameters as Record<string, unknown>, // TypeBox already generates JSON Schema
+				// TypeBox already generates JSON Schema; normalize `required` on
+				// object schemas so strict providers accept all-optional tools.
+				parameters: normalizeToolSchemaForOpenAI(tool.parameters) as Record<string, unknown>,
 				// Only include strict if provider supports it. Some reject unknown fields.
 				...(compat.supportsStrictMode !== false && { strict: strict ?? false }),
 			},

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -31,6 +31,7 @@ import type {
 import type { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
+import { normalizeToolSchemaForOpenAI } from "../utils/normalize-json-schema.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import {
 	appendGrammarToolInputJsonDelta,
@@ -369,7 +370,9 @@ export function convertResponsesTools(tools: readonly Tool[], options?: ConvertR
 			type: "function",
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters as Record<string, unknown>, // TypeBox already generates JSON Schema
+			// TypeBox already generates JSON Schema; normalize `required` on object
+			// schemas so strict providers accept all-optional tools.
+			parameters: normalizeToolSchemaForOpenAI(tool.parameters) as Record<string, unknown>,
 			...(options?.deferLoading ? { defer_loading: true } : {}),
 		};
 		if (supportsStrictMode) {

--- a/packages/ai/src/utils/normalize-json-schema.ts
+++ b/packages/ai/src/utils/normalize-json-schema.ts
@@ -1,0 +1,75 @@
+/**
+ * Normalizes JSON Schemas before they are forwarded to strict OpenAI-compatible
+ * providers.
+ *
+ * TypeBox omits `required` entirely for object schemas whose top-level
+ * properties are all optional. Some strict OpenAI-compatible endpoints reject
+ * such function schemas with errors like:
+ *
+ *   400: Invalid schema for function 'mcp': null is not of type "array"
+ *
+ * because they expect `required` to be an array. This normalizer guarantees a
+ * valid `required` array on every object schema so those providers accept the
+ * tool definitions consistently. See earendil-works/pi#7010.
+ */
+
+/** Schema container keys whose values are themselves schemas. */
+const SCHEMA_VALUE_KEYS = ["items", "additionalProperties", "not", "if", "then", "else"];
+/** Schema container keys whose values are arrays of schemas. */
+const SCHEMA_ARRAY_KEYS = ["anyOf", "oneOf", "allOf", "prefixItems"];
+/** Schema container keys whose values are maps of name -> schema. */
+const SCHEMA_MAP_KEYS = ["properties", "$defs", "definitions", "patternProperties"];
+
+type JsonSchema = Record<string, unknown>;
+
+function isSchemaObject(value: unknown): value is JsonSchema {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalize(schema: unknown): unknown {
+	if (Array.isArray(schema)) {
+		return schema.map(normalize);
+	}
+	if (!isSchemaObject(schema)) {
+		return schema;
+	}
+
+	const result: JsonSchema = { ...schema };
+
+	// An object schema must carry a `required` array. TypeBox omits it when all
+	// properties are optional; some providers send `null`. Normalize both.
+	if (result.type === "object" && (result.required === undefined || result.required === null)) {
+		result.required = [];
+	}
+
+	for (const key of SCHEMA_VALUE_KEYS) {
+		if (key in result && isSchemaObject(result[key])) {
+			result[key] = normalize(result[key]);
+		}
+	}
+	for (const key of SCHEMA_ARRAY_KEYS) {
+		if (Array.isArray(result[key])) {
+			result[key] = (result[key] as unknown[]).map(normalize);
+		}
+	}
+	for (const key of SCHEMA_MAP_KEYS) {
+		if (isSchemaObject(result[key])) {
+			const source = result[key] as JsonSchema;
+			const normalized: JsonSchema = {};
+			for (const name of Object.keys(source)) {
+				normalized[name] = normalize(source[name]);
+			}
+			result[key] = normalized;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Returns a deep copy of a tool `parameters` JSON Schema with `required`
+ * normalized to an array on every object schema. The input is not mutated.
+ */
+export function normalizeToolSchemaForOpenAI(schema: unknown): unknown {
+	return normalize(schema);
+}

--- a/packages/ai/test/normalize-json-schema.test.ts
+++ b/packages/ai/test/normalize-json-schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolSchemaForOpenAI } from "../src/utils/normalize-json-schema.ts";
+
+describe("normalizeToolSchemaForOpenAI", () => {
+	it("adds an empty required array to an object schema that omits it", () => {
+		const schema = {
+			type: "object",
+			properties: { a: { type: "string" }, b: { type: "number" } },
+		};
+		expect(normalizeToolSchemaForOpenAI(schema)).toEqual({
+			type: "object",
+			properties: { a: { type: "string" }, b: { type: "number" } },
+			required: [],
+		});
+	});
+
+	it("normalizes required: null to an empty array", () => {
+		const schema = { type: "object", properties: {}, required: null };
+		expect(normalizeToolSchemaForOpenAI(schema)).toEqual({
+			type: "object",
+			properties: {},
+			required: [],
+		});
+	});
+
+	it("preserves an existing non-empty required array", () => {
+		const schema = {
+			type: "object",
+			properties: { a: { type: "string" } },
+			required: ["a"],
+		};
+		expect(normalizeToolSchemaForOpenAI(schema)).toEqual(schema);
+	});
+
+	it("recurses into nested object properties", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				nested: { type: "object", properties: { x: { type: "string" } } },
+			},
+			required: ["nested"],
+		};
+		const result = normalizeToolSchemaForOpenAI(schema) as {
+			properties: { nested: { required: unknown } };
+		};
+		expect(result.properties.nested.required).toEqual([]);
+	});
+
+	it("recurses into items, anyOf, oneOf, allOf and $defs", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				list: { type: "array", items: { type: "object", properties: {} } },
+				choice: {
+					anyOf: [{ type: "object", properties: {} }, { type: "null" }],
+				},
+			},
+			required: ["list", "choice"],
+			$defs: {
+				Ref: { type: "object", properties: { y: { type: "number" } } },
+			},
+		};
+		const result = normalizeToolSchemaForOpenAI(schema) as {
+			properties: {
+				list: { items: { required: unknown } };
+				choice: { anyOf: Array<{ required?: unknown }> };
+			};
+			$defs: { Ref: { required: unknown } };
+		};
+		expect(result.properties.list.items.required).toEqual([]);
+		expect(result.properties.choice.anyOf[0].required).toEqual([]);
+		expect(result.properties.choice.anyOf[1].required).toBeUndefined();
+		expect(result.$defs.Ref.required).toEqual([]);
+	});
+
+	it("does not touch non-object schemas", () => {
+		expect(normalizeToolSchemaForOpenAI({ type: "string" })).toEqual({ type: "string" });
+		expect(normalizeToolSchemaForOpenAI({ type: "array", items: { type: "number" } })).toEqual({
+			type: "array",
+			items: { type: "number" },
+		});
+	});
+
+	it("does not mutate the input schema", () => {
+		const schema = { type: "object", properties: {} };
+		const snapshot = JSON.stringify(schema);
+		normalizeToolSchemaForOpenAI(schema);
+		expect(JSON.stringify(schema)).toEqual(snapshot);
+	});
+});


### PR DESCRIPTION
## Problem

Closes #7010.

`convertTools` in the OpenAI-compatible completions adapter forwarded tool
JSON Schemas verbatim. TypeBox omits `required` entirely when an object schema
has only optional properties, and strict OpenAI-compatible endpoints reject
that with `null is not of type "array"` (observed on the `mcp` and `subagent`
proxy tools). The failure is intermittent because it only fires when a request
on the completions path happens to include such a schema.

## Fix

Add `packages/ai/src/utils/normalize-json-schema.ts`:
`normalizeToolSchemaForOpenAI` walks the schema and, for every object schema
missing (or null) `required`, sets `required: []`. It recurses through the
standard applicator keywords (`items`, `additionalProperties`, `not`,
`if`/`then`/`else`, `anyOf`/`oneOf`/`allOf`/`prefixItems`, `properties`,
`$defs`, `definitions`, `patternProperties`) and returns a deep copy — the
caller's schema is never mutated.

Wired into both OpenAI-compatible tool paths:
- `openai-completions.ts` `convertTools`
- `openai-responses-shared.ts` `convertResponsesTools`

## Tests

`test/normalize-json-schema.test.ts` covers the all-optional object case,
nested schemas under each applicator keyword, schemas that already have
`required`, non-object schemas, and confirms the input is not mutated.

`npm run check` and the non-e2e suite pass.
