### PR TITLE
fix(example): render tool errors via context.isError in built-in-tool-renderer

### DIFF
--- a/packages/coding-agent/examples/extensions/built-in-tool-renderer.ts
+++ b/packages/coding-agent/examples/extensions/built-in-tool-renderer.ts
@@ -56,9 +56,13 @@ export default function (pi: ExtensionAPI) {
 			return new Text(text, 0, 0);
 		},
 
-		renderResult(result, { expanded, isPartial }, theme, _context) {
+		renderResult(result, { expanded, isPartial }, theme, context) {
 			if (isPartial) return new Text(theme.fg("warning", "Reading..."), 0, 0);
 
+			if (context.isError) {
+				const errorText = result.content.find((c) => c.type === "text")?.text ?? "Error";
+				return new Text(theme.fg("error", errorText.split("\n")[0]), 0, 0);
+			}
 			const details = result.details as ReadToolDetails | undefined;
 			const content = result.content[0];
 
@@ -169,15 +173,15 @@ export default function (pi: ExtensionAPI) {
 			return new Text(text, 0, 0);
 		},
 
-		renderResult(result, { expanded, isPartial }, theme, _context) {
+		renderResult(result, { expanded, isPartial }, theme, context) {
 			if (isPartial) return new Text(theme.fg("warning", "Editing..."), 0, 0);
 
+			if (context.isError) {
+				const errorText = result.content.find((c) => c.type === "text")?.text ?? "Error";
+				return new Text(theme.fg("error", errorText.split("\n")[0]), 0, 0);
+			}
 			const details = result.details as EditToolDetails | undefined;
 			const content = result.content[0];
-
-			if (content?.type === "text" && content.text.startsWith("Error")) {
-				return new Text(theme.fg("error", content.text.split("\n")[0]), 0, 0);
-			}
 
 			if (!details?.diff) {
 				return new Text(theme.fg("success", "Applied"), 0, 0);
@@ -235,13 +239,14 @@ export default function (pi: ExtensionAPI) {
 			return new Text(text, 0, 0);
 		},
 
-		renderResult(result, { isPartial }, theme, _context) {
+		renderResult(result, { isPartial }, theme, context) {
 			if (isPartial) return new Text(theme.fg("warning", "Writing..."), 0, 0);
 
-			const content = result.content[0];
-			if (content?.type === "text" && content.text.startsWith("Error")) {
-				return new Text(theme.fg("error", content.text.split("\n")[0]), 0, 0);
+			if (context.isError) {
+				const errorText = result.content.find((c) => c.type === "text")?.text ?? "Error";
+				return new Text(theme.fg("error", errorText.split("\n")[0]), 0, 0);
 			}
+			const content = result.content[0];
 
 			return new Text(theme.fg("success", "Written"), 0, 0);
 		},


### PR DESCRIPTION
## Problem

`examples/extensions/built-in-tool-renderer.ts` detects tool errors by string matching `content.text.startsWith("Error")` in the `edit` and `write` renderers. This is unreliable: when the built-in tools fail they **throw** errors, and none of the failure messages start with the word "Error":

- `Could not edit file: {path}. {errorMessage}.`
- `Could not find the exact text in {path}. The old text must match exactly...`
- `Found {N} occurrences of the text in {path}. The text must be unique...`
- `No changes made to {path}. The replacement produced identical content...`
- `Operation aborted`
- etc. (11 distinct failure paths verified in `edit.js` / `edit-diff.js`)

When a tool throws, `createErrorToolResult(message)` (agent-loop.js) produces `content: [{ type: "text", text: message }]` with `details: {}` and `isError: true`. Since the error text does not start with "Error" and `details.diff` is empty, the example renders a failed edit as a green **"Applied"** (and a failed write as green **"Written"**) — masking the error entirely.

The `read` renderer has the same class of issue: a failed read renders as green `1 lines` because the error message is counted as file content.

## Fix

Use the `context.isError` flag (already provided to `renderResult`, previously ignored as `_context`) as the source of truth, matching the approach of the framework's built-in renderer (`formatEditResult` in `core/tools/edit.js`):

- `read`, `edit`, `write`: add an early `if (context.isError)` branch that renders the error text in red; remove the `startsWith("Error")` string matching.
- `bash` is left unchanged — it already surfaces failures via the exit-code parse.

## Reproduction

1. Run `pi` with this example loaded: `pi -e examples/extensions/built-in-tool-renderer.ts`
2. Ask the agent to edit a file replacing text that does not exist
3. Before: the failed edit renders as green "Applied"
4. After: the failed edit renders the actual error message in red
