### PR TITLE
fix(coding-agent): fail compaction when summary is truncated at token cap

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -553,6 +553,22 @@ function createSummarizationOptions(
 }
 
 /**
+ * Guard a summarization response before its text is persisted as a compaction
+ * checkpoint. A `length` stop means generation hit the token cap and returned a
+ * partial summary; persisting it silently truncates the checkpoint mid-word,
+ * which is worse than a failed compaction because it looks valid. Fail loudly
+ * instead so the caller can fall back. See earendil-works/pi#7048.
+ */
+function assertSummaryComplete(response: AssistantMessage, label: string): void {
+	if (response.stopReason === "error") {
+		throw new Error(`${label} failed: ${response.errorMessage || "Unknown error"}`);
+	}
+	if (response.stopReason === "length") {
+		throw new Error(`${label} failed: generation hit the token cap and would persist a truncated summary`);
+	}
+}
+
+/**
  * Shared choke point for every compaction/branch-summary summarization call. Wraps the
  * single LLM call in {@link retryAssistantCall} so transient stream drops (e.g.
  * `terminated`, socket close) honor the configured retry policy instead of failing
@@ -676,9 +692,7 @@ export async function generateSummaryWithUsage(
 		callbacks,
 	);
 
-	if (response.stopReason === "error") {
-		throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);
-	}
+	assertSummaryComplete(response, "Summarization");
 
 	const textContent = contentText(response.content);
 
@@ -958,9 +972,7 @@ async function generateTurnPrefixSummary(
 		callbacks,
 	);
 
-	if (response.stopReason === "error") {
-		throw new Error(`Turn prefix summarization failed: ${response.errorMessage || "Unknown error"}`);
-	}
+	assertSummaryComplete(response, "Turn prefix summarization");
 
 	return {
 		text: contentText(response.content),

--- a/packages/coding-agent/test/suite/regressions/7048-compaction-truncated-summary.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7048-compaction-truncated-summary.test.ts
@@ -1,0 +1,103 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage, Model, Usage } from "@earendil-works/pi-ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateSummary, generateSummaryWithUsage } from "../../../src/core/compaction/index.ts";
+
+// Regression for earendil-works/pi#7048:
+// When summarization hits the token cap the provider returns stopReason "length"
+// with a partial summary. Previously only stopReason "error" was checked, so the
+// truncated text was persisted as the compaction checkpoint. It must fail loudly.
+
+const { completeSimpleMock } = vi.hoisted(() => ({
+	completeSimpleMock: vi.fn(),
+}));
+
+vi.mock("@earendil-works/pi-ai/compat", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@earendil-works/pi-ai/compat")>();
+	return {
+		...actual,
+		completeSimple: completeSimpleMock,
+	};
+});
+
+function createModel(maxTokens = 8192): Model<"anthropic-messages"> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens,
+	};
+}
+
+function createUsage(): Usage {
+	return {
+		input: 10,
+		output: 10,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 20,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function summaryResponse(stopReason: AssistantMessage["stopReason"], text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: createUsage(),
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+const messages: AgentMessage[] = [{ role: "user", content: "Summarize this.", timestamp: Date.now() }];
+
+describe("compaction summary truncation (#7048)", () => {
+	beforeEach(() => {
+		completeSimpleMock.mockReset();
+	});
+
+	it("throws when the summary was truncated at the token cap (stopReason length)", async () => {
+		completeSimpleMock.mockResolvedValue(summaryResponse("length", "...you went fro"));
+
+		await expect(generateSummaryWithUsage(messages, createModel(), 2000, "test-key")).rejects.toThrow(
+			/token cap/,
+		);
+	});
+
+	it("propagates the truncation failure through generateSummary", async () => {
+		completeSimpleMock.mockResolvedValue(summaryResponse("length", "partial"));
+
+		await expect(generateSummary(messages, createModel(), 2000, "test-key")).rejects.toThrow(
+			/Summarization failed/,
+		);
+	});
+
+	it("still returns a complete summary when generation stops normally", async () => {
+		completeSimpleMock.mockResolvedValue(summaryResponse("stop", "## Goal\nComplete summary"));
+
+		await expect(generateSummary(messages, createModel(), 2000, "test-key")).resolves.toBe(
+			"## Goal\nComplete summary",
+		);
+	});
+
+	it("still throws on an error stop reason", async () => {
+		completeSimpleMock.mockResolvedValue({
+			...summaryResponse("error", ""),
+			errorMessage: "boom",
+		});
+
+		await expect(generateSummaryWithUsage(messages, createModel(), 2000, "test-key")).rejects.toThrow(
+			/boom/,
+		);
+	});
+});


### PR DESCRIPTION
## Problem

Closes #7048.

Compaction caps the summary generation at `min(0.8 * reserveTokens,
model.maxTokens)` but only treated `stopReason === "error"` as a failure. When
generation hits the cap the provider returns `stopReason: "length"` with a
partial summary, and that truncated text was persisted as the compaction
checkpoint — the session then resumed on a summary that could end mid-word,
with the content past the cut silently lost.

## Fix

Add an `assertSummaryComplete` guard used by both `generateSummaryWithUsage`
and `generateTurnPrefixSummary`. It throws on `stopReason === "error"` (as
before) and now also on `stopReason === "length"`, so a run that hits the token
cap fails loudly instead of writing a truncated checkpoint. Failing compaction
is recoverable; a checkpoint that looks valid but is truncated is not.

I went with fail-loud rather than the "retry with a larger cap" option in the
issue: the cap is derived from the reserve/model limits, so a silent retry can
mask a persistently undersized budget, and a heuristic mid-word check would let
some truncations through. Happy to switch to a bounded retry if you prefer.

## Tests

`test/suite/regressions/7048-compaction-truncated-summary.test.ts` mocks
`completeSimple` to return each `stopReason` and asserts: `length` and `error`
throw, a normal completion is persisted unchanged.

`npm run check` and the non-e2e suite pass.
