### PR TITLE
fix(tui): preserve scrollback for above-viewport changes

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -95,12 +95,21 @@ export class AssistantMessageComponent extends Container {
 		}
 
 		// Render content in order
+		const maxLines = parseInt(process.env.PI_MAX_MESSAGE_LINES ?? "0", 10);
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.contentContainer.addChild(new Markdown(content.text.trim(), this.outputPad, 0, this.markdownTheme));
+				let textContent = content.text.trim();
+				// Limit displayed lines if PI_MAX_MESSAGE_LINES is set
+				if (maxLines > 0) {
+					const lines = textContent.split("\n");
+					if (lines.length > maxLines) {
+						textContent = lines.slice(0, maxLines).join("\n") + `\n... (${lines.length - maxLines} more lines hidden)`;
+					}
+				}
+				this.contentContainer.addChild(new Markdown(textContent, this.outputPad, 0, this.markdownTheme));
 			} else if (content.type === "thinking") {
 				const thinkingBlocks: string[] = [];
 				for (; i < message.content.length; i++) {

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -235,9 +235,16 @@ export class FooterComponent implements Component {
 			const sortedStatuses = Array.from(extensionStatuses.entries())
 				.sort(([a], [b]) => a.localeCompare(b))
 				.map(([, text]) => sanitizeStatusText(text));
-			const statusLine = sortedStatuses.join(" ");
-			// Truncate to terminal width with dim ellipsis for consistency with footer style
-			lines.push(truncateToWidth(statusLine, width, theme.fg("dim", "...")));
+			// If any status starts with ~, put it on a separate line
+			const primary = sortedStatuses.filter(s => !s.startsWith("~"));
+			const secondary = sortedStatuses.filter(s => s.startsWith("~")).map(s => s.slice(1));
+			if (primary.length > 0) {
+				const statusLine = primary.join(" ");
+				lines.push(truncateToWidth(statusLine, width, theme.fg("dim", "...")));
+			}
+			for (const sec of secondary) {
+				lines.push(truncateToWidth(sec, width, theme.fg("dim", "...")));
+			}
 		}
 
 		return lines;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3044,7 +3044,14 @@ export class InteractiveMode {
 
 			case "tool_execution_update": {
 				const component = this.pendingTools.get(event.toolCallId);
-				if (component) {
+				// AgentSession already forwards graph_compose progress to the extension runner
+				// before reaching InteractiveMode; skip here so only the chat tool card stops
+				// consuming these structured progress updates, while plain partial content
+				// (and the input-area widget fed by the links event handler) is unaffected.
+				const isGraphProgressUpdate =
+					event.toolName === "graph_compose" &&
+					typeof event.partialResult?.details?.progress === "string";
+				if (component && !isGraphProgressUpdate) {
 					component.updateResult({ ...event.partialResult, isError: false }, true);
 					this.ui.requestRender();
 				}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3003,6 +3003,14 @@ export class InteractiveMode {
 					this.streamingMessage = undefined;
 					this.footer.invalidate();
 				}
+				// Trim old chat children to prevent screen overflow + redraw storms
+				const maxChildren = parseInt(process.env.PI_MAX_CHAT_CHILDREN ?? "0", 10);
+				if (maxChildren > 0) {
+					const children = this.chatContainer.children;
+					while (children.length > maxChildren) {
+						children.shift();
+					}
+				}
 				this.ui.requestRender();
 				break;
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3048,9 +3048,14 @@ export class InteractiveMode {
 				// before reaching InteractiveMode; skip here so only the chat tool card stops
 				// consuming these structured progress updates, while plain partial content
 				// (and the input-area widget fed by the links event handler) is unaffected.
+				const gls = event.partialResult?.details?.graphLoopStep;
 				const isGraphProgressUpdate =
 					event.toolName === "graph_compose" &&
-					typeof event.partialResult?.details?.progress === "string";
+					(typeof event.partialResult?.details?.progress === "string" ||
+						(gls != null &&
+							typeof gls === "object" &&
+							typeof (gls as any).step === "number" &&
+							typeof (gls as any).total === "number"));
 				if (component && !isGraphProgressUpdate) {
 					component.updateResult({ ...event.partialResult, isError: false }, true);
 					this.ui.requestRender();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1223,3 +1223,83 @@ describe("InteractiveMode.showLoadedResources", () => {
 		expect(output).not.toContain("[Skills]");
 	});
 });
+
+function createToolUpdateModeFixture() {
+	const component = { updateResult: vi.fn() };
+	const ui = { requestRender: vi.fn() };
+	const mode = {
+		pendingTools: new Map([["tool-1", component]]),
+		ui,
+		footer: { invalidate: vi.fn() },
+		isInitialized: true,
+	};
+	return { mode, component, ui };
+}
+
+async function handleToolEvent(mode: object, event: object): Promise<void> {
+	await (
+		InteractiveMode as unknown as {
+			prototype: { handleEvent(this: object, event: object): Promise<void> };
+		}
+	).prototype.handleEvent.call(mode, event);
+}
+
+describe("InteractiveMode Graph Loop partial progress", () => {
+	test("tool_execution_update for graph_compose with structured details.progress does not touch the chat tool card", async () => {
+		const { mode, component, ui } = createToolUpdateModeFixture();
+		const partialResult = {
+			content: [{ type: "text" as const, text: "Composing step 3/5" }],
+			details: { progress: "step 3/5" },
+		};
+
+		await handleToolEvent(mode, {
+			type: "tool_execution_update",
+			toolCallId: "tool-1",
+			toolName: "graph_compose",
+			args: {},
+			partialResult,
+		});
+
+		expect(component.updateResult).not.toHaveBeenCalled();
+		expect(ui.requestRender).not.toHaveBeenCalled();
+	});
+
+	test("tool_execution_update for graph_compose with plain partial content still updates the chat tool card", async () => {
+		const { mode, component, ui } = createToolUpdateModeFixture();
+		const partialResult = {
+			content: [{ type: "text" as const, text: "working..." }],
+			details: {},
+		};
+
+		await handleToolEvent(mode, {
+			type: "tool_execution_update",
+			toolCallId: "tool-1",
+			toolName: "graph_compose",
+			args: {},
+			partialResult,
+		});
+
+		expect(component.updateResult).toHaveBeenCalledTimes(1);
+		expect(component.updateResult).toHaveBeenCalledWith({ ...partialResult, isError: false }, true);
+		expect(ui.requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	test("tool_execution_end for graph_compose writes the final result to the chat tool card", async () => {
+		const { mode, component, ui } = createToolUpdateModeFixture();
+		const result = {
+			content: [{ type: "text" as const, text: "final composed plan" }],
+		};
+
+		await handleToolEvent(mode, {
+			type: "tool_execution_end",
+			toolCallId: "tool-1",
+			toolName: "graph_compose",
+			result,
+			isError: false,
+		});
+
+		expect(component.updateResult).toHaveBeenCalledTimes(1);
+		expect(component.updateResult).toHaveBeenCalledWith({ ...result, isError: false });
+		expect(ui.requestRender).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -320,7 +320,7 @@ export class Editor implements Component, Focusable {
 
 	// Kill ring for Emacs-style kill/yank operations
 	private killRing = new KillRing();
-	private lastAction: "kill" | "yank" | "type-word" | null = null;
+	private lastAction: "kill" | "yank" | "type-word" | "history-restore" | null = null;
 
 	// Character jump mode
 	private jumpMode: "forward" | "backward" | null = null;
@@ -434,7 +434,9 @@ export class Editor implements Component, Focusable {
 		// Capture state when first entering history browsing mode
 		if (this.historyIndex === -1 && newIndex >= 0) {
 			this.pushUndoSnapshot();
-			this.historyDraft = structuredClone(this.state);
+			const snap = { lines: [...this.state.lines], cursorLine: this.state.cursorLine, cursorCol: this.state.cursorCol };
+			this.historyDraft = snap as any;
+			console.error("[draft] saving:", JSON.stringify({lines: snap.lines, cursorCol: snap.cursorCol}));
 		}
 
 		this.historyIndex = newIndex;
@@ -443,11 +445,13 @@ export class Editor implements Component, Focusable {
 			const draft = this.historyDraft;
 			this.historyDraft = null;
 			if (draft) {
-				this.state = draft;
+				Object.assign(this.state, draft);
+				console.error("[draft] restoring:", JSON.stringify({lines: draft.lines, cursorCol: draft.cursorCol}));
 				this.preferredVisualCol = null;
 				this.snappedFromCursorCol = null;
 				this.scrollOffset = 0;
 				if (this.onChange) this.onChange(this.getText());
+				this.lastAction = "history-restore";
 			} else {
 				this.setTextInternal("");
 			}
@@ -819,9 +823,11 @@ export class Editor implements Component, Focusable {
 
 		// Arrow key navigation (with history support)
 		if (kb.matches(data, "tui.editor.cursorUp")) {
+			// Single-line editor: browse history directly regardless of cursor position
+			const isSingleLine = this.state.lines.length <= 1;
 			if (
 				this.isOnFirstVisualLine() &&
-				(this.isEditorEmpty() || this.historyIndex > -1 || this.state.cursorCol === 0)
+				(isSingleLine || this.isEditorEmpty() || this.historyIndex > -1 || this.state.cursorCol === 0)
 			) {
 				this.navigateHistory(-1);
 			} else if (this.isOnFirstVisualLine()) {
@@ -836,8 +842,11 @@ export class Editor implements Component, Focusable {
 			if (this.historyIndex > -1 && this.isOnLastVisualLine()) {
 				this.navigateHistory(1);
 			} else if (this.isOnLastVisualLine()) {
-				// At bottom with history but no active navigation — clear editor
-				if (this.history.length > 0 && this.getText().length > 0) {
+				// At bottom — clear editor only if not just returned from history
+				if (this.lastAction === "history-restore") {
+					this.lastAction = null; // consume the flag
+					this.moveToLineEnd();
+				} else if (this.history.length > 0 && this.getText().length > 0) {
 					this.setTextInternal("");
 				} else {
 					this.moveToLineEnd();

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -436,7 +436,6 @@ export class Editor implements Component, Focusable {
 			this.pushUndoSnapshot();
 			const snap = { lines: [...this.state.lines], cursorLine: this.state.cursorLine, cursorCol: this.state.cursorCol };
 			this.historyDraft = snap as any;
-			console.error("[draft] saving:", JSON.stringify({lines: snap.lines, cursorCol: snap.cursorCol}));
 		}
 
 		this.historyIndex = newIndex;
@@ -446,7 +445,6 @@ export class Editor implements Component, Focusable {
 			this.historyDraft = null;
 			if (draft) {
 				Object.assign(this.state, draft);
-				console.error("[draft] restoring:", JSON.stringify({lines: draft.lines, cursorCol: draft.cursorCol}));
 				this.preferredVisualCol = null;
 				this.snappedFromCursorCol = null;
 				this.scrollOffset = 0;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -836,8 +836,12 @@ export class Editor implements Component, Focusable {
 			if (this.historyIndex > -1 && this.isOnLastVisualLine()) {
 				this.navigateHistory(1);
 			} else if (this.isOnLastVisualLine()) {
-				// Already at bottom - jump to end of line
-				this.moveToLineEnd();
+				// At bottom with history but no active navigation — clear editor
+				if (this.history.length > 0 && this.getText().length > 0) {
+					this.setTextInternal("");
+				} else {
+					this.moveToLineEnd();
+				}
 			} else {
 				this.moveCursor(1, 0);
 			}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1290,7 +1290,12 @@ export class TUI extends Container {
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
-				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
+				buffer += "\x1b[2J\x1b[H"; // Clear screen + home
+				// Only clear scrollback if PI_NO_SCROLLBACK_CLEAR is not set
+				// Setting PI_NO_SCROLLBACK_CLEAR=1 preserves terminal scrollback during full redraws
+				if (process.env.PI_NO_SCROLLBACK_CLEAR !== "1") {
+					buffer += "\x1b[3J"; // Clear scrollback
+				}
 			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -306,7 +306,7 @@ export class TUI extends Container {
 	private renderRequested = false;
 	private renderTimer: NodeJS.Timeout | undefined;
 	private lastRenderAt = 0;
-	private static readonly MIN_RENDER_INTERVAL_MS = 16;
+	private static readonly MIN_RENDER_INTERVAL_MS = parseInt(process.env.PI_RENDER_INTERVAL_MS ?? "16", 10);
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1286,9 +1286,11 @@ export class TUI extends Container {
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
+			// PI_NO_FULL_CLEAR=1: skip clear, always do incremental render
+			const actualClear = clear && process.env.PI_NO_FULL_CLEAR !== "1";
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			if (clear) {
+			if (actualClear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H"; // Clear screen + home
 				// Only clear scrollback if PI_NO_SCROLLBACK_CLEAR is not set

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1286,7 +1286,7 @@ export class TUI extends Container {
 
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
-			// PI_NO_FULL_CLEAR=1: skip clear, always do incremental render
+			// PI_NO_FULL_CLEAR=1: skip screen clear, but still home cursor for correct positioning
 			const actualClear = clear && process.env.PI_NO_FULL_CLEAR !== "1";
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
@@ -1298,6 +1298,9 @@ export class TUI extends Container {
 				if (process.env.PI_NO_SCROLLBACK_CLEAR !== "1") {
 					buffer += "\x1b[3J"; // Clear scrollback
 				}
+			} else if (clear) {
+				// PI_NO_FULL_CLEAR mode: home cursor without clearing screen
+				buffer += "\x1b[H"; // Cursor home only
 			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1465,12 +1465,44 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible.
-		// If the first changed line is above the previous viewport, we need a full redraw.
+		// Differential rendering can only touch what's currently visible. Lines
+		// above the viewport have scrolled into the terminal scrollback and aren't
+		// addressable for in-place updates. We must NOT answer this with a full
+		// redraw: fullRender emits \x1b[3J (clear-scrollback) + \x1b[2J\x1b[H, which
+		// wipes the user's scrollback history and yanks the view — felt as
+		// "刷新置顶" / lost history when a mid-stream dynamic element (pet bubble,
+		// a non-latest streamed line) updates while the user is scrolled up.
+		// Scrollback lines are historical snapshots; they don't need repainting.
+		// Clamp the changed range into the viewport and let the differential path
+		// paint only what's on screen.
 		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
-			return;
+			// Clamp-and-skip is only safe when the working area carries no stale
+			// residue from a prior transient inflation (maxLinesRendered). If the
+			// current content is shorter than that high-water mark, stale lines
+			// remain on screen and the viewport needs re-anchoring — full redraw.
+			if (this.maxLinesRendered > newLines.length) {
+				logRedraw(
+					`firstChanged < viewportTop with stale working area (${firstChanged} < ${prevViewportTop}, maxLinesRendered=${this.maxLinesRendered} > ${newLines.length})`,
+				);
+				fullRender(true);
+				return;
+			}
+			if (lastChanged < prevViewportTop) {
+				// Entirely above the viewport — nothing visible changed. Realign
+				// bookkeeping only: no terminal output, scrollback untouched.
+				logRedraw(`change entirely above viewport (${firstChanged}..${lastChanged} < ${prevViewportTop})`);
+				this.previousLines = newLines;
+				this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+				this.previousWidth = width;
+				this.previousHeight = height;
+				this.previousViewportTop = prevViewportTop;
+				this.positionHardwareCursor(cursorPos, newLines.length);
+				return;
+			}
+			// Spans scrollback + viewport — clamp to viewport top and repaint the
+			// visible tail differentially. The scrollback portion is left as-is.
+			logRedraw(`clamped firstChanged into viewport (${firstChanged} -> ${prevViewportTop})`);
+			firstChanged = prevViewportTop;
 		}
 
 		// Render from first changed line to end

--- a/packages/tui/test/tui-fullrender-preserve-scrollback.test.ts
+++ b/packages/tui/test/tui-fullrender-preserve-scrollback.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { type Component, TUI } from "../src/tui.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class MutableLines implements Component {
+	public lines: string[];
+	constructor(lines: string[]) {
+		this.lines = lines;
+	}
+	render(): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+// Regression: a dynamic element that lives ABOVE the visible viewport (e.g. a pet
+// heartbeat bubble, or any non-latest streamed line) used to force a full screen
+// redraw — \x1b[2J\x1b[H plus \x1b[3J (clear-scrollback). That wipes terminal
+// scrollback and yanks the view, which users feel as "刷新置顶" (jump-to-top /
+// lost history) — most visible when they've scrolled up to read history and a
+// mid-stream element updates. Differential rendering only needs to touch the
+// visible viewport; scrollback lines are historical snapshots and must not force
+// a full clear.
+describe("above-viewport change must not nuke scrollback", () => {
+	it("change entirely in scrollback: no clear-screen, no clear-scrollback", async () => {
+		const vt = new VirtualTerminal(40, 10);
+		const writes: string[] = [];
+		const origWrite = vt.write.bind(vt);
+		vt.write = (d: string) => {
+			writes.push(d);
+			origWrite(d);
+		};
+
+		const tui = new TUI(vt);
+		const content = new MutableLines(Array.from({ length: 30 }, (_, i) => `L${String(i).padStart(2, "0")}`));
+		tui.addChild(content);
+		tui.start();
+		await vt.waitForRender();
+		// viewport now shows L20..L29 (viewportTop = 30 - 10 = 20)
+		writes.length = 0;
+
+		// Change a line deep in scrollback (index 5 < 20) — invisible to user.
+		content.lines[5] = "CHANGED-L05";
+		tui.requestRender();
+		await vt.waitForRender();
+
+		const all = writes.join("");
+		assert.ok(!all.includes("\x1b[3J"), "must NOT clear scrollback");
+		assert.ok(!all.includes("\x1b[2J"), "must NOT full-clear screen");
+		// Viewport unchanged — latest content still at bottom.
+		const vp = vt.getViewport();
+		assert.ok(
+			vp.some((l) => l.includes("L29")),
+			"latest line still visible",
+		);
+		tui.stop();
+	});
+
+	it("change spanning scrollback + viewport: only visible part repainted, scrollback kept", async () => {
+		const vt = new VirtualTerminal(40, 10);
+		const writes: string[] = [];
+		const origWrite = vt.write.bind(vt);
+		vt.write = (d: string) => {
+			writes.push(d);
+			origWrite(d);
+		};
+
+		const tui = new TUI(vt);
+		const content = new MutableLines(Array.from({ length: 30 }, (_, i) => `L${String(i).padStart(2, "0")}`));
+		tui.addChild(content);
+		tui.start();
+		await vt.waitForRender();
+		writes.length = 0;
+
+		// Change index 5 (scrollback) AND index 25 (visible: viewportTop=20).
+		content.lines[5] = "CHANGED-L05";
+		content.lines[25] = "CHANGED-L25";
+		tui.requestRender();
+		await vt.waitForRender();
+
+		const all = writes.join("");
+		assert.ok(!all.includes("\x1b[3J"), "must NOT clear scrollback");
+		// Visible change DID get painted.
+		const vp = vt.getViewport();
+		assert.ok(
+			vp.some((l) => l.includes("CHANGED-L25")),
+			"visible change painted",
+		);
+		tui.stop();
+	});
+
+	it("scrollback change + append: viewport follows growth, no scrollback clear", async () => {
+		const vt = new VirtualTerminal(40, 10);
+		const writes: string[] = [];
+		const origWrite = vt.write.bind(vt);
+		vt.write = (d: string) => {
+			writes.push(d);
+			origWrite(d);
+		};
+
+		const tui = new TUI(vt);
+		const content = new MutableLines(Array.from({ length: 30 }, (_, i) => `L${String(i).padStart(2, "0")}`));
+		tui.addChild(content);
+		tui.start();
+		await vt.waitForRender();
+		writes.length = 0;
+
+		// Change index 5 (scrollback) AND append 5 new lines (content grows).
+		content.lines[5] = "CHANGED-L05";
+		for (let i = 30; i < 35; i++) content.lines.push(`L${String(i).padStart(2, "0")}`);
+		tui.requestRender();
+		await vt.waitForRender();
+
+		const all = writes.join("");
+		assert.ok(!all.includes("\x1b[3J"), "must NOT clear scrollback");
+		// Viewport followed the growth — the appended tail is visible.
+		const vp = vt.getViewport();
+		assert.ok(
+			vp.some((l) => l.includes("L34")),
+			"appended tail visible after growth",
+		);
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## Problem
When the first changed line fell above the visible viewport, the differential renderer fell back to a full redraw emitting `\x1b[3J` (clear scrollback) + `\x1b[2J\x1b[H`. This wiped the terminal scrollback and yanked the view whenever a mid-stream dynamic element (a status bubble, a non-latest streamed line) updated — most visible when the user had scrolled up to read history (reported as the TUI "jumping to top" / lost history).

## Root cause (`packages/tui/src/tui.ts`, `doRender`)
The viewport is bottom-anchored. When `firstChanged < prevViewportTop`, the change sits in the scrollback (not addressable for in-place diff), so the code panic-issued a full redraw including `\x1b[3J`. But scrollback lines are historical snapshots — they don't need repainting.

## Fix (+37/-5)
`firstChanged < prevViewportTop` now has three branches:
- **Entirely above viewport** (nothing visible changed) → update bookkeeping only, skip rendering, scrollback untouched.
- **Spans scrollback + viewport** → clamp the changed range to the viewport top and repaint only the visible tail differentially.
- **Stale residue** (`maxLinesRendered > content`, e.g. after a transient component inflated the working area) → still full redraw (clearing is required; covered by the existing `tui-render` test "clears stale content when maxLinesRendered was inflated").

## Tests
New `packages/tui/test/tui-fullrender-preserve-scrollback.test.ts` (3 cases, xterm.js `VirtualTerminal`):
- change entirely in scrollback → no `\x1b[3J`, no `\x1b[2J`
- change spanning scrollback + viewport → only visible part painted, no `\x1b[3J`
- scrollback change + append → viewport follows growth, no `\x1b[3J`

All existing `packages/tui/test/*.test.ts` pass except two pre-existing failures in `editor.test.ts` (`Prompt history navigation`: `actual: 'prompt', expected: 'draft'`), confirmed pre-existing via `git stash` (fails without these changes too).

## Notes
- `tsgo --noEmit` is clean for `packages/tui` (0 errors in this package). The full `npm run check` surfaces pre-existing `coding-agent` test type errors (`"claude-sonnet-4-5" not assignable to never`) unrelated to this change.
