### PR TITLE
feat(coding-agent): expose context files at session start

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -397,7 +397,9 @@ Fired when a session is started, loaded, or reloaded.
 pi.on("session_start", async (event, ctx) => {
   // event.reason - "startup" | "reload" | "new" | "resume" | "fork"
   // event.previousSessionFile - present for "new", "resume", and "fork"
-  ctx.ui.notify(`Session: ${ctx.sessionManager.getSessionFile() ?? "ephemeral"}`, "info");
+  // event.contextFiles - loaded context files, in system-prompt order
+  const contextBytes = event.contextFiles?.reduce((total, file) => total + Buffer.byteLength(file.content), 0) ?? 0;
+  ctx.ui.notify(`Session: ${ctx.sessionManager.getSessionFile() ?? "ephemeral"} (${contextBytes} context bytes)`, "info");
 });
 ```
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2255,8 +2255,15 @@ export class AgentSession {
 		}
 
 		this._applyExtensionBindings(this._extensionRunner);
-		await this._extensionRunner.emit(this._sessionStartEvent);
+		await this._extensionRunner.emit(this._withLoadedContextFiles(this._sessionStartEvent));
 		await this.extendResourcesFromExtensions(this._sessionStartEvent.reason === "reload" ? "reload" : "startup");
+	}
+
+	private _withLoadedContextFiles(event: SessionStartEvent): SessionStartEvent {
+		const contextFiles = this._resourceLoader
+			.getAgentsFiles()
+			.agentsFiles.map(({ path, content }) => ({ path, content }));
+		return contextFiles.length > 0 ? { ...event, contextFiles } : event;
 	}
 
 	private async extendResourcesFromExtensions(reason: "startup" | "reload"): Promise<void> {
@@ -2629,7 +2636,7 @@ export class AgentSession {
 			this._extensionErrorListener;
 		if (hasBindings) {
 			await options?.beforeSessionStart?.();
-			await this._extensionRunner.emit({ type: "session_start", reason: "reload" });
+			await this._extensionRunner.emit(this._withLoadedContextFiles({ type: "session_start", reason: "reload" }));
 			await this.extendResourcesFromExtensions("reload");
 		}
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -565,6 +565,8 @@ export interface SessionStartEvent {
 	reason: "startup" | "reload" | "new" | "resume" | "fork";
 	/** Previously active session file. Present for "new", "resume", and "fork". */
 	previousSessionFile?: string;
+	/** Context files loaded into the system prompt, in prompt order. */
+	contextFiles?: Array<{ path: string; content: string }>;
 }
 
 /** Fired when the current session metadata changes. */

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -373,6 +373,25 @@ describe("AgentSession model and extension characterization", () => {
 		).toBe(true);
 	});
 
+	it("includes loaded context files in session_start", async () => {
+		const received: Array<{ path: string; content: string }> = [];
+		const harness = await createHarness({
+			contextFiles: [{ path: "/repo/AGENTS.md", content: "Follow project policy." }],
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (event) => {
+						received.push(...(event.contextFiles ?? []));
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		await harness.session.bindExtensions({});
+
+		expect(received).toEqual([{ path: "/repo/AGENTS.md", content: "Follow project policy." }]);
+	});
+
 	it("bindExtensions emits session_start and reload emits session_shutdown then session_start", async () => {
 		const lifecycleEvents: string[] = [];
 		const harness = await createHarness({

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -69,6 +69,7 @@ export interface HarnessOptions {
 	allowedToolNames?: string[];
 	excludedToolNames?: string[];
 	resourceLoader?: ResourceLoader;
+	contextFiles?: Array<{ path: string; content: string }>;
 	extensionFactories?: Array<InlineExtension | CreateTestExtensionsResultInput>;
 	withConfiguredAuth?: boolean;
 	modelsJson?: Record<string, unknown>;
@@ -177,7 +178,11 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		? await createTestExtensionsResult(options.extensionFactories, tempDir)
 		: undefined;
 	const resourceLoader =
-		options.resourceLoader ?? createTestResourceLoader(extensionsResult ? { extensionsResult } : undefined);
+		options.resourceLoader ??
+		createTestResourceLoader({
+			extensionsResult,
+			contextFiles: options.contextFiles,
+		});
 
 	const session = new AgentSession({
 		agent,

--- a/packages/coding-agent/test/utilities.ts
+++ b/packages/coding-agent/test/utilities.ts
@@ -208,6 +208,7 @@ export async function createTestExtensionsResult(
 
 export interface CreateTestResourceLoaderOptions {
 	extensionsResult?: LoadExtensionsResult;
+	contextFiles?: Array<{ path: string; content: string }>;
 }
 
 export function createTestResourceLoader(options: CreateTestResourceLoaderOptions = {}): ResourceLoader {
@@ -222,7 +223,7 @@ export function createTestResourceLoader(options: CreateTestResourceLoaderOption
 		getSkills: () => ({ skills: [], diagnostics: [] }),
 		getPrompts: () => ({ prompts: [], diagnostics: [] }),
 		getThemes: () => ({ themes: [], diagnostics: [] }),
-		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getAgentsFiles: () => ({ agentsFiles: options.contextFiles ?? [] }),
 		getSystemPrompt: () => undefined,
 		getSystemPromptSource: () => undefined,
 		getAppendSystemPrompt: () => [],


### PR DESCRIPTION
## Summary
- expose the loaded AGENTS/CLAUDE context files on `session_start`
- document the extension event field
- add focused session-start coverage

## Validation
- `node ../../node_modules/vitest/dist/cli.js --run test/suite/agent-session-model-extension.test.ts`
- `node ../../node_modules/vitest/dist/cli.js --run test/agent-session-runtime-events.test.ts test/suite/agent-session-runtime.test.ts`
- `npm run check`
