### PR TITLE
fix(coding-agent): recover model availability after a stalled refresh

### DIFF
--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -112,6 +112,7 @@ export class ModelRuntime implements Models {
 		auth: new Map(),
 	};
 	private availabilityRefresh: Promise<void> | undefined;
+	private availabilityRefreshSeq = 0;
 	private availabilityError: string | undefined;
 
 	private constructor(
@@ -239,7 +240,7 @@ export class ModelRuntime implements Models {
 		};
 	}
 
-	private async runAvailabilityRefresh(): Promise<void> {
+	private async runAvailabilityRefresh(seq: number): Promise<void> {
 		const providers = this.models.getProviders();
 		const [available, checks, credentials] = await Promise.all([
 			this.models.getAvailable(),
@@ -253,6 +254,10 @@ export class ModelRuntime implements Models {
 			),
 			this.credentials.list(),
 		]);
+		// A newer rebuild was requested while this one was in flight; drop this
+		// result so a slow, superseded refresh cannot clobber the snapshot with
+		// stale data.
+		if (seq !== this.availabilityRefreshSeq) return;
 		const auth = new Map(checks);
 		const configuredProviders = new Set(
 			checks
@@ -269,10 +274,14 @@ export class ModelRuntime implements Models {
 		this.availabilityError = undefined;
 	}
 
-	private queueAvailabilityRefresh(after: Promise<void> | undefined): Promise<void> {
-		const refresh = (after ?? Promise.resolve()).catch(() => {}).then(() => this.runAvailabilityRefresh());
+	private queueAvailabilityRefresh(): Promise<void> {
+		const seq = ++this.availabilityRefreshSeq;
+		const refresh = this.runAvailabilityRefresh(seq);
 		const recorded = refresh.catch((error) => {
-			this.availabilityError = error instanceof Error ? error.message : String(error);
+			// Only the latest requested rebuild owns the error state.
+			if (seq === this.availabilityRefreshSeq) {
+				this.availabilityError = error instanceof Error ? error.message : String(error);
+			}
 			throw error;
 		});
 		const tracked = recorded.finally(() => {
@@ -284,12 +293,18 @@ export class ModelRuntime implements Models {
 
 	/** Coalesce concurrent readers onto the pending refresh. */
 	private refreshAvailability(): Promise<void> {
-		return this.availabilityRefresh ?? this.queueAvailabilityRefresh(undefined);
+		return this.availabilityRefresh ?? this.queueAvailabilityRefresh();
 	}
 
-	/** Mutations must not observe an in-flight refresh started before them. */
+	/**
+	 * Mutations must observe a rebuild that starts after their state change, and a
+	 * stuck in-flight refresh must not block them. Start a fresh, independent
+	 * rebuild instead of chaining onto the pending one (which never fires if that
+	 * promise never settles). The sequence guard in runAvailabilityRefresh ensures
+	 * a superseded rebuild cannot clobber this one's result.
+	 */
 	private forceRefreshAvailability(): Promise<void> {
-		return this.queueAvailabilityRefresh(this.availabilityRefresh);
+		return this.queueAvailabilityRefresh();
 	}
 
 	getProviders(): readonly Provider[] {

--- a/packages/coding-agent/test/suite/regressions/7301-force-refresh-availability-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7301-force-refresh-availability-recovery.test.ts
@@ -1,0 +1,64 @@
+import type { CredentialStore } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { ModelRuntime } from "../../../src/core/model-runtime.ts";
+
+// Regression for earendil-works/pi#7301:
+// forceRefreshAvailability() used to .then()-chain a new rebuild onto the
+// pending one. If that pending refresh never settled, refresh() chained onto it
+// never fired and the runtime was permanently stuck even after the cause
+// cleared. A fresh independent rebuild must recover.
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A credential store whose list() can be made to hang, then released. read()
+ * always resolves so ModelRuntime.create() (which triggers a refresh) succeeds.
+ */
+function createControllableStore(): {
+	store: CredentialStore;
+	setHang: (value: boolean) => void;
+} {
+	let hang = false;
+	const store: CredentialStore = {
+		read: async (providerId) => (providerId === "anthropic" ? { type: "api_key", key: "sk-test" } : undefined),
+		delete: async () => {},
+		modify: async (_providerId, fn) => fn(undefined),
+		list: async () => {
+			if (hang) await new Promise<never>(() => {});
+			return [{ providerId: "anthropic", type: "api_key" }];
+		},
+	};
+	return { store, setHang: (value) => (hang = value) };
+}
+
+describe("model-runtime availability recovery (#7301)", () => {
+	it("recovers via refresh() after an availability rebuild stalls and the cause clears", async () => {
+		const { store, setHang } = createControllableStore();
+		const runtime = await ModelRuntime.create({ credentials: store, modelsPath: null, allowModelNetwork: false });
+
+		// Start a rebuild that cannot finish (list() hangs), leaving a pending
+		// availabilityRefresh behind, exactly as the report describes.
+		setHang(true);
+		const stalled = runtime.getAvailable();
+		const stalledSettled = Promise.race([stalled.then(() => true), sleep(200).then(() => false)]);
+		expect(await stalledSettled).toBe(false);
+
+		// Cause removed. A forced refresh must start a fresh rebuild rather than
+		// chaining onto the stuck promise, so it settles.
+		setHang(false);
+		const recovered = await Promise.race([
+			runtime.refresh({ allowNetwork: false }).then(() => true),
+			sleep(3000).then(() => false),
+		]);
+		expect(recovered).toBe(true);
+
+		// And availability reads work again.
+		const available = await Promise.race([
+			runtime.getAvailable().then(() => true),
+			sleep(3000).then(() => false),
+		]);
+		expect(available).toBe(true);
+	});
+});


### PR DESCRIPTION
## Problem

Closes #7301.

`forceRefreshAvailability()` chained the new rebuild onto the currently stored
`availabilityRefresh` promise via `.then()`. If that promise never settled, the
`.then()` never fired, the new rebuild never started, and every subsequent
`getAvailable()` / `refresh()` caller was handed a promise that could never
settle — the runtime stayed stuck even after the stalling input recovered.

## Fix

Replace promise-chaining with a monotonic sequence guard:

- `availabilityRefreshSeq` increments on each queued refresh.
- `runAvailabilityRefresh(seq)` runs its `Promise.all(...)` independently (no
  chaining onto a prior promise) and only commits the resulting snapshot / error
  if its `seq` is still the latest — a stale rebuild that finishes late is
  discarded rather than clobbering a newer result.
- `forceRefreshAvailability()` starts a fresh independent rebuild instead of
  chaining onto the in-flight one, so a stalled refresh can never block recovery.

This preserves the original intent (a mutation must not observe an earlier
in-flight refresh) — the seq guard gives newer-wins ordering without the
liveness hazard of chaining.

## Tests

`test/suite/regressions/7301-force-refresh-availability-recovery.test.ts` uses a
`CredentialStore` whose `list()` can be made to hang, stalls a refresh, then
unstalls and asserts `forceRefreshAvailability()` settles and rebuilds. I
confirmed the test fails (times out) against the chaining version and passes
with the fix.

`npm run check` and the non-e2e suite pass.
