### PR TITLE
docs(agent): 为agent包所有源代码添加中文JSDoc注释

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1,4 +1,7 @@
 /**
+ * 贯穿整个流程使用 AgentMessage 的 Agent 循环。
+ * 仅在 LLM 调用边界处转换为 Message[]。
+ *
  * Agent loop that works with AgentMessage throughout.
  * Transforms to Message[] only at the LLM call boundary.
  */
@@ -25,6 +28,9 @@ import type {
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
 /**
+ * 使用新的提示消息启动 Agent 循环。
+ * 提示消息会被添加到上下文中，并为其发出事件。
+ *
  * Start an agent loop with a new prompt message.
  * The prompt is added to the context and events are emitted for it.
  */
@@ -54,6 +60,13 @@ export function agentLoop(
 }
 
 /**
+ * 从当前上下文继续 Agent 循环，不添加新消息。
+ * 用于重试场景——上下文中已有用户消息或工具结果。
+ *
+ * **重要：** 上下文中的最后一条消息必须通过 `convertToLlm` 转换为 `user` 或 `toolResult` 消息。
+ * 否则 LLM 提供商会拒绝该请求。
+ * 由于 `convertToLlm` 每轮只调用一次，此处无法进行校验。
+ *
  * Continue an agent loop from the current context without adding a new message.
  * Used for retries - context already has user message or tool results.
  *
@@ -142,6 +155,10 @@ export async function runAgentLoopContinue(
 	return newMessages;
 }
 
+/**
+ * 为 Agent 循环事件创建新的 EventStream。
+ * 当发出 "agent_end" 事件时流结束，最终结果是该事件中累积的 AgentMessage 数组。
+ */
 function createAgentStream(): EventStream<AgentEvent, AgentMessage[]> {
 	return new EventStream<AgentEvent, AgentMessage[]>(
 		(event: AgentEvent) => event.type === "agent_end",
@@ -150,6 +167,13 @@ function createAgentStream(): EventStream<AgentEvent, AgentMessage[]> {
 }
 
 /**
+ * agentLoop 和 agentLoopContinue 共享的主循环逻辑。
+ *
+ * 采用嵌套循环结构：
+ * - **外层循环**处理 Agent 本应停止后排队的后续消息，为每批消息创建新的内层循环周期。
+ * - **内层循环**在单次对话轮次内处理引导消息和工具调用，
+ *   只要有待处理消息或模型返回了需要继续的工具调用，就会持续迭代。
+ *
  * Main loop logic shared by agentLoop and agentLoopContinue.
  */
 async function runLoop(
@@ -275,6 +299,9 @@ async function runLoop(
 }
 
 /**
+ * 从 LLM 流式获取助手响应。
+ * AgentMessage[] 在此处被转换为 Message[] 以传递给 LLM。
+ *
  * Stream an assistant response from the LLM.
  * This is where AgentMessage[] gets transformed to Message[] for the LLM.
  */
@@ -372,6 +399,11 @@ async function streamAssistantResponse(
 }
 
 /**
+ * 将因输出 token 限制而被截断的助手消息中的所有工具调用标记为失败。
+ * 流式工具调用参数会由 best-effort JSON 补救解析器最终化，因此截断消息可能会产生
+ * 参数解析和校验通过但不完整的工具调用。这些调用都不安全，
+ * 应全部报告为错误，以便模型重新发起。
+ *
  * Fail all tool calls from an assistant message that was truncated by the
  * output token limit. Streamed tool-call arguments are finalized with a
  * best-effort JSON salvage parser, so a truncated message can yield tool calls
@@ -406,6 +438,8 @@ async function failToolCallsFromTruncatedMessage(
 }
 
 /**
+ * 执行助手消息中的工具调用。
+ *
  * Execute tool calls from an assistant message.
  */
 async function executeToolCalls(
@@ -430,6 +464,12 @@ type ExecutedToolCallBatch = {
 	terminate: boolean;
 };
 
+/**
+ * 按顺序逐个执行工具调用。
+ * 每个工具调用在下一个开始之前都会经过完整的 prepare -> execute -> finalize 流水线。
+ * 每一步都会发出事件，以便调用方观察进度。如果在批量执行途中触发了中止信号，
+ * 剩余的调用将被跳过，批量执行提前终止。
+ */
 async function executeToolCallsSequential(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
@@ -486,6 +526,13 @@ async function executeToolCallsSequential(
 	};
 }
 
+/**
+ * 使用 Promise.all 并发执行工具调用。
+ * 每个工具调用首先进行准备。如果准备阶段产生了即时结果
+ * （例如工具未找到、被 beforeToolCall 阻止），该结果会同步完成。
+ * 否则准备好的调用会被包装为延迟函数，所有延迟调用并行执行。
+ * 结果按原始顺序重新组装，确保工具结果消息与工具调用序列匹配。
+ */
 async function executeToolCallsParallel(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
@@ -553,6 +600,10 @@ async function executeToolCallsParallel(
 	};
 }
 
+/**
+ * 已验证并与注册工具匹配的工具调用，已准备好执行。
+ * 由 `prepareToolCall` 在准备成功时产生。
+ */
 type PreparedToolCall = {
 	kind: "prepared";
 	toolCall: AgentToolCall;
@@ -560,29 +611,61 @@ type PreparedToolCall = {
 	args: unknown;
 };
 
+/**
+ * 在工具调用准备阶段产生的结果，未实际调用工具。
+ * 例如：指定的工具未注册、beforeToolCall 钩子阻止了执行、
+ * 或在执行开始前触发了中止信号。
+ */
 type ImmediateToolCallOutcome = {
 	kind: "immediate";
 	result: AgentToolResult<any>;
 	isError: boolean;
 };
 
+/**
+ * 执行准备好的工具调用后、经过 afterToolCall 后处理之前的原始结果。
+ * 由 `executePreparedToolCall` 产生。
+ */
 type ExecutedToolCallOutcome = {
 	result: AgentToolResult<any>;
 	isError: boolean;
 };
 
+/**
+ * 工具调用经过完整的 prepare -> execute -> finalize 流水线后的最终结果。
+ * 组合了原始工具调用元数据与（可能经过后处理的）结果和错误标志。
+ */
 type FinalizedToolCallOutcome = {
 	toolCall: AgentToolCall;
 	result: AgentToolResult<any>;
 	isError: boolean;
 };
 
+/**
+ * 可以是预先解析的最终结果（来自即时/即时错误路径），
+ * 也可以是产生最终结果的延迟异步函数（用于并行执行）。
+ * `Promise.all` 会将两种变体展平为有序的结果数组。
+ */
 type FinalizedToolCallEntry = FinalizedToolCallOutcome | (() => Promise<FinalizedToolCallOutcome>);
 
+/**
+ * 当批量中每个已完成的工具调用都满足 `result.terminate === true` 时返回 true，
+ * 表示 Agent 应在此轮后停止，而不是继续发起下一次助手请求。
+ * 如果批量为空或任一调用未请求终止，则返回 false。
+ */
 function shouldTerminateToolBatch(finalizedCalls: FinalizedToolCallOutcome[]): boolean {
 	return finalizedCalls.length > 0 && finalizedCalls.every((finalized) => finalized.result.terminate === true);
 }
 
+/**
+ * 对来自 LLM 的原始参数应用工具可选的 `prepareArguments` 转换。
+ * 如果工具没有 `prepareArguments` 钩子，或钩子返回了相同的对象引用，
+ * 则原封不动地返回原始工具调用。否则返回带有转换后参数的新工具调用对象。
+ *
+ * @param tool - 已注册的 Agent 工具定义。
+ * @param toolCall - 来自助手消息的原始工具调用。
+ * @returns 相同的工具调用，或带有更新参数的新浅拷贝。
+ */
 function prepareToolCallArguments(tool: AgentTool<any>, toolCall: AgentToolCall): AgentToolCall {
 	if (!tool.prepareArguments) {
 		return toolCall;
@@ -597,6 +680,18 @@ function prepareToolCallArguments(tool: AgentTool<any>, toolCall: AgentToolCall)
 	};
 }
 
+/**
+ * 准备单个工具调用以执行。这是工具调用流水线的入口点。它处理以下步骤：
+ *
+ * 1. 按名称查找工具；如果未找到则返回即时错误。
+ * 2. 运行 `prepareArguments` 转换原始 LLM 参数。
+ * 3. 根据工具的输入 schema 校验最终参数。
+ * 4. 调用 `beforeToolCall` 钩子；如果钩子要求阻止则阻止执行。
+ * 5. 在每个阶段检查中止信号。
+ *
+ * 返回 `PreparedToolCall`（已准备好执行）或
+ * `ImmediateToolCallOutcome`（错误/被阻止/已中止——跳过执行）。
+ */
 async function prepareToolCall(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
@@ -663,6 +758,18 @@ async function prepareToolCall(
 	}
 }
 
+/**
+ * 使用已验证的参数调用工具的 `execute` 函数。
+ * 支持流式部分结果：如果工具实现调用了 `onPartialResult` 回调，
+ * 则会发出 `tool_execution_update` 事件。
+ * 执行完成（或抛出异常）后，所有待处理的部分结果事件会在返回前被刷新。
+ * 错误会被捕获并转换为错误结果。
+ *
+ * @param prepared - 已验证、可执行的工具调用。
+ * @param signal - 转发给工具 execute 函数的 AbortSignal。
+ * @param emit - 用于发出部分更新事件的事件接收器。
+ * @returns 原始执行结果（afterToolCall 后处理之前）。
+ */
 async function executePreparedToolCall(
 	prepared: PreparedToolCall,
 	signal: AbortSignal | undefined,
@@ -706,6 +813,12 @@ async function executePreparedToolCall(
 	}
 }
 
+/**
+ * 通过可选的 `afterToolCall` 钩子对已执行的工具调用进行后处理。
+ * 该钩子可以修改结果内容、详情、终止标志和错误状态。
+ * 如果钩子抛出异常，结果会被替换为错误结果。
+ * 返回最终结果，组合原始工具调用元数据与（可能已修改的）结果。
+ */
 async function finalizeExecutedToolCall(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
@@ -753,6 +866,12 @@ async function finalizeExecutedToolCall(
 	};
 }
 
+/**
+ * 从错误消息字符串创建合成的错误工具结果。
+ * 内容为包含该消息的单个文本块，详情为空。
+ * 用于工具调用无法继续的任何情况（工具未找到、被阻止、已中止、
+ * 校验失败或执行错误）。
+ */
 function createErrorToolResult(message: string): AgentToolResult<any> {
 	return {
 		content: [{ type: "text", text: message }],
@@ -760,6 +879,10 @@ function createErrorToolResult(message: string): AgentToolResult<any> {
 	};
 }
 
+/**
+ * 发出带有已完成工具调用结果的 `tool_execution_end` 事件。
+ * 在工具完全执行并经过后处理后（或在准备阶段产生了即时结果后）调用。
+ */
 async function emitToolExecutionEnd(finalized: FinalizedToolCallOutcome, emit: AgentEventSink): Promise<void> {
 	await emit({
 		type: "tool_execution_end",
@@ -770,13 +893,17 @@ async function emitToolExecutionEnd(finalized: FinalizedToolCallOutcome, emit: A
 	});
 }
 
+/**
+ * 将已完成的工具调用结果转换为适合追加到对话上下文中的 `ToolResultMessage`。
+ * 包含工具调用 ID、名称、结果内容、详情、错误标志和时间戳。
+ */
 function createToolResultMessage(finalized: FinalizedToolCallOutcome): ToolResultMessage {
 	return {
 		role: "toolResult",
 		toolCallId: finalized.toolCall.id,
 		toolName: finalized.toolCall.name,
-		// Untyped tools (JS extensions) can return results without content; normalize
-		// so the null never enters session history or provider payloads.
+		// 未类型化的工具（JS 扩展）可能返回无 content 的结果；标准化处理，
+		// 确保 null 不会进入会话历史或 provider 负载。
 		content: finalized.result.content ?? [],
 		details: finalized.result.details,
 		usage: finalized.result.usage,
@@ -786,6 +913,10 @@ function createToolResultMessage(finalized: FinalizedToolCallOutcome): ToolResul
 	};
 }
 
+/**
+ * 为工具结果消息发出 `message_start` 和 `message_end` 事件，
+ * 通知调用方一条新的工具结果消息已被添加到对话中。
+ */
 async function emitToolResultMessage(toolResultMessage: ToolResultMessage, emit: AgentEventSink): Promise<void> {
 	await emit({ type: "message_start", message: toolResultMessage });
 	await emit({ type: "message_end", message: toolResultMessage });

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -29,12 +29,17 @@ import type {
 
 export type { QueueMode } from "./types.ts";
 
+/**
+ * 默认的 LLM 消息转换器：仅保留标准的 `user`、`assistant` 和 `toolResult` 角色。
+ * 自定义消息类型（如 bashExecution、notification）会被过滤掉。
+ */
 function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
 	return messages.filter(
 		(message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
 	);
 }
 
+/** 零值 usage 对象，用作失败/空 assistant 消息的兜底。 */
 const EMPTY_USAGE = {
 	input: 0,
 	output: 0,
@@ -44,6 +49,7 @@ const EMPTY_USAGE = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
+/** 占位模型，当 agent 状态中尚未配置模型时使用。 */
 const DEFAULT_MODEL = {
 	id: "unknown",
 	name: "unknown",
@@ -57,6 +63,7 @@ const DEFAULT_MODEL = {
 	maxTokens: 0,
 } satisfies Model<any>;
 
+/** 内部可变状态，支撑公开的 {@link AgentState} 接口。 */
 type MutableAgentState = Omit<AgentState, "isStreaming" | "streamingMessage" | "pendingToolCalls" | "errorMessage"> & {
 	isStreaming: boolean;
 	streamingMessage?: AgentMessage;
@@ -64,6 +71,7 @@ type MutableAgentState = Omit<AgentState, "isStreaming" | "streamingMessage" | "
 	errorMessage?: string;
 };
 
+/** 创建一个新的可变 agent 状态，从初始状态中拷贝 tools 和 messages 数组。 */
 function createMutableAgentState(
 	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>,
 ): MutableAgentState {
@@ -93,7 +101,7 @@ function createMutableAgentState(
 	};
 }
 
-/** Options for constructing an {@link Agent}. */
+/** 构造 {@link Agent} 时的配置选项。 */
 export interface AgentOptions {
 	initialState?: Partial<Omit<AgentState, "pendingToolCalls" | "isStreaming" | "streamingMessage" | "errorMessage">>;
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
@@ -120,22 +128,39 @@ export interface AgentOptions {
 	toolExecution?: ToolExecutionMode;
 }
 
+/**
+ * 线程安全的消息队列，用于 steering 和 follow-up 消息注入。
+ *
+ * 支持两种排放策略：
+ * - `"all"`: 一次性排放所有排队消息
+ * - `"one-at-a-time"`: 每次只排放最早的一条消息
+ */
 class PendingMessageQueue {
+	/** 内部消息存储数组。 */
 	private messages: AgentMessage[] = [];
+	/** 排放策略：`"all"` 一次性返回全部，`"one-at-a-time"` 每次只返回一条。 */
 	public mode: QueueMode;
 
+	/** @param mode - 队列的初始排放策略。 */
 	constructor(mode: QueueMode) {
 		this.mode = mode;
 	}
 
+	/** 将消息追加到队列尾部。 */
 	enqueue(message: AgentMessage): void {
 		this.messages.push(message);
 	}
 
+	/** 队列中是否有待处理的消息。 */
 	hasItems(): boolean {
 		return this.messages.length > 0;
 	}
 
+	/**
+	 * 根据配置的 {@link mode} 排放消息。
+	 * - `"all"`: 按 FIFO 顺序返回全部消息并清空队列
+	 * - `"one-at-a-time"`: 只返回最早的一条消息
+	 */
 	drain(): AgentMessage[] {
 		if (this.mode === "all") {
 			const drained = this.messages.slice();
@@ -151,11 +176,13 @@ class PendingMessageQueue {
 		return [first];
 	}
 
+	/** 丢弃所有排队消息且不返回它们。 */
 	clear(): void {
 		this.messages = [];
 	}
 }
 
+/** 追踪单次活跃的 agent 运行：Promise、resolver 和 abort controller。 */
 type ActiveRun = {
 	promise: Promise<void>;
 	resolve: () => void;
@@ -163,38 +190,53 @@ type ActiveRun = {
 };
 
 /**
- * Stateful wrapper around the low-level agent loop.
+ * 底层 agent loop 的有状态包装器。
  *
- * `Agent` owns the current transcript, emits lifecycle events, executes tools,
- * and exposes queueing APIs for steering and follow-up messages.
+ * `Agent` 维护当前对话记录，发出生命周期事件，执行工具，
+ * 并暴露 steering 和 follow-up 消息的排队 API。
  */
 export class Agent {
+	/** 可变内部状态，支撑公开的 {@link Agent.state} getter。 */
 	private _state: MutableAgentState;
+	/** 已注册的事件订阅者，按插入顺序为每个生命周期事件触发。 */
 	private readonly listeners = new Set<(event: AgentEvent, signal: AbortSignal) => Promise<void> | void>();
+	/** steering 消息队列，在当前 assistant 回合结束后注入。 */
 	private readonly steeringQueue: PendingMessageQueue;
+	/** follow-up 消息队列，仅在 agent 即将空闲时发送。 */
 	private readonly followUpQueue: PendingMessageQueue;
 
+	/** 在每次模型调用前将 agent 消息转换为 LLM 兼容的消息格式。 */
 	public convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
+	/** 可选钩子，在将完整消息上下文发送给模型前对其进行转换。 */
 	public transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+	/** agent loop 中每次模型调用使用的流式函数。 */
 	public streamFunction: StreamFn;
+	/** 可选钩子，用于在调用时解析给定 provider 的 API key。 */
 	public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+	/** 可选回调，在 provider 每次发出原始流式载荷事件时触发。 */
 	public onPayload?: SimpleStreamOptions["onPayload"];
+	/** 可选回调，在 provider 每次发出原始 HTTP 响应事件时触发。 */
 	public onResponse?: SimpleStreamOptions["onResponse"];
+	/** 可选钩子，在每次工具执行前调用；返回结果可跳过实际执行。 */
 	public beforeToolCall?: (
 		context: BeforeToolCallContext,
 		signal?: AbortSignal,
 	) => Promise<BeforeToolCallResult | undefined>;
+	/** 可选钩子，在每次工具完成后调用；可修改或替换结果。 */
 	public afterToolCall?: (
 		context: AfterToolCallContext,
 		signal?: AbortSignal,
 	) => Promise<AfterToolCallResult | undefined>;
+	/** 可选钩子，在 loop 回合之间注入消息或改变控制流。 */
 	public prepareNextTurn?: (
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
+	/** 可选钩子，在 loop 回合之间注入消息或改变控制流（带上下文版本）。 */
 	public prepareNextTurnWithContext?: (
 		context: PrepareNextTurnContext,
 		signal?: AbortSignal,
 	) => Promise<AgentLoopTurnUpdate | undefined> | AgentLoopTurnUpdate | undefined;
+	/** 当前活跃的 run（agent 正在处理时）或 `undefined`（空闲时）。 */
 	private activeRun?: ActiveRun;
 	/** Session identifier forwarded to providers for cache-aware backends. */
 	public sessionId?: string;
@@ -254,7 +296,7 @@ export class Agent {
 		return this._state;
 	}
 
-	/** Controls how queued steering messages are drained. */
+	/** 控制排队的 steering 消息如何被排放。 */
 	set steeringMode(mode: QueueMode) {
 		this.steeringQueue.mode = mode;
 	}
@@ -263,7 +305,7 @@ export class Agent {
 		return this.steeringQueue.mode;
 	}
 
-	/** Controls how queued follow-up messages are drained. */
+	/** 控制排队的 follow-up 消息如何被排放。 */
 	set followUpMode(mode: QueueMode) {
 		this.followUpQueue.mode = mode;
 	}
@@ -272,43 +314,43 @@ export class Agent {
 		return this.followUpQueue.mode;
 	}
 
-	/** Queue a message to be injected after the current assistant turn finishes. */
+	/** 将消息加入队列，在当前 assistant 回合结束后注入。 */
 	steer(message: AgentMessage): void {
 		this.steeringQueue.enqueue(message);
 	}
 
-	/** Queue a message to run only after the agent would otherwise stop. */
+	/** 将消息加入队列，仅在 agent 即将停止时才会执行。 */
 	followUp(message: AgentMessage): void {
 		this.followUpQueue.enqueue(message);
 	}
 
-	/** Remove all queued steering messages. */
+	/** 移除所有排队的 steering 消息。 */
 	clearSteeringQueue(): void {
 		this.steeringQueue.clear();
 	}
 
-	/** Remove all queued follow-up messages. */
+	/** 移除所有排队的 follow-up 消息。 */
 	clearFollowUpQueue(): void {
 		this.followUpQueue.clear();
 	}
 
-	/** Remove all queued steering and follow-up messages. */
+	/** 移除所有排队的 steering 和 follow-up 消息。 */
 	clearAllQueues(): void {
 		this.clearSteeringQueue();
 		this.clearFollowUpQueue();
 	}
 
-	/** Returns true when either queue still contains pending messages. */
+	/** 当任一队列仍有待处理消息时返回 true。 */
 	hasQueuedMessages(): boolean {
 		return this.steeringQueue.hasItems() || this.followUpQueue.hasItems();
 	}
 
-	/** Active abort signal for the current run, if any. */
+	/** 当前 run 的活跃 abort signal（如果有）。 */
 	get signal(): AbortSignal | undefined {
 		return this.activeRun?.abortController.signal;
 	}
 
-	/** Abort the current run, if one is active. */
+	/** 中止当前 run（如果正在运行）。 */
 	abort(): void {
 		this.activeRun?.abortController.abort();
 	}
@@ -322,7 +364,7 @@ export class Agent {
 		return this.activeRun?.promise ?? Promise.resolve();
 	}
 
-	/** Clear transcript state, runtime state, and queued messages. */
+	/** 清除对话记录、运行时状态和排队消息。 */
 	reset(): void {
 		this._state.messages = [];
 		this._state.isStreaming = false;
@@ -333,7 +375,7 @@ export class Agent {
 		this.clearSteeringQueue();
 	}
 
-	/** Start a new prompt from text, a single message, or a batch of messages. */
+	/** 从文本、单条消息或一批消息启动新的 prompt。 */
 	async prompt(message: AgentMessage | AgentMessage[]): Promise<void>;
 	async prompt(input: string, images?: ImageContent[]): Promise<void>;
 	async prompt(input: string | AgentMessage | AgentMessage[], images?: ImageContent[]): Promise<void> {
@@ -346,7 +388,7 @@ export class Agent {
 		await this.runPromptMessages(messages);
 	}
 
-	/** Continue from the current transcript. The last message must be a user or tool-result message. */
+	/** 从当前对话记录继续。最后一条消息必须是 user 或 tool-result 消息。 */
 	async continue(): Promise<void> {
 		if (this.activeRun) {
 			throw new Error("Agent is already processing. Wait for completion before continuing.");
@@ -376,6 +418,7 @@ export class Agent {
 		await this.runContinuation();
 	}
 
+	/** 将 prompt 的各种输入格式（字符串、单条消息、消息数组）统一规范化为 AgentMessage[]。 */
 	private normalizePromptInput(
 		input: string | AgentMessage | AgentMessage[],
 		images?: ImageContent[],
@@ -395,6 +438,7 @@ export class Agent {
 		return [{ role: "user", content, timestamp: Date.now() }];
 	}
 
+	/** 构造 AgentLoopConfig 并启动新 prompt 的 agent loop。支持跳过首次 steering poll（用于 continue 场景）。 */
 	private async runPromptMessages(
 		messages: AgentMessage[],
 		options: { skipInitialSteeringPoll?: boolean } = {},
@@ -411,6 +455,7 @@ export class Agent {
 		});
 	}
 
+	/** 从当前 transcript 末尾继续 agent loop（当前最后一条消息必须是 user 或 toolResult）。 */
 	private async runContinuation(): Promise<void> {
 		await this.runWithLifecycle(async (signal) => {
 			await runAgentLoopContinue(
@@ -423,6 +468,7 @@ export class Agent {
 		});
 	}
 
+	/** 从当前 agent state 创建只读的快照，包含 system prompt、messages 和 tools 的副本。 */
 	private createContextSnapshot(): AgentContext {
 		return {
 			systemPrompt: this._state.systemPrompt,
@@ -431,6 +477,7 @@ export class Agent {
 		};
 	}
 
+	/** 将 Agent 的当前配置和回调组装成 AgentLoopConfig，桥接 Agent 层与底层 agent loop。 */
 	private createLoopConfig(options: { skipInitialSteeringPoll?: boolean } = {}): AgentLoopConfig {
 		let skipInitialSteeringPoll = options.skipInitialSteeringPoll === true;
 		return {
@@ -468,6 +515,10 @@ export class Agent {
 		};
 	}
 
+	/**
+	 * 管理单次 agent 执行的完整生命周期：创建 AbortController、设置流式状态、
+	 * 执行器运行、失败处理、以及 run 结束时的清理。
+	 */
 	private async runWithLifecycle(executor: (signal: AbortSignal) => Promise<void>): Promise<void> {
 		if (this.activeRun) {
 			throw new Error("Agent is already processing.");
@@ -493,6 +544,7 @@ export class Agent {
 		}
 	}
 
+	/** 构造失败的 assistant 消息并发出完整的生命周期事件序列（message_start → message_end → turn_end → agent_end）。 */
 	private async handleRunFailure(error: unknown, aborted: boolean): Promise<void> {
 		const failureMessage = {
 			role: "assistant",
@@ -511,6 +563,7 @@ export class Agent {
 		await this.processEvents({ type: "agent_end", messages: [failureMessage] });
 	}
 
+	/** 清理运行时状态：停止流式标记、pending tool calls、resolve active run promise。 */
 	private finishRun(): void {
 		this._state.isStreaming = false;
 		this._state.streamingMessage = undefined;

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -46,12 +46,14 @@ import type {
 } from "./types.ts";
 import { AgentHarnessError, BranchSummaryError, CompactionError, SessionError, toError } from "./types.ts";
 
+/** 构建用户消息，可附带可选图片附件，供 AI provider API 使用。 */
 function createUserMessage(text: string, images?: ImageContent[]): UserMessage {
 	const content: Array<{ type: "text"; text: string } | ImageContent> = [{ type: "text", text }];
 	if (images) content.push(...images);
 	return { role: "user", content, timestamp: Date.now() };
 }
 
+/** 构建表示失败或中止的合成 assistant 消息，usage 为零。 */
 function createFailureMessage(model: Model<any>, error: unknown, aborted: boolean): AssistantMessage {
 	return {
 		role: "assistant",
@@ -73,6 +75,7 @@ function createFailureMessage(model: Model<any>, error: unknown, aborted: boolea
 	};
 }
 
+/** 深拷贝 stream options，复制嵌套的 headers 和 metadata 对象以避免共享引用导致的变更。 */
 function cloneStreamOptions(streamOptions?: AgentHarnessStreamOptions): AgentHarnessStreamOptions {
 	return {
 		...streamOptions,
@@ -81,6 +84,7 @@ function cloneStreamOptions(streamOptions?: AgentHarnessStreamOptions): AgentHar
 	};
 }
 
+/** 查找名称列表中的重复项，每个重复的名称只返回一次。 */
 function findDuplicateNames(names: string[]): string[] {
 	const seen = new Set<string>();
 	const duplicates = new Set<string>();
@@ -91,6 +95,10 @@ function findDuplicateNames(names: string[]): string[] {
 	return [...duplicates];
 }
 
+/**
+ * 应用补丁到 stream options，在键级别合并 header 和 metadata 对象。
+ * 补丁中将值设为 `undefined` 会从合并结果中移除该键。
+ */
 function applyStreamOptionsPatch(
 	base: AgentHarnessStreamOptions,
 	patch?: AgentHarnessStreamOptionsPatch,
@@ -139,6 +147,11 @@ type AgentHarnessHandler = (event: any, signal?: AbortSignal) => Promise<any> | 
 
 type TrackedTaskKind = "operation" | "mutation";
 
+/**
+ * 将任意抛出的值转换为 {@link AgentHarnessError}。已知子类型
+ * (SessionError, CompactionError, BranchSummaryError) 会用相应的 code 包装；
+ * 其他所有类型则使用提供的 fallback code。
+ */
 function normalizeHarnessError(error: unknown, fallbackCode: AgentHarnessError["code"]): AgentHarnessError {
 	if (error instanceof AgentHarnessError) return error;
 	const cause = toError(error);
@@ -148,10 +161,16 @@ function normalizeHarnessError(error: unknown, fallbackCode: AgentHarnessError["
 	return new AgentHarnessError(fallbackCode, cause.message, cause);
 }
 
+/** {@link normalizeHarnessError} 的快捷方式，使用 `"hook"` 作为 fallback code。 */
 function normalizeHookError(error: unknown): AgentHarnessError {
 	return normalizeHarnessError(error, "hook");
 }
 
+/**
+ * 每个 turn 开始时捕获的 harness 状态冻结快照。
+ * 用于让 agent loop 在 harness 可能被并发修改时，
+ * 能获得 messages、tools、model 和 resources 的一致视图。
+ */
 interface AgentHarnessTurnState<
 	TContext extends object | undefined,
 	TSkill extends Skill = Skill,
@@ -170,6 +189,13 @@ interface AgentHarnessTurnState<
 	activeTools: TTool[];
 }
 
+/**
+ * Agent harness 是 agent loop 的完整生命周期管理器。
+ *
+ * 管理 session、model、tools、thinking level、消息队列、事件订阅和生命周期操作
+ * （prompt、skill、compact、navigateTree、abort、shutdown 等）。
+ * 通过事件 hooks 机制支持外部扩展和自定义行为。
+ */
 export class AgentHarness<
 	TContext extends object | undefined = undefined,
 	TSkill extends Skill = Skill,
@@ -226,14 +252,17 @@ export class AgentHarness<
 		this.followUpQueueMode = options.followUpMode ?? "one-at-a-time";
 	}
 
+	/** 断言 harness 尚未 shutdown，否则抛出 invalid_state 错误。 */
 	private assertNotShutDown(): void {
 		if (this.isShutdown) throw new AgentHarnessError("invalid_state", "AgentHarness has been shut down");
 	}
 
+	/** 查找某个事件类型已注册的 handlers。没有注册任何 handler 时返回 undefined。 */
 	private getHandlers(type: string): Set<AgentHarnessHandler> | undefined {
 		return this.handlers.get(type);
 	}
 
+	/** 向所有通配符订阅者发送 harness 特定事件。来自 hooks 的错误会被包装并重新抛出。 */
 	private async emitOwn(event: AgentHarnessOwnEvent<TSkill, TPromptTemplate>, signal?: AbortSignal): Promise<void> {
 		for (const listener of this.getHandlers(SUBSCRIBER_EVENT_TYPE) ?? []) {
 			try {
@@ -244,6 +273,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 向所有通配符订阅者发送任意类型的事件（harness 或 agent）。 */
 	private async emitAny(event: AgentHarnessEvent<TSkill, TPromptTemplate>, signal?: AbortSignal): Promise<void> {
 		for (const listener of this.getHandlers(SUBSCRIBER_EVENT_TYPE) ?? []) {
 			try {
@@ -254,6 +284,11 @@ export class AgentHarness<
 		}
 	}
 
+	/**
+	 * 向注册了该特定事件类型的 handlers 发送带类型的 hook 事件。
+	 * 每个 handler 按顺序执行；最后一个非 undefined 的结果生效。
+	 * 当没有为该类型注册 handlers 时返回 undefined。
+	 */
 	private async emitHook<TType extends keyof AgentHarnessEventResultMap>(
 		event: Extract<AgentHarnessOwnEvent, { type: TType }>,
 	): Promise<AgentHarnessEventResultMap[TType] | undefined> {
@@ -273,6 +308,7 @@ export class AgentHarness<
 		return lastResult;
 	}
 
+	/** 构建 compaction/branch_summary 操作的重试回调，将重试事件转发给订阅者。 */
 	private retryCallbacks(operation: "compaction" | "branch_summary"): RetryCallbacks {
 		return {
 			onRetryScheduled: (attempt, maxAttempts, delayMs, errorMessage) =>
@@ -282,6 +318,11 @@ export class AgentHarness<
 		};
 	}
 
+	/**
+	 * 运行所有 `before_provider_request` hooks，将 stream-options 补丁
+	 * 依次传递通过每个 handler。每个 handler 接收当前 options 的副本，
+	 * 可以返回一个补丁，该补丁会在传递给下一个 handler 之前合并。
+	 */
 	private async emitBeforeProviderRequest(
 		model: Model<any>,
 		sessionId: string,
@@ -308,6 +349,7 @@ export class AgentHarness<
 		return current;
 	}
 
+	/** 运行所有 `before_provider_payload` hooks，将 payload 按顺序传递通过每个 handler。 */
 	private async emitBeforeProviderPayload(model: Model<any>, payload: unknown): Promise<unknown> {
 		const handlers = this.getHandlers("before_provider_payload");
 		let current = payload;
@@ -325,6 +367,7 @@ export class AgentHarness<
 		return current;
 	}
 
+	/** 向订阅者发送三个消息队列（steer、followUp、nextTurn）的快照。 */
 	private async emitQueueUpdate(): Promise<void> {
 		await this.emitOwn({
 			type: "queue_update",
@@ -334,6 +377,7 @@ export class AgentHarness<
 		});
 	}
 
+	/** 启动一个可中止的操作，创建 AbortController 并追踪操作生命周期，返回 signal 和完成回调。 */
 	private startOperation(): { signal: AbortSignal; finish: () => void } {
 		const abortController = new AbortController();
 		let finish = () => {};
@@ -354,6 +398,7 @@ export class AgentHarness<
 		};
 	}
 
+	/** 追踪异步任务（operation 或 mutation），确保 shutdown 时能等待所有任务完成。 */
 	private async track<T>(kind: TrackedTaskKind, operation: () => Promise<T>): Promise<T> {
 		let settle = () => {};
 		const settled = new Promise<void>((resolve) => {
@@ -368,6 +413,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 等待所有正在进行的任务完成，可选择按 kind 过滤。 */
 	private async waitForTasks(kind?: TrackedTaskKind): Promise<void> {
 		while (true) {
 			const tasks = [...this.activeTasks].flatMap(([task, taskKind]) =>
@@ -378,6 +424,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 解析工具上下文：如果是函数则调用，否则直接返回静态值。 */
 	private async resolveToolContext(): Promise<TContext> {
 		if (typeof this.toolContext === "function") {
 			return await (this.toolContext as () => TContext | Promise<TContext>)();
@@ -385,6 +432,7 @@ export class AgentHarness<
 		return this.toolContext as TContext;
 	}
 
+	/** 将解析后的上下文绑定到工具，使 execute 方法能接收 context 参数。 */
 	private bindToolContext(tool: TTool, context: TContext): AgentTool {
 		return {
 			...tool,
@@ -392,6 +440,11 @@ export class AgentHarness<
 		};
 	}
 
+	/**
+	 * 构建当前 harness 状态的快照，供新的 agent turn 使用。
+	 * 解析 system prompt（字符串或函数），收集 active tools，
+	 * 克隆 stream options，并复制当前的 model 和 thinking level。
+	 */
 	private async createTurnState(): Promise<AgentHarnessTurnState<TContext, TSkill, TPromptTemplate, TTool>> {
 		this.assertNotShutDown();
 		const context = await this.session.buildContext();
@@ -428,6 +481,10 @@ export class AgentHarness<
 		};
 	}
 
+	/**
+	 * 从 turn state 构建 {@link AgentContext}，可选择覆盖 system prompt。
+	 * messages 和 tools 进行浅拷贝以避免变更。
+	 */
 	private createContext(
 		turnState: AgentHarnessTurnState<TContext, TSkill, TPromptTemplate, TTool>,
 		systemPrompt?: string,
@@ -439,6 +496,11 @@ export class AgentHarness<
 		};
 	}
 
+	/**
+	 * 创建一个 streaming 函数，供 agent loop 用于调用 provider。
+	 * 通过 turn-state getter 获取当前状态，运行 `before_provider_request` hooks，
+	 * 并委托给 models.streamSimple。
+	 */
 	private createStreamFn(
 		getTurnState: () => AgentHarnessTurnState<TContext, TSkill, TPromptTemplate, TTool>,
 	): StreamFn {
@@ -469,6 +531,11 @@ export class AgentHarness<
 		};
 	}
 
+	/**
+	 * 根据模式从队列中取出消息：`"all"` 取出所有，
+	 * `"one-at-a-time"` 取出一个。取出后发送队列更新事件。
+	 * 如果 hook 出错，取出的消息会被重新插入队首，错误会重新抛出。
+	 */
 	private async drainQueuedMessages(queue: AgentMessage[], mode: QueueMode): Promise<AgentMessage[]> {
 		const messages = mode === "all" ? queue.splice(0) : queue.splice(0, 1);
 		if (messages.length === 0) return messages;
@@ -481,6 +548,13 @@ export class AgentHarness<
 		}
 	}
 
+	/**
+	 * 构建供 {@link runAgentLoop} 使用的配置对象。
+	 *
+	 * 将 harness hooks 连接到 agent loop 生命周期中：context 转换、
+	 * tool call 拦截，以及准备下一个 turn（刷新待处理的 session 写入
+	 * 并创建新的 turn-state 快照）。
+	 */
 	private createLoopConfig(
 		getTurnState: () => AgentHarnessTurnState<TContext, TSkill, TPromptTemplate, TTool>,
 		setTurnState: (turnState: AgentHarnessTurnState<TContext, TSkill, TPromptTemplate, TTool>) => void,
@@ -539,18 +613,25 @@ export class AgentHarness<
 		};
 	}
 
+	/** 如果列表中任何名称出现超过一次则抛出 {@link AgentHarnessError}。 */
 	private validateUniqueNames(names: string[], message: string): void {
 		const duplicates = findDuplicateNames(names);
 		if (duplicates.length > 0)
 			throw new AgentHarnessError("invalid_argument", `${message}: ${duplicates.join(", ")}`);
 	}
 
+	/** 验证 tool 名称唯一且每个名称都能解析到已注册的 tool。 */
 	private validateToolNames(toolNames: string[], tools: Map<string, TTool> = this.tools): void {
 		this.validateUniqueNames(toolNames, "Duplicate active tool name(s)");
 		const missing = toolNames.filter((name) => !tools.has(name));
 		if (missing.length > 0) throw new AgentHarnessError("invalid_argument", `Unknown tool(s): ${missing.join(", ")}`);
 	}
 
+	/**
+	 * 按 FIFO 顺序取出所有排队的 session 写入，将每个分发到
+	 * 相应的 session 方法（appendMessage、appendModelChange 等）。
+	 * 在 turn 边界执行以确保 session 状态一致。
+	 */
 	private async flushPendingSessionWrites(): Promise<void> {
 		while (this.pendingSessionWrites.length > 0) {
 			const write = this.pendingSessionWrites[0]!;
@@ -577,6 +658,11 @@ export class AgentHarness<
 		}
 	}
 
+	/**
+	 * 处理 agent-loop 生命周期事件：在 `message_end` 时持久化消息，
+	 * 在 `turn_end` 和 `agent_end` 时刷新待处理的写入并发送保存/完成标记，
+	 * 以及将所有事件转发给订阅者。
+	 */
 	private async handleAgentEvent(event: AgentEvent, signal?: AbortSignal): Promise<void> {
 		if (event.type === "message_end") {
 			await this.session.appendMessage(event.message);
@@ -606,6 +692,11 @@ export class AgentHarness<
 		await this.emitAny(event, signal);
 	}
 
+	/**
+	 * 合成一条 failure/abort assistant 消息，并让其走完完整的
+	 * agent-event 生命周期，使订阅者能看到干净的终止序列。
+	 * 返回 failure 消息供调用者检查。
+	 */
 	private async emitRunFailure(
 		model: Model<any>,
 		error: unknown,
@@ -620,6 +711,14 @@ export class AgentHarness<
 		return [failureMessage];
 	}
 
+	/**
+	 * 运行 agent loop 的单个 turn。
+	 *
+	 * 创建初始 user message，如果 `nextTurnQueue` 有内容则取出，
+	 * 运行 `before_agent_start` hooks，并委托给 {@link runAgentLoop}。
+	 * 失败时调用 {@link emitRunFailure} 产生干净的终止。
+	 * 在 `finally` 块中刷新待处理的 session 写入。
+	 */
 	private async executeTurn(
 		turnState: AgentHarnessTurnState<TContext, TSkill, TPromptTemplate, TTool>,
 		text: string,
@@ -689,6 +788,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 启动一个新的 agent turn，发送文本提示并可附带可选图片。如果 harness 正忙则抛出 busy 错误。 */
 	async prompt(text: string, options?: { images?: ImageContent[] }): Promise<AssistantMessage> {
 		this.assertNotShutDown();
 		if (this.phase !== "idle") throw new AgentHarnessError("busy", "AgentHarness is busy");
@@ -705,6 +805,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 按名称调用已注册的 skill，可附带额外指令。如果 skill 不存在则抛出错误。 */
 	async skill(name: string, additionalInstructions?: string): Promise<AssistantMessage> {
 		this.assertNotShutDown();
 		if (this.phase !== "idle") throw new AgentHarnessError("busy", "AgentHarness is busy");
@@ -727,6 +828,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 按名称调用已注册的 prompt template，用传入的 args 进行格式化。如果模板不存在则抛出错误。 */
 	async promptFromTemplate(name: string, args: string[] = []): Promise<AssistantMessage> {
 		this.assertNotShutDown();
 		if (this.phase !== "idle") throw new AgentHarnessError("busy", "AgentHarness is busy");
@@ -745,6 +847,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 向正在运行的 agent turn 发送 steering 消息，放入 steer 队列。harness 空闲时抛出错误。 */
 	async steer(text: string, options?: { images?: ImageContent[] }): Promise<void> {
 		this.assertNotShutDown();
 		if (this.phase === "idle") throw new AgentHarnessError("invalid_state", "Cannot steer while idle");
@@ -752,6 +855,7 @@ export class AgentHarness<
 		await this.emitQueueUpdate();
 	}
 
+	/** 向正在运行的 agent turn 发送 followUp 消息，放入 followUp 队列。harness 空闲时抛出错误。 */
 	async followUp(text: string, options?: { images?: ImageContent[] }): Promise<void> {
 		this.assertNotShutDown();
 		if (this.phase === "idle") throw new AgentHarnessError("invalid_state", "Cannot follow up while idle");
@@ -759,12 +863,14 @@ export class AgentHarness<
 		await this.emitQueueUpdate();
 	}
 
+	/** 为下一个 turn 预先排队一条用户消息，作为当前 turn 后续的第一条消息。 */
 	async nextTurn(text: string, options?: { images?: ImageContent[] }): Promise<void> {
 		this.assertNotShutDown();
 		this.nextTurnQueue.push(createUserMessage(text, options?.images));
 		await this.emitQueueUpdate();
 	}
 
+	/** 追加一条消息到 session。harness 忙时排队到待处理写入，空闲时直接写入。 */
 	async appendMessage(message: AgentMessage): Promise<void> {
 		this.assertNotShutDown();
 		return this.track("mutation", async () => {
@@ -780,6 +886,7 @@ export class AgentHarness<
 		});
 	}
 
+	/** 执行对话压缩，用 LLM 为较早的对话历史生成摘要。要求 harness 处于 idle 状态。 */
 	async compact(customInstructions?: string): Promise<CompactResult> {
 		this.assertNotShutDown();
 		if (this.phase !== "idle") throw new AgentHarnessError("busy", "compact() requires idle harness");
@@ -839,6 +946,7 @@ export class AgentHarness<
 		}
 	}
 
+	/** 导航到 session 树中的另一个节点，可选择在移动前对目标分支进行摘要。要求 harness 处于 idle 状态。 */
 	async navigateTree(
 		targetId: string,
 		options?: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string },
@@ -943,6 +1051,7 @@ export class AgentHarness<
 		return this.model;
 	}
 
+	/** 更改当前 model，记录 model_change 到 session 并发送 model_update 事件。 */
 	async setModel(model: Model<any>): Promise<void> {
 		this.assertNotShutDown();
 		return this.track("mutation", async () => {
@@ -965,6 +1074,7 @@ export class AgentHarness<
 		return this.thinkingLevel;
 	}
 
+	/** 更改 thinking level，记录到 session 并发送 thinking_level_update 事件。 */
 	async setThinkingLevel(level: ThinkingLevel): Promise<void> {
 		this.assertNotShutDown();
 		return this.track("mutation", async () => {
@@ -987,6 +1097,7 @@ export class AgentHarness<
 		return [...this.tools.values()];
 	}
 
+	/** 替换全部 tools 并可选设置 active tool 列表，记录到 session 并发送 tools_update 事件。 */
 	async setTools(tools: TTool[], activeToolNames?: string[]): Promise<void> {
 		this.assertNotShutDown();
 		return this.track("mutation", () => this.applyTools(tools, activeToolNames));
@@ -1027,6 +1138,7 @@ export class AgentHarness<
 		return this.activeToolNames.map((name) => this.tools.get(name)!);
 	}
 
+	/** 仅更改 active tool 列表，记录到 session 并发送 tools_update 事件。不会修改已注册的 tools。 */
 	async setActiveTools(toolNames: string[]): Promise<void> {
 		this.assertNotShutDown();
 		return this.track("mutation", () => this.applyActiveTools(toolNames));
@@ -1081,6 +1193,7 @@ export class AgentHarness<
 		};
 	}
 
+	/** 替换 skills 和 prompt templates 资源，发送 resources_update 事件。 */
 	async setResources(resources: AgentHarnessResources<TSkill, TPromptTemplate>): Promise<void> {
 		this.assertNotShutDown();
 		const previousResources = this.getResources();
@@ -1101,8 +1214,8 @@ export class AgentHarness<
 	}
 
 	/**
-	 * Permanently stop this harness instance without deleting its durable session.
-	 * Clears queued work, aborts the active operation, and waits for it to settle.
+	 * 永久停止此 harness 实例但不删除其持久化 session。
+	 * 清除排队任务，中止活跃操作，并等待其完成。
 	 */
 	async shutdown(): Promise<void> {
 		if (this.shutdownPromise) return this.shutdownPromise;
@@ -1116,6 +1229,7 @@ export class AgentHarness<
 		return this.shutdownPromise;
 	}
 
+	/** 中止当前操作，清除 steer 和 followUp 队列，等待 harness 进入 idle 状态。 */
 	async abort(): Promise<AbortResult> {
 		this.assertNotShutDown();
 		const clearedSteer = [...this.steerQueue];
@@ -1150,6 +1264,7 @@ export class AgentHarness<
 		await this.waitForTasks("operation");
 	}
 
+	/** 注册通配符事件监听器，接收所有 harness 事件。返回取消订阅函数。 */
 	subscribe(
 		listener: (event: AgentHarnessEvent<TSkill, TPromptTemplate>, signal?: AbortSignal) => Promise<void> | void,
 	): () => void {
@@ -1163,6 +1278,7 @@ export class AgentHarness<
 		return () => handlers!.delete(listener as AgentHarnessHandler);
 	}
 
+	/** 注册特定事件类型的 handler，可返回结果影响后续行为。返回取消订阅函数。 */
 	on<TType extends keyof AgentHarnessEventResultMap>(
 		type: TType,
 		handler: (

--- a/packages/agent/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent/src/harness/compaction/branch-summarization.ts
@@ -19,55 +19,55 @@ import {
 	serializeConversation,
 } from "./utils.ts";
 
-/** File-operation details stored on generated branch summary entries. */
+/** 存储在生成的分支摘要条目上的文件操作详情。 */
 export interface BranchSummaryDetails {
-	/** Files read while exploring the summarized branch. */
+	/** 在探索被摘要分支时读取的文件。 */
 	readFiles: string[];
-	/** Files modified while exploring the summarized branch. */
+	/** 在探索被摘要分支时修改的文件。 */
 	modifiedFiles: string[];
 }
 
 export type { FileOperations } from "./utils.ts";
 
-/** Prepared branch content for summarization. */
+/** 准备好用于摘要的分支内容。 */
 export interface BranchPreparation {
-	/** Messages selected for the branch summary. */
+	/** 选择用于分支摘要的消息。 */
 	messages: AgentMessage[];
-	/** File operations extracted from the branch. */
+	/** 从分支提取的文件操作。 */
 	fileOps: FileOperations;
-	/** Estimated token count for selected messages. */
+	/** 所选消息的预估 token 数。 */
 	totalTokens: number;
 }
 
-/** Entries selected for branch summarization. */
+/** 选择用于分支摘要的条目。 */
 export interface CollectEntriesResult {
-	/** Entries to summarize in chronological order. */
+	/** 按时间顺序排列的待摘要条目。 */
 	entries: SessionTreeEntry[];
-	/** Deepest common ancestor between the previous leaf and target entry. */
+	/** 上一个叶节点和目标条目之间最深层的公共祖先。 */
 	commonAncestorId: string | null;
 }
 
-/** Options for generating a branch summary. */
+/** 生成分支摘要的选项。 */
 export interface GenerateBranchSummaryOptions {
-	/** Provider collection the summarization request goes through; owns auth resolution. */
+	/** 摘要请求经过的提供商集合；拥有认证解析。 */
 	models: Models;
-	/** Model used for summarization. */
+	/** 用于摘要的模型。 */
 	model: Model<any>;
-	/** Abort signal for the summarization request. */
+	/** 摘要请求的中止信号。 */
 	signal: AbortSignal;
-	/** Optional instructions appended to or replacing the default prompt. */
+	/** 追加到或替换默认提示词的可选指令。 */
 	customInstructions?: string;
-	/** Replace the default prompt with custom instructions instead of appending them. */
+	/** 用自定义指令替换默认提示词，而不是追加。 */
 	replaceInstructions?: boolean;
-	/** Tokens reserved for prompt and model output. Defaults to 16384. */
+	/** 为提示词和模型输出预留的 token 数。默认为 16384。 */
 	reserveTokens?: number;
-	/** Optional retry policy for transient summarization errors. */
+	/** 可选的重试策略，用于瞬时摘要错误。 */
 	retry?: RetryPolicy;
-	/** Optional callbacks for retry reporting. */
+	/** 可选的重试回调。 */
 	callbacks?: RetryCallbacks;
 }
 
-/** Collect entries that should be summarized before navigating to a different session tree entry. */
+/** 在导航到不同会话树条目之前收集应被摘要的条目。 */
 export async function collectEntriesForBranchSummary(
 	session: Session,
 	oldLeafId: string | null,
@@ -98,6 +98,13 @@ export async function collectEntriesForBranchSummary(
 
 	return { entries, commonAncestorId };
 }
+/**
+ * 将会话树条目转换为具体的 {@link AgentMessage}，用于分支摘要。
+ *
+ * 与此函数的压缩版本不同，工具结果消息被排除，
+ * 因为它们增加了噪音而无助于分支摘要的上下文。
+ * 压缩条目在此处也被映射为摘要消息。
+ */
 function getMessageFromEntry(entry: SessionTreeEntry): AgentMessage | undefined {
 	switch (entry.type) {
 		case "message":
@@ -123,7 +130,14 @@ function getMessageFromEntry(entry: SessionTreeEntry): AgentMessage | undefined 
 	}
 }
 
-/** Prepare branch entries for summarization within an optional token budget. */
+/**
+ * 在可选的 token 预算内准备用于摘要的分支条目。
+ *
+ * 按时间倒序遍历条目，收集消息直到 token 预算耗尽。
+ * 文件操作从条目级分支摘要详情和单个助手消息中提取。
+ * 当设置了预算且即将超出时，压缩和分支摘要条目如果
+ * 落在预算的 90% 以内仍会被包含，以保留关键的上下文标记。
+ */
 export function prepareBranchEntries(entries: SessionTreeEntry[], tokenBudget: number = 0): BranchPreparation {
 	const messages: AgentMessage[] = [];
 	const fileOps = createFileOps();
@@ -165,11 +179,13 @@ export function prepareBranchEntries(entries: SessionTreeEntry[], tokenBudget: n
 	return { messages, fileOps, totalTokens };
 }
 
+/** 附加在每个分支摘要前面的前言，用于表明它涵盖了不同的对话分支。 */
 const BRANCH_SUMMARY_PREAMBLE = `The user explored a different conversation branch before returning here.
 Summary of that exploration:
 
 `;
 
+/** 指示模型为已放弃的对话分支创建结构化摘要的提示词模板。 */
 const BRANCH_SUMMARY_PROMPT = `Create a structured summary of this conversation branch for context when returning later.
 
 Use this EXACT format:
@@ -199,7 +215,13 @@ Use this EXACT format:
 
 Keep each section concise. Preserve exact file paths, function names, and error messages.`;
 
-/** Generate a summary for abandoned branch entries. */
+/**
+ * 为已放弃的分支条目生成摘要。
+ *
+ * 从分支条目中准备消息，token 预算由模型的上下文窗口减去预留 token 数得出。
+ * 文件操作（读取、写入、编辑）被跟踪并以元数据标签的形式追加。
+ * 摘要以一段前言开头，说明用户曾探索了不同的分支。
+ */
 export async function generateBranchSummary(
 	entries: SessionTreeEntry[],
 	options: GenerateBranchSummaryOptions,

--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -31,13 +31,14 @@ import {
 	serializeConversation,
 } from "./utils.ts";
 
-/** File-operation details stored on generated compaction entries. */
+/** 存储在生成的压缩条目上的文件操作详情。 */
 export interface CompactionDetails {
-	/** Files read in the compacted history. */
+	/** 压缩历史中已读取的文件。 */
 	readFiles: string[];
-	/** Files modified in the compacted history. */
+	/** 压缩历史中已修改的文件。 */
 	modifiedFiles: string[];
 }
+/** 安全地将值序列化为 JSON，当值存在循环引用或无法序列化时返回备用字符串。 */
 function safeJsonStringify(value: unknown): string {
 	try {
 		return JSON.stringify(value) ?? "undefined";
@@ -46,6 +47,11 @@ function safeJsonStringify(value: unknown): string {
 	}
 }
 
+/**
+ * 从压缩历史中提取累积的文件操作。
+ *
+ * 合并三个来源的文件操作：上一次压缩条目存储的详情、被摘要的消息，以及（当回合被分割时）分割点后保留的前缀消息。
+ */
 function extractFileOperations(
 	messages: AgentMessage[],
 	entries: SessionTreeEntry[],
@@ -70,6 +76,11 @@ function extractFileOperations(
 
 	return fileOps;
 }
+/**
+ * 将会话树条目转换为具体的 {@link AgentMessage}，用于显示或序列化。
+ * 处理 message、custom_message、branch_summary 和 compaction 条目类型。
+ * 对于无法表示的条目（例如 label 或 session_info），返回 `undefined`。
+ */
 function getMessageFromEntry(entry: SessionTreeEntry): AgentMessage | undefined {
 	if (entry.type === "message") {
 		return entry.message as AgentMessage;
@@ -92,6 +103,10 @@ function getMessageFromEntry(entry: SessionTreeEntry): AgentMessage | undefined 
 	return undefined;
 }
 
+/**
+ * 与 {@link getMessageFromEntry} 类似，但过滤掉压缩条目。
+ * 压缩摘要条目本身不应被再次压缩，因此它们被排除在传递给摘要模型的消息之外。
+ */
 function getMessageFromEntryForCompaction(entry: SessionTreeEntry): AgentMessage | undefined {
 	if (entry.type === "compaction") {
 		return undefined;
@@ -99,22 +114,26 @@ function getMessageFromEntryForCompaction(entry: SessionTreeEntry): AgentMessage
 	return getMessageFromEntry(entry);
 }
 
-/** Generated compaction data ready to be persisted as a compaction entry. */
+/** 准备好持久化为压缩条目的压缩数据。 */
 export interface CompactionResult<T = unknown> {
-	/** Summary text that replaces compacted history in future context. */
+	/** 在未来上下文中替换压缩历史的摘要文本。 */
 	summary: string;
-	/** Entry id where retained history starts. Optional during Pi 2.0 transition. */
+	/** 保留的历史开始的条目 ID。Pi 2.0 过渡期间可选。 */
 	firstKeptEntryId?: string;
-	/** Estimated context tokens before compaction. */
+	/** 压缩前预估的上下文 token 数。 */
 	tokensBefore: number;
-	/** Usage from the LLM call(s) that generated this summary, if available. */
+	/** 生成此摘要的 LLM 调用的用量（如果可用）。 */
 	usage?: Usage;
-	/** Retained recent messages stored directly on the compaction entry. Optional during Pi 2.0 transition. */
+	/** 压缩后保留的近期消息，直接存储在压缩条目上。Pi 2.0 过渡期间可选。 */
 	retainedTail?: AgentMessage[];
-	/** Optional implementation-specific details stored with the compaction entry. */
+	/** 与压缩条目一起存储的可选实现特定详情。 */
 	details?: T;
 }
 
+/**
+ * 带重试的简化 completion 调用包装器。
+ * 摘要请求是独立的，因此隔离路由并避免无法复用的缓存写入。
+ */
 export async function completeSimpleWithRetries(
 	models: Models,
 	model: Model<any>,
@@ -137,6 +156,7 @@ export async function completeSimpleWithRetries(
 	);
 }
 
+/** 合并两次 LLM 调用的用量数据。 */
 function combineUsage(first: Usage, second: Usage): Usage {
 	return {
 		input: first.input + second.input,
@@ -160,27 +180,30 @@ function combineUsage(first: Usage, second: Usage): Usage {
 	};
 }
 
-/** Compaction thresholds and retention settings. */
+/** 压缩阈值和保留设置。 */
 export interface CompactionSettings {
-	/** Enable automatic compaction decisions. */
+	/** 启用自动压缩决策。 */
 	enabled: boolean;
-	/** Tokens reserved for summary prompt and output. */
+	/** 为摘要提示词和输出预留的 token 数。 */
 	reserveTokens: number;
-	/** Approximate recent-context tokens to keep after compaction. */
+	/** 压缩后保留的近似近期上下文 token 数。 */
 	keepRecentTokens: number;
 }
 
-/** Default compaction settings used by the harness. */
+/** 框架使用的默认压缩设置。 */
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 	enabled: true,
 	reserveTokens: 16384,
 	keepRecentTokens: 20000,
 };
 
-/** Calculate total context tokens from provider usage. */
+/** 根据提供商用量计算上下文 token 总数。 */
 export function calculateContextTokens(usage: Usage): number {
 	return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
 }
+/**
+ * 从助手消息中提取提供商报告的用量，跳过已中止或出错的消息（其用量数据不可靠）。
+ */
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {
 	if (msg.role === "assistant" && "usage" in msg) {
 		const assistantMsg = msg as AssistantMessage;
@@ -196,7 +219,7 @@ function getAssistantUsage(msg: AgentMessage): Usage | undefined {
 	return undefined;
 }
 
-/** Return usage from the last valid assistant message in session entries. */
+/** 返回会话条目中最后一条成功助手消息的用量。 */
 export function getLastAssistantUsage(entries: SessionTreeEntry[]): Usage | undefined {
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
@@ -208,18 +231,22 @@ export function getLastAssistantUsage(entries: SessionTreeEntry[]): Usage | unde
 	return undefined;
 }
 
-/** Estimated context-token usage for a message list. */
+/** 消息列表的预估上下文 token 用量。 */
 export interface ContextUsageEstimate {
-	/** Estimated total context tokens. */
+	/** 预估的上下文 token 总数。 */
 	tokens: number;
-	/** Tokens reported by the most recent assistant usage block. */
+	/** 最近一次助手用量块报告的 token 数。 */
 	usageTokens: number;
-	/** Estimated tokens after the most recent assistant usage block. */
+	/** 最近一次助手用量块之后的预估 token 数。 */
 	trailingTokens: number;
-	/** Index of the message that provided usage, or null when none exists. */
+	/** 提供用量数据的消息索引，不存在时为 null。 */
 	lastUsageIndex: number | null;
 }
 
+/**
+ * 反向扫描消息，找到最近一次成功的助手用量块及其索引。
+ * 当没有可用的用量数据时（例如，没有完成助手轮次的会话），返回 `undefined`。
+ */
 function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; index: number } | undefined {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const usage = getAssistantUsage(messages[i]);
@@ -228,7 +255,7 @@ function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; in
 	return undefined;
 }
 
-/** Estimate context tokens for messages using provider usage when available. */
+/** 使用提供商用量（如果可用）估算消息的上下文 token 数。 */
 export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEstimate {
 	const usageInfo = getLastAssistantUsageInfo(messages);
 
@@ -259,7 +286,7 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
 	};
 }
 
-/** Return whether context usage exceeds the configured compaction threshold. */
+/** 返回上下文用量是否超过配置的压缩阈值。 */
 export function shouldCompact(contextTokens: number, contextWindow: number, settings: CompactionSettings): boolean {
 	if (!settings.enabled) return false;
 	return contextTokens > contextWindow - settings.reserveTokens;
@@ -267,6 +294,10 @@ export function shouldCompact(contextTokens: number, contextWindow: number, sett
 
 const ESTIMATED_IMAGE_CHARS = 4800;
 
+/**
+ * 估算消息内容的字符数，将图像块视为固定宽度。
+ * 字符串内容直接测量；结构化内容数组汇总文本长度和图像块估算值。
+ */
 function estimateTextAndImageContentChars(content: string | Array<{ type: string; text?: string }>): number {
 	if (typeof content === "string") {
 		return content.length;
@@ -283,7 +314,7 @@ function estimateTextAndImageContentChars(content: string | Array<{ type: string
 	return chars;
 }
 
-/** Estimate token count for one message using a conservative character heuristic. */
+/** 使用保守的字符启发式方法估算单条消息的 token 数。 */
 export function estimateTokens(message: AgentMessage): number {
 	let chars = 0;
 
@@ -325,6 +356,14 @@ export function estimateTokens(message: AgentMessage): number {
 
 	return 0;
 }
+/**
+ * 识别条目列表中压缩可以安全分割历史的索引位置。
+ *
+ * 允许在用户消息、助手消息、bash 执行、自定义消息、分支摘要、压缩摘要
+ * 以及非工具结果的消息条目处设置分割点。工具结果消息被排除，因为在工具调用
+ * 与其结果之间分割会破坏上下文完整性。非消息条目（标签、会话信息等）被跳过，
+ * 因为它们本身不携带任何有意义的上下文。
+ */
 function findValidCutPoints(entries: SessionTreeEntry[], startIndex: number, endIndex: number): number[] {
 	const cutPoints: number[] = [];
 	for (let i = startIndex; i < endIndex; i++) {
@@ -365,7 +404,13 @@ function findValidCutPoints(entries: SessionTreeEntry[], startIndex: number, end
 	return cutPoints;
 }
 
-/** Find the user-visible message that starts the turn containing an entry. */
+/**
+ * 找到包含某个条目的回合的起始可见消息。
+ *
+ * 从 `entryIndex` 向下反向搜索至 `startIndex`。一个回合开始于分支摘要、
+ * 自定义消息或用户/bash 执行消息 —— 以反向扫描时最先出现的为准。
+ * 这在分割回合压缩中用于识别部分回合的起始位置，以便单独摘要其前缀。
+ */
 export function findTurnStartIndex(entries: SessionTreeEntry[], entryIndex: number, startIndex: number): number {
 	for (let i = entryIndex; i >= startIndex; i--) {
 		const entry = entries[i];
@@ -382,17 +427,17 @@ export function findTurnStartIndex(entries: SessionTreeEntry[], entryIndex: numb
 	return -1;
 }
 
-/** Cut point selected for compaction. */
+/** 为压缩选择的分割点。 */
 export interface CutPointResult {
-	/** Index of the first entry retained after compaction. */
+	/** 压缩后保留的第一个条目的索引。 */
 	firstKeptEntryIndex: number;
-	/** Index of the turn-start entry when the cut splits a turn, otherwise -1. */
+	/** 分割点分裂一个回合时回合起始条目的索引，否则为 -1。 */
 	turnStartIndex: number;
-	/** Whether the selected cut point splits an in-progress turn. */
+	/** 选择的分割点是否分裂了一个进行中的回合。 */
 	isSplitTurn: boolean;
 }
 
-/** Find the compaction cut point that keeps approximately the requested recent-token budget. */
+/** 找到大约保留所请求的近期 token 预算的压缩分割点。 */
 export function findCutPoint(
 	entries: SessionTreeEntry[],
 	startIndex: number,
@@ -443,10 +488,12 @@ export function findCutPoint(
 	};
 }
 
+/** 指示模型充当摘要助手的系统提示词模板。 */
 export const SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant, then produce a structured summary following the exact format specified.
 
 Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`;
 
+/** 根据对话历史创建新的结构化上下文检查点摘要的提示词模板。 */
 const SUMMARIZATION_PROMPT = `The messages above are a conversation to summarize. Create a structured context checkpoint summary that another LLM will use to continue the work.
 
 Use this EXACT format:
@@ -480,6 +527,7 @@ Use this EXACT format:
 
 Keep each section concise. Preserve exact file paths, function names, and error messages.`;
 
+/** 使用新的对话消息更新现有压缩摘要的提示词模板（增量压缩）。 */
 const UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages to incorporate into the existing summary provided in <previous-summary> tags.
 
 Update the existing structured summary with new information. RULES:
@@ -519,7 +567,7 @@ Use this EXACT format:
 
 Keep each section concise. Preserve exact file paths, function names, and error messages.`;
 
-/** Generate or update a conversation summary for compaction. */
+/** 生成或更新用于压缩的对话摘要。 */
 export async function generateSummary(
 	currentMessages: AgentMessage[],
 	models: Models,
@@ -547,7 +595,7 @@ export async function generateSummary(
 	return result.ok ? ok(result.value.text) : err(result.error);
 }
 
-/** Generate or update a conversation summary and return its provider usage. */
+/** 生成或更新用于压缩的对话摘要并返回其提供商用量。 */
 export async function generateSummaryWithUsage(
 	currentMessages: AgentMessage[],
 	models: Models,
@@ -614,29 +662,29 @@ export async function generateSummaryWithUsage(
 	return ok({ text: textContent, usage: response.usage });
 }
 
-/** Prepared inputs for a compaction run. */
+/** 一次压缩运行的准备输入。 */
 export interface CompactionPreparation {
-	/** Entry id where retained history starts. */
+	/** 保留的历史开始的条目 ID。 */
 	firstKeptEntryId: string;
-	/** Messages summarized into the history summary. */
+	/** 被摘要为历史摘要的消息。 */
 	messagesToSummarize: AgentMessage[];
-	/** Prefix messages summarized separately when compaction splits a turn. */
+	/** 当压缩分割一个回合时，单独摘要的前缀消息。 */
 	turnPrefixMessages: AgentMessage[];
-	/** Recent messages retained after compaction and stored on the compaction entry. */
+	/** 压缩后保留并存储在压缩条目上的近期消息。 */
 	retainedTail: AgentMessage[];
-	/** Whether compaction splits a turn. */
+	/** 压缩是否分割了一个回合。 */
 	isSplitTurn: boolean;
-	/** Estimated context tokens before compaction. */
+	/** 压缩前预估的上下文 token 数。 */
 	tokensBefore: number;
-	/** Previous compaction summary used for iterative updates. */
+	/** 用于迭代更新的上一次压缩摘要。 */
 	previousSummary?: string;
-	/** File operations extracted from summarized history. */
+	/** 从被摘要的历史中提取的文件操作。 */
 	fileOps: FileOperations;
-	/** Settings used to prepare compaction. */
+	/** 用于准备压缩的设置。 */
 	settings: CompactionSettings;
 }
 
-/** Prepare session entries for compaction, or return undefined when compaction is not applicable. */
+/** 准备用于压缩的会话条目，当压缩不适用时返回 undefined。 */
 export function prepareCompaction(
 	pathEntries: SessionTreeEntry[],
 	settings: CompactionSettings,
@@ -712,6 +760,7 @@ export function prepareCompaction(
 	});
 }
 
+/** 用于摘要分割回合前缀部分（被压缩掉的部分）的提示词模板。 */
 const TURN_PREFIX_SUMMARIZATION_PROMPT = `This is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.
 
 Summarize the prefix to provide context for the retained suffix:
@@ -729,7 +778,7 @@ Be concise. Focus on what's needed to understand the kept suffix.`;
 
 export { serializeConversation } from "./utils.ts";
 
-/** Generate compaction summary data from prepared session history. */
+/** 从准备好的会话历史生成压缩摘要数据。 */
 export async function compact(
 	preparation: CompactionPreparation,
 	models: Models,
@@ -824,6 +873,14 @@ export async function compact(
 		details: { readFiles, modifiedFiles } as CompactionDetails,
 	});
 }
+/**
+ * 为分割回合的前缀部分生成轻量摘要。
+ *
+ * 当回合过大无法完整保留时，对较早的前缀消息进行摘要，以便保留的后缀
+ * 仍有足够的上下文。这里使用一个单独的、更短的提示词
+ * ({@link TURN_PREFIX_SUMMARIZATION_PROMPT}) 和更小的 token 预算
+ * （预留 token 的 50%，而主压缩是 80%）。
+ */
 async function generateTurnPrefixSummary(
 	messages: AgentMessage[],
 	models: Models,

--- a/packages/agent/src/harness/compaction/utils.ts
+++ b/packages/agent/src/harness/compaction/utils.ts
@@ -1,17 +1,17 @@
 import { contentText, type Message } from "@earendil-works/pi-ai";
 import type { AgentMessage } from "../../types.ts";
 
-/** File paths touched by a session branch or compaction range. */
+/** 会话分支或压缩范围涉及的文件路径。 */
 export interface FileOperations {
-	/** Files read but not necessarily modified. */
+	/** 已读取但未必被修改的文件。 */
 	read: Set<string>;
-	/** Files written by full-file write operations. */
+	/** 通过全文件写入操作写入的文件。 */
 	written: Set<string>;
-	/** Files modified by edit operations. */
+	/** 通过编辑操作修改的文件。 */
 	edited: Set<string>;
 }
 
-/** Create an empty file-operation accumulator. */
+/** 创建一个空的文件操作累加器。 */
 export function createFileOps(): FileOperations {
 	return {
 		read: new Set(),
@@ -20,7 +20,7 @@ export function createFileOps(): FileOperations {
 	};
 }
 
-/** Add file operations from assistant tool calls to an accumulator. */
+/** 将助手工具调用中的文件操作添加到累加器中。 */
 export function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOperations): void {
 	if (message.role !== "assistant") return;
 	if (!("content" in message) || !Array.isArray(message.content)) return;
@@ -50,7 +50,7 @@ export function extractFileOpsFromMessage(message: AgentMessage, fileOps: FileOp
 	}
 }
 
-/** Compute sorted read-only and modified file lists from accumulated operations. */
+/** 从累积的操作中计算排序后的只读文件和已修改文件列表。 */
 export function computeFileLists(fileOps: FileOperations): { readFiles: string[]; modifiedFiles: string[] } {
 	const modified = new Set([...fileOps.edited, ...fileOps.written]);
 	const readOnly = [...fileOps.read].filter((f) => !modified.has(f)).sort();
@@ -58,7 +58,7 @@ export function computeFileLists(fileOps: FileOperations): { readFiles: string[]
 	return { readFiles: readOnly, modifiedFiles };
 }
 
-/** Format file lists as summary metadata tags. */
+/** 将文件列表格式化为摘要元数据标签。 */
 export function formatFileOperations(readFiles: string[], modifiedFiles: string[]): string {
 	const sections: string[] = [];
 	if (readFiles.length > 0) {
@@ -73,6 +73,7 @@ export function formatFileOperations(readFiles: string[], modifiedFiles: string[
 
 const TOOL_RESULT_MAX_CHARS = 2000;
 
+/** 安全地将值序列化为 JSON，当值存在循环引用或无法序列化时返回备用字符串。 */
 function safeJsonStringify(value: unknown): string {
 	try {
 		return JSON.stringify(value) ?? "undefined";
@@ -81,13 +82,17 @@ function safeJsonStringify(value: unknown): string {
 	}
 }
 
+/**
+ * 截断超出 `maxChars` 的文本，用于摘要提示词。
+ * 追加已截断字符数，以便摘要器知道内容被裁剪。
+ */
 function truncateForSummary(text: string, maxChars: number): string {
 	if (text.length <= maxChars) return text;
 	const truncatedChars = text.length - maxChars;
 	return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
-/** Serialize LLM messages to plain text for summarization prompts. */
+/** 将 LLM 消息序列化为纯文本，用于摘要提示词。 */
 export function serializeConversation(messages: Message[]): string {
 	const parts: string[] = [];
 

--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -47,6 +47,13 @@ function resolveTimeoutMs(timeout: number | undefined): Result<number | undefine
 	return ok(timeoutMs);
 }
 
+/**
+ * 解析相对路径或绝对路径，支持 `~` 主目录展开和 `file://` URI 转换。
+ * 如果传入的是绝对路径则直接返回，否则基于当前工作目录拼接为绝对路径。
+ * @param cwd - 当前工作目录
+ * @param path - 需要解析的路径
+ * @returns 解析后的绝对路径
+ */
 function resolvePath(cwd: string, path: string): string {
 	let normalized = path;
 	if (normalized === "~") {
@@ -63,6 +70,12 @@ function resolvePath(cwd: string, path: string): string {
 	return isAbsolute(normalized) ? resolve(normalized) : resolve(cwd, normalized);
 }
 
+/**
+ * 根据文件系统状态信息判断文件类型。
+ * 依次检查是否为普通文件、目录或符号链接，不支持的类型（如 socket、FIFO）返回 undefined。
+ * @param stats - 包含 isFile、isDirectory、isSymbolicLink 方法的文件状态对象
+ * @returns 文件类型字符串（"file"、"directory"、"symlink"），无法识别时返回 undefined
+ */
 function fileKindFromStats(stats: {
 	isFile(): boolean;
 	isDirectory(): boolean;
@@ -74,6 +87,13 @@ function fileKindFromStats(stats: {
 	return undefined;
 }
 
+/**
+ * 根据文件系统状态信息创建 {@link FileInfo} 对象。
+ * 从文件状态中提取文件类型、大小、修改时间等信息，文件类型不支持时返回错误。
+ * @param path - 文件路径
+ * @param stats - 包含文件类型判断方法和大小、修改时间等属性的状态对象
+ * @returns 包装 FileInfo 的 Result，文件类型不支持时返回错误
+ */
 function fileInfoFromStats(
 	path: string,
 	stats: { isFile(): boolean; isDirectory(): boolean; isSymbolicLink(): boolean; size: number; mtimeMs: number },
@@ -89,10 +109,24 @@ function fileInfoFromStats(
 	});
 }
 
+/**
+ * 类型守卫：判断一个错误是否为 Node.js 的 ErrnoException。
+ * 通过检查是否存在 "code" 属性来区分 Node.js 原生错误与普通 Error。
+ * @param error - 待检查的未知类型错误对象
+ * @returns 如果是 Node.js 原生错误则返回 true
+ */
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
 	return error instanceof Error && "code" in error;
 }
 
+/**
+ * 将各种类型的错误统一转换为 {@link FileError}。
+ * 对 Node.js 原生错误，根据错误码（ENOENT、EACCES、EPERM、ENOTDIR、EISDIR、ABORT_ERR 等）
+ * 映射为对应的 FileError 类型码；无法识别的错误统一归为 "unknown"。
+ * @param error - 原始错误对象
+ * @param path - 关联的文件路径（可选）
+ * @returns 转换后的 FileError 实例
+ */
 function toFileError(error: unknown, path?: string): FileError {
 	if (error instanceof FileError) return error;
 	const cause = toError(error);
@@ -117,10 +151,23 @@ function toFileError(error: unknown, path?: string): FileError {
 	return new FileError("unknown", cause.message, path, cause);
 }
 
+/**
+ * 检查 AbortSignal 是否已中止，若已中止则返回对应的错误结果。
+ * 用于在异步文件操作前快速判断是否需要提前终止，避免不必要的 I/O。
+ * @param signal - 可选的 AbortSignal 对象
+ * @param path - 关联的文件路径（可选）
+ * @returns 如果 signal 已中止则返回 aborted 错误，否则返回 undefined 表示可继续执行
+ */
 function abortResult<TValue>(signal: AbortSignal | undefined, path?: string): Result<TValue, FileError> | undefined {
 	return signal?.aborted ? err(new FileError("aborted", "aborted", path)) : undefined;
 }
 
+/**
+ * 检查给定路径是否存在。
+ * 使用 fs.access 配合 F_OK 常量进行存在性检查，不抛出异常。
+ * @param path - 需要检查的路径
+ * @returns 路径存在返回 true，否则返回 false
+ */
 async function pathExists(path: string): Promise<boolean> {
 	try {
 		await access(path, constants.F_OK);
@@ -130,6 +177,15 @@ async function pathExists(path: string): Promise<boolean> {
 	}
 }
 
+/**
+ * 运行一个命令并设置超时。
+ * 通过 spawn 启动子进程，捕获 stdout 输出；超时后通过 killProcessTree 强制终止进程树。
+ * spawn 失败或进程出错时返回 null status，调用方可据此判断执行是否成功。
+ * @param command - 要执行的命令
+ * @param args - 命令参数数组
+ * @param timeoutMs - 超时时间（毫秒）
+ * @returns 包含 stdout 输出和退出状态码的对象（失败时 status 为 null）
+ */
 async function runCommand(
 	command: string,
 	args: string[],
@@ -165,6 +221,12 @@ async function runCommand(
 	});
 }
 
+/**
+ * 在系统 PATH 中查找 bash 可执行文件的路径。
+ * Windows 下使用 where 命令，类 Unix 系统使用 which 命令。
+ * 返回第一个匹配且通过文件系统存在性检查的路径。
+ * @returns bash 的绝对路径，未找到时返回 null
+ */
 async function findBashOnPath(): Promise<string | null> {
 	const result =
 		process.platform === "win32"
@@ -175,21 +237,45 @@ async function findBashOnPath(): Promise<string | null> {
 	return firstMatch && (await pathExists(firstMatch)) ? firstMatch : null;
 }
 
+/**
+ * Shell 配置接口。
+ * 定义 shell 可执行文件路径、参数格式以及命令传输方式。
+ */
 interface ShellConfig {
 	shell: string;
 	args: string[];
 	commandTransport?: "argv" | "stdin";
 }
 
+/**
+ * 检测是否为旧版 WSL（Windows Subsystem for Linux）的 bash 路径。
+ * 检查路径是否匹配 C:\Windows\System32\bash.exe 或 C:\Windows\SysNative\bash.exe 格式。
+ * 旧版 WSL bash 需要通过 stdin 传递命令（-s 模式），而非使用 -c 参数。
+ * @param path - 需要检查的 shell 路径
+ * @returns 如果匹配旧版 WSL bash 路径则返回 true
+ */
 function isLegacyWslBashPath(path: string): boolean {
 	const normalized = path.replace(/\//g, "\\").toLowerCase();
 	return /^[a-z]:\\windows\\(?:system32|sysnative)\\bash\.exe$/.test(normalized);
 }
 
+/**
+ * 根据 shell 路径确定对应的 Shell 配置。
+ * 旧版 WSL bash 需要使用 -s 参数并通过 stdin 传输命令，现代 bash 使用 -c 参数。
+ * @param shell - shell 可执行文件的路径
+ * @returns 包含 shell、args 和 commandTransport 的配置对象
+ */
 function getBashShellConfig(shell: string): ShellConfig {
 	return isLegacyWslBashPath(shell) ? { shell, args: ["-s"], commandTransport: "stdin" } : { shell, args: ["-c"] };
 }
 
+/**
+ * 解析并获取当前环境可用的 shell 配置。
+ * 查找优先级：自定义路径 → Windows Git Bash（Program Files） → PATH 中的 bash → /bin/bash → 回退到 sh。
+ * 找不到任何可用 shell 时返回 shell_unavailable 错误。
+ * @param customShellPath - 用户自定义的 shell 路径（可选）
+ * @returns 包含 ShellConfig 的 Result，找不到可用 shell 时返回错误
+ */
 async function getShellConfig(customShellPath?: string): Promise<Result<ShellConfig, ExecutionError>> {
 	if (customShellPath) {
 		if (await pathExists(customShellPath)) {
@@ -234,6 +320,15 @@ async function getShellConfig(customShellPath?: string): Promise<Result<ShellCon
 	return ok({ shell: "sh", args: ["-c"] });
 }
 
+/**
+ * 合并环境变量。
+ * 按优先级从低到高依次合并：当前进程环境变量 → baseEnv → extraEnv。
+ * extraEnv 中的变量具有最高优先级，可覆盖 baseEnv 和进程环境变量中的同名变量。
+ * @param baseEnv - 基础环境变量（可选）
+ * @param extraEnv - 额外覆盖的环境变量（可选）
+ * @param inheritEnv - 是否继承进程环境变量，默认 true
+ * @returns 合并后的完整环境变量对象
+ */
 function getShellEnv(
 	baseEnv?: NodeJS.ProcessEnv,
 	extraEnv?: Record<string, string>,
@@ -247,6 +342,13 @@ function getShellEnv(
 	};
 }
 
+/**
+ * 强制终止进程及其所有子进程（跨平台实现）。
+ * Windows 下使用 taskkill /F /T /PID 命令，类 Unix 系统使用 SIGKILL 信号。
+ * 优先尝试通过进程组（-pid）杀死整个进程组，失败后回退到直接终止单个进程。
+ * 所有异常均静默忽略（进程可能已经退出）。
+ * @param pid - 需要终止的进程 ID
+ */
 function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
 		try {
@@ -256,7 +358,7 @@ function killProcessTree(pid: number): void {
 				windowsHide: true,
 			});
 		} catch {
-			// Ignore errors.
+			// 忽略错误。
 		}
 		return;
 	}
@@ -267,11 +369,12 @@ function killProcessTree(pid: number): void {
 		try {
 			process.kill(pid, "SIGKILL");
 		} catch {
-			// Process already dead.
+			// 进程已终止。
 		}
 	}
 }
 
+/** 等待子进程退出，协调 stdout/stderr 流的关闭与进程退出事件，返回退出码。 */
 function waitForChildProcess(child: ChildProcess): Promise<number | null> {
 	return new Promise((resolvePromise, reject) => {
 		let settled = false;
@@ -341,6 +444,18 @@ function waitForChildProcess(child: ChildProcess): Promise<number | null> {
 	});
 }
 
+/**
+ * Node.js 执行环境实现类。
+ *
+ * 实现 {@link ExecutionEnv} 接口，提供完整的文件系统操作和命令执行能力，包括：
+ * - 文件操作：文本/二进制文件的读写、目录管理、临时文件和目录创建
+ * - 命令执行：通过 shell 执行命令，支持超时、中断信号、流式回调输出
+ * - 路径处理：绝对/相对路径解析、路径拼接、规范路径获取
+ * - 跨平台支持：同时兼容 Windows 和类 Unix 系统的进程管理
+ *
+ * 内部通过 {@link getShellConfig} 自动检测可用的 shell（bash/sh），
+ * 通过 {@link killProcessTree} 实现跨平台的进程树清理。
+ */
 export class NodeExecutionEnv implements ExecutionEnv {
 	cwd: string;
 	private shellPath?: string;

--- a/packages/agent/src/harness/messages.ts
+++ b/packages/agent/src/harness/messages.ts
@@ -1,21 +1,42 @@
 import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
 import type { AgentMessage } from "../types.ts";
 
+/**
+ * 向 LLM 展示压缩摘要时使用的前缀。
+ * 摘要文本插入在此前缀和 {@link COMPACTION_SUMMARY_SUFFIX} 之间。
+ */
 export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
 
 <summary>
 `;
 
+/**
+ * 向 LLM 展示压缩摘要时使用的后缀，用于闭合压缩摘要包装。
+ * 与 {@link COMPACTION_SUMMARY_PREFIX} 配对使用。
+ */
 export const COMPACTION_SUMMARY_SUFFIX = `
 </summary>`;
 
+/**
+ * 向 LLM 展示分支摘要时使用的前缀。
+ * 当对话从子代理分支返回时插入分支摘要，提供该分支中已完成操作的上下文。
+ * 摘要文本插入在此前缀和 {@link BRANCH_SUMMARY_SUFFIX} 之间。
+ */
 export const BRANCH_SUMMARY_PREFIX = `The following is a summary of a branch that this conversation came back from:
 
 <summary>
 `;
 
+/**
+ * 向 LLM 展示分支摘要时使用的后缀，用于闭合分支摘要包装。
+ * 与 {@link BRANCH_SUMMARY_PREFIX} 配对使用。
+ */
 export const BRANCH_SUMMARY_SUFFIX = `</summary>`;
 
+/**
+ * 表示由 harness 捕获的 bash/shell 命令执行事件。
+ * 通过 {@link bashExecutionToText} 转换为对 LLM 可见的 user 角色消息。
+ */
 export interface BashExecutionMessage {
 	role: "bashExecution";
 	command: string;
@@ -28,6 +49,12 @@ export interface BashExecutionMessage {
 	excludeFromContext?: boolean;
 }
 
+/**
+ * 表示应用自定义消息，可以包含文本、图片或任意详细数据。
+ * 当 {@link display} 为 true 时，在 LLM 上下文中显示为 user 角色消息。
+ *
+ * @typeParam T - 可选 {@link details} 载荷的类型。
+ */
 export interface CustomMessage<T = unknown> {
 	role: "custom";
 	customType: string;
@@ -37,6 +64,11 @@ export interface CustomMessage<T = unknown> {
 	timestamp: number;
 }
 
+/**
+ * 表示对话从子代理分支返回时的摘要。
+ * 转换为 LLM 可见消息时，用 {@link BRANCH_SUMMARY_PREFIX} 和 {@link BRANCH_SUMMARY_SUFFIX}
+ * 包装。
+ */
 export interface BranchSummaryMessage {
 	role: "branchSummary";
 	summary: string;
@@ -44,6 +76,11 @@ export interface BranchSummaryMessage {
 	timestamp: number;
 }
 
+/**
+ * 表示对话压缩摘要，当上下文窗口过大时替换较早的消息。
+ * 转换为 LLM 可见消息时，用 {@link COMPACTION_SUMMARY_PREFIX} 和
+ * {@link COMPACTION_SUMMARY_SUFFIX} 包装。
+ */
 export interface CompactionSummaryMessage {
 	role: "compactionSummary";
 	summary: string;
@@ -60,6 +97,11 @@ declare module "../types.ts" {
 	}
 }
 
+/**
+ * 将 {@link BashExecutionMessage} 转换为对 LLM 可见的人类可读文本表示。
+ * 包括执行的命令、输出（用代码块包裹）、退出码、取消状态以及
+ * 适用时的截断提示。
+ */
 export function bashExecutionToText(msg: BashExecutionMessage): string {
 	let text = `Ran \`${msg.command}\`\n`;
 	if (msg.output) {
@@ -78,6 +120,15 @@ export function bashExecutionToText(msg: BashExecutionMessage): string {
 	return text;
 }
 
+/**
+ * 创建一个 {@link BranchSummaryMessage}，捕获在返回主对话前子代理分支中
+ * 发生的事件。
+ *
+ * @param summary - 分支活动的人类可读摘要。
+ * @param fromId - 此摘要来源的分支标识符。
+ * @param timestamp - 表示摘要创建时间的 ISO-8601 时间戳字符串。
+ * @returns 一个新的 {@link BranchSummaryMessage} 实例。
+ */
 export function createBranchSummaryMessage(summary: string, fromId: string, timestamp: string): BranchSummaryMessage {
 	return {
 		role: "branchSummary",
@@ -87,6 +138,15 @@ export function createBranchSummaryMessage(summary: string, fromId: string, time
 	};
 }
 
+/**
+ * 创建一个 {@link CompactionSummaryMessage}，对话历史被压缩以保持在
+ * 上下文窗口限制内后的摘要。
+ *
+ * @param summary - 较早对话历史的压缩摘要。
+ * @param tokensBefore - 压缩发生前的近似 token 数量。
+ * @param timestamp - 表示压缩发生时间的 ISO-8601 时间戳字符串。
+ * @returns 一个新的 {@link CompactionSummaryMessage} 实例。
+ */
 export function createCompactionSummaryMessage(
 	summary: string,
 	tokensBefore: number,
@@ -100,6 +160,16 @@ export function createCompactionSummaryMessage(
 	};
 }
 
+/**
+ * 为应出现在 LLM 对话上下文中的应用自定义内容创建一个 {@link CustomMessage}。
+ *
+ * @param customType - 标识自定义消息类型的字符串标签。
+ * @param content - 消息内容，可以是纯文本字符串或文本/图片块数组。
+ * @param display - 此消息是否应在 LLM 上下文中可见。
+ * @param details - 与消息关联的可选任意载荷。
+ * @param timestamp - 表示消息创建时间的 ISO-8601 时间戳字符串。
+ * @returns 一个新的 {@link CustomMessage} 实例。
+ */
 export function createCustomMessage(
 	customType: string,
 	content: string | (TextContent | ImageContent)[],
@@ -117,6 +187,27 @@ export function createCustomMessage(
 	};
 }
 
+/**
+ * 将 {@link AgentMessage} 对象数组转换为标准 LLM {@link Message} 格式，
+ * 用于模型提供商 API。
+ *
+ * 角色转换规则：
+ * - **bashExecution**：转换为 `user` 角色消息，命令输出通过
+ *   {@link bashExecutionToText} 渲染。如果 `excludeFromContext` 为 true，
+ *   则完全跳过。
+ * - **custom**：转换为 `user` 角色消息，直接使用消息的
+ *   内容（字符串或结构化内容数组）。
+ * - **branchSummary**：转换为 `user` 角色消息，摘要文本用
+ *   {@link BRANCH_SUMMARY_PREFIX}/{@link BRANCH_SUMMARY_SUFFIX} 包装。
+ * - **compactionSummary**：转换为 `user` 角色消息，摘要文本用
+ *   {@link COMPACTION_SUMMARY_PREFIX}/{@link COMPACTION_SUMMARY_SUFFIX} 包装。
+ * - **user / assistant / toolResult**：原样传递
+ *   （已经是标准 LLM 消息格式）。
+ * - **所有其他角色**：过滤掉（从结果中省略）。
+ *
+ * @param messages - 要转换的代理消息数组。
+ * @returns 适用于模型提供商的标准 LLM {@link Message} 对象数组。
+ */
 export function convertToLlm(messages: AgentMessage[]): Message[] {
 	return messages
 		.map((m): Message | undefined => {

--- a/packages/agent/src/harness/prompt-templates.ts
+++ b/packages/agent/src/harness/prompt-templates.ts
@@ -3,29 +3,33 @@ import { type ExecutionEnv, type FileInfo, type PromptTemplate, type Result, toE
 
 export type PromptTemplateDiagnosticCode = "file_info_failed" | "list_failed" | "read_failed" | "parse_failed";
 
-/** Warning produced while loading prompt templates. */
+/** 加载 prompt template 时产生的警告。 */
 export interface PromptTemplateDiagnostic {
-	/** Diagnostic severity. Currently only warnings are emitted. */
+	/** 诊断严重级别。目前仅发出警告。 */
 	type: "warning";
-	/** Stable diagnostic code. */
+	/** 稳定的诊断代码。 */
 	code: PromptTemplateDiagnosticCode;
-	/** Human-readable diagnostic message. */
+	/** 人类可读的诊断消息。 */
 	message: string;
-	/** Path associated with the diagnostic. */
+	/** 与诊断关联的路径。 */
 	path: string;
 }
 
+/** 从 prompt template markdown 文件解析出的 YAML frontmatter 的结构。 */
 interface PromptTemplateFrontmatter {
+	/** 在斜杠命令菜单中显示的人类可读描述。 */
 	description?: string;
+	/** 用户调用接受参数的命令时显示的占位提示。 */
 	"argument-hint"?: string;
+	/** 允许任意额外的 frontmatter 键用于应用特定元数据。 */
 	[key: string]: unknown;
 }
 
 /**
- * Load prompt templates from one or more paths.
+ * 从一个或多个路径加载 prompt template。
  *
- * Directory inputs load direct `.md` children non-recursively. File inputs load explicit `.md` files. Missing paths and
- * non-markdown files are skipped. Read and parse failures are returned as diagnostics.
+ * 目录输入非递归地加载直接子级 `.md` 文件。文件输入加载显式的 `.md` 文件。缺失路径和
+ * 非 markdown 文件会被跳过。读取和解析失败以诊断信息形式返回。
  */
 export async function loadPromptTemplates(
 	env: ExecutionEnv,
@@ -62,10 +66,10 @@ export async function loadPromptTemplates(
 }
 
 /**
- * Load prompt templates from source-tagged paths.
+ * 从带 source 标记的路径加载 prompt template。
  *
- * Source values are preserved exactly and attached to every loaded prompt template and diagnostic. The agent package does
- * not interpret source values; applications define their own provenance shape.
+ * Source 值被原样保留并附加到每个加载的 prompt template 和诊断信息上。agent 包不解释 source 值；
+ * 应用程序自行定义其来源形状。
  */
 export async function loadSourcedPromptTemplates<TSource, TPromptTemplate extends PromptTemplate = PromptTemplate>(
 	env: ExecutionEnv,
@@ -92,6 +96,12 @@ export async function loadSourcedPromptTemplates<TSource, TPromptTemplate extend
 	return { promptTemplates, diagnostics };
 }
 
+/**
+ * 从单个目录加载所有 `.md` prompt template（非递归）。
+ *
+ * 条目按名称字母顺序排序。仅加载直接子级中的普通 `.md` 文件；
+ * 子目录和非 markdown 文件会被跳过。读取和解析失败以诊断信息形式返回。
+ */
 async function loadTemplatesFromDir(
 	env: ExecutionEnv,
 	dir: string,
@@ -120,6 +130,13 @@ async function loadTemplatesFromDir(
 	return { promptTemplates, diagnostics };
 }
 
+/**
+ * 将单个 `.md` 文件加载为 prompt template。
+ *
+ * 解析 YAML frontmatter 获取描述；回退到正文的第一个非空行
+ * （截断到 60 个字符）。读取或解析失败时返回 `null` promptTemplate，
+ * 并附带描述每次失败的诊断信息。
+ */
 async function loadTemplateFromFile(
 	env: ExecutionEnv,
 	filePath: string,
@@ -164,6 +181,13 @@ async function loadTemplateFromFile(
 	};
 }
 
+/**
+ * 解析符号链接的真实文件系统类型（`"file"` 或 `"directory"`）。
+ *
+ * 如果 `info.kind` 已已知，则直接返回。否则通过 `canonicalPath` 解析符号链接目标
+ * 并重新 stat。当目标无法确定或不存在时返回 `undefined`，
+ * 并为非 not-found 错误附加诊断信息。
+ */
 async function resolveKind(
 	env: ExecutionEnv,
 	info: FileInfo,
@@ -197,6 +221,14 @@ async function resolveKind(
 	return target.value.kind === "file" || target.value.kind === "directory" ? target.value.kind : undefined;
 }
 
+/**
+ * 从 markdown 内容中解析 YAML frontmatter。
+ *
+ * 期望文档以单独一行的 `---` 开头。frontmatter 块从第二行开始，到下一个 `---` 行结束。
+ * 如果未找到开头的 `---` 或缺少闭合分隔符，则返回空的 frontmatter 对象，并将全部内容视为正文。
+ * 解析前行尾符会被规范化（`\r\n` 和 `\r` 转换为 `\n`）。YAML 块使用 `yaml` 库解析；
+ * 解析错误会被捕获并以 `Result` 错误形式返回。
+ */
 function parseFrontmatter<T extends Record<string, unknown>>(
 	content: string,
 ): Result<{ frontmatter: T; body: string }, Error> {
@@ -213,13 +245,26 @@ function parseFrontmatter<T extends Record<string, unknown>>(
 	}
 }
 
+/**
+ * 从环境风格路径中提取 basename。
+ *
+ * 去除尾部斜杠，然后返回最后一个 `/` 之后的所有内容。当没有 `/` 时返回整个字符串。
+ * 这模拟了 POSIX 风格路径的 `basename(1)` 行为。
+ */
 function basenameEnvPath(path: string): string {
 	const normalized = path.replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
 }
 
-/** Parse an argument string using simple shell-style single and double quotes. */
+/**
+ * 使用 shell 风格的引号将参数字符串解析为位置标记。
+ *
+ * 按未引用的空白字符（空格和制表符）分割。单引号（`'...'`）和双引号
+ * （`"..."`）段会抑制分割和转义：引号字符本身被去除，
+ * 引号之间的所有内容按原样保留。连续的空白分隔符会被折叠
+ * （不会产生空参数）。未匹配的引号被视为在输入末尾闭合。
+ */
 export function parseCommandArgs(argsString: string): string[] {
 	const args: string[] = [];
 	let current = "";
@@ -245,7 +290,18 @@ export function parseCommandArgs(argsString: string): string[] {
 	return args;
 }
 
-/** Substitute prompt template placeholders (`$1`, `$@`, `$ARGUMENTS`, `${@:N}`, `${@:N:L}`) with command arguments. */
+/**
+ * 用命令参数替换 prompt template 中的占位符。
+ *
+ * 可识别的占位符：
+ * - `$N`（例如 `$1`、`$2`）：替换为第 N 个位置参数（从 1 开始）。缺失的参数
+ *   变为空字符串。
+ * - `$@` 和 `$ARGUMENTS`：替换为所有参数以单个空格连接。
+ * - `${@:N}`：替换为从位置 N（从 1 开始）到末尾的所有参数，以空格连接。
+ *   N 会被限制在第一个参数范围内。
+ * - `${@:N:L}`：替换为从位置 N 开始、最多取 L 个参数，以空格连接。
+ *   N 会被限制在第一个参数范围内。
+ */
 export function substituteArgs(content: string, args: string[]): string {
 	let result = content;
 	result = result.replace(/\$(\d+)/g, (_, num: string) => args[parseInt(num, 10) - 1] ?? "");
@@ -261,7 +317,7 @@ export function substituteArgs(content: string, args: string[]): string {
 	return result;
 }
 
-/** Format a prompt template invocation with positional arguments. */
+/** 使用位置参数格式化 prompt template 调用。 */
 export function formatPromptTemplateInvocation(template: PromptTemplate, args: string[] = []): string {
 	return substituteArgs(template.content, args);
 }

--- a/packages/agent/src/harness/session/jsonl-repo.ts
+++ b/packages/agent/src/harness/session/jsonl-repo.ts
@@ -38,6 +38,14 @@ export type JsonlSessionStoreFileSystem = Pick<
 	| "remove"
 >;
 
+/**
+ * 将工作目录路径编码为会话存储所需的文件系统安全目录名。
+ * 去除前导斜杠/反斜杠，然后将每个路径分隔符（`/`、`\\`）和冒号（`:`）替换为连字符（`-`）。
+ * 结果用双连字符分隔符包裹，使目录名清晰地标识一个已编码的 CWD。
+ * @param cwd - 要编码的绝对工作目录路径。
+ * @returns 适合在文件系统路径中使用的安全目录名。
+ * @example encodeCwd("/home/user/project") // => "--home-user-project--"
+ */
 function encodeCwd(cwd: string): string {
 	return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
 }
@@ -52,6 +60,11 @@ export class JsonlSessionStore implements JsonlSessionStoreApi {
 		this.sessionsRootInput = options.sessionsRoot;
 	}
 
+	/**
+	 * 解析并缓存会话根目录的绝对路径。
+	 * @returns 会话根目录的绝对文件系统路径。
+	 * @throws {SessionError} 如果路径无法解析。
+	 */
 	private async getSessionsRoot(): Promise<string> {
 		if (!this.sessionsRoot) {
 			this.sessionsRoot = getFileSystemResultOrThrow(
@@ -62,6 +75,12 @@ export class JsonlSessionStore implements JsonlSessionStoreApi {
 		return this.sessionsRoot;
 	}
 
+	/**
+	 * 为给定工作目录计算会话目录路径。将会话根目录与编码后的 CWD 拼接。
+	 * @param cwd - 需要获取会话目录的工作目录。
+	 * @returns 每个 CWD 的会话目录的绝对路径。
+	 * @throws {SessionError} 如果路径无法解析。
+	 */
 	private async getSessionDir(cwd: string): Promise<string> {
 		return getFileSystemResultOrThrow(
 			await this.fs.joinPath([await this.getSessionsRoot(), encodeCwd(cwd)]),
@@ -69,6 +88,15 @@ export class JsonlSessionStore implements JsonlSessionStoreApi {
 		);
 	}
 
+	/**
+	 * 为新会话生成确定性 JSONL 文件路径。
+	 * 文件名遵循 `<sanitizedTimestamp>_<sessionId>.jsonl` 模式，按创建时间字典序排序。
+	 * @param cwd - 会话的工作目录。
+	 * @param sessionId - 唯一会话标识符。
+	 * @param timestamp - ISO-8601 创建时间戳。
+	 * @returns 会话 JSONL 文件的绝对路径。
+	 * @throws {SessionError} 如果路径无法解析。
+	 */
 	private async createSessionFilePath(cwd: string, sessionId: string, timestamp: string): Promise<string> {
 		return getFileSystemResultOrThrow(
 			await this.fs.joinPath([
@@ -191,6 +219,11 @@ export class JsonlSessionStore implements JsonlSessionStoreApi {
 		return await storage.getMetadata();
 	}
 
+	/**
+	 * 列出会话根目录下所有按 CWD 分类的会话目录。
+	 * 读取会话根目录并返回所有直接子目录的路径（每个对应一个编码后的 CWD）。
+	 * @returns 绝对目录路径数组，每个编码的 CWD 对应一个。
+	 */
 	private async listSessionDirs(): Promise<string[]> {
 		const sessionsRoot = await this.getSessionsRoot();
 		if (
@@ -209,10 +242,12 @@ export class JsonlSessionStore implements JsonlSessionStoreApi {
 	}
 }
 
+/** 创建 JSONL 会话存储实例的工厂函数。 */
 export function createJsonlSessionStore(options: JsonlSessionStoreOptions): JsonlSessionStore {
 	return new JsonlSessionStore(options);
 }
 
+/** 创建 JSONL 会话仓库实例，包含存储和搜索后端。 */
 export function createJsonlSessionRepo(
 	options: JsonlSessionStoreOptions,
 ): SessionRepo<JsonlSessionMetadata, JsonlSessionCreateOptions, JsonlSessionListOptions> {

--- a/packages/agent/src/harness/session/jsonl-storage.ts
+++ b/packages/agent/src/harness/session/jsonl-storage.ts
@@ -22,6 +22,13 @@ interface SessionHeader {
 	metadata?: Record<string, unknown>;
 }
 
+/**
+ * 使用单个条目的标签数据更新内存中的标签查找映射。
+ * 仅作用于类型为 `"label"` 的条目。如果标签文本非空，则将目标条目 ID 映射到该标签；
+ * 如果标签为空或 `undefined`，则移除该目标的任何现有映射。
+ * @param labelsById - 从目标条目 ID 到其当前标签的可变映射。
+ * @param entry - 会话树条目，可能是也可能不是标签条目。
+ */
 function updateLabelCache(labelsById: Map<string, string>, entry: SessionTreeEntry): void {
 	if (entry.type !== "label") return;
 	const label = entry.label?.trim();
@@ -32,6 +39,12 @@ function updateLabelCache(labelsById: Map<string, string>, entry: SessionTreeEnt
 	}
 }
 
+/**
+ * 从会话树条目数组构建完整的标签查找映射。
+ * 遍历所有条目并累积每个目标 ID 的最新标签。后出现的标签条目会覆盖先出现的。
+ * @param entries - 要扫描标签条目的会话树条目数组。
+ * @returns 从条目 ID 到其当前标签字符串的映射。
+ */
 function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
 	const labelsById = new Map<string, string>();
 	for (const entry of entries) {
@@ -40,6 +53,12 @@ function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
 	return labelsById;
 }
 
+/**
+ * 生成一个保证不与现有 ID 冲突的唯一条目 ID。
+ * 最多尝试 100 次生成 UUIDv7 的 8 字符后缀，确保其在提供的查找表中不存在。
+ * @param byId - 具有 `has(id)` 方法用于检查 ID 冲突的对象。
+ * @returns 新会话条目的唯一字符串 ID。
+ */
 function generateEntryId(byId: { has(id: string): boolean }): string {
 	for (let i = 0; i < 100; i++) {
 		// The uuidv7 prefix is timestamp-derived and nearly constant between calls,
@@ -50,10 +69,27 @@ function generateEntryId(byId: { has(id: string): boolean }): string {
 	return uuidv7();
 }
 
+/**
+ * 构造一个代码为 `"invalid_session"` 的 {@link SessionError}。
+ * 当 JSONL 会话文件的头部或整体结构格式错误或缺少必需字段时使用。
+ * @param filePath - 有问题的会话文件路径。
+ * @param message - 验证失败的简短描述。
+ * @param cause - 触发此失败的可选底层错误。
+ * @returns 可抛出的 {@link SessionError}。
+ */
 function invalidSession(filePath: string, message: string, cause?: Error): SessionError {
 	return new SessionError("invalid_session", `Invalid JSONL session file ${filePath}: ${message}`, cause);
 }
 
+/**
+ * 构造一个代码为 `"invalid_entry"` 的 {@link SessionError}。
+ * 当 JSONL 会话文件中的特定行未通过结构验证时使用。
+ * @param filePath - 包含无效条目的会话文件路径。
+ * @param lineNumber - 发现无效条目的行号（从 1 开始）。
+ * @param message - 验证失败的简短描述。
+ * @param cause - 触发此失败的可选底层错误。
+ * @returns 可抛出的 {@link SessionError}。
+ */
 function invalidEntry(filePath: string, lineNumber: number, message: string, cause?: Error): SessionError {
 	return new SessionError(
 		"invalid_entry",
@@ -62,6 +98,13 @@ function invalidEntry(filePath: string, lineNumber: number, message: string, cau
 	);
 }
 
+/**
+ * 解析并验证 JSONL 会话文件的第一行作为会话头部。有效的头部必须包含 type、version、id、timestamp、cwd 字段。
+ * @param line - JSONL 文件的原始第一行（未修剪）。
+ * @param filePath - 正在解析的文件路径（用于错误消息）。
+ * @returns 已验证的 {@link SessionHeader} 对象。
+ * @throws {SessionError} 如果验证失败，代码为 `"invalid_session"`。
+ */
 function parseHeaderLine(line: string, filePath: string): SessionHeader {
 	let parsed: unknown;
 	try {
@@ -100,6 +143,15 @@ function parseHeaderLine(line: string, filePath: string): SessionHeader {
 	};
 }
 
+/**
+ * 解析并验证单行（头部之后的行）作为会话树条目。
+ * 每个条目行必须是一个 JSON 对象，至少包含 type、id、parentId、timestamp 字段。
+ * @param line - 要解析的原始 JSON 行。
+ * @param filePath - 文件路径（用于错误消息）。
+ * @param lineNumber - 文件内的行号（从 1 开始）。
+ * @returns 解析后的条目，强制转换为 {@link SessionTreeEntry}。
+ * @throws {SessionError} 如果验证失败，代码为 `"invalid_entry"`。
+ */
 function parseEntryLine(line: string, filePath: string, lineNumber: number): SessionTreeEntry {
 	let parsed: unknown;
 	try {
@@ -131,10 +183,24 @@ function parseEntryLine(line: string, filePath: string, lineNumber: number): Ses
 	return entry as SessionTreeEntry;
 }
 
+/**
+ * 确定处理给定条目后的有效叶节点 ID。
+ * 对于叶节点条目（`type === "leaf"`），叶节点 ID 是条目的 `targetId`；
+ * 对于所有其他条目类型，叶节点 ID 是条目自身的 ID。
+ * @param entry - 刚被追加或处理的条目。
+ * @returns 新的叶节点 ID，如果树指向根节点则为 `null`。
+ */
 function leafIdAfterEntry(entry: SessionTreeEntry): string | null {
 	return entry.type === "leaf" ? entry.targetId : entry.id;
 }
 
+/**
+ * 将解析后的会话头部及其文件路径转换为 {@link JsonlSessionMetadata}。
+ * 提取会话 ID、创建时间戳、工作目录、可选的父会话路径以及 JSONL 文件路径本身。
+ * @param header - 从 JSONL 文件解析出的已验证 {@link SessionHeader}。
+ * @param path - 会话 JSONL 文件的绝对路径。
+ * @returns {@link JsonlSessionMetadata} 对象。
+ */
 function headerToSessionMetadata(header: SessionHeader, path: string): JsonlSessionMetadata {
 	return {
 		id: header.id,
@@ -159,6 +225,14 @@ export async function loadJsonlSessionMetadata(
 	throw invalidSession(filePath, "missing session header");
 }
 
+/**
+ * 从磁盘加载并解析整个 JSONL 会话文件到其内存表示。
+ * 读取完整文件内容，解析头部和所有条目行，跟踪当前叶节点 ID。
+ * @param fs - 用于读取文件的文件系统抽象。
+ * @param filePath - JSONL 会话文件的绝对路径。
+ * @returns 包含解析后的头部、所有条目的有序数组以及当前叶节点 ID 的对象。
+ * @throws {SessionError} 如果文件缺失、为空或包含无效行。
+ */
 async function loadJsonlStorage(
 	fs: JsonlSessionStorageFileSystem,
 	filePath: string,
@@ -301,11 +375,13 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 		return this.labelsById.get(id);
 	}
 
+	/** 返回最近的会话名称（如果有记录）。 */
 	async getSessionName(): Promise<string | undefined> {
 		const entries = await this.findEntries("session_info");
 		return entries[entries.length - 1]?.name?.trim() || undefined;
 	}
 
+	/** 计算会话统计信息（消息数量、缓存/非缓存 token 数、总费用）。 */
 	async getSessionStats() {
 		let messageCount = 0;
 		let cachedTokens = 0;
@@ -348,6 +424,7 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 		};
 	}
 
+	/** 从叶节点到根或到压缩边界的路径。遇到带有 retainedTail 的压缩条目时停止。 */
 	async getPathToRootOrCompaction(leafId: string | null): Promise<SessionTreeEntry[]> {
 		if (leafId === null) return [];
 		const path: SessionTreeEntry[] = [];
@@ -369,6 +446,7 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 		return path;
 	}
 
+	/** 支持游标分页地返回条目的子集。 */
 	async getEntries(options?: SessionEntryCursorOptions): Promise<SessionTreeEntry[]> {
 		const start = options?.afterEntrySeq ?? 0;
 		const end = options?.limit === undefined ? undefined : start + options.limit;

--- a/packages/agent/src/harness/session/memory-repo.ts
+++ b/packages/agent/src/harness/session/memory-repo.ts
@@ -14,9 +14,21 @@ import { ScanningSessionSearch } from "./search-backend.ts";
 
 export type InMemorySessionCreateOptions = { id?: string };
 
+/**
+ * {@link SessionStore} 的内存实现，底层使用 {@link Map}。
+ * 所有会话仅在存储实例的生命周期内存在——没有磁盘持久化。
+ * 适用于测试、短期 harness 运行或任何不需要持久化会话存储的场景。
+ */
 export class InMemorySessionStore implements SessionStore<SessionMetadata, InMemorySessionCreateOptions, void> {
 	private sessions = new Map<string, InMemorySessionStorage<SessionMetadata>>();
 
+	/**
+	 * 创建一个新的内存会话，并自动生成元数据。
+	 * 可以提供可选的 `id`；否则将生成 UUIDv7。
+	 * @param options - 可选的创建参数。
+	 * @param options.id - 显式会话 ID，省略时自动生成。
+	 * @returns 会话元数据。
+	 */
 	async create(options: InMemorySessionCreateOptions = {}): Promise<SessionMetadata> {
 		const metadata: SessionMetadata = {
 			id: options.id ?? createSessionId(),
@@ -27,12 +39,20 @@ export class InMemorySessionStore implements SessionStore<SessionMetadata, InMem
 		return metadata;
 	}
 
+	/**
+	 * 通过元数据检索之前创建的会话存储。
+	 * 在内部映射中按 ID 查找。如果不存在则抛出 `"not_found"` 错误。
+	 * @param metadata - 会话元数据（必须包含现有会话的 `id`）。
+	 * @returns 现有的 {@link SessionStorage} 实例。
+	 * @throws {SessionError} 如果未找到具有给定 ID 的会话。
+	 */
 	async open(metadata: SessionMetadata): Promise<SessionStorage<SessionMetadata>> {
 		const storage = this.sessions.get(metadata.id);
 		if (!storage) throw new SessionError("not_found", `Session not found: ${metadata.id}`);
 		return storage;
 	}
 
+	/** 加载完整会话快照（元数据、叶节点 ID、所有条目）。 */
 	async load(metadata: SessionMetadata): Promise<SessionSnapshot<SessionMetadata>> {
 		const storage = await this.open(metadata);
 		return {
@@ -42,30 +62,53 @@ export class InMemorySessionStore implements SessionStore<SessionMetadata, InMem
 		};
 	}
 
+	/**
+	 * 列出当前内存中所有会话的元数据。
+	 * @returns 每个存储会话的 {@link SessionMetadata} 数组。
+	 */
 	async list(): Promise<SessionMetadata[]> {
 		return Promise.all([...this.sessions.values()].map((storage) => storage.getMetadata()));
 	}
 
+	/** 通过元数据获取会话的条目列表（支持游标分页）。 */
 	async getEntries(metadata: SessionMetadata, options?: SessionEntryCursorOptions): Promise<SessionTreeEntry[]> {
 		return await (await this.open(metadata)).getEntries(options);
 	}
 
+	/** 为指定会话生成新的唯一条目 ID。 */
 	async createEntryId(metadata: SessionMetadata): Promise<string> {
 		return (await this.open(metadata)).createEntryId();
 	}
 
+	/** 向指定会话追加一个条目。 */
 	async appendEntry(metadata: SessionMetadata, entry: SessionTreeEntry): Promise<void> {
 		await (await this.open(metadata)).appendEntry(entry);
 	}
 
+	/** 设置指定会话的叶节点 ID，返回创建的 LeafEntry。 */
 	async setLeafId(metadata: SessionMetadata, leafId: string | null): Promise<LeafEntry> {
 		return await (await this.open(metadata)).setLeafId(leafId);
 	}
 
+	/**
+	 * 从内存存储中移除一个会话。如果不存在具有给定 ID 的会话，则为空操作。
+	 * @param metadata - 标识要移除的会话的会话元数据。
+	 */
 	async delete(metadata: SessionMetadata): Promise<void> {
 		this.sessions.delete(metadata.id);
 	}
 
+	/**
+	 * 分叉一个现有会话，将条目复制到指定的分叉点。
+	 * 打开源会话，计算要分叉的条目，并创建一个新的独立会话。
+	 * @param sourceMetadata - 源会话的元数据。
+	 * @param options - 分叉配置。
+	 * @param options.entryId - 要在此条目处或之前分叉（可选）。
+	 * @param options.position - 是在条目 `"at"`（处）分叉还是 `"before"`（之前）分叉（默认为 `"before"`）。
+	 * @param options.id - 新会话的显式 ID（省略时自动生成）。
+	 * @returns 新会话的元数据。
+	 * @throws {SessionError} 如果未找到源会话或分叉目标条目。
+	 */
 	async fork(
 		sourceMetadata: SessionMetadata,
 		options: { entryId?: string; position?: "before" | "at"; id?: string },
@@ -82,10 +125,12 @@ export class InMemorySessionStore implements SessionStore<SessionMetadata, InMem
 	}
 }
 
+/** 创建内存会话存储实例的工厂函数。 */
 export function createInMemorySessionStore(): InMemorySessionStore {
 	return new InMemorySessionStore();
 }
 
+/** 创建内存会话仓库实例，包含存储和搜索后端。 */
 export function createInMemorySessionRepo(): SessionRepo<SessionMetadata, InMemorySessionCreateOptions, void> {
 	const store = createInMemorySessionStore();
 	return new SessionRepo({ store, search: new ScanningSessionSearch(store) });

--- a/packages/agent/src/harness/session/memory-storage.ts
+++ b/packages/agent/src/harness/session/memory-storage.ts
@@ -8,6 +8,13 @@ import {
 	type SessionTreeEntry,
 } from "../types.ts";
 
+/**
+ * 使用单个条目的标签数据更新内存中的标签查找映射。
+ * 仅作用于类型为 `"label"` 的条目。如果标签文本非空，则将目标条目 ID 映射到该标签；
+ * 如果标签为空或 `undefined`，则移除该目标的任何现有映射。
+ * @param labelsById - 从目标条目 ID 到其当前标签的可变映射。
+ * @param entry - 会话树条目，可能是也可能不是标签条目。
+ */
 function updateLabelCache(labelsById: Map<string, string>, entry: SessionTreeEntry): void {
 	if (entry.type !== "label") return;
 	const label = entry.label?.trim();
@@ -18,6 +25,12 @@ function updateLabelCache(labelsById: Map<string, string>, entry: SessionTreeEnt
 	}
 }
 
+/**
+ * 从会话树条目数组构建完整的标签查找映射。
+ * 遍历所有条目并累积每个目标 ID 的最新标签。后出现的标签条目会覆盖先出现的。
+ * @param entries - 要扫描标签条目的会话树条目数组。
+ * @returns 从条目 ID 到其当前标签字符串的映射。
+ */
 function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
 	const labelsById = new Map<string, string>();
 	for (const entry of entries) {
@@ -26,6 +39,12 @@ function buildLabelsById(entries: SessionTreeEntry[]): Map<string, string> {
 	return labelsById;
 }
 
+/**
+ * 生成一个保证不与现有 ID 冲突的唯一条目 ID。
+ * 最多尝试 100 次生成 UUIDv7 的 8 字符后缀，确保其在提供的查找表中不存在。
+ * @param byId - 具有 `has(id)` 方法用于冲突检查的对象（通常是现有条目的 `Map`）。
+ * @returns 新会话条目的唯一字符串 ID。
+ */
 function generateEntryId(byId: { has(id: string): boolean }): string {
 	for (let i = 0; i < 100; i++) {
 		// The uuidv7 prefix is timestamp-derived and nearly constant between calls,
@@ -36,10 +55,23 @@ function generateEntryId(byId: { has(id: string): boolean }): string {
 	return uuidv7();
 }
 
+/**
+ * 确定处理给定条目后的有效叶节点 ID。
+ * 对于叶节点条目（`type === "leaf"`），叶节点 ID 是条目的 `targetId`；
+ * 对于所有其他条目类型，叶节点 ID 是条目自身的 ID——条目本身成为分支的新顶端。
+ * @param entry - 刚被追加或处理的条目。
+ * @returns 新的叶节点 ID，如果树指向根节点则为 `null`。
+ */
 function leafIdAfterEntry(entry: SessionTreeEntry): string | null {
 	return entry.type === "leaf" ? entry.targetId : entry.id;
 }
 
+/**
+ * {@link SessionStorage} 的内存实现，无磁盘持久化。
+ * 在 JavaScript 数据结构（`Map` 和数组）中维护所有会话条目、标签和当前叶节点位置。
+ * 适用于测试或不需要持久化存储的临时 harness 运行。
+ * @typeParam TMetadata - 会话元数据类型，默认为 {@link SessionMetadata}。
+ */
 export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionMetadata>
 	implements SessionStorage<TMetadata>
 {
@@ -49,6 +81,14 @@ export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionM
 	private labelsById: Map<string, string>;
 	private leafId: string | null;
 
+	/**
+	 * 构造一个新的内存存储实例，可带有可选的初始状态。
+	 * 如果提供了 `entries`，则将其深拷贝到内部数组中。叶节点 ID 通过对每个条目依次应用 leafIdAfterEntry 来派生。
+	 * @param options - 可选的初始状态。
+	 * @param options.entries - 预填充的会话条目，用于初始化存储。
+	 * @param options.metadata - 会话元数据；省略时自动生成。
+	 * @throws {SessionError} 如果叶节点条目引用了不存在的目标。
+	 */
 	constructor(options?: { entries?: SessionTreeEntry[]; metadata?: TMetadata }) {
 		this.entries = options?.entries ? [...options.entries] : [];
 		this.byId = new Map(this.entries.map((entry) => [entry.id, entry]));
@@ -61,10 +101,20 @@ export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionM
 		this.metadata = options?.metadata ?? ({ id: uuidv7(), createdAt: new Date().toISOString() } as TMetadata);
 	}
 
+	/**
+	 * 返回会话元数据（ID、创建时间戳以及任何类型特定的字段）。
+	 * @returns 存储的会话元数据。
+	 */
 	async getMetadata(): Promise<TMetadata> {
 		return this.metadata;
 	}
 
+	/**
+	 * 返回当前叶节点条目 ID，如果树在根节点则为 `null`。
+	 * 验证存储的叶节点 ID 在条目映射中仍然存在。
+	 * @returns 当前叶节点 ID，或 `null`。
+	 * @throws {SessionError} 如果叶节点 ID 引用了不存在的条目。
+	 */
 	async getLeafId(): Promise<string | null> {
 		if (this.leafId !== null && !this.byId.has(this.leafId)) {
 			throw new SessionError("invalid_session", `Entry ${this.leafId} not found`);
@@ -72,6 +122,12 @@ export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionM
 		return this.leafId;
 	}
 
+	/**
+	 * 将会话叶节点移动到不同的条目。追加一个新的 LeafEntry 以记录位置变化。
+	 * @param leafId - 目标条目 ID，或 `null` 指向根节点。
+	 * @returns 创建的 LeafEntry。
+	 * @throws {SessionError} 如果目标条目不存在。
+	 */
 	async setLeafId(leafId: string | null): Promise<LeafEntry> {
 		if (leafId !== null && !this.byId.has(leafId)) {
 			throw new SessionError("not_found", `Entry ${leafId} not found`);
@@ -89,10 +145,18 @@ export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionM
 		return entry;
 	}
 
+	/**
+	 * 为新条目生成无冲突的条目 ID。委托给 generateEntryId，使用当前条目映射进行冲突检测。
+	 * @returns 唯一条目 ID。
+	 */
 	async createEntryId(): Promise<string> {
 		return generateEntryId(this.byId);
 	}
 
+	/**
+	 * 向内存存储追加一个会话树条目。更新条目数组、ID 映射、标签缓存和叶节点位置。
+	 * @param entry - 要追加的会话树条目。
+	 */
 	async appendEntry(entry: SessionTreeEntry): Promise<void> {
 		this.entries.push(entry);
 		this.byId.set(entry.id, entry);
@@ -100,25 +164,42 @@ export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionM
 		this.leafId = leafIdAfterEntry(entry);
 	}
 
+	/**
+	 * 通过 ID 查找单个会话树条目。
+	 * @param id - 要检索的条目 ID。
+	 * @returns 条目（如果找到），或 `undefined`。
+	 */
 	async getEntry(id: string): Promise<SessionTreeEntry | undefined> {
 		return this.byId.get(id);
 	}
 
+	/**
+	 * 查找所有匹配给定类型的条目。按指定的 `type` 字符串过滤内部条目数组。
+	 * @param type - 要过滤的条目类型（例如 `"message"`、`"label"`）。
+	 * @returns 其 `type` 匹配过滤器的条目数组。
+	 */
 	async findEntries<TType extends SessionTreeEntry["type"]>(
 		type: TType,
 	): Promise<Array<Extract<SessionTreeEntry, { type: TType }>>> {
 		return this.entries.filter((entry): entry is Extract<SessionTreeEntry, { type: TType }> => entry.type === type);
 	}
 
+	/**
+	 * 检索分配给给定条目的最近标签。标签通过内存标签缓存来跟踪。
+	 * @param id - 要查询标签的条目 ID。
+	 * @returns 标签字符串，如果不存在标签则为 `undefined`。
+	 */
 	async getLabel(id: string): Promise<string | undefined> {
 		return this.labelsById.get(id);
 	}
 
+	/** 返回最近的会话名称（如果有记录）。 */
 	async getSessionName(): Promise<string | undefined> {
 		const entries = await this.findEntries("session_info");
 		return entries[entries.length - 1]?.name?.trim() || undefined;
 	}
 
+	/** 计算会话统计信息（消息数量、缓存/非缓存 token 数、总费用）。 */
 	async getSessionStats() {
 		let messageCount = 0;
 		let cachedTokens = 0;
@@ -161,6 +242,7 @@ export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionM
 		};
 	}
 
+	/** 从叶节点到根或到压缩边界的路径。遇到带有 retainedTail 的压缩条目时停止。 */
 	async getPathToRootOrCompaction(leafId: string | null): Promise<SessionTreeEntry[]> {
 		if (leafId === null) return [];
 		const path: SessionTreeEntry[] = [];
@@ -182,6 +264,7 @@ export class InMemorySessionStorage<TMetadata extends SessionMetadata = SessionM
 		return path;
 	}
 
+	/** 支持游标分页地返回条目的子集。 */
 	async getEntries(options?: SessionEntryCursorOptions): Promise<SessionTreeEntry[]> {
 		const start = options?.afterEntrySeq ?? 0;
 		const end = options?.limit === undefined ? undefined : start + options.limit;

--- a/packages/agent/src/harness/session/repo-utils.ts
+++ b/packages/agent/src/harness/session/repo-utils.ts
@@ -15,22 +15,40 @@ import {
 } from "../types.ts";
 import { Session } from "./session.ts";
 
+/**
+ * 生成一个新的唯一 session 标识符。
+ * 使用 UUIDv7 生成按时间排序的全局唯一 ID，适合作为 session 元数据主键和文件名。
+ * @returns UUIDv7 字符串。
+ */
 export function createSessionId(): string {
 	return uuidv7();
 }
 
+/**
+ * 创建表示当前时刻的 ISO-8601 时间戳字符串。
+ * 在整个 session 系统中用于记录创建时间和条目时间戳。
+ * @returns ISO-8601 格式的日期时间字符串。
+ */
 export function createTimestamp(): string {
 	return new Date().toISOString();
 }
 
+/**
+ * 将 SessionStorage 实例包装为 Session 对象。
+ * Session 类在原始存储接口之上提供了更高层的 API（append 辅助方法、context 构建、分支管理）。
+ * @param storage - 要包装的 session 存储后端。
+ * @returns 由给定存储支持的新 Session 实例。
+ */
 export function toSession<TMetadata extends SessionMetadata>(storage: SessionStorage<TMetadata>): Session<TMetadata> {
 	return new Session(storage);
 }
 
+/** 根据 ID 构建条目查找映射。 */
 function entriesById(entries: readonly SessionTreeEntry[]): Map<string, SessionTreeEntry> {
 	return new Map(entries.map((entry) => [entry.id, entry]));
 }
 
+/** 在条目列表中查找给定条目 ID 的最近标签。 */
 function getLabel(entries: readonly SessionTreeEntry[], id: string): string | undefined {
 	let label: string | undefined;
 	for (const entry of entries) {
@@ -40,6 +58,7 @@ function getLabel(entries: readonly SessionTreeEntry[], id: string): string | un
 	return label;
 }
 
+/** 返回最近的会话名称（如果有记录）。在会话树中搜索最后一个 session_info 条目。 */
 function getSessionName(entries: readonly SessionTreeEntry[]): string | undefined {
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i]!;
@@ -48,6 +67,7 @@ function getSessionName(entries: readonly SessionTreeEntry[]): string | undefine
 	return undefined;
 }
 
+/** 计算会话统计信息（消息数量、缓存/非缓存 token 数、总费用）。 */
 function getSessionStats(entries: readonly SessionTreeEntry[]): SessionStats {
 	let messageCount = 0;
 	let cachedTokens = 0;
@@ -82,6 +102,7 @@ function getSessionStats(entries: readonly SessionTreeEntry[]): SessionStats {
 	return { messageCount, cachedTokens, uncachedTokens, totalTokens, costTotal };
 }
 
+/** 从叶节点到根或到压缩边界的路径。遇到带有 retainedTail 的压缩条目时停止。 */
 function getPathToRootOrCompaction(entries: readonly SessionTreeEntry[], leafId: string | null): SessionTreeEntry[] {
 	if (leafId === null) return [];
 	const byId = entriesById(entries);
@@ -104,6 +125,7 @@ function getPathToRootOrCompaction(entries: readonly SessionTreeEntry[], leafId:
 	return path;
 }
 
+/** 将 SessionStore 适配为 Session 实例，使用 store 的 load/getEntries/createEntryId/appendEntry/setLeafId 方法。 */
 export function toStoreSession<TMetadata extends SessionMetadata>(
 	store: Pick<SessionStore<TMetadata>, "load" | "getEntries" | "createEntryId" | "appendEntry" | "setLeafId">,
 	metadata: TMetadata,
@@ -144,6 +166,12 @@ export function toStoreSession<TMetadata extends SessionMetadata>(
 	return new Session(storage);
 }
 
+/**
+ * 通用 SessionRepo 实现，委托给 SessionStore 和可选的 SessionSearch 后端。
+ * @typeParam TMetadata - 会话元数据类型。
+ * @typeParam TCreateOptions - create 方法的选项类型。
+ * @typeParam TListOptions - list 方法的选项类型。
+ */
 export class SessionRepo<
 	TMetadata extends SessionMetadata = SessionMetadata,
 	TCreateOptions extends SessionCreateOptions = SessionCreateOptions,
@@ -186,6 +214,7 @@ export class SessionRepo<
 	}
 }
 
+/** 创建 SessionRepo 实例的工厂函数。 */
 export function createSessionRepo<
 	TMetadata extends SessionMetadata = SessionMetadata,
 	TCreateOptions extends SessionCreateOptions = SessionCreateOptions,
@@ -197,6 +226,7 @@ export function createSessionRepo<
 	return new SessionRepo(options);
 }
 
+/** 在会话条目中搜索包含指定文本的匹配项，返回搜索结果列表。 */
 export function findSessionEntryMatches<TMetadata extends SessionMetadata>(
 	metadata: TMetadata,
 	entries: SessionTreeEntry[],
@@ -211,6 +241,14 @@ export function findSessionEntryMatches<TMetadata extends SessionMetadata>(
 	});
 }
 
+/**
+ * 解包文件系统 Result，失败时抛出 SessionError。
+ * 成功时返回内部值；失败时将文件系统错误映射为 SessionError。
+ * @param result - 文件系统操作结果。
+ * @param message - 抛出错误时的描述信息。
+ * @returns 成功结果中的解包值。
+ * @throws {SessionError} 当结果表示失败时。
+ */
 export function getFileSystemResultOrThrow<TValue>(result: Result<TValue, FileError>, message: string): TValue {
 	if (!result.ok) {
 		const code = result.error.code === "not_found" ? "not_found" : "storage";
@@ -219,6 +257,17 @@ export function getFileSystemResultOrThrow<TValue>(result: Result<TValue, FileEr
 	return result.value;
 }
 
+/**
+ * 确定 fork session 时需要复制的条目。
+ * fork 位置行为取决于 position 参数：未指定 entryId 时复制所有条目；
+ * `"at"` 分支包含目标条目本身；`"before"`（默认）分支在目标条目之前分割。
+ * @param storage - 要 fork 的源 session 存储。
+ * @param options - fork 配置。
+ * @param options.entryId - 要 fork 到或之前的条目 ID。省略时复制所有条目。
+ * @param options.position - fork 位置："before"（默认）或 "at"。
+ * @returns 要复制到新 session 的有序条目数组。
+ * @throws {SessionError} 当目标条目未找到，或 "before" 位置的目标不是 user 消息时。
+ */
 export async function getEntriesToFork(
 	storage: SessionStorage,
 	options: { entryId?: string; position?: "before" | "at" },

--- a/packages/agent/src/harness/session/search-backend.ts
+++ b/packages/agent/src/harness/session/search-backend.ts
@@ -7,12 +7,16 @@ import type {
 } from "../types.ts";
 import { findSessionEntryMatches } from "./repo-utils.ts";
 
+/** Session 搜索数据源：提供加载和列表能力。 */
 type SessionSearchSource<TMetadata extends SessionMetadata> = {
 	load(metadata: TMetadata): Promise<SessionSnapshot<TMetadata>>;
 	list(): Promise<TMetadata[]>;
 };
 
-/** Searches canonical sessions directly and therefore has no index to maintain. */
+/**
+ * 基于扫描的 session 搜索实现，直接搜索规范 session，无需维护索引。
+ * 适合 session 数量较少的场景。
+ */
 export class ScanningSessionSearch<TMetadata extends SessionMetadata = SessionMetadata>
 	implements SessionSearch<TMetadata>
 {
@@ -22,6 +26,7 @@ export class ScanningSessionSearch<TMetadata extends SessionMetadata = SessionMe
 		this.source = source;
 	}
 
+	/** 在所有 session 中搜索匹配文本，支持按 cwd 过滤。 */
 	async search(options: SessionSearchOptions): Promise<SessionSearchHit<TMetadata>[]> {
 		const hits: SessionSearchHit<TMetadata>[] = [];
 		for (const metadata of await this.source.list()) {

--- a/packages/agent/src/harness/session/session.ts
+++ b/packages/agent/src/harness/session/session.ts
@@ -23,21 +23,25 @@ import type {
 } from "../types.ts";
 import { SessionError } from "../types.ts";
 
+/** 对上下文条目列表应用转换，用于过滤或重新排列条目。 */
 export type ContextEntryTransform = (entries: readonly SessionTreeEntry[]) => readonly SessionTreeEntry[];
 
+/** 将自定义条目投射为上下文消息，未定义时表示该自定义类型不应出现在上下文消息中。 */
 export type CustomEntryContextMessageProjector = (
 	entry: CustomEntry,
 	index: number,
 	entries: readonly SessionTreeEntry[],
 ) => readonly AgentMessage[] | undefined;
 
+/** 构建会话上下文的选项。 */
 export interface SessionContextBuildOptions {
-	/** Additional entry transforms applied after the default compaction transform. */
+	/** 在默认压缩转换之后应用的额外条目转换。 */
 	entryTransforms?: readonly ContextEntryTransform[];
-	/** Optional custom-entry projectors. Custom entries are omitted from model context by default. */
+	/** 可选的自定义条目投射器。自定义条目默认不会出现在模型上下文中。 */
 	entryProjectors?: Readonly<Record<string, CustomEntryContextMessageProjector>>;
 }
 
+/** 从路径条目中派生会话上下文状态（思考等级、模型、活跃工具），不包含消息列表。 */
 function deriveSessionContextState(pathEntries: readonly SessionTreeEntry[]): Omit<SessionContext, "messages"> {
 	let thinkingLevel = "off";
 	let model: { provider: string; modelId: string } | null = null;
@@ -58,6 +62,7 @@ function deriveSessionContextState(pathEntries: readonly SessionTreeEntry[]): Om
 	return { thinkingLevel, model, activeToolNames };
 }
 
+/** 默认的压缩上下文转换：当存在压缩条目时，仅保留压缩条目及其后的存活条目。 */
 export function defaultContextEntryTransform(pathEntries: readonly SessionTreeEntry[]): SessionTreeEntry[] {
 	let compaction: CompactionEntry | null = null;
 	for (const entry of pathEntries) {
@@ -91,6 +96,7 @@ export function defaultContextEntryTransform(pathEntries: readonly SessionTreeEn
 	return entries;
 }
 
+/** 应用默认压缩转换和所有自定义转换，构建最终的上下文条目列表。 */
 export function buildContextEntries(
 	pathEntries: readonly SessionTreeEntry[],
 	options: SessionContextBuildOptions = {},
@@ -102,6 +108,7 @@ export function buildContextEntries(
 	return entries;
 }
 
+/** 将单个会话树条目转换为上下文消息。自定义条目通过 entryProjectors 投射，默认不产生消息。 */
 export function sessionEntryToContextMessages(
 	entry: SessionTreeEntry,
 	index: number,
@@ -137,6 +144,12 @@ export function sessionEntryToContextMessages(
 	return [];
 }
 
+/**
+ * 从会话树条目（从根到叶）的线性路径重建 {@link SessionContext}。
+ *
+ * 按顺序遍历路径条目以跟踪可变会话属性的最新状态，然后组装消息列表。
+ * 应用默认压缩转换以及所有自定义条目转换和投射器。
+ */
 export function buildSessionContext(
 	pathEntries: readonly SessionTreeEntry[],
 	options: SessionContextBuildOptions = {},
@@ -149,6 +162,7 @@ export function buildSessionContext(
 	return { ...state, messages };
 }
 
+/** Session 类使用的存储依赖抽象，用于解耦 Session 与具体存储实现。 */
 interface SessionDependencies<TMetadata extends SessionMetadata = SessionMetadata> {
 	load(): Promise<SessionSnapshot<TMetadata>>;
 	getEntries(options?: SessionEntryCursorOptions): Promise<SessionTreeEntry[]>;
@@ -157,10 +171,12 @@ interface SessionDependencies<TMetadata extends SessionMetadata = SessionMetadat
 	setLeafId(leafId: string | null): Promise<LeafEntry>;
 }
 
+/** 根据 ID 构建条目查找映射。 */
 function entriesById(entries: readonly SessionTreeEntry[]): Map<string, SessionTreeEntry> {
 	return new Map(entries.map((entry) => [entry.id, entry]));
 }
 
+/** 从叶节点到根或到压缩边界的路径。压缩条目之后的条目不会包含在路径中。 */
 function getPathToRootOrCompaction(entries: readonly SessionTreeEntry[], leafId: string | null): SessionTreeEntry[] {
 	if (leafId === null) return [];
 	const byId = entriesById(entries);
@@ -183,6 +199,7 @@ function getPathToRootOrCompaction(entries: readonly SessionTreeEntry[], leafId:
 	return path;
 }
 
+/** 在条目列表中查找给定条目 ID 的最近标签。 */
 function getLabel(entries: readonly SessionTreeEntry[], id: string): string | undefined {
 	let label: string | undefined;
 	for (const entry of entries) {
@@ -193,6 +210,7 @@ function getLabel(entries: readonly SessionTreeEntry[], id: string): string | un
 	return label;
 }
 
+/** 返回最近的会话名称（如果有记录）。在会话树中搜索最后一个 session_info 条目。 */
 function getSessionName(entries: readonly SessionTreeEntry[]): string | undefined {
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i]!;
@@ -201,6 +219,7 @@ function getSessionName(entries: readonly SessionTreeEntry[]): string | undefine
 	return undefined;
 }
 
+/** 计算会话统计信息（消息数量、缓存/非缓存 token 数、总费用）。 */
 function getSessionStats(entries: readonly SessionTreeEntry[]): SessionStats {
 	let messageCount = 0;
 	let cachedTokens = 0;
@@ -235,6 +254,7 @@ function getSessionStats(entries: readonly SessionTreeEntry[]): SessionStats {
 	return { messageCount, cachedTokens, uncachedTokens, totalTokens, costTotal };
 }
 
+/** 将 SessionStorage 适配为 Session 类使用的 SessionDependencies 接口。 */
 function storageToDependencies<TMetadata extends SessionMetadata>(
 	storage: SessionStorage<TMetadata>,
 ): SessionDependencies<TMetadata> {
@@ -278,19 +298,32 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		return this.dependencies.getEntries(options);
 	}
 
+	/**
+	 * 解析分支——从根到给定条目或当前叶节点的有序路径。
+	 * 如果提供了 `fromId`，则该条目作为路径终点；否则从存储中获取当前叶节点 ID。
+	 * @param fromId - 可选的条目 ID，用作叶节点。默认为当前叶节点。
+	 * @returns 从根到叶节点（含）的有序条目数组。
+	 */
 	async getBranch(fromId?: string): Promise<SessionTreeEntry[]> {
 		const state = await this.dependencies.load();
 		return getPathToRootOrCompaction(state.entries, fromId ?? state.leafId);
 	}
 
+	/** 从结束于当前叶节点的分支构建上下文条目列表（可能已压缩）。 */
 	async buildContextEntries(options: SessionContextBuildOptions = {}): Promise<SessionTreeEntry[]> {
 		return buildContextEntries(await this.getBranch(), this.mergeContextBuildOptions(options));
 	}
 
+	/**
+	 * 从结束于当前叶节点的分支构建当前 {@link SessionContext}。
+	 * 重建当前位置的消息、思考等级、模型信息和活跃工具名称。
+	 * @returns 当前叶节点的完整会话上下文。
+	 */
 	async buildContext(options: SessionContextBuildOptions = {}): Promise<SessionContext> {
 		return buildSessionContext(await this.getBranch(), this.mergeContextBuildOptions(options));
 	}
 
+	/** 合并实例级别的上下文构建选项与方法调用级别的选项。 */
 	private mergeContextBuildOptions(options: SessionContextBuildOptions): SessionContextBuildOptions {
 		return {
 			entryTransforms: [...(this.contextBuildOptions.entryTransforms ?? []), ...(options.entryTransforms ?? [])],
@@ -301,14 +334,21 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		};
 	}
 
+	/** 检索分配给给定条目的最近标签。 */
 	async getLabel(id: string): Promise<string | undefined> {
 		return getLabel((await this.dependencies.load()).entries, id);
 	}
 
+	/** 返回当前会话的统计信息（消息数量、token 用量、费用）。 */
 	async getSessionStats(): Promise<SessionStats> {
 		return getSessionStats((await this.dependencies.load()).entries);
 	}
 
+	/**
+	 * 返回最近的会话名称（如果有记录）。
+	 * 在会话树中搜索最后一个 session_info 条目，并返回其去除空白后的名称。
+	 * @returns 会话显示名称，或 `undefined`。
+	 */
 	async getSessionName(): Promise<string | undefined> {
 		return getSessionName((await this.dependencies.load()).entries);
 	}
@@ -330,6 +370,11 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		return entry.id;
 	}
 
+	/**
+	 * 在当前叶节点位置向会话追加一条代理消息条目。
+	 * @param message - 要存储的 {@link AgentMessage}。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendMessage(message: AgentMessage): Promise<string> {
 		return this.appendTypedEntry({
 			type: "message",
@@ -340,6 +385,11 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies MessageEntry);
 	}
 
+	/**
+	 * 记录助手思考等级的变化。
+	 * @param thinkingLevel - 新的思考等级（例如 `"low"`、`"medium"`、`"high"`、`"off"`）。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendThinkingLevelChange(thinkingLevel: string): Promise<string> {
 		return this.appendTypedEntry({
 			type: "thinking_level_change",
@@ -350,6 +400,12 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies ThinkingLevelChangeEntry);
 	}
 
+	/**
+	 * 记录活跃模型提供商和模型 ID 的变化。
+	 * @param provider - 模型提供商名称。
+	 * @param modelId - 具体模型标识符。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendModelChange(provider: string, modelId: string): Promise<string> {
 		return this.appendTypedEntry({
 			type: "model_change",
@@ -361,6 +417,12 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies ModelChangeEntry);
 	}
 
+	/**
+	 * 记录当前助手活跃工具名称的集合。
+	 * 存储数组的防御性副本以防止外部修改会话数据。
+	 * @param activeToolNames - 当前活跃的工具名称数组。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendActiveToolsChange(activeToolNames: string[]): Promise<string> {
 		return this.appendTypedEntry({
 			type: "active_tools_change",
@@ -371,6 +433,17 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies ActiveToolsChangeEntry);
 	}
 
+	/**
+	 * 记录一个压缩事件，该事件总结早期条目以减少上下文长度。
+	 * @param summary - 被压缩内容的可读摘要。
+	 * @param firstKeptEntryId - 压缩后保留的第一个条目的 ID。
+	 * @param tokensBefore - 压缩前的大致令牌数。
+	 * @param details - 描述压缩结果的可选额外数据。
+	 * @param fromHook - 压缩是否由钩子触发。
+	 * @param usage - 生成此摘要的 LLM 调用用量。
+	 * @param retainedTail - 压缩后保留的近期消息。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendCompaction<T = unknown>(
 		summary: string,
 		firstKeptEntryId: string | undefined,
@@ -395,6 +468,13 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies CompactionEntry<T>);
 	}
 
+	/**
+	 * 追加一个通用的自定义条目，带有任意类型标签和可选负载。
+	 * 与 appendCustomMessageEntry 不同，此处创建的条目是结构化的而非对话性的。
+	 * @param customType - 标识自定义条目类型的字符串标签。
+	 * @param data - 与此条目关联的可选负载。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendCustomEntry(customType: string, data?: unknown): Promise<string> {
 		return this.appendTypedEntry({
 			type: "custom",
@@ -406,6 +486,14 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies CustomEntry);
 	}
 
+	/**
+	 * 追加一个自定义消息条目，它渲染为对话消息但携带自定义类型。
+	 * @param customType - 标识自定义消息类型的字符串标签。
+	 * @param content - 消息内容（纯字符串或内容块数组）。
+	 * @param display - 此消息是否应对用户可见。
+	 * @param details - 关于此自定义消息的可选额外数据。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendCustomMessageEntry<T = unknown>(
 		customType: string,
 		content: string | (TextContent | ImageContent)[],
@@ -424,6 +512,13 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies CustomMessageEntry<T>);
 	}
 
+	/**
+	 * 为目标条目分配或清除可读标签。目标条目必须已存在。
+	 * @param targetId - 要标记的条目 ID。
+	 * @param label - 标签文本，或 `undefined` 以移除标签。
+	 * @returns 标签条目本身的生成条目 ID。
+	 * @throws {SessionError} 如果目标条目不存在。
+	 */
 	async appendLabel(targetId: string, label: string | undefined): Promise<string> {
 		if (!(await this.getEntry(targetId))) {
 			throw new SessionError("not_found", `Entry ${targetId} not found`);
@@ -438,6 +533,11 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies LabelEntry);
 	}
 
+	/**
+	 * 通过追加 session_info 条目设置会话显示名称。名称在存储前会去除空白。
+	 * @param name - 期望的会话显示名称。
+	 * @returns 生成的条目 ID。
+	 */
 	async appendSessionName(name: string): Promise<string> {
 		const sanitizedName = name.replace(/[\r\n]+/g, " ").trim();
 		return this.appendTypedEntry({
@@ -449,6 +549,15 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
 		} satisfies SessionInfoEntry);
 	}
 
+	/**
+	 * 将会话叶节点移动到不同条目，实现在会话树内的导航。
+	 * 叶节点重新定位到 `entryId`（或 `null` 时回到根节点）。如果提供了 summary，
+	 * 则在新位置追加一个分支摘要条目来记录分支切换。
+	 * @param entryId - 要移动到的目标条目 ID，或 `null` 重置到根节点。
+	 * @param summary - 描述移动原因的可选摘要。
+	 * @returns 分支摘要条目的生成条目 ID，如果未提供摘要则返回 `undefined`。
+	 * @throws {SessionError} 如果目标条目不存在。
+	 */
 	async moveTo(
 		entryId: string | null,
 		summary?: { summary: string; details?: unknown; usage?: Usage; fromHook?: boolean },

--- a/packages/agent/src/harness/skills.ts
+++ b/packages/agent/src/harness/skills.ts
@@ -15,36 +15,40 @@ export type SkillDiagnosticCode =
 	| "parse_failed"
 	| "invalid_metadata";
 
-/** Warning produced while loading skills. */
+/** 加载技能时产生的警告。 */
 export interface SkillDiagnostic {
-	/** Diagnostic severity. Currently only warnings are emitted. */
+	/** 诊断严重性。目前仅发出警告。 */
 	type: "warning";
-	/** Stable diagnostic code. */
+	/** 稳定的诊断代码。 */
 	code: SkillDiagnosticCode;
-	/** Human-readable diagnostic message. */
+	/** 人类可读的诊断消息。 */
 	message: string;
-	/** Path associated with the diagnostic. */
+	/** 与诊断关联的路径。 */
 	path: string;
 }
 
+/** 从 SKILL.md 文件解析的 YAML frontmatter。所有字段均为可选，以允许优雅降级。 */
 interface SkillFrontmatter {
+	/** 技能名称。省略时默认为父目录名称。 */
 	name?: string;
+	/** 技能描述。没有描述的技能会被静默丢弃。 */
 	description?: string;
+	/** 为 true 时，技能内容对模型可见，但模型无法直接调用该技能。 */
 	"disable-model-invocation"?: boolean;
 	[key: string]: unknown;
 }
 
-/** Format a skill invocation prompt, optionally appending additional user instructions. */
+/** 格式化技能调用提示词，可选择追加额外的用户指令。 */
 export function formatSkillInvocation(skill: Skill, additionalInstructions?: string): string {
 	const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${dirnameEnvPath(skill.filePath)}.\n\n${skill.content}\n</skill>`;
 	return additionalInstructions ? `${skillBlock}\n\n${additionalInstructions}` : skillBlock;
 }
 
 /**
- * Load skills from one or more directories.
+ * 从一个或多个目录加载技能。
  *
- * Traverses directories recursively, loads `SKILL.md` files, loads direct root `.md` files as skills, honors ignore files,
- * and returns diagnostics for invalid skill files. Missing input directories are skipped.
+ * 递归遍历目录，加载 `SKILL.md` 文件，加载直接的根级别 `.md` 文件作为技能，遵循忽略文件规则，
+ * 并返回无效技能文件的诊断信息。缺失的输入目录会被跳过。
  */
 export async function loadSkills(
 	env: ExecutionEnv,
@@ -75,10 +79,10 @@ export async function loadSkills(
 }
 
 /**
- * Load skills from source-tagged directories.
+ * 从带 source 标记的目录加载技能。
  *
- * Source values are preserved exactly and attached to every loaded skill and diagnostic. The agent package does not
- * interpret source values; applications define their own provenance shape.
+ * source 值会被原样保留并附加到每个加载的技能和诊断信息上。agent 包不解释 source 值；
+ * 应用程序定义各自的来源形状。
  */
 export async function loadSourcedSkills<TSource, TSkill extends Skill = Skill>(
 	env: ExecutionEnv,
@@ -100,6 +104,21 @@ export async function loadSourcedSkills<TSource, TSkill extends Skill = Skill>(
 	return { skills, diagnostics };
 }
 
+/**
+ * 递归遍历目录以发现并加载 SKILL.md 文件。
+ *
+ * 在每个目录层级，函数首先查找 SKILL.md 文件并将其作为该目录的技能定义加载。
+ * 当 includeRootFiles 为 true 时，顶层根目录中的独立 .md 文件也会作为技能加载。
+ * 递归会跳过名称以点号开头或为 `node_modules` 的条目，同时也会排除匹配累积忽略规则
+ * （来自遍历过程中发现的 .gitignore、.ignore 和 .fdignore 文件）的条目。
+ *
+ * @param env - 提供文件系统访问的执行环境。
+ * @param dir - 需要扫描的目录的绝对路径。
+ * @param includeRootFiles - 是否将独立的 .md 文件作为技能加载（仅顶层输入目录为 true）。
+ * @param ignoreMatcher - 累积的忽略匹配器，携带来自祖先目录的模式。
+ * @param rootDir - 用于计算相对忽略路径的顶层技能目录。
+ * @returns 加载的技能以及遇到的诊断信息。
+ */
 async function loadSkillsFromDirInternal(
 	env: ExecutionEnv,
 	dir: string,
@@ -174,6 +193,18 @@ async function loadSkillsFromDirInternal(
 	return { skills, diagnostics };
 }
 
+/**
+ * 从给定目录读取忽略文件（`.gitignore`、`.ignore`、`.fdignore`）并将其模式合并到累积的忽略匹配器中。
+ *
+ * 忽略文件中的每个模式行都会加上目录相对于根技能目录的路径前缀，以确保模式无论在哪个子目录中定义
+ * 都能正确应用。注释和空行在预处理过程中会被过滤掉。
+ *
+ * @param env - 提供文件系统访问的执行环境。
+ * @param ig - 需要合并模式到的累积忽略匹配器。
+ * @param dir - 需要检查忽略文件的目录的绝对路径。
+ * @param rootDir - 用于计算相对前缀的顶层技能目录。
+ * @param diagnostics - 读取忽略文件时遇到的警告的累积器。
+ */
 async function addIgnoreRules(
 	env: ExecutionEnv,
 	ig: IgnoreMatcher,
@@ -212,6 +243,16 @@ async function addIgnoreRules(
 	}
 }
 
+/**
+ * 预处理单行忽略模式，添加目录前缀使模式相对于根技能目录生效。
+ *
+ * 开头的 `/` 会被去除（gitignore 模式本身已相对于文件所在位置）。开头的 `!` 否定符号在
+ * 前缀转换过程中会被保留。去除空白后为空或纯注释的行返回 null（调用方应将其丢弃）。
+ *
+ * @param line - 来自忽略文件的一行原始文本。
+ * @param prefix - 需要添加的目录前缀，以 `/` 结尾（根目录时为空字符串）。
+ * @returns 添加前缀后的模式，如果该行应被跳过则返回 null。
+ */
 function prefixIgnorePattern(line: string, prefix: string): string | null {
 	const trimmed = line.trim();
 	if (!trimmed) return null;
@@ -230,6 +271,17 @@ function prefixIgnorePattern(line: string, prefix: string): string | null {
 	return negated ? `!${prefixed}` : prefixed;
 }
 
+/**
+ * 将单个 SKILL.md（或独立的 .md）文件解析为 {@link Skill} 对象。
+ *
+ * 通过 {@link parseFrontmatter} 提取 YAML frontmatter 和 markdown 正文。技能名称取自 frontmatter 的
+ * `name` 字段，如果缺失则回退到父目录名称。当描述缺失或为空时，该技能会被丢弃（返回 null）。
+ * `name` 和 `description` 的验证错误会作为诊断信息发出，但不会阻止技能加载（除非描述缺失）。
+ *
+ * @param env - 提供文件系统访问的执行环境。
+ * @param filePath - markdown 技能文件的绝对路径。
+ * @returns 解析后的技能（可能为 null）以及诊断信息。
+ */
 async function loadSkillFromFile(
 	env: ExecutionEnv,
 	filePath: string,
@@ -278,6 +330,20 @@ async function loadSkillFromFile(
 	};
 }
 
+/**
+ * 根据命名约定验证技能名称。
+ *
+ * 规则：
+ * - 必须与父目录名称匹配（除非通过 frontmatter 显式设置）。
+ * - 最大长度为 {@link MAX_NAME_LENGTH} 个字符。
+ * - 仅允许小写字母（`a-z`）、数字（`0-9`）和连字符（`-`）。
+ * - 不能以连字符开头或结尾。
+ * - 不能包含连续的连字符（`--`）。
+ *
+ * @param name - 需要验证的技能名称。
+ * @param parentDirName - 用于比较的期望目录名称。
+ * @returns 人类可读的错误消息数组（有效时为空）。
+ */
 function validateName(name: string, parentDirName: string): string[] {
 	const errors: string[] = [];
 	if (name !== parentDirName) errors.push(`name "${name}" does not match parent directory "${parentDirName}"`);
@@ -290,6 +356,14 @@ function validateName(name: string, parentDirName: string): string[] {
 	return errors;
 }
 
+/**
+ * 验证技能描述。
+ *
+ * 描述为必填项（去除空白后不能为空），且不能超过 {@link MAX_DESCRIPTION_LENGTH} 个字符。
+ *
+ * @param description - 来自 frontmatter 的描述字符串（可能为 undefined）。
+ * @returns 人类可读的错误消息数组（有效时为空）。
+ */
 function validateDescription(description: string | undefined): string[] {
 	const errors: string[] = [];
 	if (!description || description.trim() === "") {
@@ -300,6 +374,15 @@ function validateDescription(description: string | undefined): string[] {
 	return errors;
 }
 
+/**
+ * 从 markdown 字符串中解析 YAML frontmatter。
+ *
+ * 要求 frontmatter 以独立一行的 `---` 开头（位于内容起始处）。闭合的 `---` 必须单独占一行。
+ * 当找不到有效的 frontmatter 块时，整个内容将被视为正文，frontmatter 对象为空。
+ *
+ * @param content - 包含可选 YAML frontmatter 的原始文件内容。
+ * @returns 包含解析后的 frontmatter（类型为 T）和剩余 markdown 正文的结果，如果 YAML 解析失败则返回错误。
+ */
 function parseFrontmatter<T extends Record<string, unknown>>(
 	content: string,
 ): Result<{ frontmatter: T; body: string }, Error> {
@@ -316,6 +399,14 @@ function parseFrontmatter<T extends Record<string, unknown>>(
 	}
 }
 
+/**
+ * 解析文件系统条目的规范类型，当初始类型既不是文件也不是目录时（例如符号链接），会跟踪符号链接。
+ *
+ * @param env - 提供文件系统访问的执行环境。
+ * @param info - 需要解析的条目的文件信息。
+ * @param diagnostics - 符号链接解析过程中遇到的警告的累积器。
+ * @returns `"file"`、`"directory"`，如果条目无法解析则返回 `undefined`。
+ */
 async function resolveKind(
 	env: ExecutionEnv,
 	info: FileInfo,
@@ -349,22 +440,26 @@ async function resolveKind(
 	return target.value.kind === "file" || target.value.kind === "directory" ? target.value.kind : undefined;
 }
 
+/** 将基础路径和子名称用单个 `/` 分隔符拼接，规范化多余的斜杠。 */
 function joinEnvPath(base: string, child: string): string {
 	return `${base.replace(/\/+$/, "")}/${child.replace(/^\/+/, "")}`;
 }
 
+/** 返回父目录路径，去除末尾斜杠和最后一个路径段。根路径返回 `"/"`。 */
 function dirnameEnvPath(path: string): string {
 	const normalized = path.replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex <= 0 ? "/" : normalized.slice(0, slashIndex);
 }
 
+/** 返回最后一个路径段（文件或目录名），去除末尾斜杠。 */
 function basenameEnvPath(path: string): string {
 	const normalized = path.replace(/\/+$/, "");
 	const slashIndex = normalized.lastIndexOf("/");
 	return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
 }
 
+/** 计算从 `root` 到 `path` 的相对路径。相等时返回空字符串，否则去除开头的斜杠。 */
 function relativeEnvPath(root: string, path: string): string {
 	const normalizedRoot = root.replace(/\/+$/, "");
 	const normalizedPath = path.replace(/\/+$/, "");

--- a/packages/agent/src/harness/system-prompt.ts
+++ b/packages/agent/src/harness/system-prompt.ts
@@ -1,5 +1,9 @@
 import type { Skill } from "./types.ts";
 
+/**
+ * 将可见技能列表格式化为 XML 块，用于嵌入 system prompt。
+ * 被标记为 disableModelInvocation 的技能会被排除。
+ */
 export function formatSkillsForSystemPrompt(skills: Skill[]): string {
 	const visibleSkills = skills.filter((skill) => !skill.disableModelInvocation);
 	if (visibleSkills.length === 0) return "";
@@ -24,6 +28,7 @@ export function formatSkillsForSystemPrompt(skills: Skill[]): string {
 	return lines.join("\n");
 }
 
+/** 转义 XML 特殊字符，防止在 XML 格式的 system prompt 中发生注入。 */
 function escapeXml(value: string): string {
 	return value
 		.replace(/&/g, "&amp;")

--- a/packages/agent/src/harness/tools/edit-diff.ts
+++ b/packages/agent/src/harness/tools/edit-diff.ts
@@ -1,5 +1,5 @@
 /**
- * Shared diff computation utilities for the edit and similar tools.
+ * edit 及类似工具使用的共享 diff 计算工具函数。
  */
 
 import * as Diff from "diff";
@@ -21,32 +21,32 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
 }
 
 /**
- * Normalize text for fuzzy matching. Applies progressive transformations:
- * - Strip trailing whitespace from each line
- * - Normalize smart quotes to ASCII equivalents
- * - Normalize Unicode dashes/hyphens to ASCII hyphen
- * - Normalize special Unicode spaces to regular space
+ * 对文本进行模糊匹配用的标准化处理。应用逐步变换：
+ * - 去除每行末尾的空白字符
+ * - 将智能引号标准化为 ASCII 等价字符
+ * - 将 Unicode 破折号/连字符标准化为 ASCII 连字符
+ * - 将特殊的 Unicode 空格标准化为普通空格
  */
 export function normalizeForFuzzyMatch(text: string): string {
 	return (
 		text
 			.normalize("NFKC")
-			// Strip trailing whitespace per line
+			// 去除每行末尾空白字符
 			.split("\n")
 			.map((line) => line.trimEnd())
 			.join("\n")
-			// Smart single quotes → '
-			.replace(/[\u2018\u2019\u201A\u201B]/g, "'")
-			// Smart double quotes → "
-			.replace(/[\u201C\u201D\u201E\u201F]/g, '"')
-			// Various dashes/hyphens → -
-			// U+2010 hyphen, U+2011 non-breaking hyphen, U+2012 figure dash,
-			// U+2013 en-dash, U+2014 em-dash, U+2015 horizontal bar, U+2212 minus
-			.replace(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g, "-")
-			// Special spaces → regular space
-			// U+00A0 NBSP, U+2002-U+200A various spaces, U+202F narrow NBSP,
-			// U+205F medium math space, U+3000 ideographic space
-			.replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ")
+			// 智能单引号 → '
+			.replace(/[‘’‚‛]/g, "'")
+			// 智能双引号 → "
+			.replace(/[“”„‟]/g, '"')
+			// 各种破折号/连字符 → -
+			// U+2010 连字符, U+2011 不间断连字符, U+2012 数字破折号,
+			// U+2013 短破折号, U+2014 长破折号, U+2015 水平线, U+2212 减号
+			.replace(/[‐‑‒–—―−]/g, "-")
+			// 特殊空格 → 普通空格
+			// U+00A0 不间断空格, U+2002-U+200A 各种空格, U+202F 窄不间断空格,
+			// U+205F 中等数学空格, U+3000 表意空格
+			.replace(/[  -   　]/g, " ")
 	);
 }
 
@@ -116,14 +116,13 @@ function applyReplacements(content: string, replacements: TextReplacement[], off
 }
 
 /**
- * Apply replacements matched against `baseContent` to `originalContent` while
- * preserving unchanged line blocks from the original.
+ * 将基于 `baseContent` 匹配到的替换应用到 `originalContent` 上，
+ * 同时保留原始内容中未更改的行块。
  *
- * This is useful when `baseContent` is a normalized view of the original. Each
- * replacement is widened to the lines it actually touches, those touched lines
- * are rewritten from the normalized base, and all other lines are copied back
- * from `originalContent`. The actual replacement ranges drive preservation so
- * duplicate normalized lines cannot be aligned to the wrong occurrence.
+ * 当 `baseContent` 是原始内容的标准化视图时，此函数非常有用。
+ * 每个替换都会扩展到它实际触及的行，这些触到的行会从标准化基础内容中重写，
+ * 而其他所有行则从 `originalContent` 复制回来。实际的替换范围驱动保留逻辑，
+ * 因此重复的标准化行不会被错误地对齐到错误的位置。
  */
 export function applyReplacementsPreservingUnchangedLines(
 	originalContent: string,
@@ -169,17 +168,17 @@ export function applyReplacementsPreservingUnchangedLines(
 }
 
 export interface FuzzyMatchResult {
-	/** Whether a match was found */
+	/** 是否找到了匹配 */
 	found: boolean;
-	/** The index where the match starts (in the content that should be used for replacement) */
+	/** 匹配开始的索引位置（在用于替换的内容中） */
 	index: number;
-	/** Length of the matched text */
+	/** 匹配文本的长度 */
 	matchLength: number;
-	/** Whether fuzzy matching was used (false = exact match) */
+	/** 是否使用了模糊匹配（false = 精确匹配） */
 	usedFuzzyMatch: boolean;
 	/**
-	 * The content to use for replacement operations.
-	 * When exact match: original content. When fuzzy match: normalized content.
+	 * 用于替换操作的内容。
+	 * 精确匹配时：原始内容。模糊匹配时：标准化后的内容。
 	 */
 	contentForReplacement: string;
 }
@@ -195,13 +194,12 @@ export interface AppliedEditsResult {
 }
 
 /**
- * Find oldText in content, trying exact match first, then fuzzy match.
- * When fuzzy matching is used, the returned contentForReplacement is the
- * fuzzy-normalized version of the content (trailing whitespace stripped,
- * Unicode quotes/dashes normalized to ASCII).
+ * 在内容中查找 oldText，先尝试精确匹配，再尝试模糊匹配。
+ * 当使用模糊匹配时，返回的 contentForReplacement 是经过模糊标准化处理的内容
+ * （去除尾部空白字符，Unicode 引号/破折号标准化为 ASCII）。
  */
 export function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
-	// Try exact match first
+	// 先尝试精确匹配
 	const exactIndex = content.indexOf(oldText);
 	if (exactIndex !== -1) {
 		return {
@@ -213,7 +211,7 @@ export function fuzzyFindText(content: string, oldText: string): FuzzyMatchResul
 		};
 	}
 
-	// Try fuzzy match - work entirely in normalized space
+	// 尝试模糊匹配 - 完全在标准化空间中操作
 	const fuzzyContent = normalizeForFuzzyMatch(content);
 	const fuzzyOldText = normalizeForFuzzyMatch(oldText);
 	const fuzzyIndex = fuzzyContent.indexOf(fuzzyOldText);
@@ -228,9 +226,8 @@ export function fuzzyFindText(content: string, oldText: string): FuzzyMatchResul
 		};
 	}
 
-	// When fuzzy matching, return offsets in normalized space. Callers can use
-	// the normalized content to compute replacements, then decide how much of
-	// that normalized output should be written back.
+	// 模糊匹配时，返回标准化空间中的偏移量。调用者可以使用
+	// 标准化后的内容来计算替换，然后决定应该写回多少标准化输出。
 	return {
 		found: true,
 		index: fuzzyIndex,
@@ -240,9 +237,9 @@ export function fuzzyFindText(content: string, oldText: string): FuzzyMatchResul
 	};
 }
 
-/** Strip UTF-8 BOM if present, return both the BOM (if any) and the text without it */
+/** 如果存在 UTF-8 BOM 则去除，同时返回 BOM（如果有）和去除后的文本 */
 export function stripBom(content: string): { bom: string; text: string } {
-	return content.startsWith("\uFEFF") ? { bom: "\uFEFF", text: content.slice(1) } : { bom: "", text: content };
+	return content.startsWith("﻿") ? { bom: "﻿", text: content.slice(1) } : { bom: "", text: content };
 }
 
 function countOccurrences(content: string, oldText: string): number {
@@ -290,13 +287,11 @@ function getNoChangeError(path: string, totalEdits: number): Error {
 }
 
 /**
- * Apply one or more exact-text replacements to LF-normalized content.
+ * 对 LF 标准化后的内容应用一个或多个精确文本替换。
  *
- * All edits are matched against the same original content. Replacements are
- * then applied in reverse order so offsets remain stable. If any edit needs
- * fuzzy matching, the operation runs in fuzzy-normalized content space and then
- * overlays those line-level changes onto the original content so unchanged line
- * blocks keep their original bytes.
+ * 所有编辑都基于同一份原始内容进行匹配。替换随后按逆序应用以保持偏移量稳定。
+ * 如果任何编辑需要模糊匹配，则整个操作在模糊标准化后的内容空间中进行，
+ * 然后将这些行级别的变更覆盖到原始内容上，使未更改的行块保持其原始字节。
  */
 export function applyEditsToNormalizedContent(
 	normalizedContent: string,
@@ -362,7 +357,7 @@ export function applyEditsToNormalizedContent(
 	return { baseContent, newContent };
 }
 
-/** Generate a standard unified patch. */
+/** 生成标准的统一格式补丁。 */
 export function generateUnifiedPatch(path: string, oldContent: string, newContent: string, contextLines = 4): string {
 	return Diff.createTwoFilesPatch(path, path, oldContent, newContent, undefined, undefined, {
 		context: contextLines,
@@ -371,8 +366,8 @@ export function generateUnifiedPatch(path: string, oldContent: string, newConten
 }
 
 /**
- * Generate a display-oriented diff string with line numbers and context.
- * Returns both the diff string and the first changed line number (in the new file).
+ * 生成面向展示的 diff 字符串，包含行号和上下文。
+ * 返回 diff 字符串和（新文件中的）第一个变更行号。
  */
 export function generateDiffString(
 	oldContent: string,
@@ -400,19 +395,19 @@ export function generateDiffString(
 		}
 
 		if (part.added || part.removed) {
-			// Capture the first changed line (in the new file)
+			// 记录第一个变更行（在新文件中）
 			if (firstChangedLine === undefined) {
 				firstChangedLine = newLineNum;
 			}
 
-			// Show the change
+			// 显示变更
 			for (const line of raw) {
 				if (part.added) {
 					const lineNum = String(newLineNum).padStart(lineNumWidth, " ");
 					output.push(`+${lineNum} ${line}`);
 					newLineNum++;
 				} else {
-					// removed
+					// 已删除
 					const lineNum = String(oldLineNum).padStart(lineNumWidth, " ");
 					output.push(`-${lineNum} ${line}`);
 					oldLineNum++;
@@ -420,7 +415,7 @@ export function generateDiffString(
 			}
 			lastWasChange = true;
 		} else {
-			// Context lines - only show a few before/after changes
+			// 上下文行 - 仅在变更前后各显示几行
 			const nextPartIsChange = i < parts.length - 1 && (parts[i + 1].added || parts[i + 1].removed);
 			const hasLeadingChange = lastWasChange;
 			const hasTrailingChange = nextPartIsChange;
@@ -487,7 +482,7 @@ export function generateDiffString(
 					newLineNum++;
 				}
 			} else {
-				// Skip these context lines entirely
+				// 完全跳过这些上下文行
 				oldLineNum += raw.length;
 				newLineNum += raw.length;
 			}

--- a/packages/agent/src/harness/tools/file-mutation-queue.ts
+++ b/packages/agent/src/harness/tools/file-mutation-queue.ts
@@ -1,13 +1,16 @@
 import type { ExecutionEnv } from "../types.ts";
 import { getOrThrow } from "../types.ts";
 
+/** 文件变更队列的内部状态：每个规范路径对应一个 Promise 链。 */
 type MutationQueueState = {
 	queues: Map<string, Promise<void>>;
 	registration: Promise<void>;
 };
 
+/** 每个 ExecutionEnv 实例维护独立的变更队列，通过 WeakMap 关联。 */
 const states = new WeakMap<ExecutionEnv, MutationQueueState>();
 
+/** 获取或创建指定 ExecutionEnv 的变更队列状态。 */
 function getState(env: ExecutionEnv): MutationQueueState {
 	let state = states.get(env);
 	if (!state) {
@@ -17,6 +20,7 @@ function getState(env: ExecutionEnv): MutationQueueState {
 	return state;
 }
 
+/** 解析文件的规范路径作为队列 key，优先使用 canonical path，降级使用绝对路径。 */
 async function getMutationQueueKey(env: ExecutionEnv, path: string): Promise<string> {
 	const absolutePath = getOrThrow(await env.absolutePath(path));
 	const canonicalPath = await env.canonicalPath(absolutePath);
@@ -25,7 +29,10 @@ async function getMutationQueueKey(env: ExecutionEnv, path: string): Promise<str
 	throw canonicalPath.error;
 }
 
-/** Serialize file mutations targeting the same environment and canonical path. */
+/**
+ * 对同一 ExecutionEnv 和规范路径下的文件变更进行序列化。
+ * 确保对同一文件的并发写入/编辑按顺序执行，避免竞态条件。
+ */
 export async function withFileMutationQueue<T>(env: ExecutionEnv, path: string, fn: () => Promise<T>): Promise<T> {
 	const state = getState(env);
 	const registration = state.registration.then(async () => {

--- a/packages/agent/src/harness/tools/read.ts
+++ b/packages/agent/src/harness/tools/read.ts
@@ -36,9 +36,9 @@ export type ReadImageProcessor = (
 ) => Promise<ReadImageProcessorResult>;
 
 export interface ReadToolOptions {
-	/** Whether an injected image processor should resize images. Default: true. */
+	/** 注入的图片处理器是否应调整图片尺寸。默认：true。 */
 	autoResizeImages?: boolean;
-	/** Optional image conversion/resizing implementation. */
+	/** 可选的图片转换/调整尺寸实现。 */
 	imageProcessor?: ReadImageProcessor;
 }
 

--- a/packages/agent/src/harness/tools/tool-context.ts
+++ b/packages/agent/src/harness/tools/tool-context.ts
@@ -1,6 +1,6 @@
 import type { ExecutionEnv } from "../types.ts";
 
-/** Filesystem and shell context required by the built-in execution tools. */
+/** 内置执行工具所需的文件系统和 shell 上下文。 */
 export interface ExecutionToolContext {
 	env: ExecutionEnv;
 }

--- a/packages/agent/src/harness/types.ts
+++ b/packages/agent/src/harness/types.ts
@@ -20,31 +20,31 @@ import type {
 } from "../index.ts";
 import type { Session } from "./session/session.ts";
 
-/** Result of a fallible operation. Expected failures are returned as `ok: false` instead of thrown. */
+/** 可失败操作的结果。预期的失败以 `ok: false` 形式返回，而不是抛出异常。 */
 export type Result<TValue, TError> = { ok: true; value: TValue } | { ok: false; error: TError };
 
-/** Create a successful {@link Result}. */
+/** 创建一个成功的 {@link Result}。 */
 export function ok<TValue, TError>(value: TValue): Result<TValue, TError> {
 	return { ok: true, value };
 }
 
-/** Create a failed {@link Result}. */
+/** 创建一个失败的 {@link Result}。 */
 export function err<TValue, TError>(error: TError): Result<TValue, TError> {
 	return { ok: false, error };
 }
 
-/** Return the success value or throw the failure error. Intended for tests and explicit adapter boundaries. */
+/** 返回成功值，如果是失败则抛出错误。适用于测试和显式适配器边界。 */
 export function getOrThrow<TValue, TError>(result: Result<TValue, TError>): TValue {
 	if (!result.ok) throw result.error;
 	return result.value;
 }
 
-/** Return the success value or `undefined`. Only object values are allowed to avoid truthiness bugs with primitives. */
+/** 返回成功值或 `undefined`。仅允许对象类型值，以避免原始类型的真值判断错误。 */
 export function getOrUndefined<TValue extends object, TError>(result: Result<TValue, TError>): TValue | undefined {
 	return result.ok ? result.value : undefined;
 }
 
-/** Normalize unknown thrown values into Error instances before using them as typed error causes. */
+/** 将未知的抛出值标准化为 Error 实例，以便用作类型化的错误原因。 */
 export function toError(error: unknown): Error {
 	if (error instanceof Error) return error;
 	if (typeof error === "string") return new Error(error);
@@ -56,10 +56,10 @@ export function toError(error: unknown): Error {
 }
 
 /**
- * Skill loaded from a `SKILL.md` file or provided by an application.
+ * 从 `SKILL.md` 文件加载或由应用提供的技能。
  *
- * `name`, `description`, and `filePath` are inserted into the system prompt in an XML-formatted block as suggested by agentskills.io.
- * Use {@link formatSkillsForSystemPrompt} to generate the spec-compatible system prompt block.
+ * `name`、`description` 和 `filePath` 会按照 agentskills.io 的建议，以 XML 格式块插入到系统提示中。
+ * 使用 {@link formatSkillsForSystemPrompt} 生成符合规范的 system prompt 块。
  */
 export interface Skill {
 	/** Stable skill name used for lookup and model-visible listings. */
@@ -74,7 +74,7 @@ export interface Skill {
 	disableModelInvocation?: boolean;
 }
 
-/** Prompt template that can be formatted into a prompt for explicit invocation. */
+/** 可被格式化为显式调用提示的提示模板。 */
 export interface PromptTemplate {
 	/** Stable template name used for lookup or application command routing. */
 	name: string;
@@ -84,7 +84,7 @@ export interface PromptTemplate {
 	content: string;
 }
 
-/** Resources made available to explicit invocation methods and system-prompt callbacks. */
+/** 提供给显式调用方法和 system prompt 回调的资源。 */
 export interface AgentHarnessResources<
 	TSkill extends Skill = Skill,
 	TPromptTemplate extends PromptTemplate = PromptTemplate,
@@ -95,7 +95,7 @@ export interface AgentHarnessResources<
 	skills?: TSkill[];
 }
 
-/** Tool definition executed by an {@link AgentHarness} with an application-defined context. */
+/** 由 {@link AgentHarness} 执行并带有应用自定义上下文的工具定义。 */
 export type AgentHarnessTool<
 	TContext extends object | undefined,
 	TParameters extends TSchema = TSchema,
@@ -111,12 +111,12 @@ export type AgentHarnessTool<
 	): Promise<AgentToolResult<TDetails>>;
 };
 
-/** Static tool context or zero-argument provider resolved for each turn snapshot. */
+/** 静态工具上下文或零参数提供者，在每个 turn 快照时解析。 */
 export type AgentHarnessToolContextSource<TContext extends object | undefined> =
 	| TContext
 	| (() => TContext | Promise<TContext>);
 
-/** Curated provider request options owned by the harness and snapshotted per turn. */
+/** 由 harness 管理并在每轮对话中快照的精选 provider 请求选项。 */
 export interface AgentHarnessStreamOptions {
 	/** Preferred transport forwarded to the stream function. */
 	transport?: Transport;
@@ -134,7 +134,7 @@ export interface AgentHarnessStreamOptions {
 	cacheRetention?: SimpleStreamOptions["cacheRetention"];
 }
 
-/** Per-request stream option patch returned by provider hooks. */
+/** Provider 钩子返回的每次请求的流选项补丁。 */
 export interface AgentHarnessStreamOptionsPatch
 	extends Omit<Partial<AgentHarnessStreamOptions>, "headers" | "metadata"> {
 	/** Header patch. `undefined` values delete keys; explicit `headers: undefined` clears all headers. */
@@ -143,10 +143,10 @@ export interface AgentHarnessStreamOptionsPatch
 	metadata?: Record<string, unknown | undefined>;
 }
 
-/** Kind of filesystem object as addressed by a {@link FileSystem}. Symlinks are not followed automatically. */
+/** {@link FileSystem} 寻址的文件系统对象类型。不会自动跟随符号链接。 */
 export type FileKind = "file" | "directory" | "symlink";
 
-/** Stable, backend-independent file error codes returned by {@link FileSystem} file operations. */
+/** {@link FileSystem} 文件操作返回的、不依赖后端的稳定错误码。 */
 export type FileErrorCode =
 	| "aborted"
 	| "not_found"
@@ -157,7 +157,7 @@ export type FileErrorCode =
 	| "not_supported"
 	| "unknown";
 
-/** Error returned by {@link FileSystem} file operations. */
+/** {@link FileSystem} 文件操作返回的错误。 */
 export class FileError extends Error {
 	/** Backend-independent error code. */
 	public code: FileErrorCode;
@@ -172,7 +172,7 @@ export class FileError extends Error {
 	}
 }
 
-/** Stable, backend-independent execution error codes returned by {@link ExecutionEnv.exec}. */
+/** {@link ExecutionEnv.exec} 返回的、不依赖后端的稳定执行错误码。 */
 export type ExecutionErrorCode =
 	| "aborted"
 	| "timeout"
@@ -181,7 +181,7 @@ export type ExecutionErrorCode =
 	| "callback_error"
 	| "unknown";
 
-/** Error returned by {@link ExecutionEnv.exec}. */
+/** {@link ExecutionEnv.exec} 返回的错误。 */
 export class ExecutionError extends Error {
 	/** Backend-independent error code. */
 	public code: ExecutionErrorCode;
@@ -193,10 +193,10 @@ export class ExecutionError extends Error {
 	}
 }
 
-/** Stable compaction error codes returned by compaction helpers. */
+/** compaction 辅助函数返回的稳定压缩错误码。 */
 export type CompactionErrorCode = "aborted" | "summarization_failed" | "invalid_session" | "unknown";
 
-/** Error returned by compaction helpers. */
+/** compaction 辅助函数返回的错误。 */
 export class CompactionError extends Error {
 	/** Backend-independent error code. */
 	public code: CompactionErrorCode;
@@ -208,10 +208,10 @@ export class CompactionError extends Error {
 	}
 }
 
-/** Stable branch-summary error codes returned by branch summarization helpers. */
+/** 分支摘要辅助函数返回的稳定分支摘要错误码。 */
 export type BranchSummaryErrorCode = "aborted" | "summarization_failed" | "invalid_session";
 
-/** Error returned by branch summarization helpers. */
+/** 分支摘要辅助函数返回的错误。 */
 export class BranchSummaryError extends Error {
 	/** Backend-independent error code. */
 	public code: BranchSummaryErrorCode;
@@ -231,7 +231,7 @@ export type SessionErrorCode =
 	| "storage"
 	| "unknown";
 
-/** Error thrown by session storage, repositories, and session tree operations. */
+/** session 存储、仓库和会话树操作抛出的错误。 */
 export class SessionError extends Error {
 	/** Session subsystem error code. */
 	public code: SessionErrorCode;
@@ -254,7 +254,7 @@ export type AgentHarnessErrorCode =
 	| "branch_summary"
 	| "unknown";
 
-/** Public AgentHarness failure with a stable top-level classification. */
+/** 具有稳定顶层分类的 AgentHarness 公开失败。 */
 export class AgentHarnessError extends Error {
 	public code: AgentHarnessErrorCode;
 
@@ -265,7 +265,7 @@ export class AgentHarnessError extends Error {
 	}
 }
 
-/** Metadata for one filesystem object in a {@link FileSystem}. */
+/** {@link FileSystem} 中单个文件系统对象的元数据。 */
 export interface FileInfo {
 	/** Basename of {@link path}. */
 	name: string;
@@ -280,13 +280,13 @@ export interface FileInfo {
 }
 
 /**
- * Filesystem capability used by the harness.
+ * harness 使用的文件系统能力。
  *
- * Paths passed to methods may be absolute or relative to {@link cwd}. Paths returned by file operations are addressed paths
- * in the filesystem namespace, but are not canonicalized through symlinks unless returned by {@link canonicalPath}.
+ * 传递给方法的路径可以是绝对路径，也可以是相对于 {@link cwd} 的相对路径。文件操作返回的路径是文件系统命名空间中的寻址路径，
+ * 但除非由 {@link canonicalPath} 返回，否则不会通过符号链接进行规范化。
  *
- * Operation methods must never throw or reject. All filesystem failures, including unexpected backend failures, must be
- * encoded in the returned {@link Result}. Implementations must preserve this invariant.
+ * 操作方法绝不能抛出或拒绝。所有文件系统失败（包括意外的后端失败）都必须
+ * 编码在返回的 {@link Result} 中。实现必须保持此不变性。
  */
 export interface FileSystem {
 	/** Current working directory for relative paths. */
@@ -340,7 +340,7 @@ export interface FileSystem {
 	cleanup(): Promise<void>;
 }
 
-/** Options for {@link Shell.exec}. */
+/** {@link Shell.exec} 的选项。 */
 export interface ShellExecOptions {
 	/** Working directory for the command. Relative paths are resolved against {@link ExecutionEnv.cwd}. Defaults to {@link ExecutionEnv.cwd}. */
 	cwd?: string;
@@ -358,7 +358,7 @@ export interface ShellExecOptions {
 	onStderr?: (chunk: string) => void;
 }
 
-/** Shell execution capability used by the harness. */
+/** harness 使用的 Shell 执行能力。 */
 export interface Shell {
 	/** Execute a shell command in {@link FileSystem.cwd} unless `options.cwd` is provided. */
 	exec(
@@ -369,7 +369,7 @@ export interface Shell {
 	cleanup(): Promise<void>;
 }
 
-/** Filesystem and process execution environment used by the harness. */
+/** harness 使用的文件系统和进程执行环境。 */
 export interface ExecutionEnv extends FileSystem, Shell {}
 
 export interface SessionTreeEntryBase {
@@ -441,7 +441,7 @@ export interface LabelEntry extends SessionTreeEntryBase {
 }
 
 export interface SessionInfoEntry extends SessionTreeEntryBase {
-	type: "session_info"; // legacy name, kept for backwards compatibility
+	type: "session_info"; // 旧名称，为向后兼容而保留
 	name?: string;
 }
 

--- a/packages/agent/src/harness/utils/shell-output.ts
+++ b/packages/agent/src/harness/utils/shell-output.ts
@@ -1,6 +1,7 @@
 import { type ExecutionEnv, ExecutionError, err, ok, type Result, type ShellExecOptions, toError } from "../types.ts";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, type TruncationResult, truncateTail } from "./truncate.ts";
 
+/** 命令执行过程中的实时进度数据，可通过 onChunk 回调中的 getProgress 获取。 */
 export interface ShellCaptureProgress {
 	output: string;
 	truncation: TruncationResult;
@@ -8,12 +9,14 @@ export interface ShellCaptureProgress {
 	lastLineBytes: number;
 }
 
+/** Shell 命令捕获选项，继承 ShellExecOptions 但移除 stdout/stderr 回调（由内部流式捕获逻辑管理）。 */
 export interface ShellCaptureOptions extends Omit<ShellExecOptions, "onStdout" | "onStderr"> {
 	onChunk?: (chunk: string, getProgress: () => ShellCaptureProgress) => void;
 	/** Return shell execution failures with captured output instead of as a failed Result. */
 	returnExecutionErrors?: boolean;
 }
 
+/** Shell 命令捕获的完整结果，继承进度信息并附加最终状态。 */
 export interface ShellCaptureResult extends ShellCaptureProgress {
 	exitCode: number | undefined;
 	cancelled: boolean;
@@ -21,12 +24,20 @@ export interface ShellCaptureResult extends ShellCaptureProgress {
 	executionError?: ExecutionError;
 }
 
+/** 将任意错误包装为 ExecutionError，已存在的 ExecutionError 实例直接返回。 */
 function toExecutionError(error: unknown): ExecutionError {
 	if (error instanceof ExecutionError) return error;
 	const cause = toError(error);
 	return new ExecutionError("unknown", cause.message, cause);
 }
 
+/**
+ * 过滤 shell 输出中的控制字符，防止二进制数据污染上下文。
+ * 保留常见的文本控制字符：制表符（0x09）、换行符（0x0a）、回车符（0x0d），
+ * 过滤其他 C0 控制字符（0x00-0x1f）以及 Unicode 行间注释字符（U+FFF9-U+FFFB）。
+ * @param str - 原始输出字符串
+ * @returns 过滤后的安全文本字符串
+ */
 export function sanitizeBinaryOutput(str: string): string {
 	return Array.from(str)
 		.filter((char) => {
@@ -40,6 +51,7 @@ export function sanitizeBinaryOutput(str: string): string {
 		.join("");
 }
 
+/** 从末尾截断文本至指定的 UTF-8 字节数，确保不截断多字节字符。 */
 function trimToLastUtf8Bytes(text: string, maxBytes: number, encoder: { encode(input?: string): Uint8Array }): string {
 	const bytes = encoder.encode(text);
 	if (bytes.byteLength <= maxBytes) return text;
@@ -48,6 +60,27 @@ function trimToLastUtf8Bytes(text: string, maxBytes: number, encoder: { encode(i
 	return new TextDecoder().decode(bytes.subarray(start));
 }
 
+/**
+ * 执行 shell 命令并捕获其输出，提供二进制过滤、输出截断和溢出写盘等完整处理。
+ *
+ * 整个捕获流程分为三层：
+ * 1. **流式捕获**：通过 env.exec 的 onStdout/onStderr 回调实时接收输出块，
+ *    合并 stdout 和 stderr 为统一流，逐块进行二进制过滤和累积。
+ * 2. **内存管理**：在内存中维护一个环形缓冲区（outputChunks），当输出字节数
+ *    超过 maxOutputBytes（DEFAULT_MAX_BYTES * 2）时，丢弃最早的 chunk，
+ *    保证内存占用不会无限增长。
+ * 3. **溢出写盘**：当原始输出超过 DEFAULT_MAX_BYTES 时，延迟创建临时日志文件，
+ *    通过串行化的 writeChain Promise 链将完整的原始输出追加写入磁盘。
+ *    最终返回的 ShellCaptureResult.fullOutputPath 指向该文件。
+ *
+ * **取消处理**：当 AbortSignal 触发时，不会抛出错误，而是返回部分结果，
+ * 其中 cancelled 标记为 true，exitCode 设为 undefined。
+ *
+ * @param env - 执行环境实例，提供 exec 和文件操作方法
+ * @param command - 要执行的 shell 命令字符串
+ * @param options - 可选的捕获配置，支持超时、工作目录、环境变量、中断信号等
+ * @returns 包含 ShellCaptureResult 的 Result，执行失败时返回 ExecutionError
+ */
 export async function executeShellWithCapture(
 	env: ExecutionEnv,
 	command: string,

--- a/packages/agent/src/harness/utils/truncate.ts
+++ b/packages/agent/src/harness/utils/truncate.ts
@@ -1,46 +1,46 @@
 /**
- * Shared truncation utilities for tool outputs.
+ * 工具输出的共享截断工具函数。
  *
- * Truncation is based on two independent limits - whichever is hit first wins:
- * - Line limit (default: 2000 lines)
- * - Byte limit (default: 50KB)
+ * 截断基于两个独立的限制——以先触发者为准：
+ * - 行数限制（默认：2000 行）
+ * - 字节数限制（默认：50KB）
  *
- * Never returns partial lines (except bash tail truncation edge case).
+ * 从不返回不完整的行（bash 尾部截断边缘情况除外）。
  */
 
 export const DEFAULT_MAX_LINES = 2000;
 export const DEFAULT_MAX_BYTES = 50 * 1024; // 50KB
-export const GREP_MAX_LINE_LENGTH = 500; // Max chars per grep match line
+export const GREP_MAX_LINE_LENGTH = 500; // grep 匹配行的最大字符数
 
 export interface TruncationResult {
-	/** The truncated content */
+	/** 截断后的内容 */
 	content: string;
-	/** Whether truncation occurred */
+	/** 是否发生了截断 */
 	truncated: boolean;
-	/** Which limit was hit: "lines", "bytes", or null if not truncated */
+	/** 触发截断的限制："lines"（行数）、"bytes"（字节数），未截断时为 null */
 	truncatedBy: "lines" | "bytes" | null;
-	/** Total number of lines in the original content */
+	/** 原始内容的总行数 */
 	totalLines: number;
-	/** Total number of bytes in the original content */
+	/** 原始内容的总字节数 */
 	totalBytes: number;
-	/** Number of complete lines in the truncated output */
+	/** 截断输出中的完整行数 */
 	outputLines: number;
-	/** Number of bytes in the truncated output */
+	/** 截断输出的字节数 */
 	outputBytes: number;
-	/** Whether the last line was partially truncated (only for tail truncation edge case) */
+	/** 最后一行是否被部分截断（仅尾部截断边缘情况） */
 	lastLinePartial: boolean;
-	/** Whether the first line exceeded the byte limit (for head truncation) */
+	/** 第一行是否超过字节限制（用于头部截断） */
 	firstLineExceedsLimit: boolean;
-	/** The max lines limit that was applied */
+	/** 应用的最大行数限制 */
 	maxLines: number;
-	/** The max bytes limit that was applied */
+	/** 应用的最大字节数限制 */
 	maxBytes: number;
 }
 
 export interface TruncationOptions {
-	/** Maximum number of lines (default: 2000) */
+	/** 最大行数（默认：2000） */
 	maxLines?: number;
-	/** Maximum number of bytes (default: 50KB) */
+	/** 最大字节数（默认：50KB） */
 	maxBytes?: number;
 }
 
@@ -110,7 +110,7 @@ function replaceUnpairedSurrogates(content: string): string {
 }
 
 /**
- * Format bytes as human-readable size.
+ * 将字节数格式化为人类可读的大小。
  */
 export function formatSize(bytes: number): string {
 	if (bytes < 1024) {
@@ -123,11 +123,11 @@ export function formatSize(bytes: number): string {
 }
 
 /**
- * Truncate content from the head (keep first N lines/bytes).
- * Suitable for file reads where you want to see the beginning.
+ * 从头部截断内容（保留前 N 行/字节）。
+ * 适用于需要查看开头的文件读取场景。
  *
- * Never returns partial lines. If first line exceeds byte limit,
- * returns empty content with firstLineExceedsLimit=true.
+ * 从不返回不完整的行。如果第一行就超过字节限制，
+ * 则返回空内容并将 firstLineExceedsLimit 设为 true。
  */
 export function truncateHead(content: string, options: TruncationOptions = {}): TruncationResult {
 	const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
@@ -137,7 +137,7 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
 	const lines = splitLinesForCounting(content);
 	const totalLines = lines.length;
 
-	// Check if no truncation needed
+	// 检查是否不需要截断
 	if (totalLines <= maxLines && totalBytes <= maxBytes) {
 		return {
 			content,
@@ -154,7 +154,7 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
 		};
 	}
 
-	// Check if first line alone exceeds byte limit
+	// 检查第一行是否单独就超过字节限制
 	const firstLineBytes = utf8ByteLength(lines[0]);
 	if (firstLineBytes > maxBytes) {
 		return {
@@ -172,14 +172,14 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
 		};
 	}
 
-	// Collect complete lines that fit
+	// 收集能容纳的完整行
 	const outputLinesArr: string[] = [];
 	let outputBytesCount = 0;
 	let truncatedBy: "lines" | "bytes" = "lines";
 
 	for (let i = 0; i < lines.length && i < maxLines; i++) {
 		const line = lines[i];
-		const lineBytes = utf8ByteLength(line) + (i > 0 ? 1 : 0); // +1 for newline
+		const lineBytes = utf8ByteLength(line) + (i > 0 ? 1 : 0); // +1 表示换行符
 
 		if (outputBytesCount + lineBytes > maxBytes) {
 			truncatedBy = "bytes";
@@ -190,7 +190,7 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
 		outputBytesCount += lineBytes;
 	}
 
-	// If we exited due to line limit
+	// 如果是因行数限制而退出的
 	if (outputLinesArr.length >= maxLines && outputBytesCount <= maxBytes) {
 		truncatedBy = "lines";
 	}
@@ -214,10 +214,10 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
 }
 
 /**
- * Truncate content from the tail (keep last N lines/bytes).
- * Suitable for bash output where you want to see the end (errors, final results).
+ * 从尾部截断内容（保留最后 N 行/字节）。
+ * 适用于需要查看末尾（错误信息、最终结果）的 bash 输出场景。
  *
- * May return partial first line if the last line of original content exceeds byte limit.
+ * 如果原始内容的最后一行超过字节限制，可能返回不完整的第一行。
  */
 export function truncateTail(content: string, options: TruncationOptions = {}): TruncationResult {
 	const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
@@ -227,7 +227,7 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 	const lines = splitLinesForCounting(content);
 	const totalLines = lines.length;
 
-	// Check if no truncation needed
+	// 检查是否不需要截断
 	if (totalLines <= maxLines && totalBytes <= maxBytes) {
 		return {
 			content,
@@ -244,7 +244,7 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 		};
 	}
 
-	// Work backwards from the end
+	// 从末尾反向遍历
 	const outputLinesArr: string[] = [];
 	let outputBytesCount = 0;
 	let truncatedBy: "lines" | "bytes" = "lines";
@@ -252,12 +252,12 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 
 	for (let i = lines.length - 1; i >= 0 && outputLinesArr.length < maxLines; i--) {
 		const line = lines[i];
-		const lineBytes = utf8ByteLength(line) + (outputLinesArr.length > 0 ? 1 : 0); // +1 for newline
+		const lineBytes = utf8ByteLength(line) + (outputLinesArr.length > 0 ? 1 : 0); // +1 表示换行符
 
 		if (outputBytesCount + lineBytes > maxBytes) {
 			truncatedBy = "bytes";
-			// Edge case: if we haven't added ANY lines yet and this line exceeds maxBytes,
-			// take the end of the line (partial)
+			// 边缘情况：如果还没有添加任何行且该行超过 maxBytes，
+			// 则截取行的末尾部分（不完整）
 			if (outputLinesArr.length === 0) {
 				const truncatedLine = truncateStringToBytesFromEnd(line, maxBytes);
 				outputLinesArr.unshift(truncatedLine);
@@ -271,7 +271,7 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 		outputBytesCount += lineBytes;
 	}
 
-	// If we exited due to line limit
+	// 如果是因行数限制而退出的
 	if (outputLinesArr.length >= maxLines && outputBytesCount <= maxBytes) {
 		truncatedBy = "lines";
 	}
@@ -295,8 +295,8 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
 }
 
 /**
- * Truncate a string to fit within a byte limit (from the end).
- * Handles multi-byte UTF-8 characters correctly.
+ * 从末尾截断字符串以适应字节限制。
+ * 正确处理多字节 UTF-8 字符。
  */
 function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
 	if (maxBytes <= 0) return "";
@@ -336,8 +336,8 @@ function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
 }
 
 /**
- * Truncate a single line to max characters, adding [truncated] suffix.
- * Used for grep match lines.
+ * 将单行截断到最大字符数，并添加 [truncated] 后缀。
+ * 用于 grep 匹配行。
  */
 export function truncateLine(
 	line: string,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,7 +1,7 @@
-// Core Agent
+// 核心 Agent 模块
 export { uuidv7 } from "@earendil-works/pi-ai";
 export * from "./agent.ts";
-// Loop functions
+// Agent 循环函数
 export * from "./agent-loop.ts";
 export * from "./harness/agent-harness.ts";
 export {
@@ -40,13 +40,13 @@ export * from "./harness/session/session.ts";
 export * from "./harness/skills.ts";
 export * from "./harness/system-prompt.ts";
 export * from "./harness/tools/index.ts";
-// Harness
+// Agent Harness（工具链/会话管理/压缩等）
 export * from "./harness/types.ts";
 export * from "./harness/utils/shell-output.ts";
 export * from "./harness/utils/truncate.ts";
-// Proxy utilities
+// 代理工具函数
 export * from "./proxy.ts";
-// Stream defaults
+// 默认 Stream 配置
 export { setDefaultStreamFn } from "./stream-fn.ts";
-// Types
+// 类型定义
 export * from "./types.ts";

--- a/packages/agent/src/node.ts
+++ b/packages/agent/src/node.ts
@@ -1,2 +1,7 @@
+/**
+ * Node.js 入口：导出 NodeExecutionEnv 以及所有公共 API。
+ *
+ * 使用此入口的应用运行在 Node.js 环境下，获得基于 Node.js fs/spawn 的文件系统和 shell 能力。
+ */
 export { NodeExecutionEnv } from "./harness/env/nodejs.ts";
 export * from "./index.ts";

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -1,9 +1,9 @@
 /**
- * Proxy stream function for apps that route LLM calls through a server.
- * The server manages auth and proxies requests to LLM providers.
+ * 通过服务端中转 LLM 调用的代理 stream 函数。
+ * 服务端管理认证并将请求代理转发给 LLM provider。
  */
 
-// Internal import for JSON parsing utility
+// 导入 JSON 解析工具的内部模块
 import {
 	type AssistantMessage,
 	type AssistantMessageEvent,
@@ -16,7 +16,7 @@ import {
 	type ToolCall,
 } from "@earendil-works/pi-ai";
 
-// Create stream class matching ProxyMessageEventStream
+// 与 ProxyMessageEventStream 匹配的 stream 类，在事件流结束时提取最终的 AssistantMessage。
 class ProxyMessageEventStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
 	constructor() {
 		super(
@@ -31,7 +31,7 @@ class ProxyMessageEventStream extends EventStream<AssistantMessageEvent, Assista
 }
 
 /**
- * Proxy event types - server sends these with partial field stripped to reduce bandwidth.
+ * 代理事件类型 —— 服务端发送时移除了 partial 字段以节省带宽。
  */
 export type ProxyAssistantMessageEvent =
 	| { type: "start" }
@@ -71,32 +71,16 @@ type ProxySerializableStreamOptions = Pick<
 >;
 
 export interface ProxyStreamOptions extends ProxySerializableStreamOptions {
-	/** Local abort signal for the proxy request */
+	/** 代理请求的本地中止信号 */
 	signal?: AbortSignal;
-	/** Auth token for the proxy server */
+	/** 代理服务器的认证令牌 */
 	authToken: string;
-	/** Proxy server URL (e.g., "https://genai.example.com") */
+	/** 代理服务器 URL（例如 "https://genai.example.com"） */
 	proxyUrl: string;
 }
 
 /**
- * Stream function that proxies through a server instead of calling LLM providers directly.
- * The server strips the partial field from delta events to reduce bandwidth.
- * We reconstruct the partial message client-side.
- *
- * Use this as the `streamFn` option when creating an Agent that needs to go through a proxy.
- *
- * @example
- * ```typescript
- * const agent = new Agent({
- *   streamFn: (model, context, options) =>
- *     streamProxy(model, context, {
- *       ...options,
- *       authToken: await getAuthToken(),
- *       proxyUrl: "https://genai.example.com",
- *     }),
- * });
- * ```
+ * 从完整的 ProxyStreamOptions 中提取可序列化的 stream 选项，用于发送给代理服务器。
  */
 function buildProxyRequestOptions(options: ProxyStreamOptions): ProxySerializableStreamOptions {
 	return {
@@ -113,11 +97,17 @@ function buildProxyRequestOptions(options: ProxyStreamOptions): ProxySerializabl
 	};
 }
 
+/**
+ * 通过代理服务器中转 LLM 调用的 stream 函数。
+ * 服务端移除 delta 事件中的 partial 字段以节省带宽，客户端负责重建完整的 partial message。
+ *
+ * 在创建需要通过代理的 Agent 时，将此函数作为 `streamFn` 选项传入。
+ */
 export function streamProxy(model: Model<any>, context: Context, options: ProxyStreamOptions): ProxyMessageEventStream {
 	const stream = new ProxyMessageEventStream();
 
 	(async () => {
-		// Initialize the partial message that we'll build up from events
+		/** 从事件流逐步构建的 partial assistant message。 */
 		const partial: AssistantMessage = {
 			role: "assistant",
 			stopReason: "pending",
@@ -171,7 +161,7 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 						errorMessage = `Proxy error: ${errorData.error}`;
 					}
 				} catch {
-					// Couldn't parse error response
+					// 无法解析错误响应
 				}
 				throw new Error(errorMessage);
 			}
@@ -233,7 +223,7 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 }
 
 /**
- * Process a proxy event and update the partial message.
+ * 处理代理事件并更新 partial 消息。
  */
 function processProxyEvent(
 	proxyEvent: ProxyAssistantMessageEvent,
@@ -322,7 +312,7 @@ function processProxyEvent(
 			if (content?.type === "toolCall") {
 				(content as any).partialJson += proxyEvent.delta;
 				content.arguments = parseStreamingJson((content as any).partialJson) || {};
-				partial.content[proxyEvent.contentIndex] = { ...content }; // Trigger reactivity
+				partial.content[proxyEvent.contentIndex] = { ...content }; // 触发响应式更新
 				return {
 					type: "toolcall_delta",
 					contentIndex: proxyEvent.contentIndex,

--- a/packages/agent/src/stream-fn.ts
+++ b/packages/agent/src/stream-fn.ts
@@ -1,17 +1,18 @@
 import type { StreamFn } from "./types.ts";
 
+/** 默认的 stream 函数实例，由宿主通过 setDefaultStreamFn 配置。 */
 let defaultStreamFn: StreamFn | undefined;
 
 /**
- * Configure the fallback used by Agent and low-level loops when callers omit streamFn.
- *
- * Hosts that provide a default model runtime can install its stream function here
- * without making pi-agent-core depend on a provider catalog or compatibility layer.
+ * 配置 Agent 和底层 loop 在调用方省略 streamFn 时使用的兜底 stream 函数。
+ * 提供默认模型运行时的宿主可以在此安装其 stream 函数，
+ * 无需让 pi-agent-core 依赖 provider 目录或兼容层。
  */
 export function setDefaultStreamFn(streamFn: StreamFn | undefined): void {
 	defaultStreamFn = streamFn;
 }
 
+/** 获取默认 stream 函数，未配置时抛出错误。 */
 export function getDefaultStreamFn(): StreamFn {
 	if (!defaultStreamFn) {
 		throw new Error("No default stream function configured. Pass streamFn explicitly or call setDefaultStreamFn().");

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -16,14 +16,13 @@ import type {
 import type { Static, TSchema } from "typebox";
 
 /**
- * Stream function used by the agent loop. `Models.streamSimple` satisfies
- * this shape.
+ * agent 循环使用的流函数。`Models.streamSimple` 满足此形状。
  *
- * Contract:
- * - Must not throw or return a rejected promise for request/model/runtime failures.
- * - Must return an AssistantMessageEventStream.
- * - Failures must be encoded in the returned stream via protocol events and a
- *   final AssistantMessage with stopReason "error" or "aborted" and errorMessage.
+ * 契约：
+ * - 对于请求/模型/运行时失败，不得抛出异常或返回 reject 的 promise。
+ * - 必须返回一个 AssistantMessageEventStream。
+ * - 失败必须通过协议事件以及一个 stopReason 为 "error" 或 "aborted" 且带 errorMessage 的
+ *   最终 AssistantMessage 编码到返回的流中。
  */
 export type StreamFn = (
 	model: Model<Api>,
@@ -32,31 +31,31 @@ export type StreamFn = (
 ) => AssistantMessageEventStream | Promise<AssistantMessageEventStream>;
 
 /**
- * Configuration for how tool calls from a single assistant message are executed.
+ * 控制单条 assistant 消息中的工具调用如何执行。
  *
- * - "sequential": each tool call is prepared, executed, and finalized before the next one starts.
- * - "parallel": tool calls are prepared sequentially, then allowed tools execute concurrently.
- *   `tool_execution_end` is emitted in tool completion order after each tool is finalized,
- *   while tool-result message artifacts are emitted later in assistant source order.
+ * - "sequential"：每个工具调用在上一个完成后才准备、执行和最终化。
+ * - "parallel"：工具调用按顺序预检，然后允许的工具并发执行。
+ *   每个工具最终化后按完成顺序发出 `tool_execution_end`，
+ *   而工具结果消息则稍后按 assistant 源顺序发出。
  */
 export type ToolExecutionMode = "sequential" | "parallel";
 
 /**
- * Controls how many queued user messages are injected when the agent loop reaches a queue drain point.
+ * 控制 agent 循环到达队列排空点时注入多少条排队的用户消息。
  *
- * - "all": drain and inject every queued message at that point.
- * - "one-at-a-time": drain and inject only the oldest queued message, leaving the rest queued for later drain points.
+ * - "all"：在该点排空并注入所有排队消息。
+ * - "one-at-a-time"：仅排空并注入最早的一条排队消息，其余留待后续排空点处理。
  */
 export type QueueMode = "all" | "one-at-a-time";
 
-/** A single tool call content block emitted by an assistant message. */
+/** assistant 消息发出的单个工具调用内容块。 */
 export type AgentToolCall = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
 
 /**
- * Result returned from `beforeToolCall`.
+ * `beforeToolCall` 返回的结果。
  *
- * Returning `{ block: true }` prevents the tool from executing. The loop emits an error tool result instead.
- * `reason` becomes the text shown in that error result. If omitted, a default blocked message is used.
+ * 返回 `{ block: true }` 可阻止工具执行，loop 会改为发出错误工具结果。
+ * `reason` 会成为该错误结果中显示的文本。如果省略，则使用默认的阻止消息。
  */
 export interface BeforeToolCallResult {
 	block?: boolean;
@@ -64,78 +63,78 @@ export interface BeforeToolCallResult {
 }
 
 /**
- * Partial override returned from `afterToolCall`.
+ * `afterToolCall` 返回的部分覆盖结果。
  *
- * Merge semantics are field-by-field:
- * - `content`: if provided, replaces the tool result content array in full
- * - `details`: if provided, replaces the tool result details value in full
- * - `isError`: if provided, replaces the tool result error flag
- * - `usage`: if provided, replaces the tool result usage
- * - `terminate`: if provided, replaces the early-termination hint
+ * 合并语义为逐字段覆盖：
+ * - `content`：如果提供，完整替换工具结果的内容数组
+ * - `details`：如果提供，完整替换工具结果的 details 值
+ * - `isError`：如果提供，替换工具结果的错误标志
+ * - `usage`：如果提供，替换工具结果的 usage
+ * - `terminate`：如果提供，替换提前终止提示
  *
- * Omitted fields keep the original executed tool result values.
- * There is no deep merge for `content`, `details`, or `usage`.
+ * 未提供的字段保留已执行工具结果的原始值。
+ * `content`、`details` 和 `usage` 不执行深度合并。
  */
 export interface AfterToolCallResult {
 	content?: (TextContent | ImageContent)[];
 	details?: unknown;
 	isError?: boolean;
-	/** Usage from the final tool execution itself, if available. Not used for main LLM context accounting. */
+	/** 工具执行本身的 usage，如果有的话。不用于主 LLM 上下文的计费统计。 */
 	usage?: Usage;
 	/**
-	 * Hint that the agent should stop after the current tool batch.
-	 * Early termination only happens when every finalized tool result in the batch sets this to true.
+	 * 提示 agent 应在当前工具批次完成后停止。
+	 * 仅当批次中每个已最终化的工具结果都将此设为 true 时，才会触发提前终止。
 	 */
 	terminate?: boolean;
 }
 
-/** Context passed to `beforeToolCall`. */
+/** 传递给 `beforeToolCall` 的上下文。 */
 export interface BeforeToolCallContext {
-	/** The assistant message that requested the tool call. */
+	/** 请求该工具调用的 assistant 消息。 */
 	assistantMessage: AssistantMessage;
-	/** The raw tool call block from `assistantMessage.content`. */
+	/** `assistantMessage.content` 中的原始工具调用块。 */
 	toolCall: AgentToolCall;
-	/** Validated tool arguments for the target tool schema. */
+	/** 已验证的、针对目标工具 schema 的工具参数。 */
 	args: unknown;
-	/** Current agent context at the time the tool call is prepared. */
+	/** 工具调用准备时的当前 agent 上下文。 */
 	context: AgentContext;
 }
 
-/** Context passed to `afterToolCall`. */
+/** 传递给 `afterToolCall` 的上下文。 */
 export interface AfterToolCallContext {
-	/** The assistant message that requested the tool call. */
+	/** 请求工具调用的 assistant 消息。 */
 	assistantMessage: AssistantMessage;
-	/** The raw tool call block from `assistantMessage.content`. */
+	/** `assistantMessage.content` 中的原始工具调用块。 */
 	toolCall: AgentToolCall;
-	/** Validated tool arguments for the target tool schema. */
+	/** 针对目标工具 schema 验证后的工具参数。 */
 	args: unknown;
-	/** The executed tool result before any `afterToolCall` overrides are applied. */
+	/** 应用 `afterToolCall` 覆盖之前的已执行工具结果。 */
 	result: AgentToolResult<any>;
-	/** Whether the executed tool result is currently treated as an error. */
+	/** 已执行的工具结果当前是否被视为错误。 */
 	isError: boolean;
-	/** Current agent context at the time the tool call is finalized. */
+	/** 工具调用最终化时的当前 agent 上下文。 */
 	context: AgentContext;
 }
 
-/** Context passed to `shouldStopAfterTurn`. */
+/** 传递给 `shouldStopAfterTurn` 的上下文。 */
 export interface ShouldStopAfterTurnContext {
-	/** The assistant message that completed the turn. */
+	/** 完成该 turn 的 assistant 消息。 */
 	message: AssistantMessage;
-	/** Tool result messages passed to the preceding `turn_end` event. */
+	/** 传递给前置 `turn_end` 事件的工具结果消息。 */
 	toolResults: ToolResultMessage[];
-	/** Current agent context after the turn's assistant message and tool results have been appended. */
+	/** 在该 turn 的 assistant 消息和工具结果追加后的当前 agent 上下文。 */
 	context: AgentContext;
-	/** Messages that this loop invocation will return if it exits at this point. Prompt runs include the initial prompt messages; continuation runs do not include pre-existing context messages. */
+	/** 如果在此点退出，本轮循环调用将返回的消息。prompt 运行包含初始提示消息；continuation 运行不包含已有的上下文消息。 */
 	newMessages: AgentMessage[];
 }
 
-/** Replacement runtime state used by the agent loop before starting another provider request. */
+/** agent 循环在发起下一次 provider 请求前使用的替换运行时状态。 */
 export interface AgentLoopTurnUpdate {
-	/** Context for the next provider request. */
+	/** 下一次 provider 请求的上下文。 */
 	context?: AgentContext;
-	/** Model for the next provider request. */
+	/** 下一次 provider 请求的模型。 */
 	model?: Model<any>;
-	/** Thinking level for the next provider request. */
+	/** 下一次 provider 请求的思考级别。 */
 	thinkingLevel?: ThinkingLevel;
 }
 
@@ -145,27 +144,26 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	model: Model<any>;
 
 	/**
-	 * Converts AgentMessage[] to LLM-compatible Message[] before each LLM call.
+	 * 在每次 LLM 调用前将 AgentMessage[] 转换为 LLM 兼容的 Message[]。
 	 *
-	 * Each AgentMessage must be converted to a UserMessage, AssistantMessage, or ToolResultMessage
-	 * that the LLM can understand. AgentMessages that cannot be converted (e.g., UI-only notifications,
-	 * status messages) should be filtered out.
+	 * 每个 AgentMessage 必须被转换为 LLM 可以理解的 UserMessage、AssistantMessage 或 ToolResultMessage。
+	 * 无法转换的 AgentMessage（例如仅用于 UI 的通知、状态消息）应当被过滤掉。
 	 *
-	 * Contract: must not throw or reject. Return a safe fallback value instead.
-	 * Throwing interrupts the low-level agent loop without producing a normal event sequence.
+	 * 约定：不得抛出异常或返回被拒绝的 Promise。应返回安全的回退值。
+	 * 抛出异常会中断底层 agent loop，导致无法产生正常的事件序列。
 	 *
 	 * @example
 	 * ```typescript
 	 * convertToLlm: (messages) => messages.flatMap(m => {
 	 *   if (m.role === "custom") {
-	 *     // Convert custom message to user message
+	 *     // 将自定义消息转换为用户消息
 	 *     return [{ role: "user", content: m.content, timestamp: m.timestamp }];
 	 *   }
 	 *   if (m.role === "notification") {
-	 *     // Filter out UI-only messages
+	 *     // 过滤掉仅用于 UI 的消息
 	 *     return [];
 	 *   }
-	 *   // Pass through standard LLM messages
+	 *   // 透传标准 LLM 消息
 	 *   return [m];
 	 * })
 	 * ```
@@ -173,14 +171,13 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 
 	/**
-	 * Optional transform applied to the context before `convertToLlm`.
+	 * 在 `convertToLlm` 之前对上下文应用的可选变换。
 	 *
-	 * Use this for operations that work at the AgentMessage level:
-	 * - Context window management (pruning old messages)
-	 * - Injecting context from external sources
+	 * 用于在 AgentMessage 层面进行的操作：
+	 * - 上下文窗口管理（裁剪旧消息）
+	 * - 从外部来源注入上下文
 	 *
-	 * Contract: must not throw or reject. Return the original messages or another
-	 * safe fallback value instead.
+	 * 约定：不得抛出异常或返回被拒绝的 Promise。应返回原始消息或其他安全的回退值。
 	 *
 	 * @example
 	 * ```typescript
@@ -195,107 +192,105 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 
 	/**
-	 * Resolves an API key dynamically for each LLM call.
+	 * 为每次 LLM 调用动态解析 API 密钥。
 	 *
-	 * Useful for short-lived OAuth tokens (e.g., GitHub Copilot) that may expire
-	 * during long-running tool execution phases.
+	 * 适用于可能在长时间运行的工具执行阶段过期的短期 OAuth 令牌（例如 GitHub Copilot）。
 	 *
-	 * Contract: must not throw or reject. Return undefined when no key is available.
+	 * 约定：不得抛出异常或返回被拒绝的 Promise。无可用密钥时返回 undefined。
 	 */
 	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
 
 	/**
-	 * Called after each turn fully completes and `turn_end` has been emitted.
+	 * 在每次 turn 完全完成且 `turn_end` 已发出后调用。
 	 *
-	 * If it returns true, the loop emits `agent_end` and exits before polling steering or follow-up queues,
-	 * without starting another LLM call. The current assistant response and any tool executions finish normally.
+	 * 如果返回 true，则 loop 发出 `agent_end` 并退出，不再检查 steering 或 follow-up 队列，
+	 * 也不会发起下一次 LLM 调用。当前 assistant 响应和任何工具执行会正常完成。
 	 *
-	 * Use this to request a graceful stop after the current turn, e.g. before context gets too full.
+	 * 用于在当前 turn 完成后请求优雅停止，例如在上下文即将超出限制之前。
 	 *
-	 * Contract: must not throw or reject. Throwing interrupts the low-level agent loop without producing a normal event sequence.
+	 * 约定：不得抛出异常或返回被拒绝的 Promise。抛出异常会中断底层 agent loop，导致无法产生正常的事件序列。
 	 */
 	shouldStopAfterTurn?: (context: ShouldStopAfterTurnContext) => boolean | Promise<boolean>;
 
 	/**
-	 * Called after `turn_end` and before the loop decides whether another provider request should start.
-	 * Return replacement context/model/thinking state to affect the next turn in this run.
-	 * Return undefined to keep using the current context/config.
+	 * 在 `turn_end` 之后、loop 决定是否发起下一次 provider 请求之前调用。
+	 * 返回替换的 context/model/thinking 状态以影响本次运行的下一轮。
+	 * 返回 undefined 则继续使用当前 context/config。
 	 */
 	prepareNextTurn?: (
 		context: PrepareNextTurnContext,
 	) => AgentLoopTurnUpdate | undefined | Promise<AgentLoopTurnUpdate | undefined>;
 
 	/**
-	 * Returns steering messages to inject into the conversation mid-run.
+	 * 返回要在运行中注入对话的 steering 消息。
 	 *
-	 * Called after the current assistant turn finishes executing its tool calls, unless `shouldStopAfterTurn` exits first.
-	 * If messages are returned, they are added to the context before the next LLM call.
-	 * Tool calls from the current assistant message are not skipped.
+	 * 在当前 assistant turn 完成工具调用执行后调用，除非 `shouldStopAfterTurn` 先退出。
+	 * 如果返回消息，则在下一次 LLM 调用前将其添加到上下文中。
+	 * 当前 assistant 消息中的工具调用不会被跳过。
 	 *
-	 * Use this for "steering" the agent while it's working.
+	 * 用于在 agent 工作时对其进行"引导"。
 	 *
-	 * Contract: must not throw or reject. Return [] when no steering messages are available.
+	 * 约定：不得抛出异常或返回被拒绝的 Promise。无可用 steering 消息时返回 []。
 	 */
 	getSteeringMessages?: () => Promise<AgentMessage[]>;
 
 	/**
-	 * Returns follow-up messages to process after the agent would otherwise stop.
+	 * 返回在 agent 本应停止后需要处理的 follow-up 消息。
 	 *
-	 * Called when the agent has no more tool calls and no steering messages.
-	 * If messages are returned, they're added to the context and the agent
-	 * continues with another turn.
+	 * 当 agent 没有更多工具调用且没有 steering 消息时调用。
+	 * 如果返回消息，则将其添加到上下文中，agent 会继续进行下一轮。
 	 *
-	 * Use this for follow-up messages that should wait until the agent finishes.
+	 * 用于需要等到 agent 完成后再处理的后续消息。
 	 *
-	 * Contract: must not throw or reject. Return [] when no follow-up messages are available.
+	 * 约定：不得抛出异常或返回被拒绝的 Promise。无可用 follow-up 消息时返回 []。
 	 */
 	getFollowUpMessages?: () => Promise<AgentMessage[]>;
 
 	/**
-	 * Tool execution mode.
-	 * - "sequential": execute tool calls one by one
-	 * - "parallel": preflight tool calls sequentially, then execute allowed tools concurrently;
-	 *   emit `tool_execution_end` in tool completion order after each tool is finalized,
-	 *   then emit tool-result message artifacts later in assistant source order
+	 * 工具执行模式。
+	 * - "sequential"：逐个执行工具调用
+	 * - "parallel"：依次预检工具调用，然后并发执行允许的工具；
+	 *   每个工具最终化后按完成顺序发出 `tool_execution_end`，
+	 *   然后按 assistant 源顺序发出工具结果消息
 	 *
-	 * Default: "parallel"
+	 * 默认值："parallel"
 	 */
 	toolExecution?: ToolExecutionMode;
 
 	/**
-	 * Called before a tool is executed, after arguments have been validated.
+	 * 在工具执行前、参数验证后调用。
 	 *
-	 * Return `{ block: true }` to prevent execution. The loop emits an error tool result instead.
-	 * The hook receives the agent abort signal and is responsible for honoring it.
+	 * 返回 `{ block: true }` 可阻止执行，loop 会改为发出错误工具结果。
+	 * 该钩子接收 agent 的 abort signal 并负责响应它。
 	 */
 	beforeToolCall?: (context: BeforeToolCallContext, signal?: AbortSignal) => Promise<BeforeToolCallResult | undefined>;
 
 	/**
-	 * Called after a tool finishes executing, before `tool_execution_end` and tool-result message events are emitted.
+	 * 在工具执行完成后、`tool_execution_end` 和工具结果消息事件发出之前调用。
 	 *
-	 * Return an `AfterToolCallResult` to override parts of the executed tool result:
-	 * - `content` replaces the full content array
-	 * - `details` replaces the full details payload
-	 * - `isError` replaces the error flag
-	 * - `usage` replaces the tool result usage
-	 * - `terminate` replaces the early-termination hint
+	 * 返回 `AfterToolCallResult` 以覆盖已执行工具结果的部分字段：
+	 * - `content` 替换完整的内容数组
+	 * - `details` 替换完整的 details 负载
+	 * - `isError` 替换错误标志
+	 * - `usage` 替换 tool result usage
+	 * - `terminate` 替换提前终止提示
 	 *
-	 * Any omitted fields keep their original values. No deep merge is performed.
-	 * The hook receives the agent abort signal and is responsible for honoring it.
+	 * 未提供的字段保留其原始值。不执行深度合并。
+	 * 该钩子接收 agent 的 abort signal 并负责响应它。
 	 */
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
 }
 
 /**
- * Thinking/reasoning level for models that support it.
- * Note: "xhigh" and "max" are only supported by selected model families. Use model
- * thinking-level metadata from @earendil-works/pi-ai to detect support for a concrete model.
+ * 支持思考/推理功能的模型的思考级别。
+ * 注意："xhigh" 和 "max" 仅受部分模型系列支持。使用来自 @earendil-works/pi-ai 的
+ * 模型 thinking-level 元数据来检测具体模型是否支持。
  */
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 /**
- * Extensible interface for custom app messages.
- * Apps can extend via declaration merging:
+ * 用于自定义应用消息的可扩展接口。
+ * 应用可通过声明合并进行扩展：
  *
  * @example
  * ```typescript
@@ -308,84 +303,81 @@ export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhi
  * ```
  */
 export interface CustomAgentMessages {
-	// Empty by default - apps extend via declaration merging
+	// 默认为空 —— 应用通过声明合并进行扩展
 }
 
 /**
- * AgentMessage: Union of LLM messages + custom messages.
- * This abstraction allows apps to add custom message types while maintaining
- * type safety and compatibility with the base LLM messages.
+ * AgentMessage：LLM 消息与自定义消息的联合类型。
+ * 此抽象允许应用添加自定义消息类型，同时保持类型安全以及与基础 LLM 消息的兼容性。
  */
 export type AgentMessage = Message | CustomAgentMessages[keyof CustomAgentMessages];
 
 /**
- * Public agent state.
+ * 公开的 agent 状态。
  *
- * `tools` and `messages` use accessor properties so implementations can copy
- * assigned arrays before storing them.
+ * `tools` 和 `messages` 使用访问器属性，以便实现在存储之前可以复制传入的数组。
  */
 export interface AgentState {
-	/** System prompt sent with each model request. */
+	/** 每次模型请求时发送的系统提示词。 */
 	systemPrompt: string;
-	/** Active model used for future turns. */
+	/** 用于后续 turn 的当前活跃模型。 */
 	model: Model<any>;
-	/** Requested reasoning level for future turns. */
+	/** 用于后续 turn 的请求推理级别。 */
 	thinkingLevel: ThinkingLevel;
-	/** Available tools. Assigning a new array copies the top-level array. */
+	/** 可用工具。赋值新数组时会复制顶层数组。 */
 	set tools(tools: AgentTool<any>[]);
 	get tools(): AgentTool<any>[];
-	/** Conversation transcript. Assigning a new array copies the top-level array. */
+	/** 对话记录。赋值新数组时会复制顶层数组。 */
 	set messages(messages: AgentMessage[]);
 	get messages(): AgentMessage[];
 	/**
-	 * True while the agent is processing a prompt or continuation.
+	 * agent 正在处理 prompt 或 continuation 时为 true。
 	 *
-	 * This remains true until awaited `agent_end` listeners settle.
+	 * 此值在等待的 `agent_end` 监听器全部完成之前保持为 true。
 	 */
 	readonly isStreaming: boolean;
-	/** Partial assistant message for the current streamed response, if any. */
+	/** 当前流式响应的部分 assistant 消息（如果有的话）。 */
 	readonly streamingMessage?: AgentMessage;
-	/** Tool call ids currently executing. */
+	/** 当前正在执行的工具调用 ID。 */
 	readonly pendingToolCalls: ReadonlySet<string>;
-	/** Error message from the most recent failed or aborted assistant turn, if any. */
+	/** 最近一次失败或中止的 assistant turn 的错误消息（如果有的话）。 */
 	readonly errorMessage?: string;
 }
 
-/** Final or partial result produced by a tool. */
+/** 工具产生的最终或部分结果。 */
 export interface AgentToolResult<T> {
-	/** Text or image content returned to the model. */
+	/** 返回给模型的文本或图片内容。 */
 	content: (TextContent | ImageContent)[];
-	/** Arbitrary structured details for logs or UI rendering. */
+	/** 用于日志或 UI 渲染的任意结构化详情。 */
 	details: T;
-	/** Usage from the final tool execution itself, if available. Not used for main LLM context accounting. */
+	/** 工具执行本身的 usage，如果有的话。不用于主 LLM 上下文的计费统计。 */
 	usage?: Usage;
-	/** Names of tools introduced by this result and available from this transcript point onward. */
+	/** 由此结果引入、从此对话点开始可用的工具名称。 */
 	addedToolNames?: string[];
 	/**
-	 * Hint that the agent should stop after the current tool batch.
-	 * Early termination only happens when every finalized tool result in the batch sets this to true.
+	 * 提示 agent 应在当前工具批次完成后停止。
+	 * 仅当批次中每个已最终化的工具结果都将此设为 true 时，才会触发提前终止。
 	 */
 	terminate?: boolean;
 }
 
 /**
- * Callback used by tools to stream partial execution updates.
+ * 工具用于流式传输部分执行更新的回调。
  *
- * The callback is scoped to the current `execute()` invocation. Calls made after
- * the tool promise settles are ignored.
+ * 该回调的作用域限定在当前 `execute()` 调用内。在工具 promise 敲定之后进行的调用会被忽略。
  */
 export type AgentToolUpdateCallback<T = any> = (partialResult: AgentToolResult<T>) => void;
 
-/** Tool definition used by the agent runtime. */
+/** agent 运行时使用的工具定义。 */
 export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any> extends Tool<TParameters> {
-	/** Human-readable label for UI display. */
+	/** 用于 UI 显示的人类可读标签。 */
 	label: string;
 	/**
-	 * Optional compatibility shim for raw tool-call arguments before schema validation.
-	 * Must return an object that matches `TParameters`.
+	 * 在 schema 验证之前对原始工具调用参数的可选兼容性适配。
+	 * 必须返回匹配 `TParameters` 的对象。
 	 */
 	prepareArguments?: (args: unknown) => Static<TParameters>;
-	/** Execute the tool call. Throw on failure instead of encoding errors in `content`. */
+	/** 执行工具调用。失败时抛出异常，而不是在 `content` 中编码错误。 */
 	execute: (
 		toolCallId: string,
 		params: Static<TParameters>,
@@ -393,45 +385,44 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 		onUpdate?: AgentToolUpdateCallback<TDetails>,
 	) => Promise<AgentToolResult<TDetails>>;
 	/**
-	 * Per-tool execution mode override.
-	 * - "sequential": this tool must execute one at a time with other tool calls.
-	 * - "parallel": this tool can execute concurrently with other tool calls.
+	 * 单个工具的执行模式覆盖。
+	 * - "sequential"：此工具必须与其他工具调用逐个执行。
+	 * - "parallel"：此工具可以与其他工具调用并发执行。
 	 *
-	 * If omitted, the default execution mode applies.
+	 * 如果省略，则应用默认执行模式。
 	 */
 	executionMode?: ToolExecutionMode;
 }
 
-/** Context snapshot passed into the low-level agent loop. */
+/** 传入底层 agent 循环的上下文快照。 */
 export interface AgentContext {
-	/** System prompt included with the request. */
+	/** 随请求包含的系统提示词。 */
 	systemPrompt: string;
-	/** Transcript visible to the model. */
+	/** 模型可见的对话记录。 */
 	messages: AgentMessage[];
-	/** Tools available for this run. */
+	/** 本次运行可用的工具。 */
 	tools?: AgentTool<any>[];
 }
 
 /**
- * Events emitted by the Agent for UI updates.
+ * Agent 发出的用于 UI 更新的事件。
  *
- * `agent_end` is the last event emitted for a run, but awaited `Agent.subscribe()`
- * listeners for that event are still part of run settlement. The agent becomes
- * idle only after those listeners finish.
+ * `agent_end` 是一次运行中发出的最后一个事件，但等待该事件的 `Agent.subscribe()`
+ * 监听器仍然属于运行结算的一部分。agent 仅在这些监听器完成后才会变为空闲状态。
  */
 export type AgentEvent =
-	// Agent lifecycle
+	// agent 生命周期
 	| { type: "agent_start" }
 	| { type: "agent_end"; messages: AgentMessage[] }
-	// Turn lifecycle - a turn is one assistant response + any tool calls/results
+	// turn 生命周期 —— 一个 turn 包含一次 assistant 响应加上任何工具调用/结果
 	| { type: "turn_start" }
 	| { type: "turn_end"; message: AgentMessage; toolResults: ToolResultMessage[] }
-	// Message lifecycle - emitted for user, assistant, and toolResult messages
+	// 消息生命周期 —— 针对 user、assistant 和 toolResult 消息发出
 	| { type: "message_start"; message: AgentMessage }
-	// Only emitted for assistant messages during streaming
+	// 仅在流式传输期间针对 assistant 消息发出
 	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }
 	| { type: "message_end"; message: AgentMessage }
-	// Tool execution lifecycle
+	// 工具执行生命周期
 	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any }
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
 	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean };


### PR DESCRIPTION
- 覆盖全部37个TypeScript源文件
- 638个JSDoc注释块，20016个中文字符
- 所有导出函数/类/接口/类型均有中文注释
- 关键内部辅助函数和复杂逻辑均有注释说明
- 原有英文行内注释同步翻译为中文