### PR TITLE
fix(ai): let an explicit chatgpt-account-id header override JWT extraction for Codex

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -273,7 +273,7 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 				throw new Error(`No API key for provider: ${model.provider}`);
 			}
 
-			const accountId = extractAccountId(apiKey);
+			const accountId = resolveAccountId(options?.headers, apiKey);
 			const grammarToolInputProperties = createGrammarToolInputProperties(
 				context.tools,
 				model.compat?.supportsOpenAIGrammarTools ?? false,
@@ -1575,6 +1575,22 @@ async function parseErrorResponse(response: Response): Promise<{ message: string
 // ============================================================================
 // Auth & Headers
 // ============================================================================
+
+/**
+ * An explicitly provided chatgpt-account-id header wins over JWT extraction.
+ *
+ * Not every ChatGPT access token carries the chatgpt_account_id claim, so a
+ * caller that already knows the account (from the login exchange) must be able
+ * to state it instead of failing the request on a claim-less token.
+ */
+function resolveAccountId(headers: ProviderHeaders | undefined, token: string): string {
+	for (const [name, value] of Object.entries(headers || {})) {
+		if (name.toLowerCase() === "chatgpt-account-id" && typeof value === "string" && value.length > 0) {
+			return value;
+		}
+	}
+	return extractAccountId(token);
+}
 
 function extractAccountId(token: string): string {
 	try {

--- a/packages/ai/test/codex-account-id-header.test.ts
+++ b/packages/ai/test/codex-account-id-header.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { stream as streamCodex } from "../src/api/openai-codex-responses.ts";
+import type { Context, Model } from "../src/types.ts";
+
+/**
+ * An explicitly provided chatgpt-account-id header must win over JWT
+ * extraction: not every ChatGPT access token carries the chatgpt_account_id
+ * claim, and a caller that already knows the account (from the login
+ * exchange) must be able to state it instead of failing the request.
+ */
+
+const model: Model<"openai-codex-responses"> = {
+	id: "gpt-5.2-codex",
+	name: "GPT-5.2 Codex",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api/codex",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 272000,
+	maxTokens: 128000,
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+};
+
+function emptySseResponse(): Response {
+	return new Response("", { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+describe("OpenAI Codex account id resolution", () => {
+	it("prefers an explicit chatgpt-account-id header over JWT extraction", async () => {
+		let capturedAccountId: string | null | undefined;
+		const fetchMock = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			capturedAccountId = new Headers(init?.headers).get("chatgpt-account-id");
+			return emptySseResponse();
+		};
+
+		const stream = streamCodex(model, context, {
+			apiKey: "opaque-token-without-account-claim",
+			fetch: fetchMock as typeof fetch,
+			headers: { "chatgpt-account-id": "acct-explicit" },
+			transport: "sse",
+		});
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedAccountId).toBe("acct-explicit");
+	});
+});


### PR DESCRIPTION
Not every ChatGPT access token carries the `chatgpt_account_id` claim, so requests built purely from `extractAccountId(apiKey)` fail for accounts whose tokens omit it — even when the caller already knows the account id from the login exchange (the OAuth flow itself stores `credential.accountId`).

An explicitly provided `chatgpt-account-id` request header now wins, with JWT extraction as the unchanged fallback. Header lookup is case-insensitive; empty values are ignored.

Test: `codex-account-id-header.test.ts` drives `stream` over the SSE transport with a mocked `fetch`, an opaque non-JWT api key, and an explicit header, and asserts the outbound request carries the explicit account id. It fails without the source change (`Failed to extract accountId from token`).