### PR TITLE
fix(coding-agent): ignore docs in custom skill directories

### DIFF
--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -35,10 +35,11 @@ Pi loads skills from:
 
 Discovery rules:
 - In `~/.pi/agent/skills/` and `.pi/skills/`, direct root `.md` files are discovered as individual skills
+- In directories supplied through Settings or `--skill`, direct root `.md` files are discovered only when their frontmatter has a non-empty `description`; other root Markdown files are ignored
 - In all skill locations, directories containing `SKILL.md` are discovered recursively
 - In `~/.agents/skills/` and project `.agents/skills/`, root `.md` files are ignored
 
-Disable discovery with `--no-skills` (explicit `--skill` paths still load).
+Disable discovery with `--no-skills` (explicit `--skill` paths still load). A `--skill` path to an individual Markdown file is always treated as a skill and validated.
 
 ### Using Skills from Other Harnesses
 

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -30,11 +30,13 @@ import { minimatch } from "minimatch";
 import { maxSatisfying, rcompare, satisfies, valid, validRange } from "semver";
 import { CONFIG_DIR_NAME } from "../config.ts";
 import { spawnProcess, spawnProcessSync } from "../utils/child-process.ts";
+import { parseFrontmatter } from "../utils/frontmatter.ts";
 import { type GitSource, parseGitUrl } from "../utils/git.ts";
 import { canonicalizePath, isLocalPath, markPathIgnoredByCloudSync, resolvePath } from "../utils/paths.ts";
 import { isStdoutTakenOver } from "./output-guard.ts";
 import { type PiManifest, readPiManifest } from "./pi-manifest.ts";
 import type { PackageSource, SettingsManager } from "./settings-manager.ts";
+import { isSkillCandidate, type SkillFrontmatter } from "./skills.ts";
 
 const NETWORK_TIMEOUT_MS = 10000;
 const UPDATE_CHECK_CONCURRENCY = 4;
@@ -338,7 +340,24 @@ function collectFiles(
 	return files;
 }
 
-type SkillDiscoveryMode = "pi" | "agents";
+type SkillDiscoveryMode = "pi" | "agents" | "candidate";
+
+function isRootSkillCandidate(filePath: string): boolean {
+	let content: string;
+	try {
+		content = readFileSync(filePath, "utf-8");
+	} catch {
+		// Keep unreadable files so the loader can report the I/O error.
+		return true;
+	}
+
+	try {
+		const { frontmatter } = parseFrontmatter<SkillFrontmatter>(content);
+		return isSkillCandidate(frontmatter);
+	} catch {
+		return false;
+	}
+}
 
 function collectSkillEntries(
 	dir: string,
@@ -397,8 +416,10 @@ function collectSkillEntries(
 			}
 
 			const relPath = toPosixPath(relative(root, fullPath));
-			if (mode === "pi" && dir === root && isFile && entry.name.endsWith(".md") && !ig.ignores(relPath)) {
-				entries.push(fullPath);
+			if (dir === root && isFile && entry.name.endsWith(".md") && !ig.ignores(relPath)) {
+				if (mode === "pi" || (mode === "candidate" && isRootSkillCandidate(fullPath))) {
+					entries.push(fullPath);
+				}
 				continue;
 			}
 
@@ -2316,7 +2337,11 @@ export class DefaultPackageManager implements PackageManager {
 		// Collect all files from plain entries (non-pattern entries)
 		const { plain, patterns } = splitPatterns(entries);
 		const resolvedPlain = plain.map((p) => this.resolvePathFromBase(p, baseDir));
-		const allFiles = this.collectFilesFromPaths(resolvedPlain, resourceType);
+		const allFiles = this.collectFilesFromPaths(
+			resolvedPlain,
+			resourceType,
+			resourceType === "skills" ? "candidate" : "pi",
+		);
 
 		// Determine which files are enabled based on patterns
 		const enabledPaths = applyPatterns(allFiles, patterns, baseDir);
@@ -2493,7 +2518,11 @@ export class DefaultPackageManager implements PackageManager {
 		);
 	}
 
-	private collectFilesFromPaths(paths: string[], resourceType: ResourceType): string[] {
+	private collectFilesFromPaths(
+		paths: string[],
+		resourceType: ResourceType,
+		skillDiscoveryMode: SkillDiscoveryMode = "pi",
+	): string[] {
 		const files: string[] = [];
 		for (const p of paths) {
 			if (!existsSync(p)) continue;
@@ -2503,7 +2532,11 @@ export class DefaultPackageManager implements PackageManager {
 				if (stats.isFile()) {
 					files.push(p);
 				} else if (stats.isDirectory()) {
-					files.push(...collectResourceFiles(p, resourceType));
+					files.push(
+						...(resourceType === "skills"
+							? collectSkillEntries(p, skillDiscoveryMode)
+							: collectResourceFiles(p, resourceType)),
+					);
 				}
 			} catch {
 				// Ignore errors

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -162,6 +162,7 @@ export interface DefaultResourceLoaderOptions {
 	eventBus?: EventBus;
 	additionalExtensionPaths?: string[];
 	additionalSkillPaths?: string[];
+	candidateSkillDirectories?: string[];
 	additionalPromptTemplatePaths?: string[];
 	additionalThemePaths?: string[];
 	extensionFactories?: InlineExtension[];
@@ -200,6 +201,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private packageManager: DefaultPackageManager;
 	private additionalExtensionPaths: string[];
 	private additionalSkillPaths: string[];
+	private candidateSkillDirectories: string[];
 	private additionalPromptTemplatePaths: string[];
 	private additionalThemePaths: string[];
 	private extensionFactories: InlineExtension[];
@@ -262,6 +264,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		});
 		this.additionalExtensionPaths = options.additionalExtensionPaths ?? [];
 		this.additionalSkillPaths = options.additionalSkillPaths ?? [];
+		this.candidateSkillDirectories = options.candidateSkillDirectories ?? [];
 		this.additionalPromptTemplatePaths = options.additionalPromptTemplatePaths ?? [];
 		this.additionalThemePaths = options.additionalThemePaths ?? [];
 		this.extensionFactories = options.extensionFactories ?? [];
@@ -677,6 +680,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 				cwd: this.cwd,
 				agentDir: this.agentDir,
 				skillPaths,
+				candidateSkillDirectories: this.candidateSkillDirectories,
 				includeDefaults: false,
 			});
 		}

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -16,7 +16,8 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 const IGNORE_FILE_NAMES = [".gitignore", ".ignore", ".fdignore"];
 
 type IgnoreMatcher = ReturnType<typeof ignore>;
-type RootFileMode = "all" | "described" | "none";
+type SkillFileMode = "strict" | "candidate";
+type RootFileMode = SkillFileMode | "none";
 
 function toPosixPath(p: string): string {
 	return p.split(sep).join("/");
@@ -70,6 +71,12 @@ export interface SkillFrontmatter {
 	description?: string;
 	"disable-model-invocation"?: boolean;
 	[key: string]: unknown;
+}
+
+export function isSkillCandidate(frontmatter: SkillFrontmatter): frontmatter is SkillFrontmatter & {
+	description: string;
+} {
+	return typeof frontmatter.description === "string" && frontmatter.description.trim() !== "";
 }
 
 export interface Skill {
@@ -168,7 +175,7 @@ function createSkillSourceInfo(filePath: string, baseDir: string, source: string
  */
 export function loadSkillsFromDir(options: LoadSkillsFromDirOptions): LoadSkillsResult {
 	const { dir, source } = options;
-	return loadSkillsFromDirInternal(dir, source, "all");
+	return loadSkillsFromDirInternal(dir, source, "strict");
 }
 
 function loadSkillsFromDirInternal(
@@ -264,7 +271,7 @@ function loadSkillsFromDirInternal(
 				continue;
 			}
 
-			const result = loadSkillFromFile(fullPath, source, rootFileMode === "described");
+			const result = loadSkillFromFile(fullPath, source, rootFileMode);
 			if (result.skill) {
 				skills.push(result.skill);
 			}
@@ -278,19 +285,36 @@ function loadSkillsFromDirInternal(
 function loadSkillFromFile(
 	filePath: string,
 	source: string,
-	requireDescriptionForCandidate = false,
+	mode: SkillFileMode = "strict",
 ): { skill: Skill | null; diagnostics: ResourceDiagnostic[] } {
 	const diagnostics: ResourceDiagnostic[] = [];
 
+	let rawContent: string;
 	try {
-		const rawContent = readFileSync(filePath, "utf-8");
-		const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
-		if (
-			requireDescriptionForCandidate &&
-			(typeof frontmatter.description !== "string" || frontmatter.description.trim() === "")
-		) {
+		rawContent = readFileSync(filePath, "utf-8");
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "failed to read skill file";
+		diagnostics.push({ type: "warning", message, path: filePath });
+		return { skill: null, diagnostics };
+	}
+
+	let frontmatter: SkillFrontmatter;
+	try {
+		({ frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent));
+	} catch (error) {
+		if (mode === "candidate") {
 			return { skill: null, diagnostics };
 		}
+		const message = error instanceof Error ? error.message : "failed to parse skill file";
+		diagnostics.push({ type: "warning", message, path: filePath });
+		return { skill: null, diagnostics };
+	}
+
+	if (mode === "candidate" && !isSkillCandidate(frontmatter)) {
+		return { skill: null, diagnostics };
+	}
+
+	try {
 		const skillDir = dirname(filePath);
 		const parentDirName = basename(skillDir);
 
@@ -326,10 +350,7 @@ function loadSkillFromFile(
 			diagnostics,
 		};
 	} catch (error) {
-		if (requireDescriptionForCandidate) {
-			return { skill: null, diagnostics };
-		}
-		const message = error instanceof Error ? error.message : "failed to parse skill file";
+		const message = error instanceof Error ? error.message : "failed to validate skill file";
 		diagnostics.push({ type: "warning", message, path: filePath });
 		return { skill: null, diagnostics };
 	}
@@ -387,6 +408,8 @@ export interface LoadSkillsOptions {
 	agentDir: string;
 	/** Explicit skill paths (files or directories) */
 	skillPaths: string[];
+	/** Directories whose root Markdown files must declare a description to be skill candidates. */
+	candidateSkillDirectories?: string[];
 	/** Include default skills directories. */
 	includeDefaults: boolean;
 }
@@ -401,6 +424,9 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 	// Resolve agentDir - if not provided, use default from config
 	const resolvedCwd = resolvePath(options.cwd);
 	const resolvedAgentDir = resolvePath(agentDir ?? getAgentDir());
+	const candidateSkillDirectories = new Set(
+		(options.candidateSkillDirectories ?? []).map((path) => resolvePath(path, resolvedCwd, { trim: true })),
+	);
 
 	const skillMap = new Map<string, Skill>();
 	const realPathSet = new Set<string>();
@@ -439,8 +465,8 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 	}
 
 	if (includeDefaults) {
-		addSkills(loadSkillsFromDirInternal(join(resolvedAgentDir, "skills"), "user", "all"));
-		addSkills(loadSkillsFromDirInternal(resolve(resolvedCwd, CONFIG_DIR_NAME, "skills"), "project", "all"));
+		addSkills(loadSkillsFromDirInternal(join(resolvedAgentDir, "skills"), "user", "strict"));
+		addSkills(loadSkillsFromDirInternal(resolve(resolvedCwd, CONFIG_DIR_NAME, "skills"), "project", "strict"));
 	}
 
 	const userSkillsDir = join(resolvedAgentDir, "skills");
@@ -474,7 +500,8 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 			const stats = statSync(resolvedPath);
 			const source = getSource(resolvedPath);
 			if (stats.isDirectory()) {
-				addSkills(loadSkillsFromDirInternal(resolvedPath, source, "described"));
+				const mode = candidateSkillDirectories.has(resolvedPath) ? "candidate" : "strict";
+				addSkills(loadSkillsFromDirInternal(resolvedPath, source, mode));
 			} else if (stats.isFile() && resolvedPath.endsWith(".md")) {
 				const result = loadSkillFromFile(resolvedPath, source);
 				if (result.skill) {

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -16,6 +16,7 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 const IGNORE_FILE_NAMES = [".gitignore", ".ignore", ".fdignore"];
 
 type IgnoreMatcher = ReturnType<typeof ignore>;
+type RootFileMode = "all" | "described" | "none";
 
 function toPosixPath(p: string): string {
 	return p.split(sep).join("/");
@@ -167,13 +168,13 @@ function createSkillSourceInfo(filePath: string, baseDir: string, source: string
  */
 export function loadSkillsFromDir(options: LoadSkillsFromDirOptions): LoadSkillsResult {
 	const { dir, source } = options;
-	return loadSkillsFromDirInternal(dir, source, true);
+	return loadSkillsFromDirInternal(dir, source, "all");
 }
 
 function loadSkillsFromDirInternal(
 	dir: string,
 	source: string,
-	includeRootFiles: boolean,
+	rootFileMode: RootFileMode,
 	ignoreMatcher?: IgnoreMatcher,
 	rootDir?: string,
 ): LoadSkillsResult {
@@ -253,17 +254,17 @@ function loadSkillsFromDirInternal(
 			}
 
 			if (isDirectory) {
-				const subResult = loadSkillsFromDirInternal(fullPath, source, false, ig, root);
+				const subResult = loadSkillsFromDirInternal(fullPath, source, "none", ig, root);
 				skills.push(...subResult.skills);
 				diagnostics.push(...subResult.diagnostics);
 				continue;
 			}
 
-			if (!isFile || !includeRootFiles || !entry.name.endsWith(".md")) {
+			if (!isFile || rootFileMode === "none" || !entry.name.endsWith(".md")) {
 				continue;
 			}
 
-			const result = loadSkillFromFile(fullPath, source);
+			const result = loadSkillFromFile(fullPath, source, rootFileMode === "described");
 			if (result.skill) {
 				skills.push(result.skill);
 			}
@@ -277,12 +278,19 @@ function loadSkillsFromDirInternal(
 function loadSkillFromFile(
 	filePath: string,
 	source: string,
+	requireDescriptionForCandidate = false,
 ): { skill: Skill | null; diagnostics: ResourceDiagnostic[] } {
 	const diagnostics: ResourceDiagnostic[] = [];
 
 	try {
 		const rawContent = readFileSync(filePath, "utf-8");
 		const { frontmatter } = parseFrontmatter<SkillFrontmatter>(rawContent);
+		if (
+			requireDescriptionForCandidate &&
+			(typeof frontmatter.description !== "string" || frontmatter.description.trim() === "")
+		) {
+			return { skill: null, diagnostics };
+		}
 		const skillDir = dirname(filePath);
 		const parentDirName = basename(skillDir);
 
@@ -318,6 +326,9 @@ function loadSkillFromFile(
 			diagnostics,
 		};
 	} catch (error) {
+		if (requireDescriptionForCandidate) {
+			return { skill: null, diagnostics };
+		}
 		const message = error instanceof Error ? error.message : "failed to parse skill file";
 		diagnostics.push({ type: "warning", message, path: filePath });
 		return { skill: null, diagnostics };
@@ -428,8 +439,8 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 	}
 
 	if (includeDefaults) {
-		addSkills(loadSkillsFromDirInternal(join(resolvedAgentDir, "skills"), "user", true));
-		addSkills(loadSkillsFromDirInternal(resolve(resolvedCwd, CONFIG_DIR_NAME, "skills"), "project", true));
+		addSkills(loadSkillsFromDirInternal(join(resolvedAgentDir, "skills"), "user", "all"));
+		addSkills(loadSkillsFromDirInternal(resolve(resolvedCwd, CONFIG_DIR_NAME, "skills"), "project", "all"));
 	}
 
 	const userSkillsDir = join(resolvedAgentDir, "skills");
@@ -463,7 +474,7 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
 			const stats = statSync(resolvedPath);
 			const source = getSource(resolvedPath);
 			if (stats.isDirectory()) {
-				addSkills(loadSkillsFromDirInternal(resolvedPath, source, true));
+				addSkills(loadSkillsFromDirInternal(resolvedPath, source, "described"));
 			} else if (stats.isFile() && resolvedPath.endsWith(".md")) {
 				const result = loadSkillFromFile(resolvedPath, source);
 				if (result.skill) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -764,6 +764,7 @@ export async function main(args: string[], options?: MainOptions) {
 			resourceLoaderOptions: {
 				additionalExtensionPaths: resolvedExtensionPaths,
 				additionalSkillPaths: resolvedSkillPaths,
+				candidateSkillDirectories: resolvedSkillPaths,
 				additionalPromptTemplatePaths: resolvedPromptTemplatePaths,
 				additionalThemePaths: resolvedThemePaths,
 				noExtensions: parsed.noExtensions,

--- a/packages/coding-agent/test/fixtures/skills/custom-directory/README.md
+++ b/packages/coding-agent/test/fixtures/skills/custom-directory/README.md
@@ -1,0 +1,3 @@
+# Shared Skills
+
+Documentation for people using this skill repository.

--- a/packages/coding-agent/test/fixtures/skills/custom-directory/broken-frontmatter.md
+++ b/packages/coding-agent/test/fixtures/skills/custom-directory/broken-frontmatter.md
@@ -1,0 +1,6 @@
+---
+name: broken-frontmatter
+description: [invalid
+---
+
+This is not a valid skill document.

--- a/packages/coding-agent/test/fixtures/skills/custom-directory/nested-skill/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/custom-directory/nested-skill/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: nested-custom-skill
+description: A nested skill in a custom directory.
+---
+
+# Nested Custom Skill

--- a/packages/coding-agent/test/fixtures/skills/custom-directory/root-skill.md
+++ b/packages/coding-agent/test/fixtures/skills/custom-directory/root-skill.md
@@ -1,0 +1,6 @@
+---
+name: root-skill
+description: A root markdown skill in a custom directory.
+---
+
+# Root Skill

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -361,32 +361,6 @@ describe("skills", () => {
 			expect(diagnostics).toHaveLength(0);
 		});
 
-		it("should ignore documentation in custom skill directories", () => {
-			const customDirectory = join(fixturesDir, "custom-directory");
-			const { skills, diagnostics } = loadSkills({
-				agentDir: emptyAgentDir,
-				cwd: emptyCwd,
-				skillPaths: [customDirectory],
-				includeDefaults: true,
-			});
-
-			expect(skills.map((skill) => skill.name)).toEqual(["nested-custom-skill", "root-skill"]);
-			expect(diagnostics).toHaveLength(0);
-		});
-
-		it("should still validate explicit markdown skill paths", () => {
-			const explicitDocumentation = join(fixturesDir, "custom-directory", "README.md");
-			const { skills, diagnostics } = loadSkills({
-				agentDir: emptyAgentDir,
-				cwd: emptyCwd,
-				skillPaths: [explicitDocumentation],
-				includeDefaults: true,
-			});
-
-			expect(skills).toHaveLength(0);
-			expect(diagnostics.some((diagnostic) => diagnostic.message === "description is required")).toBe(true);
-		});
-
 		it("should warn when skill path does not exist", () => {
 			const { skills, diagnostics } = loadSkills({
 				agentDir: emptyAgentDir,

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -361,6 +361,32 @@ describe("skills", () => {
 			expect(diagnostics).toHaveLength(0);
 		});
 
+		it("should ignore documentation in custom skill directories", () => {
+			const customDirectory = join(fixturesDir, "custom-directory");
+			const { skills, diagnostics } = loadSkills({
+				agentDir: emptyAgentDir,
+				cwd: emptyCwd,
+				skillPaths: [customDirectory],
+				includeDefaults: true,
+			});
+
+			expect(skills.map((skill) => skill.name)).toEqual(["nested-custom-skill", "root-skill"]);
+			expect(diagnostics).toHaveLength(0);
+		});
+
+		it("should still validate explicit markdown skill paths", () => {
+			const explicitDocumentation = join(fixturesDir, "custom-directory", "README.md");
+			const { skills, diagnostics } = loadSkills({
+				agentDir: emptyAgentDir,
+				cwd: emptyCwd,
+				skillPaths: [explicitDocumentation],
+				includeDefaults: true,
+			});
+
+			expect(skills).toHaveLength(0);
+			expect(diagnostics.some((diagnostic) => diagnostic.message === "description is required")).toBe(true);
+		});
+
 		it("should warn when skill path does not exist", () => {
 			const { skills, diagnostics } = loadSkills({
 				agentDir: emptyAgentDir,

--- a/packages/coding-agent/test/suite/regressions/7805-custom-skill-directory-docs.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7805-custom-skill-directory-docs.test.ts
@@ -1,0 +1,131 @@
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DefaultResourceLoader } from "../../../src/core/resource-loader.ts";
+import { SettingsManager } from "../../../src/core/settings-manager.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const customDirectory = resolve(__dirname, "../../fixtures/skills/custom-directory");
+const readmePath = join(customDirectory, "README.md");
+
+describe("regression #7805: custom skill directories ignore root documentation", () => {
+	let tempDir: string;
+	let agentDir: string;
+	let cwd: string;
+	let originalHome: string | undefined;
+	const harnesses: Harness[] = [];
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-7805-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		agentDir = join(tempDir, "agent");
+		cwd = join(tempDir, "project");
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(cwd, { recursive: true });
+		originalHome = process.env.HOME;
+		process.env.HOME = tempDir;
+	});
+
+	afterEach(() => {
+		for (const harness of harnesses.splice(0)) {
+			harness.cleanup();
+		}
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	async function loadWithHarness(loader: DefaultResourceLoader) {
+		await loader.reload();
+		harnesses.push(await createHarness({ resourceLoader: loader }));
+		return loader.getSkills();
+	}
+
+	function expectCustomDirectoryLoaded(result: ReturnType<DefaultResourceLoader["getSkills"]>) {
+		const names = result.skills
+			.filter((skill) => skill.filePath.startsWith(customDirectory))
+			.map((skill) => skill.name)
+			.sort();
+		const diagnostics = result.diagnostics.filter((diagnostic) => diagnostic.path?.startsWith(customDirectory));
+
+		expect(names).toEqual(["nested-custom-skill", "root-skill"]);
+		expect(diagnostics).toEqual([]);
+	}
+
+	it("ignores root documentation in settings directories", async () => {
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			settingsManager: SettingsManager.inMemory({ skills: [customDirectory] }),
+		});
+
+		expectCustomDirectoryLoaded(await loadWithHarness(loader));
+	});
+
+	it("ignores root documentation in CLI directories", async () => {
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			additionalSkillPaths: [customDirectory],
+			candidateSkillDirectories: [customDirectory],
+		});
+
+		expectCustomDirectoryLoaded(await loadWithHarness(loader));
+	});
+
+	it("strictly validates explicitly configured Markdown files", async () => {
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			settingsManager: SettingsManager.inMemory({ skills: [readmePath] }),
+		});
+
+		const result = await loadWithHarness(loader);
+
+		expect(result.skills.some((skill) => skill.filePath === readmePath)).toBe(false);
+		expect(result.diagnostics).toContainEqual({
+			type: "warning",
+			message: "description is required",
+			path: readmePath,
+		});
+	});
+
+	it("keeps programmatic skill directories strict by default", async () => {
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			additionalSkillPaths: [customDirectory],
+		});
+
+		const result = await loadWithHarness(loader);
+		const diagnostics = result.diagnostics.filter((diagnostic) => diagnostic.path?.startsWith(customDirectory));
+
+		expect(diagnostics.some((diagnostic) => diagnostic.path === readmePath)).toBe(true);
+		expect(diagnostics.some((diagnostic) => diagnostic.path?.endsWith("broken-frontmatter.md"))).toBe(true);
+	});
+
+	it.skipIf(process.platform === "win32")("reports unreadable files in candidate directories", async () => {
+		const candidateDirectory = join(tempDir, "candidate-skills");
+		const unreadablePath = join(candidateDirectory, "unreadable.md");
+		mkdirSync(candidateDirectory);
+		writeFileSync(unreadablePath, "---\ndescription: Unreadable skill\n---\n");
+		chmodSync(unreadablePath, 0);
+
+		try {
+			const loader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				settingsManager: SettingsManager.inMemory({ skills: [candidateDirectory] }),
+			});
+
+			const result = await loadWithHarness(loader);
+
+			expect(result.diagnostics.some((diagnostic) => diagnostic.path === unreadablePath)).toBe(true);
+		} finally {
+			chmodSync(unreadablePath, 0o600);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- treat root Markdown files discovered from Settings and `--skill` directories as candidates only when they declare a non-empty `description`
- silently ignore documentation and malformed non-candidates while preserving strict validation for explicit files, default Pi directories, packages, extension/SDK directories, and file I/O errors
- document the rule and cover the production Settings/CLI loading paths with an issue-specific regression

Fixes #7805.

## Testing

- `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/suite/regressions/7805-custom-skill-directory-docs.test.ts test/skills.test.ts test/package-manager.test.ts`
- `npm run check`
- `./test.sh`
