### PR TITLE
feat(agent): restore suspended harness operations.

### DIFF
--- a/packages/agent/docs/harness-v2.md
+++ b/packages/agent/docs/harness-v2.md
@@ -2086,6 +2086,8 @@ interface LaneState {
     kind: "run" | "compaction" | "navigation";
     intent: OperationStartedRecord["intent"];
     aborting: boolean;
+    /** Queue payloads cleared by an accepted abort, retained for suspended inventory and requeue. */
+    abortingQueues: null | { steer: AgentMessage[]; followUp: AgentMessage[] };
     step: null | {                          // unfinished step: newest attempt's result entry missing
       kind: "assistant" | "compaction" | "branch_summary";
       attempts: number;
@@ -3235,7 +3237,8 @@ These packages merge R0 → R1 → R2 → R3. R1 and R2 add a reducer module ins
 - [ ] **R3 — harness restore inventory.** Dependencies: F0, R2.
   - Primary files: `packages/agent/src/harness/agent-harness.ts`, reducer integration helpers, and restore tests.
   - Wire `AgentHarness.create()` to use indexed open-operation discovery, bounded idle/open scans, explicit provisioned-id point lookups, and bounded configuration lookups. Return accurate `SuspendedOperation[]` without starting effects.
-  - Acceptance: idle and multi-lane restore write nothing, multiple open operations reject as corruption, suspended metadata is complete, and one lane never scans another lane's traffic. `resume()` may still reject as unimplemented.
+  - Known limitation: anchor configuration currently restores model state from `model_change` entries or harness defaults; restoring a newer assistant message's model requires the bounded role-aware branch query assigned to H4.
+  - Acceptance: idle and multi-lane restore write nothing, multiple open operations reject as corruption, suspended metadata is complete subject to the assistant-derived model limitation above, and one lane never scans another lane's traffic. `resume()` may still reject as unimplemented.
 
 ### Track J — JSONL storage
 
@@ -3333,7 +3336,8 @@ H0 converges restore and primitives into `agent-harness.ts`. H0–H8 then merge 
   - Acceptance: both orders of race rows 2, 5, 7, and 12; provider context grows only at the tail.
 - [ ] **H4 — deferred writes, persisted configuration, and adjustments.** Dependencies: H3.
   - Add deferred lane-view tree/configuration writes, direct idle writes, model/thinking/active-tool persistence and lookup, `recordUsage`, pending-write snapshots/events, and finish conditionals.
-  - Acceptance: both orders of race rows 3 and 9; accepted writes survive crashes and abort markers; adjustments affect ledger totals but never entries.
+  - Extend the bounded branch-query contract to find the newest assistant message at an anchor. Restore effective model state from that message or the latest `model_change`, whichever has the newer sequence, and use the result for missing-model inventory.
+  - Acceptance: both orders of race rows 3 and 9; accepted writes survive crashes and abort markers; restored effective model state and missing-model inventory honor the newest assistant message versus `model_change`; adjustments affect ledger totals but never entries.
 - [ ] **H5 — abort, wait, run-when-idle, and close.** Dependencies: H4.
   - Add durable abort acceptance, queue draining, pending-write application, synthetic closure messages/results, suspended abort, idle waiters/callbacks, and process-local close settlement.
   - Acceptance: both orders of race rows 4, 6, 8, and 10 and crash/reopen after every abort action.

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -328,16 +328,16 @@ async function readOwnEntries(
 	// A root-positioned lane has no entries, while an unchanged source leaf means
 	// the operation has not appended any entries.
 	if (leafId === null) {
-     if (sourceLeafId !== null) {
-       throw new RecordLogCorruption(
-         "inconsistent_step",
-         `Operation source leaf ${sourceLeafId} cannot restore with root current leaf`,
-       );
-     }
-     return [];
-   }
+		if (sourceLeafId !== null) {
+			throw new RecordLogCorruption(
+				"inconsistent_step",
+				`Operation source leaf ${sourceLeafId} cannot restore with root current leaf`,
+			);
+		}
+		return [];
+	}
 
-   if (leafId === sourceLeafId) return [];
+	if (leafId === sourceLeafId) return [];
 
 	const newestFirst = await session.findEntriesOnBranch({
 		start: leafId,

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -12,12 +12,20 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { AgentMessage, AgentTool, QueueMode, ThinkingLevel } from "../types.ts";
 import type { CompactionSettings } from "./compaction/compaction.ts";
+import {
+	type EffectiveLaneConfiguration,
+	type LaneReductionInput,
+	type LaneReductionResult,
+	RecordLogCorruption,
+	reduceLaneState,
+} from "./reducer.ts";
 import { type Result as ResultValue, TaggedError } from "./result.ts";
 import type {
 	BranchSummaryEntry,
 	CompactionEntry,
 	Entry,
 	JsonValue,
+	OperationStartedRecord,
 	ProvisionedEntry,
 	Session,
 	SessionTree,
@@ -302,12 +310,373 @@ export interface AgentLane {
 	watch(): Promise<WatchHandle<LaneSnapshot>>;
 }
 
+/**
+ * Reads entries appended by an operation whose starting leaf remains an
+ * ancestor of the lane's current leaf. The branch query walks newest-first
+ * from `leafId` to the inclusive `sourceLeafId` boundary; this helper removes
+ * that pre-operation anchor and returns only operation-owned entries in
+ * oldest-first reducer order. A null source denotes an operation accepted at
+ * the root. Post-move navigation does not satisfy the ancestry requirement;
+ * its provisioned summary must be restored by point lookup instead.
+ */
+async function readOwnEntries(
+	session: Session,
+	leafId: string | null,
+	sourceLeafId: string | null,
+	operationStartedSeq: number,
+): Promise<Entry[]> {
+	// A root-positioned lane has no entries, while an unchanged source leaf means
+	// the operation has not appended any entries.
+	if (leafId === null || leafId === sourceLeafId) return [];
+
+	const newestFirst = await session.findEntriesOnBranch({
+		start: leafId,
+		...(sourceLeafId === null ? {} : { stopAtId: sourceLeafId }),
+		order: "newestFirst",
+	});
+	if (sourceLeafId !== null) {
+		// stopAtId is inclusive, so remove the pre-operation source anchor.
+		const sourceEntry = newestFirst.pop();
+		if (sourceEntry?.id !== sourceLeafId) {
+			throw new RecordLogCorruption(
+				"inconsistent_step",
+				`Operation source leaf ${sourceLeafId} is not an ancestor of current leaf ${leafId}`,
+			);
+		}
+	}
+	const ownEntries = newestFirst.reverse();
+	if (ownEntries.some((entry) => entry.seq <= operationStartedSeq)) {
+		throw new RecordLogCorruption(
+			"inconsistent_step",
+			`Operation at sequence ${operationStartedSeq} includes a pre-operation entry on its current branch`,
+		);
+	}
+	return ownEntries;
+}
+
+/**
+ * Navigation moves away from its source before appending its only possible own
+ * tree entry. The lane move and optional label are not entries, so this returns
+ * no entries before the summary append and exactly the summary afterward.
+ *
+ * The point lookup distinguishes the three durable states: source (before
+ * move), target (after move), and summary (after append). A null leaf is the
+ * tree root and can therefore be either the source or target; source and target
+ * must differ, so those states remain distinguishable.
+ */
+function restoreNavigationOwnEntries(
+	started: OperationStartedRecord,
+	leafId: string | null,
+	recoveryTargetEntries: readonly Entry[],
+): Entry[] {
+	if (started.intent.kind !== "navigation") throw new Error("Expected a navigation operation");
+	const intent = started.intent;
+	const hasSummaryId = intent.summaryEntryId !== undefined;
+	if (intent.targetId === started.sourceLeafId || intent.summarize !== hasSummaryId) {
+		throw new RecordLogCorruption(
+			"inconsistent_step",
+			`Navigation ${started.id} has an inconsistent source, target, or summary intent`,
+		);
+	}
+
+	const summary = intent.summaryEntryId
+		? recoveryTargetEntries.find((entry) => entry.id === intent.summaryEntryId)
+		: undefined;
+	if (!summary) {
+		const laneIsBeforeOrAfterMove = leafId === started.sourceLeafId || leafId === intent.targetId;
+		if (!laneIsBeforeOrAfterMove) {
+			throw new RecordLogCorruption(
+				"inconsistent_step",
+				`Navigation ${started.id} has leaf ${leafId} before its summary was appended`,
+			);
+		}
+		return [];
+	}
+
+	// A committed summary must be the first post-start entry on the target
+	// branch, describe the abandoned source branch, and remain the lane leaf.
+	const isPostStartEntry = summary.seq > started.seq;
+	const isOnTargetBranch = summary.parentId === intent.targetId;
+	const describesSourceBranch = summary.type === "branch_summary" && summary.fromId === started.sourceLeafId;
+	const isLaneLeaf = leafId === summary.id;
+	const isValidSummary = isPostStartEntry && isOnTargetBranch && describesSourceBranch && isLaneLeaf;
+	if (!isValidSummary) {
+		throw new RecordLogCorruption(
+			"inconsistent_step",
+			`Navigation ${started.id} has a summary that is not the post-move lane leaf`,
+		);
+	}
+	return [summary];
+}
+
+/**
+ * Point-looks up entries named by recovery records. These lookups both close
+ * provisioned intents and detect an id whose entry exists outside this lane's
+ * current branch with content different from its durable intent.
+ */
+async function readRecoveryTargetEntries(session: Session, records: LaneReductionInput["records"]): Promise<Entry[]> {
+	const targetIds = new Set<string>();
+	for (const record of records) {
+		switch (record.type) {
+			case "operation_started":
+				switch (record.intent.kind) {
+					case "run":
+						for (const target of record.intent.initialMessages) targetIds.add(target.id);
+						break;
+					case "compaction":
+						targetIds.add(record.intent.resultEntryId);
+						break;
+					case "navigation":
+						if (record.intent.summaryEntryId) targetIds.add(record.intent.summaryEntryId);
+						break;
+				}
+				break;
+			case "step_attempt":
+				targetIds.add(record.resultEntryId);
+				break;
+			case "tool_started":
+				targetIds.add(record.assistantEntryId);
+				targetIds.add(record.resultEntryId);
+				break;
+			case "queue_enqueued":
+				targetIds.add(record.target.id);
+				break;
+			case "write_deferred":
+				targetIds.add(record.target.id);
+				break;
+		}
+	}
+	// TODO: Add a batched lookup or bounded concurrency before remote storage backends use restore;
+	// one request per recovery target currently has no backpressure.
+	const entries = await Promise.all([...targetIds].map((id) => session.getEntry(id)));
+	return entries.filter((entry): entry is Entry => entry !== undefined);
+}
+
+/**
+ * Reads the bounded queue slice relevant to an idle lane. The latest run start
+ * is the cutoff because that run captured every older next-run item; only
+ * subsequent next-run enqueues and cancellations can still be pending.
+ */
+async function readIdleQueueRecords(session: Session, lane: string): Promise<LaneReductionInput["records"]> {
+	const [latestRun] = await session.findRecords({
+		lane,
+		type: "operation_started",
+		operationKind: "run",
+		order: "newestFirst",
+		limit: 1,
+	});
+	const afterLatestRun = latestRun === undefined ? {} : { afterSeq: latestRun.seq };
+	const [enqueued, cancelled] = await Promise.all([
+		session.findRecords({
+			lane,
+			type: "queue_enqueued",
+			...afterLatestRun,
+			order: "oldestFirst",
+		}),
+		session.findRecords({
+			lane,
+			type: "queue_cancelled",
+			...afterLatestRun,
+			order: "oldestFirst",
+		}),
+	]);
+
+	// A run captures every older next-run item at acceptance. Only uncaptured
+	// next-run records after that boundary remain relevant while the lane is idle.
+	return [
+		...enqueued.filter((record) => record.queue === "nextRun"),
+		...cancelled.filter((record) => record.runId === undefined),
+	].sort((left, right) => left.seq - right.seq);
+}
+
+/** Reads the latest explicit persisted value for each lane configuration dimension. */
+async function readConfigurationEntries(session: Session, leafId: string | null): Promise<Entry[]> {
+	// A root-positioned lane has no ancestor entries from which to derive configuration.
+	if (leafId === null) return [];
+
+	// Read each independent persisted configuration dimension concurrently.
+	// Operation-owned assistant entries are supplied separately through ownEntries.
+	// TODO(H4): Also restore model state from the newest assistant message or model_change,
+	// whichever is newer. This requires a bounded branch query that can filter by message role.
+	// TODO: Push entry filters and limits into SQLite's branch query before treating these as
+	// bounded lookups; it currently filters and slices after decoding the complete branch.
+	const entries = await Promise.all([
+		session.findEntryOnBranch({ start: leafId, type: "model_change" }),
+		session.findEntryOnBranch({ start: leafId, type: "thinking_level_change" }),
+		session.findEntryOnBranch({ start: leafId, type: "active_tools_change" }),
+	]);
+
+	// Drop configuration dimensions with no persisted value, then order the
+	// remaining entries chronologically so the reducer applies the newest last.
+	return entries.filter((entry): entry is Entry => entry !== undefined).sort((left, right) => left.seq - right.seq);
+}
+
+interface RestoredLane {
+	reduction: LaneReductionResult;
+	started?: OperationStartedRecord;
+}
+
+/**
+ * Restores one lane from its current durable pointer and recovery records.
+ * `leafId === null` means the lane currently points at the tree root; it does
+ * not imply that the lane is idle or has no records. A root-positioned lane
+ * may still have an open operation or pending next-run input.
+ */
+async function restoreLane(
+	options: AgentHarnessOptions,
+	lane: string,
+	leafId: string | null,
+	defaultConfiguration: EffectiveLaneConfiguration,
+): Promise<RestoredLane> {
+	const openOperations = await options.session.findOpenOperations(lane, { limit: 2 });
+	if (openOperations.length > 1) {
+		throw new RecordLogCorruption("multiple_open_operations", `Lane ${lane} has multiple open operations`);
+	}
+
+	// One open start means the lane is suspended; reconstruct its operation
+	// records, operation-owned entries, and configuration at the start anchor.
+	const started = openOperations[0];
+	if (started) {
+		const ownEntriesPromise =
+			started.intent.kind === "navigation"
+				? Promise.resolve<Entry[]>([])
+				: readOwnEntries(options.session, leafId, started.sourceLeafId, started.seq);
+		const [laterRecords, branchOwnEntries, configurationEntries] = await Promise.all([
+			options.session.findRecords({ lane, afterSeq: started.seq, order: "oldestFirst" }),
+			ownEntriesPromise,
+			readConfigurationEntries(options.session, started.sourceLeafId),
+		]);
+
+		const recoveryTargetEntries = await readRecoveryTargetEntries(options.session, [started, ...laterRecords]);
+		const ownEntries =
+			started.intent.kind === "navigation"
+				? restoreNavigationOwnEntries(started, leafId, recoveryTargetEntries)
+				: branchOwnEntries;
+		// Deduplicate targets already present in the operation-owned entries.
+		const entries = [
+			...new Map([...ownEntries, ...recoveryTargetEntries].map((entry) => [entry.id, entry])).values(),
+		];
+		const laneReductionInput: LaneReductionInput = {
+			lane,
+			leafId,
+			openOperations,
+			records: [started, ...laterRecords],
+			entries,
+			ownEntries,
+			configurationEntries,
+			defaults: defaultConfiguration,
+		};
+		return { reduction: reduceLaneState(laneReductionInput), started };
+	}
+
+	// An idle lane has no operation-owned entries; restore only pending next-run
+	// input and the effective configuration at its current leaf.
+	const [records, configurationEntries] = await Promise.all([
+		readIdleQueueRecords(options.session, lane),
+		readConfigurationEntries(options.session, leafId),
+	]);
+	const entries = await readRecoveryTargetEntries(options.session, records);
+	return {
+		reduction: reduceLaneState({
+			lane,
+			leafId,
+			openOperations,
+			records,
+			entries,
+			ownEntries: [],
+			configurationEntries,
+			defaults: defaultConfiguration,
+		}),
+	};
+}
+
+function findMissingIdentities(
+	options: AgentHarnessOptions,
+	reduction: LaneReductionResult,
+): SuspendedOperation["missing"] {
+	const operation = reduction.laneState.operation;
+	if (!operation || operation.aborting) return { tools: [], models: [] };
+
+	const availableTools = new Set((options.tools ?? []).map((tool) => tool.name));
+	const requiredTools = new Set(operation.kind === "run" ? reduction.effectiveConfiguration.activeToolNames : []);
+	const toolBatch = operation.toolBatch;
+	// Truncated batches and replay-never calls synthesize unresolved results
+	// without executing the referenced tools.
+	if (toolBatch && !toolBatch.truncated) {
+		for (const call of toolBatch.calls) {
+			if (!call.resultExists && call.started?.replay !== "never") {
+				requiredTools.add(call.started?.toolName ?? call.toolCall.name);
+			}
+		}
+	}
+
+	const requiredModels = new Map<string, { provider: string; modelId: string }>();
+	const needsEffectiveModel =
+		operation.kind === "run" ||
+		(operation.kind === "compaction" && operation.targets.result !== true) ||
+		(operation.kind === "navigation" &&
+			operation.intent.kind === "navigation" &&
+			operation.intent.summarize &&
+			operation.targets.summary !== true);
+	if (needsEffectiveModel) {
+		const effectiveModel = reduction.effectiveConfiguration.model;
+		requiredModels.set(`${effectiveModel.provider}/${effectiveModel.modelId}`, effectiveModel);
+	}
+	const deferred = operation.deferred;
+	if (deferred) {
+		requiredModels.set(`${deferred.provider}/${deferred.modelId}`, {
+			provider: deferred.provider,
+			modelId: deferred.modelId,
+		});
+	}
+
+	return {
+		tools: [...requiredTools].filter((name) => !availableTools.has(name)),
+		models: [...requiredModels].flatMap(([identity, model]) =>
+			options.models.getModel(model.provider, model.modelId) ? [] : [identity],
+		),
+	};
+}
+
+/**
+ * Projects reducer-owned restored state into the public suspended inventory.
+ * This performs runtime identity checks only; it neither mutates durable state
+ * nor starts recovery work.
+ */
+function buildSuspendedOperation(options: AgentHarnessOptions, restored: RestoredLane): SuspendedOperation | undefined {
+	const operation = restored.reduction.laneState.operation;
+	if (!operation) return undefined;
+	if (!restored.started || restored.started.id !== operation.id) {
+		throw new Error(`Restored lane ${restored.reduction.laneState.lane} is missing its operation start`);
+	}
+
+	const deferred = operation.deferred ? structuredClone(operation.deferred) : undefined;
+	let abortingQueues: { steer: AgentMessage[]; followUp: AgentMessage[] } | undefined;
+	if (operation.aborting) {
+		if (operation.abortingQueues === null) {
+			throw new Error(`Restored aborting lane ${restored.reduction.laneState.lane} is missing its cleared queues`);
+		}
+		abortingQueues = operation.abortingQueues;
+	}
+	return {
+		lane: restored.reduction.laneState.lane,
+		kind: operation.kind,
+		id: operation.id,
+		startedAt: restored.started.timestamp,
+		reason: deferred ? "deferred" : "crash",
+		...(operation.intent.kind === "run" ? { prompt: structuredClone(operation.intent.originalPrompt) } : {}),
+		...(deferred ? { deferred } : {}),
+		...(abortingQueues ? { aborting: structuredClone(abortingQueues) } : {}),
+		missing: findMissingIdentities(options, restored.reduction),
+	};
+}
+
 export class AgentHarness implements AgentLane {
 	readonly name = "main";
 	readonly session: SessionTree;
 	readonly hooks: Hooks;
 	readonly events: Events;
-	private readonly durableSession: Session;
+	private readonly restoredLanes: Map<string, LaneReductionResult>;
 	private model: Model<Api>;
 	private thinkingLevel: ThinkingLevel;
 	private activeToolNames: string[];
@@ -320,8 +689,8 @@ export class AgentHarness implements AgentLane {
 	private followUpMode: QueueMode;
 	private closed = false;
 
-	private constructor(options: AgentHarnessOptions) {
-		this.durableSession = options.session;
+	private constructor(options: AgentHarnessOptions, restoredLanes: ReadonlyMap<string, LaneReductionResult>) {
+		this.restoredLanes = new Map(restoredLanes);
 		this.session = options.session;
 		this.hooks = new UnavailableRegistry("hooks.on", () => this.closed);
 		this.events = new UnavailableRegistry("events.on", () => this.closed);
@@ -344,12 +713,41 @@ export class AgentHarness implements AgentLane {
 		this.followUpMode = options.followUpMode ?? "one-at-a-time";
 	}
 
+	/**
+	 * Opens the durable session and reconstructs every lane without starting work.
+	 * For each lane, restore performs bounded recovery queries, validates the
+	 * durable prefix (the committed operation sequence up to the crash boundary),
+	 * reduces it into process-local lane state and effective configuration,
+	 * and retains that state in the returned harness. Corrupt session state rejects
+	 * creation. Missing tools or models are reported on the corresponding suspended
+	 * operation instead of rejecting creation.
+	 *
+	 * The returned suspended inventory describes every open operation so the
+	 * caller can decide whether to resume or abort it. Creation itself performs
+	 * no durable writes, provider requests, tool calls, hooks, or automatic
+	 * resumes.
+	 */
 	static async create(
 		options: AgentHarnessOptions,
 	): Promise<{ harness: AgentHarness; suspended: SuspendedOperation[] }> {
-		const [record] = await options.session.findRecords({ limit: 1 });
-		if (record !== undefined) throw new HarnessNotImplemented("create.restore");
-		return { harness: new AgentHarness(options), suspended: [] };
+		// Use the spread operator here to snapshot the option so
+		// caller mutations during async restore cannot change lane defaults.
+		const activeToolNames = [...(options.activeToolNames ?? options.tools?.map((tool) => tool.name) ?? [])];
+		const defaultConfiguration: EffectiveLaneConfiguration = {
+			model: { provider: options.model.provider, modelId: options.model.id },
+			thinkingLevel: options.thinkingLevel ?? "off",
+			activeToolNames,
+		};
+		const restoredLanes = new Map<string, LaneReductionResult>();
+		const suspended: SuspendedOperation[] = [];
+		for (const { lane, leafId } of await options.session.getLanes()) {
+			const restored = await restoreLane(options, lane, leafId, defaultConfiguration);
+			restoredLanes.set(lane, restored.reduction);
+			const suspendedOperation = buildSuspendedOperation(options, restored);
+			if (suspendedOperation) suspended.push(suspendedOperation);
+		}
+
+		return { harness: new AgentHarness(options, restoredLanes), suspended };
 	}
 
 	private unavailable<T>(operation: string): Promise<T> {
@@ -357,7 +755,8 @@ export class AgentHarness implements AgentLane {
 	}
 
 	async getLeafId(): Promise<string | null> {
-		return this.durableSession.getLeafId();
+		if (!this.restoredLanes.has("main")) throw new Error("Restored session does not contain the main lane");
+		return this.session.getLeafId();
 	}
 
 	async prompt(_text: string, _images?: ImageContent[]): Promise<RunResult>;

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -327,7 +327,17 @@ async function readOwnEntries(
 ): Promise<Entry[]> {
 	// A root-positioned lane has no entries, while an unchanged source leaf means
 	// the operation has not appended any entries.
-	if (leafId === null || leafId === sourceLeafId) return [];
+	if (leafId === null) {
+     if (sourceLeafId !== null) {
+       throw new RecordLogCorruption(
+         "inconsistent_step",
+         `Operation source leaf ${sourceLeafId} cannot restore with root current leaf`,
+       );
+     }
+     return [];
+   }
+
+   if (leafId === sourceLeafId) return [];
 
 	const newestFirst = await session.findEntriesOnBranch({
 		start: leafId,

--- a/packages/agent/src/harness/reducer.ts
+++ b/packages/agent/src/harness/reducer.ts
@@ -84,6 +84,8 @@ export interface LaneState {
 		kind: "run" | "compaction" | "navigation";
 		intent: OperationStartedRecord["intent"];
 		aborting: boolean;
+		/** Queue payloads cleared by an accepted abort, retained for suspended inventory and requeue. */
+		abortingQueues: null | { steer: AgentMessage[]; followUp: AgentMessage[] };
 		step: null | {
 			kind: "assistant" | "compaction" | "branch_summary";
 			attempts: number;
@@ -540,16 +542,25 @@ export function reduceLaneState(input: LaneReductionInput): LaneReductionResult 
 		record.type === "operation_started" ? record.id === started.id : "runId" in record && record.runId === started.id,
 	);
 	const aborting = operationRecords.some((record) => record.type === "abort_requested");
+	const runQueueRecords = pendingQueueRecords.filter(
+		(record) => record.queue !== "nextRun" && record.runId === started.id,
+	);
+	const abortingQueues = aborting
+		? {
+				steer: runQueueRecords.flatMap((record) =>
+					record.queue === "steer" && record.target.type === "message" ? [clone(record.target.message)] : [],
+				),
+				followUp: runQueueRecords.flatMap((record) =>
+					record.queue === "followUp" && record.target.type === "message" ? [clone(record.target.message)] : [],
+				),
+			}
+		: null;
 	const pendingSteer = aborting
 		? []
-		: pendingQueueRecords
-				.filter((record) => record.queue === "steer" && record.runId === started.id)
-				.map((record) => clone(record.target));
+		: runQueueRecords.filter((record) => record.queue === "steer").map((record) => clone(record.target));
 	const pendingFollowUp = aborting
 		? []
-		: pendingQueueRecords
-				.filter((record) => record.queue === "followUp" && record.runId === started.id)
-				.map((record) => clone(record.target));
+		: runQueueRecords.filter((record) => record.queue === "followUp").map((record) => clone(record.target));
 	const pendingWrites = operationRecords
 		.filter(
 			(record): record is WriteDeferredRecord =>
@@ -648,6 +659,7 @@ export function reduceLaneState(input: LaneReductionInput): LaneReductionResult 
 				kind: started.intent.kind,
 				intent: clone(started.intent),
 				aborting,
+				abortingQueues,
 				step,
 				toolBatch: deriveToolBatch(started.id, operationRecords, ownEntries, entriesById, deferredWriteIds),
 				missingInitialMessages,

--- a/packages/agent/src/harness/session/session.ts
+++ b/packages/agent/src/harness/session/session.ts
@@ -172,6 +172,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> implem
 	}
 
 	async findEntryOnBranch(query: EntryQuery & BranchBounds = {}): Promise<Entry | undefined> {
+		// TODO: Improve! The query has a leafId so main gets ignored.
 		return (await this.queryBranchEntries("main", query, 1))[0];
 	}
 

--- a/packages/agent/test/harness/agent-harness-restore.test.ts
+++ b/packages/agent/test/harness/agent-harness-restore.test.ts
@@ -1,0 +1,1044 @@
+import {
+	type AssistantMessage,
+	createModels,
+	type DeferredHandle,
+	fauxProvider,
+	type Usage,
+	type UserMessage,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { AgentHarness, type HarnessTool } from "../../src/harness/agent-harness.ts";
+import type { LaneReductionResult } from "../../src/harness/reducer.ts";
+import {
+	InMemorySessionStorage,
+	type NewRecord,
+	type OperationStartedRecord,
+	type RecordQuery,
+	Session,
+} from "../../src/harness/session/index.ts";
+
+const usage: Usage = {
+	input: 1,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 2,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function createSession(id = "restore-test"): { session: Session; storage: InMemorySessionStorage } {
+	const storage = new InMemorySessionStorage({ id, createdAt: 1 });
+	return { session: new Session(storage), storage };
+}
+
+function createRuntime() {
+	const faux = fauxProvider({ provider: "restore-provider", models: [{ id: "restore-model" }] });
+	const models = createModels();
+	models.setProvider(faux.provider);
+	return { models, model: faux.getModel() };
+}
+
+function userMessage(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: 1 };
+}
+
+function operationStarted(
+	id: string,
+	lane: string,
+	intent: OperationStartedRecord["intent"],
+	sourceLeafId: string | null = null,
+): NewRecord<OperationStartedRecord> {
+	return { type: "operation_started", id, lane, sourceLeafId, intent };
+}
+
+function deferredMessage(handle: DeferredHandle): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: handle.api,
+		provider: handle.provider,
+		model: handle.modelId,
+		usage,
+		stopReason: "deferred",
+		deferred: handle,
+		timestamp: 1,
+	};
+}
+
+async function createHarness(session: Session, runtime = createRuntime()) {
+	return AgentHarness.create({ session, models: runtime.models, model: runtime.model });
+}
+
+describe("AgentHarness restore acceptance", () => {
+	it("opens an idle session with record history without writes or provider effects", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		const started = await session.appendRecord(
+			operationStarted("finished-run", "main", {
+				kind: "run",
+				originalPrompt: [userMessage("finished")],
+				initialMessages: [],
+			}),
+		);
+		await session.appendRecord({
+			type: "operation_finished",
+			id: "finished-run-result",
+			lane: "main",
+			runId: started.id,
+			outcome: "completed",
+		});
+		const logBefore = await session.getLog();
+		const stream = vi.spyOn(runtime.models, "streamSimple");
+		const fetchDeferred = vi.spyOn(runtime.models, "fetchDeferred");
+
+		const { harness, suspended } = await createHarness(session, runtime);
+
+		expect(suspended).toEqual([]);
+		expect(await session.getLog()).toEqual(logBefore);
+		expect(stream).not.toHaveBeenCalled();
+		expect(fetchDeferred).not.toHaveBeenCalled();
+		await harness.close();
+	});
+
+	it("inventories suspended run, compaction, and navigation operations without resuming them", async () => {
+		const { session } = createSession();
+		const prompt = userMessage("continue the run");
+		const run = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [prompt], initialMessages: [] }),
+		);
+		await session.createLane("compact", null);
+		const compaction = await session.appendRecord(
+			operationStarted("compact", "compact", { kind: "compaction", resultEntryId: "compaction-result" }),
+		);
+		await session.createLane("navigate", null);
+		await session.appendEntry(
+			{ type: "message", id: "navigation-source", message: userMessage("navigation source") },
+			"navigate",
+		);
+		const navigation = await session.appendRecord(
+			operationStarted(
+				"navigate",
+				"navigate",
+				{ kind: "navigation", targetId: null, summarize: false },
+				"navigation-source",
+			),
+		);
+		const logBefore = await session.getLog();
+		const runtime = createRuntime();
+		const stream = vi.spyOn(runtime.models, "streamSimple");
+		const fetchDeferred = vi.spyOn(runtime.models, "fetchDeferred");
+
+		const { suspended } = await createHarness(session, runtime);
+
+		expect(suspended).toHaveLength(3);
+		expect(suspended).toEqual(
+			expect.arrayContaining([
+				{
+					lane: "main",
+					kind: "run",
+					id: run.id,
+					startedAt: run.timestamp,
+					reason: "crash",
+					prompt: [prompt],
+					missing: { tools: [], models: [] },
+				},
+				{
+					lane: "compact",
+					kind: "compaction",
+					id: compaction.id,
+					startedAt: compaction.timestamp,
+					reason: "crash",
+					missing: { tools: [], models: [] },
+				},
+				{
+					lane: "navigate",
+					kind: "navigation",
+					id: navigation.id,
+					startedAt: navigation.timestamp,
+					reason: "crash",
+					missing: { tools: [], models: [] },
+				},
+			]),
+		);
+		expect(await session.getLog()).toEqual(logBefore);
+		expect(stream).not.toHaveBeenCalled();
+		expect(fetchDeferred).not.toHaveBeenCalled();
+	});
+
+	it("reports deferred and aborting details from durable state", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		const prompt = userMessage("run in the background");
+		const steer = userMessage("focus on tests");
+		const followUp = userMessage("then document it");
+		const started = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [prompt], initialMessages: [] }),
+		);
+		await session.appendRecord({
+			type: "queue_enqueued",
+			id: "steer-record",
+			lane: "main",
+			queue: "steer",
+			runId: started.id,
+			target: { type: "message", id: "steer-message", message: steer },
+		});
+		await session.appendRecord({
+			type: "queue_enqueued",
+			id: "follow-up-record",
+			lane: "main",
+			queue: "followUp",
+			runId: started.id,
+			target: { type: "message", id: "follow-up-message", message: followUp },
+		});
+		const handle: DeferredHandle = {
+			provider: runtime.model.provider,
+			modelId: runtime.model.id,
+			api: runtime.model.api,
+			id: "deferred-response",
+			pollAfterMs: 100,
+		};
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-deferred",
+		});
+		await session.appendEntry(
+			{ type: "message", id: "assistant-deferred", message: deferredMessage(handle) },
+			"main",
+		);
+		await session.appendRecord({
+			type: "abort_requested",
+			id: "abort",
+			lane: "main",
+			runId: started.id,
+		});
+
+		const { suspended } = await createHarness(session, runtime);
+
+		expect(suspended).toEqual([
+			{
+				lane: "main",
+				kind: "run",
+				id: started.id,
+				startedAt: started.timestamp,
+				reason: "deferred",
+				prompt: [prompt],
+				deferred: handle,
+				aborting: { steer: [steer], followUp: [followUp] },
+				missing: { tools: [], models: [] },
+			},
+		]);
+	});
+
+	it.each([
+		{ name: "replay-safe", replay: "safe", aborting: false, expectedTools: ["missing-tool"] },
+		{ name: "replay-never", replay: "never", aborting: false, expectedTools: [] },
+		{ name: "aborting", replay: "safe", aborting: true, expectedTools: [] },
+	] as const)("derives required tools for an unfinished $name batch", async ({ replay, aborting, expectedTools }) => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		const started = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }),
+		);
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-tools",
+		});
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "call-1", name: "missing-tool", arguments: {} }],
+			api: runtime.model.api,
+			provider: runtime.model.provider,
+			model: runtime.model.id,
+			usage,
+			stopReason: "toolUse",
+			timestamp: 1,
+		};
+		await session.appendEntry({ type: "message", id: "assistant-tools", message: assistant }, "main");
+		await session.appendRecord({
+			type: "tool_started",
+			id: "tool-started",
+			lane: "main",
+			runId: started.id,
+			assistantEntryId: "assistant-tools",
+			toolIndex: 0,
+			toolCallId: "call-1",
+			toolName: "missing-tool",
+			effectiveArgs: {},
+			resultEntryId: "tool-result",
+			replay,
+		});
+		if (aborting) {
+			await session.appendRecord({
+				type: "abort_requested",
+				id: "abort",
+				lane: "main",
+				runId: started.id,
+			});
+		}
+
+		const { suspended } = await createHarness(session, runtime);
+
+		expect(suspended).toHaveLength(1);
+		expect(suspended[0]?.missing).toEqual({ tools: expectedTools, models: [] });
+	});
+
+	it("reports the tool required for an unfinished X1/X2 call without a tool-started record", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		const started = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }),
+		);
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-tools",
+		});
+		await session.appendEntry(
+			{
+				type: "message",
+				id: "assistant-tools",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: "missing-x1-tool", arguments: {} }],
+					api: runtime.model.api,
+					provider: runtime.model.provider,
+					model: runtime.model.id,
+					usage,
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+			},
+			"main",
+		);
+
+		const { harness, suspended } = await createHarness(session, runtime);
+		const restoredLanes = Reflect.get(harness, "restoredLanes") as Map<string, LaneReductionResult>;
+
+		expect(restoredLanes.get("main")?.laneState.operation?.toolBatch?.calls[0]).toMatchObject({
+			toolCall: { id: "call-1", name: "missing-x1-tool" },
+			resultExists: false,
+		});
+		expect(restoredLanes.get("main")?.laneState.operation?.toolBatch?.calls[0]?.started).toBeUndefined();
+		expect(suspended[0]?.missing).toEqual({ tools: ["missing-x1-tool"], models: [] });
+	});
+
+	it("does not require tools for a truncated batch", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		const started = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }),
+		);
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-truncated",
+		});
+		await session.appendEntry(
+			{
+				type: "message",
+				id: "assistant-truncated",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: "missing-tool", arguments: {} }],
+					api: runtime.model.api,
+					provider: runtime.model.provider,
+					model: runtime.model.id,
+					usage,
+					stopReason: "length",
+					timestamp: 1,
+				},
+			},
+			"main",
+		);
+
+		const { harness, suspended } = await createHarness(session, runtime);
+		const restoredLanes = Reflect.get(harness, "restoredLanes") as Map<string, LaneReductionResult>;
+
+		expect(restoredLanes.get("main")?.laneState.operation?.toolBatch).toMatchObject({
+			truncated: true,
+			unresolved: true,
+		});
+		expect(suspended[0]?.missing).toEqual({ tools: [], models: [] });
+	});
+
+	it("rejects multiple open operations reported for one lane as corruption", async () => {
+		const { session } = createSession();
+		const first = await session.appendRecord(
+			operationStarted("run-1", "main", { kind: "run", originalPrompt: [], initialMessages: [] }),
+		);
+		const second: OperationStartedRecord = {
+			...first,
+			id: "run-2",
+			seq: first.seq + 1,
+			timestamp: first.timestamp + 1,
+		};
+		vi.spyOn(session, "findOpenOperations").mockResolvedValue([second, first]);
+
+		await expect(createHarness(session)).rejects.toMatchObject({
+			name: "RecordLogCorruption",
+			reason: "multiple_open_operations",
+		});
+	});
+
+	it("uses bounded lane-local recovery queries and never scans all entries", async () => {
+		const { session, storage } = createSession();
+		await session.appendEntry({ type: "message", id: "anchor", message: userMessage("anchor") }, "main");
+		const main = await session.appendRecord(
+			operationStarted("main-finished", "main", { kind: "run", originalPrompt: [], initialMessages: [] }, "anchor"),
+		);
+		await session.appendRecord({
+			type: "operation_finished",
+			id: "main-finish",
+			lane: "main",
+			runId: main.id,
+			outcome: "completed",
+		});
+		await session.createLane("thread", "anchor");
+		const thread = await session.appendRecord(
+			operationStarted(
+				"thread-run",
+				"thread",
+				{
+					kind: "run",
+					originalPrompt: [userMessage("thread prompt")],
+					initialMessages: [{ type: "message", id: "thread-prompt", message: userMessage("thread prompt") }],
+				},
+				"anchor",
+			),
+		);
+		await session.appendEntry(
+			{ type: "message", id: "thread-prompt", message: userMessage("thread prompt") },
+			"thread",
+		);
+		const findOpenOperations = vi.spyOn(storage, "findOpenOperations");
+		const findRecords = vi.spyOn(storage, "findRecords");
+		const findEntries = vi.spyOn(storage, "findEntries");
+		const findEntriesOnBranch = vi.spyOn(storage, "findEntriesOnBranch");
+		const logBefore = await session.getLog();
+
+		const { suspended } = await createHarness(session);
+
+		expect(suspended.map((operation) => operation.lane)).toEqual(["thread"]);
+		expect(findOpenOperations.mock.calls).toEqual([
+			["main", { limit: 2 }],
+			["thread", { limit: 2 }],
+		]);
+		const recordQueries = findRecords.mock.calls.map(([query]) => query as RecordQuery | undefined);
+		expect(recordQueries.length).toBeGreaterThan(0);
+		expect(recordQueries.every((query) => query?.lane !== undefined)).toBe(true);
+		expect(recordQueries).toContainEqual(expect.objectContaining({ lane: "thread", afterSeq: thread.seq }));
+		expect(findEntries).not.toHaveBeenCalled();
+		expect(findEntriesOnBranch).toHaveBeenCalledWith(
+			expect.objectContaining({ start: "thread-prompt", stopAtId: "anchor", order: "newestFirst" }),
+		);
+		expect(findEntriesOnBranch.mock.calls.every(([query]) => query.stopAtId !== undefined || query.limit === 1)).toBe(
+			true,
+		);
+		expect(await session.getLog()).toEqual(logBefore);
+	});
+
+	it("reports missing persisted model and active-tool identities", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		await session.appendEntry(
+			{ type: "model_change", id: "missing-model", provider: "missing-provider", modelId: "missing-model" },
+			"main",
+		);
+		await session.appendEntry(
+			{ type: "active_tools_change", id: "missing-tools", activeToolNames: ["missing-tool"] },
+			"main",
+		);
+		await session.appendEntry(
+			{ type: "thinking_level_change", id: "persisted-thinking", thinkingLevel: "high" },
+			"main",
+		);
+		const sourceLeafId = await session.getLeafId();
+		await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }, sourceLeafId),
+		);
+
+		const { harness, suspended } = await createHarness(session, runtime);
+		const restoredLanes = Reflect.get(harness, "restoredLanes") as Map<string, LaneReductionResult>;
+
+		expect(suspended).toHaveLength(1);
+		expect(suspended[0]?.missing).toEqual({
+			tools: ["missing-tool"],
+			models: ["missing-provider/missing-model"],
+		});
+		expect(restoredLanes.get("main")?.effectiveConfiguration).toEqual({
+			model: { provider: "missing-provider", modelId: "missing-model" },
+			thinkingLevel: "high",
+			activeToolNames: ["missing-tool"],
+		});
+	});
+
+	it("does not require inactive identities to finish a completed structural operation", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		await session.appendEntry(
+			{ type: "model_change", id: "missing-model", provider: "missing-provider", modelId: "missing-model" },
+			"main",
+		);
+		await session.appendEntry(
+			{ type: "active_tools_change", id: "missing-tools", activeToolNames: ["missing-tool"] },
+			"main",
+		);
+		const sourceLeafId = await session.getLeafId();
+		await session.appendRecord(
+			operationStarted(
+				"compaction",
+				"main",
+				{ kind: "compaction", resultEntryId: "compaction-result" },
+				sourceLeafId,
+			),
+		);
+		await session.appendEntry(
+			{
+				type: "compaction",
+				id: "compaction-result",
+				summary: "summary",
+				retainedTail: [],
+				tokensBefore: 1,
+			},
+			"main",
+		);
+
+		const { suspended } = await AgentHarness.create({
+			session,
+			models: createModels(),
+			model: runtime.model,
+		});
+
+		expect(suspended[0]?.missing).toEqual({ tools: [], models: [] });
+	});
+
+	it("reports each unavailable effective and deferred model identity once", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		await session.appendEntry(
+			{ type: "model_change", id: "missing-model", provider: "missing-provider", modelId: "missing-model" },
+			"main",
+		);
+		const sourceLeafId = await session.getLeafId();
+		const started = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }, sourceLeafId),
+		);
+		const handle: DeferredHandle = {
+			provider: "missing-provider",
+			modelId: "missing-model",
+			api: runtime.model.api,
+			id: "missing-deferred",
+		};
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-deferred",
+		});
+		await session.appendEntry(
+			{ type: "message", id: "assistant-deferred", message: deferredMessage(handle) },
+			"main",
+		);
+
+		const { suspended } = await createHarness(session, runtime);
+
+		expect(suspended[0]?.missing.models).toEqual(["missing-provider/missing-model"]);
+	});
+
+	it("accepts available active tools and unfinished batch tools", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		const tool = { name: "available-tool", label: "Available tool" } as HarnessTool;
+		await session.appendEntry(
+			{ type: "active_tools_change", id: "available-tools", activeToolNames: [tool.name] },
+			"main",
+		);
+		const sourceLeafId = await session.getLeafId();
+		const started = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }, sourceLeafId),
+		);
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-tools",
+		});
+		await session.appendEntry(
+			{
+				type: "message",
+				id: "assistant-tools",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: tool.name, arguments: {} }],
+					api: runtime.model.api,
+					provider: runtime.model.provider,
+					model: runtime.model.id,
+					usage,
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+			},
+			"main",
+		);
+		await session.appendRecord({
+			type: "tool_started",
+			id: "tool-started",
+			lane: "main",
+			runId: started.id,
+			assistantEntryId: "assistant-tools",
+			toolIndex: 0,
+			toolCallId: "call-1",
+			toolName: tool.name,
+			effectiveArgs: {},
+			resultEntryId: "tool-result",
+			replay: "safe",
+		});
+
+		const { suspended } = await AgentHarness.create({
+			session,
+			models: runtime.models,
+			model: runtime.model,
+			tools: [tool],
+		});
+
+		expect(suspended[0]?.missing).toEqual({ tools: [], models: [] });
+	});
+
+	it("restores effective configuration for an idle lane", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		await session.appendEntry(
+			{
+				type: "model_change",
+				id: "persisted-model",
+				provider: runtime.model.provider,
+				modelId: runtime.model.id,
+			},
+			"main",
+		);
+		await session.appendEntry(
+			{ type: "thinking_level_change", id: "persisted-thinking", thinkingLevel: "high" },
+			"main",
+		);
+		await session.appendEntry(
+			{ type: "active_tools_change", id: "persisted-tools", activeToolNames: ["persisted-tool"] },
+			"main",
+		);
+
+		const { harness, suspended } = await createHarness(session, runtime);
+		const restoredLanes = Reflect.get(harness, "restoredLanes") as Map<string, LaneReductionResult>;
+
+		expect(suspended).toEqual([]);
+		expect(restoredLanes.get("main")?.effectiveConfiguration).toEqual({
+			model: { provider: runtime.model.provider, modelId: runtime.model.id },
+			thinkingLevel: "high",
+			activeToolNames: ["persisted-tool"],
+		});
+	});
+
+	it("reports a missing model needed to redeem a deferred response", async () => {
+		const { session } = createSession();
+		const runtime = createRuntime();
+		const started = await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }),
+		);
+		const handle: DeferredHandle = {
+			provider: "missing-provider",
+			modelId: "missing-deferred-model",
+			api: runtime.model.api,
+			id: "missing-deferred",
+		};
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-deferred",
+		});
+		await session.appendEntry(
+			{ type: "message", id: "assistant-deferred", message: deferredMessage(handle) },
+			"main",
+		);
+
+		const { suspended } = await createHarness(session, runtime);
+
+		expect(suspended[0]).toMatchObject({
+			reason: "deferred",
+			deferred: handle,
+			missing: { tools: [], models: ["missing-provider/missing-deferred-model"] },
+		});
+	});
+
+	it("point-looks up provisioned recovery targets", async () => {
+		const { session, storage } = createSession();
+		const runtime = createRuntime();
+		const prompt = userMessage("prompt");
+		const started = await session.appendRecord(
+			operationStarted("run", "main", {
+				kind: "run",
+				originalPrompt: [prompt],
+				initialMessages: [{ type: "message", id: "prompt", message: prompt }],
+			}),
+		);
+		await session.appendEntry({ type: "message", id: "prompt", message: prompt }, "main");
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "assistant-attempt",
+			lane: "main",
+			runId: started.id,
+			step: "assistant",
+			attempt: 1,
+			resultEntryId: "assistant-tools",
+		});
+		await session.appendEntry(
+			{
+				type: "message",
+				id: "assistant-tools",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: "tool", arguments: {} }],
+					api: runtime.model.api,
+					provider: runtime.model.provider,
+					model: runtime.model.id,
+					usage,
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+			},
+			"main",
+		);
+		await session.appendRecord({
+			type: "tool_started",
+			id: "tool-started",
+			lane: "main",
+			runId: started.id,
+			assistantEntryId: "assistant-tools",
+			toolIndex: 0,
+			toolCallId: "call-1",
+			toolName: "tool",
+			effectiveArgs: {},
+			resultEntryId: "tool-result",
+			replay: "safe",
+		});
+		await session.appendRecord({
+			type: "queue_enqueued",
+			id: "follow-up-record",
+			lane: "main",
+			queue: "followUp",
+			runId: started.id,
+			target: { type: "message", id: "follow-up", message: userMessage("follow up") },
+		});
+		await session.appendRecord({
+			type: "write_deferred",
+			id: "deferred-write-record",
+			lane: "main",
+			runId: started.id,
+			target: { type: "message", id: "deferred-write", message: userMessage("write") },
+		});
+		await session.createLane("compact", null);
+		const compaction = await session.appendRecord(
+			operationStarted("compaction", "compact", { kind: "compaction", resultEntryId: "compaction-result" }),
+		);
+		await session.appendRecord({
+			type: "step_attempt",
+			id: "compaction-attempt",
+			lane: "compact",
+			runId: compaction.id,
+			step: "compaction",
+			attempt: 1,
+			resultEntryId: "compaction-result",
+			compactionReason: "manual",
+		});
+		const getEntry = vi.spyOn(storage, "getEntry");
+
+		await createHarness(session, runtime);
+
+		expect(getEntry.mock.calls.map(([id]) => id)).toEqual([
+			"prompt",
+			"assistant-tools",
+			"tool-result",
+			"follow-up",
+			"deferred-write",
+			"compaction-result",
+		]);
+	});
+
+	it("finds provisioned-id content mismatches outside the lane branch", async () => {
+		const { session } = createSession();
+		await session.appendEntry(
+			{ type: "message", id: "shared-id", message: userMessage("different payload") },
+			"main",
+		);
+		await session.createLane("thread", null);
+		await session.appendRecord(
+			operationStarted("thread-run", "thread", {
+				kind: "run",
+				originalPrompt: [userMessage("expected payload")],
+				initialMessages: [{ type: "message", id: "shared-id", message: userMessage("expected payload") }],
+			}),
+		);
+
+		await expect(createHarness(session)).rejects.toMatchObject({
+			name: "RecordLogCorruption",
+			reason: "provisioned_entry_mismatch",
+		});
+	});
+
+	it.each(["before_move", "after_move", "after_summary"] as const)(
+		"restores move-first navigation at %s",
+		async (phase) => {
+			const { session, storage } = createSession(`navigation-${phase}`);
+			await session.appendEntry({ type: "message", id: "target", message: userMessage("target") }, "main");
+			await session.appendEntry({ type: "message", id: "source", message: userMessage("source") }, "main");
+			const started = await session.appendRecord(
+				operationStarted(
+					"navigation",
+					"main",
+					{
+						kind: "navigation",
+						targetId: "target",
+						summarize: true,
+						summaryEntryId: "summary",
+					},
+					"source",
+				),
+			);
+			if (phase !== "before_move") await session.moveLane("main", "target");
+			if (phase === "after_summary") {
+				await session.appendEntry(
+					{
+						type: "branch_summary",
+						id: "summary",
+						fromId: "source",
+						summary: "summary",
+					},
+					"main",
+				);
+			}
+			const logBefore = await session.getLog();
+			const getEntry = vi.spyOn(storage, "getEntry");
+			const findEntriesOnBranch = vi.spyOn(storage, "findEntriesOnBranch");
+
+			const { harness, suspended } = await createHarness(session);
+			const restoredLanes = Reflect.get(harness, "restoredLanes") as Map<string, LaneReductionResult>;
+			const restored = restoredLanes.get("main")?.laneState;
+
+			expect(suspended).toEqual([
+				{
+					lane: "main",
+					kind: "navigation",
+					id: started.id,
+					startedAt: started.timestamp,
+					reason: "crash",
+					missing: { tools: [], models: [] },
+				},
+			]);
+			expect(restored?.leafId).toBe(
+				phase === "before_move" ? "source" : phase === "after_move" ? "target" : "summary",
+			);
+			expect(restored?.operation?.targets).toEqual({ summary: phase === "after_summary" });
+			expect(restored?.operation?.newestOwn).toEqual(
+				phase === "after_summary" ? { entryId: "summary", type: "branch_summary" } : null,
+			);
+			expect(getEntry).toHaveBeenCalledWith("summary");
+			expect(findEntriesOnBranch.mock.calls).not.toContainEqual([expect.objectContaining({ stopAtId: "source" })]);
+			expect(await session.getLog()).toEqual(logBefore);
+		},
+	);
+
+	it("rejects a non-navigation leaf outside the operation source branch as corruption", async () => {
+		const { session } = createSession("invalid-operation-branch");
+		await session.appendEntry({ type: "message", id: "source", message: userMessage("source") }, "main");
+		await session.createLane("other", null);
+		await session.appendEntry({ type: "message", id: "unrelated", message: userMessage("unrelated") }, "other");
+		await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }, "source"),
+		);
+		await session.moveLane("main", "unrelated");
+
+		await expect(createHarness(session)).rejects.toMatchObject({
+			name: "RecordLogCorruption",
+			reason: "inconsistent_step",
+		});
+	});
+
+	it("rejects a pre-operation descendant as operation-owned state", async () => {
+		const { session } = createSession("pre-operation-descendant");
+		await session.appendEntry({ type: "message", id: "source", message: userMessage("source") }, "main");
+		await session.createLane("other", "source");
+		await session.appendEntry(
+			{ type: "message", id: "old-descendant", message: userMessage("old descendant") },
+			"other",
+		);
+		await session.appendRecord(
+			operationStarted("run", "main", { kind: "run", originalPrompt: [], initialMessages: [] }, "source"),
+		);
+		await session.moveLane("main", "old-descendant");
+
+		await expect(createHarness(session)).rejects.toMatchObject({
+			name: "RecordLogCorruption",
+			reason: "inconsistent_step",
+		});
+	});
+
+	it("rejects navigation leaves outside the move-first durable states as corruption", async () => {
+		const { session } = createSession("navigation-invalid-leaf");
+		await session.appendEntry({ type: "message", id: "target", message: userMessage("target") }, "main");
+		await session.appendEntry({ type: "message", id: "unrelated", message: userMessage("unrelated") }, "main");
+		await session.appendEntry({ type: "message", id: "source", message: userMessage("source") }, "main");
+		await session.appendRecord(
+			operationStarted(
+				"navigation",
+				"main",
+				{
+					kind: "navigation",
+					targetId: "target",
+					summarize: true,
+					summaryEntryId: "summary",
+				},
+				"source",
+			),
+		);
+		await session.moveLane("main", "unrelated");
+
+		await expect(createHarness(session)).rejects.toMatchObject({
+			name: "RecordLogCorruption",
+			reason: "inconsistent_step",
+		});
+	});
+
+	it("bounds idle next-run recovery after the latest run start", async () => {
+		const { session, storage } = createSession();
+		const captured = userMessage("captured by the previous run");
+		const beforeCompaction = userMessage("queued before a newer compaction");
+		const afterCompaction = userMessage("queued after the compaction");
+		const cancelled = userMessage("do not run");
+		await session.appendRecord({
+			type: "queue_enqueued",
+			id: "captured-record",
+			lane: "main",
+			queue: "nextRun",
+			target: { type: "message", id: "captured", message: captured },
+		});
+		const latestRun = await session.appendRecord(
+			operationStarted("finished-run", "main", {
+				kind: "run",
+				originalPrompt: [captured],
+				initialMessages: [{ type: "message", id: "captured", message: captured }],
+			}),
+		);
+		await session.appendRecord({
+			type: "operation_finished",
+			id: "run-finished",
+			lane: "main",
+			runId: latestRun.id,
+			outcome: "completed",
+		});
+		await session.appendRecord({
+			type: "queue_enqueued",
+			id: "before-compaction-record",
+			lane: "main",
+			queue: "nextRun",
+			target: { type: "message", id: "before-compaction", message: beforeCompaction },
+		});
+		const compaction = await session.appendRecord(
+			operationStarted("newer-compaction", "main", { kind: "compaction", resultEntryId: "unused-result" }),
+		);
+		await session.appendRecord({
+			type: "operation_finished",
+			id: "compaction-finished",
+			lane: "main",
+			runId: compaction.id,
+			outcome: "declined",
+		});
+		await session.appendRecord({
+			type: "queue_enqueued",
+			id: "after-compaction-record",
+			lane: "main",
+			queue: "nextRun",
+			target: { type: "message", id: "after-compaction", message: afterCompaction },
+		});
+		await session.appendRecord({
+			type: "queue_enqueued",
+			id: "cancelled-record",
+			lane: "main",
+			queue: "nextRun",
+			target: { type: "message", id: "cancelled", message: cancelled },
+		});
+		await session.appendRecord({
+			type: "queue_cancelled",
+			id: "cancellation",
+			lane: "main",
+			entryId: "cancelled",
+		});
+		const findRecords = vi.spyOn(storage, "findRecords");
+		const logBefore = await session.getLog();
+
+		const { harness, suspended } = await createHarness(session);
+		const restoredLanes = Reflect.get(harness, "restoredLanes") as Map<string, LaneReductionResult>;
+		const recordQueries = findRecords.mock.calls.map(([query]) => query as RecordQuery | undefined);
+
+		expect(suspended).toEqual([]);
+		expect(restoredLanes.get("main")?.laneState.pendingNextRun).toEqual([
+			{ type: "message", id: "before-compaction", message: beforeCompaction },
+			{ type: "message", id: "after-compaction", message: afterCompaction },
+		]);
+		expect(recordQueries).toEqual([
+			{
+				lane: "main",
+				type: "operation_started",
+				operationKind: "run",
+				order: "newestFirst",
+				limit: 1,
+			},
+			{
+				lane: "main",
+				type: "queue_enqueued",
+				afterSeq: latestRun.seq,
+				order: "oldestFirst",
+			},
+			{
+				lane: "main",
+				type: "queue_cancelled",
+				afterSeq: latestRun.seq,
+				order: "oldestFirst",
+			},
+		]);
+		expect(await session.getLog()).toEqual(logBefore);
+	});
+
+	it("keeps getLeafId synchronized with direct session writes", async () => {
+		const { session } = createSession();
+		const { harness } = await createHarness(session);
+
+		const entryId = await harness.session.appendMessage(userMessage("appended after restore"));
+
+		expect(await harness.getLeafId()).toBe(entryId);
+	});
+});

--- a/packages/agent/test/harness/agent-harness-scaffold.test.ts
+++ b/packages/agent/test/harness/agent-harness-scaffold.test.ts
@@ -8,12 +8,7 @@ import {
 	type HarnessTool,
 	type Resources,
 } from "../../src/harness/agent-harness.ts";
-import {
-	InMemorySessionStorage,
-	type NewRecord,
-	type OperationStartedRecord,
-	Session,
-} from "../../src/harness/session/index.ts";
+import { InMemorySessionStorage, Session } from "../../src/harness/session/index.ts";
 import type { AgentMessage } from "../../src/types.ts";
 
 function createSession(id = "session"): Session {
@@ -26,16 +21,6 @@ function createHarness(session = createSession()): Promise<AgentHarness> {
 		models: createModels(),
 		model: getModel("google", "gemini-2.5-flash"),
 	}).then(({ harness }) => harness);
-}
-
-function operationStarted(id: string): NewRecord<OperationStartedRecord> {
-	return {
-		type: "operation_started",
-		id,
-		lane: "main",
-		sourceLeafId: null,
-		intent: { kind: "run", originalPrompt: [], initialMessages: [] },
-	};
 }
 
 const userMessage: AgentMessage = {
@@ -54,7 +39,7 @@ const usage: Usage = {
 };
 
 describe("AgentHarness v2 scaffold", () => {
-	it("opens only record-free sessions before restore is implemented", async () => {
+	it("opens record-free sessions", async () => {
 		const session = createSession();
 		const { harness, suspended } = await AgentHarness.create({
 			session,
@@ -69,16 +54,6 @@ describe("AgentHarness v2 scaffold", () => {
 		expect(await harness.session.getLeafId()).toBeNull();
 
 		await expect(harness.close()).resolves.toBeUndefined();
-
-		const recorded = createSession("recorded");
-		await recorded.appendRecord(operationStarted("run"));
-		await expect(
-			AgentHarness.create({
-				session: recorded,
-				models: createModels(),
-				model: getModel("google", "gemini-2.5-flash"),
-			}),
-		).rejects.toMatchObject({ name: "HarnessNotImplemented", operation: "create.restore" });
 	});
 
 	it("keeps scaffold-safe configuration as defensive copies", async () => {

--- a/packages/agent/test/harness/reducer.test.ts
+++ b/packages/agent/test/harness/reducer.test.ts
@@ -827,6 +827,10 @@ describe("lane-state reduction", () => {
 			pendingFollowUp: [],
 			pendingWrites: [pendingWrite],
 		});
+		expect(result.laneState.operation?.abortingQueues).toEqual({
+			steer: [steer.message],
+			followUp: [followUp.message],
+		});
 	});
 
 	it.each([


### PR DESCRIPTION
Implements [R3 in the harness v2 plan](https://github.com/earendil-works/pi/blob/main/packages/agent/docs/harness-v2.md#track-r--recovery-query-reducer-and-restore) which was quite big. It fills out `AgentHarness.create` such that we can create (load) a new harness from a session with the existing lanes and their config and suspended operations.

There's a lot going on here, so I would appreciate you guys pushing back so I'm not a meat proxy.

Uncovered some things in the storage implementations:
- we need an API to get latest assistant message which I've added to H4 (and noted under R3)
- SQLite's branch query `findEntriesOnBranch` fetches and decodes the entire cached branch before applying the type filter and `limit: 1`. Thus `restore` performs this three times per lane, making startup scale poorly with session history. We should push type and limit into the SQLite query or add indexed configuration lookups. I've marked this with a TODO in the `harness.ts` file I'm touching here

Also marked a TODO on the concurrency level used here, we might need to bound it.