### PR TITLE
fix(tui): add size param to iterm2 image encoder to support xterm.js image addon

### DIFF
--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -250,7 +250,10 @@ export function encodeITerm2(
 		inline?: boolean;
 	} = {},
 ): string {
-	const params: string[] = [`inline=${options.inline !== false ? 1 : 0}`];
+	const params: string[] = [
+		`inline=${options.inline !== false ? 1 : 0}`,
+		`size=${Buffer.byteLength(base64Data, "base64")}`,
+	];
 
 	if (options.width !== undefined) params.push(`width=${options.width}`);
 	if (options.height !== undefined) params.push(`height=${options.height}`);

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -13,6 +13,7 @@ import {
 	deleteAllKittyPlacements,
 	deleteKittyImage,
 	detectCapabilities,
+	encodeITerm2,
 	encodeKitty,
 	getKittyImageMetadata,
 	getKittyImagePlacement,
@@ -372,6 +373,13 @@ describe("detectCapabilities", () => {
 			assert.strictEqual(caps.hyperlinks, false);
 			assert.strictEqual(caps.images, null);
 		});
+	});
+});
+
+describe("iTerm2 image encoding", () => {
+	it("includes the decoded payload size in OSC 1337 metadata", () => {
+		const sequence = encodeITerm2("AAAA", { width: 2, height: "auto" });
+		assert.strictEqual(sequence, "\x1b]1337;File=inline=1;size=3;width=2;height=auto:AAAA\x07");
 	});
 });
 


### PR DESCRIPTION
- include decoded byte count in iterm2 osc 1337 sequences via `size` (see [docs](https://iterm2.com/documentation-images.html), search for `File size in bytes.`) so it satisfies `@xterm/addon-image@0.9.0` check (see [this](https://github.com/xtermjs/xterm.js/blob/6.0.0/addons/addon-image/src/IIPHandler.ts#L69))
  - will be fixed in the upcoming `0.10.0` though ([as commented](https://github.com/earendil-works/pi/issues/7465#issuecomment-5169247361) on the issue itself and visible [here](https://github.com/xtermjs/xterm.js/pull/5859/changes#diff-4322e48a4bf22b6c85545fa40374ebcdbfe93043aaf68d083d585cf5bac91081L80)) 
- fixes #7465