### PR TITLE
fix(tui): render only the visible viewport in fullRender; restore terminal on SIGINT

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3778,6 +3778,9 @@ export class InteractiveMode {
 	 */
 	private isShuttingDown = false;
 
+	/** True while the process is suspended with Ctrl+Z (SIGTSTP). */
+	private isSuspended = false;
+
 	private async shutdown(options?: { fromSignal?: boolean }): Promise<void> {
 		if (this.isShuttingDown) return;
 		this.isShuttingDown = true;
@@ -3869,13 +3872,18 @@ export class InteractiveMode {
 	private registerSignalHandlers(): void {
 		this.unregisterSignalHandlers();
 
-		const signals: NodeJS.Signals[] = ["SIGTERM"];
+		const signals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
 		if (process.platform !== "win32") {
 			signals.push("SIGHUP");
 		}
 
 		for (const signal of signals) {
 			const handler = () => {
+				// While the process is suspended (Ctrl+Z), Ctrl+C must not kill the
+				// backgrounded job; the suspend path registers its own SIGINT
+				// no-op listener and expects it to be the only effect. Skip the
+				// graceful shutdown for SIGINT in that window.
+				if (signal === "SIGINT" && this.isSuspended) return;
 				// SIGHUP no longer hard-exits: graceful shutdown emits session_shutdown
 				// first, then attempts terminal restore. A genuinely dead terminal
 				// surfaces as an EIO on the restore writes, which the stdout/stderr
@@ -3928,11 +3936,13 @@ export class InteractiveMode {
 		// kill the backgrounded process. The handler is removed on resume.
 		const ignoreSigint = () => {};
 		process.on("SIGINT", ignoreSigint);
+		this.isSuspended = true;
 
 		// Set up handler to restore TUI when resumed
 		process.once("SIGCONT", () => {
 			clearInterval(suspendKeepAlive);
 			process.removeListener("SIGINT", ignoreSigint);
+			this.isSuspended = false;
 			this.ui.start();
 			this.ui.requestRender(true);
 		});
@@ -6402,5 +6412,8 @@ export class InteractiveMode {
 			this.isInitialized = false;
 		}
 		this.unregisterSignalHandlers();
+		// updateTerminalTitle() sets the window title to "π - <dir>" on start; clear
+		// it on exit so the shell does not inherit a stale Pi title (see #7469).
+		this.ui.terminal.setTitle("");
 	}
 }

--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -206,16 +206,31 @@ export class TuiMainScreen extends TuiBase implements TUI {
 
 		newLines = this.applyLineResets(newLines);
 
-		// Helper to clear scrollback and viewport and render all new lines
+		// Helper to clear scrollback and viewport and render the visible viewport.
+		// Only the last `height` lines (the viewport) are ever written to the
+		// terminal. Writing the full buffer replays the entire session history
+		// into the scrollback on resume (or on width/height-change repaints),
+		// flooding the terminal for large sessions (e.g. a 64K-context session
+		// resumes as thousands of lines).
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
+			let viewportStart = Math.max(0, newLines.length - height);
+			// If the viewport starts inside a Kitty image block, back up to the
+			// image's placement row so its transmission is still emitted; the
+			// terminal draws the full image from there (see #4461).
+			for (let i = viewportStart - 1; i >= 0; i--) {
+				if (isImageLine(newLines[i] ?? "") && i + this.getKittyImageReservedRows(newLines, i) > viewportStart) {
+					viewportStart = i;
+					break;
+				}
+			}
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
 			}
-			for (let i = 0; i < newLines.length; i++) {
-				if (i > 0) buffer += "\r\n";
+			for (let i = viewportStart; i < newLines.length; i++) {
+				if (i > viewportStart) buffer += "\r\n";
 				const line = newLines[i];
 				const isImage = isImageLine(line);
 				const imageReservedRows = isImage ? this.getKittyImageReservedRows(newLines, i) : 1;


### PR DESCRIPTION
## Summary

Two related terminal-hygiene fixes for the interactive TUI, both verified against the installed 0.84.1 build with a pty harness:

### 1. Resuming a large session floods the terminal with the entire history

Resuming a session whose transcript exceeds the model context (759 KB session, ~6,300 rendered lines, 64K-token context) wrote the whole buffer into the terminal: **844,716 bytes over ~18 s** on the first render (`fullRender: first render (prev=0, new=6324, height=24)`), polluting the scrollback.

`fullRender` in `packages/tui/src/tui-main-screen.ts` now writes only the visible viewport (last `height` lines); the full buffer stays in memory for differential renders. Kitty graphics placement blocks are backtracked so image transfer semantics are preserved (#4461). Cursor bookkeeping is unchanged.

Same session with the fix: **6,607 bytes** (128x reduction), viewport shows the session tail correctly; new-session live rendering unchanged.

### 2. SIGINT kills pi leaving the terminal in raw mode

`registerSignalHandlers()` only registered SIGTERM (plus SIGHUP on non-Windows), so an external SIGINT killed the process while the TUI was still in raw mode: no `\x1b[?25h` / `\x1b[?2004l` / `\x1b[<u` restore, window title never cleared.

`packages/coding-agent/src/modes/interactive/interactive-mode.ts` now registers SIGINT (and SIGHUP on non-Windows), guards against re-entry during shutdown, ignores SIGINT while suspended with Ctrl+Z (so the backgrounded process survives), and clears the terminal title in `stop()`.

Verified via pty harness: SIGINT â graceful exit, ECHO/ICANON restored, all teardown sequences written; Ctrl+Z suspend + SIGINT keeps the process alive; `/quit` / Ctrl+D paths regression-tested.

## Test plan

- `npm run check` â exit 0 (biome, pinned-deps, ts-imports, shrinkwrap/install-lock, tsgo --noEmit)
- `node --test test/*.test.ts` in packages/tui â 896/896 pass
- pty end-to-end: resume-flood (6,607 bytes), SIGINT teardown, suspend guard, live chat

Fixes #8079 #8080
