### PR TITLE
fix(tui): avoid full transcript work during active renders

### DIFF
--- a/docs/adr/0001-segment-active-tui-rendering.md
+++ b/docs/adr/0001-segment-active-tui-rendering.md
@@ -1,0 +1,19 @@
+---
+status: accepted
+---
+
+# Segment active TUI rendering by transcript stability
+
+Active renders will process explicit TUI render regions instead of rebuilding the full transcript. Pi will promote the current Dynamic transcript tail into the Stable transcript at `agent_end`; ordinary text streaming and spinner renders will reuse the stable region, while explicit presentation changes may invalidate it. Existing parameterless `requestRender()` calls remain conservative full invalidations for extension compatibility, and core high-frequency paths opt into region-scoped rendering.
+
+## Considered Options
+
+Per-line memoization reduces allocation but remains proportional to session length. Freezing prior transcript content would be faster but would break historical tool expansion, theme and image settings, and extension renderer invalidation. Application-only caching cannot prevent renderer-level reset, image, and diff scans.
+
+## Consequences
+
+Regular and fullscreen renderers share the region contract. Promotion must not change displayed content, scrollback, selection, overlays, images, viewport, or mode-switch state when transcript content is unchanged; harmless terminal cursor control remains allowed. Stable snapshots retain one prepared line representation plus sparse image metadata rather than duplicating the transcript. Cumulative usage becomes append-only core session state. Context usage keeps its completed-message semantics and caches results until the completed message state changes.
+
+Active renders with overlays, dynamic images, dynamic line shrinkage, terminal resize, or an invalid stable revision fall back to the conservative full path. Correct terminal state takes priority over making these low-frequency cases independent of transcript length.
+
+This decision addresses render-path CPU growth with completed transcript length. Session memory retention and incremental rebuilding of the current streaming message require separate evidence and are outside this decision.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -108,7 +108,6 @@ import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-promp
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.ts";
 import { createAllToolDefinitions } from "./tools/index.ts";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.ts";
-import { addUsageToTotals, createUsageTotals } from "./usage-totals.ts";
 
 // ============================================================================
 // Skill Block Parsing
@@ -605,6 +604,20 @@ export class AgentSession {
 
 	// Track last assistant message for auto-compaction check
 	private _lastAssistantMessage: AssistantMessage | undefined = undefined;
+	private _contextUsageRevision = 0;
+	private _contextUsageCache:
+		| {
+				revision: number;
+				model: Model<any>;
+				contextWindow: number;
+				value: ContextUsage;
+		  }
+		| undefined;
+
+	private _invalidateContextUsage(): void {
+		this._contextUsageRevision += 1;
+		this._contextUsageCache = undefined;
+	}
 
 	/** Internal handler for agent events - shared by subscribe and reconnect */
 	private _handleAgentEvent = async (event: AgentEvent): Promise<void> => {
@@ -629,6 +642,7 @@ export class AgentSession {
 				}
 			}
 		}
+		if (event.type === "message_end") this._invalidateContextUsage();
 
 		// Emit to extensions first
 		await this._emitExtensionEvent(event);
@@ -655,6 +669,7 @@ export class AgentSession {
 				// Regular LLM message - persist as SessionMessageEntry
 				this.sessionManager.appendMessage(event.message);
 			}
+			this._invalidateContextUsage();
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 
 			// Track assistant message for auto-compaction (checked on agent_end)
@@ -1459,6 +1474,7 @@ export class AgentSession {
 			await this._runAgentPrompt(appMessage);
 		} else {
 			this.agent.state.messages.push(appMessage);
+			this._invalidateContextUsage();
 			this.sessionManager.appendCustomMessageEntry(
 				message.customType,
 				message.content,
@@ -1879,6 +1895,7 @@ export class AgentSession {
 			const newEntries = this.sessionManager.getEntries();
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._invalidateContextUsage();
 			const estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
 
 			// Get the saved compaction entry for the extension event
@@ -2017,6 +2034,7 @@ export class AgentSession {
 			const messages = this.agent.state.messages;
 			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
 				this.agent.state.messages = messages.slice(0, -1);
+				this._invalidateContextUsage();
 			}
 			return await this._runAutoCompaction("overflow", willRetry);
 		}
@@ -2158,6 +2176,7 @@ export class AgentSession {
 			const newEntries = this.sessionManager.getEntries();
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._invalidateContextUsage();
 			const estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
 
 			// Get the saved compaction entry for the extension event
@@ -2194,6 +2213,7 @@ export class AgentSession {
 				// the retriable error or truncated-length response again before continuing the interrupted turn.
 				if (lastMsg?.role === "assistant" && (lastMsg.stopReason === "error" || lastMsg.stopReason === "length")) {
 					this.agent.state.messages = messages.slice(0, -1);
+					this._invalidateContextUsage();
 				}
 				return true;
 			}
@@ -2711,6 +2731,7 @@ export class AgentSession {
 		const messages = this.agent.state.messages;
 		if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
 			this.agent.state.messages = messages.slice(0, -1);
+			this._invalidateContextUsage();
 		}
 
 		// Wait with exponential backoff (abortable)
@@ -2830,6 +2851,7 @@ export class AgentSession {
 		} else {
 			// Add to agent state immediately
 			this.agent.state.messages.push(bashMessage);
+			this._invalidateContextUsage();
 
 			// Save to session
 			this.sessionManager.appendMessage(bashMessage);
@@ -2865,6 +2887,7 @@ export class AgentSession {
 		for (const bashMessage of this._pendingBashMessages) {
 			// Add to agent state
 			this.agent.state.messages.push(bashMessage);
+			this._invalidateContextUsage();
 
 			// Save to session
 			this.sessionManager.appendMessage(bashMessage);
@@ -3076,6 +3099,7 @@ export class AgentSession {
 			// Update agent state
 			const sessionContext = this.sessionManager.buildSessionContext();
 			this.agent.state.messages = sessionContext.messages;
+			this._invalidateContextUsage();
 
 			// Emit session_tree event
 			await this._extensionRunner.emit({
@@ -3125,12 +3149,9 @@ export class AgentSession {
 		let toolResults = 0;
 		let totalMessages = 0;
 		let toolCalls = 0;
-		const usageTotals = createUsageTotals();
+		const usageTotals = this.sessionManager.getUsageSnapshot().totals;
 
 		for (const entry of this.sessionManager.getEntries()) {
-			if ((entry.type === "branch_summary" || entry.type === "compaction") && entry.usage) {
-				addUsageToTotals(usageTotals, entry.usage);
-			}
 			if (entry.type !== "message") continue;
 			totalMessages++;
 			const message = entry.message;
@@ -3138,16 +3159,12 @@ export class AgentSession {
 				userMessages++;
 			} else if (message.role === "toolResult") {
 				toolResults++;
-				if (message.usage) {
-					addUsageToTotals(usageTotals, message.usage);
-				}
 			} else if (message.role === "assistant") {
 				assistantMessages++;
 				const assistantMsg = message as AssistantMessage;
 				if (Array.isArray(assistantMsg.content)) {
 					toolCalls += assistantMsg.content.filter((c) => c.type === "toolCall").length;
 				}
-				addUsageToTotals(usageTotals, assistantMsg.usage);
 			}
 		}
 
@@ -3177,6 +3194,22 @@ export class AgentSession {
 
 		const contextWindow = model.contextWindow ?? 0;
 		if (contextWindow <= 0) return undefined;
+		if (
+			this._contextUsageCache?.revision === this._contextUsageRevision &&
+			this._contextUsageCache.model === model &&
+			this._contextUsageCache.contextWindow === contextWindow
+		) {
+			return { ...this._contextUsageCache.value };
+		}
+		const cache = (value: ContextUsage): ContextUsage => {
+			this._contextUsageCache = {
+				revision: this._contextUsageRevision,
+				model,
+				contextWindow,
+				value,
+			};
+			return { ...value };
+		};
 
 		// After compaction, the last assistant usage reflects pre-compaction context size.
 		// We can only trust usage from an assistant that responded after the latest compaction.
@@ -3203,18 +3236,18 @@ export class AgentSession {
 			}
 
 			if (!hasPostCompactionUsage) {
-				return { tokens: null, contextWindow, percent: null };
+				return cache({ tokens: null, contextWindow, percent: null });
 			}
 		}
 
 		const estimate = estimateContextTokens(this.messages);
 		const percent = (estimate.tokens / contextWindow) * 100;
 
-		return {
+		return cache({
 			tokens: estimate.tokens,
 			contextWindow,
 			percent,
-		};
+		});
 	}
 
 	/**

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -26,6 +26,7 @@ import {
 	createCompactionSummaryMessage,
 	createCustomMessage,
 } from "./messages.ts";
+import { addUsageToTotals, createUsageTotals, type UsageTotals } from "./usage-totals.ts";
 
 export const CURRENT_SESSION_VERSION = 3;
 
@@ -187,6 +188,11 @@ export interface SessionInfo {
 	allMessagesText: string;
 }
 
+export interface SessionUsageSnapshot {
+	totals: UsageTotals;
+	latestCacheHitRate: number | undefined;
+}
+
 export type ReadonlySessionManager = Pick<
 	SessionManager,
 	| "getCwd"
@@ -207,6 +213,33 @@ export type ReadonlySessionManager = Pick<
 
 function createSessionId(): string {
 	return uuidv7();
+}
+
+function createSessionUsageSnapshot(): SessionUsageSnapshot {
+	return {
+		totals: createUsageTotals(),
+		latestCacheHitRate: undefined,
+	};
+}
+
+function getEntryUsage(entry: SessionEntry): Usage | undefined {
+	if (entry.type === "message") {
+		const message = entry.message as AgentMessage & { usage?: Usage };
+		if (message.role === "assistant" || message.role === "toolResult") return message.usage;
+	}
+	if ((entry.type === "branch_summary" || entry.type === "compaction") && entry.usage) return entry.usage;
+	return undefined;
+}
+
+function addEntryUsage(snapshot: SessionUsageSnapshot, entry: SessionEntry): void {
+	const usage = getEntryUsage(entry);
+	if (!usage) return;
+	addUsageToTotals(snapshot.totals, usage);
+
+	if (entry.type === "message" && entry.message.role === "assistant") {
+		const promptTokens = usage.input + usage.cacheRead + usage.cacheWrite;
+		snapshot.latestCacheHitRate = promptTokens > 0 ? (usage.cacheRead / promptTokens) * 100 : undefined;
+	}
 }
 
 export function assertValidSessionId(id: string): void {
@@ -864,6 +897,7 @@ export class SessionManager {
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
+	private usageSnapshot = createSessionUsageSnapshot();
 
 	private constructor(
 		cwd: string,
@@ -946,6 +980,7 @@ export class SessionManager {
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
 		this.leafId = null;
+		this.usageSnapshot = createSessionUsageSnapshot();
 		this.flushed = false;
 
 		if (this.persist) {
@@ -960,10 +995,12 @@ export class SessionManager {
 		this.labelsById.clear();
 		this.labelTimestampsById.clear();
 		this.leafId = null;
+		this.usageSnapshot = createSessionUsageSnapshot();
 		for (const entry of this.fileEntries) {
 			if (entry.type === "session") continue;
 			this.byId.set(entry.id, entry);
 			this.leafId = entry.id;
+			addEntryUsage(this.usageSnapshot, entry);
 			if (entry.type === "label") {
 				if (entry.label) {
 					this.labelsById.set(entry.targetId, entry.label);
@@ -1045,6 +1082,7 @@ export class SessionManager {
 		this.fileEntries.push(entry);
 		this.byId.set(entry.id, entry);
 		this.leafId = entry.id;
+		addEntryUsage(this.usageSnapshot, entry);
 		this._persist(entry);
 	}
 
@@ -1300,6 +1338,13 @@ export class SessionManager {
 	 */
 	getEntries(): SessionEntry[] {
 		return this.fileEntries.filter((e): e is SessionEntry => e.type !== "session");
+	}
+
+	getUsageSnapshot(): SessionUsageSnapshot {
+		return {
+			totals: { ...this.usageSnapshot.totals },
+			latestCacheHitRate: this.usageSnapshot.latestCacheHitRate,
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -3,7 +3,6 @@ import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/p
 import type { AgentSession } from "../../../core/agent-session.ts";
 import { areExperimentalFeaturesEnabled } from "../../../core/experimental.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
-import { addUsageToTotals, createUsageTotals } from "../../../core/usage-totals.ts";
 import { theme } from "../theme/theme.ts";
 
 /**
@@ -84,24 +83,7 @@ export class FooterComponent implements Component {
 	render(width: number): string[] {
 		const state = this.session.state;
 
-		// Calculate cumulative usage from ALL session entries (not just post-compaction messages)
-		const usageTotals = createUsageTotals();
-		let latestCacheHitRate: number | undefined;
-
-		for (const entry of this.session.sessionManager.getEntries()) {
-			if (entry.type === "message" && entry.message.role === "assistant") {
-				addUsageToTotals(usageTotals, entry.message.usage);
-
-				const latestPromptTokens =
-					entry.message.usage.input + entry.message.usage.cacheRead + entry.message.usage.cacheWrite;
-				latestCacheHitRate =
-					latestPromptTokens > 0 ? (entry.message.usage.cacheRead / latestPromptTokens) * 100 : undefined;
-			} else if (entry.type === "message" && entry.message.role === "toolResult" && entry.message.usage) {
-				addUsageToTotals(usageTotals, entry.message.usage);
-			} else if ((entry.type === "branch_summary" || entry.type === "compaction") && entry.usage) {
-				addUsageToTotals(usageTotals, entry.usage);
-			}
-		}
+		const { totals: usageTotals, latestCacheHitRate } = this.session.sessionManager.getUsageSnapshot();
 
 		// Calculate context usage from session (handles compaction correctly).
 		// After compaction, tokens are unknown until the next LLM response.

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -118,7 +118,8 @@ export class ToolExecutionComponent extends Container {
 			toolCallId: this.toolCallId,
 			invalidate: () => {
 				this.invalidate();
-				this.ui.requestRender();
+				if (this.isPartial && this.ui.requestActiveRender) this.ui.requestActiveRender();
+				else this.ui.requestRender();
 			},
 			lastComponent,
 			state: this.rendererState,
@@ -152,13 +153,15 @@ export class ToolExecutionComponent extends Container {
 	markExecutionStarted(): void {
 		this.executionStarted = true;
 		this.updateDisplay();
-		this.ui.requestRender();
+		if (this.ui.requestActiveRender) this.ui.requestActiveRender();
+		else this.ui.requestRender();
 	}
 
 	setArgsComplete(): void {
 		this.argsComplete = true;
 		this.updateDisplay();
-		this.ui.requestRender();
+		if (this.ui.requestActiveRender) this.ui.requestActiveRender();
+		else this.ui.requestRender();
 	}
 
 	updateResult(
@@ -192,7 +195,8 @@ export class ToolExecutionComponent extends Container {
 				if (converted) {
 					this.convertedImages.set(index, converted);
 					this.updateDisplay();
-					this.ui.requestRender();
+					if (this.isPartial && this.ui.requestActiveRender) this.ui.requestActiveRender();
+					else this.ui.requestRender();
 				}
 			});
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -230,6 +230,43 @@ function isUnknownModel(model: Model<any> | undefined): boolean {
 	return !!model && model.provider === "unknown" && model.id === "unknown" && model.api === "unknown";
 }
 
+function createRenderRegion(kind: "stable" | "dynamic", children: readonly Component[]): Container {
+	const container = new Container();
+	for (const child of children) container.addChild(child);
+	container.setRenderRegion?.(kind);
+	return container;
+}
+
+function getTranscriptContainers(stable: Container | undefined, dynamic: Container): readonly Container[] {
+	return stable ? [stable, dynamic] : [dynamic];
+}
+
+function hasTranscriptContent(stable: Container | undefined, dynamic: Container): boolean {
+	return (stable?.children.length ?? 0) > 0 || dynamic.children.length > 0;
+}
+
+function promoteDynamicTranscript(
+	stable: Container | undefined,
+	dynamic: Container,
+	stableRegion: Container | undefined,
+): void {
+	if (!stable || dynamic.children.length === 0) return;
+	stable.children.push(...dynamic.children);
+	dynamic.children = [];
+	stableRegion?.expireRenderRegion?.();
+}
+
+function clearTranscript(stable: Container | undefined, dynamic: Container, stableRegion: Container | undefined): void {
+	stable?.clear();
+	dynamic.clear();
+	stableRegion?.expireRenderRegion?.();
+}
+
+function requestActiveRender(tui: TUI): void {
+	if (tui.requestActiveRender) tui.requestActiveRender();
+	else tui.requestRender();
+}
+
 function quoteIfNeeded(value: string): string {
 	if (value.length > 0 && !/[^a-zA-Z0-9_\-./~:@]/.test(value)) {
 		return value;
@@ -388,8 +425,11 @@ export class InteractiveMode {
 	private ui: TUI;
 	private mainScreenRenderState: TuiMainScreenRenderState | undefined;
 	private loadedResourcesContainer: Container;
+	private stableChatContainer: Container;
 	private chatContainer: Container;
-	private documentContainer: Container;
+	private stableTranscriptRegion: Container;
+	private dynamicTranscriptRegion: Container;
+	private documentContainer: Component;
 	private transcriptScrollView: TuiLayouts.ScrollView | undefined;
 	private fullscreenLayoutRoot: Component | undefined;
 	private pendingMessagesContainer: Container;
@@ -547,11 +587,15 @@ export class InteractiveMode {
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 		this.headerContainer = new Container();
 		this.loadedResourcesContainer = new Container();
+		this.stableChatContainer = new Container();
 		this.chatContainer = new Container();
-		this.documentContainer = new Container();
-		this.documentContainer.addChild(this.headerContainer);
-		this.documentContainer.addChild(this.loadedResourcesContainer);
-		this.documentContainer.addChild(this.chatContainer);
+		this.stableTranscriptRegion = createRenderRegion("stable", [
+			this.headerContainer,
+			this.loadedResourcesContainer,
+			this.stableChatContainer,
+		]);
+		this.dynamicTranscriptRegion = createRenderRegion("dynamic", [this.chatContainer]);
+		this.documentContainer = new TuiLayouts.VStack([this.stableTranscriptRegion, this.dynamicTranscriptRegion]);
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();
 		this.widgetContainerAbove = new Container();
@@ -748,7 +792,7 @@ export class InteractiveMode {
 			return;
 		}
 
-		if (this.chatContainer.children.length > 0) {
+		if (hasTranscriptContent(this.stableChatContainer, this.chatContainer)) {
 			this.chatContainer.addChild(new Spacer(1));
 		}
 		this.chatContainer.addChild(new DynamicBorder());
@@ -886,7 +930,8 @@ export class InteractiveMode {
 			{ component: dock, basis: "auto", grow: 0, shrink: 1, minSize: 1 },
 		]);
 		this.mountInteractiveTui(this.renderer, [
-			this.documentContainer,
+			this.stableTranscriptRegion,
+			this.dynamicTranscriptRegion,
 			this.pendingMessagesContainer,
 			this.statusContainer,
 			this.widgetContainerAbove,
@@ -1855,7 +1900,7 @@ export class InteractiveMode {
 						return { cancelled: true };
 					}
 
-					this.chatContainer.clear();
+					clearTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 					this.renderInitialMessages();
 					if (result.editorText && !this.editor.getText().trim()) {
 						this.editor.setText(result.editorText);
@@ -1956,7 +2001,7 @@ export class InteractiveMode {
 
 	private renderCurrentSessionState(): void {
 		this.loadedResourcesContainer.clear();
-		this.chatContainer.clear();
+		clearTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 		this.pendingMessagesContainer.clear();
 		this.compactionQueuedMessages = [];
 		this.streamingComponent = undefined;
@@ -2092,9 +2137,11 @@ export class InteractiveMode {
 
 	private setHiddenThinkingLabel(label?: string): void {
 		this.hiddenThinkingLabel = label ?? this.defaultHiddenThinkingLabel;
-		for (const child of this.chatContainer.children) {
-			if (child instanceof AssistantMessageComponent) {
-				child.setHiddenThinkingLabel(this.hiddenThinkingLabel);
+		for (const container of getTranscriptContainers(this.stableChatContainer, this.chatContainer)) {
+			for (const child of container.children) {
+				if (child instanceof AssistantMessageComponent) {
+					child.setHiddenThinkingLabel(this.hiddenThinkingLabel);
+				}
 			}
 		}
 		if (this.streamingComponent) {
@@ -3071,6 +3118,7 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
+				promoteDynamicTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 				this.pendingTools.clear();
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(true);
@@ -3092,18 +3140,18 @@ export class InteractiveMode {
 				} else {
 					this.clearStatusIndicator();
 				}
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 
 			case "queue_update":
 				this.updatePendingMessagesDisplay();
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 
 			case "entry_appended":
 				if (event.entry.type === "custom") {
 					this.addCustomEntryToChat(event.entry);
-					this.ui.requestRender();
+					requestActiveRender(this.ui);
 				}
 				break;
 
@@ -3121,11 +3169,11 @@ export class InteractiveMode {
 			case "message_start":
 				if (event.message.role === "custom") {
 					this.addMessageToChat(event.message);
-					this.ui.requestRender();
+					requestActiveRender(this.ui);
 				} else if (event.message.role === "user") {
 					this.addMessageToChat(event.message);
 					this.updatePendingMessagesDisplay();
-					this.ui.requestRender();
+					requestActiveRender(this.ui);
 				} else if (event.message.role === "assistant") {
 					this.streamingComponent = new AssistantMessageComponent(
 						undefined,
@@ -3138,7 +3186,7 @@ export class InteractiveMode {
 					this.streamingMessage = event.message;
 					this.chatContainer.addChild(this.streamingComponent);
 					this.streamingComponent.updateContent(this.streamingMessage, true);
-					this.ui.requestRender();
+					requestActiveRender(this.ui);
 				}
 				break;
 
@@ -3173,7 +3221,7 @@ export class InteractiveMode {
 							}
 						}
 					}
-					this.ui.requestRender();
+					requestActiveRender(this.ui);
 				}
 				break;
 
@@ -3214,7 +3262,7 @@ export class InteractiveMode {
 					this.streamingMessage = undefined;
 					this.footer.invalidate();
 				}
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 
 			case "bash_execution_update":
@@ -3241,7 +3289,7 @@ export class InteractiveMode {
 					this.pendingTools.set(event.toolCallId, component);
 				}
 				component.markExecutionStarted();
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 			}
 
@@ -3249,7 +3297,7 @@ export class InteractiveMode {
 				const component = this.pendingTools.get(event.toolCallId);
 				if (component) {
 					component.updateResult({ ...event.partialResult, isError: false }, true);
-					this.ui.requestRender();
+					requestActiveRender(this.ui);
 				}
 				break;
 			}
@@ -3259,7 +3307,7 @@ export class InteractiveMode {
 				if (component) {
 					component.updateResult({ ...event.result, isError: event.isError });
 					this.pendingTools.delete(event.toolCallId);
-					this.ui.requestRender();
+					requestActiveRender(this.ui);
 				}
 				break;
 			}
@@ -3275,7 +3323,7 @@ export class InteractiveMode {
 					this.streamingMessage = undefined;
 				}
 				this.pendingTools.clear();
-
+				promoteDynamicTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 				this.ui.requestRender();
 				break;
 
@@ -3293,7 +3341,7 @@ export class InteractiveMode {
 					this.session.abortCompaction();
 				};
 				this.showStatusIndicator(new CompactionStatusIndicator(this.ui, event.reason));
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 			}
 
@@ -3313,7 +3361,7 @@ export class InteractiveMode {
 						this.showStatus("Auto-compaction cancelled");
 					}
 				} else if (event.result) {
-					this.chatContainer.clear();
+					clearTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 					this.rebuildChatFromMessages();
 					this.addMessageToChat(
 						createCompactionSummaryMessage(
@@ -3345,7 +3393,7 @@ export class InteractiveMode {
 				this.showStatusIndicator(
 					new RetryStatusIndicator(this.ui, event.attempt, event.maxAttempts, event.delayMs),
 				);
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 			}
 
@@ -3360,7 +3408,7 @@ export class InteractiveMode {
 				if (!event.success) {
 					this.showError(`Retry failed after ${event.attempt} attempts: ${event.finalError || "Unknown error"}`);
 				}
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 			}
 
@@ -3369,7 +3417,7 @@ export class InteractiveMode {
 				this.showStatusIndicator(
 					new RetryStatusIndicator(this.ui, event.attempt, event.maxAttempts, event.delayMs),
 				);
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 			}
 
@@ -3380,13 +3428,13 @@ export class InteractiveMode {
 				} else {
 					this.showStatusIndicator(new CompactionStatusIndicator(this.ui, event.reason));
 				}
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 			}
 
 			case "summarization_retry_finished": {
 				this.clearStatusIndicator("retry");
-				this.ui.requestRender();
+				requestActiveRender(this.ui);
 				break;
 			}
 		}
@@ -3497,7 +3545,7 @@ export class InteractiveMode {
 			case "user": {
 				const textContent = this.getUserMessageText(message);
 				if (textContent) {
-					if (this.chatContainer.children.length > 0) {
+					if (hasTranscriptContent(this.stableChatContainer, this.chatContainer)) {
 						this.chatContainer.addChild(new Spacer(1));
 					}
 					const skillBlock = parseSkillBlock(textContent);
@@ -3705,6 +3753,7 @@ export class InteractiveMode {
 			const times = compactionCount === 1 ? "1 time" : `${compactionCount} times`;
 			this.showStatus(`Session compacted ${times}`);
 		}
+		promoteDynamicTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 	}
 
 	private renderProjectTrustWarningIfNeeded(): void {
@@ -3712,7 +3761,7 @@ export class InteractiveMode {
 			return;
 		}
 
-		if (this.chatContainer.children.length > 0) {
+		if (hasTranscriptContent(this.stableChatContainer, this.chatContainer)) {
 			this.chatContainer.addChild(new Spacer(1));
 		}
 		this.chatContainer.addChild(
@@ -3742,8 +3791,9 @@ export class InteractiveMode {
 	}
 
 	private rebuildChatFromMessages(): void {
-		this.chatContainer.clear();
+		clearTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 		this.renderSessionEntries(this.sessionManager.buildContextEntries());
+		promoteDynamicTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 	}
 
 	// =========================================================================
@@ -4037,7 +4087,10 @@ export class InteractiveMode {
 		if (isExpandable(activeHeader)) {
 			activeHeader.setExpanded(expanded);
 		}
-		for (const container of [this.loadedResourcesContainer, this.chatContainer]) {
+		for (const container of [
+			this.loadedResourcesContainer,
+			...getTranscriptContainers(this.stableChatContainer, this.chatContainer),
+		]) {
 			for (const child of container.children) {
 				if (isExpandable(child)) {
 					child.setExpanded(expanded);
@@ -4052,7 +4105,6 @@ export class InteractiveMode {
 		this.settingsManager.setHideThinkingBlock(this.hideThinkingBlock);
 
 		// Rebuild chat from session messages
-		this.chatContainer.clear();
 		this.rebuildChatFromMessages();
 
 		// If streaming, re-add the streaming component with updated visibility and re-render
@@ -4420,17 +4472,21 @@ export class InteractiveMode {
 					},
 					onShowImagesChange: (enabled) => {
 						this.settingsManager.setShowImages(enabled);
-						for (const child of this.chatContainer.children) {
-							if (child instanceof ToolExecutionComponent) {
-								child.setShowImages(enabled);
+						for (const container of getTranscriptContainers(this.stableChatContainer, this.chatContainer)) {
+							for (const child of container.children) {
+								if (child instanceof ToolExecutionComponent) {
+									child.setShowImages(enabled);
+								}
 							}
 						}
 					},
 					onImageWidthCellsChange: (width) => {
 						this.settingsManager.setImageWidthCells(width);
-						for (const child of this.chatContainer.children) {
-							if (child instanceof ToolExecutionComponent) {
-								child.setImageWidthCells(width);
+						for (const container of getTranscriptContainers(this.stableChatContainer, this.chatContainer)) {
+							for (const child of container.children) {
+								if (child instanceof ToolExecutionComponent) {
+									child.setImageWidthCells(width);
+								}
 							}
 						}
 					},
@@ -4472,17 +4528,20 @@ export class InteractiveMode {
 					onHideThinkingBlockChange: (hidden) => {
 						this.hideThinkingBlock = hidden;
 						this.settingsManager.setHideThinkingBlock(hidden);
-						for (const child of this.chatContainer.children) {
-							if (child instanceof AssistantMessageComponent) {
-								child.setHideThinkingBlock(hidden);
+						for (const container of getTranscriptContainers(this.stableChatContainer, this.chatContainer)) {
+							for (const child of container.children) {
+								if (child instanceof AssistantMessageComponent) {
+									child.setHideThinkingBlock(hidden);
+								}
 							}
 						}
-						this.chatContainer.clear();
 						this.rebuildChatFromMessages();
 					},
 					onMermaidRenderingModeChange: (mode) => {
 						this.settingsManager.setMermaidRenderingMode(mode);
-						this.chatContainer.invalidate();
+						for (const container of getTranscriptContainers(this.stableChatContainer, this.chatContainer)) {
+							container.invalidate();
+						}
 						this.ui.requestRender();
 					},
 					onShowCacheMissNoticesChange: (shown) => {
@@ -4522,13 +4581,15 @@ export class InteractiveMode {
 						this.settingsManager.setOutputPad(padding);
 						this.outputPad = padding;
 						if (this.streamingComponent || this.session.isStreaming) {
-							for (const child of this.chatContainer.children) {
-								if (
-									child instanceof AssistantMessageComponent ||
-									child instanceof CustomMessageComponent ||
-									child instanceof UserMessageComponent
-								) {
-									child.setOutputPad(padding);
+							for (const container of getTranscriptContainers(this.stableChatContainer, this.chatContainer)) {
+								for (const child of container.children) {
+									if (
+										child instanceof AssistantMessageComponent ||
+										child instanceof CustomMessageComponent ||
+										child instanceof UserMessageComponent
+									) {
+										child.setOutputPad(padding);
+									}
 								}
 							}
 							if (this.streamingComponent) {
@@ -5047,7 +5108,7 @@ export class InteractiveMode {
 						}
 
 						// Update UI
-						this.chatContainer.clear();
+						clearTranscript(this.stableChatContainer, this.chatContainer, this.stableTranscriptRegion);
 						this.renderInitialMessages();
 						if (result.editorText && !this.editor.getText().trim()) {
 							this.editor.setText(result.editorText);

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Agent } from "@earendil-works/pi-agent-core";
 import {
 	type AssistantMessage,
@@ -6,7 +9,7 @@ import {
 	type ToolResultMessage,
 	type Usage,
 } from "@earendil-works/pi-ai/compat";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AgentSession } from "../src/core/agent-session.ts";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
@@ -98,6 +101,28 @@ function syncAgentMessages(session: AgentSession, sessionManager: SessionManager
 }
 
 describe("AgentSession.getSessionStats", () => {
+	it("rebuilds usage snapshots when reopening a session", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-usage-snapshot-"));
+		try {
+			const manager = SessionManager.create(tempDir, tempDir);
+			manager.appendMessage(createUserMessage("hello", 1));
+			manager.appendMessage({
+				...createAssistantMessage("hi", 200, 2),
+				usage: {
+					...createUsage(200),
+					cacheRead: 50,
+					cacheWrite: 50,
+					cost: { ...createUsage(200).cost, total: 1.25 },
+				},
+			});
+
+			const reopened = SessionManager.open(manager.getSessionFile()!);
+			expect(reopened.getUsageSnapshot()).toEqual(manager.getUsageSnapshot());
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("exposes the current context usage alongside token totals", async () => {
 		const { session, sessionManager } = await createSession();
 
@@ -111,6 +136,36 @@ describe("AgentSession.getSessionStats", () => {
 			expect(stats.contextUsage?.tokens).toBe(200);
 			expect(stats.contextUsage?.contextWindow).toBe(model.contextWindow);
 			expect(stats.contextUsage?.percent).toBe((200 / model.contextWindow) * 100);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("reuses context usage until session state changes and returns defensive copies", async () => {
+		const { session, sessionManager } = await createSession();
+
+		try {
+			sessionManager.appendMessage(createUserMessage("hello", 1));
+			sessionManager.appendMessage(createAssistantMessage("hi", 200, 2));
+			syncAgentMessages(session, sessionManager);
+			const getBranch = vi.spyOn(sessionManager, "getBranch");
+
+			const first = session.getContextUsage();
+			expect(first?.tokens).toBe(200);
+			expect(session.getContextUsage()?.tokens).toBe(200);
+			expect(getBranch).toHaveBeenCalledTimes(1);
+			if (!first) throw new Error("expected context usage");
+			first.tokens = 999;
+			expect(session.getContextUsage()?.tokens).toBe(200);
+
+			await session.sendCustomMessage({
+				customType: "test",
+				content: [{ type: "text", text: "12345678" }],
+				display: false,
+			});
+
+			expect(session.getContextUsage()?.tokens).toBe(202);
+			expect(getBranch).toHaveBeenCalledTimes(2);
 		} finally {
 			session.dispose();
 		}

--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -63,6 +63,25 @@ function createSession(options: {
 		});
 	}
 
+	const usageTotals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
+	let latestCacheHitRate: number | undefined;
+	for (const entry of entries) {
+		const entryUsage =
+			entry.type === "message"
+				? (entry.message as { usage?: AssistantUsage }).usage
+				: (entry.usage as AssistantUsage | undefined);
+		if (!entryUsage) continue;
+		usageTotals.input += entryUsage.input;
+		usageTotals.output += entryUsage.output;
+		usageTotals.cacheRead += entryUsage.cacheRead;
+		usageTotals.cacheWrite += entryUsage.cacheWrite;
+		usageTotals.cost += entryUsage.cost.total;
+		if (entry.type === "message" && (entry.message as { role?: string }).role === "assistant") {
+			const promptTokens = entryUsage.input + entryUsage.cacheRead + entryUsage.cacheWrite;
+			latestCacheHitRate = promptTokens > 0 ? (entryUsage.cacheRead / promptTokens) * 100 : undefined;
+		}
+	}
+
 	const session = {
 		state: {
 			model: {
@@ -75,6 +94,7 @@ function createSession(options: {
 		},
 		sessionManager: {
 			getEntries: () => entries,
+			getUsageSnapshot: () => ({ totals: usageTotals, latestCacheHitRate }),
 			getSessionName: () => options.sessionName,
 			getCwd: () => "/tmp/project",
 		},
@@ -205,6 +225,25 @@ describe("FooterComponent width handling", () => {
 
 		const statsLine = stripAnsi(footer.render(120)[1]);
 		expect(statsLine).toContain("CH25.0%");
+	});
+
+	it("does not scan session entries while rendering", () => {
+		const session = createSession({
+			sessionName: "",
+			usage: {
+				input: 100,
+				output: 10,
+				cacheRead: 50,
+				cacheWrite: 50,
+				cost: { total: 0.001 },
+			},
+		});
+		session.sessionManager.getEntries = () => {
+			throw new Error("footer render must not scan session entries");
+		};
+		const footer = new FooterComponent(session, createFooterData(1));
+
+		expect(() => footer.render(120)).not.toThrow();
 	});
 
 	it("marks Kimi Coding costs as subscription estimates", () => {

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -86,7 +86,8 @@ export class Loader extends Text {
 		const indicator = frame.length > 0 ? `${renderedFrame} ` : "";
 		this.setText(`${indicator}${this.messageColorFn(this.message)}`);
 		if (this.ui) {
-			this.ui.requestRender();
+			if (this.ui.requestActiveRender) this.ui.requestActiveRender();
+			else this.ui.requestRender();
 		}
 	}
 }

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -121,6 +121,7 @@ export {
 	type OverlayMargin,
 	type OverlayOptions,
 	type OverlayUnfocusOptions,
+	type RenderRegionKind,
 	type SizeValue,
 	type TUI,
 	type TuiInputListener,

--- a/packages/tui/src/layout.ts
+++ b/packages/tui/src/layout.ts
@@ -153,7 +153,9 @@ function layoutComponent(
 			clip: childClip,
 			children: [childBox],
 			scrollView,
-			scrollContentLines: renderCached(context, node.component, contentWidth),
+			...(getLayoutNode(node.component)
+				? {}
+				: { scrollContentLines: renderCached(context, node.component, contentWidth) }),
 			layer: 0,
 		};
 		childBox.parent = box;
@@ -301,6 +303,16 @@ function paintScrollbar(box: LayoutBox, screen: string[], totalWidth: number): v
 	}
 }
 
+function getLineAtRow(box: LayoutBox, row: number): string | undefined {
+	if (row < box.rect.y || row >= box.rect.y + box.rect.height) return undefined;
+	if (box.lines) return box.lines[(box.lineOffset ?? 0) + row - box.rect.y];
+	for (const child of box.children) {
+		const line = getLineAtRow(child, row);
+		if (line !== undefined) return line;
+	}
+	return undefined;
+}
+
 function paintBox(box: LayoutBox, screen: string[], totalWidth: number): void {
 	if (box.lines) {
 		const offset = box.lineOffset ?? 0;
@@ -330,9 +342,13 @@ function paintBox(box: LayoutBox, screen: string[], totalWidth: number): void {
 	}
 	for (const child of box.children) paintBox(child, screen, totalWidth);
 
-	if (box.scrollView && box.scrollContentLines && box.scrollView.scrollTop > 0 && box.rect.height > 0) {
+	if (box.scrollView && box.scrollView.scrollTop > 0 && box.rect.height > 0) {
+		const scrollRoot = box.children[0];
 		for (let imageRow = box.scrollView.scrollTop - 1; imageRow >= 0; imageRow--) {
-			const imageLine = box.scrollContentLines[imageRow] ?? "";
+			const imageLine =
+				box.scrollContentLines?.[imageRow] ??
+				(scrollRoot ? getLineAtRow(scrollRoot, scrollRoot.rect.y + imageRow) : undefined) ??
+				"";
 			const metadata = getKittyImageMetadata(imageLine);
 			if (metadata) {
 				const hiddenRows = box.scrollView.scrollTop - imageRow;

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -980,7 +980,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		return result;
 	}
 
-	protected override doRender(): void {
+	protected override doRender(_scope: "active" | "full"): void {
 		if (this.stopped || !this.altScreenActive) return;
 		const width = Math.max(1, this.terminal.columns);
 		const height = Math.max(1, this.terminal.rows);

--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { deleteKittyImage, isImageLine } from "./terminal-image.ts";
-import { type TUI, TuiBase, type TuiStopOptions } from "./tui.ts";
+import { Container, type TUI, TuiBase, type TuiStopOptions } from "./tui.ts";
 import { visibleWidth } from "./utils.ts";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
@@ -64,6 +64,8 @@ export class TuiMainScreen extends TuiBase implements TUI {
 	private hardwareCursorRow = 0;
 	private maxLinesRendered = 0;
 	private previousViewportTop = 0;
+	private stableRegion: { component: Container; revision: number; width: number; lineCount: number } | undefined;
+	private previousDynamicLines: string[] = [];
 
 	captureRenderState(): TuiMainScreenRenderState {
 		return {
@@ -79,6 +81,8 @@ export class TuiMainScreen extends TuiBase implements TUI {
 
 	restoreRenderState(state: TuiMainScreenRenderState): void {
 		this.previousLines = state.previousLines.map((line) => (isImageLine(line) ? "" : line));
+		this.stableRegion = undefined;
+		this.previousDynamicLines = [];
 		this.previousKittyImageIds = new Set();
 		this.previousWidth = state.previousWidth;
 		this.previousHeight = state.previousHeight;
@@ -90,6 +94,8 @@ export class TuiMainScreen extends TuiBase implements TUI {
 
 	protected override resetRenderState(): void {
 		this.previousLines = [];
+		this.stableRegion = undefined;
+		this.previousDynamicLines = [];
 		this.previousWidth = -1;
 		this.previousHeight = -1;
 		this.cursorRow = 0;
@@ -177,10 +183,142 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		return this.deleteKittyImages(ids);
 	}
 
-	protected doRender(): void {
+	private getStablePrefix(width: number): { component: Container; lineCount: number } | undefined {
+		const component = this.children[0];
+		if (!(component instanceof Container) || component.renderRegionKind !== "stable") return undefined;
+		const lineCount = component.getCachedLineCount(width);
+		return lineCount === undefined ? undefined : { component, lineCount };
+	}
+
+	private captureRegionState(width: number, lines: string[]): void {
+		const stablePrefix = this.getStablePrefix(width);
+		if (!stablePrefix) {
+			this.stableRegion = undefined;
+			this.previousDynamicLines = [];
+			return;
+		}
+		this.stableRegion = {
+			component: stablePrefix.component,
+			revision: stablePrefix.component.renderRegionRevision,
+			width,
+			lineCount: stablePrefix.lineCount,
+		};
+		this.previousDynamicLines = lines.slice(stablePrefix.lineCount);
+	}
+
+	private renderDynamicLines(width: number): string[] {
+		const lines: string[] = [];
+		for (let index = 1; index < this.children.length; index++) {
+			for (const line of this.children[index]!.render(width)) lines.push(line);
+		}
+		return lines;
+	}
+
+	private tryActiveRender(width: number, height: number): boolean {
+		const stable = this.stableRegion;
+		if (
+			!stable ||
+			this.hasOverlayEntries ||
+			this.previousWidth !== width ||
+			this.previousHeight !== height ||
+			this.children[0] !== stable.component ||
+			stable.component.renderRegionRevision !== stable.revision ||
+			stable.component.getCachedLineCount(width) !== stable.lineCount
+		) {
+			return false;
+		}
+
+		let newDynamicLines = this.renderDynamicLines(width);
+		const cursorPos = this.extractCursorPosition(newDynamicLines, height);
+		newDynamicLines = this.applyLineResets(newDynamicLines);
+		if (
+			newDynamicLines.some(isImageLine) ||
+			this.previousDynamicLines.some(isImageLine) ||
+			newDynamicLines.length < this.previousDynamicLines.length
+		) {
+			return false;
+		}
+
+		let firstChanged = -1;
+		let lastChanged = -1;
+		const maxLines = Math.max(newDynamicLines.length, this.previousDynamicLines.length);
+		for (let index = 0; index < maxLines; index++) {
+			if ((this.previousDynamicLines[index] ?? "") === (newDynamicLines[index] ?? "")) continue;
+			if (firstChanged === -1) firstChanged = index;
+			lastChanged = index;
+		}
+
+		const totalLines = stable.lineCount + newDynamicLines.length;
+		const globalCursorPos = cursorPos ? { row: stable.lineCount + cursorPos.row, col: cursorPos.col } : null;
+		if (firstChanged === -1) {
+			this.positionHardwareCursor(globalCursorPos, totalLines);
+			return true;
+		}
+
+		const firstChangedRow = stable.lineCount + firstChanged;
+		const lastChangedRow = stable.lineCount + lastChanged;
+		if (
+			firstChangedRow < this.previousViewportTop ||
+			(this.getClearOnShrink() && totalLines < this.maxLinesRendered)
+		) {
+			return false;
+		}
+		for (let index = firstChanged; index <= lastChanged; index++) {
+			if (visibleWidth(newDynamicLines[index] ?? "") > width) return false;
+		}
+
+		let previousViewportTop = this.previousViewportTop;
+		let viewportTop = previousViewportTop;
+		let hardwareCursorRow = this.hardwareCursorRow;
+		const previousViewportBottom = previousViewportTop + height - 1;
+		const appended =
+			newDynamicLines.length > this.previousDynamicLines.length &&
+			firstChanged === this.previousDynamicLines.length &&
+			firstChanged > 0;
+		const moveTargetRow = appended ? firstChangedRow - 1 : firstChangedRow;
+		let buffer = "\x1b[?2026h";
+		if (moveTargetRow > previousViewportBottom) {
+			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - viewportTop));
+			const moveToBottom = height - 1 - currentScreenRow;
+			if (moveToBottom > 0) buffer += `\x1b[${moveToBottom}B`;
+			const scroll = moveTargetRow - previousViewportBottom;
+			buffer += "\r\n".repeat(scroll);
+			previousViewportTop += scroll;
+			viewportTop += scroll;
+			hardwareCursorRow = moveTargetRow;
+		}
+
+		const lineDiff = moveTargetRow - viewportTop - (hardwareCursorRow - previousViewportTop);
+		if (lineDiff > 0) buffer += `\x1b[${lineDiff}B`;
+		else if (lineDiff < 0) buffer += `\x1b[${-lineDiff}A`;
+		buffer += appended ? "\r\n" : "\r";
+
+		for (let index = firstChanged; index <= lastChanged; index++) {
+			if (index > firstChanged) buffer += "\r\n";
+			buffer += `\x1b[2K${newDynamicLines[index] ?? ""}`;
+		}
+		buffer += "\x1b[?2026l";
+		this.terminal.write(buffer);
+
+		const finalCursorRow = lastChangedRow;
+		this.cursorRow = Math.max(0, totalLines - 1);
+		this.hardwareCursorRow = finalCursorRow;
+		this.maxLinesRendered = Math.max(this.maxLinesRendered, totalLines);
+		this.previousViewportTop = Math.max(previousViewportTop, finalCursorRow - height + 1);
+		this.positionHardwareCursor(globalCursorPos, totalLines);
+
+		this.previousLines.length = stable.lineCount;
+		this.previousLines.push(...newDynamicLines);
+		this.previousDynamicLines = newDynamicLines;
+		this.previousHeight = height;
+		return true;
+	}
+
+	protected doRender(scope: "active" | "full"): void {
 		if (this.stopped) return;
 		const width = this.terminal.columns;
 		const height = this.terminal.rows;
+		if (scope === "active" && this.tryActiveRender(width, height)) return;
 		const widthChanged = this.previousWidth !== 0 && this.previousWidth !== width;
 		const heightChanged = this.previousHeight !== 0 && this.previousHeight !== height;
 		const previousBufferLength = this.previousHeight > 0 ? this.previousViewportTop + this.previousHeight : height;
@@ -245,6 +383,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 			this.previousViewportTop = Math.max(0, bufferLength - height);
 			this.positionHardwareCursor(cursorPos, newLines.length);
 			this.previousLines = newLines;
+			this.captureRegionState(width, newLines);
 			this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
@@ -323,6 +462,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
 			this.positionHardwareCursor(cursorPos, newLines.length);
+			this.captureRegionState(width, newLines);
 			this.previousViewportTop = prevViewportTop;
 			this.previousHeight = height;
 			return;
@@ -370,6 +510,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 			}
 			this.positionHardwareCursor(cursorPos, newLines.length);
 			this.previousLines = newLines;
+			this.captureRegionState(width, newLines);
 			this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 			this.previousWidth = width;
 			this.previousHeight = height;
@@ -541,6 +682,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		this.positionHardwareCursor(cursorPos, newLines.length);
 
 		this.previousLines = newLines;
+		this.captureRegionState(width, newLines);
 		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
 		this.previousWidth = width;
 		this.previousHeight = height;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -210,29 +210,71 @@ type OverlayFocusRestorePolicy = "clear" | "preserve";
  */
 export class Container implements Component {
 	children: Component[] = [];
+	private regionKind: RenderRegionKind | undefined;
+	private cachedWidth: number | undefined;
+	private cachedLines: string[] | undefined;
+	private currentRevision = 0;
+
+	get renderRegionKind(): RenderRegionKind | undefined {
+		return this.regionKind;
+	}
+
+	get renderRegionRevision(): number {
+		return this.currentRevision;
+	}
+
+	setRenderRegion(kind: RenderRegionKind): this {
+		if (this.regionKind === kind) return this;
+		this.regionKind = kind;
+		this.clearRenderRegionCache();
+		return this;
+	}
+
+	getCachedLineCount(width: number): number | undefined {
+		return this.regionKind === "stable" && this.cachedWidth === width ? this.cachedLines?.length : undefined;
+	}
+
+	expireRenderRegion(): void {
+		if (this.regionKind !== "stable") return;
+		this.clearRenderRegionCache();
+	}
+
+	private clearRenderRegionCache(): void {
+		this.cachedWidth = undefined;
+		this.cachedLines = undefined;
+		this.currentRevision += 1;
+	}
 
 	addChild(component: Component): void {
 		this.children.push(component);
+		this.expireRenderRegion();
 	}
 
 	removeChild(component: Component): void {
 		const index = this.children.indexOf(component);
 		if (index !== -1) {
 			this.children.splice(index, 1);
+			this.expireRenderRegion();
 		}
 	}
 
 	clear(): void {
+		const hadChildren = this.children.length > 0;
 		this.children = [];
+		if (hadChildren) this.expireRenderRegion();
 	}
 
 	invalidate(): void {
 		for (const child of this.children) {
 			child.invalidate?.();
 		}
+		this.expireRenderRegion();
 	}
 
 	render(width: number): string[] {
+		if (this.regionKind === "stable" && this.cachedWidth === width && this.cachedLines) {
+			return this.cachedLines;
+		}
 		const lines: string[] = [];
 		for (const child of this.children) {
 			const childLines = child.render(width);
@@ -240,9 +282,15 @@ export class Container implements Component {
 				lines.push(line);
 			}
 		}
+		if (this.regionKind === "stable") {
+			this.cachedWidth = width;
+			this.cachedLines = lines;
+		}
 		return lines;
 	}
 }
+
+export type RenderRegionKind = "stable" | "dynamic";
 
 /**
  * TUI - Main class for managing terminal UI with differential rendering
@@ -309,6 +357,7 @@ export interface TUI extends Component {
 	stop(options?: TuiStopOptions): void;
 	renderNow(force?: boolean): void;
 	requestRender(force?: boolean): void;
+	requestActiveRender?(): void;
 	addInputListener(listener: TuiInputListener): () => void;
 	removeInputListener(listener: TuiInputListener): void;
 	onTerminalColorSchemeChange(listener: (scheme: TerminalColorScheme) => void): () => void;
@@ -337,6 +386,7 @@ export abstract class TuiBase extends Container implements TUI {
 	/** Global callback for debug key (Shift+Ctrl+D). Called before input is forwarded to focused component. */
 	public onDebug?: () => void;
 	private renderRequested = false;
+	private renderScope: "active" | "full" = "active";
 	private immediateRenderScheduled = false;
 	private renderTimer: NodeJS.Timeout | undefined;
 	private lastRenderAt = 0;
@@ -369,7 +419,7 @@ export abstract class TuiBase extends Container implements TUI {
 		}
 	}
 
-	protected abstract doRender(): void;
+	protected abstract doRender(scope: "active" | "full"): void;
 
 	protected resetRenderState(): void {}
 
@@ -688,6 +738,22 @@ export abstract class TuiBase extends Container implements TUI {
 		for (const overlay of this.overlayStack) overlay.component.invalidate();
 	}
 
+	private expireStableRegions(): void {
+		const visit = (component: Component): void => {
+			if (component instanceof Container) {
+				component.expireRenderRegion();
+				for (const child of component.children) visit(child);
+			}
+		};
+		for (const root of this.getMountedRoots()) visit(root);
+	}
+
+	private consumeRenderScope(): "active" | "full" {
+		const scope = this.renderScope;
+		this.renderScope = "active";
+		return scope;
+	}
+
 	start(): void {
 		this.stopped = false;
 		this.beforeTerminalStart();
@@ -755,19 +821,29 @@ export abstract class TuiBase extends Container implements TUI {
 	}
 
 	renderNow(force = false): void {
+		this.expireStableRegions();
 		if (force) this.resetRenderState();
 		this.renderRequested = false;
+		this.renderScope = "active";
 		this.cancelRenderTimer();
 		this.lastRenderAt = performance.now();
-		this.doRender();
+		this.doRender("full");
 	}
 
 	requestRender(force = false): void {
+		this.expireStableRegions();
+		this.renderScope = "full";
 		if (force) {
 			this.resetRenderState();
 			this.requestImmediateRender();
 			return;
 		}
+		if (this.renderRequested) return;
+		this.renderRequested = true;
+		process.nextTick(() => this.scheduleRender());
+	}
+
+	requestActiveRender(): void {
 		if (this.renderRequested) return;
 		this.renderRequested = true;
 		process.nextTick(() => this.scheduleRender());
@@ -786,7 +862,7 @@ export abstract class TuiBase extends Container implements TUI {
 			this.cancelRenderTimer();
 			this.renderRequested = false;
 			this.lastRenderAt = performance.now();
-			this.doRender();
+			this.doRender(this.consumeRenderScope());
 		});
 	}
 
@@ -809,7 +885,7 @@ export abstract class TuiBase extends Container implements TUI {
 			}
 			this.renderRequested = false;
 			this.lastRenderAt = performance.now();
-			this.doRender();
+			this.doRender(this.consumeRenderScope());
 			if (this.renderRequested) {
 				this.scheduleRender();
 			}

--- a/packages/tui/test/layout.test.ts
+++ b/packages/tui/test/layout.test.ts
@@ -68,6 +68,21 @@ describe("viewport layout", () => {
 		assert.deepStrictEqual(visibleLines(frame.lines), ["visible 1", "visible 2", "visible 3"]);
 	});
 
+	it("does not flatten nested layout content after measuring a scroll view", () => {
+		let documentRenderCount = 0;
+		class CountingVStack extends VStack {
+			override render(width: number): string[] {
+				documentRenderCount += 1;
+				return super.render(width);
+			}
+		}
+		const document = new CountingVStack([new Text("one\ntwo\nthree", 0, 0), new Text("four\nfive\nsix", 0, 0)]);
+
+		renderLayoutFrame(new ScrollView(document, { follow: "end" }), 10, 3, () => {});
+
+		assert.strictEqual(documentRenderCount, 0);
+	});
+
 	it("shrinks entries to their minimum sizes", () => {
 		const frame = renderLayoutFrame(
 			new VStack([
@@ -143,6 +158,22 @@ describe("viewport layout", () => {
 		);
 
 		assert.ok(frame.lines[2]?.includes("y=0,h=34,r=1"));
+	});
+
+	it("crops a nested Kitty image whose first line is above the viewport", () => {
+		const imageId = 125;
+		const imageLine = encodeKitty("AAAA", { columns: 2, rows: 3, imageId, moveCursor: false });
+		registerKittyImageMetadata({ imageId, columns: 2, rows: 3, widthPx: 100, heightPx: 100 });
+		const image = {
+			render: () => [imageLine, "", ""],
+			invalidate: () => {},
+		};
+		const document = new VStack([new Text("one\ntwo", 0, 0), image, new Text("after\nend", 0, 0)]);
+
+		const frame = renderLayoutFrame(new ScrollView(document, { follow: "end" }), 20, 3, () => {});
+
+		assert.ok(frame.lines[0]?.includes("i=125"));
+		assert.ok(frame.lines[0]?.includes("y=66,h=34,r=1"));
 	});
 
 	it("composes horizontal children at allocated widths", () => {

--- a/packages/tui/test/render-region.test.ts
+++ b/packages/tui/test/render-region.test.ts
@@ -1,0 +1,293 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { ScrollView } from "../src/components/scroll-view.ts";
+import { Text } from "../src/components/text.ts";
+import { VStack } from "../src/components/v-stack.ts";
+import { renderLayoutFrame } from "../src/layout.ts";
+import { encodeKitty, registerKittyImageMetadata } from "../src/terminal-image.ts";
+import { type Component, Container } from "../src/tui.ts";
+import { TuiAltScreen } from "../src/tui-alt-screen.ts";
+import { TuiMainScreen } from "../src/tui-main-screen.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class CountingComponent implements Component {
+	renderCount = 0;
+	lines: string[];
+
+	constructor(lines: string[]) {
+		this.lines = lines;
+	}
+
+	render(): string[] {
+		this.renderCount += 1;
+		return this.lines;
+	}
+
+	invalidate(): void {}
+}
+
+class ResetCountingTui extends TuiMainScreen {
+	resetLineCount = 0;
+
+	protected override applyLineResets(lines: string[]): string[] {
+		this.resetLineCount += lines.length;
+		return super.applyLineResets(lines);
+	}
+}
+
+function createRenderRegion(kind: "stable" | "dynamic", children: readonly Component[]): Container {
+	const region = new Container();
+	for (const child of children) region.addChild(child);
+	return region.setRenderRegion(kind);
+}
+
+describe("RenderRegion", () => {
+	it("drops cached output when a region changes kind", () => {
+		const content = new CountingComponent(["before"]);
+		const region = createRenderRegion("stable", [content]);
+
+		assert.deepStrictEqual(region.render(20), ["before"]);
+		content.lines = ["after"];
+		region.setRenderRegion("dynamic");
+
+		assert.strictEqual(region.getCachedLineCount(20), undefined);
+		assert.deepStrictEqual(region.render(20), ["after"]);
+		assert.strictEqual(content.renderCount, 2);
+	});
+
+	it("preserves Container.clear array replacement for an empty region", () => {
+		const region = new Container();
+		const originalChildren = region.children;
+
+		region.clear();
+
+		assert.notStrictEqual(region.children, originalChildren);
+	});
+
+	it("keeps stable transcript work out of active main-screen renders", async () => {
+		const terminal = new VirtualTerminal(40, 8);
+		const tui = new ResetCountingTui(terminal);
+		const stableContent = new CountingComponent(
+			Array.from({ length: 10_000 }, (_, index) => `stable transcript line ${index}`),
+		);
+		const stableRegion = createRenderRegion("stable", [stableContent]);
+		const dynamicContent = new Text("working 0", 0, 0);
+
+		tui.addChild(stableRegion);
+		tui.addChild(dynamicContent);
+		tui.start();
+		await terminal.waitForRender();
+
+		const stableRenderCount = stableContent.renderCount;
+		const resetLineCount = tui.resetLineCount;
+		dynamicContent.setText("working 1");
+		tui.requestActiveRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(stableContent.renderCount, stableRenderCount);
+		assert.ok(tui.resetLineCount - resetLineCount <= 1, "active render should reset only dynamic lines");
+		tui.stop();
+	});
+
+	it("keeps parameterless requestRender conservative for stable content changes", async () => {
+		const terminal = new VirtualTerminal(40, 4);
+		const tui = new TuiMainScreen(terminal);
+		const stableContent = new CountingComponent(["before"]);
+		const stableRegion = createRenderRegion("stable", [stableContent]);
+
+		tui.addChild(stableRegion);
+		tui.start();
+		await terminal.waitForRender();
+		const renderCount = stableContent.renderCount;
+
+		stableContent.lines = ["after"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(stableContent.renderCount, renderCount + 1);
+		assert.match(terminal.getViewport().join("\n"), /after/);
+		tui.stop();
+	});
+
+	it("does not let active requests downgrade a queued full invalidation", async () => {
+		const terminal = new VirtualTerminal(40, 4);
+		const tui = new TuiMainScreen(terminal);
+		const stableContent = new CountingComponent(["before"]);
+		tui.addChild(createRenderRegion("stable", [stableContent]));
+		tui.start();
+		await terminal.waitForRender();
+
+		stableContent.lines = ["full then active"];
+		tui.requestRender();
+		tui.requestActiveRender();
+		await terminal.waitForRender();
+		assert.match(terminal.getViewport().join("\n"), /full then active/);
+
+		stableContent.lines = ["active then full"];
+		tui.requestActiveRender();
+		tui.requestRender();
+		await terminal.waitForRender();
+		assert.match(terminal.getViewport().join("\n"), /active then full/);
+		assert.strictEqual(stableContent.renderCount, 3);
+		tui.stop();
+	});
+
+	it("preserves the viewport while active content appends", async () => {
+		const terminal = new VirtualTerminal(24, 4);
+		const tui = new TuiMainScreen(terminal);
+		const stableContent = new CountingComponent(Array.from({ length: 20 }, (_, index) => `stable ${index}`));
+		const dynamicContent = new CountingComponent(["working"]);
+
+		tui.addChild(createRenderRegion("stable", [stableContent]));
+		tui.addChild(createRenderRegion("dynamic", [dynamicContent]));
+		tui.start();
+		await terminal.waitForRender();
+		const redraws = tui.fullRedraws;
+
+		dynamicContent.lines = ["working", "done"];
+		tui.requestActiveRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, redraws);
+		assert.deepStrictEqual(terminal.getViewport(), ["stable 18", "stable 19", "working", "done"]);
+		tui.stop();
+	});
+
+	it("falls back safely when active content shrinks", async () => {
+		const terminal = new VirtualTerminal(24, 4);
+		const tui = new ResetCountingTui(terminal);
+		const stableContent = new CountingComponent(Array.from({ length: 8 }, (_, index) => `stable ${index}`));
+		const dynamicContent = new CountingComponent(["working", "done"]);
+
+		tui.addChild(createRenderRegion("stable", [stableContent]));
+		tui.addChild(createRenderRegion("dynamic", [dynamicContent]));
+		tui.start();
+		await terminal.waitForRender();
+		const resetLineCount = tui.resetLineCount;
+
+		dynamicContent.lines = ["done"];
+		tui.requestActiveRender();
+		await terminal.waitForRender();
+
+		assert.ok(tui.resetLineCount - resetLineCount > stableContent.lines.length);
+		assert.ok(terminal.getViewport().some((line) => line.includes("done")));
+		assert.ok(terminal.getViewport().every((line) => !line.includes("working")));
+		tui.stop();
+	});
+
+	it("falls back safely for active Kitty images", async () => {
+		const terminal = new VirtualTerminal(24, 4);
+		const tui = new ResetCountingTui(terminal);
+		const stableContent = new CountingComponent(Array.from({ length: 8 }, (_, index) => `stable ${index}`));
+		const dynamicContent = new CountingComponent(["working"]);
+		const imageId = 931;
+		const imageLine = encodeKitty("AAAA", { columns: 2, rows: 2, imageId, moveCursor: false });
+		registerKittyImageMetadata({ imageId, columns: 2, rows: 2, widthPx: 100, heightPx: 100 });
+
+		tui.addChild(createRenderRegion("stable", [stableContent]));
+		tui.addChild(createRenderRegion("dynamic", [dynamicContent]));
+		tui.start();
+		await terminal.waitForRender();
+		const resetLineCount = tui.resetLineCount;
+
+		dynamicContent.lines = [imageLine, ""];
+		tui.requestActiveRender();
+		await terminal.waitForRender();
+
+		assert.ok(tui.resetLineCount - resetLineCount > stableContent.lines.length);
+		assert.ok(terminal.getViewport().every((line) => !line.includes("working")));
+		tui.stop();
+	});
+
+	it("falls back safely while an overlay is visible", async () => {
+		const terminal = new VirtualTerminal(24, 6);
+		const tui = new ResetCountingTui(terminal);
+		const stableContent = new CountingComponent(Array.from({ length: 8 }, (_, index) => `stable ${index}`));
+		const dynamicContent = new Text("working 0", 0, 0);
+
+		tui.addChild(createRenderRegion("stable", [stableContent]));
+		tui.addChild(createRenderRegion("dynamic", [dynamicContent]));
+		tui.start();
+		await terminal.waitForRender();
+		const overlay = tui.showOverlay(new Text("OVERLAY", 0, 0), { anchor: "top-left", width: 10 });
+		await terminal.waitForRender();
+		const resetLineCount = tui.resetLineCount;
+
+		dynamicContent.setText("working 1");
+		tui.requestActiveRender();
+		await terminal.waitForRender();
+
+		assert.ok(tui.resetLineCount - resetLineCount > stableContent.lines.length);
+		assert.ok(terminal.getViewport().some((line) => line.includes("OVERLAY")));
+		assert.ok(terminal.getViewport().some((line) => line.includes("working 1")));
+		overlay.hide();
+		tui.stop();
+	});
+
+	it("promotes dynamic children without redrawing unchanged transcript content", async () => {
+		const terminal = new VirtualTerminal(24, 4);
+		const tui = new TuiMainScreen(terminal);
+		const stableContainer = new Container();
+		const dynamicContainer = new Container();
+		const stableRegion = createRenderRegion("stable", [stableContainer]);
+		const dynamicRegion = createRenderRegion("dynamic", [dynamicContainer]);
+		const stableLine = new Text("stable", 0, 0);
+		const dynamicLine = new Text("dynamic", 0, 0);
+		stableContainer.addChild(stableLine);
+		dynamicContainer.addChild(dynamicLine);
+
+		tui.addChild(stableRegion);
+		tui.addChild(dynamicRegion);
+		tui.start();
+		await terminal.waitForRender();
+		const redraws = tui.fullRedraws;
+		const viewport = terminal.getViewport();
+
+		stableContainer.addChild(dynamicLine);
+		dynamicContainer.removeChild(dynamicLine);
+		stableRegion.expireRenderRegion();
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, redraws);
+		assert.deepStrictEqual(terminal.getViewport(), viewport);
+		tui.stop();
+	});
+
+	it("reuses stable region output in fullscreen layout frames", () => {
+		const stableContent = new CountingComponent(
+			Array.from({ length: 10_000 }, (_, index) => `stable transcript line ${index}`),
+		);
+		const stableRegion = createRenderRegion("stable", [stableContent]);
+		const dynamicContent = new Text("working 0", 0, 0);
+		const document = new VStack([stableRegion, dynamicContent]);
+		const viewport = new ScrollView(document, { follow: "end" });
+
+		renderLayoutFrame(viewport, 40, 8, () => {});
+		const stableRenderCount = stableContent.renderCount;
+		dynamicContent.setText("working 1");
+		renderLayoutFrame(viewport, 40, 8, () => {});
+
+		assert.strictEqual(stableContent.renderCount, stableRenderCount);
+	});
+
+	it("invalidates stable region output on fullscreen full renders", async () => {
+		const terminal = new VirtualTerminal(24, 4);
+		const tui = new TuiAltScreen(terminal);
+		const stableContent = new CountingComponent(["before"]);
+		const stableRegion = createRenderRegion("stable", [stableContent]);
+		const document = new VStack([stableRegion, new Text("dynamic", 0, 0)]);
+		tui.setLayoutRoot(new ScrollView(document, { follow: "end" }));
+		tui.start();
+		await terminal.waitForRender();
+		const renderCount = stableContent.renderCount;
+
+		stableContent.lines = ["after"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(stableContent.renderCount, renderCount + 1);
+		assert.ok(terminal.getViewport().some((line) => line.includes("after")));
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## Summary

- split the interactive transcript into stable and dynamic render regions
- keep ordinary streaming and spinner renders independent of completed session length in regular and fullscreen modes
- cache footer usage and completed-message context calculations outside the render hot path
- preserve conservative full invalidation for extensions and unsafe terminal states

## Performance

Before this change, 100,000 rendered lines cost about 21.245 ms/frame versus 0.035 ms/frame for 100 lines. After this change, both sizes render the stable region once across 200 active frames.

## Scope

This fixes render-path CPU growth with completed transcript length. Session memory retention is intentionally left for a separate investigation.

Fixes #7730

## Testing

- `npm run check`
- `./test.sh`
