### PR TITLE
feat(coding-agent): compose experimental CLI commands

### DIFF
--- a/packages/coding-agent/src/cli/experimental/cli.ts
+++ b/packages/coding-agent/src/cli/experimental/cli.ts
@@ -1,0 +1,7 @@
+import { type ClientCommandContext, clientCommand } from "./commands/client.ts";
+import { type PiCommandContext, piCommand } from "./commands/pi.ts";
+import { type ServerCommandContext, serverCommand } from "./commands/server.ts";
+
+export type ExperimentalCliContext = PiCommandContext & ServerCommandContext & ClientCommandContext;
+
+export const experimentalCli = piCommand.command(serverCommand).command(clientCommand);

--- a/packages/coding-agent/src/cli/experimental/command-options.ts
+++ b/packages/coding-agent/src/cli/experimental/command-options.ts
@@ -1,0 +1,38 @@
+import { type Args, parseArgs } from "../args.ts";
+import { type AuthInput, parseAuthInput } from "./auth.ts";
+import { type CommandOption, type ParsedCommandInput, stringOption, valueOption } from "./command.ts";
+import { parseTransportAddress, type TransportAddress } from "./transport-address.ts";
+
+export const authTokenOption = stringOption("--auth-token");
+export const authTokenFileOption = stringOption("--auth-token-file");
+
+export function transportOption(name: "--listen" | "--connect"): CommandOption<TransportAddress> {
+	return valueOption(name, (value) => {
+		const result = parseTransportAddress(value, name);
+		return result.address
+			? { ok: true, value: result.address }
+			: { ok: false, error: result.error ?? `Invalid ${name} address "${value}"` };
+	});
+}
+
+export function parseAuth(input: ParsedCommandInput): { auth?: AuthInput; errors: string[] } {
+	return parseAuthInput({
+		authToken: input.value(authTokenOption),
+		authTokenFile: input.value(authTokenFileOption),
+	});
+}
+
+export function parseLegacyOptions(input: ParsedCommandInput): { options: Args; errors: string[] } {
+	const options = parseArgs([...input.remainingArgs]);
+	return {
+		options,
+		errors: options.diagnostics
+			.filter((diagnostic) => diagnostic.type === "error")
+			.map((diagnostic) => diagnostic.message),
+	};
+}
+
+export function unsupportedLegacyOptions(command: string, input: ParsedCommandInput): string[] {
+	if (input.remainingArgs.length === 0) return [];
+	return [`The experimental ${command} command does not support existing CLI options yet`];
+}

--- a/packages/coding-agent/src/cli/experimental/command.ts
+++ b/packages/coding-agent/src/cli/experimental/command.ts
@@ -1,142 +1,205 @@
-import { type AuthInput, parseAuthInput } from "./auth.ts";
-import { parseTransportAddress, type TransportAddress } from "./transport-address.ts";
-
-interface CommandBase {
-	readonly command: "combined" | "server" | "client";
-	readonly auth?: AuthInput;
-	readonly remainingArgs: readonly string[];
+export interface NamedCommandInvocation {
+	readonly command: string;
 }
 
-export interface CombinedCommand extends CommandBase {
-	readonly command: "combined";
-	readonly listen?: readonly TransportAddress[];
-}
-
-export interface ServerCommand extends CommandBase {
-	readonly command: "server";
-	readonly listen?: readonly TransportAddress[];
-}
-
-export interface ClientCommand extends CommandBase {
-	readonly command: "client";
-	readonly connect?: TransportAddress;
-}
-
-export type Command = CombinedCommand | ServerCommand | ClientCommand;
-
-export type CommandParseResult =
-	| { readonly ok: true; readonly command: Command }
+export type CommandParseResult<TInvocation extends NamedCommandInvocation = NamedCommandInvocation> =
+	| { readonly ok: true; readonly command: TInvocation }
 	| { readonly ok: false; readonly errors: readonly string[] };
 
-const VALUE_OPTIONS = new Set(["--listen", "--connect", "--auth-token", "--auth-token-file"]);
+export type CommandExecutionResult<TInvocation extends NamedCommandInvocation = NamedCommandInvocation> =
+	| { readonly ok: true; readonly command: TInvocation }
+	| { readonly ok: false; readonly errors: readonly string[] };
 
-interface RawCommandOptions {
-	authToken?: string;
-	authTokenFile?: string;
-	listenValues: string[];
-	connectValue?: string;
-	remainingArgs: string[];
+export type CommandOptionParseResult<TValue> =
+	| { readonly ok: true; readonly value: TValue }
+	| { readonly ok: false; readonly error: string };
+
+export interface CommandOption<TValue> {
+	readonly name: `--${string}`;
+	parse(value: string): CommandOptionParseResult<TValue>;
 }
 
-function splitOption(argument: string): { option: string; inlineValue?: string } {
-	const equals = argument.indexOf("=");
-	return equals === -1
-		? { option: argument }
-		: { option: argument.slice(0, equals), inlineValue: argument.slice(equals + 1) };
+export function valueOption<TValue>(
+	name: `--${string}`,
+	parse: (value: string) => CommandOptionParseResult<TValue>,
+): CommandOption<TValue> {
+	return { name, parse };
 }
 
-function parseRawOptions(argv: readonly string[]): { raw: RawCommandOptions; errors: string[] } {
-	const raw: RawCommandOptions = { listenValues: [], remainingArgs: [] };
-	const errors: string[] = [];
-
-	for (let index = 0; index < argv.length; index++) {
-		const argument = argv[index]!;
-		if (argument === "--") {
-			raw.remainingArgs.push(...argv.slice(index));
-			break;
-		}
-
-		const { option, inlineValue } = splitOption(argument);
-		if (!VALUE_OPTIONS.has(option)) {
-			raw.remainingArgs.push(...argv.slice(index));
-			break;
-		}
-
-		let value = inlineValue;
-		if (value === undefined) {
-			const next = argv[index + 1];
-			if (next !== undefined && !next.startsWith("-")) {
-				value = next;
-				index++;
-			}
-		}
-		if (value === undefined || value === "") {
-			errors.push(`${option} requires a value`);
-			continue;
-		}
-
-		switch (option) {
-			case "--listen":
-				raw.listenValues.push(value);
-				break;
-			case "--connect":
-				if (raw.connectValue !== undefined) errors.push("--connect may only be specified once");
-				raw.connectValue = value;
-				break;
-			case "--auth-token":
-				if (raw.authToken !== undefined) errors.push("--auth-token may only be specified once");
-				else raw.authToken = value;
-				break;
-			case "--auth-token-file":
-				if (raw.authTokenFile !== undefined) errors.push("--auth-token-file may only be specified once");
-				else raw.authTokenFile = value;
-				break;
-		}
-	}
-	return { raw, errors };
+export function stringOption(name: `--${string}`): CommandOption<string> {
+	return valueOption(name, (value) => ({ ok: true, value }));
 }
 
-export function parseCommand(argv: readonly string[]): CommandParseResult {
-	const [candidate, ...rest] = argv;
-	const commandName = candidate === "server" || candidate === "client" ? candidate : "combined";
-	const { raw, errors } = parseRawOptions(commandName === "combined" ? argv : rest);
-	const listen = raw.listenValues.flatMap((value) => {
-		const result = parseTransportAddress(value, "--listen");
-		if (result.error) errors.push(result.error);
-		return result.address ? [result.address] : [];
-	});
-	const connectResult = raw.connectValue ? parseTransportAddress(raw.connectValue, "--connect") : undefined;
-	if (connectResult?.error) errors.push(connectResult.error);
-	const { auth, errors: authErrors } = parseAuthInput(raw);
-	errors.push(...authErrors);
-	if (commandName === "client" && raw.listenValues.length > 0) {
-		errors.push("--listen is only valid for combined or server mode");
-	}
-	if (commandName !== "client" && raw.connectValue !== undefined) {
-		errors.push("--connect is only valid for client mode");
-	}
-	if (errors.length > 0) return { ok: false, errors };
+export interface ParsedCommandInput {
+	readonly remainingArgs: readonly string[];
+	value<TValue>(option: CommandOption<TValue>): TValue | undefined;
+	values<TValue>(option: CommandOption<TValue>): readonly TValue[];
+}
 
-	const common = {
-		remainingArgs: raw.remainingArgs,
-		...(auth === undefined ? {} : { auth }),
-	};
-	if (commandName === "client") {
-		return {
-			ok: true,
-			command: {
-				...common,
-				command: commandName,
-				...(connectResult?.address === undefined ? {} : { connect: connectResult.address }),
-			},
+export type CommandBuildResult<TInvocation extends NamedCommandInvocation> =
+	| { readonly ok: true; readonly command: TInvocation }
+	| { readonly ok: false; readonly errors: readonly string[] };
+
+interface MutableParsedCommandInput {
+	readonly values: Map<string, unknown[]>;
+	readonly remainingArgs: string[];
+	readonly errors: string[];
+}
+
+type CommandBuilder<TInvocation extends NamedCommandInvocation> = (
+	input: ParsedCommandInput,
+) => CommandBuildResult<TInvocation>;
+
+type CommandAction<TInvocation extends NamedCommandInvocation, TContext> = (
+	command: TInvocation,
+	context: TContext,
+) => void | Promise<void>;
+
+interface RegisteredCommand {
+	parse(argv: readonly string[]): CommandParseResult;
+	execute(argv: readonly string[], context: unknown): Promise<CommandExecutionResult>;
+}
+
+export class Command<
+	TOwnInvocation extends NamedCommandInvocation,
+	TContext,
+	TInvocation extends NamedCommandInvocation = TOwnInvocation,
+> {
+	readonly name: string;
+	private readonly options = new Map<string, CommandOption<unknown>>();
+	private readonly subcommands = new Map<string, RegisteredCommand>();
+	private builder?: CommandBuilder<TOwnInvocation>;
+	private commandAction?: CommandAction<TOwnInvocation, TContext>;
+
+	constructor(name: string) {
+		this.name = name;
+	}
+
+	option<TValue>(option: CommandOption<TValue>): this {
+		if (this.options.has(option.name)) {
+			throw new Error(`Option ${option.name} is already registered for ${this.name}`);
+		}
+		this.options.set(option.name, option);
+		return this;
+	}
+
+	build(builder: CommandBuilder<TOwnInvocation>): this {
+		this.builder = builder;
+		return this;
+	}
+
+	action(action: CommandAction<TOwnInvocation, TContext>): this {
+		this.commandAction = action;
+		return this;
+	}
+
+	command<
+		TSubcommandOwnInvocation extends NamedCommandInvocation,
+		TSubcommandContext,
+		TSubcommandInvocation extends NamedCommandInvocation,
+	>(
+		command: Command<TSubcommandOwnInvocation, TSubcommandContext, TSubcommandInvocation>,
+	): Command<TOwnInvocation, TContext & TSubcommandContext, TInvocation | TSubcommandInvocation> {
+		if (this.subcommands.has(command.name)) throw new Error(`Command ${command.name} is already registered`);
+		this.subcommands.set(command.name, {
+			parse: (argv) => command.parse(argv),
+			execute: (argv, context) => command.execute(argv, context as TSubcommandContext),
+		});
+		return this as unknown as Command<
+			TOwnInvocation,
+			TContext & TSubcommandContext,
+			TInvocation | TSubcommandInvocation
+		>;
+	}
+
+	parse(argv: readonly string[]): CommandParseResult<TInvocation> {
+		const selected = this.select(argv);
+		if (selected) return selected.command.parse(selected.argv) as CommandParseResult<TInvocation>;
+		return this.parseOwn(argv) as CommandParseResult<TInvocation>;
+	}
+
+	async execute(argv: readonly string[], context: TContext): Promise<CommandExecutionResult<TInvocation>> {
+		const selected = this.select(argv);
+		if (selected) {
+			return selected.command.execute(selected.argv, context) as Promise<CommandExecutionResult<TInvocation>>;
+		}
+
+		const parsed = this.parseOwn(argv);
+		if (!parsed.ok) return parsed;
+		if (!this.commandAction) throw new Error(`Command ${this.name} does not define an action`);
+		await this.commandAction(parsed.command, context);
+		return { ok: true, command: parsed.command as unknown as TInvocation };
+	}
+
+	private select(argv: readonly string[]): { command: RegisteredCommand; argv: readonly string[] } | undefined {
+		const candidate = argv[0];
+		if (candidate === undefined) return undefined;
+		const command = this.subcommands.get(candidate);
+		return command ? { command, argv: argv.slice(1) } : undefined;
+	}
+
+	private parseOwn(argv: readonly string[]): CommandParseResult<TOwnInvocation> {
+		if (!this.builder) throw new Error(`Command ${this.name} does not define a builder`);
+		const parsed = this.parseOptions(argv);
+		const input: ParsedCommandInput = {
+			remainingArgs: parsed.remainingArgs,
+			value: <TValue>(option: CommandOption<TValue>) => parsed.values.get(option.name)?.[0] as TValue | undefined,
+			values: <TValue>(option: CommandOption<TValue>) => (parsed.values.get(option.name) ?? []) as readonly TValue[],
 		};
+		const built = this.builder(input);
+		const errors = [...parsed.errors, ...(built.ok ? [] : built.errors)];
+		if (errors.length > 0) return { ok: false, errors };
+		if (!built.ok) throw new Error(`Command ${this.name} failed without an error`);
+		return { ok: true, command: built.command };
 	}
-	return {
-		ok: true,
-		command: {
-			...common,
-			command: commandName,
-			...(listen.length === 0 ? {} : { listen }),
-		},
-	};
+
+	private parseOptions(argv: readonly string[]): MutableParsedCommandInput {
+		const parsed: MutableParsedCommandInput = {
+			values: new Map(),
+			remainingArgs: [],
+			errors: [],
+		};
+		for (let index = 0; index < argv.length; index++) {
+			const argument = argv[index]!;
+			if (argument === "--") {
+				parsed.remainingArgs.push(...argv.slice(index));
+				break;
+			}
+
+			const equals = argument.indexOf("=");
+			const name = equals === -1 ? argument : argument.slice(0, equals);
+			const option = this.options.get(name);
+			if (!option) {
+				parsed.remainingArgs.push(...argv.slice(index));
+				break;
+			}
+
+			let value = equals === -1 ? undefined : argument.slice(equals + 1);
+			if (value === undefined) {
+				const next = argv[index + 1];
+				if (next !== undefined && !next.startsWith("-")) {
+					value = next;
+					index++;
+				}
+			}
+			if (value === undefined || value === "") {
+				parsed.errors.push(`${name} requires a value`);
+				continue;
+			}
+
+			const values = parsed.values.get(name) ?? [];
+			if (values.length > 0) {
+				parsed.errors.push(`${name} may only be specified once`);
+				continue;
+			}
+			const result = option.parse(value);
+			if (!result.ok) {
+				parsed.errors.push(result.error);
+				continue;
+			}
+			values.push(result.value);
+			parsed.values.set(name, values);
+		}
+		return parsed;
+	}
 }

--- a/packages/coding-agent/src/cli/experimental/commands/client.ts
+++ b/packages/coding-agent/src/cli/experimental/commands/client.ts
@@ -1,0 +1,44 @@
+import type { AuthInput } from "../auth.ts";
+import { Command } from "../command.ts";
+import {
+	authTokenFileOption,
+	authTokenOption,
+	parseAuth,
+	parseLegacyOptions,
+	transportOption,
+	unsupportedLegacyOptions,
+} from "../command-options.ts";
+import type { TransportAddress } from "../transport-address.ts";
+
+export interface ClientCommand {
+	readonly command: "client";
+	readonly auth?: AuthInput;
+	readonly connect?: TransportAddress;
+}
+
+export interface ClientCommandContext {
+	runClient(command: ClientCommand): void | Promise<void>;
+}
+
+const connectOption = transportOption("--connect");
+
+export const clientCommand = new Command<ClientCommand, ClientCommandContext>("client")
+	.option(connectOption)
+	.option(authTokenOption)
+	.option(authTokenFileOption)
+	.build((input) => {
+		const { auth, errors: authErrors } = parseAuth(input);
+		const connect = input.value(connectOption);
+		const { errors: optionErrors } = parseLegacyOptions(input);
+		const errors = [...authErrors, ...optionErrors, ...unsupportedLegacyOptions("client", input)];
+		if (errors.length > 0) return { ok: false, errors };
+		return {
+			ok: true,
+			command: {
+				command: "client",
+				...(auth === undefined ? {} : { auth }),
+				...(connect === undefined ? {} : { connect }),
+			},
+		};
+	})
+	.action((command, context) => context.runClient(command));

--- a/packages/coding-agent/src/cli/experimental/commands/pi.ts
+++ b/packages/coding-agent/src/cli/experimental/commands/pi.ts
@@ -1,0 +1,47 @@
+import type { Args } from "../../args.ts";
+import type { AuthInput } from "../auth.ts";
+import { Command } from "../command.ts";
+import {
+	authTokenFileOption,
+	authTokenOption,
+	parseAuth,
+	parseLegacyOptions,
+	transportOption,
+} from "../command-options.ts";
+import type { TransportAddress } from "../transport-address.ts";
+
+export interface PiCommand {
+	readonly command: "pi";
+	readonly auth?: AuthInput;
+	readonly options: Args;
+	readonly listen?: readonly TransportAddress[];
+}
+
+export interface PiCommandContext {
+	runPi(command: PiCommand): void | Promise<void>;
+}
+
+const listenOption = transportOption("--listen");
+
+export const piCommand = new Command<PiCommand, PiCommandContext>("pi")
+	.option(listenOption)
+	.option(authTokenOption)
+	.option(authTokenFileOption)
+	.build((input) => {
+		const { auth, errors: authErrors } = parseAuth(input);
+		const listen = input.values(listenOption);
+		const { options, errors: optionErrors } = parseLegacyOptions(input);
+		const errors = [...authErrors, ...optionErrors];
+		if (options.unknownFlags.has("connect")) errors.push("--connect is only valid for client mode");
+		if (errors.length > 0) return { ok: false, errors };
+		return {
+			ok: true,
+			command: {
+				command: "pi",
+				options,
+				...(auth === undefined ? {} : { auth }),
+				...(listen.length === 0 ? {} : { listen }),
+			},
+		};
+	})
+	.action((command, context) => context.runPi(command));

--- a/packages/coding-agent/src/cli/experimental/commands/server.ts
+++ b/packages/coding-agent/src/cli/experimental/commands/server.ts
@@ -1,0 +1,44 @@
+import type { AuthInput } from "../auth.ts";
+import { Command } from "../command.ts";
+import {
+	authTokenFileOption,
+	authTokenOption,
+	parseAuth,
+	parseLegacyOptions,
+	transportOption,
+	unsupportedLegacyOptions,
+} from "../command-options.ts";
+import type { TransportAddress } from "../transport-address.ts";
+
+export interface ServerCommand {
+	readonly command: "server";
+	readonly auth?: AuthInput;
+	readonly listen?: readonly TransportAddress[];
+}
+
+export interface ServerCommandContext {
+	runServer(command: ServerCommand): void | Promise<void>;
+}
+
+const listenOption = transportOption("--listen");
+
+export const serverCommand = new Command<ServerCommand, ServerCommandContext>("server")
+	.option(listenOption)
+	.option(authTokenOption)
+	.option(authTokenFileOption)
+	.build((input) => {
+		const { auth, errors: authErrors } = parseAuth(input);
+		const listen = input.values(listenOption);
+		const { errors: optionErrors } = parseLegacyOptions(input);
+		const errors = [...authErrors, ...optionErrors, ...unsupportedLegacyOptions("server", input)];
+		if (errors.length > 0) return { ok: false, errors };
+		return {
+			ok: true,
+			command: {
+				command: "server",
+				...(auth === undefined ? {} : { auth }),
+				...(listen.length === 0 ? {} : { listen }),
+			},
+		};
+	})
+	.action((command, context) => context.runServer(command));

--- a/packages/coding-agent/test/experimental-cli-command.test.ts
+++ b/packages/coding-agent/test/experimental-cli-command.test.ts
@@ -1,97 +1,70 @@
 import { describe, expect, test } from "vitest";
-import { parseCommand } from "../src/cli/experimental/command.ts";
+import { experimentalCli } from "../src/cli/experimental/cli.ts";
 
-describe("parseCommand", () => {
-	test("selects combined mode and preserves existing CLI arguments", () => {
+describe("experimental CLI commands", () => {
+	test("selects pi mode and parses existing CLI arguments", () => {
 		expect(
-			parseCommand([
-				"--cwd",
-				"/workspace",
-				"--provider=anthropic",
+			experimentalCli.parse([
+				"--provider",
+				"anthropic",
 				"--model",
 				"claude-sonnet",
-				"--thinking=high",
+				"--thinking",
+				"high",
 				"inspect",
 				"the project",
 			]),
-		).toEqual({
+		).toMatchObject({
 			ok: true,
 			command: {
-				command: "combined",
-				remainingArgs: [
-					"--cwd",
-					"/workspace",
-					"--provider=anthropic",
-					"--model",
-					"claude-sonnet",
-					"--thinking=high",
-					"inspect",
-					"the project",
-				],
+				command: "pi",
+				options: {
+					provider: "anthropic",
+					model: "claude-sonnet",
+					thinking: "high",
+					messages: ["inspect", "the project"],
+				},
 			},
 		});
 	});
 
-	test("parses repeatable server listeners and preserves other arguments", () => {
-		expect(
-			parseCommand([
-				"server",
-				"--listen",
-				"unix:///tmp/pi.sock",
-				"--listen=unix:///tmp/pi-admin.sock",
-				"--model",
-				"claude-sonnet",
-			]),
-		).toEqual({
-			ok: true,
-			command: {
-				command: "server",
-				listen: [
-					{ transport: "unix", path: "/tmp/pi.sock" },
-					{ transport: "unix", path: "/tmp/pi-admin.sock" },
-				],
-				remainingArgs: ["--model", "claude-sonnet"],
-			},
-		});
-	});
-
-	test("preserves existing option values that look like experimental options", () => {
-		expect(parseCommand(["--system-prompt", "--listen", "unix:///tmp/pi.sock"])).toEqual({
-			ok: true,
-			command: {
-				command: "combined",
-				remainingArgs: ["--system-prompt", "--listen", "unix:///tmp/pi.sock"],
-			},
-		});
-	});
-
-	test("preserves experimental-looking arguments after the existing option prefix begins", () => {
-		expect(
-			parseCommand([
-				"server",
-				"--listen",
-				"unix:///tmp/pi.sock",
-				"--model",
-				"claude-sonnet",
-				"--listen=unix:///tmp/second.sock",
-			]),
-		).toEqual({
+	test("parses a server listener", () => {
+		expect(experimentalCli.parse(["server", "--listen", "unix:///tmp/pi.sock"])).toEqual({
 			ok: true,
 			command: {
 				command: "server",
 				listen: [{ transport: "unix", path: "/tmp/pi.sock" }],
-				remainingArgs: ["--model", "claude-sonnet", "--listen=unix:///tmp/second.sock"],
 			},
 		});
 	});
 
+	test("leaves experimental-looking existing option values with the existing parser", () => {
+		expect(experimentalCli.parse(["--system-prompt", "--listen", "unix:///tmp/pi.sock"])).toMatchObject({
+			ok: true,
+			command: {
+				command: "pi",
+				options: { systemPrompt: "--listen", messages: ["unix:///tmp/pi.sock"] },
+			},
+		});
+	});
+
+	test("stops parsing command options when existing CLI arguments begin", () => {
+		const result = experimentalCli.parse(["--model", "claude-sonnet", "--listen=unix:///tmp/second.sock"]);
+		expect(result).toMatchObject({
+			ok: true,
+			command: { command: "pi", options: { model: "claude-sonnet" } },
+		});
+		if (!result.ok || result.command.command !== "pi") return;
+		expect(result.command.listen).toBeUndefined();
+		expect(result.command.options.unknownFlags.get("listen")).toBe("unix:///tmp/second.sock");
+	});
+
 	test("parses a client transport address", () => {
-		expect(parseCommand(["client", "--connect", "unix:///tmp/pi.sock", "hello"])).toEqual({
+		expect(experimentalCli.parse(["client", "--connect", "unix:///tmp/pi.sock"])).toEqual({
 			ok: true,
 			command: {
 				command: "client",
 				connect: { transport: "unix", path: "/tmp/pi.sock" },
-				remainingArgs: ["hello"],
 			},
 		});
 	});
@@ -100,33 +73,37 @@ describe("parseCommand", () => {
 		[["--auth-token", "secret"], { type: "token", token: "secret" }],
 		[["--auth-token-file", "/tmp/token"], { type: "file", path: "/tmp/token" }],
 	] as const)("parses authentication source %j", (argv, auth) => {
-		expect(parseCommand(argv)).toEqual({
+		expect(experimentalCli.parse(argv)).toMatchObject({
 			ok: true,
-			command: { command: "combined", auth, remainingArgs: [] },
+			command: { command: "pi", auth },
 		});
 	});
 
 	test.each([[[]], [["server"]], [["client"]]] as const)(
 		"permits omitted authentication for later environment/default resolution",
 		(argv) => {
-			expect(parseCommand(argv)).toEqual({
-				ok: true,
-				command: { command: argv[0] ?? "combined", remainingArgs: [] },
-			});
+			const result = experimentalCli.parse(argv);
+			expect(result).toMatchObject({ ok: true, command: { command: argv[0] ?? "pi" } });
+			if (result.ok) expect(result.command.auth).toBeUndefined();
 		},
 	);
 
-	test("preserves unknown options, @file arguments, and the positional separator", () => {
-		expect(parseCommand(["--unknown", "@prompt.md", "--", "--listen", "unix:///tmp/pi.sock"])).toEqual({
+	test("passes unknown options, file arguments, and the positional separator to the existing parser", () => {
+		const result = experimentalCli.parse(["--unknown", "@prompt.md", "--", "--listen", "unix:///tmp/pi.sock"]);
+		expect(result).toMatchObject({
 			ok: true,
-			command: {
-				command: "combined",
-				remainingArgs: ["--unknown", "@prompt.md", "--", "--listen", "unix:///tmp/pi.sock"],
-			},
+			command: { command: "pi", options: { fileArgs: ["prompt.md"] } },
 		});
+		if (!result.ok || result.command.command !== "pi") return;
+		expect(result.command.options.unknownFlags.get("unknown")).toBe(true);
+		expect(result.command.options.unknownFlags.get("listen")).toBe("unix:///tmp/pi.sock");
 	});
 
 	test.each([
+		[
+			["--listen", "unix:///tmp/pi.sock", "--listen", "unix:///tmp/pi-admin.sock"],
+			"--listen may only be specified once",
+		],
 		[
 			["--auth-token", "secret", "--auth-token-file", "/tmp/token"],
 			"--auth-token and --auth-token-file are mutually exclusive",
@@ -143,20 +120,26 @@ describe("parseCommand", () => {
 		[["--listen", "unix:///tmp/pi.sock#fragment"], 'Invalid --listen address "unix:///tmp/pi.sock#fragment"'],
 		[["--listen", "unix:/tmp/pi.sock"], 'Invalid --listen address "unix:/tmp/pi.sock"'],
 		[["--listen", "unix:///tmp/%00pi.sock"], 'Invalid --listen address "unix:///tmp/%00pi.sock"'],
-		[["client", "--listen", "unix:///tmp/pi.sock"], "--listen is only valid for combined or server mode"],
-		[["server", "--connect", "unix:///tmp/pi.sock"], "--connect is only valid for client mode"],
+		[
+			["client", "--listen", "unix:///tmp/pi.sock"],
+			"The experimental client command does not support existing CLI options yet",
+		],
+		[
+			["server", "--connect", "unix:///tmp/pi.sock"],
+			"The experimental server command does not support existing CLI options yet",
+		],
 		[["client", "--connect", "ws://localhost:8080"], 'Unsupported --connect transport "ws:"'],
 		[["--listen"], "--listen requires a value"],
-		[["--connect="], "--connect requires a value"],
+		[["--connect="], "--connect is only valid for client mode"],
 	] as const)("rejects invalid experimental input %j", (argv, error) => {
-		const result = parseCommand(argv);
+		const result = experimentalCli.parse(argv);
 		expect(result).toMatchObject({ ok: false });
 		if (!result.ok) expect(result.errors).toContainEqual(expect.stringContaining(error));
 	});
 
-	test("reports independent experimental errors together", () => {
+	test("rejects unsupported options without parsing them", () => {
 		expect(
-			parseCommand([
+			experimentalCli.parse([
 				"client",
 				"--listen",
 				"ws://localhost:8080",
@@ -167,18 +150,14 @@ describe("parseCommand", () => {
 			]),
 		).toEqual({
 			ok: false,
-			errors: [
-				'Unsupported --listen transport "ws:"',
-				"--auth-token and --auth-token-file are mutually exclusive",
-				"--listen is only valid for combined or server mode",
-			],
+			errors: ["The experimental client command does not support existing CLI options yet"],
 		});
 	});
 
 	test("treats command names after the first argument as existing CLI arguments", () => {
-		expect(parseCommand(["--cwd", "/workspace", "server"])).toEqual({
+		expect(experimentalCli.parse(["--cwd", "/workspace", "server"])).toMatchObject({
 			ok: true,
-			command: { command: "combined", remainingArgs: ["--cwd", "/workspace", "server"] },
+			command: { command: "pi", options: { messages: ["server"] } },
 		});
 	});
 });

--- a/packages/coding-agent/test/experimental-cli-resolution.test.ts
+++ b/packages/coding-agent/test/experimental-cli-resolution.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from "vitest";
+import { experimentalCli } from "../src/cli/experimental/cli.ts";
+
+const UNSUPPORTED_SERVER_OPTIONS = "The experimental server command does not support existing CLI options yet";
+const UNSUPPORTED_CLIENT_OPTIONS = "The experimental client command does not support existing CLI options yet";
+
+describe("experimental CLI command composition", () => {
+	test("composes pi command options with the existing parser", () => {
+		const result = experimentalCli.parse([
+			"--listen",
+			"unix:///tmp/pi.sock",
+			"--auth-token",
+			"secret",
+			"--provider",
+			"anthropic",
+			"--model",
+			"claude-sonnet",
+			"--thinking",
+			"high",
+			"inspect",
+		]);
+
+		expect(result).toMatchObject({
+			ok: true,
+			command: {
+				command: "pi",
+				listen: [{ transport: "unix", path: "/tmp/pi.sock" }],
+				auth: { type: "token", token: "secret" },
+				options: {
+					provider: "anthropic",
+					model: "claude-sonnet",
+					thinking: "high",
+					messages: ["inspect"],
+				},
+			},
+		});
+	});
+
+	test.each(["--help", "--version"] as const)("keeps Pi %s handling in existing CLI options", (option) => {
+		expect(experimentalCli.parse([option])).toMatchObject({
+			ok: true,
+			command: { command: "pi", options: { [option === "--help" ? "help" : "version"]: true } },
+		});
+	});
+
+	test.each([
+		["server", "--help", UNSUPPORTED_SERVER_OPTIONS],
+		["server", "--version", UNSUPPORTED_SERVER_OPTIONS],
+		["client", "--help", UNSUPPORTED_CLIENT_OPTIONS],
+		["client", "--version", UNSUPPORTED_CLIENT_OPTIONS],
+	] as const)("rejects deferred %s %s handling", (command, option, error) => {
+		expect(experimentalCli.parse([command, option])).toEqual({ ok: false, errors: [error] });
+	});
+
+	test("rejects existing options that the server command does not support yet", () => {
+		expect(experimentalCli.parse(["server", "--model", "claude-sonnet", "prompt"])).toEqual({
+			ok: false,
+			errors: [UNSUPPORTED_SERVER_OPTIONS],
+		});
+	});
+
+	test("rejects existing options that the client command does not support yet", () => {
+		expect(experimentalCli.parse(["client", "--ui-mode", "fullscreen", "@prompt.md"])).toEqual({
+			ok: false,
+			errors: [UNSUPPORTED_CLIENT_OPTIONS],
+		});
+	});
+
+	test("reports existing parser errors before capability errors", () => {
+		expect(experimentalCli.parse(["client", "--ui-mode", "wrong", "--model", "claude-sonnet"])).toEqual({
+			ok: false,
+			errors: ['Invalid UI mode "wrong". Valid values: regular, fullscreen', UNSUPPORTED_CLIENT_OPTIONS],
+		});
+	});
+
+	test("parses an empty server command", () => {
+		expect(experimentalCli.parse(["server"])).toEqual({
+			ok: true,
+			command: { command: "server" },
+		});
+	});
+
+	test.each(["pi", "server", "client"] as const)("executes the parsed %s command", async (name) => {
+		const context = {
+			runPi: vi.fn(() => undefined),
+			runServer: vi.fn(() => undefined),
+			runClient: vi.fn(() => undefined),
+		};
+		const result = await experimentalCli.execute(name === "pi" ? [] : [name], context);
+
+		expect(result).toMatchObject({ ok: true, command: { command: name } });
+		expect(context.runPi).toHaveBeenCalledTimes(name === "pi" ? 1 : 0);
+		expect(context.runServer).toHaveBeenCalledTimes(name === "server" ? 1 : 0);
+		expect(context.runClient).toHaveBeenCalledTimes(name === "client" ? 1 : 0);
+	});
+});


### PR DESCRIPTION
## Summary

- compose experimental command parsing with the existing CLI parser
- reject unsupported legacy options for server and client commands
- add typed dispatch for resolved combined, server, and client commands
- cover composition, validation, metadata, and dispatch behavior

## Testing

- `npm run build`
- `./test.sh`
- `npm run check`
