### PR TITLE
fix(coding-agent): don't swallow the prompt after boolean extension flags

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -54,6 +54,11 @@ export interface Args {
 	fileArgs: string[];
 	/** Unknown flags (potentially extension flags) - map of flag name to value */
 	unknownFlags: Map<string, boolean | string>;
+	/** For unknown flags that consumed a following token: index into `messages` where
+	 * that token would sit. Extension flag resolution restores the token for boolean
+	 * flags (it was consumed here because flag types are only known after extensions
+	 * load); string flags keep it as the flag value. */
+	unknownFlagValueIndices: Map<string, number>;
 	diagnostics: Array<{ type: "warning" | "error"; message: string }>;
 }
 
@@ -68,6 +73,7 @@ export function parseArgs(args: string[]): Args {
 		messages: [],
 		fileArgs: [],
 		unknownFlags: new Map(),
+		unknownFlagValueIndices: new Map(),
 		diagnostics: [],
 	};
 
@@ -219,6 +225,10 @@ export function parseArgs(args: string[]): Args {
 				const next = args[i + 1];
 				if (next !== undefined && !next.startsWith("-") && !next.startsWith("@")) {
 					result.unknownFlags.set(flagName, next);
+					// Flag types are only known after extensions load, so the consumed
+					// token is recorded by position and restored to the message stream
+					// during extension flag resolution if the flag is boolean.
+					result.unknownFlagValueIndices.set(flagName, result.messages.length);
 					i++;
 				} else {
 					result.unknownFlags.set(flagName, true);

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -41,6 +41,13 @@ export interface CreateAgentSessionServicesOptions {
 	modelRuntime?: ModelRuntime;
 	modelRuntimeSignal?: AbortSignal;
 	extensionFlagValues?: Map<string, boolean | string>;
+	/** Indexes into `extensionFlagMessages` of tokens consumed as candidate values by
+	 * `parseArgs` (see `Args.unknownFlagValueIndices`). Boolean flags restore their
+	 * candidate token into the message stream; string flags keep the consumed value. */
+	extensionFlagValueMessageIndices?: Map<string, number>;
+	/** `Args.messages` from the parsed CLI args. Mutated in place when boolean flags
+	 * restore their candidate token (idempotent: resolution re-runs on resume/fork). */
+	extensionFlagMessages?: string[];
 	resourceLoaderOptions?: Omit<DefaultResourceLoaderOptions, "cwd" | "agentDir" | "settingsManager">;
 	resourceLoaderReloadOptions?: ResourceLoaderReloadOptions;
 }
@@ -82,6 +89,8 @@ export interface AgentSessionServices {
 function applyExtensionFlagValues(
 	resourceLoader: ResourceLoader,
 	extensionFlagValues: Map<string, boolean | string> | undefined,
+	extensionFlagValueMessageIndices?: Map<string, number>,
+	extensionFlagMessages?: string[],
 ): AgentSessionRuntimeDiagnostic[] {
 	if (!extensionFlagValues) {
 		return [];
@@ -96,6 +105,9 @@ function applyExtensionFlagValues(
 		}
 	}
 
+	// Candidate tokens consumed by boolean flags, restored to the message stream in
+	// reverse order of appearance so earlier insertions do not shift later indices.
+	const messageInsertions: Array<{ index: number; value: string }> = [];
 	const unknownFlags: string[] = [];
 	for (const [name, value] of extensionFlagValues) {
 		const flag = registeredFlags.get(name);
@@ -105,6 +117,15 @@ function applyExtensionFlagValues(
 		}
 		if (flag.type === "boolean") {
 			extensionsResult.runtime.flagValues.set(name, true);
+			const index = extensionFlagValueMessageIndices?.get(name);
+			if (
+				typeof value === "string" &&
+				extensionFlagMessages &&
+				index !== undefined &&
+				extensionFlagMessages[index] !== value
+			) {
+				messageInsertions.push({ index, value });
+			}
 			continue;
 		}
 		if (typeof value === "string") {
@@ -115,6 +136,13 @@ function applyExtensionFlagValues(
 			type: "error",
 			message: `Extension flag "--${name}" requires a value`,
 		});
+	}
+
+	// Idempotent: the `extensionFlagMessages[index] !== value` guard above fails on
+	// re-runs (runtime replacement on resume/fork re-invokes this function), so a
+	// restored token is never inserted twice.
+	for (const { index, value } of messageInsertions.reverse()) {
+		extensionFlagMessages!.splice(index, 0, value);
 	}
 
 	if (unknownFlags.length > 0) {
@@ -180,7 +208,14 @@ export async function createAgentSessionServices(
 	}
 	extensionsResult.runtime.pendingNativeProviderRegistrations = [];
 	await modelRuntime.refresh({ allowNetwork: false });
-	diagnostics.push(...applyExtensionFlagValues(resourceLoader, options.extensionFlagValues));
+	diagnostics.push(
+		...applyExtensionFlagValues(
+			resourceLoader,
+			options.extensionFlagValues,
+			options.extensionFlagValueMessageIndices,
+			options.extensionFlagMessages,
+		),
+	);
 
 	return {
 		cwd,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -741,6 +741,8 @@ export async function main(args: string[], options?: MainOptions) {
 			settingsManager: runtimeSettingsManager,
 			modelRuntimeSignal: AbortSignal.timeout(15_000),
 			extensionFlagValues: parsed.unknownFlags,
+			extensionFlagValueMessageIndices: parsed.unknownFlagValueIndices,
+			extensionFlagMessages: parsed.messages,
 			resourceLoaderReloadOptions: shouldResolveProjectTrust
 				? {
 						resolveProjectTrust: async ({ extensionsResult }) => {

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -443,6 +443,37 @@ describe("parseArgs", () => {
 			const result = parseArgs(["--unknown-flag", "message"]);
 			expect(result.messages).toEqual([]);
 			expect(result.unknownFlags.get("unknown-flag")).toBe("message");
+			// The candidate token is consumed into the flag; its message-stream position
+			// is recorded so boolean flag resolution can restore it.
+			expect(result.unknownFlagValueIndices.get("unknown-flag")).toBe(0);
+		});
+
+		test("records the candidate position without disturbing messages", () => {
+			const result = parseArgs(["--plan", "first", "second"]);
+			expect(result.messages).toEqual(["second"]);
+			expect(result.unknownFlags.get("plan")).toBe("first");
+			expect(result.unknownFlagValueIndices.get("plan")).toBe(0);
+		});
+
+		test("records the candidate position after existing messages", () => {
+			const result = parseArgs(["-p", "before", "--plan", "after"]);
+			expect(result.messages).toEqual(["before"]);
+			expect(result.unknownFlags.get("plan")).toBe("after");
+			expect(result.unknownFlagValueIndices.get("plan")).toBe(1);
+		});
+
+		test("does not record a candidate index for equals syntax", () => {
+			const result = parseArgs(["--unknown-flag=value", "prompt"]);
+			expect(result.messages).toEqual(["prompt"]);
+			expect(result.unknownFlags.get("unknown-flag")).toBe("value");
+			expect(result.unknownFlagValueIndices.has("unknown-flag")).toBe(false);
+		});
+
+		test("does not record a candidate index when the next token is a flag", () => {
+			const result = parseArgs(["--plan", "--verbose", "prompt"]);
+			expect(result.messages).toEqual(["prompt"]);
+			expect(result.unknownFlags.get("plan")).toBe(true);
+			expect(result.unknownFlagValueIndices.has("plan")).toBe(false);
 		});
 
 		test("captures unknown boolean long flags", () => {

--- a/packages/coding-agent/test/initial-message.test.ts
+++ b/packages/coding-agent/test/initial-message.test.ts
@@ -7,6 +7,7 @@ function createArgs(messages: string[] = []): Args {
 		messages: [...messages],
 		fileArgs: [],
 		unknownFlags: new Map(),
+		unknownFlagValueIndices: new Map(),
 		diagnostics: [],
 	};
 }

--- a/packages/coding-agent/test/suite/regressions/7139-boolean-extension-flag-prompt.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7139-boolean-extension-flag-prompt.test.ts
@@ -1,0 +1,125 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseArgs } from "../../../src/cli/args.ts";
+import { createAgentSessionServices } from "../../../src/core/agent-session-runtime.ts";
+import { SettingsManager } from "../../../src/core/settings-manager.ts";
+
+describe("regression #7139: boolean extension flags do not swallow the prompt", () => {
+	let tempDir: string;
+	let agentDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-flag-swallow-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		agentDir = join(tempDir, "agent");
+		mkdirSync(agentDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	async function resolveArgs(args: string[]) {
+		const parsed = parseArgs(args);
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const services = await createAgentSessionServices({
+			cwd: tempDir,
+			agentDir,
+			settingsManager,
+			extensionFlagValues: parsed.unknownFlags,
+			extensionFlagValueMessageIndices: parsed.unknownFlagValueIndices,
+			extensionFlagMessages: parsed.messages,
+			resourceLoaderOptions: {
+				extensionFactories: [
+					(pi) => {
+						pi.registerFlag("plan", { description: "Plan mode", type: "boolean", default: false });
+						pi.registerFlag("ssh", { description: "SSH remote", type: "string" });
+						pi.registerFlag("preset", { description: "Preset name", type: "string" });
+					},
+				],
+			},
+		});
+		const flagValues = services.resourceLoader.getExtensions().runtime.flagValues;
+		const flagErrors = services.diagnostics.filter(
+			(diagnostic) =>
+				diagnostic.type === "error" &&
+				(diagnostic.message.startsWith("Unknown option") || diagnostic.message.includes("requires a value")),
+		);
+		return { parsed, flagValues, flagErrors };
+	}
+
+	it("keeps the prompt when a boolean flag precedes it", async () => {
+		const { parsed, flagValues, flagErrors } = await resolveArgs(["-p", "--plan", "Say exactly: MARKER123"]);
+
+		expect(flagValues.get("plan")).toBe(true);
+		expect(parsed.messages).toEqual(["Say exactly: MARKER123"]);
+		expect(flagErrors).toEqual([]);
+	});
+
+	it("keeps all messages in order after a boolean flag", async () => {
+		const { parsed, flagValues, flagErrors } = await resolveArgs(["-p", "--plan", "FIRST-ARG", "SECOND-ARG"]);
+
+		expect(flagValues.get("plan")).toBe(true);
+		expect(parsed.messages).toEqual(["FIRST-ARG", "SECOND-ARG"]);
+		expect(flagErrors).toEqual([]);
+	});
+
+	it("claims the next token as value for a string flag", async () => {
+		const { parsed, flagValues, flagErrors } = await resolveArgs(["-p", "--ssh", "user@host", "prompt"]);
+
+		expect(flagValues.get("ssh")).toBe("user@host");
+		expect(parsed.messages).toEqual(["prompt"]);
+		expect(flagErrors).toEqual([]);
+	});
+
+	it("claims the next token for multiple string flags without disturbing messages", async () => {
+		const { parsed, flagValues, flagErrors } = await resolveArgs([
+			"-p",
+			"--ssh",
+			"user@host",
+			"--preset",
+			"my-preset",
+			"prompt",
+		]);
+
+		expect(flagValues.get("ssh")).toBe("user@host");
+		expect(flagValues.get("preset")).toBe("my-preset");
+		expect(parsed.messages).toEqual(["prompt"]);
+		expect(flagErrors).toEqual([]);
+	});
+
+	it("keeps the prompt when the boolean flag comes after it", async () => {
+		const { parsed, flagValues, flagErrors } = await resolveArgs(["-p", "prompt", "--plan"]);
+
+		expect(flagValues.get("plan")).toBe(true);
+		expect(parsed.messages).toEqual(["prompt"]);
+		expect(flagErrors).toEqual([]);
+	});
+
+	it("supports equals syntax for boolean flags", async () => {
+		const { parsed, flagValues, flagErrors } = await resolveArgs(["-p", "--plan=true", "prompt"]);
+
+		expect(flagValues.get("plan")).toBe(true);
+		expect(parsed.messages).toEqual(["prompt"]);
+		expect(flagErrors).toEqual([]);
+	});
+
+	it("reports unknown options", async () => {
+		const { parsed, flagValues, flagErrors } = await resolveArgs(["-p", "--nope", "prompt"]);
+
+		expect(flagValues.has("nope")).toBe(false);
+		// Unregistered flags keep their pre-fix behavior: the candidate token is
+		// consumed and the run aborts on the diagnostic error.
+		expect(parsed.messages).toEqual([]);
+		expect(flagErrors.map((error) => error.message)).toEqual(["Unknown option: --nope"]);
+	});
+
+	it("reports string flags without a value", async () => {
+		const { flagErrors } = await resolveArgs(["-p", "--ssh"]);
+
+		expect(flagErrors.map((error) => error.message)).toEqual(['Extension flag "--ssh" requires a value']);
+	});
+});


### PR DESCRIPTION
Boolean extension flags (e.g. --plan) consumed the next CLI argument as their value because flag types are only known after extensions load. applyExtensionFlagValues discarded the swallowed token for boolean flags, so 'pi -p --plan "prompt"' started a session with no messages and exited 0 without doing anything.

parseArgs now records the message-stream position of the consumed token in Args.unknownFlagValueIndices. applyExtensionFlagValues restores the token for boolean flags (reverse insertion order so multiple flags keep their relative order; guarded so resume/fork runtime replacement does not re-insert) and keeps it as the value for string flags.

Fixes #7139 