### PR TITLE
fix(coding-agent): expose tool metadata at stream start

### DIFF
--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -15,12 +15,16 @@ except that streaming message updates omit cumulative snapshots:
 ```typescript
 type WithoutPartial<T> = T extends { partial: unknown } ? Omit<T, "partial"> : T;
 
+type JsonAssistantMessageEvent<T> = T extends { type: "toolcall_start"; partial: unknown }
+  ? WithoutPartial<T> & { id: string; toolName: string }
+  : WithoutPartial<T>;
+
 type JsonAgentSessionEvent =
   | Exclude<AgentSessionEvent, { type: "message_update" }>
   | {
       type: "message_update";
       usage: Usage;
-      assistantMessageEvent: WithoutPartial<AssistantMessageEvent>;
+      assistantMessageEvent: JsonAssistantMessageEvent<AssistantMessageEvent>;
     };
 ```
 
@@ -84,7 +88,8 @@ Followed by events as they occur:
 `assistantMessageEvent.partial` to keep stream size linear. The top-level `usage` field contains
 the latest cumulative provider-reported usage and may remain zero when a provider only reports
 usage at completion. Use `contentIndex` and `delta` to assemble live text, thinking, or tool-call
-arguments if needed. `message_end` contains the final authoritative message.
+arguments if needed. A `toolcall_start` event also includes the constant-sized `id` and `toolName`
+fields. `message_end` contains the final authoritative message.
 
 ## Example
 

--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -15,11 +15,15 @@ except that streaming message updates omit cumulative snapshots:
 ```typescript
 type WithoutPartial<T> = T extends { partial: unknown } ? Omit<T, "partial"> : T;
 
+type JsonAssistantMessageEvent<T> = T extends { type: "toolcall_start"; partial: unknown }
+  ? WithoutPartial<T> & { id: string; toolName: string }
+  : WithoutPartial<T>;
+
 type JsonAgentSessionEvent =
   | Exclude<AgentSessionEvent, { type: "message_update" }>
   | {
       type: "message_update";
-      assistantMessageEvent: WithoutPartial<AssistantMessageEvent>;
+      assistantMessageEvent: JsonAssistantMessageEvent<AssistantMessageEvent>;
     };
 ```
 
@@ -81,8 +85,9 @@ Followed by events as they occur:
 
 `message_update` records are delta-only. They omit both the cumulative `message` field and
 `assistantMessageEvent.partial` to keep stream size linear. Use `contentIndex` and `delta`
-to assemble live text, thinking, or tool-call arguments if needed. `message_end` contains
-the final authoritative message.
+to assemble live text, thinking, or tool-call arguments if needed. A `toolcall_start` event
+also includes the constant-sized `id` and `toolName` fields. `message_end` contains the final
+authoritative message.
 
 ## Example
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -945,7 +945,7 @@ The `assistantMessageEvent` field contains one of these delta types:
 | `thinking_start` | Thinking block started |
 | `thinking_delta` | Thinking content chunk |
 | `thinking_end` | Thinking block ended |
-| `toolcall_start` | Tool call started |
+| `toolcall_start` | Tool call started (includes `id` and `toolName`) |
 | `toolcall_delta` | Tool call arguments chunk |
 | `toolcall_end` | Tool call ended (includes full `toolCall` object) |
 
@@ -960,11 +960,17 @@ Example streaming a text response:
 The top-level `usage` field contains the latest cumulative provider-reported usage. It may remain
 zero until completion when a provider does not report usage during streaming.
 
+Example starting a tool call:
+```json
+{"type":"message_update","usage":{...},"assistantMessageEvent":{"type":"toolcall_start","contentIndex":1,"id":"call_abc123","toolName":"write"}}
+```
+
 `message_update` intentionally omits the former cumulative `message` field and
 `assistantMessageEvent.partial`. Clients that need a live partial message must assemble it
 from `message_start` and subsequent events using `contentIndex`. Treat `message_end.message`
-as authoritative. For tool calls, buffer `toolcall_delta.delta`; `toolcall_end.toolCall`
-contains the completed call.
+as authoritative. For tool calls, `toolcall_start` provides the call `id` and `toolName`;
+buffer `toolcall_delta.delta` for arguments. `toolcall_end.toolCall` contains the completed
+call.
 
 ### bash_execution_update
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -937,7 +937,7 @@ The `assistantMessageEvent` field contains one of these delta types:
 | `thinking_start` | Thinking block started |
 | `thinking_delta` | Thinking content chunk |
 | `thinking_end` | Thinking block ended |
-| `toolcall_start` | Tool call started |
+| `toolcall_start` | Tool call started (includes `id` and `toolName`) |
 | `toolcall_delta` | Tool call arguments chunk |
 | `toolcall_end` | Tool call ended (includes full `toolCall` object) |
 
@@ -949,11 +949,17 @@ Example streaming a text response:
 {"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"Hello world"}}
 ```
 
+Example starting a tool call:
+```json
+{"type":"message_update","assistantMessageEvent":{"type":"toolcall_start","contentIndex":1,"id":"call_abc123","toolName":"write"}}
+```
+
 `message_update` intentionally omits the former cumulative `message` field and
 `assistantMessageEvent.partial`. Clients that need a live partial message must assemble it
 from `message_start` and subsequent events using `contentIndex`. Treat `message_end.message`
-as authoritative. For tool calls, buffer `toolcall_delta.delta`; `toolcall_end.toolCall`
-contains the completed call.
+as authoritative. For tool calls, `toolcall_start` provides the call `id` and `toolName`;
+buffer `toolcall_delta.delta` for arguments. `toolcall_end.toolCall` contains the completed
+call.
 
 ### bash_execution_update
 

--- a/packages/coding-agent/src/modes/json-event.ts
+++ b/packages/coding-agent/src/modes/json-event.ts
@@ -6,21 +6,34 @@ type ToJsonAssistantMessageEvent<T> = T extends { type: "toolcall_start"; partia
 	? WithoutPartial<T> & { id: string; toolName: string }
 	: WithoutPartial<T>;
 
-type ToJsonEvent<T> = T extends {
+type MessageUpdateEvent = Extract<AgentSessionEvent, { type: "message_update" }>;
+type JsonMessageUpdateEvent = {
 	type: "message_update";
-	assistantMessageEvent: infer TAssistantMessageEvent;
-}
-	? {
-			type: "message_update";
-			assistantMessageEvent: ToJsonAssistantMessageEvent<TAssistantMessageEvent>;
-		}
-	: T;
+	assistantMessageEvent: ToJsonAssistantMessageEvent<MessageUpdateEvent["assistantMessageEvent"]>;
+};
 
 /** Session event shape emitted by the JSON and RPC stdout protocols. */
-export type JsonAgentSessionEvent = ToJsonEvent<AgentSessionEvent>;
+export type JsonAgentSessionEvent = Exclude<AgentSessionEvent, { type: "message_update" }> | JsonMessageUpdateEvent;
 
-type MessageUpdateEvent = Extract<AgentSessionEvent, { type: "message_update" }>;
-type JsonMessageUpdateEvent = Extract<JsonAgentSessionEvent, { type: "message_update" }>;
+function toJsonAssistantMessageEvent(
+	event: MessageUpdateEvent["assistantMessageEvent"],
+): JsonMessageUpdateEvent["assistantMessageEvent"] {
+	if (event.type === "toolcall_start") {
+		const toolCall = event.partial.content[event.contentIndex];
+		if (toolCall?.type !== "toolCall") {
+			throw new Error(`toolcall_start content at index ${event.contentIndex} is not a tool call`);
+		}
+		const { partial: _partial, ...deltaEvent } = event;
+		return { ...deltaEvent, id: toolCall.id, toolName: toolCall.name };
+	}
+
+	if (!("partial" in event)) {
+		return event;
+	}
+
+	const { partial: _partial, ...deltaEvent } = event;
+	return deltaEvent;
+}
 
 /**
  * Remove cumulative assistant snapshots from streaming wire events.
@@ -35,23 +48,8 @@ export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent {
 		return event;
 	}
 
-	const assistantMessageEvent = event.assistantMessageEvent;
-	if (assistantMessageEvent.type === "toolcall_start") {
-		const toolCall = assistantMessageEvent.partial.content[assistantMessageEvent.contentIndex];
-		if (toolCall?.type !== "toolCall") {
-			throw new Error(`toolcall_start content at index ${assistantMessageEvent.contentIndex} is not a tool call`);
-		}
-		const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
-		return {
-			type: "message_update",
-			assistantMessageEvent: { ...deltaEvent, id: toolCall.id, toolName: toolCall.name },
-		};
-	}
-
-	if (!("partial" in assistantMessageEvent)) {
-		return { type: "message_update", assistantMessageEvent };
-	}
-
-	const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
-	return { type: "message_update", assistantMessageEvent: deltaEvent };
+	return {
+		type: "message_update",
+		assistantMessageEvent: toJsonAssistantMessageEvent(event.assistantMessageEvent),
+	};
 }

--- a/packages/coding-agent/src/modes/json-event.ts
+++ b/packages/coding-agent/src/modes/json-event.ts
@@ -2,13 +2,17 @@ import type { AgentSessionEvent } from "../core/agent-session.ts";
 
 type WithoutPartial<T> = T extends { partial: unknown } ? Omit<T, "partial"> : T;
 
+type ToJsonAssistantMessageEvent<T> = T extends { type: "toolcall_start"; partial: unknown }
+	? WithoutPartial<T> & { id: string; toolName: string }
+	: WithoutPartial<T>;
+
 type ToJsonEvent<T> = T extends {
 	type: "message_update";
 	assistantMessageEvent: infer TAssistantMessageEvent;
 }
 	? {
 			type: "message_update";
-			assistantMessageEvent: WithoutPartial<TAssistantMessageEvent>;
+			assistantMessageEvent: ToJsonAssistantMessageEvent<TAssistantMessageEvent>;
 		}
 	: T;
 
@@ -21,7 +25,8 @@ type JsonMessageUpdateEvent = Extract<JsonAgentSessionEvent, { type: "message_up
 /**
  * Remove cumulative assistant snapshots from streaming wire events.
  * `message_start` provides the initial message, deltas build it, and
- * `message_end` provides the final authoritative message.
+ * `message_end` provides the final authoritative message. Tool-call starts
+ * retain their constant-sized id and name so clients can identify the tool.
  */
 export function toJsonEvent(event: MessageUpdateEvent): JsonMessageUpdateEvent;
 export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent;
@@ -31,6 +36,18 @@ export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent {
 	}
 
 	const assistantMessageEvent = event.assistantMessageEvent;
+	if (assistantMessageEvent.type === "toolcall_start") {
+		const toolCall = assistantMessageEvent.partial.content[assistantMessageEvent.contentIndex];
+		if (toolCall?.type !== "toolCall") {
+			throw new Error(`toolcall_start content at index ${assistantMessageEvent.contentIndex} is not a tool call`);
+		}
+		const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
+		return {
+			type: "message_update",
+			assistantMessageEvent: { ...deltaEvent, id: toolCall.id, toolName: toolCall.name },
+		};
+	}
+
 	if (!("partial" in assistantMessageEvent)) {
 		return { type: "message_update", assistantMessageEvent };
 	}

--- a/packages/coding-agent/src/modes/json-event.ts
+++ b/packages/coding-agent/src/modes/json-event.ts
@@ -3,6 +3,10 @@ import type { AgentSessionEvent } from "../core/agent-session.ts";
 
 type WithoutPartial<T> = T extends { partial: unknown } ? Omit<T, "partial"> : T;
 
+type ToJsonAssistantMessageEvent<T> = T extends { type: "toolcall_start"; partial: unknown }
+	? WithoutPartial<T> & { id: string; toolName: string }
+	: WithoutPartial<T>;
+
 type ToJsonEvent<T> = T extends {
 	type: "message_update";
 	assistantMessageEvent: infer TAssistantMessageEvent;
@@ -10,7 +14,7 @@ type ToJsonEvent<T> = T extends {
 	? {
 			type: "message_update";
 			usage: Usage;
-			assistantMessageEvent: WithoutPartial<TAssistantMessageEvent>;
+			assistantMessageEvent: ToJsonAssistantMessageEvent<TAssistantMessageEvent>;
 		}
 	: T;
 
@@ -23,8 +27,8 @@ type JsonMessageUpdateEvent = Extract<JsonAgentSessionEvent, { type: "message_up
 /**
  * Remove cumulative assistant snapshots from streaming wire events.
  * `message_start` provides the initial message, deltas build it, and
- * `message_end` provides the final authoritative message. Cumulative usage
- * remains available because its size is constant.
+ * `message_end` provides the final authoritative message. Cumulative usage,
+ * tool-call ids, and tool names remain available because their size is constant.
  */
 export function toJsonEvent(event: MessageUpdateEvent): JsonMessageUpdateEvent;
 export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent;
@@ -37,6 +41,19 @@ export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent {
 	}
 
 	const assistantMessageEvent = event.assistantMessageEvent;
+	if (assistantMessageEvent.type === "toolcall_start") {
+		const toolCall = assistantMessageEvent.partial.content[assistantMessageEvent.contentIndex];
+		if (toolCall?.type !== "toolCall") {
+			throw new Error(`toolcall_start content at index ${assistantMessageEvent.contentIndex} is not a tool call`);
+		}
+		const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
+		return {
+			type: "message_update",
+			usage: event.message.usage,
+			assistantMessageEvent: { ...deltaEvent, id: toolCall.id, toolName: toolCall.name },
+		};
+	}
+
 	if (!("partial" in assistantMessageEvent)) {
 		return { type: "message_update", usage: event.message.usage, assistantMessageEvent };
 	}

--- a/packages/coding-agent/src/modes/json-event.ts
+++ b/packages/coding-agent/src/modes/json-event.ts
@@ -7,22 +7,35 @@ type ToJsonAssistantMessageEvent<T> = T extends { type: "toolcall_start"; partia
 	? WithoutPartial<T> & { id: string; toolName: string }
 	: WithoutPartial<T>;
 
-type ToJsonEvent<T> = T extends {
+type MessageUpdateEvent = Extract<AgentSessionEvent, { type: "message_update" }>;
+type JsonMessageUpdateEvent = {
 	type: "message_update";
-	assistantMessageEvent: infer TAssistantMessageEvent;
-}
-	? {
-			type: "message_update";
-			usage: Usage;
-			assistantMessageEvent: ToJsonAssistantMessageEvent<TAssistantMessageEvent>;
-		}
-	: T;
+	usage: Usage;
+	assistantMessageEvent: ToJsonAssistantMessageEvent<MessageUpdateEvent["assistantMessageEvent"]>;
+};
 
 /** Session event shape emitted by the JSON and RPC stdout protocols. */
-export type JsonAgentSessionEvent = ToJsonEvent<AgentSessionEvent>;
+export type JsonAgentSessionEvent = Exclude<AgentSessionEvent, { type: "message_update" }> | JsonMessageUpdateEvent;
 
-type MessageUpdateEvent = Extract<AgentSessionEvent, { type: "message_update" }>;
-type JsonMessageUpdateEvent = Extract<JsonAgentSessionEvent, { type: "message_update" }>;
+function toJsonAssistantMessageEvent(
+	event: MessageUpdateEvent["assistantMessageEvent"],
+): JsonMessageUpdateEvent["assistantMessageEvent"] {
+	if (event.type === "toolcall_start") {
+		const toolCall = event.partial.content[event.contentIndex];
+		if (toolCall?.type !== "toolCall") {
+			throw new Error(`toolcall_start content at index ${event.contentIndex} is not a tool call`);
+		}
+		const { partial: _partial, ...deltaEvent } = event;
+		return { ...deltaEvent, id: toolCall.id, toolName: toolCall.name };
+	}
+
+	if (!("partial" in event)) {
+		return event;
+	}
+
+	const { partial: _partial, ...deltaEvent } = event;
+	return deltaEvent;
+}
 
 /**
  * Remove cumulative assistant snapshots from streaming wire events.
@@ -40,24 +53,9 @@ export function toJsonEvent(event: AgentSessionEvent): JsonAgentSessionEvent {
 		throw new Error("message_update message is not an assistant message");
 	}
 
-	const assistantMessageEvent = event.assistantMessageEvent;
-	if (assistantMessageEvent.type === "toolcall_start") {
-		const toolCall = assistantMessageEvent.partial.content[assistantMessageEvent.contentIndex];
-		if (toolCall?.type !== "toolCall") {
-			throw new Error(`toolcall_start content at index ${assistantMessageEvent.contentIndex} is not a tool call`);
-		}
-		const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
-		return {
-			type: "message_update",
-			usage: event.message.usage,
-			assistantMessageEvent: { ...deltaEvent, id: toolCall.id, toolName: toolCall.name },
-		};
-	}
-
-	if (!("partial" in assistantMessageEvent)) {
-		return { type: "message_update", usage: event.message.usage, assistantMessageEvent };
-	}
-
-	const { partial: _partial, ...deltaEvent } = assistantMessageEvent;
-	return { type: "message_update", usage: event.message.usage, assistantMessageEvent: deltaEvent };
+	return {
+		type: "message_update",
+		usage: event.message.usage,
+		assistantMessageEvent: toJsonAssistantMessageEvent(event.assistantMessageEvent),
+	};
 }

--- a/packages/coding-agent/test/suite/regressions/7925-toolcall-start-metadata.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7925-toolcall-start-metadata.test.ts
@@ -1,0 +1,40 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { toJsonEvent } from "../../../src/modes/json-event.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("regression #7925: tool-call metadata is available when streaming starts", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+	});
+
+	it("includes the tool call id and name without cumulative snapshots", async () => {
+		harness = await createHarness();
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("write", { path: "output.txt", content: "x".repeat(100) }, { id: "call_7925" }),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("write a file");
+
+		const update = harness
+			.eventsOfType("message_update")
+			.find((event) => event.assistantMessageEvent.type === "toolcall_start");
+		if (!update) throw new Error("Expected toolcall_start update");
+
+		expect(toJsonEvent(update)).toEqual({
+			type: "message_update",
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				id: "call_7925",
+				toolName: "write",
+			},
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/7925-toolcall-start-metadata.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7925-toolcall-start-metadata.test.ts
@@ -1,0 +1,41 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { toJsonEvent } from "../../../src/modes/json-event.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("regression #7925: tool-call metadata is available when streaming starts", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+	});
+
+	it("includes the tool call id and name without cumulative snapshots", async () => {
+		harness = await createHarness();
+		harness.setResponses([
+			fauxAssistantMessage(
+				fauxToolCall("write", { path: "output.txt", content: "x".repeat(100) }, { id: "call_7925" }),
+				{ stopReason: "toolUse" },
+			),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("write a file");
+
+		const update = harness
+			.eventsOfType("message_update")
+			.find((event) => event.assistantMessageEvent.type === "toolcall_start");
+		if (!update) throw new Error("Expected toolcall_start update");
+
+		expect(toJsonEvent(update)).toEqual({
+			type: "message_update",
+			usage: update.message.usage,
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				id: "call_7925",
+				toolName: "write",
+			},
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/7925-toolcall-start-metadata.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7925-toolcall-start-metadata.test.ts
@@ -25,7 +25,9 @@ describe("regression #7925: tool-call metadata is available when streaming start
 		const update = harness
 			.eventsOfType("message_update")
 			.find((event) => event.assistantMessageEvent.type === "toolcall_start");
-		if (!update) throw new Error("Expected toolcall_start update");
+		if (!update || update.message.role !== "assistant") {
+			throw new Error("Expected toolcall_start assistant update");
+		}
 
 		expect(toJsonEvent(update)).toEqual({
 			type: "message_update",


### PR DESCRIPTION
## Summary

- include constant-sized `id` and `toolName` fields in JSON and RPC `toolcall_start` events
- keep cumulative `message` and `partial` snapshots removed so stream size remains linear
- document the wire shape and add a regression test

## Testing

- `npm run check`
- `npm run build`
- `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/suite/regressions/7925-toolcall-start-metadata.test.ts test/suite/regressions/7290-json-stream-linear.test.ts`
- `./test.sh` has one unrelated failure in `packages/ai/test/supports-xhigh.test.ts`: the generated `opencode-go/deepseek-v4-flash` metadata exposes `off`, `minimal`, `low`, `medium`, and `high`, while the test expects `off`, `high`, and `max`

Fixes #7925
