### PR TITLE
fix(tui): handle tui.select.pageUp/pageDown in base SelectList and model-selector

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -341,6 +341,18 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			this.selectedIndex = this.selectedIndex === this.filteredModels.length - 1 ? 0 : this.selectedIndex + 1;
 			this.updateList();
 		}
+		// Page up - move up by one page
+		else if (kb.matches(keyData, "tui.select.pageUp")) {
+			if (this.filteredModels.length === 0) return;
+			this.selectedIndex = Math.max(0, this.selectedIndex - 10);
+			this.updateList();
+		}
+		// Page down - move down by one page
+		else if (kb.matches(keyData, "tui.select.pageDown")) {
+			if (this.filteredModels.length === 0) return;
+			this.selectedIndex = Math.min(this.filteredModels.length - 1, this.selectedIndex + 10);
+			this.updateList();
+		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			const selectedModel = this.filteredModels[this.selectedIndex];

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -121,6 +121,16 @@ export class SelectList implements Component {
 			this.selectedIndex = this.selectedIndex === this.filteredItems.length - 1 ? 0 : this.selectedIndex + 1;
 			this.notifySelectionChange();
 		}
+		// Page up - move up by one page
+		else if (kb.matches(keyData, "tui.select.pageUp")) {
+			this.selectedIndex = Math.max(0, this.selectedIndex - this.maxVisible);
+			this.notifySelectionChange();
+		}
+		// Page down - move down by one page
+		else if (kb.matches(keyData, "tui.select.pageDown")) {
+			this.selectedIndex = Math.min(this.filteredItems.length - 1, this.selectedIndex + this.maxVisible);
+			this.notifySelectionChange();
+		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			const selectedItem = this.filteredItems[this.selectedIndex];


### PR DESCRIPTION
## Description

This PR adds `tui.select.pageUp` and `tui.select.pageDown` keybinding handling to components that were missing them.

### Changes

1. **packages/tui/src/components/select-list.ts**: Added pageUp/pageDown handling to the base SelectList component. This fixes the issue in all selectors that delegate input to the base SelectList (e.g., /settings menu, autocomplete lists, etc.).

2. **packages/coding-agent/src/modes/interactive/components/model-selector.ts**: Added pageUp/pageDown handling to the model selector component.

The keybindings were already defined and handled in some select components (config-selector, session-selector, tree-selector), but the base SelectList and model-selector were missing them.

### Behavior
- pageUp: Moves selection up by one page (maxVisible items)
- pageDown: Moves selection down by one page (maxVisible items)

Fixes #7629