### PR TITLE
fix(examples): todo renderResult returns undefined on validation errors

### DIFF
--- a/packages/coding-agent/examples/extensions/todo.ts
+++ b/packages/coding-agent/examples/extensions/todo.ts
@@ -276,6 +276,13 @@ export default function (pi: ExtensionAPI) {
 
 				case "clear":
 					return new Text(theme.fg("success", "✓ ") + theme.fg("muted", "Cleared all todos"), 0, 0);
+
+				default:
+					return new Text(
+						result.content[0]?.type === "text" ? theme.fg("error", result.content[0].text) : "",
+						0,
+						0,
+					);
 			}
 		},
 	});


### PR DESCRIPTION
A `todo` call that fails schema validation crashes the whole TUI in interactive mode.

For a validation failure `details` is `{}` (a truthy empty object), so `renderResult` skips both `if (!details)` and `if (details.error)`, then `switch (details.action)` has no `default` and returns `undefined`. `ToolExecutionComponent.updateDisplay()` then calls `addChild(undefined)`, and the next render pass throws:

```
TypeError: Cannot read properties of undefined (reading 'render')
    at Box.render (pi-tui/dist/components/box.js:62:33)
```

`pi -p` is unaffected (the agent loop recovers; only the TUI render crashes).

Add a `default` case to render the validation error:

```ts
default:
    return new Text(
        result.content[0]?.type === "text" ? theme.fg("error", result.content[0].text) : "",
        0,
        0,
    );
```

Scoped to the example; the framework-level "tolerate a renderer returning `undefined`" question is tracked in #2627 / #7291.
