### PR TITLE
fix: add trailing newline after current working directory

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -66,7 +66,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 			prompt += formatSkillsForPrompt(skills);
 		}
 
-		prompt += `\nCurrent working directory: ${promptCwd}`;
+		prompt += `\nCurrent working directory: ${promptCwd}\n`;
 
 		return prompt;
 	}


### PR DESCRIPTION
## Overview

The generated system prompt does not end with a newline. As a result, the first user message can appear directly after the working directory.

This happens in vanilla Pi. It does not require extensions, custom prompts, or wrappers.

## Reproduction

1. Install Pi 0.84.1.
2. Start Pi with a clean configuration in a directory named `work`.
3. Send `test` as the first user message.
4. Inspect the working directory text received by the model.

Actual result:

```text
Current working directory: /path/to/worktest
```

Expected result:

```text
Current working directory: /path/to/work
test
```

The real process working directory remains correct. The issue only affects the generated prompt text.

## Cause

Both system-prompt branches end with:

```js
prompt += `\nCurrent working directory: ${promptCwd}`;
```

The string has a newline before the line, but no newline after `${promptCwd}`.

