### PR TITLE
docs(coding-agent): refresh development setup, testing, and project structure                                                                              

### DIFF
--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -1,23 +1,25 @@
 # Development
 
-See [AGENTS.md](https://github.com/earendil-works/pi-mono/blob/main/AGENTS.md) for additional guidelines.
+See [AGENTS.md](../../AGENTS.md) for additional guidelines.
 
 ## Setup
 
 ```bash
-git clone https://github.com/earendil-works/pi-mono
-cd pi-mono
-npm install
-npm run build
+git clone git@github.com:earendil-works/pi.git
+cd pi
+npm install --ignore-scripts  # Install all dependencies without running lifecycle scripts
+npm run build         # Refresh model data, then build all packages
+npm run build:offline # Rebuild using existing model data without network access
+npm run check         # Lint, format, and type check
 ```
 
 Run from source:
 
 ```bash
-/path/to/pi-mono/pi-test.sh
+./pi-test.sh
 ```
 
-The script can be run from any directory. Pi keeps the caller's current working directory.
+The script can be run from any directory. Pi keeps the caller's current working directory. Pass `--no-env` to run without API keys (unsets provider credential environment variables).
 
 ## Forking / Rebranding
 
@@ -55,17 +57,33 @@ Never use `__dirname` directly for package assets.
 ## Testing
 
 ```bash
-./test.sh                         # Run non-LLM tests (no API keys needed)
-npm test                          # Run all tests
-npm test -- test/specific.test.ts # Run specific test
+./test.sh         # Run non-LLM tests in an isolated home (no API keys needed)
+npm test          # Run all tests (requires API keys for LLM-dependent tests)
+```
+
+`./test.sh` wipes the environment and runs `npm test` with an empty temporary `HOME`, so it never picks up your credentials or user resources. To run a specific test file, invoke the workspace test runner directly:
+
+```bash
+# Vitest (most packages)
+node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/specific.test.ts
+
+# node:test (packages/tui)
+node --test test/specific.test.ts
 ```
 
 ## Project Structure
 
 ```
 packages/
-  ai/           # LLM provider abstraction
-  agent/        # Agent loop and message types  
-  tui/          # Terminal UI components
-  coding-agent/ # CLI and interactive mode
+  ai/                     # @earendil-works/pi-ai: unified multi-provider LLM API with model discovery
+  agent/                  # @earendil-works/pi-agent-core: agent runtime, transport abstraction, state, attachments
+  tui/                    # @earendil-works/pi-tui: terminal UI library with differential rendering
+  coding-agent/           # @earendil-works/pi-coding-agent: interactive coding agent CLI
+  telemetry/              # @earendil-works/pi-telemetry: vendor-neutral telemetry contracts and typed schemas
+  protocol/               # @earendil-works/pi-protocol: transport-neutral CBOR protocol for remote sessions
+  client/                 # @earendil-works/pi-client: transport-neutral client over framed CBOR bytes
+  server/                 # @earendil-works/pi-server: experimental server package
+  session-backends/
+    sqlite-node/          # @earendil-works/pi-session-backend-sqlite-node: Node sqlite session backend
+  evals/                  # @earendil-works/pi-evals: evaluations
 ```


### PR DESCRIPTION
  ## Summary                                                                                                                                                 
                                                                                                                                                              
   `packages/coding-agent/docs/development.md` was out of date relative to the                                                                                
   repo root README and the current monorepo layout.                                                                                                          
                                                                                                                                                              
   ## Changes                                                                                                                                                 
                                                                                                                                                              
   - **Setup**: switch clone URL to `git@github.com:earendil-works/pi.git` and                                                                                
     directory to `pi`; align commands with the root README                                                                                                   
     (`npm install --ignore-scripts`, `npm run build:offline`, `npm run check`).                                                                              
   - **Run from source**: use `./pi-test.sh` and document the `--no-env` flag.                                                                                
   - **Testing**: note that `./test.sh` runs in an isolated empty HOME and never                                                                              
     picks up local credentials. Replace the incorrect                                                                                                        
     `npm test -- test/specific.test.ts` example with the supported direct                                                                                    
     invocations (Vitest for most packages, `node --test` for `packages/tui`).                                                                                
   - **Project structure**: list all packages under `packages/` with accurate                                                                                 
     descriptions, including the nested `session-backends/sqlite-node`, and note                                                                              
     that `server` is experimental.                                                                                                                           
   - Link `AGENTS.md` via a relative path instead of a fixed GitHub URL.                                                                                      
                                                                                                                                                              
   ## Testing                                                                                                                                                 
                                                                                                                                                              
   Docs only; no code changes. `npm run check` passes via the pre-commit hook.          