### PR TITLE
fix(ai): repair JSON-serialized structured tool arguments during validation

### DIFF
--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -171,7 +171,75 @@ function applySchemaArrayCoercion(value: unknown[], schema: JsonSchemaObject): v
 	}
 }
 
+function parseJsonStringForTypes(
+	value: unknown,
+	wantsObject: boolean,
+	wantsArray: boolean,
+): unknown {
+	if (typeof value !== "string") {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	const looksObject = trimmed.startsWith("{") && trimmed.endsWith("}");
+	const looksArray = trimmed.startsWith("[") && trimmed.endsWith("]");
+	if (!(wantsObject && looksObject) && !(wantsArray && looksArray)) {
+		return undefined;
+	}
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		if (wantsObject && typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+			return parsed;
+		}
+		if (wantsArray && Array.isArray(parsed)) {
+			return parsed;
+		}
+	} catch {
+		// Not JSON: leave the original string for normal validation errors.
+	}
+	return undefined;
+}
+
+/**
+ * Repair a JSON-serialized object/array delivered as a string for a schema
+ * that expects the structured type. Providers and models double-serialize
+ * nested tool arguments often enough that this is a common failure mode.
+ * The parsed value is adopted only when, after recursive coercion, it fully
+ * validates against the target schema; anything else is left untouched so
+ * validation still fails with the original precise error.
+ */
+function coerceJsonStringWithSchema(value: unknown, schema: JsonSchemaObject): unknown {
+	const schemaTypes = getSchemaTypes(schema);
+	if (schemaTypes.includes("string")) {
+		return undefined;
+	}
+	const parsed = parseJsonStringForTypes(
+		value,
+		schemaTypes.includes("object"),
+		schemaTypes.includes("array"),
+	);
+	if (parsed === undefined) {
+		return undefined;
+	}
+	const candidate = coerceWithJsonSchema(parsed, schema);
+	const validator = getSubSchemaValidator(schema);
+	if (validator?.Check(candidate)) {
+		return candidate;
+	}
+	return undefined;
+}
+
 function coerceWithUnionSchema(value: unknown, schemas: JsonSchemaObject[]): unknown {
+	// Prefer a typed member for a string that parses as validating JSON so a
+	// double-serialized object is not silently kept as a string member.
+	if (typeof value === "string") {
+		for (const schema of schemas) {
+			const repaired = coerceJsonStringWithSchema(value, schema);
+			if (repaired !== undefined) {
+				return repaired;
+			}
+		}
+	}
+
 	for (const schema of schemas) {
 		const validator = getSubSchemaValidator(schema);
 		if (validator?.Check(value)) {
@@ -217,6 +285,16 @@ function coerceWithJsonSchema(value: unknown, schema: JsonSchemaObject): unknown
 				nextValue = candidate;
 				break;
 			}
+		}
+	}
+
+	if (
+		typeof nextValue === "string" &&
+		(schemaTypes.includes("object") || schemaTypes.includes("array"))
+	) {
+		const repaired = coerceJsonStringWithSchema(nextValue, schema);
+		if (repaired !== undefined) {
+			nextValue = repaired;
 		}
 	}
 
@@ -303,6 +381,15 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 
 	if (validator.Check(args)) {
 		return args;
+	}
+
+	// Last-chance repair for JSON-serialized structured arguments. This pass
+	// is reached only when validation has already failed, so it cannot change
+	// the behavior of any currently-valid call, and it also covers TypeBox
+	// schemas that skip the generic pre-check coercion above.
+	const repaired = coerceWithJsonSchema(structuredClone(args), tool.parameters as JsonSchemaObject);
+	if (validator.Check(repaired)) {
+		return repaired;
 	}
 
 	const errors =

--- a/packages/ai/test/validation.test.ts
+++ b/packages/ai/test/validation.test.ts
@@ -162,4 +162,125 @@ describe("validateToolArguments", () => {
 			expect(() => validateToolArguments(tool, toolCall)).toThrow("Validation failed");
 		}
 	});
+
+	it("repairs a JSON-serialized object string for an object-typed property", () => {
+		const { tool, toolCall } = createToolCallWithPlainSchema(
+			{
+				type: "object",
+				properties: { inline: { type: "string" }, version: { type: "integer" } },
+				required: ["inline"],
+				additionalProperties: false,
+			} as Tool["parameters"],
+			'{"inline":"echo hi","version":"2"}',
+		);
+
+		// Nested primitive coercion still applies to the parsed value.
+		expect(validateToolArguments(tool, toolCall)).toEqual({
+			value: { inline: "echo hi", version: 2 },
+		});
+	});
+
+	it("repairs a JSON-serialized array string for an array-typed property", () => {
+		const { tool, toolCall } = createToolCallWithPlainSchema(
+			{ type: "array", items: { type: "integer" } } as Tool["parameters"],
+			'["1", 2]',
+		);
+
+		expect(validateToolArguments(tool, toolCall)).toEqual({ value: [1, 2] });
+	});
+
+	it("still rejects non-JSON strings for object-typed properties", () => {
+		const { tool, toolCall } = createToolCallWithPlainSchema(
+			{
+				type: "object",
+				properties: { inline: { type: "string" } },
+				additionalProperties: false,
+			} as Tool["parameters"],
+			'\n<parameter name="inline">cd /repo\necho hi',
+		);
+
+		expect(() => validateToolArguments(tool, toolCall)).toThrow("must be object");
+	});
+
+	it("rejects a JSON object string that does not validate the object schema", () => {
+		const { tool, toolCall } = createToolCallWithPlainSchema(
+			{
+				type: "object",
+				properties: { inline: { type: "string" } },
+				required: ["inline"],
+				additionalProperties: false,
+			} as Tool["parameters"],
+			'{"weird":true}',
+		);
+
+		expect(() => validateToolArguments(tool, toolCall)).toThrow("Validation failed");
+	});
+
+	it("prefers a validating object member over a string member in unions", () => {
+		const unionSchema = {
+			anyOf: [
+				{
+					type: "object",
+					properties: { inline: { type: "string" } },
+					required: ["inline"],
+					additionalProperties: false,
+				},
+				{ type: "string" },
+			],
+		} as Tool["parameters"];
+
+		const serialized = createToolCallWithPlainSchema(unionSchema, '{"inline":"echo hi"}');
+		expect(validateToolArguments(serialized.tool, serialized.toolCall)).toEqual({
+			value: { inline: "echo hi" },
+		});
+
+		// Ordinary strings and JSON not matching the object member keep the
+		// string member.
+		const plain = createToolCallWithPlainSchema(unionSchema, "just a plain command");
+		expect(validateToolArguments(plain.tool, plain.toolCall)).toEqual({
+			value: "just a plain command",
+		});
+
+		const mismatched = createToolCallWithPlainSchema(unionSchema, '{"weird":true}');
+		expect(validateToolArguments(mismatched.tool, mismatched.toolCall)).toEqual({
+			value: '{"weird":true}',
+		});
+	});
+
+	it("repairs JSON-serialized object strings for TypeBox schemas", () => {
+		// TypeBox schemas skip the generic pre-check coercion, so the repair
+		// must also run as a last-chance pass after validation fails.
+		const tool: Tool = {
+			name: "spawn",
+			description: "Spawn tool",
+			parameters: Type.Object(
+				{
+					script: Type.Object(
+						{
+							inline: Type.Optional(Type.String({ minLength: 1 })),
+							artifactId: Type.Optional(Type.String({ minLength: 1 })),
+						},
+						{ additionalProperties: false },
+					),
+				},
+				{ additionalProperties: false },
+			),
+		};
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tool-1",
+			name: "spawn",
+			arguments: { script: '{"inline":"echo hi"}' },
+		};
+
+		expect(validateToolArguments(tool, toolCall)).toEqual({
+			script: { inline: "echo hi" },
+		});
+
+		const garbage: ToolCall = {
+			...toolCall,
+			arguments: { script: '\n<parameter name="inline">cd /repo' },
+		};
+		expect(() => validateToolArguments(tool, garbage)).toThrow("must be object");
+	});
 });


### PR DESCRIPTION
## Problem

Providers and models sometimes double-serialize nested tool arguments, delivering a JSON object/array as a **string**. Two defects in `packages/ai/src/utils/validation.ts` made this worse than a simple retry:

1. **Object-typed parameters hard-fail** with `must be object`. This pushes extension authors toward permissive `prepareArguments` workarounds. In one real deployment such a workaround converted *any* string into executable inline Bash — including a model-emitted `<parameter name="inline">…` wrapper, which then ran with its first line destroyed by shell redirection (5 separate incidents in retained session ledgers; the worst wasted 500 s polling GitHub from the wrong cwd, and a sibling hid a 70 KB stderr traceback behind `exit=0`).
2. **Unions silently mis-type**: for `anyOf:[{object},{string}]`, a JSON-serialized object validates as the *string* member with no error at all.

## Fix

Conservative JSON-string repair in three places:

- `parseJsonStringForTypes` / `coerceJsonStringWithSchema`: a string is parsed only when it syntactically looks like a JSON object/array **and** the schema expects that type; the parsed value is adopted **only if, after recursive coercion, it fully validates** against the target schema. Anything else is left untouched so validation still fails with the original precise error.
- `coerceWithUnionSchema`: before the existing raw member checks, a string that validates (after parse + coercion) against an object/array member is adopted as that member. Ordinary strings and JSON not matching any typed member still resolve to the string member.
- `validateToolArguments`: a last-chance repair pass runs **after** `validator.Check(args)` fails, so it cannot change the behavior of any currently-valid call, and it also covers TypeBox schemas that skip the generic pre-check coercion (gated on the `TypeBox.Kind` symbol).

## Behavior table

| Input for object-typed `script` | Before | After |
|---|---|---|
| `{"inline":"echo hi"}` (object) | OK | OK (unchanged) |
| `"{\"inline\":\"echo hi\"}"` (JSON string) | rejected | repaired to object |
| `"{\"inline\":\"x\",\"version\":\"2\"}"` | rejected | repaired, nested `"2"` → `2` |
| `"\n<parameter name=\"inline\">…"` (garbage) | rejected | rejected (unchanged) |
| `"{\"weird\":true}"` (JSON, wrong shape) | rejected | rejected (unchanged) |
| union `[object,string]` + JSON-serialized object | silently kept as string | object member selected |
| union `[object,string]` + ordinary string | string member | string member (unchanged) |

## Trade-off

In a union containing both a string member and an object member, a string that parses to JSON validating the object member is now treated as double-serialized. In tool-call context this is almost always the intent; a caller who genuinely needs to pass JSON text through such a union should use a dedicated property rather than rely on the ambiguity.

## Testing

- 6 new tests in `packages/ai/test/validation.test.ts` (plain schemas, arrays, garbage rejection, non-validating JSON, union preference, TypeBox last-chance path).
- `vitest --run test/validation.test.ts`: 13/13 pass.
- Full `packages/ai` suite: same 9 pre-existing failures as unmodified `main` (environment-dependent); +6 new passing, no regressions.
- `tsc --noEmit -p tsconfig.build.json`: clean.
