### PR TITLE
fix(coding-agent): create bash output temp files with 0600 perms

### DIFF
--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -67,7 +67,8 @@ export async function executeBashWithOperations(
 		}
 		const id = randomBytes(8).toString("hex");
 		tempFilePath = join(tmpdir(), `pi-bash-${id}.log`);
-		tempFileStream = createWriteStream(tempFilePath);
+		// 0600: output may contain secrets; /tmp is world-readable.
+		tempFileStream = createWriteStream(tempFilePath, { mode: 0o600 });
 		for (const chunk of outputChunks) {
 			tempFileStream.write(chunk);
 		}

--- a/packages/coding-agent/src/core/tools/output-accumulator.ts
+++ b/packages/coding-agent/src/core/tools/output-accumulator.ts
@@ -213,7 +213,8 @@ export class OutputAccumulator {
 			return;
 		}
 		this.tempFilePath = defaultTempFilePath(this.tempFilePrefix);
-		this.tempFileStream = createWriteStream(this.tempFilePath);
+		// 0600: output may contain secrets; /tmp is world-readable.
+		this.tempFileStream = createWriteStream(this.tempFilePath, { mode: 0o600 });
 		for (const chunk of this.rawChunks) {
 			this.tempFileStream.write(chunk);
 		}

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1,5 +1,5 @@
 import { applyPatch } from "diff";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -745,6 +745,7 @@ describe("Coding Agent Tools", () => {
 
 			expect(fullOutputPath).toBeDefined();
 			expect(existsSync(fullOutputPath!)).toBe(true);
+			expect(statSync(fullOutputPath!).mode & 0o777).toBe(0o600);
 			const fullOutput = readFileSync(fullOutputPath!, "utf-8");
 			expect(fullOutput).toContain("1\n2\n3");
 			expect(fullOutput).toContain("2998\n2999\n3000");
@@ -763,6 +764,7 @@ describe("Coding Agent Tools", () => {
 
 			expect(fullOutputPath).toBeDefined();
 			expect(existsSync(fullOutputPath!)).toBe(true);
+			expect(statSync(fullOutputPath!).mode & 0o777).toBe(0o600);
 			const fullOutput = readFileSync(fullOutputPath!, "utf-8");
 			expect(fullOutput).toContain("1\n2\n3");
 			expect(fullOutput).toContain("2998\n2999\n3000");


### PR DESCRIPTION
Fixes #7521

## Summary

Bash and command output temp files (`pi-bash-*.log`, `pi-output-*.log`) were
created in the world-readable tmpdir with default (umask-dependent) permissions,
so other local users could read command output that may contain secrets.

`createWriteStream` now passes `{ mode: 0o600 }` in both
`packages/coding-agent/src/core/bash-executor.ts` and
`packages/coding-agent/src/core/tools/output-accumulator.ts`.

Note: lifecycle cleanup of these files is intentionally left as a follow-up —
the path is referenced by session transcripts, so unlink timing needs a session
lifecycle hook (design decision).

## Context

Filed from a security audit of the pi-modded fork (pentest finding V-10).

## Testing

- Extended `tools.test.ts` to assert `statSync(...).mode & 0o777 === 0o600` on
  the persisted full-output files.
- `node ../../node_modules/vitest/dist/cli.js --run test/tools.test.ts` passes.
- `npm run check` passes.
