### PR TITLE
fix(ai): send max_tokens to native DeepSeek

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -2421,6 +2421,7 @@ async function generateModels() {
 	const deepseekCompat: OpenAICompletionsCompat = {
 		requiresReasoningContentOnAssistantMessages: true,
 		thinkingFormat: "deepseek",
+		maxTokensField: "max_tokens",
 	};
 	const deepseekV4Models: Model<"openai-completions">[] = [
 		{

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1429,6 +1429,33 @@ describe("openai-completions tool_choice", () => {
 		}
 	});
 
+	it("sends max_tokens for native DeepSeek completions models", async () => {
+		const cases = [getModel("deepseek", "deepseek-v4-flash")!, getModel("deepseek", "deepseek-v4-pro")!] as const;
+
+		for (const model of cases) {
+			let payload: unknown;
+			expect(model.compat?.maxTokensField).toBe("max_tokens");
+
+			await streamSimple(
+				model,
+				{
+					messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+				},
+				{
+					apiKey: "test",
+					maxTokens: 123,
+					onPayload: (params: unknown) => {
+						payload = params;
+					},
+				},
+			).result();
+
+			const params = (payload ?? mockState.lastParams) as { max_tokens?: number; max_completion_tokens?: number };
+			expect(params.max_tokens).toBe(123);
+			expect(params.max_completion_tokens).toBeUndefined();
+		}
+	});
+
 	it("sends max_tokens for Z.AI completions models", async () => {
 		const cases = [getModel("zai", "glm-5-turbo")!, getModel("zai", "glm-5.2")!] as const;
 


### PR DESCRIPTION
DeepSeek documents `max_tokens`, but Pi sends `max_completion_tokens` for native DeepSeek models:

https://api-docs.deepseek.com/api/create-chat-completion

Direct API testing confirmed that DeepSeek silently ignores `max_completion_tokens`, while `max_tokens` is enforced.

Set `maxTokensField` to `max_tokens` for native DeepSeek V4 Flash and Pro. 

Add payload tests for both models.
