### PR TITLE
fix(ai): retry Codex websocket rate limits

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -69,6 +69,7 @@ const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
 const WEBSOCKET_CONNECTION_LIMIT_REACHED_CODE = "websocket_connection_limit_reached";
 const PREVIOUS_RESPONSE_NOT_FOUND_CODE = "previous_response_not_found";
+const RATE_LIMIT_EXCEEDED_CODE = "rate_limit_exceeded";
 
 const CODEX_RESPONSE_STATUSES = new Set<CodexResponseStatus>([
 	"completed",
@@ -141,6 +142,16 @@ function isRetryableError(status: number, errorText: string): boolean {
 		return true;
 	}
 	return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(errorText);
+}
+
+/** Extracts the retry delay embedded in a Codex `rate_limit_exceeded` error message. */
+function getCodexRateLimitRetryDelayMs(errorMessage: string): number | undefined {
+	const match = /try again in\s*(\d+(?:\.\d+)?)\s*(ms|s|seconds?)/i.exec(errorMessage);
+	if (!match) return undefined;
+
+	const value = Number(match[1]);
+	if (!Number.isFinite(value) || value < 0) return undefined;
+	return match[2].toLowerCase() === "ms" ? value : value * 1000;
 }
 
 function getRetryAfterDelayMs(headers: Headers): number | undefined {
@@ -308,6 +319,7 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 				let websocketStarted = false;
 				let retriedWebSocketConnectionLimit = false;
 				let retriedMissingWebSocketContinuation = false;
+				let retriedWebSocketRateLimit = false;
 				while (true) {
 					websocketStarted = false;
 					try {
@@ -348,12 +360,28 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 						const aborted = options?.signal?.aborted;
 						const connectionLimitBeforeStart = !websocketStarted && isWebSocketConnectionLimitReachedError(error);
 						const previousResponseNotFound = isPreviousResponseNotFoundError(error);
+						// Replaying after an output item risks duplicating visible content or tool calls.
+						const rateLimitBeforeOutput = output.content.length === 0 && isCodexRateLimitError(error);
+						// Missing continuations get one full-request retry on a fresh connection.
 						if (!aborted && previousResponseNotFound && !retriedMissingWebSocketContinuation) {
 							retriedMissingWebSocketContinuation = true;
 							continue;
 						}
+						// Connection limits before stream start get one fresh-connection retry.
 						if (!aborted && connectionLimitBeforeStart && !retriedWebSocketConnectionLimit) {
 							retriedWebSocketConnectionLimit = true;
+							continue;
+						}
+						// Rate limits get one delayed retry; persistent limits are surfaced to the caller.
+						if (!aborted && rateLimitBeforeOutput && !retriedWebSocketRateLimit) {
+							retriedWebSocketRateLimit = true;
+							// response.created may have populated this before the failed attempt.
+							delete output.responseId;
+							const delayMs =
+								error instanceof CodexApiError
+									? (getCodexRateLimitRetryDelayMs(error.message) ?? BASE_DELAY_MS)
+									: BASE_DELAY_MS;
+							await sleep(validateRetryDelayMs(delayMs, options), options?.signal);
 							continue;
 						}
 						if (aborted || (isCodexNonTransportError(error) && !connectionLimitBeforeStart)) {
@@ -710,6 +738,10 @@ function isWebSocketConnectionLimitReachedError(error: unknown): boolean {
 
 function isPreviousResponseNotFoundError(error: unknown): boolean {
 	return error instanceof CodexApiError && error.code === PREVIOUS_RESPONSE_NOT_FOUND_CODE;
+}
+
+function isCodexRateLimitError(error: unknown): boolean {
+	return error instanceof CodexApiError && error.code === RATE_LIMIT_EXCEEDED_CODE;
 }
 
 function extractCodexEventError(event: Record<string, unknown>): { code?: string; message?: string } {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -1674,6 +1674,80 @@ describe("openai-codex streaming", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
+	it("reconnects once after the websocket rate limit delay before output starts", async () => {
+		vi.useFakeTimers();
+		const token = mockToken();
+		let connections = 0;
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		class MockWebSocket extends EventTarget {
+			private readonly rateLimited = connections++ === 0;
+
+			constructor() {
+				super();
+				queueMicrotask(() => this.dispatchEvent(new Event("open")));
+			}
+
+			send(): void {
+				const event = this.rateLimited
+					? {
+							type: "response.failed",
+							response: {
+								id: "resp_rate_limited",
+								status: "failed",
+								error: { code: "rate_limit_exceeded", message: "Rate limit reached. Try again in 50ms." },
+							},
+						}
+					: {
+							type: "response.completed",
+							response: {
+								id: "resp_1",
+								status: "completed",
+								usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+							},
+						};
+				queueMicrotask(() => {
+					this.dispatchEvent(Object.assign(new Event("message"), { data: JSON.stringify(event) }));
+				});
+			}
+
+			close(): void {}
+		}
+
+		vi.stubGlobal("WebSocket", MockWebSocket);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+
+		const resultPromise = streamOpenAICodexResponses(
+			model,
+			{ systemPrompt: "", messages: [] },
+			{ apiKey: token },
+		).result();
+		await vi.advanceTimersByTimeAsync(0);
+		expect(connections).toBe(1);
+		await vi.advanceTimersByTimeAsync(49);
+		expect(connections).toBe(1);
+		await vi.advanceTimersByTimeAsync(1);
+		const result = await resultPromise;
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.responseId).toBe("resp_1");
+		expect(connections).toBe(2);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("falls back to SSE when a websocket is idle before the first event", async () => {
 		vi.useFakeTimers();
 		const token = mockToken();


### PR DESCRIPTION
Ref #7444, which points out that Codex [retries any `response.failed` websocket error except for known non-retryable cases (context window, quota, usage-not-included, policy, invalid prompt, and overloaded)](https://github.com/openai/codex/blob/41ece455b7fa7166f4fc38522952afdaa2604e18/codex-rs/codex-api/src/sse/responses.rs#L408-L443). WebSocket responses [use that same event handler]( https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/endpoint/responses_websocket.rs#L720-L809).

Currently in Pi, we only retry these two websocket errors once:
- `previous_response_not_found`
- `websocket_connection_limit_reached`

Every other `CodexApiError`, including `rate_limit_exceeded`, fails immediately.
 
For `rate_limit_exceeded`, what Codex extracts the `Try again in N ms|s|seconds` delay from the provider error message and retries after that time has passed ([see](https://github.com/openai/codex/blob/41ece455b7fa7166f4fc38522952afdaa2604e18/codex-rs/codex-api/src/sse/responses.rs#L627-L669)). This PR implements that change specifically, but keeping to the same pattern of just retrying once: Before assistant output begins, retry one `rate_limit_exceeded` failure after the server-indicated delay, capped by existing`maxRetryDelayMs`.