### PR TITLE
feat(coding-agent): add exit foreground task and ctx.version

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -941,6 +941,10 @@ UI methods for user interaction. See [Custom UI](#custom-ui) for full details.
 
 Current run mode: `"tui"`, `"rpc"`, `"json"`, or `"print"`. Use `ctx.mode === "tui"` to guard terminal-only features such as `custom()`, component factories, terminal input, and direct TUI rendering.
 
+### ctx.version
+
+The version of the host pi running the extension (for example `"0.82.1"`). Use it to gate features that depend on a minimum host version, e.g. before calling `ctx.setExitForegroundTask()`.
+
 ### ctx.hasUI
 
 `true` in TUI and RPC modes. `false` in print mode (`-p`) and JSON mode. Use this to guard dialog methods (`select`, `confirm`, `input`, `editor`) and fire-and-forget methods (`notify`, `setStatus`, `setWidget`, `setTitle`, `setEditorText`) that work in both TUI and RPC modes. In RPC mode, some TUI-specific methods are no-ops or return defaults (see [rpc.md](rpc.md#extension-ui-protocol)).
@@ -1079,6 +1083,25 @@ pi.on("before_agent_start", (event, ctx) => {
 ## ExtensionCommandContext
 
 Command handlers receive `ExtensionCommandContext`, which extends `ExtensionContext` with session control methods. These are only available in commands because they can deadlock if called from event handlers.
+
+### ctx.setExitForegroundTask()
+
+Register a task that takes over the foreground process after pi's TUI shuts down. Available **only in TUI command contexts** and **at most once per process** (a second registration throws `Error("An exit foreground task is already registered")`). Calling it from RPC, print, or JSON mode throws `Error("setExitForegroundTask is only available in TUI mode")`.
+
+The task runs after the TUI has stopped, the agent session has been fully disposed (`session_shutdown` emitted, `runtimeHost.dispose()` completed) and the terminal has been restored, but before the process exits. When shutdown was triggered by a signal (`SIGTERM`/`SIGHUP`), the task does not run. Once the task returns, the process exits with the code the task was given. While the task owns the foreground process, pi's own signal handlers are dropped: a later `SIGTERM` or `SIGHUP` exits the process with code 143 or 129 instead of re-entering pi's shutdown sequence.
+
+Because the extension context is already torn down by the time the task runs, the task must only use plain data captured at registration time (for example the session id, session directory, and cwd), and must not call any `ctx` or `pi` methods.
+
+```typescript
+pi.on("command", async (args, ctx) => {
+  if (args.trim() !== "/web") return;
+  const sessionId = ctx.sessionManager.getSessionId();
+  ctx.setExitForegroundTask(async (code) => {
+    await startWebServer({ sessionId, cwd: ctx.cwd });
+  });
+  ctx.shutdown();
+});
+```
 
 ### ctx.getSystemPromptOptions()
 
@@ -1327,6 +1350,10 @@ export default function (pi: ExtensionAPI) {
 ```
 
 ## ExtensionAPI Methods
+
+### pi.version
+
+The version of the host pi running the extension, identical to `ctx.version`.
 
 ### pi.on(event, handler)
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -45,6 +45,7 @@ import {
 	resetApiProviders,
 	streamSimple,
 } from "@earendil-works/pi-ai/compat";
+import { VERSION } from "../config.ts";
 import { getThemeByName, theme } from "../modes/interactive/theme/theme.ts";
 import { stripFrontmatter } from "../utils/frontmatter.ts";
 import { resolvePath } from "../utils/paths.ts";
@@ -2433,6 +2434,7 @@ export class AgentSession {
 				},
 				getSystemPrompt: () => this.systemPrompt,
 				getSystemPromptOptions: () => this._baseSystemPromptOptions,
+				getVersion: () => VERSION,
 			},
 			{
 				registerProvider: (name, config) => {

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -21,7 +21,7 @@ import { createJiti } from "jiti/static";
 import * as _bundledTypebox from "typebox";
 import * as _bundledTypeboxCompile from "typebox/compile";
 import * as _bundledTypeboxValue from "typebox/value";
-import { CONFIG_DIR_NAME, getAgentDir, isBunBinary } from "../../config.ts";
+import { CONFIG_DIR_NAME, getAgentDir, isBunBinary, VERSION } from "../../config.ts";
 // NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 // avoiding a circular dependency. Extensions can import from @earendil-works/pi-coding-agent.
 import * as _bundledPiCodingAgent from "../../index.ts";
@@ -179,6 +179,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 	};
 
 	const runtime: ExtensionRuntime = {
+		version: VERSION,
 		sendMessage: notInitialized,
 		sendUserMessage: notInitialized,
 		appendEntry: notInitialized,
@@ -235,6 +236,11 @@ function createExtensionAPI(
 ): ExtensionAPI {
 	const api = {
 		// Registration methods - write to extension
+		get version(): string {
+			runtime.assertActive();
+			return runtime.version;
+		},
+
 		on(event: string, handler: HandlerFn): void {
 			runtime.assertActive();
 			const list = extension.handlers.get(event) ?? [];

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -5,6 +5,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Model, Provider, ProviderHeaders } from "@earendil-works/pi-ai";
 import type { KeyId } from "@earendil-works/pi-tui";
+import { VERSION } from "../../config.ts";
 import { type Theme, theme } from "../../modes/interactive/theme/theme.ts";
 import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
@@ -289,6 +290,12 @@ export class ExtensionRunner {
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private reloadHandler: ReloadHandler = async () => {};
 	private shutdownHandler: ShutdownHandler = () => {};
+	private version = VERSION;
+	private getVersionFn: () => string = () => this.version;
+	private exitForegroundTaskHandler: (task: (exitCode: number) => Promise<void> | void) => void = () => {
+		throw new Error("setExitForegroundTask is only available in TUI mode");
+	};
+	private exitForegroundTaskRegistered = false;
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
 	private staleMessage: string | undefined;
@@ -345,6 +352,8 @@ export class ExtensionRunner {
 		this.compactFn = contextActions.compact;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
 		this.getSystemPromptOptionsFn = contextActions.getSystemPromptOptions ?? (() => ({ cwd: this.cwd }));
+		this.getVersionFn = contextActions.getVersion;
+		this.runtime.version = this.getVersionFn();
 
 		// Flush provider registrations queued during extension loading
 		for (const { name, config, extensionPath } of this.runtime.pendingProviderRegistrations) {
@@ -415,6 +424,7 @@ export class ExtensionRunner {
 			this.navigateTreeHandler = actions.navigateTree;
 			this.switchSessionHandler = actions.switchSession;
 			this.reloadHandler = actions.reload;
+			this.exitForegroundTaskHandler = actions.setExitForegroundTask;
 			return;
 		}
 
@@ -424,6 +434,9 @@ export class ExtensionRunner {
 		this.navigateTreeHandler = async () => ({ cancelled: false });
 		this.switchSessionHandler = async () => ({ cancelled: false });
 		this.reloadHandler = async () => {};
+		this.exitForegroundTaskHandler = () => {
+			throw new Error("setExitForegroundTask is only available in TUI mode");
+		};
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext, mode: ExtensionMode = "print"): void {
@@ -734,6 +747,10 @@ export class ExtensionRunner {
 				runner.assertActive();
 				return runner.getSystemPromptFn();
 			},
+			get version() {
+				runner.assertActive();
+				return runner.getVersionFn();
+			},
 		};
 	}
 
@@ -772,6 +789,14 @@ export class ExtensionRunner {
 		context.reload = () => {
 			this.assertActive();
 			return this.reloadHandler();
+		};
+		context.setExitForegroundTask = (task) => {
+			this.assertActive();
+			if (this.exitForegroundTaskRegistered) {
+				throw new Error("An exit foreground task is already registered");
+			}
+			this.exitForegroundTaskHandler(task);
+			this.exitForegroundTaskRegistered = true;
 		};
 		return context;
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -310,6 +310,8 @@ export interface ExtensionContext {
 	mode: ExtensionMode;
 	/** Whether dialog-capable UI is available (true in TUI and RPC modes) */
 	hasUI: boolean;
+	/** The version of the host pi that is running this extension. */
+	version: string;
 	/** Current working directory */
 	cwd: string;
 	/** Session manager (read-only) */
@@ -378,6 +380,13 @@ export interface ExtensionCommandContext extends ExtensionContext {
 
 	/** Reload extensions, skills, prompts, themes, and context files. */
 	reload(): Promise<void>;
+
+	/**
+	 * Register a task that runs after the TUI shuts down, before the process
+	 * exits. The task takes over the foreground process (e.g. to run a server).
+	 * Only available in TUI mode, at most once per process.
+	 */
+	setExitForegroundTask: (task: (exitCode: number) => Promise<void> | void) => void;
 }
 
 /**
@@ -1310,6 +1319,9 @@ export interface ExtensionAPI {
 	/** Execute a shell command. */
 	exec(command: string, args: string[], options?: ExecOptions): Promise<ExecResult>;
 
+	/** The version of the host pi that is running this extension. */
+	version: string;
+
 	/** Get the list of currently active tool names. */
 	getActiveTools(): string[];
 
@@ -1568,6 +1580,8 @@ export type SetLabelHandler = (entryId: string, label: string | undefined) => vo
  * Contains flag values (defaults set during registration, CLI values set after).
  */
 export interface ExtensionRuntimeState {
+	/** The version of the host pi that is running this extension. */
+	version: string;
 	flagValues: Map<string, boolean | string>;
 	/** Legacy provider-config registrations queued during extension loading, processed when runner binds. */
 	pendingProviderRegistrations: Array<{ name: string; config: ProviderConfig; extensionPath: string }>;
@@ -1625,6 +1639,7 @@ export interface ExtensionContextActions {
 	compact: (options?: CompactOptions) => void;
 	getSystemPrompt: () => string;
 	getSystemPromptOptions?: () => BuildSystemPromptOptions;
+	getVersion: () => string;
 }
 
 /**
@@ -1651,6 +1666,7 @@ export interface ExtensionCommandContextActions {
 		options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	) => Promise<{ cancelled: boolean }>;
 	reload: () => Promise<void>;
+	setExitForegroundTask: (task: (exitCode: number) => Promise<void> | void) => void;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1685,6 +1685,12 @@ export class InteractiveMode {
 				reload: async () => {
 					await this.handleReloadCommand();
 				},
+				setExitForegroundTask: (task) => {
+					if (this.exitForegroundTask !== undefined) {
+						throw new Error("An exit foreground task is already registered");
+					}
+					this.exitForegroundTask = task;
+				},
 			},
 			shutdownHandler: () => {
 				this.shutdownRequested = true;
@@ -1812,6 +1818,7 @@ export class InteractiveMode {
 				})();
 			},
 			getSystemPrompt: () => this.session.systemPrompt,
+			version: VERSION,
 		});
 
 		// Set up the extension shortcut handler on the default editor
@@ -3541,6 +3548,7 @@ export class InteractiveMode {
 	 * repaint the final frame while the process is exiting.
 	 */
 	private isShuttingDown = false;
+	private exitForegroundTask: ((exitCode: number) => Promise<void> | void) | undefined = undefined;
 
 	private async shutdown(options?: { fromSignal?: boolean }): Promise<void> {
 		if (this.isShuttingDown) return;
@@ -3578,6 +3586,19 @@ export class InteractiveMode {
 		const resumeCommand = formatResumeCommand(this.sessionManager);
 		if (resumeCommand) {
 			process.stdout.write(`${chalk.dim("To resume this session:")} ${resumeCommand}\n`);
+		}
+
+		const exitForegroundTask = this.exitForegroundTask;
+		if (exitForegroundTask !== undefined) {
+			// The foreground task owns the terminal now (like Kimi's /web server).
+			// Drop pi's TUI signal handlers; plain exit handlers forward the
+			// signal as an exit code instead of re-entering shutdown().
+			this.unregisterSignalHandlers();
+			process.once("SIGTERM", () => process.exit(143));
+			if (process.platform !== "win32") {
+				process.once("SIGHUP", () => process.exit(129));
+			}
+			await exitForegroundTask(0);
 		}
 
 		process.exit(0);

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -94,6 +94,9 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 				reload: async () => {
 					await session.reload();
 				},
+				setExitForegroundTask: () => {
+					throw new Error("setExitForegroundTask is only available in TUI mode");
+				},
 			},
 			onError: (err) => {
 				console.error(`Extension error (${err.extensionPath}): ${err.error}`);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -340,6 +340,9 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				reload: async () => {
 					await session.reload();
 				},
+				setExitForegroundTask: () => {
+					throw new Error("setExitForegroundTask is only available in TUI mode");
+				},
 			},
 			shutdownHandler: () => {
 				shutdownRequested = true;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -99,6 +99,7 @@ describe("ExtensionRunner", () => {
 		getContextUsage: () => undefined,
 		compact: () => {},
 		getSystemPrompt: () => "",
+		getVersion: () => "0.0.0-test",
 	};
 
 	describe("project_trust", () => {
@@ -902,6 +903,7 @@ describe("ExtensionRunner", () => {
 				navigateTree: async () => ({ cancelled: false }),
 				switchSession: async () => ({ cancelled: false }),
 				reload: async () => {},
+				setExitForegroundTask: vi.fn(),
 			});
 
 			const commandContext = runner.createCommandContext();

--- a/packages/coding-agent/test/runner.test.ts
+++ b/packages/coding-agent/test/runner.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { VERSION } from "../src/config.ts";
+import { createExtensionRuntime } from "../src/core/extensions/loader.ts";
+import { ExtensionRunner } from "../src/core/extensions/runner.ts";
+import type { ModelRegistry } from "../src/core/model-registry.ts";
+import type { SessionManager } from "../src/core/session-manager.ts";
+
+function createRunner(): ExtensionRunner {
+	const runtime = createExtensionRuntime();
+	return new ExtensionRunner([], runtime, process.cwd(), {} as SessionManager, {} as ModelRegistry);
+}
+
+describe("setExitForegroundTask", () => {
+	it("throws while no command context actions are bound", () => {
+		const runner = createRunner();
+		expect(() => runner.createCommandContext().setExitForegroundTask(() => {})).toThrow(/only available in TUI mode/);
+	});
+
+	it("throws in RPC/print/json mode even when a throwing action is bound", () => {
+		// print-mode.ts and rpc-mode.ts bind a throwing action for
+		// setExitForegroundTask; the rejection must persist across calls.
+		const runner = createRunner();
+		runner.bindCommandContext({
+			setExitForegroundTask: () => {
+				throw new Error("setExitForegroundTask is only available in TUI mode");
+			},
+		} as never);
+		const ctx = runner.createCommandContext();
+		expect(() => ctx.setExitForegroundTask(() => {})).toThrow(/only available in TUI mode/);
+		expect(() => ctx.setExitForegroundTask(() => {})).toThrow(/only available in TUI mode/);
+	});
+
+	it("wires the task handler and rejects a second registration", () => {
+		const runner = createRunner();
+		const tasks: Array<(code: number) => Promise<void> | void> = [];
+		runner.bindCommandContext({
+			setExitForegroundTask: (task: (code: number) => Promise<void> | void) => {
+				tasks.push(task);
+			},
+		} as never);
+		const ctx = runner.createCommandContext();
+		ctx.setExitForegroundTask(async () => {});
+		expect(tasks).toHaveLength(1);
+		expect(() => ctx.setExitForegroundTask(async () => {})).toThrow(/already registered/);
+	});
+
+	it("keeps rejecting after command context actions are unbound", () => {
+		const runner = createRunner();
+		const tasks: Array<(code: number) => Promise<void> | void> = [];
+		runner.bindCommandContext({
+			setExitForegroundTask: (task: (code: number) => Promise<void> | void) => {
+				tasks.push(task);
+			},
+		} as never);
+		runner.createCommandContext().setExitForegroundTask(() => {});
+		runner.bindCommandContext(undefined);
+		// Per-process semantics: a registration stays registered even if the
+		// command context actions are later unbound.
+		expect(() => runner.createCommandContext().setExitForegroundTask(() => {})).toThrow(/already registered/);
+	});
+
+	it("throws when the command context is stale", () => {
+		const runner = createRunner();
+		runner.bindCommandContext({ setExitForegroundTask: () => {} } as never);
+		const ctx = runner.createCommandContext();
+		runner.invalidate("stale test context");
+		expect(() => ctx.setExitForegroundTask(() => {})).toThrow(/stale test context/);
+	});
+});
+
+describe("ctx.version", () => {
+	it("exposes the package version in event and command contexts", () => {
+		const runner = createRunner();
+		expect(runner.createContext().version).toBe(VERSION);
+		expect(runner.createCommandContext().version).toBe(VERSION);
+	});
+
+	it("uses the version provided by the host via bindCore", () => {
+		const runtime = createExtensionRuntime();
+		const runner = new ExtensionRunner([], runtime, process.cwd(), {} as SessionManager, {} as ModelRegistry);
+		runner.bindCore({} as never, { getVersion: () => "1.2.3-test" } as never);
+		expect(runner.createContext().version).toBe("1.2.3-test");
+		expect(runner.createCommandContext().version).toBe("1.2.3-test");
+		expect(runtime.version).toBe("1.2.3-test");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
@@ -124,6 +124,9 @@ describe("regression #2860: replaced session callbacks", () => {
 					reload: async () => {
 						await session.reload();
 					},
+					setExitForegroundTask: () => {
+						throw new Error("setExitForegroundTask is only available in TUI mode");
+					},
 				},
 			});
 		};

--- a/packages/coding-agent/test/suite/regressions/6363-agent-settled-event.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6363-agent-settled-event.test.ts
@@ -123,6 +123,9 @@ describe("regression #6363: agent settled event and idle waiting", () => {
 				navigateTree: async () => ({ cancelled: false }),
 				switchSession: async () => ({ cancelled: false }),
 				reload: async () => {},
+				setExitForegroundTask: () => {
+					throw new Error("setExitForegroundTask is only available in TUI mode");
+				},
 			},
 		});
 		const toolStarted = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -20,6 +20,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,
 		getSystemPrompt: () => "",
+		version: "0.0.0-test",
 	};
 }
 


### PR DESCRIPTION
## Motivation

Extensions currently have no way to take over the foreground process after pi shuts down. This blocks a class of features where the TUI hands off to a long-running foreground server (e.g. a `/web` command that starts a web UI for the current session) while keeping the terminal occupied and the process supervised.

## Changes

Add two extension APIs:

- **`ctx.setExitForegroundTask(task)`** (TUI command contexts only): registers a task that runs after the TUI has stopped, `session_shutdown` has been emitted, `runtimeHost.dispose()` has completed and the terminal has been restored, but before the process exits. When the task returns, the process exits with the code the task was given.
  - At most once per process; a second registration throws `Error("An exit foreground task is already registered")`.
  - RPC/print/JSON modes throw `Error("setExitForegroundTask is only available in TUI mode")`.
  - While the task owns the foreground process, pi's TUI signal handlers are dropped; `SIGTERM`/`SIGHUP` exit with code 143/129 instead of re-entering the shutdown sequence.
  - Signal-triggered shutdowns (`fromSignal`) do not run the task.
- **`ctx.version` / `pi.version`**: the host pi version, so extensions can gate features on a minimum host version before using new APIs.

## Files

- `src/core/extensions/types.ts` – new interface fields (`ExtensionContext.version`, `ExtensionCommandContext.setExitForegroundTask`, `ExtensionAPI.version`, `ExtensionRuntimeState.version`, `ExtensionContextActions.getVersion`, `ExtensionCommandContextActions.setExitForegroundTask`)
- `src/core/extensions/runner.ts` – handler wiring, per-runner single-registration guard, `version` getters
- `src/core/extensions/loader.ts` – `pi.version` via shared runtime
- `src/core/agent-session.ts` – supplies `getVersion`
- `src/modes/interactive/interactive-mode.ts` – per-process task storage, execution in `shutdown()` after dispose, signal forwarding
- `src/modes/print-mode.ts`, `src/modes/rpc/rpc-mode.ts` – explicit TUI-only rejection
- `docs/extensions.md` – documents `ctx.setExitForegroundTask()`, `ctx.version`, `pi.version`
- `test/runner.test.ts` – 7 new unit tests (rejection outside TUI mode, mode-level rejection without state pollution, single registration, unbind persistence, stale context, version wiring)

## Verification

- New unit tests pass; affected regression suites pass (extensions-runner, trigger-compact, replaced-session-context, agent-settled-event).
- `tsc --noEmit` clean for changed packages; biome clean.
- Manual PTY smoke: extension registers a task via `/probe`, TUI prints `PROBE-RUN`, terminal restores, task runs with exit code 0, process exits 0. A hanging task keeps the process alive; `SIGTERM` exits 143.
