### PR TITLE
feat(agent,coding-agent): accept Claude Code skill frontmatter

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Claude Code skill frontmatter compatibility: relaxed boolean coercion (`yes`/`no`/`on`/`off`/`1`/`0`), `description` fallback to the first body paragraph, and parsed `user-invocable`, `when_to_use` (appended to descriptions in `formatSkillsForSystemPrompt`), and `argument-hint` fields on `Skill`.
+
 ## [0.82.0] - 2026-07-24
 
 ### Breaking Changes

--- a/packages/agent/src/harness/skills.ts
+++ b/packages/agent/src/harness/skills.ts
@@ -30,8 +30,52 @@ export interface SkillDiagnostic {
 interface SkillFrontmatter {
 	name?: string;
 	description?: string;
+	when_to_use?: string;
+	"argument-hint"?: string;
 	"disable-model-invocation"?: boolean;
+	"user-invocable"?: boolean;
 	[key: string]: unknown;
+}
+
+/**
+ * Parse a frontmatter boolean. Claude Code accepts true/false/yes/no/on/off/1/0 in any letter case,
+ * while the YAML parser only produces real booleans for true/false.
+ */
+function parseFrontmatterBoolean(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "number") {
+		if (value === 1) return true;
+		if (value === 0) return false;
+		return undefined;
+	}
+	if (typeof value === "string") {
+		switch (value.trim().toLowerCase()) {
+			case "true":
+			case "yes":
+			case "on":
+			case "1":
+				return true;
+			case "false":
+			case "no":
+			case "off":
+			case "0":
+				return false;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * First paragraph of a markdown body, used as the description fallback (Claude Code compatibility).
+ * Skips headings, HTML comments, and fenced code blocks; collapses internal newlines.
+ */
+function firstParagraph(body: string): string | undefined {
+	for (const block of body.split(/\n\s*\n/)) {
+		const text = block.trim();
+		if (!text || text.startsWith("#") || text.startsWith("<!--") || text.startsWith("```")) continue;
+		return text.replace(/\s*\n\s*/g, " ");
+	}
+	return undefined;
 }
 
 /** Format a skill invocation prompt, optionally appending additional user instructions. */
@@ -250,7 +294,9 @@ async function loadSkillFromFile(
 	const { frontmatter, body } = parsed.value;
 	const skillDir = dirnameEnvPath(filePath);
 	const parentDirName = basenameEnvPath(skillDir);
-	const description = typeof frontmatter.description === "string" ? frontmatter.description : undefined;
+	const rawDescription = typeof frontmatter.description === "string" ? frontmatter.description : undefined;
+	// Claude Code compatibility: when `description` is omitted, use the first paragraph of the markdown body.
+	const description = rawDescription ?? firstParagraph(body);
 
 	for (const error of validateDescription(description)) {
 		diagnostics.push({ type: "warning", code: "invalid_metadata", message: error, path: filePath });
@@ -266,13 +312,45 @@ async function loadSkillFromFile(
 		return { skill: null, diagnostics };
 	}
 
+	const disableModelInvocation = parseFrontmatterBoolean(frontmatter["disable-model-invocation"]);
+	if (frontmatter["disable-model-invocation"] !== undefined && disableModelInvocation === undefined) {
+		diagnostics.push({
+			type: "warning",
+			code: "invalid_metadata",
+			message: `invalid boolean value for "disable-model-invocation"`,
+			path: filePath,
+		});
+	}
+	const parsedUserInvocable = parseFrontmatterBoolean(frontmatter["user-invocable"]);
+	if (frontmatter["user-invocable"] !== undefined && parsedUserInvocable === undefined) {
+		diagnostics.push({
+			type: "warning",
+			code: "invalid_metadata",
+			message: `invalid boolean value for "user-invocable"`,
+			path: filePath,
+		});
+	}
+	const whenToUse = typeof frontmatter.when_to_use === "string" ? frontmatter.when_to_use : undefined;
+	// Claude Code documents argument-hint as `[issue-number]`, which YAML parses as a flow list;
+	// re-wrap list elements in brackets so the hint displays as documented.
+	const rawArgumentHint: unknown = frontmatter["argument-hint"];
+	const argumentHint =
+		typeof rawArgumentHint === "string"
+			? rawArgumentHint
+			: Array.isArray(rawArgumentHint)
+				? rawArgumentHint.map((element: unknown) => `[${String(element)}]`).join(" ")
+				: undefined;
+
 	return {
 		skill: {
 			name,
 			description,
 			content: body,
 			filePath,
-			disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+			disableModelInvocation: disableModelInvocation === true,
+			userInvocable: parsedUserInvocable ?? true,
+			...(whenToUse !== undefined ? { whenToUse } : {}),
+			...(argumentHint !== undefined ? { argumentHint } : {}),
 		},
 		diagnostics,
 	};

--- a/packages/agent/src/harness/system-prompt.ts
+++ b/packages/agent/src/harness/system-prompt.ts
@@ -13,9 +13,10 @@ export function formatSkillsForSystemPrompt(skills: Skill[]): string {
 	];
 
 	for (const skill of visibleSkills) {
+		const description = skill.whenToUse ? `${skill.description} ${skill.whenToUse}` : skill.description;
 		lines.push("  <skill>");
 		lines.push(`    <name>${escapeXml(skill.name)}</name>`);
-		lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+		lines.push(`    <description>${escapeXml(description)}</description>`);
 		lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
 		lines.push("  </skill>");
 	}

--- a/packages/agent/src/harness/types.ts
+++ b/packages/agent/src/harness/types.ts
@@ -72,6 +72,18 @@ export interface Skill {
 	filePath: string;
 	/** Exclude this skill from model-visible skill lists while still allowing explicit application invocation. */
 	disableModelInvocation?: boolean;
+	/**
+	 * Claude Code-compatible supplementary guidance on when to use the skill (`when_to_use`).
+	 * Appended to {@link Skill.description} in model-visible skill lists.
+	 */
+	whenToUse?: string;
+	/**
+	 * Claude Code-compatible invocation control (`user-invocable`). When false, applications should hide the
+	 * skill from user-facing invocation menus. Defaults to true.
+	 */
+	userInvocable?: boolean;
+	/** Claude Code-compatible autocomplete hint (`argument-hint`) describing expected invocation arguments. */
+	argumentHint?: string;
 }
 
 /** Prompt template that can be formatted into a prompt for explicit invocation. */

--- a/packages/agent/test/harness/skills.test.ts
+++ b/packages/agent/test/harness/skills.test.ts
@@ -31,6 +31,7 @@ Use this skill.
 				content: "Use this skill.",
 				filePath: join(root, ".agents/skills/example/SKILL.md"),
 				disableModelInvocation: true,
+				userInvocable: true,
 			},
 		]);
 	});
@@ -73,6 +74,7 @@ Use this skill.
 					content: "Use this skill.",
 					filePath: join(root, "user/example/SKILL.md"),
 					disableModelInvocation: false,
+					userInvocable: true,
 				},
 				source: { type: "user" },
 			},
@@ -83,7 +85,7 @@ Use this skill.
 		const root = createTempDir();
 		const env = new NodeExecutionEnv({ cwd: root });
 		await env.createDir("user/broken", { recursive: true });
-		await env.writeFile("user/broken/SKILL.md", "---\nname: broken\n---\nMissing description.");
+		await env.writeFile("user/broken/SKILL.md", "---\nname: broken\n---\n# Broken, no usable paragraph");
 
 		const { skills, diagnostics } = await loadSourcedSkills(env, [
 			{ path: "user", source: { type: "user" as const } },
@@ -112,5 +114,95 @@ Use this skill.
 
 		expect(skills.map((skill) => skill.name)).toEqual(["skills"]);
 		expect(skills[0]?.content).toBe("Root content");
+	});
+
+	it("falls back to the first body paragraph when description is omitted", async () => {
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		await env.createDir("skills/fallback", { recursive: true });
+		await env.writeFile(
+			"skills/fallback/SKILL.md",
+			"---\nname: fallback\n---\n# Fallback Skill\n\nFirst paragraph\nspanning two lines.\n\nSecond paragraph.",
+		);
+
+		const { skills, diagnostics } = await loadSkills(env, "skills");
+
+		expect(diagnostics).toEqual([]);
+		expect(skills).toHaveLength(1);
+		expect(skills[0]?.description).toBe("First paragraph spanning two lines.");
+	});
+
+	it("coerces Claude Code boolean frontmatter values", async () => {
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		const cases: Array<[string, boolean]> = [
+			["yes", true],
+			["on", true],
+			["1", true],
+			["YES", true],
+			["True", true],
+			["no", false],
+			["off", false],
+			["0", false],
+		];
+		for (const [index, [value]] of cases.entries()) {
+			await env.createDir(`skills/case-${index}`, { recursive: true });
+			await env.writeFile(
+				`skills/case-${index}/SKILL.md`,
+				`---\ndescription: Coercion test\ndisable-model-invocation: ${value}\n---\nBody.`,
+			);
+		}
+
+		for (const [index, [, expected]] of cases.entries()) {
+			const { skills, diagnostics } = await loadSkills(env, `skills/case-${index}`);
+			expect(diagnostics).toEqual([]);
+			expect(skills[0]?.disableModelInvocation).toBe(expected);
+		}
+	});
+
+	it("warns and defaults on invalid boolean frontmatter values", async () => {
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		await env.createDir("skills/invalid", { recursive: true });
+		await env.writeFile(
+			"skills/invalid/SKILL.md",
+			"---\ndescription: Invalid boolean\ndisable-model-invocation: maybe\n---\nBody.",
+		);
+
+		const { skills, diagnostics } = await loadSkills(env, "skills");
+
+		expect(skills[0]?.disableModelInvocation).toBe(false);
+		expect(diagnostics).toEqual([
+			{
+				type: "warning",
+				code: "invalid_metadata",
+				message: 'invalid boolean value for "disable-model-invocation"',
+				path: join(root, "skills/invalid/SKILL.md"),
+			},
+		]);
+	});
+
+	it("parses Claude Code user-invocable, when_to_use, and argument-hint fields", async () => {
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		await env.createDir("skills/claude", { recursive: true });
+		await env.writeFile(
+			"skills/claude/SKILL.md",
+			`---
+name: claude
+description: Claude field test
+when_to_use: Use when testing Claude compatibility.
+argument-hint: [issue-number]
+user-invocable: false
+---
+Body.`,
+		);
+
+		const { skills, diagnostics } = await loadSkills(env, "skills");
+
+		expect(diagnostics).toEqual([]);
+		expect(skills[0]?.userInvocable).toBe(false);
+		expect(skills[0]?.whenToUse).toBe("Use when testing Claude compatibility.");
+		expect(skills[0]?.argumentHint).toBe("[issue-number]");
 	});
 });

--- a/packages/agent/test/harness/system-prompt.test.ts
+++ b/packages/agent/test/harness/system-prompt.test.ts
@@ -49,6 +49,12 @@ When a skill file references a relative path, resolve it against the skill direc
 		expect(formatSkillsForSystemPrompt([disabledSkill])).toBe("");
 	});
 
+	it("appends whenToUse to the listed description", () => {
+		expect(formatSkillsForSystemPrompt([{ ...visibleSkill, whenToUse: "Use when things happen." }])).toContain(
+			"<description>Use &lt;this&gt; &amp; that Use when things happen.</description>",
+		);
+	});
+
 	it("escapes XML in all model-visible skill fields", () => {
 		expect(
 			formatSkillsForSystemPrompt([

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Claude Code skill frontmatter compatibility: relaxed boolean coercion for `disable-model-invocation`/`user-invocable`, `description` fallback to the first body paragraph, `when_to_use` appended to system-prompt skill listings, and `user-invocable: false` plus `argument-hint` honored by `/skill:name` command menus. See [Skills](docs/skills.md#claude-code-frontmatter).
+
 ### Fixed
 
 - Fixed compaction and branch summaries for providers whose authentication resolves entirely to request headers ([#5871](https://github.com/earendil-works/pi/issues/5871))

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -141,12 +141,23 @@ Per the [Agent Skills specification](https://agentskills.io/specification#frontm
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Max 64 chars. Lowercase a-z, 0-9, hyphens. Unlike the standard, Pi does not require this to match the parent directory because that standard requirement is suboptimal for shared skill directories. |
-| `description` | Yes | Max 1024 chars. What the skill does and when to use it. |
+| `description` | Recommended | Max 1024 chars. What the skill does and when to use it. When omitted, Pi falls back to the first paragraph of the markdown body (Claude Code behavior). |
 | `license` | No | License name or reference to bundled file. |
 | `compatibility` | No | Max 500 chars. Environment requirements. |
 | `metadata` | No | Arbitrary key-value mapping. |
 | `allowed-tools` | No | Space-delimited list of pre-approved tools (experimental). |
 | `disable-model-invocation` | No | When `true`, skill is hidden from system prompt. Users must use `/skill:name`. |
+| `user-invocable` | No | Claude Code field. When `false`, the skill is hidden from `/skill:name` command menus and listings. Defaults to `true`. |
+| `when_to_use` | No | Claude Code field. Extra when-to-use guidance, appended to `description` in the system prompt skill listing. |
+| `argument-hint` | No | Claude Code field. Hint shown in `/skill:name` autocomplete, e.g. `<pr-url>` or `[issue-number]`. Unquoted bracket forms parse as YAML flow lists and are re-wrapped in brackets per element. |
+
+Boolean frontmatter fields (`disable-model-invocation`, `user-invocable`) accept `true`, `false`, `yes`, `no`, `on`, `off`, `1`, and `0` in any letter case, per Claude Code. Invalid values warn and fall back to the default.
+
+### Claude Code Frontmatter
+
+Skills written for [Claude Code](https://code.claude.com/docs/en/skills#frontmatter-reference) load in Pi. Pi honors `disable-model-invocation`, `user-invocable`, `when_to_use`, `argument-hint`, the relaxed boolean values, and the description fallback described above.
+
+The remaining Claude Code fields are ignored: `name` (display-only), `arguments` and `$ARGUMENTS` substitution (Pi appends arguments as `User: <args>` instead), `allowed-tools`/`disallowed-tools` (no per-skill tool gating), `model`, `effort`, `context: fork`, `agent`, `background` (no per-skill model, effort, or forked execution), `hooks`, `paths`, and `shell`.
 
 ### Name Rules
 
@@ -180,10 +191,11 @@ Pi validates skills against the Agent Skills standard. Most issues produce warni
 - Name exceeds 64 characters or contains invalid characters
 - Name starts/ends with hyphen or has consecutive hyphens
 - Description exceeds 1024 characters
+- Boolean fields with invalid values
 
 Unknown frontmatter fields are ignored.
 
-**Exception:** Skills with missing description are not loaded.
+**Exception:** Skills with no usable description are not loaded. When `description` is omitted, Pi falls back to the first paragraph of the markdown body, skipping headings, HTML comments, and fenced code blocks. A skill with neither a frontmatter `description` nor a usable body paragraph is not loaded.
 
 Name collisions (same name from different locations) warn and keep the first skill found.
 

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -67,8 +67,52 @@ function addIgnoreRules(ig: IgnoreMatcher, dir: string, rootDir: string): void {
 export interface SkillFrontmatter {
 	name?: string;
 	description?: string;
+	when_to_use?: string;
+	"argument-hint"?: string;
 	"disable-model-invocation"?: boolean;
+	"user-invocable"?: boolean;
 	[key: string]: unknown;
+}
+
+/**
+ * Parse a frontmatter boolean. Claude Code accepts true/false/yes/no/on/off/1/0 in any letter case,
+ * while the YAML parser only produces real booleans for true/false.
+ */
+function parseFrontmatterBoolean(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "number") {
+		if (value === 1) return true;
+		if (value === 0) return false;
+		return undefined;
+	}
+	if (typeof value === "string") {
+		switch (value.trim().toLowerCase()) {
+			case "true":
+			case "yes":
+			case "on":
+			case "1":
+				return true;
+			case "false":
+			case "no":
+			case "off":
+			case "0":
+				return false;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * First paragraph of a markdown body, used as the description fallback (Claude Code compatibility).
+ * Skips headings, HTML comments, and fenced code blocks; collapses internal newlines.
+ */
+function firstParagraph(body: string): string | undefined {
+	for (const block of body.split(/\n\s*\n/)) {
+		const text = block.trim();
+		if (!text || text.startsWith("#") || text.startsWith("<!--") || text.startsWith("```")) continue;
+		return text.replace(/\s*\n\s*/g, " ");
+	}
+	return undefined;
 }
 
 export interface Skill {
@@ -78,6 +122,12 @@ export interface Skill {
 	baseDir: string;
 	sourceInfo: SourceInfo;
 	disableModelInvocation: boolean;
+	/** Claude Code `user-invocable`: when false, the skill is hidden from /skill:name command menus. Defaults to true. */
+	userInvocable?: boolean;
+	/** Claude Code `when_to_use`: supplementary guidance appended to the description in model-visible skill lists. */
+	whenToUse?: string;
+	/** Claude Code `argument-hint`: autocomplete hint describing expected /skill:name arguments. */
+	argumentHint?: string;
 }
 
 export interface LoadSkillsResult {
@@ -282,12 +332,16 @@ function loadSkillFromFile(
 
 	try {
 		const rawContent = readFileSync(filePath, "utf-8");
-		const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
+		const { frontmatter, body } = parseFrontmatter<SkillFrontmatter>(rawContent);
 		const skillDir = dirname(filePath);
 		const parentDirName = basename(skillDir);
 
+		const rawDescription = typeof frontmatter.description === "string" ? frontmatter.description : undefined;
+		// Claude Code compatibility: when `description` is omitted, use the first paragraph of the markdown body.
+		const description = rawDescription ?? firstParagraph(body);
+
 		// Validate description
-		const descErrors = validateDescription(frontmatter.description);
+		const descErrors = validateDescription(description);
 		for (const error of descErrors) {
 			diagnostics.push({ type: "warning", message: error, path: filePath });
 		}
@@ -302,18 +356,48 @@ function loadSkillFromFile(
 		}
 
 		// Still load the skill even with warnings (unless description is completely missing)
-		if (!frontmatter.description || frontmatter.description.trim() === "") {
+		if (!description || description.trim() === "") {
 			return { skill: null, diagnostics };
 		}
+
+		const disableModelInvocation = parseFrontmatterBoolean(frontmatter["disable-model-invocation"]);
+		if (frontmatter["disable-model-invocation"] !== undefined && disableModelInvocation === undefined) {
+			diagnostics.push({
+				type: "warning",
+				message: `invalid boolean value for "disable-model-invocation"`,
+				path: filePath,
+			});
+		}
+		const parsedUserInvocable = parseFrontmatterBoolean(frontmatter["user-invocable"]);
+		if (frontmatter["user-invocable"] !== undefined && parsedUserInvocable === undefined) {
+			diagnostics.push({
+				type: "warning",
+				message: `invalid boolean value for "user-invocable"`,
+				path: filePath,
+			});
+		}
+		const whenToUse = typeof frontmatter.when_to_use === "string" ? frontmatter.when_to_use : undefined;
+		// Claude Code documents argument-hint as `[issue-number]`, which YAML parses as a flow list;
+		// re-wrap list elements in brackets so the hint displays as documented.
+		const rawArgumentHint: unknown = frontmatter["argument-hint"];
+		const argumentHint =
+			typeof rawArgumentHint === "string"
+				? rawArgumentHint
+				: Array.isArray(rawArgumentHint)
+					? rawArgumentHint.map((element: unknown) => `[${String(element)}]`).join(" ")
+					: undefined;
 
 		return {
 			skill: {
 				name,
-				description: frontmatter.description,
+				description,
 				filePath,
 				baseDir: skillDir,
 				sourceInfo: createSkillSourceInfo(filePath, skillDir, source),
-				disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+				disableModelInvocation: disableModelInvocation === true,
+				userInvocable: parsedUserInvocable ?? true,
+				...(whenToUse !== undefined ? { whenToUse } : {}),
+				...(argumentHint !== undefined ? { argumentHint } : {}),
 			},
 			diagnostics,
 		};
@@ -348,9 +432,10 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
 	];
 
 	for (const skill of visibleSkills) {
+		const description = skill.whenToUse ? `${skill.description} ${skill.whenToUse}` : skill.description;
 		lines.push("  <skill>");
 		lines.push(`    <name>${escapeXml(skill.name)}</name>`);
-		lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+		lines.push(`    <description>${escapeXml(description)}</description>`);
 		lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
 		lines.push("  </skill>");
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -607,11 +607,13 @@ export class InteractiveMode {
 		const skillCommandList: SlashCommand[] = [];
 		if (this.settingsManager.getEnableSkillCommands()) {
 			for (const skill of this.session.resourceLoader.getSkills().skills) {
+				if (skill.userInvocable === false) continue;
 				const commandName = `skill:${skill.name}`;
 				this.skillCommands.set(commandName, skill.filePath);
 				skillCommandList.push({
 					name: commandName,
 					description: this.prefixAutocompleteDescription(skill.description, skill.sourceInfo),
+					...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
 				});
 			}
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -681,6 +681,7 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				}
 
 				for (const skill of session.resourceLoader.getSkills().skills) {
+					if (skill.userInvocable === false) continue;
 					commands.push({
 						name: `skill:${skill.name}`,
 						description: skill.description,

--- a/packages/coding-agent/test/fixtures/skills/claude-frontmatter/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/claude-frontmatter/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: claude-frontmatter
+description: Uses Claude Code frontmatter fields.
+when_to_use: Use when testing Claude compatibility.
+argument-hint: [issue-number]
+disable-model-invocation: yes
+user-invocable: no
+---
+
+# Claude Frontmatter
+
+Body text.

--- a/packages/coding-agent/test/fixtures/skills/invalid-boolean/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/invalid-boolean/SKILL.md
@@ -1,0 +1,8 @@
+---
+description: Invalid boolean value test.
+disable-model-invocation: maybe
+---
+
+# Invalid Boolean
+
+Body text.

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -14,6 +14,9 @@ function createTestSkill(options: {
 	filePath: string;
 	baseDir: string;
 	disableModelInvocation?: boolean;
+	userInvocable?: boolean;
+	whenToUse?: string;
+	argumentHint?: string;
 	source?: string;
 }): Skill {
 	return {
@@ -23,6 +26,9 @@ function createTestSkill(options: {
 		baseDir: options.baseDir,
 		sourceInfo: createSyntheticSourceInfo(options.filePath, { source: options.source ?? "test" }),
 		disableModelInvocation: options.disableModelInvocation ?? false,
+		...(options.userInvocable !== undefined ? { userInvocable: options.userInvocable } : {}),
+		...(options.whenToUse !== undefined ? { whenToUse: options.whenToUse } : {}),
+		...(options.argumentHint !== undefined ? { argumentHint: options.argumentHint } : {}),
 	};
 }
 
@@ -74,14 +80,15 @@ describe("skills", () => {
 			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("exceeds 64 characters"))).toBe(true);
 		});
 
-		it("should warn and skip skill when description is missing", () => {
+		it("should fall back to the first body paragraph when description is missing", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "missing-description"),
 				source: "test",
 			});
 
-			expect(skills).toHaveLength(0);
-			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("description is required"))).toBe(true);
+			expect(skills).toHaveLength(1);
+			expect(skills[0].description).toBe("This skill has no description field.");
+			expect(diagnostics).toHaveLength(0);
 		});
 
 		it("should ignore unknown frontmatter fields", () => {
@@ -117,15 +124,18 @@ describe("skills", () => {
 			expect(diagnostics).toHaveLength(0);
 		});
 
-		it("should skip files without frontmatter", () => {
+		it("should load files without frontmatter using fallback metadata", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "no-frontmatter"),
 				source: "test",
 			});
 
-			// no-frontmatter has no description, so it should be skipped
-			expect(skills).toHaveLength(0);
-			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("description is required"))).toBe(true);
+			// no-frontmatter has no frontmatter, so the name comes from the directory
+			// and the description falls back to the first body paragraph
+			expect(skills).toHaveLength(1);
+			expect(skills[0].name).toBe("no-frontmatter");
+			expect(skills[0].description).toBe("This skill has no YAML frontmatter at all.");
+			expect(diagnostics).toHaveLength(0);
 		});
 
 		it("should warn and skip skill when YAML frontmatter is invalid", () => {
@@ -166,10 +176,10 @@ describe("skills", () => {
 				source: "test",
 			});
 
-			// Should load all skills that have descriptions (even with warnings)
-			// valid-skill, name-mismatch, invalid-name-chars, long-name, unknown-field, nested/child-skill, consecutive-hyphens
-			// NOT: missing-description, no-frontmatter (both missing descriptions)
-			expect(skills.length).toBeGreaterThanOrEqual(6);
+			// All fixtures load, including those relying on fallback metadata
+			// (missing-description, no-frontmatter) and Claude Code frontmatter fields
+			// (claude-frontmatter, invalid-boolean)
+			expect(skills.length).toBeGreaterThanOrEqual(10);
 		});
 
 		it("should return empty for non-existent directory", () => {
@@ -218,6 +228,45 @@ describe("skills", () => {
 
 			expect(skills).toHaveLength(1);
 			expect(skills[0].disableModelInvocation).toBe(false);
+		});
+
+		it("should parse Claude Code frontmatter fields with boolean coercion", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "claude-frontmatter"),
+				source: "test",
+			});
+
+			expect(diagnostics).toHaveLength(0);
+			expect(skills).toHaveLength(1);
+			expect(skills[0].disableModelInvocation).toBe(true); // yes
+			expect(skills[0].userInvocable).toBe(false); // no
+			expect(skills[0].whenToUse).toBe("Use when testing Claude compatibility.");
+			expect(skills[0].argumentHint).toBe("[issue-number]");
+		});
+
+		it("should warn and default on invalid boolean frontmatter values", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "invalid-boolean"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].disableModelInvocation).toBe(false);
+			expect(
+				diagnostics.some((d: ResourceDiagnostic) =>
+					d.message.includes('invalid boolean value for "disable-model-invocation"'),
+				),
+			).toBe(true);
+		});
+
+		it("should default userInvocable to true when not specified", () => {
+			const { skills } = loadSkillsFromDir({
+				dir: join(fixturesDir, "valid-skill"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].userInvocable).toBe(true);
 		});
 	});
 
@@ -342,6 +391,22 @@ describe("skills", () => {
 
 			const result = formatSkillsForPrompt(skills);
 			expect(result).toBe("");
+		});
+
+		it("should append whenToUse to the listed description", () => {
+			const skills: Skill[] = [
+				createTestSkill({
+					name: "test-skill",
+					description: "A test skill.",
+					filePath: "/path/to/skill/SKILL.md",
+					baseDir: "/path/to/skill",
+					whenToUse: "Use when testing things.",
+				}),
+			];
+
+			const result = formatSkillsForPrompt(skills);
+
+			expect(result).toContain("<description>A test skill. Use when testing things.</description>");
 		});
 	});
 


### PR DESCRIPTION
Makes both skill loaders (`packages/agent` harness and `packages/coding-agent`) compatible with the [Claude Code SKILL.md frontmatter reference](https://code.claude.com/docs/en/skills#frontmatter-reference), so skills written for Claude Code load and behave sensibly in pi.

**Loader changes (both packages)**
- Relaxed boolean coercion for `disable-model-invocation` and `user-invocable`: accepts `true/false/yes/no/on/off/1/0` in any letter case. This was a live bug — the `yaml` package (1.2 core schema) only booleans `true/false`, so `disable-model-invocation: yes` was silently ignored. Invalid values now warn and fall back to defaults.
- `description` falls back to the first markdown body paragraph when omitted (Claude behavior), skipping headings, HTML comments, and fenced code blocks. Skills with neither are still rejected.
- New `Skill` fields: `userInvocable`, `whenToUse`, `argumentHint`.
- `argument-hint` written in Claude's documented unquoted form (`[issue-number]`, a YAML flow list) is re-wrapped in brackets per element.

**Consumers**
- `when_to_use` is appended to the description in system-prompt skill listings (`formatSkillsForSystemPrompt` / `formatSkillsForPrompt`).
- `user-invocable: false` hides skills from `/skill:name` menus (interactive autocomplete and RPC `get_commands`); typing `/skill:name` manually still expands, mirroring `disable-model-invocation` semantics.
- `argument-hint` renders in `/skill:name` autocomplete.

**Ignored Claude fields** (documented in `docs/skills.md`): `arguments`/`$ARGUMENTS` substitution, `allowed-tools`/`disallowed-tools`, `model`, `effort`, `context`/`agent`/`background`, `hooks`, `paths`, `shell`.

**Verification**
- `npm run check` passes (biome, tsgo, shrinkwrap, browser-smoke).
- Targeted vitest: 13/13 `packages/agent` (harness skills + system-prompt), 48/48 `packages/coding-agent` (skills, sdk-skills, agent-session-prompt suite).
- The 5 `resource-loader.test.ts` extension-test failures in this checkout are pre-existing on clean HEAD (verified by temporary revert); unrelated.

This comment is AI-generated.
