### PR TITLE
fix(ai): abort OpenAI-compatible streams that stall mid-response

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -145,7 +145,18 @@ export interface OpenAICompletionsOptions extends StreamOptions {
 	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	/** Token budgets per thinking level. Only used when `compat.supportsThinkingTokenBudget` is set. */
 	thinkingBudgets?: ThinkingBudgets;
+	/**
+	 * Inactivity timeout in milliseconds for the stream body read, applied after the
+	 * first chunk has arrived. The SDK's `timeout` only covers time-to-first-byte, so
+	 * a provider that stalls mid-stream (content delivered, connection never closed)
+	 * would otherwise block the stream forever. The timer resets on every chunk and
+	 * aborts the request when no chunk arrives for this long, surfacing a retryable
+	 * "timeout" error. Default: 60000.
+	 */
+	streamIdleTimeoutMs?: number;
 }
+
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 60_000;
 
 export interface ConvertCompletionsMessagesOptions {
 	grammarToolInputProperties?: ReadonlyMap<string, string>;
@@ -224,6 +235,19 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			timestamp: Date.now(),
 		};
 
+		const streamIdleTimeoutMs = options?.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+		const idleController = new AbortController();
+		const requestSignal = options?.signal
+			? AbortSignal.any([options.signal, idleController.signal])
+			: idleController.signal;
+		let idleTimer: ReturnType<typeof setTimeout> | undefined;
+		const resetIdleTimer = () => {
+			clearTimeout(idleTimer);
+			idleTimer = setTimeout(() => {
+				idleController.abort(new Error(`stream idle timeout after ${streamIdleTimeoutMs}ms without a new chunk`));
+			}, streamIdleTimeoutMs);
+		};
+
 		try {
 			const apiKey = getClientApiKey(model.provider, options?.apiKey, options?.headers);
 			const compat = getCompat(model);
@@ -240,7 +264,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				params = nextParams as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming;
 			}
 			const requestOptions = {
-				...(options?.signal ? { signal: options.signal } : {}),
+				signal: requestSignal,
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
 				maxRetries: 0,
 			};
@@ -439,6 +463,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			};
 
 			for await (const chunk of openaiStream) {
+				resetIdleTimer();
 				if (!chunk || typeof chunk !== "object") continue;
 
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
@@ -565,6 +590,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 					}
 				}
 			}
+			clearTimeout(idleTimer);
 
 			for (const block of blocks) {
 				finishBlock(block);
@@ -596,8 +622,15 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				delete (block as { customInput?: unknown }).customInput;
 				delete (block as { streamIndex?: number }).streamIndex;
 			}
+			clearTimeout(idleTimer);
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = formatProviderError(normalizeProviderError(error));
+			if (idleController.signal.aborted) {
+				output.errorMessage = formatProviderError(
+					normalizeProviderError(new Error(`stream idle timeout after ${streamIdleTimeoutMs}ms without a new chunk`)),
+				);
+			} else {
+				output.errorMessage = formatProviderError(normalizeProviderError(error));
+			}
 			// Some providers via OpenRouter give additional information in this field.
 			// normalizeProviderError already stringifies the parsed body (error.error)
 			// into errorMessage, so only append the raw metadata when it is not already

--- a/packages/ai/test/openai-completions-stream-idle-timeout.test.ts
+++ b/packages/ai/test/openai-completions-stream-idle-timeout.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import type { Context, Model } from "../src/types.ts";
+
+type Scenario = "normal" | "stall" | "done-hold" | "slow" | "delayed-first";
+
+const mockState = vi.hoisted(() => ({
+	scenario: "normal" as Scenario,
+	requestOptions: [] as unknown[],
+}));
+
+vi.mock("openai", () => {
+	class FakeOpenAI {
+		chat = {
+			completions: {
+				create: (_params: unknown, options: unknown) => {
+					mockState.requestOptions.push(options);
+					const signal = (options as { signal?: AbortSignal }).signal;
+					const stream = {
+						async *[Symbol.asyncIterator]() {
+							const stall = (): Promise<void> =>
+								new Promise((resolve) => {
+									signal?.addEventListener("abort", () => resolve());
+								});
+							switch (mockState.scenario) {
+								case "stall":
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: { content: "hello" } }] };
+									await stall();
+									throw new Error("request aborted");
+								case "done-hold":
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: { content: "hello" } }] };
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] };
+									await stall();
+									throw new Error("request aborted");
+								case "slow":
+									for (let i = 0; i < 5; i++) {
+										await new Promise<void>((resolve) => setTimeout(resolve, 30));
+										yield { id: "chatcmpl-test", choices: [{ index: 0, delta: { content: "x" } }] };
+									}
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] };
+									return;
+								case "delayed-first":
+									await new Promise<void>((resolve) => setTimeout(resolve, 500));
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: { content: "hi" } }] };
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] };
+									return;
+								default:
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: { content: "ok" } }] };
+									yield { id: "chatcmpl-test", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] };
+							}
+						},
+					};
+					const promise = Promise.resolve(stream) as Promise<typeof stream> & {
+						withResponse: () => Promise<{
+							data: typeof stream;
+							response: { status: number; headers: Headers };
+						}>;
+					};
+					promise.withResponse = async () => ({
+						data: stream,
+						response: { status: 200, headers: new Headers() },
+					});
+					return promise;
+				},
+			},
+		};
+	}
+	return { default: FakeOpenAI };
+});
+
+const model: Model<"openai-completions"> = {
+	id: "test-model",
+	name: "Test Model",
+	api: "openai-completions",
+	provider: "opencode-go",
+	baseUrl: "https://opencode.ai/zen/go/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1000,
+	maxTokens: 100,
+};
+
+const context: Context = {
+	systemPrompt: "",
+	messages: [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 }],
+	tools: [],
+};
+
+async function consume(streamIdleTimeoutMs?: number) {
+	const stream = streamOpenAICompletions(model, context, { apiKey: "test", ...(streamIdleTimeoutMs !== undefined ? { streamIdleTimeoutMs } : {}) });
+	for await (const _event of stream) {
+		void _event;
+	}
+	return stream.result();
+}
+
+describe("openai-completions stream idle timeout", () => {
+	beforeEach(() => {
+		mockState.scenario = "normal";
+		mockState.requestOptions = [];
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("aborts with a retryable timeout error when the stream stalls after content", async () => {
+		mockState.scenario = "stall";
+		const resultPromise = consume(100);
+		await vi.advanceTimersByTimeAsync(100);
+		const result = await resultPromise;
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("timeout");
+		expect(result.errorMessage).toContain("100ms");
+	});
+
+	it("aborts even when finish_reason was delivered but the connection never closes", async () => {
+		mockState.scenario = "done-hold";
+		const resultPromise = consume(100);
+		await vi.advanceTimersByTimeAsync(100);
+		const result = await resultPromise;
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("timeout");
+	});
+
+	it("keeps the stream alive while chunks arrive within the deadline", async () => {
+		mockState.scenario = "slow";
+		const resultPromise = consume(100);
+		for (let i = 0; i < 6; i++) {
+			await vi.advanceTimersByTimeAsync(30);
+		}
+		const result = await resultPromise;
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+	});
+
+	it("does not apply the deadline before the first chunk (TTFB covered by the SDK timeout)", async () => {
+		mockState.scenario = "delayed-first";
+		const resultPromise = consume(100);
+		await vi.advanceTimersByTimeAsync(500);
+		const result = await resultPromise;
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+	});
+
+	it("leaves normal streams untouched and still passes the merged signal", async () => {
+		const result = await consume();
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+		expect(mockState.requestOptions[0]).toMatchObject({ maxRetries: 0 });
+		expect((mockState.requestOptions[0] as { signal?: unknown }).signal).toBeDefined();
+	});
+});


### PR DESCRIPTION
Fixes #7954 — OpenAI-compatible SSE turns can hang forever when the provider delivers content and then lingers without closing the response body.

## Root cause

`stream()` in `openai-completions.ts` only had a **time-to-first-byte** timeout: the bundled SDK clears it once the headers arrive, so the rest of the stream read has **no timeout at all**. `data: [DONE]` does not end the stream either — the iterator only finishes when the response body actually ends (connection close / chunked terminator / HTTP/2 END_STREAM). A stalled body leaves the `for await` loop blocked forever: no error, no timeout, turn never ends.

## What this PR does

- Adds `streamIdleTimeoutMs` option to `OpenAICompletionsOptions` (default **60s**).
- Arms an inactivity timer **after the first chunk** and **resets it on every chunk** — so it only covers the mid-stream phase, while TTFB stays covered by the SDK's existing `timeout` (via `AbortSignal.any` merge of the caller signal + the idle controller).
- On expiry, aborts with a retryable error (`stream idle timeout after 60000ms without a new chunk`) — `isRetryableAssistantError` already matches `"timeout"`, so the agent loop retries instead of hanging.

**Why 60s:** measured real-world chunk gaps are <250ms; SSE keepalives arrive at ≤30s, so a healthy stream never trips a 60s inactivity deadline (2× keepalive + 240× headroom). Raw byte-idle would be defeated by keepalives; resetting on *content* deltas is the only reliable signal.

## Tests

New `openai-completions-stream-idle-timeout.test.ts` (fake timers + mocked openai SDK stream):
- stall after first content chunk → aborts with timeout error
- finish_reason delivered but connection never closes → still aborts
- chunks every 30ms under a 100ms deadline → completes normally
- first chunk delayed 500ms under a 100ms deadline → not aborted (TTFB belongs to the SDK timeout)
- normal stream → merged signal passed, `maxRetries: 0` preserved

All related suites pass locally (openai-completions-*, retry, provider-retry); the pre-existing typecheck failures (missing generated model-data JSONs, unbuilt `pi-telemetry`) are unrelated to this change and CI generates them.

(AI-assisted draft, reviewed by me.)
