### PR TITLE
feat(ai): add synchronous speech generation

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -8,7 +8,9 @@
 	"sideEffects": [
 		"./dist/compat.js",
 		"./dist/images.js",
-		"./dist/providers/images/register-builtins.js"
+		"./dist/providers/images/register-builtins.js",
+		"./dist/speech.js",
+		"./dist/providers/speech/register-builtins.js"
 	],
 	"exports": {
 		".": {

--- a/packages/ai/src/api/minimax-speech.lazy.ts
+++ b/packages/ai/src/api/minimax-speech.lazy.ts
@@ -1,0 +1,6 @@
+import type { ProviderSpeech, SpeechModel } from "../types.ts";
+
+export const minimaxSpeechApi = (): ProviderSpeech => ({
+	generateSpeech: async (model, context, options) =>
+		(await import("./minimax-speech.ts")).generateSpeech(model as SpeechModel<"minimax-speech">, context, options),
+});

--- a/packages/ai/src/api/minimax-speech.ts
+++ b/packages/ai/src/api/minimax-speech.ts
@@ -1,0 +1,254 @@
+import type {
+	AssistantSpeech,
+	SpeechAudioFormat,
+	SpeechContext,
+	SpeechFunction,
+	SpeechModel,
+	SpeechOptions,
+} from "../types.ts";
+import { combineAbortSignals } from "../utils/abort-signals.ts";
+import { formatProviderError, normalizeProviderError, truncateErrorText } from "../utils/error-body.ts";
+import { headersToRecord, providerHeadersToRecord } from "../utils/headers.ts";
+import { retryProviderRequest } from "../utils/provider-retry.ts";
+
+interface MinimaxSpeechRequest {
+	model: string;
+	text: string;
+	stream: false;
+	language_boost?: string;
+	output_format: "hex" | "url";
+	voice_setting?: {
+		voice_id: string;
+		speed?: number;
+		vol?: number;
+		pitch?: number;
+		emotion?: string;
+	};
+	pronunciation_dict?: { tone?: string[] };
+	audio_setting?: {
+		sample_rate?: number;
+		bitrate?: number;
+		format?: SpeechAudioFormat;
+		channel?: number;
+	};
+	voice_modify?: {
+		pitch?: number;
+		intensity?: number;
+		timbre?: number;
+		sound_effects?: string;
+	};
+	subtitle_enable?: boolean;
+}
+
+interface MinimaxSpeechResponse {
+	data?: { audio?: string; status?: number } | null;
+	trace_id?: string;
+	base_resp?: { status_code?: number; status_msg?: string };
+}
+
+class SpeechHttpError extends Error {
+	status: number;
+	headers: Headers;
+	body: string;
+
+	constructor(response: Response, body: string) {
+		super(`Speech request failed with status ${response.status}`);
+		this.name = "SpeechHttpError";
+		this.status = response.status;
+		this.headers = response.headers;
+		this.body = truncateErrorText(body, 4000);
+	}
+}
+
+export const generateSpeech: SpeechFunction<"minimax-speech", SpeechOptions> = async (
+	model: SpeechModel<"minimax-speech">,
+	context: SpeechContext,
+	options?: SpeechOptions,
+) => {
+	const output: AssistantSpeech = {
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		output: [],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	let cleanupSignal = () => {};
+	try {
+		if (!options?.apiKey) {
+			throw new Error(`No API key for provider: ${model.provider}`);
+		}
+		if (context.text.length === 0) {
+			throw new Error("Speech text must not be empty");
+		}
+
+		let payload = buildPayload(model, context, options);
+		const nextPayload = await options.onPayload?.(payload, model);
+		if (nextPayload !== undefined) {
+			payload = nextPayload as MinimaxSpeechRequest;
+		}
+		const format = payload.audio_setting?.format ?? "mp3";
+		if (!model.audioFormats.includes(format)) {
+			throw new Error(`Unsupported audio format: ${format}`);
+		}
+
+		const timeoutController = options.timeoutMs === undefined ? undefined : new AbortController();
+		if (timeoutController) {
+			timeout = setTimeout(() => timeoutController.abort(new Error("Speech request timed out")), options.timeoutMs);
+		}
+		const combinedSignal = combineAbortSignals([options.signal, timeoutController?.signal]);
+		cleanupSignal = combinedSignal.cleanup;
+
+		const headers = providerHeadersToRecord({
+			...model.headers,
+			Authorization: `Bearer ${options.apiKey}`,
+			"Content-Type": "application/json",
+			...options.headers,
+		});
+		const requestFetch = options.fetch ?? globalThis.fetch;
+		const { response, responseBody } = await retryProviderRequest(
+			async () => {
+				const response = await requestFetch(model.baseUrl, {
+					method: "POST",
+					headers,
+					body: JSON.stringify(payload),
+					signal: combinedSignal.signal,
+				});
+				const responseBody = await response.text();
+				if (!response.ok) {
+					throw new SpeechHttpError(response, responseBody);
+				}
+				return { response, responseBody };
+			},
+			{
+				maxRetries: options.maxRetries,
+				maxRetryDelayMs: options.maxRetryDelayMs,
+				signal: combinedSignal.signal,
+			},
+		);
+		await options.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
+
+		const parsed = JSON.parse(responseBody) as MinimaxSpeechResponse;
+		const statusCode = parsed.base_resp?.status_code;
+		if (statusCode !== 0) {
+			throw new Error(
+				`Speech request failed (${statusCode ?? "unknown"}): ${parsed.base_resp?.status_msg ?? "unknown error"}`,
+			);
+		}
+		if (parsed.data?.status !== 2) {
+			throw new Error(`Speech response is incomplete (status ${parsed.data?.status ?? "missing"})`);
+		}
+		if (!parsed.data.audio) {
+			throw new Error("Speech response did not include audio");
+		}
+
+		const mimeType = audioMimeType(format);
+		output.responseId = parsed.trace_id;
+		output.output.push(
+			payload.output_format === "url"
+				? { type: "audio", url: validateAudioUrl(parsed.data.audio), mimeType }
+				: { type: "audio", data: hexToBase64(parsed.data.audio), mimeType },
+		);
+		return output;
+	} catch (error) {
+		output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+		output.errorMessage = formatProviderError(normalizeProviderError(error));
+		return output;
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout);
+		cleanupSignal();
+	}
+};
+
+function buildPayload(
+	model: SpeechModel<"minimax-speech">,
+	context: SpeechContext,
+	options: SpeechOptions,
+): MinimaxSpeechRequest {
+	return {
+		model: model.id,
+		text: context.text,
+		stream: false,
+		output_format: options.outputFormat ?? "hex",
+		...(options.languageBoost === undefined ? {} : { language_boost: options.languageBoost }),
+		...(options.voiceSetting === undefined
+			? {}
+			: {
+					voice_setting: {
+						voice_id: options.voiceSetting.voiceId,
+						...(options.voiceSetting.speed === undefined ? {} : { speed: options.voiceSetting.speed }),
+						...(options.voiceSetting.volume === undefined ? {} : { vol: options.voiceSetting.volume }),
+						...(options.voiceSetting.pitch === undefined ? {} : { pitch: options.voiceSetting.pitch }),
+						...(options.voiceSetting.emotion === undefined ? {} : { emotion: options.voiceSetting.emotion }),
+					},
+				}),
+		...(options.pronunciationDictionary === undefined ? {} : { pronunciation_dict: options.pronunciationDictionary }),
+		...(options.audioSetting === undefined
+			? {}
+			: {
+					audio_setting: {
+						...(options.audioSetting.sampleRate === undefined
+							? {}
+							: { sample_rate: options.audioSetting.sampleRate }),
+						...(options.audioSetting.bitrate === undefined ? {} : { bitrate: options.audioSetting.bitrate }),
+						...(options.audioSetting.format === undefined ? {} : { format: options.audioSetting.format }),
+						...(options.audioSetting.channel === undefined ? {} : { channel: options.audioSetting.channel }),
+					},
+				}),
+		...(options.voiceModification === undefined
+			? {}
+			: {
+					voice_modify: {
+						...(options.voiceModification.pitch === undefined ? {} : { pitch: options.voiceModification.pitch }),
+						...(options.voiceModification.intensity === undefined
+							? {}
+							: { intensity: options.voiceModification.intensity }),
+						...(options.voiceModification.timbre === undefined
+							? {}
+							: { timbre: options.voiceModification.timbre }),
+						...(options.voiceModification.soundEffects === undefined
+							? {}
+							: { sound_effects: options.voiceModification.soundEffects }),
+					},
+				}),
+		...(options.subtitleEnabled === undefined ? {} : { subtitle_enable: options.subtitleEnabled }),
+	};
+}
+
+function audioMimeType(format: SpeechAudioFormat): string {
+	switch (format) {
+		case "mp3":
+			return "audio/mpeg";
+		case "wav":
+			return "audio/wav";
+		case "flac":
+			return "audio/flac";
+		case "pcm":
+			return "audio/L16";
+	}
+}
+
+function validateAudioUrl(value: string): string {
+	const url = new URL(value);
+	if (url.protocol !== "https:" && url.protocol !== "http:") {
+		throw new Error(`Unsupported audio URL protocol: ${url.protocol}`);
+	}
+	return url.toString();
+}
+
+function hexToBase64(hex: string): string {
+	if (hex.length === 0 || hex.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(hex)) {
+		throw new Error("Speech response audio is not valid hexadecimal data");
+	}
+	const bytes = new Uint8Array(hex.length / 2);
+	for (let index = 0; index < bytes.length; index++) {
+		bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+	}
+	let binary = "";
+	for (let index = 0; index < bytes.length; index += 32768) {
+		binary += String.fromCharCode(...bytes.subarray(index, index + 32768));
+	}
+	return btoa(binary);
+}

--- a/packages/ai/src/compat.ts
+++ b/packages/ai/src/compat.ts
@@ -27,6 +27,10 @@ export * from "./images-api-registry.ts";
 export * from "./index.ts";
 export * from "./legacy-api-aliases.ts";
 export * from "./providers/images/register-builtins.ts";
+export * from "./providers/speech/register-builtins.ts";
+export * from "./speech.ts";
+export * from "./speech-api-registry.ts";
+export * from "./speech-models.ts";
 
 import { anthropicMessagesApi } from "./api/anthropic-messages.lazy.ts";
 import { azureOpenAIResponsesApi } from "./api/azure-openai-responses.lazy.ts";

--- a/packages/ai/src/providers/speech/register-builtins.ts
+++ b/packages/ai/src/providers/speech/register-builtins.ts
@@ -1,0 +1,46 @@
+import type { generateSpeech as generateMinimaxSpeechFunction } from "../../api/minimax-speech.ts";
+import { registerSpeechApiProvider } from "../../speech-api-registry.ts";
+import type { AssistantSpeech, SpeechContext, SpeechFunction, SpeechModel, SpeechOptions } from "../../types.ts";
+
+interface MinimaxSpeechProviderModule {
+	generateSpeech: typeof generateMinimaxSpeechFunction;
+}
+
+let minimaxSpeechProviderModulePromise: Promise<MinimaxSpeechProviderModule> | undefined;
+
+function loadMinimaxSpeechProviderModule(): Promise<MinimaxSpeechProviderModule> {
+	minimaxSpeechProviderModulePromise ??= import("../../api/minimax-speech.ts").then(
+		(module) => module as MinimaxSpeechProviderModule,
+	);
+	return minimaxSpeechProviderModulePromise;
+}
+
+export const generateSpeechMinimax: SpeechFunction<"minimax-speech", SpeechOptions> = async (
+	model: SpeechModel<"minimax-speech">,
+	context: SpeechContext,
+	options?: SpeechOptions,
+) => {
+	try {
+		const module = await loadMinimaxSpeechProviderModule();
+		return await module.generateSpeech(model, context, options);
+	} catch (error) {
+		return {
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			output: [],
+			stopReason: options?.signal?.aborted ? "aborted" : "error",
+			errorMessage: error instanceof Error ? error.message : String(error),
+			timestamp: Date.now(),
+		} satisfies AssistantSpeech;
+	}
+};
+
+export function registerBuiltInSpeechApiProviders(): void {
+	registerSpeechApiProvider({
+		api: "minimax-speech",
+		generateSpeech: generateSpeechMinimax,
+	});
+}
+
+registerBuiltInSpeechApiProviders();

--- a/packages/ai/src/speech-api-registry.ts
+++ b/packages/ai/src/speech-api-registry.ts
@@ -1,0 +1,37 @@
+import type { AssistantSpeech, SpeechApi, SpeechContext, SpeechFunction, SpeechModel, SpeechOptions } from "./types.ts";
+
+export type SpeechApiFunction = (
+	model: SpeechModel<SpeechApi>,
+	context: SpeechContext,
+	options?: SpeechOptions,
+) => Promise<AssistantSpeech>;
+
+export interface SpeechApiProvider<TApi extends SpeechApi = SpeechApi, TOptions extends SpeechOptions = SpeechOptions> {
+	api: TApi;
+	generateSpeech: SpeechFunction<TApi, TOptions>;
+}
+
+interface SpeechApiProviderInternal {
+	api: SpeechApi;
+	generateSpeech: SpeechApiFunction;
+}
+
+const speechApiProviderRegistry = new Map<string, SpeechApiProviderInternal>();
+
+export function registerSpeechApiProvider<TApi extends SpeechApi, TOptions extends SpeechOptions>(
+	provider: SpeechApiProvider<TApi, TOptions>,
+): void {
+	speechApiProviderRegistry.set(provider.api, {
+		api: provider.api,
+		generateSpeech: (model, context, options) => {
+			if (model.api !== provider.api) {
+				throw new Error(`Mismatched api: ${model.api} expected ${provider.api}`);
+			}
+			return provider.generateSpeech(model as SpeechModel<TApi>, context, options as TOptions);
+		},
+	});
+}
+
+export function getSpeechApiProvider(api: SpeechApi): SpeechApiProviderInternal | undefined {
+	return speechApiProviderRegistry.get(api);
+}

--- a/packages/ai/src/speech-models.ts
+++ b/packages/ai/src/speech-models.ts
@@ -1,0 +1,49 @@
+import type { KnownSpeechProvider, SpeechModel } from "./types.ts";
+
+export const SPEECH_MODEL_IDS = [
+	"speech-2.8-hd",
+	"speech-2.8-turbo",
+	"speech-2.6-hd",
+	"speech-2.6-turbo",
+	"speech-02-hd",
+	"speech-02-turbo",
+	"speech-01-hd",
+	"speech-01-turbo",
+] as const;
+
+export type SpeechModelId = (typeof SPEECH_MODEL_IDS)[number];
+
+function buildModels(
+	provider: KnownSpeechProvider,
+	baseUrl: string,
+): Record<SpeechModelId, SpeechModel<"minimax-speech">> {
+	const models = {} as Record<SpeechModelId, SpeechModel<"minimax-speech">>;
+	for (const id of SPEECH_MODEL_IDS) {
+		models[id] = {
+			id,
+			name: id,
+			api: "minimax-speech",
+			provider,
+			baseUrl,
+			audioFormats: ["mp3", "wav", "flac", "pcm"],
+		};
+	}
+	return models;
+}
+
+export const SPEECH_MODELS: Record<KnownSpeechProvider, Record<SpeechModelId, SpeechModel<"minimax-speech">>> = {
+	minimax: buildModels("minimax", "https://api.minimax.io/v1/t2a_v2"),
+	"minimax-cn": buildModels("minimax-cn", "https://api.minimaxi.com/v1/t2a_v2"),
+};
+
+export function getSpeechModel(provider: KnownSpeechProvider, modelId: SpeechModelId): SpeechModel<"minimax-speech"> {
+	return SPEECH_MODELS[provider][modelId];
+}
+
+export function getSpeechProviders(): KnownSpeechProvider[] {
+	return Object.keys(SPEECH_MODELS) as KnownSpeechProvider[];
+}
+
+export function getSpeechModels(provider: KnownSpeechProvider): SpeechModel<"minimax-speech">[] {
+	return Object.values(SPEECH_MODELS[provider]);
+}

--- a/packages/ai/src/speech.ts
+++ b/packages/ai/src/speech.ts
@@ -1,0 +1,16 @@
+import "./providers/speech/register-builtins.ts";
+
+import { getSpeechApiProvider } from "./speech-api-registry.ts";
+import type { AssistantSpeech, ProviderSpeechOptions, SpeechApi, SpeechContext, SpeechModel } from "./types.ts";
+
+export async function generateSpeech<TApi extends SpeechApi>(
+	model: SpeechModel<TApi>,
+	context: SpeechContext,
+	options?: ProviderSpeechOptions,
+): Promise<AssistantSpeech> {
+	const provider = getSpeechApiProvider(model.api);
+	if (!provider) {
+		throw new Error(`No API provider registered for api: ${model.api}`);
+	}
+	return provider.generateSpeech(model, context, options);
+}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -32,6 +32,10 @@ export type KnownImagesApi = "openrouter-images";
 
 export type ImagesApi = KnownImagesApi | (string & {});
 
+export type KnownSpeechApi = "minimax-speech";
+
+export type SpeechApi = KnownSpeechApi | (string & {});
+
 export type KnownProvider =
 	| "amazon-bedrock"
 	| "ant-ling"
@@ -78,6 +82,10 @@ export type ProviderId = KnownProvider | string;
 export type KnownImagesProvider = "openrouter";
 
 export type ImagesProviderId = KnownImagesProvider | string;
+
+export type KnownSpeechProvider = "minimax" | "minimax-cn";
+
+export type SpeechProviderId = KnownSpeechProvider | string;
 
 export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 export type ModelThinkingLevel = "off" | ThinkingLevel;
@@ -300,6 +308,58 @@ export interface ImagesOptions extends ProviderRequestOptions<ImagesModel<Images
 
 export type ProviderImagesOptions = ImagesOptions & Record<string, unknown>;
 
+/** The uniform contract implemented by speech-generation API modules. */
+export interface ProviderSpeech {
+	generateSpeech(
+		model: SpeechModel<SpeechApi>,
+		context: SpeechContext,
+		options?: SpeechOptions,
+	): Promise<AssistantSpeech>;
+}
+
+export type SpeechAudioFormat = "mp3" | "wav" | "flac" | "pcm";
+export type SpeechOutputFormat = "hex" | "url";
+
+export interface SpeechVoiceSetting {
+	voiceId: string;
+	speed?: number;
+	volume?: number;
+	pitch?: number;
+	emotion?: string;
+}
+
+export interface SpeechAudioSetting {
+	sampleRate?: number;
+	bitrate?: number;
+	format?: SpeechAudioFormat;
+	channel?: number;
+}
+
+export interface SpeechPronunciationDictionary {
+	tone?: string[];
+}
+
+export interface SpeechVoiceModification {
+	pitch?: number;
+	intensity?: number;
+	timbre?: number;
+	soundEffects?: string;
+}
+
+export interface SpeechOptions extends ProviderRequestOptions<SpeechModel<SpeechApi>> {
+	/** Synchronous HTTP speech generation only. */
+	stream?: false;
+	languageBoost?: string;
+	outputFormat?: SpeechOutputFormat;
+	voiceSetting?: SpeechVoiceSetting;
+	pronunciationDictionary?: SpeechPronunciationDictionary;
+	audioSetting?: SpeechAudioSetting;
+	voiceModification?: SpeechVoiceModification;
+	subtitleEnabled?: boolean;
+}
+
+export type ProviderSpeechOptions = SpeechOptions & Record<string, unknown>;
+
 // Unified options with reasoning passed to streamSimple() and completeSimple()
 export interface SimpleStreamOptions extends StreamOptions {
 	reasoning?: ThinkingLevel;
@@ -328,6 +388,12 @@ export type ImagesFunction<TApi extends ImagesApi = ImagesApi, TOptions extends 
 	context: ImagesContext,
 	options?: TOptions,
 ) => Promise<AssistantImages>;
+
+export type SpeechFunction<TApi extends SpeechApi = SpeechApi, TOptions extends SpeechOptions = SpeechOptions> = (
+	model: SpeechModel<TApi>,
+	context: SpeechContext,
+	options?: TOptions,
+) => Promise<AssistantSpeech>;
 
 export interface TextSignatureV1 {
 	v: 1;
@@ -471,6 +537,27 @@ export interface AssistantImages {
 	responseId?: string;
 	usage?: Usage;
 	stopReason: ImagesStopReason;
+	errorMessage?: string;
+	timestamp: number; // Unix timestamp in milliseconds
+}
+
+export interface SpeechContext {
+	text: string;
+}
+
+export type SpeechAudioContent =
+	| { type: "audio"; data: string; mimeType: string }
+	| { type: "audio"; url: string; mimeType: string };
+
+export type SpeechStopReason = "stop" | "error" | "aborted";
+
+export interface AssistantSpeech {
+	api: SpeechApi;
+	provider: SpeechProviderId;
+	model: string;
+	output: SpeechAudioContent[];
+	responseId?: string;
+	stopReason: SpeechStopReason;
 	errorMessage?: string;
 	timestamp: number; // Unix timestamp in milliseconds
 }
@@ -827,4 +914,14 @@ export interface ImagesModel<TApi extends ImagesApi>
 	api: TApi;
 	provider: ImagesProviderId;
 	output: ("text" | "image")[];
+}
+
+export interface SpeechModel<TApi extends SpeechApi> {
+	id: string;
+	name: string;
+	api: TApi;
+	provider: SpeechProviderId;
+	baseUrl: string;
+	audioFormats: readonly SpeechAudioFormat[];
+	headers?: Record<string, string>;
 }

--- a/packages/ai/test/minimax-speech.test.ts
+++ b/packages/ai/test/minimax-speech.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateSpeech } from "../src/speech.ts";
+import { getSpeechModel, getSpeechModels } from "../src/speech-models.ts";
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json", "x-request-id": "request-1" },
+	});
+}
+
+describe("MiniMax speech", () => {
+	it("catalogs every configured model for global and CN endpoints", () => {
+		expect(getSpeechModels("minimax").map((model) => model.id)).toEqual([
+			"speech-2.8-hd",
+			"speech-2.8-turbo",
+			"speech-2.6-hd",
+			"speech-2.6-turbo",
+			"speech-02-hd",
+			"speech-02-turbo",
+			"speech-01-hd",
+			"speech-01-turbo",
+		]);
+		expect(getSpeechModels("minimax-cn")).toHaveLength(8);
+		expect(getSpeechModel("minimax", "speech-2.8-hd").baseUrl).toBe("https://api.minimax.io/v1/t2a_v2");
+		expect(getSpeechModel("minimax-cn", "speech-2.8-hd").baseUrl).toBe("https://api.minimaxi.com/v1/t2a_v2");
+	});
+
+	it("sends the synchronous request schema and converts hexadecimal audio to base64", async () => {
+		const fetch = vi.fn(
+			async (_input: Parameters<typeof globalThis.fetch>[0], _init?: Parameters<typeof globalThis.fetch>[1]) =>
+				jsonResponse({
+					data: { audio: "48656c6c6f", status: 2 },
+					trace_id: "trace-1",
+					base_resp: { status_code: 0, status_msg: "success" },
+				}),
+		);
+		const onResponse = vi.fn();
+		const model = getSpeechModel("minimax", "speech-2.8-hd");
+
+		const result = await generateSpeech(
+			model,
+			{ text: "Hello" },
+			{
+				apiKey: "test-key",
+				fetch,
+				onResponse,
+				languageBoost: "English",
+				voiceSetting: { voiceId: "English_expressive_narrator", speed: 1, volume: 0.8, pitch: 0 },
+				pronunciationDictionary: { tone: ["Omg/Oh my god"] },
+				audioSetting: { sampleRate: 32000, bitrate: 128000, format: "mp3", channel: 1 },
+				voiceModification: { pitch: 0, intensity: 1, timbre: 2, soundEffects: "spacious_echo" },
+				subtitleEnabled: true,
+			},
+		);
+
+		expect(result).toMatchObject({
+			stopReason: "stop",
+			responseId: "trace-1",
+			output: [{ type: "audio", data: "SGVsbG8=", mimeType: "audio/mpeg" }],
+		});
+		expect(fetch).toHaveBeenCalledOnce();
+		const [url, init] = fetch.mock.calls[0];
+		expect(url).toBe("https://api.minimax.io/v1/t2a_v2");
+		expect(new Headers(init?.headers).get("authorization")).toBe("Bearer test-key");
+		expect(JSON.parse(String(init?.body))).toEqual({
+			model: "speech-2.8-hd",
+			text: "Hello",
+			stream: false,
+			output_format: "hex",
+			language_boost: "English",
+			voice_setting: {
+				voice_id: "English_expressive_narrator",
+				speed: 1,
+				vol: 0.8,
+				pitch: 0,
+			},
+			pronunciation_dict: { tone: ["Omg/Oh my god"] },
+			audio_setting: { sample_rate: 32000, bitrate: 128000, format: "mp3", channel: 1 },
+			voice_modify: { pitch: 0, intensity: 1, timbre: 2, sound_effects: "spacious_echo" },
+			subtitle_enable: true,
+		});
+		expect(onResponse).toHaveBeenCalledWith(expect.objectContaining({ status: 200 }), model);
+	});
+
+	it("uses the CN endpoint and preserves URL output", async () => {
+		const fetch = vi.fn(
+			async (_input: Parameters<typeof globalThis.fetch>[0], _init?: Parameters<typeof globalThis.fetch>[1]) =>
+				jsonResponse({
+					data: { audio: "https://audio.example.test/result.wav", status: 2 },
+					base_resp: { status_code: 0, status_msg: "success" },
+				}),
+		);
+		const result = await generateSpeech(
+			getSpeechModel("minimax-cn", "speech-2.8-turbo"),
+			{ text: "你好" },
+			{
+				apiKey: "test-key",
+				fetch,
+				outputFormat: "url",
+				audioSetting: { format: "wav" },
+			},
+		);
+
+		expect(fetch.mock.calls[0][0]).toBe("https://api.minimaxi.com/v1/t2a_v2");
+		expect(result.output).toEqual([
+			{ type: "audio", url: "https://audio.example.test/result.wav", mimeType: "audio/wav" },
+		]);
+	});
+
+	it("returns API status failures as error results", async () => {
+		const result = await generateSpeech(
+			getSpeechModel("minimax", "speech-2.8-hd"),
+			{ text: "Hello" },
+			{
+				apiKey: "test-key",
+				fetch: async () =>
+					jsonResponse({
+						data: null,
+						base_resp: { status_code: 2013, status_msg: "invalid input parameters" },
+					}),
+			},
+		);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.output).toEqual([]);
+		expect(result.errorMessage).toContain("2013");
+	});
+
+	it("rejects incomplete audio responses", async () => {
+		const result = await generateSpeech(
+			getSpeechModel("minimax", "speech-2.8-hd"),
+			{ text: "Hello" },
+			{
+				apiKey: "test-key",
+				fetch: async () =>
+					jsonResponse({
+						data: { audio: "4869", status: 1 },
+						base_resp: { status_code: 0, status_msg: "success" },
+					}),
+			},
+		);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("incomplete");
+	});
+
+	it("passes through abort signals", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const result = await generateSpeech(
+			getSpeechModel("minimax", "speech-2.8-hd"),
+			{ text: "Hello" },
+			{
+				apiKey: "test-key",
+				signal: controller.signal,
+				fetch: async (_input, init) => {
+					init?.signal?.throwIfAborted();
+					return jsonResponse({});
+				},
+			},
+		);
+
+		expect(result.stopReason).toBe("aborted");
+		expect(result.output).toEqual([]);
+	});
+});


### PR DESCRIPTION
Reason: Add the missing synchronous speech-generation SDK path for the configured global and CN endpoints.

- Add typed speech generation types, registry, and model catalogs for both regional endpoints.
- Add synchronous bearer-authenticated transport with request mapping, status validation, and hex or URL audio decoding.
- Add unit coverage for the catalog, schema, regional routing, parsing, error handling, and cancellation.

Checks:
- `npm run check`
- `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/minimax-speech.test.ts`
