### PR TITLE
fix(coding-agent): stream delta-only message_updates in json mode

### DIFF
--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -38,7 +38,7 @@ type AgentEvent =
   | { type: "turn_end"; message: AgentMessage; toolResults: ToolResultMessage[] }
   // Message lifecycle
   | { type: "message_start"; message: AgentMessage }
-  | { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }
+  | { type: "message_update"; assistantMessageEvent: AssistantMessageEvent }
   | { type: "message_end"; message: AgentMessage }
   // Tool execution
   | { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any }
@@ -73,11 +73,28 @@ Followed by events as they occur:
 {"type":"agent_start"}
 {"type":"turn_start"}
 {"type":"message_start","message":{"role":"assistant","content":[],...}}
-{"type":"message_update","message":{...},"assistantMessageEvent":{"type":"text_delta","delta":"Hello",...}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Hello"}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":" world"}}
 {"type":"message_end","message":{...}}
 {"type":"turn_end","message":{...},"toolResults":[]}
 {"type":"agent_end","messages":[...]}
 ```
+
+## Streaming Updates
+
+`message_update` lines contain only the incremental streaming event. They omit
+the accumulated assistant message (`message`) and the cumulative `partial`
+snapshot carried inside `assistantMessageEvent`, so output size grows linearly
+with the model response instead of quadratically.
+
+Consumers that need the full message during streaming should accumulate the
+delta fields (`text_delta.delta`, `thinking_delta.delta`, `toolcall_delta.delta`)
+keyed by `contentIndex`, or use the complete snapshots from `message_start` and
+`message_end`.
+
+This is a breaking change from earlier releases where each `message_update`
+included the complete `message` and `partial` snapshots. Consumers relying on
+those fields must switch to accumulating deltas or reading `message_end`.
 
 ## Example
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -7,8 +7,9 @@
  */
 
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
+import type { AgentSessionEvent } from "../core/agent-session.ts";
 import type { AgentSessionRuntime } from "../core/agent-session-runtime.ts";
-import { flushRawStdout, writeRawStdout } from "../core/output-guard.ts";
+import { flushRawStdout, waitForRawStdoutBackpressure, writeRawStdout } from "../core/output-guard.ts";
 import { killTrackedDetachedChildren } from "../utils/shell.ts";
 
 /**
@@ -26,6 +27,24 @@ export interface PrintModeOptions {
 }
 
 /**
+ * Serialize a session event for `--mode json`.
+ *
+ * Streaming `message_update` events carry the complete assistant message twice
+ * (`message` and `assistantMessageEvent.partial`). Serializing those snapshots
+ * on every delta makes the stream grow quadratically with the response size.
+ * JSON mode emits only the incremental event; `message_start` and `message_end`
+ * provide the complete snapshots.
+ */
+function serializeJsonModeEvent(event: AgentSessionEvent): string {
+	if (event.type !== "message_update") {
+		return JSON.stringify(event);
+	}
+	const assistantMessageEvent: Record<string, unknown> = { ...event.assistantMessageEvent };
+	delete assistantMessageEvent.partial;
+	return JSON.stringify({ type: "message_update", assistantMessageEvent });
+}
+
+/**
  * Run in print (single-shot) mode.
  * Sends prompts to the agent and outputs the result.
  */
@@ -34,6 +53,7 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 	let exitCode = 0;
 	let session = runtimeHost.session;
 	let unsubscribe: (() => void) | undefined;
+	let unsubscribeBackpressure: (() => void) | undefined;
 	let disposed = false;
 	const signalCleanupHandlers: Array<() => void> = [];
 
@@ -41,6 +61,7 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 		if (disposed) return;
 		disposed = true;
 		unsubscribe?.();
+		unsubscribeBackpressure?.();
 		await runtimeHost.dispose();
 	};
 
@@ -101,11 +122,17 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 		});
 
 		unsubscribe?.();
+		unsubscribeBackpressure?.();
 		unsubscribe = session.subscribe((event) => {
 			if (mode === "json") {
-				writeRawStdout(`${JSON.stringify(event)}\n`);
+				writeRawStdout(`${serializeJsonModeEvent(event)}\n`);
 			}
 		});
+		if (mode === "json") {
+			unsubscribeBackpressure = session.agent.subscribe(async () => {
+				await waitForRawStdoutBackpressure();
+			});
+		}
 	};
 
 	try {

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -12,7 +12,7 @@ type FakeExtensionRunner = {
 
 type FakeSession = {
 	sessionManager: { getHeader: () => object | undefined };
-	agent: { waitForIdle: () => Promise<void> };
+	agent: { waitForIdle: () => Promise<void>; subscribe: ReturnType<typeof vi.fn> };
 	state: { messages: AssistantMessage[] };
 	extensionRunner: FakeExtensionRunner;
 	bindExtensions: ReturnType<typeof vi.fn>;
@@ -65,7 +65,7 @@ function createRuntimeHost(assistantMessage: AssistantMessage): FakeRuntimeHost 
 
 	const session: FakeSession = {
 		sessionManager: { getHeader: () => undefined },
-		agent: { waitForIdle: async () => {} },
+		agent: { waitForIdle: async () => {}, subscribe: vi.fn(() => () => {}) },
 		state,
 		extensionRunner,
 		bindExtensions: vi.fn(async () => {}),
@@ -119,6 +119,7 @@ describe("runPrintMode", () => {
 
 		expect(exitCode).toBe(0);
 		expect(session.prompt).toHaveBeenCalledWith("hello");
+		expect(session.agent.subscribe).toHaveBeenCalledWith(expect.any(Function));
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
 	});

--- a/packages/coding-agent/test/suite/regressions/7395-json-mode-quadratic.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7395-json-mode-quadratic.test.ts
@@ -1,0 +1,99 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.ts";
+import { runPrintMode } from "../../../src/modes/print-mode.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+// Regression for https://github.com/earendil-works/pi/issues/7395
+
+const stdout = vi.hoisted(() => ({
+	lines: [] as string[],
+}));
+
+vi.mock("../../../src/core/output-guard.js", () => ({
+	flushRawStdout: vi.fn(async () => {}),
+	waitForRawStdoutBackpressure: vi.fn(async () => {}),
+	writeRawStdout: (line: string) => {
+		stdout.lines.push(line);
+	},
+}));
+
+function createRuntimeHost(harness: Harness): AgentSessionRuntime {
+	return {
+		session: harness.session,
+		newSession: vi.fn(async () => ({ cancelled: true })),
+		switchSession: vi.fn(async () => ({ cancelled: true })),
+		fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
+		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn(),
+	} as unknown as AgentSessionRuntime;
+}
+
+function parseLines(): Array<Record<string, unknown>> {
+	return stdout.lines
+		.flatMap((line) => line.split("\n"))
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("JSON mode output scales with deltas (#7395)", () => {
+	afterEach(() => {
+		stdout.lines = [];
+	});
+
+	test("streams delta-only message_updates and stays linear in output size", async () => {
+		const longText = Array.from(
+			{ length: 300 },
+			(_, i) => `Line ${i + 1}: a distinct sentence of about ten words here.`,
+		).join("\n");
+		const harness = await createHarness();
+
+		try {
+			harness.setResponses([fauxAssistantMessage(longText)]);
+			const exitCode = await runPrintMode(createRuntimeHost(harness), {
+				mode: "json",
+				initialMessage: "Write a long response",
+			});
+			expect(exitCode).toBe(0);
+
+			const events = parseLines();
+			const updates = events.filter((event) => event.type === "message_update");
+			const assistantEnds = events.filter(
+				(event) => event.type === "message_end" && (event.message as { role?: string }).role === "assistant",
+			);
+			const finalMessage = assistantEnds.at(-1)?.message;
+			const totalBytes = stdout.lines.reduce((sum, line) => sum + Buffer.byteLength(line), 0);
+			const finalBytes = Buffer.byteLength(JSON.stringify(finalMessage));
+			const maxUpdateBytes = Math.max(...updates.map((update) => Buffer.byteLength(JSON.stringify(update))));
+
+			console.log(
+				`#7395 json-mode: updates=${updates.length} totalBytes=${totalBytes} finalBytes=${finalBytes} ` +
+					`total/final=${(totalBytes / finalBytes).toFixed(1)} maxUpdate=${maxUpdateBytes}`,
+			);
+
+			expect(updates.length).toBeGreaterThan(50);
+
+			// Each streaming update serializes only the incremental event, not the accumulated
+			// assistant message. `message_start` and `message_end` carry the complete snapshots.
+			for (const update of updates) {
+				expect(update.message).toBeUndefined();
+				const assistantMessageEvent = update.assistantMessageEvent as Record<string, unknown>;
+				expect(assistantMessageEvent.partial).toBeUndefined();
+			}
+			expect(maxUpdateBytes).toBeLessThan(finalBytes);
+
+			// Linear growth bound: cumulative snapshots would make the stream hundreds of
+			// times larger than the final message for this response size.
+			expect(totalBytes).toBeLessThan(finalBytes * 15);
+
+			// Completeness: the final message still carries the full response text.
+			const finalText = ((finalMessage as { content?: Array<{ type: string; text?: string }> }).content ?? [])
+				.filter((part) => part.type === "text")
+				.map((part) => part.text ?? "")
+				.join("");
+			expect(finalText).toBe(longText);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

`--mode json` serialized the complete accumulated assistant message on every streaming update: once as `message_update.message` and once as `assistantMessageEvent.partial`. For long responses this made the JSON stream grow quadratically with the response size and left a large stdout backlog after the response completed.

This PR changes JSON mode so `message_update` lines carry only the incremental event:

```json
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Hello"}}
```

`message_start` and `message_end` still carry the complete message snapshots. JSON mode now also applies stdout backpressure (`waitForRawStdoutBackpressure()` after each agent event), matching the RPC-mode fix from #4897, so a slow consumer no longer accumulates an unbounded write queue.

## Reproduction (faux provider, same serialization path)

Before:

```text
updates=1034 totalBytes=29710445 finalBytes=17021 total/final=1745.5 maxUpdate=50859
```

After:

```text
updates=1021 totalBytes=187635 finalBytes=17022 total/final=11.0 maxUpdate=16789
```

The remaining `maxUpdate` is the single `text_end` line carrying the completed block content, emitted once per block.

## Breaking change

`message_update` no longer includes the `message` and `partial` snapshots. Consumers that need the full message during streaming should accumulate `text_delta.delta`, `thinking_delta.delta`, and `toolcall_delta.delta` keyed by `contentIndex`, or use the snapshots from `message_start` and `message_end`. See the updated [JSON Event Stream Mode docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/json.md#streaming-updates).

The in-process event shape (`AgentEvent`, extensions, SDK subscribers) is unchanged; only the JSON stream projection changed. The repo's own JSON consumer (`scripts/session-transcripts.ts`) only reads `assistantMessageEvent.delta` and is compatible.

## Changelog

Per CONTRIBUTING.md, changelog entries are added by maintainers. This needs a breaking-change entry and a fixed entry under `[Unreleased]` for the JSON-mode backpressure fix.

## Tests

- Added regression test `packages/coding-agent/test/suite/regressions/7395-json-mode-quadratic.test.ts` (fails before the fix, passes after).
- Updated `packages/coding-agent/test/print-mode.test.ts` for the backpressure subscription.
- `npm run check` passes.

Closes #7395
