### PR TITLE
docs(coding-agent): document streamSimple hook contract

### DIFF
--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1444,7 +1444,12 @@ export interface ProviderConfig {
 	apiKey?: string;
 	/** API type. Required at provider or model level when defining models. */
 	api?: Api;
-	/** Optional streamSimple handler for custom APIs. */
+	/**
+	 * Optional streamSimple handler for custom APIs.
+	 * Implementations must invoke `options.onPayload` before sending the provider request and use any
+	 * returned replacement payload. They must invoke `options.onResponse` after receiving the response
+	 * and before consuming its body, matching built-in providers.
+	 */
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	/** Custom headers to include in requests. */
 	headers?: Record<string, string>;


### PR DESCRIPTION
## Summary
- document the callback contract for custom `ProviderConfig.streamSimple` handlers
- clarify payload replacement and response hook ordering for custom provider authors

Closes #7372

## Testing
- `npm run check`
- `./test.sh` *(fails on current `main`: the AgentHarness shutdown test expects `aborted` but receives `error`; unrelated to this JSDoc-only change)*