### PR TITLE
Set AI_AGENT for child process attribution

### DIFF
--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -663,6 +663,7 @@ pi --thinking high "Solve this complex problem"
 
 | Variable | Description |
 |----------|-------------|
+| `AI_AGENT` | Set to `pi` by the CLI and RPC entry points so generic tooling can attribute child processes to Pi |
 | `PI_CODING_AGENT` | Set to `true` by the CLI and RPC entry points so child processes can detect that they run inside Pi |
 | `PI_CODING_AGENT_DIR` | Override config directory (default: `~/.pi/agent`) |
 | `PI_CODING_AGENT_SESSION_DIR` | Override session storage directory (overridden by `--session-dir`) |

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -11,6 +11,7 @@ import { main } from "./main.ts";
 
 process.title = APP_NAME;
 process.env.PI_CODING_AGENT = "true";
+process.env.AI_AGENT = "pi";
 process.emitWarning = (() => {}) as typeof process.emitWarning;
 
 // Configure undici's global dispatcher before provider SDKs issue requests.

--- a/packages/coding-agent/src/rpc-entry.ts
+++ b/packages/coding-agent/src/rpc-entry.ts
@@ -5,6 +5,7 @@ import { main } from "./main.ts";
 
 process.title = `${APP_NAME}-rpc`;
 process.env.PI_CODING_AGENT = "true";
+process.env.AI_AGENT = "pi";
 process.emitWarning = (() => {}) as typeof process.emitWarning;
 
 configureHttpDispatcher();


### PR DESCRIPTION
Resolves #7132 (approved by @badlogic with `lgtm`).

## Summary

Set `AI_AGENT=pi` in the CLI and RPC entry points, right next to the existing `PI_CODING_AGENT=true` marker.

`AI_AGENT` is an emerging cross-agent convention for a child process to identify which agent launched it. Setting it lets generic tooling attribute child processes to Pi without Pi-specific heuristics, and gives consumers that already read `AI_AGENT` Pi support for free.

The environment variable is documented in the coding-agent README.

## Testing

- `npm run check` (pre-existing, unrelated failures in `packages/ai/test/fireworks-models.test.ts`; this change is a 3-line addition and passes `git diff --check`)