### PR TITLE
fix: collapse whitespace runs in edit fuzzy match

### DIFF
--- a/packages/agent/src/harness/tools/edit-diff.ts
+++ b/packages/agent/src/harness/tools/edit-diff.ts
@@ -22,7 +22,7 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
 
 /**
  * Normalize text for fuzzy matching. Applies progressive transformations:
- * - Strip trailing whitespace from each line
+ * - Trim leading/trailing whitespace and collapse interior whitespace runs per line
  * - Normalize smart quotes to ASCII equivalents
  * - Normalize Unicode dashes/hyphens to ASCII hyphen
  * - Normalize special Unicode spaces to regular space
@@ -31,9 +31,9 @@ export function normalizeForFuzzyMatch(text: string): string {
 	return (
 		text
 			.normalize("NFKC")
-			// Strip trailing whitespace per line
+			// Trim leading/trailing whitespace and collapse interior whitespace runs to a single space
 			.split("\n")
-			.map((line) => line.trimEnd())
+			.map((line) => line.trim().replace(/\s+/g, " "))
 			.join("\n")
 			// Smart single quotes → '
 			.replace(/[\u2018\u2019\u201A\u201B]/g, "'")

--- a/packages/agent/test/harness/edit-diff-whitespace.test.ts
+++ b/packages/agent/test/harness/edit-diff-whitespace.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyEditsToNormalizedContent,
+	fuzzyFindText,
+	normalizeForFuzzyMatch,
+} from "../../src/harness/tools/edit-diff.ts";
+
+describe("normalizeForFuzzyMatch", () => {
+	it("collapses interior runs of ASCII spaces", () => {
+		expect(normalizeForFuzzyMatch("a    b")).toBe("a b");
+	});
+
+	it("collapses tabs and mixed whitespace runs", () => {
+		expect(normalizeForFuzzyMatch("a\t\tb")).toBe("a b");
+		expect(normalizeForFuzzyMatch("hello \t world")).toBe("hello world");
+	});
+
+	it("trims leading whitespace from each line", () => {
+		expect(normalizeForFuzzyMatch("    const x = 1;")).toBe("const x = 1;");
+		expect(normalizeForFuzzyMatch("  a    b")).toBe("a b");
+	});
+
+	it("collapses runs of special unicode spaces", () => {
+		expect(normalizeForFuzzyMatch("a\u00A0\u00A0b")).toBe("a b");
+		expect(normalizeForFuzzyMatch("a\u3000\u3000b")).toBe("a b");
+	});
+});
+
+describe("fuzzyFindText whitespace equivalence", () => {
+	it("matches when only the whitespace length differs", () => {
+		const result = fuzzyFindText("const a    = 1;\n", "const a = 1;\n");
+		expect(result.found).toBe(true);
+		expect(result.usedFuzzyMatch).toBe(true);
+	});
+
+	it("matches when oldText has extra interior spaces vs the file", () => {
+		const result = fuzzyFindText("const a = 1;\n", "const a    = 1;\n");
+		expect(result.found).toBe(true);
+	});
+
+	it("matches when the indentation depth differs", () => {
+		const result = fuzzyFindText("const a = 1;\n", "    const a = 1;\n");
+		expect(result.found).toBe(true);
+	});
+
+	it("matches tab/space mixing", () => {
+		const result = fuzzyFindText("hello world\n", "hello \t world\n");
+		expect(result.found).toBe(true);
+	});
+
+	it("still rejects genuinely different text", () => {
+		expect(fuzzyFindText("const a = 1;\n", "const b = 2;\n").found).toBe(false);
+	});
+
+	it("still rejects text that differs in non-whitespace content", () => {
+		expect(fuzzyFindText("const a = 1;\n", "const a = 1; // change\n").found).toBe(false);
+	});
+});
+
+describe("applyEditsToNormalizedContent with whitespace differences", () => {
+	it("applies an edit whose oldText differs only in whitespace length", () => {
+		const { newContent } = applyEditsToNormalizedContent(
+			"const a    = 1;\nconst b = 2;\n",
+			[{ oldText: "const a = 1;", newText: "const a = 10;" }],
+			"test.ts",
+		);
+		expect(newContent).toBe("const a = 10;\nconst b = 2;\n");
+	});
+
+	it("still raises a duplicate error when whitespace collapse makes oldText ambiguous", () => {
+		expect(() =>
+			applyEditsToNormalizedContent("x  = 1\nx = 1\n", [{ oldText: "x = 1", newText: "y = 1" }], "test.ts"),
+		).toThrow(/unique/);
+	});
+});

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -25,7 +25,7 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
 
 /**
  * Normalize text for fuzzy matching. Applies progressive transformations:
- * - Strip trailing whitespace from each line
+ * - Trim leading/trailing whitespace and collapse interior whitespace runs per line
  * - Normalize smart quotes to ASCII equivalents
  * - Normalize Unicode dashes/hyphens to ASCII hyphen
  * - Normalize special Unicode spaces to regular space
@@ -34,9 +34,9 @@ export function normalizeForFuzzyMatch(text: string): string {
 	return (
 		text
 			.normalize("NFKC")
-			// Strip trailing whitespace per line
+			// Trim leading/trailing whitespace and collapse interior whitespace runs to a single space
 			.split("\n")
-			.map((line) => line.trimEnd())
+			.map((line) => line.trim().replace(/\s+/g, " "))
 			.join("\n")
 			// Smart single quotes → '
 			.replace(/[\u2018\u2019\u201A\u201B]/g, "'")


### PR DESCRIPTION
## Problem

The `edit` tool's fuzzy match misses text that differs only in whitespace length. `normalizeForFuzzyMatch` trims trailing whitespace and normalizes Unicode dashes/quotes/special spaces, but it never collapses runs of ASCII whitespace nor trims leading whitespace, so `"a    b"` and `"a b"` stay distinct after normalization and `fuzzyFindText` fails to find the `oldText`.

This degrades agent behavior: when `oldText` differs from the file only in a whitespace run (tabs vs spaces, indentation depth, or extra spaces), the model falls back to rewriting the whole file via a Python/shell script instead of using `edit`.

## Root cause

`normalizeForFuzzyMatch` only performs `line.trimEnd()` per line and collapses a fixed set of Unicode spaces. Plain ASCII space runs, tabs, and leading whitespace are left untouched, so two semantically identical strings with different whitespace length normalize differently and the fuzzy `indexOf` misses.

## Fix

Collapse every interior whitespace run to a single space and trim leading whitespace per line in `normalizeForFuzzyMatch`:

```ts
.map((line) => line.trim().replace(/\s+/g, " "))
```

Applied to both copies of the function (`packages/agent/src/harness/tools/edit-diff.ts` and `packages/coding-agent/src/core/tools/edit-diff.ts`). Normalization is only used for matching — `applyEditsToNormalizedContent` slices replacement text from the original content via `applyReplacementsPreservingUnchangedLines`, so untouched lines keep their original bytes.

## Test

Added `packages/agent/test/harness/edit-diff-whitespace.test.ts` covering:
- `normalizeForFuzzyMatch` collapsing space/tab/special-unicode runs and trimming leading whitespace
- `fuzzyFindText` matching when only the whitespace length / indentation depth / tab-vs-space differs, while still rejecting genuinely different text
- `applyEditsToNormalizedContent` applying an edit whose `oldText` differs only in whitespace, and still raising the duplicate-occurrence guard when whitespace collapse makes an `oldText` ambiguous

Run with `cd packages/agent && npm run test -- test/harness/edit-diff-whitespace`.

Fixes #7836