### PR TITLE
feat: stream assistant and config with telemetry

### DIFF
--- a/packages/agent/docs/harness-v2.md
+++ b/packages/agent/docs/harness-v2.md
@@ -3302,9 +3302,7 @@ I0, I1, and I2 may proceed independently. I3 → I4 → I5 is serial and begins 
 
 These packages all own `packages/agent/src/agent-loop.ts` and therefore merge strictly L1 → L2 → L3. Existing `agent-loop` and `agent` tests pass unchanged after each package.
 
-**Reserved: L1 by @cristinaponcela.** Other agents must not pick L1 while this ownership marker remains.
-
-- [ ] **L1 — extract assistant streaming.** Dependencies: I0.
+- [x] **L1 — extract assistant streaming.** Dependencies: I0.
   - Add `streamAssistant()` and `StreamAssistantConfig`, including explicit telemetry context; route the compatibility loop's request path through it without changing events or results.
   - Acceptance: focused stream tests cover settled-result narrowing (a final `pending` value is a defect), plus unchanged existing loop tests.
 - [ ] **L2 — extract tool-call phases.** Dependencies: L1.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -26,10 +26,6 @@ import type {
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
-export type SettledAssistantMessage = AssistantMessage & {
-	stopReason: Exclude<AssistantMessage["stopReason"], "pending">;
-};
-
 export interface StreamAssistantConfig extends AgentLoopConfig {
 	/** Explicit parent context for AI-request telemetry. */
 	telemetryContext: TelemetryContext;
@@ -309,7 +305,7 @@ export async function streamAssistant(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
-): Promise<SettledAssistantMessage> {
+): Promise<AssistantMessage> {
 	return startAiSpan(
 		config.telemetryContext,
 		"pi.ai.request",
@@ -332,7 +328,7 @@ async function streamAssistantInSpan(
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
 	span: AiTelemetrySpan<"pi.ai.request">,
-): Promise<SettledAssistantMessage> {
+): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
@@ -399,7 +395,10 @@ async function streamAssistantInSpan(
 
 			case "done":
 			case "error": {
-				const finalMessage = requireSettledAssistantMessage(await response.result());
+				const finalMessage = await response.result();
+				if (finalMessage.stopReason === "pending") {
+					throw new Error("Provider stream settled with pending assistant message");
+				}
 				finishAiSpan(span, finalMessage, streamChunkCount, timeToFirstChunkMs);
 				if (addedPartial) {
 					context.messages[context.messages.length - 1] = finalMessage;
@@ -415,7 +414,10 @@ async function streamAssistantInSpan(
 		}
 	}
 
-	const finalMessage = requireSettledAssistantMessage(await response.result());
+	const finalMessage = await response.result();
+	if (finalMessage.stopReason === "pending") {
+		throw new Error("Provider stream settled with pending assistant message");
+	}
 	finishAiSpan(span, finalMessage, streamChunkCount, timeToFirstChunkMs);
 	if (addedPartial) {
 		context.messages[context.messages.length - 1] = finalMessage;
@@ -427,16 +429,9 @@ async function streamAssistantInSpan(
 	return finalMessage;
 }
 
-function requireSettledAssistantMessage(message: AssistantMessage): SettledAssistantMessage {
-	if (message.stopReason === "pending") {
-		throw new Error("Provider stream settled with pending assistant message");
-	}
-	return message as SettledAssistantMessage;
-}
-
 function finishAiSpan(
 	span: AiTelemetrySpan<"pi.ai.request">,
-	message: SettledAssistantMessage,
+	message: AssistantMessage,
 	streamChunkCount: number,
 	timeToFirstChunkMs: number | undefined,
 ): void {
@@ -465,8 +460,9 @@ function finishAiSpan(
 }
 
 function telemetryStopReason(
-	stopReason: SettledAssistantMessage["stopReason"],
+	stopReason: AssistantMessage["stopReason"],
 ): "stop" | "length" | "tool_use" | "error" | "aborted" | "deferred" {
+	if (stopReason === "pending") throw new Error("Pending assistant messages do not have telemetry stop reasons");
 	return stopReason === "toolUse" ? "tool_use" : stopReason;
 }
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -10,6 +10,8 @@ import {
 	type ToolResultMessage,
 	validateToolArguments,
 } from "@earendil-works/pi-ai";
+import { NOOP_TELEMETRY_CONTEXT, type TelemetryContext } from "@earendil-works/pi-telemetry";
+import { type AiTelemetrySpan, startAiSpan } from "./harness/telemetry.ts";
 import { getDefaultStreamFn } from "./stream-fn.ts";
 import type {
 	AgentContext,
@@ -23,6 +25,15 @@ import type {
 } from "./types.ts";
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
+
+export type SettledAssistantMessage = AssistantMessage & {
+	stopReason: Exclude<AssistantMessage["stopReason"], "pending">;
+};
+
+export interface StreamAssistantConfig extends AgentLoopConfig {
+	/** Explicit parent context for AI-request telemetry. */
+	telemetryContext: TelemetryContext;
+}
 
 /**
  * Start an agent loop with a new prompt message.
@@ -113,7 +124,14 @@ export async function runAgentLoop(
 		await emit({ type: "message_end", message: prompt });
 	}
 
-	await runLoop(currentContext, newMessages, config, signal, emit, streamFn ?? getDefaultStreamFn());
+	await runLoop(
+		currentContext,
+		newMessages,
+		{ ...config, telemetryContext: config.telemetryContext ?? NOOP_TELEMETRY_CONTEXT },
+		signal,
+		emit,
+		streamFn ?? getDefaultStreamFn(),
+	);
 	return newMessages;
 }
 
@@ -138,7 +156,14 @@ export async function runAgentLoopContinue(
 	await emit({ type: "agent_start" });
 	await emit({ type: "turn_start" });
 
-	await runLoop(currentContext, newMessages, config, signal, emit, streamFn ?? getDefaultStreamFn());
+	await runLoop(
+		currentContext,
+		newMessages,
+		{ ...config, telemetryContext: config.telemetryContext ?? NOOP_TELEMETRY_CONTEXT },
+		signal,
+		emit,
+		streamFn ?? getDefaultStreamFn(),
+	);
 	return newMessages;
 }
 
@@ -155,7 +180,7 @@ function createAgentStream(): EventStream<AgentEvent, AgentMessage[]> {
 async function runLoop(
 	initialContext: AgentContext,
 	newMessages: AgentMessage[],
-	initialConfig: AgentLoopConfig,
+	initialConfig: StreamAssistantConfig,
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
@@ -190,7 +215,7 @@ async function runLoop(
 			}
 
 			// Stream assistant response
-			const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
+			const message = await streamAssistant(currentContext, config, signal, emit, streamFunction);
 			newMessages.push(message);
 
 			if (message.stopReason === "error" || message.stopReason === "aborted") {
@@ -278,13 +303,36 @@ async function runLoop(
  * Stream an assistant response from the LLM.
  * This is where AgentMessage[] gets transformed to Message[] for the LLM.
  */
-async function streamAssistantResponse(
+export async function streamAssistant(
 	context: AgentContext,
-	config: AgentLoopConfig,
+	config: StreamAssistantConfig,
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
-): Promise<AssistantMessage> {
+): Promise<SettledAssistantMessage> {
+	return startAiSpan(
+		config.telemetryContext,
+		"pi.ai.request",
+		{
+			"pi.ai.operation": "stream",
+			"pi.ai.provider": config.model.provider,
+			"pi.ai.model": config.model.id,
+			"pi.ai.api": config.model.api,
+			"pi.ai.streaming": true,
+			"pi.ai.deferred": config.deferred === undefined ? undefined : Boolean(config.deferred),
+		},
+		async (span) => streamAssistantInSpan(context, config, signal, emit, streamFunction, span),
+	);
+}
+
+async function streamAssistantInSpan(
+	context: AgentContext,
+	config: StreamAssistantConfig,
+	signal: AbortSignal | undefined,
+	emit: AgentEventSink,
+	streamFunction: StreamFn,
+	span: AiTelemetrySpan<"pi.ai.request">,
+): Promise<SettledAssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
@@ -309,10 +357,14 @@ async function streamAssistantResponse(
 		...config,
 		apiKey: resolvedApiKey,
 		signal,
+		telemetryContext: span,
 	});
 
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;
+	let streamChunkCount = 0;
+	let timeToFirstChunkMs: number | undefined;
+	const streamStartedAt = Date.now();
 
 	for await (const event of response) {
 		switch (event.type) {
@@ -332,6 +384,8 @@ async function streamAssistantResponse(
 			case "toolcall_start":
 			case "toolcall_delta":
 			case "toolcall_end":
+				streamChunkCount += 1;
+				timeToFirstChunkMs ??= Date.now() - streamStartedAt;
 				if (partialMessage) {
 					partialMessage = event.partial;
 					context.messages[context.messages.length - 1] = partialMessage;
@@ -345,7 +399,8 @@ async function streamAssistantResponse(
 
 			case "done":
 			case "error": {
-				const finalMessage = await response.result();
+				const finalMessage = requireSettledAssistantMessage(await response.result());
+				finishAiSpan(span, finalMessage, streamChunkCount, timeToFirstChunkMs);
 				if (addedPartial) {
 					context.messages[context.messages.length - 1] = finalMessage;
 				} else {
@@ -360,7 +415,8 @@ async function streamAssistantResponse(
 		}
 	}
 
-	const finalMessage = await response.result();
+	const finalMessage = requireSettledAssistantMessage(await response.result());
+	finishAiSpan(span, finalMessage, streamChunkCount, timeToFirstChunkMs);
 	if (addedPartial) {
 		context.messages[context.messages.length - 1] = finalMessage;
 	} else {
@@ -369,6 +425,49 @@ async function streamAssistantResponse(
 	}
 	await emit({ type: "message_end", message: finalMessage });
 	return finalMessage;
+}
+
+function requireSettledAssistantMessage(message: AssistantMessage): SettledAssistantMessage {
+	if (message.stopReason === "pending") {
+		throw new Error("Provider stream settled with pending assistant message");
+	}
+	return message as SettledAssistantMessage;
+}
+
+function finishAiSpan(
+	span: AiTelemetrySpan<"pi.ai.request">,
+	message: SettledAssistantMessage,
+	streamChunkCount: number,
+	timeToFirstChunkMs: number | undefined,
+): void {
+	span.setAttributes({
+		"pi.ai.response.model": message.responseModel ?? message.model,
+		"pi.ai.response.id": message.responseId,
+		"pi.ai.response.stop_reason": telemetryStopReason(message.stopReason),
+		"pi.ai.usage.input_tokens": message.usage.input,
+		"pi.ai.usage.output_tokens": message.usage.output,
+		"pi.ai.usage.cache_read_tokens": message.usage.cacheRead,
+		"pi.ai.usage.cache_write_tokens": message.usage.cacheWrite,
+		"pi.ai.usage.reasoning_tokens": message.usage.reasoning,
+		"pi.ai.usage.total_tokens": message.usage.totalTokens,
+		"pi.ai.usage.cost": message.usage.cost.total,
+		"pi.ai.stream.chunk_count": streamChunkCount,
+		"pi.ai.stream.time_to_first_chunk_ms": timeToFirstChunkMs,
+		"pi.ai.error.type":
+			message.stopReason === "error" || message.stopReason === "aborted" ? message.stopReason : undefined,
+	});
+	if (message.stopReason === "error" || message.stopReason === "aborted") {
+		span.setStatus({
+			status: "error",
+			error: { name: message.stopReason, message: message.errorMessage ?? message.stopReason },
+		});
+	}
+}
+
+function telemetryStopReason(
+	stopReason: SettledAssistantMessage["stopReason"],
+): "stop" | "length" | "tool_use" | "error" | "aborted" | "deferred" {
+	return stopReason === "toolUse" ? "tool_use" : stopReason;
 }
 
 /**

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -31,6 +31,9 @@ export interface StreamAssistantConfig extends AgentLoopConfig {
 	telemetryContext: TelemetryContext;
 }
 
+// Maps AssistantMessage stop reasons to the telemetry schema value set: snake_case and no non-final "pending".
+type AiTelemetryStopReason = "stop" | "length" | "tool_use" | "error" | "aborted" | "deferred";
+
 /**
  * Start an agent loop with a new prompt message.
  * The prompt is added to the context and events are emitted for it.
@@ -459,9 +462,7 @@ function finishAiSpan(
 	}
 }
 
-function telemetryStopReason(
-	stopReason: AssistantMessage["stopReason"],
-): "stop" | "length" | "tool_use" | "error" | "aborted" | "deferred" {
+function telemetryStopReason(stopReason: AssistantMessage["stopReason"]): AiTelemetryStopReason {
 	if (stopReason === "pending") throw new Error("Pending assistant messages do not have telemetry stop reasons");
 	return stopReason === "toolUse" ? "tool_use" : stopReason;
 }

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -31,6 +31,10 @@ export interface StreamAssistantConfig extends AgentLoopConfig {
 	telemetryContext: TelemetryContext;
 }
 
+export type SettledAssistantMessage = Omit<AssistantMessage, "stopReason"> & {
+	stopReason: Exclude<AssistantMessage["stopReason"], "pending">;
+};
+
 // Maps AssistantMessage stop reasons to the telemetry schema value set: snake_case and no non-final "pending".
 type AiTelemetryStopReason = "stop" | "length" | "tool_use" | "error" | "aborted" | "deferred";
 
@@ -308,7 +312,7 @@ export async function streamAssistant(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
-): Promise<AssistantMessage> {
+): Promise<SettledAssistantMessage> {
 	return startAiSpan(
 		config.telemetryContext,
 		"pi.ai.request",
@@ -331,7 +335,7 @@ async function streamAssistantInSpan(
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
 	span: AiTelemetrySpan<"pi.ai.request">,
-): Promise<AssistantMessage> {
+): Promise<SettledAssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
@@ -399,9 +403,7 @@ async function streamAssistantInSpan(
 			case "done":
 			case "error": {
 				const finalMessage = await response.result();
-				if (finalMessage.stopReason === "pending") {
-					throw new Error("Provider stream settled with pending assistant message");
-				}
+				assertSettledAssistantMessage(finalMessage);
 				finishAiSpan(span, finalMessage, streamChunkCount, timeToFirstChunkMs);
 				if (addedPartial) {
 					context.messages[context.messages.length - 1] = finalMessage;
@@ -418,9 +420,7 @@ async function streamAssistantInSpan(
 	}
 
 	const finalMessage = await response.result();
-	if (finalMessage.stopReason === "pending") {
-		throw new Error("Provider stream settled with pending assistant message");
-	}
+	assertSettledAssistantMessage(finalMessage);
 	finishAiSpan(span, finalMessage, streamChunkCount, timeToFirstChunkMs);
 	if (addedPartial) {
 		context.messages[context.messages.length - 1] = finalMessage;
@@ -432,9 +432,15 @@ async function streamAssistantInSpan(
 	return finalMessage;
 }
 
+function assertSettledAssistantMessage(message: AssistantMessage): asserts message is SettledAssistantMessage {
+	if (message.stopReason === "pending") {
+		throw new Error("Provider stream settled with pending assistant message");
+	}
+}
+
 function finishAiSpan(
 	span: AiTelemetrySpan<"pi.ai.request">,
-	message: AssistantMessage,
+	message: SettledAssistantMessage,
 	streamChunkCount: number,
 	timeToFirstChunkMs: number | undefined,
 ): void {
@@ -462,8 +468,7 @@ function finishAiSpan(
 	}
 }
 
-function telemetryStopReason(stopReason: AssistantMessage["stopReason"]): AiTelemetryStopReason {
-	if (stopReason === "pending") throw new Error("Pending assistant messages do not have telemetry stop reasons");
+function telemetryStopReason(stopReason: SettledAssistantMessage["stopReason"]): AiTelemetryStopReason {
 	return stopReason === "toolUse" ? "tool_use" : stopReason;
 }
 

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -172,6 +172,8 @@ describe("streamAssistant", () => {
 		);
 
 		expect(message).toBe(finalMessage);
+		const settledStopReason: Exclude<AssistantMessage["stopReason"], "pending"> = message.stopReason;
+		expect(settledStopReason).toBe("stop");
 		expect(context.messages.at(-1)).toBe(finalMessage);
 		expect(events.map((event) => event.type)).toEqual(["message_start", "message_update", "message_end"]);
 		expect(providerTelemetryContext).not.toBe(telemetryContext);

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -8,8 +8,8 @@ import {
 } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import { agentLoop, agentLoopContinue } from "../src/agent-loop.ts";
-import { setDefaultStreamFn } from "../src/index.ts";
+import { agentLoop, agentLoopContinue, type StreamAssistantConfig, streamAssistant } from "../src/agent-loop.ts";
+import { InMemoryTelemetryContext, setDefaultStreamFn } from "../src/index.ts";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
 
 // Mock stream for testing - mimics MockAssistantStream
@@ -112,6 +112,116 @@ describe("default stream function compatibility", () => {
 		} finally {
 			setDefaultStreamFn(undefined);
 		}
+	});
+});
+
+describe("streamAssistant", () => {
+	it("streams through a logical AI request span without changing message events", async () => {
+		const telemetryContext = new InMemoryTelemetryContext();
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [createUserMessage("Hello")],
+			tools: [],
+		};
+		const config: StreamAssistantConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			telemetryContext,
+		};
+		let providerTelemetryContext: unknown;
+		const finalMessage = createAssistantMessage([{ type: "text", text: "Hi there!" }]);
+		finalMessage.responseModel = "resolved-model";
+		finalMessage.responseId = "response-1";
+		finalMessage.usage = {
+			input: 11,
+			output: 7,
+			cacheRead: 3,
+			cacheWrite: 5,
+			reasoning: 2,
+			totalTokens: 26,
+			cost: { input: 0.1, output: 0.2, cacheRead: 0.03, cacheWrite: 0.05, total: 0.38 },
+		};
+		const streamFn = async (_model: Model<any>, _context: unknown, options: { telemetryContext?: unknown } = {}) => {
+			providerTelemetryContext = options.telemetryContext;
+			const childContext = options.telemetryContext as { startSpan?: (typeof telemetryContext)["startSpan"] };
+			await childContext.startSpan?.({ name: "provider.child" }, () => undefined);
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const partial = createAssistantMessage([{ type: "text", text: "" }]);
+				stream.push({ type: "start", partial });
+				stream.push({
+					type: "text_delta",
+					contentIndex: 0,
+					delta: "Hi there!",
+					partial: finalMessage,
+				});
+				stream.push({ type: "done", reason: "stop", message: finalMessage });
+			});
+			return stream;
+		};
+		const events: AgentEvent[] = [];
+
+		const message = await streamAssistant(
+			context,
+			config,
+			undefined,
+			(event) => {
+				events.push(event);
+			},
+			streamFn,
+		);
+
+		expect(message).toBe(finalMessage);
+		expect(context.messages.at(-1)).toBe(finalMessage);
+		expect(events.map((event) => event.type)).toEqual(["message_start", "message_update", "message_end"]);
+		expect(providerTelemetryContext).not.toBe(telemetryContext);
+		const spans = telemetryContext.getSpans();
+		const aiSpan = spans.find((span) => span.name === "pi.ai.request");
+		const childSpan = spans.find((span) => span.name === "provider.child");
+		expect(childSpan?.parentId).toBe(aiSpan?.id);
+		expect(aiSpan?.attributes).toMatchObject({
+			"pi.ai.operation": "stream",
+			"pi.ai.provider": "openai",
+			"pi.ai.model": "mock",
+			"pi.ai.api": "openai-responses",
+			"pi.ai.streaming": true,
+			"pi.ai.response.model": "resolved-model",
+			"pi.ai.response.id": "response-1",
+			"pi.ai.response.stop_reason": "stop",
+			"pi.ai.usage.input_tokens": 11,
+			"pi.ai.usage.output_tokens": 7,
+			"pi.ai.usage.cache_read_tokens": 3,
+			"pi.ai.usage.cache_write_tokens": 5,
+			"pi.ai.usage.reasoning_tokens": 2,
+			"pi.ai.usage.total_tokens": 26,
+			"pi.ai.usage.cost": 0.38,
+			"pi.ai.stream.chunk_count": 1,
+			"pi.ai.stream.time_to_first_chunk_ms": expect.any(Number),
+		});
+		expect(aiSpan?.status).toEqual({ status: "ok" });
+	});
+
+	it("rejects a provider stream that settles with a pending assistant message", async () => {
+		const context: AgentContext = {
+			systemPrompt: "You are helpful.",
+			messages: [createUserMessage("Hello")],
+			tools: [],
+		};
+		const config: StreamAssistantConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			telemetryContext: new InMemoryTelemetryContext(),
+		};
+		const pendingMessage = createAssistantMessage([{ type: "text", text: "not done" }], "pending");
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => stream.push({ type: "done", reason: "stop", message: pendingMessage }));
+			return stream;
+		};
+
+		await expect(streamAssistant(context, config, undefined, () => undefined, streamFn)).rejects.toThrow(
+			"Provider stream settled with pending assistant message",
+		);
 	});
 });
 


### PR DESCRIPTION
This PR adds L1, which implements `StreamAssistant` and `StreamAssistantConfig` with the `telemetryContext` for harness v2.