### PR TITLE
fix(ai): preserve Gemini 3 tool call IDs

### DIFF
--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -69,7 +69,12 @@ function resolveThoughtSignature(isSameProviderAndModel: boolean, signature: str
  * Models via Google APIs that require explicit tool call IDs in function calls/responses.
  */
 export function requiresToolCallId(modelId: string): boolean {
-	return modelId.startsWith("claude-") || modelId.startsWith("gpt-oss-");
+	const geminiMajorVersion = getGeminiMajorVersion(modelId);
+	return (
+		modelId.startsWith("claude-") ||
+		modelId.startsWith("gpt-oss-") ||
+		(geminiMajorVersion !== undefined && geminiMajorVersion >= 3)
+	);
 }
 
 function getGeminiMajorVersion(modelId: string): number | undefined {

--- a/packages/ai/test/google-shared-gemini3-unsigned-tool-call.test.ts
+++ b/packages/ai/test/google-shared-gemini3-unsigned-tool-call.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { convertMessages } from "../src/api/google-shared.ts";
+import { convertMessages, requiresToolCallId } from "../src/api/google-shared.ts";
 import type { Context, Model } from "../src/types.ts";
 
 function makeGemini3Model<TApi extends "google-generative-ai" | "google-vertex">(
@@ -57,11 +57,45 @@ function makeContext(model: { api: string; provider: string; id: string }, thoug
 				stopReason: "toolUse",
 				timestamp: now,
 			},
+			{
+				role: "toolResult",
+				toolCallId: "call_1",
+				toolName: "bash",
+				content: [{ type: "text", text: "hi" }],
+				isError: false,
+				timestamp: now,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call_2",
+				toolName: "bash",
+				content: [{ type: "text", text: "files" }],
+				isError: false,
+				timestamp: now,
+			},
 		],
 	};
 }
 
 describe("google-shared convertMessages — Gemini 3 unsigned tool calls", () => {
+	it.each([
+		makeGemini3Model("google-generative-ai", "google"),
+		makeGemini3Model("google-generative-ai", "google", "gemini-3.6-flash"),
+		makeGemini3Model("google-vertex", "google-vertex"),
+	])("preserves tool call IDs for $id via $api history", (model) => {
+		const context = makeContext(model);
+		const contents = convertMessages(model, context);
+		const functionCallIds = contents
+			.flatMap((content) => content.parts ?? [])
+			.flatMap((part) => (part.functionCall?.id ? [part.functionCall.id] : []));
+		const functionResponseIds = contents
+			.flatMap((content) => content.parts ?? [])
+			.flatMap((part) => (part.functionResponse?.id ? [part.functionResponse.id] : []));
+
+		expect(functionCallIds).toEqual(["call_1", "call_2"]);
+		expect(functionResponseIds).toEqual(["call_1", "call_2"]);
+	});
+
 	it("does not add skip_thought_signature_validator for unsigned Google Gen AI tool calls", () => {
 		const model = makeGemini3Model("google-generative-ai", "google");
 		const contents = convertMessages(model, makeContext({ ...model, id: "other-model" }));
@@ -108,9 +142,26 @@ describe("google-shared convertMessages — Gemini 3 unsigned tool calls", () =>
 		const model = makeGemini3Model("google-generative-ai", "google", "gemini-2.5-flash");
 		const contents = convertMessages(model, makeContext({ ...model, id: "other-model" }));
 		const modelTurn = contents.find((c) => c.role === "model");
-		const fcPart = modelTurn?.parts?.find((p) => p.functionCall !== undefined);
+		const functionCallParts = modelTurn?.parts?.filter((part) => part.functionCall !== undefined) ?? [];
+		const functionResponseParts = contents
+			.flatMap((content) => content.parts ?? [])
+			.filter((part) => part.functionResponse !== undefined);
 
-		expect(fcPart).toBeTruthy();
-		expect(fcPart?.thoughtSignature).toBeUndefined();
+		expect(functionCallParts).toHaveLength(2);
+		expect(functionCallParts.every((part) => part.functionCall?.id === undefined)).toBe(true);
+		expect(functionCallParts.every((part) => part.thoughtSignature === undefined)).toBe(true);
+		expect(functionResponseParts).toHaveLength(2);
+		expect(functionResponseParts.every((part) => part.functionResponse?.id === undefined)).toBe(true);
+	});
+});
+
+describe("requiresToolCallId", () => {
+	it.each([
+		[false, "gemini-2.5-flash"],
+		[true, "gemini-3.6-flash"],
+		[true, "claude-sonnet-4-5"],
+		[true, "gpt-oss-120b"],
+	] as const)("returns %s for %s", (expected, modelId) => {
+		expect(requiresToolCallId(modelId)).toBe(expected);
 	});
 });


### PR DESCRIPTION
## Summary

Gemini 3 returns IDs on function calls and expects the same IDs on matching function responses when history is replayed. Pi currently drops both because `requiresToolCallId()` only covers Claude and GPT-OSS models routed through Google APIs.

Treat Gemini major versions 3 and newer as requiring tool-call IDs. Same-model IDs are replayed unchanged, while the existing cross-model normalization still updates calls and results together.

Regression coverage includes Google Generative AI, Vertex, `gemini-3.6-flash`, and the unchanged Gemini 2, Claude, and GPT-OSS behavior.

## Testing

- `npm run check`
- `./test.sh`

Fixes #7047.
