### PR TITLE
docs: add Aliyun Model Studio CLI (bailian-cli) to Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ I regularly publish my own `pi-mono` work sessions here:
 
 - [badlogicgames/pi-mono on Hugging Face](https://huggingface.co/datasets/badlogicgames/pi-mono)
 
+## Related Tools
+
+- [**Aliyun Model Studio CLI**](https://github.com/modelstudioai/cli) () — Official CLI for the Aliyun AI platform. Extends coding agents with image/video generation, knowledge retrieval, app orchestration, and model deployment.
+
 ## License
 
 MIT


### PR DESCRIPTION
## What this PR does

Adds [Aliyun Model Studio CLI](https://github.com/modelstudioai/cli) (`bailian-cli`) to a new **Related Tools** section in README.md, before the License section.

## Why

`bailian-cli` is the official CLI for the Aliyun AI platform (DashScope). It extends coding agents with capabilities they do not provide natively:

- **Image/video generation** — HappyHorse, WAN, and other multimodal models
- **Knowledge retrieval** — connect to Bailian knowledge bases
- **App orchestration** — deploy and call hosted Agents
- **Model deployment** — fine-tune and deploy custom models

Pi is an AI agent toolkit; `bailian-cli` complements it by providing access to Aliyun model capabilities. Listing it in Related Tools helps users discover this companion tool.

## Changes

- Added a `## Related Tools` section before `## License`
- One bullet point linking to the repo with a concise description
- No code changes, documentation only (+4 lines)