### PR TITLE
fix(tui): handle batched color scheme reports

### DIFF
--- a/packages/tui/src/terminal-colors.ts
+++ b/packages/tui/src/terminal-colors.ts
@@ -26,7 +26,7 @@ function parseOscHexChannel(channel: string): number | undefined {
 }
 
 const OSC11_BACKGROUND_COLOR_RESPONSE_PATTERN = /^\x1b\]11;([^\x07\x1b]*)(?:\x07|\x1b\\)$/i;
-const COLOR_SCHEME_REPORT_PATTERN = /^\x1b\[\?997;(1|2)n$/;
+const COLOR_SCHEME_REPORT_PATTERN = /^(?:\x1b\[\?997;(1|2)n)+$/;
 
 export function isOsc11BackgroundColorResponse(data: string): boolean {
 	return OSC11_BACKGROUND_COLOR_RESPONSE_PATTERN.test(data);

--- a/packages/tui/test/terminal-colors.test.ts
+++ b/packages/tui/test/terminal-colors.test.ts
@@ -115,6 +115,8 @@ describe("parseTerminalColorSchemeReport", () => {
 	it("parses color scheme reports", () => {
 		assert.strictEqual(parseTerminalColorSchemeReport("\x1b[?997;1n"), "dark");
 		assert.strictEqual(parseTerminalColorSchemeReport("\x1b[?997;2n"), "light");
+		assert.strictEqual(parseTerminalColorSchemeReport("\x1b[?997;2n\x1b[?997;1n\x1b[?997;1n"), "dark");
+		assert.strictEqual(parseTerminalColorSchemeReport("\x1b[?997;1n\x1b[?997;2n\x1b[?997;2n"), "light");
 		assert.strictEqual(parseTerminalColorSchemeReport("\x1b[?997;3n"), undefined);
 		assert.strictEqual(parseTerminalColorSchemeReport("\x1b[?996n"), undefined);
 		assert.strictEqual(parseTerminalColorSchemeReport("x\x1b[?997;1n"), undefined);


### PR DESCRIPTION
- adjust the regex to match batched reports
- fixes #7538

**Testing**

Aside of the manual tests, asked AI how to verify what's emitted:

```shell
printf '\033[?2031h'
cat -v
```

**Output Ghostty**

```shell
# light to dark
\x1b[?997;2n\x1b[?997;1n\x1b[?997;1n

# dark to light
\x1b[?997;1n\x1b[?997;2n\x1b[?997;2n
```

| Case | Video |
| ------------- | ------------- |
| Ghostty | <video src="https://github.com/user-attachments/assets/e68bc432-1990-4fb5-a0d4-2bde5ea69aa7" /> |
| Kitten | <video src="https://github.com/user-attachments/assets/fdec3f5c-0b3b-4d69-ac82-5a463a6dc0aa" /> |