### PR TITLE
feat(tui): add copyOnSelect option to TuiAltScreen

### DIFF
--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -123,6 +123,8 @@ export interface TuiAltScreenOptions {
 	openUrl?: (url: string) => void;
 	/** Handle an unmodified secondary-button press for clipboard paste. Currently enabled on Windows only. */
 	onRightClickPaste?: () => void;
+	/** Automatically copy selected text to the clipboard on mouse release (default: true). */
+	copyOnSelect?: boolean;
 }
 
 /** Alternate-screen TUI with a scrollable, application-owned viewport. */
@@ -159,6 +161,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 	private readonly mouseEnabled: boolean;
 	private readonly openUrl?: (url: string) => void;
 	private readonly onRightClickPaste?: () => void;
+	private readonly copyOnSelect: boolean;
 
 	constructor(
 		terminal: Terminal,
@@ -179,6 +182,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		this.mouseEnabled = options.mouse ?? true;
 		this.openUrl = options.openUrl;
 		this.onRightClickPaste = options.onRightClickPaste;
+		this.copyOnSelect = options.copyOnSelect ?? true;
 		this.addInputListener((data) => this.handleViewportInput(data));
 	}
 
@@ -794,7 +798,9 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 				this.requestRender();
 				return;
 			}
-			this.copySelectionToClipboard();
+			if (this.copyOnSelect) {
+				this.copySelectionToClipboard();
+			}
 			this.requestRender();
 			return;
 		}


### PR DESCRIPTION
## Description

Adds a `copyOnSelect` option to `TuiAltScreenOptions` that allows users to disable the automatic copy-to-clipboard behavior when selecting text with the mouse in fullscreen TUI mode.

### Changes

- Added `copyOnSelect?: boolean` to `TuiAltScreenOptions` interface (defaults to `true` to preserve existing behavior)
- Guard the `copySelectionToClipboard()` call behind this option

Previously, every mouse selection in fullscreen mode would automatically copy the selected text to the clipboard via OSC 52. When set to `false`, text selection is still visually highlighted but no longer overwrites the clipboard.

Refs #7720