### PR TITLE
feat(coding-agent): defer extension runtime reloads

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1020,47 +1020,22 @@ Control flow helpers. `ctx.isIdle()` is false while Pi is processing an agent ru
 
 ### ctx.requestReload()
 
-Request the same canonical runtime reload as `/reload` after the current extension operation safely settles.
+Schedule the same runtime reload as `/reload` after the current extension operation and agent work settle. Commands, tools, event handlers, and shortcuts can call it.
 
-Use this fire-and-forget method from commands, tools, event handlers, and shortcuts. Call it last and return from the handler. Duplicate requests are coalesced. Requests made while the agent is running wait until retries, compaction, queued messages, tool results, and `agent_settled` handlers finish. Requests made while a reload is already running are ignored, which prevents reload loops from lifecycle handlers.
-
-The method does not wait for completion, so handlers cannot catch reload failures or use the new runtime after calling it.
-
-Interactive mode preserves the normal reload UI and restores keybindings, themes, and extension UI. RPC mode reloads without model authentication or an extra model turn. Print and JSON modes ignore the request. Once session teardown begins, pending and new reload requests are discarded.
-
-RPC rejects later commands with `Runtime reload in progress` until reload finishes. Abort commands and extension UI responses remain available so lifecycle handlers cannot deadlock.
-
-If the host fails before the canonical reload starts, Pi reports the extension error and keeps the current runtime available. If reload fails after invalidating the previous runtime, Pi raises `RuntimeReloadError` and rejects later RPC commands or direct reloads instead of continuing with partial state.
-
-Command handlers use the same deferred request:
+The request is fire-and-forget. Call it last and return: the current context becomes stale when reload starts, and the handler cannot await or catch reload failures. Concurrent requests are coalesced; requests during reload are ignored, and teardown discards pending requests.
 
 ```typescript
 pi.registerCommand("reload-runtime", {
-  description: "Reload extensions, skills, prompts, themes, and context files",
+  description: "Reload runtime resources",
   handler: async (_args, ctx) => {
     ctx.requestReload();
-    return;
   },
 });
 ```
 
-Tools can request it after preparing their result:
+TUI and RPC modes support reload requests; print and JSON modes ignore them. RPC temporarily rejects non-control commands while reloading. A failure after the old runtime is invalidated raises `RuntimeReloadError` instead of leaving partial state.
 
-```typescript
-pi.registerTool({
-  name: "reload_runtime",
-  label: "Reload Runtime",
-  description: "Reload extensions, skills, prompts, themes, and context files",
-  parameters: Type.Object({}),
-  async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-    ctx.requestReload();
-    return {
-      content: [{ type: "text", text: "Reload requested." }],
-      details: {},
-    };
-  },
-});
-```
+See [reload-runtime.ts](../examples/extensions/reload-runtime.ts) for command and tool examples.
 
 ### ctx.shutdown()
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1018,6 +1018,50 @@ pi.on("tool_result", async (event, ctx) => {
 
 Control flow helpers. `ctx.isIdle()` is false while Pi is processing an agent run, automatic retry, auto-compaction retry, or queued continuation.
 
+### ctx.requestReload()
+
+Request the same canonical runtime reload as `/reload` after the current extension operation safely settles.
+
+Use this fire-and-forget method from commands, tools, event handlers, and shortcuts. Call it last and return from the handler. Duplicate requests are coalesced. Requests made while the agent is running wait until retries, compaction, queued messages, tool results, and `agent_settled` handlers finish. Requests made while a reload is already running are ignored, which prevents reload loops from lifecycle handlers.
+
+The method does not wait for completion, so handlers cannot catch reload failures or use the new runtime after calling it.
+
+Interactive mode preserves the normal reload UI and restores keybindings, themes, and extension UI. RPC mode reloads without model authentication or an extra model turn. Print and JSON modes ignore the request. Once session teardown begins, pending and new reload requests are discarded.
+
+RPC rejects later commands with `Runtime reload in progress` until reload finishes. Abort commands and extension UI responses remain available so lifecycle handlers cannot deadlock.
+
+If the host fails before the canonical reload starts, Pi reports the extension error and keeps the current runtime available. If reload fails after invalidating the previous runtime, Pi raises `RuntimeReloadError` and rejects later RPC commands or direct reloads instead of continuing with partial state.
+
+Command handlers use the same deferred request:
+
+```typescript
+pi.registerCommand("reload-runtime", {
+  description: "Reload extensions, skills, prompts, themes, and context files",
+  handler: async (_args, ctx) => {
+    ctx.requestReload();
+    return;
+  },
+});
+```
+
+Tools can request it after preparing their result:
+
+```typescript
+pi.registerTool({
+  name: "reload_runtime",
+  label: "Reload Runtime",
+  description: "Reload extensions, skills, prompts, themes, and context files",
+  parameters: Type.Object({}),
+  async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+    ctx.requestReload();
+    return {
+      content: [{ type: "text", text: "Reload requested." }],
+      details: {},
+    };
+  },
+});
+```
+
 ### ctx.shutdown()
 
 Request a graceful shutdown of pi.
@@ -1271,62 +1315,6 @@ pi.registerCommand("handoff", {
     });
   },
 });
-```
-
-### ctx.reload()
-
-Run the same reload flow as `/reload`.
-
-```typescript
-pi.registerCommand("reload-runtime", {
-  description: "Reload extensions, skills, prompts, themes, and context files",
-  handler: async (_args, ctx) => {
-    await ctx.reload();
-    return;
-  },
-});
-```
-
-Important behavior:
-- `await ctx.reload()` emits `session_shutdown` for the current extension runtime
-- It then reloads resources and emits `session_start` with `reason: "reload"` and `resources_discover` with reason `"reload"`
-- The currently running command handler still continues in the old call frame
-- Code after `await ctx.reload()` still runs from the pre-reload version
-- Code after `await ctx.reload()` must not assume old in-memory extension state is still valid
-- After the handler returns, future commands/events/tool calls use the new extension version
-
-For predictable behavior, treat reload as terminal for that handler (`await ctx.reload(); return;`).
-
-Tools run with `ExtensionContext`, so they cannot call `ctx.reload()` directly. Use a command as the reload entrypoint, then expose a tool that queues that command as a follow-up user message.
-
-Example tool the LLM can call to trigger reload:
-
-```typescript
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
-
-export default function (pi: ExtensionAPI) {
-  pi.registerCommand("reload-runtime", {
-    description: "Reload extensions, skills, prompts, themes, and context files",
-    handler: async (_args, ctx) => {
-      await ctx.reload();
-      return;
-    },
-  });
-
-  pi.registerTool({
-    name: "reload_runtime",
-    label: "Reload Runtime",
-    description: "Reload extensions, skills, prompts, themes, and context files",
-    parameters: Type.Object({}),
-    async execute() {
-      pi.sendUserMessage("/reload-runtime", { deliverAs: "followUp" });
-      return {
-        content: [{ type: "text", text: "Queued /reload-runtime as a follow-up command." }],
-      };
-    },
-  });
-}
 ```
 
 ## ExtensionAPI Methods
@@ -2922,7 +2910,7 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `handoff.ts` | Cross-provider model handoff | `registerCommand`, `ui.editor`, `ui.custom` |
 | `qna.ts` | Q&A with custom UI | `registerCommand`, `ui.custom`, `setEditorText` |
 | `send-user-message.ts` | Inject user messages | `registerCommand`, `sendUserMessage` |
-| `reload-runtime.ts` | Reload command and LLM tool handoff | `registerCommand`, `ctx.reload()`, `sendUserMessage` |
+| `reload-runtime.ts` | Deferred command and tool reload requests | `ctx.requestReload()` |
 | `shutdown-command.ts` | Graceful shutdown command | `registerCommand`, `shutdown()` |
 | **Events & Gates** |||
 | `permission-gate.ts` | Block dangerous commands | `on("tool_call")`, `ui.confirm` |

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -75,7 +75,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `overlay-qa-tests.ts` | Comprehensive overlay QA tests: anchors, margins, stacking, overflow, animation |
 | `doom-overlay/` | DOOM game running as an overlay at 35 FPS (demonstrates real-time game rendering) |
 | `shutdown-command.ts` | Adds `/quit` command demonstrating `ctx.shutdown()` |
-| `reload-runtime.ts` | Adds `/reload-runtime` and `reload_runtime` tool showing safe reload flow |
+| `reload-runtime.ts` | Shows deferred command and tool reload with `ctx.requestReload()` |
 | `interactive-shell.ts` | Run interactive commands (vim, htop) with full terminal via `user_bash` hook |
 | `inline-bash.ts` | Expands `!{command}` patterns in prompts via `input` event transformation |
 | `input-transform-streaming.ts` | Skips expensive input preprocessing for mid-stream steering via `streamingBehavior` |

--- a/packages/coding-agent/examples/extensions/reload-runtime.ts
+++ b/packages/coding-agent/examples/extensions/reload-runtime.ts
@@ -1,35 +1,32 @@
 /**
  * Reload Runtime Extension
  *
- * Demonstrates ctx.reload() from ExtensionCommandContext and an LLM-callable
- * tool that queues a follow-up command to trigger reload.
+ * Demonstrates deferred ctx.requestReload() from command and tool contexts.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
 export default function (pi: ExtensionAPI) {
-	// Command entrypoint for reload.
-	// Treat reload as terminal for this handler.
+	// Command entrypoint for reload. Treat the request as terminal for this handler.
 	pi.registerCommand("reload-runtime", {
 		description: "Reload extensions, skills, prompts, themes, and context files",
 		handler: async (_args, ctx) => {
-			await ctx.reload();
+			ctx.requestReload();
 			return;
 		},
 	});
 
-	// LLM-callable tool. Tools get ExtensionContext, so they cannot call ctx.reload() directly.
-	// Instead, queue a follow-up user command that executes the command above.
+	// LLM-callable tool. The request is coalesced and runs after this tool result settles.
 	pi.registerTool({
 		name: "reload_runtime",
 		label: "Reload Runtime",
 		description: "Reload extensions, skills, prompts, themes, and context files",
 		parameters: Type.Object({}),
-		async execute() {
-			pi.sendUserMessage("/reload-runtime", { deliverAs: "followUp" });
+		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+			ctx.requestReload();
 			return {
-				content: [{ type: "text", text: "Queued /reload-runtime as a follow-up command." }],
+				content: [{ type: "text", text: "Reload requested." }],
 				details: {},
 			};
 		},

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -165,6 +165,7 @@ export class AgentSessionRuntime {
 	}
 
 	private async teardownCurrent(reason: SessionShutdownEvent["reason"], targetSessionFile?: string): Promise<void> {
+		this.session.beginTeardown();
 		// Settle any active response first so the aborted turn (including tool
 		// results) is persisted to the outgoing session before it is replaced.
 		await this.session.abort();
@@ -189,7 +190,9 @@ export class AgentSessionRuntime {
 			await this.rebindSession(this.session);
 		}
 		if (withSession) {
-			await withSession(this.session.createReplacedSessionContext());
+			await this.session.extensionRunner.runExtensionOperation(() =>
+				withSession(this.session.createReplacedSessionContext()),
+			);
 		}
 	}
 
@@ -396,6 +399,7 @@ export class AgentSessionRuntime {
 	}
 
 	async dispose(): Promise<void> {
+		this.session.beginTeardown();
 		await emitSessionShutdownEvent(this.session.extensionRunner, {
 			type: "session_shutdown",
 			reason: "quit",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -195,6 +195,20 @@ function withoutDeletedHeaders(headers: ProviderHeaders | undefined): Record<str
 		: undefined;
 }
 
+export class RuntimeReloadError extends Error {
+	constructor(cause: unknown) {
+		super("Runtime reload failed after invalidating the previous runtime", { cause });
+		this.name = "RuntimeReloadError";
+	}
+}
+
+export interface RuntimeReloadHost {
+	beforeReload?(): void | Promise<void>;
+	beforeSessionStart?(): void | Promise<void>;
+	afterReload?(): void | Promise<void>;
+	reloadFailed?(error: unknown): void | Promise<void>;
+}
+
 export interface AgentSessionConfig {
 	agent: Agent;
 	sessionManager: SessionManager;
@@ -234,6 +248,7 @@ export interface ExtensionBindings {
 	abortHandler?: () => void;
 	shutdownHandler?: ShutdownHandler;
 	onError?: ExtensionErrorListener;
+	reloadHost?: RuntimeReloadHost;
 }
 
 /** Options for AgentSession.prompt() */
@@ -276,6 +291,11 @@ export interface SessionStats {
 	};
 	cost: number;
 	contextUsage?: ContextUsage;
+}
+
+type RuntimeAvailability = "available" | "reloadRequested" | "reloading" | "failed" | "shuttingDown";
+interface ReloadOptions {
+	beforeSessionStart?: () => void | Promise<void>;
 }
 
 interface ToolDefinitionEntry {
@@ -360,6 +380,10 @@ export class AgentSession {
 	private _extensionShutdownHandler?: ShutdownHandler;
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
+	private _runtimeReloadHost?: RuntimeReloadHost;
+	private _extensionsBound = false;
+	private _runtimeAvailability: RuntimeAvailability = "available";
+	private _runtimeReloadError?: RuntimeReloadError;
 
 	private _modelRuntime: ModelRuntime;
 
@@ -396,7 +420,7 @@ export class AgentSession {
 		this._installAgentToolHooks();
 		this._installAgentNextTurnRefresh();
 
-		this._buildRuntime({
+		this._loadRuntime({
 			activeToolNames: this._initialActiveToolNames,
 			includeAllExtensionTools: true,
 		});
@@ -591,6 +615,119 @@ export class AgentSession {
 		this._idleWaitPromise = undefined;
 		this._resolveIdleWait = undefined;
 		resolve();
+	}
+
+	assertRuntimeAvailable(): void {
+		if (this._runtimeAvailability === "failed") {
+			throw this._runtimeReloadError;
+		}
+		if (this._runtimeAvailability === "shuttingDown") {
+			throw new Error("Runtime is shutting down");
+		}
+		if (this._runtimeAvailability !== "available") {
+			throw new Error("Runtime reload in progress");
+		}
+	}
+
+	/** Prevent pending or future extension reloads while this session is being torn down. */
+	beginTeardown(): void {
+		this._runtimeAvailability = "shuttingDown";
+	}
+
+	private _isShuttingDown(): boolean {
+		return this._runtimeAvailability === "shuttingDown";
+	}
+
+	private _requestReload(): void {
+		if (this._runtimeReloadHost && this._runtimeAvailability === "available") {
+			this._runtimeAvailability = "reloadRequested";
+		}
+	}
+
+	private _cancelRequestedReload(): void {
+		if (this._runtimeAvailability === "reloadRequested") {
+			this._runtimeAvailability = "available";
+		}
+	}
+
+	private async _flushRequestedReload(): Promise<void> {
+		if (
+			this._runtimeAvailability !== "reloadRequested" ||
+			!this._extensionsBound ||
+			!this.isIdle ||
+			this.isCompacting
+		) {
+			return;
+		}
+
+		try {
+			await this._performReload(this._runtimeReloadHost);
+		} catch (error) {
+			this._extensionRunner.emitError({
+				extensionPath: "<runtime>",
+				event: "request_reload",
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			throw error;
+		}
+	}
+
+	/**
+	 * Flush after a long-lived operation clears its busy state. If both the
+	 * operation and reload fail, preserve both failures instead of masking one.
+	 */
+	private async _flushRequestedReloadAfterOperation(operationError?: unknown): Promise<void> {
+		try {
+			await this._flushRequestedReload();
+		} catch (reloadError) {
+			if (operationError !== undefined) {
+				throw new AggregateError([operationError, reloadError], "Operation and deferred runtime reload failed");
+			}
+			throw reloadError;
+		}
+	}
+
+	private async _performReload(host: RuntimeReloadHost | undefined, options?: ReloadOptions): Promise<void> {
+		let runtimeInvalidated = false;
+		this._runtimeAvailability = "reloading";
+		try {
+			await host?.beforeReload?.();
+			const beforeSessionStart =
+				options?.beforeSessionStart || host?.beforeSessionStart
+					? async () => {
+							await options?.beforeSessionStart?.();
+							await host?.beforeSessionStart?.();
+						}
+					: undefined;
+			await this._reloadRuntime(beforeSessionStart ? { beforeSessionStart } : undefined, () => {
+				runtimeInvalidated = true;
+			});
+			await host?.afterReload?.();
+			if (!this._isShuttingDown()) {
+				this._runtimeAvailability = "available";
+				this._runtimeReloadError = undefined;
+			}
+		} catch (cause) {
+			let error: unknown = cause;
+			try {
+				await host?.reloadFailed?.(cause);
+			} catch (hostCause) {
+				error = new AggregateError([cause, hostCause], "Runtime reload failed and host cleanup also failed");
+			}
+			if (runtimeInvalidated) {
+				const terminalError = error instanceof RuntimeReloadError ? error : new RuntimeReloadError(error);
+				if (!this._isShuttingDown()) {
+					this._runtimeAvailability = "failed";
+					this._runtimeReloadError = terminalError;
+				}
+				throw terminalError;
+			}
+			if (!this._isShuttingDown()) {
+				this._runtimeAvailability = "available";
+			}
+			throw error;
+		}
 	}
 
 	private async _emitAgentSettled(): Promise<void> {
@@ -837,6 +974,7 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	dispose(): void {
+		this.beginTeardown();
 		try {
 			this.abortRetry();
 			this.abortCompaction();
@@ -848,7 +986,7 @@ export class AgentSession {
 		}
 
 		this._extensionRunner.invalidate(
-			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
+			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or ctx after the runtime that created it has been replaced. For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession.",
 		);
 		this._disconnectFromAgent();
 		this._eventListeners = [];
@@ -1288,7 +1426,7 @@ export class AgentSession {
 		const ctx = this._extensionRunner.createCommandContext();
 
 		try {
-			await command.handler(args, ctx);
+			await this._extensionRunner.runExtensionOperation(() => Promise.resolve(command.handler(args, ctx)));
 			return true;
 		} catch (err) {
 			// Emit error via extension runner
@@ -1697,11 +1835,15 @@ export class AgentSession {
 				this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
 			}
 			this._emit({ type: "thinking_level_changed", level: effectiveLevel });
-			void this._extensionRunner.emit({
-				type: "thinking_level_select",
-				level: effectiveLevel,
-				previousLevel,
-			});
+			void this._extensionRunner
+				.emit({
+					type: "thinking_level_select",
+					level: effectiveLevel,
+					previousLevel,
+				})
+				.catch(() => {
+					// Deferred reload failures are reported by _flushRequestedReload().
+				});
 		}
 	}
 
@@ -1791,6 +1933,7 @@ export class AgentSession {
 		await this.abort();
 		this._compactionAbortController = new AbortController();
 		this._emit({ type: "compaction_start", reason: "manual" });
+		let compactionError: unknown;
 
 		try {
 			if (!this.model) {
@@ -1915,6 +2058,7 @@ export class AgentSession {
 			});
 			return compactionResult;
 		} catch (error) {
+			compactionError = error;
 			const message = error instanceof Error ? error.message : String(error);
 			const aborted = message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError");
 			this._compactionAbortController = undefined;
@@ -1929,6 +2073,7 @@ export class AgentSession {
 			throw error;
 		} finally {
 			this._compactionAbortController = undefined;
+			await this._flushRequestedReloadAfterOperation(compactionError);
 		}
 	}
 
@@ -2219,6 +2364,7 @@ export class AgentSession {
 			return false;
 		} finally {
 			this._autoCompactionAbortController = undefined;
+			await this._flushRequestedReloadAfterOperation();
 		}
 	}
 
@@ -2253,10 +2399,21 @@ export class AgentSession {
 		if (bindings.onError !== undefined) {
 			this._extensionErrorListener = bindings.onError;
 		}
+		if (bindings.reloadHost !== undefined) {
+			this._runtimeReloadHost = bindings.reloadHost;
+		}
 
+		this._extensionsBound = false;
 		this._applyExtensionBindings(this._extensionRunner);
-		await this._extensionRunner.emit(this._sessionStartEvent);
-		await this.extendResourcesFromExtensions(this._sessionStartEvent.reason === "reload" ? "reload" : "startup");
+		await this._startRuntime(this._sessionStartEvent);
+		this._extensionsBound = true;
+		await this._flushRequestedReload();
+	}
+
+	private async _startRuntime(event: SessionStartEvent, options?: ReloadOptions): Promise<void> {
+		await options?.beforeSessionStart?.();
+		await this._extensionRunner.emit(event);
+		await this.extendResourcesFromExtensions(event.reason === "reload" ? "reload" : "startup");
 	}
 
 	private async extendResourcesFromExtensions(reason: "startup" | "reload"): Promise<void> {
@@ -2425,8 +2582,15 @@ export class AgentSession {
 					void this.abort();
 				},
 				hasPendingMessages: () => this.pendingMessageCount > 0,
+				requestReload: () => this._requestReload(),
+				onOperationComplete: () => this._flushRequestedReload(),
 				shutdown: () => {
-					this._extensionShutdownHandler?.();
+					if (this._extensionShutdownHandler) {
+						this.beginTeardown();
+						this._extensionShutdownHandler();
+						return;
+					}
+					this._cancelRequestedReload();
 				},
 				getContextUsage: () => this.getContextUsage(),
 				compact: (options) => {
@@ -2553,7 +2717,8 @@ export class AgentSession {
 		this.setActiveToolsByName([...new Set(nextActiveToolNames)]);
 	}
 
-	private _buildRuntime(options: {
+	/** Install a runtime from the ResourceLoader's current snapshot. Used by startup and reload. */
+	private _loadRuntime(options: {
 		activeToolNames?: string[];
 		flagValues?: Map<string, boolean | string>;
 		includeAllExtensionTools?: boolean;
@@ -2607,30 +2772,33 @@ export class AgentSession {
 		});
 	}
 
-	async reload(options?: { beforeSessionStart?: () => void | Promise<void> }): Promise<void> {
+	async reload(options?: ReloadOptions): Promise<void> {
+		this.assertRuntimeAvailable();
+		if (!this.isIdle || this.isCompacting || this._extensionRunner.hasActiveOperation()) {
+			throw new Error("Cannot reload while a runtime operation is active");
+		}
+		await this._performReload(this._runtimeReloadHost, options);
+	}
+
+	/** Tear down the old runtime, then enter the same load and start path used during startup. */
+	private async _reloadRuntime(options: ReloadOptions | undefined, onInvalidated: () => void): Promise<void> {
 		const oldRunner = this._extensionRunner;
 		const previousFlagValues = oldRunner.getFlagValues();
+		const activeToolNames = this.getActiveToolNames();
 		await emitSessionShutdownEvent(oldRunner, { type: "session_shutdown", reason: "reload" });
 		oldRunner.invalidate();
+		onInvalidated();
 		await this.settingsManager.reload();
 		this.syncQueueModesFromSettings();
 		resetApiProviders();
 		await this._resourceLoader.reload();
-		this._buildRuntime({
-			activeToolNames: this.getActiveToolNames(),
+		this._loadRuntime({
+			activeToolNames,
 			flagValues: previousFlagValues,
 			includeAllExtensionTools: true,
 		});
-
-		const hasBindings =
-			this._extensionUIContext ||
-			this._extensionCommandContextActions ||
-			this._extensionShutdownHandler ||
-			this._extensionErrorListener;
-		if (hasBindings) {
-			await options?.beforeSessionStart?.();
-			await this._extensionRunner.emit({ type: "session_start", reason: "reload" });
-			await this.extendResourcesFromExtensions("reload");
+		if (this._extensionsBound) {
+			await this._startRuntime({ type: "session_start", reason: "reload" }, options);
 		}
 	}
 
@@ -2884,7 +3052,9 @@ export class AgentSession {
 		this.sessionManager.appendSessionInfo(name);
 		const event = { type: "session_info_changed", name: this.sessionManager.getSessionName() } as const;
 		this._emit(event);
-		void this._extensionRunner.emit(event);
+		void this._extensionRunner.emit(event).catch(() => {
+			// Deferred reload failures are reported by _flushRequestedReload().
+		});
 	}
 
 	// =========================================================================
@@ -2952,6 +3122,7 @@ export class AgentSession {
 
 		// Set up abort controller for summarization
 		this._branchSummaryAbortController = new AbortController();
+		let navigationError: unknown;
 
 		try {
 			let extensionSummary: { summary: string; details?: unknown; usage?: Usage } | undefined;
@@ -3089,8 +3260,13 @@ export class AgentSession {
 			// Emit to custom tools
 
 			return { editorText, cancelled: false, summaryEntry };
+		} catch (error) {
+			// Preserve the navigation failure so the finally block can report both it and a reload failure.
+			navigationError = error;
+			throw error;
 		} finally {
 			this._branchSummaryAbortController = undefined;
+			await this._flushRequestedReloadAfterOperation(navigationError);
 		}
 	}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -202,7 +202,7 @@ export class RuntimeReloadError extends Error {
 	}
 }
 
-export interface RuntimeReloadHooks {
+export interface RuntimeReloadCallbacks {
 	beforeReload?(): void | Promise<void>;
 	beforeSessionStart?(): void | Promise<void>;
 	afterReload?(): void | Promise<void>;
@@ -248,7 +248,7 @@ export interface ExtensionBindings {
 	abortHandler?: () => void;
 	shutdownHandler?: ShutdownHandler;
 	onError?: ExtensionErrorListener;
-	reloadHooks?: RuntimeReloadHooks;
+	reloadHooks?: RuntimeReloadCallbacks;
 }
 
 /** Options for AgentSession.prompt() */
@@ -376,7 +376,7 @@ export class AgentSession {
 	private _extensionShutdownHandler?: ShutdownHandler;
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
-	private _runtimeReloadHooks?: RuntimeReloadHooks;
+	private _runtimeReloadHooks?: RuntimeReloadCallbacks;
 	private _extensionsBound = false;
 	private _runtimeAvailability: RuntimeAvailability = "available";
 	private _runtimeReloadError?: RuntimeReloadError;
@@ -684,7 +684,7 @@ export class AgentSession {
 		}
 	}
 
-	private async _performReload(hooks: RuntimeReloadHooks | undefined): Promise<void> {
+	private async _performReload(hooks: RuntimeReloadCallbacks | undefined): Promise<void> {
 		let runtimeInvalidated = false;
 		this._runtimeAvailability = "reloading";
 		try {
@@ -2774,7 +2774,7 @@ export class AgentSession {
 
 	/** Tear down the old runtime, then enter the same load and start path used during startup. */
 	private async _reloadRuntime(
-		beforeSessionStart: RuntimeReloadHooks["beforeSessionStart"],
+		beforeSessionStart: RuntimeReloadCallbacks["beforeSessionStart"],
 		onInvalidated: () => void,
 	): Promise<void> {
 		const oldRunner = this._extensionRunner;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -202,7 +202,7 @@ export class RuntimeReloadError extends Error {
 	}
 }
 
-export interface RuntimeReloadHost {
+export interface RuntimeReloadHooks {
 	beforeReload?(): void | Promise<void>;
 	beforeSessionStart?(): void | Promise<void>;
 	afterReload?(): void | Promise<void>;
@@ -248,7 +248,7 @@ export interface ExtensionBindings {
 	abortHandler?: () => void;
 	shutdownHandler?: ShutdownHandler;
 	onError?: ExtensionErrorListener;
-	reloadHost?: RuntimeReloadHost;
+	reloadHooks?: RuntimeReloadHooks;
 }
 
 /** Options for AgentSession.prompt() */
@@ -294,10 +294,6 @@ export interface SessionStats {
 }
 
 type RuntimeAvailability = "available" | "reloadRequested" | "reloading" | "failed" | "shuttingDown";
-interface ReloadOptions {
-	beforeSessionStart?: () => void | Promise<void>;
-}
-
 interface ToolDefinitionEntry {
 	definition: ToolDefinition;
 	sourceInfo: SourceInfo;
@@ -380,7 +376,7 @@ export class AgentSession {
 	private _extensionShutdownHandler?: ShutdownHandler;
 	private _extensionErrorListener?: ExtensionErrorListener;
 	private _extensionErrorUnsubscriber?: () => void;
-	private _runtimeReloadHost?: RuntimeReloadHost;
+	private _runtimeReloadHooks?: RuntimeReloadHooks;
 	private _extensionsBound = false;
 	private _runtimeAvailability: RuntimeAvailability = "available";
 	private _runtimeReloadError?: RuntimeReloadError;
@@ -639,7 +635,7 @@ export class AgentSession {
 	}
 
 	private _requestReload(): void {
-		if (this._runtimeReloadHost && this._runtimeAvailability === "available") {
+		if (this._runtimeReloadHooks && this._runtimeAvailability === "available") {
 			this._runtimeAvailability = "reloadRequested";
 		}
 	}
@@ -661,7 +657,7 @@ export class AgentSession {
 		}
 
 		try {
-			await this._performReload(this._runtimeReloadHost);
+			await this._performReload(this._runtimeReloadHooks);
 		} catch (error) {
 			this._extensionRunner.emitError({
 				extensionPath: "<runtime>",
@@ -688,22 +684,15 @@ export class AgentSession {
 		}
 	}
 
-	private async _performReload(host: RuntimeReloadHost | undefined, options?: ReloadOptions): Promise<void> {
+	private async _performReload(hooks: RuntimeReloadHooks | undefined): Promise<void> {
 		let runtimeInvalidated = false;
 		this._runtimeAvailability = "reloading";
 		try {
-			await host?.beforeReload?.();
-			const beforeSessionStart =
-				options?.beforeSessionStart || host?.beforeSessionStart
-					? async () => {
-							await options?.beforeSessionStart?.();
-							await host?.beforeSessionStart?.();
-						}
-					: undefined;
-			await this._reloadRuntime(beforeSessionStart ? { beforeSessionStart } : undefined, () => {
+			await hooks?.beforeReload?.();
+			await this._reloadRuntime(hooks?.beforeSessionStart, () => {
 				runtimeInvalidated = true;
 			});
-			await host?.afterReload?.();
+			await hooks?.afterReload?.();
 			if (!this._isShuttingDown()) {
 				this._runtimeAvailability = "available";
 				this._runtimeReloadError = undefined;
@@ -711,9 +700,9 @@ export class AgentSession {
 		} catch (cause) {
 			let error: unknown = cause;
 			try {
-				await host?.reloadFailed?.(cause);
-			} catch (hostCause) {
-				error = new AggregateError([cause, hostCause], "Runtime reload failed and host cleanup also failed");
+				await hooks?.reloadFailed?.(cause);
+			} catch (hookCause) {
+				error = new AggregateError([cause, hookCause], "Runtime reload failed and reload failure hook also failed");
 			}
 			if (runtimeInvalidated) {
 				const terminalError = error instanceof RuntimeReloadError ? error : new RuntimeReloadError(error);
@@ -2399,8 +2388,8 @@ export class AgentSession {
 		if (bindings.onError !== undefined) {
 			this._extensionErrorListener = bindings.onError;
 		}
-		if (bindings.reloadHost !== undefined) {
-			this._runtimeReloadHost = bindings.reloadHost;
+		if (bindings.reloadHooks !== undefined) {
+			this._runtimeReloadHooks = bindings.reloadHooks;
 		}
 
 		this._extensionsBound = false;
@@ -2410,8 +2399,11 @@ export class AgentSession {
 		await this._flushRequestedReload();
 	}
 
-	private async _startRuntime(event: SessionStartEvent, options?: ReloadOptions): Promise<void> {
-		await options?.beforeSessionStart?.();
+	private async _startRuntime(
+		event: SessionStartEvent,
+		beforeSessionStart?: () => void | Promise<void>,
+	): Promise<void> {
+		await beforeSessionStart?.();
 		await this._extensionRunner.emit(event);
 		await this.extendResourcesFromExtensions(event.reason === "reload" ? "reload" : "startup");
 	}
@@ -2772,16 +2764,19 @@ export class AgentSession {
 		});
 	}
 
-	async reload(options?: ReloadOptions): Promise<void> {
+	async reload(): Promise<void> {
 		this.assertRuntimeAvailable();
 		if (!this.isIdle || this.isCompacting || this._extensionRunner.hasActiveOperation()) {
 			throw new Error("Cannot reload while a runtime operation is active");
 		}
-		await this._performReload(this._runtimeReloadHost, options);
+		await this._performReload(this._runtimeReloadHooks);
 	}
 
 	/** Tear down the old runtime, then enter the same load and start path used during startup. */
-	private async _reloadRuntime(options: ReloadOptions | undefined, onInvalidated: () => void): Promise<void> {
+	private async _reloadRuntime(
+		beforeSessionStart: RuntimeReloadHooks["beforeSessionStart"],
+		onInvalidated: () => void,
+	): Promise<void> {
 		const oldRunner = this._extensionRunner;
 		const previousFlagValues = oldRunner.getFlagValues();
 		const activeToolNames = this.getActiveToolNames();
@@ -2798,7 +2793,7 @@ export class AgentSession {
 			includeAllExtensionTools: true,
 		});
 		if (this._extensionsBound) {
-			await this._startRuntime({ type: "session_start", reason: "reload" }, options);
+			await this._startRuntime({ type: "session_start", reason: "reload" }, beforeSessionStart);
 		}
 	}
 

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -207,7 +207,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 			if (state.staleMessage) return;
 			state.staleMessage =
 				message ??
-				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
+				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or ctx after the runtime that created it has been replaced. For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession.";
 			for (const unsubscribe of eventBusUnsubscribers) unsubscribe();
 			eventBusUnsubscribers.clear();
 		},

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -181,8 +181,6 @@ export type SwitchSessionHandler = (
 	options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 ) => Promise<{ cancelled: boolean }>;
 
-export type ReloadHandler = () => Promise<void>;
-
 export type ShutdownHandler = () => void;
 
 /**
@@ -290,7 +288,9 @@ export class ExtensionRunner {
 	private forkHandler: ForkHandler = async () => ({ cancelled: false });
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
-	private reloadHandler: ReloadHandler = async () => {};
+	private requestReloadHandler: () => void = () => {};
+	private operationCompleteHandler: () => Promise<void> = async () => {};
+	private operationDepth = 0;
 	private shutdownHandler: ShutdownHandler = () => {};
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
@@ -344,6 +344,8 @@ export class ExtensionRunner {
 		this.getSignalFn = contextActions.getSignal;
 		this.abortFn = contextActions.abort;
 		this.hasPendingMessagesFn = contextActions.hasPendingMessages;
+		this.requestReloadHandler = contextActions.requestReload;
+		this.operationCompleteHandler = contextActions.onOperationComplete;
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
@@ -418,7 +420,6 @@ export class ExtensionRunner {
 			this.forkHandler = actions.fork;
 			this.navigateTreeHandler = actions.navigateTree;
 			this.switchSessionHandler = actions.switchSession;
-			this.reloadHandler = actions.reload;
 			return;
 		}
 
@@ -427,7 +428,6 @@ export class ExtensionRunner {
 		this.forkHandler = async () => ({ cancelled: false });
 		this.navigateTreeHandler = async () => ({ cancelled: false });
 		this.switchSessionHandler = async () => ({ cancelled: false });
-		this.reloadHandler = async () => {};
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext, mode: ExtensionMode = "print"): void {
@@ -445,6 +445,22 @@ export class ExtensionRunner {
 
 	getExtensionPaths(): string[] {
 		return this.extensions.map((e) => e.path);
+	}
+
+	hasActiveOperation(): boolean {
+		return this.operationDepth > 0;
+	}
+
+	async runExtensionOperation<T>(callback: () => Promise<T>): Promise<T> {
+		this.operationDepth++;
+		try {
+			return await callback();
+		} finally {
+			this.operationDepth--;
+			if (this.operationDepth === 0) {
+				await this.operationCompleteHandler();
+			}
+		}
 	}
 
 	/** Get all registered tools from all extensions (first registration per name wins). */
@@ -541,7 +557,7 @@ export class ExtensionRunner {
 	}
 
 	invalidate(
-		message = "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
+		message = "This extension ctx is stale after session replacement or reload. Do not use a captured pi or ctx after the runtime that created it has been replaced. For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession.",
 	): void {
 		if (!this.staleMessage) {
 			this.staleMessage = message;
@@ -731,6 +747,10 @@ export class ExtensionRunner {
 				runner.assertActive();
 				return runner.hasPendingMessagesFn();
 			},
+			requestReload: () => {
+				runner.assertActive();
+				runner.requestReloadHandler();
+			},
 			shutdown: () => {
 				runner.assertActive();
 				runner.shutdownHandler();
@@ -782,10 +802,6 @@ export class ExtensionRunner {
 			this.assertActive();
 			return this.switchSessionHandler(sessionPath, options);
 		};
-		context.reload = () => {
-			this.assertActive();
-			return this.reloadHandler();
-		};
 		return context;
 	}
 
@@ -799,6 +815,10 @@ export class ExtensionRunner {
 	}
 
 	async emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {
+		return this.runExtensionOperation(() => this._emit(event));
+	}
+
+	private async _emit<TEvent extends RunnerEmitEvent>(event: TEvent): Promise<RunnerEmitResult<TEvent>> {
 		const ctx = this.createContext();
 		let result: SessionBeforeEventResult | undefined;
 
@@ -833,6 +853,10 @@ export class ExtensionRunner {
 	}
 
 	async emitMessageEnd(event: MessageEndEvent): Promise<AgentMessage | undefined> {
+		return this.runExtensionOperation(() => this._emitMessageEnd(event));
+	}
+
+	private async _emitMessageEnd(event: MessageEndEvent): Promise<AgentMessage | undefined> {
 		const ctx = this.createContext();
 		let currentMessage = event.message;
 		let modified = false;
@@ -875,6 +899,10 @@ export class ExtensionRunner {
 	}
 
 	async emitToolResult(event: ToolResultEvent): Promise<ToolResultEventResult | undefined> {
+		return this.runExtensionOperation(() => this._emitToolResult(event));
+	}
+
+	private async _emitToolResult(event: ToolResultEvent): Promise<ToolResultEventResult | undefined> {
 		const ctx = this.createContext();
 		const currentEvent: ToolResultEvent = { ...event };
 		let modified = false;
@@ -930,6 +958,10 @@ export class ExtensionRunner {
 	}
 
 	async emitToolCall(event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
+		return this.runExtensionOperation(() => this._emitToolCall(event));
+	}
+
+	private async _emitToolCall(event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
 		const ctx = this.createContext();
 		let result: ToolCallEventResult | undefined;
 
@@ -953,6 +985,10 @@ export class ExtensionRunner {
 	}
 
 	async emitUserBash(event: UserBashEvent): Promise<UserBashEventResult | undefined> {
+		return this.runExtensionOperation(() => this._emitUserBash(event));
+	}
+
+	private async _emitUserBash(event: UserBashEvent): Promise<UserBashEventResult | undefined> {
 		const ctx = this.createContext();
 
 		for (const ext of this.extensions) {
@@ -982,6 +1018,10 @@ export class ExtensionRunner {
 	}
 
 	async emitContext(messages: AgentMessage[]): Promise<AgentMessage[]> {
+		return this.runExtensionOperation(() => this._emitContext(messages));
+	}
+
+	private async _emitContext(messages: AgentMessage[]): Promise<AgentMessage[]> {
 		const ctx = this.createContext();
 		let currentMessages = structuredClone(messages);
 
@@ -1014,6 +1054,10 @@ export class ExtensionRunner {
 	}
 
 	async emitBeforeProviderRequest(payload: unknown): Promise<unknown> {
+		return this.runExtensionOperation(() => this._emitBeforeProviderRequest(payload));
+	}
+
+	private async _emitBeforeProviderRequest(payload: unknown): Promise<unknown> {
 		const ctx = this.createContext();
 		let currentPayload = payload;
 
@@ -1048,6 +1092,10 @@ export class ExtensionRunner {
 	}
 
 	async emitBeforeProviderHeaders(headers: ProviderHeaders): Promise<ProviderHeaders> {
+		return this.runExtensionOperation(() => this._emitBeforeProviderHeaders(headers));
+	}
+
+	private async _emitBeforeProviderHeaders(headers: ProviderHeaders): Promise<ProviderHeaders> {
 		const ctx = this.createContext();
 
 		for (const ext of this.extensions) {
@@ -1079,6 +1127,17 @@ export class ExtensionRunner {
 	}
 
 	async emitBeforeAgentStart(
+		prompt: string,
+		images: ImageContent[] | undefined,
+		systemPrompt: string,
+		systemPromptOptions: BuildSystemPromptOptions,
+	): Promise<BeforeAgentStartCombinedResult | undefined> {
+		return this.runExtensionOperation(() =>
+			this._emitBeforeAgentStart(prompt, images, systemPrompt, systemPromptOptions),
+		);
+	}
+
+	private async _emitBeforeAgentStart(
 		prompt: string,
 		images: ImageContent[] | undefined,
 		systemPrompt: string,
@@ -1152,6 +1211,17 @@ export class ExtensionRunner {
 		promptPaths: Array<{ path: string; extensionPath: string }>;
 		themePaths: Array<{ path: string; extensionPath: string }>;
 	}> {
+		return this.runExtensionOperation(() => this._emitResourcesDiscover(cwd, reason));
+	}
+
+	private async _emitResourcesDiscover(
+		cwd: string,
+		reason: ResourcesDiscoverEvent["reason"],
+	): Promise<{
+		skillPaths: Array<{ path: string; extensionPath: string }>;
+		promptPaths: Array<{ path: string; extensionPath: string }>;
+		themePaths: Array<{ path: string; extensionPath: string }>;
+	}> {
 		const ctx = this.createContext();
 		const skillPaths: Array<{ path: string; extensionPath: string }> = [];
 		const promptPaths: Array<{ path: string; extensionPath: string }> = [];
@@ -1194,6 +1264,15 @@ export class ExtensionRunner {
 
 	/** Emit input event. Transforms chain, "handled" short-circuits. */
 	async emitInput(
+		text: string,
+		images: ImageContent[] | undefined,
+		source: InputSource,
+		streamingBehavior?: "steer" | "followUp",
+	): Promise<InputEventResult> {
+		return this.runExtensionOperation(() => this._emitInput(text, images, source, streamingBehavior));
+	}
+
+	private async _emitInput(
 		text: string,
 		images: ImageContent[] | undefined,
 		source: InputSource,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -336,6 +336,8 @@ export interface ExtensionContext {
 	abort(): void;
 	/** Whether there are queued messages waiting */
 	hasPendingMessages(): boolean;
+	/** Request a runtime reload after the current extension operation settles. */
+	requestReload(): void;
 	/** Gracefully shutdown pi and exit. Available in all contexts. */
 	shutdown(): void;
 	/** Get current context usage for the active model. */
@@ -381,9 +383,6 @@ export interface ExtensionCommandContext extends ExtensionContext {
 		sessionPath: string,
 		options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	): Promise<{ cancelled: boolean }>;
-
-	/** Reload extensions, skills, prompts, themes, and context files. */
-	reload(): Promise<void>;
 }
 
 /**
@@ -1652,6 +1651,8 @@ export interface ExtensionContextActions {
 	getSignal: () => AbortSignal | undefined;
 	abort: () => void;
 	hasPendingMessages: () => boolean;
+	requestReload: () => void;
+	onOperationComplete: () => Promise<void>;
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
@@ -1682,7 +1683,6 @@ export interface ExtensionCommandContextActions {
 		sessionPath: string,
 		options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	) => Promise<{ cancelled: boolean }>;
-	reload: () => Promise<void>;
 }
 
 /**

--- a/packages/coding-agent/src/core/extensions/wrapper.ts
+++ b/packages/coding-agent/src/core/extensions/wrapper.ts
@@ -21,7 +21,7 @@ export function wrapRegisteredTool(registeredTool: RegisteredTool, runner: Exten
 		...tool,
 		execute: async (toolCallId, params, signal, onUpdate) => {
 			const activeBefore = runner.getActiveTools();
-			const result = await execute(toolCallId, params, signal, onUpdate);
+			const result = await runner.runExtensionOperation(() => execute(toolCallId, params, signal, onUpdate));
 			const activeAfter = runner.getActiveTools();
 			if (!activeBefore.every((name) => activeAfter.includes(name))) return result;
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -22,7 +22,7 @@ export {
 	type PromptOptions,
 	parseSkillBlock,
 	RuntimeReloadError,
-	type RuntimeReloadHost,
+	type RuntimeReloadHooks,
 	type SessionStats,
 } from "./core/agent-session.ts";
 export { readStoredCredential } from "./core/auth-storage.ts";

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -22,7 +22,6 @@ export {
 	type PromptOptions,
 	parseSkillBlock,
 	RuntimeReloadError,
-	type RuntimeReloadHooks,
 	type SessionStats,
 } from "./core/agent-session.ts";
 export { readStoredCredential } from "./core/auth-storage.ts";

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -21,6 +21,8 @@ export {
 	type ParsedSkillBlock,
 	type PromptOptions,
 	parseSkillBlock,
+	RuntimeReloadError,
+	type RuntimeReloadHost,
 	type SessionStats,
 } from "./core/agent-session.ts";
 export { readStoredCredential } from "./core/auth-storage.ts";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -60,7 +60,7 @@ import {
 	type AgentSession,
 	type AgentSessionEvent,
 	parseSkillBlock,
-	type RuntimeReloadHooks,
+	type RuntimeReloadCallbacks,
 } from "../../core/agent-session.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 import {
@@ -5662,7 +5662,7 @@ export class InteractiveMode {
 		}
 	}
 
-	private createReloadHooks(): RuntimeReloadHooks {
+	private createReloadHooks(): RuntimeReloadCallbacks {
 		let previousEditor: Component | undefined;
 		let reloadBoxDismissed = true;
 		let chatRestoredBeforeSessionStart = false;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -60,7 +60,7 @@ import {
 	type AgentSession,
 	type AgentSessionEvent,
 	parseSkillBlock,
-	type RuntimeReloadHost,
+	type RuntimeReloadHooks,
 } from "../../core/agent-session.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 import {
@@ -1872,7 +1872,7 @@ export class InteractiveMode {
 					return this.handleResumeSession(sessionPath, options);
 				},
 			},
-			reloadHost: this.createReloadHost(),
+			reloadHooks: this.createReloadHooks(),
 			shutdownHandler: () => {
 				this.shutdownRequested = true;
 				if (this.session.isIdle) {
@@ -5662,7 +5662,7 @@ export class InteractiveMode {
 		}
 	}
 
-	private createReloadHost(): RuntimeReloadHost {
+	private createReloadHooks(): RuntimeReloadHooks {
 		let previousEditor: Component | undefined;
 		let reloadBoxDismissed = true;
 		let chatRestoredBeforeSessionStart = false;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -56,7 +56,12 @@ import {
 	getShareViewerUrl,
 	VERSION,
 } from "../../config.ts";
-import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
+import {
+	type AgentSession,
+	type AgentSessionEvent,
+	parseSkillBlock,
+	type RuntimeReloadHost,
+} from "../../core/agent-session.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 import {
 	CACHE_TTL_MS,
@@ -69,7 +74,6 @@ import type {
 	AutocompleteProviderFactory,
 	EditorFactory,
 	ExtensionCommandContext,
-	ExtensionContext,
 	ExtensionRunner,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
@@ -1867,10 +1871,8 @@ export class InteractiveMode {
 				switchSession: async (sessionPath, options) => {
 					return this.handleResumeSession(sessionPath, options);
 				},
-				reload: async () => {
-					await this.handleReloadCommand();
-				},
 			},
+			reloadHost: this.createReloadHost(),
 			shutdownHandler: () => {
 				this.shutdownRequested = true;
 				if (this.session.isIdle) {
@@ -1983,51 +1985,17 @@ export class InteractiveMode {
 		const shortcuts = extensionRunner.getShortcuts(this.keybindings.getEffectiveConfig());
 		if (shortcuts.size === 0) return;
 
-		// Create a context for shortcut handlers
-		const createContext = (): ExtensionContext => ({
-			ui: this.createExtensionUIContext(),
-			mode: "tui",
-			hasUI: true,
-			cwd: this.sessionManager.getCwd(),
-			sessionManager: this.sessionManager,
-			modelRegistry: extensionRunner.getModelRegistry(),
-			model: this.session.model,
-			scopedModels: this.session.scopedModels,
-			thinkingLevel: this.session.thinkingLevel,
-			isIdle: () => this.session.isIdle,
-			isProjectTrusted: () => this.settingsManager.isProjectTrusted(),
-			signal: this.session.agent.signal,
-			abort: () => {
-				this.restoreQueuedMessagesToEditor({ abort: true });
-			},
-			hasPendingMessages: () => this.session.pendingMessageCount > 0,
-			shutdown: () => {
-				this.shutdownRequested = true;
-			},
-			getContextUsage: () => this.session.getContextUsage(),
-			compact: (options) => {
-				void (async () => {
-					try {
-						const result = await this.session.compact(options?.customInstructions);
-						options?.onComplete?.(result);
-					} catch (error) {
-						const err = error instanceof Error ? error : new Error(String(error));
-						options?.onError?.(err);
-					}
-				})();
-			},
-			getSystemPrompt: () => this.session.systemPrompt,
-		});
-
 		// Set up the extension shortcut handler on the default editor
 		this.defaultEditor.onExtensionShortcut = (data: string) => {
 			for (const [shortcutStr, shortcut] of shortcuts) {
 				// Cast to KeyId - extension shortcuts use the same format
 				if (matchesKey(data, shortcutStr as KeyId)) {
 					// Run handler async, don't block input
-					Promise.resolve(shortcut.handler(createContext())).catch((err) => {
-						this.showError(`Shortcut handler error: ${err instanceof Error ? err.message : String(err)}`);
-					});
+					void extensionRunner
+						.runExtensionOperation(() => Promise.resolve(shortcut.handler(extensionRunner.createContext())))
+						.catch((err) => {
+							this.showError(`Shortcut handler error: ${err instanceof Error ? err.message : String(err)}`);
+						});
 					return true;
 				}
 			}
@@ -5687,28 +5655,17 @@ export class InteractiveMode {
 			return;
 		}
 
-		this.resetExtensionUI();
+		try {
+			await this.session.reload();
+		} catch (error) {
+			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
 
-		const reloadBox = new Container();
-		const borderColor = (s: string) => theme.fg("border", s);
-		reloadBox.addChild(new DynamicBorder(borderColor));
-		reloadBox.addChild(new Spacer(1));
-		reloadBox.addChild(
-			new Text(
-				theme.fg("muted", "Reloading keybindings, extensions, skills, prompts, themes, and context files..."),
-				1,
-				0,
-			),
-		);
-		reloadBox.addChild(new Spacer(1));
-		reloadBox.addChild(new DynamicBorder(borderColor));
-
-		const previousEditor = this.editor;
-		this.editorContainer.clear();
-		this.editorContainer.addChild(reloadBox);
-		this.ui.setFocus(reloadBox);
-		this.ui.requestRender(true);
-		await new Promise((resolve) => process.nextTick(resolve));
+	private createReloadHost(): RuntimeReloadHost {
+		let previousEditor: Component | undefined;
+		let reloadBoxDismissed = true;
+		let chatRestoredBeforeSessionStart = false;
 
 		const dismissReloadBox = (editor: Component) => {
 			this.editorContainer.clear();
@@ -5716,55 +5673,68 @@ export class InteractiveMode {
 			this.ui.setFocus(editor);
 			this.ui.requestRender();
 		};
-
-		let chatRestoredBeforeSessionStart = false;
-		let reloadBoxDismissed = false;
 		const restoreChatBeforeSessionStart = () => {
-			if (chatRestoredBeforeSessionStart) {
-				return;
-			}
+			if (chatRestoredBeforeSessionStart) return;
 			this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
 			this.outputPad = this.settingsManager.getOutputPad();
 			this.rebuildChatFromMessages();
 			chatRestoredBeforeSessionStart = true;
 		};
 
-		try {
-			await this.session.reload({ beforeSessionStart: restoreChatBeforeSessionStart });
-			restoreChatBeforeSessionStart();
-			this.keybindings.reload();
-			const activeHeader = this.customHeader ?? this.builtInHeader;
-			if (isExpandable(activeHeader)) {
-				activeHeader.setExpanded(this.toolOutputExpanded);
-			}
-			setRegisteredThemes(this.session.resourceLoader.getThemes().themes);
-			await this.themeController.applyFromSettings();
-			this.applyRuntimeSettings();
-			this.setupAutocompleteProvider();
-			const runner = this.session.extensionRunner;
-			this.setupExtensionShortcuts(runner);
-			this.showLoadedResources({
-				force: false,
-				showDiagnosticsWhenQuiet: true,
-			});
-			const savedImplicitProjectTrust = this.maybeSaveImplicitProjectTrustAfterReload();
-			const modelsJsonError = this.session.modelRuntime.getError();
-			if (modelsJsonError) {
-				this.showError(`models.json error: ${modelsJsonError}`);
-			}
-			this.showStatus(
-				savedImplicitProjectTrust
-					? "Reloaded keybindings, extensions, skills, prompts, themes, and context files; saved project trust"
-					: "Reloaded keybindings, extensions, skills, prompts, themes, and context files",
-			);
-			dismissReloadBox(this.editor as Component);
-			reloadBoxDismissed = true;
-		} catch (error) {
-			if (!reloadBoxDismissed) {
-				dismissReloadBox(previousEditor as Component);
-			}
-			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
-		}
+		return {
+			beforeReload: async () => {
+				this.resetExtensionUI();
+				previousEditor = this.editor;
+				reloadBoxDismissed = false;
+				chatRestoredBeforeSessionStart = false;
+
+				const reloadBox = new Container();
+				const borderColor = (s: string) => theme.fg("border", s);
+				reloadBox.addChild(new DynamicBorder(borderColor));
+				reloadBox.addChild(new Spacer(1));
+				reloadBox.addChild(
+					new Text(
+						theme.fg("muted", "Reloading keybindings, extensions, skills, prompts, themes, and context files..."),
+						1,
+						0,
+					),
+				);
+				reloadBox.addChild(new Spacer(1));
+				reloadBox.addChild(new DynamicBorder(borderColor));
+
+				this.editorContainer.clear();
+				this.editorContainer.addChild(reloadBox);
+				this.ui.setFocus(reloadBox);
+				this.ui.requestRender(true);
+				await new Promise((resolve) => process.nextTick(resolve));
+			},
+			beforeSessionStart: restoreChatBeforeSessionStart,
+			afterReload: async () => {
+				restoreChatBeforeSessionStart();
+				this.keybindings.reload();
+				const activeHeader = this.customHeader ?? this.builtInHeader;
+				if (isExpandable(activeHeader)) activeHeader.setExpanded(this.toolOutputExpanded);
+				setRegisteredThemes(this.session.resourceLoader.getThemes().themes);
+				await this.themeController.applyFromSettings();
+				this.applyRuntimeSettings();
+				this.setupAutocompleteProvider();
+				this.setupExtensionShortcuts(this.session.extensionRunner);
+				this.showLoadedResources({ force: false, showDiagnosticsWhenQuiet: true });
+				const savedImplicitProjectTrust = this.maybeSaveImplicitProjectTrustAfterReload();
+				const modelsJsonError = this.session.modelRuntime.getError();
+				if (modelsJsonError) this.showError(`models.json error: ${modelsJsonError}`);
+				this.showStatus(
+					savedImplicitProjectTrust
+						? "Reloaded keybindings, extensions, skills, prompts, themes, and context files; saved project trust"
+						: "Reloaded keybindings, extensions, skills, prompts, themes, and context files",
+				);
+				dismissReloadBox(this.editor as Component);
+				reloadBoxDismissed = true;
+			},
+			reloadFailed: () => {
+				if (!reloadBoxDismissed && previousEditor) dismissReloadBox(previousEditor);
+			},
+		};
 	}
 
 	private async handleExportCommand(text: string): Promise<void> {

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -94,9 +94,6 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 				switchSession: async (sessionPath, switchOptions) => {
 					return runtimeHost.switchSession(sessionPath, switchOptions);
 				},
-				reload: async () => {
-					await session.reload();
-				},
 			},
 			onError: (err) => {
 				console.error(`Extension error (${err.extensionPath}): ${err.error}`);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -338,10 +338,8 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				switchSession: async (sessionPath, options) => {
 					return runtimeHost.switchSession(sessionPath, options);
 				},
-				reload: async () => {
-					await session.reload();
-				},
 			},
+			reloadHost: {},
 			shutdownHandler: () => {
 				shutdownRequested = true;
 			},
@@ -779,6 +777,9 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 
 		const command = parsed as RpcCommand;
 		try {
+			if (command.type !== "abort" && command.type !== "abort_retry" && command.type !== "abort_bash") {
+				session.assertRuntimeAvailable();
+			}
 			const response = await handleCommand(command);
 			if (response) {
 				output(response);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -339,7 +339,7 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 					return runtimeHost.switchSession(sessionPath, options);
 				},
 			},
-			reloadHost: {},
+			reloadHooks: {},
 			shutdownHandler: () => {
 				shutdownRequested = true;
 			},

--- a/packages/coding-agent/test/agent-session-runtime-events.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-events.test.ts
@@ -35,7 +35,7 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		}
 	});
 
-	async function createRuntimeHost(extensionFactory: ExtensionFactory) {
+	async function createRuntimeHost(extensionFactory: ExtensionFactory, options?: { reloadHost?: boolean }) {
 		const tempDir = join(tmpdir(), `pi-runtime-events-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(tempDir, { recursive: true });
 
@@ -99,18 +99,51 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 			agentDir: tempDir,
 			sessionManager: SessionManager.create(tempDir),
 		});
-		await runtimeHost.session.bindExtensions({});
+		await runtimeHost.session.bindExtensions(options?.reloadHost ? { reloadHost: {} } : {});
+		let disposed = false;
+		const dispose = async () => {
+			if (disposed) return;
+			disposed = true;
+			await runtimeHost.dispose();
+		};
 
 		cleanups.push(async () => {
-			await runtimeHost.dispose();
+			await dispose();
 			faux.unregister();
 			if (existsSync(tempDir)) {
 				rmSync(tempDir, { recursive: true, force: true });
 			}
 		});
 
-		return { runtimeHost, faux };
+		return { runtimeHost, faux, dispose };
 	}
+
+	it("ignores reload requests from shutdown handlers during new, resume, and quit", async () => {
+		let reloadStarts = 0;
+		const { runtimeHost, dispose } = await createRuntimeHost(
+			(pi) => {
+				pi.on("session_shutdown", (_event, ctx) => {
+					ctx.requestReload();
+				});
+				pi.on("session_start", (event) => {
+					if (event.reason === "reload") reloadStarts++;
+				});
+			},
+			{ reloadHost: true },
+		);
+
+		await runtimeHost.session.prompt("hello");
+		const originalSessionFile = runtimeHost.session.sessionFile;
+		expect(originalSessionFile).toBeTruthy();
+
+		await runtimeHost.newSession();
+		await runtimeHost.session.bindExtensions({ reloadHost: {} });
+		await runtimeHost.switchSession(originalSessionFile!);
+		await runtimeHost.session.bindExtensions({ reloadHost: {} });
+		await dispose();
+
+		expect(reloadStarts).toBe(0);
+	});
 
 	it("emits session_before_switch and session_start for new and resume flows", async () => {
 		const events: RecordedSessionEvent[] = [];
@@ -200,7 +233,7 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 
 		expect(phases).toEqual(["session_shutdown", "beforeSessionInvalidate", "rebindSession"]);
 		expect(() => oldSession.extensionRunner.createContext().cwd).toThrow(
-			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
+			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or ctx after the runtime that created it has been replaced. For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession.",
 		);
 		runtimeHost.setBeforeSessionInvalidate(undefined);
 		runtimeHost.setRebindSession(undefined);

--- a/packages/coding-agent/test/agent-session-runtime-events.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-events.test.ts
@@ -35,7 +35,7 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		}
 	});
 
-	async function createRuntimeHost(extensionFactory: ExtensionFactory, options?: { reloadHost?: boolean }) {
+	async function createRuntimeHost(extensionFactory: ExtensionFactory, options?: { reloadHooks?: boolean }) {
 		const tempDir = join(tmpdir(), `pi-runtime-events-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(tempDir, { recursive: true });
 
@@ -99,7 +99,7 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 			agentDir: tempDir,
 			sessionManager: SessionManager.create(tempDir),
 		});
-		await runtimeHost.session.bindExtensions(options?.reloadHost ? { reloadHost: {} } : {});
+		await runtimeHost.session.bindExtensions(options?.reloadHooks ? { reloadHooks: {} } : {});
 		let disposed = false;
 		const dispose = async () => {
 			if (disposed) return;
@@ -129,7 +129,7 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 					if (event.reason === "reload") reloadStarts++;
 				});
 			},
-			{ reloadHost: true },
+			{ reloadHooks: true },
 		);
 
 		await runtimeHost.session.prompt("hello");
@@ -137,9 +137,9 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		expect(originalSessionFile).toBeTruthy();
 
 		await runtimeHost.newSession();
-		await runtimeHost.session.bindExtensions({ reloadHost: {} });
+		await runtimeHost.session.bindExtensions({ reloadHooks: {} });
 		await runtimeHost.switchSession(originalSessionFile!);
-		await runtimeHost.session.bindExtensions({ reloadHost: {} });
+		await runtimeHost.session.bindExtensions({ reloadHooks: {} });
 		await dispose();
 
 		expect(reloadStarts).toBe(0);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -96,11 +96,26 @@ describe("ExtensionRunner", () => {
 		abort: () => {},
 		hasPendingMessages: () => false,
 		shutdown: () => {},
+		requestReload: () => {},
+		onOperationComplete: async () => {},
 		getContextUsage: () => undefined,
 		compact: () => {},
 		getSystemPrompt: () => "",
 		getScopedModels: () => [],
 	};
+
+	describe("requestReload", () => {
+		it("routes ctx.requestReload through the bound context action", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			const requestReload = vi.fn();
+			runner.bindCore(extensionActions, { ...extensionContextActions, requestReload });
+
+			runner.createContext().requestReload();
+
+			expect(requestReload).toHaveBeenCalledOnce();
+		});
+	});
 
 	describe("scopedModels", () => {
 		it("reflects the getScopedModels context action on ctx.scopedModels", async () => {
@@ -933,7 +948,6 @@ describe("ExtensionRunner", () => {
 				fork,
 				navigateTree: async () => ({ cancelled: false }),
 				switchSession: async () => ({ cancelled: false }),
-				reload: async () => {},
 			});
 
 			const commandContext = runner.createCommandContext();

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -373,13 +373,17 @@ describe("AgentSession model and extension characterization", () => {
 		).toBe(true);
 	});
 
-	it("bindExtensions emits session_start and reload emits session_shutdown then session_start", async () => {
+	it("uses the same extension lifecycle for startup and reload", async () => {
 		const lifecycleEvents: string[] = [];
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi) => {
 					pi.on("session_start", async (event) => {
 						lifecycleEvents.push(`start:${event.reason}`);
+					});
+					pi.on("resources_discover", (event) => {
+						lifecycleEvents.push(`resources:${event.reason}`);
+						return {};
 					});
 					pi.on("session_shutdown", async (event) => {
 						lifecycleEvents.push(`shutdown:${event.reason}`);
@@ -389,9 +393,15 @@ describe("AgentSession model and extension characterization", () => {
 		});
 		harnesses.push(harness);
 
-		await harness.session.bindExtensions({ shutdownHandler: () => {} });
+		await harness.session.bindExtensions({ mode: "print" });
 		await harness.session.reload();
 
-		expect(lifecycleEvents).toEqual(["start:startup", "shutdown:reload", "start:reload"]);
+		expect(lifecycleEvents).toEqual([
+			"start:startup",
+			"resources:startup",
+			"shutdown:reload",
+			"start:reload",
+			"resources:reload",
+		]);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
@@ -121,9 +121,6 @@ describe("regression #2860: replaced session callbacks", () => {
 						return { cancelled: result.cancelled };
 					},
 					switchSession: async (sessionPath, options) => runtime.switchSession(sessionPath, options),
-					reload: async () => {
-						await session.reload();
-					},
 				},
 			});
 		};

--- a/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
@@ -1,7 +1,7 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { Container, Text } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentSessionEvent, RuntimeReloadHost } from "../../../src/core/agent-session.ts";
+import type { AgentSessionEvent, RuntimeReloadHooks } from "../../../src/core/agent-session.ts";
 import type { ExtensionUIContext } from "../../../src/core/extensions/index.ts";
 import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
 import { initTheme, type Theme, theme } from "../../../src/modes/interactive/theme/theme.ts";
@@ -91,7 +91,7 @@ type ReloadCommandContext = {
 	session: {
 		isStreaming: boolean;
 		isCompacting: boolean;
-		reload: (options?: { beforeSessionStart?: () => void | Promise<void> }) => Promise<void>;
+		reload: () => Promise<void>;
 		resourceLoader: { getThemes: () => { themes: [] } };
 		extensionRunner: unknown;
 		modelRuntime: { getError: () => string | undefined };
@@ -137,7 +137,7 @@ type InteractiveModePrototype = {
 	): void;
 	rebindCurrentSession(this: RebindContext, options?: { renderBeforeBind?: boolean }): Promise<void>;
 	handleReloadCommand(this: ReloadCommandContext): Promise<void>;
-	createReloadHost(this: ReloadCommandContext): RuntimeReloadHost;
+	createReloadHooks(this: ReloadCommandContext): RuntimeReloadHooks;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
@@ -162,9 +162,7 @@ function createReloadCommandContext(overrides: ReloadCommandContextOverrides = {
 		session: {
 			isStreaming: false,
 			isCompacting: false,
-			reload: async (options) => {
-				await options?.beforeSessionStart?.();
-			},
+			reload: async () => {},
 			resourceLoader: { getThemes: () => ({ themes: [] }) },
 			extensionRunner: {},
 			modelRuntime: { getError: () => undefined },
@@ -438,11 +436,12 @@ describe("regression #5943: session_start transient UI", () => {
 			await harness.session.bindExtensions({
 				uiContext: createUiContext((message) => events.push(message)),
 				mode: "tui",
+				reloadHooks: { beforeSessionStart },
 			});
 			expect(events).toEqual(["start:startup", "notify:startup"]);
 
 			events.length = 0;
-			await harness.session.reload({ beforeSessionStart });
+			await harness.session.reload();
 
 			expect(beforeSessionStart).toHaveBeenCalledTimes(1);
 			expect(events).toEqual(["render", "start:reload", "notify:reload"]);
@@ -457,22 +456,17 @@ describe("regression #5943: session_start transient UI", () => {
 		let context: ReloadCommandContext;
 		context = createReloadCommandContext({
 			settingsManager: { getHideThinkingBlock: () => true },
-			session: {
-				reload: async (options) => {
-					events.push("reload");
-					await options?.beforeSessionStart?.();
-					events.push(`start:${context.hideThinkingBlock}`);
-				},
-			},
 			rebuildChatFromMessages: () => {
 				events.push(`rebuild:${context.hideThinkingBlock}`);
 			},
 		});
 
-		const host = interactiveModePrototype.createReloadHost.call(context);
-		await host.beforeReload?.();
-		await context.session.reload({ beforeSessionStart: host.beforeSessionStart });
-		await host.afterReload?.();
+		const hooks = interactiveModePrototype.createReloadHooks.call(context);
+		await hooks.beforeReload?.();
+		events.push("reload");
+		await hooks.beforeSessionStart?.();
+		events.push(`start:${context.hideThinkingBlock}`);
+		await hooks.afterReload?.();
 
 		expect(context.hideThinkingBlock).toBe(true);
 		expect(events).toEqual(["reload", "rebuild:true", "start:true"]);
@@ -490,9 +484,9 @@ describe("regression #5943: session_start transient UI", () => {
 				},
 			},
 		});
-		const host = interactiveModePrototype.createReloadHost.call(context);
-		await host.beforeReload?.();
-		await host.reloadFailed?.(new Error("resource reload failed"));
+		const hooks = interactiveModePrototype.createReloadHooks.call(context);
+		await hooks.beforeReload?.();
+		await hooks.reloadFailed?.(new Error("resource reload failed"));
 		expect(focused).toBe(editor);
 	});
 
@@ -512,13 +506,6 @@ describe("regression #5943: session_start transient UI", () => {
 
 		const context = createReloadCommandContext({
 			editor,
-			session: {
-				reload: async (options) => {
-					await options?.beforeSessionStart?.();
-					markReloadWaiting();
-					await reloadFinished;
-				},
-			},
 			ui: {
 				setFocus: (component) => {
 					focused = component;
@@ -529,11 +516,13 @@ describe("regression #5943: session_start transient UI", () => {
 			},
 		});
 
-		const host = interactiveModePrototype.createReloadHost.call(context);
-		await host.beforeReload?.();
+		const hooks = interactiveModePrototype.createReloadHooks.call(context);
+		await hooks.beforeReload?.();
 		const reloadPromise = (async () => {
-			await context.session.reload({ beforeSessionStart: host.beforeSessionStart });
-			await host.afterReload?.();
+			await hooks.beforeSessionStart?.();
+			markReloadWaiting();
+			await reloadFinished;
+			await hooks.afterReload?.();
 		})();
 		await reloadWaiting;
 

--- a/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
@@ -1,7 +1,7 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { Container, Text } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentSessionEvent } from "../../../src/core/agent-session.ts";
+import type { AgentSessionEvent, RuntimeReloadHost } from "../../../src/core/agent-session.ts";
 import type { ExtensionUIContext } from "../../../src/core/extensions/index.ts";
 import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
 import { initTheme, type Theme, theme } from "../../../src/modes/interactive/theme/theme.ts";
@@ -94,7 +94,7 @@ type ReloadCommandContext = {
 		reload: (options?: { beforeSessionStart?: () => void | Promise<void> }) => Promise<void>;
 		resourceLoader: { getThemes: () => { themes: [] } };
 		extensionRunner: unknown;
-		modelRegistry: { getError: () => string | undefined };
+		modelRuntime: { getError: () => string | undefined };
 	};
 	settingsManager: {
 		getHttpIdleTimeoutMs: () => number;
@@ -118,6 +118,7 @@ type ReloadCommandContext = {
 	editor: unknown;
 	defaultEditor: { setPaddingX: (padding: number) => void; setAutocompleteMaxVisible: (maxVisible: number) => void };
 	themeController: { applyFromSettings: () => Promise<void> };
+	applyRuntimeSettings: () => void;
 	resetExtensionUI: () => void;
 	rebuildChatFromMessages: () => void;
 	setupAutocompleteProvider: () => void;
@@ -136,6 +137,7 @@ type InteractiveModePrototype = {
 	): void;
 	rebindCurrentSession(this: RebindContext, options?: { renderBeforeBind?: boolean }): Promise<void>;
 	handleReloadCommand(this: ReloadCommandContext): Promise<void>;
+	createReloadHost(this: ReloadCommandContext): RuntimeReloadHost;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
@@ -165,7 +167,7 @@ function createReloadCommandContext(overrides: ReloadCommandContextOverrides = {
 			},
 			resourceLoader: { getThemes: () => ({ themes: [] }) },
 			extensionRunner: {},
-			modelRegistry: { getError: () => undefined },
+			modelRuntime: { getError: () => undefined },
 			...overrides.session,
 		},
 		settingsManager: {
@@ -190,6 +192,7 @@ function createReloadCommandContext(overrides: ReloadCommandContextOverrides = {
 		editor,
 		defaultEditor: { setPaddingX: () => {}, setAutocompleteMaxVisible: () => {}, ...overrides.defaultEditor },
 		themeController: { applyFromSettings: async () => {}, ...overrides.themeController },
+		applyRuntimeSettings: overrides.applyRuntimeSettings ?? (() => {}),
 		customHeader: overrides.customHeader,
 		builtInHeader: overrides.builtInHeader,
 		resetExtensionUI: overrides.resetExtensionUI ?? (() => {}),
@@ -466,10 +469,31 @@ describe("regression #5943: session_start transient UI", () => {
 			},
 		});
 
-		await interactiveModePrototype.handleReloadCommand.call(context);
+		const host = interactiveModePrototype.createReloadHost.call(context);
+		await host.beforeReload?.();
+		await context.session.reload({ beforeSessionStart: host.beforeSessionStart });
+		await host.afterReload?.();
 
 		expect(context.hideThinkingBlock).toBe(true);
 		expect(events).toEqual(["reload", "rebuild:true", "start:true"]);
+	});
+
+	it("restores the editor when reload fails", async () => {
+		initTheme("dark", false);
+		const editor = {};
+		let focused: unknown;
+		const context = createReloadCommandContext({
+			editor,
+			ui: {
+				setFocus: (component) => {
+					focused = component;
+				},
+			},
+		});
+		const host = interactiveModePrototype.createReloadHost.call(context);
+		await host.beforeReload?.();
+		await host.reloadFailed?.(new Error("resource reload failed"));
+		expect(focused).toBe(editor);
 	});
 
 	it("keeps the reload blocker focused until async reload completes", async () => {
@@ -505,7 +529,12 @@ describe("regression #5943: session_start transient UI", () => {
 			},
 		});
 
-		const reloadPromise = interactiveModePrototype.handleReloadCommand.call(context);
+		const host = interactiveModePrototype.createReloadHost.call(context);
+		await host.beforeReload?.();
+		const reloadPromise = (async () => {
+			await context.session.reload({ beforeSessionStart: host.beforeSessionStart });
+			await host.afterReload?.();
+		})();
 		await reloadWaiting;
 
 		expect(chatRestored).toBe(true);

--- a/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5943-session-start-notify.test.ts
@@ -1,7 +1,7 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { Container, Text } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentSessionEvent, RuntimeReloadHooks } from "../../../src/core/agent-session.ts";
+import type { AgentSessionEvent, RuntimeReloadCallbacks } from "../../../src/core/agent-session.ts";
 import type { ExtensionUIContext } from "../../../src/core/extensions/index.ts";
 import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
 import { initTheme, type Theme, theme } from "../../../src/modes/interactive/theme/theme.ts";
@@ -137,7 +137,7 @@ type InteractiveModePrototype = {
 	): void;
 	rebindCurrentSession(this: RebindContext, options?: { renderBeforeBind?: boolean }): Promise<void>;
 	handleReloadCommand(this: ReloadCommandContext): Promise<void>;
-	createReloadHooks(this: ReloadCommandContext): RuntimeReloadHooks;
+	createReloadHooks(this: ReloadCommandContext): RuntimeReloadCallbacks;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;

--- a/packages/coding-agent/test/suite/regressions/6363-agent-settled-event.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6363-agent-settled-event.test.ts
@@ -122,7 +122,6 @@ describe("regression #6363: agent settled event and idle waiting", () => {
 				fork: async () => ({ cancelled: false }),
 				navigateTree: async () => ({ cancelled: false }),
 				switchSession: async () => ({ cancelled: false }),
-				reload: async () => {},
 			},
 		});
 		const toolStarted = new Promise<void>((resolve) => {

--- a/packages/coding-agent/test/suite/regressions/6552-deferred-extension-reload.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6552-deferred-extension-reload.test.ts
@@ -1,0 +1,232 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { RuntimeReloadError } from "../../../src/core/agent-session.ts";
+import { createEventBus } from "../../../src/core/event-bus.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../../src/core/extensions/loader.ts";
+import type {
+	ExtensionContext,
+	ExtensionFactory,
+	LoadExtensionsResult,
+	ResourceLoader,
+	RuntimeReloadHost,
+} from "../../../src/index.ts";
+import { assistantMsg, userMsg } from "../../utilities.ts";
+import { createHarness, getAssistantTexts, type Harness } from "../harness.ts";
+
+async function createReloadingResourceLoader(factory: ExtensionFactory): Promise<{
+	resourceLoader: ResourceLoader;
+	getReloadCount: () => number;
+}> {
+	const eventBus = createEventBus();
+	let reloadCount = 0;
+	const load = async (): Promise<LoadExtensionsResult> => {
+		const runtime = createExtensionRuntime();
+		const extension = await loadExtensionFromFactory(factory, process.cwd(), eventBus, runtime);
+		return { extensions: [extension], errors: [], runtime };
+	};
+	let extensionsResult = await load();
+	return {
+		resourceLoader: {
+			getExtensions: () => extensionsResult,
+			getSkills: () => ({ skills: [], diagnostics: [] }),
+			getPrompts: () => ({ prompts: [], diagnostics: [] }),
+			getThemes: () => ({ themes: [], diagnostics: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			getSystemPrompt: () => undefined,
+			getSystemPromptSource: () => undefined,
+			getAppendSystemPrompt: () => [],
+			getAppendSystemPromptSources: () => [],
+			extendResources: () => {},
+			reload: async () => {
+				reloadCount++;
+				extensionsResult = await load();
+			},
+		},
+		getReloadCount: () => reloadCount,
+	};
+}
+
+const reloadHost = (beforeReload?: () => void): RuntimeReloadHost => ({ beforeReload });
+
+describe("issue #6552 deferred extension reload", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("defers and coalesces tool requests until the agent settles", async () => {
+		const events: string[] = [];
+		const { resourceLoader, getReloadCount } = await createReloadingResourceLoader((pi) => {
+			pi.on("agent_settled", () => {
+				events.push("settled");
+			});
+			pi.on("session_shutdown", () => {
+				events.push("shutdown");
+			});
+			pi.registerTool({
+				name: "reload_runtime",
+				label: "Reload runtime",
+				description: "Request a runtime reload",
+				parameters: Type.Object({}),
+				async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+					events.push("tool");
+					ctx.requestReload();
+					ctx.requestReload();
+					return { content: [{ type: "text", text: "reload requested" }], details: {} };
+				},
+			});
+		});
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({
+			reloadHost: reloadHost(() => {
+				events.push("reload");
+			}),
+		});
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("reload_runtime", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("turn complete"),
+		]);
+
+		await harness.session.prompt("reload extensions");
+
+		expect(getAssistantTexts(harness)).toContain("turn complete");
+		expect(getReloadCount()).toBe(1);
+		expect(events).toEqual(["tool", "settled", "reload", "shutdown"]);
+	});
+
+	it("reloads after a command handler without model authentication", async () => {
+		const { resourceLoader, getReloadCount } = await createReloadingResourceLoader((pi) => {
+			pi.registerCommand("reload-runtime", {
+				description: "Reload runtime",
+				handler: async (_args, ctx) => {
+					ctx.requestReload();
+				},
+			});
+		});
+		const harness = await createHarness({ resourceLoader, withConfiguredAuth: false });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+
+		await expect(harness.session.prompt("/reload-runtime")).resolves.toBeUndefined();
+		expect(getReloadCount()).toBe(1);
+	});
+
+	it("ignores requests from reload lifecycle handlers", async () => {
+		const { resourceLoader, getReloadCount } = await createReloadingResourceLoader((pi) => {
+			pi.on("session_start", (_event, ctx) => ctx.requestReload());
+		});
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		let hostReloadCount = 0;
+
+		await harness.session.bindExtensions({
+			reloadHost: reloadHost(() => {
+				hostReloadCount++;
+			}),
+		});
+
+		expect(hostReloadCount).toBe(1);
+		expect(getReloadCount()).toBe(1);
+	});
+
+	it("flushes a request after manual compaction clears its controller", async () => {
+		const { resourceLoader, getReloadCount } = await createReloadingResourceLoader((pi) => {
+			pi.on("session_before_compact", (event, ctx) => {
+				ctx.requestReload();
+				return {
+					compaction: {
+						summary: "summary from extension",
+						firstKeptEntryId: event.preparation.firstKeptEntryId,
+						tokensBefore: event.preparation.tokensBefore,
+						details: {},
+					},
+				};
+			});
+		});
+		const harness = await createHarness({ resourceLoader, settings: { compaction: { keepRecentTokens: 1 } } });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
+		await harness.session.prompt("first");
+		await harness.session.prompt("second");
+
+		await harness.session.compact();
+
+		expect(getReloadCount()).toBe(1);
+	});
+
+	it("flushes a request after branch summarization clears its controller", async () => {
+		const { resourceLoader, getReloadCount } = await createReloadingResourceLoader((pi) => {
+			pi.on("session_before_tree", (_event, ctx) => {
+				ctx.requestReload();
+				return { summary: { summary: "summary from extension" } };
+			});
+		});
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+		const targetId = harness.sessionManager.appendMessage(userMsg("first branch"));
+		harness.sessionManager.appendMessage(assistantMsg("first reply"));
+		harness.sessionManager.appendMessage(userMsg("abandoned work"));
+		harness.sessionManager.appendMessage(assistantMsg("abandoned reply"));
+
+		await harness.session.navigateTree(targetId, { summarize: true });
+
+		expect(getReloadCount()).toBe(1);
+	});
+
+	it("rejects direct reload while an extension operation is active", async () => {
+		const { resourceLoader, getReloadCount } = await createReloadingResourceLoader(() => {});
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		let releaseOperation = () => {};
+		const operationReleased = new Promise<void>((resolve) => {
+			releaseOperation = resolve;
+		});
+		const operation = harness.session.extensionRunner.runExtensionOperation(() => operationReleased);
+
+		await expect(harness.session.reload()).rejects.toThrow("Cannot reload while a runtime operation is active");
+		expect(getReloadCount()).toBe(0);
+		releaseOperation();
+		await operation;
+	});
+
+	it("makes post-invalidation failures terminal for reload admission", async () => {
+		let oldContext: ExtensionContext | undefined;
+		const { resourceLoader } = await createReloadingResourceLoader((pi) => {
+			pi.on("input", (_event, ctx) => {
+				oldContext = ctx;
+				ctx.requestReload();
+				return { action: "handled" };
+			});
+		});
+		resourceLoader.reload = async () => {
+			throw new Error("resource reload failed");
+		};
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+
+		await expect(harness.session.prompt("reload")).rejects.toBeInstanceOf(RuntimeReloadError);
+		expect(() => oldContext?.isIdle()).toThrow("stale after session replacement or reload");
+		await expect(harness.session.reload()).rejects.toBeInstanceOf(RuntimeReloadError);
+	});
+
+	it("ignores requests when the host does not support reload", async () => {
+		const { resourceLoader, getReloadCount } = await createReloadingResourceLoader((pi) => {
+			pi.on("input", (_event, ctx) => {
+				ctx.requestReload();
+				return { action: "handled" };
+			});
+		});
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({ mode: "print" });
+
+		await harness.session.prompt("ignored reload");
+		expect(getReloadCount()).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/6552-deferred-extension-reload.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6552-deferred-extension-reload.test.ts
@@ -1,16 +1,10 @@
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
-import { RuntimeReloadError } from "../../../src/core/agent-session.ts";
+import { type RuntimeReloadCallbacks, RuntimeReloadError } from "../../../src/core/agent-session.ts";
 import { createEventBus } from "../../../src/core/event-bus.ts";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../../../src/core/extensions/loader.ts";
-import type {
-	ExtensionContext,
-	ExtensionFactory,
-	LoadExtensionsResult,
-	ResourceLoader,
-	RuntimeReloadHooks,
-} from "../../../src/index.ts";
+import type { ExtensionContext, ExtensionFactory, LoadExtensionsResult, ResourceLoader } from "../../../src/index.ts";
 import { assistantMsg, userMsg } from "../../utilities.ts";
 import { createHarness, getAssistantTexts, type Harness } from "../harness.ts";
 
@@ -47,7 +41,7 @@ async function createReloadingResourceLoader(factory: ExtensionFactory): Promise
 	};
 }
 
-const reloadHooks = (beforeReload?: () => void): RuntimeReloadHooks => ({ beforeReload });
+const reloadHooks = (beforeReload?: () => void): RuntimeReloadCallbacks => ({ beforeReload });
 
 describe("issue #6552 deferred extension reload", () => {
 	const harnesses: Harness[] = [];

--- a/packages/coding-agent/test/suite/regressions/6552-deferred-extension-reload.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6552-deferred-extension-reload.test.ts
@@ -9,7 +9,7 @@ import type {
 	ExtensionFactory,
 	LoadExtensionsResult,
 	ResourceLoader,
-	RuntimeReloadHost,
+	RuntimeReloadHooks,
 } from "../../../src/index.ts";
 import { assistantMsg, userMsg } from "../../utilities.ts";
 import { createHarness, getAssistantTexts, type Harness } from "../harness.ts";
@@ -47,7 +47,7 @@ async function createReloadingResourceLoader(factory: ExtensionFactory): Promise
 	};
 }
 
-const reloadHost = (beforeReload?: () => void): RuntimeReloadHost => ({ beforeReload });
+const reloadHooks = (beforeReload?: () => void): RuntimeReloadHooks => ({ beforeReload });
 
 describe("issue #6552 deferred extension reload", () => {
 	const harnesses: Harness[] = [];
@@ -81,7 +81,7 @@ describe("issue #6552 deferred extension reload", () => {
 		const harness = await createHarness({ resourceLoader });
 		harnesses.push(harness);
 		await harness.session.bindExtensions({
-			reloadHost: reloadHost(() => {
+			reloadHooks: reloadHooks(() => {
 				events.push("reload");
 			}),
 		});
@@ -108,7 +108,7 @@ describe("issue #6552 deferred extension reload", () => {
 		});
 		const harness = await createHarness({ resourceLoader, withConfiguredAuth: false });
 		harnesses.push(harness);
-		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+		await harness.session.bindExtensions({ reloadHooks: reloadHooks() });
 
 		await expect(harness.session.prompt("/reload-runtime")).resolves.toBeUndefined();
 		expect(getReloadCount()).toBe(1);
@@ -123,7 +123,7 @@ describe("issue #6552 deferred extension reload", () => {
 		let hostReloadCount = 0;
 
 		await harness.session.bindExtensions({
-			reloadHost: reloadHost(() => {
+			reloadHooks: reloadHooks(() => {
 				hostReloadCount++;
 			}),
 		});
@@ -148,7 +148,7 @@ describe("issue #6552 deferred extension reload", () => {
 		});
 		const harness = await createHarness({ resourceLoader, settings: { compaction: { keepRecentTokens: 1 } } });
 		harnesses.push(harness);
-		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+		await harness.session.bindExtensions({ reloadHooks: reloadHooks() });
 		harness.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two")]);
 		await harness.session.prompt("first");
 		await harness.session.prompt("second");
@@ -167,7 +167,7 @@ describe("issue #6552 deferred extension reload", () => {
 		});
 		const harness = await createHarness({ resourceLoader });
 		harnesses.push(harness);
-		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+		await harness.session.bindExtensions({ reloadHooks: reloadHooks() });
 		const targetId = harness.sessionManager.appendMessage(userMsg("first branch"));
 		harness.sessionManager.appendMessage(assistantMsg("first reply"));
 		harness.sessionManager.appendMessage(userMsg("abandoned work"));
@@ -208,7 +208,7 @@ describe("issue #6552 deferred extension reload", () => {
 		};
 		const harness = await createHarness({ resourceLoader });
 		harnesses.push(harness);
-		await harness.session.bindExtensions({ reloadHost: reloadHost() });
+		await harness.session.bindExtensions({ reloadHooks: reloadHooks() });
 
 		await expect(harness.session.prompt("reload")).rejects.toBeInstanceOf(RuntimeReloadError);
 		expect(() => oldContext?.isIdle()).toThrow("stale after session replacement or reload");

--- a/packages/coding-agent/test/suite/regressions/6552-rpc-reload-admission.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6552-rpc-reload-admission.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionRuntime } from "../../../src/core/agent-session-runtime.ts";
+import { createEventBus } from "../../../src/core/event-bus.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../../src/core/extensions/loader.ts";
+import type { ExtensionFactory, LoadExtensionsResult, ResourceLoader } from "../../../src/index.ts";
+import { runRpcMode } from "../../../src/modes/rpc/rpc-mode.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const rpcIo = vi.hoisted(() => ({
+	outputLines: [] as string[],
+	lineHandler: undefined as ((line: string) => void) | undefined,
+}));
+
+vi.mock("../../../src/core/output-guard.js", () => ({
+	flushRawStdout: vi.fn(async () => {}),
+	takeOverStdout: vi.fn(),
+	waitForRawStdoutBackpressure: vi.fn(async () => {}),
+	writeRawStdout: (line: string) => {
+		rpcIo.outputLines.push(line);
+	},
+}));
+
+vi.mock("../../../src/modes/interactive/theme/theme.js", () => ({ theme: {} }));
+
+vi.mock("../../../src/modes/rpc/jsonl.js", () => ({
+	attachJsonlLineReader: vi.fn((_stream: NodeJS.ReadableStream, onLine: (line: string) => void) => {
+		rpcIo.lineHandler = onLine;
+		return () => {
+			rpcIo.lineHandler = undefined;
+		};
+	}),
+	serializeJsonLine: (value: unknown) => `${JSON.stringify(value)}\n`,
+}));
+
+type NodeListener = Parameters<typeof process.on>[1];
+
+type ListenerSnapshot = {
+	stdinEnd: NodeListener[];
+	signals: Map<NodeJS.Signals, NodeListener[]>;
+};
+
+function takeListenerSnapshot(): ListenerSnapshot {
+	const signals: NodeJS.Signals[] = process.platform === "win32" ? ["SIGTERM"] : ["SIGTERM", "SIGHUP"];
+	return {
+		stdinEnd: process.stdin.listeners("end") as NodeListener[],
+		signals: new Map(signals.map((signal) => [signal, process.listeners(signal) as NodeListener[]])),
+	};
+}
+
+function restoreListeners(snapshot: ListenerSnapshot): void {
+	for (const listener of process.stdin.listeners("end") as NodeListener[]) {
+		if (!snapshot.stdinEnd.includes(listener)) {
+			process.stdin.off("end", listener);
+		}
+	}
+	for (const [signal, previousListeners] of snapshot.signals) {
+		for (const listener of process.listeners(signal) as NodeListener[]) {
+			if (!previousListeners.includes(listener)) {
+				process.off(signal, listener);
+			}
+		}
+	}
+}
+
+async function createReloadingResourceLoader(factory: ExtensionFactory): Promise<ResourceLoader> {
+	const eventBus = createEventBus();
+	const load = async (): Promise<LoadExtensionsResult> => {
+		const runtime = createExtensionRuntime();
+		const extension = await loadExtensionFromFactory(factory, process.cwd(), eventBus, runtime);
+		return { extensions: [extension], errors: [], runtime };
+	};
+	let extensionsResult = await load();
+	return {
+		getExtensions: () => extensionsResult,
+		getSkills: () => ({ skills: [], diagnostics: [] }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => undefined,
+		getSystemPromptSource: () => undefined,
+		getAppendSystemPrompt: () => [],
+		getAppendSystemPromptSources: () => [],
+		extendResources: () => {},
+		reload: async () => {
+			extensionsResult = await load();
+		},
+	};
+}
+
+function createRuntimeHost(harness: Harness): AgentSessionRuntime {
+	return {
+		session: harness.session,
+		newSession: vi.fn(async () => ({ cancelled: true })),
+		switchSession: vi.fn(async () => ({ cancelled: true })),
+		fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
+		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn(),
+	} as unknown as AgentSessionRuntime;
+}
+
+function parseOutputLines(): Array<Record<string, unknown>> {
+	return rpcIo.outputLines
+		.flatMap((line) => line.split("\n"))
+		.filter((line) => line.length > 0)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function getResponse(id: string): Record<string, unknown> | undefined {
+	return parseOutputLines().find((record) => record.type === "response" && record.id === id);
+}
+
+// Regression: concurrent RPC input must not enter a runtime while deferred reload is replacing it.
+describe("issue #6552 RPC reload admission", () => {
+	afterEach(() => {
+		rpcIo.outputLines = [];
+		rpcIo.lineHandler = undefined;
+	});
+
+	it("rejects a second prompt until asynchronous reload shutdown completes", async () => {
+		const listenerSnapshot = takeListenerSnapshot();
+		let markShutdownStarted = () => {};
+		const shutdownStarted = new Promise<void>((resolve) => {
+			markShutdownStarted = resolve;
+		});
+		let releaseShutdown = () => {};
+		const shutdownReleased = new Promise<void>((resolve) => {
+			releaseShutdown = resolve;
+		});
+		let secondPromptCalls = 0;
+		let uiResponseReceived = false;
+		const resourceLoader = await createReloadingResourceLoader((pi) => {
+			pi.on("input", (event, ctx) => {
+				if (event.text === "first") {
+					ctx.requestReload();
+				} else if (event.text === "second") {
+					secondPromptCalls++;
+				}
+				return { action: "handled" };
+			});
+			pi.on("session_shutdown", async (_event, ctx) => {
+				markShutdownStarted();
+				uiResponseReceived = await ctx.ui.confirm("Reload", "Continue reload?");
+				await shutdownReleased;
+			});
+		});
+		const harness = await createHarness({ resourceLoader });
+
+		try {
+			void runRpcMode(createRuntimeHost(harness));
+			await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
+			rpcIo.lineHandler?.(JSON.stringify({ id: "first", type: "prompt", message: "first" }));
+			await shutdownStarted;
+			let uiRequest: Record<string, unknown> | undefined;
+			await vi.waitFor(() => {
+				uiRequest = parseOutputLines().find(
+					(record) => record.type === "extension_ui_request" && record.method === "confirm",
+				);
+				expect(uiRequest?.id).toEqual(expect.any(String));
+			});
+			rpcIo.lineHandler?.(JSON.stringify({ id: uiRequest?.id, type: "extension_ui_response", confirmed: true }));
+			await vi.waitFor(() => expect(uiResponseReceived).toBe(true));
+
+			rpcIo.lineHandler?.(JSON.stringify({ id: "second", type: "prompt", message: "second" }));
+			rpcIo.lineHandler?.(JSON.stringify({ id: "abort", type: "abort" }));
+			await vi.waitFor(() => {
+				expect(getResponse("abort")).toMatchObject({ success: true, command: "abort" });
+				expect(getResponse("second")).toMatchObject({
+					success: false,
+					command: "prompt",
+					error: "Runtime reload in progress",
+				});
+			});
+			expect(secondPromptCalls).toBe(0);
+
+			releaseShutdown();
+			let retryResponse: Record<string, unknown> | undefined;
+			for (let attempt = 1; attempt <= 10; attempt++) {
+				const retryId = `second-retry-${attempt}`;
+				rpcIo.lineHandler?.(JSON.stringify({ id: retryId, type: "prompt", message: "second" }));
+				await vi.waitFor(() => expect(getResponse(retryId)).toBeDefined());
+				retryResponse = getResponse(retryId);
+				if (retryResponse?.success === true) {
+					break;
+				}
+				expect(retryResponse).toMatchObject({
+					success: false,
+					error: "Runtime reload in progress",
+				});
+				await new Promise<void>((resolve) => setImmediate(resolve));
+			}
+			expect(retryResponse).toMatchObject({ success: true, command: "prompt" });
+			expect(secondPromptCalls).toBe(1);
+		} finally {
+			releaseShutdown();
+			harness.cleanup();
+			restoreListeners(listenerSnapshot);
+		}
+	});
+});

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -17,6 +17,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		signal: undefined,
 		abort: vi.fn(),
 		hasPendingMessages: () => false,
+		requestReload: () => {},
 		shutdown: vi.fn(),
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,


### PR DESCRIPTION
## Summary

- replace awaited command-only `ctx.reload()` with fire-and-forget `ctx.requestReload()` in every extension context
- coalesce reload requests and defer canonical runtime replacement until extension operations, compaction, or branch summarization settle
- reject unsafe direct reload and RPC admission while preserving abort controls, teardown, and terminal failure behavior
- document the API and add lifecycle, admission, teardown, compaction, and RPC regressions

## Breaking change

`ExtensionCommandContext.reload()` is removed. Extensions must use `ExtensionContext.requestReload()`. The request does not return reload completion because replacement starts only after the requesting extension operation settles.

## Testing

- `npm run check`
- `npm run build`
- focused reload, runtime lifecycle, compaction, tree summarization, and RPC suites
- `./test.sh`: one unrelated deterministic failure in `packages/ai/test/supports-xhigh.test.ts`; one footer watcher timeout passed when rerun individually

Fixes #6552
