### PR TITLE
fix(auth): support short-lived OAuth tokens

### DIFF
--- a/packages/ai/src/auth/resolve.ts
+++ b/packages/ai/src/auth/resolve.ts
@@ -92,11 +92,11 @@ function overlayEnvAuthContext(base: AuthContext, env: ProviderEnv): AuthContext
 	};
 }
 
-const DEFAULT_OAUTH_MINIMUM_VALIDITY_MS = 5 * 60 * 1000;
+const DEFAULT_OAUTH_MINIMUM_VALIDITY_MS = 60 * 1000;
 
 /**
- * OAuth resolution with double-checked locking: tokens with less than five
- * minutes remaining lock, re-check expiry under the lock, refresh once
+ * OAuth resolution with double-checked locking: tokens with less than one
+ * minute remaining lock, re-check expiry under the lock, refresh once
  * globally, and persist the rotated credential before release.
  */
 async function resolveStoredOAuth(

--- a/packages/ai/test/models-runtime.test.ts
+++ b/packages/ai/test/models-runtime.test.ts
@@ -476,7 +476,27 @@ describe("Models runtime", () => {
 		expect(((await credentials.read("p1")) as { access: string }).access).toBe("new-token");
 	});
 
-	it("refreshes oauth credentials with less than five minutes remaining", async () => {
+	it("does not refresh a short-lived OAuth token with more than one minute remaining", async () => {
+		const credentials = new InMemoryCredentialStore();
+		const refresh = vi.fn(async (credential) => ({
+			...credential,
+			access: "new-token",
+			expires: Date.now() + 60 * 60_000,
+		}));
+		const models = createModels({ credentials });
+		models.setProvider(testProvider({ id: "p1", auth: { oauth: testOAuth({ refresh }) } }));
+		await credentials.modify("p1", async () => ({
+			type: "oauth",
+			access: "current-token",
+			refresh: "r",
+			expires: Date.now() + 4 * 60_000,
+		}));
+
+		expect((await models.getAuth("p1"))?.auth.apiKey).toBe("current-token");
+		expect(refresh).not.toHaveBeenCalled();
+	});
+
+	it("refreshes OAuth credentials with less than one minute remaining", async () => {
 		const credentials = new InMemoryCredentialStore();
 		const refresh = vi.fn(async (credential) => ({
 			...credential,
@@ -489,7 +509,7 @@ describe("Models runtime", () => {
 			type: "oauth",
 			access: "old-token",
 			refresh: "r",
-			expires: Date.now() + 60_000,
+			expires: Date.now() + 30_000,
 		}));
 
 		expect((await models.getAuth("p1"))?.auth.apiKey).toBe("new-token");


### PR DESCRIPTION
## Summary
- refresh stored OAuth credentials only when less than one minute remains
- retain explicit longer validity requirements for callers that need them
- cover a token with four minutes of usable lifetime, preventing refresh on every request

## Validation
- `npm run test --workspace=@earendil-works/pi-ai -- models-runtime.test.ts`
- `npm run build`
- `npm test` (external Ollama tests could not run: Ollama is not available locally; the focused AI tests pass)