### PR TITLE
fix(tui): handle selection page keybindings

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -82,13 +82,13 @@ Modifier combinations: `ctrl+shift+x`, `alt+ctrl+x`, `ctrl+shift+alt+x`, `ctrl+1
 
 These actions apply when interactive mode uses `--ui-mode fullscreen` and target the primary transcript scroll region. Two-finger trackpad and mouse-wheel input scroll the region under the pointer, falling back to the transcript over the fixed editor/status/footer dock. Clicking an OSC 8 hyperlink opens it in the default handler. Dragging with the primary mouse button selects text and copies it to the clipboard; holding at the transcript's top or bottom edge auto-scrolls into off-screen content.
 
-Fullscreen transcript bindings take precedence over editor bindings. The default unmodified navigation keys therefore control the transcript in fullscreen mode, while their `ctrl` variants continue to control the editor. Outside fullscreen mode, both variants control the editor.
+Fullscreen transcript bindings take precedence over editor bindings. The exception is a focused selection component that declares `capturesSelectPageInput`: overlapping `tui.select.pageUp` and `tui.select.pageDown` bindings then reach the selection instead of scrolling the transcript. The default unmodified navigation keys therefore control the transcript in fullscreen mode when no selection list is active, while their `ctrl` variants continue to control the editor. Outside fullscreen mode, both variants control the editor.
 
 | Key | Default mode | Fullscreen mode |
 |-----|--------------|-----------------|
 | `home`, `end` | Editor | Transcript |
 | `ctrl+home`, `ctrl+end` | Editor | Editor |
-| `pageUp`, `pageDown` | Editor | Transcript |
+| `pageUp`, `pageDown` | Editor | Active selection, otherwise transcript |
 | `ctrl+pageUp`, `ctrl+pageDown` | Editor | Editor |
 
 This routing remains configurable through the ordinary action bindings. For example, `"tui.altScreen.pageUp": "ctrl+pageUp"` makes `pageUp` control the editor and `ctrl+pageUp` control the transcript in fullscreen mode. Setting `"tui.altScreen.pageUp": []` disables that transcript shortcut entirely. User bindings replace the defaults for that action.

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -14,6 +14,7 @@ All components implement:
 interface Component {
   render(width: number): string[];
   handleInput?(data: string): void;
+  readonly capturesSelectPageInput?: boolean;
   wantsKeyRelease?: boolean;
   invalidate(): void;
 }
@@ -23,8 +24,20 @@ interface Component {
 |--------|-------------|
 | `render(width)` | Return array of strings (one per line). Each line **must not exceed `width`**. |
 | `handleInput?(data)` | Receive keyboard input when component has focus. |
+| `capturesSelectPageInput?` | If true, selection page keys take precedence over fullscreen viewport scrolling. |
 | `wantsKeyRelease?` | If true, component receives key release events (Kitty protocol). Default: false. |
 | `invalidate()` | Clear cached render state. Called on theme changes. |
+
+`SelectList` and `SettingsList` set `capturesSelectPageInput` automatically. `Container` propagates the capability from its children. When adding `handleInput` to a container, preserve the container instance instead of returning a plain wrapper object, which would drop propagated component capabilities:
+
+```typescript
+return Object.assign(container, {
+  handleInput(data: string) {
+    selectList.handleInput(data);
+    tui.requestRender();
+  },
+});
+```
 
 The TUI appends a full SGR reset and OSC 8 reset at the end of each rendered line. Styles do not carry across lines. If you emit multi-line text with styling, reapply styles per line or use `wrapTextWithAnsi()` so styles are preserved for each wrapped line.
 
@@ -283,23 +296,29 @@ const image = new Image(
 
 ## Keyboard Input
 
-Use `matchesKey()` for key detection:
+Use the injected keybindings manager for configurable selection actions. Selection components should also set `capturesSelectPageInput` so overlapping PageUp/PageDown bindings reach the focused list in fullscreen mode:
 
 ```typescript
-import { matchesKey, Key } from "@earendil-works/pi-tui";
+readonly capturesSelectPageInput = true;
 
 handleInput(data: string) {
-  if (matchesKey(data, Key.up)) {
-    this.selectedIndex--;
-  } else if (matchesKey(data, Key.enter)) {
+  if (this.keybindings.matches(data, "tui.select.pageUp")) {
+    this.selectedIndex = Math.max(0, this.selectedIndex - this.pageSize);
+  } else if (this.keybindings.matches(data, "tui.select.pageDown")) {
+    this.selectedIndex = Math.min(this.items.length - 1, this.selectedIndex + this.pageSize);
+  } else if (this.keybindings.matches(data, "tui.select.up")) {
+    this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+  } else if (this.keybindings.matches(data, "tui.select.down")) {
+    this.selectedIndex = Math.min(this.items.length - 1, this.selectedIndex + 1);
+  } else if (this.keybindings.matches(data, "tui.select.confirm")) {
     this.onSelect?.(this.selectedIndex);
-  } else if (matchesKey(data, Key.escape)) {
+  } else if (this.keybindings.matches(data, "tui.select.cancel")) {
     this.onCancel?.();
-  } else if (matchesKey(data, Key.ctrl("c"))) {
-    // Ctrl+C
   }
 }
 ```
+
+Use `matchesKey()` with `Key.*` only when a component intentionally handles a physical key rather than a configurable action.
 
 **Key identifiers** (use `Key.*` for autocomplete, or string literals):
 - Basic keys: `Key.enter`, `Key.escape`, `Key.tab`, `Key.space`, `Key.backspace`, `Key.delete`, `Key.home`, `Key.end`
@@ -331,12 +350,15 @@ Example: Interactive selector
 
 ```typescript
 import {
-  matchesKey, Key,
-  truncateToWidth, visibleWidth
+  type KeybindingsManager,
+  truncateToWidth
 } from "@earendil-works/pi-tui";
 
 class MySelector {
+  readonly capturesSelectPageInput = true;
   private items: string[];
+  private keybindings: Pick<KeybindingsManager, "matches">;
+  private onChange: () => void;
   private selected = 0;
   private cachedWidth?: number;
   private cachedLines?: string[];
@@ -344,20 +366,36 @@ class MySelector {
   public onSelect?: (item: string) => void;
   public onCancel?: () => void;
 
-  constructor(items: string[]) {
+  constructor(
+    items: string[],
+    keybindings: Pick<KeybindingsManager, "matches">,
+    onChange: () => void,
+  ) {
     this.items = items;
+    this.keybindings = keybindings;
+    this.onChange = onChange;
   }
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.up) && this.selected > 0) {
-      this.selected--;
+    if (this.keybindings.matches(data, "tui.select.pageUp")) {
+      this.selected = Math.max(0, this.selected - 5);
       this.invalidate();
-    } else if (matchesKey(data, Key.down) && this.selected < this.items.length - 1) {
-      this.selected++;
+      this.onChange();
+    } else if (this.keybindings.matches(data, "tui.select.pageDown")) {
+      this.selected = Math.min(this.items.length - 1, this.selected + 5);
       this.invalidate();
-    } else if (matchesKey(data, Key.enter)) {
+      this.onChange();
+    } else if (this.keybindings.matches(data, "tui.select.up")) {
+      this.selected = Math.max(0, this.selected - 1);
+      this.invalidate();
+      this.onChange();
+    } else if (this.keybindings.matches(data, "tui.select.down")) {
+      this.selected = Math.min(this.items.length - 1, this.selected + 1);
+      this.invalidate();
+      this.onChange();
+    } else if (this.keybindings.matches(data, "tui.select.confirm")) {
       this.onSelect?.(this.items[this.selected]);
-    } else if (matchesKey(data, Key.escape)) {
+    } else if (this.keybindings.matches(data, "tui.select.cancel")) {
       this.onCancel?.();
     }
   }
@@ -389,19 +427,12 @@ pi.registerCommand("pick", {
   description: "Pick an item",
   handler: async (_args, ctx) => {
     const items = ["Option A", "Option B", "Option C"];
-    const selected = await ctx.ui.custom<string | null>((tui, _theme, _keybindings, done) => {
-      const selector = new MySelector(items);
+    const selected = await ctx.ui.custom<string | null>((tui, _theme, keybindings, done) => {
+      const selector = new MySelector(items, keybindings, () => tui.requestRender());
       selector.onSelect = done;
       selector.onCancel = () => done(null);
 
-      return {
-        render: (width) => selector.render(width),
-        handleInput: (data) => {
-          selector.handleInput(data);
-          tui.requestRender();
-        },
-        invalidate: () => selector.invalidate(),
-      };
+      return selector;
     });
 
     if (selected !== null) {
@@ -653,11 +684,9 @@ pi.registerCommand("pick", {
       // Bottom border
       container.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
 
-      return {
-        render: (w) => container.render(w),
-        invalidate: () => container.invalidate(),
+      return Object.assign(container, {
         handleInput: (data) => { selectList.handleInput(data); tui.requestRender(); },
-      };
+      });
     });
 
     if (result) {
@@ -733,11 +762,9 @@ pi.registerCommand("settings", {
       );
       container.addChild(settingsList);
 
-      return {
-        render: (w) => container.render(w),
-        invalidate: () => container.invalidate(),
+      return Object.assign(container, {
         handleInput: (data) => settingsList.handleInput?.(data),
-      };
+      });
     });
   },
 });
@@ -925,7 +952,7 @@ export default function (pi: ExtensionAPI) {
 
 3. **Call tui.requestRender() after state changes** - In `handleInput`, call `tui.requestRender()` after updating state.
 
-4. **Return the three-method object** - Custom components need `{ render, invalidate, handleInput }`.
+4. **Preserve component capabilities** - When adding input handling to a `Container`, return the container itself with `Object.assign()` instead of wrapping its `render()` and `invalidate()` methods in a plain object.
 
 5. **Use existing components** - `SelectList`, `SettingsList`, `BorderedLoader` cover 90% of cases. Don't rebuild them.
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -246,7 +246,7 @@ pi --no-extensions -e ./my-extension.ts
 | `-h`, `--help` | Show help |
 | `-v`, `--version` | Show version |
 
-In `fullscreen` mode, the transcript scrolls inside the terminal viewport while queued messages, working status, extension widgets, editor, and footer remain fixed at the bottom. Mouse/trackpad input scrolls the region under the pointer; keyboard viewport actions always remain available. Inline images work in terminals that support the Kitty graphics protocol, including Kitty and Ghostty. In iTerm2 they render as text placeholders because its inline-image protocol cannot delete or crop placements during application-owned scrolling. In `regular` mode, pi uses the main screen and terminal-owned scrollback, and iTerm2 inline images continue to render normally.
+In `fullscreen` mode, the transcript scrolls inside the terminal viewport while queued messages, working status, extension widgets, editor, and footer remain fixed at the bottom. Mouse/trackpad input scrolls the region under the pointer. Keyboard viewport actions remain available except when an active selection list handles an overlapping selection page action. Inline images work in terminals that support the Kitty graphics protocol, including Kitty and Ghostty. In iTerm2 they render as text placeholders because its inline-image protocol cannot delete or crop placements during application-owned scrolling. In `regular` mode, pi uses the main screen and terminal-owned scrollback, and iTerm2 inline images continue to render normally.
 
 Set **UI mode** in `/settings` to switch between `regular` and `fullscreen` immediately and choose the default for future sessions.
 

--- a/packages/coding-agent/examples/extensions/overlay-qa-tests.ts
+++ b/packages/coding-agent/examples/extensions/overlay-qa-tests.ts
@@ -20,7 +20,14 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
-import type { Component, OverlayAnchor, OverlayHandle, OverlayOptions, TUI } from "@earendil-works/pi-tui";
+import type {
+	Component,
+	KeybindingsManager,
+	OverlayAnchor,
+	OverlayHandle,
+	OverlayOptions,
+	TUI,
+} from "@earendil-works/pi-tui";
 import { Input, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { spawn } from "child_process";
 
@@ -228,17 +235,20 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("overlay-sidepanel", {
 		description: "Test responsive sidepanel (hides when terminal < 100 cols)",
 		handler: async (_args: string, ctx: ExtensionCommandContext) => {
-			await ctx.ui.custom<void>((tui, theme, _kb, done) => new SidepanelComponent(tui, theme, done), {
-				overlay: true,
-				overlayOptions: {
-					anchor: "right-center",
-					width: "25%",
-					minWidth: 30,
-					margin: { right: 1 },
-					// Only show when terminal is wide enough
-					visible: (termWidth) => termWidth >= 100,
+			await ctx.ui.custom<void>(
+				(tui, theme, keybindings, done) => new SidepanelComponent(tui, theme, keybindings, done),
+				{
+					overlay: true,
+					overlayOptions: {
+						anchor: "right-center",
+						width: "25%",
+						minWidth: 30,
+						margin: { right: 1 },
+						// Only show when terminal is wide enough
+						visible: (termWidth) => termWidth >= 100,
+					},
 				},
-			});
+			);
 		},
 	});
 
@@ -701,24 +711,33 @@ class MaxHeightTestComponent extends BaseOverlay {
 
 // Responsive sidepanel - demonstrates percentage width and visibility callback
 class SidepanelComponent extends BaseOverlay {
+	readonly capturesSelectPageInput = true;
 	private tui: TUI;
 	private items = ["Dashboard", "Messages", "Settings", "Help", "About"];
 	private selectedIndex = 0;
+	private keybindings: Pick<KeybindingsManager, "matches">;
 	private done: () => void;
 
-	constructor(tui: TUI, theme: Theme, done: () => void) {
+	constructor(tui: TUI, theme: Theme, keybindings: Pick<KeybindingsManager, "matches">, done: () => void) {
 		super(theme);
 		this.tui = tui;
+		this.keybindings = keybindings;
 		this.done = done;
 	}
 
 	handleInput(data: string): void {
 		if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) {
 			this.done();
-		} else if (matchesKey(data, "up")) {
+		} else if (this.keybindings.matches(data, "tui.select.pageUp")) {
+			this.selectedIndex = Math.max(0, this.selectedIndex - this.items.length);
+			this.tui.requestRender();
+		} else if (this.keybindings.matches(data, "tui.select.pageDown")) {
+			this.selectedIndex = Math.min(this.items.length - 1, this.selectedIndex + this.items.length);
+			this.tui.requestRender();
+		} else if (this.keybindings.matches(data, "tui.select.up")) {
 			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
 			this.tui.requestRender();
-		} else if (matchesKey(data, "down")) {
+		} else if (this.keybindings.matches(data, "tui.select.down")) {
 			this.selectedIndex = Math.min(this.items.length - 1, this.selectedIndex + 1);
 			this.tui.requestRender();
 		} else if (matchesKey(data, "return")) {

--- a/packages/coding-agent/examples/extensions/overlay-test.ts
+++ b/packages/coding-agent/examples/extensions/overlay-test.ts
@@ -9,14 +9,20 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
-import { CURSOR_MARKER, type Focusable, matchesKey, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	CURSOR_MARKER,
+	type Focusable,
+	type KeybindingsManager,
+	matchesKey,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 
 export default function (pi: ExtensionAPI) {
 	pi.registerCommand("overlay-test", {
 		description: "Test overlay rendering with edge cases",
 		handler: async (_args: string, ctx: ExtensionCommandContext) => {
 			const result = await ctx.ui.custom<{ action: string; query?: string } | undefined>(
-				(_tui, theme, _keybindings, done) => new OverlayTestComponent(theme, done),
+				(_tui, theme, keybindings, done) => new OverlayTestComponent(theme, keybindings, done),
 				{ overlay: true },
 			);
 
@@ -30,6 +36,7 @@ export default function (pi: ExtensionAPI) {
 
 class OverlayTestComponent implements Focusable {
 	readonly width = 70;
+	readonly capturesSelectPageInput = true;
 
 	/** Focusable interface - set by TUI when focus changes */
 	focused = false;
@@ -43,10 +50,16 @@ class OverlayTestComponent implements Focusable {
 	];
 
 	private theme: Theme;
+	private keybindings: Pick<KeybindingsManager, "matches">;
 	private done: (result: { action: string; query?: string } | undefined) => void;
 
-	constructor(theme: Theme, done: (result: { action: string; query?: string } | undefined) => void) {
+	constructor(
+		theme: Theme,
+		keybindings: Pick<KeybindingsManager, "matches">,
+		done: (result: { action: string; query?: string } | undefined) => void,
+	) {
 		this.theme = theme;
+		this.keybindings = keybindings;
 		this.done = done;
 	}
 
@@ -63,9 +76,13 @@ class OverlayTestComponent implements Focusable {
 			return;
 		}
 
-		if (matchesKey(data, "up")) {
+		if (this.keybindings.matches(data, "tui.select.pageUp")) {
+			this.selected = Math.max(0, this.selected - this.items.length);
+		} else if (this.keybindings.matches(data, "tui.select.pageDown")) {
+			this.selected = Math.min(this.items.length - 1, this.selected + this.items.length);
+		} else if (this.keybindings.matches(data, "tui.select.up")) {
 			this.selected = Math.max(0, this.selected - 1);
-		} else if (matchesKey(data, "down")) {
+		} else if (this.keybindings.matches(data, "tui.select.down")) {
 			this.selected = Math.min(this.items.length - 1, this.selected + 1);
 		} else if (current.hasInput) {
 			if (matchesKey(data, "backspace")) {

--- a/packages/coding-agent/examples/extensions/preset.ts
+++ b/packages/coding-agent/examples/extensions/preset.ts
@@ -251,18 +251,12 @@ export default function presetExtension(pi: ExtensionAPI) {
 
 			container.addChild(new DynamicBorder((str) => theme.fg("accent", str)));
 
-			return {
-				render(width: number) {
-					return container.render(width);
-				},
-				invalidate() {
-					container.invalidate();
-				},
+			return Object.assign(container, {
 				handleInput(data: string) {
 					selectList.handleInput(data);
 					tui.requestRender();
 				},
-			};
+			});
 		});
 
 		if (!result) return;

--- a/packages/coding-agent/examples/extensions/question.ts
+++ b/packages/coding-agent/examples/extensions/question.ts
@@ -71,7 +71,7 @@ export default function question(pi: ExtensionAPI) {
 			const allOptions: DisplayOption[] = [...params.options, { label: "Type something.", isOther: true }];
 
 			const result = await ctx.ui.custom<{ answer: string; wasCustom: boolean; index?: number } | null>(
-				(tui, theme, _kb, done) => {
+				(tui, theme, keybindings, done) => {
 					let optionIndex = 0;
 					let editMode = false;
 					let cachedLines: string[] | undefined;
@@ -117,12 +117,23 @@ export default function question(pi: ExtensionAPI) {
 							return;
 						}
 
-						if (matchesKey(data, Key.up)) {
+						const pageSize = Math.max(1, tui.terminal.rows - 6);
+						if (keybindings.matches(data, "tui.select.pageUp")) {
+							optionIndex = Math.max(0, optionIndex - pageSize);
+							refresh();
+							return;
+						}
+						if (keybindings.matches(data, "tui.select.pageDown")) {
+							optionIndex = Math.min(allOptions.length - 1, optionIndex + pageSize);
+							refresh();
+							return;
+						}
+						if (keybindings.matches(data, "tui.select.up")) {
 							optionIndex = Math.max(0, optionIndex - 1);
 							refresh();
 							return;
 						}
-						if (matchesKey(data, Key.down)) {
+						if (keybindings.matches(data, "tui.select.down")) {
 							optionIndex = Math.min(allOptions.length - 1, optionIndex + 1);
 							refresh();
 							return;
@@ -208,6 +219,9 @@ export default function question(pi: ExtensionAPI) {
 					}
 
 					return {
+						get capturesSelectPageInput() {
+							return !editMode;
+						},
 						render,
 						invalidate: () => {
 							cachedLines = undefined;

--- a/packages/coding-agent/examples/extensions/questionnaire.ts
+++ b/packages/coding-agent/examples/extensions/questionnaire.ts
@@ -107,7 +107,7 @@ export default function questionnaire(pi: ExtensionAPI) {
 			const isMulti = questions.length > 1;
 			const totalTabs = questions.length + 1; // questions + Submit
 
-			const result = await ctx.ui.custom<QuestionnaireResult>((tui, theme, _kb, done) => {
+			const result = await ctx.ui.custom<QuestionnaireResult>((tui, theme, keybindings, done) => {
 				// State
 				let currentTab = 0;
 				let optionIndex = 0;
@@ -231,12 +231,27 @@ export default function questionnaire(pi: ExtensionAPI) {
 					}
 
 					// Option navigation
-					if (matchesKey(data, Key.up)) {
+					const pageSize = Math.max(1, tui.terminal.rows - (isMulti ? 9 : 6));
+					if (keybindings.matches(data, "tui.select.pageUp")) {
+						if (opts.length === 0) return;
+						optionIndex = Math.max(0, optionIndex - pageSize);
+						refresh();
+						return;
+					}
+					if (keybindings.matches(data, "tui.select.pageDown")) {
+						if (opts.length === 0) return;
+						optionIndex = Math.min(opts.length - 1, optionIndex + pageSize);
+						refresh();
+						return;
+					}
+					if (keybindings.matches(data, "tui.select.up")) {
+						if (opts.length === 0) return;
 						optionIndex = Math.max(0, optionIndex - 1);
 						refresh();
 						return;
 					}
-					if (matchesKey(data, Key.down)) {
+					if (keybindings.matches(data, "tui.select.down")) {
+						if (opts.length === 0) return;
 						optionIndex = Math.min(opts.length - 1, optionIndex + 1);
 						refresh();
 						return;
@@ -385,6 +400,9 @@ export default function questionnaire(pi: ExtensionAPI) {
 				}
 
 				return {
+					get capturesSelectPageInput() {
+						return !inputMode && currentTab < questions.length;
+					},
 					render,
 					invalidate: () => {
 						cachedLines = undefined;

--- a/packages/coding-agent/examples/extensions/tools.ts
+++ b/packages/coding-agent/examples/extensions/tools.ts
@@ -116,20 +116,12 @@ export default function toolsExtension(pi: ExtensionAPI) {
 
 				container.addChild(settingsList);
 
-				const component = {
-					render(width: number) {
-						return container.render(width);
-					},
-					invalidate() {
-						container.invalidate();
-					},
+				return Object.assign(container, {
 					handleInput(data: string) {
 						settingsList.handleInput?.(data);
 						tui.requestRender();
 					},
-				};
-
-				return component;
+				});
 			});
 		},
 	});

--- a/packages/coding-agent/examples/rpc-extension-ui.ts
+++ b/packages/coding-agent/examples/rpc-extension-ui.ts
@@ -173,6 +173,10 @@ class SelectDialog implements Component {
 	onSelect?: (value: string) => void;
 	onCancel?: () => void;
 
+	get capturesSelectPageInput(): boolean {
+		return this.list.capturesSelectPageInput;
+	}
+
 	constructor(title: string, options: string[]) {
 		this.title = title;
 		const items = options.map((o) => ({ value: o, label: o }));

--- a/packages/coding-agent/src/extensions/llama/ui.ts
+++ b/packages/coding-agent/src/extensions/llama/ui.ts
@@ -16,11 +16,13 @@ import type { ExtensionCommandContext } from "../../core/extensions/types.ts";
 import type { KeybindingsManager } from "../../core/keybindings.ts";
 import { DynamicBorder } from "../../modes/interactive/components/dynamic-border.ts";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.ts";
+import { getPageSelectionIndex } from "../../modes/interactive/components/select-navigation.ts";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
 import type { LlamaModelInfo, LlamaProgress } from "./client.ts";
 import type { HuggingFaceModel } from "./huggingface.ts";
 
 const DOWNLOAD_VALUE = "\0download";
+const SEARCH_PAGE_SIZE = 10;
 
 export type LlamaManagerAction = { type: "model"; model: LlamaModelInfo } | { type: "download" } | { type: "close" };
 
@@ -94,6 +96,10 @@ function compactCount(value: number): string {
 }
 
 class HuggingFaceSearch extends Container implements Focusable {
+	override get capturesSelectPageInput(): boolean {
+		return true;
+	}
+
 	private readonly tui: TUI;
 	private readonly theme: Theme;
 	private readonly keybindings: KeybindingsManager;
@@ -145,12 +151,14 @@ class HuggingFaceSearch extends Container implements Focusable {
 
 	private updateResults(): void {
 		this.resultsContainer.clear();
-		const maxVisible = 10;
 		const start = Math.max(
 			0,
-			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredResults.length - maxVisible),
+			Math.min(
+				this.selectedIndex - Math.floor(SEARCH_PAGE_SIZE / 2),
+				this.filteredResults.length - SEARCH_PAGE_SIZE,
+			),
 		);
-		const end = Math.min(start + maxVisible, this.filteredResults.length);
+		const end = Math.min(start + SEARCH_PAGE_SIZE, this.filteredResults.length);
 		for (let index = start; index < end; index++) {
 			const model = this.filteredResults[index];
 			if (!model) continue;
@@ -241,6 +249,13 @@ class HuggingFaceSearch extends Container implements Focusable {
 	}
 
 	handleInput(data: string): void {
+		const pageIndex = getPageSelectionIndex(
+			this.keybindings,
+			data,
+			this.selectedIndex,
+			this.filteredResults.length,
+			SEARCH_PAGE_SIZE,
+		);
 		if (this.keybindings.matches(data, "tui.select.up")) {
 			if (this.filteredResults.length > 0) {
 				this.selectedIndex = this.selectedIndex === 0 ? this.filteredResults.length - 1 : this.selectedIndex - 1;
@@ -253,6 +268,11 @@ class HuggingFaceSearch extends Container implements Focusable {
 				this.selectedIndex = this.selectedIndex === this.filteredResults.length - 1 ? 0 : this.selectedIndex + 1;
 				this.updateResults();
 			}
+			return;
+		}
+		if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
+			this.updateResults();
 			return;
 		}
 		if (this.keybindings.matches(data, "tui.select.confirm")) {
@@ -279,7 +299,7 @@ class LlamaView implements LlamaUi, Focusable {
 	private readonly keybindings: KeybindingsManager;
 	private readonly searchCache = new Map<string, HuggingFaceModel[]>();
 	private content: Container;
-	private inputHandler: { handleInput?(data: string): void } | undefined;
+	private inputHandler: { handleInput?(data: string): void; readonly capturesSelectPageInput?: boolean } | undefined;
 	private inputTarget: Focusable | undefined;
 	private progressPromise: Promise<void> | undefined;
 	private progressResolver: (() => void) | undefined;
@@ -302,9 +322,13 @@ class LlamaView implements LlamaUi, Focusable {
 		if (this.inputTarget) this.inputTarget.focused = value;
 	}
 
+	get capturesSelectPageInput(): boolean {
+		return this.inputHandler?.capturesSelectPageInput === true;
+	}
+
 	private setContent(
 		content: Container,
-		inputHandler?: { handleInput?(data: string): void },
+		inputHandler?: { handleInput?(data: string): void; readonly capturesSelectPageInput?: boolean },
 		inputTarget?: Focusable,
 	): void {
 		if (this.inputTarget) this.inputTarget.focused = false;

--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -220,6 +220,7 @@ class ConfigSelectorHeader implements Component {
 }
 
 class ResourceList implements Component, Focusable {
+	readonly capturesSelectPageInput = true;
 	private groupsByScope: Record<ConfigWriteScope, ResourceGroup[]>;
 	private flatItems: FlatEntry[] = [];
 	private filteredItems: FlatEntry[] = [];

--- a/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-editor.ts
@@ -33,6 +33,14 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
+		if (
+			this.isShowingAutocomplete() &&
+			(this.keybindings.matches(data, "tui.select.pageUp") || this.keybindings.matches(data, "tui.select.pageDown"))
+		) {
+			super.handleInput(data);
+			return;
+		}
+
 		// Check for clipboard paste keybinding
 		if (this.keybindings.matches(data, "app.clipboard.pasteImage")) {
 			this.onPasteImage?.();

--- a/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/extension-selector.ts
@@ -8,6 +8,9 @@ import { theme } from "../theme/theme.ts";
 import { CountdownTimer } from "./countdown-timer.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint, rawKeyHint } from "./keybinding-hints.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
+
+const PAGE_SIZE = 8;
 
 export interface ExtensionSelectorOptions {
 	tui?: TUI;
@@ -16,6 +19,10 @@ export interface ExtensionSelectorOptions {
 }
 
 export class ExtensionSelectorComponent extends Container {
+	override get capturesSelectPageInput(): boolean {
+		return true;
+	}
+
 	private options: string[];
 	private selectedIndex = 0;
 	private listContainer: Container;
@@ -90,6 +97,7 @@ export class ExtensionSelectorComponent extends Container {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(kb, keyData, this.selectedIndex, this.options.length, PAGE_SIZE);
 		if (kb.matches(keyData, "app.tools.expand")) {
 			this.onToggleToolsExpanded?.();
 		} else if (kb.matches(keyData, "tui.select.up") || keyData === "k") {
@@ -97,6 +105,9 @@ export class ExtensionSelectorComponent extends Container {
 			this.updateList();
 		} else if (kb.matches(keyData, "tui.select.down") || keyData === "j") {
 			this.selectedIndex = Math.min(this.options.length - 1, this.selectedIndex + 1);
+			this.updateList();
+		} else if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 			this.updateList();
 		} else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
 			const selected = this.options[this.selectedIndex];

--- a/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
+++ b/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
@@ -30,6 +30,10 @@ const SETUP_LOGO_LINES = ["██████", "██  ██", "████ 
 
 /** First-time setup dialog: theme choice and analytics opt-in. */
 export class FirstTimeSetupComponent extends Container {
+	override get capturesSelectPageInput(): boolean {
+		return true;
+	}
+
 	private step: "theme" | "analytics" = "theme";
 	private themeIndex: number;
 	private analyticsIndex = 0;
@@ -122,12 +126,20 @@ export class FirstTimeSetupComponent extends Container {
 		this.update();
 	}
 
+	private getPageSize(): number {
+		return this.step === "theme" ? THEME_OPTIONS.length : ANALYTICS_OPTIONS.length;
+	}
+
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
 		if (kb.matches(keyData, "tui.select.up") || keyData === "k") {
 			this.moveSelection(-1);
 		} else if (kb.matches(keyData, "tui.select.down") || keyData === "j") {
 			this.moveSelection(1);
+		} else if (kb.matches(keyData, "tui.select.pageUp")) {
+			this.moveSelection(-this.getPageSize());
+		} else if (kb.matches(keyData, "tui.select.pageDown")) {
+			this.moveSelection(this.getPageSize());
 		} else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
 			if (this.step === "theme") {
 				this.step = "analytics";

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -15,6 +15,7 @@ import { getModelSelectorSearchText } from "../model-search.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint } from "./keybinding-hints.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
 
 interface ModelItem {
 	provider: string;
@@ -28,11 +29,16 @@ interface ScopedModelItem {
 }
 
 type ModelScope = "all" | "scoped";
+const PAGE_SIZE = 10;
 
 /**
  * Component that renders a model selector with search
  */
 export class ModelSelectorComponent extends Container implements Focusable {
+	override get capturesSelectPageInput(): boolean {
+		return true;
+	}
+
 	private searchInput: Input;
 
 	// Focusable implementation - propagate to searchInput for IME cursor positioning
@@ -257,12 +263,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private updateList(): void {
 		this.listContainer.clear();
 
-		const maxVisible = 10;
 		const startIndex = Math.max(
 			0,
-			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredModels.length - maxVisible),
+			Math.min(this.selectedIndex - Math.floor(PAGE_SIZE / 2), this.filteredModels.length - PAGE_SIZE),
 		);
-		const endIndex = Math.min(startIndex + maxVisible, this.filteredModels.length);
+		const endIndex = Math.min(startIndex + PAGE_SIZE, this.filteredModels.length);
 
 		// Show visible slice of filtered models
 		for (let i = startIndex; i < endIndex; i++) {
@@ -319,6 +324,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(kb, keyData, this.selectedIndex, this.filteredModels.length, PAGE_SIZE);
 		if (kb.matches(keyData, "tui.input.tab")) {
 			if (this.scopedModelItems.length > 0) {
 				const nextScope: ModelScope = this.scope === "all" ? "scoped" : "all";
@@ -339,6 +345,9 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		else if (kb.matches(keyData, "tui.select.down")) {
 			if (this.filteredModels.length === 0) return;
 			this.selectedIndex = this.selectedIndex === this.filteredModels.length - 1 ? 0 : this.selectedIndex + 1;
+			this.updateList();
+		} else if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 			this.updateList();
 		}
 		// Enter

--- a/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -10,6 +10,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
 
 export type AuthSelectorProvider = {
 	id: string;
@@ -23,10 +24,16 @@ export function formatAuthSelectorProviderType(authType: AuthSelectorProvider["a
 	return authType === "oauth" ? "subscription" : "API key";
 }
 
+const PAGE_SIZE = 8;
+
 /**
  * Component that renders an auth provider selector
  */
 export class OAuthSelectorComponent extends Container implements Focusable {
+	override get capturesSelectPageInput(): boolean {
+		return true;
+	}
+
 	private searchInput: Input;
 
 	// Focusable implementation - propagate to search input for IME cursor positioning
@@ -114,12 +121,11 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 	private updateList(): void {
 		this.listContainer.clear();
 
-		const maxVisible = 8;
 		const startIndex = Math.max(
 			0,
-			Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredProviders.length - maxVisible),
+			Math.min(this.selectedIndex - Math.floor(PAGE_SIZE / 2), this.filteredProviders.length - PAGE_SIZE),
 		);
-		const endIndex = Math.min(startIndex + maxVisible, this.filteredProviders.length);
+		const endIndex = Math.min(startIndex + PAGE_SIZE, this.filteredProviders.length);
 
 		for (let i = startIndex; i < endIndex; i++) {
 			const provider = this.filteredProviders[i];
@@ -182,6 +188,13 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(
+			kb,
+			keyData,
+			this.selectedIndex,
+			this.filteredProviders.length,
+			PAGE_SIZE,
+		);
 		// Up arrow
 		if (kb.matches(keyData, "tui.select.up")) {
 			if (this.filteredProviders.length === 0) return;
@@ -192,6 +205,9 @@ export class OAuthSelectorComponent extends Container implements Focusable {
 		else if (kb.matches(keyData, "tui.select.down")) {
 			if (this.filteredProviders.length === 0) return;
 			this.selectedIndex = Math.min(this.filteredProviders.length - 1, this.selectedIndex + 1);
+			this.updateList();
+		} else if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 			this.updateList();
 		}
 		// Enter

--- a/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
@@ -14,6 +14,7 @@ import { getModelSearchText } from "../model-search.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyText } from "./keybinding-hints.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
 
 // EnabledIds: null = all enabled (no filter), string[] = explicit ordered list
 type EnabledIds = string[] | null;
@@ -90,6 +91,10 @@ export interface ModelsCallbacks {
  * Changes are session-only until explicitly persisted with Ctrl+S.
  */
 export class ScopedModelsSelectorComponent extends Container implements Focusable {
+	override get capturesSelectPageInput(): boolean {
+		return true;
+	}
+
 	private modelsById: Map<string, Model<any>> = new Map();
 	private allIds: string[] = [];
 	private enabledIds: EnabledIds = null;
@@ -281,6 +286,7 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 
 	handleInput(data: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(kb, data, this.selectedIndex, this.filteredItems.length, this.maxVisible);
 
 		// Navigation
 		if (kb.matches(data, "tui.select.up")) {
@@ -292,6 +298,11 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 		if (kb.matches(data, "tui.select.down")) {
 			if (this.filteredItems.length === 0) return;
 			this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
+			this.updateList();
+			return;
+		}
+		if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 			this.updateList();
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive/components/select-navigation.ts
+++ b/packages/coding-agent/src/modes/interactive/components/select-navigation.ts
@@ -1,0 +1,17 @@
+import type { KeybindingsManager } from "../../../core/keybindings.ts";
+
+export function getPageSelectionIndex(
+	keybindings: Pick<KeybindingsManager, "matches">,
+	data: string,
+	selectedIndex: number,
+	itemCount: number,
+	pageSize: number,
+): number | undefined {
+	const direction = keybindings.matches(data, "tui.select.pageUp")
+		? -1
+		: keybindings.matches(data, "tui.select.pageDown")
+			? 1
+			: undefined;
+	if (direction === undefined) return undefined;
+	return Math.max(0, Math.min(itemCount - 1, selectedIndex + direction * pageSize));
+}

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -19,6 +19,7 @@ import { canonicalizePath as _canonicalizePath } from "../../../utils/paths.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint, keyText } from "./keybinding-hints.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
 import { filterAndSortSessions, hasSessionName, type NameFilter, type SortMode } from "./session-selector-search.ts";
 
 type SessionScope = "current" | "all";
@@ -281,6 +282,7 @@ function flattenSessionTree(roots: SessionTreeNode[]): FlatSessionNode[] {
  * Custom session list component with multi-line items and search
  */
 class SessionList implements Component, Focusable {
+	readonly capturesSelectPageInput = true;
 	public getSelectedSessionPath(): string | undefined {
 		const selected = this.filteredSessions[this.selectedIndex];
 		return selected?.session.path;
@@ -531,6 +533,13 @@ class SessionList implements Component, Focusable {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(
+			kb,
+			keyData,
+			this.selectedIndex,
+			this.filteredSessions.length,
+			this.maxVisible,
+		);
 
 		// Handle delete confirmation state first - intercept all keys
 		if (this.confirmingDeletePath !== null) {
@@ -607,14 +616,8 @@ class SessionList implements Component, Focusable {
 		// Down arrow
 		else if (kb.matches(keyData, "tui.select.down")) {
 			this.selectedIndex = Math.min(this.filteredSessions.length - 1, this.selectedIndex + 1);
-		}
-		// Page up - jump up by maxVisible items
-		else if (kb.matches(keyData, "tui.select.pageUp")) {
-			this.selectedIndex = Math.max(0, this.selectedIndex - this.maxVisible);
-		}
-		// Page down - jump down by maxVisible items
-		else if (kb.matches(keyData, "tui.select.pageDown")) {
-			this.selectedIndex = Math.min(this.filteredSessions.length - 1, this.selectedIndex + this.maxVisible);
+		} else if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -16,6 +16,7 @@ import type { SessionTreeNode } from "../../../core/session-manager.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { formatKeyText, keyHint } from "./keybinding-hints.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
 
 /** Gutter info: position (displayIndent where connector was) and whether to show │ */
 interface GutterInfo {
@@ -104,6 +105,7 @@ interface ToolCallInfo {
 }
 
 class TreeList implements Component {
+	readonly capturesSelectPageInput = true;
 	private flatNodes: FlatNode[] = [];
 	private filteredNodes: FlatNode[] = [];
 	private selectedIndex = 0;
@@ -995,6 +997,13 @@ class TreeList implements Component {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(
+			kb,
+			keyData,
+			this.selectedIndex,
+			this.filteredNodes.length,
+			this.maxVisibleLines,
+		);
 		if (kb.matches(keyData, "tui.select.up")) {
 			this.selectedIndex = this.selectedIndex === 0 ? this.filteredNodes.length - 1 : this.selectedIndex - 1;
 		} else if (kb.matches(keyData, "tui.select.down")) {
@@ -1015,12 +1024,12 @@ class TreeList implements Component {
 			} else {
 				this.selectedIndex = this.findBranchSegmentStart("down");
 			}
-		} else if (kb.matches(keyData, "tui.editor.cursorLeft") || kb.matches(keyData, "tui.select.pageUp")) {
-			// Page up
+		} else if (kb.matches(keyData, "tui.editor.cursorLeft")) {
 			this.selectedIndex = Math.max(0, this.selectedIndex - this.maxVisibleLines);
-		} else if (kb.matches(keyData, "tui.editor.cursorRight") || kb.matches(keyData, "tui.select.pageDown")) {
-			// Page down
+		} else if (kb.matches(keyData, "tui.editor.cursorRight")) {
 			this.selectedIndex = Math.min(this.filteredNodes.length - 1, this.selectedIndex + this.maxVisibleLines);
+		} else if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 		} else if (kb.matches(keyData, "tui.select.confirm")) {
 			const selected = this.filteredNodes[this.selectedIndex];
 			if (selected && this.onSelect) {

--- a/packages/coding-agent/src/modes/interactive/components/trust-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/trust-selector.ts
@@ -7,6 +7,7 @@ import {
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint, rawKeyHint } from "./keybinding-hints.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
 
 export type TrustSelection = Pick<ProjectTrustOption, "trusted" | "updates">;
 
@@ -30,6 +31,10 @@ function formatDecision(trustPath: string | undefined, decision: ProjectTrustSto
 }
 
 export class TrustSelectorComponent extends Container {
+	override get capturesSelectPageInput(): boolean {
+		return true;
+	}
+
 	private selectedIndex: number;
 	private readonly listContainer: Container;
 	private readonly trustOptions: ProjectTrustOption[];
@@ -116,11 +121,21 @@ export class TrustSelectorComponent extends Container {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(
+			kb,
+			keyData,
+			this.selectedIndex,
+			this.trustOptions.length,
+			this.trustOptions.length,
+		);
 		if (kb.matches(keyData, "tui.select.up") || keyData === "k") {
 			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
 			this.updateList();
 		} else if (kb.matches(keyData, "tui.select.down") || keyData === "j") {
 			this.selectedIndex = Math.min(this.trustOptions.length - 1, this.selectedIndex + 1);
+			this.updateList();
+		} else if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 			this.updateList();
 		} else if (kb.matches(keyData, "tui.select.confirm") || keyData === "\n") {
 			const selected = this.trustOptions[this.selectedIndex];

--- a/packages/coding-agent/src/modes/interactive/components/user-message-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message-selector.ts
@@ -1,6 +1,7 @@
 import { type Component, Container, getKeybindings, Spacer, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
+import { getPageSelectionIndex } from "./select-navigation.ts";
 
 interface UserMessageItem {
 	id: string; // Entry ID in the session
@@ -12,6 +13,7 @@ interface UserMessageItem {
  * Custom user message list component with selection
  */
 class UserMessageList implements Component {
+	readonly capturesSelectPageInput = true;
 	private messages: UserMessageItem[] = [];
 	private selectedIndex: number = 0;
 	public onSelect?: (entryId: string) => void;
@@ -80,6 +82,7 @@ class UserMessageList implements Component {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(kb, keyData, this.selectedIndex, this.messages.length, this.maxVisible);
 		// Up arrow - go to previous (older) message, wrap to bottom when at top
 		if (kb.matches(keyData, "tui.select.up")) {
 			this.selectedIndex = this.selectedIndex === 0 ? this.messages.length - 1 : this.selectedIndex - 1;
@@ -87,6 +90,8 @@ class UserMessageList implements Component {
 		// Down arrow - go to next (newer) message, wrap to top when at bottom
 		else if (kb.matches(keyData, "tui.select.down")) {
 			this.selectedIndex = this.selectedIndex === this.messages.length - 1 ? 0 : this.selectedIndex + 1;
+		} else if (pageIndex !== undefined) {
+			this.selectedIndex = pageIndex;
 		}
 		// Enter - select message and branch
 		else if (kb.matches(keyData, "tui.select.confirm")) {

--- a/packages/coding-agent/test/suite/regressions/7629-select-page-keys.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7629-select-page-keys.test.ts
@@ -1,0 +1,248 @@
+import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeybindingsManager } from "../../../src/core/keybindings.ts";
+import type { SessionInfo } from "../../../src/core/session-manager.ts";
+import { CustomEditor } from "../../../src/modes/interactive/components/custom-editor.ts";
+import { ExtensionSelectorComponent } from "../../../src/modes/interactive/components/extension-selector.ts";
+import { FirstTimeSetupComponent } from "../../../src/modes/interactive/components/first-time-setup.ts";
+import { ModelSelectorComponent } from "../../../src/modes/interactive/components/model-selector.ts";
+import { OAuthSelectorComponent } from "../../../src/modes/interactive/components/oauth-selector.ts";
+import { ScopedModelsSelectorComponent } from "../../../src/modes/interactive/components/scoped-models-selector.ts";
+import { SessionSelectorComponent } from "../../../src/modes/interactive/components/session-selector.ts";
+import { ShowImagesSelectorComponent } from "../../../src/modes/interactive/components/show-images-selector.ts";
+import { ThemeSelectorComponent } from "../../../src/modes/interactive/components/theme-selector.ts";
+import { ThinkingSelectorComponent } from "../../../src/modes/interactive/components/thinking-selector.ts";
+import { TrustSelectorComponent } from "../../../src/modes/interactive/components/trust-selector.ts";
+import { UserMessageSelectorComponent } from "../../../src/modes/interactive/components/user-message-selector.ts";
+import { getEditorTheme, initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../../src/utils/ansi.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+function createFakeTui(): TUI {
+	return { requestRender: () => {} } as unknown as TUI;
+}
+
+const REMAPPED_PAGE_KEYS = {
+	"tui.editor.pageUp": "alt+v",
+	"tui.editor.pageDown": "ctrl+v",
+	"tui.select.pageUp": "alt+v",
+	"tui.select.pageDown": "ctrl+v",
+} as const;
+
+describe("issue #7629 selection page key handling", () => {
+	let harness: Harness | undefined;
+
+	beforeAll(() => initTheme("dark"));
+	beforeEach(() => {
+		setKeybindings(new KeybindingsManager(REMAPPED_PAGE_KEYS));
+	});
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+		setKeybindings(new KeybindingsManager());
+		vi.restoreAllMocks();
+	});
+
+	it("pages through model selectors with remapped keys", async () => {
+		harness = await createHarness({
+			models: Array.from({ length: 12 }, (_, index) => ({
+				id: `model-${index}`,
+				name: `Model ${index}`,
+			})),
+		});
+		const onModelSelect = vi.fn();
+		const modelSelector = new ModelSelectorComponent(
+			createFakeTui(),
+			undefined,
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			harness.models.map((model) => ({ model })),
+			onModelSelect,
+			() => {},
+		);
+
+		await vi.waitFor(() => {
+			expect(stripAnsi(modelSelector.render(120).join("\n"))).toContain("Model catalogs refreshed.");
+		});
+		modelSelector.handleInput("\x16");
+		modelSelector.handleInput("\r");
+		expect(onModelSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "model-10" }));
+
+		const onScopedChange = vi.fn();
+		const scopedSelector = new ScopedModelsSelectorComponent(
+			{ allModels: harness.models, enabledModelIds: null },
+			{
+				onChange: onScopedChange,
+				onPersist: () => {},
+				onCancel: () => {},
+			},
+		);
+		scopedSelector.handleInput("\x16");
+		scopedSelector.handleInput("\r");
+		expect(onScopedChange).toHaveBeenCalledWith([`${harness.models[8].provider}/model-8`]);
+	});
+
+	it("prioritizes autocomplete page keys over the image paste shortcut", async () => {
+		const keybindings = new KeybindingsManager(REMAPPED_PAGE_KEYS);
+		setKeybindings(keybindings);
+		const editor = new CustomEditor(createFakeTui(), getEditorTheme(), keybindings);
+		const onPasteImage = vi.fn();
+		let submitted = "";
+		editor.onPasteImage = onPasteImage;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.setAutocompleteProvider({
+			getSuggestions: async () => ({
+				items: Array.from({ length: 12 }, (_, index) => ({
+					value: `/command-${index}`,
+					label: `command-${index}`,
+				})),
+				prefix: "/",
+			}),
+			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
+				const newLines = [...lines];
+				newLines[cursorLine] = (lines[cursorLine] ?? "").slice(0, cursorCol - prefix.length) + item.value;
+				return { lines: newLines, cursorLine, cursorCol: item.value.length };
+			},
+		});
+
+		editor.handleInput("/");
+		await vi.waitFor(() => expect(editor.isShowingAutocomplete()).toBe(true));
+		editor.handleInput("\x16");
+		editor.handleInput("\r");
+
+		expect(onPasteImage).not.toHaveBeenCalled();
+		expect(submitted).toBe("/command-5");
+	});
+
+	it("keeps the session selection valid when paging before sessions load", async () => {
+		let completeLoad: (sessions: SessionInfo[]) => void = () => {
+			throw new Error("Session load did not start");
+		};
+		const pendingSessions = new Promise<SessionInfo[]>((resolve) => {
+			completeLoad = resolve;
+		});
+		const onSelect = vi.fn();
+		const selector = new SessionSelectorComponent(
+			async () => pendingSessions,
+			async () => [],
+			onSelect,
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings: new KeybindingsManager(REMAPPED_PAGE_KEYS) },
+		);
+
+		selector.getSessionList().handleInput("\x16");
+		completeLoad([
+			{
+				path: "/tmp/session.jsonl",
+				id: "session",
+				cwd: "/tmp",
+				created: new Date(0),
+				modified: new Date(0),
+				messageCount: 1,
+				firstMessage: "hello",
+				allMessagesText: "hello",
+			},
+		]);
+		await vi.waitFor(() => expect(selector.render(120).join("\n")).toContain("hello"));
+		selector.getSessionList().handleInput("\r");
+
+		expect(onSelect).toHaveBeenCalledWith("/tmp/session.jsonl");
+	});
+
+	it("pages through standalone selectors with remapped keys", () => {
+		const onOAuthSelect = vi.fn();
+		const oauthSelector = new OAuthSelectorComponent(
+			"login",
+			Array.from({ length: 10 }, (_, index) => ({
+				id: `provider-${index}`,
+				name: `Provider ${index}`,
+				authType: "api_key" as const,
+			})),
+			onOAuthSelect,
+			() => {},
+		);
+		oauthSelector.handleInput("\x16");
+		oauthSelector.handleInput("\r");
+		expect(onOAuthSelect).toHaveBeenCalledWith("provider-8", "api_key");
+
+		const onExtensionSelect = vi.fn();
+		const extensionSelector = new ExtensionSelectorComponent(
+			"Select",
+			Array.from({ length: 10 }, (_, index) => `option-${index}`),
+			onExtensionSelect,
+			() => {},
+		);
+		extensionSelector.handleInput("\x16");
+		extensionSelector.handleInput("\r");
+		expect(onExtensionSelect).toHaveBeenCalledWith("option-8");
+
+		const onMessageSelect = vi.fn();
+		const messageSelector = new UserMessageSelectorComponent(
+			Array.from({ length: 12 }, (_, index) => ({ id: `message-${index}`, text: `Message ${index}` })),
+			onMessageSelect,
+			() => {},
+		);
+		messageSelector.getMessageList().handleInput("\x1bv");
+		messageSelector.getMessageList().handleInput("\r");
+		expect(onMessageSelect).toHaveBeenCalledWith("message-1");
+
+		const onTrustSelect = vi.fn();
+		const trustSelector = new TrustSelectorComponent({
+			cwd: "/project",
+			savedDecision: null,
+			projectTrusted: false,
+			onSelect: onTrustSelect,
+			onCancel: () => {},
+		});
+		trustSelector.handleInput("\x16");
+		trustSelector.handleInput("\r");
+		expect(onTrustSelect).toHaveBeenCalledWith({
+			trusted: false,
+			updates: [{ path: "/project", decision: false }],
+		});
+	});
+
+	it("pages through SelectList-backed selectors", () => {
+		const onThemePreview = vi.fn();
+		const setup = new FirstTimeSetupComponent({
+			detectedTheme: "dark",
+			onThemePreview,
+			onSubmit: () => {},
+			onCancel: () => {},
+		});
+		setup.handleInput("\x16");
+		expect(onThemePreview).toHaveBeenCalledWith("light");
+
+		const onThinkingSelect = vi.fn();
+		const thinkingSelector = new ThinkingSelectorComponent(
+			"off",
+			["off", "minimal", "low", "medium", "high", "xhigh", "max"],
+			onThinkingSelect,
+			() => {},
+		);
+		thinkingSelector.getSelectList().handleInput("\x16");
+		thinkingSelector.getSelectList().handleInput("\r");
+		expect(onThinkingSelect).toHaveBeenCalledWith("max");
+
+		const onShowImagesSelect = vi.fn();
+		const showImagesSelector = new ShowImagesSelectorComponent(true, onShowImagesSelect, () => {});
+		showImagesSelector.getSelectList().handleInput("\x16");
+		showImagesSelector.getSelectList().handleInput("\r");
+		expect(onShowImagesSelect).toHaveBeenCalledWith(false);
+
+		const onThemeSelect = vi.fn();
+		const themeSelector = new ThemeSelectorComponent(
+			"dark",
+			onThemeSelect,
+			() => {},
+			() => {},
+		);
+		themeSelector.getSelectList().handleInput("\x16");
+		themeSelector.getSelectList().handleInput("\r");
+		expect(onThemeSelect).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -211,6 +211,7 @@ All components implement:
 interface Component {
   render(width: number): string[];
   handleInput?(data: string): void;
+  readonly capturesSelectPageInput?: boolean;
   invalidate?(): void;
 }
 ```
@@ -219,7 +220,10 @@ interface Component {
 |--------|-------------|
 | `render(width)` | Returns an array of strings, one per line. Each line **must not exceed `width`** or the TUI will error. Use `truncateToWidth()` or manual wrapping to ensure this. |
 | `handleInput?(data)` | Called when the component has focus and receives keyboard input. The `data` string contains raw terminal input (may include ANSI escape sequences). |
+| `capturesSelectPageInput?` | If true, selection page keys take precedence over alternate-screen viewport scrolling. |
 | `invalidate?()` | Called to clear any cached render state. Components should re-render from scratch on the next `render()` call. |
+
+`SelectList` and `SettingsList` set `capturesSelectPageInput` automatically. `Container` propagates the capability from its children, so return the container itself when adding input handling instead of wrapping its methods in a plain object.
 
 The TUI appends a full SGR reset and OSC 8 reset at the end of each rendered line. Styles do not carry across lines. If you emit multi-line text with styling, reapply styles per line or use `wrapTextWithAnsi()` so styles are preserved for each wrapped line.
 
@@ -515,6 +519,7 @@ list.setFilter("opt"); // Filter items
 
 **Controls:**
 - Arrow keys: Navigate
+- PageUp/PageDown: Move by one visible page
 - Enter: Select
 - Escape: Cancel
 
@@ -555,6 +560,7 @@ settings.updateValue("theme", "light");
 
 **Controls:**
 - Arrow keys: Navigate
+- PageUp/PageDown: Move by one visible page
 - Enter/Space: Activate (cycle value or open submenu)
 - Escape: Cancel
 
@@ -710,13 +716,14 @@ When creating custom components, **each line returned by `render()` must not exc
 
 ### Handling Input
 
-Use `matchesKey()` with the `Key` helper for keyboard input:
+Use keybinding actions for configurable selection navigation:
 
 ```typescript
-import { matchesKey, Key, truncateToWidth } from "@earendil-works/pi-tui";
+import { getKeybindings, truncateToWidth } from "@earendil-works/pi-tui";
 import type { Component } from "@earendil-works/pi-tui";
 
 class MyInteractiveComponent implements Component {
+  readonly capturesSelectPageInput = true;
   private selectedIndex = 0;
   private items = ["Option 1", "Option 2", "Option 3"];
   
@@ -724,13 +731,18 @@ class MyInteractiveComponent implements Component {
   public onCancel?: () => void;
 
   handleInput(data: string): void {
-    if (matchesKey(data, Key.up)) {
+    const keybindings = getKeybindings();
+    if (keybindings.matches(data, "tui.select.pageUp")) {
+      this.selectedIndex = Math.max(0, this.selectedIndex - 5);
+    } else if (keybindings.matches(data, "tui.select.pageDown")) {
+      this.selectedIndex = Math.min(this.items.length - 1, this.selectedIndex + 5);
+    } else if (keybindings.matches(data, "tui.select.up")) {
       this.selectedIndex = Math.max(0, this.selectedIndex - 1);
-    } else if (matchesKey(data, Key.down)) {
+    } else if (keybindings.matches(data, "tui.select.down")) {
       this.selectedIndex = Math.min(this.items.length - 1, this.selectedIndex + 1);
-    } else if (matchesKey(data, Key.enter)) {
+    } else if (keybindings.matches(data, "tui.select.confirm")) {
       this.onSelect?.(this.selectedIndex);
-    } else if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+    } else if (keybindings.matches(data, "tui.select.cancel")) {
       this.onCancel?.();
     }
   }

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -277,6 +277,10 @@ export class Editor implements Component, Focusable {
 	/** Focusable interface - set by TUI when focus changes */
 	focused: boolean = false;
 
+	get capturesSelectPageInput(): boolean {
+		return this.autocompleteState !== null;
+	}
+
 	protected tui: TUI;
 	private theme: EditorTheme;
 	private paddingX: number = 0;
@@ -668,7 +672,12 @@ export class Editor implements Component, Focusable {
 				return;
 			}
 
-			if (kb.matches(data, "tui.select.up") || kb.matches(data, "tui.select.down")) {
+			if (
+				kb.matches(data, "tui.select.up") ||
+				kb.matches(data, "tui.select.down") ||
+				kb.matches(data, "tui.select.pageUp") ||
+				kb.matches(data, "tui.select.pageDown")
+			) {
 				this.autocompleteList.handleInput(data);
 				return;
 			}

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -1,4 +1,5 @@
 import { getKeybindings } from "../keybindings.ts";
+import { getPageSelectionIndex } from "../selection-navigation.ts";
 import type { Component } from "../tui.ts";
 import { truncateToWidth, visibleWidth } from "../utils.ts";
 
@@ -38,6 +39,7 @@ export interface SelectListLayoutOptions {
 }
 
 export class SelectList implements Component {
+	readonly capturesSelectPageInput = true;
 	private items: SelectItem[] = [];
 	private filteredItems: SelectItem[] = [];
 	private selectedIndex: number = 0;
@@ -111,6 +113,13 @@ export class SelectList implements Component {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		const pageIndex = getPageSelectionIndex(
+			kb,
+			keyData,
+			this.selectedIndex,
+			this.filteredItems.length,
+			this.maxVisible,
+		);
 		// Up arrow - wrap to bottom when at top
 		if (kb.matches(keyData, "tui.select.up")) {
 			this.selectedIndex = this.selectedIndex === 0 ? this.filteredItems.length - 1 : this.selectedIndex - 1;
@@ -119,6 +128,10 @@ export class SelectList implements Component {
 		// Down arrow - wrap to top when at bottom
 		else if (kb.matches(keyData, "tui.select.down")) {
 			this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
+			this.notifySelectionChange();
+		} else if (pageIndex !== undefined) {
+			if (this.filteredItems.length === 0) return;
+			this.selectedIndex = pageIndex;
 			this.notifySelectionChange();
 		}
 		// Enter

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -1,5 +1,6 @@
 import { fuzzyFilter } from "../fuzzy.ts";
 import { getKeybindings } from "../keybindings.ts";
+import { getPageSelectionIndex } from "../selection-navigation.ts";
 import type { Component } from "../tui.ts";
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "../utils.ts";
 import { Input } from "./input.ts";
@@ -32,6 +33,7 @@ export interface SettingsListOptions {
 }
 
 export class SettingsList implements Component {
+	readonly capturesSelectPageInput = true;
 	private items: SettingItem[];
 	private filteredItems: SettingItem[];
 	private theme: SettingsListTheme;
@@ -176,12 +178,16 @@ export class SettingsList implements Component {
 		// Main list input handling
 		const kb = getKeybindings();
 		const displayItems = this.searchEnabled ? this.filteredItems : this.items;
+		const pageIndex = getPageSelectionIndex(kb, data, this.selectedIndex, displayItems.length, this.maxVisible);
 		if (kb.matches(data, "tui.select.up")) {
 			if (displayItems.length === 0) return;
 			this.selectedIndex = this.selectedIndex === 0 ? displayItems.length - 1 : this.selectedIndex - 1;
 		} else if (kb.matches(data, "tui.select.down")) {
 			if (displayItems.length === 0) return;
 			this.selectedIndex = this.selectedIndex === displayItems.length - 1 ? 0 : this.selectedIndex + 1;
+		} else if (pageIndex !== undefined) {
+			if (displayItems.length === 0) return;
+			this.selectedIndex = pageIndex;
 		} else if (
 			kb.matches(data, "tui.select.confirm") ||
 			(data === " " && (!this.searchEnabled || this.searchInput?.getValue().length === 0))

--- a/packages/tui/src/selection-navigation.ts
+++ b/packages/tui/src/selection-navigation.ts
@@ -1,0 +1,17 @@
+import type { KeybindingsManager } from "./keybindings.ts";
+
+export function getPageSelectionIndex(
+	keybindings: Pick<KeybindingsManager, "matches">,
+	data: string,
+	selectedIndex: number,
+	itemCount: number,
+	pageSize: number,
+): number | undefined {
+	const direction = keybindings.matches(data, "tui.select.pageUp")
+		? -1
+		: keybindings.matches(data, "tui.select.pageDown")
+			? 1
+			: undefined;
+	if (direction === undefined) return undefined;
+	return Math.max(0, Math.min(itemCount - 1, selectedIndex + direction * pageSize));
+}

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -373,6 +373,13 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 		const keybindings = getKeybindings();
 		const isRelease = isKeyRelease(data);
+		const focusedComponent = this.getFocusedComponent();
+		if (
+			focusedComponent?.capturesSelectPageInput &&
+			(keybindings.matches(data, "tui.select.pageUp") || keybindings.matches(data, "tui.select.pageDown"))
+		) {
+			return undefined;
+		}
 		if (keybindings.matches(data, "tui.altScreen.pageUp")) {
 			if (!isRelease) {
 				this.scrollBy(-Math.max(1, this.getPrimaryScrollView().viewportHeight - PAGE_SCROLL_OVERLAP));

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -33,6 +33,9 @@ export interface Component {
 	 */
 	handleInput?(data: string): void;
 
+	/** If true, selection page keys take precedence over viewport page scrolling. */
+	readonly capturesSelectPageInput?: boolean;
+
 	/**
 	 * If true, component receives key release events (Kitty protocol).
 	 * Default is false - release events are filtered out.
@@ -210,6 +213,10 @@ type OverlayFocusRestorePolicy = "clear" | "preserve";
  */
 export class Container implements Component {
 	children: Component[] = [];
+
+	get capturesSelectPageInput(): boolean {
+		return this.children.some((child) => child.capturesSelectPageInput === true);
+	}
 
 	addChild(component: Component): void {
 		this.children.push(component);

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { stripVTControlCharacters } from "node:util";
 import { type AutocompleteProvider, CombinedAutocompleteProvider } from "../src/autocomplete.ts";
 import { Editor, wordWrapLine } from "../src/components/editor.ts";
+import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings.ts";
 import type { TUI } from "../src/tui.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
 import { visibleWidth } from "../src/utils.ts";
@@ -2199,6 +2200,41 @@ describe("Editor component", () => {
 			editor.handleInput("\t");
 			assert.strictEqual(editor.getText(), "src/");
 			assert.strictEqual(editor.isShowingAutocomplete(), false);
+		});
+
+		it("forwards remapped selection page keys to the autocomplete menu", async () => {
+			setKeybindings(
+				new KeybindingsManager(TUI_KEYBINDINGS, {
+					"tui.editor.pageDown": "ctrl+v",
+					"tui.select.pageDown": "ctrl+v",
+				}),
+			);
+			try {
+				const editor = new Editor(createTestTUI(), defaultEditorTheme);
+				let submitted = "";
+				editor.onSubmit = (text) => {
+					submitted = text;
+				};
+				editor.setAutocompleteProvider({
+					getSuggestions: async () => ({
+						items: Array.from({ length: 12 }, (_, index) => ({
+							value: `/command-${index}`,
+							label: `command-${index}`,
+						})),
+						prefix: "/",
+					}),
+					applyCompletion,
+				});
+
+				editor.handleInput("/");
+				await flushAutocomplete();
+				editor.handleInput("\x16");
+				editor.handleInput("\r");
+
+				assert.strictEqual(submitted, "/command-5");
+			} finally {
+				setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+			}
 		});
 
 		it("keeps suggestions open when typing in force mode (Tab-triggered)", async () => {

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { SelectList } from "../src/components/select-list.ts";
+import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings.ts";
 import { visibleWidth } from "../src/utils.ts";
 
 const testTheme = {
@@ -112,5 +113,32 @@ describe("SelectList", () => {
 
 		assert.ok(rendered[0].includes("…"));
 		assert.equal(visibleIndexOf(rendered[0], "first"), visibleIndexOf(rendered[1], "second"));
+	});
+
+	it("moves by one visible page using remapped selection bindings", () => {
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.select.pageUp": "alt+v",
+				"tui.select.pageDown": "ctrl+v",
+			}),
+		);
+		try {
+			const items = Array.from({ length: 12 }, (_, index) => ({
+				value: `item-${index}`,
+				label: `Item ${index}`,
+			}));
+			const list = new SelectList(items, 5, testTheme);
+			const selections: string[] = [];
+			list.onSelectionChange = (item) => selections.push(item.value);
+
+			list.handleInput("\x16");
+			list.handleInput("\x16");
+			list.handleInput("\x16");
+			list.handleInput("\x1bv");
+
+			assert.deepStrictEqual(selections, ["item-5", "item-10", "item-11", "item-6"]);
+		} finally {
+			setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+		}
 	});
 });

--- a/packages/tui/test/settings-list.test.ts
+++ b/packages/tui/test/settings-list.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { SettingsList, type SettingsListTheme } from "../src/components/settings-list.ts";
+import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings.ts";
 
 const testTheme: SettingsListTheme = {
 	label: (text) => text,
@@ -54,5 +55,38 @@ describe("SettingsList", () => {
 		list.handleInput(" ");
 
 		assert.deepStrictEqual(changes, [{ id: "ui-mode", value: "fullscreen" }]);
+	});
+
+	it("moves by one visible page using remapped selection bindings", () => {
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.select.pageUp": "alt+v",
+				"tui.select.pageDown": "ctrl+v",
+			}),
+		);
+		try {
+			const list = new SettingsList(
+				Array.from({ length: 12 }, (_, index) => ({
+					id: `setting-${index}`,
+					label: `Setting ${index}`,
+					currentValue: String(index),
+				})),
+				5,
+				testTheme,
+				() => {},
+				() => {},
+			);
+
+			list.handleInput("\x16");
+			assert.match(list.render(80).join("\n"), /> Setting 5/);
+
+			list.handleInput("\x16");
+			assert.match(list.render(80).join("\n"), /> Setting 10/);
+
+			list.handleInput("\x1bv");
+			assert.match(list.render(80).join("\n"), /> Setting 5/);
+		} finally {
+			setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+		}
 	});
 });

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
+import { Editor } from "../src/components/editor.ts";
 import { HStack } from "../src/components/h-stack.ts";
 import { Image } from "../src/components/image.ts";
 import { ScrollView } from "../src/components/scroll-view.ts";
+import { SelectList } from "../src/components/select-list.ts";
 import { Text } from "../src/components/text.ts";
 import { VStack } from "../src/components/v-stack.ts";
+import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings.ts";
 import {
 	encodeKitty,
 	hyperlink,
@@ -12,7 +15,9 @@ import {
 	resetCapabilitiesCache,
 	setCapabilities,
 } from "../src/terminal-image.ts";
+import { Container } from "../src/tui.ts";
 import { TuiAltScreen } from "../src/tui-alt-screen.ts";
+import { defaultEditorTheme } from "./test-themes.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -37,6 +42,10 @@ class RecordingTerminal extends VirtualTerminal {
 }
 
 describe("TuiAltScreen", () => {
+	afterEach(() => {
+		setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+	});
+
 	it("renders a terminal-height viewport and preserves manual scroll position", async () => {
 		const terminal = new VirtualTerminal(20, 4);
 		const tui = new TuiAltScreen(terminal);
@@ -348,6 +357,107 @@ describe("TuiAltScreen", () => {
 		assert.strictEqual(transcript.scrollTop, 1);
 		assert.deepStrictEqual(editorInputs, modifiedInputs);
 
+		tui.stop();
+	});
+
+	it("routes an overlapping remapped page key to an open editor autocomplete menu", async () => {
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.editor.pageDown": "ctrl+v",
+				"tui.select.pageDown": "ctrl+v",
+				"tui.altScreen.pageDown": "ctrl+v",
+			}),
+		);
+		const terminal = new VirtualTerminal(80, 12);
+		const tui = new TuiAltScreen(terminal);
+		const transcript = new ScrollView(
+			new Text(Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join("\n"), 0, 0),
+			{ follow: "end", primary: true },
+		);
+		const editor = new Editor(tui, defaultEditorTheme);
+		let submitted = "";
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+		editor.setAutocompleteProvider({
+			getSuggestions: async () => ({
+				items: Array.from({ length: 12 }, (_, index) => ({
+					value: `/command-${index}`,
+					label: `command-${index}`,
+				})),
+				prefix: "/",
+			}),
+			applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
+				const newLines = [...lines];
+				newLines[cursorLine] = (lines[cursorLine] ?? "").slice(0, cursorCol - prefix.length) + item.value;
+				return { lines: newLines, cursorLine, cursorCol: item.value.length };
+			},
+		});
+		tui.setLayoutRoot(
+			new VStack([
+				{ component: transcript, basis: 0, grow: 1, minSize: 1 },
+				{ component: editor, basis: "auto", shrink: 0 },
+			]),
+		);
+		tui.setFocus(editor);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("/");
+		await new Promise((resolve) => setImmediate(resolve));
+		await terminal.waitForRender();
+		assert.strictEqual(editor.isShowingAutocomplete(), true);
+		const scrollTop = transcript.scrollTop;
+
+		terminal.sendInput("\x16");
+		await terminal.waitForRender();
+		assert.strictEqual(transcript.scrollTop, scrollTop);
+
+		terminal.sendInput("\r");
+		assert.strictEqual(submitted, "/command-5");
+		tui.stop();
+	});
+
+	it("routes selection page keys through a focused container wrapper", async () => {
+		const terminal = new VirtualTerminal(80, 12);
+		const tui = new TuiAltScreen(terminal);
+		const transcript = new ScrollView(
+			new Text(Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join("\n"), 0, 0),
+			{ follow: "end", primary: true },
+		);
+		const selectList = new SelectList(
+			Array.from({ length: 12 }, (_, index) => ({ value: `item-${index}`, label: `Item ${index}` })),
+			5,
+			{
+				selectedPrefix: (text) => text,
+				selectedText: (text) => text,
+				description: (text) => text,
+				scrollInfo: (text) => text,
+				noMatch: (text) => text,
+			},
+		);
+		const wrapper = Object.assign(new Container(), {
+			handleInput(data: string) {
+				selectList.handleInput(data);
+			},
+		});
+		wrapper.addChild(selectList);
+		tui.setLayoutRoot(
+			new VStack([
+				{ component: transcript, basis: 0, grow: 1, minSize: 1 },
+				{ component: wrapper, basis: "auto", shrink: 0 },
+			]),
+		);
+		tui.setFocus(wrapper);
+		tui.start();
+		await terminal.waitForRender();
+		const scrollTop = transcript.scrollTop;
+
+		terminal.sendInput("\x1b[6~");
+		await terminal.waitForRender();
+
+		assert.strictEqual(transcript.scrollTop, scrollTop);
+		assert.strictEqual(selectList.getSelectedItem()?.value, "item-5");
 		tui.stop();
 	});
 


### PR DESCRIPTION
## Summary
- handle `tui.select.pageUp` and `tui.select.pageDown` in built-in selection components, editor autocomplete, coding-agent selectors, and bundled examples
- give active selections precedence over fullscreen transcript scrolling while preserving existing viewport behavior when no selection is active
- document selection-page capture propagation and wrapper requirements

Fixes #7629

## Testing
- `npm run check`
- `node ../../node_modules/vitest/dist/cli.js --run test/suite/regressions/7629-select-page-keys.test.ts` (5 passed)
- `node --test test/editor.test.ts test/select-list.test.ts test/settings-list.test.ts test/tui-alt-screen.test.ts` (222 passed)
- manual regular/fullscreen TUI checks for remapped `Ctrl+V` / `Alt+V`
- `./test.sh`: affected packages pass; intermittent unrelated failures in `test/agent-session-concurrent.test.ts` and one `test/config.test.ts` timeout pass on isolated rerun (22/22)