### PR TITLE
fix(tui): correct multi-click text selection

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added double-click word selection, word-aware drag selection, and triple-click line selection in the fullscreen TUI ([#7725](https://github.com/earendil-works/pi/issues/7725)).
+- Added double-click word selection, word-aware drag selection, and triple-click paragraph selection in the fullscreen TUI ([#7725](https://github.com/earendil-works/pi/issues/7725)).
 
 ### Fixed
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added double-click word selection, word-aware drag selection, and triple-click paragraph selection in the fullscreen TUI ([#7725](https://github.com/earendil-works/pi/issues/7725)).
+- Added double-click word selection, word-aware drag selection, and triple-click line selection in the fullscreen TUI ([#7725](https://github.com/earendil-works/pi/issues/7725)).
 
 ### Fixed
 

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -80,7 +80,7 @@ interface SelectionRange {
 	end: SelectionPoint;
 }
 
-type SelectionGranularity = "character" | "word" | "paragraph";
+type SelectionGranularity = "character" | "word" | "line";
 
 interface ClickTarget {
 	timestamp: number;
@@ -608,16 +608,16 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		};
 	}
 
-	private getSelectionSourceLines(point: SelectionPoint): readonly string[] {
+	private getSelectionSourceLine(point: SelectionPoint): string {
 		if (point.scrollView && this.currentLayout) {
 			const lines = getScrollViewBox(this.currentLayout, point.scrollView)?.scrollContentLines;
-			if (lines) return lines;
+			if (lines) return lines[point.row] ?? "";
 		}
-		return this.previousScreen;
+		return this.previousScreen[point.row] ?? "";
 	}
 
 	private getWordSelection(point: SelectionPoint): SelectionRange | undefined {
-		const line = stripTerminalSequences(this.getSelectionSourceLines(point)[point.row] ?? "");
+		const line = stripTerminalSequences(this.getSelectionSourceLine(point));
 		let start = 0;
 		for (const segment of wordSegmenter.segment(line)) {
 			const end = start + visibleWidth(segment.segment);
@@ -632,23 +632,10 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		return undefined;
 	}
 
-	private getParagraphSelection(point: SelectionPoint): SelectionRange {
-		const lines = this.getSelectionSourceLines(point);
-		const isBlank = (row: number) => stripTerminalSequences(lines[row] ?? "").trim().length === 0;
-		let startRow = point.row;
-		let endRow = point.row;
-		if (!isBlank(point.row)) {
-			while (startRow > 0 && !isBlank(startRow - 1)) startRow--;
-			while (endRow + 1 < lines.length && !isBlank(endRow + 1)) endRow++;
-		}
+	private getLineSelection(point: SelectionPoint): SelectionRange {
 		return {
-			start: { ...point, row: startRow, col: 0 },
-			end: {
-				...point,
-				row: endRow,
-				col: visibleWidth(lines[endRow] ?? ""),
-				boundary: true,
-			},
+			start: { ...point, col: 0 },
+			end: { ...point, col: visibleWidth(this.getSelectionSourceLine(point)), boundary: true },
 		};
 	}
 
@@ -657,8 +644,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 			this.selectionFocus = point;
 			return;
 		}
-		const range =
-			this.selectionGranularity === "word" ? this.getWordSelection(point) : this.getParagraphSelection(point);
+		const range = this.selectionGranularity === "word" ? this.getWordSelection(point) : this.getLineSelection(point);
 		if (!range) return;
 		const initial = this.selectionInitialRange;
 		const targetBeforeInitial =
@@ -806,8 +792,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		const anchor = this.getSelectionPoint(event, scrollView);
 		const word = this.getWordSelection(anchor);
 		const clickCount = this.getClickCount(anchor, word);
-		const range = clickCount === 2 ? word : clickCount === 3 ? this.getParagraphSelection(anchor) : undefined;
-		this.selectionGranularity = range ? (clickCount === 2 ? "word" : "paragraph") : "character";
+		const range = clickCount === 2 ? word : clickCount === 3 ? this.getLineSelection(anchor) : undefined;
+		this.selectionGranularity = range ? (clickCount === 2 ? "word" : "line") : "character";
 		this.selectionInitialRange = range;
 		this.selectionAnchor = range?.start ?? anchor;
 		this.selectionFocus = range?.end ?? anchor;

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -80,7 +80,7 @@ interface SelectionRange {
 	end: SelectionPoint;
 }
 
-type SelectionGranularity = "character" | "word" | "line";
+type SelectionGranularity = "character" | "word" | "paragraph";
 
 interface ClickTarget {
 	timestamp: number;
@@ -608,16 +608,16 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		};
 	}
 
-	private getSelectionSourceLine(point: SelectionPoint): string {
+	private getSelectionSourceLines(point: SelectionPoint): readonly string[] {
 		if (point.scrollView && this.currentLayout) {
 			const lines = getScrollViewBox(this.currentLayout, point.scrollView)?.scrollContentLines;
-			if (lines) return lines[point.row] ?? "";
+			if (lines) return lines;
 		}
-		return this.previousScreen[point.row] ?? "";
+		return this.previousScreen;
 	}
 
 	private getWordSelection(point: SelectionPoint): SelectionRange | undefined {
-		const line = stripTerminalSequences(this.getSelectionSourceLine(point));
+		const line = stripTerminalSequences(this.getSelectionSourceLines(point)[point.row] ?? "");
 		let start = 0;
 		for (const segment of wordSegmenter.segment(line)) {
 			const end = start + visibleWidth(segment.segment);
@@ -632,10 +632,23 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		return undefined;
 	}
 
-	private getLineSelection(point: SelectionPoint): SelectionRange {
+	private getParagraphSelection(point: SelectionPoint): SelectionRange {
+		const lines = this.getSelectionSourceLines(point);
+		const isBlank = (row: number) => stripTerminalSequences(lines[row] ?? "").trim().length === 0;
+		let startRow = point.row;
+		let endRow = point.row;
+		if (!isBlank(point.row)) {
+			while (startRow > 0 && !isBlank(startRow - 1)) startRow--;
+			while (endRow + 1 < lines.length && !isBlank(endRow + 1)) endRow++;
+		}
 		return {
-			start: { ...point, col: 0 },
-			end: { ...point, col: visibleWidth(this.getSelectionSourceLine(point)), boundary: true },
+			start: { ...point, row: startRow, col: 0 },
+			end: {
+				...point,
+				row: endRow,
+				col: visibleWidth(lines[endRow] ?? ""),
+				boundary: true,
+			},
 		};
 	}
 
@@ -644,7 +657,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 			this.selectionFocus = point;
 			return;
 		}
-		const range = this.selectionGranularity === "word" ? this.getWordSelection(point) : this.getLineSelection(point);
+		const range =
+			this.selectionGranularity === "word" ? this.getWordSelection(point) : this.getParagraphSelection(point);
 		if (!range) return;
 		const initial = this.selectionInitialRange;
 		const targetBeforeInitial =
@@ -792,8 +806,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		const anchor = this.getSelectionPoint(event, scrollView);
 		const word = this.getWordSelection(anchor);
 		const clickCount = this.getClickCount(anchor, word);
-		const range = clickCount === 2 ? word : clickCount === 3 ? this.getLineSelection(anchor) : undefined;
-		this.selectionGranularity = range ? (clickCount === 2 ? "word" : "line") : "character";
+		const range = clickCount === 2 ? word : clickCount === 3 ? this.getParagraphSelection(anchor) : undefined;
+		this.selectionGranularity = range ? (clickCount === 2 ? "word" : "paragraph") : "character";
 		this.selectionInitialRange = range;
 		this.selectionAnchor = range?.start ?? anchor;
 		this.selectionFocus = range?.end ?? anchor;
@@ -906,14 +920,14 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 			maxColumn = Math.min(this.terminal.columns, box.rect.x + box.rect.width, box.clip.x + box.clip.width);
 			screenSelection = {
 				start: {
+					...selection.start,
 					row: box.rect.y + selection.start.row - selection.start.scrollView.scrollTop,
 					col: box.rect.x + selection.start.col,
-					scrollView: selection.start.scrollView,
 				},
 				end: {
+					...selection.end,
 					row: box.rect.y + selection.end.row - selection.start.scrollView.scrollTop,
 					col: box.rect.x + selection.end.col,
-					scrollView: selection.start.scrollView,
 				},
 			};
 		}

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -796,10 +796,10 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
-	it("selects whole words on double click, extends word drags, and selects paragraphs on triple click", async () => {
-		const terminal = new RecordingTerminal(20, 5);
+	it("selects whole words on double click, extends word drags, and selects lines on triple click", async () => {
+		const terminal = new RecordingTerminal(20, 2);
 		const tui = new TuiAltScreen(terminal);
-		tui.addChild(new Text("zero alpha beta\ngamma delta\ncontinued here\n\nfinal paragraph", 0, 0));
+		tui.addChild(new Text("zero alpha beta\ngamma delta", 0, 0));
 		tui.start();
 		await terminal.waitForRender();
 
@@ -829,8 +829,8 @@ describe("TuiAltScreen", () => {
 		terminal.sendInput("\x1b[<0;11;2M");
 		terminal.sendInput("\x1b[<0;11;2m");
 		await terminal.waitForRender();
-		const paragraph = `\x1b]52;c;${Buffer.from("zero alpha beta\ngamma delta\ncontinued here").toString("base64")}\x07`;
-		assert.ok(terminal.events.some((event) => event.type === "write" && event.data.includes(paragraph)));
+		const line = `\x1b]52;c;${Buffer.from("gamma delta").toString("base64")}\x07`;
+		assert.ok(terminal.events.some((event) => event.type === "write" && event.data.includes(line)));
 
 		tui.stop();
 	});

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -763,10 +763,43 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
-	it("selects whole words on double click, extends word drags, and selects lines on triple click", async () => {
-		const terminal = new RecordingTerminal(20, 2);
+	it("does not append whitespace to double-click word highlighting", async () => {
+		const terminal = new RecordingTerminal(20, 1);
 		const tui = new TuiAltScreen(terminal);
-		tui.addChild(new Text("zero alpha beta\ngamma delta", 0, 0));
+		tui.addChild(new Text("foo  bar", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<0;1;1m");
+		terminal.sendInput("\x1b[<0;3;1M");
+		await terminal.waitForRender();
+
+		assert.ok(terminal.events.some((event) => event.type === "write" && event.data.includes("foo\x1b[27m")));
+		tui.stop();
+	});
+
+	it("highlights a complete whitespace segment during a word drag", async () => {
+		const terminal = new RecordingTerminal(20, 1);
+		const tui = new TuiAltScreen(terminal);
+		tui.addChild(new Text("foo  bar", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<0;1;1m");
+		terminal.sendInput("\x1b[<0;2;1M");
+		terminal.sendInput("\x1b[<32;4;1M");
+		await terminal.waitForRender();
+
+		assert.ok(terminal.events.some((event) => event.type === "write" && event.data.includes("foo  \x1b[27m")));
+		tui.stop();
+	});
+
+	it("selects whole words on double click, extends word drags, and selects paragraphs on triple click", async () => {
+		const terminal = new RecordingTerminal(20, 5);
+		const tui = new TuiAltScreen(terminal);
+		tui.addChild(new Text("zero alpha beta\ngamma delta\ncontinued here\n\nfinal paragraph", 0, 0));
 		tui.start();
 		await terminal.waitForRender();
 
@@ -796,8 +829,8 @@ describe("TuiAltScreen", () => {
 		terminal.sendInput("\x1b[<0;11;2M");
 		terminal.sendInput("\x1b[<0;11;2m");
 		await terminal.waitForRender();
-		const line = `\x1b]52;c;${Buffer.from("gamma delta").toString("base64")}\x07`;
-		assert.ok(terminal.events.some((event) => event.type === "write" && event.data.includes(line)));
+		const paragraph = `\x1b]52;c;${Buffer.from("zero alpha beta\ngamma delta\ncontinued here").toString("base64")}\x07`;
+		assert.ok(terminal.events.some((event) => event.type === "write" && event.data.includes(paragraph)));
 
 		tui.stop();
 	});


### PR DESCRIPTION
Fixes some behavioral issues introduced with https://github.com/earendil-works/pi/commit/58fc0431a7e3bb573b5943aa8e3af7a4ce6109ad, specifically

 - Double clicking a word no longer includes the first whitespace character immediately following it
 - Double clicking a whitespace group no longer includes the first non whitespace character immediately following it
 - Triple clicking selects the complete paragraph (bounded by blank lines) rather than a single line

Before and after:

https://github.com/user-attachments/assets/35bc41af-89e6-476a-8049-162990f7a59b

