### PR TITLE
fix(ai): replace qwen3.8-max-preview with qwen3.8-max on token plan

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -293,6 +293,8 @@ const QWEN_TOKEN_PLAN_REASONING_EFFORT_UNSUPPORTED_MODEL_IDS = new Set([
 	"qwen3.7-max",
 	"qwen3.7-plus",
 ]);
+// Retired preview id — models.dev may still list it after GA ships.
+const QWEN_TOKEN_PLAN_EXCLUDED_MODEL_IDS = new Set(["qwen3.8-max-preview"]);
 
 const KIMI_K3_MAX_TOKENS = 131072;
 const KIMI_K3_COST = {
@@ -2132,6 +2134,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 			for (const [modelId, model] of Object.entries(providerModels)) {
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
+				if (QWEN_TOKEN_PLAN_EXCLUDED_MODEL_IDS.has(modelId)) continue;
 				const supportsReasoningEffort = !QWEN_TOKEN_PLAN_REASONING_EFFORT_UNSUPPORTED_MODEL_IDS.has(modelId);
 
 				models.push({
@@ -2146,7 +2149,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					...(supportsReasoningEffort
 						? {
 								thinkingLevelMap:
-									modelId === "qwen3.8-max-preview"
+									modelId === "qwen3.8-max"
 										? QWEN_TOKEN_PLAN_QWEN38_THINKING_LEVEL_MAP
 										: QWEN_TOKEN_PLAN_HIGH_MAX_THINKING_LEVEL_MAP,
 							}

--- a/packages/ai/test/qwen-token-plan-models.test.ts
+++ b/packages/ai/test/qwen-token-plan-models.test.ts
@@ -53,7 +53,7 @@ const TEXT_MODELS = [
 	"qwen3.6-plus",
 	"qwen3.7-max",
 	"qwen3.7-plus",
-	"qwen3.8-max-preview",
+	"qwen3.8-max",
 ];
 
 const IMAGE_MODELS = ["qwen-image-2.0", "qwen-image-2.0-pro", "wan2.7-image", "wan2.7-image-pro"];
@@ -72,7 +72,7 @@ const QWEN_THINKING_MODELS = [
 	"qwen3.6-plus",
 	"qwen3.7-max",
 	"qwen3.7-plus",
-	"qwen3.8-max-preview",
+	"qwen3.8-max",
 ] as const;
 
 const QWEN_THINKING_MODEL_CASES = (["qwen-token-plan", "qwen-token-plan-cn"] as const).flatMap((provider) =>
@@ -155,9 +155,9 @@ describe("Qwen Token Plan models", () => {
 	it.each(["qwen-token-plan", "qwen-token-plan-cn"] as const)(
 		"exposes qwen3.8 reasoning_effort levels on %s",
 		(provider) => {
-			const model = getModels(provider).find((candidate) => candidate.id === "qwen3.8-max-preview");
+			const model = getModels(provider).find((candidate) => candidate.id === "qwen3.8-max");
 			expect(model).toBeDefined();
-			if (!model) throw new Error(`Missing model: ${provider}/qwen3.8-max-preview`);
+			if (!model) throw new Error(`Missing model: ${provider}/qwen3.8-max`);
 
 			expect(model.thinkingLevelMap).toMatchObject({
 				minimal: null,
@@ -167,6 +167,14 @@ describe("Qwen Token Plan models", () => {
 				xhigh: "xhigh",
 				max: null,
 			});
+		},
+	);
+
+	it.each(["qwen-token-plan", "qwen-token-plan-cn"] as const)(
+		"omits retired qwen3.8-max-preview on %s",
+		(provider) => {
+			const modelIds = getModels(provider).map((model) => model.id);
+			expect(modelIds).not.toContain("qwen3.8-max-preview");
 		},
 	);
 
@@ -205,9 +213,9 @@ describe("Qwen Token Plan models", () => {
 	it.each(["qwen-token-plan", "qwen-token-plan-cn"] as const)(
 		"sends qwen3.8 max reasoning_effort on %s",
 		async (provider) => {
-			const model = getModels(provider).find((candidate) => candidate.id === "qwen3.8-max-preview");
+			const model = getModels(provider).find((candidate) => candidate.id === "qwen3.8-max");
 			expect(model).toBeDefined();
-			if (!model) throw new Error(`Missing model: ${provider}/qwen3.8-max-preview`);
+			if (!model) throw new Error(`Missing model: ${provider}/qwen3.8-max`);
 
 			let payload: unknown;
 			await streamSimple(


### PR DESCRIPTION
## Summary

- Replace `qwen3.8-max-preview` with the GA `qwen3.8-max` model for both Qwen Token Plan providers.
- Apply the Qwen 3.8 reasoning effort mapping (`low`, `medium`, and `xhigh`) to the GA model.
- Explicitly exclude the preview model from generated catalogs so stale models.dev data cannot reintroduce it.
- Update tests to require the GA model and verify that the preview model is absent from both regions.

## Context

`qwen3.8-max` is now available through models.dev for both `alibaba-token-plan` and `alibaba-token-plan-cn`.

Alibaba Cloud has announced that `qwen3.8-max-preview` will be retired on August 5, 2026, with the change taking effect by August 6, 2026 00:00 Beijing time:

https://www.aliyun.com/notice/118516 (alibaba-token-plan-cn)
https://www.alibabacloud.com/notice/detail?_p_lc=1&id=2069 (alibaba-token-plan intl)

Because models.dev still lists the preview model, the generator needs an explicit exclusion to prevent it from remaining in the Qwen Token Plan catalog after retirement.

## Validation

- Generated the model catalog from the current models.dev data.
- Confirmed both Qwen Token Plan providers include `qwen3.8-max` with `maxTokens: 131072` and `low` / `medium` / `xhigh` reasoning levels.
- Confirmed neither provider includes `qwen3.8-max-preview`.
- `qwen-token-plan-models.test.ts`: 58/58 passed.
- `npm run check`: passed.
