### PR TITLE
fix(tui): align Myanmar grapheme cluster widths with terminal cell layout

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -43,8 +43,7 @@ const nonPrintingCharRegex = /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\
 const markCharRegex = /^\p{Mark}$/v;
 // Marks that terminals allocate cells for when attached to a base character.
 // This includes Unicode spacing marks and non-spacing exceptions in legacy wcwidth tables.
-const terminalSpacingMarkRegex =
-	/^(?:[\p{Spacing_Mark}--[\u1734\u302E\u302F]]|[\u065F\u0F7F\u102B\u102C\u1031\u1033-\u1035\u1038\u103A-\u103E])+$/v;
+const terminalSpacingMarkRegex = /^(?:[\p{Spacing_Mark}--[\u1734\u302E\u302F\p{Script=Myanmar}]]|[\u065F\u0F7F])+$/v;
 const rgiEmojiRegex = /^\p{RGI_Emoji}$/v;
 
 // Cache for non-ASCII strings
@@ -220,7 +219,8 @@ function graphemeWidth(segment: string): number {
 			followsMark = true;
 		} else if (!nonPrintingCharRegex.test(char)) {
 			const c = char.codePointAt(0)!;
-			if (followsMark || (c >= 0xff00 && c <= 0xffef)) {
+			const isMyanmar = /\p{Script=Myanmar}/u.test(char);
+			if (!isMyanmar && (followsMark || (c >= 0xff00 && c <= 0xffef))) {
 				// halfwidth + fullwidth forms
 				width += eastAsianWidth(c);
 			} else if (c === 0x0e33 || c === 0x0eb3) {

--- a/packages/tui/test/regression-burmese-width-redraw.test.ts
+++ b/packages/tui/test/regression-burmese-width-redraw.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Input } from "../src/components/input.ts";
+import { visibleWidth, wrapTextWithAnsi } from "../src/utils.ts";
+
+describe("Burmese text width and editor redraw regression", () => {
+	it("measures Burmese grapheme clusters and representative strings correctly", () => {
+		// Proven ASCII control
+		const asciiControl = "Hello World!";
+		assert.strictEqual(visibleWidth(asciiControl), 12);
+
+		// Representative Burmese strings
+		const myanmarSa = "မြန်မာစာ";
+		const mingalarPar = "မင်္ဂလာပါ";
+
+		assert.strictEqual(visibleWidth(myanmarSa), 4);
+		assert.strictEqual(visibleWidth(mingalarPar), 4);
+
+		// Individual grapheme cluster cell widths
+		assert.strictEqual(visibleWidth("မြ"), 1);
+		assert.strictEqual(visibleWidth("န်"), 1);
+		assert.strictEqual(visibleWidth("င်္ဂ"), 1);
+		assert.strictEqual(visibleWidth("ကျ"), 1);
+		assert.strictEqual(visibleWidth("ကြ"), 1);
+		assert.strictEqual(visibleWidth("က်"), 1);
+		assert.strictEqual(visibleWidth("ကေ"), 1);
+	});
+
+	it("keeps input line widths and hardware cursor positions consistent between ASCII and Burmese", () => {
+		const input = new Input();
+		input.focused = true;
+
+		// ASCII input
+		input.setValue("Hello");
+		const asciiRender = input.render(20);
+		assert.strictEqual(visibleWidth(asciiRender[0] || ""), 20);
+
+		// Burmese input
+		input.setValue("မြန်မာစာ");
+		const burmeseRender = input.render(20);
+		assert.strictEqual(visibleWidth(burmeseRender[0] || ""), 20);
+
+		// Hardware cursor column calculation for Burmese text
+		const burmeseText = "မြန်မာစာ";
+		const cursorCol = visibleWidth(burmeseText);
+		assert.strictEqual(cursorCol, 4);
+	});
+
+	it("prevents premature line wrapping for Burmese text in constrained widths", () => {
+		const text = "မြန်မာစာ"; // width 4
+		const wrapped = wrapTextWithAnsi(text, 10);
+		assert.strictEqual(wrapped.length, 1);
+		assert.strictEqual(visibleWidth(wrapped[0] || ""), 4);
+	});
+});

--- a/packages/tui/test/regression-burmese-width-redraw.test.ts
+++ b/packages/tui/test/regression-burmese-width-redraw.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { Input } from "../src/components/input.ts";
+import { CURSOR_MARKER } from "../src/tui.ts";
 import { visibleWidth, wrapTextWithAnsi } from "../src/utils.ts";
 
 describe("Burmese text width and editor redraw regression", () => {
@@ -24,26 +25,51 @@ describe("Burmese text width and editor redraw regression", () => {
 		assert.strictEqual(visibleWidth("ကြ"), 1);
 		assert.strictEqual(visibleWidth("က်"), 1);
 		assert.strictEqual(visibleWidth("ကေ"), 1);
+
+		// Standalone combining mark behavior
+		assert.strictEqual(visibleWidth("ာ"), 0);
 	});
 
-	it("keeps input line widths and hardware cursor positions consistent between ASCII and Burmese", () => {
+	it("keeps input line widths and hardware cursor marker position consistent between ASCII and Burmese", () => {
 		const input = new Input();
 		input.focused = true;
 
-		// ASCII input
+		// ASCII input - cursor at end ("Hello")
+		// Prompt prefix is "> " (width 2)
 		input.setValue("Hello");
+		input.handleInput("\x1b[F");
 		const asciiRender = input.render(20);
 		assert.strictEqual(visibleWidth(asciiRender[0] || ""), 20);
 
-		// Burmese input
+		const asciiLine = asciiRender[0] || "";
+		const asciiMarkerIdx = asciiLine.indexOf(CURSOR_MARKER);
+		assert.notStrictEqual(asciiMarkerIdx, -1);
+		// "> " (2) + "Hello" (5) = 7
+		assert.strictEqual(visibleWidth(asciiLine.slice(0, asciiMarkerIdx)), 7);
+
+		// Burmese input - cursor at end ("မြန်မာစာ")
 		input.setValue("မြန်မာစာ");
+		input.handleInput("\x1b[F");
 		const burmeseRender = input.render(20);
 		assert.strictEqual(visibleWidth(burmeseRender[0] || ""), 20);
 
-		// Hardware cursor column calculation for Burmese text
-		const burmeseText = "မြန်မာစာ";
-		const cursorCol = visibleWidth(burmeseText);
-		assert.strictEqual(cursorCol, 4);
+		const burmeseLine = burmeseRender[0] || "";
+		const burmeseMarkerIdx = burmeseLine.indexOf(CURSOR_MARKER);
+		assert.notStrictEqual(burmeseMarkerIdx, -1);
+		// "> " (2) + "မြန်မာစာ" (4) = 6
+		assert.strictEqual(visibleWidth(burmeseLine.slice(0, burmeseMarkerIdx)), 6);
+
+		// Burmese input - cursor in middle (after "မြန်မာ")
+		input.setValue("မြန်မာစာ");
+		input.handleInput("\x1b[F"); // move to end
+		input.handleInput("\x1b[D"); // move left 1 char
+		input.handleInput("\x1b[D"); // move left 1 char ("မြန်မာ")
+		const midRender = input.render(20);
+		const midLine = midRender[0] || "";
+		const midMarkerIdx = midLine.indexOf(CURSOR_MARKER);
+		assert.notStrictEqual(midMarkerIdx, -1);
+		// "> " (2) + "မြန်မာ" (3) = 5
+		assert.strictEqual(visibleWidth(midLine.slice(0, midMarkerIdx)), 5);
 	});
 
 	it("prevents premature line wrapping for Burmese text in constrained widths", () => {

--- a/packages/tui/test/truncate-to-width.test.ts
+++ b/packages/tui/test/truncate-to-width.test.ts
@@ -89,16 +89,18 @@ describe("visibleWidth", () => {
 		assert.strictEqual(visibleWidth("か\u3099"), 2);
 	});
 
-	it("counts Myanmar marks that terminals allocate cells for", () => {
-		assert.strictEqual(visibleWidth("ကာ"), 2);
-		assert.strictEqual(visibleWidth("ကေ"), 2);
-		assert.strictEqual(visibleWidth("က်"), 2);
-		assert.strictEqual(visibleWidth("ကျ"), 2);
-		assert.strictEqual(visibleWidth("ကြ"), 2);
-		assert.strictEqual(visibleWidth("ကဳ"), 2);
-		assert.strictEqual(visibleWidth("ကဴ"), 2);
-		assert.strictEqual(visibleWidth("ကဵ"), 2);
-		assert.strictEqual(visibleWidth("ကး"), 2);
+	it("keeps Myanmar grapheme clusters at their normal cell width", () => {
+		assert.strictEqual(visibleWidth("မြန်မာစာ"), 4);
+		assert.strictEqual(visibleWidth("မင်္ဂလာပါ"), 4);
+		assert.strictEqual(visibleWidth("ကာ"), 1);
+		assert.strictEqual(visibleWidth("ကေ"), 1);
+		assert.strictEqual(visibleWidth("က်"), 1);
+		assert.strictEqual(visibleWidth("ကျ"), 1);
+		assert.strictEqual(visibleWidth("ကြ"), 1);
+		assert.strictEqual(visibleWidth("ကဳ"), 1);
+		assert.strictEqual(visibleWidth("ကဴ"), 1);
+		assert.strictEqual(visibleWidth("ကဵ"), 1);
+		assert.strictEqual(visibleWidth("ကး"), 1);
 		assert.strictEqual(visibleWidth("ကို"), 1);
 		assert.strictEqual(visibleWidth("က္"), 1);
 	});


### PR DESCRIPTION
## Summary
Fixes Pi TUI input redraw and cursor positioning for Burmese text by correcting grapheme width calculations for Myanmar script code points.

## Root Cause
In commit `dfe47d3fbd8bf27841becaf8ec042dc0e73804a6`, Myanmar marks (`\u102B\u102C\u1031\u1033-\u1035\u1038\u103A-\u103E`) were explicitly added to `terminalSpacingMarkRegex` and left matching `\p{Spacing_Mark}`. This caused `graphemeWidth()` to count attached Myanmar combining marks/medials (`ြ`, `်`, `ျ`, `ွ`, `ှ`, `ေ`, etc.) as additional terminal columns (+1 cell each).

In terminal cell grids (Ghostty, xterm, Kitty, WezTerm, etc.), attached Myanmar marks/medials combine with the base consonant inside its single cell. Overcounting grapheme cluster widths caused line length overestimation, improper editor padding, hardware cursor positioning drift (`\x1b[NG`), and premature line wrapping—leading to stale cumulative renders being left on new lines during single-grapheme input.

## Fix
1. Subtracted `\p{Script=Myanmar}` from `terminalSpacingMarkRegex` in `packages/tui/src/utils.ts` and removed explicit Myanmar ranges.
2. Added an `isMyanmar` check in `graphemeWidth()` to ensure Myanmar characters following marks do not trigger generic Indic extra-cell logic.
3. Updated Myanmar width assertions in `truncate-to-width.test.ts` and added a focused regression suite in `regression-burmese-width-redraw.test.ts`.

## Invariants Verified
- `visibleWidth("မြန်မာစာ") === 4`
- `visibleWidth("မင်္ဂလာပါ") === 4`
- Hardware cursor marker visual column positioning verified for ASCII, Burmese at end, and Burmese in middle.
- All 883 unit tests in `packages/tui` pass. `npm run check` passes with 0 errors/warnings.
