### PR TITLE
fix(coding-agent): fix typo in RPC example

### DIFF
--- a/packages/coding-agent/examples/rpc-extension-ui.ts
+++ b/packages/coding-agent/examples/rpc-extension-ui.ts
@@ -258,7 +258,7 @@ async function main() {
 
 	const agent = spawn(
 		"node",
-		[cliPath, "--mode", "rpc", "--no-session", "--no-extension", "--extension", extensionPath],
+		[cliPath, "--mode", "rpc", "--no-session", "--no-extensions", "--extension", extensionPath],
 		{ stdio: ["pipe", "pipe", "pipe"] },
 	);
 


### PR DESCRIPTION
I asked pi to write an RPC extension using the examples, and it copied this typo. This fixes `--no-extension` to `--no-extensions`.

Thanks for the package!! 