### PR TITLE
fix(ai): retry transient Codex websocket errors

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -59,6 +59,7 @@ import { buildBaseOptions } from "./simple-options.ts";
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth" as const;
 const DEFAULT_MAX_RETRIES = 0;
+const DEFAULT_WEBSOCKET_STREAM_ERROR_MAX_RETRIES = 1;
 const BASE_DELAY_MS = 1000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 60_000;
 const DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS = 15_000;
@@ -69,6 +70,20 @@ const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
 const WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 const PREVIOUS_RESPONSE_NOT_FOUND_CODE = "previous_response_not_found";
+const NON_RETRYABLE_CODEX_ERROR_CODES = new Set([
+	"authentication_error",
+	"bio_policy",
+	"context_length_exceeded",
+	"cyber_policy",
+	"insufficient_quota",
+	"invalid_prompt",
+	"invalid_request_error",
+	"permission_error",
+	"server_is_overloaded",
+	"slow_down",
+	"usage_limit_reached",
+	"usage_not_included",
+]);
 
 const CODEX_RESPONSE_STATUSES = new Set<CodexResponseStatus>([
 	"completed",
@@ -297,6 +312,8 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 			const bodyJson = JSON.stringify(body);
 			const httpTimeoutMs = normalizeTimeoutMs(options?.timeoutMs);
 			const websocketConnectTimeoutMs = normalizeTimeoutMs(options?.websocketConnectTimeoutMs);
+			const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+			const websocketStreamErrorMaxRetries = options?.maxRetries ?? DEFAULT_WEBSOCKET_STREAM_ERROR_MAX_RETRIES;
 			const transport = options?.transport || "auto";
 			let startEmitted = false;
 			const websocketDisabledForSession = transport !== "sse" && isWebSocketSseFallbackActive(cacheSessionId);
@@ -308,6 +325,7 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 				let websocketStarted = false;
 				let retriedWebSocketConnectionLimit = false;
 				let retriedMissingWebSocketContinuation = false;
+				let websocketRetryAttempts = 0;
 				while (true) {
 					websocketStarted = false;
 					try {
@@ -346,33 +364,51 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 						return;
 					} catch (error) {
 						const aborted = options?.signal?.aborted;
-						const connectionLimitBeforeStart = !websocketStarted && isWebSocketConnectionLimitReachedError(error);
-						const previousResponseNotFound = isPreviousResponseNotFoundError(error);
-						if (!aborted && previousResponseNotFound && !retriedMissingWebSocketContinuation) {
-							retriedMissingWebSocketContinuation = true;
-							continue;
-						}
-						if (!aborted && connectionLimitBeforeStart && !retriedWebSocketConnectionLimit) {
-							retriedWebSocketConnectionLimit = true;
-							continue;
-						}
-						if (aborted || (isCodexNonTransportError(error) && !connectionLimitBeforeStart)) {
+						const websocketOutputStarted = output.content.length > 0;
+						const action = classifyCodexWebSocketFailure(error);
+						if (aborted || action === "terminal") {
 							throw error;
+						}
+						if (action === "retry-missing-continuation") {
+							if (!retriedMissingWebSocketContinuation) {
+								retriedMissingWebSocketContinuation = true;
+								resetCodexReplayState(output);
+								continue;
+							}
+							throw error;
+						}
+						if (action === "retry-connection-limit" && !websocketOutputStarted) {
+							if (!retriedWebSocketConnectionLimit) {
+								retriedWebSocketConnectionLimit = true;
+								resetCodexReplayState(output);
+								continue;
+							}
+						} else if (
+							action === "retryable" &&
+							!websocketOutputStarted &&
+							websocketRetryAttempts < websocketStreamErrorMaxRetries
+						) {
+							const delayMs = BASE_DELAY_MS * 2 ** websocketRetryAttempts;
+							websocketRetryAttempts++;
+							resetCodexReplayState(output);
+							await sleep(delayMs, options?.signal);
+							continue;
 						}
 						appendAssistantMessageDiagnostic(
 							output,
 							createAssistantMessageDiagnostic("provider_transport_failure", error, {
 								configuredTransport: transport,
-								fallbackTransport: websocketStarted ? undefined : "sse",
+								fallbackTransport: websocketOutputStarted ? undefined : "sse",
 								eventsEmitted: websocketStarted,
 								phase: websocketStarted ? "after_message_stream_start" : "before_message_stream_start",
 								requestBytes: new TextEncoder().encode(bodyJson).byteLength,
 							}),
 						);
 						recordWebSocketFailure(cacheSessionId, error);
-						if (websocketStarted) {
+						if (websocketOutputStarted) {
 							throw error;
 						}
+						resetCodexReplayState(output);
 						recordWebSocketSseFallback(cacheSessionId);
 						break;
 					}
@@ -391,7 +427,6 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 			// Fetch with retry logic for rate limits and transient errors
 			let response: Response | undefined;
 			let lastError: Error | undefined;
-			const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
 
 			for (let attempt = 0; attempt <= maxRetries; attempt++) {
 				if (options?.signal?.aborted) {
@@ -672,12 +707,17 @@ async function processStream(
 
 class CodexApiError extends Error {
 	readonly code?: string;
+	readonly errorType?: string;
 	readonly payload?: Record<string, unknown>;
 
-	constructor(message: string, options?: { code?: string; payload?: Record<string, unknown>; cause?: unknown }) {
+	constructor(
+		message: string,
+		options?: { code?: string; errorType?: string; payload?: Record<string, unknown>; cause?: unknown },
+	) {
 		super(message);
 		this.name = "CodexApiError";
 		this.code = options?.code;
+		this.errorType = options?.errorType;
 		this.payload = options?.payload;
 		this.cause = options?.cause;
 	}
@@ -694,22 +734,36 @@ class CodexProtocolError extends Error {
 	}
 }
 
-function isCodexNonTransportError(error: unknown): boolean {
-	return error instanceof CodexApiError || error instanceof CodexProtocolError;
+type CodexWebSocketFailureAction =
+	| "transport"
+	| "retry-missing-continuation"
+	| "retry-connection-limit"
+	| "retryable"
+	| "terminal";
+
+function classifyCodexWebSocketFailure(error: unknown): CodexWebSocketFailureAction {
+	if (error instanceof CodexProtocolError) return "terminal";
+	if (!(error instanceof CodexApiError)) return "transport";
+	if (error.code === PREVIOUS_RESPONSE_NOT_FOUND_CODE) return "retry-missing-continuation";
+	if (error.code === WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE) return "retry-connection-limit";
+	const semanticCode = error.code ?? error.errorType;
+	if (semanticCode !== undefined && NON_RETRYABLE_CODEX_ERROR_CODES.has(semanticCode)) return "terminal";
+	return "retryable";
 }
 
-function isWebSocketConnectionLimitReachedError(error: unknown): boolean {
-	return error instanceof CodexApiError && error.code === WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE;
+function resetCodexReplayState(output: AssistantMessage): void {
+	delete output.responseId;
 }
 
-function isPreviousResponseNotFoundError(error: unknown): boolean {
-	return error instanceof CodexApiError && error.code === PREVIOUS_RESPONSE_NOT_FOUND_CODE;
-}
-
-function extractCodexEventError(event: Record<string, unknown>): { code?: string; message?: string } {
+function extractCodexEventError(event: Record<string, unknown>): {
+	code?: string;
+	errorType?: string;
+	message?: string;
+} {
 	const nested = event.error && typeof event.error === "object" ? (event.error as Record<string, unknown>) : undefined;
 	return {
 		code: typeof event.code === "string" ? event.code : typeof nested?.code === "string" ? nested.code : undefined,
+		errorType: typeof nested?.type === "string" ? nested.type : undefined,
 		message:
 			typeof event.message === "string"
 				? event.message
@@ -725,18 +779,25 @@ async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): 
 		if (!type) continue;
 
 		if (type === "error") {
-			const { code, message } = extractCodexEventError(event);
+			const { code, errorType, message } = extractCodexEventError(event);
 			throw new CodexApiError(`Codex error: ${message || code || JSON.stringify(event)}`, {
 				code,
+				errorType,
 				payload: event,
 			});
 		}
 
 		if (type === "response.failed") {
-			const response = (event as { response?: { error?: { code?: string; message?: string } } }).response;
-			const code = response?.error?.code;
-			const message = response?.error?.message;
-			throw new CodexApiError(message || "Codex response failed", { code, payload: event });
+			const response =
+				event.response && typeof event.response === "object"
+					? (event.response as Record<string, unknown>)
+					: undefined;
+			const { code, errorType, message } = extractCodexEventError(response ?? event);
+			throw new CodexApiError(message || "Codex response failed", {
+				code,
+				errorType,
+				payload: event,
+			});
 		}
 
 		if (type === "response.done" || type === "response.completed" || type === "response.incomplete") {

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -370,6 +370,9 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 							throw error;
 						}
 						if (action === "retry-missing-continuation") {
+							if (websocketOutputStarted) {
+								throw error;
+							}
 							if (!retriedMissingWebSocketContinuation) {
 								retriedMissingWebSocketContinuation = true;
 								resetCodexReplayState(output);

--- a/packages/ai/test/openai-codex-websocket-errors.test.ts
+++ b/packages/ai/test/openai-codex-websocket-errors.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+	closeOpenAICodexWebSocketSessions,
+	resetOpenAICodexWebSocketDebugStats,
+	stream as streamOpenAICodexResponses,
+} from "../src/api/openai-codex-responses.ts";
+import type { Context, Model } from "../src/types.ts";
+
+const MODEL: Model<"openai-codex-responses"> = {
+	id: "gpt-5.1-codex",
+	name: "GPT-5.1 Codex",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
+const CONTEXT: Context = {
+	systemPrompt: "You are a helpful assistant.",
+	messages: [{ role: "user", content: "Say hello", timestamp: 1 }],
+};
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	closeOpenAICodexWebSocketSessions();
+	resetOpenAICodexWebSocketDebugStats();
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+function mockToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+		"utf8",
+	).toString("base64");
+	return `aaa.${payload}.bbb`;
+}
+
+function successEvents(responseId: string, text?: string): Record<string, unknown>[] {
+	const outputEvents = text
+		? [
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: {
+						type: "message",
+						id: `msg_${responseId}`,
+						role: "assistant",
+						status: "in_progress",
+						content: [],
+					},
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: {
+						type: "message",
+						id: `msg_${responseId}`,
+						role: "assistant",
+						status: "completed",
+						content: [{ type: "output_text", text }],
+					},
+				},
+			]
+		: [];
+	return [
+		{ type: "response.created", response: { id: responseId } },
+		...outputEvents,
+		{
+			type: "response.completed",
+			response: {
+				id: responseId,
+				status: "completed",
+				usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+			},
+		},
+	];
+}
+
+function successfulSseResponse(): Response {
+	const events = [
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { type: "message", id: "msg_sse", role: "assistant", status: "in_progress", content: [] },
+		},
+		{
+			type: "response.output_item.done",
+			output_index: 0,
+			item: {
+				type: "message",
+				id: "msg_sse",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "Hello" }],
+			},
+		},
+		{
+			type: "response.completed",
+			response: {
+				status: "completed",
+				usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+			},
+		},
+	].map((event) => `data: ${JSON.stringify(event)}`);
+	const encoder = new TextEncoder();
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(`${events.join("\n\n")}\n\n`));
+				controller.close();
+			},
+		}),
+		{ status: 200, headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+interface MockWebSocketServer {
+	connectionCount(): number;
+	requests: Array<{ connectionId: number; body: Record<string, unknown> }>;
+}
+
+function stubWebSocketServer(
+	getEvents: (connectionId: number, requestIndex: number) => Record<string, unknown>[],
+): MockWebSocketServer {
+	let connections = 0;
+	const requests: MockWebSocketServer["requests"] = [];
+
+	class MockWebSocket extends EventTarget {
+		static OPEN = 1;
+		static CLOSED = 3;
+		readyState = MockWebSocket.OPEN;
+		private readonly connectionId = ++connections;
+
+		constructor() {
+			super();
+			queueMicrotask(() => this.dispatchEvent(new Event("open")));
+		}
+
+		send(data: string): void {
+			requests.push({ connectionId: this.connectionId, body: JSON.parse(data) as Record<string, unknown> });
+			const events = getEvents(this.connectionId, requests.length);
+			queueMicrotask(() => {
+				for (const event of events) {
+					this.dispatchEvent(Object.assign(new Event("message"), { data: JSON.stringify(event) }));
+				}
+			});
+		}
+
+		close(): void {
+			this.readyState = MockWebSocket.CLOSED;
+		}
+	}
+
+	vi.stubGlobal("WebSocket", MockWebSocket);
+	return { connectionCount: () => connections, requests };
+}
+
+function transientFailure(type: "response.failed" | "error" = "response.failed"): Record<string, unknown> {
+	const error = {
+		code: "account_temporarily_unavailable",
+		message: "This account is temporarily unavailable",
+	};
+	return type === "response.failed" ? { type, response: { error } } : { type, error };
+}
+
+it.each(["response.failed", "error"] as const)(
+	"retries an unknown %s once by default before assistant content",
+	async (failureType) => {
+		vi.useFakeTimers();
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const server = stubWebSocketServer((connectionId) =>
+			connectionId === 1
+				? [
+						{ type: "response.created", response: { id: "failed_response" } },
+						{ type: "codex.rate_limits", rate_limits: {} },
+						transientFailure(failureType),
+					]
+				: successEvents("recovered_response"),
+		);
+		const responseStream = streamOpenAICodexResponses(MODEL, CONTEXT, {
+			apiKey: mockToken(),
+			transport: "auto",
+		});
+		const eventTypes: string[] = [];
+		const resultPromise = (async () => {
+			for await (const event of responseStream) eventTypes.push(event.type);
+			return responseStream.result();
+		})();
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(server.connectionCount()).toBe(1);
+		await vi.advanceTimersByTimeAsync(1000);
+		const result = await resultPromise;
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.responseId).toBe("recovered_response");
+		expect(server.connectionCount()).toBe(2);
+		expect(server.requests[1].body).toEqual(server.requests[0].body);
+		expect(eventTypes.filter((type) => type === "start")).toHaveLength(1);
+		expect(fetchMock).not.toHaveBeenCalled();
+	},
+);
+
+it("falls back to SSE after the default websocket retry and keeps fallback sticky", async () => {
+	vi.useFakeTimers();
+	const fetchMock = vi.fn(async () => successfulSseResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [
+		{ type: "response.created", response: { id: "failed_response" } },
+		transientFailure(),
+	]);
+	const options = { apiKey: mockToken(), sessionId: "sticky-fallback", transport: "websocket" as const };
+
+	const firstPromise = streamOpenAICodexResponses(MODEL, CONTEXT, options).result();
+	await vi.advanceTimersByTimeAsync(0);
+	await vi.advanceTimersByTimeAsync(1000);
+	const first = await firstPromise;
+
+	expect(first.stopReason).toBe("stop");
+	expect(first.responseId).toBeUndefined();
+	expect(server.connectionCount()).toBe(2);
+	expect(fetchMock).toHaveBeenCalledTimes(1);
+
+	const second = await streamOpenAICodexResponses(MODEL, CONTEXT, options).result();
+	expect(second.stopReason).toBe("stop");
+	expect(server.connectionCount()).toBe(2);
+	expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it("respects explicit maxRetries zero", async () => {
+	const fetchMock = vi.fn(async () => successfulSseResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [transientFailure()]);
+
+	const result = await streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+		maxRetries: 0,
+	}).result();
+
+	expect(result.stopReason).toBe("stop");
+	expect(server.connectionCount()).toBe(1);
+	expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it("honors a larger configured websocket retry budget before falling back", async () => {
+	vi.useFakeTimers();
+	const fetchMock = vi.fn(async () => successfulSseResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [transientFailure()]);
+
+	const resultPromise = streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+		maxRetries: 2,
+	}).result();
+	await vi.advanceTimersByTimeAsync(0);
+	await vi.advanceTimersByTimeAsync(1000);
+	await vi.advanceTimersByTimeAsync(2000);
+	const result = await resultPromise;
+
+	expect(result.stopReason).toBe("stop");
+	expect(server.connectionCount()).toBe(3);
+	expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+const TERMINAL_CODES = [
+	"authentication_error",
+	"bio_policy",
+	"context_length_exceeded",
+	"cyber_policy",
+	"insufficient_quota",
+	"invalid_prompt",
+	"invalid_request_error",
+	"permission_error",
+	"server_is_overloaded",
+	"slow_down",
+	"usage_limit_reached",
+	"usage_not_included",
+];
+
+it.each([
+	...TERMINAL_CODES.map((code) => [code, { code, message: "Terminal" }]),
+	...["authentication_error", "invalid_request_error", "permission_error", "usage_limit_reached"].map((type) => [
+		`error.type ${type}`,
+		{ type, message: "Terminal" },
+	]),
+] as Array<[string, Record<string, unknown>]>)("does not retry terminal stream failure %s", async (_name, error) => {
+	const fetchMock = vi.fn();
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [{ type: "response.failed", response: { error } }]);
+
+	const result = await streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+		maxRetries: 3,
+	}).result();
+
+	expect(result.stopReason).toBe("error");
+	expect(server.connectionCount()).toBe(1);
+	expect(fetchMock).not.toHaveBeenCalled();
+});
+
+it("prefers a specific unknown code over a generic terminal error type", async () => {
+	vi.useFakeTimers();
+	const fetchMock = vi.fn();
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer((connectionId) =>
+		connectionId === 1
+			? [
+					{
+						type: "response.failed",
+						response: {
+							error: {
+								code: "account_temporarily_unavailable",
+								type: "invalid_request_error",
+								message: "This account is temporarily unavailable",
+							},
+						},
+					},
+				]
+			: successEvents("recovered_response"),
+	);
+
+	const resultPromise = streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+	}).result();
+	await vi.advanceTimersByTimeAsync(0);
+	await vi.advanceTimersByTimeAsync(1000);
+	const result = await resultPromise;
+
+	expect(result.stopReason).toBe("stop");
+	expect(server.connectionCount()).toBe(2);
+	expect(fetchMock).not.toHaveBeenCalled();
+});
+
+it("keeps connection-limit recovery outside the general retry budget", async () => {
+	const fetchMock = vi.fn(async () => successfulSseResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [{ type: "error", error: { code: "websocket_connection_limit_reached" } }]);
+
+	const result = await streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+		maxRetries: 3,
+	}).result();
+
+	expect(result.stopReason).toBe("stop");
+	expect(server.connectionCount()).toBe(2);
+	expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it("keeps missing-continuation recovery outside the general retry budget", async () => {
+	const fetchMock = vi.fn();
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [
+		{ type: "error", error: { code: "previous_response_not_found", message: "Previous response not found" } },
+	]);
+
+	const result = await streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+		maxRetries: 3,
+	}).result();
+
+	expect(result.stopReason).toBe("error");
+	expect(server.connectionCount()).toBe(2);
+	expect(fetchMock).not.toHaveBeenCalled();
+});
+
+it("retries cached websocket failures with full history", async () => {
+	vi.useFakeTimers();
+	const server = stubWebSocketServer((_connectionId, requestIndex) => {
+		if (requestIndex === 1) return successEvents("resp_1", "Hello");
+		if (requestIndex === 2) return [{ type: "codex.rate_limits", rate_limits: {} }, transientFailure()];
+		return successEvents("resp_2");
+	});
+
+	const first = await streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		sessionId: "cached-retry",
+		transport: "websocket-cached",
+	}).result();
+	const secondContext: Context = {
+		...CONTEXT,
+		messages: [...CONTEXT.messages, first, { role: "user", content: "Continue", timestamp: 2 }],
+	};
+	const resultPromise = streamOpenAICodexResponses(MODEL, secondContext, {
+		apiKey: mockToken(),
+		sessionId: "cached-retry",
+		transport: "websocket-cached",
+	}).result();
+
+	await vi.advanceTimersByTimeAsync(0);
+	await vi.advanceTimersByTimeAsync(1000);
+	const result = await resultPromise;
+
+	expect(result.stopReason).toBe("stop");
+	expect(server.requests).toHaveLength(3);
+	expect(server.requests[1].body.previous_response_id).toBe("resp_1");
+	expect(server.requests[1].body.input).toHaveLength(1);
+	expect(server.requests[2].body.previous_response_id).toBeUndefined();
+	expect(server.requests[2].body.input).toHaveLength(3);
+});
+
+it("does not retry after assistant content has started", async () => {
+	const fetchMock = vi.fn();
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [
+		{ type: "response.created", response: { id: "resp_1" } },
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+		},
+		transientFailure(),
+	]);
+
+	const result = await streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+		maxRetries: 2,
+	}).result();
+
+	expect(result.stopReason).toBe("error");
+	expect(server.connectionCount()).toBe(1);
+	expect(fetchMock).not.toHaveBeenCalled();
+});

--- a/packages/ai/test/openai-codex-websocket-errors.test.ts
+++ b/packages/ai/test/openai-codex-websocket-errors.test.ts
@@ -433,3 +433,27 @@ it("does not retry after assistant content has started", async () => {
 	expect(server.connectionCount()).toBe(1);
 	expect(fetchMock).not.toHaveBeenCalled();
 });
+
+it("does not retry a missing continuation after assistant content has started", async () => {
+	const fetchMock = vi.fn();
+	vi.stubGlobal("fetch", fetchMock);
+	const server = stubWebSocketServer(() => [
+		{ type: "response.created", response: { id: "resp_1" } },
+		{
+			type: "response.output_item.added",
+			output_index: 0,
+			item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+		},
+		{ type: "error", error: { code: "previous_response_not_found", message: "Previous response not found" } },
+	]);
+
+	const result = await streamOpenAICodexResponses(MODEL, CONTEXT, {
+		apiKey: mockToken(),
+		transport: "auto",
+		maxRetries: 2,
+	}).result();
+
+	expect(result.stopReason).toBe("error");
+	expect(server.connectionCount()).toBe(1);
+	expect(fetchMock).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

- Retry unknown Codex WebSocket `response.failed` and top-level `error` frames before assistant output starts.
- Preserve terminal error handling and the existing one-shot recovery paths for missing continuations and connection limits.
- Clear stale response state before replay or SSE fallback, while preventing replay after assistant content begins.
- Add focused regression coverage for retry budgets, fallback behavior, cached continuation recovery, and replay safety.

Fixes #7444

## Testing

- `node ../../node_modules/vitest/dist/cli.js --run test/openai-codex-websocket-errors.test.ts test/openai-codex-stream.test.ts` (65 passed)
- `npx biome check packages/ai/src/api/openai-codex-responses.ts packages/ai/test/openai-codex-websocket-errors.test.ts`
- `npm run check` (blocked by unrelated missing generated model entries for GitHub Copilot `grok-4.5` and Groq `qwen/qwen3.6-27b`)
- `./test.sh` (same two unrelated model catalog failures; all Codex tests and other workspaces pass)
