### PR TITLE
docs(tui): Clarify TUI test runner and remove stale Vitest  config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,10 @@
 
 - After code changes (not docs): `npm run check` (full output, no tail). Fix all errors, warnings, and infos before committing. Does not run tests.
 - Never run `npm run build` or `npm test` unless requested by the user.
-- Never run the full vitest suite directly: it includes e2e tests that activate when endpoint/auth env vars are present. For all non-e2e tests, run `./test.sh` from the repo root. Otherwise run specific tests from the package root: `node ../../node_modules/vitest/dist/cli.js --run test/specific.test.ts`.
+- Never run the full Vitest suite directly: it includes e2e tests that activate when endpoint/auth env vars are present. To run the full non-e2e suite, use `./test.sh` from the repo root. Run individual test files with the package's native runner from the package root:
+  - Vitest packages: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/specific.test.ts`
+  - `packages/evals` unit tests: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run --config vitest.test.config.ts test/specific.test.ts`
+  - `packages/tui` (`node:test`): `node --test test/specific.test.ts`
 - If you create or modify a test file, run it and iterate on test or implementation until it passes.
 - For `packages/coding-agent/test/suite/`, use `test/suite/harness.ts` + the faux provider. No real provider APIs, keys, or paid tokens.
 - Put issue-specific regressions under `packages/coding-agent/test/suite/regressions/` named `<issue-number>-<short-slug>.test.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@
 
 - After code changes (not docs): `npm run check` (full output, no tail). Fix all errors, warnings, and infos before committing. Does not run tests.
 - Never run `npm run build` or `npm test` unless requested by the user.
-- Never run the full Vitest suite directly: it includes e2e tests that activate when endpoint/auth env vars are present. To run the full non-e2e suite, use `./test.sh` from the repo root. Run individual test files with the package's native runner from the package root:
-  - Vitest packages: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/specific.test.ts`
+- Never run the full vitest suite directly: it includes e2e tests that activate when endpoint/auth env vars are present. For all non-e2e tests, run `./test.sh` from the repo root. Otherwise run specific tests from the package root:
+  - Vitest: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/specific.test.ts`
   - `packages/evals` unit tests: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run --config vitest.test.config.ts test/specific.test.ts`
   - `packages/tui` (`node:test`): `node --test test/specific.test.ts`
 - If you create or modify a test file, run it and iterate on test or implementation until it passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,6 @@
 - Never run `npm run build` or `npm test` unless requested by the user.
 - Never run the full vitest suite directly: it includes e2e tests that activate when endpoint/auth env vars are present. For all non-e2e tests, run `./test.sh` from the repo root. Otherwise run specific tests from the package root:
   - Vitest: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/specific.test.ts`
-  - `packages/evals` unit tests: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run --config vitest.test.config.ts test/specific.test.ts`
   - `packages/tui` (`node:test`): `node --test test/specific.test.ts`
 - If you create or modify a test file, run it and iterate on test or implementation until it passes.
 - For `packages/coding-agent/test/suite/`, use `test/suite/harness.ts` + the faux provider. No real provider APIs, keys, or paid tokens.

--- a/packages/tui/vitest.config.ts
+++ b/packages/tui/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-	test: {
-		include: ["test/wrap-ansi.test.ts"],
-	},
-});


### PR DESCRIPTION
Hey there, 

Small cleanup:
- Currently AGENTS.md says to run individual tests with vitest, but the TUI uses `node --test` which creates friction (fails with "no tests found" in the TUI). 
- Additionally `packages/tui/vitest.config.ts` is redundant (leftover from a TUI test switched to vitest in December 2025 then switched back next day).

So this PR adds a line to call out the TUI explicitly and delete that file.