### PR TITLE
fix(edit): normalize single-object edits argument to array

### DIFF
--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -112,8 +112,21 @@ function prepareEditArguments(input: unknown): EditToolInput {
 	if (typeof args.edits === "string") {
 		try {
 			const parsed = JSON.parse(args.edits);
-			if (Array.isArray(parsed)) args.edits = parsed;
+			if (Array.isArray(parsed)) {
+				args.edits = parsed;
+			} else if (parsed && typeof parsed === "object" && "oldText" in parsed && "newText" in parsed) {
+				// Single object: wrap into a one-element array
+				args.edits = [parsed];
+			}
 		} catch {}
+	}
+
+	// Some models send edits as a single object instead of an array
+	if (args.edits && typeof args.edits === "object" && !Array.isArray(args.edits)) {
+		const single = args.edits as Record<string, unknown>;
+		if (typeof single.oldText === "string" && typeof single.newText === "string") {
+			args.edits = [single];
+		}
 	}
 
 	const legacy = args as LegacyEditToolInput;


### PR DESCRIPTION
## Summary

The edit tool rejects calls where `edits` is a single object (or a JSON string holding one object) instead of an array. Some models wrap their arguments for the edit tool in a single object `{oldText, newText}` rather than `[{oldText, newText}]`.

The existing `prepareEditArguments` function already handles stringified arrays but does not handle:
- Stringified single objects: `edits: '{"oldText": "...", "newText": "..."}'`
- Native single objects: `edits: {oldText: "...", newText: "..."}`

## Changes

- When `args.edits` is a JSON string that parses to a single object with `oldText`/`newText`, wrap it into a one-element array
- When `args.edits` is a plain object (not array, not string) with `oldText`/`newText` properties, wrap it into a one-element array

## Example

Before:
```
Validation failed for tool "edit":
  - edits.0: must be object
```

After: Object is normalized to `[{oldText, newText}]` and the edit is applied normally.

Fixes #7835