### PR TITLE
fix(coding-agent): route extension commands regardless of expandPromptTemplates

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1119,9 +1119,13 @@ export class AgentSession {
 		let messages: AgentMessage[] | undefined;
 
 		try {
-			// Handle extension commands first (execute immediately, even during streaming)
+			// Handle extension commands first (execute immediately, even during streaming).
 			// Extension commands manage their own LLM interaction via pi.sendMessage()
-			if (expandPromptTemplates && text.startsWith("/")) {
+			// NOTE: command routing is intentionally NOT gated by expandPromptTemplates,
+			// so programmatic messages (pi.sendUserMessage with expandPromptTemplates:false)
+			// can still trigger extension commands like /mdr-reload. Only exact command
+			// names match, so arbitrary "/..." text still flows through as a normal prompt.
+			if (text.startsWith("/")) {
 				const handled = await this._tryExecuteExtensionCommand(text);
 				if (handled) {
 					// Extension command executed, no prompt to send


### PR DESCRIPTION
## Problem

`pi.sendUserMessage()` calls `prompt()` with `expandPromptTemplates: false`, which skips extension-command handling. The documented pattern in `extensions.md` —

> "Use a command as the reload entrypoint, then expose a tool that queues that command as a follow-up user message."

— therefore never actually triggers the command. The queued message (`/my-command`) is swallowed as a plain user prompt instead, and the agent sees it as a message rather than the extension command executing. This breaks any extension that tries to programmatically invoke one of its own commands (e.g. a tool that triggers a reload command).

## Change

In `prompt()`, route extension commands regardless of `expandPromptTemplates`:

```diff
- if (expandPromptTemplates && text.startsWith("/")) {
+ if (text.startsWith("/")) {
```

- Only **exact matches** against registered extension command names route to the handler, so arbitrary `"/..."` text still flows through as a normal prompt.
- Template expansion and `/skill:` expansion remain gated by `expandPromptTemplates` as before (`_expandSkillCommand` / `expandPromptTemplate` calls are untouched).
- TUI user input is unaffected (it already calls `prompt()` with the default `expandPromptTemplates: true`).

## Why not just fix the docs?

The docs describe a useful capability (agent-driven tool → command → side-effect loop, e.g. self-reload). Making `sendUserMessage` trigger commands matches that documented contract. The blast radius is small: only messages that exactly match a registered extension command name change behavior.

## Testing

- Verified locally: an extension tool calls `pi.sendUserMessage("/mdr-reload", { deliverAs: "followUp" })`; with this change the `mdr-reload` command handler runs (previously the message was swallowed).
- `packages/coding-agent` agent-session test suite passes: 39 passed | 18 skipped (vitest).
