### PR TITLE
feat(coding-agent): add unified tool authorization boundary

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Revalidate tool arguments after pre-execution hooks so hook mutations cannot bypass the registered schema.
+
 ### Fixed
 
 - Fixed `streamProxy()` dropping finalized tool-call metadata such as OpenAI Responses namespaces ([#7709](https://github.com/earendil-works/pi/issues/7709)).

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -652,11 +652,15 @@ async function prepareToolCall(
 				isError: true,
 			};
 		}
+		const finalArgs = validateToolArguments(tool, {
+			...preparedToolCall,
+			arguments: validatedArgs as AgentToolCall["arguments"],
+		});
 		return {
 			kind: "prepared",
 			toolCall,
 			tool,
-			args: validatedArgs,
+			args: finalArgs,
 		};
 	} catch (error) {
 		return {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a single final tool-authorizer registration, semantic tool metadata, immutable action fingerprints, and trusted execution of approved captured actions.
 - Added a fullscreen exit output setting to choose between printing the final transcript and only a session resume hint.
 
 ### Changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -13,6 +13,7 @@
  * Modes use this class and add their own I/O layer on top.
  */
 
+import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname } from "node:path";
 import type {
@@ -21,10 +22,12 @@ import type {
 	AgentMessage,
 	AgentState,
 	AgentTool,
+	AgentToolResult,
+	AgentToolUpdateCallback,
 	PrepareNextTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
-import { contentText } from "@earendil-works/pi-ai";
+import { contentText, validateToolArguments } from "@earendil-works/pi-ai";
 import type {
 	AssistantMessage,
 	AuthResult,
@@ -52,6 +55,14 @@ import { resolvePath } from "../utils/paths.ts";
 import { sleep } from "../utils/sleep.ts";
 import { normalizeToolResultImages } from "../utils/tool-result-images.ts";
 import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.ts";
+import {
+	type AuthorizationActionSnapshot,
+	type AuthorizationDecision,
+	type AuthorizationGrant,
+	classifyToolAuthorization,
+	createAuthorizationAction,
+	fingerprintAuthorizationAction,
+} from "./authorization.ts";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.ts";
 import {
 	type CompactionResult,
@@ -479,17 +490,25 @@ export class AgentSession {
 	private _installAgentToolHooks(): void {
 		this.agent.beforeToolCall = async ({ toolCall, args }) => {
 			const runner = this._extensionRunner;
-			if (!runner.hasHandlers("tool_call")) {
-				return undefined;
-			}
-
 			try {
-				return await runner.emitToolCall({
-					type: "tool_call",
-					toolName: toolCall.name,
-					toolCallId: toolCall.id,
-					input: args as Record<string, unknown>,
-				});
+				const hookResult = runner.hasHandlers("tool_call")
+					? await runner.emitToolCall({
+							type: "tool_call",
+							toolName: toolCall.name,
+							toolCallId: toolCall.id,
+							input: args as Record<string, unknown>,
+						})
+					: undefined;
+				if (hookResult?.block) return hookResult;
+				const authorizer = runner.getRegisteredAuthorizer();
+				if (!authorizer) return hookResult;
+				const action = await this.captureToolAction(toolCall.name, args as Record<string, unknown>, toolCall.id);
+				const decision = await authorizer.authorize(action, { grants: [] });
+				if (decision.kind === "permit") return hookResult;
+				return {
+					block: true,
+					reason: this._authorizationBlockReason(decision, action),
+				};
 			} catch (err) {
 				if (err instanceof Error) {
 					throw err;
@@ -911,8 +930,137 @@ export class AgentSession {
 			description: definition.description,
 			parameters: definition.parameters,
 			promptGuidelines: definition.promptGuidelines,
+			authorization: definition.authorization,
 			sourceInfo,
 		}));
+	}
+
+	private _validatedToolInput(
+		definition: ToolDefinition,
+		toolCallId: string,
+		input: Record<string, unknown>,
+	): Record<string, unknown> {
+		const prepared = definition.prepareArguments?.(input) ?? input;
+		return validateToolArguments(definition, {
+			type: "toolCall",
+			id: toolCallId,
+			name: definition.name,
+			arguments: prepared as Record<string, unknown>,
+		});
+	}
+
+	async captureToolAction(
+		toolName: string,
+		input: Record<string, unknown>,
+		toolCallId: string = randomUUID(),
+	): Promise<AuthorizationActionSnapshot> {
+		const definition = this.getToolDefinition(toolName);
+		if (!definition) throw new Error(`Tool ${toolName} is not registered`);
+		const authorizer = this._extensionRunner.getRegisteredAuthorizer();
+		if (!authorizer) throw new Error("No tool authorizer is registered");
+		const policyRevision = authorizer.getPolicyRevision();
+		const validatedInput = this._validatedToolInput(definition, toolCallId, input);
+		const authorization = definition.authorization ?? {
+			operation: "tool.invoke",
+			effect: "execute" as const,
+			capabilities: [`tool.${toolName}`],
+			resources: [{ kind: "tool", value: toolName }],
+		};
+		const descriptor = classifyToolAuthorization(authorization, validatedInput, {
+			cwd: this._cwd,
+			sessionId: this.sessionId,
+			policyRevision,
+			toolCallId,
+		});
+		return createAuthorizationAction({
+			toolCallId,
+			toolName,
+			input: validatedInput,
+			cwd: this._cwd,
+			sessionId: this.sessionId,
+			policyRevision,
+			descriptor,
+		});
+	}
+
+	private _authorizationBlockReason(
+		decision: Exclude<AuthorizationDecision, { kind: "permit" }>,
+		action: AuthorizationActionSnapshot,
+	): string {
+		const reasons = decision.reasons.map((reason) => `${reason.code}: ${reason.message}`).join("\n");
+		if (decision.kind === "reject") return reasons;
+		return `${reasons}\n\nAuthorization requires consent for action ${action.fingerprint}. Use may_request with the exact target tool and input.`;
+	}
+
+	async executeAuthorized(
+		action: AuthorizationActionSnapshot,
+		grant: AuthorizationGrant,
+		options?: { signal?: AbortSignal; onUpdate?: AgentToolUpdateCallback },
+	): Promise<AgentToolResult<unknown>> {
+		if (action.sessionId !== this.sessionId || grant.scope.sessionId !== this.sessionId) {
+			throw new Error("Authorized action does not belong to the active session");
+		}
+		if (grant.expiresAt !== undefined && grant.expiresAt <= Date.now()) {
+			throw new Error("Authorization grant has expired");
+		}
+		if (
+			grant.constraints.actionFingerprint !== undefined &&
+			grant.constraints.actionFingerprint !== action.fingerprint
+		) {
+			throw new Error("Authorization grant does not match the captured action");
+		}
+		const { fingerprint: _fingerprint, ...unsignedAction } = action;
+		if (fingerprintAuthorizationAction(unsignedAction) !== action.fingerprint) {
+			throw new Error("Authorized action fingerprint is invalid");
+		}
+		const definition = this.getToolDefinition(action.toolName);
+		const tool = this._toolRegistry.get(action.toolName);
+		if (!definition || !tool) throw new Error(`Tool ${action.toolName} is not registered`);
+		const finalInput = structuredClone(action.input) as Record<string, unknown>;
+		const hookResult = this._extensionRunner.hasHandlers("tool_call")
+			? await this._extensionRunner.emitToolCall({
+					type: "tool_call",
+					toolName: action.toolName,
+					toolCallId: action.toolCallId,
+					input: finalInput,
+				})
+			: undefined;
+		if (hookResult?.block) throw new Error(hookResult.reason || "Tool execution was blocked");
+		const currentAction = await this.captureToolAction(action.toolName, finalInput, action.toolCallId);
+		if (currentAction.fingerprint !== action.fingerprint) {
+			throw new Error("Authorized action changed before execution");
+		}
+		const authorizer = this._extensionRunner.getRegisteredAuthorizer();
+		if (!authorizer) throw new Error("No tool authorizer is registered");
+		const decision = await authorizer.authorize(currentAction, { grants: [grant] });
+		if (decision.kind !== "permit") throw new Error(this._authorizationBlockReason(decision, currentAction));
+		const result = await tool.execute(
+			action.toolCallId,
+			currentAction.input as Record<string, unknown>,
+			options?.signal,
+			options?.onUpdate,
+		);
+		const resultHook = this._extensionRunner.hasHandlers("tool_result")
+			? await this._extensionRunner.emitToolResult({
+					type: "tool_result",
+					toolName: action.toolName,
+					toolCallId: action.toolCallId,
+					input: currentAction.input as Record<string, unknown>,
+					content: result.content,
+					details: result.details,
+					isError: false,
+					usage: result.usage,
+				})
+			: undefined;
+		const content = await normalizeToolResultImages(resultHook?.content ?? result.content ?? [], {
+			autoResizeImages: this.settingsManager.getImageAutoResize(),
+		});
+		return {
+			...result,
+			content,
+			details: resultHook?.details ?? result.details,
+			usage: resultHook?.usage ?? result.usage,
+		};
 	}
 
 	getToolDefinition(name: string): ToolDefinition | undefined {
@@ -2401,6 +2549,8 @@ export class AgentSession {
 				getActiveTools: () => this.getActiveToolNames(),
 				getAllTools: () => this.getAllTools(),
 				setActiveTools: (toolNames) => this.setActiveToolsByName(toolNames),
+				captureToolAction: (toolName, input, toolCallId) => this.captureToolAction(toolName, input, toolCallId),
+				executeAuthorized: (action, grant, options) => this.executeAuthorized(action, grant, options),
 				refreshTools: () => this._refreshToolRegistry(),
 				getCommands,
 				setModel: async (model) => {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1017,50 +1017,96 @@ export class AgentSession {
 		const tool = this._toolRegistry.get(action.toolName);
 		if (!definition || !tool) throw new Error(`Tool ${action.toolName} is not registered`);
 		const finalInput = structuredClone(action.input) as Record<string, unknown>;
-		const hookResult = this._extensionRunner.hasHandlers("tool_call")
-			? await this._extensionRunner.emitToolCall({
-					type: "tool_call",
-					toolName: action.toolName,
-					toolCallId: action.toolCallId,
-					input: finalInput,
-				})
-			: undefined;
-		if (hookResult?.block) throw new Error(hookResult.reason || "Tool execution was blocked");
-		const currentAction = await this.captureToolAction(action.toolName, finalInput, action.toolCallId);
-		if (currentAction.fingerprint !== action.fingerprint) {
-			throw new Error("Authorized action changed before execution");
-		}
-		const authorizer = this._extensionRunner.getRegisteredAuthorizer();
-		if (!authorizer) throw new Error("No tool authorizer is registered");
-		const decision = await authorizer.authorize(currentAction, { grants: [grant] });
-		if (decision.kind !== "permit") throw new Error(this._authorizationBlockReason(decision, currentAction));
-		const result = await tool.execute(
-			action.toolCallId,
-			currentAction.input as Record<string, unknown>,
-			options?.signal,
-			options?.onUpdate,
-		);
-		const resultHook = this._extensionRunner.hasHandlers("tool_result")
-			? await this._extensionRunner.emitToolResult({
-					type: "tool_result",
-					toolName: action.toolName,
-					toolCallId: action.toolCallId,
-					input: currentAction.input as Record<string, unknown>,
-					content: result.content,
-					details: result.details,
-					isError: false,
-					usage: result.usage,
-				})
-			: undefined;
-		const content = await normalizeToolResultImages(resultHook?.content ?? result.content ?? [], {
-			autoResizeImages: this.settingsManager.getImageAutoResize(),
-		});
-		return {
-			...result,
-			content,
-			details: resultHook?.details ?? result.details,
-			usage: resultHook?.usage ?? result.usage,
+		const startEvent = {
+			type: "tool_execution_start" as const,
+			toolCallId: action.toolCallId,
+			toolName: action.toolName,
+			args: finalInput,
 		};
+		await this._emitExtensionEvent(startEvent);
+		this._emit(startEvent);
+		let completedResult: AgentToolResult<unknown> | undefined;
+		let executionError: Error | undefined;
+		try {
+			const hookResult = this._extensionRunner.hasHandlers("tool_call")
+				? await this._extensionRunner.emitToolCall({
+						type: "tool_call",
+						toolName: action.toolName,
+						toolCallId: action.toolCallId,
+						input: finalInput,
+					})
+				: undefined;
+			if (hookResult?.block) throw new Error(hookResult.reason || "Tool execution was blocked");
+			const currentAction = await this.captureToolAction(action.toolName, finalInput, action.toolCallId);
+			if (currentAction.fingerprint !== action.fingerprint) {
+				throw new Error("Authorized action changed before execution");
+			}
+			const authorizer = this._extensionRunner.getRegisteredAuthorizer();
+			if (!authorizer) throw new Error("No tool authorizer is registered");
+			const decision = await authorizer.authorize(currentAction, { grants: [grant] });
+			if (decision.kind !== "permit") throw new Error(this._authorizationBlockReason(decision, currentAction));
+			const updateEvents: Promise<void>[] = [];
+			const result = await tool.execute(
+				action.toolCallId,
+				currentAction.input as Record<string, unknown>,
+				options?.signal,
+				(partialResult) => {
+					const updateEvent = {
+						type: "tool_execution_update" as const,
+						toolCallId: action.toolCallId,
+						toolName: action.toolName,
+						args: currentAction.input,
+						partialResult,
+					};
+					updateEvents.push(
+						this._emitExtensionEvent(updateEvent).then(() => {
+							this._emit(updateEvent);
+							options?.onUpdate?.(partialResult);
+						}),
+					);
+				},
+			);
+			await Promise.all(updateEvents);
+			const resultHook = this._extensionRunner.hasHandlers("tool_result")
+				? await this._extensionRunner.emitToolResult({
+						type: "tool_result",
+						toolName: action.toolName,
+						toolCallId: action.toolCallId,
+						input: currentAction.input as Record<string, unknown>,
+						content: result.content,
+						details: result.details,
+						isError: false,
+						usage: result.usage,
+					})
+				: undefined;
+			const content = await normalizeToolResultImages(resultHook?.content ?? result.content ?? [], {
+				autoResizeImages: this.settingsManager.getImageAutoResize(),
+			});
+			completedResult = {
+				...result,
+				content,
+				details: resultHook?.details ?? result.details,
+				usage: resultHook?.usage ?? result.usage,
+			};
+			return completedResult;
+		} catch (error) {
+			executionError = error instanceof Error ? error : new Error(String(error));
+			throw executionError;
+		} finally {
+			const endResult = completedResult ?? {
+				content: [{ type: "text" as const, text: executionError?.message ?? "Authorized execution failed" }],
+				details: {},
+			};
+			const endEvent = {
+				type: "tool_execution_end" as const,
+				toolCallId: action.toolCallId,
+				toolName: action.toolName,
+				result: endResult,
+				isError: executionError !== undefined,
+			};
+			await this._emitExtensionEvent(endEvent);
+			this._emit(endEvent);
+		}
 	}
 
 	getToolDefinition(name: string): ToolDefinition | undefined {

--- a/packages/coding-agent/src/core/authorization.ts
+++ b/packages/coding-agent/src/core/authorization.ts
@@ -1,0 +1,208 @@
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+
+export const AUTHORIZATION_SCHEMA_VERSION = 1 as const;
+
+export type AuthorizationEffect = "inspect" | "modify" | "execute" | "administer";
+export type GrantScopeKind = "action" | "user-epoch" | "session";
+
+export interface AuthorizationResource {
+	kind: string;
+	value: string;
+}
+
+export interface AuthorizationDescriptor {
+	operation: string;
+	effect: AuthorizationEffect;
+	capabilities: readonly string[];
+	resources: readonly AuthorizationResource[];
+}
+
+export interface AuthorizationClassificationContext {
+	cwd: string;
+	repository?: string;
+	sessionId: string;
+	policyRevision: string;
+	toolCallId: string;
+}
+
+export type AuthorizationClassifier<TParams = Record<string, unknown>> = {
+	bivarianceHack(
+		params: Readonly<TParams>,
+		context: Readonly<AuthorizationClassificationContext>,
+	): AuthorizationDescriptor;
+}["bivarianceHack"];
+
+export interface ToolAuthorization<TParams = Record<string, unknown>> {
+	operation: string;
+	effect: AuthorizationEffect;
+	capabilities: readonly string[];
+	resources?: readonly AuthorizationResource[];
+	classify?: AuthorizationClassifier<TParams>;
+}
+
+export interface Capability {
+	id: string;
+	description: string;
+}
+
+export interface ModeProfile {
+	id: string;
+	capabilities: readonly string[];
+	requestableCapabilities: readonly string[];
+}
+
+export interface GrantConstraints {
+	tools?: readonly string[];
+	operations?: readonly string[];
+	resources?: readonly AuthorizationResource[];
+	actionFingerprint?: string;
+}
+
+export interface GrantScope {
+	kind: GrantScopeKind;
+	sessionId: string;
+	epoch?: number;
+}
+
+export interface AuthorizationGrant {
+	id: string;
+	capabilities: readonly string[];
+	constraints: Readonly<GrantConstraints>;
+	scope: Readonly<GrantScope>;
+	issuedAt: number;
+	expiresAt?: number;
+}
+
+export interface AuthorizationActionSnapshot {
+	schemaVersion: typeof AUTHORIZATION_SCHEMA_VERSION;
+	fingerprint: string;
+	toolCallId: string;
+	toolName: string;
+	input: Readonly<Record<string, unknown>>;
+	cwd: string;
+	repository?: string;
+	sessionId: string;
+	policyRevision: string;
+	descriptor: Readonly<AuthorizationDescriptor>;
+}
+
+export interface AuthorizationReason {
+	code: string;
+	message: string;
+	policyId?: string;
+}
+
+export type AuthorizationDecision =
+	| {
+			kind: "permit";
+			reasons?: readonly AuthorizationReason[];
+	  }
+	| {
+			kind: "require-consent";
+			reasons: readonly AuthorizationReason[];
+			approval: "action" | "grant";
+			eligibleScopes: readonly GrantScopeKind[];
+	  }
+	| {
+			kind: "reject";
+			reasons: readonly AuthorizationReason[];
+	  };
+
+export interface AuthorizationEvaluationContext {
+	grants: readonly AuthorizationGrant[];
+}
+
+export interface ToolAuthorizer {
+	getPolicyRevision(): string;
+	authorize(
+		action: Readonly<AuthorizationActionSnapshot>,
+		context: Readonly<AuthorizationEvaluationContext>,
+	): AuthorizationDecision | Promise<AuthorizationDecision>;
+}
+
+export interface CreateAuthorizationActionInput {
+	toolCallId: string;
+	toolName: string;
+	input: Record<string, unknown>;
+	cwd: string;
+	repository?: string;
+	sessionId: string;
+	policyRevision: string;
+	descriptor: AuthorizationDescriptor;
+}
+
+type CanonicalValue = null | boolean | number | string | CanonicalValue[] | { [key: string]: CanonicalValue };
+
+function canonicalize(value: unknown): CanonicalValue {
+	if (value === null || typeof value === "boolean" || typeof value === "string") return value;
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) throw new TypeError("Authorization values must contain only finite numbers");
+		return value;
+	}
+	if (Array.isArray(value)) return value.map(canonicalize);
+	if (typeof value !== "object") {
+		throw new TypeError(`Unsupported authorization value: ${typeof value}`);
+	}
+	const canonical: { [key: string]: CanonicalValue } = {};
+	for (const key of Object.keys(value).sort()) {
+		const entry = (value as Record<string, unknown>)[key];
+		if (entry !== undefined) canonical[key] = canonicalize(entry);
+	}
+	return canonical;
+}
+
+function immutableClone<T>(value: T): Readonly<T> {
+	const clone = structuredClone(value);
+	const freeze = (entry: unknown): void => {
+		if (entry === null || typeof entry !== "object" || Object.isFrozen(entry)) return;
+		for (const child of Object.values(entry)) freeze(child);
+		Object.freeze(entry);
+	};
+	freeze(clone);
+	return clone;
+}
+
+export function fingerprintAuthorizationAction(action: Omit<AuthorizationActionSnapshot, "fingerprint">): string {
+	return createHash("sha256")
+		.update(JSON.stringify(canonicalize(action)))
+		.digest("hex");
+}
+
+export function createAuthorizationAction(input: CreateAuthorizationActionInput): AuthorizationActionSnapshot {
+	const action = immutableClone({
+		schemaVersion: AUTHORIZATION_SCHEMA_VERSION,
+		toolCallId: input.toolCallId,
+		toolName: input.toolName,
+		input: input.input,
+		cwd: resolve(input.cwd),
+		...(input.repository ? { repository: resolve(input.repository) } : {}),
+		sessionId: input.sessionId,
+		policyRevision: input.policyRevision,
+		descriptor: input.descriptor,
+	});
+	return immutableClone({
+		...action,
+		fingerprint: fingerprintAuthorizationAction(action),
+	});
+}
+
+export function classifyToolAuthorization<TParams>(
+	authorization: ToolAuthorization<TParams>,
+	params: Readonly<TParams>,
+	context: Readonly<AuthorizationClassificationContext>,
+): AuthorizationDescriptor {
+	const descriptor = authorization.classify?.(params, context) ?? {
+		operation: authorization.operation,
+		effect: authorization.effect,
+		capabilities: authorization.capabilities,
+		resources: authorization.resources ?? [],
+	};
+	return immutableClone({
+		...descriptor,
+		capabilities: [...new Set(descriptor.capabilities)].sort(),
+		resources: [...descriptor.resources].sort((left, right) =>
+			`${left.kind}\u0000${left.value}`.localeCompare(`${right.kind}\u0000${right.value}`),
+		),
+	});
+}

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -26,6 +26,7 @@ import { CONFIG_DIR_NAME, getAgentDir, isBunBinary } from "../../config.ts";
 // avoiding a circular dependency. Extensions can import from @earendil-works/pi-coding-agent.
 import * as _bundledPiCodingAgent from "../../index.ts";
 import { resolvePath } from "../../utils/paths.ts";
+import type { ToolAuthorizer } from "../authorization.ts";
 import { createEventBus, type EventBus } from "../event-bus.ts";
 import type { ExecOptions } from "../exec.ts";
 import { execCommand } from "../exec.ts";
@@ -193,6 +194,8 @@ export function createExtensionRuntime(): ExtensionRuntime {
 		getActiveTools: notInitialized,
 		getAllTools: notInitialized,
 		setActiveTools: notInitialized,
+		captureToolAction: () => Promise.reject(new Error("Extension runtime not initialized")),
+		executeAuthorized: () => Promise.reject(new Error("Extension runtime not initialized")),
 		// registerTool() is valid during extension load; refresh is only needed post-bind.
 		refreshTools: () => {},
 		getCommands: notInitialized,
@@ -268,6 +271,12 @@ function createExtensionAPI(
 				sourceInfo: extension.sourceInfo,
 			});
 			runtime.refreshTools();
+		},
+
+		registerAuthorizer(authorizer: ToolAuthorizer): void {
+			runtime.assertActive();
+			if (extension.authorizer) throw new Error(`Extension ${extension.path} registered more than one authorizer`);
+			extension.authorizer = authorizer;
 		},
 
 		registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void {
@@ -373,6 +382,16 @@ function createExtensionAPI(
 		setActiveTools(toolNames: string[]): void {
 			runtime.assertActive();
 			runtime.setActiveTools(toolNames);
+		},
+
+		captureToolAction(toolName, input, toolCallId) {
+			runtime.assertActive();
+			return runtime.captureToolAction(toolName, input, toolCallId);
+		},
+
+		executeAuthorized(action, grant, options) {
+			runtime.assertActive();
+			return runtime.executeAuthorized(action, grant, options);
 		},
 
 		getCommands() {

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -6,6 +6,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Model, Provider, ProviderHeaders } from "@earendil-works/pi-ai";
 import type { KeyId } from "@earendil-works/pi-tui";
 import { type Theme, theme } from "../../modes/interactive/theme/theme.ts";
+import type { ToolAuthorizer } from "../authorization.ts";
 import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
 import type { ModelRegistry } from "../model-registry.ts";
@@ -330,6 +331,8 @@ export class ExtensionRunner {
 		this.runtime.getActiveTools = actions.getActiveTools;
 		this.runtime.getAllTools = actions.getAllTools;
 		this.runtime.setActiveTools = actions.setActiveTools;
+		if (actions.captureToolAction) this.runtime.captureToolAction = actions.captureToolAction;
+		if (actions.executeAuthorized) this.runtime.executeAuthorized = actions.executeAuthorized;
 		this.runtime.refreshTools = actions.refreshTools;
 		this.runtime.getCommands = actions.getCommands;
 		this.runtime.setModel = actions.setModel;
@@ -458,6 +461,18 @@ export class ExtensionRunner {
 			}
 		}
 		return Array.from(toolsByName.values());
+	}
+
+	getRegisteredAuthorizer(): ToolAuthorizer | undefined {
+		const registrations = this.extensions.flatMap((extension) =>
+			extension.authorizer ? [{ authorizer: extension.authorizer, path: extension.path }] : [],
+		);
+		if (registrations.length > 1) {
+			throw new Error(
+				`Multiple tool authorizers registered: ${registrations.map((registration) => registration.path).join(", ")}`,
+			);
+		}
+		return registrations[0]?.authorizer;
 	}
 
 	/** Get a tool definition by name. Returns undefined if not found. */

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -46,6 +46,12 @@ import type {
 } from "@earendil-works/pi-tui";
 import type { Static, TSchema } from "typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
+import type {
+	AuthorizationActionSnapshot,
+	AuthorizationGrant,
+	ToolAuthorization,
+	ToolAuthorizer,
+} from "../authorization.ts";
 import type { BashResult } from "../bash-executor.ts";
 import type { CompactionPreparation, CompactionResult } from "../compaction/index.ts";
 import type { EventBus } from "../event-bus.ts";
@@ -459,6 +465,7 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	promptGuidelines?: string[];
 	/** Parameter schema (TypeBox) */
 	parameters: TParams;
+	authorization?: ToolAuthorization<Static<TParams>>;
 	/** Optional provider-side constrained sampling request for this tool. Set false to explicitly disable it, equivalent to leaving it undefined. */
 	constrainedSampling?: false | ConstrainedSamplingConfig;
 	/** Controls whether ToolExecutionComponent renders the standard colored shell or the tool renders its own framing. */
@@ -1252,6 +1259,8 @@ export interface ExtensionAPI {
 		tool: ToolDefinition<TParams, TDetails, TState>,
 	): void;
 
+	registerAuthorizer(authorizer: ToolAuthorizer): void;
+
 	// =========================================================================
 	// Command, Shortcut, Flag Registration
 	// =========================================================================
@@ -1340,6 +1349,18 @@ export interface ExtensionAPI {
 
 	/** Set the active tools by name. */
 	setActiveTools(toolNames: string[]): void;
+
+	captureToolAction(
+		toolName: string,
+		input: Record<string, unknown>,
+		toolCallId?: string,
+	): Promise<AuthorizationActionSnapshot>;
+
+	executeAuthorized(
+		action: AuthorizationActionSnapshot,
+		grant: AuthorizationGrant,
+		options?: { signal?: AbortSignal; onUpdate?: AgentToolUpdateCallback },
+	): Promise<AgentToolResult<unknown>>;
 
 	/** Get available slash commands in the current session. */
 	getCommands(): SlashCommandInfo[];
@@ -1571,8 +1592,11 @@ export type GetSessionNameHandler = () => string | undefined;
 
 export type GetActiveToolsHandler = () => string[];
 
-/** Tool info with name, description, parameter schema, prompt guidelines, and source metadata. */
-export type ToolInfo = Pick<ToolDefinition, "name" | "description" | "parameters" | "promptGuidelines"> & {
+/** Tool info with name, description, parameter schema, prompt guidelines, authorization metadata, and source metadata. */
+export type ToolInfo = Pick<
+	ToolDefinition,
+	"name" | "description" | "parameters" | "promptGuidelines" | "authorization"
+> & {
 	sourceInfo: SourceInfo;
 };
 
@@ -1581,6 +1605,18 @@ export type GetAllToolsHandler = () => ToolInfo[];
 export type GetCommandsHandler = () => SlashCommandInfo[];
 
 export type SetActiveToolsHandler = (toolNames: string[]) => void;
+
+export type CaptureToolActionHandler = (
+	toolName: string,
+	input: Record<string, unknown>,
+	toolCallId?: string,
+) => Promise<AuthorizationActionSnapshot>;
+
+export type ExecuteAuthorizedHandler = (
+	action: AuthorizationActionSnapshot,
+	grant: AuthorizationGrant,
+	options?: { signal?: AbortSignal; onUpdate?: AgentToolUpdateCallback },
+) => Promise<AgentToolResult<unknown>>;
 
 export type RefreshToolsHandler = () => void;
 
@@ -1633,6 +1669,8 @@ export interface ExtensionActions {
 	getActiveTools: GetActiveToolsHandler;
 	getAllTools: GetAllToolsHandler;
 	setActiveTools: SetActiveToolsHandler;
+	captureToolAction?: CaptureToolActionHandler;
+	executeAuthorized?: ExecuteAuthorizedHandler;
 	refreshTools: RefreshToolsHandler;
 	getCommands: GetCommandsHandler;
 	setModel: SetModelHandler;
@@ -1689,7 +1727,10 @@ export interface ExtensionCommandContextActions {
  * Full runtime = state + actions.
  * Created by loader with throwing action stubs, completed by runner.initialize().
  */
-export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {}
+export interface ExtensionRuntime extends ExtensionRuntimeState, ExtensionActions {
+	captureToolAction: CaptureToolActionHandler;
+	executeAuthorized: ExecuteAuthorizedHandler;
+}
 
 /** Loaded extension with all registered items. */
 export interface Extension {
@@ -1699,6 +1740,7 @@ export interface Extension {
 	sourceInfo: SourceInfo;
 	handlers: Map<string, HandlerFn[]>;
 	tools: Map<string, RegisteredTool>;
+	authorizer?: ToolAuthorizer;
 	messageRenderers: Map<string, MessageRenderer>;
 	markdownTransformer?: MarkdownTransformer;
 	entryRenderers?: Map<string, EntryRenderer>;

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -333,6 +333,17 @@ export function createBashToolDefinition(
 		promptSnippet: bashToolSystemPromptContribution.snippet,
 		promptGuidelines: exposeSessionEnvironment ? [...bashToolSystemPromptContribution.guidelines] : undefined,
 		parameters: bashSchema,
+		authorization: {
+			operation: "shell.execute",
+			effect: "execute",
+			capabilities: ["shell.execute"],
+			classify: ({ command }) => ({
+				operation: "shell.execute",
+				effect: "execute",
+				capabilities: ["shell.execute"],
+				resources: [{ kind: "command", value: command }],
+			}),
+		},
 		async execute(
 			_toolCallId,
 			{ command, timeout }: { command: string; timeout?: number },

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -307,6 +307,17 @@ export function createEditToolDefinition(
 		promptSnippet: editToolSystemPromptContribution.snippet,
 		promptGuidelines: [...editToolSystemPromptContribution.guidelines],
 		parameters: editSchema,
+		authorization: {
+			operation: "filesystem.edit",
+			effect: "modify",
+			capabilities: ["filesystem.write"],
+			classify: ({ path }) => ({
+				operation: "filesystem.edit",
+				effect: "modify",
+				capabilities: ["filesystem.write"],
+				resources: [{ kind: "path", value: resolveToCwd(path, cwd) }],
+			}),
+		},
 		renderShell: "self",
 		prepareArguments: prepareEditArguments,
 		async execute(_toolCallId, input: EditToolInput, signal?: AbortSignal, _onUpdate?, _ctx?) {

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -131,6 +131,17 @@ export function createFindToolDefinition(
 		description: `Search for files by glob pattern. Returns matching file paths relative to the search directory. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} results or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
 		promptSnippet: findToolSystemPromptContribution.snippet,
 		parameters: findSchema,
+		authorization: {
+			operation: "filesystem.search-paths",
+			effect: "inspect",
+			capabilities: ["filesystem.search"],
+			classify: ({ path: searchPath }) => ({
+				operation: "filesystem.search-paths",
+				effect: "inspect",
+				capabilities: ["filesystem.search"],
+				resources: [{ kind: "path", value: resolveToCwd(searchPath ?? ".", cwd) }],
+			}),
+		},
 		async execute(
 			_toolCallId,
 			{ pattern, path: searchDir, limit }: { pattern: string; path?: string; limit?: number },

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -136,6 +136,17 @@ export function createGrepToolDefinition(
 		description: `Search file contents for a pattern. Returns matching lines with file paths and line numbers. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} matches or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Long lines are truncated to ${GREP_MAX_LINE_LENGTH} chars.`,
 		promptSnippet: grepToolSystemPromptContribution.snippet,
 		parameters: grepSchema,
+		authorization: {
+			operation: "filesystem.search-content",
+			effect: "inspect",
+			capabilities: ["filesystem.search"],
+			classify: ({ path: searchPath }) => ({
+				operation: "filesystem.search-content",
+				effect: "inspect",
+				capabilities: ["filesystem.search"],
+				resources: [{ kind: "path", value: resolveToCwd(searchPath ?? ".", cwd) }],
+			}),
+		},
 		async execute(
 			_toolCallId,
 			{

--- a/packages/coding-agent/src/core/tools/ls.ts
+++ b/packages/coding-agent/src/core/tools/ls.ts
@@ -108,6 +108,17 @@ export function createLsToolDefinition(
 		description: `List directory contents. Returns entries sorted alphabetically, with '/' suffix for directories. Includes dotfiles. Output is truncated to ${DEFAULT_LIMIT} entries or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
 		promptSnippet: lsToolSystemPromptContribution.snippet,
 		parameters: lsSchema,
+		authorization: {
+			operation: "filesystem.list",
+			effect: "inspect",
+			capabilities: ["filesystem.read"],
+			classify: ({ path }) => ({
+				operation: "filesystem.list",
+				effect: "inspect",
+				capabilities: ["filesystem.read"],
+				resources: [{ kind: "path", value: resolveToCwd(path ?? ".", cwd) }],
+			}),
+		},
 		async execute(
 			_toolCallId,
 			{ path, limit }: { path?: string; limit?: number },

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -218,6 +218,17 @@ export function createReadToolDefinition(
 		promptSnippet: readToolSystemPromptContribution.snippet,
 		promptGuidelines: [...readToolSystemPromptContribution.guidelines],
 		parameters: readSchema,
+		authorization: {
+			operation: "filesystem.read",
+			effect: "inspect",
+			capabilities: ["filesystem.read"],
+			classify: ({ path }) => ({
+				operation: "filesystem.read",
+				effect: "inspect",
+				capabilities: ["filesystem.read"],
+				resources: [{ kind: "path", value: resolveToCwd(path, cwd) }],
+			}),
+		},
 		async execute(
 			_toolCallId,
 			{ path, offset, limit }: { path: string; offset?: number; limit?: number },

--- a/packages/coding-agent/src/core/tools/write.ts
+++ b/packages/coding-agent/src/core/tools/write.ts
@@ -196,6 +196,17 @@ export function createWriteToolDefinition(
 		promptSnippet: writeToolSystemPromptContribution.snippet,
 		promptGuidelines: [...writeToolSystemPromptContribution.guidelines],
 		parameters: writeSchema,
+		authorization: {
+			operation: "filesystem.write",
+			effect: "modify",
+			capabilities: ["filesystem.write"],
+			classify: ({ path }) => ({
+				operation: "filesystem.write",
+				effect: "modify",
+				capabilities: ["filesystem.write"],
+				resources: [{ kind: "path", value: resolveToCwd(path, cwd) }],
+			}),
+		},
 		async execute(
 			_toolCallId,
 			{ path, content }: { path: string; content: string },

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -24,6 +24,30 @@ export {
 	type SessionStats,
 } from "./core/agent-session.ts";
 export { readStoredCredential } from "./core/auth-storage.ts";
+export {
+	AUTHORIZATION_SCHEMA_VERSION,
+	type AuthorizationActionSnapshot,
+	type AuthorizationClassificationContext,
+	type AuthorizationClassifier,
+	type AuthorizationDecision,
+	type AuthorizationDescriptor,
+	type AuthorizationEffect,
+	type AuthorizationEvaluationContext,
+	type AuthorizationGrant,
+	type AuthorizationReason,
+	type AuthorizationResource,
+	type Capability,
+	type CreateAuthorizationActionInput,
+	classifyToolAuthorization,
+	createAuthorizationAction,
+	fingerprintAuthorizationAction,
+	type GrantConstraints,
+	type GrantScope,
+	type GrantScopeKind,
+	type ModeProfile,
+	type ToolAuthorization,
+	type ToolAuthorizer,
+} from "./core/authorization.ts";
 // Compaction
 export {
 	type BranchPreparation,


### PR DESCRIPTION
Adds a single final tool-authorization boundary to coding-agent:

- semantic authorization metadata on `ToolDefinition`
- immutable canonical action snapshots and SHA-256 fingerprints
- one `registerAuthorizer()` authority per session
- `captureToolAction()` and `executeAuthorized()` APIs
- execution-time session, policy, fingerprint, and grant revalidation
- built-in authorization metadata and classifiers
- post-hook schema revalidation
- normal execution hooks, updates, results, and lifecycle events for approved execution

Validation: `npm run build` and `npm run check` pass.

This PR was generated by an AI coding agent.
