### PR TITLE
feat(coding-agent): add PI_JITI_CACHE env var

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added chainable `pi.registerMarkdownTransformer()` hooks for display-only transformation of user and assistant Markdown.
+- Added the `PI_JITI_CACHE` env var to point the extension loaders jiti transpile cache at a persistent directory (defaults to jiti auto-detect), so packagers with a read only store or a fresh `TMPDIR` per session can avoid cold recompiles.
 - Added an experimental fullscreen UI mode, selectable through `--ui-mode fullscreen` or `/settings` ([#7304](https://github.com/earendil-works/pi/issues/7304)).
 - Added a sticky editor, status, widget, and footer dock to fullscreen mode while keeping the transcript independently scrollable.
 - Added a draggable transcript scrollbar to fullscreen mode with configurable `auto`, `always`, and `hidden` modes through `/settings`; `always` reserves the rightmost column.

--- a/packages/coding-agent/docs/environment-variables.md
+++ b/packages/coding-agent/docs/environment-variables.md
@@ -76,6 +76,7 @@ These variables are read by Pi itself:
 | `PI_CODING_AGENT_DIR` | Override the config directory; default is `~/.pi/agent` |
 | `PI_CODING_AGENT_SESSION_DIR` | Override session storage; overridden by `--session-dir` |
 | `PI_PACKAGE_DIR` | Override the package directory, useful for Nix/Guix store paths |
+| `PI_JITI_CACHE` | Directory for the jiti transpile cache used when loading extensions, unset defaults to jiti auto-detect |
 | `PI_OFFLINE` | Disable startup network operations, including update checks, package updates, and install/update telemetry |
 | `PI_SKIP_VERSION_CHECK` | Disable the `pi.dev` latest-version request |
 | `PI_TELEMETRY` | Override install/update telemetry and provider attribution headers: `1`/`true`/`yes` or `0`/`false`/`no` |

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -419,6 +419,8 @@ async function loadExtensionModule(extensionPath: string, cacheToken?: Extension
 
 	const jiti = createJiti(import.meta.url, {
 		moduleCache: false,
+		// Allow packagers to point the transpile cache at a persistent dir
+		fsCache: process.env.PI_JITI_CACHE || true,
 		// Bun uses modules embedded in the executable. Source TypeScript reuses the
 		// host-resolved modules and root tsconfig paths. Built Node uses dist aliases.
 		...(isBunBinary


### PR DESCRIPTION
**Summary**
This env var is necesary so packagers like nix (nixpkgs) have the option to point the jiti cache to a persistent directory.

Done in this PR:
- add `PI_JITI_CACHE` env var to point the jiti transpile cache to a persistent dir
- lets packagers with a read-only store (nix) or a fresh `TMPDIR` per session avoid cold recompiles on every extension load
- documents the new var in `docs/environment-variables.md`

**Testing**
- `npm run check`
- `./test.sh`
