### PR TITLE
feat(ai): add MiniMax video generation

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -8,7 +8,9 @@
 	"sideEffects": [
 		"./dist/compat.js",
 		"./dist/images.js",
-		"./dist/providers/images/register-builtins.js"
+		"./dist/providers/images/register-builtins.js",
+		"./dist/providers/videos/register-builtins.js",
+		"./dist/videos.js"
 	],
 	"exports": {
 		".": {

--- a/packages/ai/src/api/minimax-videos.lazy.ts
+++ b/packages/ai/src/api/minimax-videos.lazy.ts
@@ -1,0 +1,23 @@
+import type { ProviderVideos, VideosModel } from "../types.ts";
+import type { MiniMaxVideosOptions } from "./minimax-videos.ts";
+
+export const minimaxVideosApi = (): ProviderVideos => ({
+	generateVideos: async (model, context, options) =>
+		(await import("./minimax-videos.ts")).generateVideos(
+			model as VideosModel<"minimax-videos">,
+			context,
+			options as MiniMaxVideosOptions,
+		),
+	queryVideoGeneration: async (model, taskId, options) =>
+		(await import("./minimax-videos.ts")).queryVideoGeneration(
+			model as VideosModel<"minimax-videos">,
+			taskId,
+			options as MiniMaxVideosOptions,
+		),
+	downloadVideo: async (model, fileId, options) =>
+		(await import("./minimax-videos.ts")).downloadVideo(
+			model as VideosModel<"minimax-videos">,
+			fileId,
+			options as MiniMaxVideosOptions,
+		),
+});

--- a/packages/ai/src/api/minimax-videos.ts
+++ b/packages/ai/src/api/minimax-videos.ts
@@ -1,0 +1,347 @@
+import type {
+	AssistantVideos,
+	ProviderHeaders,
+	ProviderResponse,
+	VideoGenerationAsset,
+	VideosContext,
+	VideosFunction,
+	VideosModel,
+	VideosOptions,
+} from "../types.ts";
+import { combineAbortSignals } from "../utils/abort-signals.ts";
+import { formatProviderError, normalizeProviderError, truncateErrorText } from "../utils/error-body.ts";
+import { providerHeadersToRecord } from "../utils/headers.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
+import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+
+export const MINIMAX_VIDEO_MODELS = {
+	v2: ["MiniMax-H3"],
+	v1: [
+		"MiniMax-Hailuo-2.3",
+		"MiniMax-Hailuo-2.3-Fast",
+		"MiniMax-Hailuo-02",
+		"T2V-01-Director",
+		"T2V-01",
+		"I2V-01-Director",
+		"I2V-01-live",
+		"I2V-01",
+	],
+} as const;
+
+export const MINIMAX_VIDEO_BASE_URLS = {
+	minimax: {
+		v2: "https://api.minimax.io/v2/video_generation",
+		v1: "https://api.minimax.io/v1/video_generation",
+	},
+	"minimax-cn": {
+		v2: "https://api.minimaxi.com/v2/video_generation",
+		v1: "https://api.minimaxi.com/v1/video_generation",
+	},
+} as const;
+
+export interface MiniMaxVideosOptions extends VideosOptions {
+	[key: string]: unknown;
+}
+
+type MiniMaxVideoPayload = Record<string, unknown>;
+
+interface MiniMaxVideoResponse {
+	task_id?: unknown;
+	status?: unknown;
+	file_id?: unknown;
+	file?: { download_url?: unknown; url?: unknown };
+	task?: {
+		id?: unknown;
+		model?: unknown;
+		status?: unknown;
+		error?: unknown;
+		content?: { url?: unknown };
+	};
+	base_resp?: {
+		status_code?: unknown;
+		status_msg?: unknown;
+	};
+}
+
+class MiniMaxVideoHttpError extends Error {
+	readonly status: number;
+	readonly headers: Headers;
+	readonly body: string;
+
+	constructor(response: Response, body: string) {
+		const detail = body.trim();
+		super(
+			`MiniMax video request failed with HTTP ${response.status}${detail ? `: ${truncateErrorText(detail, 4000)}` : ""}`,
+		);
+		this.name = "MiniMaxVideoHttpError";
+		this.status = response.status;
+		this.headers = response.headers;
+		this.body = detail;
+	}
+}
+
+export const generateVideos: VideosFunction<"minimax-videos", MiniMaxVideosOptions> = async (
+	model: VideosModel<"minimax-videos">,
+	context: VideosContext,
+	options?: MiniMaxVideosOptions,
+) =>
+	withVideoErrors(model, options, async (output) => {
+		const apiKey = requireApiKey(model, options);
+		let payload =
+			model.apiVersion === "v2" ? buildV2CreatePayload(model, context) : buildV1CreatePayload(model, context);
+		const nextPayload = await options?.onPayload?.(payload, model);
+		if (nextPayload !== undefined) payload = nextPayload as MiniMaxVideoPayload;
+		const response = await requestJson(model, model.baseUrl, "POST", apiKey, payload, options);
+		applyResponse(output, response.body);
+		return output;
+	});
+
+export async function queryVideoGeneration(
+	model: VideosModel<"minimax-videos">,
+	taskId: string,
+	options?: MiniMaxVideosOptions,
+): Promise<AssistantVideos> {
+	return withVideoErrors(model, options, async (output) => {
+		const apiKey = requireApiKey(model, options);
+		const url =
+			model.apiVersion === "v2"
+				? `${model.baseUrl.replace(/\/video_generation$/, "/query/video_generation")}/${encodeURIComponent(taskId)}`
+				: `${model.baseUrl.replace(/\/video_generation$/, "/query/video_generation")}?task_id=${encodeURIComponent(taskId)}`;
+		const response = await requestJson(model, url, "GET", apiKey, undefined, options);
+		applyResponse(output, response.body);
+		if (!output.taskId) output.taskId = taskId;
+		return output;
+	});
+}
+
+export async function downloadVideo(
+	model: VideosModel<"minimax-videos">,
+	fileId: string,
+	options?: MiniMaxVideosOptions,
+): Promise<AssistantVideos> {
+	return withVideoErrors(model, options, async (output) => {
+		if (model.apiVersion !== "v1") throw new Error("MiniMax video download is available for v1 file IDs");
+		const apiKey = requireApiKey(model, options);
+		const url = `${model.baseUrl.replace(/\/video_generation$/, "/files/retrieve")}?file_id=${encodeURIComponent(fileId)}`;
+		const response = await requestJson(model, url, "GET", apiKey, undefined, options);
+		applyResponse(output, response.body);
+		output.fileId = output.fileId ?? fileId;
+		return output;
+	});
+}
+
+function buildV2CreatePayload(model: VideosModel<"minimax-videos">, context: VideosContext): MiniMaxVideoPayload {
+	const content = buildV2Content(context);
+	if (!content.some((item) => item.type === "text")) throw new Error("MiniMax video generation requires text content");
+	const duration = context.duration ?? model.durationSeconds.min;
+	assertDuration(model, duration);
+	const resolution = context.resolution ?? model.resolutions[0];
+	assertIncludes(model.resolutions, resolution, "resolution");
+	const payload: MiniMaxVideoPayload = {
+		model: model.id,
+		content,
+		resolution,
+		duration,
+	};
+	if (context.ratio !== undefined) payload.ratio = context.ratio;
+	if (context.callbackUrl !== undefined) payload.callback_url = context.callbackUrl;
+	if (model.provider === "minimax-cn" && context.aigcWatermark !== undefined)
+		payload.aigc_watermark = context.aigcWatermark;
+	return payload;
+}
+
+function buildV2Content(context: VideosContext): Array<Record<string, unknown>> {
+	const items: Array<Record<string, unknown>> = [];
+	if (context.prompt !== undefined) items.push({ type: "text", text: sanitizeSurrogates(context.prompt) });
+	for (const item of context.input ?? []) {
+		if (item.type === "text") {
+			items.push({ type: "text", text: sanitizeSurrogates(item.text) });
+		} else if (item.type === "image") {
+			items.push({ type: "image_url", image_url: `data:${item.mimeType};base64,${item.data}` });
+		} else {
+			items.push(contentAsset(item));
+		}
+	}
+	return items;
+}
+
+function contentAsset(item: VideoGenerationAsset): Record<string, unknown> {
+	const field = item.type;
+	return {
+		type: item.type,
+		[field]: item.url,
+		...(item.role ? { role: item.role } : {}),
+	};
+}
+
+function buildV1CreatePayload(model: VideosModel<"minimax-videos">, context: VideosContext): MiniMaxVideoPayload {
+	const payload: MiniMaxVideoPayload = { model: model.id };
+	if (context.prompt !== undefined) payload.prompt = sanitizeSurrogates(context.prompt);
+	const firstImage = context.firstFrameImage ?? firstImageFromInput(context);
+	if (firstImage !== undefined) payload.first_frame_image = firstImage;
+	if (!payload.prompt && !payload.first_frame_image)
+		throw new Error("MiniMax video generation requires prompt or first frame");
+	if (context.promptOptimizer !== undefined) payload.prompt_optimizer = context.promptOptimizer;
+	if (context.fastPretreatment !== undefined) payload.fast_pretreatment = context.fastPretreatment;
+	if (context.duration !== undefined) payload.duration = context.duration;
+	if (context.resolution !== undefined) payload.resolution = context.resolution;
+	if (context.callbackUrl !== undefined) payload.callback_url = context.callbackUrl;
+	return payload;
+}
+
+function firstImageFromInput(context: VideosContext): string | undefined {
+	for (const item of context.input ?? []) {
+		if (item.type === "image") return `data:${item.mimeType};base64,${item.data}`;
+		if (item.type === "image_url") return item.url;
+	}
+	return undefined;
+}
+
+async function requestJson(
+	model: VideosModel<"minimax-videos">,
+	url: string,
+	method: "GET" | "POST" | "DELETE",
+	apiKey: string,
+	payload: MiniMaxVideoPayload | undefined,
+	options?: MiniMaxVideosOptions,
+): Promise<{ response: ProviderResponse; body: MiniMaxVideoResponse }> {
+	const combinedSignal = combineAbortSignals([
+		options?.signal,
+		options?.timeoutMs !== undefined && options.timeoutMs > 0 ? AbortSignal.timeout(options.timeoutMs) : undefined,
+	]);
+	try {
+		const response = await retryProviderRequest(
+			() => fetchJson(url, method, apiKey, model.headers, options, payload, combinedSignal.signal),
+			{ maxRetries: options?.maxRetries, maxRetryDelayMs: options?.maxRetryDelayMs, signal: combinedSignal.signal },
+		);
+		await options?.onResponse?.(response.response, model);
+		return response;
+	} finally {
+		combinedSignal.cleanup();
+	}
+}
+
+async function fetchJson(
+	url: string,
+	method: "GET" | "POST" | "DELETE",
+	apiKey: string,
+	modelHeaders: ProviderHeaders | undefined,
+	options: MiniMaxVideosOptions | undefined,
+	payload: MiniMaxVideoPayload | undefined,
+	signal: AbortSignal | undefined,
+): Promise<{ response: ProviderResponse; body: MiniMaxVideoResponse }> {
+	const fetcher = options?.fetch ?? globalThis.fetch;
+	const response = await fetcher(url, {
+		method,
+		headers: {
+			authorization: `Bearer ${apiKey}`,
+			...(payload !== undefined ? { "content-type": "application/json" } : {}),
+			...providerHeadersToRecord({ ...modelHeaders, ...options?.headers }),
+		},
+		...(payload !== undefined ? { body: JSON.stringify(payload) } : {}),
+		signal,
+	});
+	const bodyText = await response.text();
+	if (!response.ok) throw new MiniMaxVideoHttpError(response, bodyText);
+	return {
+		response: { status: response.status, headers: Object.fromEntries(response.headers.entries()) },
+		body: parseResponse(bodyText),
+	};
+}
+
+function applyResponse(output: AssistantVideos, response: MiniMaxVideoResponse): void {
+	const statusCode = response.base_resp?.status_code;
+	if (statusCode !== undefined && statusCode !== 0) {
+		const message =
+			typeof response.base_resp?.status_msg === "string" ? response.base_resp.status_msg : "unknown error";
+		throw new Error(`MiniMax video API error (${String(statusCode)}): ${message}`);
+	}
+	const taskId = stringValue(response.task_id) ?? stringValue(response.task?.id);
+	if (taskId) {
+		output.taskId = taskId;
+		output.responseId = taskId;
+	}
+	const fileId = stringValue(response.file_id);
+	if (fileId) output.fileId = fileId;
+	const status = normalizeStatus(response.task?.status ?? response.status);
+	if (status) {
+		output.status = status;
+		output.stopReason = status === "completed" ? "stop" : status === "in_progress" ? "in_progress" : "error";
+	}
+	const error = response.task?.error;
+	if (typeof error === "string" && error.length > 0) output.errorMessage = error;
+	const url =
+		stringValue(response.task?.content?.url) ??
+		stringValue(response.file?.download_url) ??
+		stringValue(response.file?.url);
+	if (url) output.output.push({ type: "video", url });
+}
+
+async function withVideoErrors(
+	model: VideosModel<"minimax-videos">,
+	options: MiniMaxVideosOptions | undefined,
+	fn: (output: AssistantVideos) => Promise<AssistantVideos>,
+): Promise<AssistantVideos> {
+	const output: AssistantVideos = {
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		output: [],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+	try {
+		return await fn(output);
+	} catch (error) {
+		output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+		output.errorMessage = formatProviderError(normalizeProviderError(error));
+		return output;
+	}
+}
+
+function requireApiKey(model: VideosModel<"minimax-videos">, options?: MiniMaxVideosOptions): string {
+	const apiKey = options?.apiKey;
+	if (!apiKey) throw new Error(`No API key for provider: ${model.provider}`);
+	return apiKey;
+}
+
+function parseResponse(bodyText: string): MiniMaxVideoResponse {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(bodyText);
+	} catch (error) {
+		throw new Error(
+			`MiniMax video response was not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new Error("MiniMax video response was not an object");
+	}
+	return parsed as MiniMaxVideoResponse;
+}
+
+function normalizeStatus(status: unknown): AssistantVideos["status"] | undefined {
+	if (typeof status !== "string") return undefined;
+	const value = status.toLowerCase();
+	if (["success", "completed", "complete"].includes(value)) return "completed";
+	if (["processing", "queueing", "preparing", "running", "in_progress", "pending"].includes(value))
+		return "in_progress";
+	if (["failed", "fail", "error"].includes(value)) return "failed";
+	if (value === "deleted") return "deleted";
+	return undefined;
+}
+
+function assertIncludes(values: readonly string[], value: string, label: string): void {
+	if (!values.includes(value)) throw new Error(`Unsupported MiniMax video ${label}: ${value}`);
+}
+
+function assertDuration(model: VideosModel<"minimax-videos">, duration: number): void {
+	const { min, max, integer } = model.durationSeconds;
+	if (duration < min || duration > max || (integer && !Number.isInteger(duration))) {
+		throw new Error(`Unsupported MiniMax video duration: ${duration}`);
+	}
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -45,3 +45,4 @@ export { contentText } from "./utils/text.ts";
 export * from "./utils/typebox-helpers.ts";
 export { uuidv7 } from "./utils/uuid.ts";
 export * from "./utils/validation.ts";
+export * from "./videos-models.ts";

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -2,6 +2,7 @@ import { createImagesModels, type ImagesProvider, type MutableImagesModels } fro
 import { MODELS } from "../models.generated.ts";
 import { type CreateModelsOptions, createModels, type MutableModels, type Provider } from "../models.ts";
 import type { Api, Model } from "../types.ts";
+import { createVideosModels, type MutableVideosModels, type VideosProvider } from "../videos-models.ts";
 import { amazonBedrockProvider } from "./amazon-bedrock.ts";
 import { antLingProvider } from "./ant-ling.ts";
 import { anthropicProvider } from "./anthropic.ts";
@@ -20,6 +21,8 @@ import { huggingfaceProvider } from "./huggingface.ts";
 import { kimiCodingProvider } from "./kimi-coding.ts";
 import { minimaxProvider } from "./minimax.ts";
 import { minimaxCnProvider } from "./minimax-cn.ts";
+import { minimaxCnVideosProvider } from "./minimax-cn-videos.ts";
+import { minimaxVideosProvider } from "./minimax-videos.ts";
 import { mistralProvider } from "./mistral.ts";
 import { moonshotaiProvider } from "./moonshotai.ts";
 import { moonshotaiCnProvider } from "./moonshotai-cn.ts";
@@ -145,6 +148,20 @@ export function builtinImagesProviders(): ImagesProvider[] {
 export function builtinImagesModels(options?: CreateModelsOptions): MutableImagesModels {
 	const models = createImagesModels(options);
 	for (const provider of builtinImagesProviders()) {
+		models.setProvider(provider);
+	}
+	return models;
+}
+
+/** All built-in video-generation providers, freshly constructed. */
+export function builtinVideosProviders(): VideosProvider[] {
+	return [minimaxVideosProvider(), minimaxCnVideosProvider()];
+}
+
+/** A VideosModels collection with every built-in video-generation provider registered. */
+export function builtinVideosModels(options?: CreateModelsOptions): MutableVideosModels {
+	const models = createVideosModels(options);
+	for (const provider of builtinVideosProviders()) {
 		models.setProvider(provider);
 	}
 	return models;

--- a/packages/ai/src/providers/minimax-cn-videos.ts
+++ b/packages/ai/src/providers/minimax-cn-videos.ts
@@ -1,0 +1,16 @@
+import { minimaxVideosApi } from "../api/minimax-videos.lazy.ts";
+import { envApiKeyAuth } from "../auth/helpers.ts";
+import { createVideosProvider, type VideosProvider } from "../videos-models.ts";
+import { createMiniMaxVideoModels } from "./minimax-videos.ts";
+
+export function minimaxCnVideosProvider(): VideosProvider {
+	return createVideosProvider({
+		id: "minimax-cn",
+		name: "MiniMax CN",
+		auth: {
+			apiKey: envApiKeyAuth("MiniMax API key", ["MINIMAX_API_KEY"]),
+		},
+		models: createMiniMaxVideoModels("minimax-cn", "CNY"),
+		api: minimaxVideosApi(),
+	});
+}

--- a/packages/ai/src/providers/minimax-videos.ts
+++ b/packages/ai/src/providers/minimax-videos.ts
@@ -1,0 +1,55 @@
+import { minimaxVideosApi } from "../api/minimax-videos.lazy.ts";
+import { MINIMAX_VIDEO_BASE_URLS, MINIMAX_VIDEO_MODELS } from "../api/minimax-videos.ts";
+import { envApiKeyAuth } from "../auth/helpers.ts";
+import type { VideosModel } from "../types.ts";
+import { createVideosProvider, type VideosProvider } from "../videos-models.ts";
+
+export function minimaxVideosProvider(): VideosProvider {
+	return createMiniMaxVideosProvider("minimax", "MiniMax", "USD");
+}
+
+function createMiniMaxVideosProvider(provider: "minimax", name: string, currency: "USD" | "CNY"): VideosProvider {
+	return createVideosProvider({
+		id: provider,
+		name,
+		auth: {
+			apiKey: envApiKeyAuth("MiniMax API key", ["MINIMAX_API_KEY"]),
+		},
+		models: createMiniMaxVideoModels(provider, currency),
+		api: minimaxVideosApi(),
+	});
+}
+
+export function createMiniMaxVideoModels(provider: "minimax" | "minimax-cn", currency: "USD" | "CNY") {
+	const pricing =
+		currency === "USD"
+			? { outputVideo: 0.13, inputReferenceVideo: 0.02, inputReferenceAudio: 0, additionalReferenceImage: 0.03 }
+			: { outputVideo: 0.8, inputReferenceVideo: 0.8, inputReferenceAudio: 0, additionalReferenceImage: 0.2 };
+	const v2Models: VideosModel<"minimax-videos">[] = MINIMAX_VIDEO_MODELS.v2.map((id) => ({
+		id,
+		name: id,
+		api: "minimax-videos",
+		provider,
+		baseUrl: MINIMAX_VIDEO_BASE_URLS[provider].v2,
+		apiVersion: "v2",
+		input: ["text", "image", "video", "audio"],
+		output: ["video", "audio"],
+		resolutions: ["2K"],
+		durationSeconds: { min: 4, max: 15, integer: true },
+		cost: pricing,
+	}));
+	const v1Models: VideosModel<"minimax-videos">[] = MINIMAX_VIDEO_MODELS.v1.map((id) => ({
+		id,
+		name: id,
+		api: "minimax-videos",
+		provider,
+		baseUrl: MINIMAX_VIDEO_BASE_URLS[provider].v1,
+		apiVersion: "v1",
+		input: ["text", "image"],
+		output: ["video"],
+		resolutions: ["768P", "1080P"],
+		durationSeconds: { min: 1, max: 10, integer: true },
+		cost: pricing,
+	}));
+	return [...v2Models, ...v1Models];
+}

--- a/packages/ai/src/providers/videos/register-builtins.ts
+++ b/packages/ai/src/providers/videos/register-builtins.ts
@@ -1,0 +1,10 @@
+import { minimaxVideosApi } from "../../api/minimax-videos.lazy.ts";
+import { registerVideosApiProvider } from "../../videos-api-registry.ts";
+
+registerVideosApiProvider(
+	{
+		api: "minimax-videos",
+		...minimaxVideosApi(),
+	},
+	"minimax-videos",
+);

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -31,6 +31,10 @@ export type KnownImagesApi = "openrouter-images";
 
 export type ImagesApi = KnownImagesApi | (string & {});
 
+export type KnownVideosApi = "minimax-videos";
+
+export type VideosApi = KnownVideosApi | (string & {});
+
 export type KnownProvider =
 	| "amazon-bedrock"
 	| "ant-ling"
@@ -75,6 +79,10 @@ export type ProviderId = KnownProvider | string;
 export type KnownImagesProvider = "openrouter";
 
 export type ImagesProviderId = KnownImagesProvider | string;
+
+export type KnownVideosProvider = "minimax" | "minimax-cn";
+
+export type VideosProviderId = KnownVideosProvider | string;
 
 export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 export type ModelThinkingLevel = "off" | ThinkingLevel;
@@ -252,6 +260,20 @@ export interface ProviderImages {
 	): Promise<AssistantImages>;
 }
 
+export interface ProviderVideos {
+	generateVideos(
+		model: VideosModel<VideosApi>,
+		context: VideosContext,
+		options?: VideosOptions,
+	): Promise<AssistantVideos>;
+	queryVideoGeneration?(
+		model: VideosModel<VideosApi>,
+		taskId: string,
+		options?: VideosOptions,
+	): Promise<AssistantVideos>;
+	downloadVideo?(model: VideosModel<VideosApi>, fileId: string, options?: VideosOptions): Promise<AssistantVideos>;
+}
+
 export interface ImagesOptions {
 	signal?: AbortSignal;
 	apiKey?: string;
@@ -302,6 +324,22 @@ export interface ImagesOptions {
 
 export type ProviderImagesOptions = ImagesOptions & Record<string, unknown>;
 
+export interface VideosOptions {
+	signal?: AbortSignal;
+	apiKey?: string;
+	fetch?: FetchFunction;
+	env?: ProviderEnv;
+	onPayload?: (payload: unknown, model: VideosModel<VideosApi>) => unknown | undefined | Promise<unknown | undefined>;
+	onResponse?: (response: ProviderResponse, model: VideosModel<VideosApi>) => void | Promise<void>;
+	headers?: ProviderHeaders;
+	timeoutMs?: number;
+	maxRetries?: number;
+	maxRetryDelayMs?: number;
+	metadata?: Record<string, unknown>;
+}
+
+export type ProviderVideosOptions = VideosOptions & Record<string, unknown>;
+
 // Unified options with reasoning passed to streamSimple() and completeSimple()
 export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ThinkingLevel;
@@ -329,6 +367,12 @@ export type ImagesFunction<TApi extends ImagesApi = ImagesApi, TOptions extends 
 	options?: TOptions,
 ) => Promise<AssistantImages>;
 
+export type VideosFunction<TApi extends VideosApi = VideosApi, TOptions extends VideosOptions = VideosOptions> = (
+	model: VideosModel<TApi>,
+	context: VideosContext,
+	options?: TOptions,
+) => Promise<AssistantVideos>;
+
 export interface TextSignatureV1 {
 	v: 1;
 	id: string;
@@ -355,6 +399,11 @@ export interface ImageContent {
 	type: "image";
 	data: string; // base64 encoded image data
 	mimeType: string; // e.g., "image/jpeg", "image/png"
+}
+
+export interface VideoContent {
+	type: "video";
+	url: string;
 }
 
 export interface ToolCall {
@@ -435,11 +484,43 @@ export type Message = UserMessage | AssistantMessage | ToolResultMessage;
 export type ImagesInputContent = TextContent | ImageContent;
 export type ImagesOutputContent = TextContent | ImageContent;
 
+export type VideoGenerationContentRole =
+	| "first_frame"
+	| "last_frame"
+	| "reference_image"
+	| "reference_video"
+	| "reference_audio";
+
+export interface VideoGenerationAsset {
+	type: "image_url" | "video_url" | "audio_url";
+	url: string;
+	role?: VideoGenerationContentRole;
+}
+
+export type VideosInputContent = TextContent | ImageContent | VideoGenerationAsset;
+export type VideosOutputContent = TextContent | VideoContent;
+
 export interface ImagesContext {
 	input: ImagesInputContent[];
 }
 
+export interface VideosContext {
+	prompt?: string;
+	input?: VideosInputContent[];
+	firstFrameImage?: string;
+	promptOptimizer?: boolean;
+	fastPretreatment?: boolean;
+	resolution?: "2K" | (string & {});
+	duration?: number;
+	ratio?: "adaptive" | "21:9" | "16:9" | "4:3" | "1:1" | "3:4" | "9:16" | (string & {});
+	callbackUrl?: string;
+	aigcWatermark?: boolean;
+}
+
 export type ImagesStopReason = "stop" | "error" | "aborted";
+
+export type VideosStopReason = ImagesStopReason | "in_progress";
+export type VideoGenerationStatus = "in_progress" | "completed" | "failed" | "deleted";
 
 export interface AssistantImages {
 	api: ImagesApi;
@@ -449,6 +530,20 @@ export interface AssistantImages {
 	responseId?: string;
 	usage?: Usage;
 	stopReason: ImagesStopReason;
+	errorMessage?: string;
+	timestamp: number; // Unix timestamp in milliseconds
+}
+
+export interface AssistantVideos {
+	api: VideosApi;
+	provider: VideosProviderId;
+	model: string;
+	output: VideosOutputContent[];
+	responseId?: string;
+	taskId?: string;
+	fileId?: string;
+	status?: VideoGenerationStatus;
+	stopReason: VideosStopReason;
 	errorMessage?: string;
 	timestamp: number; // Unix timestamp in milliseconds
 }
@@ -792,4 +887,24 @@ export interface ImagesModel<TApi extends ImagesApi>
 	api: TApi;
 	provider: ImagesProviderId;
 	output: ("text" | "image")[];
+}
+
+export interface VideosModel<TApi extends VideosApi> {
+	id: string;
+	name: string;
+	api: TApi;
+	provider: VideosProviderId;
+	baseUrl: string;
+	apiVersion: "v1" | "v2";
+	input: ("text" | "image" | "video" | "audio")[];
+	output: ("video" | "audio")[];
+	resolutions: string[];
+	durationSeconds: { min: number; max: number; integer: boolean };
+	cost: {
+		outputVideo: number;
+		inputReferenceVideo: number;
+		inputReferenceAudio: number;
+		additionalReferenceImage: number;
+	};
+	headers?: Record<string, string>;
 }

--- a/packages/ai/src/videos-api-registry.ts
+++ b/packages/ai/src/videos-api-registry.ts
@@ -1,0 +1,75 @@
+import type { AssistantVideos, VideosApi, VideosContext, VideosFunction, VideosModel, VideosOptions } from "./types.ts";
+
+export type VideosApiFunction = (
+	model: VideosModel<VideosApi>,
+	context: VideosContext,
+	options?: VideosOptions,
+) => Promise<AssistantVideos>;
+
+export type VideoTaskApiFunction = (
+	model: VideosModel<VideosApi>,
+	taskOrFileId: string,
+	options?: VideosOptions,
+) => Promise<AssistantVideos>;
+
+export interface VideosApiProvider<TApi extends VideosApi = VideosApi, TOptions extends VideosOptions = VideosOptions> {
+	api: TApi;
+	generateVideos: VideosFunction<TApi, TOptions>;
+	queryVideoGeneration?: (model: VideosModel<TApi>, taskId: string, options?: TOptions) => Promise<AssistantVideos>;
+	downloadVideo?: (model: VideosModel<TApi>, fileId: string, options?: TOptions) => Promise<AssistantVideos>;
+}
+
+interface VideosApiProviderInternal {
+	api: VideosApi;
+	generateVideos: VideosApiFunction;
+	queryVideoGeneration?: VideoTaskApiFunction;
+	downloadVideo?: VideoTaskApiFunction;
+}
+
+type RegisteredVideosApiProvider = {
+	provider: VideosApiProviderInternal;
+	sourceId?: string;
+};
+
+const videosApiProviderRegistry = new Map<string, RegisteredVideosApiProvider>();
+
+function wrapGenerateVideos<TApi extends VideosApi, TOptions extends VideosOptions>(
+	api: TApi,
+	generateVideos: VideosFunction<TApi, TOptions>,
+): VideosApiFunction {
+	return (model, context, options) => {
+		if (model.api !== api) throw new Error(`Mismatched api: ${model.api} expected ${api}`);
+		return generateVideos(model as VideosModel<TApi>, context, options as TOptions);
+	};
+}
+
+function wrapVideoTask<TApi extends VideosApi, TOptions extends VideosOptions>(
+	api: TApi,
+	fn: (model: VideosModel<TApi>, id: string, options?: TOptions) => Promise<AssistantVideos>,
+): VideoTaskApiFunction {
+	return (model, id, options) => {
+		if (model.api !== api) throw new Error(`Mismatched api: ${model.api} expected ${api}`);
+		return fn(model as VideosModel<TApi>, id, options as TOptions);
+	};
+}
+
+export function registerVideosApiProvider<TApi extends VideosApi, TOptions extends VideosOptions>(
+	provider: VideosApiProvider<TApi, TOptions>,
+	sourceId?: string,
+): void {
+	videosApiProviderRegistry.set(provider.api, {
+		provider: {
+			api: provider.api,
+			generateVideos: wrapGenerateVideos(provider.api, provider.generateVideos),
+			queryVideoGeneration: provider.queryVideoGeneration
+				? wrapVideoTask(provider.api, provider.queryVideoGeneration)
+				: undefined,
+			downloadVideo: provider.downloadVideo ? wrapVideoTask(provider.api, provider.downloadVideo) : undefined,
+		},
+		sourceId,
+	});
+}
+
+export function getVideosApiProvider(api: VideosApi): VideosApiProviderInternal | undefined {
+	return videosApiProviderRegistry.get(api)?.provider;
+}

--- a/packages/ai/src/videos-models.ts
+++ b/packages/ai/src/videos-models.ts
@@ -1,0 +1,197 @@
+import { defaultProviderAuthContext as defaultAuthContext } from "./auth/context.ts";
+import { InMemoryCredentialStore } from "./auth/credential-store.ts";
+import { type AuthResolutionOverrides, ModelsError, resolveProviderAuth } from "./auth/resolve.ts";
+import type { AuthContext, AuthResult, CredentialStore, ProviderAuth } from "./auth/types.ts";
+import type { CreateModelsOptions } from "./models.ts";
+import type { AssistantVideos, ProviderVideos, VideosApi, VideosContext, VideosModel, VideosOptions } from "./types.ts";
+
+export interface VideosProvider {
+	readonly id: string;
+	readonly name: string;
+	readonly auth: ProviderAuth;
+	getModels(): readonly VideosModel<VideosApi>[];
+	refreshModels?(): Promise<void>;
+	generateVideos(
+		model: VideosModel<VideosApi>,
+		context: VideosContext,
+		options?: VideosOptions,
+	): Promise<AssistantVideos>;
+	queryVideoGeneration?(
+		model: VideosModel<VideosApi>,
+		taskId: string,
+		options?: VideosOptions,
+	): Promise<AssistantVideos>;
+	downloadVideo?(model: VideosModel<VideosApi>, fileId: string, options?: VideosOptions): Promise<AssistantVideos>;
+}
+
+export interface VideosModels {
+	getProviders(): readonly VideosProvider[];
+	getProvider(id: string): VideosProvider | undefined;
+	getModels(provider?: string): readonly VideosModel<VideosApi>[];
+	getModel(provider: string, id: string): VideosModel<VideosApi> | undefined;
+	refresh(provider?: string): Promise<void>;
+	getAuth(providerId: string, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	getAuth(model: VideosModel<VideosApi>, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	generateVideos(
+		model: VideosModel<VideosApi>,
+		context: VideosContext,
+		options?: VideosOptions,
+	): Promise<AssistantVideos>;
+}
+
+export interface MutableVideosModels extends VideosModels {
+	setProvider(provider: VideosProvider): void;
+	deleteProvider(id: string): void;
+	clearProviders(): void;
+}
+
+class VideosModelsImpl implements MutableVideosModels {
+	private providers = new Map<string, VideosProvider>();
+	private credentials: CredentialStore;
+	private authContext: AuthContext;
+
+	constructor(options?: CreateModelsOptions) {
+		this.credentials = options?.credentials ?? new InMemoryCredentialStore();
+		this.authContext = options?.authContext ?? defaultAuthContext();
+	}
+
+	setProvider(provider: VideosProvider): void {
+		this.providers.set(provider.id, provider);
+	}
+
+	deleteProvider(id: string): void {
+		this.providers.delete(id);
+	}
+
+	clearProviders(): void {
+		this.providers.clear();
+	}
+
+	getProviders(): readonly VideosProvider[] {
+		return Array.from(this.providers.values());
+	}
+
+	getProvider(id: string): VideosProvider | undefined {
+		return this.providers.get(id);
+	}
+
+	getModels(provider?: string): readonly VideosModel<VideosApi>[] {
+		const entries = provider !== undefined ? [this.providers.get(provider)] : Array.from(this.providers.values());
+		const models: VideosModel<VideosApi>[] = [];
+		for (const entry of entries) {
+			if (!entry) continue;
+			try {
+				models.push(...entry.getModels());
+			} catch {
+				// Best-effort: ill-behaved providers yield no models.
+			}
+		}
+		return models;
+	}
+
+	getModel(provider: string, id: string): VideosModel<VideosApi> | undefined {
+		return this.getModels(provider).find((model) => model.id === id);
+	}
+
+	async refresh(provider?: string): Promise<void> {
+		if (provider !== undefined) {
+			const entry = this.providers.get(provider);
+			if (!entry?.refreshModels) return;
+			try {
+				await entry.refreshModels();
+			} catch (error) {
+				if (error instanceof ModelsError) throw error;
+				throw new ModelsError("model_source", `Model refresh failed for ${provider}`, { cause: error });
+			}
+			return;
+		}
+		await Promise.allSettled(Array.from(this.providers.values(), async (entry) => entry.refreshModels?.()));
+	}
+
+	getAuth(providerId: string, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	getAuth(model: VideosModel<VideosApi>, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	async getAuth(
+		providerOrModel: string | VideosModel<VideosApi>,
+		overrides?: AuthResolutionOverrides,
+	): Promise<AuthResult | undefined> {
+		const providerId = typeof providerOrModel === "string" ? providerOrModel : providerOrModel.provider;
+		const provider = this.providers.get(providerId);
+		if (!provider) return undefined;
+		return resolveProviderAuth(provider, this.credentials, this.authContext, overrides);
+	}
+
+	async generateVideos(
+		model: VideosModel<VideosApi>,
+		context: VideosContext,
+		options?: VideosOptions,
+	): Promise<AssistantVideos> {
+		try {
+			const provider = this.providers.get(model.provider);
+			if (!provider) throw new ModelsError("provider", `Unknown provider: ${model.provider}`);
+			const resolution = await this.getAuth(model, { apiKey: options?.apiKey, env: options?.env });
+			const auth = resolution?.auth;
+			if (!auth) return provider.generateVideos(model, context, options);
+			const requestModel = auth.baseUrl ? { ...model, baseUrl: auth.baseUrl } : model;
+			const apiKey = options?.apiKey ?? auth.apiKey;
+			const headers = auth.headers || options?.headers ? { ...auth.headers, ...options?.headers } : undefined;
+			const env =
+				resolution.env || options?.env ? { ...(resolution.env ?? {}), ...(options?.env ?? {}) } : undefined;
+			return await provider.generateVideos(requestModel, context, { ...options, apiKey, headers, env });
+		} catch (error) {
+			return {
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				output: [],
+				stopReason: "error",
+				errorMessage: error instanceof Error ? error.message : String(error),
+				timestamp: Date.now(),
+			};
+		}
+	}
+}
+
+export function createVideosModels(options?: CreateModelsOptions): MutableVideosModels {
+	return new VideosModelsImpl(options);
+}
+
+export interface CreateVideosProviderOptions {
+	id: string;
+	name?: string;
+	auth: ProviderAuth;
+	models: readonly VideosModel<VideosApi>[];
+	refreshModels?: () => Promise<readonly VideosModel<VideosApi>[]>;
+	api: ProviderVideos;
+}
+
+export function createVideosProvider(input: CreateVideosProviderOptions): VideosProvider {
+	let models = input.models;
+	let inflightRefresh: Promise<void> | undefined;
+	const refreshModels = input.refreshModels;
+	return {
+		id: input.id,
+		name: input.name ?? input.id,
+		auth: input.auth,
+		getModels: () => models,
+		refreshModels: refreshModels
+			? () => {
+					inflightRefresh ??= (async () => {
+						try {
+							models = await refreshModels();
+						} finally {
+							inflightRefresh = undefined;
+						}
+					})();
+					return inflightRefresh;
+				}
+			: undefined,
+		generateVideos: (model, context, options) => input.api.generateVideos(model, context, options),
+		queryVideoGeneration: input.api.queryVideoGeneration
+			? (model, taskId, options) =>
+					input.api.queryVideoGeneration?.(model, taskId, options) as Promise<AssistantVideos>
+			: undefined,
+		downloadVideo: input.api.downloadVideo
+			? (model, fileId, options) => input.api.downloadVideo?.(model, fileId, options) as Promise<AssistantVideos>
+			: undefined,
+	};
+}

--- a/packages/ai/src/videos.ts
+++ b/packages/ai/src/videos.ts
@@ -1,0 +1,38 @@
+import "./providers/videos/register-builtins.ts";
+
+import type { AssistantVideos, ProviderVideosOptions, VideosApi, VideosContext, VideosModel } from "./types.ts";
+import { getVideosApiProvider } from "./videos-api-registry.ts";
+
+function resolveVideosApiProvider(api: VideosApi) {
+	const provider = getVideosApiProvider(api);
+	if (!provider) throw new Error(`No API provider registered for api: ${api}`);
+	return provider;
+}
+
+export async function generateVideos<TApi extends VideosApi>(
+	model: VideosModel<TApi>,
+	context: VideosContext,
+	options?: ProviderVideosOptions,
+): Promise<AssistantVideos> {
+	return resolveVideosApiProvider(model.api).generateVideos(model, context, options);
+}
+
+export async function queryVideoGeneration<TApi extends VideosApi>(
+	model: VideosModel<TApi>,
+	taskId: string,
+	options?: ProviderVideosOptions,
+): Promise<AssistantVideos> {
+	const query = resolveVideosApiProvider(model.api).queryVideoGeneration;
+	if (!query) throw new Error(`No video query provider registered for api: ${model.api}`);
+	return query(model, taskId, options);
+}
+
+export async function downloadVideo<TApi extends VideosApi>(
+	model: VideosModel<TApi>,
+	fileId: string,
+	options?: ProviderVideosOptions,
+): Promise<AssistantVideos> {
+	const download = resolveVideosApiProvider(model.api).downloadVideo;
+	if (!download) throw new Error(`No video download provider registered for api: ${model.api}`);
+	return download(model, fileId, options);
+}

--- a/packages/ai/test/minimax-videos.test.ts
+++ b/packages/ai/test/minimax-videos.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import type { VideosContext, VideosModel } from "../src/types.ts";
+import { downloadVideo, generateVideos, queryVideoGeneration } from "../src/videos.ts";
+
+function testModel(input: Partial<VideosModel<"minimax-videos">> = {}): VideosModel<"minimax-videos"> {
+	return {
+		id: "MiniMax-H3",
+		name: "MiniMax-H3",
+		api: "minimax-videos",
+		provider: "minimax",
+		baseUrl: "https://api.minimax.io/v2/video_generation",
+		apiVersion: "v2",
+		input: ["text", "image", "video", "audio"],
+		output: ["video", "audio"],
+		resolutions: ["2K"],
+		durationSeconds: { min: 4, max: 15, integer: true },
+		cost: { outputVideo: 0.13, inputReferenceVideo: 0.02, inputReferenceAudio: 0, additionalReferenceImage: 0.03 },
+		...input,
+	};
+}
+
+function jsonResponse(body: unknown): Response {
+	return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("MiniMax videos", () => {
+	it("creates a v2 video task with content, duration, ratio, and CN regional fields", async () => {
+		const calls: Array<{ url: string; init: RequestInit; body: Record<string, unknown> }> = [];
+		const fetch = async (url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+			calls.push({
+				url: String(url),
+				init: init ?? {},
+				body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+			});
+			return jsonResponse({ task_id: "task-1", base_resp: { status_code: 0 } });
+		};
+		const model = testModel({
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/v2/video_generation",
+		});
+		const context: VideosContext = {
+			prompt: "Generate a short launch clip",
+			input: [
+				{ type: "image_url", url: "https://example.test/first.png", role: "first_frame" },
+				{ type: "audio_url", url: "https://example.test/ref.mp3", role: "reference_audio" },
+			],
+			resolution: "2K",
+			duration: 6,
+			ratio: "16:9",
+			callbackUrl: "https://example.test/callback",
+			aigcWatermark: true,
+		};
+
+		const output = await generateVideos(model, context, { apiKey: "test", fetch });
+
+		expect(output).toMatchObject({ stopReason: "stop", taskId: "task-1", responseId: "task-1" });
+		expect(calls[0].url).toBe("https://api.minimaxi.com/v2/video_generation");
+		expect(calls[0].init.method).toBe("POST");
+		expect(calls[0].body).toMatchObject({
+			model: "MiniMax-H3",
+			resolution: "2K",
+			duration: 6,
+			ratio: "16:9",
+			callback_url: "https://example.test/callback",
+			aigc_watermark: true,
+		});
+		expect(calls[0].body.content).toEqual([
+			{ type: "text", text: "Generate a short launch clip" },
+			{ type: "image_url", image_url: "https://example.test/first.png", role: "first_frame" },
+			{ type: "audio_url", audio_url: "https://example.test/ref.mp3", role: "reference_audio" },
+		]);
+	});
+
+	it("queries a v2 task and parses completed video URLs", async () => {
+		const urls: string[] = [];
+		const fetch = async (url: Parameters<typeof globalThis.fetch>[0]) => {
+			urls.push(String(url));
+			return jsonResponse({
+				task: {
+					id: "task-2",
+					status: "Success",
+					content: { url: "https://example.test/video.mp4" },
+				},
+				base_resp: { status_code: 0 },
+			});
+		};
+
+		const output = await queryVideoGeneration(testModel(), "task-2", { apiKey: "test", fetch });
+
+		expect(urls[0]).toBe("https://api.minimax.io/v2/query/video_generation/task-2");
+		expect(output).toMatchObject({
+			stopReason: "stop",
+			status: "completed",
+			taskId: "task-2",
+			output: [{ type: "video", url: "https://example.test/video.mp4" }],
+		});
+	});
+
+	it("builds v1 image-to-video requests and parses query/download fields", async () => {
+		const calls: string[] = [];
+		const bodies: Record<string, unknown>[] = [];
+		const fetch = async (url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+			calls.push(String(url));
+			if (init?.body) bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			if (String(url).includes("/files/retrieve")) {
+				return jsonResponse({
+					file: { download_url: "https://example.test/file.mp4" },
+					base_resp: { status_code: 0 },
+				});
+			}
+			if (String(url).includes("/query/")) {
+				return jsonResponse({ status: "Processing", file_id: "file-1", base_resp: { status_code: 0 } });
+			}
+			return jsonResponse({ task_id: "task-3", base_resp: { status_code: 0 } });
+		};
+		const model = testModel({
+			id: "MiniMax-Hailuo-2.3",
+			baseUrl: "https://api.minimax.io/v1/video_generation",
+			apiVersion: "v1",
+			input: ["text", "image"],
+			output: ["video"],
+			resolutions: ["768P", "1080P"],
+			durationSeconds: { min: 1, max: 10, integer: true },
+		});
+
+		const created = await generateVideos(
+			model,
+			{
+				prompt: "Animate this frame",
+				firstFrameImage: "https://example.test/frame.png",
+				duration: 5,
+				resolution: "1080P",
+			},
+			{ apiKey: "test", fetch },
+		);
+		const queried = await queryVideoGeneration(model, "task-3", { apiKey: "test", fetch });
+		const downloaded = await downloadVideo(model, "file-1", { apiKey: "test", fetch });
+
+		expect(created.taskId).toBe("task-3");
+		expect(bodies[0]).toMatchObject({
+			model: "MiniMax-Hailuo-2.3",
+			prompt: "Animate this frame",
+			first_frame_image: "https://example.test/frame.png",
+			duration: 5,
+			resolution: "1080P",
+		});
+		expect(calls[1]).toBe("https://api.minimax.io/v1/query/video_generation?task_id=task-3");
+		expect(queried).toMatchObject({ stopReason: "in_progress", status: "in_progress", fileId: "file-1" });
+		expect(calls[2]).toBe("https://api.minimax.io/v1/files/retrieve?file_id=file-1");
+		expect(downloaded.output).toEqual([{ type: "video", url: "https://example.test/file.mp4" }]);
+	});
+});

--- a/packages/ai/test/videos-models.test.ts
+++ b/packages/ai/test/videos-models.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { AuthContext } from "../src/auth/types.ts";
+import { minimaxCnVideosProvider } from "../src/providers/minimax-cn-videos.ts";
+import { minimaxVideosProvider } from "../src/providers/minimax-videos.ts";
+import type { AssistantVideos, VideosApi, VideosModel, VideosOptions } from "../src/types.ts";
+import { createVideosModels, createVideosProvider } from "../src/videos-models.ts";
+
+function fakeAuthContext(env: Record<string, string>): AuthContext {
+	return {
+		env: async (name) => env[name],
+		fileExists: async () => false,
+	};
+}
+
+function testVideoModel(provider: string, id = "model-a"): VideosModel<VideosApi> {
+	return {
+		id,
+		name: id,
+		api: "test-videos",
+		provider,
+		baseUrl: "https://example.test/v1",
+		apiVersion: "v2",
+		input: ["text"],
+		output: ["video"],
+		resolutions: ["2K"],
+		durationSeconds: { min: 4, max: 15, integer: true },
+		cost: { outputVideo: 0, inputReferenceVideo: 0, inputReferenceAudio: 0, additionalReferenceImage: 0 },
+	};
+}
+
+function okResult(model: VideosModel<VideosApi>): AssistantVideos {
+	return {
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		output: [{ type: "video", url: "https://example.test/video.mp4" }],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("VideosModels", () => {
+	it("resolves auth and merges explicit request options", async () => {
+		const calls: Array<{ model: VideosModel<VideosApi>; options: VideosOptions | undefined }> = [];
+		const models = createVideosModels({ authContext: fakeAuthContext({ TEST_KEY: "env-key" }) });
+		models.setProvider(
+			createVideosProvider({
+				id: "p1",
+				auth: {
+					apiKey: {
+						name: "Test key",
+						resolve: async ({ ctx }) => ({ auth: { apiKey: await ctx.env("TEST_KEY") } }),
+					},
+				},
+				models: [testVideoModel("p1")],
+				api: {
+					generateVideos: async (model, _context, options) => {
+						calls.push({ model, options });
+						return okResult(model);
+					},
+				},
+			}),
+		);
+
+		const model = models.getModel("p1", "model-a")!;
+		expect((await models.getAuth(model))?.auth.apiKey).toBe("env-key");
+		await models.generateVideos(model, { prompt: "clip" });
+		await models.generateVideos(model, { prompt: "clip" }, { apiKey: "explicit" });
+
+		expect(calls[0].options?.apiKey).toBe("env-key");
+		expect(calls[1].options?.apiKey).toBe("explicit");
+	});
+
+	it("registers MiniMax global and CN built-in video models", async () => {
+		const models = createVideosModels({ authContext: fakeAuthContext({ MINIMAX_API_KEY: "key" }) });
+		models.setProvider(minimaxVideosProvider());
+		models.setProvider(minimaxCnVideosProvider());
+
+		expect(models.getProviders().map((provider) => provider.id)).toEqual(["minimax", "minimax-cn"]);
+		expect(models.getModel("minimax", "MiniMax-H3")).toMatchObject({
+			api: "minimax-videos",
+			baseUrl: "https://api.minimax.io/v2/video_generation",
+			apiVersion: "v2",
+			input: ["text", "image", "video", "audio"],
+			output: ["video", "audio"],
+			resolutions: ["2K"],
+		});
+		expect(models.getModel("minimax-cn", "MiniMax-Hailuo-2.3")).toMatchObject({
+			baseUrl: "https://api.minimaxi.com/v1/video_generation",
+			apiVersion: "v1",
+		});
+		expect((await models.getAuth("minimax"))?.auth.apiKey).toBe("key");
+	});
+});


### PR DESCRIPTION
Reason: Add MiniMax video generation support for text-to-video workflows.

Changes:
- Added a video-generation API registry and runtime model collection.
- Added MiniMax global and CN video providers with v2 and v1 endpoints.
- Added MiniMax video create, query, and v1 download handling with task, status, file, and URL parsing.
- Added focused tests for provider registration, request payloads, and response parsing.

Checks:
- npm --prefix packages/ai test -- minimax-videos.test.ts videos-models.test.ts
- npx biome check packages/ai/src/api/minimax-videos.ts packages/ai/src/api/minimax-videos.lazy.ts packages/ai/src/providers/minimax-videos.ts packages/ai/src/providers/minimax-cn-videos.ts packages/ai/src/providers/videos/register-builtins.ts packages/ai/src/videos-api-registry.ts packages/ai/src/videos-models.ts packages/ai/src/videos.ts packages/ai/test/minimax-videos.test.ts packages/ai/test/videos-models.test.ts packages/ai/src/types.ts packages/ai/src/providers/all.ts packages/ai/src/index.ts packages/ai/package.json
- npx tsgo -p packages/ai/tsconfig.build.json --noEmit
- npm run check
