### PR TITLE
fix(ai): mark Claude Sonnet 5 as not supporting temperature

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -573,7 +573,9 @@ function isAnthropicTemperatureUnsupportedModel(modelId: string): boolean {
 		id.includes("opus-4-8") ||
 		id.includes("opus-4.8") ||
 		id.includes("opus-5") ||
-		id.includes("opus.5")
+		id.includes("opus.5") ||
+		id.includes("sonnet-5") ||
+		id.includes("sonnet.5")
 	);
 }
 

--- a/packages/ai/test/anthropic-temperature-compat.test.ts
+++ b/packages/ai/test/anthropic-temperature-compat.test.ts
@@ -83,6 +83,12 @@ describe("Anthropic temperature compatibility", () => {
 		expect(payload.temperature).toBeUndefined();
 	});
 
+	it("omits temperature for Claude Sonnet 5", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-sonnet-5"), { temperature: 0 });
+
+		expect(payload.temperature).toBeUndefined();
+	});
+
 	it("keeps temperature for Claude Opus 4.6", async () => {
 		const payload = await capturePayload(getModel("anthropic", "claude-opus-4-6"), { temperature: 0 });
 


### PR DESCRIPTION
`claude-sonnet-5` rejects `temperature` just like the Opus models that are already
in `isAnthropicTemperatureUnsupportedModel`, but it isn't listed, so the field is
still sent and every call fails:

```
400 {"type":"error","error":{"type":"invalid_request_error",
     "message":"`temperature` is deprecated for this model."}}
```

Checked directly against `api.anthropic.com/v1/messages`:

| model | with `temperature: 0` | without |
| --- | --- | --- |
| claude-sonnet-5 | 400 `temperature` is deprecated | 200 |
| claude-opus-5 | 400 `temperature` is deprecated | 200 |
| claude-haiku-4-5-20251001 | 200 | 200 |

Added `sonnet-5` / `sonnet.5` to the predicate, matching the `opus` spellings
around it, plus a case in `anthropic-temperature-compat.test.ts`. Regenerated the
catalog: `claude-sonnet-5` now carries `supportsTemperature: false` and
`claude-sonnet-4-6` is untouched.
