### PR TITLE
fix(coding-agent): increase connection attempt timeout

### DIFF
--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from "node:events";
 import * as undici from "undici";
 
 export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
+// Node's 250ms default can terminate valid connection attempts on high-latency routes.
+const DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 2_000;
 
 export const HTTP_IDLE_TIMEOUT_CHOICES = [
 	{ label: "30 sec", timeoutMs: 30_000 },
@@ -85,6 +87,9 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 		new undici.EnvHttpProxyAgent({
 			allowH2: false,
 			bodyTimeout: normalizedTimeoutMs,
+			connect: {
+				autoSelectFamilyAttemptTimeout: DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS,
+			},
 			headersTimeout: normalizedTimeoutMs,
 			clientFactory: createUndiciClient,
 			factory: createUndiciOriginDispatcher,

--- a/packages/coding-agent/test/http-dispatcher.test.ts
+++ b/packages/coding-agent/test/http-dispatcher.test.ts
@@ -1,7 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { applyHttpProxySettings } from "../src/core/http-dispatcher.ts";
+import net from "node:net";
+import tls from "node:tls";
+import * as undici from "undici";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyHttpProxySettings, configureHttpDispatcher } from "../src/core/http-dispatcher.ts";
 
 const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY"] as const;
+const DISPATCHER_PROXY_ENV_KEYS = [...PROXY_ENV_KEYS, "http_proxy", "https_proxy"] as const;
 
 describe("http proxy settings", () => {
 	let savedEnv: Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>;
@@ -49,5 +53,61 @@ describe("http proxy settings", () => {
 
 		expect(process.env.HTTP_PROXY).toBeUndefined();
 		expect(process.env.HTTPS_PROXY).toBeUndefined();
+	});
+});
+
+describe("http dispatcher", () => {
+	const originalDispatcher = undici.getGlobalDispatcher();
+	const originalFetch = globalThis.fetch;
+	let savedProxyEnv: Record<(typeof DISPATCHER_PROXY_ENV_KEYS)[number], string | undefined>;
+
+	beforeEach(() => {
+		savedProxyEnv = Object.fromEntries(DISPATCHER_PROXY_ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
+			(typeof DISPATCHER_PROXY_ENV_KEYS)[number],
+			string | undefined
+		>;
+		for (const key of DISPATCHER_PROXY_ENV_KEYS) {
+			delete process.env[key];
+		}
+	});
+
+	afterEach(async () => {
+		const dispatcher = undici.getGlobalDispatcher();
+		if (dispatcher !== originalDispatcher) {
+			await dispatcher.close();
+			undici.setGlobalDispatcher(originalDispatcher);
+		}
+		for (const key of DISPATCHER_PROXY_ENV_KEYS) {
+			const value = savedProxyEnv[key];
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it("allows two seconds for HTTPS connection attempts without changing the Node default", async () => {
+		// Preserve a deliberate host fetch override while testing the dispatcher itself.
+		globalThis.fetch = async () => {
+			throw new Error("Unexpected global fetch");
+		};
+		const originalAttemptTimeoutMs = net.getDefaultAutoSelectFamilyAttemptTimeout();
+		const connectSpy = vi.spyOn(tls, "connect").mockImplementation(() => {
+			throw new Error("Connection captured");
+		});
+
+		configureHttpDispatcher();
+		await expect(undici.fetch("https://example.invalid")).rejects.toThrow();
+
+		expect(connectSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				autoSelectFamilyAttemptTimeout: 2_000,
+			}),
+		);
+		expect(connectSpy.mock.calls[0]?.[0]).not.toHaveProperty("autoSelectFamily");
+		expect(net.getDefaultAutoSelectFamilyAttemptTimeout()).toBe(originalAttemptTimeoutMs);
 	});
 });


### PR DESCRIPTION
## Summary

Node's 250 ms address-family attempt timeout can abort valid Fireworks connections on high-latency routes. This raises the timeout to 2 seconds for Pi's Undici connector without changing Node's process-wide defaults or forcing `autoSelectFamily`.

The regression test follows the HTTPS path to `tls.connect` and verifies both the connector option and the unchanged Node default.

## Testing

- `npm run check`
- `./test.sh`

Fixes #7315.