### PR TITLE
fix(coding-agent): skip lifecycle scripts for managed installs

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -1745,9 +1745,11 @@ export class DefaultPackageManager implements PackageManager {
 	private getGitDependencyInstallArgs(): string[] {
 		const configuredCommand = this.settingsManager.getNpmCommand();
 		if (configuredCommand && configuredCommand.length > 0) {
-			return ["install"];
+			// Lifecycle scripts of untrusted dependency trees can run arbitrary code
+			// with the user's environment; skip them for managed installs.
+			return ["install", "--ignore-scripts"];
 		}
-		return ["install", "--omit=dev"];
+		return ["install", "--omit=dev", "--ignore-scripts"];
 	}
 
 	private runNpmCommandSync(args: string[]): string {
@@ -1761,8 +1763,10 @@ export class DefaultPackageManager implements PackageManager {
 		// Disable peer dependency resolution for managed installs (npm's --legacy-peer-deps, and
 		// equivalent bun/pnpm settings) so package managers do not install or solve host-provided
 		// @earendil-works/pi-* peers. Stale auto-installed pi peers can otherwise block updates.
+		// Lifecycle scripts of untrusted dependency trees can run arbitrary code with the user's
+		// environment; skip them for managed installs.
 		if (packageManagerName === "bun") {
-			return ["install", ...specs, "--cwd", installRoot, "--omit=peer"];
+			return ["install", ...specs, "--cwd", installRoot, "--omit=peer", "--ignore-scripts"];
 		}
 		if (packageManagerName === "pnpm") {
 			return [
@@ -1773,9 +1777,10 @@ export class DefaultPackageManager implements PackageManager {
 				"--config.auto-install-peers=false",
 				"--config.strict-peer-dependencies=false",
 				"--config.strict-dep-builds=false",
+				"--ignore-scripts",
 			];
 		}
-		return ["install", ...specs, "--prefix", installRoot, "--legacy-peer-deps"];
+		return ["install", ...specs, "--prefix", installRoot, "--legacy-peer-deps", "--ignore-scripts"];
 	}
 
 	private async installNpm(source: NpmSource, scope: SourceScope, temporary: boolean): Promise<void> {


### PR DESCRIPTION
Fixes #7517

## Summary

`pi install` (npm:/git: sources) runs package lifecycle scripts of installed
dependency trees with the user's full environment. For managed installs into pi
storage dirs this is an unnecessary code-execution surface.

All managed installs now pass `--ignore-scripts`:
- `getNpmInstallArgs` (npm / bun / pnpm branches)
- `getGitDependencyInstallArgs` (git-source dependency install)

## Context

Filed from a security audit of the pi-modded fork (pentest finding V-06). The
trust gate (`assertProjectTrustedForScope`) only covers project scope; this
closes the user-scope install path.

## Testing

- `npm run check` passes.

## Follow-up

A settings toggle to opt back into lifecycle scripts for trusted packages could
be added if a real use case emerges; none exists in the repo today.
