### PR TITLE
fix(provider): enable GitHub Copilot model policies sequentially

### DIFF
--- a/packages/ai/src/auth/oauth/github-copilot.ts
+++ b/packages/ai/src/auth/oauth/github-copilot.ts
@@ -344,11 +344,9 @@ async function enableAllGitHubCopilotModels(
 	signal: AbortSignal,
 ): Promise<void> {
 	const models = Object.values(GITHUB_COPILOT_MODELS);
-	await Promise.all(
-		models.map(async (model) => {
-			await enableGitHubCopilotModel(token, model.id, enterpriseDomain, signal);
-		}),
-	);
+	for (const model of models) {
+		await enableGitHubCopilotModel(token, model.id, enterpriseDomain, signal);
+	}
 }
 
 async function loginGitHubCopilot(interaction: ProviderAuthInteraction): Promise<OAuthCredential> {

--- a/packages/ai/test/github-copilot-oauth.test.ts
+++ b/packages/ai/test/github-copilot-oauth.test.ts
@@ -239,6 +239,59 @@ describe("GitHub Copilot OAuth device flow", () => {
 		await loginPromise;
 	});
 
+	it("enables model policies one at a time after device authorization", async () => {
+		vi.useFakeTimers();
+		let policyRequests = 0;
+		let inFlightPolicyRequests = 0;
+		let maxInFlightPolicyRequests = 0;
+
+		const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
+			const url = getUrl(input);
+
+			if (url.endsWith("/login/device/code")) {
+				return jsonResponse({
+					device_code: "device-code",
+					user_code: "ABCD-EFGH",
+					verification_uri: "https://github.com/login/device",
+					interval: 1,
+					expires_in: 900,
+				});
+			}
+			if (url.endsWith("/login/oauth/access_token")) {
+				return jsonResponse({ access_token: "ghu_refresh_token" });
+			}
+			if (url.includes("/copilot_internal/v2/token")) {
+				return jsonResponse({
+					token: "tid=test;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;",
+					expires_at: 9999999999,
+				});
+			}
+			if (url.includes("/models/") && url.endsWith("/policy")) {
+				policyRequests++;
+				inFlightPolicyRequests++;
+				maxInFlightPolicyRequests = Math.max(maxInFlightPolicyRequests, inFlightPolicyRequests);
+				await Promise.resolve();
+				inFlightPolicyRequests--;
+				return new Response("", { status: 200 });
+			}
+			if (url.endsWith("/models")) {
+				return jsonResponse({ data: [] });
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const loginPromise = loginGitHubCopilotForTest({
+			onDeviceCode: () => {},
+			onPrompt: async () => "",
+		});
+		await vi.advanceTimersByTimeAsync(1000);
+		await loginPromise;
+
+		expect(policyRequests).toBeGreaterThan(1);
+		expect(maxInFlightPolicyRequests).toBe(1);
+	});
+
 	it("rejects a non-http(s) verification_uri before it reaches onDeviceCode", async () => {
 		// A malicious enterprise OAuth server could return a verification_uri that
 		// the browser launcher would otherwise hand to the OS. Ensure such values


### PR DESCRIPTION
Enable GitHub Copilot model policies sequentially after device authorization.

Previously, Pi sent one policy-enablement request for every known model concurrently. Organizations with many available models could exceed Copilot’s request limit and fail login with HTTP 429.

Sequential requests avoid the burst.

Fixes #7850
