### PR TITLE
feat(coding-agent): bridge Cursor CLI auth via local agent session

### DIFF
--- a/packages/coding-agent/docs/environment-variables.md
+++ b/packages/coding-agent/docs/environment-variables.md
@@ -84,5 +84,6 @@ These variables are read by Pi itself:
 | `PI_HARDWARE_CURSOR` | Set to `1` to show the hardware cursor; see [Terminal setup](terminal-setup.md) |
 | `VISUAL`, `EDITOR` | External editor fallback when `externalEditor` is unset |
 | `HTTP_PROXY`, `HTTPS_PROXY` | Proxy outbound HTTP requests |
+| `CURSOR_AGENT_BIN` | Absolute path to the Cursor agent CLI binary (`agent` / `cursor-agent`). Used by the built-in Cursor CLI bridge when the binary is not on `PATH`. See [Cursor (CLI bridge)](providers.md#cursor-cli-bridge). |
 
-Provider credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and cloud-provider configuration are listed in [Providers](providers.md#environment-variables-or-auth-file).
+Provider credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and cloud-provider configuration are listed in [Providers](providers.md#environment-variables-or-auth-file). The Cursor CLI bridge does not use `CURSOR_API_KEY`; authenticate with `agent login` instead.

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -9,6 +9,7 @@ Pi supports subscription-based providers via OAuth and API key providers via env
 - [Auth File](#auth-file)
 - [Cloud Providers](#cloud-providers)
 - [llama.cpp](#llamacpp)
+- [Cursor (CLI bridge)](#cursor-cli-bridge)
 - [Custom Providers](#custom-providers)
 - [Resolution Order](#resolution-order)
 
@@ -300,6 +301,28 @@ Or set `GOOGLE_APPLICATION_CREDENTIALS` to a service account key file.
 Pi supports the llama.cpp router server. Configure it with `/login llama.cpp`, manage loaded models with `/llama`, and select a loaded model with `/model`.
 
 See [llama.cpp](llama-cpp.md) for server setup, model directory layout, environment variables, and command usage.
+
+## Cursor (CLI bridge)
+
+Pi can use an already-authenticated local [Cursor CLI](https://cursor.com/docs/cli/overview) session (`agent` / `cursor-agent`) as a provider. This path does **not** use `CURSOR_API_KEY`, Pi OAuth, or entries in `~/.pi/agent/auth.json`. Login stays on the Cursor CLI.
+
+Prerequisites:
+
+1. Install the Cursor agent CLI and ensure `agent` (or `cursor-agent`) is on `PATH` (or set `CURSOR_AGENT_BIN`; see [Environment variables](environment-variables.md)).
+2. Run `agent login` and confirm with `agent status`.
+
+Then:
+
+```bash
+pi cursor status          # human-readable; exit 0 when authenticated
+pi cursor status --json   # normalized JSON
+pi --list-models          # includes provider "cursor" Team models when the CLI session is ready
+pi -p --provider cursor --model <id> "Say exactly: ok"
+```
+
+While a Cursor model is selected, Pi built-in tools are disabled so the child `agent` turn does not nest Pi tool loops. The child runs in Cursor `--mode ask`.
+
+`agent status` / `agent login` remain the source of truth for authentication. `pi cursor status` only reports what the local CLI reports.
 
 ## Custom Providers
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -249,7 +249,8 @@ ${chalk.bold("Commands:")}
   ${APP_NAME} list                      List installed extensions from settings
   ${APP_NAME} config [-l]               Open TUI to enable/disable package resources (Tab switches scope)
   ${APP_NAME} auth <command>            Print credentials or check provider readiness
-  ${APP_NAME} <command> --help          Show help for install/remove/uninstall/update/list/config/auth
+  ${APP_NAME} cursor status [--json]    Check local Cursor CLI session auth
+  ${APP_NAME} <command> --help          Show help for install/remove/uninstall/update/list/config/auth/cursor
 
 ${chalk.bold("Options:")}
   --provider <name>              Provider name (default: google)

--- a/packages/coding-agent/src/cli/cursor-command.ts
+++ b/packages/coding-agent/src/cli/cursor-command.ts
@@ -1,0 +1,161 @@
+/**
+ * Early-dispatch CLI surface for Cursor CLI bridge health checks.
+ * Auth/login remains on the external Cursor CLI (`agent login` / `agent status`).
+ */
+
+import chalk from "chalk";
+import {
+	type CursorAgentCliDeps,
+	CursorAgentCliError,
+	type CursorAgentStatus,
+	formatCursorAgentCliErrorMessage,
+	formatNotAuthenticatedMessage,
+	resolveCursorAgentBin,
+	runCursorAgentStatus,
+} from "../core/cursor-agent-cli.ts";
+
+export type CursorCommandKind = "status";
+
+export interface CursorCommand {
+	kind: CursorCommandKind;
+	json: boolean;
+}
+
+export class CursorCommandError extends Error {}
+
+export function isCursorCommandHelp(args: string[]): boolean {
+	return (
+		args[0] === "cursor" &&
+		(args[1] === undefined || args[1] === "help" || args.includes("--help") || args.includes("-h"))
+	);
+}
+
+export function printCursorCommandHelp(): void {
+	console.log(`Usage:
+  pi cursor status [--json]
+  pi cursor help
+
+Show whether the local Cursor CLI (\`agent\` / \`cursor-agent\`) session is authenticated.
+
+Exit codes:
+  0  authenticated
+  1  not authenticated, binary missing, or status failed
+
+The Cursor CLI remains the source of truth for login:
+  agent login
+  agent status
+
+Optional binary override: CURSOR_AGENT_BIN`);
+}
+
+export function parseCursorCommand(args: string[]): CursorCommand | undefined {
+	if (args[0] !== "cursor") return undefined;
+
+	const kind = args[1] === "status" ? "status" : undefined;
+	if (!kind) {
+		throw new CursorCommandError(
+			`Unknown cursor command "${args[1] ?? ""}". Use "pi cursor status" or "pi cursor help".`,
+		);
+	}
+
+	let json = false;
+	for (let index = 2; index < args.length; index++) {
+		const arg = args[index];
+		if (arg === "--json") {
+			json = true;
+			continue;
+		}
+		throw new CursorCommandError(`Unknown option ${arg} for "cursor status". Use "pi cursor status [--json]".`);
+	}
+
+	return { kind, json };
+}
+
+export function formatCursorStatusHuman(status: CursorAgentStatus, bin?: string): string {
+	const lines: string[] = [`Authenticated: ${status.isAuthenticated ? "yes" : "no"}`];
+	if (status.status) lines.push(`Status: ${status.status}`);
+	const email = status.userInfo?.email;
+	if (email) lines.push(`Email: ${email}`);
+	const teamId = status.userInfo?.teamId;
+	if (teamId !== undefined) lines.push(`Team ID: ${teamId}`);
+	const name = [status.userInfo?.firstName, status.userInfo?.lastName].filter(Boolean).join(" ");
+	if (name) lines.push(`Name: ${name}`);
+	if (bin) lines.push(`Binary: ${bin}`);
+	if (!status.isAuthenticated) {
+		lines.push("");
+		lines.push(formatNotAuthenticatedMessage());
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+export function formatCursorStatusJson(status: CursorAgentStatus, bin?: string): string {
+	return `${JSON.stringify({
+		isAuthenticated: status.isAuthenticated,
+		status: status.status,
+		userInfo: status.userInfo,
+		binary: bin,
+	})}\n`;
+}
+
+export type CursorCommandIo = {
+	stdout?: (text: string) => void;
+	stderr?: (text: string) => void;
+	setExitCode?: (code: number) => void;
+};
+
+/**
+ * Handle `pi cursor …` early subcommands.
+ * @returns true if argv was consumed as a cursor command.
+ */
+export async function runCursorCommand(
+	args: string[],
+	deps: CursorAgentCliDeps & CursorCommandIo = {},
+): Promise<boolean> {
+	const writeStdout = deps.stdout ?? ((text: string) => process.stdout.write(text));
+	const writeStderr = deps.stderr ?? ((text: string) => console.error(text));
+	const setExitCode =
+		deps.setExitCode ??
+		((code: number) => {
+			process.exitCode = code;
+		});
+
+	if (isCursorCommandHelp(args)) {
+		printCursorCommandHelp();
+		return true;
+	}
+
+	let command: CursorCommand | undefined;
+	try {
+		command = parseCursorCommand(args);
+	} catch (error) {
+		const message = error instanceof CursorCommandError ? error.message : "Failed to parse cursor command";
+		writeStderr(chalk.red(`Error: ${message}`));
+		setExitCode(1);
+		return true;
+	}
+	if (!command) return false;
+
+	try {
+		const status = await runCursorAgentStatus(deps);
+		const bin = resolveCursorAgentBin(deps);
+		if (command.json) {
+			writeStdout(formatCursorStatusJson(status, bin));
+		} else {
+			writeStdout(formatCursorStatusHuman(status, bin));
+		}
+		setExitCode(status.isAuthenticated ? 0 : 1);
+	} catch (error) {
+		writeStderr(chalk.red(`Error: ${formatCursorAgentCliErrorMessage(error)}`));
+		if (error instanceof CursorAgentCliError) {
+			if (error.code === "not_authenticated") {
+				writeStderr(formatNotAuthenticatedMessage());
+			} else if (error.code === "binary_not_found") {
+				writeStderr(chalk.dim("Install the Cursor agent CLI, or set CURSOR_AGENT_BIN."));
+			} else {
+				writeStderr(chalk.dim("Source of truth: `agent status` / `agent login`."));
+			}
+		}
+		setExitCode(1);
+	}
+	return true;
+}

--- a/packages/coding-agent/src/core/cursor-agent-cli.ts
+++ b/packages/coding-agent/src/core/cursor-agent-cli.ts
@@ -1,0 +1,446 @@
+/**
+ * Shared helpers for the local Cursor CLI (`agent` / `cursor-agent`) sidecar.
+ * Used by the built-in cursor-agent extension and `pi cursor status`.
+ */
+
+import { spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
+import { waitForChildProcess } from "../utils/child-process.ts";
+import type { ExecResult } from "./exec.ts";
+
+export const CURSOR_AGENT_BIN_ENV = "CURSOR_AGENT_BIN";
+export const CURSOR_API_KEY_ENV = "CURSOR_API_KEY";
+
+/** Status / list-models should fail fast; print may wait on a full agent turn. */
+export const CURSOR_AGENT_STATUS_TIMEOUT_MS = 15_000;
+export const CURSOR_AGENT_LIST_MODELS_TIMEOUT_MS = 30_000;
+export const CURSOR_AGENT_PRINT_TIMEOUT_MS = 10 * 60_000;
+
+export class CursorAgentCliError extends Error {
+	readonly code: "binary_not_found" | "not_authenticated" | "command_failed" | "parse_error";
+	readonly stderr?: string;
+	readonly exitCode?: number;
+
+	constructor(
+		code: CursorAgentCliError["code"],
+		message: string,
+		options?: { cause?: unknown; stderr?: string; exitCode?: number },
+	) {
+		super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+		this.name = "CursorAgentCliError";
+		this.code = code;
+		this.stderr = options?.stderr;
+		this.exitCode = options?.exitCode;
+	}
+}
+
+export interface CursorAgentUserInfo {
+	email?: string;
+	userId?: number;
+	firstName?: string;
+	lastName?: string;
+	teamId?: number;
+	createdAt?: string;
+}
+
+export interface CursorAgentStatus {
+	isAuthenticated: boolean;
+	status?: string;
+	userInfo?: CursorAgentUserInfo;
+	raw: unknown;
+}
+
+export interface CursorAgentModelLine {
+	id: string;
+	name: string;
+}
+
+export interface CursorAgentPrintResult {
+	result: string;
+	usage?: {
+		inputTokens?: number;
+		outputTokens?: number;
+		cacheReadTokens?: number;
+		cacheWriteTokens?: number;
+	};
+	raw: unknown;
+}
+
+export type CursorAgentRunner = (
+	bin: string,
+	args: string[],
+	options: {
+		cwd?: string;
+		env?: NodeJS.ProcessEnv;
+		signal?: AbortSignal;
+		timeout?: number;
+	},
+) => Promise<ExecResult>;
+
+export interface CursorAgentCliDeps {
+	env?: NodeJS.ProcessEnv;
+	/** Override PATH directories for binary discovery (tests). */
+	pathDirs?: string[];
+	run?: CursorAgentRunner;
+	/** Working directory for print (--workspace). */
+	cwd?: string;
+}
+
+function isExecutable(path: string): boolean {
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function candidatePaths(dir: string, name: string): string[] {
+	const base = join(dir, name);
+	if (process.platform === "win32") {
+		return [base, `${base}.exe`, `${base}.cmd`, `${base}.bat`];
+	}
+	return [base];
+}
+
+/**
+ * Resolve the Cursor agent binary.
+ * Order: `CURSOR_AGENT_BIN` → `agent` on PATH → `cursor-agent` on PATH.
+ */
+export function resolveCursorAgentBin(deps: CursorAgentCliDeps = {}): string | undefined {
+	const env = deps.env ?? process.env;
+	const override = env[CURSOR_AGENT_BIN_ENV]?.trim();
+	if (override) return override;
+
+	const pathDirs = deps.pathDirs ?? (env.PATH ?? "").split(delimiter);
+	for (const name of ["agent", "cursor-agent"]) {
+		for (const dir of pathDirs) {
+			if (!dir) continue;
+			for (const candidate of candidatePaths(dir, name)) {
+				if (isExecutable(candidate)) return candidate;
+			}
+		}
+	}
+	return undefined;
+}
+
+/** Child env: inherit parent, but never pass CURSOR_API_KEY (overrides local login). */
+export function scrubCursorAgentChildEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	const next = { ...env };
+	delete next[CURSOR_API_KEY_ENV];
+	return next;
+}
+
+export function runCursorAgentProcess(
+	bin: string,
+	args: string[],
+	options: {
+		cwd?: string;
+		env?: NodeJS.ProcessEnv;
+		signal?: AbortSignal;
+		timeout?: number;
+	} = {},
+): Promise<ExecResult> {
+	return new Promise((resolve) => {
+		const proc = spawn(bin, args, {
+			cwd: options.cwd ?? process.cwd(),
+			env: options.env,
+			shell: false,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let killed = false;
+		let timeoutId: NodeJS.Timeout | undefined;
+
+		const killProcess = () => {
+			if (!killed) {
+				killed = true;
+				proc.kill("SIGTERM");
+				setTimeout(() => {
+					if (!proc.killed) proc.kill("SIGKILL");
+				}, 5000);
+			}
+		};
+
+		if (options.signal) {
+			if (options.signal.aborted) killProcess();
+			else options.signal.addEventListener("abort", killProcess, { once: true });
+		}
+		if (options.timeout && options.timeout > 0) {
+			timeoutId = setTimeout(killProcess, options.timeout);
+		}
+
+		proc.stdout?.on("data", (data: Buffer | string) => {
+			stdout += data.toString();
+		});
+		proc.stderr?.on("data", (data: Buffer | string) => {
+			stderr += data.toString();
+		});
+
+		waitForChildProcess(proc)
+			.then((code) => {
+				if (timeoutId) clearTimeout(timeoutId);
+				if (options.signal) options.signal.removeEventListener("abort", killProcess);
+				resolve({ stdout, stderr, code: code ?? 0, killed });
+			})
+			.catch(() => {
+				if (timeoutId) clearTimeout(timeoutId);
+				if (options.signal) options.signal.removeEventListener("abort", killProcess);
+				resolve({ stdout, stderr, code: 1, killed });
+			});
+	});
+}
+
+function invoke(
+	bin: string,
+	args: string[],
+	deps: CursorAgentCliDeps & { signal?: AbortSignal; timeout?: number },
+): Promise<ExecResult> {
+	const options = {
+		cwd: deps.cwd,
+		env: scrubCursorAgentChildEnv(deps.env ?? process.env),
+		signal: deps.signal,
+		timeout: deps.timeout,
+	};
+	return deps.run ? deps.run(bin, args, options) : runCursorAgentProcess(bin, args, options);
+}
+
+function requireBin(deps: CursorAgentCliDeps): string {
+	const bin = resolveCursorAgentBin(deps);
+	if (!bin) {
+		throw new CursorAgentCliError(
+			"binary_not_found",
+			`Cursor CLI binary not found. Install the Cursor agent CLI and ensure \`agent\` (or \`cursor-agent\`) is on PATH, or set ${CURSOR_AGENT_BIN_ENV}.`,
+		);
+	}
+	return bin;
+}
+
+function stderrSnippet(stderr: string, max = 500): string {
+	const trimmed = stderr.trim();
+	if (!trimmed) return "";
+	return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
+}
+
+/** Map killed/non-zero child results to a clear CursorAgentCliError (abort vs timeout vs exit). */
+function ensureSuccessfulCursorAgentResult(
+	label: string,
+	result: ExecResult,
+	options: { signal?: AbortSignal; timeout?: number; stdoutFallback?: boolean } = {},
+): void {
+	if (result.killed) {
+		if (options.signal?.aborted) {
+			throw new CursorAgentCliError("command_failed", `${label} aborted`, {
+				exitCode: result.code,
+				stderr: result.stderr,
+			});
+		}
+		const timeout = options.timeout;
+		throw new CursorAgentCliError(
+			"command_failed",
+			timeout !== undefined ? `${label} timed out after ${timeout}ms` : `${label} was terminated`,
+			{ exitCode: result.code, stderr: result.stderr },
+		);
+	}
+	if (result.code !== 0) {
+		const snippet = stderrSnippet(result.stderr) || (options.stdoutFallback ? stderrSnippet(result.stdout) : "");
+		throw new CursorAgentCliError(
+			"command_failed",
+			snippet
+				? `${label} failed (exit ${result.code}): ${snippet}`
+				: `${label} failed with exit code ${result.code}`,
+			{ stderr: result.stderr, exitCode: result.code },
+		);
+	}
+}
+
+/** Prefer structured CLI errors (already include stderr snippets) for user-facing messages. */
+export function formatCursorAgentCliErrorMessage(error: unknown): string {
+	if (error instanceof CursorAgentCliError) return error.message;
+	if (error instanceof Error) return error.message;
+	return String(error);
+}
+
+export function parseCursorAgentStatusJson(stdout: string): CursorAgentStatus {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(stdout);
+	} catch (error) {
+		throw new CursorAgentCliError("parse_error", "Failed to parse `agent status --format json` output", {
+			cause: error,
+		});
+	}
+	if (typeof raw !== "object" || raw === null) {
+		throw new CursorAgentCliError("parse_error", "Invalid `agent status` JSON: expected an object");
+	}
+	const record = raw as {
+		isAuthenticated?: unknown;
+		status?: unknown;
+		userInfo?: unknown;
+	};
+	const status = typeof record.status === "string" ? record.status : undefined;
+	const isAuthenticated =
+		record.isAuthenticated === true || (record.isAuthenticated === undefined && status === "authenticated");
+
+	let userInfo: CursorAgentUserInfo | undefined;
+	if (typeof record.userInfo === "object" && record.userInfo !== null) {
+		const info = record.userInfo as Record<string, unknown>;
+		userInfo = {
+			email: typeof info.email === "string" ? info.email : undefined,
+			userId: typeof info.userId === "number" ? info.userId : undefined,
+			firstName: typeof info.firstName === "string" ? info.firstName : undefined,
+			lastName: typeof info.lastName === "string" ? info.lastName : undefined,
+			teamId: typeof info.teamId === "number" ? info.teamId : undefined,
+			createdAt: typeof info.createdAt === "string" ? info.createdAt : undefined,
+		};
+	}
+
+	return { isAuthenticated, status, userInfo, raw };
+}
+
+/**
+ * Parse `agent --list-models` text lines: `<id> - <Name>` (optional trailing tags).
+ */
+export function parseCursorAgentListModels(stdout: string): CursorAgentModelLine[] {
+	const models: CursorAgentModelLine[] = [];
+	const lineRe = /^(\S+)\s+-\s+(.+)$/u;
+	for (const line of stdout.split(/\r?\n/u)) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		const match = lineRe.exec(trimmed);
+		if (!match) continue;
+		const id = match[1]!;
+		let name = match[2]!.trim();
+		// Strip trailing parenthetical tags: (current), (default), (current, default), (NO ZDR), etc.
+		name = name.replace(/\s*\([^)]*\)\s*$/u, "").trim() || id;
+		models.push({ id, name });
+	}
+	return models;
+}
+
+export function parseCursorAgentPrintJson(stdout: string): CursorAgentPrintResult {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(stdout);
+	} catch (error) {
+		throw new CursorAgentCliError("parse_error", "Failed to parse `agent -p --output-format json` output", {
+			cause: error,
+			stderr: stdout.slice(0, 500),
+		});
+	}
+	if (typeof raw !== "object" || raw === null) {
+		throw new CursorAgentCliError("parse_error", "Invalid `agent -p` JSON: expected an object");
+	}
+	const record = raw as {
+		type?: unknown;
+		subtype?: unknown;
+		is_error?: unknown;
+		result?: unknown;
+		usage?: unknown;
+	};
+	if (record.is_error === true || record.subtype === "error") {
+		const message = typeof record.result === "string" && record.result ? record.result : "Cursor agent print failed";
+		throw new CursorAgentCliError("command_failed", message);
+	}
+	if (typeof record.result !== "string") {
+		throw new CursorAgentCliError("parse_error", "Cursor agent print JSON missing string `result` field");
+	}
+
+	let usage: CursorAgentPrintResult["usage"];
+	if (typeof record.usage === "object" && record.usage !== null) {
+		const u = record.usage as Record<string, unknown>;
+		usage = {
+			inputTokens: typeof u.inputTokens === "number" ? u.inputTokens : undefined,
+			outputTokens: typeof u.outputTokens === "number" ? u.outputTokens : undefined,
+			cacheReadTokens: typeof u.cacheReadTokens === "number" ? u.cacheReadTokens : undefined,
+			cacheWriteTokens: typeof u.cacheWriteTokens === "number" ? u.cacheWriteTokens : undefined,
+		};
+	}
+
+	return { result: record.result, usage, raw };
+}
+
+export async function runCursorAgentStatus(
+	deps: CursorAgentCliDeps & { signal?: AbortSignal; timeout?: number } = {},
+): Promise<CursorAgentStatus> {
+	const bin = requireBin(deps);
+	const timeout = deps.timeout ?? CURSOR_AGENT_STATUS_TIMEOUT_MS;
+	const result = await invoke(bin, ["status", "--format", "json"], {
+		...deps,
+		timeout,
+	});
+	ensureSuccessfulCursorAgentResult("`agent status`", result, { signal: deps.signal, timeout });
+	return parseCursorAgentStatusJson(result.stdout);
+}
+
+export async function runCursorAgentListModels(
+	deps: CursorAgentCliDeps & { signal?: AbortSignal; timeout?: number } = {},
+): Promise<CursorAgentModelLine[]> {
+	const bin = requireBin(deps);
+	const timeout = deps.timeout ?? CURSOR_AGENT_LIST_MODELS_TIMEOUT_MS;
+	const result = await invoke(bin, ["--list-models"], {
+		...deps,
+		timeout,
+	});
+	ensureSuccessfulCursorAgentResult("`agent --list-models`", result, { signal: deps.signal, timeout });
+	const models = parseCursorAgentListModels(result.stdout);
+	if (models.length === 0) {
+		throw new CursorAgentCliError(
+			"parse_error",
+			"No models parsed from `agent --list-models` output. Is the Cursor CLI up to date?",
+		);
+	}
+	return models;
+}
+
+export async function runCursorAgentPrint(
+	deps: CursorAgentCliDeps & {
+		modelId: string;
+		prompt: string;
+		signal?: AbortSignal;
+		timeout?: number;
+		workspace?: string;
+	},
+): Promise<CursorAgentPrintResult> {
+	const bin = requireBin(deps);
+	const workspace = deps.workspace ?? deps.cwd ?? process.cwd();
+	const timeout = deps.timeout ?? CURSOR_AGENT_PRINT_TIMEOUT_MS;
+	const args = [
+		"-p",
+		"--output-format",
+		"json",
+		"--mode",
+		"ask",
+		"--trust",
+		"--model",
+		deps.modelId,
+		"--workspace",
+		workspace,
+		deps.prompt,
+	];
+	const result = await invoke(bin, args, {
+		...deps,
+		cwd: workspace,
+		timeout,
+	});
+	ensureSuccessfulCursorAgentResult("`agent -p`", result, {
+		signal: deps.signal,
+		timeout,
+		stdoutFallback: true,
+	});
+	const payload = result.stdout.trim();
+	if (!payload) {
+		throw new CursorAgentCliError("parse_error", "`agent -p` returned empty stdout", {
+			stderr: result.stderr,
+			exitCode: result.code,
+		});
+	}
+	return parseCursorAgentPrintJson(payload);
+}
+
+export function formatNotAuthenticatedMessage(): string {
+	return "Cursor CLI is not authenticated. Run `agent login`, then verify with `agent status` (or `pi cursor status`).";
+}

--- a/packages/coding-agent/src/extensions/cursor-agent/index.ts
+++ b/packages/coding-agent/src/extensions/cursor-agent/index.ts
@@ -1,0 +1,42 @@
+import type { ExtensionAPI, ExtensionContext } from "../../core/extensions/types.ts";
+import { CURSOR_PROVIDER_ID, createCursorAgentProvider } from "./provider.ts";
+
+function isCursorModel(model: { provider?: string } | undefined): boolean {
+	return model?.provider === CURSOR_PROVIDER_ID;
+}
+
+export default function cursorAgentExtension(pi: ExtensionAPI): void {
+	const { provider } = createCursorAgentProvider();
+	pi.registerProvider(provider);
+
+	let toolsBeforeCursor: string[] | undefined;
+
+	const disableToolsForCursor = (): void => {
+		if (toolsBeforeCursor === undefined) {
+			toolsBeforeCursor = pi.getActiveTools();
+		}
+		pi.setActiveTools([]);
+	};
+
+	const restoreToolsIfNeeded = (): void => {
+		if (toolsBeforeCursor === undefined) return;
+		pi.setActiveTools(toolsBeforeCursor);
+		toolsBeforeCursor = undefined;
+	};
+
+	const syncToolsForModel = (ctx: ExtensionContext, model = ctx.model): void => {
+		if (isCursorModel(model)) {
+			disableToolsForCursor();
+		} else {
+			restoreToolsIfNeeded();
+		}
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		syncToolsForModel(ctx);
+	});
+
+	pi.on("model_select", async (event, ctx) => {
+		syncToolsForModel(ctx, event.model);
+	});
+}

--- a/packages/coding-agent/src/extensions/cursor-agent/provider.ts
+++ b/packages/coding-agent/src/extensions/cursor-agent/provider.ts
@@ -1,0 +1,138 @@
+import type { AuthResult, Model, Provider, RefreshModelsContext, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import type { CursorAgentCliDeps } from "../../core/cursor-agent-cli.ts";
+import {
+	CursorAgentCliError,
+	formatNotAuthenticatedMessage,
+	runCursorAgentListModels,
+	runCursorAgentStatus,
+} from "../../core/cursor-agent-cli.ts";
+import { streamCursorAgent } from "./stream.ts";
+
+export const CURSOR_PROVIDER_ID = "cursor";
+export const CURSOR_AGENT_API = "cursor-agent-cli";
+export const CURSOR_AGENT_BASE_URL = "cli://cursor-agent";
+
+/** Placeholder limits — Cursor CLI does not expose per-model windows to Pi. */
+export const CURSOR_DEFAULT_CONTEXT_WINDOW = 128_000;
+export const CURSOR_DEFAULT_MAX_TOKENS = 8_192;
+
+const AUTH_SOURCE = "cursor-agent CLI session";
+
+function toPiModel(id: string, name: string): Model<typeof CURSOR_AGENT_API> {
+	const reasoning = /thinking/i.test(name) || /thinking/i.test(id);
+	return {
+		id,
+		name,
+		api: CURSOR_AGENT_API,
+		provider: CURSOR_PROVIDER_ID,
+		baseUrl: CURSOR_AGENT_BASE_URL,
+		reasoning,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: CURSOR_DEFAULT_CONTEXT_WINDOW,
+		maxTokens: CURSOR_DEFAULT_MAX_TOKENS,
+	};
+}
+
+async function isAuthenticatedSession(
+	deps: CursorAgentCliDeps,
+	signal: AbortSignal,
+): Promise<{ ok: true } | { ok: false; reason?: string }> {
+	try {
+		const status = await runCursorAgentStatus({ ...deps, signal });
+		if (!status.isAuthenticated) {
+			return { ok: false, reason: formatNotAuthenticatedMessage() };
+		}
+		return { ok: true };
+	} catch (error) {
+		if (error instanceof CursorAgentCliError && error.code === "binary_not_found") {
+			return { ok: false, reason: error.message };
+		}
+		return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+export interface CursorAgentProviderController {
+	provider: Provider<typeof CURSOR_AGENT_API>;
+}
+
+export function createCursorAgentProvider(deps: CursorAgentCliDeps = {}): CursorAgentProviderController {
+	let models: readonly Model<typeof CURSOR_AGENT_API>[] = [];
+
+	const provider: Provider<typeof CURSOR_AGENT_API> = {
+		id: CURSOR_PROVIDER_ID,
+		name: "Cursor",
+		baseUrl: CURSOR_AGENT_BASE_URL,
+		auth: {
+			apiKey: {
+				name: "Cursor CLI session",
+				// Ambient-only: credentials live in the Cursor CLI login session, not auth.json.
+				check: async ({ signal }) => {
+					const result = await isAuthenticatedSession(deps, signal);
+					return result.ok ? { type: "api_key", source: AUTH_SOURCE } : undefined;
+				},
+				resolve: async ({ signal }): Promise<AuthResult | undefined> => {
+					const result = await isAuthenticatedSession(deps, signal);
+					if (!result.ok) return undefined;
+					return {
+						auth: { apiKey: "local", baseUrl: CURSOR_AGENT_BASE_URL },
+						source: AUTH_SOURCE,
+					};
+				},
+			},
+		},
+		getModels: () => models,
+		refreshModels: async (context: RefreshModelsContext): Promise<void> => {
+			if (context.stored) {
+				const restored = context.stored.models.filter(
+					(model): model is Model<typeof CURSOR_AGENT_API> =>
+						model.provider === CURSOR_PROVIDER_ID && model.api === CURSOR_AGENT_API,
+				);
+				if (
+					!(await context.publish({
+						update: () => {
+							models = restored;
+						},
+					}))
+				) {
+					return;
+				}
+			}
+
+			if (context.signal.aborted) return;
+
+			// Local CLI sidecar is not an HTTP catalog fetch — allow even when allowNetwork is false
+			// so `--offline` still discovers Cursor Team models from the machine login session.
+			const auth = await isAuthenticatedSession(deps, context.signal);
+			if (!auth.ok) {
+				if (!context.stored) {
+					await context.publish({
+						update: () => {
+							models = [];
+						},
+					});
+				}
+				return;
+			}
+
+			try {
+				const listed = await runCursorAgentListModels({ ...deps, signal: context.signal });
+				if (context.signal.aborted) return;
+				const refreshed = listed.map((entry) => toPiModel(entry.id, entry.name));
+				await context.publish({
+					persist: { models: refreshed, checkedAt: Date.now() },
+					update: () => {
+						models = refreshed;
+					},
+				});
+			} catch {
+				// Retain previous / restored catalog on failure.
+			}
+		},
+		stream: (model, context, options) =>
+			streamCursorAgent(model, context, options as SimpleStreamOptions | undefined, deps),
+		streamSimple: (model, context, options) => streamCursorAgent(model, context, options, deps),
+	};
+
+	return { provider };
+}

--- a/packages/coding-agent/src/extensions/cursor-agent/stream.ts
+++ b/packages/coding-agent/src/extensions/cursor-agent/stream.ts
@@ -1,0 +1,194 @@
+import type {
+	AssistantMessage,
+	AssistantMessageEventStream,
+	Context,
+	ImageContent,
+	Model,
+	SimpleStreamOptions,
+	TextContent,
+	Usage,
+} from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import {
+	type CursorAgentCliDeps,
+	CursorAgentCliError,
+	type CursorAgentPrintResult,
+	formatCursorAgentCliErrorMessage,
+	runCursorAgentPrint,
+} from "../../core/cursor-agent-cli.ts";
+
+const EMPTY_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { ...EMPTY_COST },
+	};
+}
+
+function usageFromPrint(result: CursorAgentPrintResult): Usage {
+	const input = result.usage?.inputTokens ?? 0;
+	const output = result.usage?.outputTokens ?? 0;
+	const cacheRead = result.usage?.cacheReadTokens ?? 0;
+	const cacheWrite = result.usage?.cacheWriteTokens ?? 0;
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output + cacheRead + cacheWrite,
+		cost: { ...EMPTY_COST },
+	};
+}
+
+function contentToText(content: string | Array<TextContent | ImageContent>): string {
+	if (typeof content === "string") return content;
+	return content
+		.map((block) => {
+			if (block.type === "text") return block.text;
+			return `[image:${block.mimeType}]`;
+		})
+		.join("\n");
+}
+
+/** Build a plain-text transcript for `agent -p` (no tool schemas). */
+export function buildCursorAgentPrompt(context: Context): string {
+	const parts: string[] = [];
+	if (context.systemPrompt?.trim()) {
+		parts.push(`System:\n${context.systemPrompt.trim()}`);
+	}
+
+	let lastUser = "";
+	for (const message of context.messages) {
+		if (message.role === "user") {
+			const text = contentToText(message.content).trim();
+			if (!text) continue;
+			lastUser = text;
+			parts.push(`User:\n${text}`);
+		} else if (message.role === "assistant") {
+			const text = message.content
+				.filter((block): block is TextContent => block.type === "text")
+				.map((block) => block.text)
+				.join("\n")
+				.trim();
+			if (text) parts.push(`Assistant:\n${text}`);
+		} else if (message.role === "toolResult") {
+			const text = contentToText(message.content).trim();
+			if (text) parts.push(`Tool result (${message.toolName}):\n${text}`);
+		}
+	}
+
+	if (parts.length === 0) {
+		return lastUser || "";
+	}
+	return parts.join("\n\n");
+}
+
+function createBaseMessage(
+	model: Model<"cursor-agent-cli">,
+	stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: emptyUsage(),
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function isAbortError(error: unknown, signal: AbortSignal | undefined): boolean {
+	if (signal?.aborted) return true;
+	if (error instanceof CursorAgentCliError && error.message.toLowerCase().includes("aborted")) return true;
+	if (error instanceof Error && error.name === "AbortError") return true;
+	return false;
+}
+
+export function streamCursorAgent(
+	model: Model<"cursor-agent-cli">,
+	context: Context,
+	options: SimpleStreamOptions | undefined,
+	deps: CursorAgentCliDeps = {},
+): AssistantMessageEventStream {
+	const stream = createAssistantMessageEventStream();
+
+	void (async () => {
+		const partial = createBaseMessage(model, "pending");
+		try {
+			await options?.onResponse?.({ status: 200, headers: {} }, model);
+
+			if (options?.signal?.aborted) {
+				const aborted = { ...partial, stopReason: "aborted" as const, errorMessage: "Request was aborted" };
+				stream.push({ type: "error", reason: "aborted", error: aborted });
+				stream.end(aborted);
+				return;
+			}
+
+			const prompt = buildCursorAgentPrompt(context);
+			if (!prompt.trim()) {
+				throw new CursorAgentCliError("parse_error", "No user prompt to send to Cursor agent CLI");
+			}
+
+			stream.push({ type: "start", partial: { ...partial } });
+
+			const printResult = await runCursorAgentPrint({
+				...deps,
+				modelId: model.id,
+				prompt,
+				signal: options?.signal,
+				cwd: deps.cwd ?? process.cwd(),
+			});
+
+			if (options?.signal?.aborted) {
+				const aborted = { ...partial, stopReason: "aborted" as const, errorMessage: "Request was aborted" };
+				stream.push({ type: "error", reason: "aborted", error: aborted });
+				stream.end(aborted);
+				return;
+			}
+
+			const text = printResult.result;
+			partial.content = [{ type: "text", text: "" }];
+			stream.push({ type: "text_start", contentIndex: 0, partial: { ...partial, content: [...partial.content] } });
+			(partial.content[0] as TextContent).text = text;
+			stream.push({
+				type: "text_delta",
+				contentIndex: 0,
+				delta: text,
+				partial: { ...partial, content: [{ type: "text", text }] },
+			});
+			stream.push({
+				type: "text_end",
+				contentIndex: 0,
+				content: text,
+				partial: { ...partial, content: [{ type: "text", text }] },
+			});
+
+			const done: AssistantMessage = {
+				...partial,
+				content: [{ type: "text", text }],
+				usage: usageFromPrint(printResult),
+				stopReason: "stop",
+				timestamp: Date.now(),
+			};
+			stream.push({ type: "done", reason: "stop", message: done });
+			stream.end(done);
+		} catch (error) {
+			const aborted = isAbortError(error, options?.signal);
+			const message: AssistantMessage = {
+				...createBaseMessage(model, aborted ? "aborted" : "error"),
+				errorMessage: formatCursorAgentCliErrorMessage(error),
+			};
+			stream.push({ type: "error", reason: aborted ? "aborted" : "error", error: message });
+			stream.end(message);
+		}
+	})();
+
+	return stream;
+}

--- a/packages/coding-agent/src/extensions/index.ts
+++ b/packages/coding-agent/src/extensions/index.ts
@@ -1,4 +1,8 @@
 import type { InlineExtension } from "../core/extensions/types.ts";
+import cursorAgentExtension from "./cursor-agent/index.ts";
 import llamaExtension from "./llama/index.ts";
 
-export const builtInExtensions: InlineExtension[] = [{ name: "llama.cpp", factory: llamaExtension, hidden: true }];
+export const builtInExtensions: InlineExtension[] = [
+	{ name: "llama.cpp", factory: llamaExtension, hidden: true },
+	{ name: "cursor-agent", factory: cursorAgentExtension, hidden: true },
+];

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -26,6 +26,7 @@ import {
 	validateAuthCommandArgs,
 } from "./cli/auth-command.ts";
 import { resolveCredentialForPrint } from "./cli/credential-print.ts";
+import { runCursorCommand } from "./cli/cursor-command.ts";
 import { processFileArguments } from "./cli/file-processor.ts";
 import { buildInitialMessage } from "./cli/initial-message.ts";
 import { listModels } from "./cli/list-models.ts";
@@ -576,6 +577,10 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	if (await runAuthCommand(args)) {
+		return;
+	}
+
+	if (await runCursorCommand(args)) {
 		return;
 	}
 

--- a/packages/coding-agent/test/cursor-agent-cli.test.ts
+++ b/packages/coding-agent/test/cursor-agent-cli.test.ts
@@ -1,0 +1,248 @@
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	CURSOR_AGENT_BIN_ENV,
+	CURSOR_API_KEY_ENV,
+	CursorAgentCliError,
+	formatCursorAgentCliErrorMessage,
+	parseCursorAgentListModels,
+	parseCursorAgentPrintJson,
+	parseCursorAgentStatusJson,
+	resolveCursorAgentBin,
+	runCursorAgentListModels,
+	runCursorAgentPrint,
+	runCursorAgentStatus,
+	scrubCursorAgentChildEnv,
+} from "../src/core/cursor-agent-cli.ts";
+
+function makeFakeBinDir(names: string[]): string {
+	const dir = join(tmpdir(), `cursor-agent-bin-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	for (const name of names) {
+		const path = join(dir, name);
+		writeFileSync(path, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		chmodSync(path, 0o755);
+	}
+	return dir;
+}
+
+describe("cursor-agent-cli", () => {
+	it("resolves CURSOR_AGENT_BIN before PATH names", () => {
+		const agentDir = makeFakeBinDir(["agent"]);
+		const custom = join(agentDir, "custom-agent");
+		writeFileSync(custom, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		chmodSync(custom, 0o755);
+
+		expect(
+			resolveCursorAgentBin({
+				env: { [CURSOR_AGENT_BIN_ENV]: custom, PATH: agentDir },
+				pathDirs: [agentDir],
+			}),
+		).toBe(custom);
+	});
+
+	it("prefers agent over cursor-agent on PATH", () => {
+		const dir = makeFakeBinDir(["agent", "cursor-agent"]);
+		expect(resolveCursorAgentBin({ env: { PATH: dir }, pathDirs: [dir] })).toBe(join(dir, "agent"));
+	});
+
+	it("falls back to cursor-agent when agent is missing", () => {
+		const dir = makeFakeBinDir(["cursor-agent"]);
+		expect(resolveCursorAgentBin({ env: { PATH: dir }, pathDirs: [dir] })).toBe(join(dir, "cursor-agent"));
+	});
+
+	it("returns undefined when no binary is available", () => {
+		const dir = makeFakeBinDir([]);
+		expect(resolveCursorAgentBin({ env: { PATH: dir }, pathDirs: [dir] })).toBeUndefined();
+	});
+
+	it("strips CURSOR_API_KEY from child env", () => {
+		const scrubbed = scrubCursorAgentChildEnv({
+			HOME: "/home/test",
+			PATH: "/bin",
+			[CURSOR_API_KEY_ENV]: "secret-key",
+		});
+		expect(scrubbed[CURSOR_API_KEY_ENV]).toBeUndefined();
+		expect(scrubbed.HOME).toBe("/home/test");
+		expect(scrubbed.PATH).toBe("/bin");
+	});
+
+	it("parses authenticated status JSON", () => {
+		const status = parseCursorAgentStatusJson(
+			JSON.stringify({
+				status: "authenticated",
+				isAuthenticated: true,
+				userInfo: { email: "a@b.com", teamId: 1 },
+			}),
+		);
+		expect(status.isAuthenticated).toBe(true);
+		expect(status.userInfo?.email).toBe("a@b.com");
+		expect(status.userInfo?.teamId).toBe(1);
+	});
+
+	it("treats status authenticated without isAuthenticated as authenticated", () => {
+		expect(parseCursorAgentStatusJson(JSON.stringify({ status: "authenticated" })).isAuthenticated).toBe(true);
+	});
+
+	it("rejects unauthenticated status", () => {
+		expect(
+			parseCursorAgentStatusJson(JSON.stringify({ isAuthenticated: false, status: "logged_out" })).isAuthenticated,
+		).toBe(false);
+	});
+
+	it("parses list-models lines and strips tags", () => {
+		const models = parseCursorAgentListModels(`Available models
+
+auto - Auto (current, default)
+gpt-5.2 - GPT-5.2
+claude-fable-5-thinking-high - Fable 5 1M Thinking (NO ZDR)
+Tip: use agent --model <id>
+`);
+		expect(models).toEqual([
+			{ id: "auto", name: "Auto" },
+			{ id: "gpt-5.2", name: "GPT-5.2" },
+			{ id: "claude-fable-5-thinking-high", name: "Fable 5 1M Thinking" },
+		]);
+	});
+
+	it("parses print JSON success payload", () => {
+		const parsed = parseCursorAgentPrintJson(
+			JSON.stringify({
+				type: "result",
+				subtype: "success",
+				is_error: false,
+				result: "ok",
+				usage: { inputTokens: 10, outputTokens: 2 },
+			}),
+		);
+		expect(parsed.result).toBe("ok");
+		expect(parsed.usage?.inputTokens).toBe(10);
+	});
+
+	it("fails print JSON without result string", () => {
+		expect(() => parseCursorAgentPrintJson(JSON.stringify({ type: "result", is_error: false }))).toThrow(
+			/missing string `result`/,
+		);
+	});
+
+	it("runs status/list/print through injected runner and scrubbed env", async () => {
+		const calls: Array<{ bin: string; args: string[]; env?: NodeJS.ProcessEnv }> = [];
+		const run = async (bin: string, args: string[], options: { env?: NodeJS.ProcessEnv }) => {
+			calls.push({ bin, args, env: options.env });
+			if (args[0] === "status") {
+				return {
+					stdout: JSON.stringify({ isAuthenticated: true, status: "authenticated" }),
+					stderr: "",
+					code: 0,
+					killed: false,
+				};
+			}
+			if (args[0] === "--list-models") {
+				return { stdout: "auto - Auto\n", stderr: "", code: 0, killed: false };
+			}
+			return {
+				stdout: JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "hi" }),
+				stderr: "",
+				code: 0,
+				killed: false,
+			};
+		};
+
+		const deps = {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent", [CURSOR_API_KEY_ENV]: "leak", PATH: "/bin" },
+			run,
+		};
+
+		const status = await runCursorAgentStatus(deps);
+		expect(status.isAuthenticated).toBe(true);
+		expect(await runCursorAgentListModels(deps)).toEqual([{ id: "auto", name: "Auto" }]);
+		expect((await runCursorAgentPrint({ ...deps, modelId: "auto", prompt: "Say hi" })).result).toBe("hi");
+
+		expect(calls[0]?.args).toEqual(["status", "--format", "json"]);
+		expect(calls[1]?.args).toEqual(["--list-models"]);
+		expect(calls[2]?.args).toEqual([
+			"-p",
+			"--output-format",
+			"json",
+			"--mode",
+			"ask",
+			"--trust",
+			"--model",
+			"auto",
+			"--workspace",
+			expect.any(String),
+			"Say hi",
+		]);
+		for (const call of calls) {
+			expect(call.env?.[CURSOR_API_KEY_ENV]).toBeUndefined();
+		}
+	});
+
+	it("surfaces stderr snippets on non-zero status/list/print exits", async () => {
+		const deps = {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+			run: async (_bin: string, args: string[]) => {
+				if (args[0] === "status") {
+					return { stdout: "", stderr: "status boom", code: 3, killed: false };
+				}
+				if (args[0] === "--list-models") {
+					return { stdout: "", stderr: "list boom", code: 4, killed: false };
+				}
+				return { stdout: "print boom", stderr: "", code: 5, killed: false };
+			},
+		};
+		await expect(runCursorAgentStatus(deps)).rejects.toThrow(/status boom/);
+		await expect(runCursorAgentListModels(deps)).rejects.toThrow(/list boom/);
+		await expect(runCursorAgentPrint({ ...deps, modelId: "auto", prompt: "x" })).rejects.toThrow(/print boom/);
+	});
+
+	it("rejects empty list-models output and print JSON without result", async () => {
+		await expect(
+			runCursorAgentListModels({
+				env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+				run: async () => ({
+					stdout: "Available models\nTip: use agent --model <id>\n",
+					stderr: "",
+					code: 0,
+					killed: false,
+				}),
+			}),
+		).rejects.toMatchObject({ code: "parse_error" });
+
+		expect(() =>
+			parseCursorAgentPrintJson(JSON.stringify({ type: "result", is_error: true, result: "nope" })),
+		).toThrow(/nope/);
+	});
+
+	it("reports abort vs timeout when the child is killed", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			runCursorAgentStatus({
+				env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+				signal: controller.signal,
+				timeout: 12_000,
+				run: async () => ({ stdout: "", stderr: "", code: 1, killed: true }),
+			}),
+		).rejects.toThrow(/aborted/);
+
+		await expect(
+			runCursorAgentPrint({
+				env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+				modelId: "auto",
+				prompt: "hi",
+				timeout: 99,
+				run: async () => ({ stdout: "", stderr: "", code: 1, killed: true }),
+			}),
+		).rejects.toThrow(/timed out after 99ms/);
+	});
+
+	it("formats CLI errors for user-facing messages", () => {
+		const error = new CursorAgentCliError("binary_not_found", "missing binary");
+		expect(formatCursorAgentCliErrorMessage(error)).toBe("missing binary");
+		expect(formatCursorAgentCliErrorMessage(new Error("other"))).toBe("other");
+		expect(formatCursorAgentCliErrorMessage("raw")).toBe("raw");
+	});
+});

--- a/packages/coding-agent/test/cursor-agent-extension.test.ts
+++ b/packages/coding-agent/test/cursor-agent-extension.test.ts
@@ -1,0 +1,373 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AuthContext, ModelsPublication, ModelsStoreEntry, Provider } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import type { CursorAgentRunner } from "../src/core/cursor-agent-cli.ts";
+import { CURSOR_AGENT_BIN_ENV, CURSOR_API_KEY_ENV } from "../src/core/cursor-agent-cli.ts";
+import type { ExtensionAPI, ExtensionContext, ModelSelectEvent } from "../src/core/extensions/types.ts";
+import cursorAgentExtension from "../src/extensions/cursor-agent/index.ts";
+import {
+	CURSOR_AGENT_API,
+	CURSOR_PROVIDER_ID,
+	createCursorAgentProvider,
+} from "../src/extensions/cursor-agent/provider.ts";
+import { buildCursorAgentPrompt, streamCursorAgent } from "../src/extensions/cursor-agent/stream.ts";
+import { builtInExtensions } from "../src/extensions/index.ts";
+
+function stubRunner(handlers: {
+	status?: unknown;
+	listModels?: string;
+	print?: unknown;
+	onCall?: (bin: string, args: string[], env?: NodeJS.ProcessEnv) => void;
+}): CursorAgentRunner {
+	return async (bin, args, options) => {
+		handlers.onCall?.(bin, args, options.env);
+		if (args[0] === "status") {
+			return {
+				stdout: JSON.stringify(handlers.status ?? { isAuthenticated: true, status: "authenticated" }),
+				stderr: "",
+				code: 0,
+				killed: false,
+			};
+		}
+		if (args[0] === "--list-models") {
+			return { stdout: handlers.listModels ?? "auto - Auto\n", stderr: "", code: 0, killed: false };
+		}
+		return {
+			stdout: JSON.stringify(
+				handlers.print ?? { type: "result", subtype: "success", is_error: false, result: "ok" },
+			),
+			stderr: "",
+			code: 0,
+			killed: false,
+		};
+	};
+}
+
+describe("cursor-agent extension", () => {
+	it("is registered as a hidden built-in extension", () => {
+		expect(
+			builtInExtensions.some(
+				(entry) => typeof entry !== "function" && entry.name === "cursor-agent" && entry.hidden === true,
+			),
+		).toBe(true);
+	});
+
+	it("registers a native provider with id cursor", () => {
+		let registered: Provider | undefined;
+		const api = {
+			registerProvider: (provider: Provider) => {
+				registered = provider;
+			},
+			on: vi.fn(),
+			getActiveTools: () => [],
+			setActiveTools: vi.fn(),
+		} as unknown as ExtensionAPI;
+
+		cursorAgentExtension(api);
+
+		expect(registered?.id).toBe(CURSOR_PROVIDER_ID);
+		expect(registered?.name).toBe("Cursor");
+	});
+
+	it("disables Pi tools for cursor models and restores when leaving", async () => {
+		let activeTools = ["read", "bash", "edit", "write"];
+		const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => Promise<void> | void>>();
+		const api = {
+			registerProvider: vi.fn(),
+			on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void) {
+				const list = handlers.get(event) ?? [];
+				list.push(handler);
+				handlers.set(event, list);
+			},
+			getActiveTools: () => [...activeTools],
+			setActiveTools: (names: string[]) => {
+				activeTools = [...names];
+			},
+		} as unknown as ExtensionAPI;
+
+		cursorAgentExtension(api);
+
+		const ctx = {
+			model: { provider: "anthropic", id: "claude" },
+		} as unknown as ExtensionContext;
+
+		for (const handler of handlers.get("session_start") ?? []) {
+			await handler({ type: "session_start", reason: "startup" }, ctx);
+		}
+		expect(activeTools).toEqual(["read", "bash", "edit", "write"]);
+
+		const selectCursor: ModelSelectEvent = {
+			type: "model_select",
+			model: {
+				id: "auto",
+				name: "Auto",
+				api: CURSOR_AGENT_API,
+				provider: CURSOR_PROVIDER_ID,
+				baseUrl: "cli://cursor-agent",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 8192,
+			},
+			previousModel: ctx.model,
+			source: "set",
+		};
+		for (const handler of handlers.get("model_select") ?? []) {
+			await handler(selectCursor, { ...ctx, model: selectCursor.model });
+		}
+		expect(activeTools).toEqual([]);
+
+		const selectOther: ModelSelectEvent = {
+			type: "model_select",
+			model: {
+				id: "claude",
+				name: "Claude",
+				api: "anthropic-messages",
+				provider: "anthropic",
+				baseUrl: "https://api.anthropic.com",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 200000,
+				maxTokens: 8192,
+			},
+			previousModel: selectCursor.model,
+			source: "set",
+		};
+		for (const handler of handlers.get("model_select") ?? []) {
+			await handler(selectOther, { ...ctx, model: selectOther.model });
+		}
+		expect(activeTools).toEqual(["read", "bash", "edit", "write"]);
+	});
+
+	it("resolves ambient auth from CLI status without writing credentials", async () => {
+		const { provider } = createCursorAgentProvider({
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+			run: stubRunner({ status: { isAuthenticated: true, status: "authenticated" } }),
+		});
+		const auth = provider.auth.apiKey!;
+		const ctx: AuthContext = { env: async () => undefined, fileExists: async () => false };
+		const signal = new AbortController().signal;
+
+		expect(await auth.check?.({ ctx, signal })).toEqual({ type: "api_key", source: "cursor-agent CLI session" });
+		expect(await auth.resolve({ ctx, signal })).toEqual({
+			auth: { apiKey: "local", baseUrl: "cli://cursor-agent" },
+			source: "cursor-agent CLI session",
+		});
+		expect(auth.login).toBeUndefined();
+	});
+
+	it("refreshes models from agent --list-models even when allowNetwork is false", async () => {
+		let cached: ModelsStoreEntry | undefined;
+		const publish = async (publication: ModelsPublication): Promise<boolean> => {
+			if (publication.persist !== undefined && publication.persist !== null) {
+				cached = structuredClone(publication.persist);
+			}
+			publication.update?.();
+			return true;
+		};
+
+		const { provider } = createCursorAgentProvider({
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+			run: stubRunner({
+				listModels: "auto - Auto\ncomposer-2.5 - Composer 2.5\n",
+			}),
+		});
+
+		await provider.refreshModels?.({
+			credential: { type: "api_key", key: "local" },
+			stored: cached,
+			publish,
+			allowNetwork: false,
+			signal: new AbortController().signal,
+		});
+
+		expect(provider.getModels().map((model) => model.id)).toEqual(["auto", "composer-2.5"]);
+		expect(provider.getModels()[0]).toEqual(
+			expect.objectContaining({
+				api: CURSOR_AGENT_API,
+				provider: CURSOR_PROVIDER_ID,
+				baseUrl: "cli://cursor-agent",
+			}),
+		);
+		expect(cached?.models.map((model) => model.id)).toEqual(["auto", "composer-2.5"]);
+	});
+
+	it("builds a transcript prompt and streamSimple emits text events from stubbed CLI", async () => {
+		const envs: Array<NodeJS.ProcessEnv | undefined> = [];
+		const model = {
+			id: "auto",
+			name: "Auto",
+			api: CURSOR_AGENT_API,
+			provider: CURSOR_PROVIDER_ID,
+			baseUrl: "cli://cursor-agent",
+			reasoning: false,
+			input: ["text"] as ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		} as const;
+		const context = {
+			systemPrompt: "Be brief.",
+			messages: [
+				{ role: "user" as const, content: "Hello", timestamp: 1 },
+				{
+					role: "assistant" as const,
+					content: [{ type: "text" as const, text: "Hi" }],
+					api: CURSOR_AGENT_API,
+					provider: CURSOR_PROVIDER_ID,
+					model: "auto",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop" as const,
+					timestamp: 2,
+				},
+				{ role: "user" as const, content: "Say exactly: ok", timestamp: 3 },
+			],
+		};
+
+		expect(buildCursorAgentPrompt(context)).toContain("System:\nBe brief.");
+		expect(buildCursorAgentPrompt(context)).toContain("User:\nSay exactly: ok");
+
+		const stream = streamCursorAgent(model, context, undefined, {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent", [CURSOR_API_KEY_ENV]: "should-not-leak" },
+			run: stubRunner({
+				print: {
+					type: "result",
+					subtype: "success",
+					is_error: false,
+					result: "ok",
+					usage: { inputTokens: 5, outputTokens: 1 },
+				},
+				onCall: (_bin, _args, env) => envs.push(env),
+			}),
+		});
+
+		const events: string[] = [];
+		for await (const event of stream) {
+			events.push(event.type);
+		}
+		const result = await stream.result();
+		expect(events).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+		expect(result.usage.input).toBe(5);
+		expect(envs.every((env) => env?.[CURSOR_API_KEY_ENV] === undefined)).toBe(true);
+	});
+
+	it("does not write cursor credentials to auth.json (no login path)", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-cursor-auth-"));
+		const authPath = join(dir, "auth.json");
+		const before = `${JSON.stringify({ openai: { type: "api_key", key: "sk-test" } }, null, 2)}\n`;
+		writeFileSync(authPath, before);
+		const storage = AuthStorage.create(authPath);
+
+		const { provider } = createCursorAgentProvider({
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+			run: stubRunner({ status: { isAuthenticated: true, status: "authenticated" } }),
+		});
+		const auth = provider.auth.apiKey!;
+		const ctx: AuthContext = { env: async () => undefined, fileExists: async () => false };
+		const signal = new AbortController().signal;
+
+		expect(auth.login).toBeUndefined();
+		expect(await auth.resolve({ ctx, signal })).toMatchObject({
+			auth: { apiKey: "local" },
+			source: "cursor-agent CLI session",
+		});
+		expect(await storage.read("cursor")).toBeUndefined();
+		expect((await storage.list()).some((entry) => entry.providerId === "cursor")).toBe(false);
+		expect(readFileSync(authPath, "utf8")).toBe(before);
+	});
+
+	it("retains previous catalog when list-models fails after a successful refresh", async () => {
+		let cached: ModelsStoreEntry | undefined;
+		const publish = async (publication: ModelsPublication): Promise<boolean> => {
+			if (publication.persist !== undefined && publication.persist !== null) {
+				cached = structuredClone(publication.persist);
+			}
+			publication.update?.();
+			return true;
+		};
+		let listFail = false;
+		const { provider } = createCursorAgentProvider({
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+			run: async (_bin, args) => {
+				if (args[0] === "status") {
+					return {
+						stdout: JSON.stringify({ isAuthenticated: true, status: "authenticated" }),
+						stderr: "",
+						code: 0,
+						killed: false,
+					};
+				}
+				if (listFail) {
+					return { stdout: "", stderr: "list failed", code: 1, killed: false };
+				}
+				return { stdout: "auto - Auto\n", stderr: "", code: 0, killed: false };
+			},
+		});
+
+		const refreshCtx = {
+			credential: { type: "api_key" as const, key: "local" },
+			publish,
+			allowNetwork: false,
+			signal: new AbortController().signal,
+		};
+		await provider.refreshModels?.({ ...refreshCtx, stored: cached });
+		expect(provider.getModels().map((model) => model.id)).toEqual(["auto"]);
+
+		listFail = true;
+		await provider.refreshModels?.({ ...refreshCtx, stored: cached });
+		expect(provider.getModels().map((model) => model.id)).toEqual(["auto"]);
+	});
+
+	it("surfaces stream errors for empty prompts and aborted prints", async () => {
+		const model = {
+			id: "auto",
+			name: "Auto",
+			api: CURSOR_AGENT_API,
+			provider: CURSOR_PROVIDER_ID,
+			baseUrl: "cli://cursor-agent",
+			reasoning: false,
+			input: ["text"] as ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		} as const;
+
+		const emptyStream = streamCursorAgent(model, { messages: [] }, undefined, {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+			run: stubRunner({}),
+		});
+		const emptyResult = await emptyStream.result();
+		expect(emptyResult.stopReason).toBe("error");
+		expect(emptyResult.errorMessage).toMatch(/No user prompt/);
+
+		const controller = new AbortController();
+		controller.abort();
+		const abortedStream = streamCursorAgent(
+			model,
+			{ messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+			{
+				signal: controller.signal,
+			},
+			{
+				env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent" },
+				run: stubRunner({}),
+			},
+		);
+		const abortedResult = await abortedStream.result();
+		expect(abortedResult.stopReason).toBe("aborted");
+	});
+});

--- a/packages/coding-agent/test/cursor-command.test.ts
+++ b/packages/coding-agent/test/cursor-command.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	CursorCommandError,
+	formatCursorStatusHuman,
+	formatCursorStatusJson,
+	isCursorCommandHelp,
+	parseCursorCommand,
+	runCursorCommand,
+} from "../src/cli/cursor-command.ts";
+import { CURSOR_AGENT_BIN_ENV } from "../src/core/cursor-agent-cli.ts";
+import type { ExecResult } from "../src/core/exec.ts";
+
+function stubStatusRun(payload: unknown, code = 0): (bin: string, args: string[]) => Promise<ExecResult> {
+	return async (_bin, args) => {
+		expect(args).toEqual(["status", "--format", "json"]);
+		return {
+			stdout: JSON.stringify(payload),
+			stderr: "",
+			code,
+			killed: false,
+		};
+	};
+}
+
+describe("cursor-command parse/help", () => {
+	it("parses status and --json", () => {
+		expect(parseCursorCommand(["cursor", "status"])).toEqual({ kind: "status", json: false });
+		expect(parseCursorCommand(["cursor", "status", "--json"])).toEqual({ kind: "status", json: true });
+		expect(parseCursorCommand(["auth", "check"])).toBeUndefined();
+	});
+
+	it("rejects unknown commands and options", () => {
+		expect(() => parseCursorCommand(["cursor", "login"])).toThrow(CursorCommandError);
+		expect(() => parseCursorCommand(["cursor", "status", "--verbose"])).toThrow(/Unknown option/);
+	});
+
+	it("detects help", () => {
+		expect(isCursorCommandHelp(["cursor"])).toBe(true);
+		expect(isCursorCommandHelp(["cursor", "help"])).toBe(true);
+		expect(isCursorCommandHelp(["cursor", "--help"])).toBe(true);
+		expect(isCursorCommandHelp(["cursor", "status", "-h"])).toBe(true);
+		expect(isCursorCommandHelp(["cursor", "status"])).toBe(false);
+	});
+});
+
+describe("cursor-command formatting", () => {
+	it("formats human and json status", () => {
+		const status = {
+			isAuthenticated: true,
+			status: "authenticated",
+			userInfo: { email: "a@b.com", teamId: 42, firstName: "Ada", lastName: "Lovelace" },
+			raw: {},
+		};
+		const human = formatCursorStatusHuman(status, "/usr/bin/agent");
+		expect(human).toContain("Authenticated: yes");
+		expect(human).toContain("Email: a@b.com");
+		expect(human).toContain("Team ID: 42");
+		expect(human).toContain("Name: Ada Lovelace");
+		expect(human).toContain("Binary: /usr/bin/agent");
+
+		expect(JSON.parse(formatCursorStatusJson(status, "/usr/bin/agent"))).toEqual({
+			isAuthenticated: true,
+			status: "authenticated",
+			userInfo: status.userInfo,
+			binary: "/usr/bin/agent",
+		});
+	});
+
+	it("includes login guidance when not authenticated", () => {
+		const human = formatCursorStatusHuman({ isAuthenticated: false, raw: {} });
+		expect(human).toContain("Authenticated: no");
+		expect(human).toContain("agent login");
+	});
+});
+
+describe("runCursorCommand", () => {
+	it("returns false for non-cursor argv", async () => {
+		expect(await runCursorCommand(["auth", "check"])).toBe(false);
+	});
+
+	it("prints help and returns true", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			expect(await runCursorCommand(["cursor", "help"])).toBe(true);
+			expect(log).toHaveBeenCalled();
+			expect(String(log.mock.calls[0]?.[0])).toContain("pi cursor status");
+		} finally {
+			log.mockRestore();
+		}
+	});
+
+	it("exits 0 when authenticated (human)", async () => {
+		const chunks: string[] = [];
+		let exitCode: number | undefined;
+		const ok = await runCursorCommand(["cursor", "status"], {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent", PATH: "" },
+			run: stubStatusRun({
+				isAuthenticated: true,
+				status: "authenticated",
+				userInfo: { email: "dev@example.com", teamId: 7 },
+			}),
+			stdout: (text) => {
+				chunks.push(text);
+			},
+			stderr: () => {},
+			setExitCode: (code) => {
+				exitCode = code;
+			},
+		});
+		expect(ok).toBe(true);
+		expect(exitCode).toBe(0);
+		expect(chunks.join("")).toContain("Authenticated: yes");
+		expect(chunks.join("")).toContain("dev@example.com");
+	});
+
+	it("exits 0 with --json when authenticated", async () => {
+		const chunks: string[] = [];
+		let exitCode: number | undefined;
+		await runCursorCommand(["cursor", "status", "--json"], {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent", PATH: "" },
+			run: stubStatusRun({ isAuthenticated: true, status: "authenticated" }),
+			stdout: (text) => {
+				chunks.push(text);
+			},
+			stderr: () => {},
+			setExitCode: (code) => {
+				exitCode = code;
+			},
+		});
+		expect(exitCode).toBe(0);
+		expect(JSON.parse(chunks.join(""))).toMatchObject({ isAuthenticated: true, binary: "/fake/agent" });
+	});
+
+	it("exits 1 when not authenticated", async () => {
+		const chunks: string[] = [];
+		let exitCode: number | undefined;
+		await runCursorCommand(["cursor", "status"], {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent", PATH: "" },
+			run: stubStatusRun({ isAuthenticated: false, status: "unauthenticated" }),
+			stdout: (text) => {
+				chunks.push(text);
+			},
+			stderr: () => {},
+			setExitCode: (code) => {
+				exitCode = code;
+			},
+		});
+		expect(exitCode).toBe(1);
+		expect(chunks.join("")).toContain("Authenticated: no");
+		expect(chunks.join("")).toContain("agent login");
+	});
+
+	it("exits 1 with a clear message when binary is missing", async () => {
+		const errors: string[] = [];
+		let exitCode: number | undefined;
+		await runCursorCommand(["cursor", "status"], {
+			env: { PATH: "" },
+			pathDirs: [],
+			stdout: () => {},
+			stderr: (text) => {
+				errors.push(text);
+			},
+			setExitCode: (code) => {
+				exitCode = code;
+			},
+		});
+		expect(exitCode).toBe(1);
+		expect(errors.join("\n")).toMatch(/Cursor CLI binary not found|CURSOR_AGENT_BIN/i);
+	});
+
+	it("exits 1 when status command fails", async () => {
+		const errors: string[] = [];
+		let exitCode: number | undefined;
+		await runCursorCommand(["cursor", "status"], {
+			env: { [CURSOR_AGENT_BIN_ENV]: "/fake/agent", PATH: "" },
+			run: async () => ({ stdout: "", stderr: "boom", code: 2, killed: false }),
+			stdout: () => {},
+			stderr: (text) => {
+				errors.push(text);
+			},
+			setExitCode: (code) => {
+				exitCode = code;
+			},
+		});
+		expect(exitCode).toBe(1);
+		expect(errors.join("\n")).toContain("boom");
+	});
+});


### PR DESCRIPTION
## Summary
- Add a hidden built-in `cursor-agent` extension that bridges Pi to an already-authenticated local Cursor CLI (`agent` / `cursor-agent`) session — no `CURSOR_API_KEY`, Pi OAuth, or `auth.json` Cursor credentials.
- Expose `pi cursor status [--json]` for health checks; discover Team models via `agent --list-models` and run one-shot prompts with `pi -p --provider cursor` through `agent -p` (`--mode ask`, Pi tools disabled while a Cursor model is selected).
- Document `CURSOR_AGENT_BIN` and the Cursor CLI bridge workflow; cover CLI helpers, extension behavior, and `pi cursor status` with stubbed unit tests.

## Test plan
- [x] `cd packages/coding-agent && node \"\$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js\" --run test/cursor-agent-cli.test.ts test/cursor-agent-extension.test.ts test/cursor-command.test.ts`
- [x] `npm run check`
- [x] Manual: `agent status` authenticated on a Team machine
- [x] Manual: `pi cursor status` / `--json` reports account identity
- [x] Manual: `pi --list-models` includes provider `cursor`
- [x] Manual: `pi -p --provider cursor --model <id> \"Say exactly: ok\"` succeeds without a Pi API key
- [x] Confirm child env strips `CURSOR_API_KEY` (unit coverage + manual)