### PR TITLE
fix(coding-agent): shell-quote path in read tool bash fallback suggestion

### DIFF
--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -290,7 +290,10 @@ export function createReadToolDefinition(
 								if (truncation.firstLineExceedsLimit) {
 									// First line alone exceeds the byte limit. Point the model at a bash fallback.
 									const firstLineSize = formatSize(Buffer.byteLength(allLines[startLine], "utf-8"));
-									outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${path} | head -c ${DEFAULT_MAX_BYTES}]`;
+									// Shell-quote the path (single-quote escaping) so the suggested command
+									// survives paths containing quotes or metacharacters.
+									const shellQuotedPath = path.replace(/'/g, "'\\''");
+									outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' '${shellQuotedPath}' | head -c ${DEFAULT_MAX_BYTES}]`;
 									details = { truncation };
 								} else if (truncation.truncated) {
 									// Truncation occurred. Build an actionable continuation notice.

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeBashWithOperations } from "../src/core/bash-executor.ts";
 import { type BashOperations, createBashTool, createLocalBashOperations } from "../src/core/tools/bash.ts";
 import { computeEditsDiff } from "../src/core/tools/edit-diff.ts";
+import { DEFAULT_MAX_BYTES } from "../src/core/tools/truncate.ts";
 import {
 	createEditTool,
 	createFindTool,
@@ -183,6 +184,22 @@ describe("Coding Agent Tools", () => {
 			expect(result.details?.truncation?.truncatedBy).toBe("lines");
 			expect(result.details?.truncation?.totalLines).toBe(2500);
 			expect(result.details?.truncation?.outputLines).toBe(2000);
+		});
+
+		it("should shell-quote the path in the bash fallback suggestion when the first line exceeds the byte limit", async () => {
+			const testFile = join(testDir, "quote'file.txt");
+			// First line alone exceeds DEFAULT_MAX_BYTES (50KB).
+			writeFileSync(testFile, "x".repeat(DEFAULT_MAX_BYTES + 1) + "\nsecond line");
+
+			const result = await readTool.execute("test-call-sed", { path: testFile });
+			const output = getTextOutput(result);
+
+			// Path must be single-quoted with proper escaping so the suggested command
+			// survives paths containing quotes.
+			const expectedEscaped = testFile.replace(/'/g, "'\\''");
+			expect(output).toContain(`Use bash: sed -n '1p' '${expectedEscaped}' | head -c`);
+			// The raw, unescaped path must not appear in the suggestion.
+			expect(output).not.toContain(`sed -n '1p' ${testFile}`);
 		});
 
 		it("should detect image MIME type from file magic (not extension)", async () => {


### PR DESCRIPTION
Fixes #7523

## Summary

The `read` tool emits a bash fallback suggestion when the first line of a file
exceeds the byte limit (`packages/coding-agent/src/core/tools/read.ts`). The
model-supplied `path` was interpolated into the suggested `sed` command without
shell quoting, so a path containing single quotes or other metacharacters would
produce a broken or reinterpreted command.

This change single-quote-escapes the path in the suggestion.

## Context

Filed from a security audit of the pi-modded fork (pentest findings V-13).

## Testing

- Added a regression test in `packages/coding-agent/test/tools.test.ts` that
  reads a file whose first line exceeds the limit, with a `'` in the path, and
  asserts the escaped suggestion is emitted.
- `node ../../node_modules/vitest/dist/cli.js --run test/tools.test.ts` passes.
- `npm run check` passes.
