### PR TITLE
fix(coding-agent): normalize find root results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an experimental first-time setup flow behind `PI_EXPERIMENTAL=1` that asks for a dark/light theme choice (preselecting the detected appearance) and opt-in analytics data sharing on first launch with the default agent directory; opting in stores a `trackingId` in `settings.json`.
 
+### Fixed
+
+- Fixed `find` results when searching from filesystem roots, including POSIX `/` and Windows bare drive roots, so relative paths preserve the first segment and directory matches use a single trailing slash ([#6104](https://github.com/earendil-works/pi/issues/6104)).
+
 ## [0.79.1] - 2026-06-09
 
 ### New Features

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -13,8 +13,17 @@ import { getTextOutput, invalidArgText, shortenPath, str } from "./render-utils.
 import { wrapToolDefinition } from "./tool-definition-wrapper.ts";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.ts";
 
-function toPosixPath(value: string): string {
-	return value.split(path.sep).join("/");
+/** Relativize a find result against the search root and normalize it to posix separators. */
+export function relativizeFindResultPath(
+	resultPath: string,
+	searchPath: string,
+	pathModule: path.PlatformPath = path,
+): string {
+	const hadTrailingSeparator =
+		resultPath.endsWith(pathModule.sep) || (pathModule.sep === "\\" && resultPath.endsWith("/"));
+	const relativePath = pathModule.isAbsolute(resultPath) ? pathModule.relative(searchPath, resultPath) : resultPath;
+	const posixPath = relativePath.split(pathModule.sep).join("/");
+	return hadTrailingSeparator && !posixPath.endsWith("/") ? `${posixPath}/` : posixPath;
 }
 
 const findSchema = Type.Object({
@@ -180,10 +189,7 @@ export function createFindToolDefinition(
 							}
 
 							// Relativize paths against the search root for stable output.
-							const relativized = results.map((p) => {
-								if (p.startsWith(searchPath)) return toPosixPath(p.slice(searchPath.length + 1));
-								return toPosixPath(path.relative(searchPath, p));
-							});
+							const relativized = results.map((p) => relativizeFindResultPath(p, searchPath));
 							const resultLimitReached = relativized.length >= effectiveLimit;
 							const rawOutput = relativized.join("\n");
 							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
@@ -301,15 +307,7 @@ export function createFindToolDefinition(
 							for (const rawLine of lines) {
 								const line = rawLine.replace(/\r$/, "").trim();
 								if (!line) continue;
-								const hadTrailingSlash = line.endsWith("/") || line.endsWith("\\");
-								let relativePath = line;
-								if (line.startsWith(searchPath)) {
-									relativePath = line.slice(searchPath.length + 1);
-								} else {
-									relativePath = path.relative(searchPath, line);
-								}
-								if (hadTrailingSlash && !relativePath.endsWith("/")) relativePath += "/";
-								relativized.push(toPosixPath(relativePath));
+								relativized.push(relativizeFindResultPath(line, searchPath));
 							}
 
 							const resultLimitReached = relativized.length >= effectiveLimit;

--- a/packages/coding-agent/test/suite/regressions/6104-find-root-relativization.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6104-find-root-relativization.test.ts
@@ -1,0 +1,91 @@
+import { posix, win32 } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createFindToolDefinition, relativizeFindResultPath } from "../../../src/core/tools/find.ts";
+
+/**
+ * Regression test for https://github.com/earendil-works/pi/issues/6104
+ *
+ * path.resolve() preserves a trailing separator when resolving to a root path,
+ * such as POSIX / or Windows I:\\. The find tool used to slice absolute
+ * results at searchPath.length + 1, which dropped the first character of the
+ * first path segment for root searches. Windows directory results that ended in
+ * backslash also gained an extra slash.
+ */
+describe("issue #6104 find relativizes root search paths", () => {
+	describe("Windows drive root", () => {
+		const searchRoot = "I:\\";
+
+		it("preserves the first segment and emits one trailing slash for fd directory output", () => {
+			expect(relativizeFindResultPath("I:\\AI\\Models\\TextGen\\gemma4\\", searchRoot, win32)).toBe(
+				"AI/Models/TextGen/gemma4/",
+			);
+		});
+
+		it("handles fd output that uses forward slashes under a drive root", () => {
+			expect(relativizeFindResultPath("I:/AI/Models/TextGen/gemma4/", searchRoot, win32)).toBe(
+				"AI/Models/TextGen/gemma4/",
+			);
+		});
+
+		it("keeps deeper search paths unchanged", () => {
+			expect(relativizeFindResultPath("I:\\AI\\Models\\", "I:\\AI", win32)).toBe("Models/");
+		});
+
+		it("does not relativize a sibling directory that shares a name prefix", () => {
+			expect(relativizeFindResultPath("I:\\AI\\Models2\\file.txt", "I:\\AI\\Models", win32)).toBe(
+				"../Models2/file.txt",
+			);
+		});
+
+		it("normalizes relative custom-glob results without corrupting them", () => {
+			expect(relativizeFindResultPath("AI\\Models\\TextGen\\gemma4\\", searchRoot, win32)).toBe(
+				"AI/Models/TextGen/gemma4/",
+			);
+		});
+	});
+
+	describe("POSIX root", () => {
+		it("preserves the first segment for files under /", () => {
+			expect(relativizeFindResultPath("/home/user/file.txt", "/", posix)).toBe("home/user/file.txt");
+		});
+
+		it("preserves the first segment and one trailing slash for directories under /", () => {
+			expect(relativizeFindResultPath("/home/user/project/", "/", posix)).toBe("home/user/project/");
+		});
+
+		it("preserves backslashes in POSIX filenames", () => {
+			expect(relativizeFindResultPath("/home/user/file\\", "/home/user", posix)).toBe("file\\");
+		});
+	});
+
+	describe("absolute results outside the search path", () => {
+		it("falls back to path.relative when the absolute paths do not share a prefix", () => {
+			expect(relativizeFindResultPath("/tmp/results/file.txt", "/workspace/project", posix)).toBe(
+				"../../tmp/results/file.txt",
+			);
+		});
+
+		it("keeps a trailing slash on directories resolved through path.relative", () => {
+			expect(relativizeFindResultPath("/tmp/results/dir/", "/workspace/project", posix)).toBe(
+				"../../tmp/results/dir/",
+			);
+		});
+	});
+
+	describe("through the find tool", () => {
+		it("relativizes custom glob results against a root search path", async () => {
+			const def = createFindToolDefinition("/", {
+				operations: {
+					exists: () => true,
+					glob: () => ["/home/user/project/", "/home/user/project/file.txt"],
+				},
+			});
+			// The find tool implementation does not touch ctx; pass a minimal stub.
+			const ctx = {} as Parameters<typeof def.execute>[4];
+			const result = (await def.execute("call-1", { pattern: "**" }, undefined, undefined, ctx)) as {
+				content: Array<{ type: string; text?: string }>;
+			};
+			expect(result.content[0]?.text).toBe("home/user/project/\nhome/user/project/file.txt");
+		});
+	});
+});


### PR DESCRIPTION
Fixes find's handling of relativizng paths. Uses .relative() always instead of slicing (easier, and shouldn't be that much less performant (clanker-should be fs-access free)) and handles path selectors correctly using (mostly) node facilities instead of hand rolling heuristics.

Should fix normalized root results both on linux and windows (no longer drops trailing separator) + also fix broken relative paths if the process had different `cwd` to search root (this might've been desired, but if anything I'd expect it'd confuse models; as if models invoke search from folder X they would assume paths relative to that; not to ambient cwd).

Examples: 
 ```ts
   // Windows root: first path segment was truncated
   relativize("I:\\AI\\file.txt", "I:\\") // "I/file.txt" -> "AI/file.txt"

   // Windows root: directory received a doubled trailing slash
   relativize("I:\\AI\\Models\\", "I:\\") // "I/Models//" -> "AI/Models/"

   // Relative custom-glob result with process.cwd() === "/app"
   relativize("src/file.ts", "/workspace/project") // "../../app/src/file.ts" -> "src/file.ts"
 ```

Fixes #6104