### PR TITLE
fix(edit): normalize single-object edits argument to array and collapse whitespace in fuzzy match

### DIFF
--- a/packages/agent/src/harness/tools/edit-diff.ts
+++ b/packages/agent/src/harness/tools/edit-diff.ts
@@ -47,6 +47,8 @@ export function normalizeForFuzzyMatch(text: string): string {
 			// U+00A0 NBSP, U+2002-U+200A various spaces, U+202F narrow NBSP,
 			// U+205F medium math space, U+3000 ideographic space
 			.replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ")
+			// Collapse interior whitespace runs (tabs, multiple spaces → single space)
+			.replace(/[^\S\n]+/g, " ")
 	);
 }
 

--- a/packages/agent/src/harness/tools/edit.ts
+++ b/packages/agent/src/harness/tools/edit.ts
@@ -45,14 +45,33 @@ export interface EditToolDetails {
 	firstChangedLine?: number;
 }
 
+function isSingleEditObject(value: unknown): value is Record<string, unknown> {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		"oldText" in value &&
+		"newText" in value
+	);
+}
+
 function prepareEditArguments(input: unknown): EditToolInput {
 	if (!input || typeof input !== "object") return input as EditToolInput;
 	const args = input as Record<string, unknown>;
 	if (typeof args.edits === "string") {
 		try {
 			const parsed: unknown = JSON.parse(args.edits);
-			if (Array.isArray(parsed)) args.edits = parsed;
+			if (Array.isArray(parsed)) {
+				args.edits = parsed;
+			} else if (isSingleEditObject(parsed)) {
+				args.edits = [parsed];
+			}
 		} catch {}
+	}
+
+	// Some models send a bare single edit object instead of an array
+	if (isSingleEditObject(args.edits)) {
+		args.edits = [args.edits];
 	}
 
 	const legacy = args as LegacyEditToolInput;

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -50,6 +50,8 @@ export function normalizeForFuzzyMatch(text: string): string {
 			// U+00A0 NBSP, U+2002-U+200A various spaces, U+202F narrow NBSP,
 			// U+205F medium math space, U+3000 ideographic space
 			.replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ")
+			// Collapse interior whitespace runs (tabs, multiple spaces → single space)
+			.replace(/[^\S\n]+/g, " ")
 	);
 }
 

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -102,6 +102,16 @@ export interface EditToolOptions {
 	operations?: EditOperations;
 }
 
+function isSingleEditObject(value: unknown): value is Record<string, unknown> {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		"oldText" in value &&
+		"newText" in value
+	);
+}
+
 function prepareEditArguments(input: unknown): EditToolInput {
 	if (!input || typeof input !== "object") {
 		return input as EditToolInput;
@@ -112,9 +122,18 @@ function prepareEditArguments(input: unknown): EditToolInput {
 	// Some models (Opus 4.6, GLM-5.1) send edits as a JSON string instead of an array
 	if (typeof args.edits === "string") {
 		try {
-			const parsed = JSON.parse(args.edits);
-			if (Array.isArray(parsed)) args.edits = parsed;
+			const parsed: unknown = JSON.parse(args.edits);
+			if (Array.isArray(parsed)) {
+				args.edits = parsed;
+			} else if (isSingleEditObject(parsed)) {
+				args.edits = [parsed];
+			}
 		} catch {}
+	}
+
+	// Some models send a bare single edit object instead of an array
+	if (isSingleEditObject(args.edits)) {
+		args.edits = [args.edits];
 	}
 
 	const legacy = args as LegacyEditToolInput;


### PR DESCRIPTION
## Summary

The edit tool rejects calls where `edits` is a single object (or a JSON string holding one object) instead of an array. Some models wrap their arguments for the edit tool in a single object `{oldText, newText}` rather than `[{oldText, newText}]`.

The existing `prepareEditArguments` function already handles stringified arrays but does not handle:
- Stringified single objects: `edits: '{"oldText": "...", "newText": "..."}'`
- Native single objects: `edits: {oldText: "...", newText: "..."}`

## Changes

- When `args.edits` is a JSON string that parses to a single object with `oldText`/`newText`, wrap it into a one-element array
- When `args.edits` is a plain object (not array, not string) with `oldText`/`newText` properties, wrap it into a one-element array
- Also collapsed interior whitespace runs in `normalizeForFuzzyMatch` for #7836

Fixes #7835
