### PR TITLE
feat(tui): dispatch mouse events to components via onMouse

### DIFF
--- a/packages/tui/src/layout.ts
+++ b/packages/tui/src/layout.ts
@@ -408,3 +408,29 @@ export function getScrollViewsAt(frame: LayoutFrame, x: number, y: number): Scro
 	result.sort((a, b) => b.depth - a.depth);
 	return result.map((entry) => entry.scrollView);
 }
+
+export interface ComponentMouseTarget {
+	component: Component;
+	/** Row relative to the component's box (0 = first rendered line). */
+	row: number;
+	/** Column relative to the component's box. */
+	col: number;
+}
+
+/**
+ * Find the deepest layout box containing the point whose component opts into
+ * `onMouse`. Children are hit-tested before their parents, so the most
+ * specific component wins. Relative row/col are offsets from that box's rect.
+ */
+export function getComponentMouseTarget(frame: LayoutFrame, x: number, y: number): ComponentMouseTarget | undefined {
+	let best: ComponentMouseTarget | undefined;
+	const visit = (box: LayoutBox): void => {
+		if (!containsPoint(box.rect, x, y) || !containsPoint(box.clip, x, y)) return;
+		if (typeof box.component.onMouse === "function") {
+			best = { component: box.component, row: y - box.rect.y, col: x - box.rect.x };
+		}
+		for (const child of box.children) visit(child);
+	};
+	visit(frame.root);
+	return best;
+}

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -9,6 +9,7 @@ import { ScrollView } from "./components/scroll-view.ts";
 import { getKeybindings } from "./keybindings.ts";
 import { isKeyRelease } from "./keys.ts";
 import {
+	getComponentMouseTarget,
 	getScrollbarGeometry,
 	getScrollViewBox,
 	getScrollViewsAt,
@@ -30,6 +31,8 @@ import {
 } from "./terminal-image.ts";
 import {
 	type Component,
+	type ComponentMouseEvent,
+	type ComponentMouseEventResult,
 	CURSOR_MARKER,
 	compositeTuiLine,
 	type OverlayHandle,
@@ -529,6 +532,44 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		return this.isOverlayFocused() && this.activeSearch?.overlay?.isFocused() !== true;
 	}
 
+	/**
+	 * Dispatch a mouse event to components that opted into `onMouse`.
+	 *
+	 * Hit-testing order: visible overlays (frontmost first, using the geometry
+	 * recorded by compositeOverlays), then the layout tree (deepest box
+	 * containing the pointer). Returns true when a component handled the event
+	 * — the caller then skips the built-in scrollbar/selection/viewport handling.
+	 */
+	private dispatchMouseEvent(event: Omit<ComponentMouseEvent, "row" | "col">): boolean {
+		for (const entry of [...this.overlayStack].reverse()) {
+			if (!this.isOverlayVisible(entry) || typeof entry.component.onMouse !== "function") continue;
+			const geometry = entry.geometry;
+			if (!geometry) continue;
+			const { row, col, width, height } = geometry;
+			if (event.x < col || event.x >= col + width || event.y < row || event.y >= row + height) {
+				continue;
+			}
+			const result: ComponentMouseEventResult | undefined = entry.component.onMouse({
+				...event,
+				row: event.y - row,
+				col: event.x - col,
+			});
+			if (result?.handled) return true;
+		}
+		if (this.currentLayout) {
+			const target = getComponentMouseTarget(this.currentLayout, event.x, event.y);
+			if (target) {
+				const result: ComponentMouseEventResult | undefined = target.component.onMouse?.({
+					...event,
+					row: target.row,
+					col: target.col,
+				});
+				if (result?.handled) return true;
+			}
+		}
+		return false;
+	}
+
 	private handleViewportInput(data: string): { consume?: boolean } | undefined {
 		if (data === FOCUS_OUT) {
 			const hadActiveSelection = this.selectionPressActive;
@@ -553,12 +594,33 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 		const wheelEvent = this.parseWheelEvent(data);
 		if (wheelEvent) {
+			if (
+				this.dispatchMouseEvent({
+					button: wheelEvent.direction === -1 ? 64 : 65,
+					x: wheelEvent.x,
+					y: wheelEvent.y,
+					release: false,
+					wheel: wheelEvent.direction,
+				})
+			) {
+				return { consume: true };
+			}
 			if (this.shouldDeferViewportInputToOverlay()) return undefined;
 			this.routeWheel(wheelEvent);
 			return { consume: true };
 		}
 		const mouseEvent = this.parseSgrMouseEvent(data);
 		if (mouseEvent) {
+			if (
+				this.dispatchMouseEvent({
+					button: mouseEvent.button,
+					x: mouseEvent.x,
+					y: mouseEvent.y,
+					release: mouseEvent.release,
+				})
+			) {
+				return { consume: true };
+			}
 			if (this.handleRightClickPaste(mouseEvent)) return { consume: true };
 			const handled = this.handleScrollbarMouseEvent(mouseEvent);
 			if (!this.scrollbarDrag) this.updateScrollbarHover(mouseEvent.x, mouseEvent.y);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -18,6 +18,38 @@ import { getCapabilities, isImageLine, setCellDimensions } from "./terminal-imag
 import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.ts";
 
 /**
+ * Mouse event delivered to a component's `onMouse` handler (fullscreen TUI only).
+ *
+ * Coordinates are 0-based: `x`/`y` are terminal screen coordinates, `row`/`col`
+ * are relative to the component's own box (row 0 = the component's first
+ * rendered line).
+ */
+export interface ComponentMouseEvent {
+	/** Raw SGR button code (bits: 0-1 button, 4 shift, 5 meta, 6 wheel). */
+	button: number;
+	/** Terminal column (0-based). */
+	x: number;
+	/** Terminal row (0-based). */
+	y: number;
+	/** Row relative to the component's box (0 = first rendered line). */
+	row: number;
+	/** Column relative to the component's box. */
+	col: number;
+	/** True for a button release (SGR "m"). */
+	release: boolean;
+	/** Wheel direction (-1 up, 1 down) when this is a wheel event. */
+	wheel?: -1 | 1;
+}
+
+export interface ComponentMouseEventResult {
+	/**
+	 * True if the component handled the event. Handled events skip the built-in
+	 * scrollbar, selection, and viewport-scroll handling for that event.
+	 */
+	handled: boolean;
+}
+
+/**
  * Component interface - all components must implement this
  */
 export interface Component {
@@ -38,6 +70,14 @@ export interface Component {
 	 * Default is false - release events are filtered out.
 	 */
 	wantsKeyRelease?: boolean;
+
+	/**
+	 * Optional handler for mouse events on the component's own rows.
+	 * Dispatched in fullscreen mode (TuiAltScreen) before the built-in
+	 * scrollbar and selection handling. Return `{ handled: true }` to keep
+	 * selection and scrolling out of it.
+	 */
+	onMouse?(event: ComponentMouseEvent): ComponentMouseEventResult | undefined;
 
 	/**
 	 * Invalidate any cached rendering state.
@@ -191,6 +231,8 @@ type OverlayStackEntry = {
 	preFocus: Component | null;
 	hidden: boolean;
 	focusOrder: number;
+	/** Screen-space geometry of the last rendered frame (set by compositeOverlays). */
+	geometry?: { row: number; col: number; width: number; height: number };
 };
 
 type OverlayBlockedFocusResume = { status: "restore-overlay" } | { status: "focus-target"; target: Component | null };
@@ -353,7 +395,7 @@ export abstract class TuiBase extends Container implements TUI {
 
 	// Overlay stack for modal components rendered on top of base content
 	private focusOrderCounter = 0;
-	private overlayStack: OverlayStackEntry[] = [];
+	protected overlayStack: OverlayStackEntry[] = [];
 
 	get hasOverlayEntries(): boolean {
 		return this.overlayStack.length > 0;
@@ -670,7 +712,7 @@ export abstract class TuiBase extends Container implements TUI {
 	}
 
 	/** Check if an overlay entry is currently visible */
-	private isOverlayVisible(entry: OverlayStackEntry): boolean {
+	protected isOverlayVisible(entry: OverlayStackEntry): boolean {
 		if (entry.hidden) return false;
 		if (entry.options?.visible) {
 			return entry.options.visible(this.terminal.columns, this.terminal.rows);
@@ -1101,7 +1143,7 @@ export abstract class TuiBase extends Container implements TUI {
 		const result = [...lines];
 
 		// Pre-render all visible overlays and calculate positions
-		const rendered: { overlayLines: string[]; row: number; col: number; w: number }[] = [];
+		const rendered: { entry: OverlayStackEntry; overlayLines: string[]; row: number; col: number; w: number }[] = [];
 		let minLinesNeeded = result.length;
 
 		const visibleEntries = this.overlayStack.filter((e) => this.isOverlayVisible(e));
@@ -1124,7 +1166,7 @@ export abstract class TuiBase extends Container implements TUI {
 			// Get final row/col with actual overlay height
 			const { row, col } = this.resolveOverlayLayout(options, overlayLines.length, termWidth, termHeight);
 
-			rendered.push({ overlayLines, row, col, w: width });
+			rendered.push({ entry, overlayLines, row, col, w: width });
 			minLinesNeeded = Math.max(minLinesNeeded, row + overlayLines.length);
 		}
 
@@ -1139,6 +1181,11 @@ export abstract class TuiBase extends Container implements TUI {
 		}
 
 		const viewportStart = Math.max(0, workingHeight - termHeight);
+
+		// Record screen-space geometry for mouse hit-testing (dispatchMouseEvent).
+		for (const { entry, overlayLines, row, col, w } of rendered) {
+			entry.geometry = { row: viewportStart + row, col, width: w, height: overlayLines.length };
+		}
 
 		// Composite each overlay
 		for (const { overlayLines, row, col, w } of rendered) {

--- a/packages/tui/test/mouse-events.test.ts
+++ b/packages/tui/test/mouse-events.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { ScrollView } from "../src/components/scroll-view.ts";
+import { Text } from "../src/components/text.ts";
+import { VStack } from "../src/components/v-stack.ts";
+import type { Component, ComponentMouseEvent, ComponentMouseEventResult } from "../src/tui.ts";
+import { TuiAltScreen } from "../src/tui-alt-screen.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+/**
+ * Component that records mouse events and handles them.
+ */
+class MouseComponent implements Component {
+	readonly events: ComponentMouseEvent[] = [];
+	private readonly lines: string[];
+	private readonly handle: (event: ComponentMouseEvent) => ComponentMouseEventResult | undefined;
+
+	constructor(
+		lines: string[],
+		handle: (event: ComponentMouseEvent) => ComponentMouseEventResult | undefined = () => ({ handled: true }),
+	) {
+		this.lines = lines;
+		this.handle = handle;
+	}
+	onMouse(event: ComponentMouseEvent): ComponentMouseEventResult | undefined {
+		this.events.push(event);
+		return this.handle(event);
+	}
+
+	render(width: number): string[] {
+		return this.lines.map((line) => line.slice(0, width));
+	}
+
+	invalidate(): void {}
+}
+
+/** Layout: scrollable transcript on top, mouse target docked below. */
+function buildTui(terminal: VirtualTerminal, target: Component) {
+	const transcriptText = new Text(Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n"), 0, 0);
+	const transcript = new ScrollView(transcriptText, { follow: "end", primary: true });
+	const tui = new TuiAltScreen(terminal);
+	tui.setLayoutRoot(
+		new VStack([
+			{ component: transcript, basis: 0, grow: 1, minSize: 1 },
+			{ component: target, basis: "auto", minSize: 1 },
+		]),
+	);
+	return { tui, transcript, transcriptText };
+}
+
+describe("TuiAltScreen component mouse events", () => {
+	it("delivers wheel events to a layout component and skips viewport scrolling", async () => {
+		const terminal = new VirtualTerminal(20, 6);
+		const target = new MouseComponent(["target"]);
+		const { tui, transcript } = buildTui(terminal, target);
+		tui.start();
+		await terminal.waitForRender();
+		const before = tui.viewportTop;
+
+		// Wheel up at row 6 (1-based) = the docked target's only row.
+		terminal.sendInput("\x1b[<64;1;6M");
+		await terminal.waitForRender();
+
+		assert.strictEqual(target.events.length, 1);
+		assert.deepStrictEqual(
+			{ ...target.events[0] },
+			{ button: 64, x: 0, y: 5, row: 0, col: 0, release: false, wheel: -1 },
+		);
+		assert.strictEqual(tui.viewportTop, before, "viewport must not scroll when a component handles the wheel");
+		assert.strictEqual(transcript.isFollowingEnd, true);
+		tui.stop();
+	});
+
+	it("delivers wheel events with box-relative coordinates", async () => {
+		const terminal = new VirtualTerminal(20, 6);
+		const target = new MouseComponent(["first", "second"]);
+		const { tui } = buildTui(terminal, target);
+		tui.start();
+		await terminal.waitForRender();
+
+		// Wheel down at row 6, column 5 → target row 1, col 4.
+		terminal.sendInput("\x1b[<65;5;6M");
+		await terminal.waitForRender();
+
+		assert.strictEqual(target.events.length, 1);
+		assert.strictEqual(target.events[0]?.wheel, 1);
+		assert.strictEqual(target.events[0]?.row, 1);
+		assert.strictEqual(target.events[0]?.col, 4);
+		tui.stop();
+	});
+
+	it("falls through to viewport scrolling when the component does not handle", async () => {
+		const terminal = new VirtualTerminal(20, 6);
+		const target = new MouseComponent(["target"], () => undefined);
+		const { tui } = buildTui(terminal, target);
+		tui.start();
+		await terminal.waitForRender();
+		const before = tui.viewportTop;
+
+		terminal.sendInput("\x1b[<64;1;6M");
+		await terminal.waitForRender();
+
+		assert.strictEqual(target.events.length, 1, "component still observes the event");
+		assert.strictEqual(tui.viewportTop, before - 1, "unhandled wheel falls through to the viewport");
+		tui.stop();
+	});
+
+	it("delivers click press and release to a layout component", async () => {
+		const terminal = new VirtualTerminal(20, 6);
+		const target = new MouseComponent(["target"]);
+		const { tui } = buildTui(terminal, target);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;3;6M");
+		terminal.sendInput("\x1b[<0;3;6m");
+		await terminal.waitForRender();
+
+		assert.strictEqual(target.events.length, 2);
+		assert.strictEqual(target.events[0]?.release, false);
+		assert.strictEqual(target.events[0]?.button, 0);
+		assert.strictEqual(target.events[1]?.release, true);
+		assert.strictEqual(target.events[1]?.col, 2);
+		tui.stop();
+	});
+
+	it("delivers events to the frontmost overlay before the layout beneath it", async () => {
+		const terminal = new VirtualTerminal(20, 8);
+		const overlay = new MouseComponent(["overlay"]);
+		const layoutTarget = new MouseComponent(["target"]);
+		const { tui } = buildTui(terminal, layoutTarget);
+		tui.showOverlay(overlay, { anchor: "top-left", width: 10, margin: 1 });
+		tui.start();
+		await terminal.waitForRender();
+
+		// Overlay occupies row 1, col 1..10. Click inside it.
+		terminal.sendInput("\x1b[<0;2;2M");
+		terminal.sendInput("\x1b[<0;2;2m");
+		await terminal.waitForRender();
+
+		assert.strictEqual(overlay.events.length, 2, "overlay receives the click");
+		assert.strictEqual(overlay.events[0]?.row, 0);
+		assert.strictEqual(overlay.events[0]?.col, 0);
+		assert.strictEqual(layoutTarget.events.length, 0, "layout beneath the overlay must not receive it");
+		tui.stop();
+	});
+
+	it("delivers wheel to a focused overlay via onMouse instead of handleInput", async () => {
+		const terminal = new VirtualTerminal(20, 6);
+		const overlay = new MouseComponent(["overlay"]);
+		const { tui, transcript } = buildTui(terminal, new MouseComponent(["target"]));
+		tui.showOverlay(overlay, { anchor: "bottom-center", width: 10, margin: 1 });
+		tui.start();
+		await terminal.waitForRender();
+		const before = tui.viewportTop;
+
+		// Bottom-center overlay in a 20x6 terminal: col 5..15, row 4.
+		terminal.sendInput("\x1b[<64;10;5M");
+		await terminal.waitForRender();
+
+		assert.strictEqual(overlay.events.length, 1);
+		assert.strictEqual(overlay.events[0]?.wheel, -1);
+		assert.strictEqual(overlay.events[0]?.row, 0);
+		assert.strictEqual(overlay.events[0]?.col, 4);
+		assert.strictEqual(tui.viewportTop, before, "viewport stays put: overlay handled the wheel");
+		assert.strictEqual(transcript.isFollowingEnd, true);
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## What

Implement the `Component.onMouse` hook proposed in #7683 so extension widgets and overlays can receive mouse events in the fullscreen TUI.

## Why

`TuiAltScreen` swallows every mouse event (wheel and SGR clicks) in its viewport input listener before extensions can observe them. Extension UI (widgets, `ctx.ui.custom` overlays such as a side-question popup) therefore cannot scroll with the wheel or handle clicks in fullscreen mode — the wheel always scrolls the chat viewport instead.

## Changes

- `Component.onMouse?(event)` — new optional hook with terminal coordinates plus `row`/`col` relative to the component's box (`ComponentMouseEvent`, `ComponentMouseEventResult` in `packages/tui/src/tui.ts`).
- Dispatch in `TuiAltScreen.handleViewportInput`, before the built-in scrollbar/selection/viewport handling:
  - visible overlays first, frontmost first, using the screen-space geometry recorded by `compositeOverlays`;
  - then the layout tree, deepest box containing the pointer (`getComponentMouseTarget` in `packages/tui/src/layout.ts`).
  - A `{ handled: true }` result consumes the event; unhandled events fall through to the existing behavior unchanged.
- `overlayStack` / `isOverlayVisible` move from private to protected for the alt-screen subclass.

## Tests

New `packages/tui/test/mouse-events.test.ts` (6 cases): wheel to a layout component skips viewport scrolling; box-relative coordinates; fall-through when unhandled; click press/release; overlay hit-testing before the layout beneath it; wheel to a focused overlay. Full tui suite: 918/918 pass. `biome check` and `tsgo` on `packages/tui` are clean.

Note: repo-wide `npm run check` and `./test.sh` fail on main regardless of this change — `packages/ai/src/providers/data/` is missing from the checkout (model data must be hydrated with `npm run hydrate-model-data`), which also breaks the `packages/ai`, `packages/agent`, and `packages/coding-agent` test files.

Closes #7683
