### PR TITLE
feat: use local Ollama models in pi via a local model proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
 		"diff:model-catalog": "node scripts/diff-model-catalog.mjs",
 		"eval": "npm run eval --workspace=@earendil-works/pi-evals --",
 		"check:model-catalog": "node scripts/publish-model-catalog.mjs --input .artifacts/model-catalog --dry-run",
+		"ollama:proxy": "node scripts/ollama/ollama-proxy.mjs",
+		"ollama:pi": "node scripts/ollama/pi-with-ollama.mjs",
 		"profile:tui": "node scripts/profile-coding-agent-node.mjs --mode tui",
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",
 		"test": "npm run test:scripts && npm run test --workspaces --if-present",

--- a/scripts/ollama/README.md
+++ b/scripts/ollama/README.md
@@ -1,0 +1,76 @@
+# Ollama models for pi
+
+Use local [Ollama](https://ollama.com) models in the pi coding agent through a small local model proxy.
+
+Two scripts, run in order:
+
+1. `ollama-proxy.mjs` — starts a local LLM model proxy in front of the Ollama server. pi talks to the proxy's OpenAI-compatible endpoint (`http://127.0.0.1:11435/v1` by default), and the proxy forwards every request (including streaming) to Ollama.
+2. `pi-with-ollama.mjs` — discovers the models available through the proxy, registers them as an `ollama` provider in pi's `models.json`, and launches pi with an Ollama model preselected.
+
+Both scripts are plain Node.js (18+) with no dependencies and work on Linux, macOS, and Windows.
+
+## Prerequisites
+
+- [Node.js 18+](https://nodejs.org)
+- [Ollama](https://ollama.com/download) installed and running (`ollama serve`, or the Ollama desktop app)
+- At least one model pulled, e.g. `ollama pull qwen2.5-coder:7b` (pick a model that supports tool calling so pi's coding tools work)
+- pi installed (`npm install -g @earendil-works/pi-coding-agent`), or run from this repo after `npm install --ignore-scripts`
+
+## Usage
+
+Terminal 1 — start the proxy:
+
+```bash
+node scripts/ollama/ollama-proxy.mjs
+```
+
+Terminal 2 — run pi with the Ollama models:
+
+```bash
+node scripts/ollama/pi-with-ollama.mjs
+```
+
+Or via npm from the repo root: `npm run ollama:proxy` and `npm run ollama:pi`.
+
+On Windows, run the same commands in PowerShell or cmd.exe.
+
+Arguments after `--` are passed to pi as-is:
+
+```bash
+node scripts/ollama/pi-with-ollama.mjs -- -p "Explain this repository"
+node scripts/ollama/pi-with-ollama.mjs -- --model llama3.1:8b
+```
+
+Once inside pi, switch between Ollama models with `/model`.
+
+## ollama-proxy.mjs options
+
+| Option | Description |
+|--------|-------------|
+| `--port <port>` | Port the proxy listens on (default: `11435`, env: `PI_OLLAMA_PROXY_PORT`) |
+| `--host <host>` | Address the proxy binds to (default: `127.0.0.1`) |
+| `--ollama <url>` | Ollama server URL (default: env `OLLAMA_HOST` or `http://127.0.0.1:11434`) |
+| `--quiet` | Do not log individual requests |
+
+The proxy exposes `/healthz` (proxy + Ollama health as JSON); every other path is forwarded to Ollama verbatim.
+
+## pi-with-ollama.mjs options
+
+| Option | Description |
+|--------|-------------|
+| `--proxy <url>` | Proxy base URL (default: `http://127.0.0.1:11435`, env: `PI_OLLAMA_PROXY_URL`) |
+| `--pi <command>` | pi executable to launch (default: `pi` from `PATH`, falling back to this repo's sources via `tsx`) |
+| `--configure-only` | Update `models.json` and exit without launching pi |
+
+## What gets written
+
+`pi-with-ollama.mjs` merges an `ollama` provider entry into pi's `models.json` (`~/.pi/agent/models.json`, or `$PI_CODING_AGENT_DIR/models.json` if set). Other provider entries are left untouched, and the previous file is backed up to `models.json.bak` before each update. Model context windows and reasoning support are detected from Ollama's `/api/show` endpoint.
+
+See [docs/models.md](../../packages/coding-agent/docs/models.md) for the full `models.json` format.
+
+## Troubleshooting
+
+- **"cannot reach the model proxy"** — start `ollama-proxy.mjs` first, and check that `--proxy` matches the proxy's `--port`.
+- **"the proxy is running but Ollama is not reachable"** — start Ollama (`ollama serve` or the desktop app). If Ollama runs on a non-default address, pass `--ollama <url>` to the proxy or set `OLLAMA_HOST`.
+- **Model errors on tool calls** — the model does not support tool calling. Pull one that does (the launcher prints a warning for models without the `tools` capability).
+- **Port already in use** — another proxy instance is running, or pass `--port` to the proxy and `--proxy` to the launcher.

--- a/scripts/ollama/ollama-proxy.mjs
+++ b/scripts/ollama/ollama-proxy.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Local LLM model proxy for pi.
+ *
+ * Sits between pi and a local Ollama server, forwarding every HTTP request
+ * (including streaming responses) to Ollama. pi talks to the proxy's
+ * OpenAI-compatible endpoint (http://127.0.0.1:11435/v1 by default).
+ *
+ * Usage:
+ *   node scripts/ollama/ollama-proxy.mjs [options]
+ *
+ * Options:
+ *   --port <port>     Port the proxy listens on (default: 11435, env: PI_OLLAMA_PROXY_PORT)
+ *   --host <host>     Address the proxy binds to (default: 127.0.0.1)
+ *   --ollama <url>    Ollama server URL (default: env OLLAMA_HOST or http://127.0.0.1:11434)
+ *   --quiet           Do not log individual requests
+ *   --help            Show this help
+ *
+ * Endpoints:
+ *   /healthz          Proxy + Ollama health as JSON (used by pi-with-ollama.mjs)
+ *   /*                Everything else is forwarded to Ollama verbatim
+ *
+ * Works on Linux, macOS, and Windows (requires Node.js 18+).
+ */
+
+import http from "node:http";
+import { URL } from "node:url";
+
+const HOP_BY_HOP_HEADERS = new Set([
+	"connection",
+	"keep-alive",
+	"proxy-authenticate",
+	"proxy-authorization",
+	"te",
+	"trailer",
+	"transfer-encoding",
+	"upgrade",
+]);
+
+function printHelp() {
+	console.log(`ollama-proxy - local LLM model proxy for pi
+
+Usage: node scripts/ollama/ollama-proxy.mjs [options]
+
+Options:
+  --port <port>    Port the proxy listens on (default: 11435, env: PI_OLLAMA_PROXY_PORT)
+  --host <host>    Address the proxy binds to (default: 127.0.0.1)
+  --ollama <url>   Ollama server URL (default: env OLLAMA_HOST or http://127.0.0.1:11434)
+  --quiet          Do not log individual requests
+  --help           Show this help`);
+}
+
+/** OLLAMA_HOST may be "host:port" or "http://host:port"; normalize to a URL string. */
+function normalizeOllamaUrl(raw) {
+	let url = raw.trim().replace(/\/+$/, "");
+	if (!/^https?:\/\//i.test(url)) {
+		url = `http://${url}`;
+	}
+	return url;
+}
+
+function parseArgs(argv) {
+	const options = {
+		port: Number(process.env.PI_OLLAMA_PROXY_PORT) || 11435,
+		host: "127.0.0.1",
+		ollama: normalizeOllamaUrl(process.env.OLLAMA_HOST || "http://127.0.0.1:11434"),
+		quiet: false,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		switch (arg) {
+			case "--port":
+				options.port = Number(argv[++i]);
+				break;
+			case "--host":
+				options.host = argv[++i];
+				break;
+			case "--ollama":
+				options.ollama = normalizeOllamaUrl(argv[++i] ?? "");
+				break;
+			case "--quiet":
+				options.quiet = true;
+				break;
+			case "--help":
+			case "-h":
+				printHelp();
+				process.exit(0);
+				break;
+			default:
+				console.error(`Unknown option: ${arg}`);
+				printHelp();
+				process.exit(1);
+		}
+	}
+	if (!Number.isInteger(options.port) || options.port <= 0 || options.port > 65535) {
+		console.error(`Invalid --port value: ${options.port}`);
+		process.exit(1);
+	}
+	return options;
+}
+
+async function fetchJson(url, init) {
+	const response = await fetch(url, init);
+	if (!response.ok) {
+		throw new Error(`${init?.method ?? "GET"} ${url} failed: HTTP ${response.status}`);
+	}
+	return response.json();
+}
+
+async function checkOllama(ollamaUrl) {
+	const version = await fetchJson(`${ollamaUrl}/api/version`);
+	const tags = await fetchJson(`${ollamaUrl}/api/tags`);
+	const models = (tags.models ?? []).map((model) => model.name ?? model.model).filter(Boolean);
+	return { version: version.version ?? "unknown", models };
+}
+
+function proxyRequest(clientRequest, clientResponse, ollamaUrl, quiet) {
+	const startedAt = Date.now();
+	const target = new URL(clientRequest.url, ollamaUrl);
+
+	const headers = {};
+	for (const [name, value] of Object.entries(clientRequest.headers)) {
+		if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase()) && name.toLowerCase() !== "host") {
+			headers[name] = value;
+		}
+	}
+
+	const upstreamRequest = http.request(
+		target,
+		{ method: clientRequest.method, headers },
+		(upstreamResponse) => {
+			const responseHeaders = {};
+			for (const [name, value] of Object.entries(upstreamResponse.headers)) {
+				if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+					responseHeaders[name] = value;
+				}
+			}
+			clientResponse.writeHead(upstreamResponse.statusCode ?? 502, responseHeaders);
+			upstreamResponse.pipe(clientResponse);
+			upstreamResponse.on("end", () => {
+				if (!quiet) {
+					const elapsed = Date.now() - startedAt;
+					console.log(
+						`${clientRequest.method} ${clientRequest.url} -> ${upstreamResponse.statusCode} (${elapsed}ms)`,
+					);
+				}
+			});
+		},
+	);
+
+	upstreamRequest.on("error", (error) => {
+		if (!quiet) {
+			console.error(`${clientRequest.method} ${clientRequest.url} -> upstream error: ${error.message}`);
+		}
+		if (!clientResponse.headersSent) {
+			clientResponse.writeHead(502, { "content-type": "application/json" });
+		}
+		clientResponse.end(
+			JSON.stringify({
+				error: {
+					message: `ollama-proxy could not reach Ollama at ${ollamaUrl}: ${error.message}. Is 'ollama serve' running?`,
+					type: "upstream_unreachable",
+				},
+			}),
+		);
+	});
+
+	clientRequest.on("aborted", () => upstreamRequest.destroy());
+	clientRequest.pipe(upstreamRequest);
+}
+
+async function handleHealth(clientResponse, ollamaUrl) {
+	try {
+		const { version, models } = await checkOllama(ollamaUrl);
+		clientResponse.writeHead(200, { "content-type": "application/json" });
+		clientResponse.end(JSON.stringify({ status: "ok", proxy: "ollama-proxy", ollama: { url: ollamaUrl, version, models } }));
+	} catch (error) {
+		clientResponse.writeHead(503, { "content-type": "application/json" });
+		clientResponse.end(
+			JSON.stringify({
+				status: "error",
+				proxy: "ollama-proxy",
+				ollama: { url: ollamaUrl, error: error instanceof Error ? error.message : String(error) },
+			}),
+		);
+	}
+}
+
+async function main() {
+	const options = parseArgs(process.argv.slice(2));
+
+	console.log(`ollama-proxy: forwarding to ${options.ollama}`);
+	try {
+		const { version, models } = await checkOllama(options.ollama);
+		console.log(`ollama-proxy: Ollama ${version} is reachable, ${models.length} model(s) available`);
+		for (const model of models) {
+			console.log(`  - ${model}`);
+		}
+		if (models.length === 0) {
+			console.warn("ollama-proxy: no models installed. Pull one first, e.g.: ollama pull qwen2.5-coder:7b");
+		}
+	} catch (error) {
+		console.warn(`ollama-proxy: warning: Ollama is not reachable at ${options.ollama} (${error.message}).`);
+		console.warn("ollama-proxy: start it with 'ollama serve' (or open the Ollama app). The proxy will keep running.");
+	}
+
+	const server = http.createServer((request, response) => {
+		if (request.url === "/healthz") {
+			void handleHealth(response, options.ollama);
+			return;
+		}
+		proxyRequest(request, response, options.ollama, options.quiet);
+	});
+
+	server.on("error", (error) => {
+		if (error.code === "EADDRINUSE") {
+			console.error(`ollama-proxy: port ${options.port} is already in use on ${options.host}.`);
+			console.error("ollama-proxy: is another proxy instance running? Use --port to pick a different port.");
+		} else {
+			console.error(`ollama-proxy: server error: ${error.message}`);
+		}
+		process.exit(1);
+	});
+
+	server.listen(options.port, options.host, () => {
+		const base = `http://${options.host}:${options.port}`;
+		console.log(`ollama-proxy: listening on ${base}`);
+		console.log(`ollama-proxy: OpenAI-compatible endpoint for pi: ${base}/v1`);
+		console.log(`ollama-proxy: health check: ${base}/healthz`);
+		console.log("ollama-proxy: next step: node scripts/ollama/pi-with-ollama.mjs");
+		console.log("ollama-proxy: press Ctrl+C to stop");
+	});
+
+	const shutdown = () => {
+		console.log("\nollama-proxy: shutting down");
+		server.close(() => process.exit(0));
+		setTimeout(() => process.exit(0), 1000).unref();
+	};
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+	console.error(`ollama-proxy: fatal: ${error instanceof Error ? error.message : String(error)}`);
+	process.exit(1);
+});

--- a/scripts/ollama/pi-with-ollama.mjs
+++ b/scripts/ollama/pi-with-ollama.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Run pi with the Ollama models served by the local model proxy.
+ *
+ * Run scripts/ollama/ollama-proxy.mjs first, then this script. It:
+ *   1. Checks that the proxy (and Ollama behind it) is healthy.
+ *   2. Discovers the available models through the proxy.
+ *   3. Registers them as an "ollama" provider in pi's models.json
+ *      (~/.pi/agent/models.json or $PI_CODING_AGENT_DIR/models.json),
+ *      keeping every other provider entry untouched.
+ *   4. Launches pi with the first Ollama model preselected.
+ *
+ * Usage:
+ *   node scripts/ollama/pi-with-ollama.mjs [options] [-- <pi args>]
+ *
+ * Options:
+ *   --proxy <url>    Proxy base URL (default: http://127.0.0.1:11435, env: PI_OLLAMA_PROXY_URL)
+ *   --pi <command>   pi executable to launch (default: "pi" from PATH, falling back to repo sources)
+ *   --configure-only Update models.json and exit without launching pi
+ *   --help           Show this help
+ *
+ * Everything after "--" (or any unrecognized argument) is passed to pi as-is.
+ *
+ * Works on Linux, macOS, and Windows (requires Node.js 18+).
+ */
+
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PROVIDER_KEY = "ollama";
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(SCRIPT_DIR, "..", "..");
+
+function printHelp() {
+	console.log(`pi-with-ollama - run pi with Ollama models from the local model proxy
+
+Usage: node scripts/ollama/pi-with-ollama.mjs [options] [-- <pi args>]
+
+Options:
+  --proxy <url>     Proxy base URL (default: http://127.0.0.1:11435, env: PI_OLLAMA_PROXY_URL)
+  --pi <command>    pi executable to launch (default: "pi" from PATH, falling back to repo sources)
+  --configure-only  Update models.json and exit without launching pi
+  --help            Show this help
+
+Start the proxy first:
+  node scripts/ollama/ollama-proxy.mjs`);
+}
+
+function parseArgs(argv) {
+	const options = {
+		proxy: (process.env.PI_OLLAMA_PROXY_URL || "http://127.0.0.1:11435").replace(/\/+$/, ""),
+		pi: undefined,
+		configureOnly: false,
+		piArgs: [],
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--") {
+			options.piArgs.push(...argv.slice(i + 1));
+			break;
+		}
+		switch (arg) {
+			case "--proxy":
+				options.proxy = (argv[++i] ?? "").replace(/\/+$/, "");
+				break;
+			case "--pi":
+				options.pi = argv[++i];
+				break;
+			case "--configure-only":
+				options.configureOnly = true;
+				break;
+			case "--help":
+			case "-h":
+				printHelp();
+				process.exit(0);
+				break;
+			default:
+				options.piArgs.push(arg);
+		}
+	}
+	if (!options.proxy) {
+		console.error("pi-with-ollama: --proxy requires a URL");
+		process.exit(1);
+	}
+	return options;
+}
+
+async function fetchJson(url, init) {
+	const response = await fetch(url, init);
+	if (!response.ok) {
+		throw new Error(`${init?.method ?? "GET"} ${url} failed: HTTP ${response.status}`);
+	}
+	return response.json();
+}
+
+async function checkProxy(proxyUrl) {
+	let health;
+	try {
+		const response = await fetch(`${proxyUrl}/healthz`);
+		health = await response.json();
+	} catch (error) {
+		console.error(`pi-with-ollama: cannot reach the model proxy at ${proxyUrl} (${error.message}).`);
+		console.error("pi-with-ollama: start it first in another terminal:");
+		console.error("  node scripts/ollama/ollama-proxy.mjs");
+		process.exit(1);
+	}
+	if (health.status !== "ok") {
+		console.error(`pi-with-ollama: the proxy is running but Ollama is not reachable behind it.`);
+		console.error(`pi-with-ollama: proxy said: ${health.ollama?.error ?? "unknown error"}`);
+		console.error("pi-with-ollama: start Ollama with 'ollama serve' (or open the Ollama app) and retry.");
+		process.exit(1);
+	}
+}
+
+/** Discover models through the proxy and enrich them with per-model details from Ollama. */
+async function discoverModels(proxyUrl) {
+	const list = await fetchJson(`${proxyUrl}/v1/models`);
+	const ids = (list.data ?? []).map((entry) => entry.id).filter(Boolean);
+	if (ids.length === 0) {
+		console.error("pi-with-ollama: Ollama has no models installed.");
+		console.error("pi-with-ollama: pull one first, e.g.: ollama pull qwen2.5-coder:7b");
+		process.exit(1);
+	}
+
+	const models = [];
+	for (const id of ids) {
+		const model = { id, name: `${id} (Ollama)` };
+		try {
+			const show = await fetchJson(`${proxyUrl}/api/show`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ model: id }),
+			});
+			const capabilities = show.capabilities ?? [];
+			model.reasoning = capabilities.includes("thinking");
+			if (!capabilities.includes("tools")) {
+				console.warn(
+					`pi-with-ollama: warning: '${id}' does not support tool calling; pi's coding tools will not work with it.`,
+				);
+			}
+			const contextKey = Object.keys(show.model_info ?? {}).find((key) => key.endsWith(".context_length"));
+			if (contextKey) {
+				model.contextWindow = show.model_info[contextKey];
+			}
+		} catch {
+			// /api/show is best-effort; pi applies sensible defaults when fields are omitted.
+		}
+		models.push(model);
+	}
+	return models;
+}
+
+function getAgentDir() {
+	return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+/** Merge the ollama provider into models.json without touching other providers. */
+function updateModelsJson(proxyUrl, models) {
+	const agentDir = getAgentDir();
+	const modelsPath = join(agentDir, "models.json");
+	let config = {};
+	if (existsSync(modelsPath)) {
+		const raw = readFileSync(modelsPath, "utf8");
+		try {
+			config = JSON.parse(raw);
+		} catch (error) {
+			console.error(`pi-with-ollama: ${modelsPath} exists but is not valid JSON (${error.message}).`);
+			console.error("pi-with-ollama: fix or remove it, then rerun this script. Nothing was modified.");
+			process.exit(1);
+		}
+		copyFileSync(modelsPath, `${modelsPath}.bak`);
+	} else {
+		mkdirSync(agentDir, { recursive: true });
+	}
+
+	config.providers = config.providers ?? {};
+	config.providers[PROVIDER_KEY] = {
+		name: "Ollama (local proxy)",
+		baseUrl: `${proxyUrl}/v1`,
+		api: "openai-completions",
+		// Ollama ignores API keys, but pi requires one for a model to be selectable.
+		apiKey: "ollama",
+		compat: {
+			supportsDeveloperRole: false,
+			supportsReasoningEffort: false,
+		},
+		models,
+	};
+
+	writeFileSync(modelsPath, `${JSON.stringify(config, null, "\t")}\n`, "utf8");
+	return modelsPath;
+}
+
+function commandExists(command) {
+	const probe = process.platform === "win32" ? "where" : "which";
+	const result = spawnSync(probe, [command], { stdio: "ignore", shell: process.platform === "win32" });
+	return result.status === 0;
+}
+
+/** Resolve how to launch pi: --pi flag, installed binary, or this repo's sources. */
+function resolvePiCommand(explicit) {
+	if (explicit) {
+		return { command: explicit, args: [], description: explicit };
+	}
+	if (commandExists("pi")) {
+		return { command: "pi", args: [], description: "pi (from PATH)" };
+	}
+	const tsx = join(REPO_ROOT, "node_modules", ".bin", process.platform === "win32" ? "tsx.cmd" : "tsx");
+	const cli = join(REPO_ROOT, "packages", "coding-agent", "src", "cli.ts");
+	if (existsSync(tsx) && existsSync(cli)) {
+		return {
+			command: tsx,
+			args: ["--tsconfig", join(REPO_ROOT, "tsconfig.json"), cli],
+			description: "pi (from repo sources via tsx)",
+		};
+	}
+	console.error("pi-with-ollama: could not find a way to launch pi.");
+	console.error("pi-with-ollama: install it (npm install -g @earendil-works/pi-coding-agent),");
+	console.error("pi-with-ollama: run 'npm install --ignore-scripts' in this repo, or pass --pi <command>.");
+	process.exit(1);
+}
+
+/** cmd.exe needs shell:true for .cmd shims, which in turn needs manual quoting. */
+function runInherited(command, args) {
+	if (process.platform === "win32") {
+		const quote = (value) => (/[\s"^&|<>()%!]/.test(value) ? `"${value.replaceAll('"', '\\"')}"` : value);
+		return spawnSync([command, ...args].map(quote).join(" "), { stdio: "inherit", shell: true });
+	}
+	return spawnSync(command, args, { stdio: "inherit" });
+}
+
+async function main() {
+	const options = parseArgs(process.argv.slice(2));
+
+	await checkProxy(options.proxy);
+	const models = await discoverModels(options.proxy);
+	console.log(`pi-with-ollama: found ${models.length} Ollama model(s) via ${options.proxy}:`);
+	for (const model of models) {
+		console.log(`  - ${model.id}`);
+	}
+
+	const modelsPath = updateModelsJson(options.proxy, models);
+	console.log(`pi-with-ollama: registered provider '${PROVIDER_KEY}' in ${modelsPath}`);
+
+	if (options.configureOnly) {
+		console.log("pi-with-ollama: --configure-only set, not launching pi.");
+		console.log(`pi-with-ollama: select a model in pi with /model or: pi --provider ${PROVIDER_KEY} --model <id>`);
+		return;
+	}
+
+	const piArgs = [...options.piArgs];
+	const hasModelSelection = piArgs.some((arg) => arg === "--provider" || arg === "--model" || arg === "-m");
+	if (!hasModelSelection) {
+		piArgs.unshift("--provider", PROVIDER_KEY, "--model", models[0].id);
+	}
+
+	const pi = resolvePiCommand(options.pi);
+	console.log(`pi-with-ollama: launching ${pi.description} ${piArgs.join(" ")}`);
+	const result = runInherited(pi.command, [...pi.args, ...piArgs]);
+	process.exit(result.status ?? 1);
+}
+
+main().catch((error) => {
+	console.error(`pi-with-ollama: fatal: ${error instanceof Error ? error.message : String(error)}`);
+	process.exit(1);
+});


### PR DESCRIPTION
Adds two dependency-free Node.js (18+) scripts to use local Ollama models in pi, working on Ubuntu, macOS, and Windows.

## Usage

```bash
# Terminal 1: start the local LLM model proxy
node scripts/ollama/ollama-proxy.mjs

# Terminal 2: run pi with the Ollama models from the proxy
node scripts/ollama/pi-with-ollama.mjs
```

Also available as `npm run ollama:proxy` / `npm run ollama:pi`.

## Changes

- `scripts/ollama/ollama-proxy.mjs`: local model proxy in front of the Ollama server (default `127.0.0.1:11435` -> `127.0.0.1:11434`). Forwards all requests including SSE streaming, verifies Ollama and lists installed models on startup, and exposes `/healthz`. Configurable via `--port`, `--host`, `--ollama` (or `OLLAMA_HOST`).
- `scripts/ollama/pi-with-ollama.mjs`: checks proxy health, discovers models via `/v1/models`, enriches them with context window and reasoning/tool-calling capabilities from `/api/show`, and registers them as an `ollama` provider in pi's `models.json` (`~/.pi/agent` or `$PI_CODING_AGENT_DIR`). The merge preserves existing providers and backs up the previous file to `models.json.bak`. Then launches pi with the first Ollama model preselected (`pi` from PATH, falling back to repo sources via tsx, or `--pi <command>`). Arguments after `--` pass through to pi; `--configure-only` skips the launch.
- `scripts/ollama/README.md`: usage, options, and troubleshooting.
- `package.json`: `ollama:proxy` and `ollama:pi` npm scripts.

## Testing

Verified end-to-end on macOS against Ollama 0.23.0 with `qwen2.5-coder:7b`:

- Streaming chat completions flow through the proxy (confirmed in the proxy request log).
- `models.json` generation, merge with an existing provider entry, and backup all work.
- `node scripts/ollama/pi-with-ollama.mjs -- -p "Reply with exactly one word: pong"` launched pi with `--provider ollama --model qwen2.5-coder:7b` and answered `pong` through the proxy.
- Error paths: proxy down (clear instruction to start it), Ollama down (proxy stays up and reports it via `/healthz`), invalid existing `models.json` (aborts without modifying anything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
