### PR TITLE
fix(ai): tolerate missing finish_reason on non-empty openai-completions streams

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed `openai-completions` streaming handler throwing `Stream ended without finish_reason` when a gateway omits the terminal finish_reason chunk but delivers content; an absent finish_reason on a non-empty stream now logs a warning and resolves as a normal stop instead of an error.
 - Updated GPT-5.6 Terra and Luna pricing across OpenAI and passthrough model catalogs.
 - Fixed Fireworks Kimi K3 models to use the OpenAI-compatible API with native reasoning-effort levels and deferred tools ([#7199](https://github.com/earendil-works/pi/issues/7199), [#7230](https://github.com/earendil-works/pi/pull/7230) by [@XBeg9](https://github.com/XBeg9)).
 

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -270,6 +270,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			let textBlock: TextContent | null = null;
 			let thinkingBlock: ThinkingContent | null = null;
 			let hasFinishReason = false;
+			let receivedAnyChunk = false;
 			const toolCallBlocksByIndex = new Map<number, StreamingToolCallBlock>();
 			const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
 			const pendingReasoningDetailsByToolCallId = new Map<string, string>();
@@ -435,6 +436,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 
 			for await (const chunk of openaiStream) {
 				if (!chunk || typeof chunk !== "object") continue;
+				receivedAnyChunk = true;
 
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
 				// and each chunk in a streamed completion carries the same id.
@@ -578,7 +580,11 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				throw new Error(output.errorMessage || "Provider returned an error stop reason");
 			}
 			if ((compat.supportsFinishReason && !hasFinishReason) || output.stopReason === "pending") {
-				throw new Error("Stream ended without finish_reason");
+				if (!receivedAnyChunk) {
+					throw new Error("Stream ended without finish_reason");
+				}
+				console.warn("[pi] stream ended without finish_reason; treating as stop");
+				output.stopReason = output.content.some((block) => block.type === "toolCall") ? "toolUse" : "stop";
 			}
 
 			stream.push({ type: "done", reason: output.stopReason, message: output });

--- a/packages/ai/test/openai-completions-missing-finish-reason.test.ts
+++ b/packages/ai/test/openai-completions-missing-finish-reason.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import type { Context, Model } from "../src/types.ts";
+
+const mockState = vi.hoisted(() => ({
+	chunks: [] as unknown[],
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: () => {
+					const chunks = mockState.chunks;
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							for (const chunk of chunks) yield chunk;
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+	return { default: FakeOpenAI };
+});
+
+const model: Model<"openai-completions"> = {
+	id: "test-model",
+	name: "Test Model",
+	api: "openai-completions",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 4096,
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+
+describe("openai-completions missing finish_reason tolerance", () => {
+	beforeEach(() => {
+		mockState.chunks = [];
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("completes with stop and a warning when content arrives but finish_reason is absent", async () => {
+		// Simulate a gateway that sends content chunks with finish_reason: null,
+		// then only a metadata/usage chunk with choices: [] and no finish_reason.
+		mockState.chunks = [
+			{
+				id: "chatcmpl-1",
+				choices: [{ index: 0, delta: { content: "hello" }, finish_reason: null }],
+			},
+			{
+				id: "chatcmpl-1",
+				choices: [],
+				usage: { prompt_tokens: 5, completion_tokens: 1 },
+			},
+		];
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("stop");
+		expect(warnSpy).toHaveBeenCalledOnce();
+		expect(warnSpy.mock.calls[0][0]).toContain("finish_reason");
+	});
+
+	it("throws when the stream ends with zero chunks (real transport failure)", async () => {
+		mockState.chunks = [];
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("Stream ended without finish_reason");
+	});
+
+	it("normal stream with finish_reason behaves unchanged", async () => {
+		mockState.chunks = [
+			{ id: "chatcmpl-2", choices: [{ index: 0, delta: { content: "hi" }, finish_reason: null }] },
+			{ id: "chatcmpl-2", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+		];
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("stop");
+		expect(message.rawStopReason).toBe("stop");
+	});
+});

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -583,7 +583,9 @@ describe("openai-completions tool_choice", () => {
 		expect(response.content).toEqual([{ type: "text", text: "OK" }]);
 	});
 
-	it("errors when a stream ends after only null finish_reason chunks", async () => {
+	it("warns and stops when content arrives but finish_reason is absent", async () => {
+		// Gateways that omit the terminal finish_reason chunk after delivering content
+		// should not kill the session. The handler now warns and resolves as a normal stop.
 		mockState.chunks = [
 			{
 				id: "chatcmpl-truncated",
@@ -594,6 +596,8 @@ describe("openai-completions tool_choice", () => {
 				choices: [{ delta: { content: "partial answer" }, finish_reason: null }],
 			},
 		];
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
 		const model = { ...baseModel, api: "openai-completions" } as const;
@@ -611,8 +615,10 @@ describe("openai-completions tool_choice", () => {
 			{ apiKey: "test" },
 		).result();
 
-		expect(response.stopReason).toBe("error");
-		expect(response.errorMessage).toBe("Stream ended without finish_reason");
+		expect(response.stopReason).toBe("stop");
+		expect(response.errorMessage).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalledOnce();
+		warnSpy.mockRestore();
 	});
 
 	it("accepts streams without finish_reason when compat disables it", async () => {


### PR DESCRIPTION

## Problem

The `openai-completions` streaming handler throws `Stream ended without finish_reason` whenever the SSE stream closes without any chunk carrying a truthy `choice.finish_reason`. This kills every session on gateways that violate the spec by omitting the terminal finish_reason chunk.

The observable SSE pattern from such a gateway:

```
data: {"id":"...","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}
data: {"id":"...","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}
```

The final content chunk has `finish_reason: null`; the next chunk has `choices: []` (a metadata/usage chunk). Then the stream closes — no `[DONE]` sentinel. The existing code skips `choices: []` chunks via `if (!choice) continue` without ever setting `hasFinishReason`. After the loop, `output.stopReason` is still `"pending"` and the handler throws.

## Fix

Track `receivedAnyChunk` — set `true` for any structurally valid chunk (after the `!chunk || typeof chunk !== "object"` guard, before the choices-based `continue`). At end-of-stream:

- **No finish_reason, no chunks received** → keep throwing (`"Stream ended without finish_reason"`). A genuinely empty stream is a real transport failure and must stay loud.
- **No finish_reason, but chunks were received** → emit `console.warn` and resolve with `stopReason: "stop"` (or `"toolUse"` if tool calls are present), matching the existing `!compat.supportsFinishReason` fallback semantics.

The diff is seven lines across one file. No behaviour change for spec-compliant streams.

## Test coverage

Two test files updated/added:

**`packages/ai/test/openai-completions-missing-finish-reason.test.ts`** (new) — uses an isolated OpenAI mock, does not import the model catalog:
1. **Content without finish_reason** — stream delivers content chunks with `finish_reason: null` then a `choices: []` usage chunk; resolves with `stopReason: "stop"` and emits exactly one warning.
2. **Zero-chunk stream** — empty stream still throws `"Stream ended without finish_reason"` (transport failure path unchanged).
3. **Normal stream** — content chunk followed by a `finish_reason: "stop"` chunk; resolves correctly with no change in behaviour.

**`packages/ai/test/openai-completions-tool-choice.test.ts`** (updated) — the existing test `"errors when a stream ends after only null finish_reason chunks"` asserted the old error contract for a content-bearing stream. It is renamed and its expectations updated to the new contract (`stopReason: "stop"` + one `console.warn`). The zero-chunk throw path is covered by the new test file above.

All tests pass. `./test.sh` and `npm run check` both exit 0 (pre-existing tsgo type errors in unrelated packages are unchanged).

## Note on test.sh and the fresh-clone environment

In a fresh clone without running `npm run generate-models`, several `packages/ai` test files that import the model catalog cannot load and are silently uncountable by vitest. This caused an earlier `./test.sh` run (before the conflicting test was identified) to report exit 0 while the tool-choice test file was actually broken at import — not because the assertion passed, but because no test in the file could execute at all. After running `npm run generate-models` to hydrate the model data, the tool-choice file loads, the conflicting test is confirmed to fail under my change, and the fix above makes it pass.

## Strictness preserved

The fix does not weaken the zero-chunk check. An empty stream — which signals a genuine transport or API failure — continues to throw. Only a stream that delivered actual data before closing without a finish_reason is treated leniently.
