### PR TITLE
fix(examples): change notify extension from agent_end to agent_settled

### DIFF
--- a/packages/coding-agent/examples/extensions/notify.ts
+++ b/packages/coding-agent/examples/extensions/notify.ts
@@ -49,7 +49,10 @@ function notify(title: string, body: string): void {
 }
 
 export default function (pi: ExtensionAPI) {
-	pi.on("agent_end", async () => {
+	// Use agent_settled instead of agent_end so that the notification fires
+	// only after Pi is truly done — after automatic retries, compaction retries,
+	// and queued follow-up continuations have all completed.
+	pi.on("agent_settled", async () => {
 		notify("Pi", "Ready for input");
 	});
 }


### PR DESCRIPTION
## Summary

The notify extension example hooks `agent_end` to send a 'Ready for input' notification, but `agent_end` fires after each low-level run — before automatic retries, compaction retries, and queued follow-up continuations have completed. The notification could fire while Pi is still working.

`agent_settled` fires only when Pi is truly done and will not continue automatically, which is the correct event for a 'Ready for input' notification.

Fixes #7350

## Changes

- `packages/coding-agent/examples/extensions/notify.ts`: Changed event from `agent_end` to `agent_settled` with explanatory comment.