### PR TITLE
refactor(server): rename backend contract to service

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -9,10 +9,10 @@ Server package for pi.
 The package exports the `PiServer` session server.
 
 ```ts
-import type { PiSessionBackend } from "@earendil-works/pi-server";
+import type { PiServerService } from "@earendil-works/pi-server";
 import { createUnixServer } from "@earendil-works/pi-server/unix";
 
-const backend: PiSessionBackend = {
+const service: PiServerService = {
   async listSessions() {
     return storage.listSessions();
   },
@@ -27,7 +27,7 @@ const backend: PiSessionBackend = {
   },
 };
 
-const server = createUnixServer(backend, {
+const server = createUnixServer(service, {
   path: "/tmp/pi/server.sock",
 });
 await server.start();
@@ -35,11 +35,11 @@ await server.start();
 
 `PiServer` composes transport listeners through the `PiServerListener` interface. Each listener must complete any transport-specific authentication and authorization before passing a connection to `PiServer`. For example, a WebSocket listener can validate credentials during the HTTP upgrade, while the Unix listener relies on socket filesystem permissions. The Unix submodule exports the `createUnixListener()` building block and `createUnixServer()` preset, keeping the common case concise without coupling the primary server to Unix sockets. The listener uses length-prefixed CBOR messages from `@earendil-works/pi-protocol`.
 
-This package does not provide a standalone CLI or coding-agent backend. Applications supply the `PiSessionBackend` implementation.
+This package does not provide a standalone CLI or coding-agent service. Applications supply the `PiServerService` implementation.
 
 ## Transport testing
 
-Custom transports can use `@earendil-works/pi-server/testing` for deterministic protocol conformance tests. It exports `createTestServer()`, `TestSessionBackend`, `ProtocolTestClient`, and the transport-neutral `WireChannel` contract. `connectUnixTestClient()` is provided for Unix transport tests.
+Custom transports can use `@earendil-works/pi-server/testing` for deterministic protocol conformance tests. It exports `createTestServer()`, `TestServerService`, `ProtocolTestClient`, and the transport-neutral `WireChannel` contract. `connectUnixTestClient()` is provided for Unix transport tests.
 
 ## `pi-ai` protocol bridge
 

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -5,7 +5,7 @@ export type PiServerOperationErrorCode = Extract<
 	"busy" | "session_locked" | "not_found" | "invalid_request"
 >;
 
-/** A backend/runtime error that can safely cross the protocol boundary. */
+/** A service/runtime error that can safely cross the protocol boundary. */
 export class PiServerError extends Error {
 	readonly code: PiServerOperationErrorCode;
 	readonly details: JsonValue | undefined;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -25,7 +25,7 @@ import { PiServerError } from "./errors.ts";
 import type { PiServerListener } from "./listener.ts";
 import { LiveSessionManager } from "./sessions.ts";
 import { ServerSnapshotPublisher } from "./snapshots.ts";
-import type { PiServerOptions, PiSessionBackend } from "./types.ts";
+import type { PiServerOptions, PiServerService } from "./types.ts";
 
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5_000;
 const MAX_UINT32 = 0xffff_ffff;
@@ -46,7 +46,7 @@ export class PiServer {
 	private startPromise?: Promise<this>;
 	private started = false;
 
-	constructor(backend: PiSessionBackend, options: PiServerOptions) {
+	constructor(service: PiServerService, options: PiServerOptions) {
 		const resolved = resolveOptions(options);
 		this.listeners = options.listeners;
 		this.id = options.serverId ?? randomUUID();
@@ -54,7 +54,7 @@ export class PiServer {
 		this.handshakeTimeoutMs = resolved.handshakeTimeoutMs;
 		this.onError = options.onError;
 		this.sessions = new LiveSessionManager({
-			backend,
+			service,
 			isClosing: () => this.closing,
 			sendMessage: (connection, message) => this.sendMessage(connection, message),
 			closeConnection: (connection) => this.closeConnection(connection),
@@ -64,7 +64,7 @@ export class PiServer {
 		});
 		this.snapshots = new ServerSnapshotPublisher({
 			serverId: this.id,
-			backend,
+			service,
 			connections: this.connections,
 			isClosing: () => this.closing,
 			listSessions: (connection) => this.sessions.listSummaries(connection),

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Command, EventEnvelope, SessionSnapshot, SessionSummary } from "@earendil-works/pi-protocol";
 import type { ByteConnection, ConnectionState } from "./connection.ts";
 import { PiServerError } from "./errors.ts";
-import type { CreateSessionOptions, PiSessionBackend, PiSessionRuntime, PiSessionRuntimeEvent } from "./types.ts";
+import type { CreateSessionOptions, PiServerService, PiSessionRuntime, PiSessionRuntimeEvent } from "./types.ts";
 
 interface LiveSession {
 	id: string;
@@ -16,7 +16,7 @@ interface LiveSession {
 }
 
 interface LiveSessionManagerOptions {
-	backend: PiSessionBackend;
+	service: PiServerService;
 	isClosing: () => boolean;
 	sendMessage: (connection: ConnectionState, message: EventEnvelope) => Promise<boolean>;
 	closeConnection: (connection: ByteConnection) => Promise<void>;
@@ -62,7 +62,7 @@ export class LiveSessionManager {
 					model: command.model,
 					thinkingLevel: command.thinkingLevel,
 				};
-				const live = await this.acquire(id, () => this.options.backend.createSession(options));
+				const live = await this.acquire(id, () => this.options.service.createSession(options));
 				await this.attach(connection, live);
 				const session = this.forConnection(await this.broadcastSnapshot(live), connection);
 				this.options.broadcastServerSnapshot();
@@ -70,7 +70,7 @@ export class LiveSessionManager {
 			}
 			case "attach": {
 				const live = await this.acquire(command.sessionId, () =>
-					this.options.backend.openSession(command.sessionId),
+					this.options.service.openSession(command.sessionId),
 				);
 				await this.attach(connection, live);
 				const session = this.forConnection(await this.broadcastSnapshot(live), connection);
@@ -137,7 +137,7 @@ export class LiveSessionManager {
 	}
 
 	async listSummaries(connection?: ConnectionState): Promise<SessionSummary[]> {
-		const stored = await this.options.backend.listSessions();
+		const stored = await this.options.service.listSessions();
 		const liveSnapshots = await Promise.all(
 			[...this.liveSessions.values()]
 				.filter((live) => !live.disposing)
@@ -225,7 +225,7 @@ export class LiveSessionManager {
 			if (snapshot.id !== id) {
 				throw new PiServerError(
 					"invalid_request",
-					`Backend returned session ${snapshot.id} for server-assigned session ${id}`,
+					`Service returned session ${snapshot.id} for server-assigned session ${id}`,
 				);
 			}
 			live = {

--- a/packages/server/src/snapshots.ts
+++ b/packages/server/src/snapshots.ts
@@ -6,11 +6,11 @@ import {
 	type SessionSummary,
 } from "@earendil-works/pi-protocol";
 import type { ConnectionState } from "./connection.ts";
-import type { PiSessionBackend } from "./types.ts";
+import type { PiServerService } from "./types.ts";
 
 interface ServerSnapshotPublisherOptions {
 	serverId: string;
-	backend: PiSessionBackend;
+	service: PiServerService;
 	connections: Set<ConnectionState>;
 	isClosing: () => boolean;
 	listSessions: (connection?: ConnectionState) => Promise<SessionSummary[]>;
@@ -37,7 +37,7 @@ export class ServerSnapshotPublisher {
 			protocolVersion: PROTOCOL_VERSION,
 			revision: this.revision,
 			sessions: await this.options.listSessions(connection),
-			models: models ?? (await this.options.backend.listModels()),
+			models: models ?? (await this.options.service.listModels()),
 		};
 	}
 
@@ -53,7 +53,7 @@ export class ServerSnapshotPublisher {
 		);
 		if (readyConnections.length === 0 || this.options.isClosing()) return;
 		const revision = ++this.revision;
-		const models = await this.options.backend.listModels();
+		const models = await this.options.service.listModels();
 		for (const connection of readyConnections) {
 			const current = await this.get(models, connection);
 			const snapshot: ServerSnapshot = { ...current, revision };

--- a/packages/server/src/testing/client.ts
+++ b/packages/server/src/testing/client.ts
@@ -9,7 +9,7 @@ import {
 	type ServerMessage,
 	ServerMessageDecoder,
 } from "@earendil-works/pi-protocol";
-import { Deferred } from "./backend.ts";
+import { Deferred } from "./service.ts";
 
 interface MessageWaiter {
 	predicate: (message: ServerMessage) => boolean;

--- a/packages/server/src/testing/index.ts
+++ b/packages/server/src/testing/index.ts
@@ -1,5 +1,5 @@
-export { Deferred, TEST_MODEL, TestSessionBackend, TestSessionRuntime } from "./backend.ts";
 export type { WireChannel } from "./client.ts";
 export { connectUnixTestClient, ProtocolTestClient } from "./client.ts";
 export type { TestServer, TestServerOptions } from "./server.ts";
 export { createTestServer } from "./server.ts";
+export { Deferred, TEST_MODEL, TestServerService, TestSessionRuntime } from "./service.ts";

--- a/packages/server/src/testing/server.ts
+++ b/packages/server/src/testing/server.ts
@@ -1,27 +1,27 @@
 import { PiServer } from "../server.ts";
-import type { PiServerOptions, PiSessionBackend } from "../types.ts";
-import { TestSessionBackend } from "./backend.ts";
+import type { PiServerOptions, PiServerService } from "../types.ts";
+import { TestServerService } from "./service.ts";
 
 export interface TestServerOptions extends PiServerOptions {
-	backend?: PiSessionBackend;
+	service?: PiServerService;
 }
 
 export interface TestServer {
 	server: PiServer;
-	backend: PiSessionBackend;
+	service: PiServerService;
 }
 
 /** Create an unstarted PiServer with deterministic defaults for transport conformance tests. */
 export function createTestServer(options: TestServerOptions): TestServer {
-	const backend = options.backend ?? new TestSessionBackend();
+	const service = options.service ?? new TestServerService();
 	return {
-		server: new PiServer(backend, {
+		server: new PiServer(service, {
 			listeners: options.listeners,
 			maxFrameLength: options.maxFrameLength,
 			handshakeTimeoutMs: options.handshakeTimeoutMs,
 			serverId: options.serverId,
 			onError: options.onError,
 		}),
-		backend,
+		service,
 	};
 }

--- a/packages/server/src/testing/service.ts
+++ b/packages/server/src/testing/service.ts
@@ -10,7 +10,7 @@ import type {
 import { PiServerError } from "../errors.ts";
 import type {
 	CreateSessionOptions,
-	PiSessionBackend,
+	PiServerService,
 	PiSessionRuntime,
 	PiSessionRuntimeEvent,
 	PromptInput,
@@ -195,7 +195,7 @@ interface ListDelay {
 	release: Deferred<void>;
 }
 
-export class TestSessionBackend implements PiSessionBackend {
+export class TestServerService implements PiServerService {
 	readonly sessions = new Map<string, StoredSession>();
 	readonly runtimes = new Map<string, TestSessionRuntime[]>();
 	readonly locked = new Set<string>();

--- a/packages/server/src/transports/unix/preset.ts
+++ b/packages/server/src/transports/unix/preset.ts
@@ -1,10 +1,10 @@
 import { PiServer } from "../../server.ts";
-import type { PiSessionBackend } from "../../types.ts";
+import type { PiServerService } from "../../types.ts";
 import { createUnixListener } from "./listener.ts";
 import type { UnixServerOptions } from "./types.ts";
 
 /** Compose PiServer with one Unix-domain socket listener. */
-export function createUnixServer(backend: PiSessionBackend, options: UnixServerOptions): PiServer {
+export function createUnixServer(service: PiServerService, options: UnixServerOptions): PiServer {
 	const listener = createUnixListener({
 		path: options.path,
 		mode: options.mode,
@@ -13,7 +13,7 @@ export function createUnixServer(backend: PiSessionBackend, options: UnixServerO
 		gracefulCloseTimeoutMs: options.gracefulCloseTimeoutMs,
 		onError: options.onError,
 	});
-	return new PiServer(backend, {
+	return new PiServer(service, {
 		listeners: [listener],
 		maxFrameLength: options.maxFrameLength,
 		handshakeTimeoutMs: options.handshakeTimeoutMs,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -25,7 +25,7 @@ export type PromptInput = Omit<Extract<Command, { command: "prompt" }>, "command
 export type SteerInput = Omit<Extract<Command, { command: "steer" }>, "command" | "sessionId">;
 
 export interface CreateSessionOptions {
-	/** A collision-resistant ID assigned by PiServer. The backend must persist this exact ID. */
+	/** A collision-resistant ID assigned by PiServer. The service must persist this exact ID. */
 	id: string;
 	cwd?: string;
 	name?: string;
@@ -51,8 +51,8 @@ export interface PiSessionRuntime {
 	dispose(): Promise<void>;
 }
 
-/** Durable storage and exclusively acquired runtime boundary. */
-export interface PiSessionBackend {
+/** Service boundary for durable sessions and exclusively acquired runtimes. */
+export interface PiServerService {
 	listSessions(): Promise<SessionSummary[]>;
 	listModels(): Promise<ModelMetadata[]>;
 	createSession(options: CreateSessionOptions): Promise<PiSessionRuntime>;
@@ -60,5 +60,4 @@ export interface PiSessionBackend {
 }
 
 export type SessionRuntime = PiSessionRuntime;
-export type SessionBackend = PiSessionBackend;
 export type SessionRuntimeEvent = PiSessionRuntimeEvent;

--- a/packages/server/test/conformance.test.ts
+++ b/packages/server/test/conformance.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { encodeClientMessage, encodeFrame, PROTOCOL_VERSION } from "@earendil-works/pi-protocol";
 import { afterEach, describe, expect, test } from "vitest";
 import { type PiServer, PiServerError } from "../src/index.ts";
-import { connectUnixTestClient, Deferred, type ProtocolTestClient, TestSessionBackend } from "../src/testing/index.ts";
+import { connectUnixTestClient, Deferred, type ProtocolTestClient, TestServerService } from "../src/testing/index.ts";
 import { createUnixServer, type UnixServerOptions } from "../src/transports/unix/index.ts";
 
 const servers = new Set<PiServer>();
@@ -12,18 +12,18 @@ const clients = new Set<ProtocolTestClient>();
 const tempDirectories = new Set<string>();
 
 async function startServer(
-	backend = new TestSessionBackend(),
+	service = new TestServerService(),
 	overrides: Partial<UnixServerOptions> = {},
-): Promise<{ server: PiServer; backend: TestSessionBackend }> {
+): Promise<{ server: PiServer; service: TestServerService }> {
 	const directory = await mkdtemp(join(tmpdir(), "pis-"));
 	tempDirectories.add(directory);
-	const server = createUnixServer(backend, {
+	const server = createUnixServer(service, {
 		path: join(directory, "server.sock"),
 		...overrides,
 	});
 	servers.add(server);
 	await server.start();
-	return { server, backend };
+	return { server, service };
 }
 
 async function connect(server: PiServer): Promise<ProtocolTestClient> {
@@ -75,7 +75,7 @@ describe("Unix transport conformance", () => {
 	});
 
 	test("closes connections that do not complete hello before the timeout", async () => {
-		const { server } = await startServer(new TestSessionBackend(), { handshakeTimeoutMs: 20 });
+		const { server } = await startServer(new TestServerService(), { handshakeTimeoutMs: 20 });
 		const client = await connect(server);
 		await client.waitForClose();
 		expect(client.messages).toContainEqual(
@@ -84,9 +84,9 @@ describe("Unix transport conformance", () => {
 	});
 
 	test("keeps the handshake timeout active until the server hello is sent", async () => {
-		const backend = new TestSessionBackend();
-		const delay = backend.delayNextList();
-		const { server } = await startServer(backend, { handshakeTimeoutMs: 20 });
+		const service = new TestServerService();
+		const delay = service.delayNextList();
+		const { server } = await startServer(service, { handshakeTimeoutMs: 20 });
 		const client = await connect(server);
 		await client.sendMessage({ type: "hello", version: PROTOCOL_VERSION });
 		await delay.entered.promise;
@@ -108,7 +108,7 @@ describe("Unix transport conformance", () => {
 		});
 		await malformed.waitForClose();
 
-		const boundedServer = await startServer(new TestSessionBackend(), { maxFrameLength: 128 });
+		const boundedServer = await startServer(new TestServerService(), { maxFrameLength: 128 });
 		const oversized = await connect(boundedServer.server);
 		const frame = new Uint8Array(4 + 129);
 		frame[3] = 129;
@@ -116,7 +116,7 @@ describe("Unix transport conformance", () => {
 		await oversized.waitForClose();
 		expect(oversized.messages.some((message) => message.type === "hello")).toBe(false);
 
-		const outboundServer = await startServer(new TestSessionBackend(), { maxFrameLength: 128 });
+		const outboundServer = await startServer(new TestServerService(), { maxFrameLength: 128 });
 		const outbound = await connect(outboundServer.server);
 		await outbound.sendMessage({ type: "hello", version: PROTOCOL_VERSION });
 		await outbound.waitForClose();
@@ -124,7 +124,7 @@ describe("Unix transport conformance", () => {
 	});
 
 	test("catches up a handshaking client after a concurrent server change", async () => {
-		class RacingBackend extends TestSessionBackend {
+		class RacingService extends TestServerService {
 			readonly entered = new Deferred<void>();
 			readonly release = new Deferred<void>();
 			race = false;
@@ -137,17 +137,17 @@ describe("Unix transport conformance", () => {
 				return sessions;
 			}
 		}
-		const backend = new RacingBackend();
-		backend.seed("shared");
-		const { server } = await startServer(backend);
+		const service = new RacingService();
+		service.seed("shared");
+		const { server } = await startServer(service);
 		const controller = await connect(server);
 		await controller.hello();
-		backend.race = true;
+		service.race = true;
 		const joining = await connect(server);
 		const hello = joining.hello();
-		await backend.entered.promise;
+		await service.entered.promise;
 		await controller.request({ command: "attach", sessionId: "shared" });
-		backend.release.resolve(undefined);
+		service.release.resolve(undefined);
 		const handshake = await hello;
 		if (handshake.type !== "hello") throw new Error("Expected server hello");
 		const catchup = await joining.next(
@@ -163,10 +163,10 @@ describe("Unix transport conformance", () => {
 	});
 
 	test("shares request, event, attachment, and disconnect behavior", async () => {
-		const backend = new TestSessionBackend();
-		backend.seed("first");
-		backend.seed("second");
-		const { server } = await startServer(backend);
+		const service = new TestServerService();
+		service.seed("first");
+		service.seed("second");
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		expect(await client.hello()).toMatchObject({
 			type: "hello",
@@ -197,7 +197,7 @@ describe("Unix transport conformance", () => {
 		const progressEvent = client.next(
 			(message) => message.type === "event" && message.event.type === "session_progress",
 		);
-		backend.latestRuntime("first").emitProgress(progress);
+		service.latestRuntime("first").emitProgress(progress);
 		expect(await progressEvent).toEqual({
 			type: "event",
 			event: { type: "session_progress", sessionId: "first", progress },
@@ -207,33 +207,33 @@ describe("Unix transport conformance", () => {
 			ok: true,
 			result: { command: "detach", sessionId: "first" },
 		});
-		expect(backend.latestRuntime("first").disposeCount).toBe(1);
+		expect(service.latestRuntime("first").disposeCount).toBe(1);
 		expect(
 			await client.request({ command: "set_thinking", sessionId: "second", thinkingLevel: "high" }),
 		).toMatchObject({ ok: true, result: { session: { id: "second", thinkingLevel: "high" } } });
 
-		const secondRuntime = backend.latestRuntime("second");
+		const secondRuntime = service.latestRuntime("second");
 		await client.close();
 		await secondRuntime.disposed.promise;
 		expect(secondRuntime.disposeCount).toBe(1);
 	});
 
 	test("disconnects attached clients when a runtime reports a terminal error", async () => {
-		const backend = new TestSessionBackend();
-		backend.seed("terminal");
+		const service = new TestServerService();
+		service.seed("terminal");
 		const errors: Error[] = [];
-		const { server } = await startServer(backend, { onError: (error) => errors.push(error) });
+		const { server } = await startServer(service, { onError: (error) => errors.push(error) });
 		const client = await connect(server);
 		await client.hello();
 		await client.request({ command: "attach", sessionId: "terminal" });
-		const runtime = backend.latestRuntime("terminal");
+		const runtime = service.latestRuntime("terminal");
 
 		runtime.setPhase("turn");
 		runtime.emitError(new PiServerError("session_locked", "lock ownership lost"));
 		await client.waitForClose();
 		await runtime.disposed.promise;
 		expect(runtime.disposeCount).toBe(1);
-		expect(backend.locked.has("terminal")).toBe(false);
+		expect(service.locked.has("terminal")).toBe(false);
 		expect(errors).toContainEqual(expect.objectContaining({ code: "session_locked" }));
 
 		const nextClient = await connect(server);
@@ -242,22 +242,22 @@ describe("Unix transport conformance", () => {
 			ok: true,
 			result: { command: "attach", session: { id: "terminal" } },
 		});
-		expect(backend.latestRuntime("terminal")).not.toBe(runtime);
+		expect(service.latestRuntime("terminal")).not.toBe(runtime);
 	});
 
-	test("does not expose unexpected backend errors to clients", async () => {
-		class FailingBackend extends TestSessionBackend {
+	test("does not expose unexpected service errors to clients", async () => {
+		class FailingService extends TestServerService {
 			private listCount = 0;
 
 			override async listSessions() {
 				this.listCount += 1;
-				if (this.listCount > 1) throw new Error("private backend detail");
+				if (this.listCount > 1) throw new Error("private service detail");
 				return super.listSessions();
 			}
 		}
 		const errors: Error[] = [];
-		const backend = new FailingBackend();
-		const { server } = await startServer(backend, {
+		const service = new FailingService();
+		const { server } = await startServer(service, {
 			onError: (error) => {
 				errors.push(error);
 				throw new Error("observer failure");
@@ -269,17 +269,17 @@ describe("Unix transport conformance", () => {
 			ok: false,
 			error: { code: "invalid_request", message: "Internal server error" },
 		});
-		expect(errors).toContainEqual(expect.objectContaining({ message: "private backend detail" }));
+		expect(errors).toContainEqual(expect.objectContaining({ message: "private service detail" }));
 	});
 
 	test("can respond out of request order after the handshake", async () => {
-		const backend = new TestSessionBackend();
-		backend.seed("first");
-		const { server } = await startServer(backend);
+		const service = new TestServerService();
+		service.seed("first");
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		await client.hello();
 
-		const delay = backend.delayNextList();
+		const delay = service.delayNextList();
 		const slow = client.request({ command: "list" }, "slow");
 		await delay.entered.promise;
 		const fast = client.request({ command: "attach", sessionId: "first" }, "fast");
@@ -295,14 +295,14 @@ describe("Unix transport conformance", () => {
 	});
 
 	test("gracefully closes connections, sessions, and listener resources", async () => {
-		const backend = new TestSessionBackend();
-		backend.seed("first");
-		const { server } = await startServer(backend);
+		const service = new TestServerService();
+		service.seed("first");
+		const { server } = await startServer(service);
 		const socketPath = server.addresses[0];
 		const client = await connect(server);
 		await client.hello();
 		await client.request({ command: "attach", sessionId: "first" });
-		const runtime = backend.latestRuntime("first");
+		const runtime = service.latestRuntime("first");
 		const clientClosed = client.waitForClose();
 
 		await server.close();

--- a/packages/server/test/server.test.ts
+++ b/packages/server/test/server.test.ts
@@ -5,10 +5,10 @@ import { ServerMessageDecoder } from "@earendil-works/pi-protocol";
 import { afterEach, expect, test, vi } from "vitest";
 import type { ByteConnection } from "../src/connection.ts";
 import { PiServer } from "../src/index.ts";
-import { TestSessionBackend } from "../src/testing/index.ts";
+import { TestServerService } from "../src/testing/index.ts";
 import { createUnixServer } from "../src/transports/unix/index.ts";
 
-const backend = new TestSessionBackend();
+const service = new TestServerService();
 
 let server: PiServer | undefined;
 let tempDirectory: string | undefined;
@@ -26,25 +26,25 @@ afterEach(async () => {
 });
 
 test("requires explicit listeners", () => {
-	expect(() => Reflect.construct(PiServer, [backend, {}])).toThrow(/listeners/);
+	expect(() => Reflect.construct(PiServer, [service, {}])).toThrow(/listeners/);
 });
 
 test("rejects Unix socket paths that cannot fit in sockaddr_un", () => {
-	expect(() => createUnixServer(backend, { path: `/tmp/${"x".repeat(512)}` })).toThrow(/too long/);
+	expect(() => createUnixServer(service, { path: `/tmp/${"x".repeat(512)}` })).toThrow(/too long/);
 });
 
 test("rejects an overlong derived private Unix bind path", async () => {
 	const maxLength = process.platform === "linux" ? 107 : 103;
 	const suffixLength = Buffer.byteLength("/tmp//s");
 	const path = `/tmp/${"x".repeat(maxLength - suffixLength)}/s`;
-	server = createUnixServer(backend, { path });
+	server = createUnixServer(service, { path });
 
 	await expect(server.start()).rejects.toThrow(/private Unix bind path.*too long/);
 });
 
 test("rejects concurrent start calls without leaking the Unix listener", async () => {
 	const path = await makeSocketPath();
-	server = createUnixServer(backend, { path });
+	server = createUnixServer(service, { path });
 	const starting = server.start();
 	await expect(server.start()).rejects.toThrow(/starting/);
 	await starting;
@@ -67,7 +67,7 @@ test("handshake timeout cleanup does not wait for a blocked output queue", async
 			this.closed = true;
 		}
 	}
-	const core = new PiServer(backend, {
+	const core = new PiServer(service, {
 		listeners: [],
 		maxFrameLength: 1024,
 		handshakeTimeoutMs: 10,
@@ -84,17 +84,17 @@ test("handshake timeout cleanup does not wait for a blocked output queue", async
 
 test("rejects timeout values above Node's maximum timer delay", () => {
 	const unix = { path: "/tmp/pi-server-timeout-test.sock" };
-	expect(() => createUnixServer(backend, { path: unix.path, handshakeTimeoutMs: 2_147_483_648 })).toThrow(
+	expect(() => createUnixServer(service, { path: unix.path, handshakeTimeoutMs: 2_147_483_648 })).toThrow(
 		/handshakeTimeoutMs/,
 	);
-	expect(() => createUnixServer(backend, { path: unix.path, gracefulCloseTimeoutMs: 2_147_483_648 })).toThrow(
+	expect(() => createUnixServer(service, { path: unix.path, gracefulCloseTimeoutMs: 2_147_483_648 })).toThrow(
 		/gracefulCloseTimeoutMs/,
 	);
 });
 
 test("rejects pending-byte limits smaller than one maximum frame", async () => {
 	const path = await makeSocketPath();
-	expect(() => createUnixServer(backend, { path, maxFrameLength: 128, maxPendingBytes: 131 })).toThrow(
+	expect(() => createUnixServer(service, { path, maxFrameLength: 128, maxPendingBytes: 131 })).toThrow(
 		/maxPendingBytes/,
 	);
 });

--- a/packages/server/test/sessions.test.ts
+++ b/packages/server/test/sessions.test.ts
@@ -9,15 +9,15 @@ import {
 	Deferred,
 	type ProtocolTestClient,
 	TEST_MODEL,
-	TestSessionBackend,
+	TestServerService,
 } from "../src/testing/index.ts";
 import { createUnixServer, type UnixServerOptions } from "../src/transports/unix/index.ts";
 
 const MODEL = TEST_MODEL;
 type Client = ProtocolTestClient;
-class MemoryBackend extends TestSessionBackend {}
+class MemoryService extends TestServerService {}
 
-class OrderedSnapshotBackend extends MemoryBackend {
+class OrderedSnapshotService extends MemoryService {
 	readonly firstStarted = new Deferred<void>();
 	readonly secondStarted = new Deferred<void>();
 	readonly firstRelease = new Deferred<void>();
@@ -43,16 +43,16 @@ const servers = new Set<PiServer>();
 const clients = new Set<Client>();
 const tempDirectories = new Set<string>();
 
-async function startServer(backend = new MemoryBackend(), options: Partial<UnixServerOptions> = {}) {
+async function startServer(service = new MemoryService(), options: Partial<UnixServerOptions> = {}) {
 	const directory = await mkdtemp(join(tmpdir(), "pst-"));
 	tempDirectories.add(directory);
-	const server = createUnixServer(backend, {
+	const server = createUnixServer(service, {
 		path: join(directory, "server.sock"),
 		...options,
 	});
 	servers.add(server);
 	await server.start();
-	return { server, backend };
+	return { server, service };
 }
 
 async function connect(server: PiServer): Promise<Client> {
@@ -78,22 +78,22 @@ afterEach(async () => {
 
 describe("PiServer Unix integration", () => {
 	test("serializes server snapshot revisions", async () => {
-		const backend = new OrderedSnapshotBackend();
-		const { server } = await startServer(backend);
+		const service = new OrderedSnapshotService();
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		await client.hello();
-		backend.controlled = true;
+		service.controlled = true;
 		const messageIndex = client.messages.length;
 
 		const firstCreate = client.request({ command: "create", name: "first" });
-		await backend.firstStarted.promise;
+		await service.firstStarted.promise;
 		const secondCreate = client.request({ command: "create", name: "second" });
 		await Promise.resolve();
-		expect(backend.startedCount).toBe(1);
+		expect(service.startedCount).toBe(1);
 
-		backend.firstRelease.resolve(undefined);
-		await backend.secondStarted.promise;
-		backend.secondRelease.resolve(undefined);
+		service.firstRelease.resolve(undefined);
+		await service.secondStarted.promise;
+		service.secondRelease.resolve(undefined);
 		await Promise.all([firstCreate, secondCreate]);
 		await client.nextFrom(
 			messageIndex,
@@ -114,7 +114,7 @@ describe("PiServer Unix integration", () => {
 	});
 
 	test("creates server-assigned durable IDs and supports list, attach, and detach", async () => {
-		const { server, backend } = await startServer();
+		const { server, service } = await startServer();
 		const client = await connect(server);
 		await client.hello();
 		const created = await client.request({ command: "create", cwd: "/work", name: "Created" });
@@ -122,7 +122,7 @@ describe("PiServer Unix integration", () => {
 		if (!created.ok || created.result.command !== "create") throw new Error("Create failed");
 		const createdId = created.result.session.id;
 		expect(created.result.session).toMatchObject({
-			id: backend.lastCreatedId,
+			id: service.lastCreatedId,
 			cwd: "/work",
 			name: "Created",
 			attached: true,
@@ -132,32 +132,32 @@ describe("PiServer Unix integration", () => {
 		const listed = await client.request({ command: "list" });
 		expect(listed).toMatchObject({
 			ok: true,
-			result: { command: "list", sessions: [{ id: backend.lastCreatedId, attached: true, locked: true }] },
+			result: { command: "list", sessions: [{ id: service.lastCreatedId, attached: true, locked: true }] },
 		});
 		const detached = await client.request({ command: "detach", sessionId: createdId });
 		expect(detached).toMatchObject({ ok: true, result: { command: "detach", sessionId: createdId } });
-		expect(backend.latestRuntime(createdId).disposeCount).toBe(1);
+		expect(service.latestRuntime(createdId).disposeCount).toBe(1);
 		const detachedAgain = await client.request({ command: "detach", sessionId: createdId });
 		expect(detachedAgain).toMatchObject({ ok: true, result: { command: "detach", sessionId: createdId } });
 
 		const attached = await attach(client, createdId);
-		expect(attached.id).toBe(backend.lastCreatedId);
-		expect(backend.runtimes.get(createdId)?.length).toBe(2);
+		expect(attached.id).toBe(service.lastCreatedId);
+		expect(service.runtimes.get(createdId)?.length).toBe(2);
 	});
 
 	test("keeps multiple attachments on one connection independent", async () => {
-		const backend = new MemoryBackend();
-		backend.seed("first");
-		backend.seed("second");
-		const { server } = await startServer(backend);
+		const service = new MemoryService();
+		service.seed("first");
+		service.seed("second");
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		await client.hello();
 		await attach(client, "first");
 		await attach(client, "second");
 
 		await client.request({ command: "detach", sessionId: "first" });
-		expect(backend.latestRuntime("first").disposeCount).toBe(1);
-		expect(backend.latestRuntime("second").disposeCount).toBe(0);
+		expect(service.latestRuntime("first").disposeCount).toBe(1);
+		expect(service.latestRuntime("second").disposeCount).toBe(0);
 		const response = await client.request({
 			command: "set_thinking",
 			sessionId: "second",
@@ -167,15 +167,15 @@ describe("PiServer Unix integration", () => {
 	});
 
 	test("broadcasts full snapshots and progress only to clients attached to that session", async () => {
-		const backend = new MemoryBackend();
-		backend.seed();
-		const { server } = await startServer(backend);
+		const service = new MemoryService();
+		service.seed();
+		const { server } = await startServer(service);
 		const attachedClient = await connect(server);
 		const unattachedClient = await connect(server);
 		await attachedClient.hello();
 		await unattachedClient.hello();
 		await attach(attachedClient, "session-1");
-		const runtime = backend.latestRuntime("session-1");
+		const runtime = service.latestRuntime("session-1");
 		const progress: TranscriptProgress = {
 			type: "assistant_delta",
 			messageId: "assistant-1",
@@ -218,9 +218,9 @@ describe("PiServer Unix integration", () => {
 	});
 
 	test("allows every attached client to control a singleton live runtime", async () => {
-		const backend = new MemoryBackend();
-		backend.seed();
-		const { server } = await startServer(backend);
+		const service = new MemoryService();
+		service.seed();
+		const { server } = await startServer(service);
 		const first = await connect(server);
 		const second = await connect(server);
 		await first.hello();
@@ -232,7 +232,7 @@ describe("PiServer Unix integration", () => {
 			result: { sessions: [{ id: "session-1", attached: false, locked: true }] },
 		});
 		await attach(second, "session-1");
-		expect(backend.runtimes.get("session-1")?.length).toBe(1);
+		expect(service.runtimes.get("session-1")?.length).toBe(1);
 
 		const modelResponse = await second.request({
 			command: "set_model",
@@ -255,9 +255,9 @@ describe("PiServer Unix integration", () => {
 	});
 
 	test("does not queue prompts and processes steer and abort while a prompt response is pending", async () => {
-		const backend = new MemoryBackend();
-		backend.seed();
-		const { server } = await startServer(backend);
+		const service = new MemoryService();
+		service.seed();
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		await client.hello();
 		await attach(client, "session-1");
@@ -274,16 +274,16 @@ describe("PiServer Unix integration", () => {
 
 		const steer = await client.request({ command: "steer", sessionId: "session-1", text: "adjust" });
 		expect(steer).toMatchObject({ ok: true, result: { command: "steer" } });
-		expect(backend.latestRuntime("session-1").steers).toEqual([{ text: "adjust" }]);
+		expect(service.latestRuntime("session-1").steers).toEqual([{ text: "adjust" }]);
 		const abort = await client.request({ command: "abort", sessionId: "session-1" });
 		expect(abort).toMatchObject({ ok: true, result: { command: "abort" } });
 		expect(await prompt).toMatchObject({ ok: true, result: { command: "prompt", session: { phase: "idle" } } });
 	});
 
 	test("returns operation attachment state relative to the requesting connection", async () => {
-		const backend = new MemoryBackend();
-		backend.seed();
-		const { server } = await startServer(backend);
+		const service = new MemoryService();
+		service.seed();
+		const { server } = await startServer(service);
 		const first = await connect(server);
 		const second = await connect(server);
 		await first.hello();
@@ -299,7 +299,7 @@ describe("PiServer Unix integration", () => {
 				message.event.snapshot.phase === "turn",
 		);
 		await first.request({ command: "detach", sessionId: "session-1" });
-		backend.latestRuntime("session-1").finishPrompt();
+		service.latestRuntime("session-1").finishPrompt();
 
 		expect(await prompt).toMatchObject({
 			ok: true,
@@ -308,9 +308,9 @@ describe("PiServer Unix integration", () => {
 	});
 
 	test("keeps busy work alive after disconnect and disposes when it next becomes idle", async () => {
-		const backend = new MemoryBackend();
-		backend.seed();
-		const { server } = await startServer(backend);
+		const service = new MemoryService();
+		service.seed();
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		await client.hello();
 		await attach(client, "session-1");
@@ -321,7 +321,7 @@ describe("PiServer Unix integration", () => {
 				message.event.type === "session_snapshot" &&
 				message.event.snapshot.phase === "turn",
 		);
-		const runtime = backend.latestRuntime("session-1");
+		const runtime = service.latestRuntime("session-1");
 		await client.close();
 		await expect(prompt).rejects.toThrow(Error);
 		expect(runtime.disposeCount).toBe(0);
@@ -337,9 +337,9 @@ describe("PiServer Unix integration", () => {
 	});
 
 	test("restores persisted sessions lazily after a server restart", async () => {
-		const backend = new MemoryBackend();
-		backend.seed();
-		const { server: firstServer } = await startServer(backend);
+		const service = new MemoryService();
+		service.seed();
+		const { server: firstServer } = await startServer(service);
 		const firstClient = await connect(firstServer);
 		await firstClient.hello();
 		await attach(firstClient, "session-1");
@@ -347,35 +347,35 @@ describe("PiServer Unix integration", () => {
 		await firstClient.close();
 		await firstServer.close();
 
-		const { server: secondServer } = await startServer(backend);
-		expect(backend.runtimes.get("session-1")).toHaveLength(1);
+		const { server: secondServer } = await startServer(service);
+		expect(service.runtimes.get("session-1")).toHaveLength(1);
 		const secondClient = await connect(secondServer);
 		await secondClient.hello();
 		const restored = await attach(secondClient, "session-1");
 		expect(restored.thinkingLevel).toBe("high");
-		expect(backend.runtimes.get("session-1")).toHaveLength(2);
+		expect(service.runtimes.get("session-1")).toHaveLength(2);
 	});
 
-	test("rejects and disposes a backend runtime with the wrong server-assigned ID", async () => {
-		class WrongIdBackend extends MemoryBackend {
+	test("rejects and disposes a service runtime with the wrong server-assigned ID", async () => {
+		class WrongIdService extends MemoryService {
 			override async createSession(options: CreateSessionOptions): Promise<PiSessionRuntime> {
 				return super.createSession({ ...options, id: "wrong-id" });
 			}
 		}
-		const backend = new WrongIdBackend();
-		const { server } = await startServer(backend);
+		const service = new WrongIdService();
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		await client.hello();
 		const response = await client.request({ command: "create" });
 		expect(response).toMatchObject({ ok: false, error: { code: "invalid_request" } });
-		expect(backend.latestRuntime("wrong-id").disposeCount).toBe(1);
+		expect(service.latestRuntime("wrong-id").disposeCount).toBe(1);
 	});
 
-	test("maps backend lock errors and rejects control from unattached clients", async () => {
-		const backend = new MemoryBackend();
-		backend.seed("locked");
-		backend.locked.add("locked");
-		const { server } = await startServer(backend);
+	test("maps service lock errors and rejects control from unattached clients", async () => {
+		const service = new MemoryService();
+		service.seed("locked");
+		service.locked.add("locked");
+		const { server } = await startServer(service);
 		const client = await connect(server);
 		await client.hello();
 		const locked = await client.request({ command: "attach", sessionId: "locked" });

--- a/packages/server/test/unix.test.ts
+++ b/packages/server/test/unix.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import type { PiServer } from "../src/index.ts";
-import { connectUnixTestClient, type ProtocolTestClient, TestSessionBackend } from "../src/testing/index.ts";
+import { connectUnixTestClient, type ProtocolTestClient, TestServerService } from "../src/testing/index.ts";
 import { createUnixServer } from "../src/transports/unix/index.ts";
 
 const servers = new Set<PiServer>();
@@ -20,7 +20,7 @@ async function makeSocketPath(nested = false): Promise<string> {
 }
 
 function makeServer(path: string): PiServer {
-	const server = createUnixServer(new TestSessionBackend(), { path });
+	const server = createUnixServer(new TestServerService(), { path });
 	servers.add(server);
 	return server;
 }


### PR DESCRIPTION
## Summary

- rename `PiSessionBackend` to `PiServerService`
- update server internals, test utilities, tests, and documentation to use service terminology
- intentionally provide no compatibility alias

## Testing

- `npm run build`
- `npm run check`
- `./test.sh`
