### PR TITLE
feat: harness v2 r2

### DIFF
--- a/packages/agent/src/harness/reducer.ts
+++ b/packages/agent/src/harness/reducer.ts
@@ -502,11 +502,14 @@ export function reduceLaneState(input: LaneReductionInput): LaneReductionResult 
 			!entriesById.has(record.target.id) &&
 			!cancelledQueueIds.has(record.target.id),
 	);
+	const started = input.openOperations[0];
+	const capturedInitialMessageIds = new Set(
+		started?.intent.kind === "run" ? started.intent.initialMessages.map((target) => target.id) : [],
+	);
 	const pendingNextRun = pendingQueueRecords
-		.filter((record) => record.queue === "nextRun")
+		.filter((record) => record.queue === "nextRun" && !capturedInitialMessageIds.has(record.target.id))
 		.map((record) => clone(record.target));
 	const effectiveConfiguration = deriveEffectiveConfiguration(input);
-	const started = input.openOperations[0];
 
 	if (!started) {
 		return {

--- a/packages/agent/src/harness/reducer.ts
+++ b/packages/agent/src/harness/reducer.ts
@@ -1,10 +1,15 @@
+import type { AssistantMessage, DeferredHandle, StopReason } from "@earendil-works/pi-ai";
 import { Guard } from "typebox/guard";
+import type { AgentMessage, AgentToolCall, ThinkingLevel } from "../types.ts";
 import type {
 	Entry,
 	LaneRecord,
 	OperationStartedRecord,
 	ProvisionedEntry,
+	QueueEnqueuedRecord,
 	StepAttemptRecord,
+	ToolStartedRecord,
+	WriteDeferredRecord,
 } from "./session/types.ts";
 
 /**
@@ -43,6 +48,79 @@ export interface RecordLogSlice {
 	records: readonly LaneRecord[];
 	/** Operation-owned entries plus entries fetched directly by provisioned or referenced ids. */
 	entries: readonly Entry[];
+}
+
+export interface EffectiveLaneConfiguration {
+	model: { provider: string; modelId: string };
+	thinkingLevel: ThinkingLevel;
+	activeToolNames: string[];
+}
+
+export interface TerminalFailureState {
+	entryId: string;
+	source: "step" | "deferred_fetch";
+	message: AssistantMessage;
+}
+
+export interface ToolBatchState {
+	assistantEntryId: string;
+	calls: {
+		toolIndex: number;
+		toolCall: AgentToolCall;
+		started?: ToolStartedRecord;
+		resultExists: boolean;
+		terminate?: boolean;
+	}[];
+	truncated: boolean;
+	unresolved: boolean;
+}
+
+export interface LaneState {
+	lane: string;
+	leafId: string | null;
+	operation: null | {
+		id: string;
+		kind: "run" | "compaction" | "navigation";
+		intent: OperationStartedRecord["intent"];
+		aborting: boolean;
+		step: null | {
+			kind: "assistant" | "compaction" | "branch_summary";
+			attempts: number;
+			resultEntryId: string;
+			compactionReason?: "manual" | "threshold" | "overflow";
+		};
+		toolBatch: ToolBatchState | null;
+		missingInitialMessages: ProvisionedEntry[];
+		pendingSteer: ProvisionedEntry[];
+		pendingFollowUp: ProvisionedEntry[];
+		pendingWrites: ProvisionedEntry[];
+		deferred: DeferredHandle | null;
+		overflowRecoveryUsed: boolean;
+		newestOwn: null | {
+			entryId: string;
+			type: Entry["type"];
+			role?: AgentMessage["role"];
+			stopReason?: StopReason;
+		};
+		targets: { result?: boolean; summary?: boolean };
+	};
+	pendingNextRun: ProvisionedEntry[];
+}
+
+export interface LaneReductionInput extends RecordLogSlice {
+	leafId: string | null;
+	/** Entries appended by the open operation, oldest first. Empty when idle. */
+	ownEntries: readonly Entry[];
+	/** Bounded effective-state lookups at the operation anchor or idle leaf, oldest first. */
+	configurationEntries: readonly Entry[];
+	/** Harness option fallbacks used when no persisted value exists. */
+	defaults: EffectiveLaneConfiguration;
+}
+
+export interface LaneReductionResult {
+	laneState: LaneState;
+	effectiveConfiguration: EffectiveLaneConfiguration;
+	terminalFailure: TerminalFailureState | null;
 }
 
 interface AttemptSeries {
@@ -294,4 +372,272 @@ export function validateRecordLog(input: RecordLogSlice): void {
 				break;
 		}
 	}
+}
+
+function clone<T>(value: T): T {
+	return structuredClone(value);
+}
+
+function bySequence<T extends { seq: number }>(values: readonly T[]): T[] {
+	return [...values].sort((left, right) => left.seq - right.seq);
+}
+
+function deriveEffectiveConfiguration(input: LaneReductionInput): EffectiveLaneConfiguration {
+	let configuration = clone(input.defaults);
+	const entriesById = new Map<string, Entry>();
+	for (const entry of [...input.configurationEntries, ...input.ownEntries]) entriesById.set(entry.id, entry);
+
+	for (const entry of bySequence([...entriesById.values()])) {
+		switch (entry.type) {
+			case "model_change":
+				configuration = { ...configuration, model: { provider: entry.provider, modelId: entry.modelId } };
+				break;
+			case "thinking_level_change":
+				configuration = { ...configuration, thinkingLevel: entry.thinkingLevel as ThinkingLevel };
+				break;
+			case "active_tools_change":
+				configuration = { ...configuration, activeToolNames: [...entry.activeToolNames] };
+				break;
+			case "message":
+				if (entry.message.role === "assistant") {
+					configuration = {
+						...configuration,
+						model: { provider: entry.message.provider, modelId: entry.message.model },
+					};
+				}
+				break;
+		}
+	}
+	return configuration;
+}
+
+function deriveNewestOwn(
+	entry: Entry | undefined,
+): NonNullable<NonNullable<LaneState["operation"]>["newestOwn"]> | null {
+	if (!entry) return null;
+	if (entry.type !== "message") return { entryId: entry.id, type: entry.type };
+	if (entry.message.role !== "assistant") {
+		return { entryId: entry.id, type: entry.type, role: entry.message.role };
+	}
+	return {
+		entryId: entry.id,
+		type: entry.type,
+		role: entry.message.role,
+		stopReason: entry.message.stopReason,
+	};
+}
+
+function deriveToolBatch(
+	operationId: string,
+	records: readonly LaneRecord[],
+	ownEntries: readonly Entry[],
+	entriesById: ReadonlyMap<string, Entry>,
+): ToolBatchState | null {
+	const assistantEntry = [...ownEntries]
+		.reverse()
+		.find(
+			(entry) =>
+				entry.type === "message" &&
+				entry.message.role === "assistant" &&
+				entry.message.content.some((content) => content.type === "toolCall"),
+		);
+	if (!assistantEntry || assistantEntry.type !== "message" || assistantEntry.message.role !== "assistant") return null;
+
+	const toolCalls = assistantEntry.message.content.filter(
+		(content): content is AgentToolCall => content.type === "toolCall",
+	);
+	const starts = new Map<number, ToolStartedRecord>();
+	for (const record of records) {
+		if (
+			record.type === "tool_started" &&
+			record.runId === operationId &&
+			record.assistantEntryId === assistantEntry.id
+		) {
+			starts.set(record.toolIndex, record);
+		}
+	}
+
+	const calls = toolCalls.map((toolCall, toolIndex) => {
+		const started = starts.get(toolIndex);
+		const startedResult = started ? entriesById.get(started.resultEntryId) : undefined;
+		const blockedResult = ownEntries.find(
+			(entry) =>
+				entry.seq > assistantEntry.seq &&
+				entry.type === "message" &&
+				entry.message.role === "toolResult" &&
+				entry.message.toolCallId === toolCall.id,
+		);
+		const result = startedResult ?? blockedResult;
+		return {
+			toolIndex,
+			toolCall: clone(toolCall),
+			...(started ? { started: clone(started) } : {}),
+			resultExists: result !== undefined,
+			...(result?.type === "message" && result.terminate === true ? { terminate: true } : {}),
+		};
+	});
+
+	return {
+		assistantEntryId: assistantEntry.id,
+		calls,
+		truncated: assistantEntry.message.stopReason === "length",
+		unresolved: calls.some((call) => !call.resultExists),
+	};
+}
+
+/** Purely reconstructs one lane's orchestration state from its bounded recovery inputs. */
+export function reduceLaneState(input: LaneReductionInput): LaneReductionResult {
+	validateRecordLog(input);
+
+	const records = bySequence(input.records);
+	const ownEntries = bySequence(input.ownEntries);
+	const entriesById = new Map<string, Entry>();
+	for (const entry of [...input.entries, ...ownEntries]) entriesById.set(entry.id, entry);
+	const cancelledQueueIds = new Set(
+		records.filter((record) => record.type === "queue_cancelled").map((record) => record.entryId),
+	);
+	const pendingQueueRecords = records.filter(
+		(record): record is QueueEnqueuedRecord =>
+			record.type === "queue_enqueued" &&
+			!entriesById.has(record.target.id) &&
+			!cancelledQueueIds.has(record.target.id),
+	);
+	const pendingNextRun = pendingQueueRecords
+		.filter((record) => record.queue === "nextRun")
+		.map((record) => clone(record.target));
+	const effectiveConfiguration = deriveEffectiveConfiguration(input);
+	const started = input.openOperations[0];
+
+	if (!started) {
+		return {
+			laneState: { lane: input.lane, leafId: input.leafId, operation: null, pendingNextRun },
+			effectiveConfiguration,
+			terminalFailure: null,
+		};
+	}
+
+	const operationRecords = records.filter((record) =>
+		record.type === "operation_started" ? record.id === started.id : "runId" in record && record.runId === started.id,
+	);
+	const aborting = operationRecords.some((record) => record.type === "abort_requested");
+	const pendingSteer = aborting
+		? []
+		: pendingQueueRecords
+				.filter((record) => record.queue === "steer" && record.runId === started.id)
+				.map((record) => clone(record.target));
+	const pendingFollowUp = aborting
+		? []
+		: pendingQueueRecords
+				.filter((record) => record.queue === "followUp" && record.runId === started.id)
+				.map((record) => clone(record.target));
+	const pendingWrites = operationRecords
+		.filter(
+			(record): record is WriteDeferredRecord =>
+				record.type === "write_deferred" && !entriesById.has(record.target.id),
+		)
+		.map((record) => clone(record.target));
+	const missingInitialMessages =
+		started.intent.kind === "run"
+			? started.intent.initialMessages.filter((target) => !entriesById.has(target.id)).map(clone)
+			: [];
+
+	const newestAttempt = operationRecords.filter((record) => record.type === "step_attempt").at(-1);
+	const step =
+		newestAttempt && !entriesById.has(newestAttempt.resultEntryId)
+			? {
+					kind: newestAttempt.step,
+					attempts: newestAttempt.attempt,
+					resultEntryId: newestAttempt.resultEntryId,
+					...(newestAttempt.step === "compaction" ? { compactionReason: newestAttempt.compactionReason } : {}),
+				}
+			: null;
+
+	const consumedInputIds = new Set<string>();
+	if (started.intent.kind === "run") {
+		for (const target of started.intent.initialMessages) consumedInputIds.add(target.id);
+	}
+	for (const record of operationRecords) {
+		if (record.type === "queue_enqueued" && record.queue !== "nextRun") consumedInputIds.add(record.target.id);
+	}
+	let newestConsumedInputSequence = Number.NEGATIVE_INFINITY;
+	for (const id of consumedInputIds) {
+		const entry = entriesById.get(id);
+		if (entry?.type === "message") newestConsumedInputSequence = Math.max(newestConsumedInputSequence, entry.seq);
+	}
+	const overflowRecoveryUsed = operationRecords.some(
+		(record) =>
+			record.type === "step_attempt" &&
+			record.step === "compaction" &&
+			record.compactionReason === "overflow" &&
+			record.seq > newestConsumedInputSequence,
+	);
+
+	const newestOwnEntry = ownEntries.at(-1);
+	const newestOwn = deriveNewestOwn(newestOwnEntry);
+	const deferred =
+		newestOwnEntry?.type === "message" &&
+		newestOwnEntry.message.role === "assistant" &&
+		newestOwnEntry.message.stopReason === "deferred" &&
+		newestOwnEntry.message.deferred
+			? clone(newestOwnEntry.message.deferred)
+			: null;
+	const targets: { result?: boolean; summary?: boolean } = {};
+	if (started.intent.kind === "compaction") {
+		targets.result = entriesById.has(started.intent.resultEntryId);
+	} else if (started.intent.kind === "navigation" && started.intent.summaryEntryId) {
+		targets.summary = entriesById.has(started.intent.summaryEntryId);
+	}
+
+	const deferredWriteIds = new Set(
+		operationRecords.filter((record) => record.type === "write_deferred").map((record) => record.target.id),
+	);
+	let terminalFailure: TerminalFailureState | null = null;
+	if (
+		newestOwnEntry?.type === "message" &&
+		newestOwnEntry.message.role === "assistant" &&
+		newestOwnEntry.message.stopReason === "error" &&
+		!deferredWriteIds.has(newestOwnEntry.id)
+	) {
+		const producedByStep = operationRecords.some(
+			(record) => record.type === "step_attempt" && record.resultEntryId === newestOwnEntry.id,
+		);
+		const previousOwnEntry = ownEntries.at(-2);
+		const producedByDeferredFetch =
+			previousOwnEntry?.type === "message" &&
+			previousOwnEntry.message.role === "assistant" &&
+			previousOwnEntry.message.stopReason === "deferred";
+		if (producedByStep || producedByDeferredFetch) {
+			terminalFailure = {
+				entryId: newestOwnEntry.id,
+				source: producedByStep ? "step" : "deferred_fetch",
+				message: clone(newestOwnEntry.message),
+			};
+		}
+	}
+
+	return {
+		laneState: {
+			lane: input.lane,
+			leafId: input.leafId,
+			operation: {
+				id: started.id,
+				kind: started.intent.kind,
+				intent: clone(started.intent),
+				aborting,
+				step,
+				toolBatch: deriveToolBatch(started.id, operationRecords, ownEntries, entriesById),
+				missingInitialMessages,
+				pendingSteer,
+				pendingFollowUp,
+				pendingWrites,
+				deferred,
+				overflowRecoveryUsed,
+				newestOwn,
+				targets,
+			},
+			pendingNextRun,
+		},
+		effectiveConfiguration,
+		terminalFailure,
+	};
 }

--- a/packages/agent/src/harness/reducer.ts
+++ b/packages/agent/src/harness/reducer.ts
@@ -30,7 +30,8 @@ export type RecordLogCorruptionReason =
 	| "inconsistent_step"
 	| "tool_call_mismatch"
 	| "duplicate_tool_invocation"
-	| "provisioned_entry_mismatch";
+	| "provisioned_entry_mismatch"
+	| "invalid_deferred_handle";
 
 export class RecordLogCorruption extends Error {
 	readonly reason: RecordLogCorruptionReason;
@@ -268,6 +269,19 @@ function validateToolStart(
 	);
 }
 
+function validateDeferredHandles(entries: Iterable<Entry>): void {
+	for (const entry of entries) {
+		if (
+			entry.type === "message" &&
+			entry.message.role === "assistant" &&
+			entry.message.stopReason === "deferred" &&
+			!entry.message.deferred
+		) {
+			corrupt("invalid_deferred_handle", `Deferred assistant entry ${entry.id} does not carry a handle`);
+		}
+	}
+}
+
 function validateOperationResult(entriesById: ReadonlyMap<string, Entry>, record: OperationStartedRecord): void {
 	switch (record.intent.kind) {
 		case "run":
@@ -301,6 +315,7 @@ export function validateRecordLog(input: RecordLogSlice): void {
 	}
 
 	const entriesById = new Map(input.entries.map((entry) => [entry.id, entry]));
+	validateDeferredHandles(entriesById.values());
 	const starts = new Map<string, OperationStartedRecord>();
 	const finishedAt = new Map<string, number>();
 	const abortedAt = new Map<string, number>();
@@ -432,6 +447,7 @@ function deriveToolBatch(
 	records: readonly LaneRecord[],
 	ownEntries: readonly Entry[],
 	entriesById: ReadonlyMap<string, Entry>,
+	deferredWriteIds: ReadonlySet<string>,
 ): ToolBatchState | null {
 	const assistantEntry = [...ownEntries]
 		.reverse()
@@ -463,6 +479,7 @@ function deriveToolBatch(
 		const blockedResult = ownEntries.find(
 			(entry) =>
 				entry.seq > assistantEntry.seq &&
+				!deferredWriteIds.has(entry.id) &&
 				entry.type === "message" &&
 				entry.message.role === "toolResult" &&
 				entry.message.toolCallId === toolCall.id,
@@ -606,9 +623,13 @@ export function reduceLaneState(input: LaneReductionInput): LaneReductionResult 
 		);
 		const previousOwnEntry = ownEntries.at(-2);
 		const producedByDeferredFetch =
-			previousOwnEntry?.type === "message" &&
-			previousOwnEntry.message.role === "assistant" &&
-			previousOwnEntry.message.stopReason === "deferred";
+			operationRecords.some(
+				(record) =>
+					record.type === "usage" && record.cause === "deferred_fetch" && record.entryId === newestOwnEntry.id,
+			) ||
+			(previousOwnEntry?.type === "message" &&
+				previousOwnEntry.message.role === "assistant" &&
+				previousOwnEntry.message.stopReason === "deferred");
 		if (producedByStep || producedByDeferredFetch) {
 			terminalFailure = {
 				entryId: newestOwnEntry.id,
@@ -628,7 +649,7 @@ export function reduceLaneState(input: LaneReductionInput): LaneReductionResult 
 				intent: clone(started.intent),
 				aborting,
 				step,
-				toolBatch: deriveToolBatch(started.id, operationRecords, ownEntries, entriesById),
+				toolBatch: deriveToolBatch(started.id, operationRecords, ownEntries, entriesById, deferredWriteIds),
 				missingInitialMessages,
 				pendingSteer,
 				pendingFollowUp,

--- a/packages/agent/test/harness/reducer.test.ts
+++ b/packages/agent/test/harness/reducer.test.ts
@@ -1,9 +1,12 @@
 import type { AssistantMessage, ToolResultMessage, Usage, UserMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+	type EffectiveLaneConfiguration,
+	type LaneReductionInput,
 	RecordLogCorruption,
 	type RecordLogCorruptionReason,
 	type RecordLogSlice,
+	reduceLaneState,
 	validateRecordLog,
 } from "../../src/harness/reducer.ts";
 import type {
@@ -264,6 +267,32 @@ function recoverySlice(records: readonly LaneRecord[], entries: readonly Entry[]
 		)
 		.sort((left, right) => right.seq - left.seq);
 	return { lane: "main", openOperations, records, entries };
+}
+
+const defaults: EffectiveLaneConfiguration = {
+	model: { provider: "default-provider", modelId: "default-model" },
+	thinkingLevel: "off",
+	activeToolNames: ["default-tool"],
+};
+
+function reductionInput(
+	records: readonly LaneRecord[],
+	ownEntries: readonly Entry[] = [],
+	options: {
+		entries?: readonly Entry[];
+		configurationEntries?: readonly Entry[];
+		leafId?: string | null;
+		defaults?: EffectiveLaneConfiguration;
+	} = {},
+): LaneReductionInput {
+	const slice = recoverySlice(records, [...ownEntries, ...(options.entries ?? [])]);
+	return {
+		...slice,
+		leafId: options.leafId === undefined ? (ownEntries.at(-1)?.id ?? null) : options.leafId,
+		ownEntries,
+		configurationEntries: options.configurationEntries ?? [],
+		defaults: options.defaults ?? defaults,
+	};
 }
 
 function expectCorruption(input: RecordLogSlice, reason: RecordLogCorruptionReason): void {
@@ -615,5 +644,418 @@ const validPrefixCases = [
 describe("valid section 6 durable prefixes", () => {
 	it.each(validPrefixCases)("accepts $name", ({ input }) => {
 		expect(validateRecordLog(input)).toBeUndefined();
+	});
+});
+
+describe("lane-state reduction", () => {
+	it("reduces an idle lane to pending next-run input and default configuration", () => {
+		const pending = messageTarget("next-pending", userMessage("pending"));
+		const cancelled = messageTarget("next-cancelled", userMessage("cancelled"));
+		const consumed = messageTarget("next-consumed", userMessage("consumed"));
+		const input = reductionInput(
+			[
+				queueEnqueued(1, pending, "nextRun"),
+				queueEnqueued(2, cancelled, "nextRun"),
+				queueCancelled(3, cancelled.id, null),
+				queueEnqueued(4, consumed, "nextRun"),
+			],
+			[],
+			{ entries: [persistedEntry(consumed, 5)], leafId: "idle-leaf" },
+		);
+
+		expect(reduceLaneState(input)).toEqual({
+			laneState: {
+				lane: "main",
+				leafId: "idle-leaf",
+				operation: null,
+				pendingNextRun: [pending],
+			},
+			effectiveConfiguration: defaults,
+			terminalFailure: null,
+		});
+	});
+
+	it("folds persisted configuration over copied defaults in sequence", () => {
+		const configurationEntries: Entry[] = [
+			{
+				type: "model_change",
+				id: "model-change",
+				parentId: null,
+				seq: 1,
+				timestamp: 1,
+				provider: "persisted-provider",
+				modelId: "persisted-model",
+			},
+			{
+				type: "thinking_level_change",
+				id: "thinking-change",
+				parentId: "model-change",
+				seq: 2,
+				timestamp: 2,
+				thinkingLevel: "high",
+			},
+			{
+				type: "active_tools_change",
+				id: "tools-change",
+				parentId: "thinking-change",
+				seq: 3,
+				timestamp: 3,
+				activeToolNames: ["persisted-tool"],
+			},
+		];
+		const input = reductionInput([], [], { configurationEntries });
+
+		expect(reduceLaneState(input).effectiveConfiguration).toEqual({
+			model: { provider: "persisted-provider", modelId: "persisted-model" },
+			thinkingLevel: "high",
+			activeToolNames: ["persisted-tool"],
+		});
+		expect(input.defaults).toEqual(defaults);
+	});
+
+	it("applies committed operation-owned configuration after the anchor", () => {
+		const assistant = persistedEntry(
+			messageTarget("assistant-config", {
+				...assistantMessage([{ type: "text", text: "response" }]),
+				provider: "response-provider",
+				model: "response-model",
+			}),
+			2,
+		);
+		const tools: Entry = {
+			type: "active_tools_change",
+			id: "operation-tools",
+			parentId: assistant.id,
+			seq: 3,
+			timestamp: 3,
+			activeToolNames: ["operation-tool"],
+		};
+		const result = reduceLaneState(reductionInput([runStarted(1)], [assistant, tools]));
+
+		expect(result.effectiveConfiguration).toEqual({
+			model: { provider: "response-provider", modelId: "response-model" },
+			thinkingLevel: "off",
+			activeToolNames: ["operation-tool"],
+		});
+	});
+
+	it("derives missing input, queues, deferred writes, and the unfinished attempt", () => {
+		const missingPrompt = messageTarget("prompt-missing", userMessage("missing"));
+		const committedPrompt = messageTarget("prompt-committed", userMessage("committed"));
+		const steer = messageTarget("steer-pending", userMessage("steer"));
+		const consumedFollowUp = messageTarget("follow-consumed", userMessage("follow"));
+		const nextRun = messageTarget("next-run", userMessage("next"));
+		const pendingWrite = messageTarget("write-pending", userMessage("write"));
+		const appliedWrite = messageTarget("write-applied", userMessage("applied"));
+		const start = runStarted(1, { initialMessages: [missingPrompt, committedPrompt] });
+		const committedPromptEntry = persistedEntry(committedPrompt, 2);
+		const consumedFollowUpEntry = persistedEntry(consumedFollowUp, 6, committedPrompt.id);
+		const appliedWriteEntry = persistedEntry(appliedWrite, 9, consumedFollowUp.id);
+		const input = reductionInput(
+			[
+				start,
+				queueEnqueued(3, steer),
+				queueEnqueued(4, consumedFollowUp, "followUp"),
+				queueEnqueued(5, nextRun, "nextRun"),
+				writeDeferred(7, pendingWrite),
+				writeDeferred(8, appliedWrite),
+				attempt(10, start.id, "assistant", 1, "assistant-pending"),
+			],
+			[committedPromptEntry, consumedFollowUpEntry, appliedWriteEntry],
+		);
+
+		const result = reduceLaneState(input);
+		expect(result.laneState.pendingNextRun).toEqual([nextRun]);
+		expect(result.laneState.operation).toMatchObject({
+			id: start.id,
+			kind: "run",
+			aborting: false,
+			missingInitialMessages: [missingPrompt],
+			pendingSteer: [steer],
+			pendingFollowUp: [],
+			pendingWrites: [pendingWrite],
+			step: { kind: "assistant", attempts: 1, resultEntryId: "assistant-pending" },
+			newestOwn: { entryId: appliedWrite.id, type: "message", role: "user" },
+		});
+	});
+
+	it("kills steer and follow-up queues on abort while preserving writes and next-run input", () => {
+		const steer = messageTarget("steer-aborted", userMessage("steer"));
+		const followUp = messageTarget("follow-aborted", userMessage("follow"));
+		const nextRun = messageTarget("next-after-abort", userMessage("next"));
+		const pendingWrite = messageTarget("write-after-abort", userMessage("write"));
+		const input = reductionInput([
+			runStarted(1),
+			queueEnqueued(2, steer),
+			queueEnqueued(3, followUp, "followUp"),
+			queueEnqueued(4, nextRun, "nextRun"),
+			writeDeferred(5, pendingWrite),
+			abortRequested(6),
+		]);
+
+		const result = reduceLaneState(input);
+		expect(result.laneState.pendingNextRun).toEqual([nextRun]);
+		expect(result.laneState.operation).toMatchObject({
+			aborting: true,
+			pendingSteer: [],
+			pendingFollowUp: [],
+			pendingWrites: [pendingWrite],
+		});
+	});
+
+	it.each([
+		{
+			name: "assistant",
+			record: attempt(2, "run-1", "assistant", 1, "result"),
+			expected: { kind: "assistant", attempts: 1, resultEntryId: "result" },
+		},
+		{
+			name: "compaction",
+			record: attempt(2, "run-1", "compaction", 1, "result", "overflow"),
+			expected: {
+				kind: "compaction",
+				attempts: 1,
+				resultEntryId: "result",
+				compactionReason: "overflow",
+			},
+		},
+		{
+			name: "branch summary",
+			record: attempt(2, "run-1", "branch_summary", 1, "result"),
+			expected: { kind: "branch_summary", attempts: 1, resultEntryId: "result" },
+		},
+	])("reduces an unfinished $name step", ({ record, expected }) => {
+		const result = reduceLaneState(reductionInput([runStarted(1), record]));
+		expect(result.laneState.operation?.step).toEqual(expected);
+	});
+
+	it("closes the newest attempt only when its provisioned result exists", () => {
+		const target = messageTarget("result", assistantMessage([{ type: "text", text: "done" }]));
+		const result = reduceLaneState(
+			reductionInput([runStarted(1), attempt(2, "run-1", "assistant", 1, target.id)], [persistedEntry(target, 3)]),
+		);
+		expect(result.laneState.operation?.step).toBeNull();
+	});
+
+	it("ignores unfulfilled result ids from earlier attempts", () => {
+		const target = messageTarget("attempt-2-result", assistantMessage([{ type: "text", text: "done" }]));
+		const result = reduceLaneState(
+			reductionInput(
+				[
+					runStarted(1),
+					attempt(2, "run-1", "assistant", 1, "attempt-1-result"),
+					attempt(3, "run-1", "assistant", 2, target.id),
+				],
+				[persistedEntry(target, 4)],
+			),
+		);
+		expect(result.laneState.operation?.step).toBeNull();
+	});
+
+	it.each([
+		{ name: "X1", records: [runStarted(1), attempt(2, "run-1", "assistant", 1, "assistant-tools")] },
+		{
+			name: "X3",
+			records: [runStarted(1), attempt(2, "run-1", "assistant", 1, "assistant-tools"), toolStarted(4)],
+		},
+		{
+			name: "X5",
+			records: [runStarted(1), attempt(2, "run-1", "assistant", 1, "assistant-tools"), toolStarted(4)],
+			result: { ...persistedEntry(toolResultTarget, 5, assistantToolsEntry.id), terminate: true as const },
+		},
+	])("reduces tool batch state at $name", ({ records, result }) => {
+		const ownEntries = result ? [assistantToolsEntry, result] : [assistantToolsEntry];
+		const reduction = reduceLaneState(reductionInput(records, ownEntries));
+		const call = reduction.laneState.operation?.toolBatch?.calls[0];
+
+		expect(reduction.laneState.operation?.toolBatch).toMatchObject({
+			assistantEntryId: assistantToolsEntry.id,
+			truncated: false,
+			unresolved: !result,
+		});
+		expect(call).toMatchObject({
+			toolIndex: 0,
+			toolCall: { id: "call-1", name: "tool-1" },
+			resultExists: result !== undefined,
+			...(result ? { terminate: true } : {}),
+		});
+		expect(call?.started !== undefined).toBe(records.some((record) => record.type === "tool_started"));
+	});
+
+	it("matches blocked results without tool-start records and preserves source order", () => {
+		const assistant = persistedEntry(
+			messageTarget(
+				"assistant-two-tools",
+				assistantMessage(
+					[
+						{ type: "toolCall", id: "call-1", name: "tool-1", arguments: {} },
+						{ type: "toolCall", id: "call-2", name: "tool-2", arguments: {} },
+					],
+					"toolUse",
+				),
+			),
+			3,
+		);
+		const blocked = persistedEntry(
+			messageTarget("blocked-result", {
+				...toolResultMessage("call-1", "tool-1"),
+				content: [{ type: "text", text: "blocked" }],
+				isError: true,
+			}),
+			4,
+			assistant.id,
+		);
+		const secondStart = toolStarted(5, {
+			assistantEntryId: assistant.id,
+			toolIndex: 1,
+			toolCallId: "call-2",
+			toolName: "tool-2",
+			resultEntryId: "call-2-result",
+		});
+		const result = reduceLaneState(
+			reductionInput(
+				[runStarted(1), attempt(2, "run-1", "assistant", 1, assistant.id), secondStart],
+				[assistant, blocked],
+			),
+		);
+
+		expect(result.laneState.operation?.toolBatch?.calls).toMatchObject([
+			{ toolIndex: 0, toolCall: { id: "call-1" }, resultExists: true },
+			{ toolIndex: 1, toolCall: { id: "call-2" }, started: secondStart, resultExists: false },
+		]);
+	});
+
+	it("marks a length-stopped tool batch as truncated without resolving it", () => {
+		const truncated = persistedEntry(
+			messageTarget(
+				"assistant-truncated",
+				assistantMessage([{ type: "toolCall", id: "call-1", name: "tool-1", arguments: {} }], "length"),
+			),
+			3,
+		);
+		const result = reduceLaneState(
+			reductionInput([runStarted(1), attempt(2, "run-1", "assistant", 1, truncated.id)], [truncated]),
+		);
+		expect(result.laneState.operation?.toolBatch).toMatchObject({ truncated: true, unresolved: true });
+	});
+
+	it("detects an unredeemed deferred handle only at the operation tail", () => {
+		const deferredMessage = assistantMessage([], "deferred");
+		const deferredEntry = persistedEntry(messageTarget("assistant-deferred", deferredMessage), 3);
+		const pending = reduceLaneState(
+			reductionInput([runStarted(1), attempt(2, "run-1", "assistant", 1, deferredEntry.id)], [deferredEntry]),
+		);
+		expect(pending.laneState.operation?.deferred).toEqual(deferredMessage.deferred);
+
+		const successor = persistedEntry(
+			messageTarget("assistant-ready", assistantMessage([{ type: "text", text: "ready" }])),
+			4,
+			deferredEntry.id,
+		);
+		const redeemed = reduceLaneState(
+			reductionInput(
+				[runStarted(1), attempt(2, "run-1", "assistant", 1, deferredEntry.id)],
+				[deferredEntry, successor],
+			),
+		);
+		expect(redeemed.laneState.operation?.deferred).toBeNull();
+	});
+
+	it.each([
+		{
+			name: "step",
+			records: [runStarted(1), attempt(2, "run-1", "assistant", 1, "assistant-error")],
+			ownEntries: [
+				persistedEntry(
+					messageTarget("assistant-error", { ...assistantMessage([], "error"), errorMessage: "failed" }),
+					3,
+				),
+			],
+			expectedSource: "step",
+		},
+		{
+			name: "deferred fetch",
+			records: [runStarted(1), attempt(2, "run-1", "assistant", 1, "assistant-deferred")],
+			ownEntries: [
+				persistedEntry(messageTarget("assistant-deferred", assistantMessage([], "deferred")), 3),
+				persistedEntry(
+					messageTarget("deferred-error", { ...assistantMessage([], "error"), errorMessage: "expired" }),
+					4,
+					"assistant-deferred",
+				),
+			],
+			expectedSource: "deferred_fetch",
+		},
+	])("derives $name terminal-failure provenance", ({ records, ownEntries, expectedSource }) => {
+		const result = reduceLaneState(reductionInput(records, ownEntries));
+		expect(result.terminalFailure).toMatchObject({ source: expectedSource });
+	});
+
+	it("does not classify an error-shaped deferred write as terminal failure", () => {
+		const target = messageTarget("written-error", { ...assistantMessage([], "error"), errorMessage: "note" });
+		const entry = persistedEntry(target, 3);
+		const result = reduceLaneState(reductionInput([runStarted(1), writeDeferred(2, target)], [entry]));
+		expect(result.terminalFailure).toBeNull();
+	});
+
+	it.each([
+		{
+			name: "manual compaction result",
+			records: [compactionStarted(1)],
+			entries: [] as Entry[],
+			expected: { result: false },
+		},
+		{
+			name: "completed manual compaction result",
+			records: [compactionStarted(1)],
+			entries: [compactionEntry("compaction-1", 2)],
+			expected: { result: true },
+		},
+		{
+			name: "missing navigation summary",
+			records: [navigationStarted(1)],
+			entries: [] as Entry[],
+			expected: { summary: false },
+		},
+		{
+			name: "navigation summary",
+			records: [navigationStarted(1)],
+			entries: [branchSummaryEntry("summary-1", 2)],
+			expected: { summary: true },
+		},
+	])("derives structural target state for $name", ({ records, entries, expected }) => {
+		const result = reduceLaneState(reductionInput(records, entries));
+		expect(result.laneState.operation?.targets).toEqual(expected);
+	});
+
+	it("resets the overflow guard only after newer conversational input is consumed", () => {
+		const initial = messageTarget("initial", userMessage("initial"));
+		const steer = messageTarget("steer", userMessage("steer"));
+		const start = runStarted(1, { initialMessages: [initial] });
+		const initialEntry = persistedEntry(initial, 2);
+		const records: LaneRecord[] = [
+			start,
+			attempt(3, start.id, "compaction", 1, "overflow-summary", "overflow"),
+			queueEnqueued(5, steer),
+		];
+
+		const used = reduceLaneState(reductionInput(records, [initialEntry]));
+		expect(used.laneState.operation?.overflowRecoveryUsed).toBe(true);
+
+		const reset = reduceLaneState(reductionInput(records, [initialEntry, persistedEntry(steer, 6, initial.id)]));
+		expect(reset.laneState.operation?.overflowRecoveryUsed).toBe(false);
+	});
+
+	it("is deterministic and does not mutate or alias its inputs", () => {
+		const pending = messageTarget("next", userMessage("next"));
+		const input = reductionInput([queueEnqueued(1, pending, "nextRun")]);
+		const before = structuredClone(input);
+		const first = reduceLaneState(input);
+		const second = reduceLaneState(input);
+
+		expect(first).toEqual(second);
+		expect(input).toEqual(before);
+		first.laneState.pendingNextRun[0]!.id = "mutated-output";
+		expect(input.records[0]).toMatchObject({ type: "queue_enqueued", target: { id: "next" } });
 	});
 });

--- a/packages/agent/test/harness/reducer.test.ts
+++ b/packages/agent/test/harness/reducer.test.ts
@@ -424,6 +424,19 @@ const corruptionCases: CorruptionCase[] = [
 			[persistedEntry(messageTarget("prompt-1", userMessage("different")), 2)],
 		),
 	},
+	{
+		name: "a deferred assistant message has no handle",
+		reason: "invalid_deferred_handle",
+		input: recoverySlice(
+			[runStarted(1)],
+			[
+				persistedEntry(
+					messageTarget("assistant-deferred", { ...assistantMessage([], "deferred"), deferred: undefined }),
+					2,
+				),
+			],
+		),
+	},
 ];
 
 describe("record-log validity", () => {
@@ -895,6 +908,20 @@ describe("lane-state reduction", () => {
 		expect(call?.started !== undefined).toBe(records.some((record) => record.type === "tool_started"));
 	});
 
+	it("does not resolve a tool batch from a deferred-write tool result", () => {
+		const assistant = persistedEntry(assistantToolTarget, 3);
+		const writtenResult = messageTarget("written-tool-result", toolResultMessage());
+		const result = reduceLaneState(
+			reductionInput(
+				[runStarted(1), attempt(2, "run-1", "assistant", 1, assistant.id), writeDeferred(4, writtenResult)],
+				[assistant, persistedEntry(writtenResult, 5, assistant.id)],
+			),
+		);
+
+		expect(result.laneState.operation?.toolBatch?.calls[0]).toMatchObject({ resultExists: false });
+		expect(result.laneState.operation?.toolBatch?.unresolved).toBe(true);
+	});
+
 	it("matches blocked results without tool-start records and preserves source order", () => {
 		const assistant = persistedEntry(
 			messageTarget(
@@ -995,6 +1022,32 @@ describe("lane-state reduction", () => {
 					messageTarget("deferred-error", { ...assistantMessage([], "error"), errorMessage: "expired" }),
 					4,
 					"assistant-deferred",
+				),
+			],
+			expectedSource: "deferred_fetch",
+		},
+		{
+			name: "deferred fetch usage record",
+			records: [
+				runStarted(1),
+				{
+					type: "usage",
+					id: "deferred-usage",
+					lane: "main",
+					seq: 3,
+					timestamp: 3,
+					cause: "deferred_fetch",
+					runId: "run-1",
+					entryId: "deferred-error",
+					attempt: 1,
+					stopReason: "error",
+					usage,
+				} satisfies UsageRecord,
+			],
+			ownEntries: [
+				persistedEntry(
+					messageTarget("deferred-error", { ...assistantMessage([], "error"), errorMessage: "expired" }),
+					2,
 				),
 			],
 			expectedSource: "deferred_fetch",

--- a/packages/agent/test/harness/reducer.test.ts
+++ b/packages/agent/test/harness/reducer.test.ts
@@ -739,6 +739,19 @@ describe("lane-state reduction", () => {
 		});
 	});
 
+	it("keeps captured next-run input with the open run instead of pending next-run", () => {
+		const captured = messageTarget("next-captured", userMessage("captured"));
+		const later = messageTarget("next-later", userMessage("later"));
+		const start = runStarted(2, { initialMessages: [captured] });
+
+		const result = reduceLaneState(
+			reductionInput([queueEnqueued(1, captured, "nextRun"), start, queueEnqueued(3, later, "nextRun")]),
+		);
+
+		expect(result.laneState.pendingNextRun).toEqual([later]);
+		expect(result.laneState.operation?.missingInitialMessages).toEqual([captured]);
+	});
+
 	it("derives missing input, queues, deferred writes, and the unfinished attempt", () => {
 		const missingPrompt = messageTarget("prompt-missing", userMessage("missing"));
 		const committedPrompt = messageTarget("prompt-committed", userMessage("committed"));


### PR DESCRIPTION
This PR adds the R2 pure lane reducer: `LaneReductionInput` → `LaneReductionResult` contract, deriving durable `LaneState`, effective lane configuration, and terminal-failure provenance from bounded recovery records/entries.

It also expands reducer tests for idle/open/suspended states, queues/writes, attempts, tool batches, deferred handles, structural targets, config overrides, overflow recovery, and corruption edge cases.