### PR TITLE
fix: triggerTurn: false should not start turn

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1449,7 +1449,7 @@ export class AgentSession {
 		} satisfies CustomMessage<T>;
 		if (options?.deliverAs === "nextTurn") {
 			this._pendingNextTurnMessages.push(appMessage);
-		} else if (this.isStreaming) {
+		} else if (this.isStreaming && options?.triggerTurn !== false) {
 			if (options?.deliverAs === "followUp") {
 				this.agent.followUp(appMessage);
 			} else {


### PR DESCRIPTION
Addresses #7783.

Issue was that an `agent_end` extension handler sending a custom display message with `{ triggerTurn: false }` was still consuming a second faux response, proving it started an unintended turn: `sendCustomMessage()` routed all messages through the streaming `agent.steer()` path while `isStreaming` was true, ignoring `triggerTurn: false`. Easy fix, we add this condition.

Verified by rerunning the repro test.