### PR TITLE
fix(coding-agent): prevent concurrent session rewrites

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -942,7 +942,7 @@ export class AgentSession {
 		this.agent.state.systemPrompt = this._systemPromptOverride ?? this._baseSystemPrompt;
 	}
 
-	/** Whether compaction or branch summarization is currently running */
+	/** Whether a compaction or tree navigation is currently running */
 	get isCompacting(): boolean {
 		return (
 			this._autoCompactionAbortController !== undefined ||
@@ -1130,7 +1130,12 @@ export class AgentSession {
 				}
 			}
 
-			if (this._compactionAbortController !== undefined) {
+			if (this.isCompacting) {
+				if (this._branchSummaryAbortController) {
+					throw new Error(
+						"Cannot submit a prompt while tree navigation is in progress. Wait for it to finish and retry.",
+					);
+				}
 				throw new Error(
 					"Cannot submit a prompt while compaction is in progress. Wait for compaction to finish and retry.",
 				);
@@ -1788,11 +1793,23 @@ export class AgentSession {
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
-		await this.abort();
-		this._compactionAbortController = new AbortController();
-		this._emit({ type: "compaction_start", reason: "manual" });
+		if (this.isCompacting) {
+			const operation = this._branchSummaryAbortController ? "Tree navigation" : "Compaction";
+			throw new Error(`${operation} already in progress`);
+		}
+
+		const abortController = new AbortController();
+		this._compactionAbortController = abortController;
+		const clearCompactionState = () => {
+			if (this._compactionAbortController === abortController) {
+				this._compactionAbortController = undefined;
+			}
+		};
 
 		try {
+			await this.abort();
+			this._emit({ type: "compaction_start", reason: "manual" });
+
 			if (!this.model) {
 				throw new Error(formatNoModelSelectedMessage());
 			}
@@ -1823,7 +1840,7 @@ export class AgentSession {
 					customInstructions,
 					reason: "manual",
 					willRetry: false,
-					signal: this._compactionAbortController.signal,
+					signal: abortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (result?.cancel) {
@@ -1857,7 +1874,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					customInstructions,
-					this._compactionAbortController.signal,
+					abortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFunction,
 					env,
@@ -1871,7 +1888,7 @@ export class AgentSession {
 				details = result.details;
 			}
 
-			if (this._compactionAbortController.signal.aborted) {
+			if (abortController.signal.aborted) {
 				throw new Error("Compaction cancelled");
 			}
 
@@ -1905,7 +1922,7 @@ export class AgentSession {
 				details,
 			};
 			// compaction_end listeners may submit queued prompts, so expose idle state before notifying them.
-			this._compactionAbortController = undefined;
+			clearCompactionState();
 			this._emit({
 				type: "compaction_end",
 				reason: "manual",
@@ -1917,7 +1934,7 @@ export class AgentSession {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			const aborted = message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
-			this._compactionAbortController = undefined;
+			clearCompactionState();
 			this._emit({
 				type: "compaction_end",
 				reason: "manual",
@@ -1928,7 +1945,7 @@ export class AgentSession {
 			});
 			throw error;
 		} finally {
-			this._compactionAbortController = undefined;
+			clearCompactionState();
 		}
 	}
 
@@ -2056,7 +2073,18 @@ export class AgentSession {
 	 * Internal: Run auto-compaction with events.
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
+		if (this.isCompacting) {
+			return false;
+		}
+
 		const settings = this.settingsManager.getCompactionSettings();
+		const abortController = new AbortController();
+		this._autoCompactionAbortController = abortController;
+		const clearCompactionState = () => {
+			if (this._autoCompactionAbortController === abortController) {
+				this._autoCompactionAbortController = undefined;
+			}
+		};
 		let started = false;
 
 		try {
@@ -2074,7 +2102,6 @@ export class AgentSession {
 			}
 
 			this._emit({ type: "compaction_start", reason });
-			this._autoCompactionAbortController = new AbortController();
 			started = true;
 
 			let extensionCompaction: CompactionResult | undefined;
@@ -2088,10 +2115,11 @@ export class AgentSession {
 					customInstructions: undefined,
 					reason,
 					willRetry,
-					signal: this._autoCompactionAbortController.signal,
+					signal: abortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (extensionResult?.cancel) {
+					clearCompactionState();
 					this._emit({
 						type: "compaction_end",
 						reason,
@@ -2129,7 +2157,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					undefined,
-					this._autoCompactionAbortController.signal,
+					abortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFunction,
 					env,
@@ -2143,7 +2171,8 @@ export class AgentSession {
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (abortController.signal.aborted) {
+				clearCompactionState();
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -2183,6 +2212,7 @@ export class AgentSession {
 				usage,
 				details,
 			};
+			clearCompactionState();
 			this._emit({ type: "compaction_end", reason, result, aborted: false, willRetry });
 
 			if (willRetry) {
@@ -2204,6 +2234,7 @@ export class AgentSession {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
 			if (started) {
+				clearCompactionState();
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -2218,7 +2249,7 @@ export class AgentSession {
 			}
 			return false;
 		} finally {
-			this._autoCompactionAbortController = undefined;
+			clearCompactionState();
 		}
 	}
 
@@ -2906,6 +2937,10 @@ export class AgentSession {
 		targetId: string,
 		options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string } = {},
 	): Promise<{ editorText?: string; cancelled: boolean; aborted?: boolean; summaryEntry?: BranchSummaryEntry }> {
+		if (this.isCompacting) {
+			const operation = this._branchSummaryAbortController ? "Tree navigation" : "Compaction";
+			throw new Error(`${operation} already in progress`);
+		}
 		if (this.isStreaming) {
 			throw new Error("Wait for the current response to finish before navigating the session tree.");
 		}
@@ -2950,8 +2985,13 @@ export class AgentSession {
 			label,
 		};
 
-		// Set up abort controller for summarization
-		this._branchSummaryAbortController = new AbortController();
+		const abortController = new AbortController();
+		this._branchSummaryAbortController = abortController;
+		const clearNavigationState = () => {
+			if (this._branchSummaryAbortController === abortController) {
+				this._branchSummaryAbortController = undefined;
+			}
+		};
 
 		try {
 			let extensionSummary: { summary: string; details?: unknown; usage?: Usage } | undefined;
@@ -2962,7 +3002,7 @@ export class AgentSession {
 				const result = (await this._extensionRunner.emit({
 					type: "session_before_tree",
 					preparation,
-					signal: this._branchSummaryAbortController.signal,
+					signal: abortController.signal,
 				})) as SessionBeforeTreeResult | undefined;
 
 				if (result?.cancel) {
@@ -2999,7 +3039,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					env,
-					signal: this._branchSummaryAbortController.signal,
+					signal: abortController.signal,
 					customInstructions,
 					replaceInstructions,
 					reserveTokens: branchSummarySettings.reserveTokens,
@@ -3078,6 +3118,7 @@ export class AgentSession {
 			this.agent.state.messages = sessionContext.messages;
 
 			// Emit session_tree event
+			clearNavigationState();
 			await this._extensionRunner.emit({
 				type: "session_tree",
 				newLeafId: this.sessionManager.getLeafId(),
@@ -3090,7 +3131,7 @@ export class AgentSession {
 
 			return { editorText, cancelled: false, summaryEntry };
 		} finally {
-			this._branchSummaryAbortController = undefined;
+			clearNavigationState();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6364,6 +6364,11 @@ export class InteractiveMode {
 	}
 
 	private async handleCompactCommand(customInstructions?: string): Promise<void> {
+		if (this.session.isCompacting) {
+			this.showStatus("Compaction already in progress");
+			return;
+		}
+
 		this.clearStatusIndicator();
 
 		try {

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -2,6 +2,27 @@ import { describe, expect, test, vi } from "vitest";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 
 describe("InteractiveMode compaction events", () => {
+	test("does not start another manual compaction while one is active", async () => {
+		const fakeThis = {
+			session: {
+				isCompacting: true,
+				compact: vi.fn(),
+			},
+			clearStatusIndicator: vi.fn(),
+			showStatus: vi.fn(),
+		};
+		const handleCompactCommand = Reflect.get(InteractiveMode.prototype, "handleCompactCommand") as (
+			this: typeof fakeThis,
+			customInstructions?: string,
+		) => Promise<void>;
+
+		await handleCompactCommand.call(fakeThis, "keep details");
+
+		expect(fakeThis.session.compact).not.toHaveBeenCalled();
+		expect(fakeThis.clearStatusIndicator).not.toHaveBeenCalled();
+		expect(fakeThis.showStatus).toHaveBeenCalledWith("Compaction already in progress");
+	});
+
 	test("rebuilds chat and appends a synthetic compaction summary at the bottom", async () => {
 		const fakeThis = {
 			isInitialized: true,

--- a/packages/coding-agent/test/suite/regressions/7738-concurrent-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7738-concurrent-compaction.test.ts
@@ -1,0 +1,357 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getUserTexts, type Harness } from "../harness.ts";
+
+type SessionWithCompactionInternals = {
+	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+};
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = () => {};
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function seedCompactableSession(harness: Harness): void {
+	const now = Date.now();
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "message to compact" }],
+		timestamp: now - 1000,
+	});
+	const assistant = fauxAssistantMessage("assistant response to compact", { timestamp: now - 500 });
+	assistant.usage = {
+		input: 100,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 100,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	harness.sessionManager.appendMessage(assistant);
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+}
+
+function seedNavigableSession(harness: Harness): string {
+	const targetId = harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "first branch" }],
+		timestamp: Date.now() - 3000,
+	});
+	harness.sessionManager.appendMessage(fauxAssistantMessage("first reply", { timestamp: Date.now() - 2000 }));
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "second branch" }],
+		timestamp: Date.now() - 1000,
+	});
+	harness.sessionManager.appendMessage(fauxAssistantMessage("second reply"));
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+	return targetId;
+}
+
+async function settle<T>(promise: Promise<T>) {
+	try {
+		return { status: "fulfilled" as const, value: await promise };
+	} catch (error) {
+		return {
+			status: "rejected" as const,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+async function createGatedHarness(): Promise<{
+	harness: Harness;
+	firstCompactionStarted: Promise<void>;
+	releaseFirstCompaction: () => void;
+}> {
+	const firstStarted = deferred();
+	const firstRelease = deferred();
+	let invocationCount = 0;
+	const harness = await createHarness({
+		settings: { compaction: { keepRecentTokens: 1 } },
+		extensionFactories: [
+			(pi) => {
+				pi.on("session_before_compact", async (event) => {
+					const invocation = ++invocationCount;
+					if (invocation === 1) {
+						firstStarted.resolve();
+						await firstRelease.promise;
+					}
+					return {
+						compaction: {
+							summary: `summary ${invocation}`,
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					};
+				});
+			},
+		],
+	});
+	seedCompactableSession(harness);
+	return {
+		harness,
+		firstCompactionStarted: firstStarted.promise,
+		releaseFirstCompaction: firstRelease.resolve,
+	};
+}
+
+async function createGatedTreeHarness(): Promise<{
+	harness: Harness;
+	targetId: string;
+	firstNavigationStarted: Promise<void>;
+	releaseFirstNavigation: () => void;
+}> {
+	const firstStarted = deferred();
+	const firstRelease = deferred();
+	let invocationCount = 0;
+	const harness = await createHarness({
+		extensionFactories: [
+			(pi) => {
+				pi.on("session_before_tree", async () => {
+					const invocation = ++invocationCount;
+					if (invocation === 1) {
+						firstStarted.resolve();
+						await firstRelease.promise;
+					}
+				});
+			},
+		],
+	});
+	return {
+		harness,
+		targetId: seedNavigableSession(harness),
+		firstNavigationStarted: firstStarted.promise,
+		releaseFirstNavigation: firstRelease.resolve,
+	};
+}
+
+describe("issue #7738: concurrent compaction", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("rejects a concurrent manual compaction without corrupting the active invocation", async () => {
+		const { harness, firstCompactionStarted, releaseFirstCompaction } = await createGatedHarness();
+		harnesses.push(harness);
+
+		const firstCompaction = harness.session.compact();
+		await firstCompactionStarted;
+		const secondResult = await settle(harness.session.compact());
+		releaseFirstCompaction();
+		const firstResult = await settle(firstCompaction);
+
+		expect(firstResult).toEqual({
+			status: "fulfilled",
+			value: expect.objectContaining({ summary: "summary 1" }),
+		});
+		expect(secondResult).toEqual({
+			status: "rejected",
+			message: "Compaction already in progress",
+		});
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(1);
+		expect(harness.session.isCompacting).toBe(false);
+	});
+
+	it("rejects manual compaction while auto-compaction is active", async () => {
+		const { harness, firstCompactionStarted, releaseFirstCompaction } = await createGatedHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		const autoCompaction = sessionInternals._runAutoCompaction("threshold", false);
+		await firstCompactionStarted;
+		const manualResult = await settle(harness.session.compact());
+		releaseFirstCompaction();
+		const autoResult = await settle(autoCompaction);
+
+		expect(autoResult).toEqual({ status: "fulfilled", value: false });
+		expect(manualResult).toEqual({
+			status: "rejected",
+			message: "Compaction already in progress",
+		});
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+	});
+
+	it("rejects a prompt while auto-compaction is active", async () => {
+		const { harness, firstCompactionStarted, releaseFirstCompaction } = await createGatedHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		harness.setResponses([fauxAssistantMessage("unexpected response")]);
+
+		const autoCompaction = sessionInternals._runAutoCompaction("threshold", false);
+		await firstCompactionStarted;
+		const promptResult = await settle(harness.session.prompt("must not run"));
+		releaseFirstCompaction();
+		await autoCompaction;
+
+		expect(promptResult).toEqual({
+			status: "rejected",
+			message: "Cannot submit a prompt while compaction is in progress. Wait for compaction to finish and retry.",
+		});
+		expect(harness.faux.state.callCount).toBe(0);
+	});
+
+	it("allows a prompt to start from an auto-compaction end listener", async () => {
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "auto compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedCompactableSession(harness);
+		harness.setResponses([fauxAssistantMessage("continued after compaction")]);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		let queuedPrompt: Promise<void> | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.reason === "threshold" && event.result) {
+				expect(harness.session.isCompacting).toBe(false);
+				queuedPrompt = harness.session.prompt("queued after auto-compaction");
+			}
+		});
+
+		await sessionInternals._runAutoCompaction("threshold", false);
+		if (!queuedPrompt) throw new Error("compaction_end did not start the queued prompt");
+		await queuedPrompt;
+
+		expect(getUserTexts(harness)).toContain("queued after auto-compaction");
+		expect(harness.session.getLastAssistantText()).toBe("continued after compaction");
+	});
+
+	it("rejects tree navigation while manual compaction is active", async () => {
+		const { harness, firstCompactionStarted, releaseFirstCompaction } = await createGatedHarness();
+		harnesses.push(harness);
+		const targetId = harness.sessionManager.getEntries()[0]?.id;
+		if (!targetId) throw new Error("missing navigation target");
+
+		const compaction = harness.session.compact();
+		await firstCompactionStarted;
+		const navigationResult = await settle(harness.session.navigateTree(targetId));
+		releaseFirstCompaction();
+		await compaction;
+
+		expect(navigationResult).toEqual({
+			status: "rejected",
+			message: "Compaction already in progress",
+		});
+	});
+
+	it("rejects manual compaction while tree navigation is active", async () => {
+		const { harness, targetId, firstNavigationStarted, releaseFirstNavigation } = await createGatedTreeHarness();
+		harnesses.push(harness);
+
+		const navigation = harness.session.navigateTree(targetId);
+		await firstNavigationStarted;
+		const compactionResult = await settle(harness.session.compact());
+		releaseFirstNavigation();
+		await navigation;
+
+		expect(compactionResult).toEqual({
+			status: "rejected",
+			message: "Tree navigation already in progress",
+		});
+	});
+
+	it("skips auto-compaction while tree navigation is active", async () => {
+		const { harness, targetId, firstNavigationStarted, releaseFirstNavigation } = await createGatedTreeHarness();
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+
+		const navigation = harness.session.navigateTree(targetId);
+		await firstNavigationStarted;
+		const autoCompactionResult = await sessionInternals._runAutoCompaction("threshold", false);
+		releaseFirstNavigation();
+		await navigation;
+
+		expect(autoCompactionResult).toBe(false);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end")).toHaveLength(0);
+	});
+
+	it("rejects a prompt while tree navigation is active", async () => {
+		const { harness, targetId, firstNavigationStarted, releaseFirstNavigation } = await createGatedTreeHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("unexpected response")]);
+
+		const navigation = harness.session.navigateTree(targetId);
+		await firstNavigationStarted;
+		const promptResult = await settle(harness.session.prompt("must not run"));
+		releaseFirstNavigation();
+		await navigation;
+
+		expect(promptResult).toEqual({
+			status: "rejected",
+			message: "Cannot submit a prompt while tree navigation is in progress. Wait for it to finish and retry.",
+		});
+		expect(harness.faux.state.callCount).toBe(0);
+	});
+
+	it("rejects concurrent tree navigation without corrupting the active invocation", async () => {
+		const { harness, targetId, firstNavigationStarted, releaseFirstNavigation } = await createGatedTreeHarness();
+		harnesses.push(harness);
+
+		const firstNavigation = harness.session.navigateTree(targetId);
+		await firstNavigationStarted;
+		const secondResult = await settle(harness.session.navigateTree(targetId));
+		releaseFirstNavigation();
+		const firstResult = await settle(firstNavigation);
+
+		expect(firstResult).toEqual({
+			status: "fulfilled",
+			value: expect.objectContaining({ cancelled: false, editorText: "first branch" }),
+		});
+		expect(secondResult).toEqual({
+			status: "rejected",
+			message: "Tree navigation already in progress",
+		});
+		expect(harness.session.isCompacting).toBe(false);
+	});
+
+	it("allows a prompt to start from a session_tree listener", async () => {
+		let activeHarness: Harness | undefined;
+		let wasCompacting: boolean | undefined;
+		let queuedPrompt: Promise<void> | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_tree", () => {
+						if (!activeHarness) throw new Error("missing active harness");
+						wasCompacting = activeHarness.session.isCompacting;
+						queuedPrompt = activeHarness.session.prompt("continued on selected branch");
+					});
+				},
+			],
+		});
+		activeHarness = harness;
+		harnesses.push(harness);
+		const targetId = seedNavigableSession(harness);
+		harness.setResponses([fauxAssistantMessage("continued after navigation")]);
+
+		await harness.session.navigateTree(targetId);
+		expect(wasCompacting).toBe(false);
+		if (!queuedPrompt) throw new Error("session_tree did not start the queued prompt");
+		await queuedPrompt;
+
+		expect(getUserTexts(harness)).toContain("continued on selected branch");
+		expect(harness.session.getLastAssistantText()).toBe("continued after navigation");
+	});
+});


### PR DESCRIPTION
## Summary

- reject overlapping manual compaction, automatic compaction, and tree navigation before shared session state can be overwritten
- keep abort controllers invocation-local and clear active state safely before completion notifications
- prevent duplicate `/compact` dispatches and reject prompts during automatic compaction or tree navigation
- add deterministic regression coverage for manual, automatic, TUI, prompt, event, and tree-navigation races

Fixes #7738

## Testing

- `44` related coding-agent tests passed
- targeted TypeScript check passed
- `npm run check:browser-smoke` passed
- Biome, dependency pinning, import, shrinkwrap, install-lock, and diff checks passed

Full `npm run check` and `./test.sh` are currently blocked by unrelated workspace state:

- `models.dev` times out, leaving ignored model JSON stale against current AI tests
- fresh worktree CLI/server tests cannot resolve unbuilt workspace `dist` entries
