### PR TITLE
fix: build error on request info and boolean type error

### DIFF
--- a/packages/coding-agent/src/utils/management-http.ts
+++ b/packages/coding-agent/src/utils/management-http.ts
@@ -1,3 +1,5 @@
+type FetchInput = Parameters<typeof fetch>[0];
+
 const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
 export interface FetchRetryOptions {
@@ -21,7 +23,7 @@ export interface FetchRetryOptions {
  * overall time budget shared by all attempts.
  */
 export async function fetchWithRetry(
-	input: RequestInfo | URL,
+	input: FetchInput,
 	init: RequestInit | undefined = undefined,
 	options: FetchRetryOptions = {},
 ): Promise<Response> {

--- a/packages/coding-agent/src/utils/version-check.ts
+++ b/packages/coding-agent/src/utils/version-check.ts
@@ -25,7 +25,9 @@ export function formatVersionCheckError(error: unknown): string {
 		.filter((code): code is string => code !== undefined);
 
 	if (codes.length > 0) return `${rootMessage} (${[...new Set(codes)].join(", ")})`;
-	const causeMessage = causes.find((value): value is Error => value instanceof Error && value.message)?.message;
+	const causeMessage = causes.find(
+		(value): value is Error => value instanceof Error && Boolean(value.message),
+	)?.message;
 	return causeMessage ? `${rootMessage} (cause: ${causeMessage})` : rootMessage;
 }
 


### PR DESCRIPTION
2 build errors:

```
Error: src/utils/management-http.ts(24,9): error TS2552: Cannot find name 'RequestInfo'. Did you mean 'RequestInit'?
Error: src/utils/version-check.ts(28,62): error TS2322: Type 'string | false' is not assignable to type 'boolean'.
```

For first, `RequestInfo` is a DOM lib type, using `Parameters<typeof fetch>[0]` instead which is equiv to `string | URL | Request`.

For second, added boolean in:
```
const causeMessage = causes.find(
        (value): value is Error => value instanceof Error && Boolean(value.message),
    )?.message;
```