### PR TITLE
feat(rpc): expose argument completions via get_argument_completions

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -30,6 +30,7 @@ import { type Theme, theme } from "../interactive/theme/theme.ts";
 import { toJsonEvent } from "../json-event.ts";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.ts";
 import type {
+	RpcArgumentCompletion,
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
@@ -706,6 +707,20 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				}
 
 				return success(id, "get_commands", { commands });
+			}
+
+			case "get_argument_completions": {
+				const resolved = session.extensionRunner.getCommand(command.commandName);
+				if (!resolved?.getArgumentCompletions) {
+					return success(id, "get_argument_completions", { items: [] });
+				}
+				const completions = await resolved.getArgumentCompletions(command.argumentPrefix ?? "");
+				const items: RpcArgumentCompletion[] = (completions ?? []).map((item) => ({
+					value: item.value,
+					label: item.label,
+					...(item.description ? { description: item.description } : {}),
+				}));
+				return success(id, "get_argument_completions", { items });
 			}
 
 			default: {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -70,7 +70,13 @@ export type RpcCommand =
 	| { id?: string; type: "get_messages" }
 
 	// Commands (available for invocation via prompt)
-	| { id?: string; type: "get_commands" };
+	| { id?: string; type: "get_commands" }
+	| {
+			id?: string;
+			type: "get_argument_completions";
+			commandName: string;
+			argumentPrefix?: string;
+	  };
 
 // ============================================================================
 // RPC Slash Command (for get_commands response)
@@ -86,6 +92,20 @@ export interface RpcSlashCommand {
 	source: "extension" | "prompt" | "skill";
 	/** Source metadata for the owning resource */
 	sourceInfo: SourceInfo;
+}
+
+// ============================================================================
+// RPC Argument Completion (for get_argument_completions response)
+// ============================================================================
+
+/** A subcommand or argument option offered by a slash command's completion provider. */
+export interface RpcArgumentCompletion {
+	/** Value inserted into the prompt when chosen */
+	value: string;
+	/** Human-readable label shown in the completion menu */
+	label: string;
+	/** Optional description shown alongside the label */
+	description?: string;
 }
 
 // ============================================================================
@@ -225,6 +245,13 @@ export type RpcResponse =
 			command: "get_commands";
 			success: true;
 			data: { commands: RpcSlashCommand[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "get_argument_completions";
+			success: true;
+			data: { items: RpcArgumentCompletion[] };
 	  }
 
 	// Error response (any command can fail)

--- a/packages/coding-agent/test/suite/regressions/rpc-get-argument-completions.test.ts
+++ b/packages/coding-agent/test/suite/regressions/rpc-get-argument-completions.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.ts";
+import { runRpcMode } from "../../../src/modes/rpc/rpc-mode.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * Tests for the `get_argument_completions` RPC command, which lets embedded
+ * clients (e.g. web UIs) surface a slash command's subcommand/argument
+ * completions via the extension's `getArgumentCompletions` hook.
+ */
+
+const rpcIo = vi.hoisted(() => ({
+	outputLines: [] as string[],
+	lineHandler: undefined as ((line: string) => void) | undefined,
+}));
+
+vi.mock("../../../src/core/output-guard.js", () => ({
+	flushRawStdout: vi.fn(async () => {}),
+	takeOverStdout: vi.fn(),
+	waitForRawStdoutBackpressure: vi.fn(async () => {}),
+	writeRawStdout: (line: string) => {
+		rpcIo.outputLines.push(line);
+	},
+}));
+
+vi.mock("../../../src/modes/interactive/theme/theme.js", () => ({ theme: {} }));
+
+vi.mock("../../../src/modes/rpc/jsonl.js", () => ({
+	attachJsonlLineReader: vi.fn((_stream: NodeJS.ReadableStream, onLine: (line: string) => void) => {
+		rpcIo.lineHandler = onLine;
+		return () => {
+			rpcIo.lineHandler = undefined;
+		};
+	}),
+	serializeJsonLine: (value: unknown) => `${JSON.stringify(value)}\n`,
+}));
+
+type NodeListener = Parameters<typeof process.on>[1];
+
+type ListenerSnapshot = {
+	stdinEnd: NodeListener[];
+	signals: Map<NodeJS.Signals, NodeListener[]>;
+};
+
+function takeListenerSnapshot(): ListenerSnapshot {
+	const signals: NodeJS.Signals[] = process.platform === "win32" ? ["SIGTERM"] : ["SIGTERM", "SIGHUP"];
+	return {
+		stdinEnd: process.stdin.listeners("end") as NodeListener[],
+		signals: new Map(signals.map((signal) => [signal, process.listeners(signal) as NodeListener[]])),
+	};
+}
+
+function restoreListeners(snapshot: ListenerSnapshot): void {
+	for (const listener of process.stdin.listeners("end") as NodeListener[]) {
+		if (!snapshot.stdinEnd.includes(listener)) {
+			process.stdin.off("end", listener);
+		}
+	}
+
+	for (const [signal, previousListeners] of snapshot.signals) {
+		for (const listener of process.listeners(signal) as NodeListener[]) {
+			if (!previousListeners.includes(listener)) {
+				process.off(signal, listener);
+			}
+		}
+	}
+}
+
+function parseOutputLines(): Array<Record<string, unknown>> {
+	return rpcIo.outputLines
+		.flatMap((line) => line.split("\n"))
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function createRuntimeHost(harness: Harness): AgentSessionRuntime {
+	return {
+		session: harness.session,
+		newSession: vi.fn(async () => ({ cancelled: true })),
+		switchSession: vi.fn(async () => ({ cancelled: true })),
+		fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
+		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn(),
+	} as unknown as AgentSessionRuntime;
+}
+
+const TEST_COMPLETIONS = [
+	{ value: "run", label: "run", description: "Run a sprint" },
+	{ value: "on", label: "on", description: "Enable agile mode" },
+	{ value: "off", label: "off" },
+];
+
+function completionExtension(pi: {
+	registerCommand: (
+		name: string,
+		command: {
+			description?: string;
+			getArgumentCompletions?: (prefix: string) => typeof TEST_COMPLETIONS;
+			handler: (args: string) => Promise<void>;
+		},
+	) => void;
+}): void {
+	pi.registerCommand("acme", {
+		description: "Acme command",
+		getArgumentCompletions: (prefix) => TEST_COMPLETIONS.filter((item) => item.value.startsWith(prefix)),
+		handler: async () => {},
+	});
+}
+
+describe("get_argument_completions RPC", () => {
+	afterEach(() => {
+		rpcIo.outputLines = [];
+		rpcIo.lineHandler = undefined;
+	});
+
+	test("returns completions filtered by argument prefix", async () => {
+		const listenerSnapshot = takeListenerSnapshot();
+		const harness = await createHarness({ extensionFactories: [completionExtension] });
+
+		try {
+			void runRpcMode(createRuntimeHost(harness));
+			await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
+
+			rpcIo.lineHandler?.(
+				JSON.stringify({ id: "t1", type: "get_argument_completions", commandName: "acme", argumentPrefix: "on" }),
+			);
+
+			await vi.waitFor(() => {
+				expect(parseOutputLines()).toContainEqual({
+					id: "t1",
+					type: "response",
+					command: "get_argument_completions",
+					success: true,
+					data: { items: [{ value: "on", label: "on", description: "Enable agile mode" }] },
+				});
+			});
+		} finally {
+			harness.cleanup();
+			restoreListeners(listenerSnapshot);
+		}
+	}, 15000);
+
+	test("returns all completions for an empty prefix", async () => {
+		const listenerSnapshot = takeListenerSnapshot();
+		const harness = await createHarness({ extensionFactories: [completionExtension] });
+
+		try {
+			void runRpcMode(createRuntimeHost(harness));
+			await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
+
+			rpcIo.lineHandler?.(JSON.stringify({ id: "t2", type: "get_argument_completions", commandName: "acme" }));
+
+			await vi.waitFor(() => {
+				const responses = parseOutputLines().filter((line) => line.id === "t2");
+				expect(responses).toHaveLength(1);
+				expect(responses[0].success).toBe(true);
+				const items = (responses[0].data as { items: unknown[] }).items;
+				expect(items).toHaveLength(3);
+			});
+		} finally {
+			harness.cleanup();
+			restoreListeners(listenerSnapshot);
+		}
+	}, 15000);
+
+	test("returns an empty list for a command without a completion provider", async () => {
+		const listenerSnapshot = takeListenerSnapshot();
+		const harness = await createHarness({ extensionFactories: [completionExtension] });
+
+		try {
+			void runRpcMode(createRuntimeHost(harness));
+			await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
+
+			rpcIo.lineHandler?.(
+				JSON.stringify({ id: "t3", type: "get_argument_completions", commandName: "nonexistent" }),
+			);
+
+			await vi.waitFor(() => {
+				expect(parseOutputLines()).toContainEqual({
+					id: "t3",
+					type: "response",
+					command: "get_argument_completions",
+					success: true,
+					data: { items: [] },
+				});
+			});
+		} finally {
+			harness.cleanup();
+			restoreListeners(listenerSnapshot);
+		}
+	}, 15000);
+});


### PR DESCRIPTION
## Summary

Adds a new RPC command, `get_argument_completions`, so embedded clients (e.g. web UIs like [pi-livecraft](https://github.com/user/pi-livecraft)) can surface a slash command's subcommand/argument completions. This data already powers the interactive TUI autocomplete via each extension's `getArgumentCompletions` hook, but it was not reachable from RPC mode — clients that embed Pi over stdin/stdout had no way to offer subcommand suggestions (e.g. typing `/agile ` could not suggest `run`, `on`, `off`, …).

## Changes

- **`src/modes/rpc/rpc-types.ts`**
  - New `get_argument_completions` request variant (`commandName` + optional `argumentPrefix`).
  - New `RpcArgumentCompletion` interface (`{ value, label, description? }`).
  - New success response variant carrying `{ items: RpcArgumentCompletion[] }`.
- **`src/modes/rpc/rpc-mode.ts`**
  - New `case "get_argument_completions"`: resolves the command by name via `session.extensionRunner.getCommand(commandName)`. If the command exposes a `getArgumentCompletions` hook, it is awaited with the prefix and the results are normalized into `RpcArgumentCompletion`. Commands without a completion provider (or unknown commands) return an empty `items` list rather than an error.
- **`test/suite/regressions/rpc-get-argument-completions.test.ts`**
  - Regression test modelled on the existing `5868-rpc-unknown-command-id` harness (mocks `jsonl`/`output-guard`, uses `createHarness` with a faux provider — **no API key required**). Covers:
    1. completions filtered by argument prefix,
    2. all completions returned for an empty prefix,
    3. empty list for a command without a completion provider.

## Scope notes

- Mirrors the shape already used by `get_commands`; no existing RPC contract changes.
- MVP scope is extension commands only (prompt templates expose a static `argumentHint`, not a `getArgumentCompletions` hook), matching `ExtensionRunner.getCommand` semantics.
- `AutocompleteItem.description` is spread conditionally so the response stays consistent with the existing `RpcSlashCommand` description handling.

## Validation

- `npx vitest --run test/suite/regressions/rpc-get-argument-completions.test.ts` → 3 passed
- `npx vitest --run test/suite/regressions/5868-rpc-unknown-command-id.test.ts test/rpc-jsonl.test.ts test/extensions-runner.test.ts` → all green (no regressions)
- `tsgo --noEmit` (full monorepo) → 0 errors
- `biome check` on the 3 changed files → clean

## Manual verification

Tested against a live `pi --mode rpc` process (v0.82.1) with the `pi-agile` extension: an empty prefix returned `[on, off, setup, run, status, stop, config, model, observer, init-checks]`, `r` returned `[run]`, and an unknown command returned `[]`.