### PR TITLE
fix(ai): preserve Gemini thought signatures in OpenAI completions

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -179,6 +179,37 @@ type OpenAIEncryptedReasoningDetail = {
 	data: string;
 };
 
+type GeminiThoughtSignatureExtraContent = Partial<Record<"google" | "vertex", { thought_signature: string }>>;
+
+type ChatCompletionMessageToolCallWithExtraContent = ChatCompletionMessageToolCall & {
+	extra_content?: GeminiThoughtSignatureExtraContent;
+};
+
+function getGeminiThoughtSignatureExtraContent(value: unknown): GeminiThoughtSignatureExtraContent | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	const record = value as Record<string, unknown>;
+	for (const namespace of ["google", "vertex"] as const) {
+		const providerContent = record[namespace];
+		if (typeof providerContent !== "object" || providerContent === null) continue;
+		const thoughtSignature = (providerContent as Record<string, unknown>).thought_signature;
+		if (typeof thoughtSignature !== "string" || thoughtSignature.length === 0) continue;
+		return { [namespace]: { thought_signature: thoughtSignature } };
+	}
+	return undefined;
+}
+
+function parseGeminiThoughtSignatureExtraContent(
+	thoughtSignature: string | undefined,
+): GeminiThoughtSignatureExtraContent | undefined {
+	if (!thoughtSignature) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(thoughtSignature);
+		return getGeminiThoughtSignatureExtraContent(parsed);
+	} catch {
+		return undefined;
+	}
+}
+
 type ChatCompletionTextPartWithCacheControl = ChatCompletionContentPartText & {
 	cache_control?: OpenAICompatCacheControl;
 };
@@ -269,6 +300,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				type?: string;
 				function?: { name?: string; arguments?: string };
 				custom?: { name?: string; input?: string };
+				extra_content?: unknown;
 			};
 
 			let textBlock: TextContent | null = null;
@@ -521,6 +553,10 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					if (choice?.delta?.tool_calls) {
 						for (const toolCall of choice.delta.tool_calls as StreamingToolCallDelta[]) {
 							const block = ensureToolCallBlock(toolCall);
+							const extraContent = getGeminiThoughtSignatureExtraContent(toolCall.extra_content);
+							if (extraContent) {
+								block.thoughtSignature = JSON.stringify(extraContent);
+							}
 							if (!block.id && toolCall.id) {
 								block.id = toolCall.id;
 								toolCallBlocksById.set(toolCall.id, block);
@@ -1197,7 +1233,7 @@ export function convertMessages(
 							},
 						};
 					}
-					return {
+					const toolCall: ChatCompletionMessageToolCallWithExtraContent = {
 						id: tc.id,
 						type: "function",
 						function: {
@@ -1205,12 +1241,18 @@ export function convertMessages(
 							arguments: JSON.stringify(tc.arguments),
 						},
 					};
+					const extraContent = parseGeminiThoughtSignatureExtraContent(tc.thoughtSignature);
+					if (extraContent) {
+						toolCall.extra_content = extraContent;
+					}
+					return toolCall;
 				});
 				const reasoningDetails = toolCalls
 					.filter((tc) => tc.thoughtSignature)
 					.map((tc) => {
 						try {
-							return JSON.parse(tc.thoughtSignature!);
+							const detail: unknown = JSON.parse(tc.thoughtSignature!);
+							return getGeminiThoughtSignatureExtraContent(detail) ? null : detail;
 						} catch {
 							return null;
 						}

--- a/packages/ai/test/openai-completions-reasoning-details.test.ts
+++ b/packages/ai/test/openai-completions-reasoning-details.test.ts
@@ -1,7 +1,7 @@
 import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
-import type { AssistantMessage, Model, Tool } from "../src/types.ts";
+import type { AssistantMessage, Message, Model, Tool } from "../src/types.ts";
 
 const mockState = vi.hoisted(() => ({
 	chunkSets: [] as unknown[][],
@@ -67,7 +67,7 @@ function chunk(delta: Record<string, unknown>, finishReason: string | null = nul
 	};
 }
 
-function toolCallChunk(): unknown {
+function toolCallChunk(extraContent?: unknown): unknown {
 	return chunk({
 		tool_calls: [
 			{
@@ -75,21 +75,27 @@ function toolCallChunk(): unknown {
 				id: "call_1",
 				type: "function",
 				function: { name: "read", arguments: '{"path":"README.md"}' },
+				...(extraContent ? { extra_content: extraContent } : {}),
 			},
 		],
 	});
 }
 
-async function runOpenAICompletionsStream(messages: AssistantMessage[] = []): Promise<AssistantMessage> {
+async function runOpenAICompletionsStream(messages: Message[] = []): Promise<AssistantMessage> {
 	return await streamOpenAICompletions(model(), { messages, tools: [readTool] }, { apiKey: "test" }).result();
 }
 
-function getAssistantPayload(payload: unknown): { reasoning_details?: unknown } | undefined {
-	const messages = (payload as { messages?: Array<{ role?: string; reasoning_details?: unknown }> }).messages ?? [];
+type AssistantPayload = {
+	reasoning_details?: unknown;
+	tool_calls?: Array<{ extra_content?: unknown }>;
+};
+
+function getAssistantPayload(payload: unknown): AssistantPayload | undefined {
+	const messages = (payload as { messages?: Array<AssistantPayload & { role?: string }> }).messages ?? [];
 	return messages.find((message) => message.role === "assistant");
 }
 
-describe("openai-completions reasoning_details streaming", () => {
+describe("openai-completions tool call signature streaming", () => {
 	beforeEach(() => {
 		mockState.chunkSets = [];
 		mockState.payloads = [];
@@ -115,4 +121,42 @@ describe("openai-completions reasoning_details streaming", () => {
 
 		expect(getAssistantPayload(mockState.payloads[1])?.reasoning_details).toEqual([reasoningDetail]);
 	});
+
+	it.each(["google", "vertex"] as const)(
+		"round-trips %s thought signatures from tool call extra_content",
+		async (namespace) => {
+			const extraContent = { [namespace]: { thought_signature: "opaque-signature" } };
+			mockState.chunkSets = [
+				[toolCallChunk(extraContent), chunk({}, "tool_calls")],
+				[chunk({ content: "ok" }), chunk({}, "stop")],
+			];
+
+			const userMessage: Message = {
+				role: "user",
+				content: "Read README.md",
+				timestamp: 1,
+			};
+			const assistantMessage = await runOpenAICompletionsStream([userMessage]);
+			const toolCall = assistantMessage.content.find((block) => block.type === "toolCall");
+			expect(toolCall).toMatchObject({
+				type: "toolCall",
+				id: "call_1",
+				thoughtSignature: JSON.stringify(extraContent),
+			});
+
+			const toolResult: Message = {
+				role: "toolResult",
+				toolCallId: "call_1",
+				toolName: "read",
+				content: [{ type: "text", text: "README contents" }],
+				isError: false,
+				timestamp: 2,
+			};
+			await runOpenAICompletionsStream([userMessage, assistantMessage, toolResult]);
+
+			const replayedAssistant = getAssistantPayload(mockState.payloads[1]);
+			expect(replayedAssistant?.tool_calls?.[0]?.extra_content).toEqual(extraContent);
+			expect(replayedAssistant?.reasoning_details).toBeUndefined();
+		},
+	);
 });


### PR DESCRIPTION
## Summary

- capture Gemini `extra_content.google.thought_signature` and `extra_content.vertex.thought_signature` from streamed OpenAI-compatible tool calls
- preserve the provider namespace and replay the signature on the assistant tool call in follow-up requests
- keep existing OpenRouter `reasoning_details` behavior unchanged

## Why

Gemini's OpenAI-compatible API requires the thought signature to be returned during multi-turn tool use. Dropping it causes the continuation request to fail with `400 INVALID_ARGUMENT`. This path is also needed for gateways that expose only an OpenAI-compatible endpoint.

Refs #6733.

## Tests

- `npm run check`
- `node ../../node_modules/vitest/dist/cli.js --run test/openai-completions-reasoning-details.test.ts`

This contribution was created with AI assistance from Pi.
