### PR TITLE
feat(ai): report provider retries through an onRetry callback

### DIFF
--- a/packages/ai/src/utils/provider-retry.ts
+++ b/packages/ai/src/utils/provider-retry.ts
@@ -1,9 +1,33 @@
 const DEFAULT_MAX_RETRY_DELAY_MS = 60_000;
 
+/** Details of a retry that is about to be slept on and then attempted. */
+export interface ProviderRetryInfo {
+	/** 1-indexed attempt number of the retry about to be made. */
+	attempt: number;
+	/** Total retries permitted for this request. */
+	maxRetries: number;
+	/** Backoff delay applied before the retry. */
+	delayMs: number;
+	/** Message of the error that triggered the retry. */
+	errorMessage: string;
+	/** HTTP status of the failed response, when the provider reported one. */
+	status: number | undefined;
+}
+
 interface ProviderRetryOptions {
 	maxRetries?: number;
 	maxRetryDelayMs?: number;
 	signal?: AbortSignal;
+	/**
+	 * Emitted before the backoff sleep of each retry.
+	 *
+	 * Provider retries are otherwise invisible to callers: a request that
+	 * succeeds on its third attempt is indistinguishable from one that succeeded
+	 * immediately but took longer, which makes latency impossible to attribute.
+	 * `retryAssistantCall` already exposes this through `RetryCallbacks`; this
+	 * brings the provider-request path in line.
+	 */
+	onRetry?: (info: ProviderRetryInfo) => void | Promise<void>;
 }
 
 interface ProviderError extends Error {
@@ -119,7 +143,24 @@ export async function retryProviderRequest<T>(
 
 			const retryIndex = maxRetries - retriesRemaining;
 			retriesRemaining--;
-			await abortableSleep(getRetryDelayMs(error, retryIndex, options.maxRetryDelayMs), options.signal);
+			const delayMs = getRetryDelayMs(error, retryIndex, options.maxRetryDelayMs);
+
+			if (options.onRetry) {
+				try {
+					await options.onRetry({
+						attempt: retryIndex + 1,
+						maxRetries,
+						delayMs,
+						errorMessage: error instanceof Error ? error.message : String(error),
+						status: isProviderError(error) ? error.status : undefined,
+					});
+				} catch {
+					// Observation must never change behaviour: a throwing observer
+					// would turn a recoverable provider error into a failed request.
+				}
+			}
+
+			await abortableSleep(delayMs, options.signal);
 		}
 	}
 }

--- a/packages/ai/test/provider-retry.test.ts
+++ b/packages/ai/test/provider-retry.test.ts
@@ -79,3 +79,89 @@ describe("provider request retries", () => {
 		expect(vi.getTimerCount()).toBe(0);
 	});
 });
+
+describe("provider request retry callbacks", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("reports each retry before its backoff sleep", async () => {
+		vi.useFakeTimers();
+		const onRetry = vi.fn();
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(429, { "retry-after-ms": "1000" }))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 2, onRetry });
+
+		// Emitted before the sleep, so a caller can attribute the wait to a retry
+		// rather than to a slow provider.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(onRetry).toHaveBeenCalledTimes(1);
+		expect(onRetry).toHaveBeenCalledWith({
+			attempt: 1,
+			maxRetries: 2,
+			delayMs: 1000,
+			errorMessage: "Provider error: 429",
+			status: 429,
+		});
+
+		await vi.advanceTimersByTimeAsync(1000);
+		await expect(result).resolves.toBe("ok");
+	});
+
+	it("numbers attempts consecutively across several retries", async () => {
+		vi.useFakeTimers();
+		const attempts: number[] = [];
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(500))
+			.mockRejectedValueOnce(providerError(500))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, {
+			maxRetries: 3,
+			onRetry: (info) => {
+				attempts.push(info.attempt);
+			},
+		});
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		await expect(result).resolves.toBe("ok");
+		expect(attempts).toEqual([1, 2]);
+	});
+
+	it("is not called when the request succeeds first time", async () => {
+		const onRetry = vi.fn();
+		const request = vi.fn<() => Promise<string>>().mockResolvedValue("ok");
+
+		await expect(retryProviderRequest(request, { maxRetries: 2, onRetry })).resolves.toBe("ok");
+		expect(onRetry).not.toHaveBeenCalled();
+	});
+
+	it("is not called for an error that is not retried", async () => {
+		const onRetry = vi.fn();
+		const error = providerError(400);
+		const request = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+
+		await expect(retryProviderRequest(request, { maxRetries: 2, onRetry })).rejects.toBe(error);
+		expect(onRetry).not.toHaveBeenCalled();
+	});
+
+	it("does not let a throwing observer break the retry", async () => {
+		vi.useFakeTimers();
+		const request = vi.fn<() => Promise<string>>().mockRejectedValueOnce(providerError(500)).mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, {
+			maxRetries: 1,
+			onRetry: () => {
+				throw new Error("observer blew up");
+			},
+		});
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		// The recoverable provider error must still recover.
+		await expect(result).resolves.toBe("ok");
+	});
+});


### PR DESCRIPTION
## Problem

`retryProviderRequest` retries silently. A request that succeeded on its third attempt is indistinguishable from one that was simply slow, so provider latency cannot be attributed: a turn showing 17s of provider time may be one slow call, or three failed ones plus their backoff, and nothing downstream can tell which.

This is already solved one layer over. `retryAssistantCall` exposes `RetryCallbacks`, and `AgentHarness` wires them for `compaction` and `branch_summary`. The provider-request path — which is every model turn — has no equivalent, so the retries that matter most for latency are the ones you cannot see.

I hit this building a run-timeline view: turn spans were unattributable because a retried turn looks exactly like a slow one.

## Change

An optional `onRetry` on `ProviderRetryOptions`, emitted before each backoff sleep:

```ts
onRetry?: (info: ProviderRetryInfo) => void | Promise<void>

interface ProviderRetryInfo {
  attempt: number;      // 1-indexed
  maxRetries: number;
  delayMs: number;      // the backoff about to be slept
  errorMessage: string;
  status: number | undefined;
}
```

Emitted *before* the sleep so a caller can attribute the wait to a retry rather than to a slow provider — matching `RetryCallbacks.onRetryScheduled`.

Additive and optional: existing callers are unaffected, and no behaviour changes when it is not supplied.

The callback runs inside a `try/catch`. Observation must never change behaviour, and a throwing observer would otherwise turn a recoverable provider error into a failed request. There is a test for exactly that.

## Tests

Five cases added to `packages/ai/test/provider-retry.test.ts`, following the existing fake-timer style:

- reports each retry before its backoff sleep, with the full payload
- numbers attempts consecutively across several retries
- not called when the request succeeds first time
- not called for an error that is not retried
- a throwing observer does not break the retry

`npx vitest --run` across all four retry suites: **34 passed**. Full pre-commit gate (`biome`, pinned deps, ts-imports, shrinkwrap, `tsgo --noEmit`, browser smoke) passes.

## Not included

Wiring this through `SimpleStreamOptions` into the harness so it surfaces as a `retry_scheduled` event alongside the compaction ones. That is the natural follow-up, but it touches the harness API, which is mid-rewrite on `main` — happy to add it here or in a follow-up, whichever you prefer.
