### PR TITLE
fix(ai): independent OAuth state and ephemeral port fallback for callback servers

### DIFF
--- a/packages/ai/src/auth/oauth/anthropic.ts
+++ b/packages/ai/src/auth/oauth/anthropic.ts
@@ -5,6 +5,7 @@
  * It is only intended for CLI use, not browser environments.
  */
 
+import { randomBytes } from "node:crypto";
 import type { Server } from "node:http";
 import { getProviderEnvValue } from "../../utils/provider-env.ts";
 import type { AuthInteraction, OAuthAuth, OAuthCredential } from "../types.ts";
@@ -32,7 +33,7 @@ const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
 const CALLBACK_HOST = getProviderEnvValue("PI_OAUTH_CALLBACK_HOST") || "127.0.0.1";
 const CALLBACK_PORT = 53692;
 const CALLBACK_PATH = "/callback";
-const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+const redirectUriForPort = (port: number) => `http://localhost:${port}${CALLBACK_PATH}`;
 const SCOPES =
 	"org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 async function getNodeApis(): Promise<NodeApis> {
@@ -150,20 +151,34 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
 			}
 		});
 
-		server.on("error", (err) => {
-			reject(err);
-		});
+		const onListenError = (err: Error) => {
+			if ((err as NodeJS.ErrnoException).code === "EADDRINUSE") {
+				// Another local process holds the default port. Fall back to an
+				// ephemeral port so a port collision can't block login.
+				server.off("error", onListenError);
+				startListening(0);
+			} else {
+				reject(err);
+			}
+		};
 
-		server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
-			resolve({
-				server,
-				redirectUri: REDIRECT_URI,
-				cancelWait: () => {
-					settleWait?.(null);
-				},
-				waitForCode: () => waitForCodePromise,
+		function startListening(port: number) {
+			server.listen(port, CALLBACK_HOST, () => {
+				const address = server.address();
+				const actualPort = typeof address === "object" && address !== null ? address.port : port;
+				resolve({
+					server,
+					redirectUri: redirectUriForPort(actualPort),
+					cancelWait: () => {
+						settleWait?.(null);
+					},
+					waitForCode: () => waitForCodePromise,
+				});
 			});
-		});
+		}
+
+		server.on("error", onListenError);
+		startListening(CALLBACK_PORT);
 	});
 }
 
@@ -228,10 +243,13 @@ async function exchangeAuthorizationCode(
 
 async function loginAnthropic(interaction: AuthInteraction): Promise<OAuthCredential> {
 	const { verifier, challenge } = await generatePKCE();
-	const server = await startCallbackServer(verifier);
+	// Independent state (distinct from the PKCE verifier) to keep verifier out of the URL.
+	const state = randomBytes(16).toString("hex");
+	const server = await startCallbackServer(state);
+	const redirectUri = server.redirectUri;
 	const manualAbort = new AbortController();
 	let code: string | undefined;
-	let state: string | undefined;
+	let stateFromCallback: string | undefined;
 	let manualInput: string | undefined;
 	let manualError: Error | undefined;
 
@@ -240,11 +258,11 @@ async function loginAnthropic(interaction: AuthInteraction): Promise<OAuthCreden
 			code: "true",
 			client_id: CLIENT_ID,
 			response_type: "code",
-			redirect_uri: REDIRECT_URI,
+			redirect_uri: redirectUri,
 			scope: SCOPES,
 			code_challenge: challenge,
 			code_challenge_method: "S256",
-			state: verifier,
+			state,
 		});
 		interaction.notify({
 			type: "auth_url",
@@ -257,7 +275,7 @@ async function loginAnthropic(interaction: AuthInteraction): Promise<OAuthCreden
 			.prompt({
 				type: "manual_code",
 				message: "Complete login in your browser, or paste the authorization code / redirect URL here:",
-				placeholder: REDIRECT_URI,
+				placeholder: redirectUri,
 				signal: manualAbort.signal,
 			})
 			.then((input) => {
@@ -273,12 +291,12 @@ async function loginAnthropic(interaction: AuthInteraction): Promise<OAuthCreden
 		if (manualError) throw manualError;
 		if (result?.code) {
 			code = result.code;
-			state = result.state;
+			stateFromCallback = result.state;
 		} else if (manualInput) {
 			const parsed = parseAuthorizationInput(manualInput);
-			if (parsed.state && parsed.state !== verifier) throw new Error("OAuth state mismatch");
+			if (parsed.state && parsed.state !== state) throw new Error("OAuth state mismatch");
 			code = parsed.code;
-			state = parsed.state ?? verifier;
+			stateFromCallback = parsed.state ?? state;
 		}
 
 		if (!code) {
@@ -286,16 +304,16 @@ async function loginAnthropic(interaction: AuthInteraction): Promise<OAuthCreden
 			if (manualError) throw manualError;
 			if (manualInput) {
 				const parsed = parseAuthorizationInput(manualInput);
-				if (parsed.state && parsed.state !== verifier) throw new Error("OAuth state mismatch");
+				if (parsed.state && parsed.state !== state) throw new Error("OAuth state mismatch");
 				code = parsed.code;
-				state = parsed.state ?? verifier;
+				stateFromCallback = parsed.state ?? state;
 			}
 		}
 
 		if (!code) throw new Error("Missing authorization code");
-		if (!state) throw new Error("Missing OAuth state");
+		if (!stateFromCallback) throw new Error("Missing OAuth state");
 		interaction.notify({ type: "progress", message: "Exchanging authorization code for tokens..." });
-		return exchangeAuthorizationCode(code, state, verifier, REDIRECT_URI);
+		return exchangeAuthorizationCode(code, stateFromCallback, verifier, redirectUri);
 	} finally {
 		manualAbort.abort();
 		server.server.close();

--- a/packages/ai/src/auth/oauth/openai-codex.ts
+++ b/packages/ai/src/auth/oauth/openai-codex.ts
@@ -290,15 +290,16 @@ async function pollOpenAICodexDeviceAuth(device: DeviceAuthInfo, signal?: AbortS
 }
 
 async function createAuthorizationFlow(
+	redirectUri: string,
+	state: string,
 	originator: string = "pi",
-): Promise<{ verifier: string; state: string; url: string }> {
+): Promise<{ verifier: string; url: string }> {
 	const { verifier, challenge } = await generatePKCE();
-	const state = createState();
 
 	const url = new URL(AUTHORIZE_URL);
 	url.searchParams.set("response_type", "code");
 	url.searchParams.set("client_id", CLIENT_ID);
-	url.searchParams.set("redirect_uri", REDIRECT_URI);
+	url.searchParams.set("redirect_uri", redirectUri);
 	url.searchParams.set("scope", SCOPE);
 	url.searchParams.set("code_challenge", challenge);
 	url.searchParams.set("code_challenge_method", "S256");
@@ -307,13 +308,14 @@ async function createAuthorizationFlow(
 	url.searchParams.set("codex_cli_simplified_flow", "true");
 	url.searchParams.set("originator", originator);
 
-	return { verifier, state, url: url.toString() };
+	return { verifier, url: url.toString() };
 }
 
 type OAuthServerInfo = {
 	close: () => void;
 	cancelWait: () => void;
 	waitForCode: () => Promise<{ code: string } | null>;
+	redirectUri: string;
 };
 
 function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
@@ -365,19 +367,16 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 	});
 
 	return new Promise((resolve) => {
-		server
-			.listen(1455, getCallbackHost(), () => {
-				resolve({
-					close: () => server.close(),
-					cancelWait: () => {
-						settleWait?.(null);
-					},
-					waitForCode: () => waitForCodePromise,
-				});
-			})
-			.on("error", (_err: NodeJS.ErrnoException) => {
+		const onListenError = (_err: NodeJS.ErrnoException) => {
+			if (_err.code === "EADDRINUSE") {
+				// Another local process holds the default port. Fall back to an
+				// ephemeral port so a port collision can't block login.
+				server.off("error", onListenError);
+				startListening(0);
+			} else {
 				settleWait?.(null);
 				resolve({
+					redirectUri: REDIRECT_URI,
 					close: () => {
 						try {
 							server.close();
@@ -388,7 +387,32 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 					cancelWait: () => {},
 					waitForCode: async () => null,
 				});
+			}
+		};
+
+		function startListening(port: number) {
+			server.listen(port, getCallbackHost(), () => {
+				const address = server.address();
+				const actualPort = typeof address === "object" && address !== null ? address.port : port;
+				resolve({
+					redirectUri: `http://localhost:${actualPort}/auth/callback`,
+					close: () => {
+						try {
+							server.close();
+						} catch {
+							// ignore
+						}
+					},
+					cancelWait: () => {
+						settleWait?.(null);
+					},
+					waitForCode: () => waitForCodePromise,
+				});
 			});
+		}
+
+		server.on("error", onListenError);
+		startListening(1455);
 	});
 }
 
@@ -442,8 +466,10 @@ async function loginOpenAICodexDeviceCode(interaction: AuthInteraction): Promise
 }
 
 async function loginOpenAICodex(interaction: AuthInteraction): Promise<OAuthCredential> {
-	const { verifier, state, url } = await createAuthorizationFlow();
+	const state = createState();
 	const server = await startLocalOAuthServer(state);
+	const redirectUri = server.redirectUri;
+	const { verifier, url } = await createAuthorizationFlow(redirectUri, state);
 	const manualAbort = new AbortController();
 	let code: string | undefined;
 	let manualCode: string | undefined;
@@ -460,7 +486,7 @@ async function loginOpenAICodex(interaction: AuthInteraction): Promise<OAuthCred
 			.prompt({
 				type: "manual_code",
 				message: "Complete login in your browser, or paste the authorization code / redirect URL here:",
-				placeholder: REDIRECT_URI,
+				placeholder: redirectUri,
 				signal: manualAbort.signal,
 			})
 			.then((input) => {
@@ -493,7 +519,7 @@ async function loginOpenAICodex(interaction: AuthInteraction): Promise<OAuthCred
 		}
 
 		if (!code) throw new Error("Missing authorization code");
-		return exchangeAuthorizationCodeForCredentials(code, verifier, REDIRECT_URI, interaction.signal);
+		return exchangeAuthorizationCodeForCredentials(code, verifier, redirectUri, interaction.signal);
 	} finally {
 		manualAbort.abort();
 		server.close();

--- a/packages/ai/src/auth/oauth/radius.ts
+++ b/packages/ai/src/auth/oauth/radius.ts
@@ -141,6 +141,7 @@ async function requestOAuthToken(
 type OAuthCallbackServer = {
 	waitForCode(): Promise<string | null>;
 	close(): void;
+	redirectUri: string;
 };
 
 function startOAuthCallbackServer(
@@ -202,20 +203,35 @@ function startOAuthCallbackServer(
 	});
 
 	return new Promise((resolve) => {
-		server
-			.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
+		const onListenError = (err: NodeJS.ErrnoException) => {
+			if (err.code === "EADDRINUSE") {
+				// Another local process holds the default port. Fall back to an
+				// ephemeral port so a port collision can't block login.
+				server.off("error", onListenError);
+				startListening(0);
+			} else {
+				finish(null);
+				resolve({ redirectUri: REDIRECT_URI, waitForCode: async () => null, close: () => {} });
+			}
+		};
+
+		function startListening(port: number) {
+			server.listen(port, CALLBACK_HOST, () => {
+				const address = server.address();
+				const actualPort = typeof address === "object" && address !== null ? address.port : port;
 				resolve({
+					redirectUri: `http://${CALLBACK_HOST}:${actualPort}${CALLBACK_PATH}`,
 					waitForCode: () => wait,
 					close: () => {
 						finish(null);
 						server.close();
 					},
 				});
-			})
-			.once("error", () => {
-				finish(null);
-				resolve({ waitForCode: async () => null, close: () => {} });
 			});
+		}
+
+		server.on("error", onListenError);
+		startListening(CALLBACK_PORT);
 	});
 }
 
@@ -226,11 +242,13 @@ async function loginWithBrowser(
 ): Promise<OAuthCredential> {
 	const { verifier, challenge } = await generatePKCE();
 	const state = crypto.randomUUID();
+	const callbackServer = await startOAuthCallbackServer(state, interaction.signal);
+	const redirectUri = callbackServer.redirectUri;
 	const authorizeUrl = new URL(authorizationEndpoint);
 	authorizeUrl.search = new URLSearchParams({
 		response_type: "code",
 		client_id: OAUTH_CLIENT_ID,
-		redirect_uri: REDIRECT_URI,
+		redirect_uri: redirectUri,
 		scope: OAUTH_SCOPE,
 		code_challenge: challenge,
 		code_challenge_method: "S256",
@@ -238,8 +256,7 @@ async function loginWithBrowser(
 		state,
 	}).toString();
 
-	const callbackServer = await startOAuthCallbackServer(state, interaction.signal);
-	interaction.notify({ type: "progress", message: `Listening for OAuth callback on ${REDIRECT_URI}` });
+	interaction.notify({ type: "progress", message: `Listening for OAuth callback on ${redirectUri}` });
 	interaction.notify({
 		type: "auth_url",
 		url: authorizeUrl.toString(),
@@ -259,7 +276,7 @@ async function loginWithBrowser(
 			new URLSearchParams({
 				grant_type: "authorization_code",
 				client_id: OAUTH_CLIENT_ID,
-				redirect_uri: REDIRECT_URI,
+				redirect_uri: redirectUri,
 				code,
 				code_verifier: verifier,
 			}),


### PR DESCRIPTION
Fixes #7515

## Summary

Three OAuth callback servers (Anthropic, OpenAI Codex, Radius) listened on fixed
localhost ports and failed hard when another process held the port, blocking
login. The Anthropic flow additionally reused the PKCE verifier as the OAuth
`state` value.

Changes:
- `anthropic.ts`: generate an independent random `state` (distinct from the PKCE
  verifier); on `EADDRINUSE`, fall back to an ephemeral port and derive the
  redirect URI from the actually-bound port.
- `openai-codex.ts` / `radius.ts`: same `EADDRINUSE` → ephemeral-port fallback
  with a dynamically derived redirect URI (they already used independent state).

The redirect URI is now threaded through from the bound port instead of being a
module constant, so the ephemeral fallback stays consistent with the authorize
URL and token exchange.

## Context

Filed from a security audit of the pi-modded fork (pentest finding V-04).
Verification showed a local pre-bind is a login DoS rather than token theft
(listen completes before the browser opens); this removes the DoS.

## Testing

- `packages/ai/test/{anthropic-oauth,openai-codex-oauth,radius-oauth,oauth-auth}.test.ts` pass.
- `npm run check` passes.
