### PR TITLE
fix(coding-agent): SessionManager._persist should not crash with ENOENT on a missing session directory

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -14,7 +14,7 @@ import {
 	writeFileSync,
 } from "fs";
 import { readdir, stat } from "fs/promises";
-import { join, resolve } from "path";
+import { dirname, join, resolve } from "path";
 import { createInterface } from "readline";
 import { StringDecoder } from "string_decoder";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.ts";
@@ -976,8 +976,26 @@ export class SessionManager {
 		}
 	}
 
+	/**
+	 * Ensure the directory that will hold the session file exists. The session
+	 * directory is normally created once (constructor / getDefaultSessionDir()),
+	 * but it can still be missing later — e.g. an explicit --session path whose
+	 * parent was never created, or the directory being removed out from under a
+	 * long-running process. Re-creating it here is cheap (mkdirSync is a no-op
+	 * when the directory already exists) and avoids ENOENT crashes from
+	 * appendFileSync/openSync deep in the persistence path.
+	 */
+	private _ensureSessionFileDir(): void {
+		if (!this.sessionFile) return;
+		const dir = dirname(this.sessionFile);
+		if (dir && !existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+	}
+
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
+		this._ensureSessionFileDir();
 		const fd = openSync(this.sessionFile, "w");
 		try {
 			for (const entry of this.fileEntries) {
@@ -1015,29 +1033,42 @@ export class SessionManager {
 	_persist(entry: SessionEntry): void {
 		if (!this.persist || !this.sessionFile) return;
 
-		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
-		if (!hasAssistant) {
-			if (this.flushed) {
-				appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
-			} else {
-				// Mark as not flushed so when assistant arrives, all entries get written
-				this.flushed = false;
-			}
-			return;
-		}
+		// _persist() runs on every appended entry, including ones written while
+		// handling an *earlier* failure (e.g. Agent.handleRunFailure ->
+		// _handleAgentEvent -> SessionManager.appendMessage -> _appendEntry ->
+		// _persist). A logging/persistence failure here must never throw and mask
+		// the original error it was trying to record, and the target directory
+		// may be missing (never created, or removed after construction), so we
+		// defensively recreate it and swallow (but report) any I/O failure.
+		try {
+			this._ensureSessionFileDir();
 
-		if (!this.flushed) {
-			const fd = openSync(this.sessionFile, "wx");
-			try {
-				for (const e of this.fileEntries) {
-					writeFileSync(fd, `${JSON.stringify(e)}\n`);
+			const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
+			if (!hasAssistant) {
+				if (this.flushed) {
+					appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+				} else {
+					// Mark as not flushed so when assistant arrives, all entries get written
+					this.flushed = false;
 				}
-			} finally {
-				closeSync(fd);
+				return;
 			}
-			this.flushed = true;
-		} else {
-			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+
+			if (!this.flushed) {
+				const fd = openSync(this.sessionFile, "wx");
+				try {
+					for (const e of this.fileEntries) {
+						writeFileSync(fd, `${JSON.stringify(e)}\n`);
+					}
+				} finally {
+					closeSync(fd);
+				}
+				this.flushed = true;
+			} else {
+				appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+			}
+		} catch (error) {
+			console.error(`[SessionManager] failed to persist session entry to ${this.sessionFile}:`, error);
 		}
 	}
 

--- a/packages/coding-agent/test/session-manager/persist-missing-dir.test.ts
+++ b/packages/coding-agent/test/session-manager/persist-missing-dir.test.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+// Regression test for: SessionManager._persist crashing with ENOENT when the
+// session directory is missing at write time (e.g. removed after the
+// SessionManager was constructed, or never created for an explicit session
+// file path). Previously this threw inside appendFileSync/openSync, which is
+// especially harmful when _persist runs while the agent is already handling
+// a failure (Agent.handleRunFailure -> ... -> SessionManager.appendMessage ->
+// _appendEntry -> _persist): the ENOENT would replace/mask the original error
+// and no session artifact would be produced at all.
+describe("SessionManager._persist directory resilience", () => {
+	let tempDir: string;
+	let cwd: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `session-persist-missing-dir-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		cwd = join(tempDir, "workspace");
+		mkdirSync(cwd, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function assistantMessage(text: string, timestamp: number) {
+		return {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text }],
+			api: "anthropic-messages" as const,
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop" as const,
+			timestamp,
+		};
+	}
+
+	it("recreates a session directory removed after construction instead of throwing ENOENT", () => {
+		const sessionDir = join(tempDir, ".pi", "sessions");
+		const session = SessionManager.create(cwd, sessionDir);
+
+		// Trigger the first flush (writes the file for the first time).
+		session.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+		session.appendMessage(assistantMessage("hello", 2));
+
+		const sessionFile = session.getSessionFile();
+		expect(sessionFile).toBeDefined();
+		expect(existsSync(sessionFile as string)).toBe(true);
+
+		// Simulate the directory disappearing out from under the session, e.g.
+		// a workspace reset or an errant `rm -rf` of .pi between writes.
+		rmSync(sessionDir, { recursive: true, force: true });
+		expect(existsSync(sessionDir)).toBe(false);
+
+		// This previously threw: Error: ENOENT: no such file or directory, open ...
+		expect(() =>
+			session.appendMessage({ role: "user", content: "after directory removed", timestamp: 3 }),
+		).not.toThrow();
+
+		expect(existsSync(sessionFile as string)).toBe(true);
+		const content = readFileSync(sessionFile as string, "utf8");
+		expect(content).toContain("after directory removed");
+	});
+
+	it("creates the parent directory for an explicit session file whose parent differs from the tracked sessionDir", () => {
+		// SessionManager.open(path, sessionDir) lets callers pass a sessionDir that
+		// differs from the explicit file's own parent directory. The constructor
+		// only ensures `sessionDir` exists, so the file's actual parent directory
+		// can still be missing the first time `_persist` tries to write to it.
+		const trackedSessionDir = join(tempDir, "tracked-dir");
+		const explicitDir = join(tempDir, "explicit", "nested", "dir");
+		const explicitFile = join(explicitDir, "custom-session.jsonl");
+		expect(existsSync(explicitDir)).toBe(false);
+
+		const session = SessionManager.open(explicitFile, trackedSessionDir);
+		session.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+
+		// Previously threw: Error: ENOENT: no such file or directory, open ...
+		expect(() => session.appendMessage(assistantMessage("hello", 2))).not.toThrow();
+
+		expect(existsSync(explicitFile)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Problem

`SessionManager._persist()` calls `appendFileSync`/`openSync` against the session file without first ensuring its parent directory exists.

If the session directory is missing at write time — e.g. it was removed after the `SessionManager` was constructed (workspace reset, external cleanup), or an explicit `--session <path>` file's parent directory was never created because it differs from the tracked `sessionDir` — the write throws an uncaught `ENOENT`.

This is especially harmful because `_persist()` runs on **every** appended entry, including ones written while the agent is already handling an *earlier* failure:

```
Error: ENOENT: no such file or directory, open '/workspace/.pi/sessions/2026-07-29T13-09-37-697Z_job-3d3355a6ed1d.jsonl'
    at Object.writeFileSync (node:fs:2422:20)
    at appendFileSync (node:fs:2504:6)
    at SessionManager._persist (.../dist/core/session-manager.js:751:13)
    at SessionManager._appendEntry (.../dist/core/session-manager.js:758:14)
    at SessionManager.appendMessage (.../dist/core/session-manager.js:774:14)
    at _handleAgentEvent (.../dist/core/agent-session.js:365:37)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async Agent.processEvents (.../pi-agent-core/dist/agent.js:409:13)
    at async Agent.handleRunFailure (.../pi-agent-core/dist/agent.js:353:9)
```

Because the crash happens inside `Agent.handleRunFailure` → `_handleAgentEvent` → `SessionManager.appendMessage` → `_appendEntry` → `_persist`, it occurs *while trying to log the original error*, replacing/masking it and losing the entire trajectory (no `session.jsonl`/`session.html` artifact is produced for that run).

## Fix

- Added `SessionManager._ensureSessionFileDir()`, which recreates the session file's parent directory (`mkdirSync(dirname(sessionFile), { recursive: true })`) if it's missing. Called from both `_persist()` and `_rewriteFile()` before any write, since `mkdirSync` is a cheap no-op when the directory already exists.
- Wrapped the body of `_persist()` in `try/catch` so a persistence failure is logged to `stderr` (`console.error`) instead of throwing and masking the error it was trying to record.

## Tests

Added `packages/coding-agent/test/session-manager/persist-missing-dir.test.ts`:
- Directory removed after `SessionManager` construction (the scenario matching the trace above) — verifies `appendMessage()` no longer throws and the entry is still persisted once the directory is recreated.
- Explicit session file path whose parent directory differs from the tracked `sessionDir` and was never created — verifies the file is still written.

Ran the full session-related test suite (`packages/coding-agent/test/session-manager/**`, `session-file-invalid.test.ts`, `session-cwd.test.ts`, `sdk-session-manager.test.ts`, `session-info-modified-timestamp.test.ts`, `session-id-readonly.test.ts`): **115/115 pass**. The repo's full pre-commit `check` script (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, `tsgo --noEmit`, browser-smoke) also passed for this commit.

No functional behavior changes outside of the missing-directory/error-swallowing fix; the message/format of persisted entries is unchanged.