### PR TITLE
Fix event bus leak 

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -115,6 +115,7 @@
 - Fixed GitHub Copilot compaction and branch summaries using the Individual endpoint instead of the credential-resolved Business or Enterprise endpoint ([#6768](https://github.com/earendil-works/pi/issues/6768)).
 - Fixed extension model calls dropping credential-resolved endpoints when forwarding request authentication, including custom compaction with GitHub Copilot Business and Enterprise accounts ([#7579](https://github.com/earendil-works/pi/issues/7579)).
 - Fixed fullscreen transcript navigation leaving no editor-accessible `Home`, `End`, `PageUp`, or `PageDown` variants by adding Ctrl-modified editor bindings ([#7574](https://github.com/earendil-works/pi/issues/7574)).
+- Fixed extension event-bus listeners surviving session reloads and disposal ([#7193](https://github.com/earendil-works/pi/issues/7193)).
 
 ## [0.83.0] - 2026-07-29
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2605,8 +2605,10 @@ export class AgentSession {
 	}
 
 	async reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<void> {
-		const previousFlagValues = this._extensionRunner.getFlagValues();
-		await emitSessionShutdownEvent(this._extensionRunner, { type: "session_shutdown", reason: "reload" });
+		const oldRunner = this._extensionRunner;
+		const previousFlagValues = oldRunner.getFlagValues();
+		await emitSessionShutdownEvent(oldRunner, { type: "session_shutdown", reason: "reload" });
+		oldRunner.invalidate();
 		await this.settingsManager.reload();
 		this.syncQueueModesFromSettings();
 		resetApiProviders();

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -176,6 +176,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
 	};
 	const state: { staleMessage?: string } = {};
+	const eventBusUnsubscribers = new Set<() => void>();
 	const assertActive = () => {
 		if (state.staleMessage) {
 			throw new Error(state.staleMessage);
@@ -203,9 +204,23 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		pendingNativeProviderRegistrations: [],
 		assertActive,
 		invalidate: (message) => {
-			state.staleMessage ??=
+			if (state.staleMessage) return;
+			state.staleMessage =
 				message ??
 				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
+			for (const unsubscribe of eventBusUnsubscribers) unsubscribe();
+			eventBusUnsubscribers.clear();
+		},
+		trackEventBusSubscription: (unsubscribe) => {
+			let active = true;
+			const trackedUnsubscribe = () => {
+				if (!active) return;
+				active = false;
+				eventBusUnsubscribers.delete(trackedUnsubscribe);
+				unsubscribe();
+			};
+			eventBusUnsubscribers.add(trackedUnsubscribe);
+			return trackedUnsubscribe;
 		},
 		// Pre-bind: queue registrations so bindCore() can flush them once the
 		// model registry is available. bindCore() replaces both with direct calls.
@@ -395,7 +410,16 @@ function createExtensionAPI(
 			runtime.unregisterProvider(name, extension.path);
 		},
 
-		events: eventBus,
+		events: {
+			emit(channel, data) {
+				runtime.assertActive();
+				eventBus.emit(channel, data);
+			},
+			on(channel, handler) {
+				runtime.assertActive();
+				return runtime.trackEventBusSubscription(eventBus.on(channel, handler));
+			},
+		},
 	} as ExtensionAPI;
 
 	return api;

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1599,6 +1599,8 @@ export interface ExtensionRuntimeState {
 	assertActive: () => void;
 	/** Marks this extension instance as stale after runtime replacement or reload. */
 	invalidate: (message?: string) => void;
+	/** Retain an event-bus subscription until this runtime is invalidated. */
+	trackEventBusSubscription: (unsubscribe: () => void) => () => void;
 	/**
 	 * Register or unregister a provider.
 	 *

--- a/packages/coding-agent/test/suite/regressions/7193-event-bus-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7193-event-bus-lifecycle.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEventBus } from "../../../src/core/event-bus.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../../src/core/extensions/loader.ts";
+import type { ExtensionAPI, ExtensionFactory, ResourceLoader } from "../../../src/index.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("issue #7193 extension event-bus lifecycle", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("removes extension-owned event-bus listeners on reload and dispose", async () => {
+		const eventBus = createEventBus();
+		let extensionCalls = 0;
+		let hostCalls = 0;
+		let firstApi: ExtensionAPI | undefined;
+		const factory: ExtensionFactory = (pi) => {
+			firstApi ??= pi;
+			pi.events.on("reload:test", () => extensionCalls++);
+		};
+		eventBus.on("reload:test", () => hostCalls++);
+
+		const loadExtensions = async () => {
+			const runtime = createExtensionRuntime();
+			const extension = await loadExtensionFromFactory(factory, process.cwd(), eventBus, runtime);
+			return { extensions: [extension], errors: [], runtime };
+		};
+		let extensionsResult = await loadExtensions();
+		const resourceLoader: ResourceLoader = {
+			getExtensions: () => extensionsResult,
+			getSkills: () => ({ skills: [], diagnostics: [] }),
+			getPrompts: () => ({ prompts: [], diagnostics: [] }),
+			getThemes: () => ({ themes: [], diagnostics: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			getSystemPrompt: () => undefined,
+			getSystemPromptSource: () => undefined,
+			getAppendSystemPrompt: () => [],
+			getAppendSystemPromptSources: () => [],
+			extendResources: () => {},
+			reload: async () => {
+				extensionsResult = await loadExtensions();
+			},
+		};
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ shutdownHandler: () => {} });
+
+		const emit = async () => {
+			const extensionBefore = extensionCalls;
+			const hostBefore = hostCalls;
+			eventBus.emit("reload:test", undefined);
+			await new Promise((resolve) => setImmediate(resolve));
+			return { extension: extensionCalls - extensionBefore, host: hostCalls - hostBefore };
+		};
+
+		expect(await emit()).toEqual({ extension: 1, host: 1 });
+		await harness.session.reload();
+		expect(() => firstApi?.getCommands()).toThrow("stale after session replacement or reload");
+		expect(await emit()).toEqual({ extension: 1, host: 1 });
+		await harness.session.reload();
+		expect(await emit()).toEqual({ extension: 1, host: 1 });
+
+		harness.session.dispose();
+		expect(await emit()).toEqual({ extension: 0, host: 1 });
+	});
+});


### PR DESCRIPTION
Fixes #7193

## Summary

- scope `pi.events.on()` subscriptions to the extension runtime that registered them
- remove stale runtime listeners after reload and disposal without affecting host-owned listeners
- invalidate the previous extension runtime during reload
- add regression coverage for repeated reloads, disposal, stale APIs, and shared event buses

## Checks

- `npx vitest --run test/suite/regressions/7193-event-bus-lifecycle.test.ts`
- `npm run check`