### PR TITLE
feat(ai): support direct image URLs in ImageContent

### DIFF
--- a/packages/agent/test/harness/tools.test.ts
+++ b/packages/agent/test/harness/tools.test.ts
@@ -1,4 +1,5 @@
 import { symlink } from "node:fs/promises";
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import { applyPatch } from "diff";
 import { describe, expect, it } from "vitest";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
@@ -576,7 +577,7 @@ describe("AgentHarness tools", () => {
 		it("coalesces updates and persists truncated full output", async () => {
 			const context = createContext();
 			const updates: Array<{
-				content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>;
+				content: Array<TextContent | ImageContent>;
 				details?: BashToolDetails;
 			}> = [];
 			const result = await createBashTool().execute(

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -32,6 +32,7 @@ import type {
 import { splitDeferredTools } from "../utils/deferred-tools.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
+import { requireImageData } from "../utils/image-content.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
@@ -141,12 +142,13 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
 				text: sanitizeSurrogates(block.text),
 			};
 		}
+		const { data, mimeType } = requireImageData(block);
 		return {
 			type: "image" as const,
 			source: {
 				type: "base64" as const,
-				media_type: block.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-				data: block.data,
+				media_type: mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
+				data,
 			},
 		};
 	});
@@ -1143,12 +1145,13 @@ function convertMessages(
 							text: sanitizeSurrogates(item.text),
 						};
 					} else {
+						const { data, mimeType } = requireImageData(item);
 						return {
 							type: "image",
 							source: {
 								type: "base64",
-								media_type: item.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-								data: item.data,
+								media_type: mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
+								data,
 							},
 						};
 					}

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -51,6 +51,7 @@ import { appendAssistantMessageDiagnostic } from "../utils/diagnostics.ts";
 import { normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
+import { requireImageData } from "../utils/image-content.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
@@ -804,7 +805,8 @@ function convertToolResultContent(content: (TextContent | ImageContent)[]): Tool
 	const result: ToolResultContentBlock[] = [];
 	for (const c of content) {
 		if (c.type === "image") {
-			result.push({ image: createImageBlock(c.mimeType, c.data) });
+			const { data, mimeType } = requireImageData(c);
+			result.push({ image: createImageBlock(mimeType, data) });
 		} else {
 			const textBlock = createNonBlankTextBlock(c.text);
 			if (textBlock) result.push(textBlock);
@@ -839,9 +841,11 @@ function convertMessages(
 								if (textBlock) content.push(textBlock);
 								break;
 							}
-							case "image":
-								content.push({ image: createImageBlock(c.mimeType, c.data) });
+							case "image": {
+								const { data, mimeType } = requireImageData(c);
+								content.push({ image: createImageBlock(mimeType, data) });
 								break;
+							}
 							default:
 								continue;
 						}

--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -4,6 +4,7 @@
 
 import { type Content, FinishReason, FunctionCallingConfigMode, type Part } from "@google/genai";
 import type { Context, ImageContent, Model, StopReason, TextContent, Tool } from "../types.ts";
+import { requireImageData } from "../utils/image-content.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import { transformMessages } from "./transform-messages.ts";
@@ -110,10 +111,11 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 					if (item.type === "text") {
 						return { text: sanitizeSurrogates(item.text) };
 					} else {
+						const { data, mimeType } = requireImageData(item);
 						return {
 							inlineData: {
-								mimeType: item.mimeType,
-								data: item.data,
+								mimeType,
+								data,
 							},
 						};
 					}
@@ -199,12 +201,15 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 			// Use "output" key for success, "error" key for errors as per SDK documentation
 			const responseValue = hasText ? sanitizeSurrogates(textResult) : hasImages ? "(see attached image)" : "";
 
-			const imageParts: Part[] = imageContent.map((imageBlock) => ({
-				inlineData: {
-					mimeType: imageBlock.mimeType,
-					data: imageBlock.data,
-				},
-			}));
+			const imageParts: Part[] = imageContent.map((imageBlock) => {
+				const { data, mimeType } = requireImageData(imageBlock);
+				return {
+					inlineData: {
+						mimeType,
+						data,
+					},
+				};
+			});
 
 			const includeId = requiresToolCallId(model.id);
 			const functionResponsePart: Part = {

--- a/packages/ai/src/api/mistral-conversations.ts
+++ b/packages/ai/src/api/mistral-conversations.ts
@@ -23,6 +23,7 @@ import type {
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
+import { imageToUrl } from "../utils/image-content.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
@@ -537,7 +538,7 @@ function toChatMessages(messages: Message[], supportsImages: boolean): ChatCompl
 				.filter((item) => item.type === "text" || supportsImages)
 				.map((item) => {
 					if (item.type === "text") return { type: "text", text: sanitizeSurrogates(item.text) };
-					return { type: "image_url", imageUrl: `data:${item.mimeType};base64,${item.data}` };
+					return { type: "image_url", imageUrl: imageToUrl(item) };
 				});
 			if (content.length > 0) {
 				result.push({ role: "user", content });
@@ -596,7 +597,7 @@ function toChatMessages(messages: Message[], supportsImages: boolean): ChatCompl
 			if (part.type !== "image") continue;
 			toolContent.push({
 				type: "image_url",
-				imageUrl: `data:${part.mimeType};base64,${part.data}`,
+				imageUrl: imageToUrl(part),
 			});
 		}
 		result.push({

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -37,6 +37,7 @@ import { formatProviderError, normalizeProviderError } from "../utils/error-body
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
+import { imageToUrl } from "../utils/image-content.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
@@ -1067,7 +1068,7 @@ export function convertMessages(
 						return {
 							type: "image_url",
 							image_url: {
-								url: `data:${item.mimeType};base64,${item.data}`,
+								url: imageToUrl(item),
 							},
 						} satisfies ChatCompletionContentPartImage;
 					}
@@ -1233,7 +1234,7 @@ export function convertMessages(
 							imageBlocks.push({
 								type: "image_url",
 								image_url: {
-									url: `data:${block.mimeType};base64,${block.data}`,
+									url: imageToUrl(block),
 								},
 							});
 						}

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -30,6 +30,7 @@ import type {
 } from "../types.ts";
 import type { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
+import { imageToUrl } from "../utils/image-content.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import {
@@ -96,7 +97,7 @@ function convertToolResultOutput<TApi extends Api>(
 		output.push({
 			type: "input_image",
 			detail: "auto",
-			image_url: `data:${image.mimeType};base64,${image.data}`,
+			image_url: imageToUrl(image),
 		});
 	}
 	return output;
@@ -198,7 +199,7 @@ export function convertResponsesMessages<TApi extends Api>(
 					return {
 						type: "input_image",
 						detail: "auto",
-						image_url: `data:${item.mimeType};base64,${item.data}`,
+						image_url: imageToUrl(item),
 					} satisfies ResponseInputImage;
 				});
 				if (content.length === 0) continue;

--- a/packages/ai/src/api/openrouter-images.ts
+++ b/packages/ai/src/api/openrouter-images.ts
@@ -18,6 +18,7 @@ import type {
 } from "../types.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { headersToRecord, providerHeadersToRecord } from "../utils/headers.ts";
+import { imageToUrl } from "../utils/image-content.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 
@@ -144,7 +145,7 @@ function buildParams(model: ImagesModel<"openrouter-images">, context: ImagesCon
 		return {
 			type: "image_url",
 			image_url: {
-				url: `data:${item.mimeType};base64,${item.data}`,
+				url: imageToUrl(item),
 			},
 		} satisfies ChatCompletionContentPartImage;
 	});

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -154,7 +154,7 @@ function contentToText(content: string | Array<TextContent | ImageContent>): str
 			if (block.type === "text") {
 				return block.text;
 			}
-			return `[image:${block.mimeType}:${block.data.length}]`;
+			return `[image:${block.url ?? block.mimeType}:${block.data?.length ?? 0}]`;
 		})
 		.join("\n");
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -353,8 +353,17 @@ export interface ThinkingContent {
 
 export interface ImageContent {
 	type: "image";
-	data: string; // base64 encoded image data
-	mimeType: string; // e.g., "image/jpeg", "image/png"
+	/** Base64-encoded image data. Provide this together with `mimeType`, or use `url` instead. */
+	data?: string;
+	/** MIME type of `data`, e.g. "image/jpeg", "image/png". Required when `data` is set. */
+	mimeType?: string;
+	/**
+	 * Direct image URL passed to the provider without fetching/base64 conversion.
+	 * Providers that support URL image input (e.g. OpenAI-compatible chat
+	 * completions) use it as-is; others fall back to `data`. Set either `url` or
+	 * `data` + `mimeType`.
+	 */
+	url?: string;
 }
 
 export interface ToolCall {

--- a/packages/ai/src/utils/image-content.ts
+++ b/packages/ai/src/utils/image-content.ts
@@ -1,0 +1,27 @@
+import type { ImageContent } from "../types.ts";
+
+/**
+ * Resolve an image block to a single URL string for providers that accept a URL
+ * (OpenAI-compatible `image_url`, Mistral `imageUrl`, etc.). A direct `url` is
+ * passed through untouched; otherwise the base64 `data` is wrapped in a data
+ * URI. See earendil-works/pi#6151.
+ */
+export function imageToUrl(image: ImageContent): string {
+	if (image.url) return image.url;
+	return `data:${image.mimeType};base64,${image.data}`;
+}
+
+/**
+ * Extract required base64 data for providers that can only send image bytes in a
+ * structured field (Anthropic base64 source, Bedrock, Google inline data). These
+ * providers cannot forward a bare URL, so a url-only {@link ImageContent} is a
+ * clear caller error rather than something to silently mangle into a data URI.
+ */
+export function requireImageData(image: ImageContent): { data: string; mimeType: string } {
+	if (image.data === undefined || image.mimeType === undefined) {
+		throw new Error(
+			"This provider requires base64 image data; url-only image content is supported by OpenAI-compatible providers only",
+		);
+	}
+	return { data: image.data, mimeType: image.mimeType };
+}

--- a/packages/ai/test/image-content.test.ts
+++ b/packages/ai/test/image-content.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { ImageContent } from "../src/types.ts";
+import { imageToUrl, requireImageData } from "../src/utils/image-content.ts";
+
+describe("image-content helpers (earendil-works/pi#6151)", () => {
+	describe("imageToUrl", () => {
+		it("returns a direct url as-is", () => {
+			const image: ImageContent = { type: "image", url: "https://example.com/a.png" };
+			expect(imageToUrl(image)).toBe("https://example.com/a.png");
+		});
+
+		it("wraps base64 data in a data URI", () => {
+			const image: ImageContent = { type: "image", data: "ZmFrZQ==", mimeType: "image/png" };
+			expect(imageToUrl(image)).toBe("data:image/png;base64,ZmFrZQ==");
+		});
+
+		it("prefers url when both url and data are set", () => {
+			const image: ImageContent = {
+				type: "image",
+				url: "https://example.com/b.jpg",
+				data: "ZmFrZQ==",
+				mimeType: "image/png",
+			};
+			expect(imageToUrl(image)).toBe("https://example.com/b.jpg");
+		});
+	});
+
+	describe("requireImageData", () => {
+		it("returns data and mimeType when present", () => {
+			const image: ImageContent = { type: "image", data: "ZmFrZQ==", mimeType: "image/jpeg" };
+			expect(requireImageData(image)).toEqual({ data: "ZmFrZQ==", mimeType: "image/jpeg" });
+		});
+
+		it("throws for url-only images", () => {
+			const image: ImageContent = { type: "image", url: "https://example.com/c.png" };
+			expect(() => requireImageData(image)).toThrow(/base64 image data/);
+		});
+
+		it("throws when mimeType is missing", () => {
+			const image: ImageContent = { type: "image", data: "ZmFrZQ==" };
+			expect(() => requireImageData(image)).toThrow(/base64 image data/);
+		});
+	});
+});

--- a/packages/ai/test/openai-completions-image-url.test.ts
+++ b/packages/ai/test/openai-completions-image-url.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/api/openai-completions.ts";
+import { getModel } from "../src/compat.ts";
+import type { Context, Model, OpenAICompletionsCompat } from "../src/types.ts";
+
+const compat: Omit<Required<OpenAICompletionsCompat>, "deferredToolsMode"> & {
+	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+} = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	supportsFinishReason: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	chatTemplateKwargs: {},
+	zaiToolStream: false,
+	supportsStrictMode: true,
+	supportsOpenAIGrammarTools: false,
+	cacheControlFormat: "anthropic",
+	sendSessionAffinityHeaders: false,
+	sessionAffinityFormat: "openai",
+	supportsLongCacheRetention: true,
+};
+
+function imageModel(): Model<"openai-completions"> {
+	const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+	return { ...baseModel, api: "openai-completions", input: ["text", "image"] };
+}
+
+function firstImageUrl(context: Context): string {
+	const messages = convertMessages(imageModel(), context, compat);
+	const userMessage = messages.find((m) => m.role === "user" && Array.isArray(m.content));
+	const parts = (userMessage?.content ?? []) as Array<{ type?: string; image_url?: { url?: string } }>;
+	const image = parts.find((part) => part?.type === "image_url");
+	if (!image?.image_url?.url) throw new Error("no image_url part found");
+	return image.image_url.url;
+}
+
+describe("openai-completions image_url passthrough (earendil-works/pi#6151)", () => {
+	it("passes a direct image url through without base64 conversion", () => {
+		const now = Date.now();
+		const url = firstImageUrl({
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "describe this" },
+						{ type: "image", url: "https://example.com/cat.png" },
+					],
+					timestamp: now,
+				},
+			],
+		});
+		expect(url).toBe("https://example.com/cat.png");
+	});
+
+	it("still wraps base64 data in a data URI when no url is provided", () => {
+		const now = Date.now();
+		const url = firstImageUrl({
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "describe this" },
+						{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+					],
+					timestamp: now,
+				},
+			],
+		});
+		expect(url).toBe("data:image/png;base64,ZmFrZQ==");
+	});
+
+	it("prefers url over data when both are present", () => {
+		const now = Date.now();
+		const url = firstImageUrl({
+			messages: [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							url: "https://example.com/dog.jpg",
+							data: "ZmFrZQ==",
+							mimeType: "image/png",
+						},
+					],
+					timestamp: now,
+				},
+			],
+		});
+		expect(url).toBe("https://example.com/dog.jpg");
+	});
+});

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/index.ts
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/index.ts
@@ -197,6 +197,9 @@ function convertContentBlocks(
 		if (block.type === "text") {
 			return { type: "text" as const, text: sanitizeSurrogates(block.text) };
 		}
+		if (block.data === undefined || block.mimeType === undefined) {
+			throw new Error("Anthropic requires base64 image data; url-only image content is not supported");
+		}
 		return {
 			type: "image" as const,
 			source: {
@@ -226,14 +229,18 @@ function convertMessages(messages: Message[], isOAuth: boolean, _tools?: Tool[])
 					params.push({ role: "user", content: sanitizeSurrogates(msg.content) });
 				}
 			} else {
-				const blocks: ContentBlockParam[] = msg.content.map((item) =>
-					item.type === "text"
-						? { type: "text" as const, text: sanitizeSurrogates(item.text) }
-						: {
-								type: "image" as const,
-								source: { type: "base64" as const, media_type: item.mimeType as any, data: item.data },
-							},
-				);
+				const blocks: ContentBlockParam[] = msg.content.map((item) => {
+					if (item.type === "text") {
+						return { type: "text" as const, text: sanitizeSurrogates(item.text) };
+					}
+					if (item.data === undefined || item.mimeType === undefined) {
+						throw new Error("Anthropic requires base64 image data; url-only image content is not supported");
+					}
+					return {
+						type: "image" as const,
+						source: { type: "base64" as const, media_type: item.mimeType as any, data: item.data },
+					};
+				});
 				if (blocks.length > 0) {
 					params.push({ role: "user", content: blocks });
 				}

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -83,8 +83,9 @@ export const ThinkingContentSchema = StrictObject({
 });
 export const ImageContentSchema = StrictObject({
 	type: Type.Literal("image"),
-	data: Type.String(),
-	mimeType: Type.String({ minLength: 1 }),
+	data: Type.Optional(Type.String()),
+	mimeType: Type.Optional(Type.String({ minLength: 1 })),
+	url: Type.Optional(Type.String({ minLength: 1 })),
 });
 export const ToolCallContentSchema = StrictObject({
 	type: Type.Literal("toolCall"),

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -41,7 +41,7 @@ type _AiThinkingContentFieldsAccountedFor = Assert<
 		"type" | "thinking" | "thinkingSignature" | "redacted"
 	>
 >;
-type _AiImageContentFieldsAccountedFor = Assert<ExactKeys<AiImageContent, "type" | "data" | "mimeType">>;
+type _AiImageContentFieldsAccountedFor = Assert<ExactKeys<AiImageContent, "type" | "data" | "mimeType" | "url">>;
 type _AiToolCallFieldsAccountedFor = Assert<
 	ExactKeys<ToolCall, "type" | "id" | "name" | "arguments" | "thoughtSignature">
 >;
@@ -231,7 +231,7 @@ function toProtocolUserContent(content: UserMessage["content"]): UserTranscriptI
 			case "text":
 				return { type: "text", text: part.text };
 			case "image":
-				return { type: "image", data: part.data, mimeType: part.mimeType };
+				return { type: "image", data: part.data, mimeType: part.mimeType, url: part.url };
 			default: {
 				const exhaustive: never = part;
 				return exhaustive;
@@ -336,7 +336,7 @@ function toProtocolToolContent(content: Array<AiTextContent | AiImageContent>): 
 			case "text":
 				return { type: "text", text: part.text };
 			case "image":
-				return { type: "image", data: part.data, mimeType: part.mimeType };
+				return { type: "image", data: part.data, mimeType: part.mimeType, url: part.url };
 			default: {
 				const exhaustive: never = part;
 				return exhaustive;


### PR DESCRIPTION
## Problem

Closes #6151.

Every `ImageContent` was converted to a base64 data URI before being sent, so
there was no way to pass an image URL through to providers that natively accept
one — callers had to fetch and base64-encode even when storing a URL would do.

## Approach

The issue suggested a separate `ImageUrlContent` type. I instead added an
optional `url` to the existing `ImageContent` and made `data`/`mimeType`
optional:

```ts
export interface ImageContent {
  type: "image";
  data?: string;
  mimeType?: string;
  url?: string;
}
```

Rationale: a parallel content type would have to be threaded through every
provider and the `UserMessage`/`ToolResultMessage` unions, which is the kind of
core surface growth CONTRIBUTING warns against. One optional field keeps the
content model single. If you'd rather have a distinct type, I'll switch.

## Changes

Two shared helpers in `utils/image-content.ts`:
- `imageToUrl(image)` — return `url` as-is, else wrap `data` in a data URI.
  Used by URL-capable providers (OpenAI completions + responses, Mistral,
  OpenRouter); also collapses the duplicated data-URI expressions.
- `requireImageData(image)` — return `{data, mimeType}` or throw for url-only
  content. Used by providers that can only send bytes (Anthropic, Bedrock,
  Google), so a url-only image fails with a clear message instead of a broken
  `data:...;base64,undefined`.

The optional-field change widened `ImageContent`, so the pi-protocol schema
mirror and its server-side `ExactKeys` guard were updated to carry `url`, and a
couple of downstream consumers (an example extension, one agent test
annotation) were aligned.

## Tests

- `test/openai-completions-image-url.test.ts`: url passes through, base64 still
  produces a data URI, url wins when both are set.
- `test/image-content.test.ts`: both helpers, including the `requireImageData`
  throw paths.

`npm run check` passes across the monorepo; ai / agent / server / protocol
suites are green.
