### PR TITLE
feat(coding-agent): opt-in pre-dispatch durability barrier

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -305,6 +305,7 @@ async function streamAssistantResponse(
 	const resolvedApiKey =
 		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
 
+	await config.beforeProviderCall?.();
 	const response = await streamFunction(config.model, llmContext, {
 		...config,
 		apiKey: resolvedApiKey,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -104,6 +104,7 @@ export interface AgentOptions {
 	onResponse?: SimpleStreamOptions["onResponse"];
 	beforeToolCall?: (context: BeforeToolCallContext, signal?: AbortSignal) => Promise<BeforeToolCallResult | undefined>;
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
+	beforeProviderCall?: () => Promise<void> | void;
 	prepareNextTurn?: (
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
@@ -188,6 +189,7 @@ export class Agent {
 		context: AfterToolCallContext,
 		signal?: AbortSignal,
 	) => Promise<AfterToolCallResult | undefined>;
+	public beforeProviderCall?: () => Promise<void> | void;
 	public prepareNextTurn?: (
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
@@ -219,6 +221,7 @@ export class Agent {
 		this.onResponse = runtimeOptions.onResponse;
 		this.beforeToolCall = runtimeOptions.beforeToolCall;
 		this.afterToolCall = runtimeOptions.afterToolCall;
+		this.beforeProviderCall = runtimeOptions.beforeProviderCall;
 		this.prepareNextTurn = runtimeOptions.prepareNextTurn;
 		this.prepareNextTurnWithContext = runtimeOptions.prepareNextTurnWithContext;
 		this.steeringQueue = new PendingMessageQueue(runtimeOptions.steeringMode ?? "one-at-a-time");
@@ -445,6 +448,7 @@ export class Agent {
 			toolExecution: this.toolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
+			beforeProviderCall: this.beforeProviderCall,
 			prepareNextTurn:
 				this.prepareNextTurnWithContext || this.prepareNextTurn
 					? async (context) => {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -143,6 +143,8 @@ export interface PrepareNextTurnContext extends ShouldStopAfterTurnContext {}
 
 export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
+	/** Awaited immediately before each provider stream function invocation. */
+	beforeProviderCall?: () => Promise<void> | void;
 
 	/**
 	 * Converts AgentMessage[] to LLM-compatible Message[] before each LLM call.

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -187,6 +187,52 @@ describe("Agent", () => {
 		expect(agent.state.errorMessage).toBe("provider exploded");
 	});
 
+	it("awaits beforeProviderCall before invoking the stream function", async () => {
+		const calls: string[] = [];
+		const agent = new Agent({
+			beforeProviderCall: async () => {
+				calls.push("barrier-start");
+				await Promise.resolve();
+				calls.push("barrier-end");
+			},
+			streamFn: () => {
+				calls.push("provider");
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("ok") });
+				});
+				return stream;
+			},
+		});
+
+		await agent.prompt("hello");
+
+		expect(calls).toEqual(["barrier-start", "barrier-end", "provider"]);
+	});
+
+	it("does not invoke the stream function when beforeProviderCall fails", async () => {
+		let providerInvoked = false;
+		const agent = new Agent({
+			beforeProviderCall: () => {
+				throw new Error("durability failed");
+			},
+			streamFn: () => {
+				providerInvoked = true;
+				throw new Error("provider should not be invoked");
+			},
+		});
+
+		await agent.prompt("hello");
+
+		expect(providerInvoked).toBe(false);
+		const lastMessage = agent.state.messages.at(-1);
+		expect(lastMessage).toMatchObject({
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: "durability failed",
+		});
+	});
+
 	it("should await async subscribers before prompt resolves", async () => {
 		const barrier = createDeferred();
 		const agent = new Agent({

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -21,9 +21,11 @@ export interface Args {
 	resume?: boolean;
 	help?: boolean;
 	version?: boolean;
+	capabilities?: boolean;
 	mode?: Mode;
 	name?: string;
 	noSession?: boolean;
+	preDispatchDurability?: boolean;
 	session?: string;
 	sessionId?: string;
 	fork?: string;
@@ -77,6 +79,8 @@ export function parseArgs(args: string[]): Args {
 			result.help = true;
 		} else if (arg === "--version" || arg === "-v") {
 			result.version = true;
+		} else if (arg === "--capabilities") {
+			result.capabilities = true;
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
 			if (mode === "text" || mode === "json" || mode === "rpc") {
@@ -105,6 +109,8 @@ export function parseArgs(args: string[]): Args {
 			}
 		} else if (arg === "--no-session") {
 			result.noSession = true;
+		} else if (arg === "--pre-dispatch-durability") {
+			result.preDispatchDurability = true;
 		} else if (arg === "--session" && i + 1 < args.length) {
 			result.session = args[++i];
 		} else if (arg === "--session-id" && i + 1 < args.length) {
@@ -268,6 +274,7 @@ ${chalk.bold("Options:")}
   --fork <path|id>               Fork specific session file or partial UUID into a new session
   --session-dir <dir>            Directory for session storage and lookup
   --no-session                   Don't save session (ephemeral)
+  --pre-dispatch-durability      Fsync session data before provider dispatch
   --name, -n <name>              Set session display name
   --models <patterns>            Comma-separated model patterns for Ctrl+P cycling
                                  Supports globs (anthropic/*, *sonnet*) and fuzzy matching
@@ -296,6 +303,7 @@ ${chalk.bold("Options:")}
   --offline                      Disable startup network operations (same as PI_OFFLINE=1)
   --help, -h                     Show this help
   --version, -v                  Show version number
+  --capabilities                 Show machine-readable runtime capabilities
 
 Extensions can register additional flags (e.g., --plan from plan-mode extension).${extensionFlagsText}
 

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -61,6 +61,7 @@ export interface CreateAgentSessionFromServicesOptions {
 	excludeTools?: CreateAgentSessionOptions["excludeTools"];
 	noTools?: CreateAgentSessionOptions["noTools"];
 	customTools?: ToolDefinition[];
+	preDispatchDurability?: boolean;
 }
 
 /**
@@ -215,5 +216,6 @@ export async function createAgentSessionFromServices(
 		noTools: options.noTools,
 		customTools: options.customTools,
 		sessionStartEvent: options.sessionStartEvent,
+		preDispatchDurability: options.preDispatchDurability,
 	});
 }

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -223,6 +223,8 @@ export interface AgentSessionConfig {
 	extensionRunnerRef?: { current?: ExtensionRunner };
 	/** Session start event metadata emitted when extensions bind to this runtime. */
 	sessionStartEvent?: SessionStartEvent;
+	/** Durably flush all session entries before each provider dispatch. Default: false. */
+	preDispatchDurability?: boolean;
 }
 
 export interface ExtensionBindings {
@@ -387,6 +389,13 @@ export class AgentSession {
 		this._excludedToolNames = config.excludedToolNames ? new Set(config.excludedToolNames) : undefined;
 		this._baseToolsOverride = config.baseToolsOverride;
 		this._sessionStartEvent = config.sessionStartEvent ?? { type: "session_start", reason: "startup" };
+		if (config.preDispatchDurability) {
+			const beforeProviderCall = this.agent.beforeProviderCall;
+			this.agent.beforeProviderCall = async () => {
+				await beforeProviderCall?.();
+				this.sessionManager.flushDurably();
+			};
+		}
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, extensions, auto-compaction, retry logic)

--- a/packages/coding-agent/src/core/capabilities.ts
+++ b/packages/coding-agent/src/core/capabilities.ts
@@ -1,0 +1,6 @@
+/** Stable capability surface for coding-agent embedders. */
+export const PI_CAPABILITIES = {
+	inputDurability: "pre_dispatch_barrier",
+} as const;
+
+export type PiCapabilities = typeof PI_CAPABILITIES;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -82,6 +82,8 @@ export interface CreateAgentSessionOptions {
 	settingsManager?: SettingsManager;
 	/** Session start event metadata for extension runtime startup. */
 	sessionStartEvent?: SessionStartEvent;
+	/** Durably flush the session file before each provider dispatch. Default: false. */
+	preDispatchDurability?: boolean;
 }
 
 /** Result from createAgentSession */
@@ -387,6 +389,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		excludedToolNames,
 		extensionRunnerRef,
 		sessionStartEvent: options.sessionStartEvent,
+		preDispatchDurability: options.preDispatchDurability,
 	});
 	const extensionsResult = resourceLoader.getExtensions();
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -6,6 +6,7 @@ import {
 	closeSync,
 	createReadStream,
 	existsSync,
+	fsyncSync,
 	mkdirSync,
 	openSync,
 	readdirSync,
@@ -14,7 +15,7 @@ import {
 	writeFileSync,
 } from "fs";
 import { readdir, stat } from "fs/promises";
-import { join, resolve } from "path";
+import { dirname, join, resolve } from "path";
 import { createInterface } from "readline";
 import { StringDecoder } from "string_decoder";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.ts";
@@ -1010,6 +1011,33 @@ export class SessionManager {
 
 	getSessionFile(): string | undefined {
 		return this.sessionFile;
+	}
+
+	/** Persist every accumulated entry, then fsync the file and its parent directory. */
+	flushDurably(): void {
+		if (!this.persist || !this.sessionFile) {
+			throw new Error("Cannot durably flush an in-memory session");
+		}
+
+		const fd = openSync(this.sessionFile, this.flushed ? "r+" : "wx");
+		try {
+			if (!this.flushed) {
+				for (const entry of this.fileEntries) {
+					writeFileSync(fd, `${JSON.stringify(entry)}\n`);
+				}
+			}
+			fsyncSync(fd);
+		} finally {
+			closeSync(fd);
+		}
+		this.flushed = true;
+
+		const dirFd = openSync(dirname(this.sessionFile), "r");
+		try {
+			fsyncSync(dirFd);
+		} finally {
+			closeSync(dirFd);
+		}
 	}
 
 	_persist(entry: SessionEntry): void {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -24,6 +24,7 @@ export {
 	type SessionStats,
 } from "./core/agent-session.ts";
 export { readStoredCredential } from "./core/auth-storage.ts";
+export { PI_CAPABILITIES, type PiCapabilities } from "./core/capabilities.ts";
 // Compaction
 export {
 	type BranchPreparation,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -32,6 +32,7 @@ import {
 	createAgentSessionServices,
 } from "./core/agent-session-services.ts";
 import { formatNoModelsAvailableMessage } from "./core/auth-guidance.ts";
+import { PI_CAPABILITIES } from "./core/capabilities.ts";
 import { exportFromFile } from "./core/export-html/index.ts";
 import type { InlineExtension } from "./core/extensions/types.ts";
 import { applyHttpProxySettings, configureHttpDispatcher } from "./core/http-dispatcher.ts";
@@ -496,6 +497,9 @@ function buildSessionOptions(
 	if (parsed.excludeTools) {
 		options.excludeTools = [...parsed.excludeTools];
 	}
+	if (parsed.preDispatchDurability) {
+		options.preDispatchDurability = true;
+	}
 
 	return { options, cliThinkingFromModel, diagnostics };
 }
@@ -572,6 +576,10 @@ export async function main(args: string[], options?: MainOptions) {
 
 	if (parsed.version) {
 		console.log(VERSION);
+		process.exit(0);
+	}
+	if (parsed.capabilities) {
+		console.log(JSON.stringify(PI_CAPABILITIES));
 		process.exit(0);
 	}
 
@@ -777,6 +785,7 @@ export async function main(args: string[], options?: MainOptions) {
 			excludeTools: sessionOptions.excludeTools,
 			noTools: sessionOptions.noTools,
 			customTools: sessionOptions.customTools,
+			preDispatchDurability: sessionOptions.preDispatchDurability,
 		});
 		const cliThinkingOverride = parsed.thinking !== undefined || cliThinkingFromModel;
 		if (created.session.model && cliThinkingOverride) {

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -21,6 +21,16 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("durability capability flags", () => {
+		test("parses --capabilities", () => {
+			expect(parseArgs(["--capabilities"]).capabilities).toBe(true);
+		});
+
+		test("parses --pre-dispatch-durability", () => {
+			expect(parseArgs(["--pre-dispatch-durability"]).preDispatchDurability).toBe(true);
+		});
+	});
+
 	describe("--help flag", () => {
 		test("parses --help flag", () => {
 			const result = parseArgs(["--help"]);

--- a/packages/coding-agent/test/capabilities.test.ts
+++ b/packages/coding-agent/test/capabilities.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PI_CAPABILITIES } from "../src/index.ts";
+
+describe("PI_CAPABILITIES", () => {
+	it("advertises the pre-dispatch durability barrier", () => {
+		expect(PI_CAPABILITIES).toEqual({ inputDurability: "pre_dispatch_barrier" });
+	});
+});

--- a/packages/coding-agent/test/stdout-cleanliness.test.ts
+++ b/packages/coding-agent/test/stdout-cleanliness.test.ts
@@ -93,6 +93,14 @@ describe("stdout cleanliness in non-interactive modes", () => {
 		expect(result.stderr).toBe("");
 	});
 
+	it("prints --capabilities as machine-readable JSON", async () => {
+		const result = await runCli(["--capabilities"]);
+
+		expect(result.code).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual({ inputDurability: "pre_dispatch_barrier" });
+		expect(result.stderr).toBe("");
+	});
+
 	it("prints plain --help to stdout when stdout is redirected", async () => {
 		const result = await runCli(["--help"]);
 

--- a/packages/coding-agent/test/suite/fixtures/pre-dispatch-durability-child.ts
+++ b/packages/coding-agent/test/suite/fixtures/pre-dispatch-durability-child.ts
@@ -1,0 +1,27 @@
+import { createHarness } from "../harness.ts";
+
+const harness = await createHarness({
+	persistSession: true,
+	preDispatchDurability: true,
+	extensionFactories: [
+		(pi) => {
+			pi.on("input", () => {
+				pi.appendEntry("work-together-attribution", {
+					requestId: "turn-fr10",
+					principalId: "human-1",
+				});
+			});
+		},
+	],
+});
+
+harness.session.agent.streamFunction = async () => {
+	const sessionFile = harness.sessionManager.getSessionFile();
+	if (!sessionFile) {
+		throw new Error("persisted test session has no file path");
+	}
+	process.send?.({ sessionFile });
+	return await new Promise<never>(() => {});
+};
+
+await harness.session.prompt("durably dispatch this turn");

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -72,6 +72,8 @@ export interface HarnessOptions {
 	extensionFactories?: Array<InlineExtension | CreateTestExtensionsResultInput>;
 	withConfiguredAuth?: boolean;
 	modelsJson?: Record<string, unknown>;
+	persistSession?: boolean;
+	preDispatchDurability?: boolean;
 }
 
 export interface Harness {
@@ -109,7 +111,9 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	const withConfiguredAuth = options.withConfiguredAuth ?? true;
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
 
-	const sessionManager = SessionManager.inMemory();
+	const sessionManager = options.persistSession
+		? SessionManager.create(tempDir, join(tempDir, "sessions"))
+		: SessionManager.inMemory();
 	const settingsManager = SettingsManager.inMemory(options.settings);
 
 	const authStorage = AuthStorage.inMemory();
@@ -191,6 +195,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		allowedToolNames: options.allowedToolNames,
 		excludedToolNames: options.excludedToolNames,
 		extensionRunnerRef,
+		preDispatchDurability: options.preDispatchDurability,
 	});
 
 	const events: AgentSessionEvent[] = [];

--- a/packages/coding-agent/test/suite/pre-dispatch-durability.test.ts
+++ b/packages/coding-agent/test/suite/pre-dispatch-durability.test.ts
@@ -1,0 +1,178 @@
+import { fork } from "node:child_process";
+import { once } from "node:events";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import type { InlineExtension } from "../../src/index.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const ATTRIBUTION_TYPE = "work-together-attribution";
+const ATTRIBUTION = { requestId: "turn-fr10", principalId: "human-1" };
+const USER_TEXT = "durably dispatch this turn";
+
+type StoredEntry = {
+	type: string;
+	customType?: string;
+	data?: unknown;
+	message?: { role: string; content: Array<{ type: string; text?: string }> };
+};
+
+const attributionExtension: InlineExtension = (pi) => {
+	pi.on("input", () => {
+		pi.appendEntry(ATTRIBUTION_TYPE, ATTRIBUTION);
+	});
+};
+
+function readStoredEntries(sessionFile: string): StoredEntry[] {
+	return readFileSync(sessionFile, "utf8")
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line) as StoredEntry);
+}
+
+function expectHeaderAttributionAndUser(entries: StoredEntry[]): void {
+	expect(entries).toHaveLength(3);
+	expect(entries[0]).toMatchObject({ type: "session" });
+	expect(entries[1]).toMatchObject({
+		type: "custom",
+		customType: ATTRIBUTION_TYPE,
+		data: ATTRIBUTION,
+	});
+	expect(entries[2]).toMatchObject({
+		type: "message",
+		message: {
+			role: "user",
+			content: [{ type: "text", text: USER_TEXT }],
+		},
+	});
+}
+
+describe("pre-dispatch durability", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		for (const harness of harnesses.splice(0)) {
+			harness.cleanup();
+		}
+	});
+
+	it("persists header, attribution, and user message before provider invocation when enabled", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			preDispatchDurability: true,
+			extensionFactories: [attributionExtension],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		const streamFunction = harness.session.agent.streamFunction;
+		let entriesAtDispatch: StoredEntry[] | undefined;
+		harness.session.agent.streamFunction = (model, context, options) => {
+			const sessionFile = harness.sessionManager.getSessionFile();
+			if (sessionFile && existsSync(sessionFile)) {
+				entriesAtDispatch = readStoredEntries(sessionFile);
+			}
+			return streamFunction(model, context, options);
+		};
+
+		await harness.session.prompt(USER_TEXT);
+
+		expect(entriesAtDispatch).toBeDefined();
+		expectHeaderAttributionAndUser(entriesAtDispatch!);
+	});
+
+	it("keeps the default behavior of no new session file before the first assistant message", async () => {
+		const harness = await createHarness({
+			persistSession: true,
+			extensionFactories: [attributionExtension],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		const streamFunction = harness.session.agent.streamFunction;
+		let sessionFileExistedAtDispatch: boolean | undefined;
+		harness.session.agent.streamFunction = (model, context, options) => {
+			const sessionFile = harness.sessionManager.getSessionFile();
+			sessionFileExistedAtDispatch = sessionFile !== undefined && existsSync(sessionFile);
+			return streamFunction(model, context, options);
+		};
+
+		await harness.session.prompt(USER_TEXT);
+
+		expect(sessionFileExistedAtDispatch).toBe(false);
+	});
+
+	it("does not invoke the provider when the durability barrier cannot persist", async () => {
+		const harness = await createHarness({ preDispatchDurability: true });
+		harnesses.push(harness);
+
+		let providerInvoked = false;
+		harness.session.agent.streamFunction = () => {
+			providerInvoked = true;
+			throw new Error("provider should not be invoked");
+		};
+
+		await harness.session.prompt(USER_TEXT);
+
+		expect(providerInvoked).toBe(false);
+		expect(harness.session.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			stopReason: "error",
+		});
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"leaves exactly header, attribution, and user message after SIGKILL at dispatch",
+		async () => {
+			const childPath = resolve(__dirname, "fixtures/pre-dispatch-durability-child.ts");
+			const child = fork(childPath, [], {
+				cwd: resolve(__dirname, "../../../.."),
+				execArgv: ["--import", "tsx"],
+				stdio: ["ignore", "pipe", "pipe", "ipc"],
+			});
+			let stderr = "";
+			child.stderr?.on("data", (chunk) => {
+				stderr += chunk.toString();
+			});
+
+			const dispatch = await new Promise<{ sessionFile: string }>((resolvePromise, reject) => {
+				const timeout = setTimeout(() => {
+					child.kill("SIGKILL");
+					reject(new Error(`child did not reach dispatch boundary: ${stderr}`));
+				}, 30_000);
+				child.once("message", (message: unknown) => {
+					clearTimeout(timeout);
+					if (
+						!message ||
+						typeof message !== "object" ||
+						!("sessionFile" in message) ||
+						typeof message.sessionFile !== "string"
+					) {
+						reject(new Error(`invalid child dispatch message: ${JSON.stringify(message)}`));
+						return;
+					}
+					resolvePromise({ sessionFile: message.sessionFile });
+				});
+				child.once("error", reject);
+				child.once("exit", (code, signal) => {
+					if (code !== null || signal !== "SIGKILL") {
+						clearTimeout(timeout);
+						reject(new Error(`child exited before dispatch: code=${code}, signal=${signal}, stderr=${stderr}`));
+					}
+				});
+			});
+
+			child.kill("SIGKILL");
+			const [code, signal] = (await once(child, "exit")) as [number | null, NodeJS.Signals | null];
+			expect(code).toBeNull();
+			expect(signal).toBe("SIGKILL");
+			try {
+				expectHeaderAttributionAndUser(readStoredEntries(dispatch.sessionFile));
+			} finally {
+				rmSync(dirname(dirname(dispatch.sessionFile)), { recursive: true, force: true });
+			}
+		},
+		40_000,
+	);
+});


### PR DESCRIPTION
**Problem.** A new session persists nothing until the first assistant message completes, but the provider request starts earlier. A crash in that window leaves no way to distinguish "provider never invoked" from "provider invoked, possibly billed, output lost" — so embedders that need at-most-once provider dispatch cannot ever safely retry an interrupted turn.

**Change.** Opt-in `preDispatchDurability` (off by default; default behavior byte-identical): immediately before each provider call, persist the session file (header + accumulated entries) and fsync file + parent directory; any failure prevents the provider call (fail closed). Capability is discoverable via `PI_CAPABILITIES.inputDurability` and `pi --capabilities`.

**Testing.** New suite proves durable header+A+U on disk before any provider invocation and across SIGKILL at the dispatch boundary; default-off unchanged-behavior tests; full coding-agent (1,667) and agent (242) suites green; `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MDKgmJy9Y4VMLtAXYQF3o
