### PR TITLE
feat(ai): support Anthropic server-side fallbacks

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -8,12 +8,14 @@ import type {
 	RefusalStopDetails,
 } from "@anthropic-ai/sdk/resources/messages.js";
 import { calculateCost } from "../models.ts";
+import { ANTHROPIC_MODELS } from "../providers/anthropic.models.ts";
 import type {
 	AnthropicMessagesCompat,
 	Api,
 	AssistantMessage,
 	CacheRetention,
 	Context,
+	FallbackContent,
 	ImageContent,
 	Message,
 	Model,
@@ -169,6 +171,7 @@ export type AnthropicThinkingDisplay = "summarized" | "omitted";
 
 const FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
 const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
+const SERVER_SIDE_FALLBACK_BETA = "server-side-fallback-2026-07-01";
 
 function getAnthropicCompat(
 	model: Model<"anthropic-messages">,
@@ -278,6 +281,25 @@ function hasHeader(headers: ProviderHeaders | undefined, name: string): boolean 
 		if (key.toLowerCase() === expected && value !== null && value.trim().length > 0) return true;
 	}
 	return false;
+}
+
+function appendBetaFeatures(headers: ProviderHeaders, betaFeatures: readonly string[]): ProviderHeaders {
+	if (betaFeatures.length === 0) return headers;
+	const result = { ...headers };
+	const values: string[] = [];
+	for (const [key, value] of Object.entries(result)) {
+		if (key.toLowerCase() !== "anthropic-beta") continue;
+		delete result[key];
+		if (value)
+			values.push(
+				...value
+					.split(",")
+					.map((feature) => feature.trim())
+					.filter(Boolean),
+			);
+	}
+	result["anthropic-beta"] = [...new Set([...values, ...betaFeatures])].join(",");
+	return result;
 }
 
 function assertRequestAuth(provider: string, apiKey: string | undefined, headers: ProviderHeaders | undefined): void {
@@ -511,6 +533,7 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 		};
 
 		try {
+			const useServerSideFallback = model.provider === "anthropic" && options?.fallbacks !== undefined;
 			let client: Anthropic;
 			let isOAuth: boolean;
 
@@ -542,11 +565,12 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 					options?.fetch,
 					copilotDynamicHeaders,
 					cacheSessionId,
+					useServerSideFallback,
 				);
 				client = created.client;
 				isOAuth = created.isOAuthToken;
 			}
-			let params = buildParams(model, context, isOAuth, options);
+			let params = buildParams(model, context, isOAuth, useServerSideFallback, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
 				params = nextParams as MessageCreateParamsStreaming;
@@ -567,12 +591,39 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
-			type Block = (ThinkingContent | TextContent | (ToolCall & { partialJson: string })) & { index: number };
+			type Block = (ThinkingContent | TextContent | FallbackContent | (ToolCall & { partialJson: string })) & {
+				index: number;
+			};
 			const blocks = output.content as Block[];
+			const updateServingModel = (responseModel: string | undefined) => {
+				if (!useServerSideFallback || !responseModel) return;
+				if (responseModel === model.id) {
+					delete output.responseModel;
+				} else {
+					output.responseModel = responseModel;
+				}
+			};
+			const calculateOutputCost = () => {
+				if (!useServerSideFallback) {
+					calculateCost(model, output.usage);
+					return;
+				}
+				const servingModelId = output.responseModel ?? model.id;
+				const servingModel =
+					servingModelId === model.id
+						? model
+						: (ANTHROPIC_MODELS as Record<string, Model<"anthropic-messages">>)[servingModelId];
+				if (servingModel) {
+					calculateCost(servingModel, output.usage);
+				} else {
+					output.usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+				}
+			};
 
 			for await (const event of iterateAnthropicEvents(response, options?.signal)) {
 				if (event.type === "message_start") {
 					output.responseId = event.message.id;
+					updateServingModel((event.message as { model?: string }).model);
 					// Capture initial token usage from message_start event
 					// This ensures we have input token counts even if the stream is aborted early
 					output.usage.input = event.message.usage.input_tokens || 0;
@@ -583,48 +634,58 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 					// Anthropic doesn't provide total_tokens, compute from components
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-					calculateCost(model, output.usage);
+					calculateOutputCost();
 				} else if (event.type === "content_block_start") {
-					if (event.content_block.type === "text") {
+					const contentBlock = event.content_block as typeof event.content_block | FallbackContent;
+					if (contentBlock.type === "text") {
 						const block: Block = {
 							type: "text",
-							text: event.content_block.text ?? "",
+							text: contentBlock.text ?? "",
 							index: event.index,
 						};
 						output.content.push(block);
 						stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
-					} else if (event.content_block.type === "thinking") {
+					} else if (contentBlock.type === "thinking") {
 						const block: Block = {
 							type: "thinking",
-							thinking: event.content_block.thinking ?? "",
-							thinkingSignature: event.content_block.signature ?? "",
+							thinking: contentBlock.thinking ?? "",
+							thinkingSignature: contentBlock.signature ?? "",
 							index: event.index,
 						};
 						output.content.push(block);
 						stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
-					} else if (event.content_block.type === "redacted_thinking") {
+					} else if (contentBlock.type === "redacted_thinking") {
 						const block: Block = {
 							type: "thinking",
 							thinking: "[Reasoning redacted]",
-							thinkingSignature: event.content_block.data,
+							thinkingSignature: contentBlock.data,
 							redacted: true,
 							index: event.index,
 						};
 						output.content.push(block);
 						stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
-					} else if (event.content_block.type === "tool_use") {
+					} else if (contentBlock.type === "tool_use") {
 						const block: Block = {
 							type: "toolCall",
-							id: event.content_block.id,
-							name: isOAuth
-								? fromClaudeCodeName(event.content_block.name, context.tools)
-								: event.content_block.name,
-							arguments: (event.content_block.input as Record<string, any>) ?? {},
+							id: contentBlock.id,
+							name: isOAuth ? fromClaudeCodeName(contentBlock.name, context.tools) : contentBlock.name,
+							arguments: (contentBlock.input as Record<string, any>) ?? {},
 							partialJson: "",
 							index: event.index,
 						};
 						output.content.push(block);
 						stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+					} else if (contentBlock.type === "fallback") {
+						const block: Block = {
+							type: "fallback",
+							from: { model: contentBlock.from.model },
+							to: { model: contentBlock.to.model },
+							trigger: { type: "refusal", category: contentBlock.trigger.category },
+							index: event.index,
+						};
+						output.content.push(block);
+						updateServingModel(block.to.model);
+						calculateOutputCost();
 					}
 				} else if (event.type === "content_block_delta") {
 					if (event.delta.type === "text_delta") {
@@ -713,9 +774,11 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 							output.errorMessage = stopReasonResult.errorMessage;
 						}
 					}
+					// Final top-level usage is cumulative across all usage.iterations, including fallback attempts.
 					// Only update usage fields if present (not null).
 					// Preserves input_tokens from message_start when proxies omit it in message_delta.
 					if (event.usage) {
+						updateServingModel(fallbackServedModelFromUsage(event.usage));
 						if (event.usage.input_tokens != null) {
 							output.usage.input = event.usage.input_tokens;
 						}
@@ -740,7 +803,7 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 					// Anthropic doesn't provide total_tokens, compute from components
 					output.usage.totalTokens =
 						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-					calculateCost(model, output.usage);
+					calculateOutputCost();
 				}
 			}
 
@@ -853,6 +916,7 @@ function createClient(
 	fetch?: typeof globalThis.fetch,
 	dynamicHeaders?: Record<string, string>,
 	sessionId?: string,
+	useServerSideFallback = false,
 ): { client: Anthropic; isOAuthToken: boolean } {
 	// Adaptive thinking models have interleaved thinking built in, so skip the beta header.
 	const needsInterleavedBeta = interleavedThinking && model.compat?.forceAdaptiveThinking !== true;
@@ -862,6 +926,9 @@ function createClient(
 	}
 	if (needsInterleavedBeta) {
 		betaFeatures.push(INTERLEAVED_THINKING_BETA);
+	}
+	if (useServerSideFallback) {
+		betaFeatures.push(SERVER_SIDE_FALLBACK_BETA);
 	}
 
 	// Copilot: Bearer auth, selective betas.
@@ -889,23 +956,24 @@ function createClient(
 
 	// OAuth: Bearer auth, Claude Code identity headers
 	if (apiKey && isOAuthToken(apiKey)) {
+		const defaultHeaders = mergeHeaders(
+			{
+				accept: "application/json",
+				"anthropic-dangerous-direct-browser-access": "true",
+				"anthropic-beta": ["claude-code-20250219", "oauth-2025-04-20", ...betaFeatures].join(","),
+				"user-agent": `claude-cli/${claudeCodeVersion}`,
+				"x-app": "cli",
+			},
+			model.headers,
+			optionsHeaders,
+		);
 		const client = new Anthropic({
 			apiKey: null,
 			authToken: apiKey,
 			baseURL: model.baseUrl,
 			dangerouslyAllowBrowser: true,
 			fetch,
-			defaultHeaders: mergeHeaders(
-				{
-					accept: "application/json",
-					"anthropic-dangerous-direct-browser-access": "true",
-					"anthropic-beta": ["claude-code-20250219", "oauth-2025-04-20", ...betaFeatures].join(","),
-					"user-agent": `claude-cli/${claudeCodeVersion}`,
-					"x-app": "cli",
-				},
-				model.headers,
-				optionsHeaders,
-			),
+			defaultHeaders: useServerSideFallback ? appendBetaFeatures(defaultHeaders, betaFeatures) : defaultHeaders,
 		});
 
 		return { client, isOAuthToken: true };
@@ -930,7 +998,7 @@ function createClient(
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		fetch,
-		defaultHeaders,
+		defaultHeaders: useServerSideFallback ? appendBetaFeatures(defaultHeaders, betaFeatures) : defaultHeaders,
 	});
 
 	return { client, isOAuthToken: false };
@@ -940,6 +1008,7 @@ function buildParams(
 	model: Model<"anthropic-messages">,
 	context: Context,
 	isOAuthToken: boolean,
+	useServerSideFallback: boolean,
 	options?: AnthropicOptions,
 ): MessageCreateParamsStreaming {
 	const { cacheControl } = getCacheControl(model, options?.cacheRetention, options?.env);
@@ -958,7 +1027,7 @@ function buildParams(
 		deferredTools = [];
 	}
 	const deferredToolNames = new Set(deferredTools.map((tool) => normalizeToolName(tool.name)));
-	const params: MessageCreateParamsStreaming = {
+	const params: MessageCreateParamsStreaming & { fallbacks?: "default" | string[] } = {
 		model: model.id,
 		messages: convertMessages(
 			transformedMessages,
@@ -967,10 +1036,14 @@ function buildParams(
 			compat.allowEmptySignature,
 			deferredToolNames,
 			normalizeToolName,
+			useServerSideFallback,
 		),
 		max_tokens: options?.maxTokens ?? model.maxTokens,
 		stream: true,
 	};
+	if (useServerSideFallback) {
+		params.fallbacks = options!.fallbacks!;
+	}
 
 	// For OAuth tokens, we MUST include Claude Code identity
 	if (isOAuthToken) {
@@ -1120,6 +1193,7 @@ function convertMessages(
 	allowEmptySignature = false,
 	deferredToolNames: ReadonlySet<string> = new Set(),
 	normalizeToolName: (name: string) => string = (name) => name,
+	allowServerSideFallback = false,
 ): MessageParam[] {
 	const params: MessageParam[] = [];
 	const loadedToolNames = new Set<string>();
@@ -1217,6 +1291,13 @@ function convertMessages(
 						name: isOAuthToken ? toClaudeCodeName(block.name) : block.name,
 						input: block.arguments ?? {},
 					});
+				} else if (block.type === "fallback" && allowServerSideFallback) {
+					blocks.push({
+						type: "fallback",
+						from: { model: block.from.model },
+						to: { model: block.to.model },
+						trigger: { type: "refusal", category: block.trigger.category },
+					} as unknown as ContentBlockParam);
 				}
 			}
 			if (blocks.length === 0) continue;
@@ -1320,6 +1401,21 @@ function convertTools(
 			...(cacheControl && index === tools.length - 1 ? { cache_control: cacheControl } : {}),
 		};
 	});
+}
+
+function fallbackServedModelFromUsage(usage: unknown): string | undefined {
+	if (!usage || typeof usage !== "object") return undefined;
+	const iterations = (usage as { iterations?: unknown }).iterations;
+	if (!Array.isArray(iterations)) return undefined;
+
+	for (let index = iterations.length - 1; index >= 0; index--) {
+		const iteration = iterations[index];
+		if (!iteration || typeof iteration !== "object") continue;
+		const { type, model } = iteration as { type?: unknown; model?: unknown };
+		if (type === "fallback_message" && typeof model === "string" && model.trim().length > 0) {
+			return model;
+		}
+	}
 }
 
 function mapStopReason(

--- a/packages/ai/src/api/mistral-conversations.ts
+++ b/packages/ai/src/api/mistral-conversations.ts
@@ -569,6 +569,7 @@ function toChatMessages(messages: Message[], supportsImages: boolean): ChatCompl
 					}
 					continue;
 				}
+				if (block.type === "fallback") continue;
 				toolCalls.push({
 					id: block.id,
 					type: "function",

--- a/packages/ai/src/api/simple-options.ts
+++ b/packages/ai/src/api/simple-options.ts
@@ -41,6 +41,7 @@ export function buildBaseOptions(
 		maxRetries: options?.maxRetries,
 		maxRetryDelayMs: options?.maxRetryDelayMs,
 		metadata: options?.metadata,
+		fallbacks: options?.fallbacks,
 		env: options?.env,
 	};
 }

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -3,6 +3,7 @@ import type {
 	AssistantMessage,
 	AssistantMessageEventStream,
 	Context,
+	FallbackContent,
 	ImageContent,
 	Message,
 	Model,
@@ -159,7 +160,7 @@ function contentToText(content: string | Array<TextContent | ImageContent>): str
 		.join("\n");
 }
 
-function assistantContentToText(content: Array<TextContent | ThinkingContent | ToolCall>): string {
+function assistantContentToText(content: Array<TextContent | ThinkingContent | ToolCall | FallbackContent>): string {
 	return content
 		.map((block) => {
 			if (block.type === "text") {
@@ -168,7 +169,10 @@ function assistantContentToText(content: Array<TextContent | ThinkingContent | T
 			if (block.type === "thinking") {
 				return block.thinking;
 			}
-			return `${block.name}:${JSON.stringify(block.arguments)}`;
+			if (block.type === "toolCall") {
+				return `${block.name}:${JSON.stringify(block.arguments)}`;
+			}
+			return "";
 		})
 		.join("\n");
 }
@@ -371,6 +375,11 @@ async function streamWithDeltas(
 				stream.push({ type: "text_delta", contentIndex: index, delta: chunk, partial: { ...partial } });
 			}
 			stream.push({ type: "text_end", contentIndex: index, content: block.text, partial: { ...partial } });
+			continue;
+		}
+
+		if (block.type === "fallback") {
+			partial.content = [...partial.content, block];
 			continue;
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -191,6 +191,12 @@ export interface StreamOptions {
 	 */
 	metadata?: Record<string, unknown>;
 	/**
+	 * Opt in to Anthropic server-side fallback (beta `server-side-fallback-2026-07-01`).
+	 * `"default"` lets Anthropic pick an eligible model by refusal category; an explicit
+	 * array names the allowed models in order. Anthropic-only; other providers ignore it.
+	 */
+	fallbacks?: "default" | string[];
+	/**
 	 * Provider-scoped environment values. These take precedence over process.env for
 	 * provider configuration such as regional settings, endpoint placeholders, and
 	 * proxy variables.
@@ -366,6 +372,14 @@ export interface ToolCall {
 	thoughtSignature?: string; // Google-specific: opaque signature for reusing thought context
 }
 
+/** Anthropic server-side fallback transition in an assistant response. */
+export interface FallbackContent {
+	type: "fallback";
+	from: { model: string };
+	to: { model: string };
+	trigger: { type: "refusal"; category: string };
+}
+
 export interface Usage {
 	input: number;
 	output: number;
@@ -399,7 +413,7 @@ export interface UserMessage {
 
 export interface AssistantMessage {
 	role: "assistant";
-	content: (TextContent | ThinkingContent | ToolCall)[];
+	content: (TextContent | ThinkingContent | ToolCall | FallbackContent)[];
 	api: Api;
 	provider: ProviderId;
 	model: string;

--- a/packages/ai/src/utils/estimate.ts
+++ b/packages/ai/src/utils/estimate.ts
@@ -53,7 +53,7 @@ export function estimateMessageTokens(message: Message): number {
 			chars += block.text.length;
 		} else if (block.type === "thinking") {
 			chars += block.thinking.length;
-		} else {
+		} else if (block.type === "toolCall") {
 			chars += block.name.length + safeJsonStringify(block.arguments).length;
 		}
 	}

--- a/packages/ai/src/utils/text.ts
+++ b/packages/ai/src/utils/text.ts
@@ -1,6 +1,6 @@
-import type { ImageContent, TextContent, ThinkingContent, ToolCall } from "../types.ts";
+import type { FallbackContent, ImageContent, TextContent, ThinkingContent, ToolCall } from "../types.ts";
 
-type Content = TextContent | ImageContent | ThinkingContent | ToolCall;
+type Content = TextContent | ImageContent | ThinkingContent | ToolCall | FallbackContent;
 
 /** Extract and join text from message content. */
 export function contentText(content: string | readonly Content[], separator = "\n"): string {

--- a/packages/ai/test/anthropic-server-side-fallback.test.ts
+++ b/packages/ai/test/anthropic-server-side-fallback.test.ts
@@ -1,0 +1,256 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import type Anthropic from "@anthropic-ai/sdk";
+import { describe, expect, it } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import { getModel } from "../src/compat.ts";
+import type { Context, Model } from "../src/types.ts";
+
+interface CapturedRequest {
+	headers: IncomingMessage["headers"];
+	body: Record<string, unknown>;
+}
+
+const context: Context = {
+	messages: [{ role: "user", content: "Say hello.", timestamp: Date.now() }],
+};
+
+function createSseResponse(events: Array<{ event: string; data: string }>): Response {
+	const body = events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n");
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+function successfulEvents(model = "claude-fable-5"): Array<{ event: string; data: string }> {
+	return [
+		{
+			event: "message_start",
+			data: JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "msg_test",
+					model,
+					usage: {
+						input_tokens: 12,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				},
+			}),
+		},
+		{
+			event: "content_block_start",
+			data: JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+		},
+		{
+			event: "content_block_delta",
+			data: JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } }),
+		},
+		{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 0 }) },
+		{
+			event: "message_delta",
+			data: JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: {
+					input_tokens: 12,
+					output_tokens: 5,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			}),
+		},
+		{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+	];
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+}
+
+function writeSseResponse(response: ServerResponse): void {
+	response.writeHead(200, { "content-type": "text/event-stream" });
+	response.end(
+		successfulEvents()
+			.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`)
+			.join("\n"),
+	);
+}
+
+function cloneModel(baseUrl: string, provider = "anthropic"): Model<"anthropic-messages"> {
+	return { ...getModel("anthropic", "claude-fable-5"), provider, baseUrl };
+}
+
+async function request(
+	model: Model<"anthropic-messages">,
+	fallbacks?: "default" | string[],
+	headers?: Record<string, string | null>,
+): Promise<CapturedRequest> {
+	let captured: CapturedRequest | undefined;
+	const server = createServer(async (incoming, response) => {
+		captured = { headers: incoming.headers, body: await readRequestBody(incoming) };
+		writeSseResponse(response);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address() as AddressInfo;
+
+	try {
+		await streamAnthropic({ ...model, baseUrl: `http://127.0.0.1:${address.port}` }, context, {
+			apiKey: "test-key",
+			cacheRetention: "none",
+			fallbacks,
+			headers,
+		}).result();
+	} finally {
+		await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+	}
+
+	if (!captured) throw new Error("Anthropic request was not captured");
+	return captured;
+}
+
+describe("Anthropic server-side fallback", () => {
+	it("sends the beta payload and header only for opted-in official Anthropic requests", async () => {
+		const official = cloneModel("https://api.anthropic.com");
+		const optedIn = await request(official, "default");
+		const optedOut = await request(official);
+		const compatible = await request(cloneModel("https://example.test", "test-anthropic"), "default");
+		const optedInWithBeta = await request(official, "default", { "anthropic-beta": "another-beta" });
+
+		expect(optedIn.body.fallbacks).toBe("default");
+		expect(optedIn.headers["anthropic-beta"]).toBe("server-side-fallback-2026-07-01");
+		expect(optedInWithBeta.headers["anthropic-beta"]).toBe("another-beta,server-side-fallback-2026-07-01");
+		expect(optedOut.body.fallbacks).toBeUndefined();
+		expect(optedOut.headers["anthropic-beta"]).toBeUndefined();
+		expect(compatible.body.fallbacks).toBeUndefined();
+		expect(compatible.headers["anthropic-beta"]).toBeUndefined();
+	});
+
+	it("keeps non-opted compatible responses on their configured model cost", async () => {
+		const model = {
+			...cloneModel("https://example.test", "test-anthropic"),
+			cost: { input: 4, output: 8, cacheRead: 0.4, cacheWrite: 5 },
+		};
+		const client = {
+			messages: {
+				create: () => ({ asResponse: async () => createSseResponse(successfulEvents("served-alias")) }),
+			},
+		} as unknown as Anthropic;
+
+		const result = await streamAnthropic(model, context, { client }).result();
+		expect(result.responseModel).toBeUndefined();
+		expect(result.usage.cost.total).toBeCloseTo(0.000088, 10);
+	});
+
+	it("persists fallback transitions, uses the serving model cost, and replays only when opted in", async () => {
+		const calls: Array<Record<string, unknown>> = [];
+		const firstResponse = createSseResponse([
+			{
+				event: "message_start",
+				data: JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_fallback",
+						model: "claude-fable-5",
+						usage: {
+							input_tokens: 100,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				}),
+			},
+			{
+				event: "content_block_start",
+				data: JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: {
+						type: "fallback",
+						from: { model: "claude-fable-5" },
+						to: { model: "claude-sonnet-5" },
+						trigger: { type: "refusal", category: "cyber" },
+					},
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 0 }) },
+			{
+				event: "content_block_start",
+				data: JSON.stringify({ type: "content_block_start", index: 1, content_block: { type: "text", text: "" } }),
+			},
+			{
+				event: "content_block_delta",
+				data: JSON.stringify({
+					type: "content_block_delta",
+					index: 1,
+					delta: { type: "text_delta", text: "Hello" },
+				}),
+			},
+			{ event: "content_block_stop", data: JSON.stringify({ type: "content_block_stop", index: 1 }) },
+			{
+				event: "message_delta",
+				data: JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: {
+						input_tokens: 100,
+						output_tokens: 10,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+						iterations: [
+							{ type: "message", model: "claude-fable-5" },
+							{ type: "fallback_message", model: "claude-sonnet-5" },
+						],
+					},
+				}),
+			},
+			{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+		]);
+		const responses = [firstResponse, createSseResponse(successfulEvents()), createSseResponse(successfulEvents())];
+		const client = {
+			messages: {
+				create: (params: Record<string, unknown>) => {
+					calls.push(params);
+					const response = responses.shift();
+					if (!response) throw new Error("Unexpected request");
+					return { asResponse: async () => response };
+				},
+			},
+		} as unknown as Anthropic;
+		const model = cloneModel("https://api.anthropic.com");
+
+		const first = await streamAnthropic(model, context, { client, fallbacks: "default" }).result();
+		expect(first.responseModel).toBe("claude-sonnet-5");
+		expect(first.content).toEqual([
+			{
+				type: "fallback",
+				from: { model: "claude-fable-5" },
+				to: { model: "claude-sonnet-5" },
+				trigger: { type: "refusal", category: "cyber" },
+			},
+			{ type: "text", text: "Hello" },
+		]);
+		expect(first.usage.cost.total).toBeCloseTo(0.0003, 10);
+
+		const history: Context = {
+			messages: [context.messages[0], first, { role: "user", content: "Continue.", timestamp: Date.now() }],
+		};
+		await streamAnthropic(model, history, { client, fallbacks: "default" }).result();
+		await streamAnthropic(model, history, { client }).result();
+
+		const optedInMessages = calls[1].messages as Array<{ role: string; content: Array<{ type: string }> }>;
+		const optedOutMessages = calls[2].messages as Array<{ role: string; content: Array<{ type: string }> }>;
+		expect(optedInMessages[1].content[0]).toEqual({
+			type: "fallback",
+			from: { model: "claude-fable-5" },
+			to: { model: "claude-sonnet-5" },
+			trigger: { type: "refusal", category: "cyber" },
+		});
+		expect(optedOutMessages[1].content).toEqual([{ type: "text", text: "Hello" }]);
+	});
+});

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -251,7 +251,8 @@ export function toProtocolUserMessage(message: UserMessage, options: UserTranscr
 }
 
 function toProtocolAssistantContent(message: AssistantMessage): AssistantTranscriptItem["content"] {
-	return message.content.map((part) => {
+	return message.content.flatMap((part) => {
+		if (part.type === "fallback") return [];
 		switch (part.type) {
 			case "text":
 				return { type: "text", text: part.text };


### PR DESCRIPTION
## Summary
- add opted-in Anthropic server-side fallback payload and beta support
- preserve fallback transitions for opted-in Anthropic replay and report the serving model
- retain existing behavior for other providers and non-opted requests

## Verification
- `npm run check`
- `npm --prefix packages/ai run build:offline`
- `cd packages/ai && node ../../node_modules/vitest/dist/cli.js --run test/anthropic-server-side-fallback.test.ts test/anthropic-sse-parsing.test.ts`