### PR TITLE
fix(coding-agent): defer idle compaction until next prompt

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -311,6 +311,10 @@ export class AgentSession {
 	private _unsubscribeAgent?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _isAgentRunActive = false;
+	private _promptAuthenticationPromise: Promise<void> | undefined;
+	private _promptAuthenticationAbortController: AbortController | undefined;
+	private _promptAuthenticationWaiterCount = 0;
+	private _promptPreparationAbortController: AbortController | undefined;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
 
@@ -569,7 +573,12 @@ export class AgentSession {
 	}
 
 	private _resolveIdleWaitIfIdle(): void {
-		if (this._isAgentRunActive || !this._resolveIdleWait) {
+		if (
+			this._isAgentRunActive ||
+			this._promptAuthenticationPromise ||
+			this._promptAuthenticationWaiterCount > 0 ||
+			!this._resolveIdleWait
+		) {
 			return;
 		}
 		const resolve = this._resolveIdleWait;
@@ -836,6 +845,8 @@ export class AgentSession {
 	 */
 	dispose(): void {
 		try {
+			this._promptAuthenticationAbortController?.abort();
+			this._promptPreparationAbortController?.abort();
 			this.abortRetry();
 			this.abortCompaction();
 			this.abortBranchSummary();
@@ -877,9 +888,11 @@ export class AgentSession {
 		return this._isAgentRunActive;
 	}
 
-	/** Whether the session has no active agent run, retry, auto-compaction, or queued continuation. */
+	/** Whether the session has no active prompt authentication or agent run. */
 	get isIdle(): boolean {
-		return !this._isAgentRunActive;
+		return (
+			!this._promptAuthenticationPromise && this._promptAuthenticationWaiterCount === 0 && !this._isAgentRunActive
+		);
 	}
 
 	/** Current effective system prompt (includes any per-turn extension modifications) */
@@ -1093,7 +1106,16 @@ export class AgentSession {
 			this._retryAttempt = 0;
 		}
 
-		if (await this._checkCompaction(msg)) {
+		// Defer non-recovery compaction while idle. The next prompt performs the
+		// same check before submission, but queued continuations need room now.
+		const hadQueuedMessages = this.agent.hasQueuedMessages();
+		if (await this._checkCompaction(msg, true, !hadQueuedMessages)) {
+			return true;
+		}
+
+		// A continuation may have been queued while checking compaction. If so,
+		// check again without deferral so it receives enough context space.
+		if (!hadQueuedMessages && this.agent.hasQueuedMessages() && (await this._checkCompaction(msg))) {
 			return true;
 		}
 
@@ -1115,6 +1137,19 @@ export class AgentSession {
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
 		let messages: AgentMessage[] | undefined;
+		let promptAuthentication: Promise<void> | undefined;
+		let resolvePromptAuthentication: (() => void) | undefined;
+		let promptAuthenticationAbortController: AbortController | undefined;
+		let runReservation: AbortController | undefined;
+		const releasePromptAuthentication = () => {
+			if (this._promptAuthenticationPromise === promptAuthentication) {
+				this._promptAuthenticationPromise = undefined;
+			}
+			if (this._promptAuthenticationAbortController === promptAuthenticationAbortController) {
+				this._promptAuthenticationAbortController = undefined;
+			}
+			resolvePromptAuthentication?.();
+		};
 
 		try {
 			// Handle extension commands first (execute immediately, even during streaming)
@@ -1155,6 +1190,17 @@ export class AgentSession {
 				expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 			}
 
+			// Serialize authentication so concurrent prompts cannot both pass the
+			// idle check before either one reserves the agent run.
+			while (this._promptAuthenticationPromise) {
+				this._promptAuthenticationWaiterCount++;
+				try {
+					await this._promptAuthenticationPromise;
+				} finally {
+					this._promptAuthenticationWaiterCount--;
+				}
+			}
+
 			// If streaming, queue via steer() or followUp() based on option
 			if (this.isStreaming) {
 				if (!options?.streamingBehavior) {
@@ -1179,9 +1225,19 @@ export class AgentSession {
 				throw new Error(formatNoModelSelectedMessage());
 			}
 
+			promptAuthentication = new Promise((resolve) => {
+				resolvePromptAuthentication = resolve;
+			});
+			this._promptAuthenticationPromise = promptAuthentication;
+			promptAuthenticationAbortController = new AbortController();
+			this._promptAuthenticationAbortController = promptAuthenticationAbortController;
+
 			const hasConfiguredAuth =
 				this._modelRuntime.hasConfiguredAuth(this.model.provider) ||
 				(await this._modelRuntime.checkAuth(this.model.provider)) !== undefined;
+			if (promptAuthenticationAbortController.signal.aborted) {
+				throw new Error("Request was aborted");
+			}
 			if (!hasConfiguredAuth) {
 				const isOAuth = this._modelRuntime.isUsingOAuth(this.model.provider);
 				if (isOAuth) {
@@ -1194,11 +1250,21 @@ export class AgentSession {
 				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
 			}
 
+			// Reserve the run before releasing authentication waiters. They will see
+			// the active run and queue instead of starting another prompt.
+			this._isAgentRunActive = true;
+			runReservation = new AbortController();
+			this._promptPreparationAbortController = runReservation;
+			releasePromptAuthentication();
+
 			// Check if we need to compact before sending (catches aborted responses).
 			// The user's new prompt is sent below, so do not call agent.continue() here.
 			const lastAssistant = this._findLastAssistantMessage();
 			if (lastAssistant) {
 				await this._checkCompaction(lastAssistant, false);
+			}
+			if (runReservation.signal.aborted) {
+				throw new Error("Request was aborted");
 			}
 
 			// Build messages array (custom message if any, then user message)
@@ -1216,10 +1282,10 @@ export class AgentSession {
 			});
 
 			// Inject any pending "nextTurn" messages as context alongside the user message
-			for (const msg of this._pendingNextTurnMessages) {
+			const pendingNextTurnMessages = this._pendingNextTurnMessages.slice();
+			for (const msg of pendingNextTurnMessages) {
 				messages.push(msg);
 			}
-			this._pendingNextTurnMessages = [];
 
 			// Emit before_agent_start extension event
 			const result = await this._extensionRunner.emitBeforeAgentStart(
@@ -1228,6 +1294,11 @@ export class AgentSession {
 				this._baseSystemPrompt,
 				this._baseSystemPromptOptions,
 			);
+			if (runReservation.signal.aborted) {
+				throw new Error("Request was aborted");
+			}
+			this._pendingNextTurnMessages.splice(0, pendingNextTurnMessages.length);
+
 			// Add all custom messages from extensions
 			if (result?.messages) {
 				for (const msg of result.messages) {
@@ -1251,7 +1322,20 @@ export class AgentSession {
 				this._systemPromptOverride = undefined;
 				this.agent.state.systemPrompt = this._baseSystemPrompt;
 			}
+
+			preflightResult?.(true);
+			if (runReservation.signal.aborted) {
+				throw new Error("Request was aborted");
+			}
 		} catch (error) {
+			if (this._promptPreparationAbortController === runReservation) {
+				this._promptPreparationAbortController = undefined;
+			}
+			if (runReservation) {
+				this._isAgentRunActive = false;
+			}
+			releasePromptAuthentication();
+			this._resolveIdleWaitIfIdle();
 			preflightResult?.(false);
 			throw error;
 		}
@@ -1260,7 +1344,9 @@ export class AgentSession {
 			return;
 		}
 
-		preflightResult?.(true);
+		if (this._promptPreparationAbortController === runReservation) {
+			this._promptPreparationAbortController = undefined;
+		}
 		await this._runAgentPrompt(messages);
 	}
 
@@ -1540,7 +1626,10 @@ export class AgentSession {
 	 * Abort current operation and wait for agent to become idle.
 	 */
 	async abort(): Promise<void> {
+		this._promptAuthenticationAbortController?.abort();
+		this._promptPreparationAbortController?.abort();
 		this.abortRetry();
+		this.abortCompaction();
 		this.agent.abort();
 		await this.waitForIdle();
 	}
@@ -1949,8 +2038,13 @@ export class AgentSession {
 	 *
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
+	 * @param deferNonRetryingCompaction If true, postpone compaction that does not immediately continue the agent.
 	 */
-	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
+	private async _checkCompaction(
+		assistantMessage: AssistantMessage,
+		skipAbortedCheck = true,
+		deferNonRetryingCompaction = false,
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled) return false;
 
@@ -1984,6 +2078,7 @@ export class AgentSession {
 			const willRetry = assistantMessage.stopReason !== "stop";
 
 			if (!willRetry) {
+				if (deferNonRetryingCompaction) return false;
 				return await this._runAutoCompaction("overflow", false);
 			}
 
@@ -2036,6 +2131,7 @@ export class AgentSession {
 			contextTokens = directContextTokens;
 		}
 		if (shouldCompact(contextTokens, contextWindow, settings)) {
+			if (deferNonRetryingCompaction) return false;
 			return await this._runAutoCompaction("threshold", false);
 		}
 		return false;
@@ -2046,12 +2142,16 @@ export class AgentSession {
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
+		let abortController: AbortController | undefined;
 		let started = false;
 
 		try {
 			if (!this.model) {
 				return false;
 			}
+
+			abortController = new AbortController();
+			this._autoCompactionAbortController = abortController;
 
 			let apiKey: string | undefined;
 			let headers: Record<string, string> | undefined;
@@ -2060,6 +2160,9 @@ export class AgentSession {
 				({ apiKey, headers, env } = await this._getRequiredRequestAuth(this.model));
 			} else {
 				({ apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model));
+			}
+			if (abortController.signal.aborted) {
+				return false;
 			}
 
 			const pathEntries = this.sessionManager.getBranch();
@@ -2070,7 +2173,6 @@ export class AgentSession {
 			}
 
 			this._emit({ type: "compaction_start", reason });
-			this._autoCompactionAbortController = new AbortController();
 			started = true;
 
 			let extensionCompaction: CompactionResult | undefined;
@@ -2084,7 +2186,7 @@ export class AgentSession {
 					customInstructions: undefined,
 					reason,
 					willRetry,
-					signal: this._autoCompactionAbortController.signal,
+					signal: abortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (extensionResult?.cancel) {
@@ -2125,7 +2227,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					undefined,
-					this._autoCompactionAbortController.signal,
+					abortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFunction,
 					env,
@@ -2139,7 +2241,7 @@ export class AgentSession {
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (abortController.signal.aborted) {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -2210,7 +2312,9 @@ export class AgentSession {
 			}
 			return false;
 		} finally {
-			this._autoCompactionAbortController = undefined;
+			if (this._autoCompactionAbortController === abortController) {
+				this._autoCompactionAbortController = undefined;
+			}
 		}
 	}
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { estimateTokens } from "../../src/core/compaction/index.ts";
-import { createHarness, type Harness } from "./harness.ts";
+import { createHarness, getMessageText, getUserTexts, type Harness, type HarnessOptions } from "./harness.ts";
 
 type SessionWithCompactionInternals = {
 	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
@@ -65,6 +65,14 @@ function useSummaryStreamFn(harness: Harness, summary: string): () => number {
 		return stream;
 	};
 	return () => callCount;
+}
+
+function createThresholdHarness(extensionFactories?: HarnessOptions["extensionFactories"]): Promise<Harness> {
+	return createHarness({
+		settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 99_000 } },
+		models: [{ id: "faux-1", contextWindow: 100_000, maxTokens: 100 }],
+		extensionFactories,
+	});
 }
 
 function seedCompactableSession(harness: Harness): void {
@@ -267,6 +275,37 @@ describe("AgentSession compaction characterization", () => {
 		await expect(compactPromise).rejects.toThrow("Compaction cancelled");
 	});
 
+	it("cancels auto-compaction while authentication is pending", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		const model = harness.getModel();
+		const auth = await harness.session.modelRuntime.getAuth(model);
+		let markAuthStarted = () => {};
+		const authStarted = new Promise<void>((resolve) => {
+			markAuthStarted = resolve;
+		});
+		let releaseAuth = () => {};
+		const authReleased = new Promise<void>((resolve) => {
+			releaseAuth = resolve;
+		});
+		vi.spyOn(harness.session.modelRuntime, "getAuth").mockImplementation(async () => {
+			markAuthStarted();
+			await authReleased;
+			return auth;
+		});
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		const compaction = sessionInternals._runAutoCompaction("threshold", false);
+		await authStarted;
+		harness.session.abortCompaction();
+		releaseAuth();
+
+		await expect(compaction).resolves.toBe(false);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(0);
+		expect(harness.faux.state.callCount).toBe(0);
+	});
+
 	it("resumes after threshold compaction when only agent-level queued messages exist", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({
@@ -328,7 +367,137 @@ describe("AgentSession compaction characterization", () => {
 		);
 	});
 
-	it("compacts successful overflow responses without retrying", async () => {
+	it("serializes prompts while authentication is pending", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const provider = harness.getModel().provider;
+		const auth = await harness.session.modelRuntime.checkAuth(provider);
+		let markAuthStarted = () => {};
+		const authStarted = new Promise<void>((resolve) => {
+			markAuthStarted = resolve;
+		});
+		let releaseAuth = () => {};
+		const authReleased = new Promise<void>((resolve) => {
+			releaseAuth = resolve;
+		});
+		vi.spyOn(harness.session.modelRuntime, "hasConfiguredAuth").mockReturnValue(false);
+		const checkAuth = vi.spyOn(harness.session.modelRuntime, "checkAuth").mockImplementation(async () => {
+			markAuthStarted();
+			await authReleased;
+			return auth;
+		});
+		harness.setResponses([fauxAssistantMessage("first answer"), fauxAssistantMessage("second answer")]);
+
+		const firstPrompt = harness.session.prompt("first");
+		await authStarted;
+		const secondPrompt = harness.session.prompt("second", { streamingBehavior: "followUp" });
+		releaseAuth();
+		await Promise.all([firstPrompt, secondPrompt]);
+
+		expect(checkAuth).toHaveBeenCalledTimes(1);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(getUserTexts(harness)).toEqual(["first", "second"]);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+
+	it("does not start a prompt when authentication is aborted", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const provider = harness.getModel().provider;
+		const auth = await harness.session.modelRuntime.checkAuth(provider);
+		let markAuthStarted = () => {};
+		const authStarted = new Promise<void>((resolve) => {
+			markAuthStarted = resolve;
+		});
+		let releaseAuth = () => {};
+		const authReleased = new Promise<void>((resolve) => {
+			releaseAuth = resolve;
+		});
+		vi.spyOn(harness.session.modelRuntime, "hasConfiguredAuth").mockReturnValue(false);
+		vi.spyOn(harness.session.modelRuntime, "checkAuth").mockImplementation(async () => {
+			markAuthStarted();
+			await authReleased;
+			return auth;
+		});
+
+		const prompt = harness.session.prompt("hello");
+		const promptResult = prompt.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		await authStarted;
+		const abortPromise = harness.session.abort();
+		releaseAuth();
+		await abortPromise;
+
+		const error = await promptResult;
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe("Request was aborted");
+		expect(harness.faux.state.callCount).toBe(0);
+		expect(harness.session.isIdle).toBe(true);
+	});
+
+	it("allows a waiting prompt to proceed after authentication fails", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const provider = harness.getModel().provider;
+		const auth = await harness.session.modelRuntime.checkAuth(provider);
+		let markAuthStarted = () => {};
+		const authStarted = new Promise<void>((resolve) => {
+			markAuthStarted = resolve;
+		});
+		let releaseAuth = () => {};
+		const authReleased = new Promise<void>((resolve) => {
+			releaseAuth = resolve;
+		});
+		let markSecondAuthStarted = () => {};
+		const secondAuthStarted = new Promise<void>((resolve) => {
+			markSecondAuthStarted = resolve;
+		});
+		let releaseSecondAuth = () => {};
+		const secondAuthReleased = new Promise<void>((resolve) => {
+			releaseSecondAuth = resolve;
+		});
+		vi.spyOn(harness.session.modelRuntime, "hasConfiguredAuth").mockReturnValue(false);
+		const checkAuth = vi
+			.spyOn(harness.session.modelRuntime, "checkAuth")
+			.mockImplementationOnce(async () => {
+				markAuthStarted();
+				await authReleased;
+				return undefined;
+			})
+			.mockImplementationOnce(async () => {
+				markSecondAuthStarted();
+				await secondAuthReleased;
+				return auth;
+			});
+		harness.setResponses([fauxAssistantMessage("second answer")]);
+
+		const firstPrompt = harness.session.prompt("first");
+		const firstResult = firstPrompt.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		await authStarted;
+		const secondPrompt = harness.session.prompt("second", { streamingBehavior: "followUp" });
+		let idleSettled = false;
+		const idlePromise = harness.session.waitForIdle().then(() => {
+			idleSettled = true;
+		});
+		releaseAuth();
+		await secondAuthStarted;
+
+		expect(idleSettled).toBe(false);
+		releaseSecondAuth();
+		const error = await firstResult;
+		expect(error).toBeInstanceOf(Error);
+		await Promise.all([secondPrompt, idlePromise]);
+		expect(checkAuth).toHaveBeenCalledTimes(2);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(getUserTexts(harness)).toEqual(["second"]);
+	});
+
+	it("defers successful overflow compaction until the next prompt", async () => {
 		const harness = await createHarness({
 			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
 			models: [{ id: "faux-1", contextWindow: 1, maxTokens: 100 }],
@@ -346,17 +515,332 @@ describe("AgentSession compaction characterization", () => {
 			],
 		});
 		harnesses.push(harness);
-		harness.setResponses([fauxAssistantMessage("completed answer")]);
+		harness.setResponses([fauxAssistantMessage("completed answer"), fauxAssistantMessage("continued answer")]);
 
-		await expect(harness.session.prompt("hello")).resolves.toBeUndefined();
+		await harness.session.prompt("hello");
 
-		const compactionEnd = harness.eventsOfType("compaction_end").at(-1);
-		expect(compactionEnd).toMatchObject({
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+
+		await harness.session.prompt("continue");
+
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
 			reason: "overflow",
 			aborted: false,
 			willRetry: false,
 		});
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+
+	it("defers threshold compaction until the next prompt while idle", async () => {
+		const extensionEvents: string[] = [];
+		const harness = await createThresholdHarness([
+			(pi) => {
+				pi.on("session_before_compact", async (event) => {
+					extensionEvents.push("session_before_compact");
+					return {
+						compaction: {
+							summary: "threshold compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					};
+				});
+				pi.on("before_agent_start", () => {
+					extensionEvents.push("before_agent_start");
+				});
+			},
+		]);
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("completed answer"), fauxAssistantMessage("continued answer")]);
+
+		await harness.session.prompt("x".repeat(2_400));
+
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+
+		extensionEvents.length = 0;
+		await harness.session.prompt("continue");
+
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			reason: "threshold",
+			aborted: false,
+			willRetry: false,
+		});
+		expect(extensionEvents).toEqual(["session_before_compact", "before_agent_start"]);
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+
+	it("does not start a prompt when deferred pre-prompt compaction is aborted", async () => {
+		let markCompactionStarted = () => {};
+		const compactionStarted = new Promise<void>((resolve) => {
+			markCompactionStarted = resolve;
+		});
+		const harness = await createThresholdHarness([
+			(pi) => {
+				pi.on("session_before_compact", async (event) => {
+					markCompactionStarted();
+					await new Promise<void>((resolve) => {
+						if (event.signal.aborted) {
+							resolve();
+							return;
+						}
+						event.signal.addEventListener("abort", () => resolve(), { once: true });
+					});
+					return { cancel: true };
+				});
+			},
+		]);
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("completed answer")]);
+
+		await harness.session.prompt("x".repeat(2_400));
+		const continuedPrompt = harness.session.prompt("continue");
+		const promptResult = continuedPrompt.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		await compactionStarted;
+
+		await harness.session.abort();
+
+		const error = await promptResult;
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe("Request was aborted");
 		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.isIdle).toBe(true);
+	});
+
+	it("preserves pending context when prompt preparation is aborted", async () => {
+		let beforeStartCount = 0;
+		let markBeforeStart = () => {};
+		const beforeStart = new Promise<void>((resolve) => {
+			markBeforeStart = resolve;
+		});
+		let releaseBeforeStart = () => {};
+		const beforeStartReleased = new Promise<void>((resolve) => {
+			releaseBeforeStart = resolve;
+		});
+		const harness = await createThresholdHarness([
+			(pi) => {
+				pi.on("session_before_compact", async (event) => ({
+					compaction: {
+						summary: "prompt preparation compacted",
+						firstKeptEntryId: event.preparation.firstKeptEntryId,
+						tokensBefore: event.preparation.tokensBefore,
+						details: {},
+					},
+				}));
+				pi.on("before_agent_start", async () => {
+					beforeStartCount++;
+					if (beforeStartCount !== 2) return;
+					markBeforeStart();
+					await beforeStartReleased;
+					return { systemPrompt: "stale aborted override" };
+				});
+			},
+		]);
+		harnesses.push(harness);
+		const baseSystemPrompt = harness.session.systemPrompt;
+		let sawPendingContext = false;
+		harness.setResponses([
+			fauxAssistantMessage("completed answer"),
+			(context) => {
+				sawPendingContext = context.messages.some(
+					(message) => message.role === "user" && getMessageText(message) === "carry this",
+				);
+				return fauxAssistantMessage("continued answer");
+			},
+		]);
+
+		await harness.session.prompt("x".repeat(2_400));
+		await harness.session.sendCustomMessage(
+			{ customType: "next-turn", content: "carry this", display: true, details: {} },
+			{ deliverAs: "nextTurn" },
+		);
+		const continuedPrompt = harness.session.prompt("continue");
+		const promptResult = continuedPrompt.then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		await beforeStart;
+
+		const abortPromise = harness.session.abort();
+		releaseBeforeStart();
+		await abortPromise;
+
+		const error = await promptResult;
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe("Request was aborted");
+		expect(harness.session.systemPrompt).toBe(baseSystemPrompt);
+
+		await harness.session.prompt("try again");
+
+		expect(sawPendingContext).toBe(true);
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+
+	it("preserves next-turn context added during prompt preparation", async () => {
+		let markBeforeStart = () => {};
+		const beforeStart = new Promise<void>((resolve) => {
+			markBeforeStart = resolve;
+		});
+		let releaseBeforeStart = () => {};
+		const beforeStartReleased = new Promise<void>((resolve) => {
+			releaseBeforeStart = resolve;
+		});
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("before_agent_start", async () => {
+						markBeforeStart();
+						await beforeStartReleased;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		let firstPromptSawPendingContext = false;
+		let secondPromptSawPendingContext = false;
+		harness.setResponses([
+			(context) => {
+				firstPromptSawPendingContext = context.messages.some(
+					(message) => message.role === "user" && getMessageText(message) === "carry this",
+				);
+				return fauxAssistantMessage("first answer");
+			},
+			(context) => {
+				secondPromptSawPendingContext = context.messages.some(
+					(message) => message.role === "user" && getMessageText(message) === "carry this",
+				);
+				return fauxAssistantMessage("second answer");
+			},
+		]);
+
+		const firstPrompt = harness.session.prompt("first");
+		await beforeStart;
+		await harness.session.sendCustomMessage(
+			{ customType: "next-turn", content: "carry this", display: true, details: {} },
+			{ deliverAs: "nextTurn" },
+		);
+		releaseBeforeStart();
+		await firstPrompt;
+		await harness.session.prompt("second");
+
+		expect(firstPromptSawPendingContext).toBe(false);
+		expect(secondPromptSawPendingContext).toBe(true);
+	});
+
+	it("queues input submitted while deferred pre-prompt compaction runs", async () => {
+		let markCompactionStarted = () => {};
+		const compactionStarted = new Promise<void>((resolve) => {
+			markCompactionStarted = resolve;
+		});
+		let releaseCompaction = () => {};
+		const compactionReleased = new Promise<void>((resolve) => {
+			releaseCompaction = resolve;
+		});
+		const harness = await createThresholdHarness([
+			(pi) => {
+				pi.on("session_before_compact", async (event) => {
+					markCompactionStarted();
+					await compactionReleased;
+					return {
+						compaction: {
+							summary: "deferred prompt compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					};
+				});
+			},
+		]);
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("completed answer"),
+			fauxAssistantMessage("continued answer"),
+			fauxAssistantMessage("queued answer"),
+		]);
+
+		await harness.session.prompt("x".repeat(2_400));
+		const continuedPrompt = harness.session.prompt("continue");
+		await compactionStarted;
+
+		expect(harness.session.isStreaming).toBe(true);
+		await harness.session.prompt("queued follow-up", { streamingBehavior: "followUp" });
+		releaseCompaction();
+		await continuedPrompt;
+
+		expect(getUserTexts(harness)).toEqual(["continue", "queued follow-up"]);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(2);
+	});
+
+	it("compacts before a queued continuation", async () => {
+		let queuedFollowUp = false;
+		const harness = await createThresholdHarness([
+			(pi) => {
+				pi.on("agent_end", () => {
+					if (queuedFollowUp) return;
+					queuedFollowUp = true;
+					pi.sendUserMessage("queued follow-up", { deliverAs: "followUp" });
+				});
+				pi.on("session_before_compact", async (event) => ({
+					compaction: {
+						summary: "queued continuation compacted",
+						firstKeptEntryId: event.preparation.firstKeptEntryId,
+						tokensBefore: event.preparation.tokensBefore,
+						details: {},
+					},
+				}));
+			},
+		]);
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("completed answer"), fauxAssistantMessage("follow-up answer")]);
+
+		await harness.session.prompt("x".repeat(2_400));
+
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			reason: "threshold",
+			aborted: false,
+			willRetry: false,
+		});
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+
+	it("does not continue when a queued message is cleared during compaction", async () => {
+		let activeSession: Harness["session"] | undefined;
+		let queuedFollowUp = false;
+		const harness = await createThresholdHarness([
+			(pi) => {
+				pi.on("agent_end", () => {
+					if (queuedFollowUp) return;
+					queuedFollowUp = true;
+					pi.sendUserMessage("queued follow-up", { deliverAs: "followUp" });
+				});
+				pi.on("session_before_compact", async (event) => {
+					activeSession?.clearQueue();
+					return {
+						compaction: {
+							summary: "queue cleared during compaction",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					};
+				});
+			},
+		]);
+		activeSession = harness.session;
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("completed answer")]);
+
+		await harness.session.prompt("x".repeat(2_400));
+
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
 	});
 
 	it("ignores stale pre-compaction assistant usage on pre-prompt checks", async () => {


### PR DESCRIPTION
i could trim tests a bit if needed,  or feel free to close and superseed it but i'd love to see this implemented because it introduces a weird edge case of an unnecessary compaction and wasting tokens.

this happens a lot with recent gpt models (not a fix but related #6879) because their context window can go beyond 272K.

- model completes their turn bypassing 272K context limit
- agent_settled
- i don't send a following prompt
- auto compact still gets triggered

which burns unnecessary tokens. my expectation is, if we overflowed the context but model is done, don't auto compact; model is already done. defer it until when i send another prompt.

   ## Summary

   - defer non-recovery auto-compaction after a completed agent run until the next prompt
   - preserve immediate overflow recovery and compaction before queued continuations
   - serialize prompt authentication and make prompt preparation and compaction cancellation-safe
   - cover concurrent prompts, cancellation, extension ordering, and queued-message races

   ## Testing

   - `npm run check`
   - focused coding-agent tests: 50 passed
   - `./test.sh`
