### PR TITLE
fix(ai): treat incomplete reason 'length' as a length stop, not an error

### DIFF
--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -766,7 +766,7 @@ function mapStopReason(
 		case "completed":
 			return { stopReason: "stop" };
 		case "incomplete":
-			if (incompleteReason === "max_output_tokens") {
+			if (incompleteReason === "max_output_tokens" || incompleteReason === "length") {
 				return { stopReason: "length" };
 			}
 			return {

--- a/packages/ai/test/openai-responses-terminal-event.test.ts
+++ b/packages/ai/test/openai-responses-terminal-event.test.ts
@@ -319,6 +319,25 @@ describe("OpenAI Responses terminal event handling", () => {
 		});
 	});
 
+	it("finalizes incomplete responses with reason=length as length stops", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+
+		await processResponsesStream(createIncompleteEvents("length"), output, stream, model);
+
+		expect(output.responseId).toBe("resp_incomplete");
+		expect(output.stopReason).toBe("length");
+		expect(output.rawStopReason).toBe("incomplete.length");
+		expect(output.usage).toMatchObject({
+			input: 25,
+			output: 12,
+			cacheRead: 5,
+			cacheWrite: 0,
+			totalTokens: 42,
+		});
+	});
+
 	it("finalizes content-filtered incomplete responses as non-retryable errors", async () => {
 		const model = createModel();
 		const output = createOutput(model);


### PR DESCRIPTION
OpenAI-compatible providers (e.g. Doubao / Volcengine Ark) return `incomplete_details.reason = 'length'` when the model hits its output token limit, instead of the `'max_output_tokens'` used by official OpenAI.

**Problem:** `mapStopReason()` only recognised `'max_output_tokens'` as a normal length stop. `'length'` fell through to the error branch, producing `stopReason: 'error'` with message `"Response incomplete: length"`. This caused the response to be displayed as an error in the UI and broke auto-continuation / goal resumption on length stops.

**Fix:** Treat `'length'` the same as `'max_output_tokens'` — both map to `stopReason: 'length'`, which is a clean output-length stop, not an error.

Added a test in `openai-responses-terminal-event.test.ts` to cover the `reason='length'` case.

Related: #7052
