### PR TITLE
fix(bedrock): expose safe stream failure diagnostics

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Re-exported the generic assistant message event-stream factory for low-level `Agent` stream wrappers.
+
 ### Fixed
 
+- Fixed `streamProxy()` dropping terminal assistant diagnostics.
+- Fixed `streamProxy()` leaving consumers unresolved when a proxy response ended without a terminal event.
 - Fixed `streamProxy()` dropping finalized tool-call metadata such as OpenAI Responses namespaces ([#7709](https://github.com/earendil-works/pi/issues/7709)).
 
 ## [0.84.1] - 2026-08-07

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,6 @@
 // Core Agent
 
-export { uuidv7 } from "@earendil-works/pi-ai";
+export { createAssistantMessageEventStream, uuidv7 } from "@earendil-works/pi-ai";
 export type {
 	AttributeValue,
 	ExactTelemetryAttributes,

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -48,12 +48,14 @@ export type ProxyAssistantMessageEvent =
 			type: "done";
 			reason: Extract<StopReason, "stop" | "length" | "toolUse">;
 			usage: AssistantMessage["usage"];
+			diagnostics?: AssistantMessage["diagnostics"];
 	  }
 	| {
 			type: "error";
 			reason: Extract<StopReason, "aborted" | "error">;
 			errorMessage?: string;
 			usage: AssistantMessage["usage"];
+			diagnostics?: AssistantMessage["diagnostics"];
 	  };
 
 type ProxySerializableStreamOptions = Pick<
@@ -181,6 +183,7 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 			reader = response.body!.getReader();
 			const decoder = new TextDecoder();
 			let buffer = "";
+			let terminalEventReceived = false;
 
 			while (true) {
 				const { done, value } = await reader.read();
@@ -201,6 +204,9 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 							const proxyEvent = JSON.parse(data) as ProxyAssistantMessageEvent;
 							const event = processProxyEvent(proxyEvent, partial);
 							if (event) {
+								if (event.type === "done" || event.type === "error") {
+									terminalEventReceived = true;
+								}
 								stream.push(event);
 							}
 						}
@@ -210,6 +216,22 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 
 			if (options.signal?.aborted) {
 				throw new Error("Request aborted by user");
+			}
+			if (!terminalEventReceived) {
+				partial.stopReason = "error";
+				partial.errorMessage = "Proxy stream ended without a terminal event";
+				partial.diagnostics = [
+					...(partial.diagnostics ?? []),
+					{
+						type: "bedrock_response_failure",
+						timestamp: Date.now(),
+						details: {
+							phase: "stream_completion",
+							failureClass: "transient_transport_failure",
+						},
+					},
+				];
+				stream.push({ type: "error", reason: "error", error: partial });
 			}
 
 			stream.end();
@@ -353,12 +375,14 @@ function processProxyEvent(
 		case "done":
 			partial.stopReason = proxyEvent.reason;
 			partial.usage = proxyEvent.usage;
+			partial.diagnostics = proxyEvent.diagnostics;
 			return { type: "done", reason: proxyEvent.reason, message: partial };
 
 		case "error":
 			partial.stopReason = proxyEvent.reason;
 			partial.errorMessage = proxyEvent.errorMessage;
 			partial.usage = proxyEvent.usage;
+			partial.diagnostics = proxyEvent.diagnostics;
 			return { type: "error", reason: proxyEvent.reason, error: partial };
 
 		default: {

--- a/packages/agent/test/index-exports.test.ts
+++ b/packages/agent/test/index-exports.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { createAssistantMessageEventStream } from "../src/index.ts";
+
+describe("pi-agent-core exports", () => {
+	it("exposes the generic assistant message event-stream factory", () => {
+		const stream = createAssistantMessageEventStream();
+
+		expect(stream).toBeDefined();
+		expect(stream.result).toBeTypeOf("function");
+	});
+});

--- a/packages/agent/test/proxy.test.ts
+++ b/packages/agent/test/proxy.test.ts
@@ -29,6 +29,114 @@ afterEach(() => {
 });
 
 describe("streamProxy", () => {
+	it("settles a clean proxy EOF without a terminal event as a safe transport failure", async () => {
+		const body = `data: ${JSON.stringify({ type: "start" } satisfies ProxyAssistantMessageEvent)}\n\n`;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(body, { status: 200 })),
+		);
+
+		const stream = streamProxy(
+			model,
+			{ systemPrompt: "", messages: [] },
+			{ authToken: "test-token", proxyUrl: "https://proxy.example.com" },
+		);
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) events.push(event);
+		const result = await stream.result();
+
+		expect(events.map((event) => event.type)).toEqual(["start", "error"]);
+		expect(result).toMatchObject({
+			stopReason: "error",
+			errorMessage: "Proxy stream ended without a terminal event",
+			diagnostics: [
+				{
+					type: "bedrock_response_failure",
+					details: {
+						phase: "stream_completion",
+						failureClass: "transient_transport_failure",
+					},
+				},
+			],
+		});
+	});
+
+	it("keeps an aborted proxy read non-diagnostic", async () => {
+		const abortController = new AbortController();
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					new TextEncoder().encode(
+						`data: ${JSON.stringify({ type: "start" } satisfies ProxyAssistantMessageEvent)}\n\n`,
+					),
+				);
+			},
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(body, { status: 200 })),
+		);
+		const stream = streamProxy(
+			model,
+			{ systemPrompt: "", messages: [] },
+			{
+				authToken: "test-token",
+				proxyUrl: "https://proxy.example.com",
+				signal: abortController.signal,
+			},
+		);
+		const events: AssistantMessageEvent[] = [];
+		const consumePromise = (async () => {
+			for await (const event of stream) events.push(event);
+		})();
+		await vi.waitFor(() => expect(events.map((event) => event.type)).toEqual(["start"]));
+
+		abortController.abort();
+		await consumePromise;
+		const result = await stream.result();
+
+		expect(events.map((event) => event.type)).toEqual(["start", "error"]);
+		expect(result.stopReason).toBe("aborted");
+		expect(result.diagnostics).toBeUndefined();
+	});
+
+	it("preserves terminal diagnostics on the reconstructed assistant message", async () => {
+		const diagnostics: NonNullable<AssistantMessage["diagnostics"]> = [
+			{
+				type: "bedrock_response_failure",
+				timestamp: 123,
+				details: {
+					phase: "stream_event",
+					failureClass: "ModelStreamErrorException",
+					requestId: "request-123",
+				},
+			},
+		];
+		const proxyEvents: ProxyAssistantMessageEvent[] = [
+			{ type: "start" },
+			{
+				type: "error",
+				reason: "error",
+				errorMessage: "Model stream error",
+				usage,
+				diagnostics,
+			},
+		];
+		const body = proxyEvents.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(body, { status: 200 })),
+		);
+
+		const result = await streamProxy(
+			model,
+			{ systemPrompt: "", messages: [] },
+			{ authToken: "test-token", proxyUrl: "https://proxy.example.com" },
+		).result();
+
+		expect(result.diagnostics).toEqual(diagnostics);
+	});
+
 	it("preserves tool-call metadata received only on toolcall_end", async () => {
 		const proxyEvents: ProxyAssistantMessageEvent[] = [
 			{ type: "start" },
@@ -75,5 +183,7 @@ describe("streamProxy", () => {
 			arguments: { value: "hello" },
 			namespace: "dynamic_tools",
 		});
+		expect(events.filter((event) => event.type === "done")).toHaveLength(1);
+		expect(events.some((event) => event.type === "error")).toBe(false);
 	});
 });

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### Changed
 
+- Enriched Amazon Bedrock failure diagnostics with bounded phase and failure classification plus AWS SDK attempt and retry-delay metadata.
 - Automatically converted supported strict tool schemas to provider-compatible closed objects with required nullable optional fields while preserving original tool definitions, and treated `null` values for optional non-nullable tool arguments as omitted.
 - Changed OpenAI Responses deferred tool loading to prefer message-anchored `additional_tools` where supported while retaining tool-search and top-level fallbacks ([#7709](https://github.com/earendil-works/pi/issues/7709)).
 - Replaced the Mistral SDK transport with a native Chat Completions HTTP stream, eliminating its generated client and schema runtime overhead.
 
 ### Fixed
 
+- Fixed terminal-less Amazon Bedrock streams being indistinguishable from other provider failures.
 - Fixed GitHub Copilot login triggering API rate limits while enabling model policies by limiting concurrent policy updates ([#6187](https://github.com/earendil-works/pi/issues/6187)).
 - Fixed upstream request buffer limit failures to trigger automatic assistant retries.
 - Fixed OpenAI Responses function and custom tool calls to preserve namespaces during streaming, proxying, and replay ([#7709](https://github.com/earendil-works/pi/issues/7709)).

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -66,6 +66,34 @@ import { transformMessages } from "./transform-messages.ts";
 
 export type BedrockThinkingDisplay = "summarized" | "omitted";
 
+export type BedrockFailurePhase = "send" | "stream_event" | "stream_completion";
+
+export type BedrockFailureClass =
+	| "AccessDeniedException"
+	| "InternalServerException"
+	| "ModelErrorException"
+	| "ModelNotReadyException"
+	| "ModelStreamErrorException"
+	| "ModelTimeoutException"
+	| "ResourceNotFoundException"
+	| "ServiceQuotaExceededException"
+	| "ServiceUnavailableException"
+	| "ThrottlingException"
+	| "ValidationException"
+	| "transient_transport_failure"
+	| "missing_terminal_response"
+	| "unknown";
+
+export interface BedrockFailureDiagnosticDetails {
+	phase: BedrockFailurePhase;
+	failureClass: BedrockFailureClass;
+	status?: number;
+	errorCode?: string;
+	requestId?: string;
+	sdkAttempts?: number;
+	sdkTotalRetryDelayMs?: number;
+}
+
 export interface BedrockOptions extends StreamOptions {
 	region?: string;
 	profile?: string;
@@ -222,7 +250,10 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 
 		// Kept outside the try so the catch can still correlate a mid-stream failure:
 		// exceptions delivered as stream events carry no HTTP metadata of their own.
-		let responseRequestId: string | undefined;
+		let failurePhase: BedrockFailurePhase = "send";
+		let responseMetadata: SdkResponseMetadata | undefined;
+		let streamEventFailure: StreamEventFailure | undefined;
+		let completionFailureClass: BedrockFailureClass | undefined;
 
 		try {
 			const supportsStrictMode = model.compat?.supportsStrictMode ?? false;
@@ -252,7 +283,8 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 			const command = new ConverseStreamCommand(commandInput);
 
 			const response = await client.send(command, { abortSignal: options.signal });
-			responseRequestId = normalizeDiagnosticValue(response.$metadata.requestId);
+			responseMetadata = normalizeSdkResponseMetadata(response.$metadata);
+			failurePhase = "stream_event";
 			if (response.$metadata.httpStatusCode !== undefined) {
 				const responseHeaders: Record<string, string> = {};
 				if (response.$metadata.requestId) {
@@ -283,23 +315,33 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 				} else if (item.metadata) {
 					handleMetadata(item.metadata, model, output);
 				} else if (item.internalServerException) {
+					streamEventFailure = createStreamEventFailure("InternalServerException", 500);
 					throw item.internalServerException;
 				} else if (item.modelStreamErrorException) {
+					streamEventFailure = createStreamEventFailure(
+						"ModelStreamErrorException",
+						item.modelStreamErrorException.originalStatusCode,
+					);
 					throw item.modelStreamErrorException;
 				} else if (item.validationException) {
+					streamEventFailure = createStreamEventFailure("ValidationException", 400);
 					throw item.validationException;
 				} else if (item.throttlingException) {
+					streamEventFailure = createStreamEventFailure("ThrottlingException", 429);
 					throw item.throttlingException;
 				} else if (item.serviceUnavailableException) {
+					streamEventFailure = createStreamEventFailure("ServiceUnavailableException", 503);
 					throw item.serviceUnavailableException;
 				}
 			}
+			failurePhase = "stream_completion";
 
 			if (options.signal?.aborted) {
 				throw new Error("Request was aborted");
 			}
 
 			if (output.stopReason === "pending") {
+				completionFailureClass = "missing_terminal_response";
 				throw new Error("Bedrock stream ended without a stop reason");
 			}
 			if (output.stopReason === "error" || output.stopReason === "aborted") {
@@ -317,7 +359,14 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 			output.stopReason = options.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatBedrockError(error);
 			if (output.stopReason === "error") {
-				appendBedrockFailureDiagnostic(output, error, responseRequestId);
+				appendBedrockFailureDiagnostic(
+					output,
+					error,
+					failurePhase,
+					responseMetadata,
+					streamEventFailure,
+					completionFailureClass,
+				);
 			}
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
@@ -374,7 +423,26 @@ function formatBedrockError(error: unknown): string {
 	return `${core}${dataRetentionHint}`;
 }
 
-type SdkErrorMetadata = { $metadata?: { httpStatusCode?: unknown; requestId?: unknown } };
+type SdkMetadata = {
+	httpStatusCode?: unknown;
+	requestId?: unknown;
+	attempts?: unknown;
+	totalRetryDelay?: unknown;
+};
+
+type SdkErrorMetadata = { $metadata?: SdkMetadata };
+
+interface SdkResponseMetadata {
+	requestId?: string;
+	sdkAttempts?: number;
+	sdkTotalRetryDelayMs?: number;
+}
+
+interface StreamEventFailure {
+	failureClass: BedrockFailureClass;
+	status?: number;
+	errorCode: string;
+}
 
 /** Over-long header values are dropped rather than truncated: a truncated request id is not a request id. */
 const MAX_BEDROCK_DIAGNOSTIC_VALUE_CHARS = 200;
@@ -384,6 +452,31 @@ function normalizeDiagnosticValue(value: unknown): string | undefined {
 	const trimmed = value.trim();
 	if (trimmed.length === 0 || trimmed.length > MAX_BEDROCK_DIAGNOSTIC_VALUE_CHARS) return undefined;
 	return trimmed;
+}
+
+function normalizeNonNegativeNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function normalizeSdkAttempts(value: unknown): number | undefined {
+	const normalized = normalizeNonNegativeNumber(value);
+	return normalized !== undefined && Number.isInteger(normalized) && normalized >= 1 ? normalized : undefined;
+}
+
+function normalizeSdkResponseMetadata(metadata: SdkMetadata): SdkResponseMetadata {
+	return {
+		requestId: normalizeDiagnosticValue(metadata.requestId),
+		sdkAttempts: normalizeSdkAttempts(metadata.attempts),
+		sdkTotalRetryDelayMs: normalizeNonNegativeNumber(metadata.totalRetryDelay),
+	};
+}
+
+function createStreamEventFailure(failureClass: BedrockFailureClass, status: unknown): StreamEventFailure {
+	return {
+		failureClass,
+		status: normalizeNonNegativeNumber(status),
+		errorCode: failureClass,
+	};
 }
 
 /**
@@ -396,30 +489,87 @@ function extractBedrockErrorCode(error: unknown): string | undefined {
 	return normalizeDiagnosticValue(error.name);
 }
 
+const BEDROCK_FAILURE_CLASSES = new Set<BedrockFailureClass>([
+	"AccessDeniedException",
+	"InternalServerException",
+	"ModelErrorException",
+	"ModelNotReadyException",
+	"ModelStreamErrorException",
+	"ModelTimeoutException",
+	"ResourceNotFoundException",
+	"ServiceQuotaExceededException",
+	"ServiceUnavailableException",
+	"ThrottlingException",
+	"ValidationException",
+]);
+
+const TRANSIENT_TRANSPORT_ERROR_NAMES = new Set(["TimeoutError"]);
+const TRANSIENT_TRANSPORT_ERROR_CODES = new Set([
+	"EAI_AGAIN",
+	"ECONNREFUSED",
+	"ECONNRESET",
+	"EHOSTUNREACH",
+	"ENETDOWN",
+	"ENETUNREACH",
+	"ETIMEDOUT",
+	"UND_ERR_CONNECT_TIMEOUT",
+	"UND_ERR_SOCKET",
+]);
+
+function classifyBedrockFailure(error: unknown, errorCode: string | undefined): BedrockFailureClass {
+	if (errorCode !== undefined && BEDROCK_FAILURE_CLASSES.has(errorCode as BedrockFailureClass)) {
+		return errorCode as BedrockFailureClass;
+	}
+	if (error instanceof Error && TRANSIENT_TRANSPORT_ERROR_NAMES.has(error.name)) {
+		return "transient_transport_failure";
+	}
+	const transportCode = (error as { code?: unknown })?.code;
+	if (typeof transportCode === "string" && TRANSIENT_TRANSPORT_ERROR_CODES.has(transportCode)) {
+		return "transient_transport_failure";
+	}
+	return "unknown";
+}
+
 /**
  * Structured metadata alongside `errorMessage`, which stays byte-identical because `isRetryableAssistantError`
- * matches against it. Unknown fields are omitted, never guessed: a modeled mid-stream exception reaches us as
- * a bare object literal, leaving only `fallbackRequestId`. `details` only, as the throw is not always `Error`.
+ * matches against it. Phase and a closed failure class are always present; unavailable provider metadata is
+ * omitted rather than inferred. The diagnostic intentionally excludes the raw thrown value and response body.
  */
 function appendBedrockFailureDiagnostic(
 	output: AssistantMessage,
 	error: unknown,
-	fallbackRequestId: string | undefined,
+	phase: BedrockFailurePhase,
+	responseMetadata: SdkResponseMetadata | undefined,
+	streamEventFailure: StreamEventFailure | undefined,
+	completionFailureClass: BedrockFailureClass | undefined,
 ): void {
 	const metadata = (error as SdkErrorMetadata)?.$metadata;
-	const details: Record<string, unknown> = {};
+	const errorCode = streamEventFailure?.errorCode ?? extractBedrockErrorCode(error);
+	const sdkMetadata = phase === "send" ? normalizeSdkResponseMetadata(metadata ?? {}) : responseMetadata;
+	const details: BedrockFailureDiagnosticDetails = {
+		phase,
+		failureClass:
+			streamEventFailure?.failureClass ?? completionFailureClass ?? classifyBedrockFailure(error, errorCode),
+	};
 
-	if (typeof metadata?.httpStatusCode === "number") details.status = metadata.httpStatusCode;
+	const status = streamEventFailure?.status ?? normalizeNonNegativeNumber(metadata?.httpStatusCode);
+	if (status !== undefined) details.status = status;
 
-	const errorCode = extractBedrockErrorCode(error);
 	if (errorCode !== undefined) details.errorCode = errorCode;
 
-	const requestId = normalizeDiagnosticValue(metadata?.requestId) ?? fallbackRequestId;
+	const requestId = normalizeDiagnosticValue(metadata?.requestId) ?? sdkMetadata?.requestId;
 	if (requestId !== undefined) details.requestId = requestId;
 
-	if (Object.keys(details).length === 0) return;
+	if (sdkMetadata?.sdkAttempts !== undefined) details.sdkAttempts = sdkMetadata.sdkAttempts;
+	if (sdkMetadata?.sdkTotalRetryDelayMs !== undefined) {
+		details.sdkTotalRetryDelayMs = sdkMetadata.sdkTotalRetryDelayMs;
+	}
 
-	appendAssistantMessageDiagnostic(output, { type: "bedrock_response_failure", timestamp: Date.now(), details });
+	appendAssistantMessageDiagnostic(output, {
+		type: "bedrock_response_failure",
+		timestamp: Date.now(),
+		details: { ...details },
+	});
 }
 
 /**

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -8,7 +8,13 @@ export { Type } from "typebox";
 // "@earendil-works/pi-ai/compat".
 export type { AnthropicEffort, AnthropicOptions, AnthropicThinkingDisplay } from "./api/anthropic-messages.ts";
 export type { AzureOpenAIResponsesOptions } from "./api/azure-openai-responses.ts";
-export type { BedrockOptions, BedrockThinkingDisplay } from "./api/bedrock-converse-stream.ts";
+export type {
+	BedrockFailureClass,
+	BedrockFailureDiagnosticDetails,
+	BedrockFailurePhase,
+	BedrockOptions,
+	BedrockThinkingDisplay,
+} from "./api/bedrock-converse-stream.ts";
 export type { GoogleOptions } from "./api/google-generative-ai.ts";
 export type { GoogleThinkingLevel } from "./api/google-shared.ts";
 export type { GoogleVertexOptions } from "./api/google-vertex.ts";

--- a/packages/ai/test/bedrock-error-metadata.test.ts
+++ b/packages/ai/test/bedrock-error-metadata.test.ts
@@ -49,7 +49,6 @@ vi.mock("@aws-sdk/client-bedrock-runtime", () => {
 });
 
 import { stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
-import { getModel } from "../src/compat.ts";
 import type { AssistantMessage, Context, Model } from "../src/types.ts";
 import type { AssistantMessageDiagnostic } from "../src/utils/diagnostics.ts";
 
@@ -62,7 +61,18 @@ const context: Context = {
 };
 
 function getModelFixture(): Model<"bedrock-converse-stream"> {
-	return getModel("amazon-bedrock", "us.anthropic.claude-opus-4-8");
+	return {
+		id: "us.anthropic.claude-opus-4-8",
+		name: "Claude Opus 4.8",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32000,
+	};
 }
 
 /** What the SDK's `handleError` path throws for a non-2xx response; `name` is the modeled AWS error code. */
@@ -104,7 +114,12 @@ describe("bedrock failure diagnostics", () => {
 		bedrockMock.send = {
 			kind: "reject",
 			error: makeServiceException("ValidationException", {
-				$metadata: { httpStatusCode: 400, requestId: REQUEST_ID },
+				$metadata: {
+					httpStatusCode: 400,
+					requestId: REQUEST_ID,
+					attempts: 3,
+					totalRetryDelay: 750,
+				},
 			}),
 		};
 
@@ -112,7 +127,15 @@ describe("bedrock failure diagnostics", () => {
 		const diagnostic = findDiagnostic(message);
 
 		expect(message.stopReason).toBe("error");
-		expect(diagnostic?.details).toEqual({ status: 400, errorCode: "ValidationException", requestId: REQUEST_ID });
+		expect(diagnostic?.details).toEqual({
+			phase: "send",
+			failureClass: "ValidationException",
+			status: 400,
+			errorCode: "ValidationException",
+			requestId: REQUEST_ID,
+			sdkAttempts: 3,
+			sdkTotalRetryDelayMs: 750,
+		});
 		expect(diagnostic?.error).toBeUndefined();
 		expect(Object.keys(diagnostic ?? {}).sort()).toEqual(["details", "timestamp", "type"]);
 	});
@@ -129,14 +152,61 @@ describe("bedrock failure diagnostics", () => {
 		expect((await runBedrock()).errorMessage).toBe(`Validation error: ${VALIDATION_MESSAGE}`);
 	});
 
-	it("reports only the request id for a modeled mid-stream exception", async () => {
-		// The SDK throws a bare object literal here, so the code is genuinely unavailable.
-		bedrockMock.send = respondWithFailingStream({ message: "Too many requests, please wait." });
+	it("classifies a modeled mid-stream exception and retains successful send metadata", async () => {
+		bedrockMock.send = {
+			kind: "resolve",
+			response: {
+				$metadata: {
+					httpStatusCode: 200,
+					requestId: REQUEST_ID,
+					attempts: 2,
+					totalRetryDelay: 125,
+				},
+				stream: (async function* () {
+					yield { messageStart: { role: "assistant" } };
+					yield { throttlingException: { message: "Too many requests, please wait." } };
+				})(),
+			},
+		};
 
 		const message = await runBedrock();
 
 		expect(message.stopReason).toBe("error");
-		expect(findDiagnostic(message)?.details).toEqual({ requestId: REQUEST_ID });
+		expect(findDiagnostic(message)?.details).toEqual({
+			phase: "stream_event",
+			failureClass: "ThrottlingException",
+			status: 429,
+			errorCode: "ThrottlingException",
+			requestId: REQUEST_ID,
+			sdkAttempts: 2,
+			sdkTotalRetryDelayMs: 125,
+		});
+	});
+
+	it("uses the modeled original status for a model stream error", async () => {
+		bedrockMock.send = {
+			kind: "resolve",
+			response: {
+				$metadata: { httpStatusCode: 200, requestId: REQUEST_ID },
+				stream: (async function* () {
+					yield { messageStart: { role: "assistant" } };
+					yield {
+						modelStreamErrorException: {
+							message: "The provider stream failed",
+							originalStatusCode: 529,
+						},
+					};
+				})(),
+			},
+		};
+
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			phase: "stream_event",
+			failureClass: "ModelStreamErrorException",
+			status: 529,
+			errorCode: "ModelStreamErrorException",
+			requestId: REQUEST_ID,
+		});
 	});
 
 	it("captures the error code for an unmodeled mid-stream error", async () => {
@@ -146,6 +216,8 @@ describe("bedrock failure diagnostics", () => {
 		bedrockMock.send = respondWithFailingStream(unmodeled);
 
 		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			phase: "stream_event",
+			failureClass: "ModelStreamErrorException",
 			errorCode: "ModelStreamErrorException",
 			requestId: REQUEST_ID,
 		});
@@ -157,17 +229,63 @@ describe("bedrock failure diagnostics", () => {
 		timeout.name = "TimeoutError";
 		bedrockMock.send = respondWithFailingStream(timeout);
 
-		expect(findDiagnostic(await runBedrock())?.details).toEqual({ requestId: REQUEST_ID });
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			phase: "stream_event",
+			failureClass: "transient_transport_failure",
+			requestId: REQUEST_ID,
+		});
 	});
 
-	it("emits no diagnostic when the failure carries no provider metadata", async () => {
+	it("classifies a stream that ends without a terminal stop reason", async () => {
+		bedrockMock.send = {
+			kind: "resolve",
+			response: {
+				$metadata: { httpStatusCode: 200, requestId: REQUEST_ID, attempts: 1, totalRetryDelay: 0 },
+				stream: (async function* () {
+					yield { messageStart: { role: "assistant" } };
+				})(),
+			},
+		};
+
+		const message = await runBedrock();
+
+		expect(message.errorMessage).toBe("Bedrock stream ended without a stop reason");
+		expect(findDiagnostic(message)?.details).toEqual({
+			phase: "stream_completion",
+			failureClass: "missing_terminal_response",
+			requestId: REQUEST_ID,
+			sdkAttempts: 1,
+			sdkTotalRetryDelayMs: 0,
+		});
+	});
+
+	it("does not misclassify an explicit provider error stop as a missing terminal response", async () => {
+		bedrockMock.send = {
+			kind: "resolve",
+			response: {
+				$metadata: { httpStatusCode: 200, requestId: REQUEST_ID },
+				stream: (async function* () {
+					yield { messageStart: { role: "assistant" } };
+					yield { messageStop: { stopReason: "guardrail_intervened" } };
+				})(),
+			},
+		};
+
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			phase: "stream_completion",
+			failureClass: "unknown",
+			requestId: REQUEST_ID,
+		});
+	});
+
+	it("classifies a failure without provider metadata as unknown", async () => {
 		bedrockMock.send = { kind: "reject", error: new Error("socket hang up") };
 
 		const message = await runBedrock();
 
 		expect(message.stopReason).toBe("error");
 		expect(message.errorMessage).toBe("socket hang up");
-		expect(findDiagnostic(message)).toBeUndefined();
+		expect(findDiagnostic(message)?.details).toEqual({ phase: "send", failureClass: "unknown" });
 	});
 
 	it("emits no diagnostic for an aborted turn", async () => {
@@ -194,7 +312,11 @@ describe("bedrock failure diagnostics", () => {
 			}),
 		};
 
-		expect(findDiagnostic(await runBedrock())?.details).toEqual({ status: 400 });
+		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			phase: "send",
+			failureClass: "unknown",
+			status: 400,
+		});
 	});
 
 	it("omits the SDK's Unknown placeholder instead of reporting it as a code", async () => {
@@ -205,6 +327,8 @@ describe("bedrock failure diagnostics", () => {
 		};
 
 		expect(findDiagnostic(await runBedrock())?.details).toEqual({
+			phase: "send",
+			failureClass: "unknown",
 			status: 403,
 			requestId: REQUEST_ID,
 		});


### PR DESCRIPTION
## Summary

- classify Amazon Bedrock send, stream-event, and stream-completion failures with bounded structured diagnostics
- preserve terminal diagnostics and finalized tool-call metadata through `streamProxy`
- settle a proxy stream that reaches EOF without a terminal event as a safe transient transport failure
- export the generic assistant event-stream factory for low-level stream wrappers

## Safety

Diagnostics contain only closed failure classes, bounded provider identifiers, status, and AWS SDK attempt metadata. Raw provider exceptions and response bodies are not included. Aborted requests remain diagnostic-free.

## Verification

- `npm test --workspace @earendil-works/pi-agent-core -- test/proxy.test.ts test/index-exports.test.ts` (5 passed)
- `npm test --workspace @earendil-works/pi-ai -- test/bedrock-error-metadata.test.ts` (12 passed)
- `npm run check`
- `npm run build:offline`
- `git diff --check`
