### PR TITLE
feat(coding-agent): add goal mode extension with autonomous continuation

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2960,6 +2960,7 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `mac-system-theme.ts` | Auto-switch theme | `setTheme`, `exec` |
 | **Complex Extensions** |||
 | `plan-mode/` | Full plan mode implementation | All event types, `registerCommand`, `registerShortcut`, `registerFlag`, `setStatus`, `setWidget`, `sendMessage`, `setActiveTools` |
+| `goal-mode/` | Long-running goal mode with `/goal` lifecycle commands, persistent state, automatic continuation, and evidence-based completion | `registerCommand`, `registerFlag`, `registerTool`, `appendEntry`, `on("turn_end")`, `on("agent_settled")`, `on("context")` |
 | `preset.ts` | Saveable presets (model, tools, thinking) | `registerCommand`, `registerShortcut`, `registerFlag`, `setModel`, `setActiveTools`, `setThinkingLevel`, `appendEntry` |
 | `tools.ts` | Toggle tools on/off UI | `registerCommand`, `setActiveTools`, `SettingsList`, session events |
 | **Remote & Sandbox** |||

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -50,6 +50,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 |-----------|-------------|
 | `preset.ts` | Named presets for model, thinking level, tools, and instructions via `--preset` flag and `/preset` command |
 | `plan-mode/` | Claude Code-style plan mode for read-only exploration with `/plan` command and step tracking |
+| `goal-mode/` | Long-running goal mode with `/goal` lifecycle commands, persistent state, automatic continuation, and evidence-based completion |
 | `tools.ts` | Interactive `/tools` command to enable/disable tools with session persistence |
 | `handoff.ts` | Transfer context to a new focused session via `/handoff <goal>` |
 | `qna.ts` | Extracts questions from last response into editor via `ctx.ui.setEditorText()` |

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -47,6 +47,10 @@ pi --extension examples/extensions/goal-mode/index.ts \
   and clear are user-only commands.
 - `/goal pause` and `/goal clear` abort any in-flight autonomous work before
   switching state, so the UI returns to the paused or normal mode immediately.
+- Setting a new goal while the agent is streaming also aborts the current run
+  and starts the new goal after the run settles.
+- Automatic continuation is deduplicated: only one continuation is queued at a
+  time, and it is reset when the next run starts.
 - Automatic continuation happens only when the goal is active, the agent is
   idle, no user input is queued, the budget is not exhausted, and the previous
   turn actually used a tool. A turn with no tool calls stops the loop instead

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -36,7 +36,8 @@ pi --extension examples/extensions/goal-mode/index.ts \
   and compaction. The active branch's most recent goal entry wins.
 - When a goal exists, the footer/status bar, editor widget, and terminal title
   show `GOAL MODE`, `GOAL PAUSED`, `GOAL COMPLETE`, or `GOAL BUDGET LIMITED`.
-  Clearing the goal restores the normal-mode display with no goal indicator.
+  With no goal, the status bar shows `goal: off` so normal mode is visually
+  distinct from active goal mode.
 - Typing `/goal` in the interactive editor shows the command usage hint and
   completes the `pause`, `resume`, and `clear` subcommands.
 - The active goal is injected into every model request. The model is told to

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -37,6 +37,8 @@ pi --extension examples/extensions/goal-mode/index.ts \
 - When a goal exists, the footer/status bar, editor widget, and terminal title
   show `GOAL MODE`, `GOAL PAUSED`, `GOAL COMPLETE`, or `GOAL BUDGET LIMITED`.
   Clearing the goal restores the normal-mode display with no goal indicator.
+- Typing `/goal` in the interactive editor shows the command usage hint and
+  completes the `pause`, `resume`, and `clear` subcommands.
 - The active goal is injected into every model request. The model is told to
   verify progress against concrete evidence and to call `complete_goal` only
   after the objective is satisfied.

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -41,7 +41,8 @@ pi --extension examples/extensions/goal-mode/index.ts \
   The status bar shows `mode: build` with no goal and `mode: goal` while a
   goal exists, so normal and goal modes are visually distinct. When an active
   goal stops because the last turn made no tool calls, the label becomes
-  `GOAL MODE (WAITING)`.
+  `GOAL MODE (WAITING)`. When a budget is set, the widget shows usage consumed
+  so far (for example `Budget: tokens 50/100`).
 - Typing `/goal` in the interactive editor shows the command usage hint and
   completes the `pause`, `resume`, and `clear` subcommands.
 - The active goal is injected into every model request, including current

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -34,6 +34,7 @@ pi --extension examples/extensions/goal-mode/index.ts \
 
 - The goal is stored as a custom session entry, so it survives resume, fork,
   and compaction. The active branch's most recent goal entry wins.
+- Navigating the session tree reloads the goal state for the selected branch.
 - When a goal exists, the footer/status bar, editor widget, and terminal title
   show `GOAL MODE`, `GOAL PAUSED`, `GOAL COMPLETE`, or `GOAL BUDGET LIMITED`.
   The status bar shows `mode: build` with no goal and `mode: goal` while a

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -34,6 +34,9 @@ pi --extension examples/extensions/goal-mode/index.ts \
 
 - The goal is stored as a custom session entry, so it survives resume, fork,
   and compaction. The active branch's most recent goal entry wins.
+- When a goal exists, the footer/status bar, editor widget, and terminal title
+  show `GOAL MODE`, `GOAL PAUSED`, `GOAL COMPLETE`, or `GOAL BUDGET LIMITED`.
+  Clearing the goal restores the normal-mode display with no goal indicator.
 - The active goal is injected into every model request. The model is told to
   verify progress against concrete evidence and to call `complete_goal` only
   after the objective is satisfied.

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -14,10 +14,10 @@ pi --extension examples/extensions/goal-mode/index.ts
 Commands:
 
 ```text
-/goal <objective> [--tokens N] [--cost N]   Set or replace the goal
+/goal <objective> [--tokens N] [--cost N]   Set or replace the goal (flags may appear anywhere)
 /goal                                       View the current goal and status
 /goal pause                                 Pause work on the goal
-/goal resume                                Resume a paused goal
+/goal resume                                Resume a paused, waiting, or budget-limited goal
 /goal clear                                 Clear the goal
 ```
 
@@ -34,18 +34,26 @@ pi --extension examples/extensions/goal-mode/index.ts \
 
 - The goal is stored as a custom session entry, so it survives resume, fork,
   and compaction. The active branch's most recent goal entry wins.
-- Navigating the session tree reloads the goal state for the selected branch.
+- Navigating the session tree reloads the goal state for the selected branch
+  without auto-continuing, so switching branches is always an inspection action.
 - When a goal exists, the footer/status bar, editor widget, and terminal title
   show `GOAL MODE`, `GOAL PAUSED`, `GOAL COMPLETE`, or `GOAL BUDGET LIMITED`.
   The status bar shows `mode: build` with no goal and `mode: goal` while a
-  goal exists, so normal and goal modes are visually distinct.
+  goal exists, so normal and goal modes are visually distinct. When an active
+  goal stops because the last turn made no tool calls, the label becomes
+  `GOAL MODE (WAITING)`.
 - Typing `/goal` in the interactive editor shows the command usage hint and
   completes the `pause`, `resume`, and `clear` subcommands.
-- The active goal is injected into every model request. The model is told to
-  verify progress against concrete evidence and to call `complete_goal` only
-  after the objective is satisfied.
+- The active goal is injected into every model request, including current
+  budget usage when a budget is set. The model is told to verify progress
+  against concrete evidence and to call `complete_goal` only after the
+  objective is satisfied.
 - The model can only request completion through `complete_goal`. Pause, resume,
-  and clear are user-only commands.
+  and clear are user-only commands. Completion evidence must be at least 20
+  characters describing concrete verification (command output, test results,
+  or file changes), so the model cannot close a goal with a bare status word.
+- `/goal view` shows budget usage in any status, so you can see what was
+  consumed after a pause or budget stop.
 - `/goal pause` and `/goal clear` abort any in-flight autonomous work before
   switching state, so the UI returns to the paused or normal mode immediately.
 - Setting a new goal while the agent is streaming also aborts the current run
@@ -57,7 +65,8 @@ pi --extension examples/extensions/goal-mode/index.ts \
   turn actually used a tool. A turn with no tool calls stops the loop instead
   of spinning.
 - Budget exhaustion transitions the goal to `budget_limited` and stops work. It
-  is not treated as completion.
+  is not treated as completion. `/goal resume` starts the budget over from the
+  current usage and continues the same objective.
 
 ## Notes
 

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -44,6 +44,8 @@ pi --extension examples/extensions/goal-mode/index.ts \
   after the objective is satisfied.
 - The model can only request completion through `complete_goal`. Pause, resume,
   and clear are user-only commands.
+- `/goal pause` and `/goal clear` abort any in-flight autonomous work before
+  switching state, so the UI returns to the paused or normal mode immediately.
 - Automatic continuation happens only when the goal is active, the agent is
   idle, no user input is queued, the budget is not exhausted, and the previous
   turn actually used a tool. A turn with no tool calls stops the loop instead

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -36,8 +36,8 @@ pi --extension examples/extensions/goal-mode/index.ts \
   and compaction. The active branch's most recent goal entry wins.
 - When a goal exists, the footer/status bar, editor widget, and terminal title
   show `GOAL MODE`, `GOAL PAUSED`, `GOAL COMPLETE`, or `GOAL BUDGET LIMITED`.
-  With no goal, the status bar shows `goal: off` so normal mode is visually
-  distinct from active goal mode.
+  The status bar shows `mode: build` with no goal and `mode: goal` while a
+  goal exists, so normal and goal modes are visually distinct.
 - Typing `/goal` in the interactive editor shows the command usage hint and
   completes the `pause`, `resume`, and `clear` subcommands.
 - The active goal is injected into every model request. The model is told to

--- a/packages/coding-agent/examples/extensions/goal-mode/README.md
+++ b/packages/coding-agent/examples/extensions/goal-mode/README.md
@@ -1,0 +1,54 @@
+# Goal Mode Extension
+
+A self-contained long-running goal mode for pi. It keeps one objective attached
+to the current session, persists it across resume/fork/compaction, and continues
+working autonomously until the objective is verified, paused, cleared, or the
+budget runs out.
+
+## Usage
+
+```bash
+pi --extension examples/extensions/goal-mode/index.ts
+```
+
+Commands:
+
+```text
+/goal <objective> [--tokens N] [--cost N]   Set or replace the goal
+/goal                                       View the current goal and status
+/goal pause                                 Pause work on the goal
+/goal resume                                Resume a paused goal
+/goal clear                                 Clear the goal
+```
+
+Startup flag:
+
+```bash
+pi --extension examples/extensions/goal-mode/index.ts \
+  --goal "Fix the flaky suite" \
+  --goal-budget-tokens 100000 \
+  --goal-budget-cost 5
+```
+
+## Behavior
+
+- The goal is stored as a custom session entry, so it survives resume, fork,
+  and compaction. The active branch's most recent goal entry wins.
+- The active goal is injected into every model request. The model is told to
+  verify progress against concrete evidence and to call `complete_goal` only
+  after the objective is satisfied.
+- The model can only request completion through `complete_goal`. Pause, resume,
+  and clear are user-only commands.
+- Automatic continuation happens only when the goal is active, the agent is
+  idle, no user input is queued, the budget is not exhausted, and the previous
+  turn actually used a tool. A turn with no tool calls stops the loop instead
+  of spinning.
+- Budget exhaustion transitions the goal to `budget_limited` and stops work. It
+  is not treated as completion.
+
+## Notes
+
+This is an extension, not a separate CLI run mode. In interactive and RPC
+sessions the extension keeps the session alive while it works. For unattended
+use, run pi in a terminal session that stays open (for example `tmux`) or build
+a small wrapper around the pi SDK.

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -111,12 +111,18 @@ function parseBudgetFlags(pi: ExtensionAPI): GoalBudget {
 
 function startGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	if (!goal || goal.status !== "active") return;
-	const prompt = buildContinuationPrompt(goal);
-	if (ctx.isIdle()) {
-		pi.sendUserMessage(prompt);
-	} else {
-		pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+	if (!ctx.isIdle()) {
+		// A user command changed the goal while a run is in flight. Stop the
+		// current work and let agent_settled start the new goal instead of
+		// queueing a duplicate continuation.
+		pendingRestart = true;
+		ctx.abort();
+		return;
 	}
+	if (continuationQueued) return;
+	continuationQueued = true;
+	const prompt = buildContinuationPrompt(goal);
+	pi.sendUserMessage(prompt);
 }
 
 function setGoal(
@@ -133,6 +139,8 @@ function setGoal(
 	}
 	if (goal?.status === "active") {
 		startGoal(pi, ctx);
+	} else {
+		pendingRestart = false;
 	}
 }
 
@@ -181,7 +189,7 @@ function clearGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 }
 
 function reportWaitingForUser(ctx: ExtensionContext): void {
-	ctx.ui.setStatus("goal-mode", "goal: waiting");
+	ctx.ui.setStatus("goal-mode", "mode: goal (waiting)");
 	ctx.ui.notify(
 		"Goal is active but the last turn made no tool calls. Stopped to avoid spinning. Use /goal resume or send a message to continue.",
 		"info",
@@ -190,6 +198,7 @@ function reportWaitingForUser(ctx: ExtensionContext): void {
 
 function transitionBudgetLimited(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	if (!goal) return;
+	pendingRestart = false;
 	const limited = { ...goal, status: "budget_limited" as const, updatedAt: Date.now() };
 	goal = limited;
 	persistGoal(pi, goal);
@@ -201,6 +210,8 @@ function transitionBudgetLimited(pi: ExtensionAPI, ctx: ExtensionContext): void 
 }
 
 let goal: GoalState | undefined;
+let pendingRestart = false;
+let continuationQueued = false;
 
 export default function goalModeExtension(pi: ExtensionAPI): void {
 	pi.registerFlag("goal", {
@@ -315,6 +326,8 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 					].slice(-20),
 				};
 				goal = completed;
+				pendingRestart = false;
+				continuationQueued = false;
 				persistGoal(pi, goal);
 				updateStatus(pi, ctx);
 				return {
@@ -330,6 +343,8 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 	);
 
 	pi.on("session_start", async (event, ctx) => {
+		pendingRestart = false;
+		continuationQueued = false;
 		goal = getLatestGoalState(ctx.sessionManager.getBranch());
 
 		if (event.reason === "startup") {
@@ -364,9 +379,18 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 		updateStatus(pi, ctx);
 	});
 
+	pi.on("agent_start", async () => {
+		continuationQueued = false;
+	});
+
 	pi.on("agent_settled", async (_event, ctx) => {
 		if (!goal || goal.status !== "active") return;
 		if (ctx.hasPendingMessages()) return;
+		if (pendingRestart) {
+			pendingRestart = false;
+			startGoal(pi, ctx);
+			return;
+		}
 		if (goal.lastTurnHadToolCall === false) {
 			reportWaitingForUser(ctx);
 			return;

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -218,6 +218,10 @@ function resumeGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 }
 
 function clearGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal) {
+		ctx.ui.notify("No goal set.", "info");
+		return;
+	}
 	// Stop any in-flight autonomous work before clearing the goal, so the UI
 	// returns to normal mode immediately instead of continuing the current run.
 	ctx.abort();

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -1,0 +1,315 @@
+/**
+ * Goal Mode Extension
+ *
+ * A self-contained long-running goal mode for pi. It adds `/goal` lifecycle
+ * commands, a `--goal` startup flag, thread-scoped persistent state, automatic
+ * continuation while the goal is active, and a `complete_goal` tool that lets
+ * the model finish only with concrete evidence.
+ *
+ * Usage:
+ *   pi --extension examples/extensions/goal-mode/index.ts
+ *   /goal Reduce checkout p95 below 120ms, verified by the benchmark
+ *   /goal
+ *   /goal pause
+ *   /goal resume
+ *   /goal clear
+ *
+ * Startup flag:
+ *   pi --extension examples/extensions/goal-mode/index.ts --goal "Fix the flaky suite"
+ */
+
+import { defineTool, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import {
+	appendProgress,
+	assistantHasToolCalls,
+	buildContinuationPrompt,
+	buildGoalContextMessage,
+	computeUsageTotals,
+	createGoalState,
+	formatGoalState,
+	type GoalBudget,
+	type GoalState,
+	getAssistantText,
+	getGoalUsage,
+	getLatestGoalState,
+	isBudgetExceeded,
+	isGoalContextMessage,
+	parseGoalCommand,
+} from "./utils.ts";
+
+const ENTRY_TYPE = "goal-mode";
+const BUDGET_TOKENS_FLAG = "goal-budget-tokens";
+const BUDGET_COST_FLAG = "goal-budget-cost";
+
+function persistGoal(pi: ExtensionAPI, goal: GoalState | undefined): void {
+	pi.appendEntry(ENTRY_TYPE, goal ?? null);
+}
+
+function updateStatus(_pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal || goal.status !== "active") {
+		ctx.ui.setStatus("goal-mode", undefined);
+		ctx.ui.setWidget("goal-mode", undefined);
+		return;
+	}
+	ctx.ui.setStatus("goal-mode", `goal: ${goal.status}`);
+	const lines = [`Goal (${goal.status}): ${goal.objective}`, ...goal.progress.slice(-3).map((line) => `  ${line}`)];
+	ctx.ui.setWidget("goal-mode", lines);
+}
+
+function parseBudgetFlags(pi: ExtensionAPI): GoalBudget {
+	const budget: GoalBudget = {};
+	const tokensValue = pi.getFlag(BUDGET_TOKENS_FLAG);
+	if (typeof tokensValue === "string" && tokensValue.trim()) {
+		const tokens = Number(tokensValue);
+		if (Number.isFinite(tokens) && tokens >= 0) budget.tokens = tokens;
+	}
+	const costValue = pi.getFlag(BUDGET_COST_FLAG);
+	if (typeof costValue === "string" && costValue.trim()) {
+		const cost = Number(costValue);
+		if (Number.isFinite(cost) && cost >= 0) budget.cost = cost;
+	}
+	return budget;
+}
+
+function startGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal || goal.status !== "active") return;
+	const prompt = buildContinuationPrompt(goal);
+	if (ctx.isIdle()) {
+		pi.sendUserMessage(prompt);
+	} else {
+		pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+	}
+}
+
+function setGoal(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	next: GoalState | undefined,
+	options: { notify?: string } = {},
+): void {
+	goal = next;
+	persistGoal(pi, goal);
+	updateStatus(pi, ctx);
+	if (options.notify) {
+		ctx.ui.notify(options.notify, "info");
+	}
+	if (goal?.status === "active") {
+		startGoal(pi, ctx);
+	}
+}
+
+function showGoal(_pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal) {
+		ctx.ui.notify("No goal set. Use /goal <objective> to start one.", "info");
+		return;
+	}
+	const usage = goal.status === "active" ? getGoalUsage(goal, ctx.sessionManager.getBranch()) : undefined;
+	ctx.ui.notify(formatGoalState(goal, usage), "info");
+}
+
+function pauseGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal) {
+		ctx.ui.notify("No goal set.", "info");
+		return;
+	}
+	if (goal.status !== "active") {
+		ctx.ui.notify(`Goal is already ${goal.status}.`, "info");
+		return;
+	}
+	setGoal(pi, ctx, { ...goal, status: "paused", updatedAt: Date.now() }, { notify: "Goal paused." });
+}
+
+function resumeGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal) {
+		ctx.ui.notify("No goal set.", "info");
+		return;
+	}
+	if (goal.status !== "paused") {
+		ctx.ui.notify(`Goal cannot be resumed from status ${goal.status}.`, "info");
+		return;
+	}
+	const resumed = { ...goal, status: "active" as const, updatedAt: Date.now() };
+	setGoal(pi, ctx, resumed, { notify: "Goal resumed." });
+}
+
+function clearGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	setGoal(pi, ctx, undefined, { notify: "Goal cleared." });
+}
+
+function reportWaitingForUser(ctx: ExtensionContext): void {
+	ctx.ui.setStatus("goal-mode", "goal: waiting");
+	ctx.ui.notify(
+		"Goal is active but the last turn made no tool calls. Stopped to avoid spinning. Use /goal resume or send a message to continue.",
+		"info",
+	);
+}
+
+function transitionBudgetLimited(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal) return;
+	const limited = { ...goal, status: "budget_limited" as const, updatedAt: Date.now() };
+	goal = limited;
+	persistGoal(pi, goal);
+	updateStatus(pi, ctx);
+	ctx.ui.notify(
+		"Goal budget exhausted. Work stopped; review progress and set a new goal or adjust the budget.",
+		"warning",
+	);
+}
+
+let goal: GoalState | undefined;
+
+export default function goalModeExtension(pi: ExtensionAPI): void {
+	pi.registerFlag("goal", {
+		description: "Start with an active goal objective",
+		type: "string",
+	});
+	pi.registerFlag(BUDGET_TOKENS_FLAG, {
+		description: "Optional token budget for --goal",
+		type: "string",
+	});
+	pi.registerFlag(BUDGET_COST_FLAG, {
+		description: "Optional cost budget for --goal",
+		type: "string",
+	});
+
+	pi.registerCommand("goal", {
+		description: "Set, view, pause, resume, or clear the current goal",
+		handler: async (args, ctx) => {
+			const command = parseGoalCommand(args);
+			switch (command.action) {
+				case "view":
+					showGoal(pi, ctx);
+					return;
+				case "pause":
+					pauseGoal(pi, ctx);
+					return;
+				case "resume":
+					resumeGoal(pi, ctx);
+					return;
+				case "clear":
+					clearGoal(pi, ctx);
+					return;
+				case "invalid":
+					ctx.ui.notify(command.message, "warning");
+					return;
+				case "set": {
+					const next = createGoalState(command.objective, {
+						budget:
+							command.budget.tokens !== undefined || command.budget.cost !== undefined
+								? command.budget
+								: undefined,
+						baseline: computeUsageTotals(ctx.sessionManager.getBranch()),
+					});
+					setGoal(pi, ctx, next, { notify: `Goal set: ${next.objective}` });
+					return;
+				}
+			}
+		},
+	});
+
+	pi.registerTool(
+		defineTool({
+			name: "complete_goal",
+			label: "Complete Goal",
+			description:
+				"Mark the active goal complete. Use only after verifying the objective against concrete evidence in the conversation or working tree.",
+			promptSnippet: "Mark the active goal complete with concrete evidence",
+			promptGuidelines: [
+				"Call complete_goal only when the active goal is verified against concrete evidence such as command output, tests, file changes, or generated artifacts.",
+				"Do not call complete_goal to ask for permission, to report a blocker, or when the goal is paused.",
+			],
+			parameters: Type.Object({
+				evidence: Type.String({
+					description: "Concrete evidence that the goal objective is satisfied",
+				}),
+			}),
+			async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+				if (!goal) {
+					throw new Error("No active goal to complete.");
+				}
+				if (goal.status !== "active") {
+					throw new Error(`Goal cannot be completed from status ${goal.status}.`);
+				}
+				const completed: GoalState = {
+					...goal,
+					status: "complete",
+					updatedAt: Date.now(),
+					lastCompletionEvidence: params.evidence,
+					progress: [
+						...goal.progress,
+						`Completed: ${params.evidence.replace(/\s+/g, " ").trim().slice(0, 200)}`,
+					].slice(-20),
+				};
+				goal = completed;
+				persistGoal(pi, goal);
+				updateStatus(pi, ctx);
+				return {
+					content: [{ type: "text", text: `Goal completed: ${completed.objective}` }],
+					details: {
+						objective: completed.objective,
+						evidence: params.evidence,
+					},
+					terminate: true,
+				};
+			},
+		}),
+	);
+
+	pi.on("session_start", async (event, ctx) => {
+		goal = getLatestGoalState(ctx.sessionManager.getBranch());
+
+		if (event.reason === "startup") {
+			const flagGoal = pi.getFlag("goal");
+			if (typeof flagGoal === "string" && flagGoal.trim()) {
+				goal = createGoalState(flagGoal, {
+					budget: parseBudgetFlags(pi),
+					baseline: computeUsageTotals(ctx.sessionManager.getBranch()),
+				});
+				persistGoal(pi, goal);
+			}
+		}
+
+		updateStatus(pi, ctx);
+
+		if (goal?.status === "active" && event.reason !== "reload") {
+			startGoal(pi, ctx);
+		}
+	});
+
+	pi.on("turn_end", async (event, ctx) => {
+		if (!goal || goal.status !== "active") return;
+
+		const text = getAssistantText(event.message);
+		const next = {
+			...goal,
+			lastTurnHadToolCall: event.toolResults.length > 0 || assistantHasToolCalls(event.message),
+			updatedAt: Date.now(),
+		};
+		goal = text ? appendProgress(next, text) : next;
+		persistGoal(pi, goal);
+		updateStatus(pi, ctx);
+	});
+
+	pi.on("agent_settled", async (_event, ctx) => {
+		if (!goal || goal.status !== "active") return;
+		if (ctx.hasPendingMessages()) return;
+		if (goal.lastTurnHadToolCall === false) {
+			reportWaitingForUser(ctx);
+			return;
+		}
+		if (isBudgetExceeded(goal, getGoalUsage(goal, ctx.sessionManager.getBranch()))) {
+			transitionBudgetLimited(pi, ctx);
+			return;
+		}
+		startGoal(pi, ctx);
+	});
+
+	pi.on("context", async (event) => {
+		const messages = event.messages.filter((message) => !isGoalContextMessage(message));
+		if (goal?.status === "active") {
+			messages.push(buildGoalContextMessage(goal));
+		}
+		return { messages };
+	});
+}

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -212,6 +212,36 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 
 	pi.registerCommand("goal", {
 		description: "Set, view, pause, resume, or clear the current goal",
+		argumentHint: "<objective> [--tokens N] [--cost N] | pause | resume | clear",
+		getArgumentCompletions: (prefix) => {
+			const subcommands = ["pause", "resume", "clear"];
+			const trimmed = prefix.trimStart();
+			if (trimmed === "") {
+				return subcommands.map((value) => ({
+					value,
+					label: value,
+					description:
+						value === "pause"
+							? "Pause the active goal"
+							: value === "resume"
+								? "Resume a paused goal"
+								: "Clear the goal",
+				}));
+			}
+			const filtered = subcommands.filter((value) => value.startsWith(trimmed));
+			return filtered.length > 0
+				? filtered.map((value) => ({
+						value,
+						label: value,
+						description:
+							value === "pause"
+								? "Pause the active goal"
+								: value === "resume"
+									? "Resume a paused goal"
+									: "Clear the goal",
+					}))
+				: null;
+		},
 		handler: async (args, ctx) => {
 			const command = parseGoalCommand(args);
 			switch (command.action) {

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -36,6 +36,7 @@ import {
 	getLatestGoalState,
 	isBudgetExceeded,
 	isGoalContextMessage,
+	isValidCompletionEvidence,
 	parseGoalCommand,
 } from "./utils.ts";
 
@@ -76,7 +77,14 @@ function updateStatus(pi: ExtensionAPI, ctx: ExtensionContext): void {
 
 	const label = getGoalStatusLabel(goal.status);
 	ctx.ui.setStatus("goal-mode", "mode: goal");
+	ctx.ui.setWidget("goal-mode", getGoalWidgetLines(label));
 
+	const titleObjective = goal.objective.length > 48 ? `${goal.objective.slice(0, 45)}...` : goal.objective;
+	ctx.ui.setTitle(`[${label}] ${titleObjective}`);
+}
+
+function getGoalWidgetLines(label: string): string[] {
+	if (!goal) return [];
 	const lines = [`[${label}]`, `Objective: ${goal.objective}`];
 	if (goal.budget?.tokens !== undefined || goal.budget?.cost !== undefined) {
 		const budget = goal.budget;
@@ -88,23 +96,28 @@ function updateStatus(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	if (goal.progress.length > 0) {
 		lines.push("Progress:", ...goal.progress.slice(-3).map((line) => `  ${line}`));
 	}
-	ctx.ui.setWidget("goal-mode", lines);
-
-	const titleObjective = goal.objective.length > 48 ? `${goal.objective.slice(0, 45)}...` : goal.objective;
-	ctx.ui.setTitle(`[${label}] ${titleObjective}`);
+	return lines;
 }
 
-function parseBudgetFlags(pi: ExtensionAPI): GoalBudget {
+function parseBudgetFlags(pi: ExtensionAPI, ctx: ExtensionContext): GoalBudget {
 	const budget: GoalBudget = {};
 	const tokensValue = pi.getFlag(BUDGET_TOKENS_FLAG);
 	if (typeof tokensValue === "string" && tokensValue.trim()) {
 		const tokens = Number(tokensValue);
-		if (Number.isFinite(tokens) && tokens >= 0) budget.tokens = tokens;
+		if (Number.isInteger(tokens) && tokens >= 0) {
+			budget.tokens = tokens;
+		} else {
+			ctx.ui.notify(`Ignoring invalid --goal-budget-tokens value: ${tokensValue}`, "warning");
+		}
 	}
 	const costValue = pi.getFlag(BUDGET_COST_FLAG);
 	if (typeof costValue === "string" && costValue.trim()) {
 		const cost = Number(costValue);
-		if (Number.isFinite(cost) && cost >= 0) budget.cost = cost;
+		if (Number.isFinite(cost) && cost >= 0) {
+			budget.cost = cost;
+		} else {
+			ctx.ui.notify(`Ignoring invalid --goal-budget-cost value: ${costValue}`, "warning");
+		}
 	}
 	return budget;
 }
@@ -149,7 +162,10 @@ function showGoal(_pi: ExtensionAPI, ctx: ExtensionContext): void {
 		ctx.ui.notify("No goal set. Use /goal <objective> to start one.", "info");
 		return;
 	}
-	const usage = goal.status === "active" ? getGoalUsage(goal, ctx.sessionManager.getBranch()) : undefined;
+	const usage =
+		goal.budget?.tokens !== undefined || goal.budget?.cost !== undefined
+			? getGoalUsage(goal, ctx.sessionManager.getBranch())
+			: undefined;
 	ctx.ui.notify(formatGoalState(goal, usage), "info");
 }
 
@@ -177,10 +193,19 @@ function resumeGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 		ctx.ui.notify("Goal is already active.", "info");
 		return;
 	}
-	if (goal.status === "active") {
-		// The goal stopped because the last turn made no tool calls. Resume
-		// sends a fresh continuation instead of leaving the user stuck.
-		setGoal(pi, ctx, { ...goal, updatedAt: Date.now() }, { notify: "Goal resumed." });
+	if (goal.status === "active" || goal.status === "budget_limited") {
+		const resumed =
+			goal.status === "budget_limited"
+				? {
+						...goal,
+						status: "active" as const,
+						// Resuming after budget exhaustion starts the budget over
+						// from current usage, so the same objective can continue.
+						baseline: computeUsageTotals(ctx.sessionManager.getBranch()),
+						updatedAt: Date.now(),
+					}
+				: { ...goal, updatedAt: Date.now() };
+		setGoal(pi, ctx, resumed, { notify: "Goal resumed." });
 		return;
 	}
 	if (goal.status !== "paused") {
@@ -199,7 +224,11 @@ function clearGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 }
 
 function reportWaitingForUser(ctx: ExtensionContext): void {
+	if (!goal) return;
 	ctx.ui.setStatus("goal-mode", "mode: goal (waiting)");
+	ctx.ui.setWidget("goal-mode", getGoalWidgetLines("GOAL MODE (WAITING)"));
+	const titleObjective = goal.objective.length > 48 ? `${goal.objective.slice(0, 45)}...` : goal.objective;
+	ctx.ui.setTitle(`[GOAL MODE (WAITING)] ${titleObjective}`);
 	ctx.ui.notify(
 		"Goal is active but the last turn made no tool calls. Stopped to avoid spinning. Use /goal resume or send a message to continue.",
 		"info",
@@ -214,7 +243,7 @@ function transitionBudgetLimited(pi: ExtensionAPI, ctx: ExtensionContext): void 
 	persistGoal(pi, goal);
 	updateStatus(pi, ctx);
 	ctx.ui.notify(
-		"Goal budget exhausted. Work stopped; review progress and set a new goal or adjust the budget.",
+		"Goal budget exhausted. Work stopped. Use /goal resume to continue with a fresh budget, or set a new goal.",
 		"warning",
 	);
 }
@@ -310,12 +339,13 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 				"Mark the active goal complete. Use only after verifying the objective against concrete evidence in the conversation or working tree.",
 			promptSnippet: "Mark the active goal complete with concrete evidence",
 			promptGuidelines: [
-				"Call complete_goal only when the active goal is verified against concrete evidence such as command output, tests, file changes, or generated artifacts.",
+				"Call complete_goal only when the active goal is verified against concrete evidence such as command output, tests, file changes, or generated artifacts, described in at least 20 characters.",
 				"Do not call complete_goal to ask for permission, to report a blocker, or when the goal is paused.",
 			],
 			parameters: Type.Object({
 				evidence: Type.String({
-					description: "Concrete evidence that the goal objective is satisfied",
+					description:
+						"Concrete evidence that the goal objective is satisfied, at least 20 characters (for example command output, test results, or file changes)",
 				}),
 			}),
 			async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -324,6 +354,11 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 				}
 				if (goal.status !== "active") {
 					throw new Error(`Goal cannot be completed from status ${goal.status}.`);
+				}
+				if (!isValidCompletionEvidence(params.evidence)) {
+					throw new Error(
+						"Evidence must be at least 20 characters describing concrete verification, such as command output, test results, or file changes.",
+					);
 				}
 				const completed: GoalState = {
 					...goal,
@@ -361,7 +396,7 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 			const flagGoal = pi.getFlag("goal");
 			if (typeof flagGoal === "string" && flagGoal.trim()) {
 				goal = createGoalState(flagGoal, {
-					budget: parseBudgetFlags(pi),
+					budget: parseBudgetFlags(pi, ctx),
 					baseline: computeUsageTotals(ctx.sessionManager.getBranch()),
 				});
 				persistGoal(pi, goal);
@@ -419,10 +454,14 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 		startGoal(pi, ctx);
 	});
 
-	pi.on("context", async (event) => {
+	pi.on("context", async (event, ctx) => {
 		const messages = event.messages.filter((message) => !isGoalContextMessage(message));
 		if (goal?.status === "active") {
-			messages.push(buildGoalContextMessage(goal));
+			const usage =
+				goal.budget?.tokens !== undefined || goal.budget?.cost !== undefined
+					? getGoalUsage(goal, ctx.sessionManager.getBranch())
+					: undefined;
+			messages.push(buildGoalContextMessage(goal, usage));
 		}
 		return { messages };
 	});

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -173,6 +173,16 @@ function resumeGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 		ctx.ui.notify("No goal set.", "info");
 		return;
 	}
+	if (goal.status === "active" && goal.lastTurnHadToolCall !== false) {
+		ctx.ui.notify("Goal is already active.", "info");
+		return;
+	}
+	if (goal.status === "active") {
+		// The goal stopped because the last turn made no tool calls. Resume
+		// sends a fresh continuation instead of leaving the user stuck.
+		setGoal(pi, ctx, { ...goal, updatedAt: Date.now() }, { notify: "Goal resumed." });
+		return;
+	}
 	if (goal.status !== "paused") {
 		ctx.ui.notify(`Goal cannot be resumed from status ${goal.status}.`, "info");
 		return;
@@ -363,6 +373,13 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 		if (goal?.status === "active" && event.reason !== "reload") {
 			startGoal(pi, ctx);
 		}
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		pendingRestart = false;
+		continuationQueued = false;
+		goal = getLatestGoalState(ctx.sessionManager.getBranch());
+		updateStatus(pi, ctx);
 	});
 
 	pi.on("turn_end", async (event, ctx) => {

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -154,6 +154,9 @@ function pauseGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 		ctx.ui.notify(`Goal is already ${goal.status}.`, "info");
 		return;
 	}
+	// Stop any in-flight autonomous work before switching state, so pause takes
+	// effect immediately instead of waiting for the current run to settle.
+	ctx.abort();
 	setGoal(pi, ctx, { ...goal, status: "paused", updatedAt: Date.now() }, { notify: "Goal paused." });
 }
 
@@ -171,6 +174,9 @@ function resumeGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 }
 
 function clearGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	// Stop any in-flight autonomous work before clearing the goal, so the UI
+	// returns to normal mode immediately instead of continuing the current run.
+	ctx.abort();
 	setGoal(pi, ctx, undefined, { notify: "Goal cleared." });
 }
 

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -68,7 +68,7 @@ function getGoalStatusLabel(status: GoalState["status"]): string {
 
 function updateStatus(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	if (!goal) {
-		ctx.ui.setStatus("goal-mode", undefined);
+		ctx.ui.setStatus("goal-mode", "goal: off");
 		ctx.ui.setWidget("goal-mode", undefined);
 		ctx.ui.setTitle(getBaseTitle(pi));
 		return;

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -363,7 +363,8 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 				if (goal.status !== "active") {
 					throw new Error(`Goal cannot be completed from status ${goal.status}.`);
 				}
-				if (!isValidCompletionEvidence(params.evidence)) {
+				const evidence = params.evidence.replace(/\s+/g, " ").trim();
+				if (!isValidCompletionEvidence(evidence)) {
 					throw new Error(
 						"Evidence must be at least 20 characters describing concrete verification, such as command output, test results, or file changes.",
 					);
@@ -372,11 +373,8 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 					...goal,
 					status: "complete",
 					updatedAt: Date.now(),
-					lastCompletionEvidence: params.evidence,
-					progress: [
-						...goal.progress,
-						`Completed: ${params.evidence.replace(/\s+/g, " ").trim().slice(0, 200)}`,
-					].slice(-20),
+					lastCompletionEvidence: evidence,
+					progress: [...goal.progress, `Completed: ${evidence.slice(0, 200)}`].slice(-20),
 				};
 				bumpGoalVersion();
 				goal = completed;
@@ -388,7 +386,7 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 					content: [{ type: "text", text: `Goal completed: ${completed.objective}` }],
 					details: {
 						objective: completed.objective,
-						evidence: params.evidence,
+						evidence,
 					},
 					terminate: true,
 				};

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -38,6 +38,7 @@ import {
 	isGoalContextMessage,
 	isValidCompletionEvidence,
 	parseGoalCommand,
+	type UsageTotals,
 } from "./utils.ts";
 
 const ENTRY_TYPE = "goal-mode";
@@ -77,20 +78,30 @@ function updateStatus(pi: ExtensionAPI, ctx: ExtensionContext): void {
 
 	const label = getGoalStatusLabel(goal.status);
 	ctx.ui.setStatus("goal-mode", "mode: goal");
-	ctx.ui.setWidget("goal-mode", getGoalWidgetLines(label));
+	ctx.ui.setWidget("goal-mode", getGoalWidgetLines(label, getGoalWidgetUsage(goal, ctx)));
 
 	const titleObjective = goal.objective.length > 48 ? `${goal.objective.slice(0, 45)}...` : goal.objective;
 	ctx.ui.setTitle(`[${label}] ${titleObjective}`);
 }
 
-function getGoalWidgetLines(label: string): string[] {
+function getGoalWidgetUsage(goal: GoalState, ctx: ExtensionContext): UsageTotals | undefined {
+	return goal.budget?.tokens !== undefined || goal.budget?.cost !== undefined
+		? getGoalUsage(goal, ctx.sessionManager.getBranch())
+		: undefined;
+}
+
+function getGoalWidgetLines(label: string, usage?: UsageTotals): string[] {
 	if (!goal) return [];
 	const lines = [`[${label}]`, `Objective: ${goal.objective}`];
 	if (goal.budget?.tokens !== undefined || goal.budget?.cost !== undefined) {
 		const budget = goal.budget;
 		const parts: string[] = [];
-		if (budget.tokens !== undefined) parts.push(`tokens ${budget.tokens}`);
-		if (budget.cost !== undefined) parts.push(`cost ${budget.cost}`);
+		if (budget.tokens !== undefined) {
+			parts.push(usage ? `tokens ${usage.tokens}/${budget.tokens}` : `tokens ${budget.tokens}`);
+		}
+		if (budget.cost !== undefined) {
+			parts.push(usage ? `cost ${usage.cost.toFixed(4)}/${budget.cost}` : `cost ${budget.cost}`);
+		}
 		lines.push(`Budget: ${parts.join(", ")}`);
 	}
 	if (goal.progress.length > 0) {
@@ -124,6 +135,13 @@ function parseBudgetFlags(pi: ExtensionAPI, ctx: ExtensionContext): GoalBudget {
 
 function startGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	if (!goal || goal.status !== "active") return;
+	if (isBudgetExceeded(goal, getGoalUsage(goal, ctx.sessionManager.getBranch()))) {
+		// A resumed goal may already have consumed its budget before the last
+		// session ended. Stop before sending another continuation instead of
+		// burning an extra turn and then transitioning at settle.
+		transitionBudgetLimited(pi, ctx);
+		return;
+	}
 	if (!ctx.isIdle()) {
 		// A user command changed the goal while a run is in flight. Stop the
 		// current work and let agent_settled start the new goal instead of
@@ -231,7 +249,7 @@ function clearGoal(pi: ExtensionAPI, ctx: ExtensionContext): void {
 function reportWaitingForUser(ctx: ExtensionContext): void {
 	if (!goal) return;
 	ctx.ui.setStatus("goal-mode", "mode: goal (waiting)");
-	ctx.ui.setWidget("goal-mode", getGoalWidgetLines("GOAL MODE (WAITING)"));
+	ctx.ui.setWidget("goal-mode", getGoalWidgetLines("GOAL MODE (WAITING)", getGoalWidgetUsage(goal, ctx)));
 	const titleObjective = goal.objective.length > 48 ? `${goal.objective.slice(0, 45)}...` : goal.objective;
 	ctx.ui.setTitle(`[GOAL MODE (WAITING)] ${titleObjective}`);
 	ctx.ui.notify(

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -292,7 +292,7 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 						value === "pause"
 							? "Pause the active goal"
 							: value === "resume"
-								? "Resume a paused goal"
+								? "Resume a paused, waiting, or budget-limited goal"
 								: "Clear the goal",
 				}));
 			}
@@ -305,7 +305,7 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 							value === "pause"
 								? "Pause the active goal"
 								: value === "resume"
-									? "Resume a paused goal"
+									? "Resume a paused, waiting, or budget-limited goal"
 									: "Clear the goal",
 					}))
 				: null;

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -18,6 +18,7 @@
  *   pi --extension examples/extensions/goal-mode/index.ts --goal "Fix the flaky suite"
  */
 
+import { basename } from "node:path";
 import { defineTool, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
@@ -46,15 +47,51 @@ function persistGoal(pi: ExtensionAPI, goal: GoalState | undefined): void {
 	pi.appendEntry(ENTRY_TYPE, goal ?? null);
 }
 
-function updateStatus(_pi: ExtensionAPI, ctx: ExtensionContext): void {
-	if (!goal || goal.status !== "active") {
+function getBaseTitle(pi: ExtensionAPI): string {
+	const cwd = basename(process.cwd());
+	const sessionName = pi.getSessionName();
+	return sessionName ? `pi - ${sessionName} - ${cwd}` : `pi - ${cwd}`;
+}
+
+function getGoalStatusLabel(status: GoalState["status"]): string {
+	switch (status) {
+		case "active":
+			return "GOAL MODE";
+		case "paused":
+			return "GOAL PAUSED";
+		case "complete":
+			return "GOAL COMPLETE";
+		case "budget_limited":
+			return "GOAL BUDGET LIMITED";
+	}
+}
+
+function updateStatus(pi: ExtensionAPI, ctx: ExtensionContext): void {
+	if (!goal) {
 		ctx.ui.setStatus("goal-mode", undefined);
 		ctx.ui.setWidget("goal-mode", undefined);
+		ctx.ui.setTitle(getBaseTitle(pi));
 		return;
 	}
+
+	const label = getGoalStatusLabel(goal.status);
 	ctx.ui.setStatus("goal-mode", `goal: ${goal.status}`);
-	const lines = [`Goal (${goal.status}): ${goal.objective}`, ...goal.progress.slice(-3).map((line) => `  ${line}`)];
+
+	const lines = [`[${label}]`, `Objective: ${goal.objective}`];
+	if (goal.budget?.tokens !== undefined || goal.budget?.cost !== undefined) {
+		const budget = goal.budget;
+		const parts: string[] = [];
+		if (budget.tokens !== undefined) parts.push(`tokens ${budget.tokens}`);
+		if (budget.cost !== undefined) parts.push(`cost ${budget.cost}`);
+		lines.push(`Budget: ${parts.join(", ")}`);
+	}
+	if (goal.progress.length > 0) {
+		lines.push("Progress:", ...goal.progress.slice(-3).map((line) => `  ${line}`));
+	}
 	ctx.ui.setWidget("goal-mode", lines);
+
+	const titleObjective = goal.objective.length > 48 ? `${goal.objective.slice(0, 45)}...` : goal.objective;
+	ctx.ui.setTitle(`[${label}] ${titleObjective}`);
 }
 
 function parseBudgetFlags(pi: ExtensionAPI): GoalBudget {

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -144,6 +144,7 @@ function setGoal(
 	next: GoalState | undefined,
 	options: { notify?: string } = {},
 ): void {
+	bumpGoalVersion();
 	goal = next;
 	persistGoal(pi, goal);
 	updateStatus(pi, ctx);
@@ -237,6 +238,7 @@ function reportWaitingForUser(ctx: ExtensionContext): void {
 
 function transitionBudgetLimited(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	if (!goal) return;
+	bumpGoalVersion();
 	pendingRestart = false;
 	const limited = { ...goal, status: "budget_limited" as const, updatedAt: Date.now() };
 	goal = limited;
@@ -251,6 +253,12 @@ function transitionBudgetLimited(pi: ExtensionAPI, ctx: ExtensionContext): void 
 let goal: GoalState | undefined;
 let pendingRestart = false;
 let continuationQueued = false;
+let goalVersion = 0;
+let activeRunGoalVersion = -1;
+
+function bumpGoalVersion(): void {
+	goalVersion++;
+}
 
 export default function goalModeExtension(pi: ExtensionAPI): void {
 	pi.registerFlag("goal", {
@@ -370,6 +378,7 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 						`Completed: ${params.evidence.replace(/\s+/g, " ").trim().slice(0, 200)}`,
 					].slice(-20),
 				};
+				bumpGoalVersion();
 				goal = completed;
 				pendingRestart = false;
 				continuationQueued = false;
@@ -390,6 +399,8 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", async (event, ctx) => {
 		pendingRestart = false;
 		continuationQueued = false;
+		activeRunGoalVersion = -1;
+		bumpGoalVersion();
 		goal = getLatestGoalState(ctx.sessionManager.getBranch());
 
 		if (event.reason === "startup") {
@@ -413,11 +424,14 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 	pi.on("session_tree", async (_event, ctx) => {
 		pendingRestart = false;
 		continuationQueued = false;
+		activeRunGoalVersion = -1;
+		bumpGoalVersion();
 		goal = getLatestGoalState(ctx.sessionManager.getBranch());
 		updateStatus(pi, ctx);
 	});
 
 	pi.on("turn_end", async (event, ctx) => {
+		if (activeRunGoalVersion !== goalVersion) return;
 		if (!goal || goal.status !== "active") return;
 
 		const text = getAssistantText(event.message);
@@ -433,9 +447,11 @@ export default function goalModeExtension(pi: ExtensionAPI): void {
 
 	pi.on("agent_start", async () => {
 		continuationQueued = false;
+		activeRunGoalVersion = goalVersion;
 	});
 
 	pi.on("agent_settled", async (_event, ctx) => {
+		if (activeRunGoalVersion === -1) return;
 		if (!goal || goal.status !== "active") return;
 		if (ctx.hasPendingMessages()) return;
 		if (pendingRestart) {

--- a/packages/coding-agent/examples/extensions/goal-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/index.ts
@@ -68,14 +68,14 @@ function getGoalStatusLabel(status: GoalState["status"]): string {
 
 function updateStatus(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	if (!goal) {
-		ctx.ui.setStatus("goal-mode", "goal: off");
+		ctx.ui.setStatus("goal-mode", "mode: build");
 		ctx.ui.setWidget("goal-mode", undefined);
 		ctx.ui.setTitle(getBaseTitle(pi));
 		return;
 	}
 
 	const label = getGoalStatusLabel(goal.status);
-	ctx.ui.setStatus("goal-mode", `goal: ${goal.status}`);
+	ctx.ui.setStatus("goal-mode", "mode: goal");
 
 	const lines = [`[${label}]`, `Objective: ${goal.objective}`];
 	if (goal.budget?.tokens !== undefined || goal.budget?.cost !== undefined) {

--- a/packages/coding-agent/examples/extensions/goal-mode/utils.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/utils.ts
@@ -79,7 +79,13 @@ export function normalizeGoalState(value: unknown): GoalState | undefined {
 	if (typeof value.createdAt !== "number" || typeof value.updatedAt !== "number") return undefined;
 
 	const baseline =
-		isRecord(value.baseline) && typeof value.baseline.tokens === "number" && typeof value.baseline.cost === "number"
+		isRecord(value.baseline) &&
+		typeof value.baseline.tokens === "number" &&
+		Number.isFinite(value.baseline.tokens) &&
+		value.baseline.tokens >= 0 &&
+		typeof value.baseline.cost === "number" &&
+		Number.isFinite(value.baseline.cost) &&
+		value.baseline.cost >= 0
 			? { tokens: value.baseline.tokens, cost: value.baseline.cost }
 			: { tokens: 0, cost: 0 };
 
@@ -131,36 +137,41 @@ export function parseGoalCommand(rawArgs: string): GoalCommandResult {
 	if (args === "resume") return { action: "resume" };
 	if (args === "clear") return { action: "clear" };
 
-	let objective = args;
 	const budget: GoalBudget = {};
+	const seen = new Set<string>();
+	let objective = args;
+	const flagPattern = /--(tokens|cost)\s+([^\s]+)/gi;
+	const numberPattern = /^[0-9]+(?:\.[0-9]+)?$/;
 
-	const flagPattern = /(?:^|\s+)--(tokens|cost)\s+([0-9]+(?:\.[0-9]+)?)\s*$/i;
-	for (let i = 0; i < 2; i++) {
-		const match = objective.match(flagPattern);
-		if (!match) break;
-		const name = match[1].toLowerCase();
-		const value = Number(match[2]);
+	let match: RegExpExecArray | null;
+	while (true) {
+		match = flagPattern.exec(objective);
+		if (match === null) break;
+		const name = match[1]!.toLowerCase();
+		if (seen.has(name)) {
+			return { action: "invalid", message: `Duplicate --${name} flag` };
+		}
+		seen.add(name);
+		const rawValue = match[2]!;
+		const value = Number(rawValue);
 		if (name === "tokens") {
-			if (match[2].includes(".")) {
-				return { action: "invalid", message: "--tokens must be a non-negative integer" };
-			}
-			if (!Number.isFinite(value) || value < 0) {
+			if (!numberPattern.test(rawValue) || !Number.isInteger(value) || value < 0) {
 				return { action: "invalid", message: "--tokens must be a non-negative integer" };
 			}
 			budget.tokens = value;
 		} else {
-			if (!Number.isFinite(value) || value < 0) {
+			if (!numberPattern.test(rawValue) || !Number.isFinite(value) || value < 0) {
 				return { action: "invalid", message: "--cost must be a non-negative number" };
 			}
 			budget.cost = value;
 		}
-		objective = objective.slice(0, match.index).trimEnd();
+		objective = objective.slice(0, match.index) + " " + objective.slice(match.index + match[0].length);
+		flagPattern.lastIndex = match.index;
 	}
 
-	const invalidFlagPattern = /(?:^|\s+)--(tokens|cost)(?:\s+([^\s]+))?\s*$/i;
-	const invalidMatch = objective.match(invalidFlagPattern);
-	if (invalidMatch) {
-		const name = invalidMatch[1].toLowerCase();
+	const leftoverFlag = /--(tokens|cost)\b/i.exec(objective);
+	if (leftoverFlag) {
+		const name = leftoverFlag[1]!.toLowerCase();
 		return {
 			action: "invalid",
 			message:
@@ -168,8 +179,15 @@ export function parseGoalCommand(rawArgs: string): GoalCommandResult {
 		};
 	}
 
+	objective = objective.replace(/\s+/g, " ").trim();
 	if (!objective) {
 		return { action: "invalid", message: "A goal objective is required" };
+	}
+	if (objective === "pause" || objective === "resume" || objective === "clear") {
+		return {
+			action: "invalid",
+			message: `The ${objective} subcommand does not accept budget flags`,
+		};
 	}
 	return { action: "set", objective, budget };
 }
@@ -224,14 +242,28 @@ function truncate(text: string, maxLength: number): string {
 
 /** Append a compact progress line, keeping only the most recent entries. */
 export function appendProgress(state: GoalState, text: string, now = Date.now(), maxEntries = 20): GoalState {
-	const time = new Date(now).toISOString().slice(11, 19);
-	const line = `[${time}] ${truncate(text.replace(/\s+/g, " ").trim(), 200)}`;
+	const normalized = text.replace(/\s+/g, " ").trim();
+	const content = normalized ? truncate(normalized, 200) : "";
+	const line = content ? `[${new Date(now).toISOString().slice(11, 19)}] ${content}` : "";
+	const last = state.progress[state.progress.length - 1];
+	const lastContent = last ? last.slice(last.indexOf("] ") + 2) : undefined;
+	if (!line || lastContent === content) {
+		return { ...state, updatedAt: now };
+	}
 	const progress = [...state.progress, line];
 	return {
 		...state,
 		progress: progress.slice(-maxEntries),
 		updatedAt: now,
 	};
+}
+
+const MIN_COMPLETION_EVIDENCE_LENGTH = 20;
+
+/** Reject completion evidence that is too short to describe concrete verification. */
+export function isValidCompletionEvidence(evidence: string): boolean {
+	const normalized = evidence.replace(/\s+/g, " ").trim();
+	return normalized.length >= MIN_COMPLETION_EVIDENCE_LENGTH;
 }
 
 export function formatGoalState(state: GoalState, usage?: UsageTotals): string {
@@ -260,11 +292,15 @@ export function isGoalContextMessage(message: AgentMessage): boolean {
 	return (message as { customType?: unknown }).customType === GOAL_CONTEXT_TYPE;
 }
 
-export function buildGoalContextMessage(state: GoalState): AgentMessage {
-	const budget =
-		state.budget?.tokens !== undefined || state.budget?.cost !== undefined
-			? `\nBudget: ${state.budget.tokens !== undefined ? `tokens ${state.budget.tokens}` : ""}${state.budget.tokens !== undefined && state.budget.cost !== undefined ? ", " : ""}${state.budget.cost !== undefined ? `cost ${state.budget.cost}` : ""}`
-			: "";
+export function buildGoalContextMessage(state: GoalState, usage?: UsageTotals): AgentMessage {
+	const budgetParts: string[] = [];
+	if (state.budget?.tokens !== undefined) {
+		budgetParts.push(usage ? `tokens ${usage.tokens}/${state.budget.tokens}` : `tokens ${state.budget.tokens}`);
+	}
+	if (state.budget?.cost !== undefined) {
+		budgetParts.push(usage ? `cost ${usage.cost.toFixed(4)}/${state.budget.cost}` : `cost ${state.budget.cost}`);
+	}
+	const budget = budgetParts.length > 0 ? `\nBudget: ${budgetParts.join(", ")}` : "";
 	return {
 		role: "custom",
 		customType: GOAL_CONTEXT_TYPE,
@@ -272,7 +308,7 @@ export function buildGoalContextMessage(state: GoalState): AgentMessage {
 
 Active goal: ${state.objective}${budget}
 
-Work autonomously toward this goal. Before each next step, inspect the current evidence in the conversation and the working tree. Call complete_goal only after the objective is verified against concrete evidence such as command output, test results, file changes, or generated artifacts. Do not call complete_goal based only on intent or a plausible summary.
+Work autonomously toward this goal. Before each next step, inspect the current evidence in the conversation and the working tree. Call complete_goal only after the objective is verified against concrete evidence such as command output, test results, file changes, or generated artifacts, described in at least 20 characters. Do not call complete_goal based only on intent or a plausible summary.
 
 If you are blocked or no defensible path remains, stop and explain the blocker in your response instead of calling complete_goal.`,
 		display: false,
@@ -283,7 +319,7 @@ If you are blocked or no defensible path remains, stop and explain the blocker i
 export function buildContinuationPrompt(state: GoalState): string {
 	return `Continue the active goal: ${state.objective}
 
-Inspect the current state, verify progress against concrete evidence, and take the next useful step. If the goal is now satisfied, call complete_goal with the evidence. If you are blocked, stop and report the blocker. Do not ask the user for permission for ordinary in-scope steps.`;
+Inspect the current state, verify progress against concrete evidence, and take the next useful step. If the goal is now satisfied, call complete_goal with at least 20 characters of evidence (for example command output, test results, or file changes). If you are blocked, stop and report the blocker. Do not ask the user for permission for ordinary in-scope steps.`;
 }
 
 export function assistantHasToolCalls(message: AgentMessage | undefined): boolean {

--- a/packages/coding-agent/examples/extensions/goal-mode/utils.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/utils.ts
@@ -263,7 +263,7 @@ const MIN_COMPLETION_EVIDENCE_LENGTH = 20;
 /** Reject completion evidence that is too short to describe concrete verification. */
 export function isValidCompletionEvidence(evidence: string): boolean {
 	const normalized = evidence.replace(/\s+/g, " ").trim();
-	return normalized.length >= MIN_COMPLETION_EVIDENCE_LENGTH;
+	return normalized.length >= MIN_COMPLETION_EVIDENCE_LENGTH && /[\p{L}\p{N}]/u.test(normalized);
 }
 
 export function formatGoalState(state: GoalState, usage?: UsageTotals): string {

--- a/packages/coding-agent/examples/extensions/goal-mode/utils.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/utils.ts
@@ -119,7 +119,7 @@ export function createGoalState(
 ): GoalState {
 	const now = options.now ?? Date.now();
 	return {
-		objective: objective.trim(),
+		objective: objective.replace(/\s+/g, " ").trim(),
 		status: "active",
 		budget: options.budget,
 		createdAt: now,

--- a/packages/coding-agent/examples/extensions/goal-mode/utils.ts
+++ b/packages/coding-agent/examples/extensions/goal-mode/utils.ts
@@ -1,0 +1,301 @@
+/**
+ * Pure helpers for the goal-mode extension.
+ *
+ * The extension keeps a small state machine in session custom entries so it can
+ * survive resume, fork, and compaction. All mutation helpers in this file are
+ * side-effect free and are covered by unit tests.
+ */
+
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+
+export const GOAL_ENTRY_TYPE = "goal-mode";
+export const GOAL_CONTEXT_TYPE = "goal-mode-context";
+
+export type GoalStatus = "active" | "paused" | "complete" | "budget_limited";
+
+export interface GoalBudget {
+	tokens?: number;
+	cost?: number;
+}
+
+export interface UsageTotals {
+	tokens: number;
+	cost: number;
+}
+
+export interface GoalState {
+	objective: string;
+	status: GoalStatus;
+	budget?: GoalBudget;
+	createdAt: number;
+	updatedAt: number;
+	progress: string[];
+	/** Usage totals recorded when the goal was created, used for delta accounting. */
+	baseline: UsageTotals;
+	/** Whether the most recent turn ended with at least one tool result. */
+	lastTurnHadToolCall?: boolean;
+	/** Evidence text supplied to complete_goal when the goal was completed. */
+	lastCompletionEvidence?: string;
+}
+
+export type GoalCommandResult =
+	| { action: "set"; objective: string; budget: GoalBudget }
+	| { action: "view" }
+	| { action: "pause" }
+	| { action: "resume" }
+	| { action: "clear" }
+	| { action: "invalid"; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isGoalStatus(value: unknown): value is GoalStatus {
+	return value === "active" || value === "paused" || value === "complete" || value === "budget_limited";
+}
+
+function normalizeBudget(value: unknown): GoalBudget | undefined {
+	if (!isRecord(value)) return undefined;
+	const budget: GoalBudget = {};
+	if (typeof value.tokens === "number" && Number.isFinite(value.tokens) && value.tokens >= 0) {
+		budget.tokens = value.tokens;
+	}
+	if (typeof value.cost === "number" && Number.isFinite(value.cost) && value.cost >= 0) {
+		budget.cost = value.cost;
+	}
+	return budget.tokens === undefined && budget.cost === undefined ? undefined : budget;
+}
+
+function normalizeProgress(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string");
+}
+
+export function normalizeGoalState(value: unknown): GoalState | undefined {
+	if (!isRecord(value)) return undefined;
+	if (typeof value.objective !== "string" || value.objective.trim().length === 0) return undefined;
+	if (!isGoalStatus(value.status)) return undefined;
+	if (typeof value.createdAt !== "number" || typeof value.updatedAt !== "number") return undefined;
+
+	const baseline =
+		isRecord(value.baseline) && typeof value.baseline.tokens === "number" && typeof value.baseline.cost === "number"
+			? { tokens: value.baseline.tokens, cost: value.baseline.cost }
+			: { tokens: 0, cost: 0 };
+
+	return {
+		objective: value.objective,
+		status: value.status,
+		budget: normalizeBudget(value.budget),
+		createdAt: value.createdAt,
+		updatedAt: value.updatedAt,
+		progress: normalizeProgress(value.progress),
+		baseline,
+		lastTurnHadToolCall: typeof value.lastTurnHadToolCall === "boolean" ? value.lastTurnHadToolCall : undefined,
+		lastCompletionEvidence:
+			typeof value.lastCompletionEvidence === "string" ? value.lastCompletionEvidence : undefined,
+	};
+}
+
+/** Find the most recent goal state on the active branch, if any. */
+export function getLatestGoalState(entries: readonly SessionEntry[]): GoalState | undefined {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
+		if (entry.type !== "custom" || entry.customType !== GOAL_ENTRY_TYPE) continue;
+		return normalizeGoalState(entry.data);
+	}
+	return undefined;
+}
+
+export function createGoalState(
+	objective: string,
+	options: { budget?: GoalBudget; baseline?: UsageTotals; now?: number } = {},
+): GoalState {
+	const now = options.now ?? Date.now();
+	return {
+		objective: objective.trim(),
+		status: "active",
+		budget: options.budget,
+		createdAt: now,
+		updatedAt: now,
+		progress: [],
+		baseline: options.baseline ?? { tokens: 0, cost: 0 },
+	};
+}
+
+/** Parse `/goal` command arguments into a state-machine operation. */
+export function parseGoalCommand(rawArgs: string): GoalCommandResult {
+	const args = rawArgs.trim();
+	if (!args) return { action: "view" };
+	if (args === "pause") return { action: "pause" };
+	if (args === "resume") return { action: "resume" };
+	if (args === "clear") return { action: "clear" };
+
+	let objective = args;
+	const budget: GoalBudget = {};
+
+	const flagPattern = /(?:^|\s+)--(tokens|cost)\s+([0-9]+(?:\.[0-9]+)?)\s*$/i;
+	for (let i = 0; i < 2; i++) {
+		const match = objective.match(flagPattern);
+		if (!match) break;
+		const name = match[1].toLowerCase();
+		const value = Number(match[2]);
+		if (name === "tokens") {
+			if (match[2].includes(".")) {
+				return { action: "invalid", message: "--tokens must be a non-negative integer" };
+			}
+			if (!Number.isFinite(value) || value < 0) {
+				return { action: "invalid", message: "--tokens must be a non-negative integer" };
+			}
+			budget.tokens = value;
+		} else {
+			if (!Number.isFinite(value) || value < 0) {
+				return { action: "invalid", message: "--cost must be a non-negative number" };
+			}
+			budget.cost = value;
+		}
+		objective = objective.slice(0, match.index).trimEnd();
+	}
+
+	const invalidFlagPattern = /(?:^|\s+)--(tokens|cost)(?:\s+([^\s]+))?\s*$/i;
+	const invalidMatch = objective.match(invalidFlagPattern);
+	if (invalidMatch) {
+		const name = invalidMatch[1].toLowerCase();
+		return {
+			action: "invalid",
+			message:
+				name === "tokens" ? "--tokens must be a non-negative integer" : "--cost must be a non-negative number",
+		};
+	}
+
+	if (!objective) {
+		return { action: "invalid", message: "A goal objective is required" };
+	}
+	return { action: "set", objective, budget };
+}
+
+interface UsageLike {
+	input?: number;
+	output?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+	cost?: { total?: number };
+}
+
+function addUsage(totals: UsageTotals, usage: UsageLike | undefined): void {
+	if (!usage) return;
+	totals.tokens += (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+	totals.cost += usage.cost?.total ?? 0;
+}
+
+/** Sum billed usage across the session branch, including compacted entries. */
+export function computeUsageTotals(entries: readonly SessionEntry[]): UsageTotals {
+	const totals: UsageTotals = { tokens: 0, cost: 0 };
+	for (const entry of entries) {
+		if (entry.type === "message") {
+			const message = entry.message as { usage?: unknown };
+			addUsage(totals, message.usage as UsageLike | undefined);
+		} else if (entry.type === "compaction" || entry.type === "branch_summary") {
+			addUsage(totals, entry.usage as unknown as UsageLike | undefined);
+		}
+	}
+	return totals;
+}
+
+/** Usage consumed since the goal was created. */
+export function getGoalUsage(state: GoalState, entries: readonly SessionEntry[]): UsageTotals {
+	const totals = computeUsageTotals(entries);
+	return {
+		tokens: Math.max(0, totals.tokens - state.baseline.tokens),
+		cost: Math.max(0, totals.cost - state.baseline.cost),
+	};
+}
+
+export function isBudgetExceeded(state: GoalState, usage: UsageTotals): boolean {
+	if (state.budget?.tokens !== undefined && usage.tokens > state.budget.tokens) return true;
+	if (state.budget?.cost !== undefined && usage.cost > state.budget.cost) return true;
+	return false;
+}
+
+function truncate(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength - 3)}...`;
+}
+
+/** Append a compact progress line, keeping only the most recent entries. */
+export function appendProgress(state: GoalState, text: string, now = Date.now(), maxEntries = 20): GoalState {
+	const time = new Date(now).toISOString().slice(11, 19);
+	const line = `[${time}] ${truncate(text.replace(/\s+/g, " ").trim(), 200)}`;
+	const progress = [...state.progress, line];
+	return {
+		...state,
+		progress: progress.slice(-maxEntries),
+		updatedAt: now,
+	};
+}
+
+export function formatGoalState(state: GoalState, usage?: UsageTotals): string {
+	const lines = [`Goal: ${state.objective}`, `Status: ${state.status}`];
+	if (state.budget?.tokens !== undefined || state.budget?.cost !== undefined) {
+		const budget = state.budget;
+		const used = usage ?? { tokens: 0, cost: 0 };
+		const parts: string[] = [];
+		if (budget.tokens !== undefined) parts.push(`tokens ${used.tokens}/${budget.tokens}`);
+		if (budget.cost !== undefined) parts.push(`cost ${used.cost.toFixed(4)}/${budget.cost}`);
+		lines.push(`Budget: ${parts.join(", ")}`);
+	}
+	if (state.lastCompletionEvidence) {
+		lines.push(`Completed evidence: ${truncate(state.lastCompletionEvidence, 200)}`);
+	}
+	if (state.progress.length > 0) {
+		lines.push("Progress:");
+		for (const item of state.progress.slice(-10)) {
+			lines.push(`- ${item}`);
+		}
+	}
+	return lines.join("\n");
+}
+
+export function isGoalContextMessage(message: AgentMessage): boolean {
+	return (message as { customType?: unknown }).customType === GOAL_CONTEXT_TYPE;
+}
+
+export function buildGoalContextMessage(state: GoalState): AgentMessage {
+	const budget =
+		state.budget?.tokens !== undefined || state.budget?.cost !== undefined
+			? `\nBudget: ${state.budget.tokens !== undefined ? `tokens ${state.budget.tokens}` : ""}${state.budget.tokens !== undefined && state.budget.cost !== undefined ? ", " : ""}${state.budget.cost !== undefined ? `cost ${state.budget.cost}` : ""}`
+			: "";
+	return {
+		role: "custom",
+		customType: GOAL_CONTEXT_TYPE,
+		content: `[GOAL MODE ACTIVE]
+
+Active goal: ${state.objective}${budget}
+
+Work autonomously toward this goal. Before each next step, inspect the current evidence in the conversation and the working tree. Call complete_goal only after the objective is verified against concrete evidence such as command output, test results, file changes, or generated artifacts. Do not call complete_goal based only on intent or a plausible summary.
+
+If you are blocked or no defensible path remains, stop and explain the blocker in your response instead of calling complete_goal.`,
+		display: false,
+		timestamp: Date.now(),
+	};
+}
+
+export function buildContinuationPrompt(state: GoalState): string {
+	return `Continue the active goal: ${state.objective}
+
+Inspect the current state, verify progress against concrete evidence, and take the next useful step. If the goal is now satisfied, call complete_goal with the evidence. If you are blocked, stop and report the blocker. Do not ask the user for permission for ordinary in-scope steps.`;
+}
+
+export function assistantHasToolCalls(message: AgentMessage | undefined): boolean {
+	if (!message || message.role !== "assistant") return false;
+	return message.content.some((part) => part.type === "toolCall");
+}
+
+export function getAssistantText(message: AgentMessage | undefined): string {
+	if (!message || message.role !== "assistant") return "";
+	return message.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("\n")
+		.trim();
+}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1176,6 +1176,8 @@ export interface RegisteredCommand {
 	name: string;
 	sourceInfo: SourceInfo;
 	description?: string;
+	/** Usage hint shown in slash-command autocomplete, e.g. "<provider/model>". */
+	argumentHint?: string;
 	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null | Promise<AutocompleteItem[] | null>;
 	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>;
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -696,6 +696,7 @@ export class InteractiveMode {
 			.map((cmd) => ({
 				name: cmd.invocationName,
 				description: this.prefixAutocompleteDescription(cmd.description, cmd.sourceInfo),
+				...(cmd.argumentHint && { argumentHint: cmd.argumentHint }),
 				getArgumentCompletions: cmd.getArgumentCompletions,
 			}));
 

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -159,11 +159,11 @@ describe("goal-mode example extension", () => {
 		expect(goalCommand?.argumentHint).toBe("<objective> [--tokens N] [--cost N] | pause | resume | clear");
 		expect(goalCommand?.getArgumentCompletions?.("")).toEqual([
 			{ value: "pause", label: "pause", description: "Pause the active goal" },
-			{ value: "resume", label: "resume", description: "Resume a paused goal" },
+			{ value: "resume", label: "resume", description: "Resume a paused, waiting, or budget-limited goal" },
 			{ value: "clear", label: "clear", description: "Clear the goal" },
 		]);
 		expect(goalCommand?.getArgumentCompletions?.("re")).toEqual([
-			{ value: "resume", label: "resume", description: "Resume a paused goal" },
+			{ value: "resume", label: "resume", description: "Resume a paused, waiting, or budget-limited goal" },
 		]);
 		expect(goalCommand?.getArgumentCompletions?.("Fix tests")).toBeNull();
 	});

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -535,6 +535,45 @@ describe("goal-mode example extension", () => {
 		expect(notify).toHaveBeenCalledWith("Goal resumed.", "info");
 	});
 
+	it("does not resume a paused goal that already exceeded its budget", async () => {
+		const { emit, entries, notify, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "Fix tests --tokens 10");
+		await emit("agent_start", { type: "agent_start" });
+		entries.push({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "mock",
+				usage: {
+					input: 10,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			id: "usage",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+		await runCommand("goal", "pause");
+		expect(customData(entries.at(-1))).toMatchObject({ status: "paused" });
+
+		const callsBefore = sendUserMessage.mock.calls.length;
+		await runCommand("goal", "resume");
+
+		expect(customData(entries.at(-1))).toMatchObject({ status: "budget_limited" });
+		expect(sendUserMessage.mock.calls.length).toBe(callsBefore);
+		expect(notify).toHaveBeenLastCalledWith(expect.stringContaining("budget exhausted"), "warning");
+	});
+
 	it("shows usage in /goal view for non-active budgets", async () => {
 		const { emit, entries, notify, runCommand } = setup();
 

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -164,7 +164,7 @@ describe("goal-mode example extension", () => {
 		});
 		expect(sendUserMessage).toHaveBeenCalledTimes(1);
 		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Fix the flaky suite");
-		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: active");
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: goal");
 		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", [
 			"[GOAL MODE]",
 			"Objective: Fix the flaky suite",
@@ -179,17 +179,17 @@ describe("goal-mode example extension", () => {
 		await runCommand("goal", "Fix tests");
 		await runCommand("goal", "pause");
 		expect(customData(entries.at(-1))).toMatchObject({ status: "paused" });
-		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: paused");
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: goal");
 		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", ["[GOAL PAUSED]", "Objective: Fix tests"]);
 		expect(abort).toHaveBeenCalledTimes(1);
 
 		await runCommand("goal", "resume");
 		expect(customData(entries.at(-1))).toMatchObject({ status: "active" });
-		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: active");
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: goal");
 
 		await runCommand("goal", "clear");
 		expect(customData(entries.at(-1))).toBeNull();
-		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: off");
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: build");
 		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", undefined);
 		expect(setTitle).toHaveBeenLastCalledWith(expect.stringContaining("pi - "));
 		expect(abort).toHaveBeenCalledTimes(2);

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -188,6 +188,7 @@ describe("goal-mode example extension", () => {
 		await runCommand("goal", "First goal");
 		expect(abort).toHaveBeenCalledTimes(1);
 		expect(sendUserMessage).not.toHaveBeenCalled();
+		await emit("agent_start", { type: "agent_start" });
 
 		await runCommand("goal", "Second goal");
 		expect(abort).toHaveBeenCalledTimes(2);
@@ -200,10 +201,38 @@ describe("goal-mode example extension", () => {
 		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Second goal");
 	});
 
+	it("ignores turn_end events from a goal that was replaced mid-run", async () => {
+		const { abort, emit, entries, runCommand, sendUserMessage, setIdle } = setup({ idle: false });
+
+		await runCommand("goal", "First goal");
+		expect(abort).toHaveBeenCalledTimes(1);
+		await emit("agent_start", { type: "agent_start" });
+
+		await runCommand("goal", "Second goal");
+		expect(abort).toHaveBeenCalledTimes(2);
+
+		await emit("turn_end", {
+			type: "turn_end",
+			turnIndex: 1,
+			message: createAssistantMessage("First goal progress"),
+			toolResults: [],
+		});
+
+		const latest = customData(entries.at(-1)) as { objective?: string; progress?: string[] };
+		expect(latest.objective).toBe("Second goal");
+		expect(latest.progress ?? []).not.toContain(expect.stringContaining("First goal progress"));
+
+		setIdle(true);
+		await emit("agent_settled", { type: "agent_settled" });
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Second goal");
+	});
+
 	it("does not restart a cleared goal after an in-flight set was aborted", async () => {
 		const { abort, emit, runCommand, sendUserMessage, setIdle } = setup({ idle: false });
 
 		await runCommand("goal", "First goal");
+		await emit("agent_start", { type: "agent_start" });
 		await runCommand("goal", "clear");
 		expect(abort).toHaveBeenCalledTimes(2);
 
@@ -289,6 +318,7 @@ describe("goal-mode example extension", () => {
 		const { emit, runCommand, entries } = setup();
 
 		await runCommand("goal", "Fix tests");
+		await emit("agent_start", { type: "agent_start" });
 		const assistant = createAssistantMessage("Ran the suite and fixed one failure");
 		await emit("turn_end", {
 			type: "turn_end",
@@ -354,6 +384,7 @@ describe("goal-mode example extension", () => {
 		const { emit, runCommand, entries } = setup();
 
 		await runCommand("goal", "Fix tests --tokens 10");
+		await emit("agent_start", { type: "agent_start" });
 		entries.push({
 			type: "message",
 			message: {
@@ -427,6 +458,7 @@ describe("goal-mode example extension", () => {
 		const { emit, entries, notify, runCommand } = setup();
 
 		await runCommand("goal", "Fix tests --tokens 10");
+		await emit("agent_start", { type: "agent_start" });
 		entries.push({
 			type: "message",
 			message: {
@@ -522,6 +554,7 @@ describe("goal-mode example extension", () => {
 		} as SessionEntry);
 		await emit("session_tree", { type: "session_tree", newLeafId: "goal-again", oldLeafId: "cleared" });
 		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: goal");
+		await emit("agent_settled", { type: "agent_settled" });
 		expect(sendUserMessage).toHaveBeenCalledTimes(1);
 	});
 

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -67,6 +67,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 	const setStatus = vi.fn();
 	const setWidget = vi.fn();
 	const setTitle = vi.fn();
+	const abort = vi.fn();
 
 	const api = {
 		registerFlag: vi.fn(),
@@ -97,6 +98,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 		sessionManager: { getBranch: () => entries },
 		isIdle: () => options.idle ?? true,
 		hasPendingMessages: () => options.pending ?? false,
+		abort,
 		mode: "tui",
 	} as unknown as ExtensionContext;
 
@@ -113,6 +115,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 	}
 
 	return {
+		abort,
 		appendEntry,
 		commandOptions,
 		commands,
@@ -171,13 +174,14 @@ describe("goal-mode example extension", () => {
 	});
 
 	it("pauses, resumes, and clears a goal", async () => {
-		const { entries, runCommand, setStatus, setTitle, setWidget } = setup();
+		const { abort, entries, runCommand, setStatus, setTitle, setWidget } = setup();
 
 		await runCommand("goal", "Fix tests");
 		await runCommand("goal", "pause");
 		expect(customData(entries.at(-1))).toMatchObject({ status: "paused" });
 		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: paused");
 		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", ["[GOAL PAUSED]", "Objective: Fix tests"]);
+		expect(abort).toHaveBeenCalledTimes(1);
 
 		await runCommand("goal", "resume");
 		expect(customData(entries.at(-1))).toMatchObject({ status: "active" });
@@ -188,6 +192,7 @@ describe("goal-mode example extension", () => {
 		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", undefined);
 		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", undefined);
 		expect(setTitle).toHaveBeenLastCalledWith(expect.stringContaining("pi - "));
+		expect(abort).toHaveBeenCalledTimes(2);
 	});
 
 	it("tracks tool usage and progress on turn end", async () => {

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -45,7 +45,15 @@ function customData(entry: SessionEntry | undefined): unknown {
 	return entry && entry.type === "custom" ? entry.data : undefined;
 }
 
-function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string; flagBudgetTokens?: string } = {}) {
+function setup(
+	options: {
+		idle?: boolean;
+		pending?: boolean;
+		flagGoal?: string;
+		flagBudgetTokens?: string;
+		flagBudgetCost?: string;
+	} = {},
+) {
 	const commands = new Map<string, CommandHandler>();
 	const commandOptions = new Map<string, CommandRegistration>();
 	const handlers = new Map<string, EventHandler>();
@@ -85,6 +93,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string; 
 		getFlag: vi.fn((name: string) => {
 			if (name === "goal") return options.flagGoal;
 			if (name === "goal-budget-tokens") return options.flagBudgetTokens;
+			if (name === "goal-budget-cost") return options.flagBudgetCost;
 			return undefined;
 		}),
 		getSessionName: vi.fn(() => undefined),
@@ -620,6 +629,51 @@ describe("goal-mode example extension", () => {
 		);
 	});
 
+	it("reports no goal for lifecycle commands without a goal", async () => {
+		const { abort, notify, runCommand, setStatus } = setup();
+
+		await runCommand("goal", "pause");
+		expect(notify).toHaveBeenLastCalledWith("No goal set.", "info");
+		await runCommand("goal", "resume");
+		expect(notify).toHaveBeenLastCalledWith("No goal set.", "info");
+		await runCommand("goal", "clear");
+		expect(notify).toHaveBeenLastCalledWith("No goal set.", "info");
+		expect(abort).not.toHaveBeenCalled();
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: build");
+	});
+
+	it("does not resume a completed goal", async () => {
+		const { ctx, entries, notify, runCommand, tools } = setup();
+		await runCommand("goal", "Fix tests");
+
+		const tool = tools.get("complete_goal");
+		await tool!.execute("call-1", { evidence: "suite passes with 0 failures" }, undefined, undefined, ctx);
+		expect(customData(entries.at(-1))).toMatchObject({ status: "complete" });
+
+		await runCommand("goal", "resume");
+		expect(notify).toHaveBeenLastCalledWith("Goal cannot be resumed from status complete.", "info");
+	});
+
+	it("rejects complete_goal without an active goal", async () => {
+		const { ctx, tools } = setup();
+
+		const tool = tools.get("complete_goal");
+		await expect(
+			tool!.execute("call-1", { evidence: "suite passes with 0 failures" }, undefined, undefined, ctx),
+		).rejects.toThrow("No active goal to complete.");
+	});
+
+	it("rejects complete_goal while the goal is paused", async () => {
+		const { ctx, runCommand, tools } = setup();
+		await runCommand("goal", "Fix tests");
+		await runCommand("goal", "pause");
+
+		const tool = tools.get("complete_goal");
+		await expect(
+			tool!.execute("call-1", { evidence: "suite passes with 0 failures" }, undefined, undefined, ctx),
+		).rejects.toThrow("Goal cannot be completed from status paused.");
+	});
+
 	it("starts a goal from the --goal startup flag", async () => {
 		const { emit, sendUserMessage, entries } = setup({ flagGoal: "Startup goal" });
 
@@ -628,6 +682,17 @@ describe("goal-mode example extension", () => {
 		expect(customData(entries.at(-1))).toMatchObject({ objective: "Startup goal", status: "active" });
 		expect(sendUserMessage).toHaveBeenCalledTimes(1);
 		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Startup goal");
+	});
+
+	it("starts a goal with budget flags", async () => {
+		const { emit, entries } = setup({ flagGoal: "Startup goal", flagBudgetTokens: "100", flagBudgetCost: "2.5" });
+
+		await emit("session_start", { type: "session_start", reason: "startup" });
+
+		expect(customData(entries.at(-1))).toMatchObject({
+			objective: "Startup goal",
+			budget: { tokens: 100, cost: 2.5 },
+		});
 	});
 
 	it("warns instead of silently ignoring an invalid budget startup flag", async () => {

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -189,7 +189,7 @@ describe("goal-mode example extension", () => {
 
 		await runCommand("goal", "clear");
 		expect(customData(entries.at(-1))).toBeNull();
-		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", undefined);
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: off");
 		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", undefined);
 		expect(setTitle).toHaveBeenLastCalledWith(expect.stringContaining("pi - "));
 		expect(abort).toHaveBeenCalledTimes(2);

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -1,0 +1,297 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import goalModeExtension from "../examples/extensions/goal-mode/index.ts";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../src/core/extensions/index.ts";
+
+type CommandHandler = (args: string, ctx: ExtensionContext) => Promise<void> | void;
+type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createTextMessage(text: string): AgentMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}
+
+function customData(entry: SessionEntry | undefined): unknown {
+	return entry && entry.type === "custom" ? entry.data : undefined;
+}
+
+function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string } = {}) {
+	const commands = new Map<string, CommandHandler>();
+	const handlers = new Map<string, EventHandler>();
+	const tools = new Map<string, ToolDefinition>();
+	const entries: SessionEntry[] = [];
+
+	const sendUserMessage = vi.fn<ExtensionAPI["sendUserMessage"]>();
+	const appendEntry = vi.fn<ExtensionAPI["appendEntry"]>((customType: string, data: unknown) => {
+		entries.push({
+			type: "custom",
+			customType,
+			data,
+			id: `entry-${entries.length}`,
+			parentId: entries.length > 0 ? entries[entries.length - 1]!.id : null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+	});
+	const notify = vi.fn();
+	const setStatus = vi.fn();
+	const setWidget = vi.fn();
+
+	const api = {
+		registerFlag: vi.fn(),
+		registerCommand(name: string, command: { handler: CommandHandler }) {
+			commands.set(name, command.handler);
+		},
+		registerTool(tool: ToolDefinition) {
+			tools.set(tool.name, tool);
+		},
+		on(event: string, handler: EventHandler) {
+			handlers.set(event, handler);
+		},
+		getFlag: vi.fn((name: string) => {
+			if (name === "goal") return options.flagGoal;
+			return undefined;
+		}),
+		sendUserMessage,
+		appendEntry,
+	} as unknown as ExtensionAPI;
+
+	goalModeExtension(api);
+
+	const ctx = {
+		hasUI: true,
+		ui: { notify, setStatus, setWidget },
+		sessionManager: { getBranch: () => entries },
+		isIdle: () => options.idle ?? true,
+		hasPendingMessages: () => options.pending ?? false,
+		mode: "tui",
+	} as unknown as ExtensionContext;
+
+	async function runCommand(name: string, args = ""): Promise<void> {
+		const command = commands.get(name);
+		if (!command) throw new Error(`Missing command: ${name}`);
+		await command(args, ctx);
+	}
+
+	async function emit(event: string, payload: unknown): Promise<unknown> {
+		const handler = handlers.get(event);
+		if (!handler) throw new Error(`Missing handler: ${event}`);
+		return await handler(payload, ctx);
+	}
+
+	return {
+		appendEntry,
+		commands,
+		ctx,
+		emit,
+		entries,
+		handlers,
+		notify,
+		runCommand,
+		sendUserMessage,
+		setStatus,
+		setWidget,
+		tools,
+	};
+}
+
+describe("goal-mode example extension", () => {
+	it("sets a goal, persists it, and starts work", async () => {
+		const { entries, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "Fix the flaky suite --tokens 100");
+
+		const goalEntry = entries.find((entry) => entry.type === "custom" && entry.customType === "goal-mode");
+		expect(goalEntry).toBeDefined();
+		expect(customData(goalEntry)).toMatchObject({
+			objective: "Fix the flaky suite",
+			status: "active",
+			budget: { tokens: 100 },
+		});
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Fix the flaky suite");
+	});
+
+	it("pauses, resumes, and clears a goal", async () => {
+		const { entries, runCommand } = setup();
+
+		await runCommand("goal", "Fix tests");
+		await runCommand("goal", "pause");
+		expect(customData(entries.at(-1))).toMatchObject({ status: "paused" });
+
+		await runCommand("goal", "resume");
+		expect(customData(entries.at(-1))).toMatchObject({ status: "active" });
+
+		await runCommand("goal", "clear");
+		expect(customData(entries.at(-1))).toBeNull();
+	});
+
+	it("tracks tool usage and progress on turn end", async () => {
+		const { emit, runCommand, entries } = setup();
+
+		await runCommand("goal", "Fix tests");
+		const assistant = createAssistantMessage("Ran the suite and fixed one failure");
+		await emit("turn_end", {
+			type: "turn_end",
+			turnIndex: 1,
+			message: assistant,
+			toolResults: [{ role: "toolResult", toolCallId: "t1", toolName: "bash", content: [], timestamp: 0 }],
+		});
+
+		const latest = customData(entries.at(-1)) as {
+			lastTurnHadToolCall?: boolean;
+			progress?: string[];
+		};
+		expect(latest.lastTurnHadToolCall).toBe(true);
+		expect(latest.progress?.[0]).toContain("Ran the suite");
+	});
+
+	it("continues only when the goal is active, idle, and the last turn used a tool", async () => {
+		const { emit, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "Fix tests");
+		const assistant = createAssistantMessage("checked the suite");
+		await emit("turn_end", {
+			type: "turn_end",
+			turnIndex: 1,
+			message: assistant,
+			toolResults: [{ role: "toolResult", toolCallId: "t1", toolName: "bash", content: [], timestamp: 0 }],
+		});
+		await emit("agent_settled", { type: "agent_settled" });
+
+		expect(sendUserMessage).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not spin after a turn with no tool calls", async () => {
+		const { emit, notify, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "Fix tests");
+		await emit("turn_end", {
+			type: "turn_end",
+			turnIndex: 1,
+			message: createAssistantMessage("I checked and the suite is green"),
+			toolResults: [],
+		});
+		await emit("agent_settled", { type: "agent_settled" });
+
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("no tool calls"), "info");
+	});
+
+	it("respects queued user input before auto-continuing", async () => {
+		const { emit, runCommand, sendUserMessage } = setup({ pending: true });
+
+		await runCommand("goal", "Fix tests");
+		await emit("agent_settled", { type: "agent_settled" });
+
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("marks the goal budget-limited instead of continuing", async () => {
+		const { emit, runCommand, entries } = setup();
+
+		await runCommand("goal", "Fix tests --tokens 10");
+		entries.push({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "mock",
+				usage: {
+					input: 10,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			id: "usage",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+		await emit("agent_settled", { type: "agent_settled" });
+
+		expect(customData(entries.at(-1))).toMatchObject({ status: "budget_limited" });
+	});
+
+	it("injects active goal context and removes stale context", async () => {
+		const { emit, runCommand } = setup();
+		const stale = {
+			role: "custom",
+			customType: "goal-mode-context",
+			content: "old",
+			display: false,
+			timestamp: 0,
+		} as AgentMessage;
+
+		await runCommand("goal", "Fix tests");
+		const activeResult = (await emit("context", {
+			type: "context",
+			messages: [createTextMessage("hello"), stale],
+		})) as { messages: AgentMessage[] };
+		expect(activeResult.messages).toHaveLength(2);
+		expect(activeResult.messages[1]).toMatchObject({ customType: "goal-mode-context" });
+
+		await runCommand("goal", "pause");
+		const pausedResult = (await emit("context", {
+			type: "context",
+			messages: [createTextMessage("hello"), stale],
+		})) as { messages: AgentMessage[] };
+		expect(pausedResult.messages).toHaveLength(1);
+		expect(pausedResult.messages[0]).toMatchObject({ role: "user" });
+	});
+
+	it("registers a complete_goal tool that requires evidence", async () => {
+		const { ctx, entries, runCommand, tools } = setup();
+		await runCommand("goal", "Fix tests");
+
+		const tool = tools.get("complete_goal");
+		expect(tool).toBeDefined();
+		const result = await tool!.execute("call-1", { evidence: "suite passes" }, undefined, undefined, ctx);
+
+		expect(result.terminate).toBe(true);
+		expect(customData(entries.at(-1))).toMatchObject({
+			status: "complete",
+			lastCompletionEvidence: "suite passes",
+		});
+	});
+
+	it("starts a goal from the --goal startup flag", async () => {
+		const { emit, sendUserMessage, entries } = setup({ flagGoal: "Startup goal" });
+
+		await emit("session_start", { type: "session_start", reason: "startup" });
+
+		expect(customData(entries.at(-1))).toMatchObject({ objective: "Startup goal", status: "active" });
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Startup goal");
+	});
+});

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -7,6 +7,11 @@ import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../src/core
 
 type CommandHandler = (args: string, ctx: ExtensionContext) => Promise<void> | void;
 type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+type CommandRegistration = {
+	handler: CommandHandler;
+	argumentHint?: string;
+	getArgumentCompletions?: (prefix: string) => unknown;
+};
 
 function createAssistantMessage(text: string): AssistantMessage {
 	return {
@@ -42,6 +47,7 @@ function customData(entry: SessionEntry | undefined): unknown {
 
 function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string } = {}) {
 	const commands = new Map<string, CommandHandler>();
+	const commandOptions = new Map<string, CommandRegistration>();
 	const handlers = new Map<string, EventHandler>();
 	const tools = new Map<string, ToolDefinition>();
 	const entries: SessionEntry[] = [];
@@ -64,7 +70,8 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 
 	const api = {
 		registerFlag: vi.fn(),
-		registerCommand(name: string, command: { handler: CommandHandler }) {
+		registerCommand(name: string, command: CommandRegistration) {
+			commandOptions.set(name, command);
 			commands.set(name, command.handler);
 		},
 		registerTool(tool: ToolDefinition) {
@@ -107,6 +114,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 
 	return {
 		appendEntry,
+		commandOptions,
 		commands,
 		ctx,
 		emit,
@@ -123,6 +131,22 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 }
 
 describe("goal-mode example extension", () => {
+	it("registers /goal with a usage hint and subcommand completions", () => {
+		const { commandOptions } = setup();
+		const goalCommand = commandOptions.get("goal");
+
+		expect(goalCommand?.argumentHint).toBe("<objective> [--tokens N] [--cost N] | pause | resume | clear");
+		expect(goalCommand?.getArgumentCompletions?.("")).toEqual([
+			{ value: "pause", label: "pause", description: "Pause the active goal" },
+			{ value: "resume", label: "resume", description: "Resume a paused goal" },
+			{ value: "clear", label: "clear", description: "Clear the goal" },
+		]);
+		expect(goalCommand?.getArgumentCompletions?.("re")).toEqual([
+			{ value: "resume", label: "resume", description: "Resume a paused goal" },
+		]);
+		expect(goalCommand?.getArgumentCompletions?.("Fix tests")).toBeNull();
+	});
+
 	it("sets a goal, persists it, and starts work", async () => {
 		const { entries, runCommand, sendUserMessage, setStatus, setTitle, setWidget } = setup();
 

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -186,9 +186,47 @@ describe("goal-mode example extension", () => {
 		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", [
 			"[GOAL MODE]",
 			"Objective: Fix the flaky suite",
-			"Budget: tokens 100",
+			"Budget: tokens 0/100",
 		]);
 		expect(setTitle).toHaveBeenLastCalledWith("[GOAL MODE] Fix the flaky suite");
+	});
+
+	it("shows budget usage in the widget", async () => {
+		const { emit, entries, runCommand, setWidget } = setup();
+
+		await runCommand("goal", "Fix tests --tokens 100");
+		await emit("agent_start", { type: "agent_start" });
+		entries.push({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "mock",
+				usage: {
+					input: 10,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			id: "usage",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+		await emit("turn_end", {
+			type: "turn_end",
+			turnIndex: 1,
+			message: createAssistantMessage("checked"),
+			toolResults: [],
+		});
+
+		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", expect.arrayContaining(["Budget: tokens 20/100"]));
 	});
 
 	it("replaces an active goal while streaming by aborting and restarting after settle", async () => {
@@ -420,6 +458,40 @@ describe("goal-mode example extension", () => {
 		await emit("agent_settled", { type: "agent_settled" });
 
 		expect(customData(entries.at(-1))).toMatchObject({ status: "budget_limited" });
+	});
+
+	it("does not continue an over-budget goal on session resume", async () => {
+		const { emit, entries, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "Fix tests --tokens 10");
+		entries.push({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "mock",
+				usage: {
+					input: 10,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			id: "usage",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+
+		await emit("session_start", { type: "session_start", reason: "resume" });
+
+		expect(customData(entries.at(-1))).toMatchObject({ status: "budget_limited" });
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
 	});
 
 	it("resumes a budget-limited goal with a fresh baseline", async () => {

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -45,7 +45,7 @@ function customData(entry: SessionEntry | undefined): unknown {
 	return entry && entry.type === "custom" ? entry.data : undefined;
 }
 
-function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string } = {}) {
+function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string; flagBudgetTokens?: string } = {}) {
 	const commands = new Map<string, CommandHandler>();
 	const commandOptions = new Map<string, CommandRegistration>();
 	const handlers = new Map<string, EventHandler>();
@@ -84,6 +84,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 		},
 		getFlag: vi.fn((name: string) => {
 			if (name === "goal") return options.flagGoal;
+			if (name === "goal-budget-tokens") return options.flagBudgetTokens;
 			return undefined;
 		}),
 		getSessionName: vi.fn(() => undefined),
@@ -322,7 +323,7 @@ describe("goal-mode example extension", () => {
 	});
 
 	it("does not spin after a turn with no tool calls", async () => {
-		const { emit, notify, runCommand, sendUserMessage } = setup();
+		const { emit, notify, runCommand, sendUserMessage, setWidget } = setup();
 
 		await runCommand("goal", "Fix tests");
 		await emit("agent_start", { type: "agent_start" });
@@ -336,6 +337,7 @@ describe("goal-mode example extension", () => {
 
 		expect(sendUserMessage).toHaveBeenCalledTimes(1);
 		expect(notify).toHaveBeenCalledWith(expect.stringContaining("no tool calls"), "info");
+		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", expect.arrayContaining(["[GOAL MODE (WAITING)]"]));
 	});
 
 	it("respects queued user input before auto-continuing", async () => {
@@ -380,6 +382,149 @@ describe("goal-mode example extension", () => {
 		expect(customData(entries.at(-1))).toMatchObject({ status: "budget_limited" });
 	});
 
+	it("resumes a budget-limited goal with a fresh baseline", async () => {
+		const { emit, entries, notify, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "Fix tests --tokens 10");
+		await emit("agent_start", { type: "agent_start" });
+		entries.push({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "mock",
+				usage: {
+					input: 10,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			id: "usage",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+		await emit("agent_settled", { type: "agent_settled" });
+		expect(customData(entries.at(-1))).toMatchObject({ status: "budget_limited" });
+
+		await runCommand("goal", "resume");
+
+		expect(customData(entries.at(-1))).toMatchObject({
+			status: "active",
+			baseline: { tokens: 20, cost: 0 },
+		});
+		expect(sendUserMessage).toHaveBeenCalledTimes(2);
+		expect(notify).toHaveBeenCalledWith("Goal resumed.", "info");
+	});
+
+	it("shows usage in /goal view for non-active budgets", async () => {
+		const { emit, entries, notify, runCommand } = setup();
+
+		await runCommand("goal", "Fix tests --tokens 10");
+		entries.push({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "mock",
+				usage: {
+					input: 10,
+					output: 10,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 20,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			id: "usage",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+		await emit("agent_settled", { type: "agent_settled" });
+
+		await runCommand("goal");
+
+		expect(notify).toHaveBeenLastCalledWith(expect.stringContaining("tokens 20/10"), "info");
+	});
+
+	it("injects budget usage into the active goal context", async () => {
+		const { emit, entries, runCommand } = setup();
+
+		await runCommand("goal", "Fix tests --tokens 100");
+		entries.push({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "mock",
+				usage: {
+					input: 50,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 50,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			id: "usage",
+			parentId: null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+
+		const result = (await emit("context", {
+			type: "context",
+			messages: [createTextMessage("hello")],
+		})) as { messages: AgentMessage[] };
+		const context = result.messages.at(-1) as { content?: string };
+		expect(context.content).toContain("Budget: tokens 50/100");
+	});
+
+	it("does not auto-continue after session tree navigation", async () => {
+		const { emit, entries, runCommand, sendUserMessage, setStatus } = setup();
+
+		await runCommand("goal", "Fix tests");
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+		const goalEntry = entries.find((entry) => entry.type === "custom" && entry.customType === "goal-mode");
+		const goalData = customData(goalEntry);
+
+		entries.push({
+			type: "custom",
+			customType: "goal-mode",
+			data: null,
+			id: "cleared",
+			parentId: goalEntry?.id ?? null,
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+		await emit("session_tree", { type: "session_tree", newLeafId: "cleared", oldLeafId: "goal-entry" });
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: build");
+
+		entries.push({
+			type: "custom",
+			customType: "goal-mode",
+			data: goalData,
+			id: "goal-again",
+			parentId: "cleared",
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+		await emit("session_tree", { type: "session_tree", newLeafId: "goal-again", oldLeafId: "cleared" });
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: goal");
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+	});
+
 	it("injects active goal context and removes stale context", async () => {
 		const { emit, runCommand } = setup();
 		const stale = {
@@ -413,13 +558,29 @@ describe("goal-mode example extension", () => {
 
 		const tool = tools.get("complete_goal");
 		expect(tool).toBeDefined();
-		const result = await tool!.execute("call-1", { evidence: "suite passes" }, undefined, undefined, ctx);
+		const result = await tool!.execute(
+			"call-1",
+			{ evidence: "suite passes with 0 failures" },
+			undefined,
+			undefined,
+			ctx,
+		);
 
 		expect(result.terminate).toBe(true);
 		expect(customData(entries.at(-1))).toMatchObject({
 			status: "complete",
-			lastCompletionEvidence: "suite passes",
+			lastCompletionEvidence: "suite passes with 0 failures",
 		});
+	});
+
+	it("rejects completion evidence that is too short", async () => {
+		const { ctx, runCommand, tools } = setup();
+		await runCommand("goal", "Fix tests");
+
+		const tool = tools.get("complete_goal");
+		await expect(tool!.execute("call-1", { evidence: "done" }, undefined, undefined, ctx)).rejects.toThrow(
+			"at least 20 characters",
+		);
 	});
 
 	it("starts a goal from the --goal startup flag", async () => {
@@ -430,5 +591,13 @@ describe("goal-mode example extension", () => {
 		expect(customData(entries.at(-1))).toMatchObject({ objective: "Startup goal", status: "active" });
 		expect(sendUserMessage).toHaveBeenCalledTimes(1);
 		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Startup goal");
+	});
+
+	it("warns instead of silently ignoring an invalid budget startup flag", async () => {
+		const { emit, notify } = setup({ flagGoal: "Startup goal", flagBudgetTokens: "abc" });
+
+		await emit("session_start", { type: "session_start", reason: "startup" });
+
+		expect(notify).toHaveBeenCalledWith("Ignoring invalid --goal-budget-tokens value: abc", "warning");
 	});
 });

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -60,6 +60,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 	const notify = vi.fn();
 	const setStatus = vi.fn();
 	const setWidget = vi.fn();
+	const setTitle = vi.fn();
 
 	const api = {
 		registerFlag: vi.fn(),
@@ -76,6 +77,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 			if (name === "goal") return options.flagGoal;
 			return undefined;
 		}),
+		getSessionName: vi.fn(() => undefined),
 		sendUserMessage,
 		appendEntry,
 	} as unknown as ExtensionAPI;
@@ -84,7 +86,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 
 	const ctx = {
 		hasUI: true,
-		ui: { notify, setStatus, setWidget },
+		ui: { notify, setStatus, setWidget, setTitle },
 		sessionManager: { getBranch: () => entries },
 		isIdle: () => options.idle ?? true,
 		hasPendingMessages: () => options.pending ?? false,
@@ -114,6 +116,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 		runCommand,
 		sendUserMessage,
 		setStatus,
+		setTitle,
 		setWidget,
 		tools,
 	};
@@ -121,7 +124,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 
 describe("goal-mode example extension", () => {
 	it("sets a goal, persists it, and starts work", async () => {
-		const { entries, runCommand, sendUserMessage } = setup();
+		const { entries, runCommand, sendUserMessage, setStatus, setTitle, setWidget } = setup();
 
 		await runCommand("goal", "Fix the flaky suite --tokens 100");
 
@@ -134,20 +137,33 @@ describe("goal-mode example extension", () => {
 		});
 		expect(sendUserMessage).toHaveBeenCalledTimes(1);
 		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Fix the flaky suite");
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: active");
+		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", [
+			"[GOAL MODE]",
+			"Objective: Fix the flaky suite",
+			"Budget: tokens 100",
+		]);
+		expect(setTitle).toHaveBeenLastCalledWith("[GOAL MODE] Fix the flaky suite");
 	});
 
 	it("pauses, resumes, and clears a goal", async () => {
-		const { entries, runCommand } = setup();
+		const { entries, runCommand, setStatus, setTitle, setWidget } = setup();
 
 		await runCommand("goal", "Fix tests");
 		await runCommand("goal", "pause");
 		expect(customData(entries.at(-1))).toMatchObject({ status: "paused" });
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: paused");
+		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", ["[GOAL PAUSED]", "Objective: Fix tests"]);
 
 		await runCommand("goal", "resume");
 		expect(customData(entries.at(-1))).toMatchObject({ status: "active" });
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "goal: active");
 
 		await runCommand("goal", "clear");
 		expect(customData(entries.at(-1))).toBeNull();
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", undefined);
+		expect(setWidget).toHaveBeenLastCalledWith("goal-mode", undefined);
+		expect(setTitle).toHaveBeenLastCalledWith(expect.stringContaining("pi - "));
 	});
 
 	it("tracks tool usage and progress on turn end", async () => {

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -226,6 +226,42 @@ describe("goal-mode example extension", () => {
 		expect(sendUserMessage).toHaveBeenCalledTimes(2);
 	});
 
+	it("resumes an active goal that stopped after a no-tool-call turn", async () => {
+		const { emit, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "Fix tests");
+		await emit("agent_start", { type: "agent_start" });
+		await emit("turn_end", {
+			type: "turn_end",
+			turnIndex: 1,
+			message: createAssistantMessage("I checked, nothing to change"),
+			toolResults: [],
+		});
+
+		await runCommand("goal", "resume");
+
+		expect(sendUserMessage).toHaveBeenCalledTimes(2);
+		expect(sendUserMessage.mock.calls[1]?.[0]).toContain("Fix tests");
+	});
+
+	it("reloads goal state after session tree navigation", async () => {
+		const { emit, entries, runCommand, setStatus } = setup();
+
+		await runCommand("goal", "Fix tests");
+		entries.push({
+			type: "custom",
+			customType: "goal-mode",
+			data: null,
+			id: "cleared",
+			parentId: "goal-entry",
+			timestamp: new Date().toISOString(),
+		} as SessionEntry);
+
+		await emit("session_tree", { type: "session_tree", newLeafId: "cleared", oldLeafId: "goal-entry" });
+
+		expect(setStatus).toHaveBeenLastCalledWith("goal-mode", "mode: build");
+	});
+
 	it("pauses, resumes, and clears a goal", async () => {
 		const { abort, entries, runCommand, setStatus, setTitle, setWidget } = setup();
 

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -593,7 +593,7 @@ describe("goal-mode example extension", () => {
 		expect(tool).toBeDefined();
 		const result = await tool!.execute(
 			"call-1",
-			{ evidence: "suite passes with 0 failures" },
+			{ evidence: "  suite   passes with 0 failures  " },
 			undefined,
 			undefined,
 			ctx,
@@ -603,6 +603,10 @@ describe("goal-mode example extension", () => {
 		expect(customData(entries.at(-1))).toMatchObject({
 			status: "complete",
 			lastCompletionEvidence: "suite passes with 0 failures",
+		});
+		expect(result.details).toEqual({
+			objective: "Fix tests",
+			evidence: "suite passes with 0 failures",
 		});
 	});
 

--- a/packages/coding-agent/test/goal-mode-extension.test.ts
+++ b/packages/coding-agent/test/goal-mode-extension.test.ts
@@ -68,6 +68,7 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 	const setWidget = vi.fn();
 	const setTitle = vi.fn();
 	const abort = vi.fn();
+	let idle = options.idle ?? true;
 
 	const api = {
 		registerFlag: vi.fn(),
@@ -96,11 +97,15 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 		hasUI: true,
 		ui: { notify, setStatus, setWidget, setTitle },
 		sessionManager: { getBranch: () => entries },
-		isIdle: () => options.idle ?? true,
+		isIdle: () => idle,
 		hasPendingMessages: () => options.pending ?? false,
 		abort,
 		mode: "tui",
 	} as unknown as ExtensionContext;
+
+	// Reset module-level extension state between setup instances, simulating a
+	// fresh session without triggering a new goal.
+	handlers.get("session_start")?.({ type: "session_start", reason: "reload" }, ctx);
 
 	async function runCommand(name: string, args = ""): Promise<void> {
 		const command = commands.get(name);
@@ -126,6 +131,9 @@ function setup(options: { idle?: boolean; pending?: boolean; flagGoal?: string }
 		notify,
 		runCommand,
 		sendUserMessage,
+		setIdle: (value: boolean) => {
+			idle = value;
+		},
 		setStatus,
 		setTitle,
 		setWidget,
@@ -171,6 +179,51 @@ describe("goal-mode example extension", () => {
 			"Budget: tokens 100",
 		]);
 		expect(setTitle).toHaveBeenLastCalledWith("[GOAL MODE] Fix the flaky suite");
+	});
+
+	it("replaces an active goal while streaming by aborting and restarting after settle", async () => {
+		const { abort, emit, runCommand, sendUserMessage, setIdle } = setup({ idle: false });
+
+		await runCommand("goal", "First goal");
+		expect(abort).toHaveBeenCalledTimes(1);
+		expect(sendUserMessage).not.toHaveBeenCalled();
+
+		await runCommand("goal", "Second goal");
+		expect(abort).toHaveBeenCalledTimes(2);
+		expect(sendUserMessage).not.toHaveBeenCalled();
+
+		setIdle(true);
+		await emit("agent_settled", { type: "agent_settled" });
+
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+		expect(sendUserMessage.mock.calls[0]?.[0]).toContain("Second goal");
+	});
+
+	it("does not restart a cleared goal after an in-flight set was aborted", async () => {
+		const { abort, emit, runCommand, sendUserMessage, setIdle } = setup({ idle: false });
+
+		await runCommand("goal", "First goal");
+		await runCommand("goal", "clear");
+		expect(abort).toHaveBeenCalledTimes(2);
+
+		setIdle(true);
+		await emit("agent_settled", { type: "agent_settled" });
+
+		expect(sendUserMessage).not.toHaveBeenCalled();
+	});
+
+	it("does not queue a second continuation while one is already queued", async () => {
+		const { emit, runCommand, sendUserMessage } = setup();
+
+		await runCommand("goal", "First goal");
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+
+		await runCommand("goal", "First goal");
+		expect(sendUserMessage).toHaveBeenCalledTimes(1);
+
+		await emit("agent_start", { type: "agent_start" });
+		await runCommand("goal", "First goal");
+		expect(sendUserMessage).toHaveBeenCalledTimes(2);
 	});
 
 	it("pauses, resumes, and clears a goal", async () => {
@@ -219,6 +272,7 @@ describe("goal-mode example extension", () => {
 		const { emit, runCommand, sendUserMessage } = setup();
 
 		await runCommand("goal", "Fix tests");
+		await emit("agent_start", { type: "agent_start" });
 		const assistant = createAssistantMessage("checked the suite");
 		await emit("turn_end", {
 			type: "turn_end",
@@ -235,6 +289,7 @@ describe("goal-mode example extension", () => {
 		const { emit, notify, runCommand, sendUserMessage } = setup();
 
 		await runCommand("goal", "Fix tests");
+		await emit("agent_start", { type: "agent_start" });
 		await emit("turn_end", {
 			type: "turn_end",
 			turnIndex: 1,
@@ -251,6 +306,7 @@ describe("goal-mode example extension", () => {
 		const { emit, runCommand, sendUserMessage } = setup({ pending: true });
 
 		await runCommand("goal", "Fix tests");
+		await emit("agent_start", { type: "agent_start" });
 		await emit("agent_settled", { type: "agent_settled" });
 
 		expect(sendUserMessage).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/goal-mode-utils.test.ts
+++ b/packages/coding-agent/test/goal-mode-utils.test.ts
@@ -10,6 +10,7 @@ import {
 	getLatestGoalState,
 	isBudgetExceeded,
 	isGoalContextMessage,
+	isValidCompletionEvidence,
 	normalizeGoalState,
 	parseGoalCommand,
 } from "../examples/extensions/goal-mode/utils.ts";
@@ -39,6 +40,16 @@ describe("parseGoalCommand", () => {
 			objective: "Fix tests",
 			budget: { tokens: 5, cost: 1 },
 		});
+		expect(parseGoalCommand("--tokens 100 Fix tests")).toEqual({
+			action: "set",
+			objective: "Fix tests",
+			budget: { tokens: 100 },
+		});
+		expect(parseGoalCommand("Fix --cost 2.5 tests --tokens 10")).toEqual({
+			action: "set",
+			objective: "Fix tests",
+			budget: { tokens: 10, cost: 2.5 },
+		});
 	});
 
 	it("rejects empty objectives and invalid budgets", () => {
@@ -53,6 +64,30 @@ describe("parseGoalCommand", () => {
 		expect(parseGoalCommand("Fix tests --cost nope")).toEqual({
 			action: "invalid",
 			message: "--cost must be a non-negative number",
+		});
+		expect(parseGoalCommand("Fix --tokens nope tests")).toEqual({
+			action: "invalid",
+			message: "--tokens must be a non-negative integer",
+		});
+		expect(parseGoalCommand("Fix tests --cost -1")).toEqual({
+			action: "invalid",
+			message: "--cost must be a non-negative number",
+		});
+		expect(parseGoalCommand("Fix tests --tokens 1.")).toEqual({
+			action: "invalid",
+			message: "--tokens must be a non-negative integer",
+		});
+		expect(parseGoalCommand("Fix tests --tokens")).toEqual({
+			action: "invalid",
+			message: "--tokens must be a non-negative integer",
+		});
+		expect(parseGoalCommand("Fix tests --tokens 1 --tokens 2")).toEqual({
+			action: "invalid",
+			message: "Duplicate --tokens flag",
+		});
+		expect(parseGoalCommand("pause --tokens 5")).toEqual({
+			action: "invalid",
+			message: "The pause subcommand does not accept budget flags",
 		});
 	});
 });
@@ -80,6 +115,10 @@ describe("goal state helpers", () => {
 		expect(normalizeGoalState({ objective: "", status: "active" })).toBeUndefined();
 		const state = createGoalState("Fix tests", { now: 1 });
 		expect(normalizeGoalState(state)).toEqual(state);
+		expect(normalizeGoalState({ ...state, baseline: { tokens: -5, cost: -1 } })?.baseline).toEqual({
+			tokens: 0,
+			cost: 0,
+		});
 	});
 
 	it("appends capped progress entries", () => {
@@ -92,6 +131,27 @@ describe("goal state helpers", () => {
 		}
 		expect(state.progress).toHaveLength(20);
 		expect(state.progress[19]).toContain("entry 24");
+	});
+
+	it("skips empty and duplicate progress lines", () => {
+		let state = createGoalState("Fix tests", { now: 0 });
+		state = appendProgress(state, "   ", 1_000);
+		expect(state.progress).toHaveLength(0);
+		expect(state.updatedAt).toBe(1_000);
+
+		state = appendProgress(state, "Ran the suite", 2_000);
+		state = appendProgress(state, "Ran the suite", 3_000);
+		expect(state.progress).toHaveLength(1);
+		expect(state.updatedAt).toBe(3_000);
+	});
+});
+
+describe("completion evidence", () => {
+	it("requires concrete evidence of a minimum length", () => {
+		expect(isValidCompletionEvidence("done")).toBe(false);
+		expect(isValidCompletionEvidence("   ")).toBe(false);
+		expect(isValidCompletionEvidence("suite passes with 0 failures")).toBe(true);
+		expect(isValidCompletionEvidence("a".repeat(20))).toBe(true);
 	});
 });
 
@@ -223,6 +283,14 @@ describe("prompt formatting", () => {
 		const content =
 			typeof (message as { content?: unknown }).content === "string" ? (message as { content: string }).content : "";
 		expect(content).toContain("Active goal: Fix tests");
+	});
+
+	it("includes budget usage in the context message when provided", () => {
+		const state = createGoalState("Fix tests", { budget: { tokens: 100, cost: 2 }, now: 1 });
+		const message = buildGoalContextMessage(state, { tokens: 50, cost: 0.5 });
+		const content =
+			typeof (message as { content?: unknown }).content === "string" ? (message as { content: string }).content : "";
+		expect(content).toContain("Budget: tokens 50/100, cost 0.5000/2");
 	});
 
 	it("builds a continuation prompt that references the objective", () => {

--- a/packages/coding-agent/test/goal-mode-utils.test.ts
+++ b/packages/coding-agent/test/goal-mode-utils.test.ts
@@ -150,8 +150,10 @@ describe("completion evidence", () => {
 	it("requires concrete evidence of a minimum length", () => {
 		expect(isValidCompletionEvidence("done")).toBe(false);
 		expect(isValidCompletionEvidence("   ")).toBe(false);
+		expect(isValidCompletionEvidence(".".repeat(20))).toBe(false);
 		expect(isValidCompletionEvidence("suite passes with 0 failures")).toBe(true);
 		expect(isValidCompletionEvidence("a".repeat(20))).toBe(true);
+		expect(isValidCompletionEvidence("修复测试通过且无回归".repeat(2))).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/goal-mode-utils.test.ts
+++ b/packages/coding-agent/test/goal-mode-utils.test.ts
@@ -108,6 +108,7 @@ describe("goal state helpers", () => {
 			updatedAt: 42,
 			progress: [],
 		});
+		expect(createGoalState("  Fix\ntests   here ", { now: 1 }).objective).toBe("Fix tests here");
 	});
 
 	it("normalizes persisted state and rejects malformed data", () => {

--- a/packages/coding-agent/test/goal-mode-utils.test.ts
+++ b/packages/coding-agent/test/goal-mode-utils.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendProgress,
+	buildContinuationPrompt,
+	buildGoalContextMessage,
+	computeUsageTotals,
+	createGoalState,
+	formatGoalState,
+	getGoalUsage,
+	getLatestGoalState,
+	isBudgetExceeded,
+	isGoalContextMessage,
+	normalizeGoalState,
+	parseGoalCommand,
+} from "../examples/extensions/goal-mode/utils.ts";
+
+describe("parseGoalCommand", () => {
+	it("parses view, pause, resume, and clear", () => {
+		expect(parseGoalCommand("")).toEqual({ action: "view" });
+		expect(parseGoalCommand("  ")).toEqual({ action: "view" });
+		expect(parseGoalCommand("pause")).toEqual({ action: "pause" });
+		expect(parseGoalCommand("resume")).toEqual({ action: "resume" });
+		expect(parseGoalCommand("clear")).toEqual({ action: "clear" });
+	});
+
+	it("parses an objective with optional budgets", () => {
+		expect(parseGoalCommand("Fix the flaky suite")).toEqual({
+			action: "set",
+			objective: "Fix the flaky suite",
+			budget: {},
+		});
+		expect(parseGoalCommand("Fix tests --tokens 1000 --cost 2.5")).toEqual({
+			action: "set",
+			objective: "Fix tests",
+			budget: { tokens: 1000, cost: 2.5 },
+		});
+		expect(parseGoalCommand("Fix tests --cost 1 --tokens 5")).toEqual({
+			action: "set",
+			objective: "Fix tests",
+			budget: { tokens: 5, cost: 1 },
+		});
+	});
+
+	it("rejects empty objectives and invalid budgets", () => {
+		expect(parseGoalCommand("--tokens 10")).toEqual({
+			action: "invalid",
+			message: "A goal objective is required",
+		});
+		expect(parseGoalCommand("Fix tests --tokens nope")).toEqual({
+			action: "invalid",
+			message: "--tokens must be a non-negative integer",
+		});
+		expect(parseGoalCommand("Fix tests --cost nope")).toEqual({
+			action: "invalid",
+			message: "--cost must be a non-negative number",
+		});
+	});
+});
+
+describe("goal state helpers", () => {
+	it("creates an active goal with a usage baseline", () => {
+		const state = createGoalState("Fix tests", {
+			budget: { tokens: 100 },
+			baseline: { tokens: 10, cost: 1 },
+			now: 42,
+		});
+		expect(state).toMatchObject({
+			objective: "Fix tests",
+			status: "active",
+			budget: { tokens: 100 },
+			baseline: { tokens: 10, cost: 1 },
+			createdAt: 42,
+			updatedAt: 42,
+			progress: [],
+		});
+	});
+
+	it("normalizes persisted state and rejects malformed data", () => {
+		expect(normalizeGoalState(null)).toBeUndefined();
+		expect(normalizeGoalState({ objective: "", status: "active" })).toBeUndefined();
+		const state = createGoalState("Fix tests", { now: 1 });
+		expect(normalizeGoalState(state)).toEqual(state);
+	});
+
+	it("appends capped progress entries", () => {
+		let state = createGoalState("Fix tests", { now: 0 });
+		state = appendProgress(state, "Ran the suite and fixed one failure", 1_000);
+		expect(state.progress).toHaveLength(1);
+		expect(state.progress[0]).toContain("Ran the suite");
+		for (let i = 0; i < 25; i++) {
+			state = appendProgress(state, `entry ${i}`, 2_000 + i);
+		}
+		expect(state.progress).toHaveLength(20);
+		expect(state.progress[19]).toContain("entry 24");
+	});
+});
+
+describe("goal persistence", () => {
+	it("finds the most recent goal entry on the active branch", () => {
+		const first = createGoalState("first", { now: 1 });
+		const second = createGoalState("second", { now: 2 });
+		const entries = [
+			{
+				type: "custom",
+				customType: "goal-mode",
+				data: first,
+				id: "a",
+				parentId: null,
+				timestamp: "t1",
+			},
+			{
+				type: "custom",
+				customType: "goal-mode",
+				data: second,
+				id: "b",
+				parentId: "a",
+				timestamp: "t2",
+			},
+		] as const;
+		expect(getLatestGoalState(entries)?.objective).toBe("second");
+	});
+});
+
+describe("usage accounting", () => {
+	const entry = (usage: unknown) => ({
+		type: "message",
+		message: { usage },
+		id: "m",
+		parentId: null,
+		timestamp: "t",
+	});
+
+	it("sums tokens and cost from message and summary entries", () => {
+		const totals = computeUsageTotals([
+			entry({
+				input: 10,
+				output: 5,
+				cacheRead: 2,
+				cacheWrite: 1,
+				cost: { total: 0.25 },
+			}),
+			{
+				type: "compaction",
+				summary: "s",
+				firstKeptEntryId: "m",
+				tokensBefore: 0,
+				usage: {
+					input: 3,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					cost: { total: 0.05 },
+				},
+				id: "c",
+				parentId: "m",
+				timestamp: "t",
+			},
+		] as never);
+		expect(totals).toEqual({ tokens: 22, cost: 0.3 });
+	});
+
+	it("computes delta usage since the goal baseline", () => {
+		const state = createGoalState("Fix tests", { baseline: { tokens: 100, cost: 2 } });
+		const usage = getGoalUsage(state, [
+			entry({
+				input: 50,
+				output: 60,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: { total: 3 },
+			}),
+		] as never);
+		expect(usage).toEqual({ tokens: 10, cost: 1 });
+	});
+
+	it("detects budget exhaustion", () => {
+		const state = createGoalState("Fix tests", { budget: { tokens: 100, cost: 1 } });
+		expect(isBudgetExceeded(state, { tokens: 100, cost: 0.5 })).toBe(false);
+		expect(isBudgetExceeded(state, { tokens: 101, cost: 0.5 })).toBe(true);
+		expect(isBudgetExceeded(state, { tokens: 50, cost: 1.01 })).toBe(true);
+	});
+});
+
+describe("prompt formatting", () => {
+	it("formats status with budget and progress", () => {
+		const state = createGoalState("Fix tests", {
+			budget: { tokens: 100 },
+			now: 1,
+		});
+		const formatted = formatGoalState(state, { tokens: 10, cost: 0 });
+		expect(formatted).toContain("Goal: Fix tests");
+		expect(formatted).toContain("Status: active");
+		expect(formatted).toContain("Budget: tokens 10/100");
+	});
+
+	it("builds an injectable context message", () => {
+		const state = createGoalState("Fix tests", { now: 1 });
+		const message = buildGoalContextMessage(state);
+		expect(isGoalContextMessage(message)).toBe(true);
+		const content =
+			typeof (message as { content?: unknown }).content === "string" ? (message as { content: string }).content : "";
+		expect(content).toContain("Active goal: Fix tests");
+	});
+
+	it("builds a continuation prompt that references the objective", () => {
+		const state = createGoalState("Fix tests", { now: 1 });
+		expect(buildContinuationPrompt(state)).toContain("Fix tests");
+		expect(buildContinuationPrompt(state)).toContain("complete_goal");
+	});
+});

--- a/packages/coding-agent/test/goal-mode-utils.test.ts
+++ b/packages/coding-agent/test/goal-mode-utils.test.ts
@@ -119,6 +119,29 @@ describe("goal persistence", () => {
 		] as const;
 		expect(getLatestGoalState(entries)?.objective).toBe("second");
 	});
+
+	it("treats a cleared goal entry as no goal", () => {
+		const state = createGoalState("first", { now: 1 });
+		const entries = [
+			{
+				type: "custom",
+				customType: "goal-mode",
+				data: state,
+				id: "a",
+				parentId: null,
+				timestamp: "t1",
+			},
+			{
+				type: "custom",
+				customType: "goal-mode",
+				data: null,
+				id: "b",
+				parentId: "a",
+				timestamp: "t2",
+			},
+		] as const;
+		expect(getLatestGoalState(entries)).toBeUndefined();
+	});
 });
 
 describe("usage accounting", () => {

--- a/packages/coding-agent/test/suite/goal-mode.test.ts
+++ b/packages/coding-agent/test/suite/goal-mode.test.ts
@@ -1,0 +1,114 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import goalModeExtension from "../../examples/extensions/goal-mode/index.ts";
+import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+describe("goal-mode extension integration", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	function latestGoalEntry(harness: Harness) {
+		const entries = harness.sessionManager.getEntries();
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const entry = entries[i];
+			if (entry.type === "custom" && entry.customType === "goal-mode") {
+				return entry.data;
+			}
+		}
+		return undefined;
+	}
+
+	it("starts from /goal and stops after a no-tool-call turn", async () => {
+		const harness = await createHarness({ extensionFactories: [goalModeExtension] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("I inspected the suite and it is green")]);
+
+		await harness.session.prompt("/goal Fix the flaky suite");
+		await harness.session.waitForIdle();
+
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+		expect(getMessageText(harness.session.messages[0]!)).toContain("Fix the flaky suite");
+		expect(getMessageText(harness.session.messages[1]!)).toContain("I inspected the suite");
+	});
+
+	it("continues after a tool-call turn and stops when the next turn has no tools", async () => {
+		const toolRuns: string[] = [];
+		const echoTool: AgentTool = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo text back",
+			parameters: Type.Object({ text: Type.String() }),
+			execute: async (_toolCallId, params) => {
+				const text = typeof params === "object" && params !== null && "text" in params ? String(params.text) : "";
+				toolRuns.push(text);
+				return {
+					content: [{ type: "text", text: `echo:${text}` }],
+					details: { text },
+				};
+			},
+		};
+		const harness = await createHarness({
+			extensionFactories: [goalModeExtension],
+			tools: [echoTool],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("echo", { text: "probe" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("/goal Verify the echo tool");
+		await harness.session.waitForIdle();
+
+		expect(toolRuns).toEqual(["probe"]);
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(harness.session.messages.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"toolResult",
+			"assistant",
+		]);
+	});
+
+	it("marks the goal complete through complete_goal and stops", async () => {
+		const harness = await createHarness({ extensionFactories: [goalModeExtension] });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("complete_goal", { evidence: "suite passes" }), {
+				stopReason: "toolUse",
+			}),
+		]);
+
+		await harness.session.prompt("/goal Fix the flaky suite");
+		await harness.session.waitForIdle();
+
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(latestGoalEntry(harness)).toMatchObject({
+			status: "complete",
+			lastCompletionEvidence: "suite passes",
+		});
+		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+	});
+
+	it("does not auto-continue while the goal is paused", async () => {
+		const harness = await createHarness({ extensionFactories: [goalModeExtension] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first answer")]);
+
+		await harness.session.prompt("/goal Fix the flaky suite");
+		await harness.session.waitForIdle();
+		await harness.session.prompt("/goal pause");
+
+		const settledBeforePause = harness.eventsOfType("agent_settled").length;
+		expect(settledBeforePause).toBeGreaterThan(0);
+		expect(latestGoalEntry(harness)).toMatchObject({ status: "paused" });
+	});
+});

--- a/packages/coding-agent/test/suite/goal-mode.test.ts
+++ b/packages/coding-agent/test/suite/goal-mode.test.ts
@@ -82,7 +82,7 @@ describe("goal-mode extension integration", () => {
 		const harness = await createHarness({ extensionFactories: [goalModeExtension] });
 		harnesses.push(harness);
 		harness.setResponses([
-			fauxAssistantMessage(fauxToolCall("complete_goal", { evidence: "suite passes" }), {
+			fauxAssistantMessage(fauxToolCall("complete_goal", { evidence: "suite passes with 0 failures" }), {
 				stopReason: "toolUse",
 			}),
 		]);
@@ -93,7 +93,7 @@ describe("goal-mode extension integration", () => {
 		expect(harness.getPendingResponseCount()).toBe(0);
 		expect(latestGoalEntry(harness)).toMatchObject({
 			status: "complete",
-			lastCompletionEvidence: "suite passes",
+			lastCompletionEvidence: "suite passes with 0 failures",
 		});
 		expect(harness.session.messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
 	});


### PR DESCRIPTION
Adds a self-contained goal mode extension for long-running autonomous work.

- /goal lifecycle commands: set, view, pause, resume, clear; --tokens/--cost budget flags accepted anywhere in the command with clear validation errors.
- --goal startup flag with optional token and cost budgets.
- Thread-scoped persistent state via custom session entries; survives resume, fork, compaction, and branch navigation.
- Automatic continuation while active, deduplicated and gated on idle state, queued input, tool use, and budget.
- complete_goal tool requiring concrete evidence (minimum length, non-punctuation-only) so a goal cannot be closed on a bare status word.
- Resume paths for paused, waiting (no-tool-call), and budget-limited goals; budget-limited resume restarts the budget from current usage.
- TUI indicators: mode build / mode goal, GOAL MODE / GOAL PAUSED / GOAL COMPLETE / GOAL BUDGET LIMITED / GOAL MODE (WAITING), budget usage in the widget, /goal command hint and completions.
- Stale turn_end and agent_settled events from replaced goals or branch switches are dropped.