### PR TITLE
skip global aliases

### DIFF
--- a/packages/coding-agent/docs/shell-aliases.md
+++ b/packages/coding-agent/docs/shell-aliases.md
@@ -6,7 +6,7 @@ To enable your shell aliases, add to `~/.pi/agent/settings.json`:
 
 ```json
 {
-  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias ' ~/.zshrc)\""
+  "shellCommandPrefix": "shopt -s expand_aliases\neval \"$(grep '^alias -- ' ~/.zshrc)\""
 }
 ```
 


### PR DESCRIPTION
The problem is visible on bash tool calls:
<img width="690" height="117" alt="image" src="https://github.com/user-attachments/assets/a3ec5e48-26b4-4120-990a-8b723336ce59" />

`grep '^alias ' ~/.zshrc` includes `alias -g -- G='| grep'` which is not supported here. Filtering them out removes the warning.

This PR does not follow any guidelines.
No AI used for anything.
I haven't checked for side effects.