### PR TITLE
feat(agent): add bounded branch entry queries

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Changed `Session` into the sole opened-session aggregate and replaced `SessionStorage`, `SessionRepo`, and concrete per-session persistence classes with a non-owning `SessionRepository` and caller-owned, async-disposable `SessionStore` instances. Create stores with `createInMemorySessionStore()` or `createJsonlSessionStore()`, compose them with `createSessionRepository({ store, search: createScanningSessionSearch(store) })`, and dispose the store after draining harness and session work.
 - `Session` instances are now created by `SessionRepository`; direct construction from an independently supplied store and snapshot was removed.
 
+### Added
+
+- Added bounded `Session.findEntriesOnBranch()` and `findEntryOnBranch()` queries with explicit traversal, filtering, ordering, and limit options.
+
 ## [0.83.0] - 2026-07-29
 
 ## [0.82.1] - 2026-07-25

--- a/packages/agent/src/harness/session/array-session-reader.ts
+++ b/packages/agent/src/harness/session/array-session-reader.ts
@@ -45,6 +45,36 @@ export function createArraySessionReader<TMetadata extends SessionMetadata>(
 			const end = options?.limit === undefined ? undefined : start + options.limit;
 			return entries.slice(start, end);
 		},
+		async findEntriesOnBranch(query) {
+			updateIndex();
+			if (query.limit !== undefined && (!Number.isInteger(query.limit) || query.limit <= 0)) {
+				throw new RangeError("Session branch query limit must be a positive integer");
+			}
+			if (query.start === null) return [];
+			const path: SessionTreeEntry[] = [];
+			const visited = new Set<string>();
+			let current = byId.get(query.start);
+			if (!current) throw new SessionError("not_found", `Entry ${query.start} not found`);
+			while (current) {
+				if (visited.has(current.id)) {
+					throw new SessionError("invalid_session", `Session branch contains a cycle at ${current.id}`);
+				}
+				visited.add(current.id);
+				path.push(current);
+				if (current.id === query.stopAtId || current.type === query.stopAtType) break;
+				if (!current.parentId) break;
+				const parent = byId.get(current.parentId);
+				if (!parent) throw new SessionError("invalid_session", `Entry ${current.parentId} not found`);
+				current = parent;
+			}
+			if (query.order === "oldestFirst") path.reverse();
+			const entries = path.filter(
+				(entry) =>
+					(query.type === undefined || entry.type === query.type) &&
+					(query.customType === undefined || (entry.type === "custom" && entry.customType === query.customType)),
+			);
+			return query.limit === undefined ? entries : entries.slice(0, query.limit);
+		},
 		async readPathToRootOrCompaction(requestedLeafId) {
 			updateIndex();
 			if (requestedLeafId === null) return [];

--- a/packages/agent/src/harness/session/array-session-reader.ts
+++ b/packages/agent/src/harness/session/array-session-reader.ts
@@ -51,7 +51,7 @@ export function createArraySessionReader<TMetadata extends SessionMetadata>(
 				throw new RangeError("Session branch query limit must be a positive integer");
 			}
 			if (query.start === null) return [];
-			const path: SessionTreeEntry[] = [];
+			const pathFromStart: SessionTreeEntry[] = [];
 			const visited = new Set<string>();
 			let current = byId.get(query.start);
 			if (!current) throw new SessionError("not_found", `Entry ${query.start} not found`);
@@ -60,15 +60,22 @@ export function createArraySessionReader<TMetadata extends SessionMetadata>(
 					throw new SessionError("invalid_session", `Session branch contains a cycle at ${current.id}`);
 				}
 				visited.add(current.id);
-				path.push(current);
-				if (current.id === query.stopAtId || current.type === query.stopAtType) break;
+				pathFromStart.push(current);
+				if (query.order !== "oldestFirst" && (current.id === query.stopAtId || current.type === query.stopAtType)) {
+					break;
+				}
 				if (!current.parentId) break;
 				const parent = byId.get(current.parentId);
 				if (!parent) throw new SessionError("invalid_session", `Entry ${current.parentId} not found`);
 				current = parent;
 			}
-			if (query.order === "oldestFirst") path.reverse();
-			const entries = path.filter(
+			const traversal = query.order === "oldestFirst" ? pathFromStart.reverse() : pathFromStart;
+			const stopIndex =
+				query.order === "oldestFirst"
+					? traversal.findIndex((entry) => entry.id === query.stopAtId || entry.type === query.stopAtType)
+					: -1;
+			const bounded = stopIndex === -1 ? traversal : traversal.slice(0, stopIndex + 1);
+			const entries = bounded.filter(
 				(entry) =>
 					(query.type === undefined || entry.type === query.type) &&
 					(query.customType === undefined || (entry.type === "custom" && entry.customType === query.customType)),

--- a/packages/agent/src/harness/session/jsonl-store.ts
+++ b/packages/agent/src/harness/session/jsonl-store.ts
@@ -400,6 +400,10 @@ class JsonlSessionStore
 				this.assertOpen();
 				return this.operations.enqueue(operationKey, () => reader.readEntries(options));
 			},
+			findEntriesOnBranch: (query) => {
+				this.assertOpen();
+				return this.operations.enqueue(operationKey, () => reader.findEntriesOnBranch(query));
+			},
 			readPathToRootOrCompaction: (leafId) => {
 				this.assertOpen();
 				return this.operations.enqueue(operationKey, () => reader.readPathToRootOrCompaction(leafId));

--- a/packages/agent/src/harness/session/memory-store.ts
+++ b/packages/agent/src/harness/session/memory-store.ts
@@ -117,6 +117,10 @@ class InMemorySessionStore implements SessionStore<SessionMetadata, InMemorySess
 				this.assertOpen();
 				return this.operations.enqueue(state.metadata.id, () => reader.readEntries(options));
 			},
+			findEntriesOnBranch: (query) => {
+				this.assertOpen();
+				return this.operations.enqueue(state.metadata.id, () => reader.findEntriesOnBranch(query));
+			},
 			readPathToRootOrCompaction: (leafId) => {
 				this.assertOpen();
 				return this.operations.enqueue(state.metadata.id, () => reader.readPathToRootOrCompaction(leafId));

--- a/packages/agent/src/harness/session/session.ts
+++ b/packages/agent/src/harness/session/session.ts
@@ -11,6 +11,7 @@ import type {
 	LeafEntry,
 	MessageEntry,
 	ModelChangeEntry,
+	SessionBranchQuery,
 	SessionContext,
 	SessionEntryCursorOptions,
 	SessionInfoEntry,
@@ -217,6 +218,8 @@ export interface Session<TMetadata extends SessionMetadata = SessionMetadata> {
 	getEntry(id: string): Promise<SessionTreeEntry | undefined>;
 	getEntries(options?: SessionEntryCursorOptions): Promise<SessionTreeEntry[]>;
 	getBranch(fromId?: string | null): Promise<SessionTreeEntry[]>;
+	findEntriesOnBranch(query?: SessionBranchQuery): Promise<SessionTreeEntry[]>;
+	findEntryOnBranch(query?: SessionBranchQuery): Promise<SessionTreeEntry | undefined>;
 	buildContextEntries(options?: SessionContextBuildOptions): Promise<SessionTreeEntry[]>;
 	buildContext(options?: SessionContextBuildOptions): Promise<SessionContext>;
 	getLabel(id: string): Promise<string | undefined>;
@@ -287,6 +290,19 @@ class StoreSession<TMetadata extends SessionMetadata = SessionMetadata> implemen
 
 	async getBranch(fromId?: string | null): Promise<SessionTreeEntry[]> {
 		return [...(await this.reader.readPathToRootOrCompaction(fromId === undefined ? this.leafId : fromId))];
+	}
+
+	async findEntriesOnBranch(query: SessionBranchQuery = {}): Promise<SessionTreeEntry[]> {
+		return [
+			...(await this.reader.findEntriesOnBranch({
+				...query,
+				start: query.start === undefined ? this.leafId : query.start,
+			})),
+		];
+	}
+
+	async findEntryOnBranch(query: SessionBranchQuery = {}): Promise<SessionTreeEntry | undefined> {
+		return (await this.findEntriesOnBranch({ ...query, limit: 1 }))[0];
 	}
 
 	async buildContextEntries(options: SessionContextBuildOptions = {}): Promise<SessionTreeEntry[]> {

--- a/packages/agent/src/harness/types.ts
+++ b/packages/agent/src/harness/types.ts
@@ -534,6 +534,23 @@ export type SessionForkSelection =
 	/** Copy the target's active path, including the target. */
 	| { kind: "through_entry"; entryId: string };
 
+export interface SessionBranchQuery {
+	/** Entry where traversal starts. Session defaults this to its active leaf. */
+	start?: string | null;
+	/** Stop after the first matching entry, inclusive. */
+	stopAtType?: SessionTreeEntry["type"];
+	/** Stop after the matching entry, inclusive. */
+	stopAtId?: string;
+	/** Filter returned entries by type after determining traversal bounds. */
+	type?: SessionTreeEntry["type"];
+	/** Filter returned custom entries by custom type. */
+	customType?: string;
+	/** Traversal order. Defaults to newest first. */
+	order?: "newestFirst" | "oldestFirst";
+	/** Maximum number of filtered entries to return. */
+	limit?: number;
+}
+
 export interface SessionHead {
 	leafId: string | null;
 }
@@ -545,6 +562,7 @@ export interface SessionReader<TMetadata extends SessionMetadata = SessionMetada
 	readHead(): Promise<SessionHead>;
 	readEntry(id: string): Promise<SessionTreeEntry | undefined>;
 	readEntries(options?: SessionEntryCursorOptions): Promise<readonly SessionTreeEntry[]>;
+	findEntriesOnBranch(query: SessionBranchQuery & { start: string | null }): Promise<readonly SessionTreeEntry[]>;
 	readPathToRootOrCompaction(leafId: string | null): Promise<readonly SessionTreeEntry[]>;
 }
 

--- a/packages/agent/test/harness/branch-query.test.ts
+++ b/packages/agent/test/harness/branch-query.test.ts
@@ -1,0 +1,153 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createNodeSqliteFactory, createSqliteSessionStore } from "../../../storage/sqlite-node/src/index.ts";
+import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
+import { createJsonlSessionStore } from "../../src/harness/session/jsonl-store.ts";
+import { createInMemorySessionStore } from "../../src/harness/session/memory-store.ts";
+import { createSessionRepository } from "../../src/harness/session/repository.ts";
+import type { Session } from "../../src/harness/session/session.ts";
+import { createAssistantMessage, createTempDir, createUserMessage } from "./session-test-utils.ts";
+
+const ownedStores: AsyncDisposable[] = [];
+
+afterEach(async () => {
+	for (const store of ownedStores.splice(0)) await store[Symbol.asyncDispose]();
+});
+
+async function verifyBranchQueries(session: Session): Promise<{ tail: string; fullPath: string[] }> {
+	const root = await session.appendMessage(createUserMessage("root"));
+	const custom = await session.appendCustomEntry("note", { value: 1 });
+	const child = await session.appendMessage(createAssistantMessage("child"));
+	const compaction = await session.appendCompaction("summary", child, 100, undefined, undefined, undefined, [
+		createAssistantMessage("child"),
+	]);
+	const tail = await session.appendMessage(createUserMessage("tail"));
+	await session.moveTo(root);
+	const sibling = await session.appendMessage(createUserMessage("sibling"));
+
+	expect((await session.findEntriesOnBranch()).map((entry) => entry.id)).toEqual([sibling, root]);
+	expect(await session.findEntriesOnBranch({ start: null })).toEqual([]);
+	expect((await session.findEntriesOnBranch({ start: tail, order: "oldestFirst" })).map((entry) => entry.id)).toEqual([
+		root,
+		custom,
+		child,
+		compaction,
+		tail,
+	]);
+	expect(
+		(await session.findEntriesOnBranch({ start: tail, stopAtType: "compaction" })).map((entry) => entry.id),
+	).toEqual([tail, compaction]);
+	expect(
+		(await session.findEntriesOnBranch({ start: tail, stopAtType: "compaction", type: "message" })).map(
+			(entry) => entry.id,
+		),
+	).toEqual([tail]);
+	expect(
+		(await session.findEntriesOnBranch({ start: tail, stopAtId: child, order: "oldestFirst" })).map(
+			(entry) => entry.id,
+		),
+	).toEqual([child, compaction, tail]);
+	expect(
+		(await session.findEntriesOnBranch({ start: tail, type: "message", order: "oldestFirst" })).map(
+			(entry) => entry.id,
+		),
+	).toEqual([root, child, tail]);
+	expect((await session.findEntriesOnBranch({ start: tail, customType: "note" })).map((entry) => entry.id)).toEqual([
+		custom,
+	]);
+	expect((await session.findEntriesOnBranch({ start: tail, limit: 1 })).map((entry) => entry.id)).toEqual([tail]);
+	expect(
+		(
+			await session.findEntriesOnBranch({
+				start: tail,
+				type: "message",
+				order: "oldestFirst",
+				limit: 1,
+			})
+		).map((entry) => entry.id),
+	).toEqual([root]);
+	expect(await session.findEntryOnBranch({ start: tail, type: "compaction" })).toMatchObject({ id: compaction });
+	await expect(session.findEntriesOnBranch({ start: "missing" })).rejects.toMatchObject({ code: "not_found" });
+	await expect(session.findEntriesOnBranch({ limit: 0 })).rejects.toThrow("limit must be a positive integer");
+	return { tail, fullPath: [root, custom, child, compaction, tail] };
+}
+
+describe("bounded session branch queries", () => {
+	it("provides identical in-memory query semantics", async () => {
+		const store = createInMemorySessionStore();
+		ownedStores.push(store);
+		const repo = createSessionRepository({ store });
+		const session = await repo.create({ id: "memory" });
+		const expected = await verifyBranchQueries(session);
+		const reopened = await repo.open(await session.getMetadata());
+		expect(
+			(await reopened.findEntriesOnBranch({ start: expected.tail, order: "oldestFirst" })).map((entry) => entry.id),
+		).toEqual(expected.fullPath);
+	});
+
+	it("rejects corrupt parent chains in array-backed readers", async () => {
+		const store = createInMemorySessionStore();
+		ownedStores.push(store);
+		const reader = await store.create({ id: "corrupt-memory" });
+		await store.appendEntry(reader.metadata, {
+			type: "message",
+			id: "orphan",
+			parentId: "missing-parent",
+			timestamp: "2026-01-01T00:00:00.000Z",
+			message: createUserMessage("orphan"),
+		});
+
+		await expect(reader.findEntriesOnBranch({ start: "orphan" })).rejects.toMatchObject({
+			code: "invalid_session",
+			message: "Entry missing-parent not found",
+		});
+		await store.appendEntry(reader.metadata, {
+			type: "message",
+			id: "cycle-a",
+			parentId: "cycle-b",
+			timestamp: "2026-01-01T00:00:01.000Z",
+			message: createUserMessage("a"),
+		});
+		await store.appendEntry(reader.metadata, {
+			type: "message",
+			id: "cycle-b",
+			parentId: "cycle-a",
+			timestamp: "2026-01-01T00:00:02.000Z",
+			message: createUserMessage("b"),
+		});
+		await expect(reader.findEntriesOnBranch({ start: "cycle-b" })).rejects.toMatchObject({
+			code: "invalid_session",
+			message: "Session branch contains a cycle at cycle-b",
+		});
+	});
+
+	it("provides identical JSONL query semantics", async () => {
+		const root = createTempDir();
+		const store = createJsonlSessionStore({ fs: new NodeExecutionEnv({ cwd: root }), sessionsRoot: root });
+		ownedStores.push(store);
+		const repo = createSessionRepository({ store });
+		const session = await repo.create({ id: "jsonl", cwd: root });
+		const expected = await verifyBranchQueries(session);
+		const reopened = await repo.open(await session.getMetadata());
+		expect(
+			(await reopened.findEntriesOnBranch({ start: expected.tail, order: "oldestFirst" })).map((entry) => entry.id),
+		).toEqual(expected.fullPath);
+	});
+
+	it("provides identical SQLite query semantics", async () => {
+		const root = createTempDir();
+		const store = createSqliteSessionStore({
+			env: new NodeExecutionEnv({ cwd: root }),
+			sqlite: createNodeSqliteFactory(),
+			databasePath: join(root, "sessions.sqlite"),
+		});
+		ownedStores.push(store);
+		const repo = createSessionRepository({ store });
+		const session = await repo.create({ id: "sqlite", cwd: root });
+		const expected = await verifyBranchQueries(session);
+		const reopened = await repo.open(await session.getMetadata());
+		expect(
+			(await reopened.findEntriesOnBranch({ start: expected.tail, order: "oldestFirst" })).map((entry) => entry.id),
+		).toEqual(expected.fullPath);
+	});
+});

--- a/packages/agent/test/harness/branch-query.test.ts
+++ b/packages/agent/test/harness/branch-query.test.ts
@@ -21,6 +21,7 @@ async function verifyBranchQueries(session: Session): Promise<{ tail: string; fu
 	const compaction = await session.appendCompaction("summary", child, 100, undefined, undefined, undefined, [
 		createAssistantMessage("child"),
 	]);
+	const recentCustom = await session.appendCustomEntry("note", { value: 2 });
 	const tail = await session.appendMessage(createUserMessage("tail"));
 	await session.moveTo(root);
 	const sibling = await session.appendMessage(createUserMessage("sibling"));
@@ -32,11 +33,12 @@ async function verifyBranchQueries(session: Session): Promise<{ tail: string; fu
 		custom,
 		child,
 		compaction,
+		recentCustom,
 		tail,
 	]);
 	expect(
 		(await session.findEntriesOnBranch({ start: tail, stopAtType: "compaction" })).map((entry) => entry.id),
-	).toEqual([tail, compaction]);
+	).toEqual([tail, recentCustom, compaction]);
 	expect(
 		(await session.findEntriesOnBranch({ start: tail, stopAtType: "compaction", type: "message" })).map(
 			(entry) => entry.id,
@@ -46,13 +48,27 @@ async function verifyBranchQueries(session: Session): Promise<{ tail: string; fu
 		(await session.findEntriesOnBranch({ start: tail, stopAtId: child, order: "oldestFirst" })).map(
 			(entry) => entry.id,
 		),
-	).toEqual([child, compaction, tail]);
+	).toEqual([root, custom, child]);
+	expect((await session.findEntriesOnBranch({ start: tail, stopAtType: "custom" })).map((entry) => entry.id)).toEqual([
+		tail,
+		recentCustom,
+	]);
+	expect(
+		(
+			await session.findEntriesOnBranch({
+				start: tail,
+				stopAtType: "custom",
+				order: "oldestFirst",
+			})
+		).map((entry) => entry.id),
+	).toEqual([root, custom]);
 	expect(
 		(await session.findEntriesOnBranch({ start: tail, type: "message", order: "oldestFirst" })).map(
 			(entry) => entry.id,
 		),
 	).toEqual([root, child, tail]);
 	expect((await session.findEntriesOnBranch({ start: tail, customType: "note" })).map((entry) => entry.id)).toEqual([
+		recentCustom,
 		custom,
 	]);
 	expect((await session.findEntriesOnBranch({ start: tail, limit: 1 })).map((entry) => entry.id)).toEqual([tail]);
@@ -69,7 +85,7 @@ async function verifyBranchQueries(session: Session): Promise<{ tail: string; fu
 	expect(await session.findEntryOnBranch({ start: tail, type: "compaction" })).toMatchObject({ id: compaction });
 	await expect(session.findEntriesOnBranch({ start: "missing" })).rejects.toMatchObject({ code: "not_found" });
 	await expect(session.findEntriesOnBranch({ limit: 0 })).rejects.toThrow("limit must be a positive integer");
-	return { tail, fullPath: [root, custom, child, compaction, tail] };
+	return { tail, fullPath: [root, custom, child, compaction, recentCustom, tail] };
 }
 
 describe("bounded session branch queries", () => {
@@ -97,6 +113,12 @@ describe("bounded session branch queries", () => {
 			message: createUserMessage("orphan"),
 		});
 
+		expect(
+			(await reader.findEntriesOnBranch({ start: "orphan", stopAtId: "orphan" })).map((entry) => entry.id),
+		).toEqual(["orphan"]);
+		expect(
+			(await reader.findEntriesOnBranch({ start: "orphan", stopAtType: "message" })).map((entry) => entry.id),
+		).toEqual(["orphan"]);
 		await expect(reader.findEntriesOnBranch({ start: "orphan" })).rejects.toMatchObject({
 			code: "invalid_session",
 			message: "Entry missing-parent not found",
@@ -132,6 +154,172 @@ describe("bounded session branch queries", () => {
 		expect(
 			(await reopened.findEntriesOnBranch({ start: expected.tail, order: "oldestFirst" })).map((entry) => entry.id),
 		).toEqual(expected.fullPath);
+	});
+
+	it("does not decode SQLite branch entries outside query bounds", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const sqlite = createNodeSqliteFactory();
+		const store = createSqliteSessionStore({
+			env: new NodeExecutionEnv({ cwd: root }),
+			sqlite,
+			databasePath,
+		});
+		ownedStores.push(store);
+		const repo = createSessionRepository({ store });
+		const session = await repo.create({ id: "bounded-sqlite", cwd: root });
+		const rootId = await session.appendMessage(createUserMessage("root"));
+		const middleId = await session.appendMessage(createAssistantMessage("middle"));
+		const tailId = await session.appendMessage(createUserMessage("tail"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db
+				.prepare("UPDATE session_entries SET payload = ? WHERE session_id = ? AND id = ?")
+				.run("not json", "bounded-sqlite", middleId);
+			const branch = await db
+				.prepare("SELECT branch_id FROM branch_entries WHERE session_id = ? AND entry_id = ?")
+				.get<{ branch_id: string }>("bounded-sqlite", tailId);
+			if (!branch) throw new Error("Missing branch cache for bounded SQLite query test");
+			await db
+				.prepare("DELETE FROM branch_entries WHERE session_id = ? AND branch_id = ? AND entry_id = ?")
+				.run("bounded-sqlite", branch.branch_id, middleId);
+		} finally {
+			await db.close();
+		}
+
+		expect((await session.findEntriesOnBranch({ start: tailId, stopAtId: tailId })).map((entry) => entry.id)).toEqual(
+			[tailId],
+		);
+		const inspection = await sqlite.open(databasePath);
+		try {
+			const repaired = await inspection
+				.prepare(
+					`SELECT entry_id FROM branch_entries
+					WHERE session_id = ? AND branch_id = (
+						SELECT branch_id FROM branch_entries WHERE session_id = ? AND entry_id = ? LIMIT 1
+					)
+					ORDER BY entry_seq`,
+				)
+				.all<{ entry_id: string }>("bounded-sqlite", "bounded-sqlite", tailId);
+			expect(repaired.map((row) => row.entry_id)).toEqual([rootId, tailId]);
+		} finally {
+			await inspection.close();
+		}
+		expect(
+			(
+				await session.findEntriesOnBranch({
+					start: tailId,
+					stopAtId: rootId,
+					order: "oldestFirst",
+					limit: 1,
+				})
+			).map((entry) => entry.id),
+		).toEqual([rootId]);
+		await expect(session.findEntriesOnBranch({ start: tailId, limit: 2 })).rejects.toMatchObject({
+			code: "invalid_entry",
+			message: expect.stringContaining(`failed to decode entry ${middleId}`),
+		});
+	});
+
+	it("validates SQLite entries before filtering and limiting branch results", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const sqlite = createNodeSqliteFactory();
+		const store = createSqliteSessionStore({
+			env: new NodeExecutionEnv({ cwd: root }),
+			sqlite,
+			databasePath,
+		});
+		ownedStores.push(store);
+		const repo = createSessionRepository({ store });
+		const session = await repo.create({ id: "invalid-filtered-sqlite", cwd: root });
+		await session.appendMessage(createUserMessage("root"));
+		const customId = await session.appendCustomEntry("note", { value: 1 });
+		const tailId = await session.appendMessage(createAssistantMessage("tail"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db
+				.prepare("UPDATE session_entries SET payload = ? WHERE session_id = ? AND id = ?")
+				.run("{}", "invalid-filtered-sqlite", customId);
+		} finally {
+			await db.close();
+		}
+		await expect(session.findEntriesOnBranch({ start: tailId, type: "message", limit: 1 })).rejects.toMatchObject({
+			code: "invalid_entry",
+			message: expect.stringContaining(`failed to decode entry ${customId}`),
+		});
+
+		const invalidJsonDb = await sqlite.open(databasePath);
+		try {
+			await invalidJsonDb
+				.prepare("UPDATE session_entries SET payload = ? WHERE session_id = ? AND id = ?")
+				.run("not json", "invalid-filtered-sqlite", customId);
+		} finally {
+			await invalidJsonDb.close();
+		}
+		await expect(session.findEntriesOnBranch({ start: tailId, customType: "other" })).rejects.toMatchObject({
+			code: "invalid_entry",
+			message: expect.stringContaining(`failed to decode entry ${customId}`),
+		});
+	});
+
+	it("does not validate SQLite ancestors beyond newest-first stop bounds", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const sqlite = createNodeSqliteFactory();
+		const store = createSqliteSessionStore({
+			env: new NodeExecutionEnv({ cwd: root }),
+			sqlite,
+			databasePath,
+		});
+		ownedStores.push(store);
+		const repo = createSessionRepository({ store });
+		const session = await repo.create({ id: "bounded-corrupt-sqlite", cwd: root });
+		const rootId = await session.appendMessage(createUserMessage("root"));
+		const childId = await session.appendMessage(createAssistantMessage("child"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db
+				.prepare("UPDATE session_entries SET parent_id = ? WHERE session_id = ? AND id = ?")
+				.run("missing-parent", "bounded-corrupt-sqlite", childId);
+		} finally {
+			await db.close();
+		}
+		expect(
+			(await session.findEntriesOnBranch({ start: childId, stopAtId: childId })).map((entry) => entry.id),
+		).toEqual([childId]);
+		expect(
+			(await session.findEntriesOnBranch({ start: childId, stopAtType: "message" })).map((entry) => entry.id),
+		).toEqual([childId]);
+		await expect(session.findEntriesOnBranch({ start: childId })).rejects.toMatchObject({
+			code: "invalid_session",
+			message: expect.stringContaining("Entry missing-parent not found"),
+		});
+
+		const cycleDb = await sqlite.open(databasePath);
+		try {
+			await cycleDb
+				.prepare("UPDATE session_entries SET parent_id = ? WHERE session_id = ? AND id = ?")
+				.run(rootId, "bounded-corrupt-sqlite", childId);
+			await cycleDb
+				.prepare("UPDATE session_entries SET parent_id = ? WHERE session_id = ? AND id = ?")
+				.run(childId, "bounded-corrupt-sqlite", rootId);
+		} finally {
+			await cycleDb.close();
+		}
+		expect(
+			(await session.findEntriesOnBranch({ start: childId, stopAtId: childId })).map((entry) => entry.id),
+		).toEqual([childId]);
+		expect(
+			(await session.findEntriesOnBranch({ start: childId, stopAtType: "message" })).map((entry) => entry.id),
+		).toEqual([childId]);
+		await expect(session.findEntriesOnBranch({ start: childId })).rejects.toMatchObject({
+			code: "invalid_session",
+			message: expect.stringContaining(`cycle in parent chain at entry ${childId}`),
+		});
 	});
 
 	it("provides identical SQLite query semantics", async () => {

--- a/packages/agent/test/harness/repo.test.ts
+++ b/packages/agent/test/harness/repo.test.ts
@@ -165,6 +165,7 @@ function createCountingInMemorySessionStore(): {
 			counter.readEntriesCount += 1;
 			return reader.readEntries(options);
 		},
+		findEntriesOnBranch: (query) => reader.findEntriesOnBranch(query),
 		readPathToRootOrCompaction: (leafId) => {
 			counter.readPathCount += 1;
 			return reader.readPathToRootOrCompaction(leafId);

--- a/packages/agent/test/harness/sqlite-branch-cache.test.ts
+++ b/packages/agent/test/harness/sqlite-branch-cache.test.ts
@@ -199,6 +199,47 @@ describe("SQLite branch cache", () => {
 		expect((await fork.getEntries()).map((entry) => entry.id)).toEqual([rootId, childId]);
 	});
 
+	it("repairs a stale branch cache from canonical parent links", async () => {
+		const root = createTempDir();
+		const databasePath = join(root, "sessions.sqlite");
+		const env = new NodeExecutionEnv({ cwd: root });
+		const sqlite = createNodeSqliteFactory();
+		const repo = createSessionRepository({ store: createSqliteSessionStore({ env, sqlite, databasePath }) });
+		const session = await repo.create({ cwd: root, id: "session-1" });
+		const rootId = await session.appendMessage(createUserMessage("root"));
+		const staleId = await session.appendMessage(createAssistantMessage("stale"));
+		const leafId = await session.appendMessage(createUserMessage("leaf"));
+
+		const db = await sqlite.open(databasePath);
+		try {
+			await db
+				.prepare("UPDATE session_entries SET parent_id = ? WHERE session_id = ? AND id = ?")
+				.run(rootId, "session-1", leafId);
+		} finally {
+			await db.close();
+		}
+
+		expect(
+			(await session.findEntriesOnBranch({ start: leafId, order: "oldestFirst" })).map((entry) => entry.id),
+		).toEqual([rootId, leafId]);
+		const inspection = await sqlite.open(databasePath);
+		try {
+			const rows = await inspection
+				.prepare(
+					`SELECT entry_id FROM branch_entries
+					WHERE session_id = ? AND branch_id = (
+						SELECT branch_id FROM branch_entries WHERE session_id = ? AND entry_id = ? LIMIT 1
+					)
+					ORDER BY entry_seq`,
+				)
+				.all<{ entry_id: string }>("session-1", "session-1", leafId);
+			expect(rows.map((row) => row.entry_id)).toEqual([rootId, leafId]);
+			expect(rows.map((row) => row.entry_id)).not.toContain(staleId);
+		} finally {
+			await inspection.close();
+		}
+	});
+
 	it("deletes branch entries and tips with the session", async () => {
 		const root = createTempDir();
 		const databasePath = join(root, "sessions.sqlite");

--- a/packages/coding-agent/test/suite/regressions/5303-bash-output-truncation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5303-bash-output-truncation.test.ts
@@ -1,7 +1,8 @@
 import type { ChildProcessByStdio } from "node:child_process";
-import type { Readable } from "node:stream";
-import { afterEach, describe, expect, it } from "vitest";
-import { spawnProcess, waitForChildProcess } from "../../../src/utils/child-process.ts";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForChildProcess } from "../../../src/utils/child-process.ts";
 
 /**
  * Regression test for https://github.com/earendil-works/pi/issues/5303
@@ -15,65 +16,67 @@ import { spawnProcess, waitForChildProcess } from "../../../src/utils/child-proc
  *
  * The fix re-arms the grace on each chunk, so an actively writing pipe keeps us
  * reading while a genuinely idle held-open handle still releases after the
- * grace elapses. Both behaviours are covered below.
+ * grace elapses. Both behaviours are covered below with virtual time so host
+ * load cannot reorder a real subprocess's writes and the grace timer.
  */
-describe.skipIf(process.platform === "win32")("issue #5303 bash output truncation past exit", () => {
-	let child: ChildProcessByStdio<null, Readable, Readable> | undefined;
+describe("issue #5303 bash output truncation past exit", () => {
+	function createChild(): ChildProcessByStdio<null, PassThrough, PassThrough> {
+		return Object.assign(new EventEmitter(), {
+			stdin: null,
+			stdout: new PassThrough(),
+			stderr: new PassThrough(),
+		}) as unknown as ChildProcessByStdio<null, PassThrough, PassThrough>;
+	}
 
-	afterEach(() => {
-		if (child?.pid) {
-			try {
-				process.kill(-child.pid, "SIGKILL");
-			} catch {
-				// Already gone.
-			}
-		}
-		child = undefined;
+	beforeEach(() => {
+		vi.useFakeTimers();
 	});
 
-	it("captures output emitted after exit while a detached child holds stdout open", async () => {
-		// The shell exits immediately, but a backgrounded subshell keeps the stdout
-		// pipe open and emits ticks every 50ms, the last well past the 100ms grace.
-		const command = 'printf "HEAD\\n"; ( for i in 1 2 3 4 5 6; do sleep 0.05; printf "TICK$i\\n"; done ) &';
-		child = spawnProcess("/bin/sh", ["-c", command], {
-			stdio: ["ignore", "pipe", "pipe"],
-			detached: true,
-		}) as ChildProcessByStdio<null, Readable, Readable>;
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
+	it("captures output emitted after exit while a descendant holds stdout open", async () => {
+		const child = createChild();
 		let output = "";
 		child.stdout.on("data", (chunk: Buffer) => {
 			output += chunk.toString();
 		});
+		let resolved = false;
+		const waiting = waitForChildProcess(child).then((exitCode) => {
+			resolved = true;
+			return exitCode;
+		});
 
-		const exitCode = await waitForChildProcess(child);
+		child.stdout.write("HEAD\n");
+		child.emit("exit", 0, null);
+		for (let index = 1; index <= 6; index++) {
+			await vi.advanceTimersByTimeAsync(50);
+			child.stdout.write(`TICK${index}\n`);
+		}
+		await vi.advanceTimersByTimeAsync(99);
+		expect(resolved).toBe(false);
+		await vi.advanceTimersByTimeAsync(1);
 
-		expect(exitCode).toBe(0);
+		expect(await waiting).toBe(0);
 		expect(output).toContain("HEAD");
 		expect(output).toContain("TICK6");
 	});
 
-	it("resolves promptly when a detached child holds stdout open but stays quiet", async () => {
-		// The shell exits, but a backgrounded sleeper inherits the stdout pipe and
-		// keeps it open for a long time without writing. `close` never fires, so we
-		// must still release via the idle grace rather than hang on the open handle.
-		const command = 'printf "DONE\\n"; ( sleep 30 ) &';
-		child = spawnProcess("/bin/sh", ["-c", command], {
-			stdio: ["ignore", "pipe", "pipe"],
-			detached: true,
-		}) as ChildProcessByStdio<null, Readable, Readable>;
-
-		let output = "";
-		child.stdout.on("data", (chunk: Buffer) => {
-			output += chunk.toString();
+	it("resolves after the grace when a descendant holds stdout open but stays quiet", async () => {
+		const child = createChild();
+		let resolved = false;
+		const waiting = waitForChildProcess(child).then((exitCode) => {
+			resolved = true;
+			return exitCode;
 		});
 
-		const start = Date.now();
-		const exitCode = await waitForChildProcess(child);
-		const elapsed = Date.now() - start;
+		child.stdout.write("DONE\n");
+		child.emit("exit", 0, null);
+		await vi.advanceTimersByTimeAsync(99);
+		expect(resolved).toBe(false);
+		await vi.advanceTimersByTimeAsync(1);
 
-		expect(exitCode).toBe(0);
-		expect(output).toContain("DONE");
-		// Must not wait for the 30s sleeper; the idle grace releases us in well under a second.
-		expect(elapsed).toBeLessThan(2000);
+		expect(await waiting).toBe(0);
 	});
 });

--- a/packages/storage/sqlite-node/CHANGELOG.md
+++ b/packages/storage/sqlite-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added bounded active-branch queries to the SQLite session reader.
+
 ## [0.83.0] - 2026-07-29
 
 ## [0.82.1] - 2026-07-25

--- a/packages/storage/sqlite-node/src/sqlite/session-store.ts
+++ b/packages/storage/sqlite-node/src/sqlite/session-store.ts
@@ -229,6 +229,10 @@ class SqliteSessionStore
 				this.assertOpen();
 				return this.operations.enqueue(() => connection.readEntries(options));
 			},
+			findEntriesOnBranch: (query) => {
+				this.assertOpen();
+				return this.operations.enqueue(() => connection.findEntriesOnBranch(query));
+			},
 			readPathToRootOrCompaction: (leafId) => {
 				this.assertOpen();
 				return this.operations.enqueue(() => connection.readPathToRootOrCompaction(leafId));

--- a/packages/storage/sqlite-node/src/sqlite/storage/branch-cache.ts
+++ b/packages/storage/sqlite-node/src/sqlite/storage/branch-cache.ts
@@ -9,6 +9,12 @@ export interface CachedBranch {
 	leafSeq: number;
 }
 
+export interface CachedBranchQuery {
+	stopAtType?: SessionEntryRow["type"];
+	stopAtId?: string;
+	order?: "newestFirst" | "oldestFirst";
+}
+
 export async function readCachedBranch(
 	db: SqliteDatabase,
 	sessionId: string,
@@ -21,6 +27,78 @@ export async function readCachedBranch(
 		.get<{ branch_id: string; entry_seq: number }>(sessionId, leafId);
 	if (!membership) return undefined;
 	return { branchId: membership.branch_id, leafSeq: membership.entry_seq };
+}
+
+export async function isCachedBranchValid(
+	db: SqliteDatabase,
+	sessionId: string,
+	branch: CachedBranch,
+	leafId: string,
+	startSeq = 0,
+): Promise<boolean> {
+	const result = await db
+		.prepare(
+			`WITH path AS (
+				SELECT
+					b.entry_id,
+					b.entry_seq,
+					e.id AS stored_entry_id,
+					e.parent_id,
+					LAG(b.entry_id) OVER (ORDER BY b.entry_seq) AS previous_entry_id
+				FROM branch_entries AS b
+				LEFT JOIN session_entries AS e ON e.session_id = b.session_id AND e.id = b.entry_id
+				WHERE b.session_id = ? AND b.branch_id = ? AND b.entry_seq BETWEEN ? AND ?
+			)
+			SELECT
+				COUNT(*) AS row_count,
+				COALESCE(SUM(
+					stored_entry_id IS NULL OR
+					(? = 0 AND previous_entry_id IS NULL AND parent_id IS NOT NULL) OR
+					(previous_entry_id IS NOT NULL AND parent_id IS NOT previous_entry_id)
+				), 0) AS invalid_count,
+				COALESCE(MAX(entry_seq = ? AND entry_id = ?), 0) AS contains_leaf
+			FROM path`,
+		)
+		.get<{ row_count: number; invalid_count: number; contains_leaf: number }>(
+			sessionId,
+			branch.branchId,
+			startSeq,
+			branch.leafSeq,
+			startSeq,
+			branch.leafSeq,
+			leafId,
+		);
+	return result?.row_count !== 0 && result?.invalid_count === 0 && result.contains_leaf === 1;
+}
+
+export async function readNewestCachedStopSeq(
+	db: SqliteDatabase,
+	sessionId: string,
+	branch: CachedBranch,
+	stopAtType: SessionEntryRow["type"] | undefined,
+	stopAtId: string | undefined,
+): Promise<number | undefined> {
+	const predicates: string[] = [];
+	const params: unknown[] = [sessionId, branch.branchId, branch.leafSeq];
+	if (stopAtType !== undefined) {
+		predicates.push("e.type = ?");
+		params.push(stopAtType);
+	}
+	if (stopAtId !== undefined) {
+		predicates.push("b.entry_id = ?");
+		params.push(stopAtId);
+	}
+	if (predicates.length === 0) return undefined;
+	const row = await db
+		.prepare(
+			`SELECT MAX(b.entry_seq) AS entry_seq
+			FROM branch_entries AS b
+			JOIN session_entries AS e ON e.session_id = b.session_id AND e.id = b.entry_id
+			WHERE b.session_id = ? AND b.branch_id = ? AND b.entry_seq <= ?
+				AND (${predicates.join(" OR ")})`,
+		)
+		.get<{ entry_seq: number | null }>(...params);
+	return row?.entry_seq ?? undefined;
 }
 
 export async function readCachedBranchRows(
@@ -38,6 +116,51 @@ export async function readCachedBranchRows(
 			ORDER BY b.entry_seq`,
 		)
 		.all<SessionEntryRow>(sessionId, branch.branchId, startSeq, branch.leafSeq);
+}
+
+export async function queryCachedBranchRows(
+	db: SqliteDatabase,
+	sessionId: string,
+	branch: CachedBranch,
+	query: CachedBranchQuery,
+): Promise<SessionEntryRow[]> {
+	const oldestFirst = query.order === "oldestFirst";
+	const boundaryParams: unknown[] = [sessionId, branch.branchId, branch.leafSeq];
+	const stopPredicates: string[] = [];
+	if (query.stopAtType !== undefined) {
+		stopPredicates.push("stop_entry.type = ?");
+		boundaryParams.push(query.stopAtType);
+	}
+	if (query.stopAtId !== undefined) {
+		stopPredicates.push("stop.entry_id = ?");
+		boundaryParams.push(query.stopAtId);
+	}
+
+	const boundary = stopPredicates.length
+		? `WITH boundary AS (
+			SELECT ${oldestFirst ? "MIN" : "MAX"}(stop.entry_seq) AS entry_seq
+			FROM branch_entries AS stop
+			JOIN session_entries AS stop_entry
+				ON stop_entry.session_id = stop.session_id AND stop_entry.id = stop.entry_id
+			WHERE stop.session_id = ? AND stop.branch_id = ? AND stop.entry_seq <= ?
+				AND (${stopPredicates.join(" OR ")})
+		)`
+		: "";
+	const range = stopPredicates.length
+		? `AND b.entry_seq ${oldestFirst ? "<=" : ">="} COALESCE(
+			(SELECT entry_seq FROM boundary), ${oldestFirst ? branch.leafSeq : 0}
+		)`
+		: "";
+	const sql = `${boundary}
+		SELECT e.session_id, e.id, e.entry_seq, e.parent_id, e.type, e.timestamp, e.payload
+		FROM branch_entries AS b
+		JOIN session_entries AS e ON e.session_id = b.session_id AND e.id = b.entry_id
+		WHERE b.session_id = ? AND b.branch_id = ? AND b.entry_seq <= ?
+			${range}
+		ORDER BY b.entry_seq ${oldestFirst ? "ASC" : "DESC"}`;
+
+	const params = [...(stopPredicates.length === 0 ? [] : boundaryParams), sessionId, branch.branchId, branch.leafSeq];
+	return db.prepare(sql).all<SessionEntryRow>(...params);
 }
 
 export async function readCachedEntryRowsByType(

--- a/packages/storage/sqlite-node/src/sqlite/storage/index.ts
+++ b/packages/storage/sqlite-node/src/sqlite/storage/index.ts
@@ -8,10 +8,14 @@ import { SessionError, toError } from "@earendil-works/pi-agent-core";
 import type { SqliteDatabase, SqliteSessionMetadata } from "../types.ts";
 import {
 	appendEntryToBranchCache,
+	type CachedBranch,
+	isCachedBranchValid,
+	queryCachedBranchRows,
 	readCachedBranch,
 	readCachedBranchRows,
 	readCachedEntryRowsByType,
 	readCachedEntrySeq,
+	readNewestCachedStopSeq,
 	rebuildCachedBranch,
 } from "./branch-cache.ts";
 import { decodeEntry, encodeEntry, type SessionEntryRow } from "./session-entries.ts";
@@ -81,32 +85,87 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 			throw new RangeError("Session branch query limit must be a positive integer");
 		}
 		if (query.start === null) return [];
-		const fullPath = await this.readPathToRoot(query.start);
-		const path: SessionTreeEntry[] = [];
-		for (let index = fullPath.length - 1; index >= 0; index--) {
-			const entry = fullPath[index]!;
-			path.push(entry);
-			if (entry.id === query.stopAtId || entry.type === query.stopAtType) break;
+		const startId = query.start;
+		let cached = await readCachedBranch(this.db, this.metadata.id, startId);
+		const validationStartSeq =
+			cached && query.order !== "oldestFirst"
+				? await readNewestCachedStopSeq(this.db, this.metadata.id, cached, query.stopAtType, query.stopAtId)
+				: undefined;
+		if (!cached || !(await isCachedBranchValid(this.db, this.metadata.id, cached, startId, validationStartSeq))) {
+			if (query.order !== "oldestFirst" && (query.stopAtId !== undefined || query.stopAtType !== undefined)) {
+				return this.findEntriesOnCanonicalBranch({ ...query, start: startId });
+			}
+			cached = await this.repairBranchCacheForQuery(startId, cached?.branchId);
 		}
-		if (query.order === "oldestFirst") path.reverse();
-		const entries = path.filter(
+		const decoded = decodeEntryRows(await queryCachedBranchRows(this.db, this.metadata.id, cached, query));
+		const filtered = decoded.filter(
 			(entry) =>
 				(query.type === undefined || entry.type === query.type) &&
 				(query.customType === undefined || (entry.type === "custom" && entry.customType === query.customType)),
 		);
-		return query.limit === undefined ? entries : entries.slice(0, query.limit);
+		const entries = query.limit === undefined ? filtered : filtered.slice(0, query.limit);
+		for (const entry of entries) this.byId.set(entry.id, entry);
+		return entries;
 	}
 
-	private async readPathToRoot(leafId: string): Promise<SessionTreeEntry[]> {
-		const cached = await readCachedBranch(this.db, this.metadata.id, leafId);
-		if (cached) {
-			const entries = decodeEntryRows(await readCachedBranchRows(this.db, this.metadata.id, cached, 0));
-			if (this.isValidCachedPath(entries, leafId, null)) {
-				for (const entry of entries) this.byId.set(entry.id, entry);
-				return entries;
+	private async findEntriesOnCanonicalBranch(
+		query: SessionBranchQuery & { start: string },
+	): Promise<SessionTreeEntry[]> {
+		const rows: SessionEntryRow[] = [];
+		const visited = new Set<string>();
+		let currentId: string | null = query.start;
+		while (currentId !== null) {
+			if (visited.has(currentId)) throw invalidSession(`cycle in parent chain at entry ${currentId}`);
+			visited.add(currentId);
+			const row: SessionEntryRow | undefined = await this.db
+				.prepare(
+					"SELECT session_id, id, entry_seq, parent_id, type, timestamp, payload FROM session_entries WHERE session_id = ? AND id = ?",
+				)
+				.get<SessionEntryRow>(this.metadata.id, currentId);
+			if (!row) {
+				if (currentId === query.start) throw new SessionError("not_found", `Entry ${query.start} not found`);
+				throw invalidSession(`Entry ${currentId} not found`);
 			}
+			rows.push(row);
+			if (row.id === query.stopAtId || row.type === query.stopAtType) break;
+			currentId = row.parent_id;
 		}
-		return this.repairBranchCache(leafId, cached?.branchId);
+		const entries = decodeEntryRows(rows).filter(
+			(entry) =>
+				(query.type === undefined || entry.type === query.type) &&
+				(query.customType === undefined || (entry.type === "custom" && entry.customType === query.customType)),
+		);
+		const limited = query.limit === undefined ? entries : entries.slice(0, query.limit);
+		for (const entry of limited) this.byId.set(entry.id, entry);
+		return limited;
+	}
+
+	private async repairBranchCacheForQuery(leafId: string, branchIdToReplace?: string): Promise<CachedBranch> {
+		const visited = new Set<string>();
+		let currentId: string | null = leafId;
+		while (currentId !== null) {
+			if (visited.has(currentId)) throw invalidSession(`cycle in parent chain at entry ${currentId}`);
+			visited.add(currentId);
+			const row: { parent_id: string | null } | undefined = await this.db
+				.prepare("SELECT parent_id FROM session_entries WHERE session_id = ? AND id = ?")
+				.get<{ parent_id: string | null }>(this.metadata.id, currentId);
+			if (!row) {
+				if (currentId === leafId) throw new SessionError("not_found", `Entry ${leafId} not found`);
+				throw invalidSession(`Entry ${currentId} not found`);
+			}
+			currentId = row.parent_id;
+		}
+		try {
+			await rebuildCachedBranch(this.db, this.metadata.id, leafId, branchIdToReplace);
+		} catch (error) {
+			if (error instanceof SessionError) throw error;
+			throw new SessionError("storage", `Failed to rebuild SQLite branch cache at entry ${leafId}`, toError(error));
+		}
+		const cached = await readCachedBranch(this.db, this.metadata.id, leafId);
+		if (!cached || !(await isCachedBranchValid(this.db, this.metadata.id, cached, leafId))) {
+			throw invalidSession(`branch cache repair did not produce a valid path to entry ${leafId}`);
+		}
+		return cached;
 	}
 
 	async readPathToRootOrCompaction(leafId: string | null): Promise<SessionTreeEntry[]> {

--- a/packages/storage/sqlite-node/src/sqlite/storage/index.ts
+++ b/packages/storage/sqlite-node/src/sqlite/storage/index.ts
@@ -1,4 +1,9 @@
-import type { SessionEntryCursorOptions, SessionReader, SessionTreeEntry } from "@earendil-works/pi-agent-core";
+import type {
+	SessionBranchQuery,
+	SessionEntryCursorOptions,
+	SessionReader,
+	SessionTreeEntry,
+} from "@earendil-works/pi-agent-core";
 import { SessionError, toError } from "@earendil-works/pi-agent-core";
 import type { SqliteDatabase, SqliteSessionMetadata } from "../types.ts";
 import {
@@ -70,6 +75,39 @@ export class SqliteSessionConnection implements SessionReader<SqliteSessionMetad
 	readonly metadata: SqliteSessionMetadata;
 	private byId: Map<string, SessionTreeEntry>;
 	private materializedState: SessionMaterializedState;
+
+	async findEntriesOnBranch(query: SessionBranchQuery & { start: string | null }): Promise<SessionTreeEntry[]> {
+		if (query.limit !== undefined && (!Number.isInteger(query.limit) || query.limit <= 0)) {
+			throw new RangeError("Session branch query limit must be a positive integer");
+		}
+		if (query.start === null) return [];
+		const fullPath = await this.readPathToRoot(query.start);
+		const path: SessionTreeEntry[] = [];
+		for (let index = fullPath.length - 1; index >= 0; index--) {
+			const entry = fullPath[index]!;
+			path.push(entry);
+			if (entry.id === query.stopAtId || entry.type === query.stopAtType) break;
+		}
+		if (query.order === "oldestFirst") path.reverse();
+		const entries = path.filter(
+			(entry) =>
+				(query.type === undefined || entry.type === query.type) &&
+				(query.customType === undefined || (entry.type === "custom" && entry.customType === query.customType)),
+		);
+		return query.limit === undefined ? entries : entries.slice(0, query.limit);
+	}
+
+	private async readPathToRoot(leafId: string): Promise<SessionTreeEntry[]> {
+		const cached = await readCachedBranch(this.db, this.metadata.id, leafId);
+		if (cached) {
+			const entries = decodeEntryRows(await readCachedBranchRows(this.db, this.metadata.id, cached, 0));
+			if (this.isValidCachedPath(entries, leafId, null)) {
+				for (const entry of entries) this.byId.set(entry.id, entry);
+				return entries;
+			}
+		}
+		return this.repairBranchCache(leafId, cached?.branchId);
+	}
 
 	async readPathToRootOrCompaction(leafId: string | null): Promise<SessionTreeEntry[]> {
 		if (leafId === null) return [];


### PR DESCRIPTION
## Summary

- add bounded branch entry lookup to session readers
- keep traversal bounds, ordering, filtering, and limits consistent across array, JSONL, and SQLite stores
- validate and repair SQLite branch caches without inspecting corruption outside explicit newest-first bounds
- decode bounded SQLite rows before filtering so malformed entries fail loudly
- make the child-output grace regression deterministic with virtual time

## Verification

- `npm run build`
- `npm run check`
- `./test.sh`
