### PR TITLE
feat(coding-agent): render Mermaid diagrams in HTML exports

### DIFF
--- a/packages/coding-agent/src/core/export-html/index.ts
+++ b/packages/coding-agent/src/core/export-html/index.ts
@@ -7,6 +7,7 @@ import { normalizePath, resolvePath } from "../../utils/paths.ts";
 import type { ToolDefinition } from "../extensions/types.ts";
 import type { SessionEntry } from "../session-manager.ts";
 import { SessionManager } from "../session-manager.ts";
+import { buildMermaidDiagramMap } from "./mermaid-html.ts";
 
 /**
  * Interface for rendering custom tools to HTML.
@@ -135,6 +136,8 @@ interface SessionData {
 	tools?: Array<Pick<ToolDefinition, "name" | "description" | "parameters">>;
 	/** Pre-rendered HTML for custom tool calls/results, keyed by tool call ID */
 	renderedTools?: Record<string, RenderedToolHtml>;
+	/** Pre-rendered Mermaid diagram HTML, keyed by trimmed diagram source */
+	mermaidDiagrams?: Record<string, string>;
 }
 
 /**
@@ -259,6 +262,7 @@ export async function exportSessionToHtml(
 			renderedTools = undefined;
 		}
 	}
+	const mermaidDiagrams = buildMermaidDiagramMap(entries);
 
 	const sessionData: SessionData = {
 		header: sm.getHeader(),
@@ -267,6 +271,7 @@ export async function exportSessionToHtml(
 		systemPrompt: state?.systemPrompt,
 		tools: state?.tools?.map((t) => ({ name: t.name, description: t.description, parameters: t.parameters })),
 		renderedTools,
+		mermaidDiagrams,
 	};
 
 	const html = generateHtml(sessionData, opts.themeName);
@@ -294,13 +299,16 @@ export async function exportFromFile(inputPath: string, options?: ExportOptions 
 	}
 
 	const sm = SessionManager.open(resolvedInputPath);
+	const entries = sm.getEntries();
+	const mermaidDiagrams = buildMermaidDiagramMap(entries);
 
 	const sessionData: SessionData = {
 		header: sm.getHeader(),
-		entries: sm.getEntries(),
+		entries,
 		leafId: sm.getLeafId(),
 		systemPrompt: undefined,
 		tools: undefined,
+		mermaidDiagrams,
 	};
 
 	const html = generateHtml(sessionData, opts.themeName);

--- a/packages/coding-agent/src/core/export-html/mermaid-html.ts
+++ b/packages/coding-agent/src/core/export-html/mermaid-html.ts
@@ -1,0 +1,93 @@
+import { Marked, type Token } from "@earendil-works/pi-tui";
+import { type Cls, render } from "grok-mermaid";
+import type { SessionEntry } from "../session-manager.ts";
+
+const markdownParser = new Marked();
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
+}
+
+function isMermaidToken(token: Token): token is Token & { type: "code"; text: string; lang?: string } {
+	return token.type === "code" && token.lang?.trim().split(/\s+/, 1)[0]?.toLowerCase() === "mermaid";
+}
+
+const SPAN_COLOR_VAR: Record<Cls, string | undefined> = {
+	border: "var(--borderMuted)",
+	text: "var(--text)",
+	edge: "var(--accent)",
+	edgeLabel: "var(--muted)",
+	title: "var(--accent)",
+	none: undefined,
+};
+
+function spanHtml(cls: Cls, text: string): string {
+	const escaped = escapeHtml(text);
+	if (!escaped) return "";
+	const color = SPAN_COLOR_VAR[cls];
+	if (!color) return escaped;
+	const style = cls === "title" ? `color:${color};font-weight:bold` : `color:${color}`;
+	return `<span style="${style}">${escaped}</span>`;
+}
+
+function renderDiagramHtml(source: string): string | undefined {
+	const art = render(source);
+	if (!art) return undefined;
+
+	const lines = art.styled.map((row) => row.map((span) => spanHtml(span.cls, span.text)).join(""));
+	let html = `<div class="mermaid-render"><pre class="mermaid-diagram" data-mermaid-rendered hidden>${lines.map((line) => `<div>${line || "&nbsp;"}</div>`).join("")}</pre><pre class="mermaid-source" data-mermaid-source hidden><code>${escapeHtml(source)}</code></pre>`;
+
+	if (art.warnings.length > 0) {
+		const suffix = art.warnings.length > 1 ? ` (+${art.warnings.length - 1} more)` : "";
+		html += `<div class="mermaid-warning">Diagram not fully rendered: ${escapeHtml(art.warnings[0])}${escapeHtml(suffix)}</div>`;
+	}
+
+	return `${html}</div>`;
+}
+
+function textBlocksOf(content: unknown): string[] {
+	if (typeof content === "string") return [content];
+	if (!Array.isArray(content)) return [];
+
+	const texts: string[] = [];
+	for (const block of content) {
+		if (!block || typeof block !== "object" || (block as { type?: unknown }).type !== "text") continue;
+		const text = (block as { text?: unknown }).text;
+		if (typeof text === "string") texts.push(text);
+	}
+	return texts;
+}
+
+function collectMarkdownText(entries: SessionEntry[]): string[] {
+	const texts: string[] = [];
+	for (const entry of entries) {
+		if (entry.type === "message") {
+			texts.push(...textBlocksOf((entry.message as { content?: unknown }).content));
+		} else if (entry.type === "branch_summary") {
+			texts.push(entry.summary);
+		} else if (entry.type === "custom_message") {
+			texts.push(...textBlocksOf(entry.content));
+		}
+	}
+	return texts;
+}
+
+export function buildMermaidDiagramMap(entries: SessionEntry[]): Record<string, string> | undefined {
+	const map: Record<string, string> = {};
+	for (const text of collectMarkdownText(entries)) {
+		if (!text.toLowerCase().includes("mermaid")) continue;
+		for (const token of markdownParser.lexer(text)) {
+			if (!isMermaidToken(token)) continue;
+			const key = token.text.trim();
+			if (!key || key in map) continue;
+			const html = renderDiagramHtml(token.text);
+			if (html) map[key] = html;
+		}
+	}
+	return Object.keys(map).length > 0 ? map : undefined;
+}

--- a/packages/coding-agent/src/core/export-html/template.css
+++ b/packages/coding-agent/src/core/export-html/template.css
@@ -909,6 +909,53 @@
       color: var(--text);
     }
 
+    .mermaid-render {
+      position: relative;
+      max-width: 100%;
+    }
+
+    .mermaid-render [hidden] {
+      display: none !important;
+    }
+
+    .markdown-content pre.mermaid-diagram {
+      display: block;
+      width: max-content;
+      margin: var(--line-height) auto;
+      max-width: 100%;
+      max-height: 60vh;
+      overflow-x: auto;
+      overflow-y: auto;
+      font-family: inherit;
+      background: transparent;
+    }
+
+    .markdown-content pre.mermaid-source {
+      display: block;
+      width: 100%;
+      margin: var(--line-height) 0;
+      max-height: 60vh;
+      overflow: auto;
+      font-family: inherit;
+      background: transparent;
+    }
+
+    .markdown-content pre.mermaid-source code {
+      display: block;
+      background: none;
+      color: var(--text);
+    }
+
+    .mermaid-diagram > div {
+      white-space: pre;
+      line-height: var(--line-height);
+    }
+
+    .mermaid-warning {
+      color: var(--warning);
+      margin-top: 2px;
+    }
+
     .markdown-content blockquote {
       border-left: 3px solid var(--mdQuoteBorder);
       padding-left: var(--line-height);

--- a/packages/coding-agent/src/core/export-html/template.js
+++ b/packages/coding-agent/src/core/export-html/template.js
@@ -12,7 +12,7 @@
         bytes[i] = binary.charCodeAt(i);
       }
       const data = JSON.parse(new TextDecoder('utf-8').decode(bytes));
-      const { header, entries, leafId: defaultLeafId, systemPrompt, tools, renderedTools } = data;
+      const { header, entries, leafId: defaultLeafId, systemPrompt, tools, renderedTools, mermaidDiagrams } = data;
 
       // ============================================================
       // URL PARAMETER HANDLING
@@ -1384,10 +1384,11 @@
           <div class="header">
             <h1>Session: ${escapeHtml(header?.id || 'unknown')}</h1>
             <div class="help-bar">
-              <span class="help-hint">T toggle thinking · O toggle tools</span>
+              <span class="help-hint">T toggle thinking · O toggle tools · M toggle Mermaid</span>
               <div class="help-actions">
                 <button type="button" class="header-toggle-btn" data-action="toggle-thinking" title="Toggle thinking (T)">Toggle thinking</button>
                 <button type="button" class="header-toggle-btn" data-action="toggle-tools" title="Toggle tools (O)">Toggle tools</button>
+                <button type="button" class="header-toggle-btn" data-action="toggle-mermaid" title="Toggle Mermaid diagrams (M)">Toggle Mermaid</button>
                 <button type="button" class="download-json-btn" onclick="downloadSessionJson()" title="Download session as JSONL">↓ JSONL</button>
               </div>
             </div>
@@ -1515,6 +1516,7 @@
 
         messagesEl.innerHTML = '';
         messagesEl.appendChild(fragment);
+        applyMermaidView();
 
         // Attach click handlers for copy-link buttons
         messagesEl.querySelectorAll('.copy-link-btn').forEach(btn => {
@@ -1612,6 +1614,11 @@
           code(token) {
             const code = token.text;
             const lang = token.lang;
+            const firstLangWord = lang ? lang.trim().split(/\s+/, 1)[0].toLowerCase() : '';
+            if (firstLangWord === 'mermaid' && mermaidDiagrams) {
+              const rendered = mermaidDiagrams[code.trim()];
+              if (rendered) return rendered;
+            }
             let highlighted;
             if (lang && hljs.getLanguage(lang)) {
               try {
@@ -1788,6 +1795,16 @@
       // Toggle states
       let thinkingExpanded = true;
       let toolOutputsExpanded = false;
+      let mermaidSourceVisible = true;
+
+      const applyMermaidView = () => {
+        document.querySelectorAll('[data-mermaid-rendered]').forEach(el => {
+          el.hidden = mermaidSourceVisible;
+        });
+        document.querySelectorAll('[data-mermaid-source]').forEach(el => {
+          el.hidden = !mermaidSourceVisible;
+        });
+      };
 
       const toggleThinking = () => {
         thinkingExpanded = !thinkingExpanded;
@@ -1812,9 +1829,15 @@
         });
       };
 
+      const toggleMermaidView = () => {
+        mermaidSourceVisible = !mermaidSourceVisible;
+        applyMermaidView();
+      };
+
       const attachHeaderHandlers = () => {
         document.querySelector('[data-action="toggle-thinking"]')?.addEventListener('click', toggleThinking);
         document.querySelector('[data-action="toggle-tools"]')?.addEventListener('click', toggleToolOutputs);
+        document.querySelector('[data-action="toggle-mermaid"]')?.addEventListener('click', toggleMermaidView);
       };
 
       const isEditableTarget = (element) => {
@@ -1845,6 +1868,9 @@
         } else if (key === 'o') {
           e.preventDefault();
           toggleToolOutputs();
+        } else if (key === 'm') {
+          e.preventDefault();
+          toggleMermaidView();
         }
       });
 


### PR DESCRIPTION
Hello!

Noticed that the exports didn't render the mermaid diagrams like the tui does, so re-used most of the code that renders the tool calls by translating them from ANSI to HTML.

By default they're not shown rendered, but they can be toggled from the header. They're also wrapped into a div with overflow so that the diagrams are not taking a massive amount of space when they're too big.

When diagrams are not renderable, it keeps the same warning as the tui but it should work as is when/if it's fixed upstream. (see https://github.com/earendil-works/pi/issues/7832 + https://github.com/xl0/grok-mermaid/issues/1)

Demo session: https://pi.dev/session/#58cb34b36dc48e2ebae711e00d8d330c

Let me know if you want / need more changes!

------

<details><summary>Summary by GLM-5.2:</summary>
<p>

## Summary

Pre-renders Mermaid fenced code blocks server-side into lightweight, themed HTML so exported sessions display real diagrams instead of raw ` ```mermaid ` source. The default export view stays as source code; a global toggle switches all blocks to the rendered diagram.

## Why

HTML exports previously showed Mermaid blocks as plain source (or Highlight.js-mangled source), which is unreadable for anything beyond a trivial graph. The TUI already renders Mermaid via `grok-mermaid`, but that path needs a live `Theme` instance and only runs interactively. This adds a standalone export-time renderer that works for both interactive (`/export`) and standalone session-file exports, with no client-side Mermaid bundle.

## What changed

**`packages/coding-agent/src/core/export-html/mermaid-html.ts`** (new)
- Self-contained helper: scans session entries for Markdown text, finds top-level fenced `mermaid` code blocks, renders each via `grok-mermaid`, and returns a `Record<trimmedSource, html>` (or `undefined` when empty).
- No `Theme` instance, no `agent-session.ts` changes, no width check (HTML scrolls), no client-side JS bundle.
- Maps `grok-mermaid`'s `Cls` runs to export CSS variables (`border`→`--borderMuted`, `text`→`--text`, `edge`→`--accent`, `edgeLabel`→`--muted`, `title`→`--accent` + bold, `none`→passthrough) — same mapping as the TUI `mermaid.ts`.
- Each diagram emits both a rendered `<pre class="mermaid-diagram">` (starts `hidden`) and an escaped `<pre class="mermaid-source">`, so the initial HTML matches the source-visible default with no pre-JS flash.
- If `grok-mermaid` returns `null`, no entry is added (falls back to source). Partial renders include an inline warning.

**`packages/coding-agent/src/core/export-html/index.ts`**
- `SessionData` gains optional `mermaidDiagrams?: Record<string, string>`.
- Both export paths build the map: `exportSessionToHtml` (interactive) and `exportFromFile` (standalone CLI). Omitted from the serialized payload when empty.

**`packages/coding-agent/src/core/export-html/template.js`**
- Destructures `mermaidDiagrams` from the payload.
- The marked `code(token)` renderer short-circuits when the first language word is `mermaid` and a pre-rendered entry exists for `token.text.trim()`; otherwise falls back to the normal Highlight.js path.
- Adds a global "Toggle Mermaid" header button and an `M` keyboard shortcut (alongside the existing thinking/tools toggles). Default state is source-visible. `applyMermaidView` runs once per navigation on the freshly built message DOM.

**`packages/coding-agent/src/core/export-html/template.css`**
- `.mermaid-diagram`: centered, `width: max-content`, constrained to `max-width: 100%` / `max-height: 60vh` with scrollbars.
- `.mermaid-source`: full-width, scrollable.
- `.mermaid-render [hidden] { display: none !important; }` guard so the `display: block` rules don't override the native `hidden` attribute.
- `.mermaid-warning`: themed via `--warning`.

## Behavior

- Default view: source code. Clicking "Toggle Mermaid" (or pressing `M`) flips all Mermaid blocks globally between source and rendered diagram. State persists across in-export navigation.
- Unsupported/invalid Mermaid: no rendered entry → normal source block. Partial renders show the diagram plus an inline "Diagram not fully rendered" warning; source is still available.
- No TUI theme or live agent state required, so standalone `pi` session-file exports render diagrams too.


</p>
</details>