### PR TITLE
Make the interactive footer responsive in narrow panes

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -125,14 +125,14 @@ export class FooterComponent implements Component {
 			pwd = `${pwd} • ${sessionName}`;
 		}
 
-		// Build stats line
-		const statsParts = [];
-		if (usageTotals.input) statsParts.push(`↑${formatTokens(usageTotals.input)}`);
-		if (usageTotals.output) statsParts.push(`↓${formatTokens(usageTotals.output)}`);
-		if (usageTotals.cacheRead) statsParts.push(`R${formatTokens(usageTotals.cacheRead)}`);
-		if (usageTotals.cacheWrite) statsParts.push(`W${formatTokens(usageTotals.cacheWrite)}`);
+		// Build cumulative usage separately so context and model can be kept together on narrow panes.
+		const usageParts: string[] = [];
+		if (usageTotals.input) usageParts.push(`↑${formatTokens(usageTotals.input)}`);
+		if (usageTotals.output) usageParts.push(`↓${formatTokens(usageTotals.output)}`);
+		if (usageTotals.cacheRead) usageParts.push(`R${formatTokens(usageTotals.cacheRead)}`);
+		if (usageTotals.cacheWrite) usageParts.push(`W${formatTokens(usageTotals.cacheWrite)}`);
 		if ((usageTotals.cacheRead > 0 || usageTotals.cacheWrite > 0) && latestCacheHitRate !== undefined) {
-			statsParts.push(`CH${latestCacheHitRate.toFixed(1)}%`);
+			usageParts.push(`CH${latestCacheHitRate.toFixed(1)}%`);
 		}
 
 		// Kimi Coding is subscription-backed despite using API-key authentication.
@@ -140,11 +140,10 @@ export class FooterComponent implements Component {
 			? state.model.provider === "kimi-coding" || this.session.modelRuntime.isUsingSubscription(state.model.provider)
 			: false;
 		if (usageTotals.cost || usingSubscription) {
-			const costStr = `$${usageTotals.cost.toFixed(3)}${usingSubscription ? " (sub)" : ""}`;
-			statsParts.push(costStr);
+			usageParts.push(`$${usageTotals.cost.toFixed(3)}${usingSubscription ? " (sub)" : ""}`);
 		}
 
-		// Colorize context percentage based on usage
+		// Colorize context percentage based on usage.
 		let contextPercentStr: string;
 		const autoIndicator = this.autoCompactEnabled ? " (auto)" : "";
 		const contextPercentDisplay =
@@ -158,28 +157,17 @@ export class FooterComponent implements Component {
 		} else {
 			contextPercentStr = contextPercentDisplay;
 		}
-		statsParts.push(contextPercentStr);
+
+		const statsParts = [...usageParts, contextPercentStr];
 		if (areExperimentalFeaturesEnabled()) {
 			statsParts.push(`${theme.fg("dim", "•")} ${theme.bold(theme.fg("warning", "xp"))}`);
 		}
+		const statsLeft = statsParts.join(" ");
+		const statsLeftWidth = visibleWidth(statsLeft);
 
-		let statsLeft = statsParts.join(" ");
-
-		// Add model name on the right side, plus thinking level if model supports it
+		// Add model name on the right side, plus thinking level if model supports it.
 		const modelName = state.model?.id || "no-model";
-
-		let statsLeftWidth = visibleWidth(statsLeft);
-
-		// If statsLeft is too wide, truncate it
-		if (statsLeftWidth > width) {
-			statsLeft = truncateToWidth(statsLeft, width, "...");
-			statsLeftWidth = visibleWidth(statsLeft);
-		}
-
-		// Calculate available space for padding (minimum 2 spaces between stats and model)
 		const minPadding = 2;
-
-		// Add thinking level indicator if model supports reasoning
 		let rightSideWithoutProvider = modelName;
 		if (state.model?.reasoning) {
 			const thinkingLevel = state.thinkingLevel || "off";
@@ -187,47 +175,54 @@ export class FooterComponent implements Component {
 				thinkingLevel === "off" ? `${modelName} • thinking off` : `${modelName} • ${thinkingLevel}`;
 		}
 
-		// Prepend the provider in parentheses if there are multiple providers and there's enough room
+		// Prepend the provider in parentheses if there are multiple providers and there's enough room.
 		let rightSide = rightSideWithoutProvider;
 		if (this.footerData.getAvailableProviderCount() > 1 && state.model) {
-			rightSide = `(${state.model!.provider}) ${rightSideWithoutProvider}`;
+			rightSide = `(${state.model.provider}) ${rightSideWithoutProvider}`;
 			if (statsLeftWidth + minPadding + visibleWidth(rightSide) > width) {
-				// Too wide, fall back
 				rightSide = rightSideWithoutProvider;
 			}
 		}
 
 		const rightSideWidth = visibleWidth(rightSide);
 		const totalNeeded = statsLeftWidth + minPadding + rightSideWidth;
-
-		let statsLine: string;
-		if (totalNeeded <= width) {
-			// Both fit - add padding to right-align model
-			const padding = " ".repeat(width - statsLeftWidth - rightSideWidth);
-			statsLine = statsLeft + padding + rightSide;
-		} else {
-			// Need to truncate right side
-			const availableForRight = width - statsLeftWidth - minPadding;
-			if (availableForRight > 0) {
-				const truncatedRight = truncateToWidth(rightSide, availableForRight, "");
-				const truncatedRightWidth = visibleWidth(truncatedRight);
-				const padding = " ".repeat(Math.max(0, width - statsLeftWidth - truncatedRightWidth));
-				statsLine = statsLeft + padding + truncatedRight;
-			} else {
-				// Not enough space for right side at all
-				statsLine = statsLeft;
-			}
-		}
-
-		// Apply dim to each part separately. statsLeft may contain color codes (for context %)
-		// that end with a reset, which would clear an outer dim wrapper. So we dim the parts
-		// before and after the colored section independently.
-		const dimStatsLeft = theme.fg("dim", statsLeft);
-		const remainder = statsLine.slice(statsLeft.length); // padding + rightSide
-		const dimRemainder = theme.fg("dim", remainder);
-
 		const pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
-		const lines = [pwdLine, dimStatsLeft + dimRemainder];
+		const lines = [pwdLine];
+
+		if (totalNeeded <= width) {
+			// Preserve the established single-line layout whenever all footer data fits.
+			const padding = " ".repeat(width - statsLeftWidth - rightSideWidth);
+			const statsLine = statsLeft + padding + rightSide;
+			// statsLeft may contain color codes that end with a reset, so dim both sections separately.
+			lines.push(theme.fg("dim", statsLeft) + theme.fg("dim", statsLine.slice(statsLeft.length)));
+		} else {
+			// Usage is cumulative and lower priority than the active context/model pair, so reflow it first.
+			const secondaryParts = [...usageParts];
+			if (areExperimentalFeaturesEnabled()) {
+				secondaryParts.push(`${theme.fg("dim", "•")} ${theme.bold(theme.fg("warning", "xp"))}`);
+			}
+			let usageLine = "";
+			for (const part of secondaryParts) {
+				const candidate = usageLine ? `${usageLine} ${part}` : part;
+				if (usageLine && visibleWidth(candidate) > width) {
+					lines.push(theme.fg("dim", truncateToWidth(usageLine, width, "")));
+					usageLine = part;
+				} else {
+					usageLine = candidate;
+				}
+			}
+			if (usageLine) {
+				lines.push(theme.fg("dim", truncateToWidth(usageLine, width, "")));
+			}
+
+			const compactContext = truncateToWidth(contextPercentStr, Math.max(1, width - minPadding - 1), "");
+			const availableForModel = Math.max(1, width - visibleWidth(compactContext) - minPadding);
+			const compactRight =
+				visibleWidth(rightSideWithoutProvider) <= availableForModel ? rightSideWithoutProvider : modelName;
+			const modelDisplay = truncateToWidth(compactRight, availableForModel, "");
+			const padding = " ".repeat(Math.max(0, width - visibleWidth(compactContext) - visibleWidth(modelDisplay)));
+			lines.push(theme.fg("dim", compactContext) + theme.fg("dim", padding + modelDisplay));
+		}
 
 		// Add extension statuses on a single line, sorted by key alphabetically
 		const extensionStatuses = this.footerData.getExtensionStatuses();

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -25,6 +25,7 @@ function createSession(options: {
 	compactionUsage?: AssistantUsage;
 	toolUsage?: AssistantUsage;
 	usingSubscription?: boolean;
+	cwd?: string;
 }): AgentSession {
 	const usage = options.usage;
 	const entries: Array<Record<string, unknown>> = [];
@@ -76,7 +77,7 @@ function createSession(options: {
 		sessionManager: {
 			getEntries: () => entries,
 			getSessionName: () => options.sessionName,
-			getCwd: () => "/tmp/project",
+			getCwd: () => options.cwd ?? "/tmp/project",
 		},
 		getContextUsage: () => ({ contextWindow: 200_000, percent: 12.3 }),
 		modelRuntime: {
@@ -87,10 +88,13 @@ function createSession(options: {
 	return session as unknown as AgentSession;
 }
 
-function createFooterData(providerCount: number): ReadonlyFooterDataProvider {
+function createFooterData(
+	providerCount: number,
+	extensionStatuses = new Map<string, string>(),
+): ReadonlyFooterDataProvider {
 	const provider = {
 		getGitBranch: () => "main",
-		getExtensionStatuses: () => new Map<string, string>(),
+		getExtensionStatuses: () => extensionStatuses,
 		getAvailableProviderCount: () => providerCount,
 		onBranchChange: (callback: () => void) => {
 			void callback;
@@ -149,6 +153,76 @@ describe("FooterComponent width handling", () => {
 		const lines = footer.render(width);
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
+	});
+
+	it("keeps context and model visible at narrow widths by reflowing cumulative usage", () => {
+		const session = createSession({
+			sessionName: "",
+			usage: {
+				input: 12_345,
+				output: 6_789,
+				cacheRead: 4_321,
+				cacheWrite: 2_345,
+				cost: { total: 1.234 },
+			},
+		});
+		const footer = new FooterComponent(session, createFooterData(1));
+
+		for (const width of [40, 60, 80]) {
+			const lines = footer.render(width);
+			const output = stripAnsi(lines.join("\n"));
+			expect(output).toContain("12.3%/200k (auto)");
+			expect(output).toContain("test-model");
+			for (const line of lines) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+		}
+	});
+
+	it("preserves the single-line stats layout at wide widths", () => {
+		const session = createSession({
+			sessionName: "",
+			usage: {
+				input: 12_345,
+				output: 6_789,
+				cacheRead: 4_321,
+				cacheWrite: 2_345,
+				cost: { total: 1.234 },
+			},
+		});
+		const footer = new FooterComponent(session, createFooterData(1));
+
+		const lines = footer.render(120);
+		expect(lines).toHaveLength(2);
+		expect(stripAnsi(lines[1]!)).toContain("↑12k ↓6.8k R4.3k W2.3k CH22.7% $1.234 12.3%/200k (auto)");
+		expect(stripAnsi(lines[1]!)).toMatch(/test-model$/);
+	});
+
+	it("truncates long path, model, and extension status values without overflowing", () => {
+		const session = createSession({
+			sessionName: "session-name-".repeat(10),
+			cwd: "/tmp/very-long-project-path/".repeat(4),
+			modelId: "model-name-".repeat(10),
+			usage: {
+				input: 12_345,
+				output: 6_789,
+				cacheRead: 4_321,
+				cacheWrite: 2_345,
+				cost: { total: 1.234 },
+			},
+		});
+		const footer = new FooterComponent(
+			session,
+			createFooterData(1, new Map([["status", "status-value-".repeat(20)]])),
+		);
+
+		const lines = footer.render(40);
+		expect(stripAnsi(lines[0]!)).toContain("...");
+		expect(stripAnsi(lines.join("\n"))).toContain("model-name-");
+		expect(stripAnsi(lines.at(-1)!)).toMatch(/^status-value-/);
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(40);
 		}
 	});
 


### PR DESCRIPTION
The built-in footer currently assembles cumulative usage before context, then truncates the full line. In narrow vertical panes that drops the context window—the thing most worth keeping visible.

This change keeps the wide layout materially unchanged, but reflows lower-priority usage onto another line when needed so model and context survive at 40/60/80 columns. Every returned line is still ANSI-width bounded, including long paths, model names, and extension statuses.

Verification:
1. Footer width tests: 12 passed across 40/60/80/120 columns and long values.
2. `npm run check` passed.
3. Dependency-chain and coding-agent builds passed.
4. Fresh independent review: approved with no findings.