### PR TITLE
feat(coding-agent): allow opting out of fullscreen copy-on-select

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -68,6 +68,7 @@ Use `/trust` in interactive mode to save a project trust decision for future ses
 | `tuiMode` | string | `"regular"` | Interactive TUI mode: `"regular"` or experimental `"fullscreen"`. Changes from `/settings` apply immediately; `--tui-mode` overrides this setting at startup |
 | `fullscreenExitOutput` | string | `"transcript"` | Fullscreen exit output: `"transcript"` prints the final transcript and resume hint, while `"resume-hint"` restores the previous screen and prints only the resume hint. Has no effect in regular TUI mode |
 | `fullscreenScrollbar` | string | `"auto"` | Fullscreen transcript scrollbar: `"auto"` shows it temporarily while scrolling, `"always"` reserves the rightmost column and keeps it visible, and `"hidden"` hides it. Has no effect in regular TUI mode |
+| `fullscreenCopyOnSelect` | boolean | `true` | Copy selected text on mouse release in fullscreen mode. When disabled, fullscreen keeps the selection highlighted so the copy shortcut can copy it explicitly. Has no effect in regular TUI mode |
 
 For VS Code, include `--wait` so pi resumes after the editor exits:
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -136,6 +136,7 @@ export interface Settings {
 	tuiMode?: TuiMode; // default: "regular"
 	fullscreenExitOutput?: FullscreenExitOutput; // default: "transcript"; no effect in regular TUI mode
 	fullscreenScrollbar?: ScrollViewScrollbar; // default: "auto"; no effect in regular TUI mode
+	fullscreenCopyOnSelect?: boolean; // default: true; no effect in regular TUI mode
 }
 
 function isMergeableObject(value: unknown): value is Record<string, unknown> {
@@ -1155,6 +1156,16 @@ export class SettingsManager {
 	setFullscreenScrollbar(mode: ScrollViewScrollbar): void {
 		this.globalSettings.fullscreenScrollbar = mode;
 		this.markModified("fullscreenScrollbar");
+		this.save();
+	}
+
+	getFullscreenCopyOnSelect(): boolean {
+		return this.settings.fullscreenCopyOnSelect !== false;
+	}
+
+	setFullscreenCopyOnSelect(enabled: boolean): void {
+		this.globalSettings.fullscreenCopyOnSelect = enabled;
+		this.markModified("fullscreenCopyOnSelect");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -90,6 +90,7 @@ export interface SettingsConfig {
 	tuiMode: TuiMode;
 	fullscreenExitOutput: FullscreenExitOutput;
 	fullscreenScrollbar: ScrollViewScrollbar;
+	fullscreenCopyOnSelect: boolean;
 	warnings: WarningSettings;
 }
 
@@ -125,6 +126,7 @@ export interface SettingsCallbacks {
 	onTuiModeChange: (mode: TuiMode) => void;
 	onFullscreenExitOutputChange: (output: FullscreenExitOutput) => void;
 	onFullscreenScrollbarChange: (mode: ScrollViewScrollbar) => void;
+	onFullscreenCopyOnSelectChange: (enabled: boolean) => void;
 	onWarningsChange: (warnings: WarningSettings) => void;
 	onCancel: () => void;
 }
@@ -654,6 +656,13 @@ export class SettingsSelectorComponent extends Container {
 				values: ["auto", "always", "hidden"],
 			},
 			{
+				id: "fullscreen-copy-on-select",
+				label: "Fullscreen copy on select",
+				description: "Copy selected text on mouse release in fullscreen mode",
+				currentValue: config.fullscreenCopyOnSelect ? "true" : "false",
+				values: ["true", "false"],
+			},
+			{
 				id: "theme",
 				label: "Theme",
 				description: "Color theme for the interface",
@@ -873,6 +882,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "fullscreen-scrollbar":
 						callbacks.onFullscreenScrollbarChange(newValue as ScrollViewScrollbar);
+						break;
+					case "fullscreen-copy-on-select":
+						callbacks.onFullscreenCopyOnSelectChange(newValue === "true");
 						break;
 					case "theme":
 						callbacks.onThemeChange(newValue);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -334,6 +334,7 @@ export interface InteractiveModeOptions {
 interface InteractiveTuiOptions {
 	tuiMode: TuiMode;
 	showHardwareCursor: boolean;
+	fullscreenCopyOnSelect: boolean;
 	logDirectory: string;
 	terminal?: Terminal;
 	onRightClickPaste?: () => void;
@@ -347,6 +348,7 @@ export function createInteractiveTui(options: InteractiveTuiOptions): TuiMainScr
 		return new TuiAltScreen(terminal, options.showHardwareCursor, options.logDirectory, {
 			searchMatchStyle: (text) => theme.underline(styleSearchMatch(text)),
 			searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
+			copyOnSelect: options.fullscreenCopyOnSelect,
 			openUrl: openBrowser,
 			onRightClickPaste: options.onRightClickPaste,
 		});
@@ -543,6 +545,7 @@ export class InteractiveMode {
 		this.renderer = createInteractiveTui({
 			tuiMode,
 			showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
+			fullscreenCopyOnSelect: this.settingsManager.getFullscreenCopyOnSelect(),
 			logDirectory: getAgentDir(),
 			onRightClickPaste: this.onRightClickPaste,
 		});
@@ -811,6 +814,7 @@ export class InteractiveMode {
 		const nextUi = createInteractiveTui({
 			tuiMode: mode,
 			showHardwareCursor,
+			fullscreenCopyOnSelect: this.settingsManager.getFullscreenCopyOnSelect(),
 			logDirectory: getAgentDir(),
 			terminal,
 			onRightClickPaste: this.onRightClickPaste,
@@ -2808,7 +2812,10 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.tools.expand", () => this.toggleToolOutputExpansion());
 		this.defaultEditor.onAction("app.thinking.toggle", () => this.toggleThinkingBlockVisibility());
 		this.defaultEditor.onAction("app.editor.external", () => void this.handleOpenExternalEditor());
-		this.defaultEditor.onAction("app.message.copy", () => void this.handleCopyCommand({ flashConfirmation: true }));
+		this.defaultEditor.onAction(
+			"app.message.copy",
+			() => void this.handleCopyCommand({ flashConfirmation: true, preferFullscreenSelection: true }),
+		);
 		this.defaultEditor.onAction("app.message.followUp", () => this.handleFollowUp());
 		this.defaultEditor.onAction("app.message.dequeue", () => this.handleDequeue());
 		this.defaultEditor.onAction("app.session.new", () => this.handleClearCommand());
@@ -4414,6 +4421,7 @@ export class InteractiveMode {
 					tuiMode: this.ui.mode,
 					fullscreenExitOutput: this.settingsManager.getFullscreenExitOutput(),
 					fullscreenScrollbar: this.settingsManager.getFullscreenScrollbar(),
+					fullscreenCopyOnSelect: this.settingsManager.getFullscreenCopyOnSelect(),
 					warnings: this.settingsManager.getWarnings(),
 				},
 				{
@@ -4575,6 +4583,10 @@ export class InteractiveMode {
 					onFullscreenScrollbarChange: (mode) => {
 						this.settingsManager.setFullscreenScrollbar(mode);
 						this.applyFullscreenScrollbarSetting();
+					},
+					onFullscreenCopyOnSelectChange: (enabled) => {
+						this.settingsManager.setFullscreenCopyOnSelect(enabled);
+						if (this.renderer instanceof TuiAltScreen) this.renderer.setCopyOnSelect(enabled);
 					},
 					onWarningsChange: (warnings) => {
 						this.settingsManager.setWarnings(warnings);
@@ -5953,7 +5965,17 @@ export class InteractiveMode {
 		}
 	}
 
-	private async handleCopyCommand(options: { flashConfirmation?: boolean } = {}): Promise<void> {
+	private async handleCopyCommand(
+		options: { flashConfirmation?: boolean; preferFullscreenSelection?: boolean } = {},
+	): Promise<void> {
+		if (
+			options.preferFullscreenSelection &&
+			this.renderer instanceof TuiAltScreen &&
+			this.renderer.copyActiveSelectionToClipboard()
+		) {
+			return;
+		}
+
 		const text = this.session.getLastAssistantText();
 		if (!text) {
 			this.showError("No agent messages to copy yet.");
@@ -5962,8 +5984,8 @@ export class InteractiveMode {
 
 		try {
 			await copyToClipboard(text);
-			if (options.flashConfirmation && this.ui instanceof TuiAltScreen) {
-				this.ui.flash("Copied!");
+			if (options.flashConfirmation && this.renderer instanceof TuiAltScreen) {
+				this.renderer.flash("Copied!");
 			} else {
 				this.showStatus("Copied last agent message to clipboard");
 			}

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -43,6 +43,7 @@ describe("createInteractiveTui", () => {
 		const mainTui = createInteractiveTui({
 			tuiMode: "regular",
 			showHardwareCursor: false,
+			fullscreenCopyOnSelect: true,
 			logDirectory: "/tmp",
 			terminal: mainTerminal,
 		});
@@ -57,6 +58,7 @@ describe("createInteractiveTui", () => {
 		const altTui = createInteractiveTui({
 			tuiMode: "fullscreen",
 			showHardwareCursor: false,
+			fullscreenCopyOnSelect: true,
 			logDirectory: "/tmp",
 			terminal: altTerminal,
 		});
@@ -73,6 +75,7 @@ describe("createInteractiveTui", () => {
 		const renderer = createInteractiveTui({
 			tuiMode: "regular",
 			showHardwareCursor: false,
+			fullscreenCopyOnSelect: true,
 			logDirectory: "/tmp",
 			terminal,
 		});
@@ -87,6 +90,7 @@ describe("createInteractiveTui", () => {
 		renderer.setFocus(component);
 
 		type SwitchContext = {
+			runtimeHost: { session: { settingsManager: { getFullscreenCopyOnSelect: () => boolean } } };
 			renderer: ReturnType<typeof createInteractiveTui>;
 			ui: TUI;
 			fullscreenLayoutRoot: Component;
@@ -95,6 +99,7 @@ describe("createInteractiveTui", () => {
 			extensionTerminalInputSubscriptions: Set<never>;
 		};
 		const context = Object.assign(Object.create(InteractiveMode.prototype), {
+			runtimeHost: { session: { settingsManager: { getFullscreenCopyOnSelect: () => true } } },
 			renderer,
 			ui: undefined as unknown as TUI,
 			fullscreenLayoutRoot: component,
@@ -151,12 +156,13 @@ describe("InteractiveMode right-click paste", () => {
 
 type CopyCommandContext = {
 	session: { getLastAssistantText: () => string | undefined };
+	renderer: ReturnType<typeof createInteractiveTui>;
 	ui: ReturnType<typeof createInteractiveTui>;
 	showStatus: (message: string) => void;
 	showError: (message: string) => void;
 };
 
-type CopyCommandOptions = { flashConfirmation?: boolean };
+type CopyCommandOptions = { flashConfirmation?: boolean; preferFullscreenSelection?: boolean };
 
 type CopyCommandPrototype = {
 	handleCopyCommand(this: CopyCommandContext, options?: CopyCommandOptions): Promise<void>;
@@ -175,6 +181,7 @@ describe("InteractiveMode copy confirmation", () => {
 		const ui = createInteractiveTui({
 			tuiMode: "fullscreen",
 			showHardwareCursor: false,
+			fullscreenCopyOnSelect: true,
 			logDirectory: "/tmp",
 			terminal,
 		});
@@ -182,6 +189,7 @@ describe("InteractiveMode copy confirmation", () => {
 		const showError = vi.fn();
 		const context: CopyCommandContext = {
 			session: { getLastAssistantText: () => "assistant response" },
+			renderer: ui,
 			ui,
 			showStatus,
 			showError,
@@ -206,6 +214,7 @@ describe("InteractiveMode copy confirmation", () => {
 		const ui = createInteractiveTui({
 			tuiMode: "regular",
 			showHardwareCursor: false,
+			fullscreenCopyOnSelect: true,
 			logDirectory: "/tmp",
 			terminal: new RecordingTerminal(),
 		});
@@ -213,6 +222,7 @@ describe("InteractiveMode copy confirmation", () => {
 		const showError = vi.fn();
 		const context: CopyCommandContext = {
 			session: { getLastAssistantText: () => "assistant response" },
+			renderer: ui,
 			ui,
 			showStatus,
 			showError,
@@ -222,6 +232,50 @@ describe("InteractiveMode copy confirmation", () => {
 
 		expect(showStatus).toHaveBeenCalledWith("Copied last agent message to clipboard");
 		expect(showError).not.toHaveBeenCalled();
+	});
+
+	it("copies the active fullscreen selection before falling back to the last assistant message", async () => {
+		const terminal = new RecordingTerminal(40, 4);
+		const ui = createInteractiveTui({
+			tuiMode: "fullscreen",
+			showHardwareCursor: false,
+			fullscreenCopyOnSelect: false,
+			logDirectory: "/tmp",
+			terminal,
+		});
+		const showStatus = vi.fn();
+		const showError = vi.fn();
+		const context: CopyCommandContext = {
+			session: { getLastAssistantText: () => "assistant response" },
+			renderer: ui,
+			ui,
+			showStatus,
+			showError,
+		};
+
+		ui.addChild(new Text("alpha\nbeta", 0, 0));
+		ui.start();
+		try {
+			await terminal.waitForRender();
+			terminal.sendInput("\x1b[<0;1;1M");
+			terminal.sendInput("\x1b[<32;4;2M");
+			terminal.sendInput("\x1b[<0;4;2m");
+			await terminal.waitForRender();
+
+			await copyCommandPrototype.handleCopyCommand.call(context, {
+				flashConfirmation: true,
+				preferFullscreenSelection: true,
+			});
+			await terminal.waitForRender();
+
+			const expectedClipboardSequence = `\x1b]52;c;${Buffer.from("alpha\nbeta").toString("base64")}\x07`;
+			expect(terminal.writes.some((write) => write.includes(expectedClipboardSequence))).toBe(true);
+			expect(clipboardMocks.copyToClipboard).not.toHaveBeenCalled();
+			expect(showStatus).not.toHaveBeenCalled();
+			expect(showError).not.toHaveBeenCalled();
+		} finally {
+			ui.stop();
+		}
 	});
 });
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -449,6 +449,19 @@ describe("SettingsManager", () => {
 		expect(reloadedManager.getFullscreenScrollbar()).toBe("auto");
 	});
 
+	it("defaults and persists fullscreen copy on select", async () => {
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getFullscreenCopyOnSelect()).toBe(true);
+
+		manager.setFullscreenCopyOnSelect(false);
+		await manager.flush();
+		expect(manager.getFullscreenCopyOnSelect()).toBe(false);
+		expect(JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8")).fullscreenCopyOnSelect).toBe(false);
+
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ fullscreenCopyOnSelect: "false" }));
+		expect(SettingsManager.create(projectDir, agentDir).getFullscreenCopyOnSelect()).toBe(true);
+	});
+
 	describe("outputPad", () => {
 		it("should default to 1 and persist binary values", async () => {
 			const manager = SettingsManager.create(projectDir, agentDir);

--- a/packages/coding-agent/test/settings-selector.test.ts
+++ b/packages/coding-agent/test/settings-selector.test.ts
@@ -40,4 +40,24 @@ describe("SettingsSelectorComponent", () => {
 		cycle("Fullscreen scrollbar", 3);
 		expect(onScrollbarChange.mock.calls.flat()).toEqual(["always", "hidden", "auto"]);
 	});
+
+	it("toggles fullscreen copy on select", () => {
+		const onChange = vi.fn();
+		const selector = new SettingsSelectorComponent(
+			{
+				fullscreenCopyOnSelect: true,
+				warnings: {},
+				availableThinkingLevels: [],
+				availableThemes: [],
+			} as unknown as SettingsConfig,
+			{ onFullscreenCopyOnSelectChange: onChange } as unknown as SettingsCallbacks,
+		);
+		const settingsList = selector.getSettingsList();
+
+		for (const character of "Fullscreen copy on select") settingsList.handleInput(character);
+		settingsList.handleInput("\r");
+		settingsList.handleInput("\r");
+
+		expect(onChange.mock.calls.flat()).toEqual([false, true]);
+	});
 });

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -149,6 +149,8 @@ export interface TuiAltScreenOptions {
 	searchMatchStyle?: (text: string) => string;
 	/** Style the current transcript search match. */
 	searchCurrentMatchStyle?: (text: string) => string;
+	/** Copy selected text to the clipboard as soon as mouse selection completes. */
+	copyOnSelect?: boolean;
 	/** Open an OSC 8 hyperlink activated with a primary-button click. */
 	openUrl?: (url: string) => void;
 	/** Handle an unmodified secondary-button press for clipboard paste. Currently enabled on Windows only. */
@@ -190,6 +192,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 	private readonly mouseEnabled: boolean;
 	private readonly searchMatchStyle: (text: string) => string;
 	private readonly searchCurrentMatchStyle: (text: string) => string;
+	private copyOnSelect: boolean;
 	private readonly openUrl?: (url: string) => void;
 	private readonly onRightClickPaste?: () => void;
 
@@ -212,6 +215,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		this.mouseEnabled = options.mouse ?? true;
 		this.searchMatchStyle = options.searchMatchStyle ?? ((text) => `\x1b[4m${text}\x1b[24m`);
 		this.searchCurrentMatchStyle = options.searchCurrentMatchStyle ?? ((text) => `\x1b[1;7m${text}\x1b[22;27m`);
+		this.copyOnSelect = options.copyOnSelect ?? true;
 		this.openUrl = options.openUrl;
 		this.onRightClickPaste = options.onRightClickPaste;
 		this.addInputListener((data) => this.handleViewportInput(data));
@@ -397,6 +401,14 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 	scrollToBottom(): void {
 		this.getPrimaryScrollView().scrollToEnd();
 		this.requestRender();
+	}
+
+	setCopyOnSelect(enabled: boolean): void {
+		this.copyOnSelect = enabled;
+	}
+
+	copyActiveSelectionToClipboard(): boolean {
+		return this.copySelectionToClipboard();
 	}
 
 	private scrollToPrompt(direction: -1 | 1): void {
@@ -964,7 +976,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 				this.requestRender();
 				return;
 			}
-			this.copySelectionToClipboard();
+			if (this.copyOnSelect) this.copySelectionToClipboard();
 			this.requestRender();
 			return;
 		}
@@ -1040,14 +1052,14 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		return { start: Math.max(minColumn, start), end: Math.min(maxColumn, end) };
 	}
 
-	private copySelectionToClipboard(): void {
+	private copySelectionToClipboard(): boolean {
 		const selection = this.getSelectionBounds();
-		if (!selection) return;
+		if (!selection) return false;
 		let sourceLines: readonly string[] = this.previousScreen;
 		if (selection.start.scrollView) {
-			if (!this.currentLayout) return;
+			if (!this.currentLayout) return false;
 			const box = getScrollViewBox(this.currentLayout, selection.start.scrollView);
-			if (!box?.scrollContentLines) return;
+			if (!box?.scrollContentLines) return false;
 			sourceLines = box.scrollContentLines;
 		}
 		const lines: string[] = [];
@@ -1061,9 +1073,10 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 			);
 		}
 		const text = lines.join("\n");
-		if (text.length === 0) return;
+		if (text.length === 0) return false;
 		this.terminal.write(`\x1b]52;c;${Buffer.from(text).toString("base64")}\x07`);
 		this.flash("Copied!");
+		return true;
 	}
 
 	private applySearchTextHighlight(text: string, current: boolean): string {

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -1020,6 +1020,53 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
+	it("keeps fullscreen selection highlighted when copy on select is disabled", async () => {
+		const terminal = new RecordingTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal, undefined, undefined, { copyOnSelect: false });
+		tui.addChild(new Text("alpha\nbeta\ngamma\ndelta", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;4;2M");
+		terminal.sendInput("\x1b[<0;4;2m");
+		await terminal.waitForRender();
+
+		assert.strictEqual(
+			terminal.events.filter((event) => event.type === "write" && event.data.includes("\x1b]52;c;")).length,
+			0,
+		);
+		assert.ok(terminal.events.some((event) => event.type === "write" && event.data.includes("\x1b[7m")));
+		assert.ok(!terminal.getViewport().some((line) => line.includes("Copied!")));
+
+		const expectedClipboardSequence = `\x1b]52;c;${Buffer.from("alpha\nbeta").toString("base64")}\x07`;
+		assert.strictEqual(tui.copyActiveSelectionToClipboard(), true);
+		await terminal.waitForRender();
+		assert.ok(
+			terminal.events.some((event) => event.type === "write" && event.data.includes(expectedClipboardSequence)),
+			JSON.stringify(terminal.events.filter((event) => event.type === "write" && event.data.includes("\x1b]52;c;"))),
+		);
+		assert.ok(terminal.getViewport().some((line) => line.includes("Copied!")));
+
+		tui.stop();
+	});
+
+	it("reports when there is no active fullscreen selection to copy", async () => {
+		const terminal = new RecordingTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal);
+		tui.addChild(new Text("alpha\nbeta", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.copyActiveSelectionToClipboard(), false);
+		assert.strictEqual(
+			terminal.events.filter((event) => event.type === "write" && event.data.includes("\x1b]52;c;")).length,
+			0,
+		);
+
+		tui.stop();
+	});
+
 	it("does not repaint idle or zero-width selections on focus loss", async () => {
 		const terminal = new RecordingTerminal(20, 4);
 		const tui = new TuiAltScreen(terminal);


### PR DESCRIPTION
Hello!

As mentioned in #7720, this adds an setting to opt out of copy-on-select in fullscreen. When disabled, it sets the `app.message.copy` keybind to copy the selected content if any, otherwise it keeps the existing behaviour of copying the last message.

Let me know if you need/want more changes!

------

<details><summary>Summary by GPT-5.5:</summary>
<p>

## Summary

Adds a fullscreen TUI setting to control automatic copy-on-select while preserving explicit selection copy through the existing message copy action.

## Changes

- `packages/tui/src/tui-alt-screen.ts`
  - Adds `copyOnSelect` to `TuiAltScreenOptions`, defaulting to `true` to preserve current behavior.
  - Adds `setCopyOnSelect(enabled)` for runtime updates.
  - Adds `copyActiveSelectionToClipboard(): boolean` for explicit copy of the current fullscreen selection.
  - Keeps fullscreen selection highlighted when automatic copy-on-select is disabled.

- `packages/coding-agent/src/core/settings-manager.ts`
  - Adds `fullscreenCopyOnSelect`, defaulting to `true`.
  - Persists the setting through `getFullscreenCopyOnSelect()` and `setFullscreenCopyOnSelect()`.

- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`
  - Passes `fullscreenCopyOnSelect` into fullscreen renderer creation and mode switches.
  - Applies setting changes live from `/settings`.
  - Makes `app.message.copy` prefer an active fullscreen selection, then fall back to copying the last assistant message.

- `packages/coding-agent/src/modes/interactive/components/settings-selector.ts`
  - Adds a `/settings` toggle: `Fullscreen copy on select`.

- `packages/coding-agent/docs/settings.md`
  - Documents `fullscreenCopyOnSelect`.

## Tests

- `npm run check` passed.
- Targeted tests passed:
  - `node --test packages/tui/test/tui-alt-screen.test.ts`
  - `node node_modules/vitest/dist/cli.js --run packages/coding-agent/test/interactive-tui.test.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/settings-selector.test.ts`
- `./test.sh` was run and hit one apparent unrelated timeout in `packages/coding-agent/test/footer-data-provider.test.ts` (`updates the cached branch when the reftable directory changes`). Other suites continued and passed.

</p>
</details>