### PR TITLE
fix(ai): make model max tokens optional

### DIFF
--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -540,7 +540,7 @@ export async function generateSummaryWithUsage(
 ): Promise<Result<{ text: string; usage: Usage }, CompactionError>> {
 	const maxTokens = Math.min(
 		Math.floor(0.8 * reserveTokens),
-		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+		model.maxTokens !== undefined && model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
 	);
 	let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
 	if (customInstructions) {
@@ -804,7 +804,7 @@ async function generateTurnPrefixSummary(
 ): Promise<Result<{ text: string; usage: Usage }, CompactionError>> {
 	const maxTokens = Math.min(
 		Math.floor(0.5 * reserveTokens),
-		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+		model.maxTokens !== undefined && model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
 	);
 	const llmMessages = convertToLlm(messages);
 	const conversationText = serializeConversation(llmMessages);

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -824,6 +824,8 @@ for (const block of response.content) {
 
 `models.stream()`/`complete()` accept the owning API's full option set. Use `hasApi()` to narrow a dynamically looked-up model to its API for full option typing:
 
+Pass `maxTokens` when a request needs an explicit output limit. Otherwise, pi uses `model.maxTokens` when it is set. If both are omitted, pi leaves the limit to the provider unless the wire protocol requires one.
+
 ```typescript
 import { hasApi } from '@earendil-works/pi-ai';
 

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -798,6 +798,16 @@ function mapThinkingLevelToEffort(
 	}
 }
 
+function requireMaxTokens(model: Model<"anthropic-messages">, requestMaxTokens: number | undefined): number {
+	const maxTokens = requestMaxTokens ?? model.maxTokens;
+	if (maxTokens === undefined) {
+		throw new Error(
+			`Anthropic Messages requires maxTokens for ${model.provider}/${model.id}; set it on the model or request`,
+		);
+	}
+	return maxTokens;
+}
+
 export const streamSimple: StreamFunction<"anthropic-messages", SimpleStreamOptions> = (
 	model: Model<"anthropic-messages">,
 	context: Context,
@@ -821,11 +831,10 @@ export const streamSimple: StreamFunction<"anthropic-messages", SimpleStreamOpti
 		} satisfies AnthropicOptions);
 	}
 
-	// Undefined means the caller did not request an output cap; let the helper use the model cap.
-	// Do not coerce to 0 here, or the thinking budget would become the entire max_tokens value.
+	const maxTokensCeiling = requireMaxTokens(model, base.maxTokens);
 	const adjusted = adjustMaxTokensForThinking(
 		base.maxTokens,
-		model.maxTokens,
+		maxTokensCeiling,
 		options.reasoning,
 		options.thinkingBudgets,
 	);
@@ -958,6 +967,7 @@ function buildParams(
 		deferredTools = [];
 	}
 	const deferredToolNames = new Set(deferredTools.map((tool) => normalizeToolName(tool.name)));
+	const maxTokens = requireMaxTokens(model, options?.maxTokens);
 	const params: MessageCreateParamsStreaming = {
 		model: model.id,
 		messages: convertMessages(
@@ -968,7 +978,7 @@ function buildParams(
 			deferredToolNames,
 			normalizeToolName,
 		),
-		max_tokens: options?.maxTokens ?? model.maxTokens,
+		max_tokens: maxTokens,
 		stream: true,
 	};
 

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -476,11 +476,15 @@ export const streamSimple: StreamFunction<"bedrock-converse-stream", SimpleStrea
 			} satisfies BedrockOptions);
 		}
 
-		// Undefined means the caller did not request an output cap; let the helper use the model cap.
-		// Do not coerce to 0 here, or the thinking budget would become the entire maxTokens value.
+		const maxTokensCeiling = base.maxTokens ?? model.maxTokens;
+		if (maxTokensCeiling === undefined) {
+			throw new Error(
+				`Budget-based Bedrock reasoning requires maxTokens for ${model.provider}/${model.id}; set it on the model or request`,
+			);
+		}
 		const adjusted = adjustMaxTokensForThinking(
 			base.maxTokens,
-			model.maxTokens,
+			maxTokensCeiling,
 			options.reasoning,
 			options.thinkingBudgets,
 		);

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -858,10 +858,12 @@ function buildParams(
 			...options.thinkingBudgets,
 		};
 		const ceiling = (params as { max_tokens?: number }).max_tokens ?? params.max_completion_tokens ?? model.maxTokens;
-		// Always leave room for the answer, otherwise the budget recreates the bug it prevents.
-		const budget = Math.min(budgets[level]!, Math.max(0, ceiling - MIN_ANSWER_TOKENS));
-		if (budget > 0) {
-			(params as { thinking_token_budget?: number }).thinking_token_budget = budget;
+		if (ceiling !== undefined) {
+			// Always leave room for the answer, otherwise the budget recreates the bug it prevents.
+			const budget = Math.min(budgets[level]!, Math.max(0, ceiling - MIN_ANSWER_TOKENS));
+			if (budget > 0) {
+				(params as { thinking_token_budget?: number }).thinking_token_budget = budget;
+			}
 		}
 	}
 

--- a/packages/ai/src/api/simple-options.ts
+++ b/packages/ai/src/api/simple-options.ts
@@ -24,6 +24,7 @@ export function buildBaseOptions(
 	options?: SimpleStreamOptions,
 	apiKey?: string,
 ): StreamOptions {
+	const maxTokens = options?.maxTokens ?? model.maxTokens;
 	const samplingParams =
 		model.samplingParams || options?.samplingParams
 			? { ...model.samplingParams, ...options?.samplingParams }
@@ -31,7 +32,7 @@ export function buildBaseOptions(
 	return {
 		temperature: options?.temperature,
 		samplingParams,
-		maxTokens: clampMaxTokensToContext(model, context, options?.maxTokens ?? model.maxTokens),
+		maxTokens: maxTokens === undefined ? undefined : clampMaxTokensToContext(model, context, maxTokens),
 		signal: options?.signal,
 		telemetryContext: options?.telemetryContext,
 		apiKey: apiKey || options?.apiKey,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -187,6 +187,10 @@ export interface StreamOptions extends ProviderRequestOptions<Model<Api>> {
 	 * OpenAI-compatible adapters (completions, responses, Azure responses); other APIs ignore it.
 	 */
 	samplingParams?: Record<string, unknown>;
+	/**
+	 * Maximum output tokens to request. Overrides {@link Model.maxTokens}. When both are omitted,
+	 * the API adapter uses the provider default unless that protocol requires an explicit value.
+	 */
 	maxTokens?: number;
 	/**
 	 * Preferred transport for providers that support multiple transports.
@@ -806,7 +810,8 @@ export interface Model<TApi extends Api> {
 	input: ("text" | "image")[];
 	cost: ModelCost;
 	contextWindow: number;
-	maxTokens: number;
+	/** Maximum output tokens supported by the model and the default request limit when set. */
+	maxTokens?: number;
 	/** Default sampling parameters for this model. See {@link StreamOptions.samplingParams}; per-request keys override these. */
 	samplingParams?: Record<string, unknown>;
 	headers?: Record<string, string>;

--- a/packages/ai/test/context-estimate.test.ts
+++ b/packages/ai/test/context-estimate.test.ts
@@ -57,7 +57,9 @@ describe("context token estimation", () => {
 			trailingTokens: 1_005,
 			lastUsageIndex: null,
 		});
+		expect(buildBaseOptions({ ...model, maxTokens: undefined }, context).maxTokens).toBeUndefined();
 		expect(buildBaseOptions(model, context).maxTokens).toBe(4_899);
+		expect(buildBaseOptions(model, context, { maxTokens: 8_000 }).maxTokens).toBe(4_899);
 	});
 
 	it("uses assistant usage again after a response to the inserted context", () => {

--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
 import { getModel } from "../src/compat.ts";
 import { getSupportedThinkingLevels } from "../src/models.ts";
@@ -54,6 +54,11 @@ describe("Copilot Claude via Anthropic Messages", () => {
 		systemPrompt: "You are a helpful assistant.",
 		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
 	};
+
+	beforeEach(() => {
+		mockState.constructorOpts = undefined;
+		mockState.createParams = undefined;
+	});
 
 	it("applies Copilot-specific adaptive thinking effort overrides", () => {
 		const opus47 = getModel("github-copilot", "claude-opus-4.7");
@@ -123,5 +128,26 @@ describe("Copilot Claude via Anthropic Messages", () => {
 
 		const headers = mockState.constructorOpts!.defaultHeaders as Record<string, string>;
 		expect(headers["anthropic-beta"] ?? "").not.toContain("interleaved-thinking-2025-05-14");
+	});
+
+	it("accepts a request maxTokens when the model omits it", async () => {
+		const { maxTokens: _maxTokens, ...model } = getModel("github-copilot", "claude-sonnet-4.6");
+		await streamAnthropic(model, context, {
+			apiKey: "tid_copilot_session_test_token",
+			maxTokens: 2048,
+		}).result();
+
+		expect(mockState.createParams?.max_tokens).toBe(2048);
+	});
+
+	it("reports a configuration error when Anthropic has no maxTokens", async () => {
+		const { maxTokens: _maxTokens, ...model } = getModel("github-copilot", "claude-sonnet-4.6");
+		const result = await streamAnthropic(model, context, {
+			apiKey: "tid_copilot_session_test_token",
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Anthropic Messages requires maxTokens");
+		expect(mockState.createParams).toBeUndefined();
 	});
 });

--- a/packages/ai/test/openai-completions-empty-tools.test.ts
+++ b/packages/ai/test/openai-completions-empty-tools.test.ts
@@ -92,7 +92,25 @@ describe("openai-completions empty tools handling", () => {
 		expect("tools" in (params as object)).toBe(false);
 	});
 
-	it("sends default maxTokens", async () => {
+	it("does not send a max token field when the model and request omit it", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const { maxTokens: _maxTokens, ...modelWithoutMaxTokens } = baseModel;
+		const model = { ...modelWithoutMaxTokens, api: "openai-completions" } as const;
+
+		await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as { max_tokens?: number; max_completion_tokens?: number };
+		expect(params.max_tokens).toBeUndefined();
+		expect(params.max_completion_tokens).toBeUndefined();
+	});
+
+	it("uses model maxTokens as the default request limit", async () => {
 		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
 		const model = { ...baseModel, api: "openai-completions" } as const;
 
@@ -107,6 +125,23 @@ describe("openai-completions empty tools handling", () => {
 		const params = mockState.lastParams as { max_tokens?: number; max_completion_tokens?: number };
 		expect(params.max_tokens).toBeUndefined();
 		expect(params.max_completion_tokens).toBe(model.maxTokens);
+	});
+
+	it("clamps model maxTokens to remaining context", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = { ...baseModel, api: "openai-completions", contextWindow: 10000, maxTokens: 8000 } as const;
+
+		await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "x".repeat(8000), timestamp: Date.now() }],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as { max_tokens?: number; max_completion_tokens?: number };
+		expect(params.max_tokens).toBeUndefined();
+		expect(params.max_completion_tokens).toBe(3904);
 	});
 
 	it("sends explicit maxTokens", async () => {
@@ -124,23 +159,6 @@ describe("openai-completions empty tools handling", () => {
 		const params = mockState.lastParams as { max_tokens?: number; max_completion_tokens?: number };
 		expect(params.max_tokens).toBeUndefined();
 		expect(params.max_completion_tokens).toBe(1234);
-	});
-
-	it("clamps default maxTokens to remaining context", async () => {
-		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
-		const model = { ...baseModel, api: "openai-completions", contextWindow: 10000, maxTokens: 8000 } as const;
-
-		await streamSimple(
-			model,
-			{
-				messages: [{ role: "user", content: "x".repeat(8000), timestamp: Date.now() }],
-			},
-			{ apiKey: "test" },
-		).result();
-
-		const params = mockState.lastParams as { max_tokens?: number; max_completion_tokens?: number };
-		expect(params.max_tokens).toBeUndefined();
-		expect(params.max_completion_tokens).toBe(3904);
 	});
 
 	it("clamps explicit maxTokens to remaining context", async () => {

--- a/packages/ai/test/openai-completions-thinking-token-budget.test.ts
+++ b/packages/ai/test/openai-completions-thinking-token-budget.test.ts
@@ -63,7 +63,12 @@ async function capture(
 		thinkingBudgets?: ThinkingBudgets;
 		maxTokens?: number;
 	},
-): Promise<{ thinking_token_budget?: number; thinking?: unknown }> {
+): Promise<{
+	max_tokens?: number;
+	max_completion_tokens?: number;
+	thinking_token_budget?: number;
+	thinking?: unknown;
+}> {
 	let payload: unknown;
 
 	await streamSimple(
@@ -80,7 +85,12 @@ async function capture(
 		},
 	).result();
 
-	return (payload ?? mockState.lastParams) as { thinking_token_budget?: number; thinking?: unknown };
+	return (payload ?? mockState.lastParams) as {
+		max_tokens?: number;
+		max_completion_tokens?: number;
+		thinking_token_budget?: number;
+		thinking?: unknown;
+	};
 }
 
 describe("openai-completions thinking_token_budget", () => {
@@ -91,6 +101,20 @@ describe("openai-completions thinking_token_budget", () => {
 	it("sends the configured budget for the requested level", async () => {
 		const params = await capture(vllmModel, { reasoning: "medium", thinkingBudgets: { medium: 4096 } });
 		expect(params.thinking_token_budget).toBe(4096);
+	});
+
+	it("uses the model output capacity as the default request limit", async () => {
+		const params = await capture(vllmModel, { reasoning: "high" });
+		expect(params.max_tokens).toBeUndefined();
+		expect(params.max_completion_tokens).toBe(16384);
+	});
+
+	it("omits token limits and the dependent thinking budget when neither limit is set", async () => {
+		const { maxTokens: _maxTokens, ...model } = vllmModel;
+		const params = await capture(model, { reasoning: "high" });
+		expect(params.max_tokens).toBeUndefined();
+		expect(params.max_completion_tokens).toBeUndefined();
+		expect(params.thinking_token_budget).toBeUndefined();
 	});
 
 	it("omits the budget when the compat flag is not set", async () => {

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -730,8 +730,8 @@ interface ProviderModelConfig {
   /** Maximum context window size in tokens. */
   contextWindow: number;
 
-  /** Maximum output tokens. */
-  maxTokens: number;
+  /** Maximum output tokens and the default request limit when set. */
+  maxTokens?: number;
 
   /** Custom headers for this specific model. */
   headers?: Record<string, string>;

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -205,7 +205,7 @@ If your command is slow, expensive, rate-limited, or should keep using a previou
 | `thinkingLevelMap` | No | omitted | Maps pi thinking levels to provider values and marks unsupported levels (see below) |
 | `input` | No | `["text"]` | Input types: `["text"]` or `["text", "image"]` |
 | `contextWindow` | No | `128000` | Context window size in tokens |
-| `maxTokens` | No | `16384` | Maximum output tokens |
+| `maxTokens` | No | API-specific | Maximum output tokens and default request limit. When omitted, APIs that support an implicit limit do not receive one; APIs that require a limit report a configuration error. |
 | `samplingParams` | No | omitted | Sampling parameters merged verbatim into every request body (see below) |
 | `cost` | No | all zeros | Per-million-token rates with optional request-wide input pricing tiers |
 | `compat` | No | provider `compat` | Provider compatibility overrides. Merged with provider-level `compat` when both are set. |

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/index.ts
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/index.ts
@@ -391,10 +391,15 @@ function streamCustomAnthropic(
 			const client = new Anthropic(clientOptions);
 
 			// Build request params
+			const maxTokens =
+				options?.maxTokens ?? (model.maxTokens === undefined ? undefined : Math.floor(model.maxTokens / 3));
+			if (maxTokens === undefined) {
+				throw new Error(`Anthropic Messages requires maxTokens for ${model.provider}/${model.id}`);
+			}
 			const params: MessageCreateParamsStreaming = {
 				model: model.id,
 				messages: convertMessages(context.messages, isOAuth, context.tools),
-				max_tokens: options?.maxTokens || Math.floor(model.maxTokens / 3),
+				max_tokens: maxTokens,
 				stream: true,
 			};
 

--- a/packages/coding-agent/src/cli/list-models.ts
+++ b/packages/coding-agent/src/cli/list-models.ts
@@ -66,7 +66,7 @@ export async function listModels(
 		provider: m.provider,
 		model: m.id,
 		context: formatTokenCount(m.contextWindow),
-		maxOut: formatTokenCount(m.maxTokens),
+		maxOut: m.maxTokens === undefined ? "-" : formatTokenCount(m.maxTokens),
 		thinking: m.reasoning ? "yes" : "no",
 		images: m.input.includes("image") ? "yes" : "no",
 	}));

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -636,7 +636,7 @@ export async function generateSummaryWithUsage(
 ): Promise<{ text: string; usage: Usage }> {
 	const maxTokens = Math.min(
 		Math.floor(0.8 * reserveTokens),
-		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+		model.maxTokens !== undefined && model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
 	);
 
 	// Use update prompt if we have a previous summary, otherwise initial prompt
@@ -936,7 +936,7 @@ async function generateTurnPrefixSummary(
 ): Promise<{ text: string; usage: Usage }> {
 	const maxTokens = Math.min(
 		Math.floor(0.5 * reserveTokens),
-		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+		model.maxTokens !== undefined && model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
 	); // Smaller budget for turn prefix
 	const llmMessages = convertToLlm(messages);
 	const conversationText = serializeConversation(llmMessages);

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1506,8 +1506,8 @@ export interface ProviderModelConfig {
 	cost: Model<Api>["cost"];
 	/** Maximum context window size in tokens. */
 	contextWindow: number;
-	/** Maximum output tokens. */
-	maxTokens: number;
+	/** Maximum output tokens and the default request limit when set. */
+	maxTokens?: number;
 	/** Custom headers for this model. */
 	headers?: Record<string, string>;
 	/** OpenAI compatibility settings. */

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -62,7 +62,7 @@ export interface ProviderConfigInput {
 		input: ("text" | "image")[];
 		cost: Model<Api>["cost"];
 		contextWindow: number;
-		maxTokens: number;
+		maxTokens?: number;
 		samplingParams?: Record<string, unknown>;
 		headers?: Record<string, string>;
 		compat?: Model<Api>["compat"];
@@ -147,6 +147,7 @@ function modelFromJson(
 	if (definition.maxTokens !== undefined && definition.maxTokens <= 0) {
 		throw new Error(`Provider ${providerId}, model ${definition.id}: invalid maxTokens`);
 	}
+	const maxTokens = definition.maxTokens ?? (defaults?.id === definition.id ? defaults.maxTokens : undefined);
 	return {
 		id: definition.id,
 		name: definition.name ?? definition.id,
@@ -158,7 +159,7 @@ function modelFromJson(
 		input: (definition.input ?? ["text"]) as ("text" | "image")[],
 		cost: definition.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: definition.contextWindow ?? 128000,
-		maxTokens: definition.maxTokens ?? 16384,
+		...(maxTokens === undefined ? {} : { maxTokens }),
 		samplingParams: definition.samplingParams,
 		headers: undefined,
 		compat: mergeCompat(providerConfig.compat, definition.compat),

--- a/packages/coding-agent/test/compaction-summary-reasoning.test.ts
+++ b/packages/coding-agent/test/compaction-summary-reasoning.test.ts
@@ -164,4 +164,21 @@ describe("generateSummary reasoning options", () => {
 		});
 		expect(completeSimpleMock.mock.calls.map((call) => call[2]?.maxTokens)).toEqual([128000, 128000]);
 	});
+
+	it("uses the compaction budgets when the model omits maxTokens", async () => {
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "entry-keep",
+			messagesToSummarize: messages,
+			turnPrefixMessages: messages,
+			isSplitTurn: true,
+			tokensBefore: 3000,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { enabled: true, reserveTokens: 2000, keepRecentTokens: 200 },
+		};
+		const { maxTokens: _maxTokens, ...model } = createModel(false);
+
+		await compact(preparation, model, "test-key");
+
+		expect(completeSimpleMock.mock.calls.map((call) => call[2]?.maxTokens)).toEqual([1600, 1000]);
+	});
 });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -259,6 +259,7 @@ describe("ModelRegistry", () => {
 			expect(model).toBeDefined();
 			expect(model?.api).toBe("openai-completions");
 			expect(model?.baseUrl).toBe("https://openrouter.ai/api/v1");
+			expect(model?.maxTokens).toBeUndefined();
 		});
 
 		test("non-built-in provider custom models still require baseUrl", async () => {

--- a/packages/protocol/src/schemas.ts
+++ b/packages/protocol/src/schemas.ts
@@ -65,7 +65,7 @@ export const ModelMetadataSchema = StrictObject({
 	reasoning: Type.Boolean(),
 	input: Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")])),
 	contextWindow: Type.Integer({ minimum: 1 }),
-	maxTokens: Type.Integer({ minimum: 1 }),
+	maxTokens: Type.Optional(Type.Integer({ minimum: 1 })),
 	cost: ModelCostSchema,
 	supportedThinkingLevels: Type.Array(ThinkingLevelSchema, { minItems: 1 }),
 	authenticated: Type.Boolean(),

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -215,7 +215,7 @@ export function toProtocolModelMetadata(model: Model<Api>, authenticated: boolea
 		reasoning: model.reasoning,
 		input: [...model.input],
 		contextWindow: Math.max(1, Math.floor(model.contextWindow)),
-		maxTokens: Math.max(1, Math.floor(model.maxTokens)),
+		...(model.maxTokens === undefined ? {} : { maxTokens: Math.max(1, Math.floor(model.maxTokens)) }),
 		cost: {
 			input: nonNegativeNumber(model.cost.input),
 			output: nonNegativeNumber(model.cost.output),

--- a/packages/server/test/protocol.test.ts
+++ b/packages/server/test/protocol.test.ts
@@ -91,6 +91,13 @@ describe("pi-ai protocol bridge", () => {
 		expect(result.supportedThinkingLevels).toContain("off");
 	});
 
+	test("omits unknown model maxTokens from protocol metadata", () => {
+		const { maxTokens: _maxTokens, ...modelWithoutMaxTokens } = model;
+		const result = toProtocolModelMetadata(modelWithoutMaxTokens, true);
+
+		expect(result).not.toHaveProperty("maxTokens");
+	});
+
 	test("exhaustively maps assistant content and stop reasons", () => {
 		const message = {
 			role: "assistant",


### PR DESCRIPTION
## Summary

- Make `Model.maxTokens` optional across pi-ai, custom provider configuration, and protocol metadata.
- Resolve request limits as `options.maxTokens ?? model.maxTokens`; when neither is set, omit the provider parameter where the API permits it.
- Keep explicit validation for APIs and features that require a token ceiling, including Anthropic Messages and budget-based Bedrock reasoning.
- Preserve catalog model behavior: generated models that define `maxTokens` continue sending that value by default.
- Stop assigning an implicit `16384` limit to custom models that omit `maxTokens`.

## Motivation

pi-ai is also consumed directly, outside the full pi model catalog. Requiring every custom `Model` to define `maxTokens` forces the SDK to send an output limit even when the caller wants the provider's own default.

At the same time, removing the model fallback globally would regress the behavior addressed by #5595, because providers with small server-side defaults could truncate responses from catalog models.

This change supports all three intended cases:

| Request `maxTokens` | Model `maxTokens` | Behavior |
| --- | --- | --- |
| Set | Any | Use the request value |
| Omitted | Set | Use the model value |
| Omitted | Omitted | Leave the limit to the provider when supported |

## Implementation

- Make `Model.maxTokens` and corresponding configuration/schema fields optional.
- Clamp a token limit to the context window only when a limit exists.
- Omit optional provider fields and derived thinking budgets when no ceiling exists.
- Fail with a configuration error when the selected wire protocol requires an explicit limit.
- Use compaction reserve budgets when model metadata has no output-token ceiling.
- Update CLI/protocol serialization, documentation, examples, and tests for omitted limits.

## Compatibility

This preserves #5595 behavior for generated catalog models because their existing `maxTokens` metadata remains unchanged. It only changes behavior for custom or directly constructed models that omit the field.

## Validation

- `npm run check`
- Targeted pi-ai, agent, coding-agent, and server protocol tests: 160 passed, 1 credential-gated Bedrock test skipped
- `git diff --check`
- `npm ci --ignore-scripts`