### PR TITLE
feat(coding-agent): add VS Code support to notify example

### DIFF
--- a/packages/coding-agent/examples/extensions/notify.ts
+++ b/packages/coding-agent/examples/extensions/notify.ts
@@ -4,7 +4,7 @@
  * Sends a native terminal notification when Pi agent is done and waiting for input.
  * Supports multiple terminal protocols:
  * - OSC 777: Ghostty, iTerm2, WezTerm, rxvt-unicode
- * - OSC 99: Kitty
+ * - OSC 99: Kitty, VSCode
  * - Windows toast: Windows Terminal (WSL)
  */
 
@@ -41,7 +41,7 @@ function notifyWindows(title: string, body: string): void {
 function notify(title: string, body: string): void {
 	if (process.env.WT_SESSION) {
 		notifyWindows(title, body);
-	} else if (process.env.KITTY_WINDOW_ID) {
+	} else if (process.env.KITTY_WINDOW_ID || process.env.TERM_PROGRAM === "vscode") {
 		notifyOSC99(title, body);
 	} else {
 		notifyOSC777(title, body);


### PR DESCRIPTION
## Summary

The `notify` example extension now sends notifications from VS Code's integrated terminal.

## Background

When running pi inside VS Code's integrated terminal, the `notify` extension's response-completion notification was not delivered. VS Code renders OSC 99 sequences as desktop notifications, so routing `TERM_PROGRAM === "vscode"` through the OSC 99 path reuses the existing Kitty notification path instead of adding a new code path.

## Changes

- `examples/extensions/notify.ts`: route `TERM_PROGRAM === "vscode"` into the same OSC 99 branch as `KITTY_WINDOW_ID`
- Updated the supported-terminals comment to include VS Code

## Verification

- Ran pi in VS Code's integrated terminal and confirmed a desktop notification appears on response completion
