### PR TITLE
fix(tui): skip OSC 8 scan for plain prefixes

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -480,6 +480,10 @@ function formatOsc8Close(terminator: Osc8Terminator): string {
 }
 
 function getActiveOsc8Close(prefix: string): string {
+	if (!prefix.includes("\x1b]8;")) {
+		return "";
+	}
+
 	let activeHyperlink: ActiveHyperlink | null = null;
 	let i = 0;
 	while (i < prefix.length) {


### PR DESCRIPTION
Follow-up to #7657.

Skip scanning the retained prefix when it cannot contain an OSC 8 sequence. This avoids per-character ANSI parsing for ordinary truncated text while preserving the existing hyperlink behavior.

Tests:
- node --test packages/tui/test/truncate-to-width.test.ts (16/16)
- npm run check (pre-existing repository-wide type errors)
- ./test.sh (pre-existing repository/environment failures)
