### PR TITLE
fix(examples): accept array-form `tools` in the subagent example

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/agents.ts
+++ b/packages/coding-agent/examples/extensions/subagent/agents.ts
@@ -23,6 +23,42 @@ export interface AgentDiscoveryResult {
 	projectAgentsDir: string | null;
 }
 
+/**
+ * Raw agent frontmatter. Values are `unknown` because `parseFrontmatter` runs a
+ * real YAML parser, so any scalar or collection can appear here.
+ *
+ * A type alias rather than an interface: `parseFrontmatter` constrains its
+ * parameter to `Record<string, unknown>`, and only an alias picks up the
+ * implicit index signature that satisfies it.
+ */
+type AgentFrontmatter = {
+	name?: unknown;
+	description?: unknown;
+	tools?: unknown;
+	model?: unknown;
+};
+
+/**
+ * Normalize a frontmatter `tools` value to a list of tool names.
+ *
+ * Both spellings are valid YAML and both are in use:
+ *
+ *     tools: read, bash        # string
+ *     tools: [read, bash]      # array
+ *
+ * so accept either. Anything else (a number, a map, a nested list) yields no
+ * tools rather than throwing: this runs inside agent discovery, where a single
+ * bad file must not take down every other agent in the same directory.
+ */
+function parseToolList(value: unknown): string[] | undefined {
+	const raw = Array.isArray(value) ? value : typeof value === "string" ? value.split(",") : [];
+	const tools = raw
+		.filter((t): t is string => typeof t === "string")
+		.map((t) => t.trim())
+		.filter(Boolean);
+	return tools.length > 0 ? tools : undefined;
+}
+
 function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
@@ -49,22 +85,17 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 			continue;
 		}
 
-		const { frontmatter, body } = parseFrontmatter<Record<string, string>>(content);
+		const { frontmatter, body } = parseFrontmatter<AgentFrontmatter>(content);
 
-		if (!frontmatter.name || !frontmatter.description) {
+		if (typeof frontmatter.name !== "string" || typeof frontmatter.description !== "string") {
 			continue;
 		}
-
-		const tools = frontmatter.tools
-			?.split(",")
-			.map((t: string) => t.trim())
-			.filter(Boolean);
 
 		agents.push({
 			name: frontmatter.name,
 			description: frontmatter.description,
-			tools: tools && tools.length > 0 ? tools : undefined,
-			model: frontmatter.model,
+			tools: parseToolList(frontmatter.tools),
+			model: typeof frontmatter.model === "string" ? frontmatter.model : undefined,
 			systemPrompt: body,
 			source,
 			filePath,


### PR DESCRIPTION
`examples/extensions/subagent/agents.ts` reads the agent `tools` frontmatter with `frontmatter.tools?.split(",")`. `parseFrontmatter` runs a real YAML parser, so

```yaml
tools: [read, bash]
```

arrives as an array and `.split` throws `TypeError: frontmatter.tools?.split is not a function`.

The throw escapes `loadAgentsFromDir` — only `readdirSync` and `readFileSync` are wrapped — so one agent file using the array form breaks discovery for **every** agent in that scope, not just itself.

The array form also looks correct from the outside: `AgentConfig.tools` is already typed `string[]`. What keeps `tsc` quiet is the `parseFrontmatter<Record<string, string>>` annotation, which asserts a shape the YAML parser never guarantees.

## Change

Normalize both spellings in one helper (array → as-is, string → split on commas, anything else → no tools), and type the frontmatter fields `unknown` so the string assumptions are explicit. `name` / `description` / `model` get the same treatment, which falls out of dropping the `Record<string, string>` annotation.

One file, no core changes.

## Verification

- `biome check --error-on-warnings` clean on the file.
- `tsgo --noEmit`: the file is clean.
- `parseToolList` exercised over array, comma string, single value, empty array, empty string, `undefined`, number, map, nested list, and mixed array.

I could not get a green `npm run check` on a fresh clone. `tsgo --noEmit` reports 745 errors on pristine `main` (model catalog plus tests: `Type 'unknown' does not satisfy the constraint 'ModelGroups'`, and cascading `never` model IDs), and the same 745 with this patch applied — so this change adds none. If there is a model-data hydrate/generate step I missed before `check`, tell me and I will rerun it.
