### PR TITLE
fix(ai): reject item_* content IDs in message-level input[].id fields

### DIFF
--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -230,7 +230,8 @@ export function convertResponsesMessages<TApi extends Api>(
 					textBlockIndex++;
 					// OpenAI requires id to be max 64 characters
 					let msgId = parsedSignature?.id;
-					if (!msgId) {
+					// Reject item_* content IDs - they belong to a different namespace than message-level msg_* IDs
+					if (!msgId || msgId.startsWith("item_")) {
 						msgId = fallbackMessageId;
 					} else if (msgId.length > 64) {
 						msgId = `msg_${shortHash(msgId)}`;

--- a/packages/ai/test/openai-responses-item-id-namespace.test.ts
+++ b/packages/ai/test/openai-responses-item-id-namespace.test.ts
@@ -1,0 +1,129 @@
+import type { ResponseOutputMessage } from "openai/resources/responses/responses.js";
+import { describe, expect, it } from "vitest";
+import { convertResponsesMessages } from "../src/api/openai-responses-shared.ts";
+import { getModel } from "../src/compat.ts";
+import type { AssistantMessage, Context, Usage } from "../src/types.ts";
+
+const usage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+describe("OpenAI Responses item_* ID namespace rejection", () => {
+	it("rejects item_* content IDs and uses fallback for message-level IDs", () => {
+		const model = getModel("openai-codex", "gpt-5.5");
+		// Simulate a persisted assistant message with textSignature containing an item_* ID
+		// (as would happen when streaming a response.output_item.done with item.type === "message")
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "text",
+					text: "This text block has an item_* ID in its signature",
+					textSignature: JSON.stringify({ v: 1, id: "item_a82c011efca1d9acdc8d92f7" }),
+				},
+			],
+			api: "openai-codex",
+			provider: "openai",
+			model: "gpt-5.5",
+			usage,
+			stopReason: "toolUse",
+			timestamp: Date.now() - 1000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a test assistant.",
+			messages: [{ role: "user", content: "test input", timestamp: Date.now() - 2000 }, assistant],
+		};
+
+		const input = convertResponsesMessages(model, context, new Set(["openai", "openai-codex"]));
+		const messages = input.filter((item): item is ResponseOutputMessage => item.type === "message" && "id" in item);
+
+		expect(messages).toHaveLength(1);
+		const msgId = messages[0].id;
+
+		// The item_* ID should have been rejected and replaced with the fallback msg_pi_* ID
+		expect(msgId).not.toContain("item_");
+		expect(msgId).toMatch(/^msg_pi_\d+$/);
+		expect(msgId).toBe("msg_pi_1");
+	});
+
+	it("never emits item_* IDs in message-level input[].id fields", () => {
+		const model = getModel("openai-codex", "gpt-5.5");
+		const assistantWithItemId: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "text",
+					text: "First block",
+					textSignature: JSON.stringify({ v: 1, id: "item_abc123" }),
+				},
+				{
+					type: "text",
+					text: "Second block",
+					textSignature: JSON.stringify({ v: 1, id: "item_def456" }),
+				},
+			],
+			api: "openai-codex",
+			provider: "openai",
+			model: "gpt-5.5",
+			usage,
+			stopReason: "stop",
+			timestamp: Date.now() - 1000,
+		};
+		const context: Context = {
+			systemPrompt: "",
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() - 2000 }, assistantWithItemId],
+		};
+
+		const input = convertResponsesMessages(model, context, new Set(["openai", "openai-codex"]));
+		const messageIds = input
+			.filter(
+				(item): item is ResponseOutputMessage =>
+					item.type === "message" && "id" in item && typeof item.id === "string",
+			)
+			.map((item) => item.id);
+
+		// Assert no item_* IDs appear in any message-level ID field
+		for (const id of messageIds) {
+			expect(id).not.toMatch(/^item_/);
+		}
+		// Verify fallback IDs were used
+		expect(messageIds).toEqual(["msg_pi_1", "msg_pi_1_1"]);
+	});
+
+	it("uses fallback when cross-provider even with valid msg_* ID in textSignature", () => {
+		const model = getModel("openai-codex", "gpt-5.5");
+		// Cross-provider messages use fallback IDs (different provider in this case)
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "text",
+					text: "This has a valid msg_* ID but from different provider",
+					textSignature: JSON.stringify({ v: 1, id: "msg_valid_abc123" }),
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic", // Different provider
+			model: "claude-opus-4-8",
+			usage,
+			stopReason: "stop",
+			timestamp: Date.now() - 1000,
+		};
+		const context: Context = {
+			systemPrompt: "",
+			messages: [{ role: "user", content: "test", timestamp: Date.now() - 2000 }, assistant],
+		};
+
+		const input = convertResponsesMessages(model, context, new Set(["openai", "openai-codex"]));
+		const messages = input.filter((item): item is ResponseOutputMessage => item.type === "message" && "id" in item);
+
+		expect(messages).toHaveLength(1);
+		// Cross-provider uses fallback, not the original ID
+		expect(messages[0].id).toBe("msg_pi_1");
+	});
+});


### PR DESCRIPTION
## Issue

The Responses API has two ID namespaces:
- `item_*` for content items (text blocks, reasoning, function calls)
- `msg_*` for message-level items in input history

When streaming a `response.output_item.done` event with `item.type === "message"`, the SDK stored the `item.id` (an `item_*` content ID) into `textSignature`. During history replay for continuation requests, this `item_*` ID was extracted and used directly as the message-level `id` field, which the API rejects with:

```
Invalid 'input[N].id': 'item_...'. Expected an ID that begins with 'msg'.
```

## Example Error

From a production VisionClaw session (2026-08-10):
```
HTTP 400 invalid_request_error / invalid_value
Invalid 'input[356].id': 'item_a82c011efca1d9acdc8d92f7'. Expected an ID that begins with 'msg'.
```

The persisted `textSignature` contained: `{"v":1,"id":"item_a82c011efca1d9acdc8d92f7"}`

## Root Cause

The bug occurs in two stages:

**Stage 1 - Streaming (line 572)**: When processing `response.output_item.done` events with `item.type === "message"`, the SDK stores the streaming item ID into `textSignature`:
```javascript
slot.block.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
// item.id here is "item_a82c..." (content item ID)
```

**Stage 2 - History replay (lines 145-162)**: When reconstructing the message for continuation, it extracts this `item_*` ID and uses it as a message-level ID:
```javascript
let msgId = parsedSignature?.id;  // Extracts "item_a82c..."
if (!msgId) {
    msgId = fallbackMessageId;  // Fallback never triggers when parsedSignature.id exists
}
```

The fallback only activates when `msgId` is falsy. When an `item_*` ID is present in `parsedSignature.id`, the condition passes and the wrong-namespace ID is used directly.

## Fix

Add prefix validation to reject `item_*` content IDs and use the deterministic fallback for message-level IDs:

```typescript
let msgId = parsedSignature?.id;
// Reject item_* content IDs - they belong to a different namespace than message-level msg_* IDs
if (!msgId || msgId.startsWith("item_")) {
    msgId = fallbackMessageId;
}
```

This follows the same pattern already established in `normalizeToolCallId` which validates `fc_*` prefixes for function call IDs.

## Tests

Added regression tests in `test/openai-responses-item-id-namespace.test.ts`:

1. ✅ Rejects `item_*` content IDs and uses fallback for message-level IDs
2. ✅ Never emits `item_*` IDs in message-level `input[].id` fields  
3. ✅ Uses fallback when cross-provider even with valid `msg_*` ID in textSignature

All existing OpenAI Responses tests pass (8 test files).

## Impact

Fixes continuation failures after successful assistant turns containing signed text + tool calls. Without this fix, the first continuation request after such a turn is deterministically rejected with HTTP 400, causing 5 retry attempts with exponential backoff before surfacing the error.