### PR TITLE
fix(tui): close dangling OSC 8 hyperlink when truncateToWidth cuts inside it

### DIFF
--- a/packages/coding-agent/examples/extensions/notify.ts
+++ b/packages/coding-agent/examples/extensions/notify.ts
@@ -49,7 +49,11 @@ function notify(title: string, body: string): void {
 }
 
 export default function (pi: ExtensionAPI) {
-	pi.on("agent_end", async () => {
+	// agent_settled fires when the agent is fully idle — after automatic
+	// retries, compaction retries, and queued follow-up continuations.
+	// agent_end fires after each low-level run and can fire while Pi is
+	// still working, so it would notify too early.
+	pi.on("agent_settled", async () => {
 		notify("Pi", "Ready for input");
 	});
 }

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed `truncateToWidth()` leaving a dangling OSC 8 hyperlink when truncation lands inside a hyperlink, which bled the link into the ellipsis and subsequent terminal output ([#7399](https://github.com/earendil-works/pi/issues/7399)).
 - Fixed Windows console truecolor detection when Windows Terminal does not provide `WT_SESSION` to child shells.
 - Fixed terminal width accounting for Indic conjunct grapheme clusters ([#6124](https://github.com/earendil-works/pi/issues/6124) by [@petrroll](https://github.com/petrroll)).
 - Fixed phantom alternate-screen text selection from unmatched mouse events when changing terminal pane focus.

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -166,6 +166,29 @@ function finalizeTruncatedResult(
 }
 
 /**
+ * If `text` ends inside an OSC 8 hyperlink (opened but not closed),
+ * return the close sequence so truncation cannot bleed the link into
+ * the ellipsis or subsequent terminal output.
+ */
+function closeDanglingHyperlink(text: string): string {
+	if (!text.includes("\x1b]8;")) return "";
+	let open: ActiveHyperlink | null = null;
+	let i = 0;
+	while (i < text.length) {
+		const ansi = extractAnsiCode(text, i);
+		if (ansi) {
+			const hyperlink = parseOsc8Hyperlink(ansi.code);
+			// undefined = not OSC 8; null = close (empty url); otherwise open.
+			if (hyperlink !== undefined) open = hyperlink;
+			i += ansi.length;
+		} else {
+			i++;
+		}
+	}
+	return open ? formatOsc8Close(open.terminator) : "";
+}
+
+/**
  * Calculate the terminal width of a single grapheme cluster.
  * Based on code from the string-width library, but includes a possible-emoji
  * check to avoid running the RGI_Emoji regex unnecessarily.
@@ -1161,6 +1184,10 @@ export function truncateToWidth(
 	if (!overflowed && exhaustedInput) {
 		return pad ? text + " ".repeat(Math.max(0, maxWidth - visibleSoFar)) : text;
 	}
+
+	// Close an OSC 8 hyperlink if truncation lands inside it, so the link
+	// does not bleed into the ellipsis or subsequent terminal output.
+	result += closeDanglingHyperlink(result);
 
 	return finalizeTruncatedResult(result, keptWidth, ellipsis, ellipsisWidth, maxWidth, pad);
 }

--- a/packages/tui/test/truncate-to-width.test.ts
+++ b/packages/tui/test/truncate-to-width.test.ts
@@ -53,6 +53,27 @@ describe("truncateToWidth", () => {
 		const truncated = truncateToWidth("🙂\t界 \x1b_abc\x07", 7, "…", true);
 		assert.strictEqual(truncated, "🙂\t\x1b[0m…\x1b[0m ");
 	});
+
+	it("closes a dangling OSC 8 hyperlink when truncating inside it", () => {
+		const link = (url: string, label: string) => `\x1b]8;;${url}\x07${label}\x1b]8;;\x07`;
+		const truncated = truncateToWidth(link("https://example.com", "some-longer-label-here"), 15);
+
+		// One open, one close — no dangling hyperlink written to the terminal.
+		const opens = (truncated.match(/\x1b\]8;[^;]*;[^\x07\x1b]+\x07/g) ?? []).length;
+		const closes = (truncated.match(/\x1b\]8;;\x07/g) ?? []).length;
+		assert.strictEqual(opens, 1);
+		assert.strictEqual(closes, 1);
+		assert.ok(visibleWidth(truncated) <= 15);
+	});
+
+	it("does not add a spurious close when truncation lands outside the hyperlink", () => {
+		const link = (url: string, label: string) => `\x1b]8;;${url}\x07${label}\x1b]8;;\x07`;
+		const fits = truncateToWidth(link("https://example.com", "short"), 40);
+		assert.strictEqual(fits, link("https://example.com", "short"));
+
+		const afterClose = truncateToWidth(link("https://example.com", "label") + "tail text", 30);
+		assert.ok(!afterClose.includes("\x1b]8;;\x07\x1b]8;;\x07")); // no double close
+	});
 });
 
 describe("visibleWidth", () => {


### PR DESCRIPTION
Fixes #7399

`truncateToWidth()` keeps ANSI codes verbatim as it walks the input, so truncating inside an OSC 8 hyperlink (open emitted, close beyond the cut) leaves a dangling link that bleeds into the ellipsis and subsequent terminal output. Reproducible with the snippet from the issue; visible when resizing widgets containing PR links.

The kept prefix is now scanned for OSC 8 balance and a close sequence with the original terminator (BEL or ST) is appended before the trailing reset, so output always has balanced hyperlink sequences. The `visibleWidth()` and wrap-time reopen-across-wrap cases were already handled; truncation was the remaining gap.

Also included: #7350 — the `notify` example hooks `agent_settled` instead of `agent_end`, so "Ready for input" no longer fires while retries or queued follow-up continuations are still running.
