### PR TITLE
fix(coding-agent): make session persistence transactional

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -10,7 +10,10 @@ import {
 	openSync,
 	readdirSync,
 	readSync,
+	renameSync,
 	statSync,
+	truncateSync,
+	unlinkSync,
 	writeFileSync,
 } from "fs";
 import { readdir, stat } from "fs/promises";
@@ -28,6 +31,20 @@ import {
 } from "./messages.ts";
 
 export const CURRENT_SESSION_VERSION = 3;
+
+function writeFileAtomically(filePath: string, content: string): void {
+	const tempPath = `${filePath}.tmp-${randomUUID()}`;
+	try {
+		writeFileSync(tempPath, content, { flag: "wx" });
+		renameSync(tempPath, filePath);
+	} finally {
+		try {
+			if (existsSync(tempPath)) unlinkSync(tempPath);
+		} catch {
+			// Preserve the original write or rename error.
+		}
+	}
+}
 
 export interface SessionHeader {
 	type: "session";
@@ -978,14 +995,7 @@ export class SessionManager {
 
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
-		const fd = openSync(this.sessionFile, "w");
-		try {
-			for (const entry of this.fileEntries) {
-				writeFileSync(fd, `${JSON.stringify(entry)}\n`);
-			}
-		} finally {
-			closeSync(fd);
-		}
+		writeFileAtomically(this.sessionFile, this.fileEntries.map((entry) => `${JSON.stringify(entry)}\n`).join(""));
 	}
 
 	isPersisted(): boolean {
@@ -1042,10 +1052,33 @@ export class SessionManager {
 	}
 
 	private _appendEntry(entry: SessionEntry): void {
+		const previousLeafId = this.leafId;
+		const previousFlushed = this.flushed;
+		const previousFileSize = this.sessionFile && existsSync(this.sessionFile) ? statSync(this.sessionFile).size : undefined;
+
 		this.fileEntries.push(entry);
 		this.byId.set(entry.id, entry);
 		this.leafId = entry.id;
-		this._persist(entry);
+		try {
+			this._persist(entry);
+		} catch (error) {
+			this.fileEntries.pop();
+			this.byId.delete(entry.id);
+			this.leafId = previousLeafId;
+			this.flushed = previousFlushed;
+			if (this.sessionFile) {
+				try {
+					if (previousFileSize === undefined) {
+						if (existsSync(this.sessionFile)) unlinkSync(this.sessionFile);
+					} else {
+						truncateSync(this.sessionFile, previousFileSize);
+					}
+				} catch {
+					// Preserve the original persistence error.
+				}
+			}
+			throw error;
+		}
 	}
 
 	/** Append a message as child of current leaf, then advance leaf. Returns entry id.
@@ -1608,7 +1641,8 @@ export class SessionManager {
 		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
 		const newSessionFile = join(dir, `${fileTimestamp}_${newSessionId}.jsonl`);
 
-		// Write new header pointing to source as parent, with updated cwd
+		// Write the new header and copied entries atomically so a failed fork does not leave
+		// a partially written session that can be discovered on the next startup.
 		const newHeader: SessionHeader = {
 			type: "session",
 			version: CURRENT_SESSION_VERSION,
@@ -1617,14 +1651,10 @@ export class SessionManager {
 			cwd: resolvedTargetCwd,
 			parentSession: resolvedSourcePath,
 		};
-		writeFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`, { flag: "wx" });
-
-		// Copy all non-header entries from source
-		for (const entry of sourceEntries) {
-			if (entry.type !== "session") {
-				appendFileSync(newSessionFile, `${JSON.stringify(entry)}\n`);
-			}
-		}
+		const forkedContent = [newHeader, ...sourceEntries.filter((entry) => entry.type !== "session")]
+			.map((entry) => `${JSON.stringify(entry)}\n`)
+			.join("");
+		writeFileAtomically(newSessionFile, forkedContent);
 
 		return new SessionManager(resolvedTargetCwd, dir, newSessionFile, true);
 	}

--- a/packages/coding-agent/test/session-manager/durability.test.ts
+++ b/packages/coding-agent/test/session-manager/durability.test.ts
@@ -1,0 +1,96 @@
+const fsMocks = vi.hoisted(() => ({
+	appendFileSync: vi.fn(),
+	actual: undefined as typeof import("fs") | undefined,
+	renameSync: vi.fn(),
+}));
+
+vi.mock("fs", async () => {
+	const actual = await vi.importActual<typeof import("fs")>("fs");
+	fsMocks.actual = actual;
+	fsMocks.appendFileSync.mockImplementation(actual.appendFileSync);
+	fsMocks.renameSync.mockImplementation(actual.renameSync);
+	return { ...actual, appendFileSync: fsMocks.appendFileSync, renameSync: fsMocks.renameSync };
+});
+
+import * as fs from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+function userMessage(text: string) {
+	return { role: "user" as const, content: text, timestamp: Date.now() };
+}
+
+function assistantMessage(text: string) {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: "test",
+		provider: "test",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: Date.now(),
+	};
+}
+
+describe("SessionManager persistence durability", () => {
+	let tempDir: string;
+
+	afterEach(() => {
+		fsMocks.appendFileSync.mockImplementation(fsMocks.actual!.appendFileSync);
+		fsMocks.renameSync.mockImplementation(fsMocks.actual!.renameSync);
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("rolls back the graph and partial append when persistence fails", () => {
+		tempDir = fs.mkdtempSync(join(tmpdir(), "session-durability-"));
+		const session = SessionManager.create(tempDir, tempDir, { id: "durability-test" });
+		session.appendMessage(userMessage("hello"));
+		const assistantId = session.appendMessage(assistantMessage("hi"));
+		const sessionFile = session.getSessionFile()!;
+		const originalContent = fs.readFileSync(sessionFile, "utf8");
+
+		fsMocks.appendFileSync.mockImplementation(((path) => {
+			fs.writeFileSync(path, "partial", { flag: "a" });
+			throw Object.assign(new Error("no space left on device"), { code: "ENOSPC" });
+		}) as typeof fs.appendFileSync);
+
+		expect(() => session.appendMessage(userMessage("this write fails"))).toThrow("no space left on device");
+		expect(session.getLeafId()).toBe(assistantId);
+		expect(session.getEntries()).toHaveLength(2);
+		expect(fs.readFileSync(sessionFile, "utf8")).toBe(originalContent);
+		expect(SessionManager.open(sessionFile, tempDir).getEntries()).toHaveLength(2);
+	});
+
+	it("does not leave a partial fork when publishing fails", () => {
+		tempDir = fs.mkdtempSync(join(tmpdir(), "session-fork-durability-"));
+		const sourceDir = join(tempDir, "source");
+		const targetDir = join(tempDir, "target");
+		const source = SessionManager.create(sourceDir, sourceDir, { id: "source-session" });
+		source.appendMessage(userMessage("hello"));
+		source.appendMessage(assistantMessage("hi"));
+
+		fsMocks.renameSync.mockImplementation(() => {
+			throw Object.assign(new Error("no space left on device"), { code: "ENOSPC" });
+		});
+
+		expect(() =>
+			SessionManager.forkFrom(
+				source.getSessionFile()!,
+				join(tempDir, "target-cwd"),
+				targetDir,
+				{ id: "fork-session" },
+			),
+		).toThrow("no space left on device");
+		expect(fs.readdirSync(targetDir)).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Problem

`SessionManager._appendEntry()` advances the in-memory session graph before the JSONL append completes. If persistence fails (for example, `ENOSPC`), the next entry can reference a parent that never reached disk. A restart then sees a broken session graph even though most of the transcript remains valid.

## Fix

- Roll back the appended entry, leaf pointer, flushed state, and any partial file append when persistence fails.
- Publish complete rewrites through a sibling temporary file and rename, so a failed rewrite does not truncate the existing session.
- Publish `forkFrom()` output atomically for the same reason.

This intentionally does not add recovery heuristics or product-specific UI. Low-disk warnings/blocking can remain owned by the consuming application.

## Validation

- Added focused append rollback and atomic fork tests.
- `vitest run packages/coding-agent/test/session-manager/durability.test.ts` — 2 passed.
- Session-manager suite: 68 tests passed; one unrelated suite could not load with the local dependency tree because `highlight.js/lib/index.js` is unavailable.
