### PR TITLE
feat(ai): add MiniMax music cover generation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added MiniMax music generation and cover generation providers for the global and CN regional endpoints, with URL and hexadecimal audio output and CN `aigc_watermark` support.
+
 ### Breaking Changes
 
 - Required dynamic model providers to accept a concrete `RefreshModelsContext.signal`; `Models.refresh()` remains unbounded when callers omit its optional signal.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -8,7 +8,9 @@
 	"sideEffects": [
 		"./dist/compat.js",
 		"./dist/images.js",
-		"./dist/providers/images/register-builtins.js"
+		"./dist/music.js",
+		"./dist/providers/images/register-builtins.js",
+		"./dist/providers/music/register-builtins.js"
 	],
 	"exports": {
 		".": {

--- a/packages/ai/src/api/minimax-music.ts
+++ b/packages/ai/src/api/minimax-music.ts
@@ -1,0 +1,259 @@
+import type {
+	AssistantMusic,
+	MusicContext,
+	MusicFunction,
+	MusicModel,
+	MusicOptions,
+	MusicOutputFormat,
+	ProviderResponse,
+} from "../types.ts";
+import { combineAbortSignals } from "../utils/abort-signals.ts";
+import { formatProviderError, normalizeProviderError, truncateErrorText } from "../utils/error-body.ts";
+import { providerHeadersToRecord } from "../utils/headers.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
+import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+
+interface MiniMaxMusicResponse {
+	trace_id?: unknown;
+	data?: {
+		status?: unknown;
+		audio?: unknown;
+	};
+	base_resp?: {
+		status_code?: unknown;
+		status_msg?: unknown;
+	};
+}
+
+type MiniMaxMusicPayload = Record<string, unknown>;
+
+class MiniMaxMusicHttpError extends Error {
+	readonly status: number;
+	readonly headers: Headers;
+	readonly body: string;
+
+	constructor(response: Response, body: string) {
+		const detail = body.trim();
+		super(
+			`MiniMax music request failed with HTTP ${response.status}${detail ? `: ${truncateErrorText(detail, 4000)}` : ""}`,
+		);
+		this.name = "MiniMaxMusicHttpError";
+		this.status = response.status;
+		this.headers = response.headers;
+		this.body = detail;
+	}
+}
+
+/**
+ * MiniMax music generation and cover generation.
+ *
+ * Both generation (`music-3.0` and friends) and cover (`music-cover`,
+ * `music-cover-free`) requests are POSTed to `/v1/music_generation`. Cover
+ * requests supply a reference track via `audio_url` or `audio_base64`
+ * together with an optional `cover_feature_id`, and the CN regional endpoint
+ * accepts the `aigc_watermark` watermark field. Responses carry
+ * `base_resp.status_code` plus `data.status` (1 = in progress, 2 = completed)
+ * and the audio payload under `data.audio` (a URL or hexadecimal bytes).
+ */
+export const generateMusic: MusicFunction<"minimax-music", MusicOptions> = async (
+	model: MusicModel<"minimax-music">,
+	context: MusicContext,
+	options?: MusicOptions,
+) => {
+	const output: AssistantMusic = {
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		output: [],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+
+	try {
+		const apiKey = options?.apiKey;
+		if (!apiKey) {
+			throw new Error(`No API key for provider: ${model.provider}`);
+		}
+
+		let payload = buildPayload(model, context);
+		const nextPayload = await options?.onPayload?.(payload, model);
+		if (nextPayload !== undefined) payload = nextPayload as MiniMaxMusicPayload;
+
+		const combinedSignal = combineAbortSignals([
+			options?.signal,
+			options?.timeoutMs !== undefined && options.timeoutMs > 0 ? AbortSignal.timeout(options.timeoutMs) : undefined,
+		]);
+		try {
+			const response = await retryProviderRequest(
+				() => requestMusic(model, payload, apiKey, options, combinedSignal.signal),
+				{
+					maxRetries: options?.maxRetries,
+					maxRetryDelayMs: options?.maxRetryDelayMs,
+					signal: combinedSignal.signal,
+				},
+			);
+			await options?.onResponse?.(response.response, model);
+			return applyResponse(output, response.body, context, model);
+		} finally {
+			combinedSignal.cleanup();
+		}
+	} catch (error) {
+		output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+		output.errorMessage = formatProviderError(normalizeProviderError(error));
+		return output;
+	}
+};
+
+async function requestMusic(
+	model: MusicModel<"minimax-music">,
+	payload: MiniMaxMusicPayload,
+	apiKey: string,
+	options: MusicOptions | undefined,
+	signal: AbortSignal | undefined,
+): Promise<{ response: ProviderResponse; body: MiniMaxMusicResponse }> {
+	const fetcher = options?.fetch ?? globalThis.fetch;
+	const response = await fetcher(model.baseUrl, {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${apiKey}`,
+			"content-type": "application/json",
+			...providerHeadersToRecord({ ...model.headers, ...options?.headers }),
+		},
+		body: JSON.stringify(payload),
+		signal,
+	});
+	const bodyText = await response.text();
+	if (!response.ok) throw new MiniMaxMusicHttpError(response, bodyText);
+
+	return {
+		response: { status: response.status, headers: Object.fromEntries(response.headers.entries()) },
+		body: parseResponse(bodyText),
+	};
+}
+
+function buildPayload(model: MusicModel<"minimax-music">, context: MusicContext): MiniMaxMusicPayload {
+	const payload: MiniMaxMusicPayload = { model: model.id };
+
+	if (model.cover) {
+		validateCoverInput(model, context);
+	}
+
+	if (context.prompt !== undefined) payload.prompt = sanitizeSurrogates(context.prompt);
+	if (context.lyrics !== undefined) payload.lyrics = sanitizeSurrogates(context.lyrics);
+	if (context.stream !== undefined) payload.stream = context.stream;
+
+	const outputFormat = context.outputFormat ?? (context.stream ? "hex" : undefined);
+	if (context.stream && outputFormat === "url") {
+		throw new Error("MiniMax music streaming supports hex output only");
+	}
+	if (outputFormat !== undefined) {
+		assertIncludes(model.outputFormats, outputFormat, "output format");
+		payload.output_format = outputFormat;
+	}
+
+	if (context.audioSetting !== undefined) {
+		const audioSetting: Record<string, unknown> = {};
+		if (context.audioSetting.sampleRate !== undefined) audioSetting.sample_rate = context.audioSetting.sampleRate;
+		if (context.audioSetting.bitrate !== undefined) audioSetting.bitrate = context.audioSetting.bitrate;
+		if (context.audioSetting.format !== undefined) {
+			assertIncludes(model.audioFormats, context.audioSetting.format, "audio format");
+			audioSetting.format = context.audioSetting.format;
+		}
+		payload.audio_setting = audioSetting;
+	}
+
+	if (context.lyricsOptimizer !== undefined) payload.lyrics_optimizer = context.lyricsOptimizer;
+	if (context.isInstrumental !== undefined) payload.is_instrumental = context.isInstrumental;
+	if (context.audioUrl !== undefined) payload.audio_url = context.audioUrl;
+	if (context.audioBase64 !== undefined) payload.audio_base64 = context.audioBase64;
+	if (context.coverFeatureId !== undefined) payload.cover_feature_id = context.coverFeatureId;
+	if (model.regionalFields.includes("aigc_watermark") && context.aigcWatermark !== undefined) {
+		payload.aigc_watermark = context.aigcWatermark;
+	}
+
+	return payload;
+}
+
+function validateCoverInput(model: MusicModel<"minimax-music">, context: MusicContext): void {
+	const cover = model.cover!;
+	const hasAudioUrl = context.audioUrl !== undefined && context.audioUrl.length > 0;
+	const hasAudioBase64 = context.audioBase64 !== undefined && context.audioBase64.length > 0;
+
+	if (hasAudioUrl === hasAudioBase64) {
+		throw new Error("MiniMax music cover requests require exactly one of audio_url or audio_base64");
+	}
+
+	if (hasAudioBase64) {
+		const bytes = Math.floor((context.audioBase64!.length * 3) / 4);
+		const maxBytes = cover.inputMaxMb * 1024 * 1024;
+		if (bytes > maxBytes) {
+			throw new Error(`MiniMax music cover reference audio exceeds the ${cover.inputMaxMb} MB size limit`);
+		}
+	}
+}
+
+function assertIncludes<T>(values: readonly T[], value: T, label: string): void {
+	if (!values.includes(value)) throw new Error(`Unsupported MiniMax music ${label}: ${String(value)}`);
+}
+
+function parseResponse(bodyText: string): MiniMaxMusicResponse {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(bodyText);
+	} catch (error) {
+		throw new Error(
+			`MiniMax music response was not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!isRecord(parsed)) throw new Error("MiniMax music response was not an object");
+	return parsed;
+}
+
+function applyResponse(
+	output: AssistantMusic,
+	response: MiniMaxMusicResponse,
+	context: MusicContext,
+	model: MusicModel<"minimax-music">,
+): AssistantMusic {
+	const statusCode = response.base_resp?.status_code;
+	if (statusCode !== 0) {
+		const message =
+			typeof response.base_resp?.status_msg === "string" ? response.base_resp.status_msg : "unknown error";
+		throw new Error(`MiniMax music API error (${String(statusCode)}): ${message}`);
+	}
+
+	const status = response.data?.status;
+	if (status !== 1 && status !== 2) throw new Error("MiniMax music response has invalid data.status");
+	output.status = status === 1 ? "in_progress" : "completed";
+	output.stopReason = status === 1 ? "in_progress" : "stop";
+	if (typeof response.trace_id === "string") output.responseId = response.trace_id;
+
+	const audio = response.data?.audio;
+	if (typeof audio !== "string" || audio.length === 0) {
+		if (status === 2) throw new Error("MiniMax music response is missing data.audio");
+		return output;
+	}
+
+	const outputFormat: MusicOutputFormat = context.outputFormat ?? (isUrl(audio) ? "url" : "hex");
+	assertIncludes(model.outputFormats, outputFormat, "output format");
+	if (outputFormat === "url" && !isUrl(audio)) throw new Error("MiniMax music response did not contain an audio URL");
+	if (outputFormat === "hex" && isUrl(audio))
+		throw new Error("MiniMax music response did not contain hexadecimal audio");
+
+	const audioFormat = context.audioSetting?.format;
+	output.output.push({
+		type: "audio",
+		data: audio,
+		outputFormat,
+		...(audioFormat ? { audioFormat } : {}),
+	});
+	return output;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isUrl(value: string): boolean {
+	return /^https?:\/\//.test(value);
+}

--- a/packages/ai/src/compat.ts
+++ b/packages/ai/src/compat.ts
@@ -26,7 +26,11 @@ export * from "./images.ts";
 export * from "./images-api-registry.ts";
 export * from "./index.ts";
 export * from "./legacy-api-aliases.ts";
+export * from "./music.ts";
+export * from "./music-api-registry.ts";
+export * from "./music-model-catalog.ts";
 export * from "./providers/images/register-builtins.ts";
+export * from "./providers/music/register-builtins.ts";
 
 import { anthropicMessagesApi } from "./api/anthropic-messages.lazy.ts";
 import { azureOpenAIResponsesApi } from "./api/azure-openai-responses.lazy.ts";

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -33,6 +33,7 @@ export type {
 export * from "./images-models.ts";
 export * from "./models.ts";
 export * from "./models-store.ts";
+export * from "./music-models.ts";
 export * from "./providers/faux.ts";
 export * from "./session-resources.ts";
 export * from "./types.ts";

--- a/packages/ai/src/music-api-registry.ts
+++ b/packages/ai/src/music-api-registry.ts
@@ -1,0 +1,44 @@
+import type { AssistantMusic, MusicApi, MusicContext, MusicFunction, MusicModel, MusicOptions } from "./types.ts";
+
+export type MusicApiFunction = (
+	model: MusicModel<MusicApi>,
+	context: MusicContext,
+	options?: MusicOptions,
+) => Promise<AssistantMusic>;
+
+export interface MusicApiProvider<TApi extends MusicApi = MusicApi, TOptions extends MusicOptions = MusicOptions> {
+	api: TApi;
+	generateMusic: MusicFunction<TApi, TOptions>;
+}
+
+interface MusicApiProviderInternal {
+	api: MusicApi;
+	generateMusic: MusicApiFunction;
+}
+
+const musicApiProviderRegistry = new Map<string, MusicApiProviderInternal>();
+
+function wrapGenerateMusic<TApi extends MusicApi, TOptions extends MusicOptions>(
+	api: TApi,
+	generateMusic: MusicFunction<TApi, TOptions>,
+): MusicApiFunction {
+	return (model, context, options) => {
+		if (model.api !== api) {
+			throw new Error(`Mismatched api: ${model.api} expected ${api}`);
+		}
+		return generateMusic(model as MusicModel<TApi>, context, options as TOptions);
+	};
+}
+
+export function registerMusicApiProvider<TApi extends MusicApi, TOptions extends MusicOptions>(
+	provider: MusicApiProvider<TApi, TOptions>,
+): void {
+	musicApiProviderRegistry.set(provider.api, {
+		api: provider.api,
+		generateMusic: wrapGenerateMusic(provider.api, provider.generateMusic),
+	});
+}
+
+export function getMusicApiProvider(api: MusicApi): MusicApiProviderInternal | undefined {
+	return musicApiProviderRegistry.get(api);
+}

--- a/packages/ai/src/music-model-catalog.ts
+++ b/packages/ai/src/music-model-catalog.ts
@@ -1,0 +1,83 @@
+import type { KnownMusicProvider, MusicApi, MusicModel, MusicRegion } from "./types.ts";
+
+export const DEFAULT_MUSIC_MODEL_ID = "music-3.0";
+
+const MUSIC_GENERATION_MODEL_IDS = ["music-3.0", "music-2.6", "music-3.0-free", "music-2.6-free"] as const;
+const MUSIC_COVER_MODEL_IDS = ["music-cover", "music-cover-free"] as const;
+const MUSIC_OUTPUT_FORMATS = ["url", "hex"] as const;
+const MUSIC_STREAM_OUTPUT_FORMATS = ["hex"] as const;
+const MUSIC_AUDIO_FORMATS = ["mp3", "wav", "pcm"] as const;
+const MUSIC_URL_TTL_HOURS = 24;
+const MUSIC_COVER_CAPABILITIES = {
+	inputOneOf: ["audio_url", "audio_base64"] as const,
+	inputMinSeconds: 6,
+	inputMaxSeconds: 360,
+	inputMaxMb: 50,
+};
+
+type MusicModelId = (typeof MUSIC_GENERATION_MODEL_IDS)[number] | (typeof MUSIC_COVER_MODEL_IDS)[number];
+type MusicCatalogForProvider<TProvider extends KnownMusicProvider> = {
+	[TModelId in MusicModelId]: MusicModel<"minimax-music"> & { id: TModelId; provider: TProvider };
+};
+
+function createMusicCatalog<TProvider extends KnownMusicProvider>(
+	provider: TProvider,
+	baseUrl: string,
+	region: MusicRegion,
+): MusicCatalogForProvider<TProvider> {
+	const modelIds: readonly MusicModelId[] = [...MUSIC_GENERATION_MODEL_IDS, ...MUSIC_COVER_MODEL_IDS];
+	return Object.fromEntries(
+		modelIds.map((id) => [
+			id,
+			{
+				id,
+				name: id,
+				api: "minimax-music" as const,
+				provider,
+				baseUrl,
+				region,
+				outputFormats: MUSIC_OUTPUT_FORMATS,
+				streamOutputFormats: MUSIC_STREAM_OUTPUT_FORMATS,
+				audioFormats: MUSIC_AUDIO_FORMATS,
+				urlTtlHours: MUSIC_URL_TTL_HOURS,
+				regionalFields: region === "cn_zh" ? (["aigc_watermark"] as const) : [],
+				cover: MUSIC_COVER_MODEL_IDS.includes(id as (typeof MUSIC_COVER_MODEL_IDS)[number])
+					? MUSIC_COVER_CAPABILITIES
+					: undefined,
+			},
+		]),
+	) as unknown as MusicCatalogForProvider<TProvider>;
+}
+
+export const MUSIC_MODELS = {
+	minimax: createMusicCatalog("minimax", "https://api.minimax.io/v1/music_generation", "global_en"),
+	"minimax-cn": createMusicCatalog("minimax-cn", "https://api.minimaxi.com/v1/music_generation", "cn_zh"),
+} as const;
+
+type MusicModelApi<
+	TProvider extends KnownMusicProvider,
+	TModelId extends keyof (typeof MUSIC_MODELS)[TProvider],
+> = (typeof MUSIC_MODELS)[TProvider][TModelId] extends { api: infer TApi }
+	? TApi extends MusicApi
+		? TApi
+		: never
+	: never;
+
+export function getMusicModel<
+	TProvider extends KnownMusicProvider,
+	TModelId extends keyof (typeof MUSIC_MODELS)[TProvider],
+>(provider: TProvider, modelId: TModelId): MusicModel<MusicModelApi<TProvider, TModelId>> {
+	return MUSIC_MODELS[provider][modelId] as MusicModel<MusicModelApi<TProvider, TModelId>>;
+}
+
+export function getMusicProviders(): KnownMusicProvider[] {
+	return Object.keys(MUSIC_MODELS) as KnownMusicProvider[];
+}
+
+export function getMusicModels<TProvider extends KnownMusicProvider>(
+	provider: TProvider,
+): MusicModel<MusicModelApi<TProvider, keyof (typeof MUSIC_MODELS)[TProvider]>>[] {
+	return Object.values(MUSIC_MODELS[provider]) as MusicModel<
+		MusicModelApi<TProvider, keyof (typeof MUSIC_MODELS)[TProvider]>
+	>[];
+}

--- a/packages/ai/src/music-models.ts
+++ b/packages/ai/src/music-models.ts
@@ -1,0 +1,187 @@
+import { defaultProviderAuthContext as defaultAuthContext } from "./auth/context.ts";
+import { InMemoryCredentialStore } from "./auth/credential-store.ts";
+import { type AuthResolutionOverrides, ModelsError, resolveProviderAuth } from "./auth/resolve.ts";
+import type { AuthContext, AuthResult, CredentialStore, ProviderAuth } from "./auth/types.ts";
+import type { CreateModelsOptions } from "./models.ts";
+import type { AssistantMusic, MusicApi, MusicContext, MusicModel, MusicOptions, ProviderMusic } from "./types.ts";
+
+/**
+ * A music-generation provider: the music-side counterpart of `ImagesProvider`.
+ * Owns id/name metadata, auth, model listing, and generation behavior.
+ */
+export interface MusicProvider {
+	readonly id: string;
+	readonly name: string;
+
+	/** Required: at least one of `apiKey`/`oauth`. */
+	readonly auth: ProviderAuth;
+
+	/** Current known models, sync. Must not throw. */
+	getModels(): readonly MusicModel<MusicApi>[];
+
+	generateMusic(model: MusicModel<MusicApi>, context: MusicContext, options?: MusicOptions): Promise<AssistantMusic>;
+}
+
+/**
+ * Runtime collection of music-generation providers plus auth application and
+ * generation convenience: the music-side counterpart of `ImagesModels`.
+ */
+export interface MusicModels {
+	getProviders(): readonly MusicProvider[];
+	getProvider(id: string): MusicProvider | undefined;
+	getModels(provider?: string): readonly MusicModel<MusicApi>[];
+	getModel(provider: string, id: string): MusicModel<MusicApi> | undefined;
+	getAuth(providerId: string, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	getAuth(model: MusicModel<MusicApi>, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	/**
+	 * Generate music through the owning provider with auth resolved and merged
+	 * (explicit options win per field). Never rejects; failures are returned as
+	 * an `AssistantMusic` with `stopReason: "error"`.
+	 */
+	generateMusic(model: MusicModel<MusicApi>, context: MusicContext, options?: MusicOptions): Promise<AssistantMusic>;
+}
+
+export interface MutableMusicModels extends MusicModels {
+	/** Upsert/replace by provider.id. Provider ids are unique. */
+	setProvider(provider: MusicProvider): void;
+	deleteProvider(id: string): void;
+	clearProviders(): void;
+}
+
+class MusicModelsImpl implements MutableMusicModels {
+	private providers = new Map<string, MusicProvider>();
+	private credentials: CredentialStore;
+	private authContext: AuthContext;
+
+	constructor(options?: CreateModelsOptions) {
+		this.credentials = options?.credentials ?? new InMemoryCredentialStore();
+		this.authContext = options?.authContext ?? defaultAuthContext();
+	}
+
+	setProvider(provider: MusicProvider): void {
+		this.providers.set(provider.id, provider);
+	}
+
+	deleteProvider(id: string): void {
+		this.providers.delete(id);
+	}
+
+	clearProviders(): void {
+		this.providers.clear();
+	}
+
+	getProviders(): readonly MusicProvider[] {
+		return Array.from(this.providers.values());
+	}
+
+	getProvider(id: string): MusicProvider | undefined {
+		return this.providers.get(id);
+	}
+
+	getModels(provider?: string): readonly MusicModel<MusicApi>[] {
+		if (provider !== undefined) {
+			const entry = this.providers.get(provider);
+			if (!entry) return [];
+			try {
+				return entry.getModels();
+			} catch {
+				return [];
+			}
+		}
+
+		const models: MusicModel<MusicApi>[] = [];
+		for (const entry of this.providers.values()) {
+			try {
+				models.push(...entry.getModels());
+			} catch {
+				// Best-effort: ill-behaved providers yield no models.
+			}
+		}
+		return models;
+	}
+
+	getModel(provider: string, id: string): MusicModel<MusicApi> | undefined {
+		return this.getModels(provider).find((model) => model.id === id);
+	}
+
+	getAuth(providerId: string, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	getAuth(model: MusicModel<MusicApi>, overrides?: AuthResolutionOverrides): Promise<AuthResult | undefined>;
+	async getAuth(
+		providerOrModel: string | MusicModel<MusicApi>,
+		overrides?: AuthResolutionOverrides,
+	): Promise<AuthResult | undefined> {
+		const providerId = typeof providerOrModel === "string" ? providerOrModel : providerOrModel.provider;
+		const provider = this.providers.get(providerId);
+		if (!provider) return undefined;
+		return resolveProviderAuth(provider, this.credentials, this.authContext, overrides);
+	}
+
+	async generateMusic(
+		model: MusicModel<MusicApi>,
+		context: MusicContext,
+		options?: MusicOptions,
+	): Promise<AssistantMusic> {
+		try {
+			const provider = this.providers.get(model.provider);
+			if (!provider) {
+				throw new ModelsError("provider", `Unknown provider: ${model.provider}`);
+			}
+
+			const resolution = await this.getAuth(model, {
+				apiKey: options?.apiKey,
+				env: options?.env,
+				signal: options?.signal,
+			});
+			const auth = resolution?.auth;
+			if (!auth) {
+				return provider.generateMusic(model, context, options);
+			}
+
+			const requestModel = auth.baseUrl ? { ...model, baseUrl: auth.baseUrl } : model;
+
+			// Explicit request options win per-field; headers/env merge per key.
+			const apiKey = options?.apiKey ?? auth.apiKey;
+			const headers = auth.headers || options?.headers ? { ...auth.headers, ...options?.headers } : undefined;
+			const env =
+				resolution.env || options?.env ? { ...(resolution.env ?? {}), ...(options?.env ?? {}) } : undefined;
+
+			return await provider.generateMusic(requestModel, context, { ...options, apiKey, headers, env });
+		} catch (error) {
+			return {
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				output: [],
+				stopReason: "error",
+				errorMessage: error instanceof Error ? error.message : String(error),
+				timestamp: Date.now(),
+			};
+		}
+	}
+}
+
+export function createMusicModels(options?: CreateModelsOptions): MutableMusicModels {
+	return new MusicModelsImpl(options);
+}
+
+export interface CreateMusicProviderOptions {
+	id: string;
+	/** Display name. Default: `id`. */
+	name?: string;
+	/** Required — every provider has auth semantics, even ambient/keyless ones. */
+	auth: ProviderAuth;
+	/** Initial model list. */
+	models: readonly MusicModel<MusicApi>[];
+	api: ProviderMusic;
+}
+
+/** Builds a music-generation provider from parts. */
+export function createMusicProvider(input: CreateMusicProviderOptions): MusicProvider {
+	return {
+		id: input.id,
+		name: input.name ?? input.id,
+		auth: input.auth,
+		getModels: () => input.models,
+		generateMusic: (model, context, options) => input.api.generateMusic(model, context, options),
+	};
+}

--- a/packages/ai/src/music.ts
+++ b/packages/ai/src/music.ts
@@ -1,0 +1,21 @@
+import "./providers/music/register-builtins.ts";
+
+import { getMusicApiProvider } from "./music-api-registry.ts";
+import type { AssistantMusic, MusicApi, MusicContext, MusicModel, ProviderMusicOptions } from "./types.ts";
+
+function resolveMusicApiProvider(api: MusicApi) {
+	const provider = getMusicApiProvider(api);
+	if (!provider) {
+		throw new Error(`No API provider registered for api: ${api}`);
+	}
+	return provider;
+}
+
+export async function generateMusic<TApi extends MusicApi>(
+	model: MusicModel<TApi>,
+	context: MusicContext,
+	options?: ProviderMusicOptions,
+): Promise<AssistantMusic> {
+	const provider = resolveMusicApiProvider(model.api);
+	return provider.generateMusic(model, context, options);
+}

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -1,4 +1,5 @@
 import { createImagesModels, type ImagesProvider, type MutableImagesModels } from "../images-models.ts";
+import { createMusicModels, type MutableMusicModels, type MusicProvider } from "../music-models.ts";
 import { MODELS } from "../models.generated.ts";
 import { type CreateModelsOptions, createModels, type MutableModels, type Provider } from "../models.ts";
 import type { Api, Model } from "../types.ts";
@@ -21,6 +22,8 @@ import { huggingfaceProvider } from "./huggingface.ts";
 import { kimiCodingProvider } from "./kimi-coding.ts";
 import { minimaxProvider } from "./minimax.ts";
 import { minimaxCnProvider } from "./minimax-cn.ts";
+import { minimaxCnMusicProvider } from "./minimax-cn-music.ts";
+import { minimaxMusicProvider } from "./minimax-music.ts";
 import { mistralProvider } from "./mistral.ts";
 import { moonshotaiProvider } from "./moonshotai.ts";
 import { moonshotaiCnProvider } from "./moonshotai-cn.ts";
@@ -147,6 +150,20 @@ export function builtinImagesProviders(): ImagesProvider[] {
 export function builtinImagesModels(options?: CreateModelsOptions): MutableImagesModels {
 	const models = createImagesModels(options);
 	for (const provider of builtinImagesProviders()) {
+		models.setProvider(provider);
+	}
+	return models;
+}
+
+/** All built-in music-generation providers, freshly constructed. */
+export function builtinMusicProviders(): MusicProvider[] {
+	return [minimaxMusicProvider(), minimaxCnMusicProvider()];
+}
+
+/** A `MusicModels` collection with every built-in music-generation provider registered. */
+export function builtinMusicModels(options?: CreateModelsOptions): MutableMusicModels {
+	const models = createMusicModels(options);
+	for (const provider of builtinMusicProviders()) {
 		models.setProvider(provider);
 	}
 	return models;

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -1,7 +1,7 @@
 import { createImagesModels, type ImagesProvider, type MutableImagesModels } from "../images-models.ts";
-import { createMusicModels, type MutableMusicModels, type MusicProvider } from "../music-models.ts";
 import { MODELS } from "../models.generated.ts";
 import { type CreateModelsOptions, createModels, type MutableModels, type Provider } from "../models.ts";
+import { createMusicModels, type MusicProvider, type MutableMusicModels } from "../music-models.ts";
 import type { Api, Model } from "../types.ts";
 import { amazonBedrockProvider } from "./amazon-bedrock.ts";
 import { antLingProvider } from "./ant-ling.ts";

--- a/packages/ai/src/providers/minimax-cn-music.ts
+++ b/packages/ai/src/providers/minimax-cn-music.ts
@@ -1,0 +1,14 @@
+import { generateMusic } from "../api/minimax-music.ts";
+import { envApiKeyAuth } from "../auth/helpers.ts";
+import { MUSIC_MODELS } from "../music-model-catalog.ts";
+import { createMusicProvider, type MusicProvider } from "../music-models.ts";
+
+export function minimaxCnMusicProvider(): MusicProvider {
+	return createMusicProvider({
+		id: "minimax-cn",
+		name: "MiniMax CN",
+		auth: { apiKey: envApiKeyAuth("MiniMax CN API key", ["MINIMAX_CN_API_KEY"]) },
+		models: Object.values(MUSIC_MODELS["minimax-cn"]),
+		api: { generateMusic },
+	});
+}

--- a/packages/ai/src/providers/minimax-music.ts
+++ b/packages/ai/src/providers/minimax-music.ts
@@ -1,0 +1,14 @@
+import { generateMusic } from "../api/minimax-music.ts";
+import { envApiKeyAuth } from "../auth/helpers.ts";
+import { MUSIC_MODELS } from "../music-model-catalog.ts";
+import { createMusicProvider, type MusicProvider } from "../music-models.ts";
+
+export function minimaxMusicProvider(): MusicProvider {
+	return createMusicProvider({
+		id: "minimax",
+		name: "MiniMax",
+		auth: { apiKey: envApiKeyAuth("MiniMax API key", ["MINIMAX_API_KEY"]) },
+		models: Object.values(MUSIC_MODELS.minimax),
+		api: { generateMusic },
+	});
+}

--- a/packages/ai/src/providers/music/register-builtins.ts
+++ b/packages/ai/src/providers/music/register-builtins.ts
@@ -1,0 +1,11 @@
+import { generateMusic } from "../../api/minimax-music.ts";
+import { registerMusicApiProvider } from "../../music-api-registry.ts";
+
+export function registerBuiltInMusicApiProviders(): void {
+	registerMusicApiProvider({
+		api: "minimax-music",
+		generateMusic,
+	});
+}
+
+registerBuiltInMusicApiProviders();

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -31,6 +31,10 @@ export type KnownImagesApi = "openrouter-images";
 
 export type ImagesApi = KnownImagesApi | (string & {});
 
+export type KnownMusicApi = "minimax-music";
+
+export type MusicApi = KnownMusicApi | (string & {});
+
 export type KnownProvider =
 	| "amazon-bedrock"
 	| "ant-ling"
@@ -76,6 +80,10 @@ export type ProviderId = KnownProvider | string;
 export type KnownImagesProvider = "openrouter";
 
 export type ImagesProviderId = KnownImagesProvider | string;
+
+export type KnownMusicProvider = "minimax" | "minimax-cn";
+
+export type MusicProviderId = KnownMusicProvider | string;
 
 export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 export type ModelThinkingLevel = "off" | ThinkingLevel;
@@ -261,6 +269,15 @@ export interface ProviderImages {
 	): Promise<AssistantImages>;
 }
 
+/**
+ * The uniform contract of a music-generation API implementation module:
+ * every music API module under `src/api/` exports exactly `generateMusic`,
+ * so the module itself satisfies this interface.
+ */
+export interface ProviderMusic {
+	generateMusic(model: MusicModel<MusicApi>, context: MusicContext, options?: MusicOptions): Promise<AssistantMusic>;
+}
+
 export interface ImagesOptions {
 	signal?: AbortSignal;
 	apiKey?: string;
@@ -311,6 +328,47 @@ export interface ImagesOptions {
 
 export type ProviderImagesOptions = ImagesOptions & Record<string, unknown>;
 
+export interface MusicOptions {
+	signal?: AbortSignal;
+	apiKey?: string;
+	/** Optional fetch implementation for provider HTTP requests. Defaults to `globalThis.fetch`. */
+	fetch?: FetchFunction;
+	/** Provider-scoped environment values. These take precedence over process.env for provider configuration. */
+	env?: ProviderEnv;
+	/**
+	 * Optional callback for inspecting or replacing provider payloads before sending.
+	 * Return undefined to keep the payload unchanged.
+	 */
+	onPayload?: (payload: unknown, model: MusicModel<MusicApi>) => unknown | undefined | Promise<unknown | undefined>;
+	/**
+	 * Optional callback invoked after an HTTP response is received.
+	 */
+	onResponse?: (response: ProviderResponse, model: MusicModel<MusicApi>) => void | Promise<void>;
+	/**
+	 * Optional custom HTTP headers to include in API requests.
+	 * Merged with provider defaults; caller values override provider defaults.
+	 */
+	headers?: ProviderHeaders;
+	/**
+	 * HTTP request timeout in milliseconds for providers/SDKs that support it.
+	 */
+	timeoutMs?: number;
+	/**
+	 * Maximum retry attempts for providers/SDKs that support client-side retries.
+	 */
+	maxRetries?: number;
+	/**
+	 * Maximum delay in milliseconds to wait for a retry when the server requests a long wait.
+	 */
+	maxRetryDelayMs?: number;
+	/**
+	 * Optional metadata to include in API requests.
+	 */
+	metadata?: Record<string, unknown>;
+}
+
+export type ProviderMusicOptions = MusicOptions & Record<string, unknown>;
+
 // Unified options with reasoning passed to streamSimple() and completeSimple()
 export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ThinkingLevel;
@@ -337,6 +395,12 @@ export type ImagesFunction<TApi extends ImagesApi = ImagesApi, TOptions extends 
 	context: ImagesContext,
 	options?: TOptions,
 ) => Promise<AssistantImages>;
+
+export type MusicFunction<TApi extends MusicApi = MusicApi, TOptions extends MusicOptions = MusicOptions> = (
+	model: MusicModel<TApi>,
+	context: MusicContext,
+	options?: TOptions,
+) => Promise<AssistantMusic>;
 
 export interface TextSignatureV1 {
 	v: 1;
@@ -458,6 +522,71 @@ export interface AssistantImages {
 	responseId?: string;
 	usage?: Usage;
 	stopReason: ImagesStopReason;
+	errorMessage?: string;
+	timestamp: number; // Unix timestamp in milliseconds
+}
+
+export type MusicOutputFormat = "url" | "hex";
+export type MusicAudioFormat = "mp3" | "wav" | "pcm";
+export type MusicRegion = "global_en" | "cn_zh";
+export type MusicRegionalField = "aigc_watermark";
+
+export interface MusicAudioSetting {
+	sampleRate?: number;
+	bitrate?: number;
+	format?: MusicAudioFormat;
+}
+
+export interface MusicContext {
+	prompt?: string;
+	lyrics?: string;
+	stream?: boolean;
+	outputFormat?: MusicOutputFormat;
+	audioSetting?: MusicAudioSetting;
+	lyricsOptimizer?: boolean;
+	isInstrumental?: boolean;
+	/** Reference audio URL for cover generation (mutually exclusive with `audioBase64`). */
+	audioUrl?: string;
+	/** Reference audio as base64 for cover generation (mutually exclusive with `audioUrl`). */
+	audioBase64?: string;
+	/** Cover feature id returned by the voice cloning flow; sent for cover requests. */
+	coverFeatureId?: string;
+	/** AI-generated content watermark, only sent for the CN regional endpoint. */
+	aigcWatermark?: boolean;
+}
+
+/**
+ * Cover input constraints for models that generate a music cover from a
+ * reference track. Cover requests must supply exactly one of the reference
+ * inputs and keep the reference within the documented duration/size bounds.
+ */
+export interface MusicCoverCapabilities {
+	inputOneOf: readonly ("audio_url" | "audio_base64")[];
+	inputMinSeconds: number;
+	inputMaxSeconds: number;
+	inputMaxMb: number;
+}
+
+export type MusicGenerationStatus = "in_progress" | "completed";
+
+export interface MusicAudioContent {
+	type: "audio";
+	data: string;
+	outputFormat: MusicOutputFormat;
+	audioFormat?: MusicAudioFormat;
+}
+
+export type MusicStopReason = "in_progress" | "stop" | "error" | "aborted";
+
+export interface AssistantMusic {
+	api: MusicApi;
+	provider: MusicProviderId;
+	model: string;
+	output: MusicAudioContent[];
+	responseId?: string;
+	/** Generation lifecycle status reported by the API. */
+	status?: MusicGenerationStatus;
+	stopReason: MusicStopReason;
 	errorMessage?: string;
 	timestamp: number; // Unix timestamp in milliseconds
 }
@@ -806,4 +935,23 @@ export interface ImagesModel<TApi extends ImagesApi>
 	api: TApi;
 	provider: ImagesProviderId;
 	output: ("text" | "image")[];
+}
+
+export interface MusicModel<TApi extends MusicApi> {
+	id: string;
+	name: string;
+	api: TApi;
+	provider: MusicProviderId;
+	baseUrl: string;
+	region: MusicRegion;
+	outputFormats: readonly MusicOutputFormat[];
+	/** Streaming only supports hexadecimal audio output. */
+	streamOutputFormats: readonly MusicOutputFormat[];
+	audioFormats: readonly MusicAudioFormat[];
+	urlTtlHours: number;
+	/** Region-specific request fields the provider accepts for this model. */
+	regionalFields: readonly MusicRegionalField[];
+	/** Present on models that generate a music cover from a reference track. */
+	cover?: MusicCoverCapabilities;
+	headers?: Record<string, string>;
 }

--- a/packages/ai/test/minimax-music.test.ts
+++ b/packages/ai/test/minimax-music.test.ts
@@ -159,11 +159,7 @@ describe("MiniMax music generation and cover", () => {
 				{ status: 200 },
 			);
 
-		const result = await generateMusic(
-			model,
-			{ audioBase64: "ZmFrZQ==" },
-			{ apiKey: "test-key", fetch: fetchMock },
-		);
+		const result = await generateMusic(model, { audioBase64: "ZmFrZQ==" }, { apiKey: "test-key", fetch: fetchMock });
 		expect(result.stopReason).toBe("error");
 		expect(result.output).toEqual([]);
 		expect(result.errorMessage).toContain("MiniMax music API error (1001): request rejected");

--- a/packages/ai/test/minimax-music.test.ts
+++ b/packages/ai/test/minimax-music.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { generateMusic } from "../src/music.ts";
+import { getMusicModel, getMusicModels } from "../src/music-model-catalog.ts";
+
+describe("MiniMax music generation and cover", () => {
+	it("sends a cover request to the global endpoint and parses URL audio output", async () => {
+		const model = getMusicModel("minimax", "music-cover");
+		let requestUrl = "";
+		let requestInit: RequestInit | undefined;
+		let responseStatus = 0;
+		const fetchMock: typeof fetch = async (input, init) => {
+			requestUrl = String(input);
+			requestInit = init;
+			return new Response(
+				JSON.stringify({
+					trace_id: "trace-cover-global",
+					data: { status: 2, audio: "https://example.test/cover.mp3" },
+					base_resp: { status_code: 0, status_msg: "success" },
+				}),
+				{ status: 200, headers: { "x-request-id": "req-cover-global" } },
+			);
+		};
+
+		const result = await generateMusic(
+			model,
+			{
+				outputFormat: "url",
+				audioUrl: "https://example.test/reference.mp3",
+				coverFeatureId: "feature-1",
+				audioSetting: { format: "mp3" },
+			},
+			{
+				apiKey: "test-key",
+				fetch: fetchMock,
+				headers: { "x-client": "pi" },
+				onResponse: (response) => {
+					responseStatus = response.status;
+				},
+			},
+		);
+
+		expect(requestUrl).toBe("https://api.minimax.io/v1/music_generation");
+		expect(requestInit?.method).toBe("POST");
+		const headers = new Headers(requestInit?.headers);
+		expect(headers.get("authorization")).toBe("Bearer test-key");
+		expect(headers.get("content-type")).toBe("application/json");
+		expect(headers.get("x-client")).toBe("pi");
+		expect(JSON.parse(String(requestInit?.body))).toEqual({
+			model: "music-cover",
+			output_format: "url",
+			audio_setting: { format: "mp3" },
+			audio_url: "https://example.test/reference.mp3",
+			cover_feature_id: "feature-1",
+		});
+		expect(responseStatus).toBe(200);
+		expect(result).toMatchObject({
+			responseId: "trace-cover-global",
+			status: "completed",
+			stopReason: "stop",
+			output: [{ type: "audio", data: "https://example.test/cover.mp3", outputFormat: "url", audioFormat: "mp3" }],
+		});
+	});
+
+	it("sends a cover request to the CN endpoint with aigc_watermark and parses hexadecimal audio", async () => {
+		const model = getMusicModel("minimax-cn", "music-cover-free");
+		let requestUrl = "";
+		let payload: Record<string, unknown> = {};
+		const fetchMock: typeof fetch = async (input, init) => {
+			requestUrl = String(input);
+			payload = JSON.parse(String(init?.body));
+			return new Response(
+				JSON.stringify({
+					trace_id: "trace-cover-cn",
+					data: { status: 2, audio: "0a0b0c0d" },
+					base_resp: { status_code: 0 },
+				}),
+				{ status: 200 },
+			);
+		};
+
+		const result = await generateMusic(
+			model,
+			{
+				outputFormat: "hex",
+				audioBase64: "ZmFrZS1hdWRpbw==",
+				aigcWatermark: true,
+			},
+			{ apiKey: "test-key", fetch: fetchMock },
+		);
+
+		expect(requestUrl).toBe("https://api.minimaxi.com/v1/music_generation");
+		expect(payload).toMatchObject({
+			model: "music-cover-free",
+			output_format: "hex",
+			audio_base64: "ZmFrZS1hdWRpbw==",
+			aigc_watermark: true,
+		});
+		expect(result.output[0]).toEqual({
+			type: "audio",
+			data: "0a0b0c0d",
+			outputFormat: "hex",
+		});
+	});
+
+	it("rejects cover requests without exactly one reference input", async () => {
+		const model = getMusicModel("minimax", "music-cover");
+		const fetchMock: typeof fetch = async () =>
+			new Response(JSON.stringify({ data: { status: 2, audio: "0a" }, base_resp: { status_code: 0 } }), {
+				status: 200,
+			});
+
+		const missing = await generateMusic(model, {}, { apiKey: "test-key", fetch: fetchMock });
+		expect(missing.stopReason).toBe("error");
+		expect(missing.errorMessage).toContain("exactly one of audio_url or audio_base64");
+
+		const both = await generateMusic(
+			model,
+			{ audioUrl: "https://example.test/a.mp3", audioBase64: "ZmFrZQ==" },
+			{ apiKey: "test-key", fetch: fetchMock },
+		);
+		expect(both.stopReason).toBe("error");
+		expect(both.errorMessage).toContain("exactly one of audio_url or audio_base64");
+	});
+
+	it("rejects cover reference audio that exceeds the documented size limit", async () => {
+		const model = getMusicModel("minimax", "music-cover");
+		const oversized = "A".repeat(70 * 1024 * 1024); // base64 representing well over 50 MB of audio
+		const result = await generateMusic(
+			model,
+			{ audioBase64: oversized },
+			{ apiKey: "test-key", fetch: async () => new Response("{}", { status: 200 }) },
+		);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("50 MB size limit");
+	});
+
+	it("returns in-progress responses for async cover generation", async () => {
+		const model = getMusicModel("minimax", "music-cover");
+		const fetchMock: typeof fetch = async () =>
+			new Response(JSON.stringify({ data: { status: 1 }, base_resp: { status_code: 0 } }), { status: 200 });
+
+		const result = await generateMusic(
+			model,
+			{ audioUrl: "https://example.test/reference.mp3" },
+			{ apiKey: "test-key", fetch: fetchMock },
+		);
+		expect(result).toMatchObject({ status: "in_progress", stopReason: "in_progress" });
+		expect(result.output).toEqual([]);
+	});
+
+	it("returns an error result when the API status code is non-zero", async () => {
+		const model = getMusicModel("minimax-cn", "music-cover");
+		const fetchMock: typeof fetch = async () =>
+			new Response(
+				JSON.stringify({
+					data: { status: 2, audio: "0a" },
+					base_resp: { status_code: 1001, status_msg: "request rejected" },
+				}),
+				{ status: 200 },
+			);
+
+		const result = await generateMusic(
+			model,
+			{ audioBase64: "ZmFrZQ==" },
+			{ apiKey: "test-key", fetch: fetchMock },
+		);
+		expect(result.stopReason).toBe("error");
+		expect(result.output).toEqual([]);
+		expect(result.errorMessage).toContain("MiniMax music API error (1001): request rejected");
+	});
+
+	it("exposes generation and cover models in both regional catalogs", () => {
+		for (const provider of ["minimax", "minimax-cn"] as const) {
+			const models = getMusicModels(provider);
+			expect(models.map((model) => model.id)).toEqual([
+				"music-3.0",
+				"music-2.6",
+				"music-3.0-free",
+				"music-2.6-free",
+				"music-cover",
+				"music-cover-free",
+			]);
+			const coverModels = models.filter((model) => model.cover);
+			expect(coverModels.map((model) => model.id)).toEqual(["music-cover", "music-cover-free"]);
+			expect(coverModels.every((model) => model.cover?.inputOneOf.join(",") === "audio_url,audio_base64")).toBe(
+				true,
+			);
+			expect(coverModels.every((model) => model.cover?.inputMaxMb === 50)).toBe(true);
+			expect(models.every((model) => model.outputFormats.join(",") === "url,hex")).toBe(true);
+			expect(models.every((model) => model.streamOutputFormats.join(",") === "hex")).toBe(true);
+			expect(models.every((model) => model.audioFormats.join(",") === "mp3,wav,pcm")).toBe(true);
+			expect(models.every((model) => model.urlTtlHours === 24)).toBe(true);
+		}
+
+		expect(getMusicModel("minimax", "music-cover").region).toBe("global_en");
+		expect(getMusicModel("minimax-cn", "music-cover").regionalFields).toEqual(["aigc_watermark"]);
+		expect(getMusicModel("minimax", "music-cover").regionalFields).toEqual([]);
+	});
+});

--- a/packages/ai/test/music-models.test.ts
+++ b/packages/ai/test/music-models.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { AuthContext } from "../src/auth/types.ts";
+import { builtinMusicModels } from "../src/providers/all.ts";
+
+function fakeAuthContext(env: Record<string, string>): AuthContext {
+	return {
+		env: async (name) => env[name],
+		fileExists: async () => false,
+	};
+}
+
+describe("MusicModels", () => {
+	it("registers both regional providers and resolves their API keys", async () => {
+		const models = builtinMusicModels({
+			authContext: fakeAuthContext({ MINIMAX_API_KEY: "global-key", MINIMAX_CN_API_KEY: "cn-key" }),
+		});
+		expect(models.getProviders().map((provider) => provider.id)).toEqual(["minimax", "minimax-cn"]);
+
+		const globalModel = models.getModel("minimax", "music-cover")!;
+		const cnModel = models.getModel("minimax-cn", "music-cover")!;
+		expect((await models.getAuth(globalModel))?.auth.apiKey).toBe("global-key");
+		expect((await models.getAuth(cnModel))?.auth.apiKey).toBe("cn-key");
+	});
+
+	it("injects resolved auth into cover requests and lets explicit options win", async () => {
+		const models = builtinMusicModels({ authContext: fakeAuthContext({ MINIMAX_API_KEY: "global-key" }) });
+		const model = models.getModel("minimax", "music-cover")!;
+		const authHeaders: string[] = [];
+		const fetchMock: typeof fetch = async (_input, init) => {
+			authHeaders.push(new Headers(init?.headers).get("authorization") ?? "");
+			return new Response(
+				JSON.stringify({ data: { status: 2, audio: "https://example.test/o.mp3" }, base_resp: { status_code: 0 } }),
+				{ status: 200 },
+			);
+		};
+
+		const fromEnv = await models.generateMusic(
+			model,
+			{ outputFormat: "url", audioUrl: "https://example.test/ref.mp3" },
+			{ fetch: fetchMock },
+		);
+		expect(fromEnv.stopReason).toBe("stop");
+
+		const explicit = await models.generateMusic(
+			model,
+			{ outputFormat: "url", audioUrl: "https://example.test/ref.mp3" },
+			{ apiKey: "explicit-key", fetch: fetchMock },
+		);
+		expect(explicit.stopReason).toBe("stop");
+		expect(authHeaders).toEqual(["Bearer global-key", "Bearer explicit-key"]);
+	});
+});

--- a/packages/ai/test/music-models.test.ts
+++ b/packages/ai/test/music-models.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { AuthContext } from "../src/auth/types.ts";
-import { builtinMusicModels } from "../src/providers/all.ts";
+import { createMusicModels } from "../src/music-models.ts";
+import { minimaxCnMusicProvider } from "../src/providers/minimax-cn-music.ts";
+import { minimaxMusicProvider } from "../src/providers/minimax-music.ts";
 
 function fakeAuthContext(env: Record<string, string>): AuthContext {
 	return {
@@ -9,11 +11,17 @@ function fakeAuthContext(env: Record<string, string>): AuthContext {
 	};
 }
 
+function builtinMusicModels(env: Record<string, string>) {
+	const models = createMusicModels({ authContext: fakeAuthContext(env) });
+	for (const provider of [minimaxMusicProvider(), minimaxCnMusicProvider()]) {
+		models.setProvider(provider);
+	}
+	return models;
+}
+
 describe("MusicModels", () => {
 	it("registers both regional providers and resolves their API keys", async () => {
-		const models = builtinMusicModels({
-			authContext: fakeAuthContext({ MINIMAX_API_KEY: "global-key", MINIMAX_CN_API_KEY: "cn-key" }),
-		});
+		const models = builtinMusicModels({ MINIMAX_API_KEY: "global-key", MINIMAX_CN_API_KEY: "cn-key" });
 		expect(models.getProviders().map((provider) => provider.id)).toEqual(["minimax", "minimax-cn"]);
 
 		const globalModel = models.getModel("minimax", "music-cover")!;
@@ -23,7 +31,7 @@ describe("MusicModels", () => {
 	});
 
 	it("injects resolved auth into cover requests and lets explicit options win", async () => {
-		const models = builtinMusicModels({ authContext: fakeAuthContext({ MINIMAX_API_KEY: "global-key" }) });
+		const models = builtinMusicModels({ MINIMAX_API_KEY: "global-key" });
 		const model = models.getModel("minimax", "music-cover")!;
 		const authHeaders: string[] = [];
 		const fetchMock: typeof fetch = async (_input, init) => {


### PR DESCRIPTION
Reason: Add the MiniMax music cover path (music-cover/music-cover-free via POST /v1/music_generation) to the runtime media-generation registry.

## What changed

- Added a music-generation API registry (`music-api-registry.ts`) plus a `MusicModels` provider collection (`music-models.ts`) mirroring the existing image-generation registry, so media generation for music is registered and resolved through the same runtime pattern.
- Added a MiniMax music API module (`api/minimax-music.ts`) that POSTs to `/v1/music_generation` with bearer auth and JSON content type. Cover requests send a reference track via `audio_url` or `audio_base64` (exactly one is required) together with an optional `cover_feature_id`, and the CN regional endpoint supports the `aigc_watermark` watermark field.
- Added the MiniMax and MiniMax CN music providers with the global (`api.minimax.io`) and CN (`api.minimaxi.com`) regional endpoints and their generation and cover model catalogs (`music-cover`, `music-cover-free`, plus the generation models).
- Responses are parsed from `base_resp.status_code` (0 = success) and `data.status` (1 = in progress, 2 = completed), with audio taken from `data.audio` as either a URL or hexadecimal bytes. Cover reference input is validated against the documented constraints (exactly one of `audio_url`/`audio_base64`, reference audio size limit).
- Wired the new modules into the package entry points, side-effect registration, and changelog.

## Checks

- `vitest --run packages/ai/test/minimax-music.test.ts packages/ai/test/music-models.test.ts` — 9 tests passed.
- `biome check` on the changed files — clean.
- `tsc --noEmit -p packages/ai/tsconfig.build.json` — no errors from the new modules (remaining pre-existing errors are the generated provider data files that are produced by `npm run generate-models`).
