### PR TITLE
Make SQLite branch caching scalable

### DIFF
--- a/packages/agent/test/harness/sqlite-branch-cache.test.ts
+++ b/packages/agent/test/harness/sqlite-branch-cache.test.ts
@@ -1,0 +1,224 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createNodeSqliteFactory, createSqliteSessionStore } from "../../../storage/sqlite-node/src/index.ts";
+import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
+import { createSessionRepository } from "../../src/harness/session/repository.ts";
+import { createAssistantMessage, createUserMessage } from "./session-test-utils.ts";
+
+function createTempDir(): string {
+	return mkdtempSync(join(tmpdir(), "pi-agent-sqlite-branch-cache-"));
+}
+
+describe("SQLite branch cache", () => {
+	it("stores complete root paths for branches created after compaction", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const sqlite = createNodeSqliteFactory();
+		const repo = createSessionRepository({ store: createSqliteSessionStore({ env, sqlite, databasePath }) });
+		const session = await repo.create({ cwd: root, id: "session-1" });
+		const rootId = await session.appendMessage(createUserMessage("root"));
+		const keptId = await session.appendMessage(createUserMessage("kept"));
+		const compactionId = await session.appendCompaction("summary", keptId, 100);
+		await session.appendMessage(createAssistantMessage("first child"));
+		await session.moveTo(compactionId);
+		const branchedId = await session.appendMessage(createAssistantMessage("branched child"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			const row = await db
+				.prepare("SELECT branch_id FROM branch_entries WHERE session_id = ? AND entry_id = ?")
+				.get<{ branch_id: string }>("session-1", branchedId);
+			if (!row) throw new Error("Missing branched entry cache row");
+			const entries = await db
+				.prepare("SELECT entry_id FROM branch_entries WHERE session_id = ? AND branch_id = ? ORDER BY entry_seq")
+				.all<{ entry_id: string }>("session-1", row.branch_id);
+			expect(entries.map((entry) => entry.entry_id)).toEqual([rootId, keptId, compactionId, branchedId]);
+		} finally {
+			await db.close();
+		}
+	});
+
+	it("reads only the compacted branch window from the complete cache", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const sqlite = createNodeSqliteFactory();
+		const repo = createSessionRepository({ store: createSqliteSessionStore({ env, sqlite, databasePath }) });
+		const session = await repo.create({ cwd: root, id: "session-1" });
+		const oldId = await session.appendMessage(createUserMessage("old"));
+		const keptId = await session.appendMessage(createUserMessage("kept"));
+		const compactionId = await session.appendCompaction("summary", keptId, 100);
+		const leafId = await session.appendMessage(createAssistantMessage("new"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db
+				.prepare("UPDATE session_entries SET payload = ? WHERE session_id = ? AND id = ?")
+				.run("not json", "session-1", oldId);
+		} finally {
+			await db.close();
+		}
+
+		expect((await session.getBranch()).map((entry) => entry.id)).toEqual([keptId, compactionId, leafId]);
+	});
+
+	it("preserves nested compaction boundaries when reading the cache", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const repo = createSessionRepository({
+			store: createSqliteSessionStore({ env, sqlite: createNodeSqliteFactory(), databasePath }),
+		});
+		const session = await repo.create({ cwd: root, id: "session-1" });
+		const rootId = await session.appendMessage(createUserMessage("root"));
+		const firstCompactionId = await session.appendCompaction(
+			"first summary",
+			rootId,
+			100,
+			undefined,
+			false,
+			undefined,
+			[],
+		);
+		const middleId = await session.appendMessage(createUserMessage("middle"));
+		const secondCompactionId = await session.appendCompaction("second summary", rootId, 200);
+		const leafId = await session.appendMessage(createAssistantMessage("new"));
+
+		expect((await session.getBranch()).map((entry) => entry.id)).toEqual([
+			firstCompactionId,
+			middleId,
+			secondCompactionId,
+			leafId,
+		]);
+	});
+
+	it("repairs a missing branch cache from canonical parent links", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const sqlite = createNodeSqliteFactory();
+		const repo = createSessionRepository({ store: createSqliteSessionStore({ env, sqlite, databasePath }) });
+		const session = await repo.create({ cwd: root, id: "session-1" });
+		const rootId = await session.appendMessage(createUserMessage("root"));
+		const childId = await session.appendMessage(createAssistantMessage("child"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db.prepare("DELETE FROM branch_tips WHERE session_id = ?").run("session-1");
+			await db.prepare("DELETE FROM branch_entries WHERE session_id = ?").run("session-1");
+		} finally {
+			await db.close();
+		}
+
+		expect((await session.getBranch()).map((entry) => entry.id)).toEqual([rootId, childId]);
+
+		const inspection = await sqlite.open(databasePath);
+		try {
+			const rows = await inspection
+				.prepare("SELECT branch_id, entry_id FROM branch_entries WHERE session_id = ? ORDER BY entry_seq")
+				.all<{ branch_id: string; entry_id: string }>("session-1");
+			expect(rows.map((row) => row.entry_id)).toEqual([rootId, childId]);
+			const tip = await inspection
+				.prepare("SELECT branch_id, tip_id FROM branch_tips WHERE session_id = ?")
+				.get<{ branch_id: string; tip_id: string }>("session-1");
+			expect(rows).toHaveLength(2);
+			expect(tip).toEqual({ branch_id: rows[0]?.branch_id, tip_id: childId });
+		} finally {
+			await inspection.close();
+		}
+	});
+
+	it("rolls back an interrupted branch cache repair", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const sqlite = createNodeSqliteFactory();
+		const repo = createSessionRepository({ store: createSqliteSessionStore({ env, sqlite, databasePath }) });
+		const session = await repo.create({ cwd: root, id: "session-1" });
+		await session.appendMessage(createUserMessage("root"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db.prepare("DELETE FROM branch_tips WHERE session_id = ?").run("session-1");
+			await db.prepare("DELETE FROM branch_entries WHERE session_id = ?").run("session-1");
+			await db.exec(`
+				CREATE TRIGGER fail_branch_cache_repair
+				BEFORE INSERT ON branch_tips
+				BEGIN
+					SELECT RAISE(ABORT, 'repair failed');
+				END;
+			`);
+		} finally {
+			await db.close();
+		}
+
+		await expect(session.getBranch()).rejects.toMatchObject({
+			code: "storage",
+			message: expect.stringContaining("Failed to rebuild SQLite branch cache"),
+		});
+
+		const inspection = await sqlite.open(databasePath);
+		try {
+			expect(
+				await inspection.prepare("SELECT entry_id FROM branch_entries WHERE session_id = ?").all("session-1"),
+			).toEqual([]);
+			await inspection.exec("DROP TRIGGER fail_branch_cache_repair");
+		} finally {
+			await inspection.close();
+		}
+		expect(await session.getBranch()).toHaveLength(1);
+	});
+
+	it("repairs a missing source branch cache while forking transactionally", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const sqlite = createNodeSqliteFactory();
+		const repo = createSessionRepository({ store: createSqliteSessionStore({ env, sqlite, databasePath }) });
+		const source = await repo.create({ cwd: root, id: "source" });
+		const rootId = await source.appendMessage(createUserMessage("root"));
+		const childId = await source.appendMessage(createAssistantMessage("child"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db.prepare("DELETE FROM branch_tips WHERE session_id = ?").run("source");
+			await db.prepare("DELETE FROM branch_entries WHERE session_id = ?").run("source");
+		} finally {
+			await db.close();
+		}
+
+		const fork = await repo.fork(await source.getMetadata(), {
+			cwd: root,
+			id: "fork",
+			entryId: childId,
+			position: "at",
+		});
+		expect((await fork.getEntries()).map((entry) => entry.id)).toEqual([rootId, childId]);
+	});
+
+	it("deletes branch entries and tips with the session", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const sqlite = createNodeSqliteFactory();
+		const repo = createSessionRepository({ store: createSqliteSessionStore({ env, sqlite, databasePath }) });
+		const session = await repo.create({ cwd: root, id: "session-1" });
+		await session.appendMessage(createUserMessage("root"));
+		const metadata = await session.getMetadata();
+
+		await repo.delete(metadata);
+
+		const db = await sqlite.open(databasePath);
+		try {
+			expect(await db.prepare("SELECT entry_id FROM branch_entries WHERE session_id = ?").all("session-1")).toEqual(
+				[],
+			);
+			expect(await db.prepare("SELECT tip_id FROM branch_tips WHERE session_id = ?").all("session-1")).toEqual([]);
+		} finally {
+			await db.close();
+		}
+	});
+});

--- a/packages/agent/test/harness/sqlite-migrations.test.ts
+++ b/packages/agent/test/harness/sqlite-migrations.test.ts
@@ -6,6 +6,7 @@ import {
 	applyMigrations,
 	createNodeSqliteFactory,
 	createSqliteSessionStore,
+	loadMigrations,
 	type SqliteDatabase,
 	type SqliteDatabaseFactory,
 	type SqliteRunResult,
@@ -103,7 +104,7 @@ describe("SQLite migrations", () => {
 		const db = await sqlite.open(databasePath);
 		try {
 			const rows = await db.prepare("SELECT id FROM migrations ORDER BY id").all<{ id: string }>();
-			expect(rows.map((row) => row.id)).toEqual(["001_initial.sql"]);
+			expect(rows.map((row) => row.id)).toEqual(["001_initial.sql", "002_branch_tips.sql"]);
 			const tables = await db
 				.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'table' ORDER BY name")
 				.all<{ name: string; sql: string | null }>();
@@ -114,22 +115,60 @@ describe("SQLite migrations", () => {
 					"session_entries",
 					"session_sequences",
 					"branch_entries",
+					"branch_tips",
 					"session_materialized",
 					"entry_materialized",
 				]),
 			);
 			const sessionColumns = await db.prepare("PRAGMA table_info(sessions)").all<{ name: string }>();
 			expect(sessionColumns.map((column) => column.name)).toContain("active_leaf_id");
+			const branchIndexes = await db
+				.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'branch_entries'")
+				.all<{ name: string }>();
+			expect(branchIndexes.map((index) => index.name)).toContain("idx_branch_entries_session_branch_seq");
+			expect(branchIndexes.map((index) => index.name)).not.toContain("idx_branch_entries_session_branch");
 			for (const tableName of [
 				"sessions",
 				"session_sequences",
 				"branch_entries",
+				"branch_tips",
 				"session_materialized",
 				"entry_materialized",
 			]) {
 				const table = tables.find((row) => row.name === tableName);
 				expect(table?.sql).toContain("WITHOUT ROWID");
 			}
+		} finally {
+			await db.close();
+		}
+	});
+
+	it("clears legacy branch projections when adding explicit tips", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const sqlite = createNodeSqliteFactory();
+		const db = await sqlite.open(databasePath);
+		try {
+			const initial = (await loadMigrations()).find((migration) => migration.id === "001_initial.sql");
+			if (!initial) throw new Error("Missing initial SQLite migration");
+			await db.exec(initial.sql);
+			await db.exec("CREATE TABLE migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL)");
+			await db
+				.prepare("INSERT INTO migrations (id, applied_at) VALUES (?, ?)")
+				.run(initial.id, "2026-01-01T00:00:00.000Z");
+			await db
+				.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
+				.run("session-1", "legacy-branch", "entry-1", 1);
+
+			await applyMigrations(db);
+
+			expect(await db.prepare("SELECT entry_id FROM branch_entries").all<{ entry_id: string }>()).toEqual([]);
+			expect(
+				await db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'branch_tips'").get(),
+			).toBeDefined();
+			expect(
+				(await db.prepare("SELECT id FROM migrations ORDER BY id").all<{ id: string }>()).map((row) => row.id),
+			).toEqual(["001_initial.sql", "002_branch_tips.sql"]);
 		} finally {
 			await db.close();
 		}
@@ -229,6 +268,11 @@ END;
 				.get<{ id: string; type: string }>("session-1");
 			expect(latestSessionEntry?.type).toBe("leaf");
 			expect(latestBranchRow?.entry_id).toBe(latestSessionEntry?.id);
+			if (!latestBranchRow) throw new Error("Missing latest branch row");
+			const branchTip = await db
+				.prepare("SELECT branch_id, tip_id FROM branch_tips WHERE session_id = ? AND branch_id = ?")
+				.get<{ branch_id: string; tip_id: string }>("session-1", latestBranchRow.branch_id);
+			expect(branchTip?.tip_id).toBe(latestSessionEntry?.id);
 		} finally {
 			await db.close();
 		}
@@ -259,10 +303,15 @@ END;
 				)
 				.all<{ branch_id: string; entry_id: string; entry_seq: number }>("session-1");
 			const branchIds = [...new Set(branchRows.map((row) => row.branch_id))];
-			expect(branchIds).toHaveLength(3);
-			expect(branchRows.filter((row) => row.entry_id === rootId)).toHaveLength(3);
+			expect(branchIds).toHaveLength(2);
+			expect(branchRows.filter((row) => row.entry_id === rootId)).toHaveLength(2);
 			expect(branchRows.filter((row) => row.entry_id === firstChildId)).toHaveLength(1);
 			expect(branchRows.filter((row) => row.entry_id === secondChildId)).toHaveLength(1);
+			const tips = await db
+				.prepare("SELECT branch_id, tip_id FROM branch_tips WHERE session_id = ? ORDER BY branch_id")
+				.all<{ branch_id: string; tip_id: string }>("session-1");
+			expect(tips.map((tip) => tip.branch_id)).toEqual(branchIds.sort());
+			expect(new Set(tips.map((tip) => tip.tip_id)).size).toBe(tips.length);
 		} finally {
 			await db.close();
 		}
@@ -451,8 +500,8 @@ END;
 			sessionId: "session-1",
 		});
 		await db.exec(`
-			CREATE TEMP TRIGGER fail_branch_entry_insert
-			BEFORE INSERT ON branch_entries
+			CREATE TEMP TRIGGER fail_branch_tip_insert
+			BEFORE INSERT ON branch_tips
 			BEGIN
 				SELECT RAISE(ABORT, 'branch insert failed');
 			END;
@@ -468,7 +517,7 @@ END;
 		try {
 			await expect(storage.appendEntry(rootEntry)).rejects.toMatchObject({ code: "storage" });
 		} finally {
-			await db.exec("DROP TRIGGER fail_branch_entry_insert");
+			await db.exec("DROP TRIGGER fail_branch_tip_insert");
 		}
 		const sessionRow = await db
 			.prepare("SELECT active_leaf_id FROM sessions WHERE id = ?")

--- a/packages/storage/sqlite-node/src/sqlite/migrations.ts
+++ b/packages/storage/sqlite-node/src/sqlite/migrations.ts
@@ -19,6 +19,11 @@ export async function loadMigrations(): Promise<SqliteMigration[]> {
 			order: 1,
 			sql: await loadMigrationSql("./migrations/001_initial.sql"),
 		},
+		{
+			id: "002_branch_tips.sql",
+			order: 2,
+			sql: await loadMigrationSql("./migrations/002_branch_tips.sql"),
+		},
 	];
 }
 

--- a/packages/storage/sqlite-node/src/sqlite/migrations/002_branch_tips.sql
+++ b/packages/storage/sqlite-node/src/sqlite/migrations/002_branch_tips.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS branch_tips (
+	session_id TEXT NOT NULL,
+	tip_id TEXT NOT NULL,
+	branch_id TEXT NOT NULL,
+	PRIMARY KEY (session_id, tip_id),
+	UNIQUE (session_id, branch_id)
+) WITHOUT ROWID;
+
+DELETE FROM branch_tips;
+DELETE FROM branch_entries;
+
+DROP INDEX IF EXISTS idx_branch_entries_session_branch;

--- a/packages/storage/sqlite-node/src/sqlite/session-store.ts
+++ b/packages/storage/sqlite-node/src/sqlite/session-store.ts
@@ -153,6 +153,7 @@ class SqliteSessionStore
 		return this.operations.enqueue(async () => {
 			const db = await this.getDatabase();
 			await db.transaction(async () => {
+				await db.prepare("DELETE FROM branch_tips WHERE session_id = ?").run(metadata.id);
 				await db.prepare("DELETE FROM branch_entries WHERE session_id = ?").run(metadata.id);
 				await db.prepare("DELETE FROM session_entries WHERE session_id = ?").run(metadata.id);
 				await db.prepare("DELETE FROM entry_materialized WHERE session_id = ?").run(metadata.id);

--- a/packages/storage/sqlite-node/src/sqlite/storage/branch-cache.ts
+++ b/packages/storage/sqlite-node/src/sqlite/storage/branch-cache.ts
@@ -1,0 +1,199 @@
+import { uuidv7 } from "@earendil-works/pi-ai";
+import type { SqliteDatabase } from "../types.ts";
+import type { SessionEntryRow } from "./session-entries.ts";
+import { invalidSession } from "./shared.ts";
+
+/** Derived root-to-tip paths. Canonical parent links remain authoritative. */
+export interface CachedBranch {
+	branchId: string;
+	leafSeq: number;
+}
+
+export async function readCachedBranch(
+	db: SqliteDatabase,
+	sessionId: string,
+	leafId: string,
+): Promise<CachedBranch | undefined> {
+	const membership = await db
+		.prepare(
+			"SELECT branch_id, entry_seq FROM branch_entries WHERE session_id = ? AND entry_id = ? ORDER BY branch_id LIMIT 1",
+		)
+		.get<{ branch_id: string; entry_seq: number }>(sessionId, leafId);
+	if (!membership) return undefined;
+	return { branchId: membership.branch_id, leafSeq: membership.entry_seq };
+}
+
+export async function readCachedBranchRows(
+	db: SqliteDatabase,
+	sessionId: string,
+	branch: CachedBranch,
+	startSeq: number,
+): Promise<SessionEntryRow[]> {
+	return db
+		.prepare(
+			`SELECT e.session_id, e.id, e.entry_seq, e.parent_id, e.type, e.timestamp, e.payload
+			FROM branch_entries AS b
+			JOIN session_entries AS e ON e.session_id = b.session_id AND e.id = b.entry_id
+			WHERE b.session_id = ? AND b.branch_id = ? AND b.entry_seq BETWEEN ? AND ?
+			ORDER BY b.entry_seq`,
+		)
+		.all<SessionEntryRow>(sessionId, branch.branchId, startSeq, branch.leafSeq);
+}
+
+export async function readCachedEntryRowsByType(
+	db: SqliteDatabase,
+	sessionId: string,
+	branch: CachedBranch,
+	type: SessionEntryRow["type"],
+): Promise<SessionEntryRow[]> {
+	return db
+		.prepare(
+			`SELECT e.session_id, e.id, e.entry_seq, e.parent_id, e.type, e.timestamp, e.payload
+			FROM branch_entries AS b
+			JOIN session_entries AS e ON e.session_id = b.session_id AND e.id = b.entry_id
+			WHERE b.session_id = ? AND b.branch_id = ? AND b.entry_seq <= ? AND e.type = ?
+			ORDER BY b.entry_seq DESC`,
+		)
+		.all<SessionEntryRow>(sessionId, branch.branchId, branch.leafSeq, type);
+}
+
+export async function readCachedEntrySeq(
+	db: SqliteDatabase,
+	sessionId: string,
+	branchId: string,
+	entryId: string,
+): Promise<number | undefined> {
+	const row = await db
+		.prepare("SELECT entry_seq FROM branch_entries WHERE session_id = ? AND branch_id = ? AND entry_id = ?")
+		.get<{ entry_seq: number }>(sessionId, branchId, entryId);
+	return row?.entry_seq;
+}
+
+export async function rebuildCachedBranch(
+	db: SqliteDatabase,
+	sessionId: string,
+	leafId: string,
+	branchIdToReplace?: string,
+): Promise<void> {
+	await db.exec("SAVEPOINT rebuild_branch_cache");
+	try {
+		const tip = await db
+			.prepare("SELECT branch_id FROM branch_tips WHERE session_id = ? AND tip_id = ?")
+			.get<{ branch_id: string }>(sessionId, leafId);
+		const branchIds = new Set([branchIdToReplace, tip?.branch_id].filter((id): id is string => id !== undefined));
+		for (const branchId of branchIds) {
+			await db.prepare("DELETE FROM branch_tips WHERE session_id = ? AND branch_id = ?").run(sessionId, branchId);
+			await db.prepare("DELETE FROM branch_entries WHERE session_id = ? AND branch_id = ?").run(sessionId, branchId);
+		}
+
+		const branchId = uuidv7();
+		await db
+			.prepare(
+				`WITH RECURSIVE path(id, entry_seq, parent_id) AS (
+					SELECT id, entry_seq, parent_id
+					FROM session_entries
+					WHERE session_id = ? AND id = ?
+					UNION ALL
+					SELECT parent.id, parent.entry_seq, parent.parent_id
+					FROM session_entries AS parent
+					JOIN path AS child ON child.parent_id = parent.id
+					WHERE parent.session_id = ?
+				)
+				INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq)
+				SELECT ?, ?, id, entry_seq FROM path`,
+			)
+			.run(sessionId, leafId, sessionId, sessionId, branchId);
+		await db
+			.prepare("INSERT INTO branch_tips (session_id, tip_id, branch_id) VALUES (?, ?, ?)")
+			.run(sessionId, leafId, branchId);
+		await db.exec("RELEASE SAVEPOINT rebuild_branch_cache");
+	} catch (error) {
+		try {
+			await db.exec("ROLLBACK TO SAVEPOINT rebuild_branch_cache");
+			await db.exec("RELEASE SAVEPOINT rebuild_branch_cache");
+		} catch {
+			// Preserve the original repair failure.
+		}
+		throw error;
+	}
+}
+
+async function extendBranch(
+	db: SqliteDatabase,
+	sessionId: string,
+	branchId: string,
+	parentId: string,
+	entryId: string,
+	entrySeq: number,
+): Promise<void> {
+	await db
+		.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
+		.run(sessionId, branchId, entryId, entrySeq);
+	const result = await db
+		.prepare("UPDATE branch_tips SET tip_id = ? WHERE session_id = ? AND branch_id = ? AND tip_id = ?")
+		.run(entryId, sessionId, branchId, parentId);
+	if (result.changes !== 1) throw invalidSession(`branch tip ${parentId} changed during append`);
+}
+
+export async function appendEntryToBranchCache(
+	db: SqliteDatabase,
+	sessionId: string,
+	entryId: string,
+	entrySeq: number,
+	parentId: string | null,
+	repairParent: (parentId: string) => Promise<void>,
+): Promise<void> {
+	if (parentId === null) {
+		const branchId = uuidv7();
+		await db
+			.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
+			.run(sessionId, branchId, entryId, entrySeq);
+		await db
+			.prepare("INSERT INTO branch_tips (session_id, tip_id, branch_id) VALUES (?, ?, ?)")
+			.run(sessionId, entryId, branchId);
+		return;
+	}
+
+	let tip = await db
+		.prepare("SELECT branch_id FROM branch_tips WHERE session_id = ? AND tip_id = ?")
+		.get<{ branch_id: string }>(sessionId, parentId);
+	if (tip) {
+		await extendBranch(db, sessionId, tip.branch_id, parentId, entryId, entrySeq);
+		return;
+	}
+
+	const source = await db
+		.prepare(
+			`SELECT b.branch_id, b.entry_seq
+			FROM branch_entries AS b
+			WHERE b.session_id = ? AND b.entry_id = ?
+			ORDER BY b.branch_id
+			LIMIT 1`,
+		)
+		.get<{ branch_id: string; entry_seq: number }>(sessionId, parentId);
+	if (!source) {
+		await repairParent(parentId);
+		tip = await db
+			.prepare("SELECT branch_id FROM branch_tips WHERE session_id = ? AND tip_id = ?")
+			.get<{ branch_id: string }>(sessionId, parentId);
+		if (!tip) throw invalidSession(`branch cache repair did not create tip ${parentId}`);
+		await extendBranch(db, sessionId, tip.branch_id, parentId, entryId, entrySeq);
+		return;
+	}
+
+	const branchId = uuidv7();
+	await db
+		.prepare(
+			`INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq)
+			SELECT session_id, ?, entry_id, entry_seq
+			FROM branch_entries
+			WHERE session_id = ? AND branch_id = ? AND entry_seq <= ?`,
+		)
+		.run(branchId, sessionId, source.branch_id, source.entry_seq);
+	await db
+		.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
+		.run(sessionId, branchId, entryId, entrySeq);
+	await db
+		.prepare("INSERT INTO branch_tips (session_id, tip_id, branch_id) VALUES (?, ?, ?)")
+		.run(sessionId, entryId, branchId);
+}

--- a/packages/storage/sqlite-node/src/sqlite/storage/index.ts
+++ b/packages/storage/sqlite-node/src/sqlite/storage/index.ts
@@ -1,7 +1,14 @@
 import type { SessionEntryCursorOptions, SessionReader, SessionTreeEntry } from "@earendil-works/pi-agent-core";
 import { SessionError, toError } from "@earendil-works/pi-agent-core";
-import { uuidv7 } from "@earendil-works/pi-ai";
 import type { SqliteDatabase, SqliteSessionMetadata } from "../types.ts";
+import {
+	appendEntryToBranchCache,
+	readCachedBranch,
+	readCachedBranchRows,
+	readCachedEntryRowsByType,
+	readCachedEntrySeq,
+	rebuildCachedBranch,
+} from "./branch-cache.ts";
 import { decodeEntry, encodeEntry, type SessionEntryRow } from "./session-entries.ts";
 import {
 	applyEntryToMaterializedState,
@@ -31,50 +38,11 @@ function decodeEntryRows(entryRows: SessionEntryRow[]): SessionTreeEntry[] {
 	return entries;
 }
 
-async function loadEntryRowsByIds(
-	db: SqliteDatabase,
-	sessionId: string,
-	entryIds: string[],
-): Promise<Map<string, SessionEntryRow>> {
-	if (entryIds.length === 0) return new Map<string, SessionEntryRow>();
-	const placeholders = entryIds.map(() => "?").join(", ");
-	const rows = await db
-		.prepare(
-			`SELECT session_id, id, entry_seq, parent_id, type, timestamp, payload FROM session_entries WHERE session_id = ? AND id IN (${placeholders})`,
-		)
-		.all<SessionEntryRow>(sessionId, ...entryIds);
-	return new Map(rows.map((row) => [row.id, row]));
-}
-
-async function loadActiveBranchId(db: SqliteDatabase, sessionId: string): Promise<string | null> {
-	// branch_entries includes leaf navigation entries for the active branch, so the
-	// newest branch_entries row identifies the branch that was most recently made active.
-	const row = await db
-		.prepare(
-			"SELECT branch_id FROM branch_entries WHERE session_id = ? ORDER BY entry_seq DESC, branch_id DESC LIMIT 1",
-		)
-		.get<{ branch_id: string }>(sessionId);
-	return row?.branch_id ?? null;
-}
-
-async function hasExistingChild(db: SqliteDatabase, sessionId: string, parentId: string | null): Promise<boolean> {
-	const row =
-		parentId === null
-			? await db
-					.prepare("SELECT 1 AS found FROM session_entries WHERE session_id = ? AND parent_id IS NULL LIMIT 1")
-					.get<{ found: number }>(sessionId)
-			: await db
-					.prepare("SELECT 1 AS found FROM session_entries WHERE session_id = ? AND parent_id = ? LIMIT 1")
-					.get<{ found: number }>(sessionId, parentId);
-	return row !== undefined;
-}
-
 async function loadSqliteSession(
 	db: SqliteDatabase,
 	sessionId: string,
 ): Promise<{
 	row: SessionRow;
-	activeBranchId: string | null;
 	materializedState: SessionMaterializedState;
 }> {
 	const row = await db
@@ -93,7 +61,6 @@ async function loadSqliteSession(
 		.all<EntryMaterializedRow>(sessionId);
 	return {
 		row,
-		activeBranchId: await loadActiveBranchId(db, sessionId),
 		materializedState: materializedStateFromRows(materializedRow, entryMaterializedRows),
 	};
 }
@@ -102,22 +69,79 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 	private readonly db: SqliteDatabase;
 	readonly metadata: SqliteSessionMetadata;
 	private byId: Map<string, SessionTreeEntry>;
-	private activeBranchId: string | null;
 	private materializedState: SessionMaterializedState;
 
 	async readPathToRootOrCompaction(leafId: string | null): Promise<SessionTreeEntry[]> {
 		if (leafId === null) return [];
+		const cached = await readCachedBranch(this.db, this.metadata.id, leafId);
+		if (cached) {
+			const compactionRows = await readCachedEntryRowsByType(this.db, this.metadata.id, cached, "compaction");
+			let startSeq = 0;
+			let expectedStartId: string | null = null;
+			let pendingStop: { id: string; seq: number } | undefined;
+			for (const compactionRow of compactionRows) {
+				if (pendingStop && pendingStop.seq >= compactionRow.entry_seq) {
+					startSeq = pendingStop.seq;
+					expectedStartId = pendingStop.id;
+					break;
+				}
+				const compaction = decodeEntryRows([compactionRow])[0]!;
+				if (compaction.type !== "compaction") throw invalidSession(`entry ${compaction.id} is not a compaction`);
+				if (compaction.retainedTail) {
+					startSeq = compactionRow.entry_seq;
+					expectedStartId = compaction.id;
+					pendingStop = undefined;
+					break;
+				} else if (compaction.firstKeptEntryId !== undefined) {
+					const firstKeptSeq = await readCachedEntrySeq(
+						this.db,
+						this.metadata.id,
+						cached.branchId,
+						compaction.firstKeptEntryId,
+					);
+					pendingStop =
+						firstKeptSeq !== undefined && firstKeptSeq < compactionRow.entry_seq
+							? { id: compaction.firstKeptEntryId, seq: firstKeptSeq }
+							: undefined;
+				} else {
+					pendingStop = undefined;
+				}
+			}
+			if (startSeq === 0 && pendingStop) {
+				startSeq = pendingStop.seq;
+				expectedStartId = pendingStop.id;
+			}
+			const entries = decodeEntryRows(await readCachedBranchRows(this.db, this.metadata.id, cached, startSeq));
+			if (this.isValidCachedPath(entries, leafId, expectedStartId)) {
+				for (const entry of entries) this.byId.set(entry.id, entry);
+				return entries;
+			}
+		}
+
+		const entries = await this.repairBranchCache(leafId, cached?.branchId);
+		return this.trimPathToRootOrCompaction(entries);
+	}
+
+	private async repairBranchCache(leafId: string, branchIdToReplace?: string): Promise<SessionTreeEntry[]> {
+		const entries = await this.readCanonicalPathToRoot(leafId);
+		try {
+			await rebuildCachedBranch(this.db, this.metadata.id, leafId, branchIdToReplace);
+		} catch (error) {
+			if (error instanceof SessionError) throw error;
+			throw new SessionError("storage", `Failed to rebuild SQLite branch cache at entry ${leafId}`, toError(error));
+		}
+		return entries;
+	}
+
+	private async readCanonicalPathToRoot(leafId: string): Promise<SessionTreeEntry[]> {
 		const path: SessionTreeEntry[] = [];
-		let stopAtEntryId: string | null = null;
 		let current = await this.readEntry(leafId);
 		if (!current) throw new SessionError("not_found", `Entry ${leafId} not found`);
+		const visited = new Set<string>();
 		while (current) {
+			if (visited.has(current.id)) throw invalidSession(`cycle in parent chain at entry ${current.id}`);
+			visited.add(current.id);
 			path.push(current);
-			if (stopAtEntryId !== null && current.id === stopAtEntryId) break;
-			if (current.type === "compaction") {
-				if (current.retainedTail) break;
-				stopAtEntryId = current.firstKeptEntryId ?? null;
-			}
 			if (!current.parentId) break;
 			const parent = await this.readEntry(current.parentId);
 			if (!parent) throw new SessionError("invalid_session", `Entry ${current.parentId} not found`);
@@ -126,67 +150,48 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 		return path.reverse();
 	}
 
-	private async materializeBranch(leafId: string | null): Promise<string> {
-		const branchId = uuidv7();
-		// Rebuild the branch path only when branch membership changes: branch switch
-		// (leaf navigation) or a new fork from a parent that already has a child.
-		// Linear appends stay cheap and extend the active branch incrementally.
-		const path = await this.readPathToRootOrCompaction(leafId);
-		const entryRowsById = await loadEntryRowsByIds(
-			this.db,
-			this.metadata.id,
-			path.map((entry) => entry.id),
-		);
-		for (const entry of path) {
-			const entryRow = entryRowsById.get(entry.id);
-			if (!entryRow) throw invalidSession(`missing entry row for session ${this.metadata.id} entry ${entry.id}`);
-			await this.db
-				.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
-				.run(this.metadata.id, branchId, entry.id, entryRow.entry_seq);
+	private isValidCachedPath(
+		entries: readonly SessionTreeEntry[],
+		leafId: string,
+		expectedStartId: string | null,
+	): boolean {
+		if (entries.length === 0 || entries.at(-1)!.id !== leafId) return false;
+		if (expectedStartId === null ? entries[0]!.parentId !== null : entries[0]!.id !== expectedStartId) return false;
+		for (let index = 1; index < entries.length; index++) {
+			if (entries[index]!.parentId !== entries[index - 1]!.id) return false;
 		}
-		return branchId;
+		return true;
 	}
 
-	private async appendToActiveBranch(
-		entryId: string,
-		parentId: string | null,
-		activeBranchId: string | null,
-	): Promise<string> {
-		let branchId = activeBranchId;
-		// Reuse the staged active branch when available. Otherwise materialize
-		// the parent path once, then add only the new tip entry below.
-		if (!branchId) branchId = await this.materializeBranch(parentId);
-		const entryRow = await this.db
-			.prepare("SELECT entry_seq FROM session_entries WHERE session_id = ? AND id = ?")
-			.get<{ entry_seq: number }>(this.metadata.id, entryId);
-		if (!entryRow) throw invalidSession(`missing entry row for session ${this.metadata.id} entry ${entryId}`);
-		await this.db
-			.prepare("INSERT INTO branch_entries (session_id, branch_id, entry_id, entry_seq) VALUES (?, ?, ?, ?)")
-			.run(this.metadata.id, branchId, entryId, entryRow.entry_seq);
-		return branchId;
+	private trimPathToRootOrCompaction(entries: readonly SessionTreeEntry[]): SessionTreeEntry[] {
+		const path: SessionTreeEntry[] = [];
+		let stopAtEntryId: string | null = null;
+		for (let index = entries.length - 1; index >= 0; index--) {
+			const entry = entries[index]!;
+			path.push(entry);
+			if (stopAtEntryId !== null && entry.id === stopAtEntryId) break;
+			if (entry.type === "compaction") {
+				if (entry.retainedTail) break;
+				stopAtEntryId = entry.firstKeptEntryId ?? null;
+			}
+		}
+		return path.reverse();
 	}
 
 	private constructor(
 		db: SqliteDatabase,
 		metadata: SqliteSessionMetadata,
-		activeBranchId: string | null,
 		materializedState: SessionMaterializedState,
 	) {
 		this.db = db;
 		this.metadata = metadata;
 		this.byId = new Map<string, SessionTreeEntry>();
 		this.materializedState = materializedState;
-		this.activeBranchId = activeBranchId;
 	}
 
 	static async open(db: SqliteDatabase, metadata: SqliteSessionMetadata): Promise<SqliteSessionConnection> {
 		const loaded = await loadSqliteSession(db, metadata.id);
-		return new SqliteSessionConnection(
-			db,
-			rowToMetadata(loaded.row, metadata.path),
-			loaded.activeBranchId,
-			loaded.materializedState,
-		);
+		return new SqliteSessionConnection(db, rowToMetadata(loaded.row, metadata.path), loaded.materializedState);
 	}
 
 	static async create(
@@ -226,7 +231,6 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 				parentSessionId: options.parentSessionId,
 				metadata: options.metadata,
 			},
-			null,
 			createEmptyMaterializedState(),
 		);
 	}
@@ -251,6 +255,9 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 	}
 
 	async appendEntry(entry: SessionTreeEntry, options: { transaction?: boolean } = {}): Promise<void> {
+		if (entry.type === "leaf" && entry.targetId !== null && !(await this.readEntry(entry.targetId))) {
+			throw new SessionError("not_found", `Entry ${entry.targetId} not found`);
+		}
 		const encoded = encodeEntry(entry);
 		const nextMaterializedState: SessionMaterializedState = {
 			...this.materializedState,
@@ -259,11 +266,9 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 			currentModel: this.materializedState.currentModel ? { ...this.materializedState.currentModel } : null,
 		};
 		const nextLeafId = leafIdAfterEntry(entry);
-		let nextActiveBranchId = this.activeBranchId;
 		try {
 			applyEntryToMaterializedState(nextMaterializedState, entry);
 			const write = async () => {
-				const parentHadExistingChild = await hasExistingChild(this.db, this.metadata.id, entry.parentId);
 				const nextSeq = await getNextSequence(this.db, this.metadata.id);
 				await this.db
 					.prepare(
@@ -282,21 +287,21 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 				await this.db
 					.prepare("UPDATE sessions SET active_leaf_id = ? WHERE id = ?")
 					.run(nextLeafId, this.metadata.id);
-				if (entry.type === "leaf") {
-					nextActiveBranchId = await this.materializeBranch(entry.targetId);
-					nextActiveBranchId = await this.appendToActiveBranch(entry.id, entry.parentId, nextActiveBranchId);
-				} else {
-					if (parentHadExistingChild) {
-						nextActiveBranchId = await this.materializeBranch(entry.parentId);
-					}
-					nextActiveBranchId = await this.appendToActiveBranch(entry.id, entry.parentId, nextActiveBranchId);
-				}
+				await appendEntryToBranchCache(
+					this.db,
+					this.metadata.id,
+					entry.id,
+					nextSeq,
+					entry.parentId,
+					async (parentId) => {
+						await this.repairBranchCache(parentId);
+					},
+				);
 			};
 			if (options.transaction === false) await write();
 			else await this.db.transaction(write);
 			this.materializedState = nextMaterializedState;
 			this.byId.set(entry.id, entry);
-			this.activeBranchId = nextActiveBranchId;
 		} catch (error) {
 			if (error instanceof SessionError) throw error;
 			throw new SessionError("storage", `Failed to append SQLite session entry ${entry.id}`, toError(error));


### PR DESCRIPTION
## Summary

- replace connection-local branch bookkeeping with explicit `branch_tips` and complete root-to-tip cached paths
- copy branch prefixes with transactional `INSERT ... SELECT` operations, avoiding SQLite variable limits on long histories
- lazily repair missing or invalid caches from canonical parent links while preserving compaction semantics
- clear legacy branch projections during migration so they rebuild in the new format

## Tests

- `npm run check`
- `./test.sh`
