### PR TITLE
fix(coding-agent): avoid Linux clipboard X11 leaks

### DIFF
--- a/packages/coding-agent/src/utils/clipboard-image.ts
+++ b/packages/coding-agent/src/utils/clipboard-image.ts
@@ -270,14 +270,12 @@ export async function readClipboardImage(options?: {
 
 		if (wayland || wsl) {
 			image = readClipboardImageViaWlPaste() ?? readClipboardImageViaXclip();
+		} else {
+			image = readClipboardImageViaXclip();
 		}
 
 		if (!image && wsl) {
 			image = readClipboardImageViaPowerShell();
-		}
-
-		if (!image && !wayland) {
-			image = (await readClipboardImageViaNativeClipboard()) ?? readClipboardImageViaXclip();
 		}
 	} else {
 		image = await readClipboardImageViaNativeClipboard();

--- a/packages/coding-agent/src/utils/clipboard-native.ts
+++ b/packages/coding-agent/src/utils/clipboard-native.ts
@@ -28,6 +28,9 @@ export function loadClipboardNative(
 	return null;
 }
 
-const clipboard = !process.env.TERMUX_VERSION && hasDisplay ? loadClipboardNative() : null;
+// On Linux, each native clipboard call creates an X11 event thread that keeps
+// its connection alive. Platform clipboard commands avoid leaking connections.
+const clipboard =
+	process.platform !== "linux" && !process.env.TERMUX_VERSION && hasDisplay ? loadClipboardNative() : null;
 
 export { clipboard };

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -49,13 +49,38 @@ function readWaylandClipboardText(): ClipboardReadResult {
 	}
 }
 
+function readX11ClipboardText(): ClipboardReadResult {
+	try {
+		const text = execFileSync("xclip", ["-selection", "clipboard", "-o"], READ_CLIPBOARD_OPTIONS);
+		return { ok: true, text: text || null };
+	} catch {
+		try {
+			const text = execFileSync("xsel", ["--clipboard", "--output"], READ_CLIPBOARD_OPTIONS);
+			return { ok: true, text: text || null };
+		} catch {
+			return { ok: false };
+		}
+	}
+}
+
 /** Read plain text from the system clipboard. */
 export async function readClipboardText(): Promise<string | null> {
-	if (platform() === "linux" && isWaylandSession() && process.env.WAYLAND_DISPLAY) {
-		const result = readWaylandClipboardText();
-		if (result.ok) {
-			return result.text;
+	if (platform() === "linux") {
+		if (isWaylandSession() && process.env.WAYLAND_DISPLAY) {
+			const result = readWaylandClipboardText();
+			if (result.ok) {
+				return result.text;
+			}
 		}
+
+		if (process.env.DISPLAY) {
+			const result = readX11ClipboardText();
+			if (result.ok) {
+				return result.text;
+			}
+		}
+
+		return null;
 	}
 
 	if (!clipboard) {

--- a/packages/coding-agent/test/clipboard-image.test.ts
+++ b/packages/coding-agent/test/clipboard-image.test.ts
@@ -145,15 +145,20 @@ describe("readClipboardImage", () => {
 		expect(Array.from(result?.bytes ?? [])).toEqual([4, 5, 6]);
 	});
 
-	test("Non-Wayland: uses clipboard", async () => {
-		mocks.spawnSync.mockImplementation(() => {
-			throw new Error(
-				"spawnSync should not be called for non-Wayland sessions when native clipboard returns an image",
-			);
+	test("X11: uses xclip and never calls the native clipboard", async () => {
+		mocks.clipboard.hasImage.mockImplementation(() => {
+			throw new Error("clipboard.hasImage should not be called on Linux");
 		});
 
-		mocks.clipboard.hasImage.mockReturnValue(true);
-		mocks.clipboard.getImageBinary.mockResolvedValue(new Uint8Array([7]));
+		mocks.spawnSync.mockImplementation((command, args, _options) => {
+			if (command === "xclip" && args.includes("TARGETS")) {
+				return spawnOk(Buffer.from("image/png\n", "utf-8"));
+			}
+			if (command === "xclip" && args.includes("image/png")) {
+				return spawnOk(Buffer.from([7]));
+			}
+			throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+		});
 
 		const { readClipboardImage } = await import("../src/utils/clipboard-image.ts");
 		const result = await readClipboardImage({ platform: "linux", env: {} });
@@ -162,23 +167,15 @@ describe("readClipboardImage", () => {
 		expect(Array.from(result?.bytes ?? [])).toEqual([7]);
 	});
 
-	test("Non-Wayland: falls back to xclip when clipboard has no image", async () => {
-		mocks.spawnSync.mockImplementation((command, args, _options) => {
-			if (command === "xclip" && args.includes("TARGETS")) {
-				return spawnOk(Buffer.from("image/png\n", "utf-8"));
-			}
-			if (command === "xclip" && args.includes("image/png")) {
-				return spawnOk(Buffer.from([8, 9]));
-			}
-			throw new Error(`Unexpected spawnSync call: ${command} ${args.join(" ")}`);
+	test("X11: returns null without using the native clipboard when xclip is unavailable", async () => {
+		mocks.clipboard.hasImage.mockImplementation(() => {
+			throw new Error("clipboard.hasImage should not be called on Linux");
 		});
-
-		mocks.clipboard.hasImage.mockReturnValue(false);
+		mocks.spawnSync.mockReturnValue(spawnError(new Error("xclip unavailable")));
 
 		const { readClipboardImage } = await import("../src/utils/clipboard-image.ts");
 		const result = await readClipboardImage({ platform: "linux", env: {} });
-		expect(result).not.toBeNull();
-		expect(result?.mimeType).toBe("image/png");
-		expect(Array.from(result?.bytes ?? [])).toEqual([8, 9]);
+		expect(result).toBeNull();
+		expect(mocks.clipboard.getImageBinary).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/clipboard-native.test.ts
+++ b/packages/coding-agent/test/clipboard-native.test.ts
@@ -29,4 +29,24 @@ describe("loadClipboardNative", () => {
 
 		expect(loadClipboardNative([missing])).toBeNull();
 	});
+
+	test("does not initialize the native clipboard on Linux", async () => {
+		const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+		if (!platformDescriptor) {
+			throw new Error("process.platform descriptor is unavailable");
+		}
+
+		try {
+			vi.stubEnv("DISPLAY", ":0");
+			Object.defineProperty(process, "platform", { ...platformDescriptor, value: "linux" });
+			vi.resetModules();
+
+			const linuxModule = await import("../src/utils/clipboard-native.ts");
+			expect(linuxModule.clipboard).toBeNull();
+		} finally {
+			Object.defineProperty(process, "platform", platformDescriptor);
+			vi.unstubAllEnvs();
+			vi.resetModules();
+		}
+	});
 });

--- a/packages/coding-agent/test/clipboard.test.ts
+++ b/packages/coding-agent/test/clipboard.test.ts
@@ -128,16 +128,71 @@ describe("readClipboardText", () => {
 		expect(mocks.clipboard.getText).not.toHaveBeenCalled();
 	});
 
-	test("falls back to the native clipboard when wl-paste is unavailable", async () => {
+	test("falls back to xclip when wl-paste is unavailable", async () => {
 		mockedPlatform.mockReturnValue("linux");
 		mocks.isWaylandSession.mockReturnValue(true);
 		vi.stubEnv("WAYLAND_DISPLAY", "wayland-0");
-		mockedExecFileSync.mockImplementation(() => {
-			throw new Error("wl-paste unavailable");
+		vi.stubEnv("DISPLAY", ":0");
+		mockedExecFileSync.mockImplementation((command) => {
+			if (command === "wl-paste") {
+				throw new Error("wl-paste unavailable");
+			}
+			return "X11 fallback text";
 		});
-		mocks.clipboard.getText.mockResolvedValue("X11 fallback text");
 
 		await expect(readClipboardText()).resolves.toBe("X11 fallback text");
+		expect(mockedExecFileSync).toHaveBeenNthCalledWith(2, "xclip", ["-selection", "clipboard", "-o"], {
+			encoding: "utf8",
+			maxBuffer: 50 * 1024 * 1024,
+			timeout: 5000,
+		});
+		expect(mocks.clipboard.getText).not.toHaveBeenCalled();
+	});
+
+	test("falls back to xsel when xclip is unavailable on X11", async () => {
+		mockedPlatform.mockReturnValue("linux");
+		vi.stubEnv("DISPLAY", ":0");
+		mockedExecFileSync.mockImplementation((command) => {
+			if (command === "xclip") {
+				throw new Error("xclip unavailable");
+			}
+			return "xsel text";
+		});
+
+		await expect(readClipboardText()).resolves.toBe("xsel text");
+		expect(mockedExecFileSync).toHaveBeenNthCalledWith(2, "xsel", ["--clipboard", "--output"], {
+			encoding: "utf8",
+			maxBuffer: 50 * 1024 * 1024,
+			timeout: 5000,
+		});
+		expect(mocks.clipboard.getText).not.toHaveBeenCalled();
+	});
+
+	test("treats an empty X11 clipboard as authoritative", async () => {
+		mockedPlatform.mockReturnValue("linux");
+		vi.stubEnv("DISPLAY", ":0");
+		mockedExecFileSync.mockReturnValue("");
+
+		await expect(readClipboardText()).resolves.toBeNull();
+		expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+		expect(mockedExecFileSync).toHaveBeenCalledWith("xclip", ["-selection", "clipboard", "-o"], {
+			encoding: "utf8",
+			maxBuffer: 50 * 1024 * 1024,
+			timeout: 5000,
+		});
+		expect(mocks.clipboard.getText).not.toHaveBeenCalled();
+	});
+
+	test("does not use the native clipboard when Linux tools are unavailable", async () => {
+		mockedPlatform.mockReturnValue("linux");
+		vi.stubEnv("DISPLAY", ":0");
+		mockedExecFileSync.mockImplementation(() => {
+			throw new Error("clipboard tool unavailable");
+		});
+		mocks.clipboard.getText.mockResolvedValue("native text");
+
+		await expect(readClipboardText()).resolves.toBeNull();
+		expect(mocks.clipboard.getText).not.toHaveBeenCalled();
 	});
 
 	test("returns null for empty or unavailable clipboard text", async () => {


### PR DESCRIPTION
## Status

Draft: the original shell-only implementation introduces a Linux clipboard regression when `wl-paste`/`xclip`/`xsel` are unavailable and will be replaced.

## Planned final change

- land and publish earendil-works/clipboard#4, which reuses a healthy X11 context, releases failed contexts, and reconnects after X server restart
- restore Pi's existing native clipboard paths and update only the exact clipboard dependency, lockfile, coding-agent shrinkwrap, and changelog
- reuse upstream Xvfb coverage for connection stability and run Pi's existing clipboard behavior tests

## Completion criteria

- upstream Xvfb CI passes repeated text/image/format reads with no socket growth and passes X server restart recovery
- a fixed clipboard npm version is published and integrated into Pi
- the Pi release is verified on the reporter's Cinnamon/X11 environment for repeated text and image Ctrl+V with no external clipboard tools required and no X11 connection growth

Refs #7600

This pull request is AI-generated by `/wr`.