### PR TITLE
feat(coding-agent): resume failed turn by selecting it in /tree

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2731,6 +2731,56 @@ export class AgentSession {
 	}
 
 	/**
+	 * Prepare to retry a failed turn: if the given entry is a failed assistant turn
+	 * (stopReason "error", e.g. network failure), move the session leaf to the last
+	 * good message before the chain of failed attempts (in-session retries chain
+	 * error entries) and rebuild agent state. The failures stay in the session file
+	 * as abandoned branches but leave the active context.
+	 * @returns true if the entry was a failed turn and the leaf moved
+	 */
+	beginFailedTurnRetry(entryId: string): boolean {
+		if (this.isStreaming) return false;
+		const isFailedAttempt = (entry: SessionEntry | undefined): boolean =>
+			entry?.type === "message" &&
+			entry.message.role === "assistant" &&
+			(entry.message as AssistantMessage).stopReason === "error";
+
+		const entry = this.sessionManager.getEntry(entryId);
+		if (!entry || !isFailedAttempt(entry)) return false;
+		let targetId: string | null = entry.parentId;
+		while (targetId) {
+			const parent = this.sessionManager.getEntry(targetId);
+			if (!parent || !isFailedAttempt(parent)) break;
+			targetId = parent.parentId;
+		}
+		if (!targetId) return false;
+		this.sessionManager.branch(targetId);
+		this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+		return true;
+	}
+
+	/**
+	 * Re-run the current turn from the session leaf, e.g. to retry a failed turn
+	 * after beginFailedTurnRetry moved the leaf to the entry before the failure.
+	 * The failed assistant entry stays in the session file as an abandoned branch
+	 * (visible in /tree) but leaves the active context, so the retried response
+	 * becomes its sibling.
+	 */
+	async continueTurn(): Promise<void> {
+		this._isAgentRunActive = true;
+		try {
+			await this.agent.continue();
+			while (await this._handlePostAgentRun()) {
+				await this.agent.continue();
+			}
+		} finally {
+			this._systemPromptOverride = undefined;
+			this._flushPendingBashMessages();
+			await this._emitAgentSettled();
+		}
+	}
+
+	/**
 	 * Cancel in-progress retry.
 	 */
 	abortRetry(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4903,6 +4903,23 @@ export class InteractiveMode {
 		}
 	}
 
+	/**
+	 * Retry a failed turn (e.g. network error) selected in the tree: moves the leaf
+	 * to the entry before the failure, re-renders without the error, and re-runs the turn.
+	 * @returns true if the entry was a failed turn
+	 */
+	private async retryFailedTurnFrom(entryId: string): Promise<boolean> {
+		if (!this.session.beginFailedTurnRetry(entryId)) return false;
+		try {
+			this.chatContainer.clear();
+			this.renderInitialMessages();
+			await this.session.continueTurn();
+		} catch (error) {
+			this.showError(error instanceof Error ? error.message : String(error));
+		}
+		return true;
+	}
+
 	private showTreeSelector(initialSelectedId?: string): void {
 		const tree = this.sessionManager.getTree();
 		const realLeafId = this.sessionManager.getLeafId();
@@ -4919,17 +4936,27 @@ export class InteractiveMode {
 				realLeafId,
 				this.ui.terminal.rows,
 				async (entryId) => {
-					// Selecting the current leaf is a no-op (already there)
+					// Selecting the current leaf is a no-op (already there), unless it is a
+					// failed turn - then resume it (e.g. retry after a network error)
 					if (entryId === this.sessionManager.getLeafId()) {
 						done();
-						this.showStatus("Already at this point");
+						if (!(await this.retryFailedTurnFrom(entryId))) {
+							this.showStatus("Already at this point");
+						}
 						return;
 					}
 
-					// Ask about summarization
 					done(); // Close selector first
 
-					// Loop until user makes a complete choice or cancels to tree
+					// Selecting a failed turn (e.g. an assistant entry that ended with a
+					// connection error) retries it from the entry before the failure: the
+					// error leaves the active context and chat but stays in the tree as an
+					// abandoned branch
+					if (await this.retryFailedTurnFrom(entryId)) {
+						return;
+					}
+
+					// Ask about summarization, looping until the user makes a complete choice or cancels back to the tree
 					let wantsSummary = false;
 					let customInstructions: string | undefined;
 

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -165,6 +165,46 @@ describe("AgentSession retry", () => {
 		expect(created.session.isRetrying).toBe(false);
 	});
 
+	it("resumes an exhausted failed turn from its parent, dropping the error from context", async () => {
+		const created = await createSession({ failCount: 2, maxRetries: 1 });
+		const sessionManager = created.session.sessionManager;
+		const lastMessage = () => {
+			const msgs = created.session.messages;
+			return msgs[msgs.length - 1] as AssistantMessage;
+		};
+
+		await created.session.prompt("Test");
+		expect(created.getCallCount()).toBe(2);
+		expect(lastMessage().stopReason).toBe("error");
+
+		// Retry the failed turn the way the tree selector does. The error entry's
+		// parent is the first failed attempt (in-session retries chain error
+		// entries), so the leaf moves past them to the user message
+		const errorEntry = sessionManager.getLeafEntry()!;
+		expect(created.session.beginFailedTurnRetry(errorEntry.id)).toBe(true);
+		const resumeTarget = sessionManager.getLeafId()!;
+		expect(resumeTarget).not.toBe(errorEntry.parentId);
+		await created.session.continueTurn();
+
+		expect(created.getCallCount()).toBe(3);
+		expect(lastMessage().stopReason).toBe("stop");
+		expect(lastMessage().content).toEqual([{ type: "text", text: "Success" }]);
+		// The failed entries stay in the session as an abandoned branch but leave the
+		// active context, and the retried response becomes their sibling
+		expect(
+			created.session.messages.some((m) => m.role === "assistant" && (m as AssistantMessage).stopReason === "error"),
+		).toBe(false);
+		expect(sessionManager.getEntry(errorEntry.id)).toBeDefined();
+		expect(sessionManager.getLeafEntry()!.parentId).toBe(resumeTarget);
+	});
+
+	it("beginFailedTurnRetry returns false for entries that are not failed turns", async () => {
+		const created = await createSession({ failCount: 0 });
+		await created.session.prompt("Test");
+		const leaf = created.session.sessionManager.getLeafEntry()!;
+		expect(created.session.beginFailedTurnRetry(leaf.id)).toBe(false);
+	});
+
 	it("prompt waits for retry completion even when assistant message_end handling is delayed", async () => {
 		const created = await createSession({ failCount: 1, delayAssistantMessageEndMs: 40 });
 


### PR DESCRIPTION
Selecting an assistant entry that ended in an error, like a dropped connection, now retries the turn instead of landing on a dead end. The error leaves the chat and model context but stays in the tree as an abandoned branch, and the retried response becomes its sibling.

### How it works

```
user: "what is the time?"
  └─ ✗ Connection error   ← 1st in-session retry
      └─ ✗ Connection error   ← LEAF (retries exhausted)

        │  select the error entry in /tree
        ▼  beginFailedTurnRetry: walk past both errors, branch(user)

user: "what is the time?"  ← LEAF (errors now an abandoned branch,
  ├─ ✗ Connection error        gone from chat + context, kept in /tree)
  │   └─ ✗ Connection error
  └─ ✓ "I can get the current time…"  ← continueTurn: retried response
                                         becomes the errors' sibling
```

[Interactive step-by-step walkthrough](https://htmlpreview.github.io/?https://gist.githubusercontent.com/arajkumar/04f5b06a2ac3cc8f736e9ab01235685b/raw/resume-failed-turn-stepper.html)

Closes #7609
