### PR TITLE
fix(handoff): review follow-ups F5-F10

### DIFF
--- a/.github/workflows/handoff-ext.yml
+++ b/.github/workflows/handoff-ext.yml
@@ -1,0 +1,50 @@
+# Gate for the session-handoff extension in `.pi/extensions/handoff/`.
+#
+# It needs its own workflow because the extension lives outside `packages/`, so nothing
+# the main CI job runs reaches it: `.pi/**` is absent from `tsconfig.json`'s `include`
+# and from `biome.json`'s `files.includes`, and it is not an npm workspace, so
+# `npm run check` and `npm test` both skip it silently.
+#
+# Kept as a separate file, rather than steps bolted onto `ci.yml`, so that rebasing this
+# fork onto upstream pi never conflicts here.
+#
+# Deliberately not filtered on `paths`. The extension typechecks against pi's *source*
+# (the root tsconfig maps `@earendil-works/*` to `packages/*/src`), so an upstream change
+# to an extension API breaks it without touching a single file under `.pi/` — which is
+# the drift this fork most needs to catch.
+
+name: Handoff extension
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: handoff-ext-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      # No build step and no system dependencies: the tests import pi types only, and
+      # the typecheck resolves pi through source paths rather than built `dist`.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Test
+        run: node node_modules/vitest/dist/cli.js --run --config .pi/extensions/handoff/vitest.config.ts
+
+      - name: Typecheck
+        run: npx tsgo --noEmit -p .pi/extensions/handoff/tsconfig.json

--- a/.pi/extensions/handoff/DESIGN.md
+++ b/.pi/extensions/handoff/DESIGN.md
@@ -1,0 +1,236 @@
+# Session Handoff Extension — v1 Design
+
+Status: **approved design, not yet built** · Author: Kyle Disch (decisions) + Claude (spec) · Date: 2026-08-10
+
+## What this is
+
+A pi extension that automates session-to-session handoff. Every session leaves a
+durable **handoff note** on disk — either a rich, LLM-composed one via `/handoff`,
+or a mechanical digest written automatically when the session ends. New sessions
+auto-detect the newest pending note and inject it as a briefing alongside the
+user's first message.
+
+This differs from upstream's `examples/extensions/handoff.ts`, which is an
+in-process, interactive-only baton pass (generate prompt → edit → `ctx.newSession`)
+that writes nothing to disk and cannot survive process exit. Ours is a dead drop:
+it works across process boundaries, in non-interactive modes, and without the
+user remembering to do anything.
+
+### Locked decisions (Kyle, 2026-08-10)
+
+1. **Storage:** project-local `.pi/handoffs/` with dated history (not latest-only).
+2. **Ingestion:** first-message memo (`custom_message`, `deliverAs: "nextTurn"`).
+3. **Consumed notes:** archived, never deleted.
+4. **Auto-note at shutdown:** mechanical digest; no LLM calls in the exit path.
+   `/handoff` is the rich, LLM-composed path.
+5. **Format:** Markdown + YAML frontmatter.
+6. **Forward-compat requirement:** every note carries a `kickoff` field — a
+   ready-made opening prompt a future autonomous spawner can use to start the
+   successor session (v2 north star: sessions detect stopping points / context
+   fullness, spawn successors, ping Kyle via messaging when decisions are needed).
+
+## Storage layout
+
+```
+<project>/.pi/handoffs/
+  2026-08-10T22-15-00-000Z_a1b2c3d4.md     # pending note(s); newest = current
+  archive/
+    2026-08-09T18-02-11-421Z_99ffee01.md   # consumed or superseded notes
+```
+
+- Filename mirrors pi's session-file naming: ISO timestamp (`:`/`.` → `-`) +
+  `_` + first 8 chars of the *writing* session's id. Lexicographic sort = age sort.
+- **Pending vs consumed is encoded by location** (top level vs `archive/`), not a
+  status field. On archive, `consumed_by` / `consumed_at` (or `superseded_by`)
+  frontmatter is appended for audit.
+- All writes are atomic: write to `<name>.md.tmp`, then `rename()`. No reader can
+  ever see a half-written note.
+- **Git hygiene:** the writer idempotently appends `.pi/handoffs/` to
+  `<repo>/.git/info/exclude` (local-only ignore; never touches the project's
+  tracked `.gitignore`). Skipped when cwd is not a git repo. We ignore
+  `.pi/handoffs/` specifically — never all of `.pi/`, which some repos track
+  (including this one).
+- Scope is exact-cwd: notes are found by scanning `<ctx.cwd>/.pi/handoffs/`.
+  Running pi from a subdirectory won't find project-root notes (v1 limitation;
+  walk-up detection is a possible v1.1).
+
+## Note format
+
+```markdown
+---
+schema: pi-handoff/v1
+session_id: 019feda9-55bc-797d-8b97-4fe03f430270
+session_file: /Users/kyle/.pi/agent/sessions/--...--/2026-08-10T21-52-05-564Z_019feda9....jsonl
+cwd: /Users/kyle/Projects/foo
+created: 2026-08-10T22:15:00.000Z
+source: command            # "command" (/handoff, LLM-composed) | "digest" (shutdown, mechanical)
+model: google/gemini-3.6-flash
+kickoff: "Continue implementing the reader module; start by wiring archive-on-delivery."
+---
+
+## Context
+What we were doing, decisions made, key findings.
+
+## Next steps
+The concrete task the successor should pick up.
+
+## Files touched
+- read: path/a.ts, path/b.ts
+- modified: path/c.ts
+
+## Last exchange        (digest-source notes only)
+**User:** <last user message>
+**Assistant:** <first lines of last assistant reply>
+```
+
+Frontmatter is machine-read by the extension (schema check, kickoff extraction,
+consumed stamping); the body is for humans and for the successor's LLM context.
+A note that fails frontmatter parsing is treated as not-pending: warned about
+once, left in place, never ingested or archived.
+
+## Components and their exact pi hooks
+
+The extension is a standard jiti-loaded factory (`export default function (pi: ExtensionAPI)`),
+developed at `.pi/extensions/handoff/` in this fork (auto-loads when running pi
+here — instant dogfooding), later symlinked from `~/.pi/agent/extensions/handoff`
+for all-projects use. Pi's loader de-dupes by resolved path, so the symlink and
+the project-local copy never double-load.
+
+```
+.pi/extensions/handoff/
+  index.ts        # factory: registers command + event hooks, wires modules
+  notes.ts        # note types, frontmatter serialize/parse, atomic write, archive ops
+  digest.ts       # session entries → mechanical digest fields (pure functions)
+  compose.ts      # /handoff LLM composition (prompt + ctx.modelRegistry.complete)
+  reader.ts       # pending-note detection, memo injection, archive-on-delivery
+  DESIGN.md       # this document
+```
+
+No npm dependencies — `node:fs`/`node:path` plus `@earendil-works/pi-coding-agent`
+imports only. Keeps installation = "copy or symlink the folder."
+
+### Writer A — `/handoff [goal]` (rich, LLM-composed)
+
+- **Hook:** `pi.registerCommand("handoff", { handler })` — handlers get
+  `ExtensionCommandContext`. The name is free (upstream's example lives in
+  `examples/` and is not auto-discovered; if a user loads both, pi suffixes
+  `/handoff:1`, `/handoff:2` rather than colliding).
+- **Gather:** `ctx.sessionManager.buildContextEntries()` — *not* the hand-rolled
+  branch walk upstream's example uses (it duplicates compaction logic and has
+  drifted before). Serialize with the exported `convertToLlm` +
+  `serializeConversation` helpers.
+- **Compose:** one-shot `ctx.modelRegistry.complete(ctx.model, …)` with
+  `cacheRetention: "none"` and a fresh `sessionId` (uuidv7) so the call never
+  pollutes the user's session. System prompt requests the note body sections plus
+  a one-line `kickoff`. The optional `goal` argument steers "Next steps";
+  without it, the prompt asks for state summary + natural next step (upstream
+  hard-requires a goal; we don't — automation is the point).
+- **Review:** in TUI mode, show the draft in `ctx.ui.editor()` for edit/approval
+  before writing. When `ctx.hasUI` is false (`-p` / JSON modes), skip review and
+  write directly — degrade gracefully where upstream hard-fails.
+- **Write:** atomic write to `.pi/handoffs/`, then `ctx.ui.notify` the path.
+- **Optional successor spawn:** in TUI mode, `ctx.ui.confirm("Start successor
+  session now?")` → `ctx.newSession({ parentSession, withSession })`. This
+  composes with the reader for free: `newSession` fires `session_start
+  {reason:"new"}`, our own reader detects the just-written note and injects it.
+  All post-switch work uses only the `withSession` callback's fresh context
+  (captured `ctx`/`pi` are invalidated after replacement — the documented
+  footgun that has bitten upstream's example before).
+- Sets an in-memory `wroteNoteThisSession` flag (see Writer B).
+
+### Writer B — shutdown digest (mechanical safety net)
+
+- **Hook:** `pi.on("session_shutdown", handler)`, acting **only when
+  `event.reason === "quit"`** — the event also fires for `reload`/`new`/`resume`/
+  `fork`, which must not each drop a note.
+- **Skip when:** `wroteNoteThisSession` is set (the `/handoff` note is richer; a
+  later digest would supersede it as "newest" with worse content — accepted v1
+  simplification: work done *after* `/handoff` but before quit isn't re-captured);
+  no assistant message exists in `getEntries()` (nothing happened — also covers
+  the fact that pi's session file isn't even flushed to disk until the first
+  assistant reply); or `getSessionFile()` is undefined (`--no-session` ephemeral
+  runs — the user asked not to be recorded; honor it).
+- **Digest fields** (pure in-memory walk of `ctx.sessionManager` — no LLM, no
+  network, bounded, idempotent; a hung shutdown handler hangs pi's exit):
+  last user message; first ~15 lines of last assistant reply; files touched
+  (walk assistant `toolCall` content blocks for `read`/`write`/`edit` path
+  arguments, deduped into read vs modified); current model; session file path +
+  id; mechanical `kickoff` = `"Continue: <first line of last user message>"`.
+- Works identically in all modes (`notify` only when `ctx.hasUI`).
+- Known limits, accepted: shutdown is best-effort in pi (fatal-error exits and
+  SIGKILL skip it). `/handoff` is the reliable path; this is the seatbelt.
+
+### Reader — detect + inject + archive
+
+- **Detect** on `pi.on("session_start")` for `reason` `"startup"` or `"new"`
+  only. `resume`/`fork` sessions carry their own live context — injecting another
+  session's briefing there invites confusion (judgment call; revisit if wrong).
+  Scan `<ctx.cwd>/.pi/handoffs/*.md`, parse frontmatter, pick the newest valid
+  pending note.
+- **Inject:** `pi.sendMessage({ customType: "handoff", content: memo, display:
+  true }, { deliverAs: "nextTurn" })`. The memo = banner line ("Handoff from
+  session <id-prefix>, ended <time>") + note body + session-recording pointer +
+  one line listing any older pending notes. `nextTurn` parks it until the first
+  real prompt — no LLM call is burned on an idle session, and the memo persists
+  as a first-class `custom_message` entry in the successor's transcript. Crucially
+  this is **spawn-agnostic**: the "first prompt" can come from a human, `pi -p`,
+  RPC, or a future autonomous spawner — the memo attaches regardless.
+- **Archive on delivery, not on detection:** `session_start` only *queues* the
+  memo and remembers the note path in memory. The first `before_agent_start`
+  (i.e., the user actually submitted a prompt — the memo is now really being
+  delivered) moves **all** pending notes to `archive/`: the ingested one stamped
+  `consumed_by: <session id>` / `consumed_at`, older ones stamped
+  `superseded_by: <ingested note filename>`. If the session is opened and quit
+  without a prompt, the note stays pending for the next session — the briefing
+  is never lost to an aborted start.
+- **Concurrency:** two sessions starting at once may both queue the same note;
+  the second archive `rename()` fails ENOENT and is swallowed. Both ingesting
+  the same briefing is acceptable; losing it is not. (Pi's v3 session layer has
+  no locking either; atomic rename is our only primitive and it's sufficient.)
+
+### Nice-to-have (build only if trivial): `pi.registerMessageRenderer("handoff", …)`
+for a styled memo box in the TUI. Default `custom_message` styling is acceptable
+for v1.
+
+## Failure modes considered
+
+| Failure | Behavior |
+|---|---|
+| Corrupt/unparseable note | Warn once, leave in place, never ingest/archive |
+| Shutdown handler slow/hung | Impossible by construction: no network, no LLM, in-memory walk + one atomic write |
+| Session file not yet on disk | Digest skips (no assistant message ⇒ nothing to hand off) |
+| `.jsonl` hazard in session dirs | N/A — notes are `.md` in the project, never in `~/.pi/agent/sessions/` |
+| Stale ctx after `newSession` | All post-switch work confined to `withSession` callback |
+| Extension throws anywhere | Pi contains it (logged, other extensions unaffected) — but every handler still guards its own I/O |
+| Both our extension and upstream example loaded | Commands suffix to `/handoff:1`, `/handoff:2`; no data conflict (example writes nothing) |
+
+## Build plan (value-ordered slices)
+
+1. **`notes.ts` + Writer B** — storage, format, atomic ops, shutdown digest.
+2. **Reader** — detection, memo injection, archive-on-delivery.
+   *After slices 1+2 the automated loop already works end-to-end with zero LLM involvement.*
+3. **Writer A** — `/handoff` LLM composition, editor review, optional successor spawn.
+4. **Polish** — git-exclude hygiene, older-notes notice line, message renderer.
+
+Each slice: unit tests for the pure modules (`notes.ts` parse/serialize
+round-trip, `digest.ts` entry-walking against a fixture session JSONL — the real
+specimen at `~/.pi/agent/sessions/--Users-kyledisch-Projects-pi--/` is a good
+fixture source), plus a manual smoke via `pi -e .pi/extensions/handoff/index.ts`
+in a scratch project. LLM smoke tests use Google Gemini free tier only — never
+Anthropic subscription auth (bills per-token).
+
+## Explicitly out of scope for v1 (v2 hooks noted)
+
+- Context-fullness watcher (`ctx.getContextUsage()` checked on `agent_settled`)
+  proposing or auto-running `/handoff`.
+- Autonomous successor spawning (the `kickoff` field is the contract it will consume).
+- Messaging integration (Slack/Telegram ping at decision points).
+- Repo-scoped event ledger (the dated-history `handoffs/` dir is its seed).
+- Walk-up note detection from subdirectories; cross-cwd note routing.
+
+---
+
+**Run-config note:** build this with a fresh session started from this file —
+recommended **Opus 5, effort high** (well-specified build, no open design
+questions): `claude --model claude-opus-5 --effort high`, opening prompt
+"Implement .pi/extensions/handoff/DESIGN.md, slice by slice."

--- a/.pi/extensions/handoff/DESIGN.md
+++ b/.pi/extensions/handoff/DESIGN.md
@@ -219,6 +219,26 @@ fixture source), plus a manual smoke via `pi -e .pi/extensions/handoff/index.ts`
 in a scratch project. LLM smoke tests use Google Gemini free tier only — never
 Anthropic subscription auth (bills per-token).
 
+## Verification gates
+
+This extension lives outside `packages/`, so none of the repo's own gates reach it:
+`.pi/**` is absent from `tsconfig.json`'s `include` and `biome.json`'s `files.includes`,
+and it is not an npm workspace, so `npm run check` and `npm test` skip it silently.
+
+Tests and typecheck are gated by their own workflow, `.github/workflows/handoff-ext.yml`,
+kept as a separate file so rebasing this fork onto upstream pi never conflicts there. Run
+the same two commands locally from the repo root:
+
+```
+node node_modules/vitest/dist/cli.js --run --config .pi/extensions/handoff/vitest.config.ts
+npx tsgo --noEmit -p .pi/extensions/handoff/tsconfig.json
+```
+
+Formatting is the remaining gap: `biome check` ignores the path by config, and covering it
+would mean editing `biome.json` — a shared upstream file. Format by hand when needed with
+`--config-path` pointing at a copy of `biome.json` whose `files.includes` is
+`["**/*.ts", "!**/node_modules/**/*"]`.
+
 ## Explicitly out of scope for v1 (v2 hooks noted)
 
 - Context-fullness watcher (`ctx.getContextUsage()` checked on `agent_settled`)

--- a/.pi/extensions/handoff/compose.ts
+++ b/.pi/extensions/handoff/compose.ts
@@ -61,6 +61,16 @@ export function splitKickoff(text: string): { body: string; kickoff?: string } {
 	return { body: text.trim() };
 }
 
+/**
+ * Inverse of `splitKickoff`: fold the note back into one editable document. `/handoff`
+ * hands this to the editor so the kickoff is reviewed alongside the body it belongs to,
+ * then re-splits the result. Kept beside `splitKickoff` so the two halves of the format
+ * cannot drift apart.
+ */
+export function joinKickoff(body: string, kickoff: string | undefined): string {
+	return kickoff ? `${body}\n\nKICKOFF: ${kickoff}` : body;
+}
+
 export interface ComposeOptions {
 	modelRegistry: ModelRegistry;
 	model: Model<any>;

--- a/.pi/extensions/handoff/compose.ts
+++ b/.pi/extensions/handoff/compose.ts
@@ -1,0 +1,111 @@
+/**
+ * `/handoff` composition: turn the current conversation into a rich handoff note
+ * with one throwaway LLM call.
+ *
+ * The call is deliberately isolated from the user's session — its own `sessionId` and
+ * `cacheRetention: "none"` — so composing a note never pollutes the conversation's
+ * cache or context.
+ *
+ * Every pi import here is type-only, which keeps this module unit-testable without
+ * pulling pi's runtime module graph into the test process.
+ */
+
+import type { Message, Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+/** Trailing marker the model uses to hand back the successor's opening prompt. */
+const KICKOFF_MARKER = /^KICKOFF:[ \t]*(.+)$/;
+
+export const COMPOSE_SYSTEM_PROMPT = `You are writing a handoff note for the next coding session. The next session starts with no memory of this conversation and will read only your note.
+
+Output Markdown with exactly these three sections, in this order:
+
+## Context
+What we were doing and why. Decisions made and the reasoning behind them, approaches ruled out, and anything discovered the hard way. Be specific: name files, functions, commands, and error messages.
+
+## Next steps
+The concrete task the next session should pick up, stated so it can act without asking questions.
+
+## Files touched
+A bullet list of the files read and the files modified, with a few words on what changed in each.
+
+Then, as the very last line and nothing after it, output:
+
+KICKOFF: <a single sentence that could be typed as the next session's opening prompt>
+
+Rules:
+- No preamble, no closing remarks, no code fences around the whole note. Start with "## Context".
+- Prefer concrete detail over summary. The next session cannot ask you follow-up questions.
+- Do not invent work that did not happen. If a section has nothing to report, say so in one line.`;
+
+export function buildComposeUserMessage(conversationText: string, goal: string): string {
+	const instruction = goal
+		? `## What the next session should focus on\n\n${goal}\n\nUse this to write the "Next steps" section.`
+		: `## What the next session should focus on\n\nNo goal was given. Infer the natural next step from where the conversation left off, and say plainly if the work reached a stopping point.`;
+	return `## Conversation history\n\n${conversationText}\n\n${instruction}`;
+}
+
+/**
+ * Split the trailing `KICKOFF:` line off the note body. Returns kickoff undefined when
+ * the model omitted it; callers supply their own fallback rather than failing.
+ */
+export function splitKickoff(text: string): { body: string; kickoff?: string } {
+	const lines = text.trimEnd().split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i].trim();
+		if (line === "" || line === "---") continue;
+		const match = KICKOFF_MARKER.exec(line);
+		if (!match) break;
+		return { body: lines.slice(0, i).join("\n").trimEnd(), kickoff: match[1].trim() };
+	}
+	return { body: text.trim() };
+}
+
+export interface ComposeOptions {
+	modelRegistry: ModelRegistry;
+	model: Model<any>;
+	conversationText: string;
+	goal: string;
+	signal?: AbortSignal;
+	/** Isolates the composition call from the user's session cache and context. */
+	sessionId: string;
+}
+
+/**
+ * Failure and cancellation are separate outcomes on purpose. `complete()` never rejects:
+ * it resolves with `stopReason: "error"` and the reason in `errorMessage`, so collapsing
+ * both into one empty result would report a provider failure as "cancelled" and throw the
+ * real message away — exactly what a long session near its context ceiling would hit.
+ */
+export type ComposeResult =
+	| { status: "ok"; body: string; kickoff?: string }
+	| { status: "aborted" }
+	| { status: "failed"; message: string };
+
+export async function composeNoteBody(options: ComposeOptions): Promise<ComposeResult> {
+	const userMessage: Message = {
+		role: "user",
+		content: [{ type: "text", text: buildComposeUserMessage(options.conversationText, options.goal) }],
+		timestamp: Date.now(),
+	};
+
+	const response = await options.modelRegistry.complete(
+		options.model,
+		{ systemPrompt: COMPOSE_SYSTEM_PROMPT, messages: [userMessage] },
+		{ signal: options.signal, cacheRetention: "none", sessionId: options.sessionId },
+	);
+
+	if (response.stopReason === "aborted") return { status: "aborted" };
+	if (response.stopReason === "error") {
+		return { status: "failed", message: response.errorMessage ?? "the provider reported an error with no message" };
+	}
+
+	const text = response.content
+		.filter((block): block is { type: "text"; text: string } => block.type === "text")
+		.map((block) => block.text)
+		.join("\n")
+		.trim();
+	if (!text) return { status: "failed", message: `the model returned no text (stop reason: ${response.stopReason})` };
+
+	return { status: "ok", ...splitKickoff(text) };
+}

--- a/.pi/extensions/handoff/digest.ts
+++ b/.pi/extensions/handoff/digest.ts
@@ -1,0 +1,210 @@
+/**
+ * Mechanical digest: session entries -> handoff note fields.
+ *
+ * Pure functions, no LLM and no network. This runs in pi's exit path, where a hung
+ * handler hangs the process, so everything here is a bounded in-memory walk.
+ */
+
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { HANDOFF_SCHEMA, type HandoffNote } from "./notes.ts";
+
+/**
+ * Excerpt bounds. Both sides of the last exchange are capped, on lines and on characters:
+ * the whole note body is re-injected into the successor's context as a user message, so an
+ * uncapped paste (a log, a stack trace, a file) at the end of one session would become a
+ * permanent oversized prefix on the next session's first turn.
+ */
+const ASSISTANT_EXCERPT_LINES = 15;
+const USER_EXCERPT_LINES = 15;
+const EXCERPT_CHARS = 2000;
+/** A frontmatter scalar, so held much tighter than the body excerpts. */
+const KICKOFF_CHARS = 200;
+
+interface TextBlock {
+	type: "text";
+	text: string;
+}
+
+interface ToolCallBlock {
+	type: "toolCall";
+	name: string;
+	arguments: Record<string, unknown>;
+}
+
+export interface FilesTouched {
+	read: string[];
+	modified: string[];
+}
+
+function isTextBlock(block: unknown): block is TextBlock {
+	return (
+		typeof block === "object" &&
+		block !== null &&
+		(block as { type?: unknown }).type === "text" &&
+		typeof (block as { text?: unknown }).text === "string"
+	);
+}
+
+function isToolCallBlock(block: unknown): block is ToolCallBlock {
+	return (
+		typeof block === "object" &&
+		block !== null &&
+		(block as { type?: unknown }).type === "toolCall" &&
+		typeof (block as { name?: unknown }).name === "string"
+	);
+}
+
+/** Flatten a message's content to plain text, dropping images and thinking blocks. */
+function contentToText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.filter(isTextBlock)
+		.map((block) => block.text)
+		.join("\n")
+		.trim();
+}
+
+export function hasAssistantMessage(entries: SessionEntry[]): boolean {
+	return entries.some((entry) => entry.type === "message" && entry.message.role === "assistant");
+}
+
+/**
+ * Text of the last user message. `custom_message` entries (including a handoff memo
+ * injected by the reader) are deliberately skipped — the successor's own prompt is
+ * what the next session should continue from, not the briefing it was handed.
+ */
+export function lastUserText(entries: SessionEntry[]): string {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (entry.type !== "message") continue;
+		const message = entry.message;
+		if (message.role !== "user") continue;
+		return contentToText(message.content);
+	}
+	return "";
+}
+
+export function lastAssistantText(entries: SessionEntry[]): string {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (entry.type !== "message") continue;
+		const message = entry.message;
+		if (message.role !== "assistant") continue;
+		return contentToText(message.content);
+	}
+	return "";
+}
+
+export function firstLines(text: string, count: number): string {
+	const lines = text.split("\n");
+	if (lines.length <= count) return text.trim();
+	return `${lines.slice(0, count).join("\n").trim()}\n...`;
+}
+
+export function truncateChars(text: string, max: number): string {
+	return text.length <= max ? text : `${text.slice(0, max).trimEnd()}...`;
+}
+
+/** An excerpt bounded on both axes: a 15-line paste can still be a megabyte. */
+export function excerpt(text: string, lines: number): string {
+	return truncateChars(firstLines(text, lines), EXCERPT_CHARS);
+}
+
+function firstLine(text: string): string {
+	return text.split("\n")[0]?.trim() ?? "";
+}
+
+/** Canonical param is `path`; pi accepts `file_path` as a provider-compat alias. */
+function toolCallPath(block: ToolCallBlock): string | undefined {
+	const raw = block.arguments?.path ?? block.arguments?.file_path;
+	return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}
+
+/**
+ * Files the session read vs. changed, deduped and in first-touch order. A file that
+ * was both read and written is reported as modified only.
+ */
+export function collectFilesTouched(entries: SessionEntry[]): FilesTouched {
+	const read: string[] = [];
+	const modified: string[] = [];
+
+	for (const entry of entries) {
+		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+		const content = entry.message.content;
+		if (!Array.isArray(content)) continue;
+		for (const block of content) {
+			if (!isToolCallBlock(block)) continue;
+			const path = toolCallPath(block);
+			if (!path) continue;
+			if (block.name === "read") {
+				if (!read.includes(path)) read.push(path);
+			} else if (block.name === "write" || block.name === "edit") {
+				if (!modified.includes(path)) modified.push(path);
+			}
+		}
+	}
+
+	return { read: read.filter((path) => !modified.includes(path)), modified };
+}
+
+export interface DigestInput {
+	entries: SessionEntry[];
+	sessionId: string;
+	sessionFile: string;
+	cwd: string;
+	model: string | undefined;
+	/** ISO 8601. Passed in rather than read from the clock so this stays pure. */
+	created: string;
+}
+
+function renderFilesSection(files: FilesTouched): string {
+	const lines: string[] = [];
+	if (files.read.length > 0) lines.push(`- read: ${files.read.join(", ")}`);
+	if (files.modified.length > 0) lines.push(`- modified: ${files.modified.join(", ")}`);
+	return lines.length > 0 ? lines.join("\n") : "- none recorded";
+}
+
+/**
+ * Build the shutdown digest note. Returns undefined when the session produced no
+ * assistant message — nothing happened, so there is nothing to hand off.
+ */
+export function buildDigestNote(input: DigestInput): HandoffNote | undefined {
+	if (!hasAssistantMessage(input.entries)) return undefined;
+
+	const userText = lastUserText(input.entries);
+	const assistantText = lastAssistantText(input.entries);
+	const files = collectFilesTouched(input.entries);
+	const lastRequest = truncateChars(firstLine(userText), KICKOFF_CHARS);
+
+	const body = [
+		"## Context",
+		"Mechanical digest written when the previous session exited. No LLM summary was made;",
+		"the transcript pointer below has the full history.",
+		"",
+		"## Next steps",
+		lastRequest ? `Pick up from the last request: ${lastRequest}` : "No user request was recorded.",
+		"",
+		"## Files touched",
+		renderFilesSection(files),
+		"",
+		"## Last exchange",
+		`**User:** ${excerpt(userText, USER_EXCERPT_LINES) || "(none)"}`,
+		"",
+		`**Assistant:** ${excerpt(assistantText, ASSISTANT_EXCERPT_LINES) || "(none)"}`,
+	].join("\n");
+
+	return {
+		frontmatter: {
+			schema: HANDOFF_SCHEMA,
+			session_id: input.sessionId,
+			session_file: input.sessionFile,
+			cwd: input.cwd,
+			created: input.created,
+			source: "digest",
+			model: input.model,
+			kickoff: lastRequest ? `Continue: ${lastRequest}` : "Continue the previous session's work.",
+		},
+		body,
+	};
+}

--- a/.pi/extensions/handoff/index.ts
+++ b/.pi/extensions/handoff/index.ts
@@ -1,0 +1,224 @@
+/**
+ * Session Handoff extension.
+ *
+ * Every session leaves a durable handoff note in `<cwd>/.pi/handoffs/`, and new
+ * sessions pick the newest pending note up as a first-message briefing. See DESIGN.md.
+ *
+ * Two writers:
+ * - `/handoff [goal]` — rich, LLM-composed.
+ * - `session_shutdown` on quit — mechanical digest, no LLM. The seatbelt.
+ */
+
+import type { Model } from "@earendil-works/pi-ai";
+import { uuidv7 } from "@earendil-works/pi-ai";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+	SessionEntry,
+} from "@earendil-works/pi-coding-agent";
+import {
+	BorderedLoader,
+	convertToLlm,
+	serializeConversation,
+	sessionEntryToContextMessages,
+} from "@earendil-works/pi-coding-agent";
+import { Box, Text } from "@earendil-works/pi-tui";
+import { type ComposeResult, composeNoteBody } from "./compose.ts";
+import { buildDigestNote } from "./digest.ts";
+import { HANDOFF_SCHEMA, type HandoffNote, writeNote } from "./notes.ts";
+import { registerReader } from "./reader.ts";
+
+export interface HandoffState {
+	/** Set by `/handoff`. Suppresses the shutdown digest, which would supersede a richer note. */
+	wroteNoteThisSession: boolean;
+}
+
+function modelLabel(ctx: ExtensionContext): string | undefined {
+	return ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+}
+
+/**
+ * Report from the shutdown path, where `ctx.ui.notify` is not enough on its own.
+ * Interactive quit stops the TUI *before* emitting `session_shutdown` — deliberately, so
+ * extension teardown cannot repaint the final frame — so a notify there paints nothing.
+ * A seatbelt that can fail silently is not a seatbelt, so failures also go to stderr,
+ * which pi itself proves still works at that point (it writes the resume hint right after).
+ */
+function reportFromShutdown(ctx: ExtensionContext, message: string, level: "info" | "warning"): void {
+	if (ctx.hasUI) ctx.ui.notify(message, level);
+	if (level === "warning") console.error(message);
+}
+
+function registerShutdownDigest(pi: ExtensionAPI, state: HandoffState): void {
+	pi.on("session_shutdown", (event, ctx) => {
+		// The event also fires for reload/new/resume/fork, which must not each drop a note.
+		if (event.reason !== "quit") return;
+		if (state.wroteNoteThisSession) return;
+
+		// Undefined for `--no-session` runs: the user asked not to be recorded, so honor it.
+		const sessionFile = ctx.sessionManager.getSessionFile();
+		if (!sessionFile) return;
+
+		try {
+			const note = buildDigestNote({
+				entries: ctx.sessionManager.getEntries(),
+				sessionId: ctx.sessionManager.getSessionId(),
+				sessionFile,
+				cwd: ctx.cwd,
+				model: modelLabel(ctx),
+				created: new Date().toISOString(),
+			});
+			if (!note) return;
+
+			const notePath = writeNote(ctx.cwd, note);
+			reportFromShutdown(ctx, `Handoff note written: ${notePath}`, "info");
+		} catch (err) {
+			// Never let a note failure interfere with pi's exit.
+			reportFromShutdown(ctx, `Handoff note failed: ${err instanceof Error ? err.message : String(err)}`, "warning");
+		}
+	});
+}
+
+/** Render the compaction-aware branch as the plain text the composer reads. */
+function serializeBranch(entries: SessionEntry[]): string {
+	return serializeConversation(convertToLlm(entries.flatMap(sessionEntryToContextMessages)));
+}
+
+/**
+ * Run the composition call, showing a cancellable loader in the TUI. Other modes just
+ * await it: they have no component surface, and `-p`/RPC callers are not watching.
+ */
+async function compose(
+	ctx: ExtensionCommandContext,
+	model: Model<any>,
+	conversationText: string,
+	goal: string,
+): Promise<ComposeResult> {
+	const run = (signal?: AbortSignal) =>
+		composeNoteBody({
+			modelRegistry: ctx.modelRegistry,
+			model,
+			conversationText,
+			goal,
+			signal,
+			sessionId: uuidv7(),
+		});
+
+	if (ctx.mode !== "tui") return run();
+
+	return ctx.ui.custom<ComposeResult>((tui, theme, _keybindings, done) => {
+		const loader = new BorderedLoader(tui, theme, "Composing handoff note...");
+		loader.onAbort = () => done({ status: "aborted" });
+		run(loader.signal)
+			.then(done)
+			// composeNoteBody reports provider failures through its result rather than by
+			// throwing, so this catches only an unexpected throw from the call itself.
+			.catch((err) => done({ status: "failed", message: err instanceof Error ? err.message : String(err) }));
+		return loader;
+	});
+}
+
+function registerHandoffCommand(pi: ExtensionAPI, state: HandoffState): void {
+	pi.registerCommand("handoff", {
+		description: "Write a handoff note for the next session",
+		handler: async (args, ctx) => {
+			const model = ctx.model;
+			if (!model) {
+				ctx.ui.notify("No model selected", "error");
+				return;
+			}
+
+			// buildContextEntries is compaction-aware; a hand-rolled branch walk would
+			// duplicate that logic and drift from it.
+			const entries = ctx.sessionManager.buildContextEntries();
+			const conversationText = serializeBranch(entries);
+			if (!conversationText.trim()) {
+				ctx.ui.notify("No conversation to hand off", "error");
+				return;
+			}
+
+			const goal = args.trim();
+			const composed = await compose(ctx, model, conversationText, goal);
+			if (composed.status === "failed") {
+				ctx.ui.notify(`Handoff composition failed: ${composed.message}`, "error");
+				return;
+			}
+			if (composed.status === "aborted") {
+				ctx.ui.notify("Handoff cancelled", "info");
+				return;
+			}
+
+			// Review is skipped where there is no dialog surface, rather than failing:
+			// automation is the point of this extension.
+			let body = composed.body;
+			if (ctx.hasUI) {
+				const edited = await ctx.ui.editor("Edit handoff note", body);
+				if (edited === undefined) {
+					ctx.ui.notify("Handoff cancelled", "info");
+					return;
+				}
+				body = edited;
+			}
+
+			const sessionFile = ctx.sessionManager.getSessionFile();
+			const note: HandoffNote = {
+				frontmatter: {
+					schema: HANDOFF_SCHEMA,
+					session_id: ctx.sessionManager.getSessionId(),
+					session_file: sessionFile,
+					cwd: ctx.cwd,
+					created: new Date().toISOString(),
+					source: "command",
+					model: modelLabel(ctx),
+					kickoff: composed.kickoff || goal || "Continue the previous session's work.",
+				},
+				body,
+			};
+
+			let notePath: string;
+			try {
+				notePath = writeNote(ctx.cwd, note);
+			} catch (err) {
+				ctx.ui.notify(`Handoff note failed: ${err instanceof Error ? err.message : String(err)}`, "error");
+				return;
+			}
+
+			state.wroteNoteThisSession = true;
+			ctx.ui.notify(`Handoff note written: ${notePath}`, "info");
+
+			if (ctx.mode !== "tui") return;
+			if (!(await ctx.ui.confirm("Handoff", "Start successor session now?"))) return;
+
+			// The successor's own session_start picks the note back up through the reader.
+			// All post-switch work must use the replacement context: the ctx captured here
+			// is invalidated once the session is replaced.
+			const result = await ctx.newSession({
+				parentSession: sessionFile,
+				withSession: async (replacementCtx) => {
+					replacementCtx.ui.notify("Handoff briefing queued for your first prompt.", "info");
+				},
+			});
+			if (result.cancelled) ctx.ui.notify("New session cancelled", "info");
+		},
+	});
+}
+
+/** Sets the injected briefing apart from the user's own first prompt in the transcript. */
+function registerMemoRenderer(pi: ExtensionAPI): void {
+	pi.registerMessageRenderer("handoff", (message, { outputPad }, theme) => {
+		const text = typeof message.content === "string" ? message.content : "";
+		const [banner, ...rest] = text.split("\n");
+		const box = new Box(outputPad, 1, (t) => theme.bg("customMessageBg", t));
+		box.addChild(new Text(`${theme.fg("accent", banner)}\n${rest.join("\n")}`, 0, 0));
+		return box;
+	});
+}
+
+export default function (pi: ExtensionAPI) {
+	const state: HandoffState = { wroteNoteThisSession: false };
+	registerReader(pi);
+	registerMemoRenderer(pi);
+	registerHandoffCommand(pi, state);
+	registerShutdownDigest(pi, state);
+}

--- a/.pi/extensions/handoff/index.ts
+++ b/.pi/extensions/handoff/index.ts
@@ -24,7 +24,7 @@ import {
 	sessionEntryToContextMessages,
 } from "@earendil-works/pi-coding-agent";
 import { Box, Text } from "@earendil-works/pi-tui";
-import { type ComposeResult, composeNoteBody } from "./compose.ts";
+import { type ComposeResult, composeNoteBody, joinKickoff, splitKickoff } from "./compose.ts";
 import { buildDigestNote } from "./digest.ts";
 import { HANDOFF_SCHEMA, type HandoffNote, writeNote } from "./notes.ts";
 import { registerReader } from "./reader.ts";
@@ -42,8 +42,15 @@ function modelLabel(ctx: ExtensionContext): string | undefined {
  * Report from the shutdown path, where `ctx.ui.notify` is not enough on its own.
  * Interactive quit stops the TUI *before* emitting `session_shutdown` — deliberately, so
  * extension teardown cannot repaint the final frame — so a notify there paints nothing.
- * A seatbelt that can fail silently is not a seatbelt, so failures also go to stderr,
- * which pi itself proves still works at that point (it writes the resume hint right after).
+ * A seatbelt that can fail silently is not a seatbelt, so failures also go to stderr.
+ *
+ * That stderr write is clean on the interactive-quit path only, and the event cannot tell
+ * the paths apart: `reason` is `"quit"` for both. On the signal path (SIGTERM/SIGHUP)
+ * `dispose()` runs *before* `stop()`, so the write can interleave with a live renderer, be
+ * dropped on exit from the alt screen, or — on a dead terminal — raise EIO, which pi turns
+ * into an immediate `process.exit(129)` that skips the rest of teardown. Accepted rather
+ * than fixed: the trigger is compound (signal shutdown *and* a failed note write), and the
+ * alternative is the silent seatbelt this exists to prevent.
  */
 function reportFromShutdown(ctx: ExtensionContext, message: string, level: "info" | "warning"): void {
 	if (ctx.hasUI) ctx.ui.notify(message, level);
@@ -62,7 +69,11 @@ function registerShutdownDigest(pi: ExtensionAPI, state: HandoffState): void {
 
 		try {
 			const note = buildDigestNote({
-				entries: ctx.sessionManager.getEntries(),
+				// The active branch, not every branch in the file. `getEntries()` is a flat
+				// append-order read, so after a `/tree` rewind it still holds the abandoned
+				// branch — and the backward scans below would hand the successor work the
+				// user explicitly rewound away from. Same reason `/handoff` uses this.
+				entries: ctx.sessionManager.buildContextEntries(),
 				sessionId: ctx.sessionManager.getSessionId(),
 				sessionFile,
 				cwd: ctx.cwd,
@@ -150,15 +161,23 @@ function registerHandoffCommand(pi: ExtensionAPI, state: HandoffState): void {
 			}
 
 			// Review is skipped where there is no dialog surface, rather than failing:
-			// automation is the point of this extension.
+			// automation is the point of this extension. Gated on `mode` rather than
+			// `hasUI`, which is also true in RPC — and pi's RPC `editor` is the one dialog
+			// with neither a timeout nor a default value, so a host that never answers
+			// would hang `/handoff` forever in the mode built to run unattended.
 			let body = composed.body;
-			if (ctx.hasUI) {
-				const edited = await ctx.ui.editor("Edit handoff note", body);
+			let kickoff = composed.kickoff;
+			if (ctx.mode === "tui") {
+				// The KICKOFF line is edited with the body, not stripped before it. It is the
+				// successor's opening prompt, so a user who rewrites "Next steps" has to be
+				// able to see and change it — otherwise the note ships a kickoff that
+				// contradicts the very section the user just corrected.
+				const edited = await ctx.ui.editor("Edit handoff note", joinKickoff(body, kickoff));
 				if (edited === undefined) {
 					ctx.ui.notify("Handoff cancelled", "info");
 					return;
 				}
-				body = edited;
+				({ body, kickoff } = splitKickoff(edited));
 			}
 
 			const sessionFile = ctx.sessionManager.getSessionFile();
@@ -171,7 +190,7 @@ function registerHandoffCommand(pi: ExtensionAPI, state: HandoffState): void {
 					created: new Date().toISOString(),
 					source: "command",
 					model: modelLabel(ctx),
-					kickoff: composed.kickoff || goal || "Continue the previous session's work.",
+					kickoff: kickoff || goal || "Continue the previous session's work.",
 				},
 				body,
 			};

--- a/.pi/extensions/handoff/notes.ts
+++ b/.pi/extensions/handoff/notes.ts
@@ -1,0 +1,334 @@
+/**
+ * Handoff note storage: types, frontmatter serialize/parse, atomic write, archive ops.
+ *
+ * Notes live in `<cwd>/.pi/handoffs/`. Pending vs consumed is encoded by location
+ * (top level vs `archive/`), never by a status field, so a crash can never leave a
+ * note in a half-consumed state.
+ *
+ * Pure + `node:fs` only. No pi imports, so this module is trivially unit-testable.
+ */
+
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+
+export const HANDOFF_SCHEMA = "pi-handoff/v1";
+
+export type HandoffSource = "command" | "digest";
+
+export interface HandoffFrontmatter {
+	schema: string;
+	session_id: string;
+	/** Absolute path to the writing session's JSONL. Absent for `--no-session` runs. */
+	session_file?: string;
+	cwd: string;
+	/** ISO 8601 timestamp. */
+	created: string;
+	source: HandoffSource;
+	model?: string;
+	/** Ready-made opening prompt for a successor session. The v2 autonomous-spawner contract. */
+	kickoff: string;
+	/** Stamped on archive: session id that ingested this note. */
+	consumed_by?: string;
+	consumed_at?: string;
+	/** Stamped on archive: filename of the note that superseded this one. */
+	superseded_by?: string;
+}
+
+export interface HandoffNote {
+	frontmatter: HandoffFrontmatter;
+	body: string;
+}
+
+/** Frontmatter keys emitted in this order; anything else is appended alphabetically. */
+const KEY_ORDER = [
+	"schema",
+	"session_id",
+	"session_file",
+	"cwd",
+	"created",
+	"source",
+	"model",
+	"kickoff",
+	"consumed_by",
+	"consumed_at",
+	"superseded_by",
+];
+
+export function handoffsDir(cwd: string): string {
+	return join(cwd, ".pi", "handoffs");
+}
+
+export function archiveDir(cwd: string): string {
+	return join(handoffsDir(cwd), "archive");
+}
+
+/**
+ * Mirror pi's session-file naming: ISO timestamp with `:`/`.` replaced by `-`, then
+ * the first 8 chars of the writing session's id. Lexicographic sort = age sort.
+ */
+export function noteFilename(created: string, sessionId: string): string {
+	return `${created.replace(/[:.]/g, "-")}_${sessionId.slice(0, 8)}.md`;
+}
+
+/**
+ * Quote a frontmatter value only when a YAML plain scalar would be ambiguous.
+ * Double-quoted YAML accepts JSON escaping, so `JSON.stringify` is a valid emitter.
+ */
+function serializeValue(value: string): string {
+	const needsQuoting =
+		value === "" ||
+		value !== value.trim() ||
+		/[\n\r\t"'#]/.test(value) ||
+		/:\s/.test(value) ||
+		value.endsWith(":") ||
+		/^[-?:,[\]{}&*!|>%@`]/.test(value);
+	return needsQuoting ? JSON.stringify(value) : value;
+}
+
+function parseValue(raw: string): string {
+	const trimmed = raw.trim();
+	if (trimmed.startsWith('"')) {
+		try {
+			const parsed: unknown = JSON.parse(trimmed);
+			if (typeof parsed === "string") return parsed;
+		} catch {
+			// Fall through to the raw value; a malformed quote is better surfaced as text
+			// than as a dropped note.
+		}
+	}
+	return trimmed;
+}
+
+export function serializeNote(note: HandoffNote): string {
+	const entries = Object.entries(note.frontmatter).filter(
+		(entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].length > 0,
+	);
+	entries.sort(([a], [b]) => {
+		const ai = KEY_ORDER.indexOf(a);
+		const bi = KEY_ORDER.indexOf(b);
+		if (ai === -1 && bi === -1) return a.localeCompare(b);
+		if (ai === -1) return 1;
+		if (bi === -1) return -1;
+		return ai - bi;
+	});
+
+	const lines = entries.map(([key, value]) => `${key}: ${serializeValue(value)}`);
+	const body = note.body.endsWith("\n") ? note.body : `${note.body}\n`;
+	return `---\n${lines.join("\n")}\n---\n\n${body}`;
+}
+
+/**
+ * Parse a note. Returns undefined when the frontmatter is missing, unterminated, or
+ * fails schema validation — callers treat that as not-pending and leave the file alone.
+ */
+export function parseNote(text: string): HandoffNote | undefined {
+	const normalized = text.startsWith("﻿") ? text.slice(1) : text;
+	const lines = normalized.split("\n");
+	if (lines[0]?.trim() !== "---") return undefined;
+
+	const closing = lines.findIndex((line, i) => i > 0 && line.trim() === "---");
+	if (closing === -1) return undefined;
+
+	const fields: Record<string, string> = {};
+	for (const line of lines.slice(1, closing)) {
+		if (line.trim() === "") continue;
+		const match = /^([A-Za-z_][A-Za-z0-9_]*):(.*)$/.exec(line);
+		if (!match) return undefined;
+		fields[match[1]] = parseValue(match[2]);
+	}
+
+	if (fields.schema !== HANDOFF_SCHEMA) return undefined;
+	if (!fields.session_id || !fields.created) return undefined;
+	if (fields.source !== "command" && fields.source !== "digest") return undefined;
+
+	const frontmatter: HandoffFrontmatter = {
+		schema: fields.schema,
+		session_id: fields.session_id,
+		cwd: fields.cwd ?? "",
+		created: fields.created,
+		source: fields.source,
+		// A hand-edited note may drop kickoff. Default it rather than discard the briefing.
+		kickoff: fields.kickoff ?? "",
+	};
+	if (fields.session_file) frontmatter.session_file = fields.session_file;
+	if (fields.model) frontmatter.model = fields.model;
+	if (fields.consumed_by) frontmatter.consumed_by = fields.consumed_by;
+	if (fields.consumed_at) frontmatter.consumed_at = fields.consumed_at;
+	if (fields.superseded_by) frontmatter.superseded_by = fields.superseded_by;
+
+	return {
+		frontmatter,
+		body: lines
+			.slice(closing + 1)
+			.join("\n")
+			.replace(/^\n+/, ""),
+	};
+}
+
+/** Write via `<name>.tmp` + rename, so no reader ever sees a half-written note. */
+export function writeFileAtomic(filePath: string, contents: string): void {
+	const tmp = `${filePath}.tmp`;
+	writeFileSync(tmp, contents, "utf8");
+	try {
+		renameSync(tmp, filePath);
+	} catch (err) {
+		try {
+			unlinkSync(tmp);
+		} catch {
+			// Best effort; the failed rename is the error worth reporting.
+		}
+		throw err;
+	}
+}
+
+// Only `.pi/handoffs/` is excluded — never all of `.pi/`, which some repos track.
+//
+// The leading double-star is load-bearing. A gitignore pattern with a separator anywhere
+// but the end is anchored to the ignore file's directory, which for `.git/info/exclude` is
+// the repo root — so a bare `.pi/handoffs/` would miss notes written when pi runs from a
+// subdirectory, which is where `<ctx.cwd>/.pi/handoffs/` puts them. One starred entry
+// covers every cwd in the repo.
+const EXCLUDE_ENTRY = "**/.pi/handoffs/";
+const EXCLUDE_COMMENT = "# pi session handoff notes (local only)";
+
+// Recognise only the starred form. A bare `.pi/handoffs/` line — what earlier runs of this
+// code wrote — does not count as satisfying the entry, so a repo carrying the old broken
+// pattern gets the working one appended rather than skipped. The stale line is a harmless
+// subset of the new one.
+function isHandoffExcludeLine(line: string): boolean {
+	return line.trim().replace(/\/$/, "") === "**/.pi/handoffs";
+}
+
+/** Linked worktrees have their own git dir but share info/exclude via `commondir`. */
+function resolveCommonGitDir(gitDir: string): string {
+	const commonDirFile = join(gitDir, "commondir");
+	if (!existsSync(commonDirFile)) return gitDir;
+	try {
+		const relative = readFileSync(commonDirFile, "utf8").trim();
+		return relative ? resolve(gitDir, relative) : gitDir;
+	} catch {
+		return gitDir;
+	}
+}
+
+/** Undefined when cwd is not inside a git repo. `.git` is a file in worktrees and submodules. */
+function findGitDir(cwd: string): string | undefined {
+	let dir = resolve(cwd);
+	for (;;) {
+		const gitPath = join(dir, ".git");
+		if (existsSync(gitPath)) {
+			const stats = statSync(gitPath);
+			if (stats.isDirectory()) return resolveCommonGitDir(gitPath);
+			if (stats.isFile()) {
+				const match = /^gitdir:\s*(.+)$/m.exec(readFileSync(gitPath, "utf8"));
+				return match ? resolveCommonGitDir(resolve(dir, match[1].trim())) : undefined;
+			}
+			return undefined;
+		}
+		const parent = dirname(dir);
+		if (parent === dir) return undefined;
+		dir = parent;
+	}
+}
+
+/**
+ * Keep handoff notes out of git status without touching the project's tracked
+ * `.gitignore` — `.git/info/exclude` is local-only and never committed. Idempotent, and
+ * a no-op outside a git repo.
+ */
+export function ensureGitExclude(cwd: string): void {
+	const gitDir = findGitDir(cwd);
+	if (!gitDir) return;
+
+	const excludePath = join(gitDir, "info", "exclude");
+	const current = existsSync(excludePath) ? readFileSync(excludePath, "utf8") : "";
+	if (current.split("\n").some(isHandoffExcludeLine)) return;
+
+	mkdirSync(join(gitDir, "info"), { recursive: true });
+	const separator = current === "" || current.endsWith("\n") ? "" : "\n";
+	appendFileSync(excludePath, `${separator}${EXCLUDE_COMMENT}\n${EXCLUDE_ENTRY}\n`);
+}
+
+/** Write a pending note into `<cwd>/.pi/handoffs/`. Returns the note's path. */
+export function writeNote(cwd: string, note: HandoffNote): string {
+	const dir = handoffsDir(cwd);
+	mkdirSync(dir, { recursive: true });
+	const filePath = join(dir, noteFilename(note.frontmatter.created, note.frontmatter.session_id));
+	writeFileAtomic(filePath, serializeNote(note));
+	try {
+		ensureGitExclude(cwd);
+	} catch {
+		// Git hygiene is a convenience; never fail a note write over it.
+	}
+	return filePath;
+}
+
+/** Pending note paths, oldest first. Archived notes and `.tmp` scratch files are excluded. */
+export function listPendingNotePaths(cwd: string): string[] {
+	const dir = handoffsDir(cwd);
+	if (!existsSync(dir)) return [];
+	let names: string[];
+	try {
+		names = readdirSync(dir, { withFileTypes: true })
+			.filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+			.map((entry) => entry.name);
+	} catch {
+		return [];
+	}
+	names.sort();
+	return names.map((name) => join(dir, name));
+}
+
+export function readNote(filePath: string): HandoffNote | undefined {
+	try {
+		return parseNote(readFileSync(filePath, "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Move a pending note into `archive/` and stamp it.
+ *
+ * The rename happens first and is the claim: when two sessions race, the loser's
+ * rename fails ENOENT and this returns false. Both sessions ingesting the same
+ * briefing is acceptable; losing it is not.
+ *
+ * Returns false when the note was already claimed or gone. A stamping failure after
+ * a successful rename still returns true — the archive move is the part that matters.
+ */
+export function archiveNote(cwd: string, notePath: string, stamp: Partial<HandoffFrontmatter>): boolean {
+	const dir = archiveDir(cwd);
+	try {
+		mkdirSync(dir, { recursive: true });
+	} catch {
+		return false;
+	}
+
+	const target = join(dir, basename(notePath));
+	try {
+		renameSync(notePath, target);
+	} catch {
+		return false;
+	}
+
+	try {
+		const note = readNote(target);
+		if (note) {
+			writeFileAtomic(target, serializeNote({ frontmatter: { ...note.frontmatter, ...stamp }, body: note.body }));
+		}
+	} catch {
+		// Archived but unstamped: audit metadata is lost, the note is not.
+	}
+	return true;
+}

--- a/.pi/extensions/handoff/reader.ts
+++ b/.pi/extensions/handoff/reader.ts
@@ -1,0 +1,120 @@
+/**
+ * Reader: detect a pending handoff note, inject it as a first-message briefing,
+ * archive it once it is actually delivered.
+ *
+ * The split between detection and archival matters. `session_start` only queues the
+ * memo; if the session is opened and quit without a prompt, the note stays pending for
+ * the next session instead of being consumed by a start nobody used.
+ */
+
+import { basename } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { archiveNote, type HandoffNote, listPendingNotePaths, readNote } from "./notes.ts";
+
+export interface PendingScan {
+	/** Newest valid pending note — the one that gets injected. */
+	ingest?: { path: string; note: HandoffNote };
+	/** Older valid pending notes, oldest first. Archived as superseded on delivery. */
+	older: string[];
+	/** Notes whose frontmatter failed to parse. Never ingested, never archived. */
+	corrupt: string[];
+}
+
+export function scanPendingNotes(cwd: string): PendingScan {
+	const scan: PendingScan = { older: [], corrupt: [] };
+	const valid: { path: string; note: HandoffNote }[] = [];
+
+	for (const path of listPendingNotePaths(cwd)) {
+		const note = readNote(path);
+		if (note) valid.push({ path, note });
+		else scan.corrupt.push(path);
+	}
+
+	// Filenames are timestamp-prefixed, so the list is already oldest-first.
+	scan.ingest = valid.pop();
+	scan.older = valid.map((entry) => entry.path);
+	return scan;
+}
+
+export function buildMemo(note: HandoffNote, olderPendingCount = 0): string {
+	const lines = [
+		`Handoff from session ${note.frontmatter.session_id.slice(0, 8)}, ended ${note.frontmatter.created}` +
+			` (${note.frontmatter.source === "command" ? "composed via /handoff" : "shutdown digest"}).`,
+		"",
+		note.body.trimEnd(),
+	];
+	if (note.frontmatter.session_file) {
+		lines.push("", `Full transcript of that session: ${note.frontmatter.session_file}`);
+	}
+	if (olderPendingCount > 0) {
+		const plural = olderPendingCount === 1 ? "note was" : "notes were";
+		lines.push(
+			"",
+			`${olderPendingCount} older pending handoff ${plural} superseded by this one and moved to .pi/handoffs/archive/.`,
+		);
+	}
+	return lines.join("\n");
+}
+
+/**
+ * Archive the notes observed at detection time — deliberately not a fresh scan. A note
+ * written after we started belongs to some other session's handoff; stamping it
+ * superseded here would swallow a briefing nobody ever read.
+ */
+export function archiveDelivered(cwd: string, scan: PendingScan, consumerSessionId: string, consumedAt: string): void {
+	if (!scan.ingest) return;
+	archiveNote(cwd, scan.ingest.path, { consumed_by: consumerSessionId, consumed_at: consumedAt });
+	const supersededBy = basename(scan.ingest.path);
+	for (const path of scan.older) {
+		archiveNote(cwd, path, { superseded_by: supersededBy });
+	}
+}
+
+function warn(ctx: ExtensionContext, message: string): void {
+	if (ctx.hasUI) ctx.ui.notify(message, "warning");
+	// Headless modes have no notification surface; stderr keeps `-p` stdout clean.
+	else console.error(message);
+}
+
+export function registerReader(pi: ExtensionAPI): void {
+	let pending: PendingScan | undefined;
+	let delivered = false;
+
+	pi.on("session_start", (event, ctx) => {
+		// resume/fork sessions carry their own live context; another session's briefing
+		// on top of it invites confusion.
+		if (event.reason !== "startup" && event.reason !== "new") return;
+
+		try {
+			const scan = scanPendingNotes(ctx.cwd);
+			for (const path of scan.corrupt) {
+				warn(ctx, `Handoff note could not be parsed, left in place: ${path}`);
+			}
+			if (!scan.ingest) return;
+
+			pending = scan;
+			pi.sendMessage(
+				{ customType: "handoff", content: buildMemo(scan.ingest.note, scan.older.length), display: true },
+				// nextTurn parks the memo until the first real prompt, so an idle session
+				// burns no LLM call and the memo lands whether that prompt comes from a
+				// human, `pi -p`, RPC, or a future autonomous spawner.
+				{ deliverAs: "nextTurn" },
+			);
+		} catch (err) {
+			warn(ctx, `Handoff detection failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	});
+
+	pi.on("before_agent_start", (_event, ctx) => {
+		if (!pending || delivered) return;
+		delivered = true;
+		const scan = pending;
+		pending = undefined;
+
+		try {
+			archiveDelivered(ctx.cwd, scan, ctx.sessionManager.getSessionId(), new Date().toISOString());
+		} catch (err) {
+			warn(ctx, `Handoff archive failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	});
+}

--- a/.pi/extensions/handoff/test/compose.test.ts
+++ b/.pi/extensions/handoff/test/compose.test.ts
@@ -1,0 +1,102 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { buildComposeUserMessage, composeNoteBody, splitKickoff } from "../compose.ts";
+
+describe("splitKickoff", () => {
+	it("splits the trailing KICKOFF line off the body", () => {
+		const text = "## Context\nWe wired the reader.\n\nKICKOFF: Wire archive-on-delivery next.";
+		expect(splitKickoff(text)).toEqual({
+			body: "## Context\nWe wired the reader.",
+			kickoff: "Wire archive-on-delivery next.",
+		});
+	});
+
+	it("tolerates trailing blank lines and a stray rule after the marker", () => {
+		const text = "## Context\nBody.\n\nKICKOFF: Do the thing.\n\n---\n\n";
+		expect(splitKickoff(text).kickoff).toBe("Do the thing.");
+	});
+
+	it("returns the whole text when the model omitted the marker", () => {
+		const text = "## Context\nBody.\n\n## Next steps\nDo the thing.";
+		expect(splitKickoff(text)).toEqual({ body: text });
+	});
+
+	it("does not treat a KICKOFF mention in the middle of the note as the marker", () => {
+		const text = "## Context\nKICKOFF: this is quoted mid-note.\n\n## Next steps\nCarry on.";
+		expect(splitKickoff(text)).toEqual({ body: text });
+	});
+
+	it("ignores a marker with no content after it", () => {
+		expect(splitKickoff("## Context\nBody.\n\nKICKOFF:").kickoff).toBeUndefined();
+	});
+});
+
+describe("buildComposeUserMessage", () => {
+	it("passes a goal through as the focus for Next steps", () => {
+		const message = buildComposeUserMessage("[User]: hi", "finish the reader");
+		expect(message).toContain("[User]: hi");
+		expect(message).toContain("finish the reader");
+		expect(message).toContain('Use this to write the "Next steps" section.');
+	});
+
+	it("asks the model to infer a next step when no goal is given", () => {
+		const message = buildComposeUserMessage("[User]: hi", "");
+		expect(message).toContain("No goal was given");
+	});
+});
+
+describe("composeNoteBody", () => {
+	/**
+	 * `complete()` resolves rather than rejecting, including on provider errors, so the
+	 * stub returns messages instead of throwing — that is the contract under test.
+	 */
+	function stubRegistry(response: Partial<AssistantMessage>): ModelRegistry {
+		return {
+			complete: async () => ({ content: [], stopReason: "stop", ...response }) as AssistantMessage,
+		} as unknown as ModelRegistry;
+	}
+
+	const options = {
+		model: {} as never,
+		conversationText: "[User]: hi",
+		goal: "",
+		sessionId: "test-session",
+	};
+
+	it("returns the composed body and kickoff on success", async () => {
+		const registry = stubRegistry({
+			content: [{ type: "text", text: "## Context\nWe did work.\n\nKICKOFF: Do the next thing." }],
+		});
+		expect(await composeNoteBody({ ...options, modelRegistry: registry })).toEqual({
+			status: "ok",
+			body: "## Context\nWe did work.",
+			kickoff: "Do the next thing.",
+		});
+	});
+
+	it("reports a provider error as failed, carrying the provider's message", async () => {
+		const registry = stubRegistry({ stopReason: "error", errorMessage: "input token count exceeds the maximum" });
+		expect(await composeNoteBody({ ...options, modelRegistry: registry })).toEqual({
+			status: "failed",
+			message: "input token count exceeds the maximum",
+		});
+	});
+
+	it("still reports a provider error when the provider gave no message", async () => {
+		const registry = stubRegistry({ stopReason: "error" });
+		const result = await composeNoteBody({ ...options, modelRegistry: registry });
+		expect(result.status).toBe("failed");
+	});
+
+	it("distinguishes an abort from a failure", async () => {
+		const registry = stubRegistry({ stopReason: "aborted" });
+		expect(await composeNoteBody({ ...options, modelRegistry: registry })).toEqual({ status: "aborted" });
+	});
+
+	it("treats an empty response as a failure, not a cancellation", async () => {
+		const registry = stubRegistry({ content: [], stopReason: "stop" });
+		const result = await composeNoteBody({ ...options, modelRegistry: registry });
+		expect(result.status).toBe("failed");
+	});
+});

--- a/.pi/extensions/handoff/test/compose.test.ts
+++ b/.pi/extensions/handoff/test/compose.test.ts
@@ -1,7 +1,7 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { buildComposeUserMessage, composeNoteBody, splitKickoff } from "../compose.ts";
+import { buildComposeUserMessage, composeNoteBody, joinKickoff, splitKickoff } from "../compose.ts";
 
 describe("splitKickoff", () => {
 	it("splits the trailing KICKOFF line off the body", () => {
@@ -29,6 +29,35 @@ describe("splitKickoff", () => {
 
 	it("ignores a marker with no content after it", () => {
 		expect(splitKickoff("## Context\nBody.\n\nKICKOFF:").kickoff).toBeUndefined();
+	});
+});
+
+describe("joinKickoff", () => {
+	// `/handoff` shows the joined document in the editor and re-splits what comes back,
+	// so the successor's opening prompt survives review only if these two are inverses.
+	it("round-trips through splitKickoff", () => {
+		const body = "## Context\nWe wired the reader.\n\n## Next steps\nDo the thing.";
+		expect(splitKickoff(joinKickoff(body, "Wire archive-on-delivery next."))).toEqual({
+			body,
+			kickoff: "Wire archive-on-delivery next.",
+		});
+	});
+
+	it("round-trips a note the model gave no kickoff for", () => {
+		const body = "## Context\nBody.";
+		expect(splitKickoff(joinKickoff(body, undefined))).toEqual({ body });
+	});
+
+	it("picks up a kickoff the user typed into a note that had none", () => {
+		const edited = `${joinKickoff("## Context\nBody.", undefined)}\n\nKICKOFF: Mine, not the model's.`;
+		expect(splitKickoff(edited).kickoff).toBe("Mine, not the model's.");
+	});
+
+	it("takes the user's rewritten kickoff, not the composed one", () => {
+		const draft = joinKickoff("## Context\nBody.", "Model's original.");
+		expect(splitKickoff(draft.replace("Model's original.", "Kyle's replacement.")).kickoff).toBe(
+			"Kyle's replacement.",
+		);
 	});
 });
 

--- a/.pi/extensions/handoff/test/digest.test.ts
+++ b/.pi/extensions/handoff/test/digest.test.ts
@@ -1,0 +1,245 @@
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import {
+	buildDigestNote,
+	collectFilesTouched,
+	firstLines,
+	hasAssistantMessage,
+	lastAssistantText,
+	lastUserText,
+	truncateChars,
+} from "../digest.ts";
+import { HANDOFF_SCHEMA } from "../notes.ts";
+
+let nextId = 0;
+
+function entry(message: unknown): SessionEntry {
+	nextId += 1;
+	return {
+		type: "message",
+		id: `e${nextId}`,
+		parentId: null,
+		timestamp: "2026-08-10T22:00:00.000Z",
+		message,
+	} as SessionEntry;
+}
+
+function user(text: string): SessionEntry {
+	return entry({ role: "user", content: [{ type: "text", text }], timestamp: 0 });
+}
+
+function assistant(content: unknown[]): SessionEntry {
+	return entry({ role: "assistant", content, timestamp: 0 });
+}
+
+function toolCall(name: string, args: Record<string, unknown>): unknown {
+	return { type: "toolCall", id: "tc", name, arguments: args };
+}
+
+const DIGEST_BASE = {
+	sessionId: "019feda9-55bc-797d",
+	sessionFile: "/sessions/019feda9.jsonl",
+	cwd: "/Users/kyle/Projects/foo",
+	model: "google/gemini-3.6-flash",
+	created: "2026-08-10T22:15:00.000Z",
+};
+
+describe("message extraction", () => {
+	it("reports whether an assistant message exists", () => {
+		expect(hasAssistantMessage([user("hi")])).toBe(false);
+		expect(hasAssistantMessage([user("hi"), assistant([{ type: "text", text: "yo" }])])).toBe(true);
+	});
+
+	it("takes the last user and last assistant message", () => {
+		const entries = [
+			user("first"),
+			assistant([{ type: "text", text: "reply one" }]),
+			user("second"),
+			assistant([{ type: "text", text: "reply two" }]),
+		];
+		expect(lastUserText(entries)).toBe("second");
+		expect(lastAssistantText(entries)).toBe("reply two");
+	});
+
+	it("handles string content and drops thinking blocks", () => {
+		const entries = [
+			entry({ role: "user", content: "plain string", timestamp: 0 }),
+			assistant([
+				{ type: "thinking", thinking: "hmm" },
+				{ type: "text", text: "visible" },
+			]),
+		];
+		expect(lastUserText(entries)).toBe("plain string");
+		expect(lastAssistantText(entries)).toBe("visible");
+	});
+
+	it("ignores custom_message entries when picking the last user message", () => {
+		const entries: SessionEntry[] = [
+			user("real prompt"),
+			{
+				type: "custom_message",
+				id: "cm1",
+				parentId: null,
+				timestamp: "2026-08-10T22:01:00.000Z",
+				customType: "handoff",
+				content: "briefing from a previous session",
+				display: true,
+			},
+			assistant([{ type: "text", text: "ok" }]),
+		];
+		expect(lastUserText(entries)).toBe("real prompt");
+	});
+
+	it("returns empty strings when nothing matches", () => {
+		expect(lastUserText([])).toBe("");
+		expect(lastAssistantText([])).toBe("");
+	});
+});
+
+describe("firstLines", () => {
+	it("returns short text untouched", () => {
+		expect(firstLines("one\ntwo", 15)).toBe("one\ntwo");
+	});
+
+	it("truncates and marks the cut", () => {
+		expect(firstLines("a\nb\nc\nd", 2)).toBe("a\nb\n...");
+	});
+});
+
+describe("truncateChars", () => {
+	it("returns short text untouched", () => {
+		expect(truncateChars("hello", 10)).toBe("hello");
+	});
+
+	it("cuts at the limit and marks the cut", () => {
+		expect(truncateChars("abcdefghij", 4)).toBe("abcd...");
+	});
+});
+
+describe("excerpt bounds in the note body", () => {
+	// The whole body is re-injected into the successor's context as a user message, so an
+	// unbounded paste at the end of one session would prefix the next session's first turn.
+	it("caps a user message that is long in lines", () => {
+		const paste = Array.from({ length: 400 }, (_, i) => `line ${i}`).join("\n");
+		const body = buildDigestNote({
+			...DIGEST_BASE,
+			entries: [user(paste), assistant([{ type: "text", text: "ok" }])],
+		})?.body as string;
+
+		expect(body).toContain("line 0");
+		expect(body).not.toContain("line 300");
+		expect(body).toContain("...");
+	});
+
+	it("caps a user message that is one enormous line", () => {
+		const paste = "x".repeat(50_000);
+		const body = buildDigestNote({
+			...DIGEST_BASE,
+			entries: [user(paste), assistant([{ type: "text", text: "ok" }])],
+		})?.body as string;
+
+		expect(body.length).toBeLessThan(4000);
+	});
+
+	it("caps an assistant reply that is one enormous line", () => {
+		const flood = "y".repeat(50_000);
+		const body = buildDigestNote({
+			...DIGEST_BASE,
+			entries: [user("hi"), assistant([{ type: "text", text: flood }])],
+		})?.body as string;
+
+		expect(body.length).toBeLessThan(4000);
+	});
+
+	it("caps the kickoff, which is a frontmatter scalar", () => {
+		const paste = `${"z".repeat(50_000)}\nsecond line`;
+		const note = buildDigestNote({
+			...DIGEST_BASE,
+			entries: [user(paste), assistant([{ type: "text", text: "ok" }])],
+		});
+
+		expect(note?.frontmatter.kickoff.length).toBeLessThan(300);
+		expect(note?.frontmatter.kickoff.startsWith("Continue: zzz")).toBe(true);
+	});
+});
+
+describe("collectFilesTouched", () => {
+	it("splits reads from modifications and dedupes", () => {
+		const entries = [
+			assistant([toolCall("read", { path: "a.ts" }), toolCall("read", { path: "b.ts" })]),
+			assistant([toolCall("read", { path: "a.ts" }), toolCall("edit", { path: "c.ts" })]),
+			assistant([toolCall("write", { path: "c.ts" })]),
+		];
+		expect(collectFilesTouched(entries)).toEqual({ read: ["a.ts", "b.ts"], modified: ["c.ts"] });
+	});
+
+	it("reports a file that was read and then written as modified only", () => {
+		const entries = [assistant([toolCall("read", { path: "a.ts" }), toolCall("write", { path: "a.ts" })])];
+		expect(collectFilesTouched(entries)).toEqual({ read: [], modified: ["a.ts"] });
+	});
+
+	it("accepts the file_path provider-compat alias", () => {
+		const entries = [assistant([toolCall("read", { file_path: "a.ts" })])];
+		expect(collectFilesTouched(entries)).toEqual({ read: ["a.ts"], modified: [] });
+	});
+
+	it("ignores tools without a path and non-file tools", () => {
+		const entries = [assistant([toolCall("bash", { command: "ls" }), toolCall("read", {})])];
+		expect(collectFilesTouched(entries)).toEqual({ read: [], modified: [] });
+	});
+});
+
+describe("buildDigestNote", () => {
+	it("returns undefined when the session produced no assistant message", () => {
+		expect(buildDigestNote({ ...DIGEST_BASE, entries: [user("hi")] })).toBeUndefined();
+	});
+
+	it("builds frontmatter with a mechanical kickoff", () => {
+		const entries = [user("Wire up the reader\nand test it"), assistant([{ type: "text", text: "Done." }])];
+		const note = buildDigestNote({ ...DIGEST_BASE, entries });
+
+		expect(note?.frontmatter).toEqual({
+			schema: HANDOFF_SCHEMA,
+			session_id: DIGEST_BASE.sessionId,
+			session_file: DIGEST_BASE.sessionFile,
+			cwd: DIGEST_BASE.cwd,
+			created: DIGEST_BASE.created,
+			source: "digest",
+			model: DIGEST_BASE.model,
+			kickoff: "Continue: Wire up the reader",
+		});
+	});
+
+	it("carries the last exchange and files touched into the body", () => {
+		const entries = [
+			user("Refactor notes.ts"),
+			assistant([toolCall("read", { path: "notes.ts" }), toolCall("edit", { path: "notes.ts" })]),
+			assistant([{ type: "text", text: "Refactored the parser." }]),
+		];
+		const body = buildDigestNote({ ...DIGEST_BASE, entries })?.body ?? "";
+
+		expect(body).toContain("- modified: notes.ts");
+		expect(body).not.toContain("- read:");
+		expect(body).toContain("**User:** Refactor notes.ts");
+		expect(body).toContain("**Assistant:** Refactored the parser.");
+		expect(body).toContain("Pick up from the last request: Refactor notes.ts");
+	});
+
+	it("reports no files when none were touched", () => {
+		const entries = [user("Explain the design"), assistant([{ type: "text", text: "It is a dead drop." }])];
+		expect(buildDigestNote({ ...DIGEST_BASE, entries })?.body).toContain("- none recorded");
+	});
+
+	it("falls back to a generic kickoff when no user message was recorded", () => {
+		const entries = [assistant([{ type: "text", text: "Auto-started." }])];
+		expect(buildDigestNote({ ...DIGEST_BASE, entries })?.frontmatter.kickoff).toBe(
+			"Continue the previous session's work.",
+		);
+	});
+
+	it("omits the model field when no model is set", () => {
+		const entries = [user("hi"), assistant([{ type: "text", text: "hello" }])];
+		const note = buildDigestNote({ ...DIGEST_BASE, model: undefined, entries });
+		expect(note?.frontmatter.model).toBeUndefined();
+	});
+});

--- a/.pi/extensions/handoff/test/notes.test.ts
+++ b/.pi/extensions/handoff/test/notes.test.ts
@@ -1,0 +1,314 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	archiveDir,
+	archiveNote,
+	ensureGitExclude,
+	HANDOFF_SCHEMA,
+	type HandoffNote,
+	handoffsDir,
+	listPendingNotePaths,
+	noteFilename,
+	parseNote,
+	readNote,
+	serializeNote,
+	writeNote,
+} from "../notes.ts";
+
+function sampleNote(overrides: Partial<HandoffNote["frontmatter"]> = {}): HandoffNote {
+	return {
+		frontmatter: {
+			schema: HANDOFF_SCHEMA,
+			session_id: "019feda9-55bc-797d-8b97-4fe03f430270",
+			session_file: "/Users/kyle/.pi/agent/sessions/--p--/2026-08-10T21-52-05-564Z_019feda9.jsonl",
+			cwd: "/Users/kyle/Projects/foo",
+			created: "2026-08-10T22:15:00.000Z",
+			source: "digest",
+			model: "google/gemini-3.6-flash",
+			kickoff: "Continue implementing the reader module",
+			...overrides,
+		},
+		body: "## Context\nWhat we were doing.\n\n## Next steps\nWire archive-on-delivery.\n",
+	};
+}
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "pi-handoff-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("serialize/parse round-trip", () => {
+	it("preserves every frontmatter field and the body", () => {
+		const note = sampleNote();
+		const parsed = parseNote(serializeNote(note));
+		expect(parsed).toEqual(note);
+	});
+
+	it("survives a kickoff containing a colon, quotes, and a hash", () => {
+		const kickoff = 'Fix: the "reader" module # not a comment';
+		const parsed = parseNote(serializeNote(sampleNote({ kickoff })));
+		expect(parsed?.frontmatter.kickoff).toBe(kickoff);
+	});
+
+	it("survives a kickoff containing a newline", () => {
+		const kickoff = "First line\nSecond line";
+		const parsed = parseNote(serializeNote(sampleNote({ kickoff })));
+		expect(parsed?.frontmatter.kickoff).toBe(kickoff);
+	});
+
+	it("keeps a body that contains its own --- separators", () => {
+		const note = sampleNote();
+		note.body = "## Context\n\n---\n\nA horizontal rule above.\n";
+		const parsed = parseNote(serializeNote(note));
+		expect(parsed?.body).toBe(note.body);
+	});
+
+	it("omits optional fields that are absent", () => {
+		const note = sampleNote();
+		delete note.frontmatter.model;
+		delete note.frontmatter.session_file;
+		const text = serializeNote(note);
+		expect(text).not.toContain("model:");
+		expect(text).not.toContain("session_file:");
+		expect(parseNote(text)).toEqual(note);
+	});
+
+	it("emits plain scalars for ordinary values", () => {
+		expect(serializeNote(sampleNote())).toContain("created: 2026-08-10T22:15:00.000Z");
+	});
+
+	it("emits frontmatter in the documented key order", () => {
+		const keys = serializeNote(sampleNote())
+			.split("\n")
+			.slice(1, 9)
+			.map((line) => line.split(":")[0]);
+		expect(keys).toEqual(["schema", "session_id", "session_file", "cwd", "created", "source", "model", "kickoff"]);
+	});
+});
+
+describe("parseNote rejection", () => {
+	it("rejects a file with no frontmatter", () => {
+		expect(parseNote("just a body\n")).toBeUndefined();
+	});
+
+	it("rejects unterminated frontmatter", () => {
+		expect(parseNote(`---\nschema: ${HANDOFF_SCHEMA}\nsession_id: a\n`)).toBeUndefined();
+	});
+
+	it("rejects an unknown schema", () => {
+		expect(parseNote(serializeNote(sampleNote({ schema: "pi-handoff/v2" })))).toBeUndefined();
+	});
+
+	it("rejects an unknown source", () => {
+		const text = serializeNote(sampleNote()).replace("source: digest", "source: telepathy");
+		expect(parseNote(text)).toBeUndefined();
+	});
+
+	it("rejects a malformed frontmatter line", () => {
+		const text = serializeNote(sampleNote()).replace("cwd: ", "cwd ");
+		expect(parseNote(text)).toBeUndefined();
+	});
+
+	it("defaults a missing kickoff rather than discarding the note", () => {
+		const text = serializeNote(sampleNote()).replace(/^kickoff:.*\n/m, "");
+		expect(parseNote(text)?.frontmatter.kickoff).toBe("");
+	});
+});
+
+describe("noteFilename", () => {
+	it("mirrors pi session-file naming and truncates the session id", () => {
+		expect(noteFilename("2026-08-10T22:15:00.000Z", "019feda9-55bc-797d")).toBe(
+			"2026-08-10T22-15-00-000Z_019feda9.md",
+		);
+	});
+});
+
+describe("writeNote / listPendingNotePaths", () => {
+	it("writes into .pi/handoffs and reads back identically", () => {
+		const note = sampleNote();
+		const path = writeNote(dir, note);
+		expect(path).toBe(join(handoffsDir(dir), noteFilename(note.frontmatter.created, note.frontmatter.session_id)));
+		expect(readNote(path)).toEqual(note);
+	});
+
+	it("returns an empty list when the directory does not exist", () => {
+		expect(listPendingNotePaths(dir)).toEqual([]);
+	});
+
+	it("sorts oldest first and ignores archive/ and .tmp leftovers", () => {
+		writeNote(dir, sampleNote({ created: "2026-08-10T22:15:00.000Z", session_id: "bbbbbbbb" }));
+		writeNote(dir, sampleNote({ created: "2026-08-09T10:00:00.000Z", session_id: "aaaaaaaa" }));
+		mkdirSync(archiveDir(dir), { recursive: true });
+		writeFileSync(join(archiveDir(dir), "2026-01-01T00-00-00-000Z_cccccccc.md"), "archived");
+		writeFileSync(join(handoffsDir(dir), "2026-08-11T00-00-00-000Z_dddddddd.md.tmp"), "half-written");
+
+		expect(listPendingNotePaths(dir).map((p) => p.split("/").pop())).toEqual([
+			"2026-08-09T10-00-00-000Z_aaaaaaaa.md",
+			"2026-08-10T22-15-00-000Z_bbbbbbbb.md",
+		]);
+	});
+
+	it("leaves no .tmp file behind after a write", () => {
+		const path = writeNote(dir, sampleNote());
+		expect(existsSync(`${path}.tmp`)).toBe(false);
+	});
+});
+
+describe("ensureGitExclude", () => {
+	const excludeOf = (repo: string) => join(repo, ".git", "info", "exclude");
+	const git = (repo: string, ...args: string[]) =>
+		spawnSync("git", args, { cwd: repo, env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1" }, encoding: "utf8" });
+	/** `git check-ignore` exits 1 for a path that is not ignored. */
+	const isIgnored = (repo: string, relativePath: string) => git(repo, "check-ignore", relativePath).status === 0;
+
+	it("does nothing outside a git repo", () => {
+		ensureGitExclude(dir);
+		expect(existsSync(join(dir, ".git"))).toBe(false);
+	});
+
+	it("appends the entry, creating info/exclude when absent", () => {
+		mkdirSync(join(dir, ".git"), { recursive: true });
+		ensureGitExclude(dir);
+
+		const contents = readFileSync(excludeOf(dir), "utf8");
+		expect(contents).toContain(".pi/handoffs/");
+		expect(contents).toContain("# pi session handoff notes (local only)");
+		// Never all of .pi/, which some repos track.
+		expect(contents.split("\n").some((line) => line.trim() === ".pi/")).toBe(false);
+	});
+
+	it("is idempotent", () => {
+		mkdirSync(join(dir, ".git", "info"), { recursive: true });
+		writeFileSync(excludeOf(dir), "# git ls-files --others --exclude-from=.git/info/exclude\nbuild/\n");
+		ensureGitExclude(dir);
+		const once = readFileSync(excludeOf(dir), "utf8");
+		ensureGitExclude(dir);
+
+		expect(readFileSync(excludeOf(dir), "utf8")).toBe(once);
+		expect(once).toContain("build/");
+		expect(once.match(/\.pi\/handoffs\//g)).toHaveLength(1);
+	});
+
+	it("recognises an existing entry written without a trailing slash", () => {
+		mkdirSync(join(dir, ".git", "info"), { recursive: true });
+		writeFileSync(excludeOf(dir), "**/.pi/handoffs\n");
+		ensureGitExclude(dir);
+		expect(readFileSync(excludeOf(dir), "utf8")).toBe("**/.pi/handoffs\n");
+	});
+
+	it("does not glue the entry onto an unterminated last line", () => {
+		mkdirSync(join(dir, ".git", "info"), { recursive: true });
+		writeFileSync(excludeOf(dir), "build/");
+		ensureGitExclude(dir);
+		expect(readFileSync(excludeOf(dir), "utf8").split("\n")[0]).toBe("build/");
+	});
+
+	it("actually ignores notes, from the repo root and from a subdirectory", () => {
+		// Asserts ignore-status via git itself, not the presence of a string: a pattern with
+		// a mid-string separator is anchored to the repo root, so a bare `.pi/handoffs/`
+		// passes a substring check while leaving subdirectory notes untracked-and-visible.
+		const repo = join(dir, "repo");
+		mkdirSync(repo, { recursive: true });
+		expect(git(repo, "init", "-q").status).toBe(0);
+
+		const nested = join(repo, "packages", "thing");
+		mkdirSync(join(nested, ".pi", "handoffs"), { recursive: true });
+		mkdirSync(join(repo, ".pi", "handoffs"), { recursive: true });
+		writeFileSync(join(repo, ".pi", "handoffs", "root.md"), "x");
+		writeFileSync(join(nested, ".pi", "handoffs", "nested.md"), "x");
+
+		ensureGitExclude(nested);
+
+		expect(isIgnored(repo, ".pi/handoffs/root.md")).toBe(true);
+		expect(isIgnored(repo, "packages/thing/.pi/handoffs/nested.md")).toBe(true);
+	});
+
+	it("never excludes all of .pi, which some repos track", () => {
+		const repo = join(dir, "repo");
+		mkdirSync(repo, { recursive: true });
+		expect(git(repo, "init", "-q").status).toBe(0);
+		mkdirSync(join(repo, ".pi", "extensions"), { recursive: true });
+		writeFileSync(join(repo, ".pi", "extensions", "thing.ts"), "x");
+
+		ensureGitExclude(repo);
+		expect(isIgnored(repo, ".pi/extensions/thing.ts")).toBe(false);
+	});
+
+	it("adds the working pattern to a repo carrying only the old root-anchored one", () => {
+		mkdirSync(join(dir, ".git", "info"), { recursive: true });
+		writeFileSync(excludeOf(dir), ".pi/handoffs/\n");
+		ensureGitExclude(dir);
+		expect(readFileSync(excludeOf(dir), "utf8")).toContain("**/.pi/handoffs/");
+	});
+
+	it("follows a .git file to the real git dir, as in worktrees and submodules", () => {
+		const gitDir = join(dir, "real-git-dir");
+		mkdirSync(gitDir, { recursive: true });
+		const workTree = join(dir, "worktree");
+		mkdirSync(workTree, { recursive: true });
+		writeFileSync(join(workTree, ".git"), `gitdir: ${gitDir}\n`);
+
+		ensureGitExclude(workTree);
+		expect(readFileSync(join(gitDir, "info", "exclude"), "utf8")).toContain(".pi/handoffs/");
+	});
+
+	it("writes to the shared common dir when the worktree declares one", () => {
+		const commonDir = join(dir, "main.git");
+		mkdirSync(commonDir, { recursive: true });
+		const linkedGitDir = join(commonDir, "worktrees", "feature");
+		mkdirSync(linkedGitDir, { recursive: true });
+		writeFileSync(join(linkedGitDir, "commondir"), "../..\n");
+		const workTree = join(dir, "feature");
+		mkdirSync(workTree, { recursive: true });
+		writeFileSync(join(workTree, ".git"), `gitdir: ${linkedGitDir}\n`);
+
+		ensureGitExclude(workTree);
+		expect(readFileSync(join(commonDir, "info", "exclude"), "utf8")).toContain(".pi/handoffs/");
+		expect(existsSync(join(linkedGitDir, "info", "exclude"))).toBe(false);
+	});
+
+	it("runs as part of writing a note", () => {
+		mkdirSync(join(dir, ".git"), { recursive: true });
+		writeNote(dir, sampleNote());
+		expect(readFileSync(excludeOf(dir), "utf8")).toContain(".pi/handoffs/");
+	});
+});
+
+describe("archiveNote", () => {
+	it("moves the note into archive/ and stamps it", () => {
+		const path = writeNote(dir, sampleNote());
+		const stamped = archiveNote(dir, path, { consumed_by: "successor-id", consumed_at: "2026-08-11T09:00:00.000Z" });
+
+		expect(stamped).toBe(true);
+		expect(existsSync(path)).toBe(false);
+		const archived = readNote(join(archiveDir(dir), path.split("/").pop() as string));
+		expect(archived?.frontmatter.consumed_by).toBe("successor-id");
+		expect(archived?.frontmatter.consumed_at).toBe("2026-08-11T09:00:00.000Z");
+		expect(archived?.body).toBe(sampleNote().body);
+	});
+
+	it("returns false when another session already claimed the note", () => {
+		const path = writeNote(dir, sampleNote());
+		expect(archiveNote(dir, path, { consumed_by: "first" })).toBe(true);
+		expect(archiveNote(dir, path, { consumed_by: "second" })).toBe(false);
+		expect(readNote(join(archiveDir(dir), path.split("/").pop() as string))?.frontmatter.consumed_by).toBe("first");
+	});
+
+	it("still archives a note whose frontmatter cannot be parsed", () => {
+		mkdirSync(handoffsDir(dir), { recursive: true });
+		const path = join(handoffsDir(dir), "2026-08-10T22-15-00-000Z_corrupt0.md");
+		writeFileSync(path, "not a note");
+
+		expect(archiveNote(dir, path, { superseded_by: "newer.md" })).toBe(true);
+		expect(existsSync(path)).toBe(false);
+		expect(readFileSync(join(archiveDir(dir), "2026-08-10T22-15-00-000Z_corrupt0.md"), "utf8")).toBe("not a note");
+	});
+});

--- a/.pi/extensions/handoff/test/notes.test.ts
+++ b/.pi/extensions/handoff/test/notes.test.ts
@@ -164,8 +164,23 @@ describe("writeNote / listPendingNotePaths", () => {
 
 describe("ensureGitExclude", () => {
 	const excludeOf = (repo: string) => join(repo, ".git", "info", "exclude");
+	/**
+	 * A git environment isolated from the developer's machine, so these assertions test
+	 * `ensureGitExclude` and nothing else. `GIT_CONFIG_NOSYSTEM` suppresses only
+	 * /etc/gitconfig: `core.excludesFile` from ~/.gitconfig still reaches `git check-ignore`,
+	 * where a global `.pi/` entry fails the negative assertion on correct code and a global
+	 * `*.md` makes the positive ones pass no matter what was written. The GIT_DIR family is
+	 * cleared so a run under a git hook or `git rebase --exec` cannot aim git at the outer repo.
+	 */
+	const gitEnv = (): NodeJS.ProcessEnv => {
+		const env: NodeJS.ProcessEnv = { ...process.env, GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null" };
+		delete env.GIT_DIR;
+		delete env.GIT_WORK_TREE;
+		delete env.GIT_INDEX_FILE;
+		return env;
+	};
 	const git = (repo: string, ...args: string[]) =>
-		spawnSync("git", args, { cwd: repo, env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1" }, encoding: "utf8" });
+		spawnSync("git", args, { cwd: repo, env: gitEnv(), encoding: "utf8" });
 	/** `git check-ignore` exits 1 for a path that is not ignored. */
 	const isIgnored = (repo: string, relativePath: string) => git(repo, "check-ignore", relativePath).status === 0;
 

--- a/.pi/extensions/handoff/test/reader-wiring.test.ts
+++ b/.pi/extensions/handoff/test/reader-wiring.test.ts
@@ -1,0 +1,169 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	BeforeAgentStartEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	SessionStartEvent,
+} from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { archiveDir, HANDOFF_SCHEMA, type HandoffNote, handoffsDir, readNote, writeNote } from "../notes.ts";
+import { registerReader } from "../reader.ts";
+
+type SentMessage = {
+	message: { customType: string; content: unknown; display: boolean };
+	options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" };
+};
+
+/**
+ * Minimal stand-in for the parts of ExtensionAPI/ExtensionContext the reader touches.
+ * The wiring is what these tests cover: which events act, and in which order.
+ */
+function harness(cwd: string, sessionId = "successor-session") {
+	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => unknown>();
+	const sent: SentMessage[] = [];
+	const warnings: string[] = [];
+
+	const pi = {
+		on: (event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => {
+			handlers.set(event, handler);
+		},
+		sendMessage: (message: SentMessage["message"], options?: SentMessage["options"]) => {
+			sent.push({ message, options });
+		},
+	} as unknown as ExtensionAPI;
+
+	const ctx = {
+		cwd,
+		hasUI: true,
+		ui: { notify: (message: string) => warnings.push(message) },
+		sessionManager: { getSessionId: () => sessionId },
+	} as unknown as ExtensionContext;
+
+	registerReader(pi);
+
+	return {
+		sent,
+		warnings,
+		sessionStart: async (reason: SessionStartEvent["reason"]) => {
+			await handlers.get("session_start")?.({ type: "session_start", reason } satisfies SessionStartEvent, ctx);
+		},
+		beforeAgentStart: async () => {
+			await handlers.get("before_agent_start")?.({ type: "before_agent_start" } as BeforeAgentStartEvent, ctx);
+		},
+	};
+}
+
+function note(overrides: Partial<HandoffNote["frontmatter"]> = {}): HandoffNote {
+	return {
+		frontmatter: {
+			schema: HANDOFF_SCHEMA,
+			session_id: "019feda9-55bc-797d",
+			cwd: "/Users/kyle/Projects/foo",
+			created: "2026-08-10T22:15:00.000Z",
+			source: "digest",
+			kickoff: "Continue: wire the reader",
+			...overrides,
+		},
+		body: "## Context\nWe wired notes.ts.\n",
+	};
+}
+
+let dir: string;
+let notePath: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "pi-handoff-wiring-"));
+	notePath = writeNote(dir, note());
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("reader wiring", () => {
+	it("queues the memo for the next turn without consuming the note", async () => {
+		const h = harness(dir);
+		await h.sessionStart("startup");
+
+		expect(h.sent).toHaveLength(1);
+		expect(h.sent[0].message.customType).toBe("handoff");
+		expect(h.sent[0].message.display).toBe(true);
+		expect(h.sent[0].options?.deliverAs).toBe("nextTurn");
+		expect(h.sent[0].message.content).toContain("We wired notes.ts.");
+		// Detection must not consume: a start nobody prompts should leave the briefing.
+		expect(existsSync(notePath)).toBe(true);
+	});
+
+	it("leaves the note pending when the session is opened and quit without a prompt", async () => {
+		const h = harness(dir);
+		await h.sessionStart("startup");
+		expect(existsSync(notePath)).toBe(true);
+		expect(existsSync(archiveDir(dir))).toBe(false);
+	});
+
+	it("archives on the first prompt, stamped with the consuming session", async () => {
+		const h = harness(dir, "019fee63-consumer");
+		await h.sessionStart("startup");
+		await h.beforeAgentStart();
+
+		expect(existsSync(notePath)).toBe(false);
+		const archived = readNote(join(archiveDir(dir), notePath.split("/").pop() as string));
+		expect(archived?.frontmatter.consumed_by).toBe("019fee63-consumer");
+		expect(archived?.frontmatter.consumed_at).toBeTruthy();
+	});
+
+	it("does nothing on later prompts", async () => {
+		const h = harness(dir);
+		await h.sessionStart("startup");
+		await h.beforeAgentStart();
+		writeNote(dir, note({ created: "2026-08-11T08:00:00.000Z", session_id: "dddddddd" }));
+		await h.beforeAgentStart();
+
+		// The note that arrived after delivery is untouched.
+		expect(existsSync(join(handoffsDir(dir), "2026-08-11T08-00-00-000Z_dddddddd.md"))).toBe(true);
+	});
+
+	it("acts on a new session, since /handoff can spawn its own successor", async () => {
+		const h = harness(dir);
+		await h.sessionStart("new");
+		expect(h.sent).toHaveLength(1);
+	});
+
+	it.each(["resume", "fork", "reload"] as const)("ignores %s starts, which carry live context", async (reason) => {
+		const h = harness(dir);
+		await h.sessionStart(reason);
+		expect(h.sent).toHaveLength(0);
+
+		await h.beforeAgentStart();
+		expect(existsSync(notePath)).toBe(true);
+	});
+
+	it("stays silent when there is nothing pending", async () => {
+		rmSync(notePath);
+		const h = harness(dir);
+		await h.sessionStart("startup");
+		await h.beforeAgentStart();
+
+		expect(h.sent).toHaveLength(0);
+		expect(h.warnings).toHaveLength(0);
+		expect(existsSync(archiveDir(dir))).toBe(false);
+	});
+
+	it("warns about an unreadable note and leaves it alone", async () => {
+		rmSync(notePath);
+		mkdirSync(handoffsDir(dir), { recursive: true });
+		const corrupt = join(handoffsDir(dir), "2026-08-11T00-00-00-000Z_zzzzzzzz.md");
+		writeFileSync(corrupt, "not a note");
+
+		const h = harness(dir);
+		await h.sessionStart("startup");
+		await h.beforeAgentStart();
+
+		expect(h.sent).toHaveLength(0);
+		expect(h.warnings).toHaveLength(1);
+		expect(h.warnings[0]).toContain("could not be parsed");
+		expect(existsSync(corrupt)).toBe(true);
+	});
+});

--- a/.pi/extensions/handoff/test/reader.test.ts
+++ b/.pi/extensions/handoff/test/reader.test.ts
@@ -1,0 +1,150 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { archiveDir, HANDOFF_SCHEMA, type HandoffNote, handoffsDir, readNote, writeNote } from "../notes.ts";
+import { archiveDelivered, buildMemo, scanPendingNotes } from "../reader.ts";
+
+function note(overrides: Partial<HandoffNote["frontmatter"]> = {}): HandoffNote {
+	return {
+		frontmatter: {
+			schema: HANDOFF_SCHEMA,
+			session_id: "019feda9-55bc-797d",
+			session_file: "/sessions/019feda9.jsonl",
+			cwd: "/Users/kyle/Projects/foo",
+			created: "2026-08-10T22:15:00.000Z",
+			source: "digest",
+			model: "google/gemini-3.6-flash",
+			kickoff: "Continue: wire the reader",
+			...overrides,
+		},
+		body: "## Context\nWe wired notes.ts.\n\n## Next steps\nWire the reader.\n",
+	};
+}
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "pi-handoff-reader-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("scanPendingNotes", () => {
+	it("returns nothing when there are no notes", () => {
+		expect(scanPendingNotes(dir)).toEqual({ older: [], corrupt: [] });
+	});
+
+	it("ingests the newest note and lists the rest as older, oldest first", () => {
+		writeNote(dir, note({ created: "2026-08-08T10:00:00.000Z", session_id: "aaaaaaaa" }));
+		writeNote(dir, note({ created: "2026-08-10T22:15:00.000Z", session_id: "cccccccc" }));
+		writeNote(dir, note({ created: "2026-08-09T10:00:00.000Z", session_id: "bbbbbbbb" }));
+
+		const scan = scanPendingNotes(dir);
+		expect(scan.ingest?.note.frontmatter.session_id).toBe("cccccccc");
+		expect(scan.older.map((p) => basename(p))).toEqual([
+			"2026-08-08T10-00-00-000Z_aaaaaaaa.md",
+			"2026-08-09T10-00-00-000Z_bbbbbbbb.md",
+		]);
+		expect(scan.corrupt).toEqual([]);
+	});
+
+	it("reports an unparseable note as corrupt instead of ingesting it", () => {
+		mkdirSync(handoffsDir(dir), { recursive: true });
+		writeFileSync(join(handoffsDir(dir), "2026-08-11T00-00-00-000Z_zzzzzzzz.md"), "not a note");
+		writeNote(dir, note({ created: "2026-08-10T22:15:00.000Z", session_id: "cccccccc" }));
+
+		const scan = scanPendingNotes(dir);
+		expect(scan.ingest?.note.frontmatter.session_id).toBe("cccccccc");
+		expect(scan.corrupt.map((p) => basename(p))).toEqual(["2026-08-11T00-00-00-000Z_zzzzzzzz.md"]);
+		expect(scan.older).toEqual([]);
+	});
+
+	it("ignores already-archived notes", () => {
+		writeNote(dir, note());
+		archiveDelivered(dir, scanPendingNotes(dir), "consumer", "2026-08-11T09:00:00.000Z");
+		expect(scanPendingNotes(dir)).toEqual({ older: [], corrupt: [] });
+	});
+});
+
+describe("buildMemo", () => {
+	it("leads with a banner naming the source session and how the note was made", () => {
+		const memo = buildMemo(note());
+		expect(memo.split("\n")[0]).toBe(
+			"Handoff from session 019feda9, ended 2026-08-10T22:15:00.000Z (shutdown digest).",
+		);
+	});
+
+	it("labels a /handoff-composed note differently", () => {
+		expect(buildMemo(note({ source: "command" })).split("\n")[0]).toContain("(composed via /handoff)");
+	});
+
+	it("carries the note body and a transcript pointer", () => {
+		const memo = buildMemo(note());
+		expect(memo).toContain("## Next steps\nWire the reader.");
+		expect(memo).toContain("Full transcript of that session: /sessions/019feda9.jsonl");
+	});
+
+	it("omits the transcript pointer when the note has no session file", () => {
+		const withoutFile = note();
+		delete withoutFile.frontmatter.session_file;
+		expect(buildMemo(withoutFile)).not.toContain("Full transcript");
+	});
+
+	it("says nothing about older notes when there are none", () => {
+		expect(buildMemo(note())).not.toContain("older pending");
+	});
+
+	it("mentions older superseded notes, in the right number", () => {
+		expect(buildMemo(note(), 1)).toContain("1 older pending handoff note was superseded by this one");
+		expect(buildMemo(note(), 3)).toContain("3 older pending handoff notes were superseded by this one");
+	});
+});
+
+describe("archiveDelivered", () => {
+	it("stamps the ingested note consumed and the older ones superseded", () => {
+		writeNote(dir, note({ created: "2026-08-09T10:00:00.000Z", session_id: "aaaaaaaa" }));
+		writeNote(dir, note({ created: "2026-08-10T22:15:00.000Z", session_id: "cccccccc" }));
+
+		const scan = scanPendingNotes(dir);
+		archiveDelivered(dir, scan, "successor-session", "2026-08-11T09:00:00.000Z");
+
+		const ingested = readNote(join(archiveDir(dir), "2026-08-10T22-15-00-000Z_cccccccc.md"));
+		expect(ingested?.frontmatter.consumed_by).toBe("successor-session");
+		expect(ingested?.frontmatter.consumed_at).toBe("2026-08-11T09:00:00.000Z");
+		expect(ingested?.frontmatter.superseded_by).toBeUndefined();
+
+		const older = readNote(join(archiveDir(dir), "2026-08-09T10-00-00-000Z_aaaaaaaa.md"));
+		expect(older?.frontmatter.superseded_by).toBe("2026-08-10T22-15-00-000Z_cccccccc.md");
+		expect(older?.frontmatter.consumed_by).toBeUndefined();
+	});
+
+	it("leaves corrupt notes pending", () => {
+		mkdirSync(handoffsDir(dir), { recursive: true });
+		const corrupt = join(handoffsDir(dir), "2026-08-11T00-00-00-000Z_zzzzzzzz.md");
+		writeFileSync(corrupt, "not a note");
+		writeNote(dir, note());
+
+		archiveDelivered(dir, scanPendingNotes(dir), "successor-session", "2026-08-11T09:00:00.000Z");
+		expect(existsSync(corrupt)).toBe(true);
+	});
+
+	it("does nothing when there was no note to ingest", () => {
+		archiveDelivered(dir, { older: [], corrupt: [] }, "successor-session", "2026-08-11T09:00:00.000Z");
+		expect(existsSync(archiveDir(dir))).toBe(false);
+	});
+
+	it("archives only the snapshot, leaving a note written after detection pending", () => {
+		writeNote(dir, note({ created: "2026-08-10T22:15:00.000Z", session_id: "cccccccc" }));
+		const scan = scanPendingNotes(dir);
+		writeNote(dir, note({ created: "2026-08-11T08:00:00.000Z", session_id: "dddddddd" }));
+
+		archiveDelivered(dir, scan, "successor-session", "2026-08-11T09:00:00.000Z");
+
+		const stillPending = scanPendingNotes(dir);
+		expect(stillPending.ingest?.note.frontmatter.session_id).toBe("dddddddd");
+		expect(stillPending.older).toEqual([]);
+	});
+});

--- a/.pi/extensions/handoff/tsconfig.json
+++ b/.pi/extensions/handoff/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"types": ["node", "vitest/globals"]
+	},
+	// The ambient declaration is not reachable by import, only by inclusion; without it
+	// pi's own syntax-highlight.ts fails to typecheck when pulled in transitively.
+	"include": ["**/*.ts", "../../../packages/coding-agent/src/utils/highlight-js-lib-index.d.ts"]
+}

--- a/.pi/extensions/handoff/vitest.config.ts
+++ b/.pi/extensions/handoff/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// Standalone config: this extension lives outside packages/, so no workspace vitest
+// project picks it up. Run from the repo root with:
+//   node node_modules/vitest/dist/cli.js --run --config .pi/extensions/handoff/vitest.config.ts
+//
+// No workspace aliases are needed: notes.ts, digest.ts, reader.ts, and compose.ts import
+// pi types only, so nothing here pulls pi's runtime module graph into the test process.
+export default defineConfig({
+	root: fileURLToPath(new URL(".", import.meta.url)),
+	test: {
+		environment: "node",
+		include: ["test/**/*.test.ts"],
+		reporters: ["dot"],
+	},
+});


### PR DESCRIPTION
Clears the six nice-to-have findings carried as `FOLLOW-UP` from the v1 adversarial review (mailbox: `~/.claude/reviews/pi/2026-08-10-feat-handoff-extension.md`). No `should-fix` or `critical` findings were outstanding — F1–F4 were fixed and verified in `05bed6d` before v1 merged.

Two of these were Kyle's calls, asked before any code was written:
- **F8** → own CI workflow file (not a wire-in to shared `biome.json`/`tsconfig.json`/`ci.yml`), so upstream rebases stay clean.
- **F9** → correct the docstring, accept the residual. No behavior change.

## Findings addressed

| ID | Grade | Fix |
|---|---|---|
| F10 | nice-to-have | Exclude tests no longer inherit the developer's global git config |
| F5 | nice-to-have | Shutdown digest uses the branch-aware `buildContextEntries()` |
| F6 | nice-to-have | `KICKOFF:` line is editable, not stripped before review |
| F7 | nice-to-have | Editor review gated on `mode === "tui"`, not `hasUI` |
| F8 | nice-to-have | Dedicated CI workflow so the suite can fail a push |
| F9 | nice-to-have | Docstring corrected to match both shutdown paths |

### F10 — test isolation
`GIT_CONFIG_NOSYSTEM` suppresses only `/etc/gitconfig`. `core.excludesFile` from `~/.gitconfig` still reached `git check-ignore`, so a global `.pi/` entry would fail the negative assertion **on correct code**, and a global `*.md` would make the positive assertions pass regardless of what `ensureGitExclude` wrote — the vacuous-assertion mode the F2 rewrite existed to kill. Adds `GIT_CONFIG_GLOBAL=/dev/null` and clears `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`. This became load-bearing once F8 put the suite on CI runners whose git config we don't control.

### F5 — branch-aware digest
`getEntries()` is a flat append-order read of every branch. After a `/tree` rewind, the digest's backward scans returned the abandoned branch — so "Pick up from the last request" and `kickoff` both pointed at work the user had explicitly rewound away from. Now uses the same compaction-aware walk `/handoff` already used.

### F6 — editable kickoff
`splitKickoff` ran *before* `ctx.ui.editor`, so the field DESIGN.md calls the v2 spawner contract was the one field human review could not touch: rewrite "Next steps" and the note still shipped the model's original kickoff. The line now goes into the editor with the body and is re-split after. `joinKickoff()` is added as the inverse of `splitKickoff()` and lives beside it so the two halves of the format can't drift; four round-trip tests pin the contract, including "user's rewritten kickoff wins".

### F7 — RPC hang
`hasUI` is true in RPC, and pi's RPC `editor` is the one dialog with neither a timeout nor a default (`rpc-mode.ts:254-271` vs. `createDialogPromise` at `:136-149`). A host that never replies blocked `/handoff` forever in the mode built to run unattended.

### F8 — gates
Nothing in the repo reaches `.pi/**`: it's outside `tsconfig.json`'s `include` and `biome.json`'s `files.includes`, and isn't an npm workspace, so `npm run check` and `npm test` skip it silently. New `.github/workflows/handoff-ext.yml` runs the suite + typecheck. Deliberately **no `paths:` filter** — the extension typechecks against pi *source* (root `tsconfig` maps `@earendil-works/*` to `packages/*/src`), so upstream API drift breaks it without touching a file under `.pi/`, and that's the drift this fork most needs to catch. Needs no build and no system deps.

**Known gap:** formatting is still uncovered — `biome check` ignores the path by config and covering it would mean editing shared upstream `biome.json`. `DESIGN.md` now records the gap and the manual `--config-path` command.

### F9 — docstring
The docstring claimed pi "proves stdio still works at that point". True on the interactive-quit path only: on SIGTERM/SIGHUP `dispose()` runs *before* `stop()`, and the event can't distinguish them (`reason` is `"quit"` for both). Per Kyle's call the residual is accepted — compound trigger, and the alternative is the silent seatbelt this exists to prevent — with the docstring now stating it accurately.

## Verification

- `vitest` — **95 pass** (91 → 95, +4 round-trip tests), 5 files
- `tsgo --noEmit -p .pi/extensions/handoff/tsconfig.json` — clean
- `biome check` via the `--config-path` workaround — clean, 11 files
- pre-commit `npm run check` — passed
- **End-to-end smoke** (`pi-test.sh -p … -e …/handoff/index.ts`, `google/gemini-3.6-flash`, scratch git repo): extension loads, digest writes a well-formed note through `buildContextEntries()` against a real shutdown context, and `git check-ignore` confirms `**/.pi/handoffs/` ignores the note while `.pi/extensions/` stays tracked.

Not verified: TUI-only paths (editor review, successor-spawn confirm, memo renderer) — no tmux on this machine, unchanged from v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MF7tkvhxrihGBznJsqd4Gf