### PR TITLE
fix(ai): detect DeepSeek reasoning_content requirement via opencode zen gateway

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1096,7 +1096,17 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const useMaxTokens = baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether;
 
 	const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
-	const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
+	// DeepSeek models can also be served through gateway proxies (e.g. opencode's
+	// zen endpoint at opencode.ai/zen/v1), where the upstream still enforces the
+	// DeepSeek API contract: `reasoning_content` must be passed back on assistant
+	// messages in multi-turn/tool-call conversations. Without this detection,
+	// those models get `requiresReasoningContentOnAssistantMessages: false` and the
+	// upstream rejects the request with a 400
+	// ("The `reasoning_content` in the thinking mode must be passed back to the API.").
+	const isDeepSeek =
+		provider === "deepseek" ||
+		baseUrl.includes("deepseek.com") ||
+		(model.id.toLowerCase().startsWith("deepseek") && baseUrl.includes("opencode.ai"));
 	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
 	return {


### PR DESCRIPTION
## 문제

DeepSeek V4 모델을 opencode zen 게이트웨이(`opencode.ai/zen/v1`)를 통해 사용하면, 툴콜/다중 턴 대화에서 HTTP 400이 발생합니다:

```
The `reasoning_content` in the thinking mode must be passed back to the API.
```

## 원인

`detectCompat()`의 DeepSeek 감지가 `provider === "deepseek"` 또는 `baseUrl.includes("deepseek.com")`만 매칭합니다. 하지만 `deepseek-v4-flash-free`, `deepseek-v4-pro` 등은 `provider: "opencode"`, `baseUrl: "https://opencode.ai/zen/v1"`로 정의되어 있어 DeepSeek으로 감지되지 않습니다.

그 결과 `requiresReasoningContentOnAssistantMessages`가 `false`가 되고, 툴콜 assistant 메시지에 `reasoning_content` 필드가 주입되지 않습니다. upstream DeepSeek API는 thinking 모드에서 이 필드를 필수로 요구하므로 400으로 거부합니다.

## 재현

opencode.ai/zen/v1에 툴콜 assistant 메시지가 `reasoning_content` 없이 전송되면:

```bash
# reasoning_content 없는 툴콜 assistant 턴 → 400
curl https://opencode.ai/zen/v1/chat/completions \
  -H "Authorization: Bearer $KEY" ... \
  -d '{"model":"deepseek-v4-flash-free",...,"messages":[...,{"role":"assistant","content":null,"tool_calls":[...]},...]}'
# → "The `reasoning_content` in the thinking mode must be passed back to the API."

# reasoning_content: "" (빈 문자열) 포함 → 통과
```

- `reasoning_content` 필드 자체 누락 → **400**
- `reasoning_content: ""` 빈 문자열 → **통과**
- 실제 reasoning 포함 → **통과**

## 수정

`isDeepSeek` 감지에 opencode.ai 게이트웨이 경유 deepseek 모델 조건을 추가합니다:

```ts
const isDeepSeek =
	provider === "deepseek" ||
	baseUrl.includes("deepseek.com") ||
	(model.id.toLowerCase().startsWith("deepseek") && baseUrl.includes("opencode.ai"));
```

- `model.compat.requiresReasoningContentOnAssistantMessages`가 명시된 모델은 기존대로 우선 적용 (`getCompat`의 `?? detected` 머지 로직)
- 자동 감지가 백업으로 동작하므로, compat가 누락된 새 deepseek 모델 정의에서도 400이 재발하지 않음
- kimi, gemini 등 다른 opencode zen 모델은 `deepseek` id 조건에 안 걸려 영향 없음

## 검증

- `tsgo --noEmit` 통과
- `biome check` 통과
- dist 빌드 후 로직 시뮬레이션: opencode zen 경유 deepseek → `requiresReasoningContentOnAssistantMessages=true`, kimi → `false` 유지, deepseek 직접 → 기존 동작 유지
