### PR TITLE
fix(coding-agent): bound model catalog refreshes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Updated the packaged `brace-expansion` dependency to 5.0.8 to address GHSA-mh99-v99m-4gvg ([#7316](https://github.com/earendil-works/pi/issues/7316)).
 - Fixed forced model availability refreshes remaining blocked behind a stalled earlier refresh ([#7301](https://github.com/earendil-works/pi/issues/7301), [#7421](https://github.com/earendil-works/pi/pull/7421) by [@a-yeyang](https://github.com/a-yeyang)).
 - Fixed `/model` catalog refresh failures to identify every catalog that failed.
-- Fixed provider login remaining stuck after saving credentials when a model catalog refresh stalls ([#7027](https://github.com/earendil-works/pi/issues/7027)).
+- Fixed model-catalog refreshes blocking `/scoped-models`, `/model <name>`, `/login` and other credential changes ([#7027](https://github.com/earendil-works/pi/issues/7027), [#7113](https://github.com/earendil-works/pi/issues/7113), [#7153](https://github.com/earendil-works/pi/issues/7153), [#7443](https://github.com/earendil-works/pi/issues/7443)).
 
 ## [0.83.0] - 2026-07-29
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1709,6 +1709,8 @@ Calls made during the extension factory function are queued and applied once the
 
 Dynamic providers can implement `refreshModels`. Pi calls it during model refresh, publishes the returned list synchronously through the provider, and passes the canonical credential/store/network/signal context. The extension decides whether to persist the catalog through `context.store`; live servers such as llama.cpp can ignore it.
 
+Honour `context.signal`. Refreshes are bounded (15 seconds by default) and cancelled when the UI that started them goes away, so a callback that ignores it keeps running after Pi already fell back to the cached catalog.
+
 Extensions that need native provider auth, filtering, refresh, or stream behavior can register a complete `Provider` from `@earendil-works/pi-ai`. The provider becomes the composition base and `models.json` overrides still apply above it.
 
 ```typescript
@@ -1818,7 +1820,7 @@ The object form accepts a complete pi-ai `Provider`, including native `auth`, `g
 - `headers` - Custom headers to include in requests.
 - `authHeader` - If true, adds `Authorization: Bearer` header automatically.
 - `models` - Array of model definitions. If provided, replaces all existing models for this provider. Model definitions can set `baseUrl` to override the provider endpoint for that model.
-- `refreshModels` - Async dynamic discovery callback. Its returned models replace extension-provided models. Use the scoped `context.store` only when results should persist.
+- `refreshModels` - Async dynamic discovery callback. Its returned models replace extension-provided models. Use the scoped `context.store` only when results should persist. Abort on `context.signal`; refreshes are bounded.
 - `oauth` - OAuth provider config for `/login` support. When provided, the provider appears in the login menu.
 - `streamSimple` - Custom streaming implementation for non-standard APIs.
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -469,6 +469,14 @@ const { session } = await createAgentSession({
 });
 ```
 
+`create()`, `boundedRefresh()` and the credential mutations (`login`, `logout`, `setRuntimeApiKey`, `removeRuntimeApiKey`) give up after `modelRefreshTimeoutMs` (15 seconds by default) and keep serving the cached catalog, so an unreachable catalog cannot block a save path. `refresh()` is unbounded unless you pass a `signal`. `login()` forwards the interaction's signal and takes an optional callback with the `BoundedRefreshResult`:
+
+```typescript
+const credential = await modelRuntime.login("openrouter", "api_key", interaction, (result) => {
+  if (result.timedOut || result.errors.size > 0) console.warn("Saved, but the model catalog is stale.");
+});
+```
+
 > See [examples/sdk/09-api-keys-and-oauth.ts](../examples/sdk/09-api-keys-and-oauth.ts)
 
 ### System Prompt

--- a/packages/coding-agent/src/core/model-registry.ts
+++ b/packages/coding-agent/src/core/model-registry.ts
@@ -34,7 +34,7 @@ export class ModelRegistry {
 
 	/** Reload models.json asynchronously. Await before making synchronous registry reads. */
 	async refresh(): Promise<void> {
-		await this.runtime.refresh();
+		await this.runtime.boundedRefresh();
 	}
 
 	getError(): string | undefined {

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -78,7 +78,7 @@ function isAlias(id: string): boolean {
  */
 export function findExactModelReferenceMatch(
 	modelReference: string,
-	availableModels: Model<Api>[],
+	availableModels: readonly Model<Api>[],
 ): Model<Api> | undefined {
 	const trimmedReference = modelReference.trim();
 	if (!trimmedReference) {
@@ -124,7 +124,7 @@ export function findExactModelReferenceMatch(
  * Try to match a pattern to a model from the available models list.
  * Returns the matched model or undefined if no match found.
  */
-function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+function tryMatchModel(modelPattern: string, availableModels: readonly Model<Api>[]): Model<Api> | undefined {
 	const exactMatch = findExactModelReferenceMatch(modelPattern, availableModels);
 	if (exactMatch) {
 		return exactMatch;
@@ -163,7 +163,11 @@ export interface ParsedModelResult {
 	warning: string | undefined;
 }
 
-function buildFallbackModel(provider: string, modelId: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+function buildFallbackModel(
+	provider: string,
+	modelId: string,
+	availableModels: readonly Model<Api>[],
+): Model<Api> | undefined {
 	const providerModels = availableModels.filter((m) => m.provider === provider);
 	if (providerModels.length === 0) return undefined;
 
@@ -194,7 +198,7 @@ function buildFallbackModel(provider: string, modelId: string, availableModels: 
  */
 export function parseModelPattern(
 	pattern: string,
-	availableModels: Model<Api>[],
+	availableModels: readonly Model<Api>[],
 	options?: { allowInvalidThinkingLevelFallback?: boolean },
 ): ParsedModelResult {
 	// Try exact match first
@@ -274,7 +278,13 @@ export async function resolveModelScopeWithDiagnostics(
 	patterns: string[],
 	modelRuntime: ModelRuntime,
 ): Promise<ResolveModelScopeResult> {
-	const availableModels = [...(await modelRuntime.getAvailable())];
+	return resolveModelScopeWithDiagnosticsFromModels(patterns, await modelRuntime.getAvailable());
+}
+
+function resolveModelScopeWithDiagnosticsFromModels(
+	patterns: string[],
+	availableModels: readonly Model<Api>[],
+): ResolveModelScopeResult {
 	const scopedModels: ScopedModel[] = [];
 	const diagnostics: ModelScopeDiagnostic[] = [];
 
@@ -350,6 +360,36 @@ export async function resolveModelScopeWithDiagnostics(
 	}
 
 	return { scopedModels, diagnostics };
+}
+
+export interface ModelScopeSelection {
+	scopedModels: ScopedModel[];
+	enabledModelIds: string[];
+	/** Patterns that matched nothing; listed so the user can still see and remove them. */
+	unmatchedPatterns: string[];
+}
+
+export function resolveModelScopeSelection(
+	patterns: string[],
+	availableModels: readonly Model<Api>[],
+): ModelScopeSelection {
+	const { scopedModels, diagnostics } = resolveModelScopeWithDiagnosticsFromModels(patterns, availableModels);
+	return {
+		scopedModels,
+		enabledModelIds: scopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`),
+		unmatchedPatterns: diagnostics.filter((d) => d.code === "no-match").map((d) => d.pattern),
+	};
+}
+
+export function isEffectiveModelScope(
+	enabledModelIds: readonly string[] | null,
+	availableModels: readonly Model<Api>[],
+): enabledModelIds is readonly string[] {
+	if (enabledModelIds === null) return false;
+	const allModelIds = new Set(availableModels.map((model) => `${model.provider}/${model.id}`));
+	return (
+		enabledModelIds.some((id) => allModelIds.has(id)) && ![...allModelIds].every((id) => enabledModelIds.includes(id))
+	);
 }
 
 export async function resolveModelScope(patterns: string[], modelRuntime: ModelRuntime): Promise<ScopedModel[]> {

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -64,7 +64,7 @@ export interface CreateModelRuntimeOptions {
 	modelsStorePath?: string;
 	/** Allow create() to refresh model catalogs over the network. Defaults to false. */
 	allowModelNetwork?: boolean;
-	/** Timeout for the create-time network model refresh. */
+	/** Timeout for create-time and post-credential network model refreshes. Defaults to 15 seconds. */
 	modelRefreshTimeoutMs?: number;
 	catalogBaseUrl?: string;
 }
@@ -74,6 +74,10 @@ export interface ModelRuntimeAuthOverrides {
 	env?: Record<string, string>;
 	/** Require this much remaining OAuth-token validity; defaults to five minutes. */
 	minOAuthValidityMs?: number;
+}
+
+export interface BoundedRefreshResult extends ModelsRefreshResult {
+	timedOut: boolean;
 }
 
 const DEFAULT_MODEL_REFRESH_TIMEOUT_MS = 15_000;
@@ -94,6 +98,13 @@ function mergeHeaders(
 	return merged;
 }
 
+function whenAborted(signal: AbortSignal): Promise<void> {
+	if (signal.aborted) return Promise.resolve();
+	return new Promise((resolve) => {
+		signal.addEventListener("abort", () => resolve(), { once: true });
+	});
+}
+
 /** Configured pi-ai Models collection used by coding-agent and SDK consumers. */
 export class ModelRuntime implements Models {
 	private readonly models: MutableModels;
@@ -105,6 +116,7 @@ export class ModelRuntime implements Models {
 	private readonly compositionErrors = new Map<string, string>();
 	private readonly modelsPath: string | undefined;
 	private readonly modelNetworkEnabled: boolean;
+	private readonly modelRefreshTimeoutMs: number;
 	private config: ModelConfig;
 	private snapshot: ModelRuntimeSnapshot = {
 		all: [],
@@ -114,7 +126,7 @@ export class ModelRuntime implements Models {
 		auth: new Map(),
 	};
 	private availabilityRefresh: Promise<void> | undefined;
-	private availabilityRefreshSeq = 0;
+	private availabilityRefreshGeneration = 0;
 	private availabilityError: string | undefined;
 
 	private constructor(
@@ -124,11 +136,13 @@ export class ModelRuntime implements Models {
 		modelsStore: ModelsStore,
 		providers: readonly Provider[],
 		modelNetworkEnabled: boolean,
+		modelRefreshTimeoutMs: number,
 	) {
 		this.credentials = credentials;
 		this.config = config;
 		this.modelsPath = modelsPath;
 		this.modelNetworkEnabled = modelNetworkEnabled;
+		this.modelRefreshTimeoutMs = modelRefreshTimeoutMs;
 		this.defaultBuiltins = new Map(providers.map((provider) => [provider.id, provider]));
 		for (const [providerId, provider] of this.defaultBuiltins) this.builtins.set(providerId, provider);
 		this.models = createModels({ credentials, modelsStore });
@@ -160,19 +174,11 @@ export class ModelRuntime implements Models {
 			modelsStore,
 			providers,
 			process.env.PI_OFFLINE === undefined,
+			options.modelRefreshTimeoutMs ?? DEFAULT_MODEL_REFRESH_TIMEOUT_MS,
 		);
 		runtime.configureRadiusProviders();
 		runtime.rebuildProviders();
-		const refreshFromNetwork = runtime.modelNetworkEnabled && options.allowModelNetwork === true;
-		const controller = refreshFromNetwork ? new AbortController() : undefined;
-		const timeout = controller
-			? setTimeout(() => controller.abort(), options.modelRefreshTimeoutMs ?? DEFAULT_MODEL_REFRESH_TIMEOUT_MS)
-			: undefined;
-		try {
-			await runtime.refresh({ allowNetwork: refreshFromNetwork, signal: controller?.signal });
-		} finally {
-			if (timeout) clearTimeout(timeout);
-		}
+		await runtime.boundedRefresh({ allowNetwork: runtime.modelNetworkEnabled && options.allowModelNetwork === true });
 		return runtime;
 	}
 
@@ -242,7 +248,7 @@ export class ModelRuntime implements Models {
 		};
 	}
 
-	private async runAvailabilityRefresh(seq: number): Promise<void> {
+	private async loadAvailabilitySnapshot(): Promise<ModelRuntimeSnapshot> {
 		const providers = this.models.getProviders();
 		const [available, checks, credentials] = await Promise.all([
 			this.models.getAvailable(),
@@ -256,56 +262,55 @@ export class ModelRuntime implements Models {
 			),
 			this.credentials.list(),
 		]);
-		// A newer rebuild was requested while this one was in flight; drop this
-		// result so a slow, superseded refresh cannot clobber the snapshot with
-		// stale data.
-		if (seq !== this.availabilityRefreshSeq) return;
-		const auth = new Map(checks);
 		const configuredProviders = new Set(
 			checks
 				.filter((entry): entry is [string, AuthCheck] => entry[1] !== undefined)
 				.map(([providerId]) => providerId),
 		);
-		this.snapshot = {
+		return {
 			all: [...this.models.getModels()],
 			available: [...available],
 			configuredProviders,
 			storedProviders: new Set(credentials.map((entry) => entry.providerId)),
-			auth,
+			auth: new Map(checks),
 		};
-		this.availabilityError = undefined;
 	}
 
 	private queueAvailabilityRefresh(): Promise<void> {
-		const seq = ++this.availabilityRefreshSeq;
-		const refresh = this.runAvailabilityRefresh(seq);
-		const recorded = refresh.catch((error) => {
-			// Only the latest requested rebuild owns the error state.
-			if (seq === this.availabilityRefreshSeq) {
-				this.availabilityError = error instanceof Error ? error.message : String(error);
-			}
-			throw error;
-		});
-		const tracked = recorded.finally(() => {
-			if (this.availabilityRefresh === tracked) this.availabilityRefresh = undefined;
-		});
+		const generation = ++this.availabilityRefreshGeneration;
+		// Only the newest refresh may publish results or clear the shared slot.
+		const isCurrent = () => generation === this.availabilityRefreshGeneration;
+		const tracked = this.loadAvailabilitySnapshot()
+			.then(
+				(snapshot) => {
+					if (!isCurrent()) return;
+					this.snapshot = snapshot;
+					this.availabilityError = undefined;
+				},
+				(error: unknown) => {
+					if (isCurrent()) {
+						this.availabilityError = error instanceof Error ? error.message : String(error);
+					}
+					throw error;
+				},
+			)
+			.finally(() => {
+				if (isCurrent()) this.availabilityRefresh = undefined;
+			});
 		this.availabilityRefresh = tracked;
 		return tracked;
 	}
 
-	/** Coalesce concurrent readers onto the pending refresh. */
-	private refreshAvailability(): Promise<void> {
-		return this.availabilityRefresh ?? this.queueAvailabilityRefresh();
+	private async waitForAvailability(refresh: Promise<void>): Promise<void> {
+		const timeout = AbortSignal.timeout(this.modelRefreshTimeoutMs);
+		await Promise.race([refresh, whenAborted(timeout)]);
+		// The refresh keeps running; the error clears once it lands.
+		if (timeout.aborted) this.availabilityError = "timed out, model list may be incomplete";
 	}
 
-	/**
-	 * Mutations must observe a rebuild that starts after their state change, and a
-	 * stuck in-flight refresh must not block them. Start a fresh, independent
-	 * rebuild instead of chaining onto the pending one. The sequence guard in
-	 * runAvailabilityRefresh ensures a superseded rebuild cannot clobber its result.
-	 */
-	private forceRefreshAvailability(): Promise<void> {
-		return this.queueAvailabilityRefresh();
+	/** Coalesce concurrent readers without letting a stalled auth check block them indefinitely. */
+	private refreshAvailability(): Promise<void> {
+		return this.waitForAvailability(this.availabilityRefresh ?? this.queueAvailabilityRefresh());
 	}
 
 	getProviders(): readonly Provider[] {
@@ -331,7 +336,7 @@ export class ModelRuntime implements Models {
 	async getAvailable(providerId?: string): Promise<readonly Model<Api>[]> {
 		if (providerId) {
 			if (this.availabilityRefresh) {
-				await this.availabilityRefresh;
+				await this.waitForAvailability(this.availabilityRefresh);
 				return this.snapshot.available.filter((model) => model.provider === providerId);
 			}
 			try {
@@ -429,12 +434,12 @@ export class ModelRuntime implements Models {
 			storedProviders,
 			available: this.snapshot.all.filter((model) => configuredProviders.has(model.provider)),
 		};
-		await this.refresh(refreshOptions);
+		await this.boundedRefresh(refreshOptions);
 	}
 
 	async removeRuntimeApiKey(providerId: string): Promise<void> {
 		this.credentials.removeRuntimeApiKey(providerId);
-		await this.refresh({ allowNetwork: this.modelNetworkEnabled });
+		await this.boundedRefresh();
 	}
 
 	listCredentials(): Promise<readonly CredentialInfo[]> {
@@ -518,13 +523,15 @@ export class ModelRuntime implements Models {
 		return this.streamSimple(model, context, options).result();
 	}
 
-	async login(providerId: string, type: AuthType, interaction: AuthInteraction): Promise<Credential> {
+	async login(
+		providerId: string,
+		type: AuthType,
+		interaction: AuthInteraction,
+		onRefresh?: (result: BoundedRefreshResult) => void,
+	): Promise<Credential> {
 		const credential = await this.models.login(providerId, type, interaction);
-		const timeoutSignal = AbortSignal.timeout(DEFAULT_MODEL_REFRESH_TIMEOUT_MS);
-		await this.refresh({
-			allowNetwork: this.modelNetworkEnabled,
-			signal: interaction.signal ? AbortSignal.any([interaction.signal, timeoutSignal]) : timeoutSignal,
-		});
+		if (this.modelNetworkEnabled) interaction.notify({ type: "progress", message: "Refreshing model catalogs…" });
+		onRefresh?.(await this.boundedRefresh({ signal: interaction.signal }));
 		return credential;
 	}
 
@@ -532,7 +539,7 @@ export class ModelRuntime implements Models {
 		await this.models.logout(providerId);
 		// Reset credential-dependent compatibility projections before the unconfigured provider is skipped by refresh.
 		this.recomposeProvider(providerId);
-		await this.refresh({ allowNetwork: this.modelNetworkEnabled });
+		await this.boundedRefresh();
 	}
 
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {
@@ -551,11 +558,31 @@ export class ModelRuntime implements Models {
 		};
 		this.updateModelSnapshot();
 		try {
-			await this.forceRefreshAvailability();
+			// A mutation must not join an older stalled refresh, so this always queues a new one.
+			await this.waitForAvailability(this.queueAvailabilityRefresh());
 		} catch {
-			// Availability errors are recorded by forceRefreshAvailability; refreshed models remain usable.
+			// Availability errors are recorded by queueAvailabilityRefresh; refreshed models remain usable.
 		}
 		return result;
+	}
+
+	/** Refresh with the runtime timeout and optional caller cancellation. */
+	async boundedRefresh(options: ModelsRefreshOptions = {}): Promise<BoundedRefreshResult> {
+		const timeoutSignal = AbortSignal.timeout(this.modelRefreshTimeoutMs);
+		const combined = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+		const refresh = this.refresh({ ...options, signal: combined }).then(
+			(result) => ({ status: "settled" as const, result }),
+			(error: unknown) => ({ status: "rejected" as const, error }),
+		);
+		const outcome = await Promise.race([refresh, whenAborted(combined).then(() => ({ status: "aborted" as const }))]);
+		if (outcome.status === "rejected") throw outcome.error;
+		if (outcome.status === "aborted") {
+			return { aborted: true, timedOut: timeoutSignal.aborted, errors: new Map() };
+		}
+		return {
+			...outcome.result,
+			timedOut: outcome.result.aborted && timeoutSignal.aborted,
+		};
 	}
 
 	registerNativeProvider(provider: Provider): void {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -178,6 +178,7 @@ export {
 	type ScopedModel,
 } from "./core/model-resolver.ts";
 export {
+	type BoundedRefreshResult,
 	type CreateModelRuntimeOptions,
 	ModelRuntime,
 	type ModelRuntimeAuthOverrides,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -862,7 +862,7 @@ export async function main(args: string[], options?: MainOptions) {
 
 	// RPC refreshes catalogs here in the background; interactive mode starts its refresh after TUI initialization.
 	if (!offlineMode && appMode === "rpc") {
-		void modelRuntime.refresh().catch(() => {});
+		void modelRuntime.boundedRefresh().catch(() => {});
 	}
 
 	if (appMode === "rpc") {

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -11,6 +11,7 @@ import {
 } from "@earendil-works/pi-tui";
 import type { ModelRuntime } from "../../../core/model-runtime.ts";
 import type { SettingsManager } from "../../../core/settings-manager.ts";
+import { formatModelRefreshWarning } from "../model-refresh-status.ts";
 import { getModelSelectorSearchText } from "../model-search.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
@@ -64,7 +65,6 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private scopeText?: Text;
 	private scopeHintText?: Text;
 	private readonly refreshAbortController = new AbortController();
-	private refreshTimeout?: ReturnType<typeof setTimeout>;
 	private closed = false;
 
 	constructor(
@@ -160,40 +160,21 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private async refreshModels(): Promise<void> {
-		const timeoutMs = 15_000;
-		let timedOut = false;
-		this.refreshTimeout = setTimeout(() => {
-			timedOut = true;
-			this.refreshAbortController.abort();
-		}, timeoutMs);
-		try {
-			const result = await this.modelRuntime.refresh({ signal: this.refreshAbortController.signal });
-			if (this.closed) return;
-			this.refreshStatusMessage = "";
-			if (result.aborted && timedOut) {
-				this.errorMessage = "Model refresh timed out; showing cached models.";
-			} else if (result.errors.size === 1) {
-				this.errorMessage = `Could not refresh ${result.errors.keys().next().value}; showing cached models.`;
-			} else if (result.errors.size > 1) {
-				this.errorMessage = `Could not refresh ${result.errors.size} model catalogs (${[...result.errors.keys()].join(", ")}); showing cached models.`;
-			} else {
-				this.errorMessage = this.modelRuntime.getError();
-				if (!this.errorMessage) {
-					this.refreshStatusMessage = "Model catalogs refreshed.";
-					this.refreshStatusSuccess = true;
-				}
-			}
-			this.loadModelsFromSnapshot();
-			this.filterModels(this.searchInput.getValue());
-			this.tui.requestRender();
-		} finally {
-			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+		const result = await this.modelRuntime.boundedRefresh({ signal: this.refreshAbortController.signal });
+		if (this.closed) return;
+		this.refreshStatusMessage = "";
+		this.errorMessage = formatModelRefreshWarning(result, "showing cached models.") ?? this.modelRuntime.getError();
+		if (!this.errorMessage) {
+			this.refreshStatusMessage = "Model catalogs refreshed.";
+			this.refreshStatusSuccess = true;
 		}
+		this.loadModelsFromSnapshot();
+		this.filterModels(this.searchInput.getValue());
+		this.tui.requestRender();
 	}
 
 	private close(): void {
 		this.closed = true;
-		if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
 		this.refreshAbortController.abort();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
@@ -1,4 +1,4 @@
-import type { Model } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import {
 	Container,
 	type Focusable,
@@ -9,7 +9,10 @@ import {
 	matchesKey,
 	Spacer,
 	Text,
+	type TUI,
 } from "@earendil-works/pi-tui";
+import type { ModelRuntime } from "../../../core/model-runtime.ts";
+import { formatModelRefreshWarning } from "../model-refresh-status.ts";
 import { getModelSearchText } from "../model-search.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
@@ -67,12 +70,12 @@ function getSortedIds(enabledIds: EnabledIds, allIds: string[]): string[] {
 
 interface ModelItem {
 	fullId: string;
-	model: Model<any> | undefined;
+	model: Model<Api> | undefined;
 	enabled: boolean;
 }
 
 export interface ModelsConfig {
-	allModels: Model<any>[];
+	allModels: Model<Api>[];
 	enabledModelIds: string[] | null;
 }
 
@@ -89,7 +92,7 @@ export interface ModelsCallbacks {
  * Changes are session-only until explicitly persisted with Ctrl+S.
  */
 export class ScopedModelsSelectorComponent extends Container implements Focusable {
-	private modelsById: Map<string, Model<any>> = new Map();
+	private modelsById: Map<string, Model<Api>> = new Map();
 	private allIds: string[] = [];
 	private enabledIds: EnabledIds = null;
 	private filteredItems: ModelItem[] = [];
@@ -110,17 +113,20 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 	private callbacks: ModelsCallbacks;
 	private maxVisible = 8;
 	private isDirty = false;
+	private refreshStatusMessage = "Refreshing model catalogs…";
+	private refreshStatusSuccess = false;
+	private errorMessage?: string;
+	private readonly tui: TUI;
+	private readonly modelRuntime: ModelRuntime;
+	private readonly refreshAbortController = new AbortController();
+	private closed = false;
 
-	constructor(config: ModelsConfig, callbacks: ModelsCallbacks) {
+	constructor(tui: TUI, modelRuntime: ModelRuntime, config: ModelsConfig, callbacks: ModelsCallbacks) {
 		super();
+		this.tui = tui;
+		this.modelRuntime = modelRuntime;
 		this.callbacks = callbacks;
-
-		for (const model of config.allModels) {
-			const fullId = `${model.provider}/${model.id}`;
-			this.modelsById.set(fullId, model);
-			this.allIds.push(fullId);
-		}
-
+		this.loadModels(config.allModels);
 		this.enabledIds = config.enabledModelIds === null ? null : [...config.enabledModelIds];
 		this.filteredItems = this.buildItems();
 
@@ -149,6 +155,37 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 
 		this.addChild(new DynamicBorder());
 		this.updateList();
+		void this.refreshModels();
+	}
+
+	private loadModels(models: readonly Model<Api>[]): void {
+		this.modelsById.clear();
+		this.allIds = [];
+		for (const model of models) {
+			const fullId = `${model.provider}/${model.id}`;
+			this.modelsById.set(fullId, model);
+			this.allIds.push(fullId);
+		}
+	}
+
+	private async refreshModels(): Promise<void> {
+		const result = await this.modelRuntime.boundedRefresh({ signal: this.refreshAbortController.signal });
+		if (this.closed) return;
+		this.refreshStatusMessage = "";
+		this.errorMessage = formatModelRefreshWarning(result, "showing cached models.") ?? this.modelRuntime.getError();
+		if (!this.errorMessage) {
+			this.refreshStatusMessage = "Model catalogs refreshed.";
+			this.refreshStatusSuccess = true;
+		}
+		const selectedId = this.filteredItems[this.selectedIndex]?.fullId;
+		this.loadModels(this.modelRuntime.getAvailableSnapshot());
+		this.refresh(selectedId);
+		this.tui.requestRender();
+	}
+
+	private close(): void {
+		this.closed = true;
+		this.refreshAbortController.abort();
 	}
 
 	private buildItems(): ModelItem[] {
@@ -180,7 +217,7 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 			: theme.fg("dim", `  ${parts.join(" · ")}`);
 	}
 
-	private refresh(): void {
+	private refresh(selectedId?: string): void {
 		const query = this.searchInput.getValue();
 		const items = this.buildItems();
 		this.filteredItems = query
@@ -190,7 +227,11 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 						: item.fullId,
 				)
 			: items;
-		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredItems.length - 1));
+		const refreshedIndex = selectedId ? this.filteredItems.findIndex((item) => item.fullId === selectedId) : -1;
+		this.selectedIndex =
+			refreshedIndex >= 0
+				? refreshedIndex
+				: Math.min(this.selectedIndex, Math.max(0, this.filteredItems.length - 1));
 		this.updateList();
 		this.footerText.setText(this.getFooterText());
 	}
@@ -204,7 +245,6 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 
 		if (this.filteredItems.length === 0) {
 			this.listContainer.addChild(new Text(theme.fg("muted", "  No matching models"), 0, 0));
-			return;
 		}
 
 		const startIndex = Math.max(
@@ -247,6 +287,15 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 					0,
 					0,
 				),
+			);
+		}
+		if (this.errorMessage) {
+			this.listContainer.addChild(new Spacer(1));
+			this.listContainer.addChild(new Text(theme.fg("error", `  ${this.errorMessage}`), 0, 0));
+		} else if (this.refreshStatusMessage) {
+			this.listContainer.addChild(new Spacer(1));
+			this.listContainer.addChild(
+				new Text(theme.fg(this.refreshStatusSuccess ? "success" : "muted", `  ${this.refreshStatusMessage}`), 0, 0),
 			);
 		}
 	}
@@ -353,6 +402,7 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 				this.searchInput.setValue("");
 				this.refresh();
 			} else {
+				this.close();
 				this.callbacks.onCancel();
 			}
 			return;
@@ -360,6 +410,7 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 
 		// Escape - cancel
 		if (matchesKey(data, Key.escape)) {
+			this.close();
 			this.callbacks.onCancel();
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -84,8 +84,8 @@ import { createCompactionSummaryMessage } from "../../core/messages.ts";
 import {
 	defaultModelPerProvider,
 	findExactModelReferenceMatch,
-	resolveModelScope,
-	resolveModelScopeWithDiagnostics,
+	isEffectiveModelScope,
+	resolveModelScopeSelection,
 } from "../../core/model-resolver.ts";
 import { DefaultPackageManager } from "../../core/package-manager.ts";
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
@@ -150,6 +150,7 @@ import { TrustSelectorComponent } from "./components/trust-selector.ts";
 import { UserMessageComponent } from "./components/user-message.ts";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.ts";
 import { editInExternalEditor } from "./external-editor.ts";
+import { formatModelRefreshWarning } from "./model-refresh-status.ts";
 import { getModelSearchText } from "./model-search.ts";
 import {
 	getAvailableThemes,
@@ -893,7 +894,7 @@ export class InteractiveMode {
 
 		if (!process.env.PI_OFFLINE) {
 			void this.session.modelRuntime
-				.refresh()
+				.boundedRefresh()
 				.then(() => this.updateAvailableProviderCount())
 				.catch(() => {});
 		}
@@ -2735,7 +2736,7 @@ export class InteractiveMode {
 			}
 			if (text === "/scoped-models") {
 				this.editor.setText("");
-				await this.showModelsSelector();
+				this.showModelsSelector();
 				return;
 			}
 			if (text === "/model" || text.startsWith("/model ")) {
@@ -4430,21 +4431,18 @@ export class InteractiveMode {
 	}
 
 	private async findExactModelMatch(searchTerm: string): Promise<Model<any> | undefined> {
-		const models = await this.getModelCandidates();
-		return findExactModelReferenceMatch(searchTerm, models);
-	}
-
-	private async getModelCandidates(): Promise<Model<any>[]> {
 		if (this.session.scopedModels.length > 0) {
-			return this.session.scopedModels.map((scoped) => scoped.model);
+			return findExactModelReferenceMatch(
+				searchTerm,
+				this.session.scopedModels.map((scoped) => scoped.model),
+			);
 		}
-
-		try {
-			await this.session.modelRuntime.refresh();
-			return [...(await this.session.modelRuntime.getAvailable())];
-		} catch {
-			return [];
-		}
+		const cached = findExactModelReferenceMatch(searchTerm, this.session.modelRuntime.getAvailableSnapshot());
+		if (cached) return cached;
+		// Only pay for a catalog refresh when the cached models cannot satisfy the name.
+		this.showStatus("Refreshing model catalogs…");
+		await this.session.modelRuntime.boundedRefresh().catch(() => {});
+		return findExactModelReferenceMatch(searchTerm, this.session.modelRuntime.getAvailableSnapshot());
 	}
 
 	/** Update the footer's available provider count from the current snapshot without refreshing catalogs. */
@@ -4570,81 +4568,54 @@ export class InteractiveMode {
 		});
 	}
 
-	private async showModelsSelector(): Promise<void> {
-		// Get all available models
-		await this.session.modelRuntime.refresh();
-		const allModels = [...(await this.session.modelRuntime.getAvailable())];
-		const allModelIds = new Set(allModels.map((model) => `${model.provider}/${model.id}`));
+	private showModelsSelector(): void {
+		const allModels = [...this.session.modelRuntime.getAvailableSnapshot()];
 		const configuredPatterns = this.settingsManager.getEnabledModels();
 		const sessionScopedModels = this.session.scopedModels;
-
-		if (allModels.length === 0 && !configuredPatterns?.length && sessionScopedModels.length === 0) {
-			this.showStatus("No models available");
-			return;
-		}
-
-		const configuredScope = configuredPatterns?.length
-			? await resolveModelScopeWithDiagnostics(configuredPatterns, this.session.modelRuntime)
+		const configuredSelection = configuredPatterns?.length
+			? resolveModelScopeSelection(configuredPatterns, allModels)
 			: undefined;
 
-		// Check if session has scoped models (from previous session-only changes or CLI --models)
-		const hasSessionScope = sessionScopedModels.length > 0;
-
-		// Build enabled model IDs from session state or settings
-		let currentEnabledIds: string[] | null = null;
-
-		if (hasSessionScope) {
-			// Use current session's scoped models
-			currentEnabledIds = sessionScopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`);
-		} else if (configuredScope) {
-			currentEnabledIds = configuredScope.scopedModels.map(
-				(scoped) => `${scoped.model.provider}/${scoped.model.id}`,
-			);
-		}
-
-		for (const diagnostic of configuredScope?.diagnostics ?? []) {
-			if (diagnostic.code !== "no-match") continue;
+		let currentEnabledIds: string[] | null =
+			sessionScopedModels.length > 0
+				? sessionScopedModels.map((scoped) => `${scoped.model.provider}/${scoped.model.id}`)
+				: (configuredSelection?.enabledModelIds ?? null);
+		for (const pattern of configuredSelection?.unmatchedPatterns ?? []) {
 			currentEnabledIds ??= [];
-			if (!currentEnabledIds.includes(diagnostic.pattern)) currentEnabledIds.push(diagnostic.pattern);
+			if (!currentEnabledIds.includes(pattern)) currentEnabledIds.push(pattern);
 		}
 
 		// Helper to update session's scoped models (session-only, no persist)
-		const updateSessionModels = async (enabledIds: string[] | null) => {
+		const updateSessionModels = (enabledIds: string[] | null) => {
 			currentEnabledIds = enabledIds === null ? null : [...enabledIds];
-			const hasEnabledAvailableModel = enabledIds?.some((id) => allModelIds.has(id)) ?? false;
-			const allAvailableModelsEnabled =
-				enabledIds !== null && [...allModelIds].every((id) => enabledIds.includes(id));
-			if (enabledIds && hasEnabledAvailableModel && !allAvailableModelsEnabled) {
-				const newScopedModels = await resolveModelScope(enabledIds, this.session.modelRuntime);
-				this.session.setScopedModels(
-					newScopedModels.map((sm) => ({
-						model: sm.model,
-						thinkingLevel: sm.thinkingLevel,
-					})),
-				);
-			} else {
-				// All enabled or none enabled = no filter
-				this.session.setScopedModels([]);
-			}
-			await this.updateAvailableProviderCount();
+			const models = this.session.modelRuntime.getAvailableSnapshot();
+			this.session.setScopedModels(
+				isEffectiveModelScope(enabledIds, models)
+					? resolveModelScopeSelection(enabledIds, models).scopedModels
+					: [],
+			);
+			this.updateAvailableProviderCount();
 			this.ui.requestRender();
 		};
 
 		this.showSelector((done) => {
 			const selector = new ScopedModelsSelectorComponent(
+				this.ui,
+				this.session.modelRuntime,
 				{
 					allModels,
 					enabledModelIds: currentEnabledIds,
 				},
 				{
-					onChange: async (enabledIds) => {
-						await updateSessionModels(enabledIds);
-					},
+					onChange: updateSessionModels,
 					onPersist: (enabledIds) => {
 						// Persist to settings
+						const allModelIds = new Set(
+							this.session.modelRuntime.getAvailableSnapshot().map((model) => `${model.provider}/${model.id}`),
+						);
 						const allEnabled =
 							enabledIds !== null &&
-							enabledIds.length === allModels.length &&
+							enabledIds.length === allModelIds.size &&
 							enabledIds.every((id) => allModelIds.has(id));
 						const newPatterns = enabledIds === null || allEnabled ? undefined : enabledIds;
 						this.settingsManager.setEnabledModels(newPatterns ? [...newPatterns] : undefined);
@@ -5178,6 +5149,7 @@ export class InteractiveMode {
 		providerName: string,
 		authType: "oauth" | "api_key",
 		previousModel: Model<any> | undefined,
+		refreshWarning?: string,
 	): Promise<void> {
 		await this.session.modelRuntime.getAvailable();
 
@@ -5224,6 +5196,7 @@ export class InteractiveMode {
 				void this.maybeWarnAboutAnthropicSubscriptionAuth();
 			}
 		}
+		if (refreshWarning) this.showWarning(refreshWarning);
 	}
 
 	private showAmbientAuthDialog(providerOption: AuthSelectorProvider): void {
@@ -5282,9 +5255,9 @@ export class InteractiveMode {
 		};
 
 		try {
-			await this.loginProvider(dialog, providerId, "api_key");
+			const refreshWarning = await this.loginProvider(dialog, providerId, "api_key");
 			restoreEditor();
-			await this.completeProviderAuthentication(providerId, providerName, "api_key", previousModel);
+			await this.completeProviderAuthentication(providerId, providerName, "api_key", previousModel, refreshWarning);
 		} catch (error: unknown) {
 			restoreEditor();
 			const errorMsg = error instanceof Error ? error.message : String(error);
@@ -5364,16 +5337,29 @@ export class InteractiveMode {
 		}
 	}
 
+	/** Returns a warning when the post-login catalog refresh could not finish; login itself still succeeded. */
 	private async loginProvider(
 		dialog: LoginDialogComponent,
 		providerId: string,
 		method: "api_key" | "oauth",
-	): Promise<void> {
-		await this.session.modelRuntime.login(providerId, method, {
-			signal: dialog.signal,
-			prompt: (prompt) => this.showAuthPrompt(dialog, prompt),
-			notify: (event) => this.notifyAuthDialog(dialog, event),
-		});
+	): Promise<string | undefined> {
+		let refreshWarning: string | undefined;
+		await this.session.modelRuntime.login(
+			providerId,
+			method,
+			{
+				signal: dialog.signal,
+				prompt: (prompt) => this.showAuthPrompt(dialog, prompt),
+				notify: (event) => this.notifyAuthDialog(dialog, event),
+			},
+			(result) => {
+				refreshWarning =
+					dialog.signal.aborted && result.aborted
+						? "Model catalog refresh cancelled after credentials were saved; using cached models."
+						: formatModelRefreshWarning(result, "using cached models.");
+			},
+		);
+		return refreshWarning;
 	}
 
 	private async showLoginDialog(providerId: string, providerName: string): Promise<void> {
@@ -5392,9 +5378,9 @@ export class InteractiveMode {
 		};
 
 		try {
-			await this.loginProvider(dialog, providerId, "oauth");
+			const refreshWarning = await this.loginProvider(dialog, providerId, "oauth");
 			restoreEditor();
-			await this.completeProviderAuthentication(providerId, providerName, "oauth", previousModel);
+			await this.completeProviderAuthentication(providerId, providerName, "oauth", previousModel, refreshWarning);
 		} catch (error: unknown) {
 			restoreEditor();
 			const errorMsg = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/modes/interactive/model-refresh-status.ts
+++ b/packages/coding-agent/src/modes/interactive/model-refresh-status.ts
@@ -1,0 +1,12 @@
+import type { BoundedRefreshResult } from "../../core/model-runtime.ts";
+
+export function formatModelRefreshWarning(result: BoundedRefreshResult, fallback: string): string | undefined {
+	if (result.timedOut) return `Model refresh timed out; ${fallback}`;
+	if (result.errors.size === 1) {
+		return `Could not refresh ${result.errors.keys().next().value}; ${fallback}`;
+	}
+	if (result.errors.size > 1) {
+		return `Could not refresh ${result.errors.size} model catalogs (${[...result.errors.keys()].join(", ")}); ${fallback}`;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/test/suite/regressions/3217-scoped-model-order.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3217-scoped-model-order.test.ts
@@ -44,6 +44,8 @@ describe("issue #3217 scoped model ordering", () => {
 		const orderedIds = harness.models.map((model) => `${model.provider}/${model.id}`);
 		const changes: Array<string[] | null> = [];
 		const selector = new ScopedModelsSelectorComponent(
+			createFakeTui(),
+			harness.session.modelRuntime,
 			{
 				allModels: [...harness.models],
 				enabledModelIds: orderedIds,

--- a/packages/coding-agent/test/suite/regressions/6949-unavailable-scoped-model.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6949-unavailable-scoped-model.test.ts
@@ -1,5 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { setKeybindings } from "@earendil-works/pi-tui";
+import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../../../src/core/keybindings.ts";
 import { ScopedModelsSelectorComponent } from "../../../src/modes/interactive/components/scoped-models-selector.ts";
@@ -16,11 +16,15 @@ function createInteractiveContext(options: {
 	let selector: ScopedModelsSelectorComponent | undefined;
 	const setScopedModels = vi.fn();
 	const getAvailable = vi.fn().mockResolvedValue(options.allModels);
+	const refresh = vi.fn().mockResolvedValue({ aborted: false, timedOut: false, errors: new Map() });
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
 	const context = {
 		session: {
 			modelRuntime: {
-				refresh: vi.fn(),
+				boundedRefresh: refresh,
 				getAvailable,
+				getAvailableSnapshot: () => options.allModels,
+				getError: () => undefined,
 			},
 			scopedModels: options.scopedModels ?? [],
 			setScopedModels,
@@ -34,14 +38,14 @@ function createInteractiveContext(options: {
 			selector = factory(() => {}).component;
 		},
 		updateAvailableProviderCount: vi.fn(),
-		ui: { requestRender: vi.fn() },
+		ui,
 	};
-	return { context, getAvailable, getSelector: () => selector, setScopedModels };
+	return { context, getSelector: () => selector, refresh, setScopedModels };
 }
 
-async function showModelsSelector(context: object): Promise<void> {
-	const show = Reflect.get(InteractiveMode.prototype, "showModelsSelector") as (this: object) => Promise<void>;
-	await show.call(context);
+function showModelsSelector(context: object): void {
+	const show = Reflect.get(InteractiveMode.prototype, "showModelsSelector") as (this: object) => void;
+	show.call(context);
 }
 
 describe("issue #6949 unavailable scoped models", () => {
@@ -67,6 +71,8 @@ describe("issue #6949 unavailable scoped models", () => {
 		const changes: Array<string[] | null> = [];
 		const persisted: Array<string[] | null> = [];
 		const selector = new ScopedModelsSelectorComponent(
+			{ requestRender: vi.fn() } as unknown as TUI,
+			harness.session.modelRuntime,
 			{
 				allModels: [...harness.models],
 				enabledModelIds: [unavailableId, availableId],
@@ -93,12 +99,12 @@ describe("issue #6949 unavailable scoped models", () => {
 		const harness = await createHarness({ models: [{ id: "available", name: "Available" }] });
 		harnesses.push(harness);
 		const unavailableIds = ["unavailable-one", "unavailable-two"].map((id) => `${harness.models[0].provider}/${id}`);
-		const { context, getAvailable, getSelector } = createInteractiveContext({
+		const { context, getSelector, refresh } = createInteractiveContext({
 			allModels: [],
 			enabledModelIds: unavailableIds,
 		});
 
-		await showModelsSelector(context);
+		showModelsSelector(context);
 
 		const selector = getSelector();
 		if (!selector) throw new Error("Expected scoped-model selector to open");
@@ -106,7 +112,7 @@ describe("issue #6949 unavailable scoped models", () => {
 		for (const unavailableId of unavailableIds) {
 			expect(rendered).toContain(`${unavailableId} [unavailable] ✗`);
 		}
-		expect(getAvailable).toHaveBeenCalledTimes(2);
+		expect(refresh).toHaveBeenCalledOnce();
 	});
 
 	it("opens when only a session-scoped model is unavailable", async () => {
@@ -120,7 +126,7 @@ describe("issue #6949 unavailable scoped models", () => {
 			scopedModels: [{ model }],
 		});
 
-		await showModelsSelector(context);
+		showModelsSelector(context);
 
 		const selector = getSelector();
 		if (!selector) throw new Error("Expected scoped-model selector to open");
@@ -145,9 +151,10 @@ describe("issue #6949 unavailable scoped models", () => {
 			scopedModels: [{ model: one }, { model: two }],
 		});
 
-		await showModelsSelector(context);
+		showModelsSelector(context);
 		const selector = getSelector();
 		if (!selector) throw new Error("Expected scoped-model selector to open");
+		expect(stripAnsi(selector.render(100).join("\n"))).toContain(`${unavailableId} [unavailable] ✗`);
 		selector.handleInput("\x1b[1;3B");
 
 		await vi.waitFor(() => {

--- a/packages/coding-agent/test/suite/regressions/7027-credential-refresh-hang.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7027-credential-refresh-hang.test.ts
@@ -1,0 +1,184 @@
+import { InMemoryModelsStore, type Provider, type RefreshModelsContext } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../../src/core/auth-storage.ts";
+import { type BoundedRefreshResult, ModelRuntime } from "../../../src/core/model-runtime.ts";
+import { formatModelRefreshWarning } from "../../../src/modes/interactive/model-refresh-status.ts";
+import { allowNetwork } from "../../test-network-env.ts";
+
+async function createStalledRuntime(modelRefreshTimeoutMs: number) {
+	allowNetwork();
+	const runtime = await ModelRuntime.create({
+		credentials: AuthStorage.inMemory(),
+		modelsStore: new InMemoryModelsStore(),
+		modelsPath: null,
+		allowModelNetwork: false,
+		modelRefreshTimeoutMs,
+	});
+	let inflightRefresh: Promise<void> | undefined;
+	let releaseRefresh = () => {};
+	const refreshModels = vi.fn(({ allowNetwork, signal }: RefreshModelsContext) => {
+		if (!allowNetwork) return Promise.resolve();
+		inflightRefresh ??= new Promise<void>((resolve) => {
+			releaseRefresh = resolve;
+			if (signal?.aborted) resolve();
+			else signal?.addEventListener("abort", () => resolve(), { once: true });
+		}).finally(() => {
+			inflightRefresh = undefined;
+		});
+		return inflightRefresh;
+	});
+	const provider: Provider = {
+		id: "stalled-login",
+		name: "Stalled Login",
+		auth: {
+			apiKey: {
+				name: "API key",
+				login: async () => ({ type: "api_key", key: "secret" }),
+				check: async ({ credential }) => (credential?.key ? { type: "api_key", source: "stored key" } : undefined),
+				resolve: async ({ credential }) => ({
+					auth: { apiKey: credential?.key ?? "ambient-key" },
+					source: credential?.key ? "stored key" : "ambient key",
+				}),
+			},
+		},
+		getModels: () => [],
+		refreshModels,
+		stream: () => {
+			throw new Error("unused");
+		},
+		streamSimple: () => {
+			throw new Error("unused");
+		},
+	};
+	runtime.registerNativeProvider(provider);
+	await runtime.refresh({ allowNetwork: false });
+	return { refreshModels, releaseRefresh: () => releaseRefresh(), runtime };
+}
+
+describe("issues #7027 and #7113 credential refresh hang", () => {
+	it("lets the login interaction cancel a stalled catalog refresh after saving credentials", async () => {
+		const { refreshModels, runtime } = await createStalledRuntime(60_000);
+		const controller = new AbortController();
+		const notify = vi.fn();
+		let refreshResult: BoundedRefreshResult | undefined;
+		const login = runtime.login(
+			"stalled-login",
+			"api_key",
+			{
+				signal: controller.signal,
+				prompt: vi.fn(),
+				notify,
+			},
+			(result) => {
+				refreshResult = result;
+			},
+		);
+
+		await vi.waitFor(() => {
+			expect(refreshModels.mock.calls.some(([context]) => context.allowNetwork)).toBe(true);
+		});
+		expect(notify).toHaveBeenCalledWith({ type: "progress", message: "Refreshing model catalogs…" });
+		controller.abort();
+
+		await expect(login).resolves.toMatchObject({ type: "api_key", key: "secret" });
+		expect(refreshResult).toMatchObject({ aborted: true, timedOut: false });
+	});
+
+	it("bounds login when it joins an older signal-less catalog refresh", async () => {
+		const { refreshModels, releaseRefresh, runtime } = await createStalledRuntime(200);
+		void runtime.refresh();
+		await vi.waitFor(() => {
+			expect(refreshModels.mock.calls.some(([context]) => context.allowNetwork)).toBe(true);
+		});
+
+		let refreshResult: BoundedRefreshResult | undefined;
+		await runtime.login("stalled-login", "api_key", { prompt: vi.fn(), notify: vi.fn() }, (result) => {
+			refreshResult = result;
+		});
+
+		expect(refreshResult).toMatchObject({ aborted: true, timedOut: true });
+		releaseRefresh();
+	});
+
+	it("bounds runtime API-key refreshes when a catalog stalls", async () => {
+		const { refreshModels, runtime } = await createStalledRuntime(200);
+
+		await expect(runtime.setRuntimeApiKey("stalled-login", "secret")).resolves.toBeUndefined();
+		expect(refreshModels.mock.calls.some(([context]) => context.allowNetwork && context.signal?.aborted)).toBe(true);
+	});
+
+	it("bounds all credential mutations when an availability check stalls", async () => {
+		allowNetwork();
+		const runtime = await ModelRuntime.create({
+			credentials: AuthStorage.inMemory(),
+			modelsStore: new InMemoryModelsStore(),
+			modelsPath: null,
+			allowModelNetwork: false,
+			modelRefreshTimeoutMs: 200,
+		});
+		let releaseCheck = () => {};
+		const checkGate = new Promise<void>((resolve) => {
+			releaseCheck = resolve;
+		});
+		const provider: Provider = {
+			id: "stalled-check",
+			name: "Stalled Check",
+			auth: {
+				apiKey: {
+					name: "API key",
+					login: async () => ({ type: "api_key", key: "secret" }),
+					check: async ({ credential }) => {
+						await checkGate;
+						return credential?.key ? { type: "api_key", source: "stored key" } : undefined;
+					},
+					resolve: async ({ credential }) =>
+						credential?.key ? { auth: { apiKey: credential.key }, source: "stored key" } : undefined,
+				},
+			},
+			getModels: () => [],
+			refreshModels: async () => {},
+			stream: () => {
+				throw new Error("unused");
+			},
+			streamSimple: () => {
+				throw new Error("unused");
+			},
+		};
+		runtime.registerNativeProvider(provider);
+
+		let refreshResult: BoundedRefreshResult | undefined;
+		const credential = await runtime.login(
+			"stalled-check",
+			"api_key",
+			{ prompt: vi.fn(), notify: vi.fn() },
+			(result) => {
+				refreshResult = result;
+			},
+		);
+
+		expect(credential).toMatchObject({ type: "api_key", key: "secret" });
+		expect(refreshResult).toMatchObject({ aborted: true, timedOut: true });
+		await expect(
+			runtime.setRuntimeApiKey("stalled-check", "runtime-secret", { allowNetwork: false }),
+		).resolves.toBeUndefined();
+		await expect(runtime.removeRuntimeApiKey("stalled-check")).resolves.toBeUndefined();
+		await expect(runtime.logout("stalled-check")).resolves.toBeUndefined();
+		releaseCheck();
+		await expect(runtime.getAvailable()).resolves.toEqual([]);
+		expect(runtime.hasConfiguredAuth("stalled-check")).toBe(false);
+	});
+
+	it("warns that the post-login catalog refresh did not finish", () => {
+		const settled: BoundedRefreshResult = { aborted: false, timedOut: false, errors: new Map() };
+		expect(formatModelRefreshWarning({ ...settled, aborted: true, timedOut: true }, "using cached models.")).toBe(
+			"Model refresh timed out; using cached models.",
+		);
+		expect(
+			formatModelRefreshWarning(
+				{ ...settled, errors: new Map([["deepseek", new Error("unreachable")]]) },
+				"using cached models.",
+			),
+		).toBe("Could not refresh deepseek; using cached models.");
+		expect(formatModelRefreshWarning(settled, "using cached models.")).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/7153-scoped-models-refresh.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7153-scoped-models-refresh.test.ts
@@ -1,0 +1,172 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeybindingsManager } from "../../../src/core/keybindings.ts";
+import type { BoundedRefreshResult } from "../../../src/core/model-runtime.ts";
+import type { ScopedModelsSelectorComponent } from "../../../src/modes/interactive/components/scoped-models-selector.ts";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../../src/utils/ansi.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const tui = { requestRender: vi.fn() } as unknown as TUI;
+const showModelsSelector = Reflect.get(InteractiveMode.prototype, "showModelsSelector") as (this: object) => void;
+
+function openSelector(harness: Harness, initialModels: readonly Model<Api>[]) {
+	let snapshot = initialModels;
+	let finishRefresh: ((result: BoundedRefreshResult) => void) | undefined;
+	let refreshSignal: AbortSignal | undefined;
+	let selector: ScopedModelsSelectorComponent | undefined;
+	const done = vi.fn();
+	vi.spyOn(harness.session.modelRuntime, "getAvailableSnapshot").mockImplementation(() => snapshot);
+	vi.spyOn(harness.session.modelRuntime, "boundedRefresh").mockImplementation(
+		(options) =>
+			new Promise((resolve) => {
+				refreshSignal = options?.signal;
+				finishRefresh = resolve;
+			}),
+	);
+	const context = {
+		session: harness.session,
+		settingsManager: harness.settingsManager,
+		showSelector: (factory: (close: () => void) => { component: ScopedModelsSelectorComponent }) => {
+			selector = factory(done).component;
+		},
+		showStatus: vi.fn(),
+		updateAvailableProviderCount: vi.fn(),
+		ui: tui,
+	};
+
+	showModelsSelector.call(context);
+	if (!selector) throw new Error("Expected scoped-model selector to open");
+	return {
+		done,
+		get refreshSignal() {
+			return refreshSignal;
+		},
+		selector,
+		complete(models: readonly Model<Api>[], result: BoundedRefreshResult) {
+			snapshot = models;
+			if (!finishRefresh) throw new Error("Expected model refresh to start");
+			finishRefresh(result);
+		},
+	};
+}
+
+describe("issue #7153 scoped models refresh", () => {
+	let harness: Harness | undefined;
+
+	beforeAll(() => initTheme("dark"));
+	beforeEach(() => setKeybindings(new KeybindingsManager()));
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+		vi.restoreAllMocks();
+	});
+
+	it("opens from the cached snapshot and updates after refresh", async () => {
+		harness = await createHarness({
+			models: [
+				{ id: "cached", name: "Cached" },
+				{ id: "refreshed", name: "Refreshed" },
+			],
+		});
+		const refresh = openSelector(harness, [harness.models[0]]);
+
+		const initial = stripAnsi(refresh.selector.render(100).join("\n"));
+		expect(initial).toContain("cached");
+		expect(initial).toContain("Refreshing model catalogs…");
+		expect(initial).not.toContain("refreshed");
+
+		refresh.complete(harness.models, { aborted: false, timedOut: false, errors: new Map() });
+		await vi.waitFor(() => {
+			const rendered = stripAnsi(refresh.selector.render(100).join("\n"));
+			expect(rendered).toContain("refreshed");
+			expect(rendered).toContain("Model catalogs refreshed.");
+		});
+	});
+
+	it("preserves the highlighted model when refresh inserts an earlier row", async () => {
+		harness = await createHarness({
+			models: [
+				{ id: "first", name: "First" },
+				{ id: "inserted", name: "Inserted" },
+				{ id: "last", name: "Last" },
+			],
+		});
+		const refresh = openSelector(harness, [harness.models[0], harness.models[2]]);
+		refresh.selector.handleInput("\x1b[B");
+
+		refresh.complete(harness.models, { aborted: false, timedOut: false, errors: new Map() });
+		await vi.waitFor(() => {
+			const selectedLine = stripAnsi(refresh.selector.render(100).join("\n"))
+				.split("\n")
+				.find((line) => line.startsWith("→ "));
+			expect(selectedLine).toContain("last [faux]");
+		});
+	});
+
+	it("does not overwrite edits made while the refresh is running", async () => {
+		harness = await createHarness({
+			models: [
+				{ id: "cached-one", name: "Cached One" },
+				{ id: "cached-two", name: "Cached Two" },
+				{ id: "other", name: "Other" },
+			],
+		});
+		const initialModels = [harness.models[0], harness.models[2]];
+		harness.session.setScopedModels([{ model: harness.models[0] }]);
+		const refresh = openSelector(harness, initialModels);
+
+		refresh.selector.handleInput("\x1b[B");
+		refresh.selector.handleInput("\r");
+		await vi.waitFor(() => expect(harness?.session.scopedModels).toEqual([]));
+		refresh.complete(harness.models, { aborted: false, timedOut: false, errors: new Map() });
+
+		await vi.waitFor(() => {
+			expect(stripAnsi(refresh.selector.render(100).join("\n"))).toContain("cached-two [faux] ✗");
+		});
+		expect(harness.session.scopedModels).toEqual([]);
+	});
+
+	it("saves the selection against the refreshed model list", async () => {
+		harness = await createHarness({
+			models: [
+				{ id: "cached", name: "Cached" },
+				{ id: "refreshed", name: "Refreshed" },
+			],
+		});
+		const refresh = openSelector(harness, [harness.models[0]]);
+		// Enabling every cached model must not persist as "no filter" once the refresh adds more.
+		refresh.selector.handleInput("\r");
+		refresh.complete(harness.models, { aborted: false, timedOut: false, errors: new Map() });
+		await vi.waitFor(() => {
+			expect(stripAnsi(refresh.selector.render(100).join("\n"))).toContain("refreshed");
+		});
+
+		refresh.selector.handleInput("\x13");
+		expect(harness.settingsManager.getEnabledModels()).toEqual(["faux/cached"]);
+	});
+
+	it("keeps cached models visible when refresh cannot complete", async () => {
+		harness = await createHarness({ models: [{ id: "cached", name: "Cached" }] });
+		const refresh = openSelector(harness, harness.models);
+		refresh.complete(harness.models, { aborted: true, timedOut: true, errors: new Map() });
+
+		await vi.waitFor(() => {
+			const rendered = stripAnsi(refresh.selector.render(100).join("\n"));
+			expect(rendered).toContain("cached");
+			expect(rendered).toContain("Model refresh timed out");
+		});
+	});
+
+	it("aborts the background refresh when the selector closes", async () => {
+		harness = await createHarness({ models: [{ id: "cached", name: "Cached" }] });
+		const refresh = openSelector(harness, harness.models);
+
+		expect(refresh.refreshSignal).toBeDefined();
+		refresh.selector.handleInput("\x1b");
+		expect(refresh.refreshSignal?.aborted).toBe(true);
+		expect(refresh.done).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/7443-model-command-cached-match.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7443-model-command-cached-match.test.ts
@@ -1,0 +1,47 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const findExactModelMatch = Reflect.get(InteractiveMode.prototype, "findExactModelMatch") as (
+	this: object,
+	searchTerm: string,
+) => Promise<Model<Api> | undefined>;
+
+describe("issue #7443 /model <name> with an unreachable catalog", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+		vi.restoreAllMocks();
+	});
+
+	it("matches a cached model without waiting for a stalled refresh", async () => {
+		harness = await createHarness({ models: [{ id: "cached", name: "Cached" }] });
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(() => new Promise(() => {}));
+		const boundedRefresh = vi.spyOn(harness.session.modelRuntime, "boundedRefresh");
+
+		const model = await findExactModelMatch.call({ session: harness.session }, harness.models[0].id);
+
+		expect(model?.id).toBe("cached");
+		expect(boundedRefresh).not.toHaveBeenCalled();
+	});
+
+	it("refreshes through the bounded path when the name is not cached", async () => {
+		harness = await createHarness({ models: [{ id: "cached", name: "Cached" }] });
+		const refresh = vi.spyOn(harness.session.modelRuntime, "refresh");
+		const boundedRefresh = vi.spyOn(harness.session.modelRuntime, "boundedRefresh").mockResolvedValue({
+			aborted: true,
+			timedOut: true,
+			errors: new Map(),
+		});
+		const context = { session: harness.session, showStatus: vi.fn() };
+
+		await expect(findExactModelMatch.call(context, "not-cached")).resolves.toBeUndefined();
+
+		expect(boundedRefresh).toHaveBeenCalledOnce();
+		expect(refresh).not.toHaveBeenCalled();
+		expect(context.showStatus).toHaveBeenCalledWith("Refreshing model catalogs…");
+	});
+});


### PR DESCRIPTION
Fixes #7027, fixes #7113, fixes #7153, fixes #7418, fixes #7443

(it proved a tad more complicated to fix this in a reasonable way without adding infinite complexity; ah cancellation and queuing)

(this PR description has AI formatting, but it's human written I swear, it's just how I write)

Catalog refreshes outside `ModelRuntime.create()` and `/model` run without any timeout/terminal signal and hanged request to pi.dev could block them forever. This included TUI operations (`/scoped-models`, `/login` as well as operations inside SDK's `refresh` etc).

## TUI operations changes

This PR fixes it by:
- moving all of such operations into centrally 15s bounded refresh.
- moving all TUI operations to use snapshot first and then update async when the (background) refresh finishes
   - this is modeled via `/model`, i.e. `/scoped-models` now behave similarly
 
/model <specific model> is now instant when the model is in the cached list. If it isn't, it still does a bounded refresh (with a status line) and falls back to the full /model dialog if the name still doesn't match — worthwhile tradeoff for making the common case immediate.

It also propagates termination signals where appropriate so that `esc` (e.g. for `/login` works as expected).

## SDK/extension API changes
This change is also applied to some SDK operations/extension API. If desired, I'm happy to remove this, I can see arguments for either way (you don't want to block indefinitely / you want the callers to be in full control).

Namely, `ctx.modelRegistry` (ditto for login, logout, setRuntimeAPIKey, ...) now used bounded operations internally and `ModelRuntime.login()` takes optional refresh callback. 

## Possible extensions of this fix:
The refresh paths also go through `Models.checkAuth()` and `getAvailable()` which currently do not take any signal at all despite being able to block (they read credentials under the auth.json lock, and provider-supplied check/resolve can do arbitrary work). Their callers are raced against 15s timeout, but they keep running after it times out. Thus there are some possible edge cases around if this stalls the lock around `auth.json` (30s timeout) might block subsequent refreshes. 

It'd be more correct to adjust the interface of `packages/ai` to accept signal on this path, but that's better left for separate PR (happy to do it) (it'd be forward/backwards compatible).

(there's also possible somewhat unrelated residual not-raced hang with github copilot, but that's at least not suseptible to pi.dev blockage)

## Edge cases / caveats (in order of relevance)
1. **`refresh()` no longer guarantees a fresh model list on return.** It waits at most 15s for the availability pass, so a slow pass means callers briefly see the previous list; the newer one replaces it when it lands, and a stale pass never overwrites a newer one.
2. **Models discovered mid-refresh start unchecked.** Toggling while `/scoped-models` is still refreshing resolves the selection against the models on screen at that moment, which is exactly what Ctrl+P cycles. Models that arrive afterwards show up unchecked; reopening the selector re-matches your saved patterns against the full list.
3. **`/login` takes up to 30s in the worst case** — 15s for the catalog refresh plus 15s for the availability check that follows it — and only if both stall. Both are bounded, and Escape cancels the first.
4. **A selector closed by something other than Escape/Ctrl+C** (e.g.
 an extension takes over the editor area) leaves its background refresh running. It finishes into a component nobody renders any more — no crash, nothing visible.
5. **Repeated waits while pi.dev is down.** A failed fetch never advances `checkedAt`, so the catalog stays stale and the next command tries again: opening `/scoped-models`, or naming a model that is not cached, costs another 15s. The UI stays usable the whole time and says what it is doing; `--offline` skips the attempt entirely.

   <details>
   <summary>Fixing 2 is surprisingly not easy</summary>

   You generally have few options (llm investigated, I didn't drill super deep into this manually / verified):

   - Re-run the pattern match in the selector when the refresh lands and tick the new rows. ~70 lines, but then the checkbox claims enabled while ctrl+p still cycles the old set. One
 inconsistency traded for another.
   - Same, but push the result into the session scope too. ~90 lines, and now merely opening `/scoped-models` and hitting esc can change which models you cycle. Worse than the thing it
 fixes.
   - Do it properly: keep the patterns on the session instead of the resolved list, add a change notification to `ModelRuntime` (there is none today) and re-match whenever a refresh
 lands. ~200 lines. This also covers the case nobody sees right now, i.e. a background refresh discovering a matching model with no selector open at all, where the scope doesn't update
 either.

   So the real bug is "pattern scopes are resolved once and never re-matched", `/scoped-models` is just where it's visible. Since the selector persists explicit model ids (patterns only
 exist if you put them in settings by hand), I left it alone; feels like its own issue rather than scope creep here.
  </details>,
---

(the edge cases are LLM discovered, but I validated it makes sense, the rest is based on my human understanding; though the complexity of the code (and my lack of familiarity with it) means it's possible I missed few things)