### PR TITLE
feat(coding-agent): add fullscreen fixed top bar

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a fullscreen-only fixed top bar showing abbreviated cwd/branch and context usage outside the transcript scroll view.
 - Added a fullscreen exit output setting to choose between printing the final transcript and only a session resume hint.
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive/components/fullscreen-top-bar.ts
+++ b/packages/coding-agent/src/modes/interactive/components/fullscreen-top-bar.ts
@@ -1,0 +1,108 @@
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { AgentSession } from "../../../core/agent-session.ts";
+import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
+import { theme } from "../theme/theme.ts";
+import { formatCwdForFooter, formatTokens } from "./footer.ts";
+
+/**
+ * Fixed single-line top bar for fullscreen mode only.
+ * Left: home-abbreviated cwd and optional git branch.
+ * Right: context usage (preserved under width pressure).
+ */
+export class FullscreenTopBar implements Component {
+	private autoCompactEnabled = true;
+	private session: AgentSession;
+	private footerData: ReadonlyFooterDataProvider;
+
+	constructor(session: AgentSession, footerData: ReadonlyFooterDataProvider) {
+		this.session = session;
+		this.footerData = footerData;
+	}
+
+	setSession(session: AgentSession): void {
+		this.session = session;
+	}
+
+	setAutoCompactEnabled(enabled: boolean): void {
+		this.autoCompactEnabled = enabled;
+	}
+
+	invalidate(): void {
+		// No-op: data comes from session + FooterDataProvider each render
+	}
+
+	dispose(): void {
+		// No resources owned; git watching lives on FooterDataProvider
+	}
+
+	render(width: number): string[] {
+		if (width <= 0) {
+			return [""];
+		}
+
+		const state = this.session.state;
+
+		let left = formatCwdForFooter(this.session.sessionManager.getCwd(), process.env.HOME || process.env.USERPROFILE);
+		const branch = this.footerData.getGitBranch();
+		if (branch) {
+			left = `${left} (${branch})`;
+		}
+
+		// Match FooterComponent context display exactly.
+		const contextUsage = this.session.getContextUsage();
+		const contextWindow = contextUsage?.contextWindow ?? state.model?.contextWindow ?? 0;
+		const contextPercentValue = contextUsage?.percent ?? 0;
+		const contextPercent = contextUsage?.percent !== null ? contextPercentValue.toFixed(1) : "?";
+		const autoIndicator = this.autoCompactEnabled ? " (auto)" : "";
+		const contextPercentDisplay =
+			contextPercent === "?"
+				? `?/${formatTokens(contextWindow)}${autoIndicator}`
+				: `${contextPercent}%/${formatTokens(contextWindow)}${autoIndicator}`;
+
+		let rightColored: string;
+		if (contextPercentValue > 90) {
+			rightColored = theme.fg("error", contextPercentDisplay);
+		} else if (contextPercentValue > 70) {
+			rightColored = theme.fg("warning", contextPercentDisplay);
+		} else {
+			rightColored = contextPercentDisplay;
+		}
+
+		const rightPlain = contextPercentDisplay;
+		const rightWidth = visibleWidth(rightPlain);
+		const minPadding = 1;
+
+		// Right side is preserved; if it alone exceeds width, truncate it.
+		if (rightWidth >= width) {
+			const truncatedRight = rightWidth > width ? truncateToWidth(rightPlain, width, "...") : rightPlain;
+			// Re-apply color to truncated plain text when thresholds apply.
+			let colored: string;
+			if (contextPercentValue > 90) {
+				colored = theme.fg("error", truncatedRight);
+			} else if (contextPercentValue > 70) {
+				colored = theme.fg("warning", truncatedRight);
+			} else {
+				colored = truncatedRight;
+			}
+			const pad = Math.max(0, width - visibleWidth(truncatedRight));
+			return [colored + (pad > 0 ? " ".repeat(pad) : "")];
+		}
+
+		const availableForLeft = width - rightWidth - minPadding;
+		let leftDisplay = left;
+		if (availableForLeft <= 0) {
+			// No room for left; show right only, left-padded so right stays at the end.
+			const padding = " ".repeat(width - rightWidth);
+			return [padding + rightColored];
+		}
+
+		if (visibleWidth(leftDisplay) > availableForLeft) {
+			leftDisplay = truncateToWidth(leftDisplay, availableForLeft, "...");
+		}
+
+		const leftWidth = visibleWidth(leftDisplay);
+		const padding = " ".repeat(Math.max(minPadding, width - leftWidth - rightWidth));
+		const dimLeft = theme.fg("dim", leftDisplay);
+		return [dimLeft + padding + rightColored];
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/interactive-layout.ts
+++ b/packages/coding-agent/src/modes/interactive/components/interactive-layout.ts
@@ -1,0 +1,60 @@
+import { type Component, VStack } from "@earendil-works/pi-tui";
+
+/**
+ * Shared chrome parts for interactive regular + fullscreen layouts.
+ * Kept pure so tests can compose the same tree InteractiveMode mounts.
+ */
+export interface InteractiveChromeParts {
+	topBar: Component;
+	transcriptScrollView: Component;
+	document: Component;
+	pendingMessages: Component;
+	status: Component;
+	widgetAbove: Component;
+	editor: Component;
+	widgetBelow: Component;
+	footer: Component;
+}
+
+export interface InteractiveLayouts {
+	/** Fullscreen root: fixed top bar, growing transcript ScrollView, dock last. */
+	fullscreenLayoutRoot: VStack;
+	/** Bottom chrome stack shared inside the fullscreen root. */
+	dock: VStack;
+	/** Regular (main-screen) mount order — no top bar. */
+	regularModeMountChildren: Component[];
+}
+
+/**
+ * Build the interactive layout trees used by InteractiveMode.
+ * Fullscreen places the top bar outside the transcript ScrollView as a fixed first row.
+ * Regular mode mounts the listed children only (document + dock parts; no top bar).
+ */
+export function buildInteractiveLayouts(parts: InteractiveChromeParts): InteractiveLayouts {
+	const dock = new VStack([
+		{ component: parts.pendingMessages, shrink: 1, minSize: 0 },
+		{ component: parts.status, shrink: 1, minSize: 0 },
+		{ component: parts.widgetAbove, shrink: 1, minSize: 0 },
+		{ component: parts.editor, shrink: 1, minSize: 3 },
+		{ component: parts.widgetBelow, shrink: 1, minSize: 0 },
+		{ component: parts.footer, shrink: 1, minSize: 1 },
+	]);
+
+	const fullscreenLayoutRoot = new VStack([
+		{ component: parts.topBar, basis: "auto", grow: 0, shrink: 0, minSize: 1 },
+		{ component: parts.transcriptScrollView, basis: 0, grow: 1, shrink: 1, minSize: 1 },
+		{ component: dock, basis: "auto", grow: 0, shrink: 1, minSize: 1 },
+	]);
+
+	const regularModeMountChildren: Component[] = [
+		parts.document,
+		parts.pendingMessages,
+		parts.status,
+		parts.widgetAbove,
+		parts.editor,
+		parts.widgetBelow,
+		parts.footer,
+	];
+
+	return { fullscreenLayoutRoot, dock, regularModeMountChildren };
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -125,6 +125,8 @@ import { ExtensionEditorComponent } from "./components/extension-editor.ts";
 import { ExtensionInputComponent } from "./components/extension-input.ts";
 import { ExtensionSelectorComponent } from "./components/extension-selector.ts";
 import { FooterComponent, formatTokens } from "./components/footer.ts";
+import { FullscreenTopBar } from "./components/fullscreen-top-bar.ts";
+import { buildInteractiveLayouts } from "./components/interactive-layout.ts";
 import { formatKeyText, keyDisplayText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.ts";
 import { LoginDialogComponent } from "./components/login-dialog.ts";
 import { createMermaidMarkdownTransformer } from "./components/mermaid.ts";
@@ -406,6 +408,7 @@ export class InteractiveMode {
 	private footer: FooterComponent;
 	private footerContainer: Container;
 	private footerDataProvider: FooterDataProvider;
+	private fullscreenTopBar: FullscreenTopBar;
 	// Stored so the same manager can be injected into custom editors, selectors, and extension UI.
 	private keybindings: KeybindingsManager;
 	private version: string;
@@ -572,6 +575,8 @@ export class InteractiveMode {
 		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
 		this.footerContainer = new Container();
 		this.footerContainer.addChild(this.footer);
+		this.fullscreenTopBar = new FullscreenTopBar(this.session, this.footerDataProvider);
+		this.fullscreenTopBar.setAutoCompactEnabled(this.session.autoCompactionEnabled);
 
 		// Load hide thinking block setting
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
@@ -873,27 +878,21 @@ export class InteractiveMode {
 			scrollbar: this.settingsManager.getFullscreenScrollbar(),
 			scrollbarStyle: (text) => theme.bg("scrollbarThumb", text),
 		});
-		const dock = new TuiLayouts.VStack([
-			{ component: this.pendingMessagesContainer, shrink: 1, minSize: 0 },
-			{ component: this.statusContainer, shrink: 1, minSize: 0 },
-			{ component: this.widgetContainerAbove, shrink: 1, minSize: 0 },
-			{ component: this.editorContainer, shrink: 1, minSize: 3 },
-			{ component: this.widgetContainerBelow, shrink: 1, minSize: 0 },
-			{ component: this.footerContainer, shrink: 1, minSize: 1 },
-		]);
-		this.fullscreenLayoutRoot = new TuiLayouts.VStack([
-			{ component: this.transcriptScrollView, basis: 0, grow: 1, shrink: 1, minSize: 1 },
-			{ component: dock, basis: "auto", grow: 0, shrink: 1, minSize: 1 },
-		]);
-		this.mountInteractiveTui(this.renderer, [
-			this.documentContainer,
-			this.pendingMessagesContainer,
-			this.statusContainer,
-			this.widgetContainerAbove,
-			this.editorContainer,
-			this.widgetContainerBelow,
-			this.footerContainer,
-		]);
+		// Top bar is fullscreen-only: fixed outside the transcript ScrollView.
+		// Regular mode mounts only the child list (no top bar) — see buildInteractiveLayouts.
+		const layouts = buildInteractiveLayouts({
+			topBar: this.fullscreenTopBar,
+			transcriptScrollView: this.transcriptScrollView,
+			document: this.documentContainer,
+			pendingMessages: this.pendingMessagesContainer,
+			status: this.statusContainer,
+			widgetAbove: this.widgetContainerAbove,
+			editor: this.editorContainer,
+			widgetBelow: this.widgetContainerBelow,
+			footer: this.footerContainer,
+		});
+		this.fullscreenLayoutRoot = layouts.fullscreenLayoutRoot;
+		this.mountInteractiveTui(this.renderer, layouts.regularModeMountChildren);
 		this.ui.setFocus(this.editor);
 
 		this.setupKeyHandlers();
@@ -1900,6 +1899,8 @@ export class InteractiveMode {
 		this.applyFullscreenScrollbarSetting();
 		this.footer.setSession(this.session);
 		this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
+		this.fullscreenTopBar.setSession(this.session);
+		this.fullscreenTopBar.setAutoCompactEnabled(this.session.autoCompactionEnabled);
 		this.footerDataProvider.setCwd(this.sessionManager.getCwd());
 		this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
 		this.outputPad = this.settingsManager.getOutputPad();
@@ -4417,6 +4418,7 @@ export class InteractiveMode {
 					onAutoCompactChange: (enabled) => {
 						this.session.setAutoCompactionEnabled(enabled);
 						this.footer.setAutoCompactEnabled(enabled);
+						this.fullscreenTopBar.setAutoCompactEnabled(enabled);
 					},
 					onShowImagesChange: (enabled) => {
 						this.settingsManager.setShowImages(enabled);
@@ -6386,6 +6388,7 @@ export class InteractiveMode {
 		this.themeController.disableAutoSync();
 		this.clearExtensionTerminalInputListeners();
 		this.footer.dispose();
+		this.fullscreenTopBar.dispose();
 		this.footerDataProvider.dispose();
 		if (this.unsubscribe) {
 			this.unsubscribe();

--- a/packages/coding-agent/test/fullscreen-top-bar.test.ts
+++ b/packages/coding-agent/test/fullscreen-top-bar.test.ts
@@ -1,0 +1,396 @@
+import { type Component, ScrollView, Text, visibleWidth } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { renderLayoutFrame } from "../../tui/src/layout.ts";
+import type { AgentSession } from "../src/core/agent-session.ts";
+import type { ReadonlyFooterDataProvider } from "../src/core/footer-data-provider.ts";
+import { FullscreenTopBar } from "../src/modes/interactive/components/fullscreen-top-bar.ts";
+import { buildInteractiveLayouts } from "../src/modes/interactive/components/interactive-layout.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function createSession(options: {
+	cwd?: string;
+	contextWindow?: number;
+	contextPercent?: number | null;
+	contextUsageUndefined?: boolean;
+}): AgentSession {
+	const contextWindow = options.contextWindow ?? 272_000;
+	const session = {
+		state: {
+			model: {
+				id: "test-model",
+				provider: "test",
+				contextWindow,
+			},
+		},
+		sessionManager: {
+			getCwd: () => options.cwd ?? "/home/user/project",
+		},
+		getContextUsage: () => {
+			if (options.contextUsageUndefined) return undefined;
+			const percent = options.contextPercent === undefined ? 50.9 : options.contextPercent;
+			return {
+				tokens: percent === null ? null : Math.round((percent / 100) * contextWindow),
+				contextWindow,
+				percent,
+			};
+		},
+	};
+
+	return session as unknown as AgentSession;
+}
+
+function createFooterData(branch: string | null): ReadonlyFooterDataProvider {
+	return {
+		getGitBranch: () => branch,
+		getExtensionStatuses: () => new Map<string, string>(),
+		getAvailableProviderCount: () => 1,
+		onBranchChange: () => () => {},
+	};
+}
+
+/** Default right-side context label for createSession({}) with auto-compact on. */
+const DEFAULT_RIGHT_LABEL = "50.9%/272k (auto)";
+
+function findBox(
+	root: { component: Component; children: unknown[] },
+	target: Component,
+):
+	| { rect: { x: number; y: number; width: number; height: number }; component: Component; children: unknown[] }
+	| undefined {
+	type Box = { component: Component; children: Box[]; rect: { x: number; y: number; width: number; height: number } };
+	const visit = (box: Box): Box | undefined => {
+		if (box.component === target) return box;
+		for (const child of box.children) {
+			const match = visit(child);
+			if (match) return match;
+		}
+		return undefined;
+	};
+	return visit(root as Box);
+}
+
+describe("FullscreenTopBar", () => {
+	const originalHome = process.env.HOME;
+	const originalUserProfile = process.env.USERPROFILE;
+
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	beforeEach(() => {
+		process.env.HOME = "/home/user";
+		delete process.env.USERPROFILE;
+	});
+
+	afterEach(() => {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		if (originalUserProfile === undefined) {
+			delete process.env.USERPROFILE;
+		} else {
+			process.env.USERPROFILE = originalUserProfile;
+		}
+	});
+
+	it("renders cwd abbreviated with branch and context usage on one line", () => {
+		const bar = new FullscreenTopBar(createSession({}), createFooterData("main"));
+		const lines = bar.render(80);
+		expect(lines).toHaveLength(1);
+		const plain = stripAnsi(lines[0]);
+		expect(plain).toContain("~/project (main)");
+		expect(plain).toContain(DEFAULT_RIGHT_LABEL);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(80);
+	});
+
+	it("omits branch when unavailable", () => {
+		const bar = new FullscreenTopBar(createSession({}), createFooterData(null));
+		const plain = stripAnsi(bar.render(80)[0]);
+		expect(plain).toContain("~/project");
+		expect(plain).not.toContain("(main)");
+		expect(plain).toContain(DEFAULT_RIGHT_LABEL);
+	});
+
+	it("shows unknown context percent as ?", () => {
+		const bar = new FullscreenTopBar(createSession({ contextPercent: null }), createFooterData("main"));
+		bar.setAutoCompactEnabled(true);
+		const plain = stripAnsi(bar.render(80)[0]);
+		expect(plain).toContain("?/272k (auto)");
+	});
+
+	it("hides auto indicator when auto-compact is disabled", () => {
+		const bar = new FullscreenTopBar(createSession({}), createFooterData(null));
+		bar.setAutoCompactEnabled(false);
+		const plain = stripAnsi(bar.render(80)[0]);
+		expect(plain).toContain("50.9%/272k");
+		expect(plain).not.toContain("(auto)");
+	});
+
+	it("falls back to model contextWindow when getContextUsage is undefined", () => {
+		const bar = new FullscreenTopBar(
+			createSession({ contextWindow: 200_000, contextUsageUndefined: true }),
+			createFooterData(null),
+		);
+		const plain = stripAnsi(bar.render(80)[0]);
+		// Matches FooterComponent: undefined usage → percent treated as 0.0 with model window.
+		expect(plain).toContain("0.0%/200k (auto)");
+	});
+
+	it("returns a single empty line when width is zero or negative", () => {
+		const bar = new FullscreenTopBar(createSession({}), createFooterData("main"));
+		expect(bar.render(0)).toEqual([""]);
+		expect(bar.render(-1)).toEqual([""]);
+		expect(bar.render(-40)).toEqual([""]);
+	});
+
+	it("shows right label only and fills exact width when width equals right-label width", () => {
+		const bar = new FullscreenTopBar(createSession({}), createFooterData("main"));
+		const rightWidth = visibleWidth(DEFAULT_RIGHT_LABEL);
+		const lines = bar.render(rightWidth);
+		expect(lines).toHaveLength(1);
+		expect(visibleWidth(lines[0])).toBe(rightWidth);
+		expect(stripAnsi(lines[0])).toBe(DEFAULT_RIGHT_LABEL);
+	});
+
+	it("truncates right label with ellipsis and exact width when narrower than right label", () => {
+		const bar = new FullscreenTopBar(createSession({}), createFooterData("main"));
+		const rightWidth = visibleWidth(DEFAULT_RIGHT_LABEL);
+		const width = rightWidth - 4;
+		expect(width).toBeGreaterThan(0);
+		const lines = bar.render(width);
+		expect(lines).toHaveLength(1);
+		expect(visibleWidth(lines[0])).toBe(width);
+		const plain = stripAnsi(lines[0]);
+		expect(plain.endsWith("...")).toBe(true);
+		expect(plain).not.toBe(DEFAULT_RIGHT_LABEL);
+		expect(plain.length).toBeLessThan(DEFAULT_RIGHT_LABEL.length);
+	});
+
+	it("preserves right side at the right edge with exact total width under left pressure", () => {
+		const bar = new FullscreenTopBar(
+			createSession({ cwd: "/home/user/very/long/path/to/a/deep/project" }),
+			createFooterData("feature/long-branch-name"),
+		);
+		const width = 36;
+		const lines = bar.render(width);
+		expect(lines).toHaveLength(1);
+		expect(visibleWidth(lines[0])).toBe(width);
+		const plain = stripAnsi(lines[0]);
+		expect(plain.endsWith(DEFAULT_RIGHT_LABEL)).toBe(true);
+		expect(plain.slice(plain.length - DEFAULT_RIGHT_LABEL.length)).toBe(DEFAULT_RIGHT_LABEL);
+		// Left is truncated; full path/branch must not both fit.
+		expect(plain).toContain("...");
+		expect(plain).not.toContain("/home/user/very/long/path/to/a/deep/project");
+	});
+
+	it("keeps exactly one line within width across a range of widths", () => {
+		const bar = new FullscreenTopBar(
+			createSession({ cwd: "/home/user/project/with/nested/dirs" }),
+			createFooterData("main"),
+		);
+		for (const width of [1, 5, 10, 15, 20, 30, 40, 80, 120]) {
+			const lines = bar.render(width);
+			expect(lines).toHaveLength(1);
+			expect(visibleWidth(lines[0])).toBeLessThanOrEqual(width);
+		}
+	});
+
+	it("applies warning color above 70% and error color above 90%", () => {
+		const warningBar = new FullscreenTopBar(createSession({ contextPercent: 75.0 }), createFooterData(null));
+		const errorBar = new FullscreenTopBar(createSession({ contextPercent: 95.0 }), createFooterData(null));
+		const warningLine = warningBar.render(80)[0];
+		const errorLine = errorBar.render(80)[0];
+		// Colored lines contain ANSI; plain content still correct
+		expect(stripAnsi(warningLine)).toContain("75.0%/272k (auto)");
+		expect(stripAnsi(errorLine)).toContain("95.0%/272k (auto)");
+		expect(warningLine).not.toBe(stripAnsi(warningLine));
+		expect(errorLine).not.toBe(stripAnsi(errorLine));
+		expect(warningLine).not.toEqual(errorLine);
+	});
+
+	it("updates after setSession and setAutoCompactEnabled", () => {
+		const bar = new FullscreenTopBar(createSession({ contextPercent: 10 }), createFooterData(null));
+		expect(stripAnsi(bar.render(80)[0])).toContain("10.0%/272k (auto)");
+
+		bar.setSession(createSession({ contextPercent: 42.5, contextWindow: 128_000 }));
+		bar.setAutoCompactEnabled(false);
+		const plain = stripAnsi(bar.render(80)[0]);
+		expect(plain).toContain("42.5%/128k");
+		expect(plain).not.toContain("(auto)");
+	});
+});
+
+describe("buildInteractiveLayouts", () => {
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	function createChromeParts() {
+		const topBar = new FullscreenTopBar(createSession({}), createFooterData("main"));
+		const document = new Text("doc", 0, 0);
+		const transcriptLines = Array.from({ length: 40 }, (_, i) => `transcript-${i}`);
+		const transcriptBody: Component = {
+			render: () => transcriptLines,
+			invalidate: () => {},
+		};
+		const transcriptScrollView = new ScrollView(transcriptBody, {
+			follow: "end",
+			primary: true,
+			scrollbar: "hidden",
+		});
+		const pendingMessages = new Text("", 0, 0);
+		const status = new Text("", 0, 0);
+		const widgetAbove = new Text("", 0, 0);
+		// Multi-line dock chrome so dock occupies a stable last band.
+		const editor = new Text("editor-1\neditor-2\neditor-3", 0, 0);
+		const widgetBelow = new Text("", 0, 0);
+		const footer = new Text("footer", 0, 0);
+
+		const layouts = buildInteractiveLayouts({
+			topBar,
+			transcriptScrollView,
+			document,
+			pendingMessages,
+			status,
+			widgetAbove,
+			editor,
+			widgetBelow,
+			footer,
+		});
+
+		return {
+			topBar,
+			document,
+			transcriptScrollView,
+			transcriptLines,
+			pendingMessages,
+			status,
+			widgetAbove,
+			editor,
+			widgetBelow,
+			footer,
+			layouts,
+		};
+	}
+
+	it("regular mode mount children exclude the top bar; fullscreen root includes it", () => {
+		const {
+			topBar,
+			document,
+			transcriptScrollView,
+			pendingMessages,
+			status,
+			widgetAbove,
+			editor,
+			widgetBelow,
+			footer,
+			layouts,
+		} = createChromeParts();
+
+		expect(layouts.regularModeMountChildren).toEqual([
+			document,
+			pendingMessages,
+			status,
+			widgetAbove,
+			editor,
+			widgetBelow,
+			footer,
+		]);
+		expect(layouts.regularModeMountChildren).not.toContain(topBar);
+		expect(layouts.regularModeMountChildren).not.toContain(transcriptScrollView);
+		expect(layouts.regularModeMountChildren).not.toContain(layouts.dock);
+
+		expect(layouts.fullscreenLayoutRoot.children).toEqual([topBar, transcriptScrollView, layouts.dock]);
+		expect(layouts.fullscreenLayoutRoot.children[0]).toBe(topBar);
+		expect(layouts.fullscreenLayoutRoot.children.at(-1)).toBe(layouts.dock);
+	});
+
+	it("places FullscreenTopBar at y=0 height=1 outside the transcript ScrollView and keeps it fixed across scroll and resize", () => {
+		const originalHome = process.env.HOME;
+		const originalUserProfile = process.env.USERPROFILE;
+		process.env.HOME = "/home/user";
+		delete process.env.USERPROFILE;
+
+		try {
+			const { topBar, transcriptScrollView, layouts } = createChromeParts();
+			const root = layouts.fullscreenLayoutRoot;
+			const dock = layouts.dock;
+
+			const assertFixedTopBar = (width: number, height: number) => {
+				const frame = renderLayoutFrame(root, width, height, () => {});
+				expect(frame.root.children.map((child) => child.component)).toEqual([topBar, transcriptScrollView, dock]);
+
+				const topBox = frame.root.children[0]!;
+				expect(topBox.component).toBe(topBar);
+				expect(topBox.rect).toEqual({ x: 0, y: 0, width, height: 1 });
+
+				const scrollBox = frame.root.children[1]!;
+				expect(scrollBox.component).toBe(transcriptScrollView);
+				expect(scrollBox.rect.y).toBe(1);
+				expect(scrollBox.rect.x).toBe(0);
+				expect(scrollBox.rect.width).toBe(width);
+				// Top bar is not nested inside the scroll view.
+				expect(findBox(scrollBox, topBar)).toBeUndefined();
+
+				const dockBox = frame.root.children[2]!;
+				expect(dockBox.component).toBe(dock);
+				expect(dockBox.rect.y).toBe(topBox.rect.height + scrollBox.rect.height);
+				expect(frame.root.children.at(-1)?.component).toBe(dock);
+
+				// Painted first row is the top bar content, not transcript.
+				const paintedTop = stripAnsi(frame.lines[0] ?? "");
+				expect(paintedTop).toContain("~/project (main)");
+				expect(paintedTop).toContain(DEFAULT_RIGHT_LABEL);
+				expect(paintedTop).not.toContain("transcript-");
+
+				return frame;
+			};
+
+			// Initial frame
+			const initial = assertFixedTopBar(80, 24);
+			const initialScrollTop = transcriptScrollView.scrollTop;
+
+			// Scroll away from follow-end; top bar geometry and paint stay fixed.
+			transcriptScrollView.scrollTo(0);
+			expect(transcriptScrollView.scrollTop).not.toBe(initialScrollTop);
+			const scrolled = assertFixedTopBar(80, 24);
+			expect(scrolled.root.children[0]!.rect).toEqual(initial.root.children[0]!.rect);
+			// Transcript viewport content changed with scroll, but y=0 did not.
+			const scrolledBody = (scrolled.lines.slice(1, 1 + scrolled.root.children[1]!.rect.height) ?? []).map((line) =>
+				stripAnsi(line),
+			);
+			const initialBody = (initial.lines.slice(1, 1 + initial.root.children[1]!.rect.height) ?? []).map((line) =>
+				stripAnsi(line),
+			);
+			expect(scrolledBody.some((line) => line.includes("transcript-0"))).toBe(true);
+			expect(initialBody.some((line) => line.includes("transcript-0"))).toBe(false);
+			expect(stripAnsi(scrolled.lines[0] ?? "")).toBe(stripAnsi(initial.lines[0] ?? ""));
+
+			// Resize frames: top bar remains y=0,h=1; dock remains last.
+			for (const [width, height] of [
+				[40, 12],
+				[100, 30],
+				[60, 8],
+			] as const) {
+				const frame = assertFixedTopBar(width, height);
+				expect(frame.root.children.at(-1)?.component).toBe(dock);
+				expect(frame.root.children[0]!.rect.y).toBe(0);
+				expect(frame.root.children[0]!.rect.height).toBe(1);
+			}
+		} finally {
+			if (originalHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = originalHome;
+			}
+			if (originalUserProfile === undefined) {
+				delete process.env.USERPROFILE;
+			} else {
+				process.env.USERPROFILE = originalUserProfile;
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Add a fullscreen-only fixed top bar above the transcript scroll view.
- Show abbreviated cwd and git branch on the left, with context usage and auto-compaction state right-aligned.
- Preserve regular-mode mounting and the existing bottom dock/footer.

## Provenance

| Field | Value |
|:---|:---|
| Origin | one-off |
| Project docs | — |
| Change-set | — |
| TC | — |
| Human_decision | on (conversation: `skillで進行すればいいよ`) |
| Closeout route | — |
| RP lens | rp-lens-frontend |
| RP decision_turn | yes |
| RP decision_record | PR body |
| RP evidence | PR body |

RP decision: purpose-fit and terminal constraint honesty are the evaluation axes. The floor risk is a fixed row overlapping content or becoming unreadable on narrow terminals; the ceiling is a single stable Grok-style status row. Reconciliation: keep the bar one row outside `ScrollView`, preserve the right context label under width pressure, truncate the left side safely, and omit the bar entirely in regular mode.

## Files in scope

| Path | Change |
|:---|:---|
| `packages/coding-agent/src/modes/interactive/components/fullscreen-top-bar.ts` | Render cwd/branch and context usage with width-aware truncation. |
| `packages/coding-agent/src/modes/interactive/components/interactive-layout.ts` | Build shared regular/fullscreen layout trees with a fixed top row. |
| `packages/coding-agent/src/modes/interactive/interactive-mode.ts` | Wire lifecycle, session rebinding, and fullscreen layout ownership. |
| `packages/coding-agent/test/fullscreen-top-bar.test.ts` | Cover content, width pressure, mode separation, scroll fixation, and resize. |
| `packages/coding-agent/CHANGELOG.md` | Record the new fullscreen UI feature. |

Out of scope: package namespace, npm publishing, GitHub release automation, Nyx statusline/footer slimming.

## Verification

| V | Check | Class | Evidence |
|:---|:---|:---|:---|
| V-1 | Component/layout tests | Verified | `vitest --run test/fullscreen-top-bar.test.ts` — 14 passed |
| V-2 | Repository checks | Verified | `npm run check` — passed |
| V-3 | Monorepo build | Verified | `npm run build` — passed |
| V-4 | Fullscreen terminal smoke | Verified | tmux at 120x30 and 80x20 — top bar remained row 0 and reflowed |

- [ ] Human: confirm visual placement in the preferred terminal/theme after installing the fork build.

## Review guide

- Focus hunks: fullscreen layout composition, lifecycle rebinding/disposal, ANSI-aware width handling, and narrow-terminal behavior.
- Judgment requested: confirm the fixed row cannot enter transcript scrolling and regular mode remains unchanged.
- Secret audit: no secrets, private paths, credentials, or internal URLs in the staged diff.

## Rollback

Revert this PR's squash commit and rerun the component/layout test plus `npm run check`.