### PR TITLE
feat(ai): add Grok 4.6

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -414,7 +414,7 @@ const OPENAI_RESPONSES_NONE_REASONING_MODELS = new Set([
 	"gpt-5.6-terra",
 	"gpt-5.6-luna",
 ]);
-const XAI_RESPONSES_MODEL_ID = "grok-4.5";
+const XAI_RESPONSES_MODEL_IDS = new Set(["grok-4.5", "grok-4.6"]);
 const XAI_BUILTIN_EXCLUDED_MODEL_IDS = new Set([
 	"grok-3",
 	"grok-3-fast",
@@ -827,7 +827,7 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	) {
 		mergeThinkingLevelMap(model, { off: "none" });
 	}
-	if (model.provider === "xai" && model.api === "openai-responses" && model.id === XAI_RESPONSES_MODEL_ID) {
+	if (model.provider === "xai" && model.api === "openai-responses" && XAI_RESPONSES_MODEL_IDS.has(model.id)) {
 		mergeThinkingLevelMap(model, XAI_RESPONSES_EFFORT_LEVEL_MAP);
 	}
 	if (supportsOpenAiXhigh(model.id)) {
@@ -1636,7 +1636,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 			for (const [modelId, model] of Object.entries(data.xai.models)) {
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
-				const useResponsesApi = modelId === XAI_RESPONSES_MODEL_ID;
+				const useResponsesApi = XAI_RESPONSES_MODEL_IDS.has(modelId);
 
 				models.push({
 					id: modelId,

--- a/packages/ai/test/xai-responses.test.ts
+++ b/packages/ai/test/xai-responses.test.ts
@@ -72,9 +72,11 @@ describe("xAI Responses provider", () => {
 		}
 	});
 
-	it("uses Responses with low/medium/high efforts only for Grok 4.5", () => {
+	it("uses Responses for Grok 4.5 and 4.6", () => {
 		expect(XAI_MODELS["grok-4.5"].api).toBe("openai-responses");
 		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.5"])).toEqual(["low", "medium", "high"]);
+		expect(XAI_MODELS["grok-4.6"].api).toBe("openai-responses");
+		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.6"])).toEqual(["low", "medium", "high", "xhigh"]);
 		expect(XAI_MODELS["grok-4.3"].api).toBe("openai-completions");
 	});
 


### PR DESCRIPTION
## Summary

- add Grok 4.6 to the xAI Responses model set
- preserve Grok 4.6's `low`, `medium`, `high`, and `xhigh` reasoning levels
- cover the generated catalog behavior in the xAI Responses test

xAI lists Grok 4.6 as a text/image reasoning model with Responses-compatible reasoning effort controls. models.dev now includes it in the xAI catalog.

## Verification

- `npm run check`
- `npm --prefix packages/ai run generate-models`
- `npm --prefix packages/ai run check:model-data`
- `node node_modules/vitest/dist/cli.js --run test/xai-responses.test.ts` from `packages/ai`

`./test.sh` was also run on Windows. The xAI tests passed; unrelated suites failed on existing Windows-specific symlink, Unix-socket, path-separator, and unbuilt workspace-dist assumptions.

This pull request is AI-generated by Pi.