### PR TITLE
fix(ai): retry transient provider errors in Google adapters

### DIFF
--- a/packages/ai/src/api/google-generative-ai.ts
+++ b/packages/ai/src/api/google-generative-ai.ts
@@ -32,6 +32,7 @@ import {
 	mapStopReason,
 	resolveGoogleFunctionCallingMode,
 	retainThoughtSignature,
+	retryGoogleRequest,
 	supportsGoogleStrictToolSampling,
 } from "./google-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -88,7 +89,7 @@ export const stream: StreamFunction<"google-generative-ai", GoogleOptions> = (
 			if (nextParams !== undefined) {
 				params = nextParams as GenerateContentParameters;
 			}
-			const googleStream = await client.models.generateContentStream(params);
+			const googleStream = await retryGoogleRequest(() => client.models.generateContentStream(params), options);
 
 			stream.push({ type: "start", partial: output });
 			let currentBlock: TextContent | ThinkingContent | null = null;

--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -3,7 +3,8 @@
  */
 
 import { type Content, FinishReason, FunctionCallingConfigMode, type Part } from "@google/genai";
-import type { Context, ImageContent, Model, StopReason, TextContent, Tool } from "../types.ts";
+import type { Context, ImageContent, Model, StopReason, StreamOptions, TextContent, Tool } from "../types.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import { transformMessages } from "./transform-messages.ts";
@@ -373,4 +374,36 @@ export function mapStopReasonString(reason: string): StopReason {
 		default:
 			return "error";
 	}
+}
+
+/**
+ * Run a Google GenAI SDK request with the shared provider retry policy
+ * (408/409/429/5xx with backoff, honoring retry-after), mirroring how the
+ * Anthropic and OpenAI adapters wrap their initial request in
+ * retryProviderRequest. The SDK's ApiError has a `status` property but no
+ * `headers` property, and retryProviderRequest only retries errors that carry
+ * both, so normalize the error by adding the missing `headers` before
+ * rethrowing.
+ */
+export function retryGoogleRequest<T>(
+	request: () => Promise<T>,
+	options?: Pick<StreamOptions, "maxRetries" | "maxRetryDelayMs" | "signal">,
+): Promise<T> {
+	return retryProviderRequest(
+		async () => {
+			try {
+				return await request();
+			} catch (error) {
+				if (error instanceof Error && "status" in error && !("headers" in error)) {
+					(error as { headers?: Headers }).headers = undefined;
+				}
+				throw error;
+			}
+		},
+		{
+			maxRetries: options?.maxRetries,
+			maxRetryDelayMs: options?.maxRetryDelayMs,
+			signal: options?.signal,
+		},
+	);
 }

--- a/packages/ai/src/api/google-vertex.ts
+++ b/packages/ai/src/api/google-vertex.ts
@@ -37,6 +37,7 @@ import {
 	mapStopReason,
 	resolveGoogleFunctionCallingMode,
 	retainThoughtSignature,
+	retryGoogleRequest,
 	supportsGoogleStrictToolSampling,
 } from "./google-shared.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -106,7 +107,7 @@ export const stream: StreamFunction<"google-vertex", GoogleVertexOptions> = (
 			if (nextParams !== undefined) {
 				params = nextParams as GenerateContentParameters;
 			}
-			const googleStream = await client.models.generateContentStream(params);
+			const googleStream = await retryGoogleRequest(() => client.models.generateContentStream(params), options);
 
 			stream.push({ type: "start", partial: output });
 			let currentBlock: TextContent | ThinkingContent | null = null;

--- a/packages/ai/test/google-shared-retry.test.ts
+++ b/packages/ai/test/google-shared-retry.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { retryGoogleRequest } from "../src/api/google-shared.ts";
+
+/** Shaped like @google/genai's ApiError: has `status`, but no `headers`. */
+function googleApiError(status: number): Error {
+	return Object.assign(new Error(`got status: ${status}`), { status });
+}
+
+describe("google request retries", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("retries a headers-less SDK error with a retryable status", async () => {
+		vi.useFakeTimers();
+		const request = vi.fn<() => Promise<string>>().mockRejectedValueOnce(googleApiError(429)).mockResolvedValue("ok");
+
+		const result = retryGoogleRequest(request, { maxRetries: 1 });
+		await vi.advanceTimersByTimeAsync(500);
+
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not retry when maxRetries is unset", async () => {
+		const error = googleApiError(429);
+		const request = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+
+		await expect(retryGoogleRequest(request)).rejects.toBe(error);
+		expect(request).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not retry a non-retryable status", async () => {
+		const error = googleApiError(400);
+		const request = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+
+		await expect(retryGoogleRequest(request, { maxRetries: 2 })).rejects.toBe(error);
+		expect(request).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
The `google-vertex` and `google-generative-ai` adapters call `client.models.generateContentStream(params)` bare, so a transient 429/5xx before the first token becomes a terminal `stopReason: "error"` message — for `AgentHarness` users that kills the whole agent thread. The Anthropic, OpenAI, Azure, and OpenRouter adapters already wrap their initial request in `retryProviderRequest`; this brings the Google adapters in line.

Fixes #7470

## Change

- `google-shared.ts`: new `retryGoogleRequest` helper that wraps a request in `retryProviderRequest` with the caller's `maxRetries` / `maxRetryDelayMs` / `signal`. It also normalizes the SDK error: `@google/genai`'s `ApiError` has a `.status` property but no `.headers`, and `retryProviderRequest`'s `isProviderError` guard requires both before it retries — so a naive wrap would never retry. The helper adds the missing `headers` property (as `undefined`) before rethrowing.
- `google-vertex.ts` / `google-generative-ai.ts`: wrap the `generateContentStream` call in `retryGoogleRequest`.
- `test/google-shared-retry.test.ts`: unit tests for the headers-less-error retry, the no-`maxRetries` default, and non-retryable statuses.

## Scope

Covers initial-request failures only — mid-stream errors after the first token are out of scope, matching what the other adapters' wrap covers. Retries are opt-in via the existing `maxRetries` stream option (`retryProviderRequest` defaults to 0), so default behavior is unchanged.

## Verification

- `npx vitest run` in `packages/ai`: new tests pass; only pre-existing Ollama E2E failures (need a local Ollama server) remain.
- `tsgo --noEmit` clean at the repo root (after `hydrate-model-data`); `biome check` clean on the changed files.
- Also verified against the compiled package with a stubbed fetch: a 429 is retried with backoff (1 + `maxRetries` attempts), and a 429-429-success sequence recovers to a normal `stop` reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)