### PR TITLE
feat(coding-agent): tiered tool disclosure (Prompt Economy)

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -15,6 +15,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname } from "node:path";
+import { Type } from "typebox";
 import type {
 	Agent,
 	AgentEvent,
@@ -283,6 +284,33 @@ interface ToolDefinitionEntry {
 	sourceInfo: SourceInfo;
 }
 
+/**
+ * Prompt Economy: minimal directory stub for a tier:"lazy" tool.
+ *
+ * Name + label + description are preserved so the model can see the tool exists
+ * without paying for the full schema. Calling the stub returns an expansion hint
+ * instead of executing with partial arguments; the full schema is sent on the next
+ * turn (see `_buildTurnTools`).
+ */
+function createDirectoryStub(tool: AgentTool): AgentTool {
+	return {
+		name: tool.name,
+		label: tool.label,
+		description: tool.description,
+		parameters: Type.Object({}),
+		execute: async () => ({
+			content: [
+				{
+					type: "text",
+					text: `[lazy-tool] "${tool.name}" was called before its full schema was loaded. It is now expanded for the next turn — re-issue this call with complete arguments.`,
+				},
+			],
+			details: { lazyExpanded: tool.name },
+			isError: false,
+		}),
+	};
+}
+
 function estimateMessagesTokens(messages: AgentMessage[]): number {
 	let tokens = 0;
 	for (const message of messages) {
@@ -368,6 +396,11 @@ export class AgentSession {
 	private _toolDefinitions: Map<string, ToolDefinitionEntry> = new Map();
 	private _toolPromptSnippets: Map<string, string> = new Map();
 	private _toolPromptGuidelines: Map<string, string[]> = new Map();
+
+	// Prompt Economy: per-turn full-schema expansion state for tier:"lazy" tools.
+	private _expandedToolNames: Set<string> = new Set();
+	private _lazyToolNames: Set<string> = new Set();
+	private _toolDirectoryStubs: Map<string, AgentTool> = new Map();
 
 	// Base system prompt (without extension appends) - used to apply fresh appends each turn
 	private _baseSystemPrompt = "";
@@ -542,12 +575,18 @@ export class AgentSession {
 			const previousSnapshot = await previousPrepareNextTurnWithContext?.(turn, signal);
 			const previousContext = previousSnapshot?.context ?? turn.context;
 
+			const previousToolCallNames =
+				this._lazyToolNames.size === 0
+					? []
+					: turn.message.content
+							.filter((block) => block.type === "toolCall")
+							.map((block) => block.name);
 			return {
 				...previousSnapshot,
 				context: {
 					...previousContext,
 					systemPrompt: this._systemPromptOverride ?? this._baseSystemPrompt,
-					tools: this.agent.state.tools.slice(),
+					tools: this._buildTurnTools(previousToolCallNames),
 				},
 				model: this.agent.state.model,
 				thinkingLevel: this.agent.state.thinkingLevel,
@@ -935,7 +974,9 @@ export class AgentSession {
 				validToolNames.push(name);
 			}
 		}
-		this.agent.state.tools = tools;
+		// Build the per-turn tool view (Prompt Economy: lazy tools become directory
+		// stubs unless expanded). Default path (no lazy tools) returns full tools.
+		this.agent.state.tools = this._buildTurnTools(undefined, tools);
 
 		// Rebuild base system prompt with new tool set
 		this._baseSystemPrompt = this._rebuildSystemPrompt(validToolNames);
@@ -1036,6 +1077,13 @@ export class AgentSession {
 			}
 		}
 
+		// Prompt Economy: teach the model the lazy-tool protocol when any active tool is lazy.
+		if (validToolNames.some((name) => this._lazyToolNames.has(name))) {
+			promptGuidelines.push(
+				"Some tools are lazy: their full parameter schemas load only when you start using them. If a lazy tool responds that it needs expansion, re-issue the call with complete arguments on the next turn.",
+			);
+		}
+
 		const loaderSystemPrompt = this._resourceLoader.getSystemPrompt();
 		const loaderAppendSystemPrompt = this._resourceLoader.getAppendSystemPrompt();
 		const appendSystemPrompt =
@@ -1054,6 +1102,45 @@ export class AgentSession {
 			promptGuidelines,
 		};
 		return buildSystemPrompt(this._baseSystemPromptOptions);
+	}
+
+	/**
+	 * Prompt Economy: assemble the per-turn tool list.
+	 *
+	 * - tier "full"/unset tools: full definition (unchanged behavior).
+	 * - tier "lazy" tools: directory stub unless expanded for this turn.
+	 * - Expanded lazy tools are appended last, so the stable directory prefix stays
+	 *   byte-identical across turns and provider prompt caches keep hitting.
+	 *
+	 * When no lazy tools are registered this returns `agent.state.tools` verbatim
+	 * (zero overhead on the default path).
+	 */
+	private _buildTurnTools(previousToolCallNames?: Iterable<string>, baseTools?: Iterable<AgentTool>): AgentTool[] {
+		if (this._lazyToolNames.size === 0) {
+			return Array.from(baseTools ?? this.agent.state.tools);
+		}
+
+		const expanded = new Set<string>(this._expandedToolNames);
+		for (const name of previousToolCallNames ?? []) {
+			if (this._lazyToolNames.has(name)) {
+				expanded.add(name);
+			}
+		}
+
+		const stable: AgentTool[] = [];
+		const tail: AgentTool[] = [];
+		for (const tool of baseTools ?? this.agent.state.tools) {
+			if (!this._lazyToolNames.has(tool.name)) {
+				stable.push(tool);
+				continue;
+			}
+			if (expanded.has(tool.name)) {
+				tail.push(this._toolRegistry.get(tool.name) ?? tool);
+			} else {
+				stable.push(this._toolDirectoryStubs.get(tool.name) ?? tool);
+			}
+		}
+		return [...stable, ...tail];
 	}
 
 	// =========================================================================
@@ -2402,6 +2489,11 @@ export class AgentSession {
 				getAllTools: () => this.getAllTools(),
 				setActiveTools: (toolNames) => this.setActiveToolsByName(toolNames),
 				refreshTools: () => this._refreshToolRegistry(),
+				expandTool: (name) => {
+					if (this._lazyToolNames.has(name)) {
+						this._expandedToolNames.add(name);
+					}
+				},
 				getCommands,
 				setModel: async (model) => {
 					if (!this._modelRuntime.hasConfiguredAuth(model.provider)) return false;
@@ -2527,6 +2619,25 @@ export class AgentSession {
 			toolRegistry.set(tool.name, tool);
 		}
 		this._toolRegistry = toolRegistry;
+
+		// Prompt Economy: precompute lazy-tool directory stubs (stable across turns).
+		this._lazyToolNames = new Set(
+			Array.from(definitionRegistry.values())
+				.filter(({ definition }) => definition.tier === "lazy")
+				.map(({ definition }) => definition.name),
+		);
+		this._toolDirectoryStubs = new Map(
+			Array.from(this._lazyToolNames)
+				.map((name) => {
+					const tool = toolRegistry.get(name);
+					return tool ? ([name, createDirectoryStub(tool)] as const) : undefined;
+				})
+				.filter((entry): entry is readonly [string, AgentTool] => entry !== undefined),
+		);
+		// Explicit expansions are scoped to the current tool set.
+		this._expandedToolNames = new Set(
+			Array.from(this._expandedToolNames).filter((name) => this._lazyToolNames.has(name)),
+		);
 
 		const nextActiveToolNames = (
 			options?.activeToolNames ? [...options.activeToolNames] : [...previousActiveToolNames]

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -457,6 +457,15 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	promptSnippet?: string;
 	/** Optional guideline bullets appended to the default system prompt Guidelines section when this tool is active. */
 	promptGuidelines?: string[];
+	/**
+	 * Tool disclosure tier (Prompt Economy feature, opt-in).
+	 * - `"full"` (default, identical to omitting this field): the full parameter schema
+	 *   is sent to the provider on every turn.
+	 * - `"lazy"`: only a directory entry (name + description + promptSnippet) is always
+	 *   present. The full schema is omitted from the provider payload until the tool is
+	 *   expanded for a turn (automatically after the model calls it, or via `pi.expandTool`).
+	 */
+	tier?: "full" | "lazy";
 	/** Parameter schema (TypeBox) */
 	parameters: TParams;
 	/** Optional provider-side constrained sampling request for this tool. Set false to explicitly disable it, equivalent to leaving it undefined. */
@@ -1341,6 +1350,14 @@ export interface ExtensionAPI {
 
 	/** Set the active tools by name. */
 	setActiveTools(toolNames: string[]): void;
+
+	/**
+	 * Prompt Economy: force the full schema of a `tier: "lazy"` tool into the provider
+	 * payload for the current tool set (until the tool set changes). No-op for tools
+	 * with `tier` unset or `"full"`. Useful for intent-based routers that pre-expand
+	 * the tools the model is likely to need next turn.
+	 */
+	expandTool(name: string): void;
 
 	/** Get available slash commands in the current session. */
 	getCommands(): SlashCommandInfo[];


### PR DESCRIPTION
# [RFC] Tiered tool disclosure (Prompt Economy) — opt-in, additive core patch

> Ready-to-paste GitHub PR description for the pi repo
> (`https://github.com/earendil-works/pi`). Companion analysis: `analysis.md`.
> Full unified diff: `patch/0001-tiered-tools.patch` (validated with `git apply --check`).

---

## Problem

Tool schemas are the single biggest contributor to input-token bloat in tool-heavy
sessions, and they degrade model tool-selection quality long before the context
window is exhausted:

- **~72–77K tokens for 50 MCP tools** — measured by lunar.dev's *Dynamic Tool
  Discovery* writeup: ~72K tokens of tool definitions alone, ~77K total before any
  work begins; production reasoning budgets (10–20K tokens) become unusable.
- **Selection accuracy cliff** — Anthropic's evals show model tool-selection quality
  degrades markedly when 30–50 tools are presented simultaneously.
- **RAG-MCP** (arXiv 2505.03275): "prompt bloat" causes "functions [to] start to
  blur together"; retrieval-based tool selection lifts accuracy **13.62% → 43.13%**
  (3.2×) while cutting prompt tokens by >50%.
- **Industry data** (Medium, *How many tools*; Berkeley function-calling
  leaderboard): accuracy falls beyond ~10 tools; leaderboards cap at 37 functions.

Today pi sends **every active tool's full parameter schema on every turn**
(`agent.state.tools` → `Context.tools` → provider `tools[]`), and any
`setActiveToolsByName` rebuilds the entire system prompt (`agent-session.ts:941`),
which also invalidates provider prompt caches. Extension authors have no way to
declare "this tool is directory-only until needed."

## Proposed change (additive, opt-in)

A **`tier` concept** on tool definitions plus a **per-turn schema-expansion set**.
Default behavior is unchanged when `tier` is unset.

1. **`tier?: "full" | "lazy"`** on `ToolDefinition`
   (`packages/coding-agent/src/core/extensions/types.ts`).
   - `"full"` / unset → exactly today's behavior (full schema every turn).
   - `"lazy"` → the system-prompt directory one-liner (`promptSnippet`, already the
     "Available tools" mechanism) is always present, and the provider payload
     carries a tiny **directory stub** (name + label + description + empty schema)
     until the tool is expanded for a turn.
2. **Per-turn expansion set** in `AgentSession` (`_buildTurnTools`):
   - A lazy tool is expanded for the next turn automatically when the model calls
     it (the stub executes, returns an "expanded — re-issue with full arguments"
     hint), or explicitly via new `pi.expandTool(name)` (for intent-based routers).
   - Expanded tools are appended **last**, keeping the directory block byte-identical
     across turns — so provider prompt caches (`cache_control` is applied to the
     last tool on Anthropic and OpenAI-compat paths) keep the stable prefix cached
     and only the variable tail changes. No new cache API needed; the existing
     `cache_control` plumbing (anthropic-messages.ts:1320, openai-completions.ts:916)
     is preserved and *leveraged* by the ordering.
   - **No system-prompt rebuild on per-turn changes** — per-turn expansion only swaps
     `context.tools` via the existing `prepareNextTurnWithContext` hook
     (agent-session.ts:535), which already overrides per-turn tools. The cached
     system prompt stays stable.
3. **Cost model**: one extra round-trip (~1–2K tokens) on a lazy tool's first use,
   in exchange for not paying ~60K tokens of schemas on every turn. At 50 tools this
   moves the session from the "selection accuracy cliff" back to the "directory +
   a handful of expanded schemas" regime (mirroring RAG-MCP's retrieval result).

## Backward-compatibility guarantees

- **Byte-identical when `tier` is unset.** `_buildTurnTools` fast-paths to the
  previous behavior (`Array.from(baseTools ?? state.tools)`) when no lazy tools are
  registered; the system prompt is untouched unless a lazy tool is active (one
  synthesized guideline rides the existing `promptGuidelines` mechanism —
  `system-prompt.ts` is not modified).
- `registerTool` / `setActiveTools` / `setActiveToolsByName` signatures unchanged;
  `_refreshToolRegistry` still rebuilds the prompt on tool-*set* changes.
- Custom tool rendering is unaffected (renderers resolve via `getToolDefinition`,
  which reads full definitions, not `state.tools`).
- `expandTool` is a brand-new API; no existing extension calls it.
- The existing transcript-driven deferred-tools machinery (Anthropic
  `defer_loading`, Kimi mode) is untouched and complementary.

## Testing strategy

- **New tests** (faux-provider harness `test/suite/harness.ts`): assert per-turn
  `context.tools` contains stubs for lazy tools on turn 1, expands after a stub
  call, keeps the directory block stable, and that `agent.state.systemPrompt` is
  unchanged across expansions.
- **Regression suite = pi's own example extensions**: `dynamic-tools.ts`,
  `6162-extension-active-tools-next-turn.test.ts` (setActiveTools within a run),
  `agent-session-dynamic-tools.test.ts`, `compaction-extensions-example.test.ts`
  must pass with zero changes — proving default-path identity.
- Type-check (`tsgo -p tsconfig.build.json`) + biome.

## Diff sketch (key edit points)

Full patch: `patch/0001-tiered-tools.patch` (11 hunks, 2 files, 130 lines added).

**1. `extensions/types.ts` — `ToolDefinition` (~line 456):**
```ts
	/** ... existing promptSnippet / promptGuidelines ... */
	tier?: "full" | "lazy";   // NEW, optional
	/** Parameter schema (TypeBox) */
	parameters: TParams;
```

**2. `agent-session.ts` — new per-turn builder (~line 1099, next to `_rebuildSystemPrompt`):**
```ts
private _buildTurnTools(previousToolCallNames?: Iterable<string>, baseTools?: Iterable<AgentTool>): AgentTool[] {
	if (this._lazyToolNames.size === 0) {
		return Array.from(baseTools ?? this.agent.state.tools); // default path: identical
	}
	const expanded = new Set<string>(this._expandedToolNames);
	for (const name of previousToolCallNames ?? []) {
		if (this._lazyToolNames.has(name)) expanded.add(name);
	}
	const stable: AgentTool[] = [];
	const tail: AgentTool[] = [];
	for (const tool of baseTools ?? this.agent.state.tools) {
		if (!this._lazyToolNames.has(tool.name)) { stable.push(tool); continue; }
		if (expanded.has(tool.name)) tail.push(this._toolRegistry.get(tool.name) ?? tool);
		else stable.push(this._toolDirectoryStubs.get(tool.name) ?? tool);
	}
	return [...stable, ...tail]; // stable directory block first, expanded tail last
}
```

**3. `agent-session.ts` — two call sites (turn 1 + every later turn):**
```ts
// setActiveToolsByName (~:971)
this.agent.state.tools = this._buildTurnTools(undefined, tools);

// _installAgentNextTurnRefresh / prepareNextTurnWithContext (~:586)
const previousToolCallNames = turn.message.content
	.filter((block) => block.type === "toolCall")
	.map((block) => block.name);
tools: this._buildTurnTools(previousToolCallNames),
```

Plus: `_expandedToolNames` / `_lazyToolNames` / `_toolDirectoryStubs` state,
stub precomputation in `_refreshToolRegistry`, `createDirectoryStub()` helper
(empty-schema stub whose `execute` returns an "expanded — re-issue" hint), one
synthesized guideline for active lazy tools, and the `expandTool` SDK binding.

## Open questions for reviewers

1. Expansion trigger policy: auto-expand on call (this patch) vs. a dedicated
   `expand_tool` meta-tool (explicit, one more call) vs. intent-based pre-expansion
   from the user message (router-driven, via `pi.expandTool`).
2. Whether `tier` should also accept provider hints (e.g. map to Anthropic
   `defer_loading`) in a follow-up.
3. Docs: add a "Prompt Economy" section to `docs/extensions.md` and an example
   extension under `examples/extensions/` before merge.
