### PR TITLE
fix(ai): keep response bodies out of OAuth error messages

### DIFF
--- a/packages/ai/src/auth/oauth/anthropic.ts
+++ b/packages/ai/src/auth/oauth/anthropic.ts
@@ -181,7 +181,7 @@ async function postJson(url: string, body: Record<string, string | number>, sign
 	const responseBody = await response.text();
 
 	if (!response.ok) {
-		throw new Error(`HTTP request failed. status=${response.status}; url=${url}; body=${responseBody}`);
+		throw new Error(`HTTP request failed. status=${response.status}; url=${url}`);
 	}
 
 	return responseBody;
@@ -219,7 +219,7 @@ async function exchangeAuthorizationCode(
 		tokenData = JSON.parse(responseBody) as { access_token: string; refresh_token: string; expires_in: number };
 	} catch (error) {
 		throw new Error(
-			`Token exchange returned invalid JSON. url=${TOKEN_URL}; body=${responseBody}; details=${formatErrorDetails(error)}`,
+			`Token exchange returned invalid JSON. url=${TOKEN_URL}; details=${formatErrorDetails(error)}`,
 		);
 	}
 
@@ -340,7 +340,7 @@ async function refreshAnthropicToken(refreshToken: string, signal: AbortSignal):
 		};
 	} catch (error) {
 		throw new Error(
-			`Anthropic token refresh returned invalid JSON. url=${TOKEN_URL}; body=${responseBody}; details=${formatErrorDetails(error)}`,
+			`Anthropic token refresh returned invalid JSON. url=${TOKEN_URL}; details=${formatErrorDetails(error)}`,
 		);
 	}
 

--- a/packages/ai/src/auth/oauth/openai-codex.ts
+++ b/packages/ai/src/auth/oauth/openai-codex.ts
@@ -125,18 +125,19 @@ async function fetchWithLoginCancellation(input: string, init: RequestInit): Pro
 
 async function readTokenResponse(response: Response, operation: TokenOperation): Promise<OAuthToken> {
 	if (!response.ok) {
-		const text = await response.text().catch(() => "");
-		throw new Error(`OpenAI Codex token ${operation} failed (${response.status}): ${text || response.statusText}`);
+		throw new Error(`OpenAI Codex token ${operation} failed (${response.status}: ${response.statusText})`);
 	}
 
-	const rawJson = await response.json();
+	const rawJson = await response.json().catch(() => {
+		throw new Error(`OpenAI Codex token ${operation} returned invalid JSON`);
+	});
 	const json = rawJson as {
 		access_token?: string;
 		refresh_token?: string;
 		expires_in?: number;
 	} | null;
 	if (!json?.access_token || !json.refresh_token || typeof json.expires_in !== "number") {
-		throw new Error(`OpenAI Codex token ${operation} response missing fields: ${JSON.stringify(json)}`);
+		throw new Error(`OpenAI Codex token ${operation} response missing fields`);
 	}
 
 	return {
@@ -202,10 +203,7 @@ async function startOpenAICodexDeviceAuth(signal: AbortSignal): Promise<DeviceAu
 				"OpenAI Codex device code login is not enabled for this server. Use browser login or verify the server URL.",
 			);
 		}
-		const responseBody = await response.text().catch(() => "");
-		throw new Error(
-			`OpenAI Codex device code request failed with status ${response.status}${responseBody ? `: ${responseBody}` : ""}`,
-		);
+		throw new Error(`OpenAI Codex device code request failed with status ${response.status}`);
 	}
 
 	const rawJson = await response.json();
@@ -222,7 +220,7 @@ async function startOpenAICodexDeviceAuth(signal: AbortSignal): Promise<DeviceAu
 		!Number.isFinite(intervalSeconds) ||
 		intervalSeconds < 0
 	) {
-		throw new Error(`Invalid OpenAI Codex device code response: ${JSON.stringify(json)}`);
+		throw new Error("Invalid OpenAI Codex device code response");
 	}
 
 	return {
@@ -254,7 +252,7 @@ async function pollOpenAICodexDeviceAuth(device: DeviceAuthInfo, signal: AbortSi
 				if (!json?.authorization_code || !json.code_verifier) {
 					return {
 						status: "failed",
-						message: `Invalid OpenAI Codex device auth token response: ${JSON.stringify(json)}`,
+						message: "Invalid OpenAI Codex device auth token response",
 					};
 				}
 				return {
@@ -284,7 +282,7 @@ async function pollOpenAICodexDeviceAuth(device: DeviceAuthInfo, signal: AbortSi
 
 			return {
 				status: "failed",
-				message: `OpenAI Codex device auth failed with status ${response.status}${responseBody ? `: ${responseBody}` : ""}`,
+				message: `OpenAI Codex device auth failed with status ${response.status}`,
 			};
 		},
 	});

--- a/packages/ai/test/oauth-error-hygiene.test.ts
+++ b/packages/ai/test/oauth-error-hygiene.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { anthropicOAuth } from "../src/auth/oauth/anthropic.ts";
+import { openaiCodexOAuth } from "../src/auth/oauth/openai-codex.ts";
+import type { OAuthCredential } from "../src/auth/types.ts";
+
+/**
+ * OAuth error messages must never embed token-endpoint response bodies.
+ *
+ * A token response carries access and refresh tokens; a failure body can echo
+ * request parameters. Error messages propagate into logs, telemetry, and user
+ * dialogs, so they carry the status and a stable description — never the body.
+ */
+
+const SECRET = "sk-live-SENTINEL-DO-NOT-LEAK";
+const neverAbortedSignal = new AbortController().signal;
+
+const credential: OAuthCredential = {
+	type: "oauth",
+	access: "stale-access",
+	refresh: "stale-refresh",
+	expires: 0,
+	accountId: "account-1",
+};
+
+function stubFetchResponse(body: string, status: number): void {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (): Promise<Response> => {
+			return new Response(body, { status, headers: { "Content-Type": "application/json" } });
+		}),
+	);
+}
+
+async function refreshError(oauth: typeof anthropicOAuth): Promise<string> {
+	const error: unknown = await oauth.refresh(credential, neverAbortedSignal).then(
+		() => {
+			throw new Error("Expected refresh to reject");
+		},
+		(refreshError: unknown) => refreshError,
+	);
+	return String(error);
+}
+
+describe.sequential("OAuth error hygiene", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("keeps an Anthropic failure body out of the refresh error", async () => {
+		stubFetchResponse(JSON.stringify({ error: "invalid_grant", hint: SECRET }), 400);
+
+		const message = await refreshError(anthropicOAuth);
+
+		expect(message).not.toContain(SECRET);
+		expect(message).toContain("400");
+	});
+
+	it("keeps an Anthropic invalid-JSON body out of the refresh error", async () => {
+		stubFetchResponse(`<html>${SECRET}</html>`, 200);
+
+		const message = await refreshError(anthropicOAuth);
+
+		expect(message).not.toContain(SECRET);
+		expect(message).toContain("invalid JSON");
+	});
+
+	it("keeps an OpenAI Codex failure body out of the refresh error", async () => {
+		stubFetchResponse(JSON.stringify({ error: SECRET }), 401);
+
+		const message = await refreshError(openaiCodexOAuth);
+
+		expect(message).not.toContain(SECRET);
+		expect(message).toContain("401");
+	});
+
+	it("keeps a partial OpenAI Codex token response out of the refresh error", async () => {
+		stubFetchResponse(JSON.stringify({ access_token: SECRET }), 200);
+
+		const message = await refreshError(openaiCodexOAuth);
+
+		expect(message).not.toContain(SECRET);
+		expect(message).toContain("missing fields");
+	});
+
+	it("keeps an OpenAI Codex invalid-JSON body out of the refresh error", async () => {
+		stubFetchResponse(`<html>${SECRET}</html>`, 200);
+
+		const message = await refreshError(openaiCodexOAuth);
+
+		expect(message).not.toContain(SECRET);
+	});
+});


### PR DESCRIPTION
Token-endpoint response bodies carry access and refresh tokens, and failure bodies can echo request parameters. These error messages propagate into logs, telemetry, and user-facing dialogs, so embedding the body — or a `JSON.stringify` of the partially-parsed token response, as in `readTokenResponse`'s missing-fields path — leaks credentials whenever a refresh or login fails partway.

Errors now carry the status and a stable description only. The previously unguarded `response.json()` calls in the Codex flow also map to a generic invalid-JSON error instead of a parser message quoting the body (V8's `JSON.parse` errors include a body snippet).

Test: `oauth-error-hygiene.test.ts` stubs `fetch` (same pattern as `anthropic-oauth.test.ts`) with responses carrying a sentinel secret across five failure modes — failure body, invalid JSON, and partial token response for both providers — and asserts the sentinel never reaches the thrown message while the status/description still does. Four of five cases fail without the source change.