### PR TITLE
fix(config): refine pnpm detection and validate managed install before suggesting update command

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -77,7 +77,13 @@ export function detectInstallMethod(): InstallMethod {
 
 	const resolvedPath = `${__dirname}\0${process.execPath || ""}`.toLowerCase().replace(/\\/g, "/");
 
-	if (resolvedPath.includes("/pnpm/") || resolvedPath.includes("/.pnpm/")) {
+	// Match genuine pnpm installations: internal store structure (.pnpm), global root, or store directory.
+	// Avoids false positives from paths that merely share PNPM_HOME but aren't pnpm-managed (e.g., $PNPM_HOME/global-nub/...).
+	if (
+		resolvedPath.includes("/.pnpm/") ||
+		resolvedPath.includes("/pnpm/global/") ||
+		resolvedPath.includes("/pnpm/store/")
+	) {
 		return "pnpm";
 	}
 	if (resolvedPath.includes("/yarn/") || resolvedPath.includes("/.yarn/")) {
@@ -348,7 +354,7 @@ export function getSelfUpdateUnavailableInstruction(
 export function getUpdateInstruction(packageName: string): string {
 	const method = detectInstallMethod();
 	const command = getSelfUpdateCommandForMethod(method, packageName);
-	if (command) {
+	if (command && isManagedByGlobalPackageManager(method, packageName)) {
 		return `Run: ${command.display}`;
 	}
 	return getSelfUpdateUnavailableInstruction(packageName);

--- a/pr-body-7835.md
+++ b/pr-body-7835.md
@@ -1,0 +1,24 @@
+## Summary
+
+The edit tool rejects calls where `edits` is a single object (or a JSON string holding one object) instead of an array. Some models wrap their arguments for the edit tool in a single object `{oldText, newText}` rather than `[{oldText, newText}]`.
+
+The existing `prepareEditArguments` function already handles stringified arrays but does not handle:
+- Stringified single objects: `edits: '{"oldText": "...", "newText": "..."}'`
+- Native single objects: `edits: {oldText: "...", newText: "..."}`
+
+## Changes
+
+- When `args.edits` is a JSON string that parses to a single object with `oldText`/`newText`, wrap it into a one-element array
+- When `args.edits` is a plain object (not array, not string) with `oldText`/`newText` properties, wrap it into a one-element array
+
+## Example
+
+Before:
+```
+Validation failed for tool "edit":
+  - edits.0: must be object
+```
+
+After: Object is normalized to `[{oldText, newText}]` and the edit is applied normally.
+
+Fixes #7835


### PR DESCRIPTION
## Summary

`detectInstallMethod()` matches any path containing `/pnpm/` as a pnpm installation, causing false positives when the package is under `$PNPM_HOME` bins directory but not actually managed by pnpm (e.g., `$PNPM_HOME/global-nub/.../node_modules/...`).

Additionally, `getUpdateInstruction()` was returning `pnpm install -g` commands without validating the install is genuinely managed by pnpm.

## Changes

1. **Tighten pnpm detection** (`detectInstallMethod`): Only match paths containing `/.pnpm/` (internal store structure), `/pnpm/global/`, or `/pnpm/store/` which indicate genuine pnpm installations. This avoids false positives from paths under `$PNPM_HOME` that aren't actually pnpm-managed.

2. **Validate managed install** (`getUpdateInstruction`): Added `isManagedByGlobalPackageManager` check before showing the method-specific update command. When the managed check fails, it falls through to the generic unavailable instruction (which uses neutral wording).

## Example

Before: Package under `$PNPM_HOME/global-nub/...` shows:
> `Run: pnpm install -g --ignore-scripts ...`

After: Package under the same path shows:
> `Update @earendil-works/pi-coding-agent using the package manager, wrapper, or source checkout that provides this installation.`

Fixes #7756