### PR TITLE
fix(coding-agent): reject concurrent compaction calls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added a fullscreen exit output setting to choose between printing the final transcript and only a session resume hint.
 
+### Fixed
+
+- Fixed a crash on concurrent manual compaction calls. Pressing the compact shortcut twice in quick succession could fail with `Cannot read properties of undefined (reading 'signal')`; a second compact request while one is in progress now rejects with "Compaction already in progress".
+
 ## [0.84.1] - 2026-08-07
 
 ### New Features

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1789,7 +1789,15 @@ export class AgentSession {
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
 		await this.abort();
+		// Reject concurrent compaction calls: the shared AbortController field
+		// would be overwritten by the new call, causing the previous call to
+		// crash on `this._compactionAbortController.signal` after the field
+		// is cleared to undefined.
+		if (this._compactionAbortController !== undefined) {
+			throw new Error("Compaction already in progress");
+		}
 		this._compactionAbortController = new AbortController();
+		const controller = this._compactionAbortController;
 		this._emit({ type: "compaction_start", reason: "manual" });
 
 		try {
@@ -1823,7 +1831,7 @@ export class AgentSession {
 					customInstructions,
 					reason: "manual",
 					willRetry: false,
-					signal: this._compactionAbortController.signal,
+					signal: controller.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (result?.cancel) {
@@ -1857,7 +1865,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					customInstructions,
-					this._compactionAbortController.signal,
+					controller.signal,
 					this.thinkingLevel,
 					this.agent.streamFunction,
 					env,
@@ -1871,7 +1879,7 @@ export class AgentSession {
 				details = result.details;
 			}
 
-			if (this._compactionAbortController.signal.aborted) {
+			if (controller.signal.aborted) {
 				throw new Error("Compaction cancelled");
 			}
 
@@ -2075,6 +2083,7 @@ export class AgentSession {
 
 			this._emit({ type: "compaction_start", reason });
 			this._autoCompactionAbortController = new AbortController();
+			const controller = this._autoCompactionAbortController;
 			started = true;
 
 			let extensionCompaction: CompactionResult | undefined;
@@ -2088,7 +2097,7 @@ export class AgentSession {
 					customInstructions: undefined,
 					reason,
 					willRetry,
-					signal: this._autoCompactionAbortController.signal,
+					signal: controller.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (extensionResult?.cancel) {
@@ -2129,7 +2138,7 @@ export class AgentSession {
 					apiKey,
 					headers,
 					undefined,
-					this._autoCompactionAbortController.signal,
+					controller.signal,
 					this.thinkingLevel,
 					this.agent.streamFunction,
 					env,
@@ -2143,7 +2152,7 @@ export class AgentSession {
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (controller.signal.aborted) {
 				this._emit({
 					type: "compaction_end",
 					reason,

--- a/packages/coding-agent/test/suite/regressions/concurrent-compact-crash.test.ts
+++ b/packages/coding-agent/test/suite/regressions/concurrent-compact-crash.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression test: concurrent compact() calls crash with
+ * "Cannot read properties of undefined (reading 'signal')".
+ *
+ * The bug: compact() stored the AbortController in a shared instance field
+ * _compactionAbortController. When a second compact() call ran while the first
+ * was suspended at an await, it overwrote the field. The first call then
+ * accessed this._compactionAbortController.signal after the field was cleared
+ * to undefined by the second call's finally block.
+ *
+ * The fix: (1) guard against concurrent calls at the start of compact(),
+ * (2) capture the controller in a local variable before any await.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createHarness } from "../harness.ts";
+
+describe("concurrent compact() calls do not crash", () => {
+	it("rejects second compact() while first is in progress", async () => {
+		const harness = await createHarness({
+			models: [
+				{
+					provider: "faux",
+					id: "test",
+					contextWindow: 200,
+					maxTokens: 100,
+					responses: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }],
+				},
+			],
+		});
+		const session = harness.session;
+
+		// Fill context with enough messages that compaction would have work.
+		await session.prompt("hello 1");
+		await session.prompt("hello 2");
+
+		// Start the first compaction (do not await).
+		const firstCompaction = session.compact();
+
+		// Immediately try a second compaction. The guard should reject it.
+		await expect(session.compact()).rejects.toThrow("Compaction already in progress");
+
+		// The first compaction may succeed or fail (e.g., "Nothing to compact").
+		// The important thing is it does NOT crash with "Cannot read properties
+		// of undefined (reading 'signal')".
+		try {
+			await firstCompaction;
+		} catch (e: unknown) {
+			const message = e instanceof Error ? e.message : String(e);
+			expect(message).not.toContain("Cannot read properties of undefined");
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Pressing the compaction shortcut (`/compact` or its keybinding) twice in quick succession can crash the TUI with:

```
Error: Compaction failed: Cannot read properties of undefined (reading 'signal')
```

## Root cause

`compact()` stores its `AbortController` in the shared instance field `_compactionAbortController`. When a second `compact()` call starts while the first is suspended at an `await`:

1. `await this.abort()` in the second call returns immediately: `isIdle` checks only `_isAgentRunActive`, and the agent is idle during compaction.
2. The second call overwrites `this._compactionAbortController` with a new controller.
3. When the second call finishes, its `finally` block clears the field to `undefined`.
4. The first call resumes and reads `this._compactionAbortController.signal` → `undefined.signal` → crash.

The same pattern exists in `_runAutoCompaction()` with `_autoCompactionAbortController`.

## Fix

Two changes in `packages/coding-agent/src/core/agent-session.ts`:

1. **Guard against concurrent calls**: `compact()` now throws `"Compaction already in progress"` when `_compactionAbortController` is already set. This matches the existing guard in `prompt()`.
2. **Capture the controller locally**: Both `compact()` and `_runAutoCompaction()` store the controller in a `const controller` local before any `await`, and use it for all subsequent `.signal` accesses. The local reference survives regardless of what happens to the instance field.

## Testing

- New regression test `packages/coding-agent/test/suite/regressions/concurrent-compact-crash.test.ts`: starts a compaction, immediately issues a second one, and asserts the second is rejected with `"Compaction already in progress"` and the first does not crash with `Cannot read properties of undefined`.
- Existing `test/suite/agent-session-compaction.test.ts` (20 tests) still passes.
