### PR TITLE
feat: A-level capabilities from oh-my-pi (stream rules, subagent tools, advisor, cross-session memory)

### DIFF
--- a/packages/agent/src/advisor.ts
+++ b/packages/agent/src/advisor.ts
@@ -1,0 +1,112 @@
+import type { AssistantMessage, Message, Model, TextContent } from "@earendil-works/pi-ai";
+import { Agent } from "./agent.ts";
+import { extractJson } from "./harness/tools/index.ts";
+import type { AgentContext, AgentMessage, StreamFn } from "./types.ts";
+
+/**
+ * An advisor observes the agent's latest assistant turn and may return a short
+ * corrective note when the agent drifts from the user's goal, gets stuck, or
+ * makes a mistake worth correcting. The note is injected into the next turn's
+ * context as a lightweight steer message (one-shot, does not burn context on
+ * every turn).
+ */
+export interface Advisor {
+	/**
+	 * Evaluate the latest assistant turn.
+	 * @returns a corrective note, or undefined when no correction is needed.
+	 */
+	evaluate(context: AgentContext, message: AssistantMessage, signal?: AbortSignal): Promise<string | undefined>;
+}
+
+/** Options for constructing an advisor. */
+export interface AdvisorOptions {
+	/** Model used by the advisor. Usually a cheap/fast model. */
+	model: Model<any>;
+	/** Stream function used by the advisor. */
+	streamFn: StreamFn;
+	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
+	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+	/** System prompt for the advisor. */
+	systemPrompt?: string;
+}
+
+const DEFAULT_SYSTEM_PROMPT =
+	'You are a careful advisor embedded in an AI coding agent. You watch for goal drift, getting stuck, and mistakes that would waste a turn. Be concise and specific. Respond with ONLY a JSON object: {"needsCorrection": true|false, "note": "brief corrective guidance or empty string"}.';
+
+function advisorPrompt(context: AgentContext, message: AssistantMessage): string {
+	const userGoal = context.messages.find((m) => m.role === "user");
+	const goalText =
+		userGoal && "content" in userGoal
+			? Array.isArray(userGoal.content)
+				? userGoal.content.map((c) => ("text" in c && typeof c.text === "string" ? c.text : "")).join("\n")
+				: String(userGoal.content)
+			: "";
+	const assistantText = message.content
+		.filter((c): c is TextContent => c.type === "text")
+		.map((c) => c.text)
+		.join("\n");
+
+	return [
+		"Review the latest assistant turn of a coding agent against the user's goal.",
+		"",
+		"USER GOAL:",
+		goalText || "(none)",
+		"",
+		"LATEST ASSISTANT TURN:",
+		assistantText || "(no text output)",
+		"",
+		"Is the assistant drifting from the goal, stuck, or making a mistake worth correcting right now?",
+		'Reply with ONLY JSON: {"needsCorrection": true|false, "note": "brief corrective guidance or empty string"}',
+		"Return only the JSON, no prose.",
+	].join("\n");
+}
+
+function parseAdvisorOutput(text: string): { needsCorrection: boolean; note: string } {
+	const raw = extractJson(text) as { needsCorrection?: unknown; note?: unknown } | undefined;
+	if (!raw || typeof raw !== "object") {
+		return { needsCorrection: false, note: "" };
+	}
+	return {
+		needsCorrection: raw.needsCorrection === true,
+		note: typeof raw.note === "string" ? raw.note : "",
+	};
+}
+
+/**
+ * Creates an advisor that runs a lightweight secondary model over the latest
+ * assistant turn and returns a corrective note on goal drift.
+ */
+export function createAdvisor(options: AdvisorOptions): Advisor {
+	const systemPrompt = options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+	return {
+		async evaluate(context, message, signal): Promise<string | undefined> {
+			const agent = new Agent({
+				streamFn: options.streamFn,
+				convertToLlm: options.convertToLlm,
+				getApiKey: options.getApiKey,
+				initialState: {
+					model: options.model,
+					systemPrompt,
+					tools: [],
+					thinkingLevel: "off",
+					messages: [],
+				},
+			});
+			if (signal) {
+				if (signal.aborted) {
+					return undefined;
+				}
+				signal.addEventListener("abort", () => agent.abort(), { once: true });
+			}
+			await agent.prompt(advisorPrompt(context, message));
+			const text = agent.state.messages
+				.filter((m): m is AssistantMessage => m.role === "assistant")
+				.flatMap((m) => m.content)
+				.filter((c): c is TextContent => c.type === "text")
+				.map((c) => c.text)
+				.join("\n");
+			const parsed = parseAdvisorOutput(text);
+			return parsed.needsCorrection && parsed.note.trim().length > 0 ? parsed.note.trim() : undefined;
+		},
+	};
+}

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -20,6 +20,7 @@ import type {
 	AgentToolCall,
 	AgentToolResult,
 	StreamFn,
+	StreamRule,
 } from "./types.ts";
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
@@ -291,84 +292,143 @@ async function streamAssistantResponse(
 		messages = await config.transformContext(messages, signal);
 	}
 
-	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
-	const llmMessages = await config.convertToLlm(messages);
+	const rules = config.streamRules ?? [];
+	const maxRetries = config.streamRuleMaxRetries ?? 2;
+	let attempts = 0;
+	let systemPrompt = context.systemPrompt;
 
-	// Build LLM context
-	const llmContext: Context = {
-		systemPrompt: context.systemPrompt,
-		messages: llmMessages,
-		tools: context.tools,
-	};
+	// Time-traveling stream rules: watch the streaming text, and when a rule
+	// matches, abort the stream mid-token, inject the reminder into the system
+	// prompt, and retry generation from the same point. The partially generated
+	// text is discarded (the aborted message is surfaced via message_end so the
+	// UI can show what was corrected).
+	while (true) {
+		// Convert to LLM-compatible messages (AgentMessage[] → Message[])
+		const llmMessages = await config.convertToLlm(messages);
 
-	// Resolve API key (important for expiring tokens)
-	const resolvedApiKey =
-		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
+		// Build LLM context
+		const llmContext: Context = {
+			systemPrompt,
+			messages: llmMessages,
+			tools: context.tools,
+		};
 
-	const response = await streamFunction(config.model, llmContext, {
-		...config,
-		apiKey: resolvedApiKey,
-		signal,
-	});
+		// Resolve API key (important for expiring tokens)
+		const resolvedApiKey =
+			(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
 
-	let partialMessage: AssistantMessage | null = null;
-	let addedPartial = false;
+		// A per-attempt AbortController lets a rule fire abort the current stream
+		// without tearing down the whole agent run.
+		const retryController = new AbortController();
+		const combinedSignal = signal ? AbortSignal.any([signal, retryController.signal]) : retryController.signal;
 
-	for await (const event of response) {
-		switch (event.type) {
-			case "start":
-				partialMessage = event.partial;
-				context.messages.push(partialMessage);
-				addedPartial = true;
-				await emit({ type: "message_start", message: { ...partialMessage } });
-				break;
+		const response = await streamFunction(config.model, llmContext, {
+			...config,
+			apiKey: resolvedApiKey,
+			signal: combinedSignal,
+		});
 
-			case "text_start":
-			case "text_delta":
-			case "text_end":
-			case "thinking_start":
-			case "thinking_delta":
-			case "thinking_end":
-			case "toolcall_start":
-			case "toolcall_delta":
-			case "toolcall_end":
-				if (partialMessage) {
+		let partialMessage: AssistantMessage | null = null;
+		let addedPartial = false;
+		let buffer = "";
+		let matchedRule: StreamRule | null = null;
+
+		for await (const event of response) {
+			// Watch the accumulated text for stream rules before dispatching.
+			if (event.type === "text_delta" && rules.length > 0) {
+				buffer += event.delta;
+				for (const rule of rules) {
+					// Defensive: patterns must not use g/y flags, but resetting
+					// lastIndex keeps a stray stateful pattern from breaking us.
+					rule.pattern.lastIndex = 0;
+					if (rule.pattern.test(buffer)) {
+						matchedRule = rule;
+						break;
+					}
+				}
+				if (matchedRule && attempts < maxRetries) {
+					// Abort and retry, but only while retries remain. On the
+					// final attempt the stream is left to finish so the response
+					// is delivered as-is (see streamRuleMaxRetries).
+					retryController.abort();
+					break;
+				}
+				// On the final attempt the rule match is accepted: keep streaming.
+			}
+
+			switch (event.type) {
+				case "start":
 					partialMessage = event.partial;
-					context.messages[context.messages.length - 1] = partialMessage;
-					await emit({
-						type: "message_update",
-						assistantMessageEvent: event,
-						message: { ...partialMessage },
-					});
-				}
-				break;
+					context.messages.push(partialMessage);
+					addedPartial = true;
+					await emit({ type: "message_start", message: { ...partialMessage } });
+					break;
 
-			case "done":
-			case "error": {
-				const finalMessage = await response.result();
-				if (addedPartial) {
-					context.messages[context.messages.length - 1] = finalMessage;
-				} else {
-					context.messages.push(finalMessage);
+				case "text_start":
+				case "text_delta":
+				case "text_end":
+				case "thinking_start":
+				case "thinking_delta":
+				case "thinking_end":
+				case "toolcall_start":
+				case "toolcall_delta":
+				case "toolcall_end":
+					if (partialMessage) {
+						partialMessage = event.partial;
+						context.messages[context.messages.length - 1] = partialMessage;
+						await emit({
+							type: "message_update",
+							assistantMessageEvent: event,
+							message: { ...partialMessage },
+						});
+					}
+					break;
+
+				case "done":
+				case "error": {
+					const finalMessage = await response.result();
+					if (addedPartial) {
+						context.messages[context.messages.length - 1] = finalMessage;
+					} else {
+						context.messages.push(finalMessage);
+					}
+					if (!addedPartial) {
+						await emit({ type: "message_start", message: { ...finalMessage } });
+					}
+					await emit({ type: "message_end", message: finalMessage });
+					return finalMessage;
 				}
-				if (!addedPartial) {
-					await emit({ type: "message_start", message: { ...finalMessage } });
-				}
-				await emit({ type: "message_end", message: finalMessage });
-				return finalMessage;
 			}
 		}
-	}
 
-	const finalMessage = await response.result();
-	if (addedPartial) {
-		context.messages[context.messages.length - 1] = finalMessage;
-	} else {
-		context.messages.push(finalMessage);
-		await emit({ type: "message_start", message: { ...finalMessage } });
+		// A rule fired: inject the reminder and retry from the same point. The
+		// discarded partial is dropped from the context only — it is never
+		// emitted as a terminal message, so it cannot leak into the agent's
+		// persisted state or a later LLM call. The UI observes the correction
+		// via the `stream_rule_triggered` event.
+		if (matchedRule && attempts < maxRetries) {
+			attempts++;
+			systemPrompt += `\n\n[System reminder (stream rule "${matchedRule.name}"): ${matchedRule.reminder}]`;
+			await emit({ type: "stream_rule_triggered", rule: matchedRule.name, attempt: attempts });
+
+			if (addedPartial) {
+				context.messages.pop();
+				addedPartial = false;
+				partialMessage = null;
+			}
+			continue;
+		}
+
+		const finalMessage = await response.result();
+		if (addedPartial) {
+			context.messages[context.messages.length - 1] = finalMessage;
+		} else {
+			context.messages.push(finalMessage);
+			await emit({ type: "message_start", message: { ...finalMessage } });
+		}
+		await emit({ type: "message_end", message: finalMessage });
+		return finalMessage;
 	}
-	await emit({ type: "message_end", message: finalMessage });
-	return finalMessage;
 }
 
 /**

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -7,6 +7,7 @@ import type {
 	ThinkingBudgets,
 	Transport,
 } from "@earendil-works/pi-ai";
+import type { Advisor } from "./advisor.ts";
 import { runAgentLoop, runAgentLoopContinue } from "./agent-loop.ts";
 import { getDefaultStreamFn } from "./stream-fn.ts";
 import type {
@@ -25,6 +26,7 @@ import type {
 	QueueMode,
 	ShouldStopAfterTurnContext,
 	StreamFn,
+	StreamRule,
 	ToolExecutionMode,
 } from "./types.ts";
 
@@ -120,6 +122,15 @@ export interface AgentOptions {
 	transport?: Transport;
 	maxRetryDelayMs?: number;
 	toolExecution?: ToolExecutionMode;
+	/** Time-traveling stream rules applied to every assistant turn (see AgentLoopConfig.streamRules). */
+	streamRules?: StreamRule[];
+	/** Maximum stream-rule retries per turn. Defaults to 2. */
+	streamRuleMaxRetries?: number;
+	/**
+	 * Optional advisor: observes each completed assistant turn and may return a
+	 * corrective note injected into the next turn's context (one-shot steer).
+	 */
+	advisor?: Advisor;
 }
 
 class PendingMessageQueue {
@@ -210,6 +221,12 @@ export class Agent {
 	public transport: Transport;
 	/** Optional cap for provider-requested retry delays. */
 	public maxRetryDelayMs?: number;
+	/** Time-traveling stream rules applied to every assistant turn. */
+	public streamRules?: StreamRule[];
+	/** Maximum stream-rule retries per turn. Defaults to 2. */
+	public streamRuleMaxRetries?: number;
+	/** Advisor observing each completed assistant turn. */
+	public advisor?: Advisor;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
 
@@ -235,6 +252,9 @@ export class Agent {
 		this.transport = runtimeOptions.transport ?? "auto";
 		this.maxRetryDelayMs = runtimeOptions.maxRetryDelayMs;
 		this.toolExecution = runtimeOptions.toolExecution ?? "parallel";
+		this.streamRules = runtimeOptions.streamRules;
+		this.streamRuleMaxRetries = runtimeOptions.streamRuleMaxRetries;
+		this.advisor = runtimeOptions.advisor;
 	}
 
 	/**
@@ -463,12 +483,14 @@ export class Agent {
 			prepareNextTurn:
 				this.prepareNextTurnWithContext || this.prepareNextTurn
 					? async (context) => {
-							if (this.prepareNextTurnWithContext) {
-								return await this.prepareNextTurnWithContext(context, this.signal);
-							}
-							return await this.prepareNextTurn?.(this.signal);
+							const update = this.prepareNextTurnWithContext
+								? await this.prepareNextTurnWithContext(context, this.signal)
+								: await this.prepareNextTurn?.(this.signal);
+							return await this.applyAdvisor(update, context, this.signal);
 						}
-					: undefined,
+					: this.advisor
+						? async (context) => await this.applyAdvisor(undefined, context, this.signal)
+						: undefined,
 			convertToLlm: this.convertToLlm,
 			transformContext: this.transformContext,
 			getApiKey: this.getApiKey,
@@ -480,7 +502,43 @@ export class Agent {
 				return this.steeringQueue.drain();
 			},
 			getFollowUpMessages: async () => this.followUpQueue.drain(),
+			streamRules: this.streamRules,
+			streamRuleMaxRetries: this.streamRuleMaxRetries,
 		};
+	}
+
+	/**
+	 * Runs the advisor over the latest assistant turn and, when a corrective
+	 * note is returned, injects it into the next turn's context as a one-shot
+	 * user steer message.
+	 */
+	private async applyAdvisor(
+		update: AgentLoopTurnUpdate | undefined,
+		turnContext: PrepareNextTurnContext,
+		signal?: AbortSignal,
+	): Promise<AgentLoopTurnUpdate | undefined> {
+		if (!this.advisor) {
+			return update;
+		}
+		const context = turnContext.context;
+		// Only review turns that produced actual text; pure tool-call turns are skipped.
+		const hasText = turnContext.message.content.some((c) => c.type === "text" && c.text.trim().length > 0);
+		if (!hasText) {
+			return update;
+		}
+		const note = await this.advisor.evaluate(context, turnContext.message, signal ?? this.signal);
+		if (!note) {
+			return update;
+		}
+		const nextContext = update?.context
+			? { ...update.context, messages: [...update.context.messages] }
+			: { systemPrompt: context.systemPrompt, messages: [...context.messages], tools: context.tools };
+		nextContext.messages.push({
+			role: "user",
+			content: `[advisor] ${note}`,
+			timestamp: Date.now(),
+		});
+		return { ...update, context: nextContext };
 	}
 
 	private async runWithLifecycle(executor: (signal: AbortSignal) => Promise<void>): Promise<void> {

--- a/packages/agent/src/harness/memory/memory-store.ts
+++ b/packages/agent/src/harness/memory/memory-store.ts
@@ -1,0 +1,151 @@
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { uuidv7 } from "@earendil-works/pi-ai";
+
+/**
+ * A single cross-session memory entry. Memories persist across sessions so a
+ * later session can recall durable facts (decisions, gotchas, conventions).
+ */
+export interface MemoryEntry {
+	id: string;
+	/** The durable fact / note text. */
+	content: string;
+	/** Session that created this memory, if any. */
+	sourceSessionId?: string;
+	/** Working directory this memory applies to (prefix-matched on recall). */
+	cwd?: string;
+	/** Optional tags for lightweight categorization. */
+	tags?: string[];
+	createdAt: number;
+	updatedAt: number;
+}
+
+/** Query for listing or recalling memories. */
+export interface MemoryQuery {
+	/** Only memories created under this cwd (prefix match). */
+	cwd?: string;
+	/** Only memories whose content/tags match at least one keyword (substring match). */
+	keywords?: string[];
+	/** Maximum number of entries to return. */
+	limit?: number;
+}
+
+/** New-memory input for {@link MemoryStore.save}. */
+export type NewMemory = Omit<MemoryEntry, "id" | "createdAt" | "updatedAt"> & {
+	id?: string;
+	createdAt?: number;
+	updatedAt?: number;
+};
+
+/** Persistent store for cross-session memories. */
+export interface MemoryStore {
+	save(memory: NewMemory): Promise<MemoryEntry>;
+	list(query?: MemoryQuery): Promise<MemoryEntry[]>;
+	delete(id: string): Promise<void>;
+}
+
+function matchesQuery(entry: MemoryEntry, query: MemoryQuery = {}): boolean {
+	if (query.cwd && entry.cwd) {
+		// The query cwd is the current working directory; a stored memory applies
+		// when it was saved for that directory or any ancestor of it.
+		const applies = entry.cwd === query.cwd || query.cwd.startsWith(`${entry.cwd}/`);
+		if (!applies) {
+			return false;
+		}
+	}
+	if (query.keywords && query.keywords.length > 0) {
+		const haystack = `${entry.content} ${(entry.tags ?? []).join(" ")}`.toLowerCase();
+		if (!query.keywords.some((k) => haystack.includes(k.toLowerCase()))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/** In-memory {@link MemoryStore}, primarily for tests. */
+export class InMemoryMemoryStore implements MemoryStore {
+	private readonly entries = new Map<string, MemoryEntry>();
+
+	async save(memory: NewMemory): Promise<MemoryEntry> {
+		const entry: MemoryEntry = {
+			...memory,
+			id: memory.id ?? uuidv7(),
+			createdAt: memory.createdAt ?? Date.now(),
+			updatedAt: memory.updatedAt ?? Date.now(),
+		};
+		this.entries.set(entry.id, structuredClone(entry));
+		return structuredClone(entry);
+	}
+
+	async list(query: MemoryQuery = {}): Promise<MemoryEntry[]> {
+		const matches = [...this.entries.values()].filter((e) => matchesQuery(e, query));
+		matches.sort((a, b) => b.updatedAt - a.updatedAt);
+		return structuredClone(query.limit ? matches.slice(0, query.limit) : matches);
+	}
+
+	async delete(id: string): Promise<void> {
+		this.entries.delete(id);
+	}
+}
+
+/**
+ * File-backed {@link MemoryStore} that persists one JSON file per memory under
+ * `<agentDir>/memories/`.
+ */
+export class FileMemoryStore implements MemoryStore {
+	private readonly agentDir: string;
+
+	constructor(agentDir: string) {
+		this.agentDir = agentDir;
+	}
+
+	private get memoriesDir(): string {
+		return join(this.agentDir, "memories");
+	}
+
+	async save(memory: NewMemory): Promise<MemoryEntry> {
+		const entry: MemoryEntry = {
+			...memory,
+			id: memory.id ?? uuidv7(),
+			createdAt: memory.createdAt ?? Date.now(),
+			updatedAt: memory.updatedAt ?? Date.now(),
+		};
+		await mkdir(this.memoriesDir, { recursive: true });
+		await writeFile(join(this.memoriesDir, `${entry.id}.json`), JSON.stringify(entry, null, 2), "utf8");
+		return structuredClone(entry);
+	}
+
+	async list(query: MemoryQuery = {}): Promise<MemoryEntry[]> {
+		await mkdir(this.memoriesDir, { recursive: true });
+		const names = await readdir(this.memoriesDir);
+		const entries: MemoryEntry[] = [];
+		for (const name of names) {
+			if (!name.endsWith(".json")) continue;
+			try {
+				const raw = await readFile(join(this.memoriesDir, name), "utf8");
+				entries.push(JSON.parse(raw) as MemoryEntry);
+			} catch {
+				// Skip corrupted/partial files.
+			}
+		}
+		const matches = entries.filter((e) => matchesQuery(e, query));
+		matches.sort((a, b) => b.updatedAt - a.updatedAt);
+		return query.limit ? matches.slice(0, query.limit) : matches;
+	}
+
+	async delete(id: string): Promise<void> {
+		await rm(join(this.memoriesDir, `${id}.json`), { force: true });
+	}
+}
+
+/**
+ * Formats recalled memories into a system-prompt appendix block, or undefined
+ * when there is nothing to inject.
+ */
+export function formatMemoriesBlock(memories: MemoryEntry[]): string | undefined {
+	if (memories.length === 0) {
+		return undefined;
+	}
+	const lines = memories.map((m) => `- ${m.content}`).join("\n");
+	return `## Project memories\n${lines}\n(These are facts from earlier sessions in this project. Use them when relevant; ignore when stale.)`;
+}

--- a/packages/agent/src/harness/tools/index.ts
+++ b/packages/agent/src/harness/tools/index.ts
@@ -19,5 +19,23 @@ export {
 	type ReadToolInput,
 	type ReadToolOptions,
 } from "./read.ts";
+export {
+	createReviewTool,
+	type ReviewIssue,
+	type ReviewParameters,
+	type ReviewSeverity,
+	type ReviewToolDetails,
+	type ReviewToolOptions,
+	type ReviewVerdict,
+	reviewParametersSchema,
+} from "./review.ts";
+export {
+	createTaskTool,
+	extractJson,
+	type TaskParameters,
+	type TaskToolDetails,
+	type TaskToolOptions,
+	taskParametersSchema,
+} from "./task.ts";
 export type { ExecutionToolContext } from "./tool-context.ts";
 export { createWriteTool, type WriteToolInput } from "./write.ts";

--- a/packages/agent/src/harness/tools/review.ts
+++ b/packages/agent/src/harness/tools/review.ts
@@ -1,0 +1,275 @@
+import type { AssistantMessage, Message, Model, TextContent } from "@earendil-works/pi-ai";
+import { type Static, Type } from "typebox";
+import { Agent } from "../../agent.ts";
+import type { AgentMessage, AgentTool, AgentToolResult, StreamFn, ThinkingLevel } from "../../types.ts";
+import { extractJson } from "./task.ts";
+
+/**
+ * Parameters for the `review` tool.
+ */
+export const reviewParametersSchema = Type.Object({
+	diff: Type.String({
+		description:
+			"The change under review as unified diff text (e.g. output of `git diff`), or a description of uncommitted changes.",
+	}),
+	focus: Type.Optional(
+		Type.String({ description: "Optional area to focus the review on (e.g. auth, error handling, perf)." }),
+	),
+	context: Type.Optional(
+		Type.String({ description: "Optional context about the change (why it exists, related PR/issue)." }),
+	),
+	reviewers: Type.Optional(
+		Type.Integer({
+			minimum: 2,
+			maximum: 5,
+			default: 3,
+			description: "Number of parallel reviewer subagents (default 3, each with a distinct lens).",
+		}),
+	),
+});
+
+export type ReviewParameters = Static<typeof reviewParametersSchema>;
+
+/** Severity levels, P0 most severe. */
+export type ReviewSeverity = "P0" | "P1" | "P2" | "P3";
+
+export type ReviewVerdict = "approve" | "changes-requested" | "reject";
+
+/** A single finding from one reviewer. */
+export interface ReviewIssue {
+	severity: ReviewSeverity;
+	confidence: number;
+	location?: string;
+	summary: string;
+	recommendation?: string;
+}
+
+/** Structured details returned alongside the review summary. */
+export interface ReviewToolDetails {
+	/** Aggregate verdict across reviewers. */
+	verdict: ReviewVerdict;
+	/** Total number of findings (all severities). */
+	issueCount: number;
+	/** Findings per severity level. */
+	bySeverity: Partial<Record<ReviewSeverity, number>>;
+	/** Number of reviewer subagents that completed. */
+	reviewerCount: number;
+	/** Wall-clock duration of the review run in milliseconds. */
+	durationMs: number;
+}
+
+/** Options for constructing the `review` tool. */
+export interface ReviewToolOptions {
+	model: Model<any>;
+	streamFn: StreamFn;
+	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
+	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+	/** System prompt for reviewer subagents. */
+	systemPrompt?: string;
+	/** Lazily resolved system prompt, evaluated per subagent spawn. Takes precedence over `systemPrompt` when both are set. */
+	getSystemPrompt?: () => string;
+	/** Thinking level for reviewer subagents. Defaults to "off". */
+	thinkingLevel?: ThinkingLevel;
+}
+
+/** Distinct reviewer lenses; the first `reviewers` lenses are used. */
+const REVIEWER_LENSES = [
+	{
+		id: "correctness",
+		instruction:
+			"Focus on CORRECTNESS: logic errors, edge cases, concurrency bugs, off-by-one, null/undefined handling, and places where the change breaks existing behavior.",
+	},
+	{
+		id: "security",
+		instruction:
+			"Focus on SECURITY: injection, authz/authn bypass, secrets exposure, path traversal, unsafe deserialization, and other vulnerabilities introduced or exposed by this change.",
+	},
+	{
+		id: "maintainability",
+		instruction:
+			"Focus on MAINTAINABILITY: readability, naming, dead code, duplication, test coverage, and whether the change fits the surrounding architecture.",
+	},
+	{
+		id: "performance",
+		instruction:
+			"Focus on PERFORMANCE: accidental quadratic behavior, N+1 queries, blocking hot paths, memory/CPU regressions, and avoidable allocations.",
+	},
+	{
+		id: "regression",
+		instruction:
+			"Focus on REGRESSIONS: behavioral changes that could break callers, API compatibility, migration concerns, and silent failures.",
+	},
+] as const;
+
+function reviewPrompt(
+	diff: string,
+	lens: (typeof REVIEWER_LENSES)[number],
+	focus: string | undefined,
+	context: string | undefined,
+): string {
+	return [
+		"Review the following code change as a senior engineer.",
+		lens.instruction,
+		focus ? `Additionally keep this focus area in mind: ${focus}` : "",
+		context ? `Change context: ${context}` : "",
+		"",
+		"```diff",
+		diff,
+		"```",
+		"",
+		"Respond with ONLY a JSON object of this exact shape:",
+		`{"verdict":"approve|changes-requested|reject","issues":[{"severity":"P0|P1|P2|P3","confidence":0.0,"location":"file:line or symbol","summary":"short description","recommendation":"suggested fix (optional)"}],"summary":"one-paragraph review summary"}`,
+		"Severity: P0 = must fix before merge, P1 = should fix, P2 = nice to fix, P3 = nit. Confidence 0-1.",
+		"Return only the JSON, no prose around it.",
+	]
+		.filter((line) => line !== "")
+		.join("\n");
+}
+
+/** Aggregate a reviewer's parsed output into a structured issue list. */
+function parseReviewOutput(text: string): { verdict?: ReviewVerdict; issues: ReviewIssue[]; summary: string } {
+	const raw = extractJson(text) as { verdict?: unknown; issues?: unknown; summary?: unknown } | undefined;
+	if (!raw || typeof raw !== "object") {
+		return { issues: [], summary: text.slice(0, 500) };
+	}
+	const issues = Array.isArray(raw.issues)
+		? (
+				raw.issues as {
+					severity?: unknown;
+					confidence?: unknown;
+					location?: unknown;
+					summary?: unknown;
+					recommendation?: unknown;
+				}[]
+			)
+				.filter((issue) => issue && typeof issue === "object" && typeof issue.summary === "string")
+				.map((issue) => ({
+					severity: (["P0", "P1", "P2", "P3"] as const).includes(issue.severity as ReviewSeverity)
+						? (issue.severity as ReviewSeverity)
+						: ("P3" as const),
+					confidence:
+						typeof issue.confidence === "number" && issue.confidence >= 0 && issue.confidence <= 1
+							? issue.confidence
+							: 0.5,
+					location: typeof issue.location === "string" ? issue.location : undefined,
+					summary: typeof issue.summary === "string" ? issue.summary : "",
+					recommendation: typeof issue.recommendation === "string" ? issue.recommendation : undefined,
+				}))
+		: [];
+	const verdict =
+		raw.verdict === "approve" || raw.verdict === "changes-requested" || raw.verdict === "reject"
+			? (raw.verdict as ReviewVerdict)
+			: undefined;
+	return {
+		verdict,
+		issues,
+		summary: typeof raw.summary === "string" ? raw.summary : "",
+	};
+}
+
+const SEVERITY_RANK: Record<ReviewSeverity, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
+
+/** Aggregate the aggregate verdict from all findings. */
+export function aggregateVerdict(allIssues: ReviewIssue[]): ReviewVerdict {
+	if (allIssues.some((issue) => issue.severity === "P0")) {
+		return "reject";
+	}
+	if (allIssues.some((issue) => issue.severity === "P1")) {
+		return "changes-requested";
+	}
+	return "approve";
+}
+
+/**
+ * The `review` tool: runs parallel reviewer subagents over a diff and returns
+ * a P0–P3 ranked issue list with an aggregate verdict. Reviewers run
+ * concurrently, each with a distinct lens (correctness/security/maintainability/
+ * performance/regression).
+ */
+export function createReviewTool(options: ReviewToolOptions): AgentTool<typeof reviewParametersSchema> {
+	const systemPrompt =
+		options.getSystemPrompt?.() ??
+		options.systemPrompt ??
+		"You are a rigorous code reviewer. Follow the requested output format exactly.";
+
+	return {
+		name: "review",
+		label: "review",
+		description:
+			"Review a code change (unified diff) with N parallel reviewer subagents, each with a distinct lens. Returns P0–P3 ranked issues and an aggregate verdict (approve / changes-requested / reject).",
+		parameters: reviewParametersSchema,
+		async execute(_toolCallId, params, signal, _onUpdate): Promise<AgentToolResult<ReviewToolDetails>> {
+			const reviewerCount = params.reviewers ?? 3;
+			const lenses = REVIEWER_LENSES.slice(0, reviewerCount);
+			const started = Date.now();
+
+			// Spawn reviewer subagents in parallel.
+			const runs = await Promise.all(
+				lenses.map((lens) => {
+					const subagent = new Agent({
+						streamFn: options.streamFn,
+						convertToLlm: options.convertToLlm,
+						getApiKey: options.getApiKey,
+						initialState: {
+							model: options.model,
+							systemPrompt,
+							tools: [],
+							thinkingLevel: options.thinkingLevel ?? "off",
+							messages: [],
+						},
+					});
+					if (signal) {
+						if (signal.aborted) {
+							throw new Error("Review was aborted before it started.");
+						}
+						signal.addEventListener("abort", () => subagent.abort(), { once: true });
+					}
+					const prompt = reviewPrompt(params.diff, lens, params.focus, params.context);
+					return subagent.prompt(prompt).then(() => {
+						const text = subagent.state.messages
+							.filter((m): m is AssistantMessage => m.role === "assistant")
+							.flatMap((m) => m.content)
+							.filter((c): c is TextContent => c.type === "text")
+							.map((c) => c.text)
+							.join("\n");
+						return parseReviewOutput(text);
+					});
+				}),
+			);
+
+			// Merge and rank all findings.
+			const allIssues = runs
+				.flatMap((run) => run.issues)
+				.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] || b.confidence - a.confidence);
+			const verdict = aggregateVerdict(allIssues);
+			const bySeverity: Partial<Record<ReviewSeverity, number>> = {};
+			for (const issue of allIssues) {
+				bySeverity[issue.severity] = (bySeverity[issue.severity] ?? 0) + 1;
+			}
+
+			const completedReviewers = runs.filter((run) => run.issues.length > 0 || run.verdict).length;
+			const details: ReviewToolDetails = {
+				verdict,
+				issueCount: allIssues.length,
+				bySeverity,
+				reviewerCount: completedReviewers,
+				durationMs: Date.now() - started,
+			};
+
+			const summary = {
+				verdict,
+				issues: allIssues,
+				reviewers: runs.map((run, index) => ({
+					lens: lenses[index]?.id,
+					verdict: run.verdict,
+					summary: run.summary,
+				})),
+			};
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(summary, null, 2) }],
+				details,
+			};
+		},
+	};
+}

--- a/packages/agent/src/harness/tools/task.ts
+++ b/packages/agent/src/harness/tools/task.ts
@@ -1,0 +1,192 @@
+import type { AssistantMessage, Message, Model, TextContent } from "@earendil-works/pi-ai";
+import { type Static, Type } from "typebox";
+import { Agent } from "../../agent.ts";
+import type { AgentMessage, AgentTool, AgentToolResult, StreamFn, ThinkingLevel } from "../../types.ts";
+
+/**
+ * Parameters for the `task` tool.
+ */
+export const taskParametersSchema = Type.Object({
+	prompt: Type.String({ description: "Instructions for the subagent." }),
+	description: Type.Optional(Type.String({ description: "Short label describing what this subagent should do." })),
+	schema: Type.Optional(
+		Type.Object(
+			{
+				description: Type.Optional(Type.String()),
+				properties: Type.Record(Type.String(), Type.Any(), {
+					description: "TypeBox schema for each expected result field.",
+				}),
+				required: Type.Optional(
+					Type.Array(Type.String(), { description: "Field names that must be present in the result." }),
+				),
+			},
+			{
+				description:
+					"Expected structured output. When provided, the subagent's final text is parsed as JSON and validated against this schema before being returned.",
+			},
+		),
+	),
+});
+
+export type TaskParameters = Static<typeof taskParametersSchema>;
+
+/** Structured details returned alongside the subagent's output. */
+export interface TaskToolDetails {
+	/** Short label describing the subagent's task. */
+	summary: string;
+	/** Number of messages produced by the subagent's transcript. */
+	messageCount: number;
+	/** Wall-clock duration of the subagent run in milliseconds. */
+	durationMs: number;
+	/** Whether the result went through JSON schema extraction/validation. */
+	hasStructuredResult: boolean;
+}
+
+/** Options for constructing the `task` tool. */
+export interface TaskToolOptions {
+	model: Model<any>;
+	streamFn: StreamFn;
+	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
+	getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
+	/** System prompt for the subagent. Defaults to the parent's system prompt if omitted. */
+	systemPrompt?: string;
+	/** Lazily resolved system prompt, evaluated per subagent spawn. Takes precedence over `systemPrompt` when both are set. */
+	getSystemPrompt?: () => string;
+	/** Tools the subagent may use. Defaults to no tools (text-only subagents). */
+	tools?: AgentTool<any>[];
+	/** Thinking level for the subagent. Defaults to "off". */
+	thinkingLevel?: ThinkingLevel;
+}
+
+/**
+ * Extracts the first balanced JSON object from arbitrary assistant text,
+ * preferring a fenced ```json block. Returns undefined when no JSON is found.
+ */
+export function extractJson(text: string): unknown | undefined {
+	const fence = text.match(/```json\s*([\s\S]*?)```/i);
+	const candidate = (fence ? fence[1] : text).trim();
+	const start = candidate.indexOf("{");
+	if (start === -1) {
+		return undefined;
+	}
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let i = start; i < candidate.length; i++) {
+		const ch = candidate[i];
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+			} else if (ch === "\\") {
+				escaped = true;
+			} else if (ch === '"') {
+				inString = false;
+			}
+			continue;
+		}
+		if (ch === '"') {
+			inString = true;
+		} else if (ch === "{") {
+			depth++;
+		} else if (ch === "}") {
+			depth--;
+			if (depth === 0) {
+				try {
+					return JSON.parse(candidate.slice(start, i + 1));
+				} catch {
+					return undefined;
+				}
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * The `task` tool: spawns an isolated subagent, waits for it to finish, and
+ * returns its output. When a `schema` is provided the subagent's final text is
+ * parsed as JSON and validated (required fields checked) before being returned,
+ * so the parent gets a typed result instead of prose to parse.
+ */
+export function createTaskTool(options: TaskToolOptions): AgentTool<typeof taskParametersSchema> {
+	const systemPrompt = options.getSystemPrompt?.() ?? options.systemPrompt ?? "";
+	const tools = options.tools ?? [];
+	const thinkingLevel = options.thinkingLevel ?? "off";
+
+	return {
+		name: "task",
+		label: "task",
+		description:
+			"Split work across a subagent. Runs the given prompt in an isolated agent with its own transcript and tool surface, waits for it to finish, and returns its output. Provide a `schema` to receive a validated structured JSON result instead of prose.",
+		parameters: taskParametersSchema,
+		async execute(_toolCallId, params, signal, _onUpdate): Promise<AgentToolResult<TaskToolDetails>> {
+			const subagent = new Agent({
+				streamFn: options.streamFn,
+				convertToLlm: options.convertToLlm,
+				getApiKey: options.getApiKey,
+				initialState: {
+					model: options.model,
+					systemPrompt,
+					tools,
+					thinkingLevel,
+					messages: [],
+				},
+			});
+
+			if (signal) {
+				if (signal.aborted) {
+					throw new Error("Subagent task was aborted before it started.");
+				}
+				signal.addEventListener("abort", () => subagent.abort(), { once: true });
+			}
+
+			const started = Date.now();
+			await subagent.prompt(params.prompt);
+
+			const messages = subagent.state.messages;
+			const text = messages
+				.filter((m): m is AssistantMessage => m.role === "assistant")
+				.flatMap((m) => m.content)
+				.filter((c): c is TextContent => c.type === "text")
+				.map((c) => c.text)
+				.join("\n");
+
+			let result: unknown;
+			if (params.schema) {
+				result = extractJson(text);
+				if (result === undefined) {
+					throw new Error(
+						`Subagent did not return a JSON object matching the requested schema.\nRaw output:\n${text}`,
+					);
+				}
+				if (params.schema.required) {
+					for (const key of params.schema.required) {
+						if (!(typeof result === "object" && result !== null && key in result)) {
+							throw new Error(`Subagent JSON result is missing required field "${key}".`);
+						}
+					}
+				}
+			} else {
+				result = { summary: text };
+			}
+
+			const summary =
+				params.description ??
+				(typeof result === "object" && result !== null && "summary" in result
+					? String((result as { summary: unknown }).summary)
+					: text.slice(0, 200));
+
+			const details: TaskToolDetails = {
+				summary,
+				messageCount: messages.length,
+				durationMs: Date.now() - started,
+				hasStructuredResult: Boolean(params.schema),
+			};
+
+			return {
+				content: [{ type: "text", text: params.schema ? JSON.stringify(result, null, 2) : text }],
+				details,
+			};
+		},
+	};
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -40,6 +40,8 @@ export {
 	InMemoryTelemetryContext,
 	NOOP_TELEMETRY_CONTEXT,
 } from "@earendil-works/pi-telemetry";
+// Advisor (secondary-model turn observer)
+export { type Advisor, type AdvisorOptions, createAdvisor } from "./advisor.ts";
 export * from "./agent.ts";
 // Loop functions
 export * from "./agent-loop.ts";
@@ -73,6 +75,16 @@ export {
 	serializeConversation,
 	shouldCompact,
 } from "./harness/compaction/compaction.ts";
+// Cross-session memory stores
+export {
+	FileMemoryStore,
+	formatMemoriesBlock,
+	InMemoryMemoryStore,
+	type MemoryEntry,
+	type MemoryQuery,
+	type MemoryStore,
+	type NewMemory,
+} from "./harness/memory/memory-store.ts";
 export * from "./harness/messages.ts";
 export * from "./harness/prompt-templates.ts";
 // Harness

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -290,6 +290,45 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * The hook receives the agent abort signal and is responsible for honoring it.
 	 */
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
+
+	/**
+	 * Time-traveling stream rules.
+	 *
+	 * Each rule watches the assistant text as it streams. When the accumulated
+	 * text matches `pattern`, the current LLM stream is aborted mid-token, the
+	 * rule's `reminder` is injected into the system prompt, and the stream is
+	 * retried from the same point (the partially generated text is discarded).
+	 * This course-corrects the model without paying context tax on every turn.
+	 *
+	 * Up to `streamRuleMaxRetries` retries are attempted per turn; if the text
+	 * still matches a rule afterwards, the response is finalized as-is.
+	 *
+	 * `pattern` must not use the `g` or `y` flags (stateful matching is not
+	 * supported; each check tests against the accumulated text from scratch).
+	 */
+	streamRules?: StreamRule[];
+
+	/**
+	 * Maximum number of stream-rule retries per assistant turn. Defaults to 2.
+	 */
+	streamRuleMaxRetries?: number;
+}
+
+/**
+ * A time-traveling stream rule.
+ *
+ * While the model streams text, every rule is tested against the text
+ * accumulated so far in the current response. The first rule whose `pattern`
+ * matches fires: the stream is aborted, `reminder` is appended to the system
+ * prompt, and generation restarts from the beginning of the response.
+ */
+export interface StreamRule {
+	/** Rule name, surfaced in `stream_rule_triggered` events and diagnostics. */
+	name: string;
+	/** Regex tested against the accumulated assistant text. Must not use `g` or `y` flags. */
+	pattern: RegExp;
+	/** Reminder injected into the system prompt when the rule fires. */
+	reminder: string;
 }
 
 /**
@@ -440,4 +479,6 @@ export type AgentEvent =
 	// Tool execution lifecycle
 	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any }
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }
-	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean };
+	| { type: "tool_execution_end"; toolCallId: string; toolName: string; result: any; isError: boolean }
+	// Stream rules (time-traveling course correction)
+	| { type: "stream_rule_triggered"; rule: string; attempt: number };

--- a/packages/agent/test/advisor.test.ts
+++ b/packages/agent/test/advisor.test.ts
@@ -1,0 +1,209 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type Message,
+	type Model,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { createAdvisor } from "../src/advisor.ts";
+import { Agent } from "../src/agent.ts";
+import type { AgentContext, AgentMessage, AgentTool } from "../src/types.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function makeAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/** streamFn that returns a single text response (used for the advisor's own sub-agent). */
+function textStreamFn(text: string) {
+	return () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+			stream.push({ type: "start", partial: makeAssistantMessage("") });
+			stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: makeAssistantMessage(text) });
+			stream.push({ type: "done", reason: "stop", message: makeAssistantMessage(text) });
+		});
+		return stream;
+	};
+}
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function makeContext(): AgentContext {
+	return {
+		systemPrompt: "You are a coding agent.",
+		messages: [
+			{ role: "user", content: "Implement the login endpoint", timestamp: Date.now() },
+			makeAssistantMessage('{"summary":"I started on the login endpoint"}'),
+		],
+		tools: [],
+	};
+}
+
+describe("createAdvisor", () => {
+	it("returns a corrective note when the secondary model flags drift", async () => {
+		const advisor = createAdvisor({
+			model: createModel(),
+			streamFn: textStreamFn(
+				'{"needsCorrection":true,"note":"You drifted from the login endpoint; finish it first."}',
+			),
+		});
+		const note = await advisor.evaluate(
+			makeContext(),
+			makeAssistantMessage("Let me implement the profile page instead."),
+		);
+		expect(note).toBe("You drifted from the login endpoint; finish it first.");
+	});
+
+	it("returns undefined when no correction is needed", async () => {
+		const advisor = createAdvisor({
+			model: createModel(),
+			streamFn: textStreamFn('{"needsCorrection":false,"note":""}'),
+		});
+		const note = await advisor.evaluate(makeContext(), makeAssistantMessage("Finishing the login endpoint."));
+		expect(note).toBeUndefined();
+	});
+
+	it("returns undefined on non-JSON output", async () => {
+		const advisor = createAdvisor({
+			model: createModel(),
+			streamFn: textStreamFn("Everything looks on track."),
+		});
+		const note = await advisor.evaluate(makeContext(), makeAssistantMessage("Finishing."));
+		expect(note).toBeUndefined();
+	});
+});
+
+describe("advisor integration with Agent loop", () => {
+	it("injects the advisor note into the next turn's LLM context", async () => {
+		// Secondary (advisor) model: flags drift once.
+		const advisorStreamFn = textStreamFn('{"needsCorrection":true,"note":"Focus on the login endpoint."}');
+		const advisor = createAdvisor({ model: createModel(), streamFn: advisorStreamFn });
+
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return { content: [{ type: "text", text: `echoed: ${params.value}` }], details: {} };
+			},
+		};
+
+		// Main agent: first turn issues a tool call (so the loop continues and
+		// prepareNextTurn runs between turns), second turn finalizes.
+		let mainCallIndex = 0;
+		const llmContextsSeen: { messages: Message[] }[] = [];
+		const mainStreamFn = (_model: Model<any>, llmContext: { messages: Message[] }) => {
+			const stream = new MockAssistantStream();
+			llmContextsSeen.push(llmContext);
+			queueMicrotask(() => {
+				if (mainCallIndex === 0) {
+					stream.push({
+						type: "done",
+						reason: "toolUse",
+						message: {
+							...makeAssistantMessage(""),
+							content: [{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hi" } }],
+							stopReason: "toolUse",
+						},
+					});
+				} else if (mainCallIndex === 1) {
+					// Second turn: text (so the advisor reviews it) plus another tool call (so the loop continues).
+					stream.push({
+						type: "done",
+						reason: "toolUse",
+						message: {
+							...makeAssistantMessage("Let me switch to the profile page."),
+							content: [
+								{ type: "text", text: "Let me switch to the profile page." },
+								{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "bye" } },
+							],
+							stopReason: "toolUse",
+						},
+					});
+				} else {
+					stream.push({ type: "done", reason: "stop", message: makeAssistantMessage("Finished.") });
+				}
+				mainCallIndex++;
+			});
+			return stream;
+		};
+
+		const agent = new Agent({
+			model: createModel(),
+			streamFn: mainStreamFn,
+			convertToLlm: identityConverter,
+			initialState: {
+				model: createModel(),
+				systemPrompt: "You are a coding agent.",
+				tools: [tool],
+				thinkingLevel: "off",
+				messages: [],
+			},
+			advisor,
+		});
+
+		await agent.prompt("Implement the login endpoint");
+
+		// The advisor note should appear in the third LLM call's context
+		// (injected after the second turn, consumed by the third).
+		expect(llmContextsSeen.length).toBeGreaterThanOrEqual(3);
+		const thirdContext = llmContextsSeen[2].messages;
+		const advisorNote = thirdContext.find(
+			(m) => m.role === "user" && typeof m.content === "string" && m.content.startsWith("[advisor]"),
+		);
+		expect(advisorNote).toBeDefined();
+		expect(typeof advisorNote!.content === "string" && advisorNote!.content).toContain(
+			"Focus on the login endpoint.",
+		);
+	});
+});

--- a/packages/agent/test/memory-store.test.ts
+++ b/packages/agent/test/memory-store.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	FileMemoryStore,
+	formatMemoriesBlock,
+	InMemoryMemoryStore,
+	type MemoryStore,
+} from "../src/harness/memory/memory-store.ts";
+
+function seedStore(store: MemoryStore): Promise<void> {
+	return Promise.all([
+		store.save({ content: "Use pnpm for this repo.", cwd: "/repo/a", tags: ["tooling"] }),
+		store.save({ content: "The build is slow; cache it.", cwd: "/repo/a", tags: ["build"] }),
+		store.save({ content: "Other project note.", cwd: "/elsewhere", tags: [] }),
+	]);
+}
+
+describe("InMemoryMemoryStore", () => {
+	it("saves and lists entries sorted by updatedAt", async () => {
+		const store = new InMemoryMemoryStore();
+		await seedStore(store);
+		const all = await store.list();
+		expect(all).toHaveLength(3);
+		expect(all.map((e) => e.content)).toContain("Use pnpm for this repo.");
+		expect(all[0].updatedAt).toBeGreaterThanOrEqual(all[all.length - 1].updatedAt);
+	});
+
+	it("filters by cwd prefix", async () => {
+		const store = new InMemoryMemoryStore();
+		await seedStore(store);
+		const inRepo = await store.list({ cwd: "/repo/a" });
+		expect(inRepo).toHaveLength(2);
+		const subdir = await store.list({ cwd: "/repo/a/src" });
+		expect(subdir).toHaveLength(2); // prefix match on stored cwd
+		const elsewhere = await store.list({ cwd: "/repo/b" });
+		expect(elsewhere).toHaveLength(0);
+	});
+
+	it("filters by keywords (content and tags)", async () => {
+		const store = new InMemoryMemoryStore();
+		await seedStore(store);
+		const byTag = await store.list({ keywords: ["tooling"] });
+		expect(byTag.map((e) => e.content)).toEqual(["Use pnpm for this repo."]);
+		const byContent = await store.list({ keywords: ["slow"] });
+		expect(byContent).toHaveLength(1);
+	});
+
+	it("deletes entries", async () => {
+		const store = new InMemoryMemoryStore();
+		await seedStore(store);
+		const all = await store.list();
+		await store.delete(all[0].id);
+		expect(await store.list()).toHaveLength(2);
+	});
+
+	it("respects limit", async () => {
+		const store = new InMemoryMemoryStore();
+		await seedStore(store);
+		expect(await store.list({ limit: 2 })).toHaveLength(2);
+	});
+});
+
+describe("FileMemoryStore", () => {
+	it("persists entries across instances", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "pi-memory-"));
+		try {
+			const a = new FileMemoryStore(dir);
+			await a.save({ content: "Remember this.", cwd: "/repo/a" });
+
+			const b = new FileMemoryStore(dir);
+			const entries = await b.list({ cwd: "/repo/a" });
+			expect(entries).toHaveLength(1);
+			expect(entries[0].content).toBe("Remember this.");
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("skips corrupted files", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "pi-memory-"));
+		try {
+			const store = new FileMemoryStore(dir);
+			await store.save({ content: "Valid", cwd: "/x" });
+			await writeFile(join(dir, "memories", "broken.json"), "not json", "utf8");
+			const entries = await store.list();
+			expect(entries).toHaveLength(1);
+			expect(entries[0].content).toBe("Valid");
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("deletes the backing file", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "pi-memory-"));
+		try {
+			const store = new FileMemoryStore(dir);
+			const saved = await store.save({ content: "bye", cwd: "/x" });
+			await store.delete(saved.id);
+			expect(await store.list()).toHaveLength(0);
+			await expect(readFile(join(dir, "memories", `${saved.id}.json`))).rejects.toThrow();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("formatMemoriesBlock", () => {
+	it("returns undefined for no memories", () => {
+		expect(formatMemoriesBlock([])).toBeUndefined();
+	});
+
+	it("renders a bullet list under a heading", () => {
+		const block = formatMemoriesBlock([
+			{ id: "1", content: "First fact", cwd: "/a", createdAt: 1, updatedAt: 1 },
+			{ id: "2", content: "Second fact", cwd: "/a", createdAt: 2, updatedAt: 2 },
+		]);
+		expect(block).toContain("## Project memories");
+		expect(block).toContain("- First fact");
+		expect(block).toContain("- Second fact");
+	});
+});

--- a/packages/agent/test/review-tool.test.ts
+++ b/packages/agent/test/review-tool.test.ts
@@ -1,0 +1,147 @@
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, type Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { aggregateVerdict, createReviewTool } from "../src/harness/tools/review.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function makeMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/** A streamFn that emits the given text for every call (each reviewer). */
+function textStreamFn(text: string) {
+	return () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+			stream.push({ type: "start", partial: makeMessage("") });
+			stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: makeMessage(text) });
+			stream.push({ type: "done", reason: "stop", message: makeMessage(text) });
+		});
+		return stream;
+	};
+}
+
+describe("aggregateVerdict", () => {
+	it("rejects on P0", () => {
+		expect(aggregateVerdict([{ severity: "P0", confidence: 0.9, summary: "x" }])).toBe("reject");
+	});
+
+	it("requests changes on P1", () => {
+		expect(aggregateVerdict([{ severity: "P1", confidence: 0.8, summary: "x" }])).toBe("changes-requested");
+	});
+
+	it("approves when only P2/P3", () => {
+		expect(
+			aggregateVerdict([
+				{ severity: "P2", confidence: 0.5, summary: "a" },
+				{ severity: "P3", confidence: 0.3, summary: "b" },
+			]),
+		).toBe("approve");
+	});
+});
+
+describe("review tool", () => {
+	it("runs reviewers in parallel and aggregates ranked issues", async () => {
+		let calls = 0;
+		const tool = createReviewTool({
+			model: createModel(),
+			streamFn: () => {
+				calls++;
+				// Each reviewer returns findings; include one P0 to force a reject verdict.
+				const text =
+					calls === 1
+						? '{"verdict":"reject","issues":[{"severity":"P0","confidence":0.9,"location":"src/auth.ts:12","summary":"SQL injection via raw query","recommendation":"use parameterized query"}],"summary":"security issue"}'
+						: '{"verdict":"approve","issues":[{"severity":"P3","confidence":0.4,"summary":"minor naming nit"}],"summary":"looks fine"}';
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: makeMessage("") });
+					stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: makeMessage(text) });
+					stream.push({ type: "done", reason: "stop", message: makeMessage(text) });
+				});
+				return stream;
+			},
+			systemPrompt: "You are a rigorous reviewer.",
+		});
+
+		const result = await tool.execute(
+			"r1",
+			{ diff: "--- a/src/auth.ts\n+++ b/src/auth.ts\n-query(sql)\n+query(sql)\n", reviewers: 2, focus: "security" },
+			undefined,
+			undefined,
+		);
+
+		expect(calls).toBe(2);
+		expect(result.details.reviewerCount).toBe(2);
+		expect(result.details.issueCount).toBe(2);
+		expect(result.details.bySeverity).toEqual({ P0: 1, P3: 1 });
+		expect(result.details.verdict).toBe("reject");
+
+		const content = result.content[0];
+		expect(content.type).toBe("text");
+		if (content.type === "text") {
+			const parsed = JSON.parse(content.text);
+			expect(parsed.verdict).toBe("reject");
+			// Issues ranked P0 first.
+			expect(parsed.issues[0].severity).toBe("P0");
+			expect(parsed.issues[0].location).toBe("src/auth.ts:12");
+			expect(parsed.reviewers).toHaveLength(2);
+			expect(parsed.reviewers[0].lens).toBe("correctness");
+			expect(parsed.reviewers[1].lens).toBe("security");
+		}
+	});
+
+	it("handles reviewers that return non-JSON prose gracefully", async () => {
+		const tool = createReviewTool({
+			model: createModel(),
+			streamFn: textStreamFn("This diff looks mostly fine but the error handling is weak."),
+		});
+
+		const result = await tool.execute("r2", { diff: "--- a/x\n+++ b/x\n", reviewers: 2 }, undefined, undefined);
+
+		// No parseable issues → approve with zero findings, but the run completes.
+		expect(result.details.issueCount).toBe(0);
+		expect(result.details.verdict).toBe("approve");
+	});
+});

--- a/packages/agent/test/stream-rules.test.ts
+++ b/packages/agent/test/stream-rules.test.ts
@@ -1,0 +1,256 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type Message,
+	type Model,
+	type UserMessage,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { agentLoop } from "../src/agent-loop.ts";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage } from "../src/types.ts";
+
+// Mirrors the mock infra in agent-loop.test.ts.
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"] = "stop",
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: createUsage(),
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function createUserMessage(text: string): UserMessage {
+	return {
+		role: "user",
+		content: text,
+		timestamp: Date.now(),
+	};
+}
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter((m) => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+function makeContext(): AgentContext {
+	return { systemPrompt: "You are helpful.", messages: [], tools: [] };
+}
+
+describe("time-traveling stream rules", () => {
+	it("aborts a matching stream, injects the reminder, and retries cleanly", async () => {
+		let calls = 0;
+		const llmMessagesSeen: Message[][] = [];
+		const streamFn = (_model: Model<any>, llmContext: { messages: Message[] }, options: { signal?: AbortSignal }) => {
+			const stream = new MockAssistantStream();
+			calls++;
+			llmMessagesSeen.push(llmContext.messages);
+			queueMicrotask(() => {
+				if (calls === 1) {
+					stream.push({ type: "start", partial: createAssistantMessage([{ type: "text", text: "" }]) });
+					stream.push({
+						type: "text_delta",
+						contentIndex: 0,
+						delta: "Box::leak",
+						partial: createAssistantMessage([{ type: "text", text: "I'll use Box::leak here" }]),
+					});
+					options.signal?.addEventListener("abort", () => {
+						stream.push({
+							type: "error",
+							reason: "aborted",
+							error: createAssistantMessage([{ type: "text", text: "I'll use Box::leak here" }], "aborted"),
+						});
+					});
+				} else {
+					stream.push({ type: "start", partial: createAssistantMessage([{ type: "text", text: "" }]) });
+					stream.push({
+						type: "text_delta",
+						contentIndex: 0,
+						delta: "Use Arc<str>",
+						partial: createAssistantMessage([{ type: "text", text: "Use Arc<str> instead." }]),
+					});
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "Use Arc<str> instead." }]),
+					});
+				}
+			});
+			return stream;
+		};
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamRules: [{ name: "box-leak", pattern: /Box::leak/, reminder: "Don't reach for Box::leak." }],
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("fix this")], makeContext(), config, undefined, streamFn);
+		for await (const event of stream) events.push(event);
+		const messages = await stream.result();
+
+		// Rule fired exactly once, stream retried.
+		const triggered = events.filter(
+			(e): e is Extract<AgentEvent, { type: "stream_rule_triggered" }> => e.type === "stream_rule_triggered",
+		);
+		expect(triggered).toHaveLength(1);
+		expect(triggered[0]).toMatchObject({ rule: "box-leak", attempt: 1 });
+		expect(calls).toBe(2);
+
+		// Final assistant message is the clean retry; the aborted partial is
+		// not part of the emitted messages.
+		expect(messages).toHaveLength(2);
+		const final = messages[messages.length - 1];
+		expect(final.role).toBe("assistant");
+		expect((final as AssistantMessage).content).toEqual([{ type: "text", text: "Use Arc<str> instead." }]);
+
+		// The retry saw a clean LLM context: both calls received only the user
+		// message. If the aborted assistant partial had leaked into the context,
+		// the second call would have seen ['user', 'assistant'].
+		expect(llmMessagesSeen).toHaveLength(2);
+		expect(llmMessagesSeen[0].map((m) => m.role)).toEqual(["user"]);
+		expect(llmMessagesSeen[1].map((m) => m.role)).toEqual(["user"]);
+	});
+
+	it("passes through untouched when no rule matches", async () => {
+		let calls = 0;
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			calls++;
+			queueMicrotask(() => {
+				stream.push({ type: "start", partial: createAssistantMessage([{ type: "text", text: "" }]) });
+				stream.push({
+					type: "text_delta",
+					contentIndex: 0,
+					delta: "plain answer",
+					partial: createAssistantMessage([{ type: "text", text: "plain answer" }]),
+				});
+				stream.push({
+					type: "done",
+					reason: "stop",
+					message: createAssistantMessage([{ type: "text", text: "plain answer" }]),
+				});
+			});
+			return stream;
+		};
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamRules: [{ name: "nope", pattern: /forbidden-token/, reminder: "Never say forbidden-token." }],
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("hi")], makeContext(), config, undefined, streamFn);
+		for await (const event of stream) events.push(event);
+
+		expect(events.some((e) => e.type === "stream_rule_triggered")).toBe(false);
+		expect(calls).toBe(1);
+	});
+
+	it("stops retrying after streamRuleMaxRetries and finalizes the last response", async () => {
+		let calls = 0;
+		const streamFn = (_model: Model<any>, _context: unknown, options: { signal?: AbortSignal }) => {
+			const stream = new MockAssistantStream();
+			calls++;
+			queueMicrotask(() => {
+				stream.push({ type: "start", partial: createAssistantMessage([{ type: "text", text: "" }]) });
+				stream.push({
+					type: "text_delta",
+					contentIndex: 0,
+					delta: "Box::leak",
+					partial: createAssistantMessage([{ type: "text", text: "still Box::leak" }]),
+				});
+				if (calls <= 2) {
+					// First two attempts get aborted by the rule machinery.
+					options.signal?.addEventListener("abort", () => {
+						stream.push({
+							type: "error",
+							reason: "aborted",
+							error: createAssistantMessage([{ type: "text", text: "still Box::leak" }], "aborted"),
+						});
+					});
+				} else {
+					// Final attempt is left to finish and delivered as-is.
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "still Box::leak" }]),
+					});
+				}
+			});
+			return stream;
+		};
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamRules: [{ name: "box-leak", pattern: /Box::leak/, reminder: "Don't use Box::leak." }],
+			streamRuleMaxRetries: 2,
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("fix this")], makeContext(), config, undefined, streamFn);
+		for await (const event of stream) events.push(event);
+
+		const triggered = events.filter(
+			(e): e is Extract<AgentEvent, { type: "stream_rule_triggered" }> => e.type === "stream_rule_triggered",
+		);
+		// initial attempt + 2 retries = 3 calls, 2 triggers.
+		expect(calls).toBe(3);
+		expect(triggered.map((t) => t.attempt)).toEqual([1, 2]);
+
+		// The final response is the last (still matching) response, delivered
+		// as-is: the final attempt is not aborted (stop rather than aborted).
+		const messages = await stream.result();
+		const final = messages[messages.length - 1] as AssistantMessage;
+		expect(final.stopReason).toBe("stop");
+		expect((final.content as { type: "text"; text: string }[])[0].text).toBe("still Box::leak");
+	});
+});

--- a/packages/agent/test/task-tool.test.ts
+++ b/packages/agent/test/task-tool.test.ts
@@ -1,0 +1,160 @@
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, type Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { createTaskTool, extractJson } from "../src/harness/tools/task.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function makeMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/** streamFn that returns a single text response. */
+function textStreamFn(text: string) {
+	return () => {
+		const stream = new MockAssistantStream();
+		queueMicrotask(() => {
+			stream.push({ type: "start", partial: makeMessage("") });
+			stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: makeMessage(text) });
+			stream.push({ type: "done", reason: "stop", message: makeMessage(text) });
+		});
+		return stream;
+	};
+}
+
+describe("extractJson", () => {
+	it("extracts from a fenced json block", () => {
+		expect(extractJson('Here you go:\n```json\n{"a": 1}\n```\n')).toEqual({ a: 1 });
+	});
+
+	it("extracts a bare object", () => {
+		expect(extractJson('{"name":"x","nested":{"ok":true}}')).toEqual({ name: "x", nested: { ok: true } });
+	});
+
+	it("returns undefined when no JSON object is present", () => {
+		expect(extractJson("no json here")).toBeUndefined();
+		expect(extractJson("array [1,2,3]")).toBeUndefined();
+	});
+});
+
+describe("task tool", () => {
+	it("runs a subagent and returns a schema-validated structured result", async () => {
+		const tool = createTaskTool({
+			model: createModel(),
+			streamFn: textStreamFn('Found it:\n```json\n{"name": "formatBytes", "fileCount": 3}\n```'),
+			systemPrompt: "You are a research subagent.",
+		});
+
+		const result = await tool.execute(
+			"tc1",
+			{
+				prompt: "Find the symbol formatBytes and count its files.",
+				description: "Symbol search",
+				schema: {
+					properties: { name: {}, fileCount: {} },
+					required: ["name", "fileCount"],
+				},
+			},
+			undefined,
+			undefined,
+		);
+
+		expect(result.details.hasStructuredResult).toBe(true);
+		expect(result.details.summary).toBe("Symbol search");
+		expect(result.details.messageCount).toBeGreaterThanOrEqual(2); // user + assistant
+		expect(result.details.durationMs).toBeGreaterThanOrEqual(0);
+
+		const content = result.content[0];
+		expect(content.type).toBe("text");
+		if (content.type === "text") {
+			expect(JSON.parse(content.text)).toEqual({ name: "formatBytes", fileCount: 3 });
+		}
+	});
+
+	it("returns prose when no schema is provided", async () => {
+		const tool = createTaskTool({
+			model: createModel(),
+			streamFn: textStreamFn("The answer is 42."),
+		});
+
+		const result = await tool.execute("tc2", { prompt: "What is the answer?" }, undefined, undefined);
+
+		expect(result.details.hasStructuredResult).toBe(false);
+		const content = result.content[0];
+		expect(content.type).toBe("text");
+		if (content.type === "text") {
+			expect(content.text).toContain("42");
+		}
+	});
+
+	it("rejects when the subagent output is missing a required field", async () => {
+		const tool = createTaskTool({
+			model: createModel(),
+			streamFn: textStreamFn('```json\n{"name": "only-name"}\n```'),
+		});
+
+		await expect(
+			tool.execute(
+				"tc3",
+				{
+					prompt: "Return only a name.",
+					schema: { properties: { name: {}, count: {} }, required: ["name", "count"] },
+				},
+				undefined,
+				undefined,
+			),
+		).rejects.toThrow(/missing required field "count"/);
+	});
+
+	it("rejects when no JSON is returned despite a schema", async () => {
+		const tool = createTaskTool({
+			model: createModel(),
+			streamFn: textStreamFn("I could not find structured data."),
+		});
+
+		await expect(
+			tool.execute("tc4", { prompt: "Return JSON.", schema: { properties: { a: {} } } }, undefined, undefined),
+		).rejects.toThrow(/did not return a JSON object/);
+	});
+});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -21,9 +21,12 @@ import type {
 	AgentMessage,
 	AgentState,
 	AgentTool,
+	MemoryEntry,
+	MemoryStore,
 	PrepareNextTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
+import { createReviewTool, createTaskTool } from "@earendil-works/pi-agent-core";
 import { contentText } from "@earendil-works/pi-ai";
 import type {
 	AssistantMessage,
@@ -225,6 +228,13 @@ export interface AgentSessionConfig {
 	extensionRunnerRef?: { current?: ExtensionRunner };
 	/** Session start event metadata emitted when extensions bind to this runtime. */
 	sessionStartEvent?: SessionStartEvent;
+	/**
+	 * Pre-formatted cross-session memory block (from `formatMemoriesBlock`),
+	 * appended to the base system prompt.
+	 */
+	memoryBlock?: string;
+	/** Optional memory store backing `session.remember()`. */
+	memoryStore?: MemoryStore;
 }
 
 export interface ExtensionBindings {
@@ -373,6 +383,8 @@ export class AgentSession {
 	private _baseSystemPrompt = "";
 	private _baseSystemPromptOptions!: BuildSystemPromptOptions;
 	private _systemPromptOverride?: string;
+	private _memoryBlock = "";
+	private _memoryStore?: MemoryStore;
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
@@ -389,6 +401,8 @@ export class AgentSession {
 		this._excludedToolNames = config.excludedToolNames ? new Set(config.excludedToolNames) : undefined;
 		this._baseToolsOverride = config.baseToolsOverride;
 		this._sessionStartEvent = config.sessionStartEvent ?? { type: "session_start", reason: "startup" };
+		this._memoryBlock = config.memoryBlock ?? "";
+		this._memoryStore = config.memoryStore;
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, extensions, auto-compaction, retry logic)
@@ -404,6 +418,23 @@ export class AgentSession {
 
 	get modelRuntime(): ModelRuntime {
 		return this._modelRuntime;
+	}
+
+	/**
+	 * Persist a durable fact to the session's memory store (if configured) so a
+	 * later session in this project can recall it via the injected memory block.
+	 * @returns the saved entry, or undefined when no memory store is configured.
+	 */
+	async remember(content: string, tags?: string[], sourceSessionId?: string): Promise<MemoryEntry | undefined> {
+		if (!this._memoryStore) {
+			return undefined;
+		}
+		return this._memoryStore.save({
+			content,
+			tags,
+			sourceSessionId: sourceSessionId ?? this.sessionManager.getSessionId(),
+			cwd: this._cwd,
+		});
 	}
 
 	private async _getRequiredRequestAuth(model: Model<any>): Promise<{
@@ -1039,7 +1070,9 @@ export class AgentSession {
 		const loaderSystemPrompt = this._resourceLoader.getSystemPrompt();
 		const loaderAppendSystemPrompt = this._resourceLoader.getAppendSystemPrompt();
 		const appendSystemPrompt =
-			loaderAppendSystemPrompt.length > 0 ? loaderAppendSystemPrompt.join("\n\n") : undefined;
+			loaderAppendSystemPrompt.length > 0 || this._memoryBlock.length > 0
+				? [...loaderAppendSystemPrompt, ...(this._memoryBlock.length > 0 ? [this._memoryBlock] : [])].join("\n\n")
+				: undefined;
 		const loadedSkills = this._resourceLoader.getSkills().skills;
 		const loadedContextFiles = this._resourceLoader.getAgentsFiles().agentsFiles;
 
@@ -2576,6 +2609,29 @@ export class AgentSession {
 		this._baseToolDefinitions = new Map(
 			Object.entries(baseToolDefinitions).map(([name, tool]) => [name, tool as ToolDefinition]),
 		);
+
+		// The `task` and `review` tools spawn subagents using this session's own
+		// model, stream function, and auth resolution, so they are wired at
+		// runtime rather than inside the pure tool factories. They are registered
+		// as built-ins (subject to noTools/active-tool filtering) but not active
+		// by default.
+		if (!this._baseToolsOverride) {
+			const subagentToolOptions = {
+				model: this.agent.state.model,
+				streamFn: this.agent.streamFunction,
+				convertToLlm: this.agent.convertToLlm,
+				getApiKey: this.agent.getApiKey,
+				// Resolved lazily per subagent spawn so children see the current
+				// system prompt (skills, AGENTS.md context, memory block) rather
+				// than the empty prompt captured at construction time.
+				getSystemPrompt: () => this.agent.state.systemPrompt,
+			};
+			this._baseToolDefinitions.set("task", createToolDefinitionFromAgentTool(createTaskTool(subagentToolOptions)));
+			this._baseToolDefinitions.set(
+				"review",
+				createToolDefinitionFromAgentTool(createReviewTool(subagentToolOptions)),
+			);
+		}
 
 		const extensionsResult = this._resourceLoader.getExtensions();
 		if (options.flagValues) {

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,5 +1,13 @@
 import { join } from "node:path";
-import { Agent, type AgentMessage, setDefaultStreamFn, type ThinkingLevel } from "@earendil-works/pi-agent-core";
+import {
+	Agent,
+	type AgentMessage,
+	formatMemoriesBlock,
+	type MemoryQuery,
+	type MemoryStore,
+	setDefaultStreamFn,
+	type ThinkingLevel,
+} from "@earendil-works/pi-agent-core";
 import { clampThinkingLevel, type Message, type Model, streamSimple } from "@earendil-works/pi-ai/compat";
 import { getAgentDir } from "../config.ts";
 import { resolvePath } from "../utils/paths.ts";
@@ -82,6 +90,15 @@ export interface CreateAgentSessionOptions {
 	settingsManager?: SettingsManager;
 	/** Session start event metadata for extension runtime startup. */
 	sessionStartEvent?: SessionStartEvent;
+
+	/**
+	 * Optional cross-session memory store. When provided, matching memories are
+	 * injected into the system prompt at session start and `session.remember()`
+	 * persists new facts.
+	 */
+	memoryStore?: MemoryStore;
+	/** Query controlling which memories are recalled at session start. */
+	memoryQuery?: Omit<MemoryQuery, "cwd">;
 }
 
 /** Result from createAgentSession */
@@ -299,6 +316,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: [],
 		},
 		convertToLlm: convertToLlmWithBlockImages,
+		// Time-traveling stream rules from settings (invalid patterns are skipped).
+		streamRules: settingsManager.getStreamRules().flatMap((rule) => {
+			try {
+				return [
+					{
+						name: rule.name,
+						pattern: new RegExp(rule.pattern),
+						reminder: rule.reminder,
+					},
+				];
+			} catch {
+				return [];
+			}
+		}),
 		streamFn: async (model, context, options) => {
 			const providerRetrySettings = settingsManager.getProviderRetrySettings();
 			const httpIdleTimeoutMs = settingsManager.getHttpIdleTimeoutMs();
@@ -373,6 +404,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		sessionManager.appendThinkingLevelChange(thinkingLevel);
 	}
 
+	// Recall cross-session memories for this project and inject them into the
+	// base system prompt at session start.
+	const memoryBlock = options.memoryStore
+		? formatMemoriesBlock(
+				await options.memoryStore.list({
+					cwd,
+					...options.memoryQuery,
+				}),
+			)
+		: undefined;
+
 	const session = new AgentSession({
 		agent,
 		sessionManager,
@@ -387,6 +429,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		excludedToolNames,
 		extensionRunnerRef,
 		sessionStartEvent: options.sessionStartEvent,
+		memoryBlock,
+		memoryStore: options.memoryStore,
 	});
 	const extensionsResult = resourceLoader.getExtensions();
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -136,6 +136,14 @@ export interface Settings {
 	tuiMode?: TuiMode; // default: "regular"
 	fullscreenExitOutput?: FullscreenExitOutput; // default: "transcript"; no effect in regular TUI mode
 	fullscreenScrollbar?: ScrollViewScrollbar; // default: "auto"; no effect in regular TUI mode
+	streamRules?: StreamRuleConfig[]; // Time-traveling stream rules
+}
+
+/** Serializable stream-rule config. `pattern` is a regex source string, compiled at load time. */
+export interface StreamRuleConfig {
+	name: string;
+	pattern: string;
+	reminder: string;
 }
 
 function isMergeableObject(value: unknown): value is Record<string, unknown> {
@@ -1280,5 +1288,10 @@ export class SettingsManager {
 		this.globalSettings.warnings = { ...warnings };
 		this.markModified("warnings");
 		this.save();
+	}
+
+	/** Stream rules configured via settings; empty when none are set. */
+	getStreamRules(): StreamRuleConfig[] {
+		return this.settings.streamRules ?? [];
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -418,6 +418,8 @@ export class InteractiveMode {
 	private workingVisible = true;
 	private workingIndicatorOptions: WorkingIndicatorOptions | undefined = undefined;
 	private readonly defaultWorkingMessage = "Working...";
+	/** Stream-rule injections fired during the current streaming turn (transient, not persisted). */
+	private streamRuleNotices: string[] = [];
 	private readonly defaultHiddenThinkingLabel = "Thinking...";
 	private hiddenThinkingLabel = this.defaultHiddenThinkingLabel;
 
@@ -3100,6 +3102,13 @@ export class InteractiveMode {
 				this.ui.requestRender();
 				break;
 
+			case "stream_rule_triggered":
+				// Time-traveling stream rule fired: record it for the aborted
+				// message's error display (transient, not persisted).
+				this.streamRuleNotices.push(`${event.rule} (attempt ${event.attempt})`);
+				this.ui.requestRender();
+				break;
+
 			case "entry_appended":
 				if (event.entry.type === "custom") {
 					this.addCustomEntryToChat(event.entry);
@@ -3188,6 +3197,10 @@ export class InteractiveMode {
 							retryAttempt > 0
 								? `Aborted after ${retryAttempt} retry attempt${retryAttempt > 1 ? "s" : ""}`
 								: "Operation aborted";
+						if (this.streamRuleNotices.length > 0) {
+							errorMessage += `\nStream rules fired: ${this.streamRuleNotices.join(", ")}`;
+							this.streamRuleNotices = [];
+						}
 						this.streamingMessage.errorMessage = errorMessage;
 					}
 					this.streamingComponent.updateContent(this.streamingMessage, false);

--- a/packages/coding-agent/test/sdk-memory.test.ts
+++ b/packages/coding-agent/test/sdk-memory.test.ts
@@ -1,0 +1,144 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryMemoryStore } from "@earendil-works/pi-agent-core";
+import { type Api, type AssistantMessage, createAssistantMessageEventStream, type Model } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { createAgentSession } from "../src/core/sdk.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+
+describe("createAgentSession cross-session memory", () => {
+	let tempDir: string;
+	let cwd: string;
+	let agentDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-sdk-memory-"));
+		cwd = join(tempDir, "project");
+		agentDir = join(tempDir, "agent");
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	function createModel(api: Api): Model<Api> {
+		return {
+			id: "capture-model",
+			name: "Capture Model",
+			api,
+			provider: "capture-provider",
+			baseUrl: "https://capture.invalid/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		};
+	}
+
+	function createDoneStream(api: Api) {
+		const stream = createAssistantMessageEventStream();
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "ok" }],
+			api,
+			provider: "capture-provider",
+			model: "capture-model",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		stream.end(message);
+		return stream;
+	}
+
+	async function createSession(options: {
+		memoryStore?: InMemoryMemoryStore;
+		memoryQuery?: Parameters<typeof createAgentSession>[0]["memoryQuery"];
+	}) {
+		const model = createModel("openai-responses");
+		const settingsManager = SettingsManager.inMemory({});
+		const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+		await authStorage.modify(model.provider, async () => ({ type: "api_key", key: "test-api-key" }));
+		const modelRegistry = await createModelRegistry(authStorage, join(agentDir, "models.json"));
+		modelRegistry.registerProvider(model.provider, {
+			api: "openai-responses",
+			streamSimple: () => createDoneStream("openai-responses"),
+		});
+		const modelRuntime = getModelRuntime(modelRegistry);
+		const sessionManager = SessionManager.inMemory(cwd);
+		const result = await createAgentSession({
+			cwd,
+			agentDir,
+			model,
+			modelRuntime,
+			settingsManager,
+			sessionManager,
+			memoryStore: options.memoryStore,
+			memoryQuery: options.memoryQuery,
+		});
+		return { ...result, modelRegistry };
+	}
+
+	it("injects matching memories into the system prompt at session start", async () => {
+		const memoryStore = new InMemoryMemoryStore();
+		await memoryStore.save({ content: "Use pnpm for this repo.", cwd });
+		await memoryStore.save({ content: "Unrelated note.", cwd: "/elsewhere" });
+
+		const { session, modelRegistry } = await createSession({ memoryStore });
+		try {
+			expect(session.systemPrompt).toContain("## Project memories");
+			expect(session.systemPrompt).toContain("Use pnpm for this repo.");
+			expect(session.systemPrompt).not.toContain("Unrelated note.");
+		} finally {
+			session.dispose();
+			modelRegistry.unregisterProvider("capture-provider");
+		}
+	});
+
+	it("does not inject anything when there are no matching memories", async () => {
+		const memoryStore = new InMemoryMemoryStore();
+		await memoryStore.save({ content: "Other project.", cwd: "/elsewhere" });
+
+		const { session, modelRegistry } = await createSession({ memoryStore });
+		try {
+			expect(session.systemPrompt).not.toContain("## Project memories");
+		} finally {
+			session.dispose();
+			modelRegistry.unregisterProvider("capture-provider");
+		}
+	});
+
+	it("session.remember persists a fact scoped to the session cwd", async () => {
+		const memoryStore = new InMemoryMemoryStore();
+		const { session, modelRegistry } = await createSession({ memoryStore });
+		try {
+			const saved = await session.remember("The deploy is done via make deploy.", ["ops"]);
+			expect(saved).toBeDefined();
+			expect(saved!.cwd).toBe(cwd);
+
+			const recalled = await memoryStore.list({ cwd });
+			expect(recalled).toHaveLength(1);
+			expect(recalled[0].content).toBe("The deploy is done via make deploy.");
+			expect(recalled[0].tags).toEqual(["ops"]);
+		} finally {
+			session.dispose();
+			modelRegistry.unregisterProvider("capture-provider");
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
@@ -78,7 +78,7 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 				.getAllTools()
 				.map((tool) => tool.name)
 				.sort(),
-		).toEqual(["bash", "dynamic_tool", "edit", "find", "grep", "ls", "read", "write"]);
+		).toEqual(["bash", "dynamic_tool", "edit", "find", "grep", "ls", "read", "review", "task", "write"]);
 		expect(session.getActiveToolNames()).toEqual(["dynamic_tool"]);
 		expect(session.systemPrompt).toContain("- dynamic_tool: Run dynamic test behavior");
 		expect(session.systemPrompt).not.toContain("- read:");


### PR DESCRIPTION
## 概述

从 oh-my-pi（omp）移植一组 A 级 agent 能力到 pi 核心，四个独立功能，已按功能拆分 commit：

### 1. Time-traveling stream rules（`agent-loop.ts` + `types.ts`）
- `AgentLoopConfig.streamRules`：对每轮 assistant 输出的累积文本做模式匹配
- 命中 → 中止当前流 → 从上下文丢弃残缺 partial（**不**作为终态消息 emit，避免泄漏进持久化状态或后续 LLM 调用）→ 向 system prompt 注入 reminder → 同点重试
- `streamRuleMaxRetries`（默认 2）限制重试；最后一次尝试不再 abort，响应按原样交付
- 新增 `stream_rule_triggered` 事件（rule + attempt），interactive mode 显示尾部提示

### 2. Subagent `task` / `review` 工具（`harness/tools/`）
- 内置注册（不默认激活，尊重 `noTools`/`excludeTools`/`_baseToolsOverride`）
- `task`：纯文本子 agent，可选 required 字段 schema 校验
- `review`：并行评审子 agent（correctness/security/maintainability/performance/regression 五种视角），返回 P0–P3 排序问题 + 聚合结论
- 子 agent 复用会话的 model/streamFn/auth，**惰性解析 system prompt**（每次 spawn 取当前值，而非构造时快照）；abort 透传

### 3. Advisor 副模型（`advisor.ts` + `agent.ts`）
- `createAdvisor()`：轻量副模型逐轮旁听，发现偏离目标/卡住/出错时返回纠正 note
- 注入为下一轮的 `[advisor]` 单次 steer 消息（不每轮烧 context）；纯工具调用轮跳过

### 4. 跨会话记忆（`harness/memory/` + `coding-agent`）
- `MemoryStore` 抽象：`InMemoryMemoryStore` + `FileMemoryStore`（`<agentDir>/memories/*.json`）
- `createAgentSession` 可选 `memoryStore`/`memoryQuery`：启动时按 cwd 前缀/keywords 召回匹配记忆，注入 base system prompt 的 `Project memories` 块
- `AgentSession.remember()`：持久化事实（自动带 sessionId + cwd）

## 测试
- 新增 29 个测试（stream-rules 3、task 7、review 5、advisor 4、memory-store 10、sdk-memory 3）
- `packages/agent`：439 passed / 1 skipped（基线 425 + 新增 14）
- `packages/coding-agent`：受影响测试全过，无新增回归（基线已知环境失败未变）
- 双包 `tsgo` 类型检查 0 错误

## 已知取舍（后续工作）
- A2 advisor 当前为同步旁听（每轮阻塞主循环一次副模型往返）；异步/纯事件驱动留作后续
- A1 `task` 子 agent 为纯文本（无工具/隔离目录）；隔离目录与 schema 类型校验留作后续
- A5 记忆为显式 `remember()`；自动从会话提取（learn/retain）留作后续
- A3 规则经 settings 配置，不随 compaction 持久化