### PR TITLE
feat(coding-agent): add configurable Harness factory

### DIFF
--- a/packages/agent/test/harness/nodejs-env.test.ts
+++ b/packages/agent/test/harness/nodejs-env.test.ts
@@ -289,6 +289,37 @@ describe("NodeExecutionEnv", () => {
 		expect(result).toEqual({ stdout: `${await realpath(root)}:ok`, stderr: "", exitCode: 0 });
 	});
 
+	it.each([
+		["a missing override preserves the base value", undefined, "x:/stale/parent.jsonl"],
+		["an empty override shadows the base value", { PI_SESSION_FILE: "" }, "x:"],
+		[
+			"a string override replaces the base value",
+			{ PI_SESSION_FILE: "/sessions/current.jsonl" },
+			"x:/sessions/current.jsonl",
+		],
+	] as const)(
+		"applies string shell environment overrides when %s",
+		async (_description, overrides, expectedSessionFile) => {
+			const root = createTempDir();
+			const env = new NodeExecutionEnv({
+				cwd: root,
+				shellEnv: {
+					PI_SESSION_FILE: "/stale/parent.jsonl",
+					PI_CODING_AGENT: "true",
+					PI_NODE_ENV_PRESERVED_TEST: "preserved",
+				},
+			});
+			const result = getOrThrow(
+				await env.exec(
+					`printf '%s:%s|%s|%s' "\${PI_SESSION_FILE+x}" "\${PI_SESSION_FILE-}" "$PI_CODING_AGENT" "$PI_NODE_ENV_PRESERVED_TEST"`,
+					{ env: overrides },
+				),
+			);
+
+			expect(result.stdout).toBe(`${expectedSessionFile}|true|preserved`);
+		},
+	);
+
 	it("can replace rather than inherit the default shell environment", async () => {
 		const root = createTempDir();
 		const inheritedKey = "PI_NODE_ENV_INHERITED_TEST";

--- a/packages/agent/test/harness/tools.test.ts
+++ b/packages/agent/test/harness/tools.test.ts
@@ -543,28 +543,6 @@ describe("AgentHarness tools", () => {
 			expect(textOutput(result)).toMatch(/Showing last 50\.0KB of line 1 \(line is 58\.6KB\)\. Full output:/);
 		});
 
-		it("forwards empty environment overrides to shell execution", async () => {
-			const env = new NodeExecutionEnv({
-				cwd: createTempDir(),
-				shellEnv: { PI_SESSION_FILE: "/stale/parent.jsonl", PI_CODING_AGENT: "true" },
-			});
-			const result = await createBashTool({
-				prepare: (execution) => {
-					execution.env.PI_SESSION_FILE = "";
-				},
-			}).execute(
-				"bash-empty-env",
-				{
-					command: `printf '%s:%s:%s' "\${PI_SESSION_FILE+x}" "$PI_SESSION_FILE" "$PI_CODING_AGENT"`,
-				},
-				undefined,
-				undefined,
-				{ env },
-			);
-
-			expect(textOutput(result)).toBe("x::true");
-		});
-
 		it("prepares command, cwd, and an explicit environment with the turn context", async () => {
 			const env = new NodeExecutionEnv({
 				cwd: createTempDir(),

--- a/packages/agent/test/harness/tools.test.ts
+++ b/packages/agent/test/harness/tools.test.ts
@@ -543,6 +543,28 @@ describe("AgentHarness tools", () => {
 			expect(textOutput(result)).toMatch(/Showing last 50\.0KB of line 1 \(line is 58\.6KB\)\. Full output:/);
 		});
 
+		it("forwards empty environment overrides to shell execution", async () => {
+			const env = new NodeExecutionEnv({
+				cwd: createTempDir(),
+				shellEnv: { PI_SESSION_FILE: "/stale/parent.jsonl", PI_CODING_AGENT: "true" },
+			});
+			const result = await createBashTool({
+				prepare: (execution) => {
+					execution.env.PI_SESSION_FILE = "";
+				},
+			}).execute(
+				"bash-empty-env",
+				{
+					command: `printf '%s:%s:%s' "\${PI_SESSION_FILE+x}" "$PI_SESSION_FILE" "$PI_CODING_AGENT"`,
+				},
+				undefined,
+				undefined,
+				{ env },
+			);
+
+			expect(textOutput(result)).toBe("x::true");
+		});
+
 		it("prepares command, cwd, and an explicit environment with the turn context", async () => {
 			const env = new NodeExecutionEnv({
 				cwd: createTempDir(),

--- a/packages/coding-agent/src/server/create-harness.ts
+++ b/packages/coding-agent/src/server/create-harness.ts
@@ -11,84 +11,145 @@ import {
 	type HarnessTool,
 } from "@earendil-works/pi-agent-core";
 import type { Static, TSchema } from "typebox";
-import { buildSystemPrompt } from "../core/system-prompt.ts";
+import { type BuildSystemPromptOptions, buildSystemPrompt } from "../core/system-prompt.ts";
 import { bashToolSystemPromptContribution } from "../core/tools/bash.ts";
 import { editToolSystemPromptContribution } from "../core/tools/edit.ts";
 import { readToolSystemPromptContribution } from "../core/tools/read.ts";
 import { writeToolSystemPromptContribution } from "../core/tools/write.ts";
 
-const HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS = {
-	read: readToolSystemPromptContribution,
-	bash: bashToolSystemPromptContribution,
-	edit: editToolSystemPromptContribution,
-	write: writeToolSystemPromptContribution,
-} as const;
+export interface CodingAgentHarnessTool extends HarnessTool {
+	promptSnippet?: string;
+	promptGuidelines?: readonly string[];
+}
 
-function bindExecutionTool<TParameters extends TSchema, TDetails>(
+function createCodingAgentHarnessTool<TParameters extends TSchema, TDetails>(
 	tool: AgentHarnessTool<ExecutionToolContext, TParameters, TDetails>,
 	context: ExecutionToolContext,
-): HarnessTool {
+	prompt: Required<Pick<CodingAgentHarnessTool, "promptSnippet" | "promptGuidelines">>,
+): CodingAgentHarnessTool {
 	return {
 		...tool,
+		...prompt,
 		execute: (toolCallId, params, signal, onUpdate) =>
 			tool.execute(toolCallId, params as Static<TParameters>, signal, onUpdate, context),
 	};
 }
 
-export interface CreateCodingAgentHarnessOptions
-	extends Omit<AgentHarnessOptions, "activeToolNames" | "systemPrompt" | "toolContext" | "tools"> {
+export interface CreateCodingAgentHarnessOptions extends Omit<AgentHarnessOptions, "toolContext" | "tools"> {
 	env: ExecutionEnv;
 	bashCommandPrefix?: string;
+	tools?: CodingAgentHarnessTool[];
+	systemPromptOptions?: Omit<BuildSystemPromptOptions, "cwd" | "promptGuidelines" | "selectedTools" | "toolSnippets">;
 }
 
-export function buildCodingAgentHarnessSystemPrompt(cwd: string): string {
+export interface BuildCodingAgentHarnessSystemPromptOptions {
+	cwd: string;
+	tools: readonly CodingAgentHarnessTool[];
+	activeToolNames: readonly string[];
+	systemPromptOptions?: CreateCodingAgentHarnessOptions["systemPromptOptions"];
+}
+
+export function buildCodingAgentHarnessSystemPrompt(options: BuildCodingAgentHarnessSystemPromptOptions): string {
+	const activeTools = options.activeToolNames.flatMap((name) => {
+		const tool = options.tools.find((candidate) => candidate.name === name);
+		return tool ? [tool] : [];
+	});
 	const toolSnippets = Object.fromEntries(
-		Object.entries(HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS).map(([name, contribution]) => [
-			name,
-			contribution.snippet,
-		]),
+		activeTools.flatMap((tool) => {
+			const promptSnippet = tool.promptSnippet
+				?.replace(/[\r\n]+/g, " ")
+				.replace(/\s+/g, " ")
+				.trim();
+			return promptSnippet ? [[tool.name, promptSnippet]] : [];
+		}),
 	);
-	const promptGuidelines = [
-		...HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS.bash.guidelines,
-		...Object.entries(HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS).flatMap(([name, contribution]) =>
-			name === "bash" ? [] : contribution.guidelines,
-		),
-	];
+	const promptGuidelines = activeTools.flatMap((tool) => tool.promptGuidelines ?? []);
 	return buildSystemPrompt({
-		cwd,
-		selectedTools: Object.keys(HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS),
+		...options.systemPromptOptions,
+		cwd: options.cwd,
+		selectedTools: activeTools.map((tool) => tool.name),
 		toolSnippets,
 		promptGuidelines,
-		contextFiles: [],
-		skills: [],
 	});
 }
 
 export async function createCodingAgentHarness(options: CreateCodingAgentHarnessOptions) {
-	const { env, bashCommandPrefix, ...harnessOptions } = options;
-	const metadata = await options.session.getMetadata();
-	const toolContext = { env } satisfies ExecutionToolContext;
-	const tools: HarnessTool[] = [
-		bindExecutionTool(createReadTool<ExecutionToolContext>(), toolContext),
-		bindExecutionTool(
-			createBashTool<ExecutionToolContext>({
-				commandPrefix: bashCommandPrefix,
-				prepare: (execution) => {
-					execution.env.PI_SESSION_ID = metadata.id;
-					execution.env.PI_PROVIDER = options.model.provider;
-					execution.env.PI_MODEL = options.model.id;
-					execution.env.PI_REASONING_LEVEL = options.thinkingLevel ?? "off";
-				},
+	const {
+		env,
+		bashCommandPrefix,
+		systemPromptOptions,
+		tools: providedTools,
+		activeToolNames: providedActiveToolNames,
+		systemPrompt: providedSystemPrompt,
+		...harnessOptions
+	} = options;
+	let harness: AgentHarness | undefined;
+	const getHarness = (): AgentHarness => {
+		if (!harness) throw new Error("Coding-agent Harness callback ran before Harness initialization");
+		return harness;
+	};
+	let tools = providedTools;
+	if (tools === undefined) {
+		const metadata = await options.session.getMetadata();
+		const toolContext = { env } satisfies ExecutionToolContext;
+		tools = [
+			createCodingAgentHarnessTool(createReadTool<ExecutionToolContext>(), toolContext, {
+				promptSnippet: readToolSystemPromptContribution.snippet,
+				promptGuidelines: readToolSystemPromptContribution.guidelines,
 			}),
-			toolContext,
-		),
-		bindExecutionTool(createEditTool<ExecutionToolContext>(), toolContext),
-		bindExecutionTool(createWriteTool<ExecutionToolContext>(), toolContext),
-	];
-	return AgentHarness.create({
+			createCodingAgentHarnessTool(
+				createBashTool<ExecutionToolContext>({
+					commandPrefix: bashCommandPrefix,
+					prepare: async (execution) => {
+						const currentHarness = getHarness();
+						const [model, thinkingLevel] = await Promise.all([
+							currentHarness.getModel(),
+							currentHarness.getThinkingLevel(),
+						]);
+						execution.env.PI_SESSION_ID = metadata.id;
+						execution.env.PI_PROVIDER = model.provider;
+						execution.env.PI_MODEL = model.id;
+						execution.env.PI_REASONING_LEVEL = thinkingLevel;
+					},
+				}),
+				toolContext,
+				{
+					promptSnippet: bashToolSystemPromptContribution.snippet,
+					promptGuidelines: bashToolSystemPromptContribution.guidelines,
+				},
+			),
+			createCodingAgentHarnessTool(createEditTool<ExecutionToolContext>(), toolContext, {
+				promptSnippet: editToolSystemPromptContribution.snippet,
+				promptGuidelines: editToolSystemPromptContribution.guidelines,
+			}),
+			createCodingAgentHarnessTool(createWriteTool<ExecutionToolContext>(), toolContext, {
+				promptSnippet: writeToolSystemPromptContribution.snippet,
+				promptGuidelines: writeToolSystemPromptContribution.guidelines,
+			}),
+		];
+	}
+	const activeToolNames = [...(providedActiveToolNames ?? tools.map((tool) => tool.name))];
+	const systemPrompt =
+		providedSystemPrompt ??
+		(async () => {
+			const currentHarness = getHarness();
+			const [currentTools, currentActiveToolNames] = await Promise.all([
+				currentHarness.getTools(),
+				currentHarness.getActiveTools(),
+			]);
+			return buildCodingAgentHarnessSystemPrompt({
+				cwd: env.cwd,
+				tools: currentTools,
+				activeToolNames: currentActiveToolNames,
+				systemPromptOptions,
+			});
+		});
+	const created = await AgentHarness.create({
 		...harnessOptions,
 		tools,
-		activeToolNames: tools.map((tool) => tool.name),
-		systemPrompt: () => buildCodingAgentHarnessSystemPrompt(env.cwd),
+		activeToolNames,
+		systemPrompt,
 	});
+	harness = created.harness;
+	return created;
 }

--- a/packages/coding-agent/src/server/create-harness.ts
+++ b/packages/coding-agent/src/server/create-harness.ts
@@ -38,6 +38,8 @@ function createCodingAgentHarnessTool<TParameters extends TSchema, TDetails>(
 export interface CreateCodingAgentHarnessOptions extends Omit<AgentHarnessOptions, "toolContext" | "tools"> {
 	env: ExecutionEnv;
 	bashCommandPrefix?: string;
+	/** Path to the JSONL session file exposed to default bash commands as PI_SESSION_FILE. */
+	sessionFile?: string;
 	tools?: CodingAgentHarnessTool[];
 	systemPromptOptions?: Omit<BuildSystemPromptOptions, "cwd" | "promptGuidelines" | "selectedTools" | "toolSnippets">;
 }
@@ -77,6 +79,7 @@ export async function createCodingAgentHarness(options: CreateCodingAgentHarness
 	const {
 		env,
 		bashCommandPrefix,
+		sessionFile,
 		systemPromptOptions,
 		tools: providedTools,
 		activeToolNames: providedActiveToolNames,
@@ -107,6 +110,7 @@ export async function createCodingAgentHarness(options: CreateCodingAgentHarness
 							currentHarness.getThinkingLevel(),
 						]);
 						execution.env.PI_SESSION_ID = metadata.id;
+						execution.env.PI_SESSION_FILE = sessionFile ?? "";
 						execution.env.PI_PROVIDER = model.provider;
 						execution.env.PI_MODEL = model.id;
 						execution.env.PI_REASONING_LEVEL = thinkingLevel;

--- a/packages/coding-agent/src/server/create-harness.ts
+++ b/packages/coding-agent/src/server/create-harness.ts
@@ -1,0 +1,94 @@
+import {
+	AgentHarness,
+	type AgentHarnessOptions,
+	type AgentHarnessTool,
+	createBashTool,
+	createEditTool,
+	createReadTool,
+	createWriteTool,
+	type ExecutionEnv,
+	type ExecutionToolContext,
+	type HarnessTool,
+} from "@earendil-works/pi-agent-core";
+import type { Static, TSchema } from "typebox";
+import { buildSystemPrompt } from "../core/system-prompt.ts";
+import { bashToolSystemPromptContribution } from "../core/tools/bash.ts";
+import { editToolSystemPromptContribution } from "../core/tools/edit.ts";
+import { readToolSystemPromptContribution } from "../core/tools/read.ts";
+import { writeToolSystemPromptContribution } from "../core/tools/write.ts";
+
+const HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS = {
+	read: readToolSystemPromptContribution,
+	bash: bashToolSystemPromptContribution,
+	edit: editToolSystemPromptContribution,
+	write: writeToolSystemPromptContribution,
+} as const;
+
+function bindExecutionTool<TParameters extends TSchema, TDetails>(
+	tool: AgentHarnessTool<ExecutionToolContext, TParameters, TDetails>,
+	context: ExecutionToolContext,
+): HarnessTool {
+	return {
+		...tool,
+		execute: (toolCallId, params, signal, onUpdate) =>
+			tool.execute(toolCallId, params as Static<TParameters>, signal, onUpdate, context),
+	};
+}
+
+export interface CreateCodingAgentHarnessOptions
+	extends Omit<AgentHarnessOptions, "activeToolNames" | "systemPrompt" | "toolContext" | "tools"> {
+	env: ExecutionEnv;
+	bashCommandPrefix?: string;
+}
+
+export function buildCodingAgentHarnessSystemPrompt(cwd: string): string {
+	const toolSnippets = Object.fromEntries(
+		Object.entries(HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS).map(([name, contribution]) => [
+			name,
+			contribution.snippet,
+		]),
+	);
+	const promptGuidelines = [
+		...HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS.bash.guidelines,
+		...Object.entries(HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS).flatMap(([name, contribution]) =>
+			name === "bash" ? [] : contribution.guidelines,
+		),
+	];
+	return buildSystemPrompt({
+		cwd,
+		selectedTools: Object.keys(HARNESS_TOOL_SYSTEM_PROMPT_CONTRIBUTIONS),
+		toolSnippets,
+		promptGuidelines,
+		contextFiles: [],
+		skills: [],
+	});
+}
+
+export async function createCodingAgentHarness(options: CreateCodingAgentHarnessOptions) {
+	const { env, bashCommandPrefix, ...harnessOptions } = options;
+	const metadata = await options.session.getMetadata();
+	const toolContext = { env } satisfies ExecutionToolContext;
+	const tools: HarnessTool[] = [
+		bindExecutionTool(createReadTool<ExecutionToolContext>(), toolContext),
+		bindExecutionTool(
+			createBashTool<ExecutionToolContext>({
+				commandPrefix: bashCommandPrefix,
+				prepare: (execution) => {
+					execution.env.PI_SESSION_ID = metadata.id;
+					execution.env.PI_PROVIDER = options.model.provider;
+					execution.env.PI_MODEL = options.model.id;
+					execution.env.PI_REASONING_LEVEL = options.thinkingLevel ?? "off";
+				},
+			}),
+			toolContext,
+		),
+		bindExecutionTool(createEditTool<ExecutionToolContext>(), toolContext),
+		bindExecutionTool(createWriteTool<ExecutionToolContext>(), toolContext),
+	];
+	return AgentHarness.create({
+		...harnessOptions,
+		tools,
+		activeToolNames: tools.map((tool) => tool.name),
+		systemPrompt: () => buildCodingAgentHarnessSystemPrompt(env.cwd),
+	});
+}

--- a/packages/coding-agent/test/server/create-harness.test.ts
+++ b/packages/coding-agent/test/server/create-harness.test.ts
@@ -1,9 +1,63 @@
-import { InMemorySessionStorage, Session } from "@earendil-works/pi-agent-core";
+import {
+	AgentHarness,
+	type AgentHarnessOptions,
+	type ExecutionError,
+	type HarnessTool,
+	InMemorySessionStorage,
+	ok,
+	type Result,
+	Session,
+	type ShellExecOptions,
+} from "@earendil-works/pi-agent-core";
 import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
 import { createModels } from "@earendil-works/pi-ai";
 import { getModel } from "@earendil-works/pi-ai/compat";
-import { describe, expect, test } from "vitest";
-import { buildCodingAgentHarnessSystemPrompt, createCodingAgentHarness } from "../../src/server/create-harness.ts";
+import { Type } from "typebox";
+import { describe, expect, test, vi } from "vitest";
+import {
+	buildCodingAgentHarnessSystemPrompt,
+	type CodingAgentHarnessTool,
+	createCodingAgentHarness,
+} from "../../src/server/create-harness.ts";
+
+class CapturingExecutionEnv extends NodeExecutionEnv {
+	executionEnv: Record<string, string> | undefined;
+
+	override async exec(
+		_command: string,
+		options?: ShellExecOptions,
+	): Promise<Result<{ stdout: string; stderr: string; exitCode: number }, ExecutionError>> {
+		this.executionEnv = options?.env;
+		return ok({ stdout: "", stderr: "", exitCode: 0 });
+	}
+}
+
+async function resolveSystemPrompt(systemPrompt: AgentHarnessOptions["systemPrompt"]): Promise<string> {
+	if (typeof systemPrompt === "string") return systemPrompt;
+	if (systemPrompt === undefined) throw new Error("Expected a system prompt callback");
+	return systemPrompt();
+}
+
+function createPromptTool(name: string, promptSnippet?: string, promptGuidelines?: string[]): CodingAgentHarnessTool {
+	return {
+		name,
+		label: name,
+		description: `${name} description`,
+		parameters: Type.Object({}),
+		execute: async () => ({ content: [{ type: "text", text: "ok" }], details: undefined }),
+		promptSnippet,
+		promptGuidelines,
+	};
+}
+
+const defaultPromptTools = [
+	createPromptTool("read", "Read file contents", ["Use read to examine files instead of cat or sed."]),
+	createPromptTool("bash", "Execute bash commands (ls, grep, find, etc.)", [
+		"Inspect PI_* environment variables for current model and session details.",
+	]),
+	createPromptTool("edit", "Edit files", ["Edit carefully."]),
+	createPromptTool("write", "Create or overwrite files", ["Use write only for new files or complete rewrites."]),
+];
 
 describe("coding-agent Harness construction", () => {
 	test("adds coding-agent policy to explicit Harness options", async () => {
@@ -35,13 +89,210 @@ describe("coding-agent Harness construction", () => {
 	});
 
 	test("preserves coding-agent prompt snippets and guideline order", () => {
-		const prompt = buildCodingAgentHarnessSystemPrompt("/workspace");
+		const prompt = buildCodingAgentHarnessSystemPrompt({
+			cwd: "/workspace",
+			tools: defaultPromptTools,
+			activeToolNames: ["read", "bash", "edit", "write"],
+		});
 		expect(prompt).toContain("- read: Read file contents");
 		expect(prompt).toContain("- bash: Execute bash commands (ls, grep, find, etc.)");
 		expect(prompt).toContain("Use read to examine files instead of cat or sed.");
 		expect(prompt).toContain("Inspect PI_* environment variables for current model and session details.");
-		expect(prompt.indexOf("Inspect PI_* environment variables")).toBeLessThan(
-			prompt.indexOf("Use read to examine files"),
+		expect(prompt.indexOf("Use read to examine files")).toBeLessThan(
+			prompt.indexOf("Inspect PI_* environment variables"),
+		);
+	});
+
+	test("preserves caller-supplied tools and activation", async () => {
+		const session = new Session(new InMemorySessionStorage({ id: "custom-harness-session", createdAt: 1 }));
+		const env = new NodeExecutionEnv({ cwd: "/workspace" });
+		const customTool: HarnessTool = {
+			name: "inspect",
+			label: "inspect",
+			description: "Inspect the configured service",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [{ type: "text", text: "ok" }], details: undefined }),
+		};
+		const created = await createCodingAgentHarness({
+			session,
+			models: createModels(),
+			model: getModel("google", "gemini-2.5-flash"),
+			env,
+			tools: [customTool],
+			activeToolNames: [],
+			systemPrompt: "Server-owned prompt",
+		});
+		try {
+			expect((await created.harness.getTools()).map((tool) => tool.name)).toEqual(["inspect"]);
+			expect(await created.harness.getActiveTools()).toEqual([]);
+		} finally {
+			await created.harness.close();
+			await env.cleanup();
+		}
+	});
+
+	test("keeps bash PI model variables synchronized with Harness state", async () => {
+		const session = new Session(new InMemorySessionStorage({ id: "dynamic-bash-session", createdAt: 1 }));
+		const env = new CapturingExecutionEnv({ cwd: "/workspace" });
+		const created = await createCodingAgentHarness({
+			session,
+			models: createModels(),
+			model: getModel("google", "gemini-2.5-flash"),
+			thinkingLevel: "high",
+			env,
+		});
+		try {
+			await created.harness.setModel(getModel("anthropic", "claude-sonnet-4-5"));
+			await created.harness.setThinkingLevel("low");
+			const bash = (await created.harness.getTools()).find((tool) => tool.name === "bash");
+			if (!bash) throw new Error("Expected the default bash tool");
+
+			await bash.execute("bash-call", { command: "echo ignored" });
+
+			expect(env.executionEnv).toEqual({
+				PI_SESSION_ID: "dynamic-bash-session",
+				PI_PROVIDER: "anthropic",
+				PI_MODEL: "claude-sonnet-4-5",
+				PI_REASONING_LEVEL: "low",
+			});
+		} finally {
+			await created.harness.close();
+			await env.cleanup();
+		}
+	});
+
+	test("builds each default system prompt from current Harness tool metadata", async () => {
+		const originalCreate = AgentHarness.create.bind(AgentHarness);
+		let configuredSystemPrompt: AgentHarnessOptions["systemPrompt"];
+		const createSpy = vi.spyOn(AgentHarness, "create").mockImplementation(async (options) => {
+			configuredSystemPrompt = options.systemPrompt;
+			return originalCreate(options);
+		});
+		const session = new Session(new InMemorySessionStorage({ id: "dynamic-prompt-session", createdAt: 1 }));
+		const env = new NodeExecutionEnv({ cwd: "/workspace" });
+		try {
+			const created = await createCodingAgentHarness({
+				session,
+				models: createModels(),
+				model: getModel("google", "gemini-2.5-flash"),
+				env,
+			});
+			createSpy.mockRestore();
+			try {
+				const initialPrompt = await resolveSystemPrompt(configuredSystemPrompt);
+				expect(initialPrompt).toContain("- read: Read file contents");
+				expect(initialPrompt).toContain("- bash: Execute bash commands (ls, grep, find, etc.)");
+				expect(initialPrompt).toContain("- edit: Make precise file edits with exact text replacement");
+				expect(initialPrompt).toContain("- write: Create or overwrite files");
+
+				await created.harness.setActiveTools(["write"]);
+				const writePrompt = await resolveSystemPrompt(configuredSystemPrompt);
+				expect(writePrompt).toContain("- write: Create or overwrite files");
+				expect(writePrompt).not.toContain("- read:");
+				expect(writePrompt).not.toContain("- bash:");
+
+				const read = (await created.harness.getTools()).find((tool) => tool.name === "read");
+				if (!read) throw new Error("Expected the default read tool");
+				await created.harness.setTools([read]);
+				const readPrompt = await resolveSystemPrompt(configuredSystemPrompt);
+				expect(readPrompt).toContain("- read: Read file contents");
+				expect(readPrompt).not.toContain("- write:");
+
+				const inspectTool: CodingAgentHarnessTool = {
+					name: "inspect",
+					label: "inspect",
+					description: "Inspect the configured service",
+					parameters: Type.Object({}),
+					execute: async () => ({ content: [{ type: "text", text: "ok" }], details: undefined }),
+					promptSnippet: "  Inspect\nthe   configured service  ",
+					promptGuidelines: ["Use inspect for service diagnostics."],
+				};
+				await created.harness.setTools([inspectTool]);
+				const inspectPrompt = await resolveSystemPrompt(configuredSystemPrompt);
+				expect(inspectPrompt).toContain("- inspect: Inspect the configured service");
+				expect(inspectPrompt).toContain("Use inspect for service diagnostics.");
+			} finally {
+				await created.harness.close();
+				await env.cleanup();
+			}
+		} finally {
+			createSpy.mockRestore();
+		}
+	});
+
+	test("omits active custom tools without prompt metadata from the textual tools section", () => {
+		const prompt = buildCodingAgentHarnessSystemPrompt({
+			cwd: "/workspace",
+			tools: [createPromptTool("hidden")],
+			activeToolNames: ["hidden"],
+		});
+
+		expect(prompt).toContain("Available tools:\n(none)");
+		expect(prompt).not.toContain("- hidden:");
+		expect(prompt).not.toContain("hidden description");
+	});
+
+	test.each([
+		[
+			"bash",
+			"Execute bash commands (ls, grep, find, etc.)",
+			"Inspect PI_* environment variables for current model and session details.",
+		],
+		["read", "Read file contents", "Use read to examine files instead of cat or sed."],
+		[
+			"edit",
+			"Make precise file edits with exact text replacement, including multiple disjoint edits in one call",
+			"Use edit for precise changes (edits[].oldText must match exactly)",
+		],
+		["write", "Create or overwrite files", "Use write only for new files or complete rewrites."],
+	] as const)(
+		"does not infer prompt metadata for a caller-supplied %s replacement",
+		(name, builtInSnippet, builtInGuideline) => {
+			const prompt = buildCodingAgentHarnessSystemPrompt({
+				cwd: "/workspace",
+				tools: [createPromptTool(name)],
+				activeToolNames: [name],
+			});
+
+			expect(prompt).toContain("Available tools:\n(none)");
+			expect(prompt).not.toContain(builtInSnippet);
+			expect(prompt).not.toContain(builtInGuideline);
+		},
+	);
+
+	test("builds the default prompt from active tools and resolved prompt resources", () => {
+		const prompt = buildCodingAgentHarnessSystemPrompt({
+			cwd: "/workspace",
+			tools: defaultPromptTools,
+			activeToolNames: ["write", "read"],
+			systemPromptOptions: {
+				contextFiles: [{ path: "/workspace/AGENTS.md", content: "Follow project policy." }],
+				skills: [
+					{
+						name: "review",
+						description: "Review server changes",
+						filePath: "/skills/review/SKILL.md",
+						baseDir: "/skills/review",
+						sourceInfo: {
+							path: "/skills/review/SKILL.md",
+							source: "test",
+							scope: "temporary",
+							origin: "top-level",
+						},
+						disableModelInvocation: false,
+					},
+				],
+			},
+		});
+
+		expect(prompt).toContain("- write: Create or overwrite files");
+		expect(prompt).toContain("- read: Read file contents");
+		expect(prompt).not.toContain("- bash:");
+		expect(prompt).not.toContain("Inspect PI_* environment variables");
+		expect(prompt).toContain('<project_instructions path="/workspace/AGENTS.md">');
+		expect(prompt).toContain("<name>review</name>");
+		expect(prompt.indexOf("Use write only for new files or complete rewrites.")).toBeLessThan(
+			prompt.indexOf("Use read to examine files instead of cat or sed."),
 		);
 	});
 });

--- a/packages/coding-agent/test/server/create-harness.test.ts
+++ b/packages/coding-agent/test/server/create-harness.test.ts
@@ -1,0 +1,47 @@
+import { InMemorySessionStorage, Session } from "@earendil-works/pi-agent-core";
+import { NodeExecutionEnv } from "@earendil-works/pi-agent-core/node";
+import { createModels } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
+import { describe, expect, test } from "vitest";
+import { buildCodingAgentHarnessSystemPrompt, createCodingAgentHarness } from "../../src/server/create-harness.ts";
+
+describe("coding-agent Harness construction", () => {
+	test("adds coding-agent policy to explicit Harness options", async () => {
+		const session = new Session(new InMemorySessionStorage({ id: "harness-session", createdAt: 1 }));
+		const env = new NodeExecutionEnv({ cwd: "/workspace" });
+		const created = await createCodingAgentHarness({
+			session,
+			models: createModels(),
+			model: getModel("google", "gemini-2.5-flash"),
+			thinkingLevel: "high",
+			env,
+			streamOptions: { maxTokens: 123 },
+			retry: { enabled: true, maxRetries: 2, baseDelayMs: 10 },
+			steeringMode: "all",
+			followUpMode: "all",
+		});
+		try {
+			expect(created.suspended).toEqual([]);
+			expect(await created.harness.getActiveTools()).toEqual(["read", "bash", "edit", "write"]);
+			expect((await created.harness.getTools()).map((tool) => tool.name)).toEqual(["read", "bash", "edit", "write"]);
+			expect(await created.harness.getStreamOptions()).toEqual({ maxTokens: 123 });
+			expect(await created.harness.getRetryPolicy()).toEqual({ enabled: true, maxRetries: 2, baseDelayMs: 10 });
+			expect(await created.harness.getSteeringMode()).toBe("all");
+			expect(await created.harness.getFollowUpMode()).toBe("all");
+		} finally {
+			await created.harness.close();
+			await env.cleanup();
+		}
+	});
+
+	test("preserves coding-agent prompt snippets and guideline order", () => {
+		const prompt = buildCodingAgentHarnessSystemPrompt("/workspace");
+		expect(prompt).toContain("- read: Read file contents");
+		expect(prompt).toContain("- bash: Execute bash commands (ls, grep, find, etc.)");
+		expect(prompt).toContain("Use read to examine files instead of cat or sed.");
+		expect(prompt).toContain("Inspect PI_* environment variables for current model and session details.");
+		expect(prompt.indexOf("Inspect PI_* environment variables")).toBeLessThan(
+			prompt.indexOf("Use read to examine files"),
+		);
+	});
+});

--- a/packages/coding-agent/test/server/create-harness.test.ts
+++ b/packages/coding-agent/test/server/create-harness.test.ts
@@ -4,7 +4,6 @@ import {
 	type ExecutionError,
 	type HarnessTool,
 	InMemorySessionStorage,
-	ok,
 	type Result,
 	Session,
 	type ShellExecOptions,
@@ -21,14 +20,14 @@ import {
 } from "../../src/server/create-harness.ts";
 
 class CapturingExecutionEnv extends NodeExecutionEnv {
-	executionEnv: Record<string, string> | undefined;
+	executionOverrides: Record<string, string> | undefined;
 
 	override async exec(
-		_command: string,
+		command: string,
 		options?: ShellExecOptions,
 	): Promise<Result<{ stdout: string; stderr: string; exitCode: number }, ExecutionError>> {
-		this.executionEnv = options?.env;
-		return ok({ stdout: "", stderr: "", exitCode: 0 });
+		this.executionOverrides = options?.env;
+		return super.exec(command, options);
 	}
 }
 
@@ -131,9 +130,53 @@ describe("coding-agent Harness construction", () => {
 		}
 	});
 
+	test("sets the optional session file in the default bash tool environment", async () => {
+		const session = new Session(new InMemorySessionStorage({ id: "session-file-harness", createdAt: 1 }));
+		const env = new CapturingExecutionEnv({
+			cwd: process.cwd(),
+			shellEnv: { PI_SESSION_FILE: "/stale/parent.jsonl", PI_CODING_AGENT: "true" },
+		});
+		const created = await createCodingAgentHarness({
+			session,
+			models: createModels(),
+			model: getModel("google", "gemini-2.5-flash"),
+			thinkingLevel: "high",
+			env,
+			sessionFile: "/sessions/current.jsonl",
+		});
+		try {
+			const bash = (await created.harness.getTools()).find((tool) => tool.name === "bash");
+			if (!bash) throw new Error("Expected the default bash tool");
+
+			const result = await bash.execute("bash-call", {
+				command: `printf '%s' "$PI_SESSION_ID|$PI_SESSION_FILE|$PI_PROVIDER|$PI_MODEL|$PI_REASONING_LEVEL|$PI_CODING_AGENT"`,
+			});
+
+			expect(env.executionOverrides).toEqual({
+				PI_SESSION_ID: "session-file-harness",
+				PI_SESSION_FILE: "/sessions/current.jsonl",
+				PI_PROVIDER: "google",
+				PI_MODEL: "gemini-2.5-flash",
+				PI_REASONING_LEVEL: "high",
+			});
+			expect(result.content).toEqual([
+				{
+					type: "text",
+					text: "session-file-harness|/sessions/current.jsonl|google|gemini-2.5-flash|high|true",
+				},
+			]);
+		} finally {
+			await created.harness.close();
+			await env.cleanup();
+		}
+	});
+
 	test("keeps bash PI model variables synchronized with Harness state", async () => {
 		const session = new Session(new InMemorySessionStorage({ id: "dynamic-bash-session", createdAt: 1 }));
-		const env = new CapturingExecutionEnv({ cwd: "/workspace" });
+		const env = new CapturingExecutionEnv({
+			cwd: process.cwd(),
+			shellEnv: { PI_SESSION_FILE: "/stale/parent.jsonl", PI_CODING_AGENT: "true" },
+		});
 		const created = await createCodingAgentHarness({
 			session,
 			models: createModels(),
@@ -147,14 +190,25 @@ describe("coding-agent Harness construction", () => {
 			const bash = (await created.harness.getTools()).find((tool) => tool.name === "bash");
 			if (!bash) throw new Error("Expected the default bash tool");
 
-			await bash.execute("bash-call", { command: "echo ignored" });
+			const result = await bash.execute("bash-call", {
+				command: `printf '%s:%s' "\${PI_SESSION_FILE+x}" "$PI_SESSION_ID|$PI_PROVIDER|$PI_MODEL|$PI_REASONING_LEVEL|$PI_CODING_AGENT"`,
+			});
 
-			expect(env.executionEnv).toEqual({
+			expect(env.executionOverrides).toEqual({
 				PI_SESSION_ID: "dynamic-bash-session",
+				PI_SESSION_FILE: "",
 				PI_PROVIDER: "anthropic",
 				PI_MODEL: "claude-sonnet-4-5",
 				PI_REASONING_LEVEL: "low",
 			});
+			expect(Object.hasOwn(env.executionOverrides ?? {}, "PI_SESSION_FILE")).toBe(true);
+			expect(env.executionOverrides?.PI_SESSION_FILE).toBe("");
+			expect(result.content).toEqual([
+				{
+					type: "text",
+					text: "x:dynamic-bash-session|anthropic|claude-sonnet-4-5|low|true",
+				},
+			]);
 		} finally {
 			await created.harness.close();
 			await env.cleanup();


### PR DESCRIPTION
## Summary

- add an internal coding-agent factory for constructing the experimental Harness
- preserve caller-provided tools, activation, prompt policy, and Harness options
- attach prompt metadata to built-in tools and rebuild prompts from current active tool objects
- keep bash session environment variables synchronized with current Harness model and thinking state

## Testing

- `npm run check`
- `node ../../node_modules/vitest/dist/cli.js --run test/server/create-harness.test.ts test/tool-system-prompt-contributions.test.ts test/system-prompt.test.ts` from `packages/coding-agent`
- `./test.sh` runs 209 coding-agent test files successfully but fails `test/agent-session-concurrent.test.ts` because the isolated test home has no Anthropic API key; all other workspaces pass


## Dependency

- Depends on #7671.
