### PR TITLE
fix(coding-agent): validate extension flag defaults

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1625,6 +1625,8 @@ pi.registerShortcut("ctrl+shift+p", {
 
 Register a CLI flag.
 
+`type` must be `"boolean"` or `"string"`, and `default` must match it. Invalid registrations cause the extension to fail loading.
+
 ```typescript
 pi.registerFlag("plan", {
   description: "Start in plan mode",

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -70,6 +70,7 @@ export type {
 	ExtensionEvent,
 	ExtensionFactory,
 	ExtensionFlag,
+	ExtensionFlagOptions,
 	ExtensionHandler,
 	ExtensionMode,
 	// Runtime

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -37,6 +37,7 @@ import type {
 	Extension,
 	ExtensionAPI,
 	ExtensionFactory,
+	ExtensionFlagOptions,
 	ExtensionRuntime,
 	LoadExtensionsResult,
 	MarkdownTransformer,
@@ -290,11 +291,19 @@ function createExtensionAPI(
 			extension.shortcuts.set(shortcut, { shortcut, extensionPath: extension.path, ...options });
 		},
 
-		registerFlag(
-			name: string,
-			options: { description?: string; type: "boolean" | "string"; default?: boolean | string },
-		): void {
+		registerFlag(name: string, options: ExtensionFlagOptions): void {
 			runtime.assertActive();
+			const flagType: unknown = options?.type;
+			if (flagType !== "boolean" && flagType !== "string") {
+				throw new Error(
+					`Invalid type for extension flag "--${name}": expected boolean or string, received ${String(flagType)}`,
+				);
+			}
+			if (options.default !== undefined && typeof options.default !== flagType) {
+				throw new Error(
+					`Invalid default for extension flag "--${name}": expected ${flagType}, received ${typeof options.default}`,
+				);
+			}
 			extension.flags.set(name, { name, extensionPath: extension.path, ...options });
 			if (options.default !== undefined && !runtime.flagValues.has(name)) {
 				runtime.flagValues.set(name, options.default);

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1188,6 +1188,18 @@ export interface ResolvedCommand extends RegisteredCommand {
 // Extension API
 // ============================================================================
 
+export type ExtensionFlagOptions =
+	| {
+			description?: string;
+			type: "boolean";
+			default?: boolean;
+	  }
+	| {
+			description?: string;
+			type: "string";
+			default?: string;
+	  };
+
 /** Handler function type for events */
 // biome-ignore lint/suspicious/noConfusingVoidType: void allows bare return statements
 export type ExtensionHandler<E, R = undefined> = (event: E, ctx: ExtensionContext) => Promise<R | void> | R | void;
@@ -1269,14 +1281,7 @@ export interface ExtensionAPI {
 	): void;
 
 	/** Register a CLI flag. */
-	registerFlag(
-		name: string,
-		options: {
-			description?: string;
-			type: "boolean" | "string";
-			default?: boolean | string;
-		},
-	): void;
+	registerFlag(name: string, options: ExtensionFlagOptions): void;
 
 	/** Get the value of a registered CLI flag. */
 	getFlag(name: string): boolean | string | undefined;

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -52,6 +52,7 @@ export {
 	type ExtensionEvent,
 	type ExtensionFactory,
 	type ExtensionFlag,
+	type ExtensionFlagOptions,
 	type ExtensionHandler,
 	ExtensionRunner,
 	type ExtensionShortcut,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -85,6 +85,7 @@ export type {
 	ExtensionEvent,
 	ExtensionFactory,
 	ExtensionFlag,
+	ExtensionFlagOptions,
 	ExtensionHandler,
 	ExtensionRuntime,
 	ExtensionShortcut,

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -487,7 +487,7 @@ describe("extensions discovery", () => {
 			export default function(pi) {
 				pi.registerFlag("my-flag", {
 					description: "My custom flag",
-					handler: async (value) => {},
+					type: "boolean",
 				});
 			}
 		`;

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -648,7 +648,7 @@ describe("ExtensionRunner", () => {
 				export default function(pi) {
 					pi.registerFlag("my-flag", {
 						description: "My flag",
-						handler: async () => {},
+						type: "boolean",
 					});
 				}
 			`;
@@ -696,7 +696,7 @@ describe("ExtensionRunner", () => {
 				export default function(pi) {
 					pi.registerFlag("test-flag", {
 						description: "Test flag",
-						handler: async () => {},
+						type: "boolean",
 					});
 				}
 			`;

--- a/packages/coding-agent/test/suite/regressions/8064-register-flag-default-type.test.ts
+++ b/packages/coding-agent/test/suite/regressions/8064-register-flag-default-type.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadExtensions } from "../../../src/core/extensions/loader.ts";
+import type { ExtensionAPI, ExtensionFlagOptions } from "../../../src/index.ts";
+
+function checkRegisterFlagTypes(pi: ExtensionAPI): void {
+	pi.registerFlag("enabled", { type: "boolean", default: true });
+	pi.registerFlag("label", { type: "string", default: "value" });
+
+	// @ts-expect-error Boolean flags require boolean defaults.
+	pi.registerFlag("invalid-boolean", { type: "boolean", default: "false" });
+	// @ts-expect-error String flags require string defaults.
+	pi.registerFlag("invalid-string", { type: "string", default: false });
+}
+void checkRegisterFlagTypes;
+
+function checkExtensionFlagOptionsTypes(options: ExtensionFlagOptions): void {
+	if (options.type === "boolean") {
+		const defaultValue: boolean | undefined = options.default;
+		void defaultValue;
+	} else {
+		const defaultValue: string | undefined = options.default;
+		void defaultValue;
+	}
+}
+void checkExtensionFlagOptionsTypes;
+
+describe("issue #8064 registerFlag default types", () => {
+	it.each([
+		{ type: "boolean", defaultSource: '"false"', received: "string" },
+		{ type: "string", defaultSource: "false", received: "boolean" },
+	])("rejects a $received default for a $type flag from JavaScript", async ({ type, defaultSource, received }) => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-8064-"));
+		try {
+			const extensionPath = join(tempDir, "invalid-default.js");
+			writeFileSync(
+				extensionPath,
+				`export default function (pi) { pi.registerFlag("safe-mode", { type: "${type}", default: ${defaultSource} }); }`,
+			);
+
+			const result = await loadExtensions([extensionPath], tempDir);
+
+			expect(result.extensions).toEqual([]);
+			expect(result.errors).toEqual([
+				{
+					path: extensionPath,
+					error: `Failed to load extension: Invalid default for extension flag "--safe-mode": expected ${type}, received ${received}`,
+				},
+			]);
+			expect(result.runtime.flagValues.has("safe-mode")).toBe(false);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects an unsupported flag type from JavaScript", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-8064-"));
+		try {
+			const extensionPath = join(tempDir, "invalid-type.js");
+			writeFileSync(
+				extensionPath,
+				'export default function (pi) { pi.registerFlag("safe-mode", { type: "number", default: 1 }); }',
+			);
+
+			const result = await loadExtensions([extensionPath], tempDir);
+
+			expect(result.extensions).toEqual([]);
+			expect(result.errors).toEqual([
+				{
+					path: extensionPath,
+					error: 'Failed to load extension: Invalid type for extension flag "--safe-mode": expected boolean or string, received number',
+				},
+			]);
+			expect(result.runtime.flagValues.has("safe-mode")).toBe(false);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Problem

`registerFlag()` allows `type` and `default` to disagree. A boolean flag with `default: "false"` returns a truthy string when omitted. JavaScript extensions can also pass unsupported flag types.

## Change

- Model `registerFlag()` options as a discriminated union and export `ExtensionFlagOptions`.
- Reject unsupported flag types and mismatched defaults before storing the flag or default.
- Document that invalid registrations fail extension loading.
- Cover TypeScript input narrowing and JavaScript loader validation.

Invalid JavaScript registrations fail extension loading rather than continuing with a missing or coerced flag. This matches `registerProvider()`, which throws on incomplete registration arguments during factory execution.

## Verification

- `npm run check`
- `npm test`

Fixes #8064
