### PR TITLE
fix(ai): map models.dev cost tiers for every provider

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1216,12 +1216,7 @@ function processBasetenModels(provider: ModelsDevProvider | undefined): Model<Ap
 			reasoning,
 			...(thinkingLevelMap ? { thinkingLevelMap } : {}),
 			input: model.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-			cost: {
-				input: model.cost?.input || 0,
-				output: model.cost?.output || 0,
-				cacheRead: model.cost?.cache_read || 0,
-				cacheWrite: model.cost?.cache_write || 0,
-			},
+			cost: getModelsDevCost(model.cost),
 			compat,
 			contextWindow: model.limit?.context || 4096,
 			maxTokens: model.limit?.output || 4096,
@@ -1266,12 +1261,7 @@ function processFireworksModels(provider: ModelsDevProvider | undefined): Model<
 			provider: "fireworks",
 			reasoning: model.reasoning === true,
 			input,
-			cost: {
-				input: model.cost?.input || 0,
-				output: model.cost?.output || 0,
-				cacheRead: model.cost?.cache_read || 0,
-				cacheWrite: model.cost?.cache_write || 0,
-			},
+			cost: getModelsDevCost(model.cost),
 			contextWindow: model.limit?.context || 4096,
 			maxTokens: model.limit?.output || 4096,
 		};
@@ -1346,12 +1336,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: getBedrockBaseUrl(id),
 					reasoning: m.reasoning === true,
 					input: (m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"]) as ("text" | "image")[],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 					...(m.structured_output === true && { compat: { supportsStrictMode: true } }),
@@ -1374,12 +1359,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: "https://api.anthropic.com",
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});
@@ -1408,12 +1388,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: "https://generativelanguage.googleapis.com/v1beta",
 					reasoning: source.reasoning === true,
 					input: source.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: source.cost?.input || 0,
-						output: source.cost?.output || 0,
-						cacheRead: source.cost?.cache_read || 0,
-						cacheWrite: source.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(source.cost),
 					contextWindow: source.limit?.context || 4096,
 					maxTokens: source.limit?.output || 4096,
 				});
@@ -1442,6 +1417,9 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 				// do not match the official Gemini API standard pricing table. pi only accounts
 				// cachedContentTokenCount as cacheRead.
 				const cacheRead = modelId === "gemini-2.5-flash" ? 0.03 : source.cost?.cache_read || 0;
+				// cacheWrite is zeroed at every tier for the same reason it is zeroed on the
+				// base rates: pi only accounts cachedContentTokenCount, as cacheRead.
+				const vertexCost = getModelsDevCost(source.cost);
 				models.push({
 					id: modelId,
 					name: m.name || modelId,
@@ -1451,10 +1429,12 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					reasoning: source.reasoning === true,
 					input: source.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {
-						input: source.cost?.input || 0,
-						output: source.cost?.output || 0,
+						...vertexCost,
 						cacheRead,
 						cacheWrite: 0,
+						...(vertexCost.tiers
+							? { tiers: vertexCost.tiers.map((tier) => ({ ...tier, cacheWrite: 0 })) }
+							: {}),
 					},
 					contextWindow: source.limit?.context || 4096,
 					maxTokens: source.limit?.output || 4096,
@@ -1479,12 +1459,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: "https://api.openai.com/v1",
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});
@@ -1506,12 +1481,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: "https://api.groq.com/openai/v1",
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});
@@ -1533,12 +1503,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: "https://api.cerebras.ai/v1",
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});
@@ -1560,12 +1525,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: CLOUDFLARE_WORKERS_AI_BASE_URL,
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 					compat: { sendSessionAffinityHeaders: true },
@@ -1617,12 +1577,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl,
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 					...(compat ? { compat } : {}),
@@ -1647,12 +1602,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					...(useResponsesApi ? { compat: { ...XAI_RESPONSES_COMPAT } } : {}),
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});
@@ -1684,12 +1634,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						reasoning: m.reasoning === true,
 						...(isGlm52 ? { thinkingLevelMap: ZAI_GLM52_THINKING_LEVEL_MAP } : {}),
 						input: supportsImage ? ["text", "image"] : ["text"],
-						cost: {
-							input: m.cost?.input || 0,
-							output: m.cost?.output || 0,
-							cacheRead: m.cost?.cache_read || 0,
-							cacheWrite: m.cost?.cache_write || 0,
-						},
+						cost: getModelsDevCost(m.cost),
 						compat: {
 							supportsDeveloperRole: false,
 							thinkingFormat: "zai",
@@ -1719,10 +1664,8 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
+						...getModelsDevCost(m.cost),
 						cacheRead: m.cost?.cache_read ?? (m.cost?.input ? roundCost(m.cost.input * 0.1) : 0),
-						cacheWrite: m.cost?.cache_write || 0,
 					},
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
@@ -1745,12 +1688,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl: "https://router.huggingface.co/v1",
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					compat: {
 						supportsDeveloperRole: false,
 					},
@@ -1784,12 +1722,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					headers: { ...NVIDIA_HEADERS },
 					reasoning: m.reasoning === true,
 					input: m.modalities.input.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					compat: NVIDIA_OPENAI_COMPAT,
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
@@ -1817,12 +1750,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					reasoning,
 					...(thinkingLevelMap ? { thinkingLevelMap } : {}),
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					compat: getTogetherCompat(modelId, reasoning),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
@@ -1927,12 +1855,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					baseUrl,
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					...(compat ? { compat } : {}),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
@@ -2016,12 +1939,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						baseUrl,
 						reasoning: m.reasoning === true,
 						input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-						cost: {
-							input: m.cost?.input || 0,
-							output: m.cost?.output || 0,
-							cacheRead: m.cost?.cache_read || 0,
-							cacheWrite: m.cost?.cache_write || 0,
-						},
+						cost: getModelsDevCost(m.cost),
 						contextWindow: m.limit?.context || 4096,
 						maxTokens: m.limit?.output || 4096,
 					});
@@ -2065,6 +1983,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					reasoning: isKimiK3 || m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {
+						...getModelsDevCost(m.cost),
 						input: m.cost?.input || impliedCost?.input || 0,
 						output: m.cost?.output || impliedCost?.output || 0,
 						cacheRead: m.cost?.cache_read || impliedCost?.cacheRead || 0,
@@ -2120,6 +2039,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					reasoning: isKimiK3 || m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {
+						...getModelsDevCost(m.cost),
 						input: m.cost?.input || (isKimiK3 ? KIMI_K3_COST.input : 0),
 						output: m.cost?.output || (isKimiK3 ? KIMI_K3_COST.output : 0),
 						cacheRead: m.cost?.cache_read || (isKimiK3 ? KIMI_K3_COST.cacheRead : 0),
@@ -2177,12 +2097,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					compat: xiaomiCompat,
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});
@@ -2252,12 +2167,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						: {}),
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
-					cost: {
-						input: m.cost?.input || 0,
-						output: m.cost?.output || 0,
-						cacheRead: m.cost?.cache_read || 0,
-						cacheWrite: m.cost?.cache_write || 0,
-					},
+					cost: getModelsDevCost(m.cost),
 					contextWindow: m.limit?.context || 4096,
 					maxTokens: m.limit?.output || 4096,
 				});

--- a/packages/ai/test/model-cost-tiers.test.ts
+++ b/packages/ai/test/model-cost-tiers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getBuiltinModel, getBuiltinModels, getBuiltinProviders } from "../src/providers/all.ts";
+
+// models.dev publishes long-context pricing as cost.tiers[].tier{type,size}.
+// Provider blocks in generate-models.ts used to build cost by hand and drop it,
+// so anything over the threshold was priced at the short-context rate (#7912).
+describe("model cost tiers", () => {
+	it("keeps xAI grok-4.5 long-context pricing", () => {
+		const model = getBuiltinModel("xai", "grok-4.5");
+		expect(model).toBeDefined();
+		if (!model) return;
+
+		const tiers = model.cost.tiers;
+		expect(tiers).toHaveLength(1);
+		// xAI bills the whole request at the higher rate once the prompt reaches
+		// 200k tokens. https://docs.x.ai/docs/models
+		expect(tiers?.[0].inputTokensAbove).toBe(200000);
+		expect(tiers?.[0].input).toBe(model.cost.input * 2);
+		expect(tiers?.[0].output).toBe(model.cost.output * 2);
+		expect(tiers?.[0].cacheRead).toBe(model.cost.cacheRead * 2);
+	});
+
+	it("prices every tier above the short-context rate it steps up from", () => {
+		for (const provider of getBuiltinProviders()) {
+			for (const model of getBuiltinModels(provider)) {
+				for (const tier of model.cost.tiers ?? []) {
+					expect(tier.inputTokensAbove).toBeGreaterThan(0);
+					expect(tier.input).toBeGreaterThanOrEqual(model.cost.input);
+					expect(tier.output).toBeGreaterThanOrEqual(model.cost.output);
+					expect(tier.cacheRead).toBeGreaterThanOrEqual(model.cost.cacheRead);
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
Fixes #7912.

## Problem

`getModelsDevCost` (generate-models.ts) already maps models.dev's `cost.tiers[].tier{type,size}` onto `cost.tiers[].inputTokensAbove`. It had exactly one call site: the github-copilot block. Every other provider built cost inline from the four scalar rates:

```ts
cost: {
  input: m.cost?.input || 0,
  output: m.cost?.output || 0,
  cacheRead: m.cost?.cache_read || 0,
  cacheWrite: m.cost?.cache_write || 0,
},
```

`m` is the models.dev model, tiers included; they were simply never copied. Anything over a provider's threshold was then priced at the short-context rate.

Concretely, models.dev has carried xAI's grok-4.5 long-context tier since 2026-07-31:

```json
"tiers": [{"input": 4, "output": 12, "cache_read": 0.6, "tier": {"type": "context", "size": 200000}}]
```

0.84.1 ships `{"input": 2, "output": 6, "cacheRead": 0.3, "cacheWrite": 0}` with no tiers. Measured over 10,119 grok-4.5 requests through our gateway, 244 (2.4%) exceeded 200k prompt tokens; catalog rates priced them at $270.83 against $302.35 on xAI's published card, 10.4% under.

`gpt-5.6-luna` looked correct only because `withOpenAiLongContextPricing` synthesizes its tier from a hardcoded allowlist, so the generic path was serving one provider out of roughly twenty-three.

## Change

Route the remaining models.dev-sourced providers through `getModelsDevCost`. For providers without tiers in models.dev the output is identical, since the helper computes the same four fields with the same `|| 0` fallbacks and only adds `tiers` when non-empty.

Four blocks have deliberate cost logic and keep it by spreading over the helper's result rather than replacing it:

- `google-vertex` keeps the `gemini-2.5-flash` cacheRead override and `cacheWrite: 0`, and zeroes `cacheWrite` on its tiers too, for the same reason it is zeroed on the base rates (pi only accounts `cachedContentTokenCount`, as cacheRead). This is the one judgement call in the diff.
- `mistral` keeps the `cache_read ?? input * 0.1` fallback.
- `kimi-for-coding` keeps its implied subscription costs.
- `moonshotai` keeps the `KIMI_K3_COST` fallbacks.

Providers priced from their own APIs (OpenRouter, Vercel AI Gateway) and the hardcoded model lists are untouched.

## Effect

Generating the catalog before and after and diffing all 1223 models:

```
models with tiers:  21 -> 56  (+35)
total models:     1223 -> 1223
base rates changed:  0
```

Zero base-rate changes: the change is purely additive. Tiers gained by provider: opencode 9, google 6, opencode-go 5, cloudflare-ai-gateway 4, amazon-bedrock 3, xai 3, google-vertex 3, minimax 1, minimax-cn 1.

`xai/grok-4.5` now generates as:

```json
{"input": 2, "output": 6, "cacheRead": 0.3, "cacheWrite": 0,
 "tiers": [{"inputTokensAbove": 200000, "input": 4, "output": 12, "cacheRead": 0.6, "cacheWrite": 0}]}
```

`src/providers/data/` is gitignored and `models.generated.ts` is unchanged, since no models were added or removed, so the diff is the generator plus one test.

## Tests

`packages/ai/test/model-cost-tiers.test.ts` pins grok-4.5's 200k tier and adds a catalog-wide invariant that no tier is priced below the rate it steps up from. Verified it fails against the pre-change catalog and passes after.

`npm run check` clean. `./test.sh` green (216 passed in coding-agent, 23 in ai, 132 in agent, all other packages passing).

Generated with [Claude Code](https://claude.com/claude-code). Reviewed and verified by me before submitting.
