### PR TITLE
fix(coding-agent): preserve custom tool renderers after reload (close…

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -149,6 +149,37 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	getToolName(): string {
+		return this.toolName;
+	}
+
+	updateToolDefinition(toolDefinition: ToolDefinition<any, any> | undefined): void {
+		this.toolDefinition = toolDefinition;
+		this.callRendererComponent = undefined;
+		this.resultRendererComponent = undefined;
+		this.rendererState = {};
+
+		for (const img of this.imageComponents) {
+			this.removeChild(img);
+		}
+		this.imageComponents = [];
+		for (const spacer of this.imageSpacers) {
+			this.removeChild(spacer);
+		}
+		this.imageSpacers = [];
+
+		this.removeChild(this.contentBox);
+		this.removeChild(this.contentText);
+		this.removeChild(this.selfRenderContainer);
+		if (this.hasRendererDefinition()) {
+			this.addChild(this.getRenderShell() === "self" ? this.selfRenderContainer : this.contentBox);
+		} else {
+			this.addChild(this.contentText);
+		}
+
+		this.updateDisplay();
+	}
+
 	markExecutionStarted(): void {
 		this.executionStarted = true;
 		this.updateDisplay();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1972,6 +1972,14 @@ export class InteractiveMode {
 		return this.session.getToolDefinition(toolName);
 	}
 
+	private refreshToolRenderers(): void {
+		for (const child of this.chatContainer.children) {
+			if (child instanceof ToolExecutionComponent) {
+				child.updateToolDefinition(this.getRegisteredToolDefinition(child.getToolName()));
+			}
+		}
+	}
+
 	private getMarkdownTransformers(): MarkdownTransformer[] {
 		return [this.mermaidMarkdownTransformer, ...this.session.extensionRunner.getMarkdownTransformers()];
 	}
@@ -5727,7 +5735,12 @@ export class InteractiveMode {
 
 		try {
 			await this.session.reload({ beforeSessionStart: restoreChatBeforeSessionStart });
-			restoreChatBeforeSessionStart();
+			if (chatRestoredBeforeSessionStart) {
+				// session_start handlers may register tool renderers after the initial rebuild.
+				this.refreshToolRenderers();
+			} else {
+				restoreChatBeforeSessionStart();
+			}
 			this.keybindings.reload();
 			const activeHeader = this.customHeader ?? this.builtInHeader;
 			if (isExpandable(activeHeader)) {

--- a/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
@@ -120,6 +120,7 @@ type ReloadCommandContext = {
 	themeController: { applyFromSettings: () => Promise<void> };
 	resetExtensionUI: () => void;
 	rebuildChatFromMessages: () => void;
+	refreshToolRenderers: () => void;
 	setupAutocompleteProvider: () => void;
 	setupExtensionShortcuts: (runner: unknown) => void;
 	showLoadedResources: (options: unknown) => void;
@@ -194,6 +195,7 @@ function createReloadCommandContext(overrides: ReloadCommandContextOverrides = {
 		builtInHeader: overrides.builtInHeader,
 		resetExtensionUI: overrides.resetExtensionUI ?? (() => {}),
 		rebuildChatFromMessages: overrides.rebuildChatFromMessages ?? (() => {}),
+		refreshToolRenderers: overrides.refreshToolRenderers ?? (() => {}),
 		setupAutocompleteProvider: overrides.setupAutocompleteProvider ?? (() => {}),
 		setupExtensionShortcuts: overrides.setupExtensionShortcuts ?? (() => {}),
 		showLoadedResources: overrides.showLoadedResources ?? (() => {}),

--- a/packages/coding-agent/test/suite/regressions/7740-reload-tool-renderers.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7740-reload-tool-renderers.test.ts
@@ -1,0 +1,123 @@
+import { type Component, Container, Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { ExtensionFactory, ResourceLoader } from "../../../src/index.ts";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+import { createTestExtensionsResult } from "../../utilities.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const TOOL_NAME = "session_start_tool";
+
+type ReloadContext = {
+	hideThinkingBlock: boolean;
+	outputPad: 0 | 1;
+	session: Harness["session"];
+	settingsManager: Harness["settingsManager"];
+	keybindings: { reload(): void };
+	editorContainer: Container;
+	ui: {
+		setFocus(component: Component): void;
+		requestRender(force?: boolean): void;
+	};
+	editor: Component;
+	themeController: { applyFromSettings(): Promise<void> };
+	resetExtensionUI(): void;
+	rebuildChatFromMessages(): void;
+	refreshToolRenderers(): void;
+	applyRuntimeSettings(): void;
+	setupAutocompleteProvider(): void;
+	setupExtensionShortcuts(): void;
+	showLoadedResources(): void;
+	maybeSaveImplicitProjectTrustAfterReload(): boolean;
+	showStatus(message: string): void;
+	showWarning(message: string): void;
+	showError(message: string): void;
+};
+
+type HandleReloadCommand = (this: ReloadContext) => Promise<void>;
+
+const handleReloadCommand = (InteractiveMode.prototype as unknown as { handleReloadCommand: HandleReloadCommand })
+	.handleReloadCommand;
+
+describe("issue #7740 reload tool renderers", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	it("refreshes historical tool calls after session_start registers custom renderers", async () => {
+		const factory: ExtensionFactory = (pi) => {
+			pi.on("session_start", () => {
+				pi.registerTool({
+					name: TOOL_NAME,
+					label: "Session Start Tool",
+					description: "Tool registered from session_start",
+					parameters: Type.Object({}),
+					execute: async () => ({ content: [{ type: "text", text: "done" }], details: {} }),
+					renderCall: () => new Text("custom call", 0, 0),
+					renderResult: () => new Text("custom result", 0, 0),
+				});
+			});
+		};
+		const loadExtensions = () => createTestExtensionsResult([{ factory, path: "<issue-7740>" }]);
+		let extensionsResult = await loadExtensions();
+		const resourceLoader: ResourceLoader = {
+			getExtensions: () => extensionsResult,
+			getSkills: () => ({ skills: [], diagnostics: [] }),
+			getPrompts: () => ({ prompts: [], diagnostics: [] }),
+			getThemes: () => ({ themes: [], diagnostics: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			getSystemPrompt: () => undefined,
+			getSystemPromptSource: () => undefined,
+			getAppendSystemPrompt: () => [],
+			getAppendSystemPromptSources: () => [],
+			extendResources: () => {},
+			reload: async () => {
+				extensionsResult = await loadExtensions();
+			},
+		};
+		const harness = await createHarness({ resourceLoader });
+
+		try {
+			await harness.session.bindExtensions({ shutdownHandler: () => {} });
+			expect(harness.session.getToolDefinition(TOOL_NAME)?.renderCall).toBeDefined();
+
+			const rendererAvailability: boolean[] = [];
+			const editor = new Text("", 0, 0);
+			const context: ReloadContext = {
+				hideThinkingBlock: false,
+				outputPad: 1,
+				session: harness.session,
+				settingsManager: harness.settingsManager,
+				keybindings: { reload: vi.fn() },
+				editorContainer: new Container(),
+				ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+				editor,
+				themeController: { applyFromSettings: async () => {} },
+				resetExtensionUI: vi.fn(),
+				rebuildChatFromMessages: () => {
+					const definition = harness.session.getToolDefinition(TOOL_NAME);
+					rendererAvailability.push(Boolean(definition?.renderCall && definition.renderResult));
+				},
+				refreshToolRenderers: () => {
+					const definition = harness.session.getToolDefinition(TOOL_NAME);
+					rendererAvailability.push(Boolean(definition?.renderCall && definition.renderResult));
+				},
+				applyRuntimeSettings: vi.fn(),
+				setupAutocompleteProvider: vi.fn(),
+				setupExtensionShortcuts: vi.fn(),
+				showLoadedResources: vi.fn(),
+				maybeSaveImplicitProjectTrustAfterReload: () => false,
+				showStatus: vi.fn(),
+				showWarning: vi.fn(),
+				showError: vi.fn(),
+			};
+
+			await handleReloadCommand.call(context);
+
+			expect(rendererAvailability).toEqual([false, true]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -67,6 +67,30 @@ describe("ToolExecutionComponent parity", () => {
 		expect(rendered).toContain("custom result");
 	});
 
+	test("updates custom renderers after the tool is registered", () => {
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-registered-late",
+			{},
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(stripAnsi(component.render(120).join("\n"))).toContain("custom_tool");
+
+		component.updateToolDefinition({
+			...createBaseToolDefinition(),
+			renderCall: () => new Text("late custom call", 0, 0),
+			renderResult: () => new Text("late custom result", 0, 0),
+		});
+		component.updateResult({ content: [{ type: "text", text: "done" }], details: {}, isError: false });
+
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("late custom call");
+		expect(rendered).toContain("late custom result");
+	});
+
 	test("self-rendered empty tool rows take no layout space", () => {
 		const toolDefinition: ToolDefinition = {
 			...createBaseToolDefinition(),


### PR DESCRIPTION
  ## Description

  Fix custom tool renderers being lost after `/reload` when the tool is registered from a `session_start` handler.

  Before this change, interactive mode rebuilt historical chat messages before emitting `session_start`. Tools registered during `session_start` were therefore unavailable when historical tool calls were rendered, causing `renderCall` and `renderResult` to fall back to the default renderer.

  This change refreshes existing `ToolExecutionComponent` instances after `session_start` completes, allowing newly registered tool definitions and custom renderers to be applied without rebuilding the entire chat. This also preserves transient `session_start` notifications and the existing reload ordering behavior.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## How Has This Been Tested?

  - Targeted coding-agent tests:
    - `test/suite/regressions/7740-reload-tool-renderers.test.ts`
    - `test/suite/regressions/5943-session-start-notify.test.ts`
    - `test/tool-execution-component.test.ts`
  - 3 test files passed, 34 tests passed.
  - `npm run check` passed.
  - `git diff --check` passed.

  The full `./test.sh` command still reports unrelated existing workspace test failures, including missing optional `fd` tooling and unbuilt workspace package entry points. The affected coding-agent tests pass.

  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have performed a self-review of my code
  - [x] I have added tests that prove this fix is effective
  - [x] Affected unit tests pass locally

  ## Related Issues

  Closes #7740