### PR TITLE
fix(harness): make path utilities cross-platform on Windows

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -81,7 +81,7 @@ function fileInfoFromStats(
 	const kind = fileKindFromStats(stats);
 	if (!kind) return err(new FileError("invalid", "Unsupported file type", path));
 	return ok({
-		name: path.replace(/\/+$/, "").split("/").pop() ?? path,
+		name: path.replace(/\\/g, "/").replace(/\/+$/, "").split("/").pop() ?? path,
 		path,
 		kind,
 		size: stats.size,

--- a/packages/agent/src/harness/prompt-templates.ts
+++ b/packages/agent/src/harness/prompt-templates.ts
@@ -214,7 +214,7 @@ function parseFrontmatter<T extends Record<string, unknown>>(
 }
 
 function basenameEnvPath(path: string): string {
-	const normalized = path.replace(/\/+$/, "");
+	const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
 }

--- a/packages/agent/src/harness/skills.ts
+++ b/packages/agent/src/harness/skills.ts
@@ -350,24 +350,24 @@ async function resolveKind(
 }
 
 function joinEnvPath(base: string, child: string): string {
-	return `${base.replace(/\/+$/, "")}/${child.replace(/^\/+/, "")}`;
+	return `${base.replace(/\\/g, "/").replace(/\/+$/, "")}/${child.replace(/\\/g, "/").replace(/^\/+/, "")}`;
 }
 
 function dirnameEnvPath(path: string): string {
-	const normalized = path.replace(/\/+$/, "");
+	const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex <= 0 ? "/" : normalized.slice(0, slashIndex);
 }
 
 function basenameEnvPath(path: string): string {
-	const normalized = path.replace(/\/+$/, "");
+	const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
 }
 
 function relativeEnvPath(root: string, path: string): string {
-	const normalizedRoot = root.replace(/\/+$/, "");
-	const normalizedPath = path.replace(/\/+$/, "");
+	const normalizedRoot = root.replace(/\\/g, "/").replace(/\/+$/, "");
+	const normalizedPath = path.replace(/\\/g, "/").replace(/\/+$/, "");
 	if (normalizedPath === normalizedRoot) return "";
 	return normalizedPath.startsWith(`${normalizedRoot}/`)
 		? normalizedPath.slice(normalizedRoot.length + 1)


### PR DESCRIPTION
## Summary

Four path utility functions and one FileInfo helper in the harness layer assume POSIX-only path separators (`/`). On Windows, where `path.resolve` returns `\`-separated paths, `loadSkills` crashes with `RangeError: path should be a \`path.relative()\`d string` from the `ignore` library, and even when it doesn't crash, `FileInfo.name` is the full absolute path instead of the basename — silently breaking skill discovery.

## Problem

### Symptom 1: `loadSkills` crashes on Windows

```
RangeError: path should be a `path.relative()`d string, but got "C:\dogear\.claude\skills\brainstorming/"
    at throwError (.../ignore/index.js:557:9)
    at checkPath (.../ignore/index.js:576:12)
    at Ignore.ignores (.../ignore/index.js:720:17)
    at loadSkillsFromDirInternal (.../pi-agent-core/dist/harness/skills.js:112:27)
```

Trigger: any Windows user calling `loadSkills(env, dirs)` where `dirs` contains a parent directory with skill subdirectories (the standard `.claude/skills/<name>/SKILL.md` layout). Flat layout (`dir/SKILL.md` directly) does **not** trigger this — only the recursive scan does.

### Symptom 2: `FileInfo.name` contains the full absolute path on Windows

Even after working around symptom 1, `loadSkills` silently returns 0 skills because the first-loop check `entry.name !== "SKILL.md"` never matches — `entry.name` is the full Windows path (`C:\...\SKILL.md`), not `"SKILL.md"`.

Affects every consumer of `NodeExecutionEnv.fileInfo()` / `.listDir()` on Windows.

## Root cause

Five spots in the harness layer compute path-derived values by splitting on or stripping `/` only:

| File | Function | Issue |
|------|----------|-------|
| `harness/skills.ts` | `joinEnvPath` | only strips trailing `/` |
| `harness/skills.ts` | `dirnameEnvPath` | only `lastIndexOf("/")` |
| `harness/skills.ts` | `basenameEnvPath` | only `lastIndexOf("/")` |
| `harness/skills.ts` | `relativeEnvPath` | `startsWith` only matches `/`-joined root; fallback doesn't strip absolute prefix |
| `harness/env/nodejs.ts` | `fileInfoFromStats` | `path.split("/").pop()` returns full path on Windows |
| `harness/prompt-templates.ts` | `basenameEnvPath` (duplicate) | only `lastIndexOf("/")` |

`NodeExecutionEnv` internally uses Node's `path.resolve`, which on Windows produces `\`-separated paths. The harness path utilities never normalize, so any `\` flows straight through and breaks the POSIX-only regex / split / indexOf logic.

## Fix

Normalize `\` to `/` at the start of each affected function. Minimal, no behavior change on POSIX systems.

```diff
function joinEnvPath(base: string, child: string): string {
-	return \`\${base.replace(/\/+\$/, "")}/\${child.replace(/^\/+/, "")}\`;
+	return \`\${base.replace(/\\/g, "/").replace(/\/+\$/, "")}/\${child.replace(/\\/g, "/").replace(/^\/+/, "")}\`;
}

function dirnameEnvPath(path: string): string {
-	const normalized = path.replace(/\/+\$/, "");
+	const normalized = path.replace(/\\/g, "/").replace(/\/+\$/, "");
	const slashIndex = normalized.lastIndexOf("/");
	return slashIndex <= 0 ? "/" : normalized.slice(0, slashIndex);
}

function basenameEnvPath(path: string): string {
-	const normalized = path.replace(/\/+\$/, "");
+	const normalized = path.replace(/\\/g, "/").replace(/\/+\$/, "");
	const slashIndex = normalized.lastIndexOf("/");
	return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
}

function relativeEnvPath(root: string, path: string): string {
-	const normalizedRoot = root.replace(/\/+\$/, "");
-	const normalizedPath = path.replace(/\/+\$/, "");
+	const normalizedRoot = root.replace(/\\/g, "/").replace(/\/+\$/, "");
+	const normalizedPath = path.replace(/\\/g, "/").replace(/\/+\$/, "");
```

```diff
function fileInfoFromStats(...) {
	return ok({
-		name: path.replace(/\/+\$/, "").split("/").pop() ?? path,
+		name: path.replace(/\\/g, "/").replace(/\/+\$/, "").split("/").pop() ?? path,
		...
	});
}
```

(Same one-liner for the duplicate `basenameEnvPath` in `prompt-templates.ts`.)

## Reproduction (Windows)

\`\`\`js
import { loadSkills } from '@earendil-works/pi-agent-core';
import { NodeExecutionEnv } from '@earendil-works/pi-agent-core/node';

const env = new NodeExecutionEnv({ cwd: process.cwd() });

// Any dir with subdirs containing SKILL.md triggers this on Windows
const { skills, diagnostics } = await loadSkills(env, ['C:\\Users\\me\\.claude\\skills']);
// Without patch: RangeError thrown
// With patch: skills array populated correctly
\`\`\`

## Why this approach

- **Minimal**: each fix is a single `.replace(/\\/g, "/")` prepend; no logic change on POSIX.
- **At the source**: normalizes once at the boundary, downstream regex/split/indexOf all work unchanged.
- **No env wrapper shenanigans**: callers shouldn't have to wrap `NodeExecutionEnv` to make `loadSkills` work cross-platform.
- **Doesn't address WSL `/mnt/c/` paths**: that's a separate concern (different package, different function — `pi-coding-agent/utils/paths.ts#resolvePath`). This PR is strictly about `\` separator handling in the harness layer.

## Test plan

- [ ] `loadSkills` round-trip on Windows + `<dir>/<name>/SKILL.md` layout → skills discovered
- [ ] `loadSkills` round-trip on macOS/Linux → unchanged behavior
- [ ] `NodeExecutionEnv.listDir` returns FileInfo with correct `name` (basename) on Windows
- [ ] `formatSkillInvocation` \`References are relative to\` segment shows correct dirname on Windows
- [ ] Existing vitest harness suite (\`bun test:harness\`) still green on POSIX

## Notes

- Discovered while integrating `loadSkills` into a Windows Electron app
- Local verification: applied as `bun patch` against \`@earendil-works/pi-agent-core@0.82.1\`, 8 skills discovered correctly post-fix, no RangeError
- Happy to add a vitest case if you point me at the preferred location/format for cross-platform path tests