### PR TITLE
feat(tui): cancel active mouse selection with escape

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -86,7 +86,7 @@ The dedicated history actions always change history entries, regardless of the c
 
 ### TUI Fullscreen Viewport
 
-These actions apply when interactive mode uses `--tui-mode fullscreen` and target the primary transcript scroll region. Two-finger trackpad and mouse-wheel input scroll the region under the pointer, falling back to the transcript over the fixed editor/status/footer dock. Clicking an OSC 8 hyperlink opens it in the default handler. Dragging with the primary mouse button selects text and copies it to the clipboard; holding at the transcript's top or bottom edge auto-scrolls into off-screen content. See [Terminal setup](terminal-setup.md) for terminal-specific mouse and trackpad behavior.
+These actions apply when interactive mode uses `--tui-mode fullscreen` and target the primary transcript scroll region. Two-finger trackpad and mouse-wheel input scroll the region under the pointer, falling back to the transcript over the fixed editor/status/footer dock. Clicking an OSC 8 hyperlink opens it in the default handler. Dragging with the primary mouse button selects text and copies it to the clipboard; holding at the transcript's top or bottom edge auto-scrolls into off-screen content. Before releasing the mouse button, `tui.altScreen.selectionCancel` (`Escape` by default) cancels the selection without copying. See [Terminal setup](terminal-setup.md) for terminal-specific mouse and trackpad behavior.
 
 Fullscreen transcript bindings take precedence over editor bindings. The default unmodified navigation keys therefore control the transcript in fullscreen mode, while their `ctrl` variants continue to control the editor. Outside fullscreen mode, both variants control the editor.
 
@@ -109,6 +109,7 @@ This routing remains configurable through the ordinary action bindings. For exam
 | `tui.altScreen.lineDown` | *(none)* | Scroll the transcript down by one line |
 | `tui.altScreen.previousPrompt` | `ctrl+shift+up` | Jump to the previous marked message |
 | `tui.altScreen.nextPrompt` | `ctrl+shift+down` | Jump to the next marked message |
+| `tui.altScreen.selectionCancel` | `escape` | Cancel an active mouse selection |
 | `tui.altScreen.search` | `ctrl+shift+f` | Search the rendered transcript |
 | `tui.altScreen.searchNext` | `enter`, `ctrl+g` | Select the next search match while searching |
 | `tui.altScreen.searchPrevious` | `shift+enter`, `ctrl+shift+g` | Select the previous search match while searching |

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -50,6 +50,7 @@ export interface Keybindings {
 	"tui.altScreen.lineDown": true;
 	"tui.altScreen.previousPrompt": true;
 	"tui.altScreen.nextPrompt": true;
+	"tui.altScreen.selectionCancel": true;
 	"tui.altScreen.search": true;
 	"tui.altScreen.searchNext": true;
 	"tui.altScreen.searchPrevious": true;
@@ -188,6 +189,10 @@ export const TUI_KEYBINDINGS = {
 	"tui.altScreen.nextPrompt": {
 		defaultKeys: "ctrl+shift+down",
 		description: "Jump to next semantic prompt",
+	},
+	"tui.altScreen.selectionCancel": {
+		defaultKeys: "escape",
+		description: "Cancel an active mouse selection",
 	},
 	"tui.altScreen.search": {
 		defaultKeys: "ctrl+shift+f",

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -529,24 +529,27 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		return this.isOverlayFocused() && this.activeSearch?.overlay?.isFocused() !== true;
 	}
 
+	private cancelSelectionPress(): void {
+		const hadActiveSelection = this.selectionPressActive;
+		const hadNonEmptyActiveSelection = hadActiveSelection && this.getSelectionBounds() !== undefined;
+		this.selectionPressActive = false;
+		this.stopSelectionAutoScroll();
+		this.pressedUrl = undefined;
+		this.selectionDragged = false;
+		this.lastClick = undefined;
+		if (!hadActiveSelection) return;
+		this.selectionAnchor = undefined;
+		this.selectionFocus = undefined;
+		this.selectionGranularity = "character";
+		this.selectionInitialRange = undefined;
+		if (hadNonEmptyActiveSelection) this.requestRender();
+	}
+
 	private handleViewportInput(data: string): { consume?: boolean } | undefined {
 		if (data === FOCUS_OUT) {
-			const hadActiveSelection = this.selectionPressActive;
-			const hadNonEmptyActiveSelection = hadActiveSelection && this.getSelectionBounds() !== undefined;
-			this.selectionPressActive = false;
-			this.stopSelectionAutoScroll();
+			this.cancelSelectionPress();
 			this.stopScrollbarHover();
 			this.stopScrollbarDrag();
-			this.pressedUrl = undefined;
-			this.selectionDragged = false;
-			if (hadActiveSelection) {
-				this.selectionAnchor = undefined;
-				this.selectionFocus = undefined;
-				this.selectionGranularity = "character";
-				this.selectionInitialRange = undefined;
-				if (hadNonEmptyActiveSelection) this.requestRender();
-			}
-			this.lastClick = undefined;
 			return { consume: true };
 		}
 		if (data === FOCUS_IN) return { consume: true };
@@ -569,6 +572,10 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 		const keybindings = getKeybindings();
 		const isRelease = isKeyRelease(data);
+		if (this.selectionPressActive && keybindings.matches(data, "tui.altScreen.selectionCancel")) {
+			if (!isRelease) this.cancelSelectionPress();
+			return { consume: true };
+		}
 		if (keybindings.matches(data, "tui.altScreen.search")) {
 			if (!isRelease) this.openSearch();
 			return { consume: true };

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -963,6 +963,90 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
+	it("cancels an active mouse selection without copying or forwarding Escape", async () => {
+		const terminal = new RecordingTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal);
+		const focused = new InputOverlay();
+		tui.addChild(new Text("alpha\nbeta\ngamma", 0, 0));
+		tui.addChild(focused);
+		tui.setFocus(focused);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;4;2M");
+		await terminal.waitForRender();
+		const cancelEventCount = terminal.events.length;
+		terminal.sendInput("\x1b");
+		await terminal.waitForRender();
+
+		const cancelWrites = terminal.events
+			.slice(cancelEventCount)
+			.filter((event): event is { type: "write"; data: string } => event.type === "write")
+			.map((event) => event.data)
+			.join("");
+		assert.ok(cancelWrites.includes("alpha"));
+		assert.ok(cancelWrites.includes("beta"));
+		assert.ok(!cancelWrites.includes("\x1b[7m"));
+		assert.deepStrictEqual(focused.inputs, []);
+
+		terminal.sendInput("\x1b[<32;6;3M");
+		terminal.sendInput("\x1b[<0;6;3m");
+		await terminal.waitForRender();
+		assert.ok(terminal.events.every((event) => event.type !== "write" || !event.data.includes("\x1b]52;c;")));
+		assert.ok(!terminal.getViewport().some((line) => line.includes("Copied!")));
+		tui.stop();
+	});
+
+	it("does not repaint when cancelling a zero-width mouse selection", async () => {
+		const terminal = new RecordingTerminal(20, 2);
+		const tui = new TuiAltScreen(terminal);
+		tui.addChild(new Text("alpha\nbeta", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		await terminal.waitForRender();
+		const pressedWriteCount = terminal.events.filter((event) => event.type === "write").length;
+		terminal.sendInput("\x1b");
+		await terminal.waitForRender();
+		assert.strictEqual(terminal.events.filter((event) => event.type === "write").length, pressedWriteCount);
+
+		terminal.sendInput("\x1b[<0;1;1m");
+		await terminal.waitForRender();
+		assert.strictEqual(terminal.events.filter((event) => event.type === "write").length, pressedWriteCount);
+		tui.stop();
+	});
+
+	it("leaves completed mouse selections intact when Escape is pressed", async () => {
+		const terminal = new RecordingTerminal(20, 3);
+		const tui = new TuiAltScreen(terminal);
+		const focused = new InputOverlay();
+		tui.addChild(new Text("alpha\nbeta", 0, 0));
+		tui.addChild(focused);
+		tui.setFocus(focused);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;4;2M");
+		terminal.sendInput("\x1b[<0;4;2m");
+		await terminal.waitForRender();
+		terminal.sendInput("\x1b");
+		await terminal.waitForRender();
+		assert.deepStrictEqual(focused.inputs, ["\x1b"]);
+
+		const redrawEventCount = terminal.events.length;
+		tui.renderNow(true);
+		const redrawWrites = terminal.events
+			.slice(redrawEventCount)
+			.filter((event): event is { type: "write"; data: string } => event.type === "write")
+			.map((event) => event.data)
+			.join("");
+		assert.ok(redrawWrites.includes("\x1b[7m"));
+		tui.stop();
+	});
+
 	it("does not append whitespace to double-click word highlighting", async () => {
 		const terminal = new RecordingTerminal(20, 1);
 		const tui = new TuiAltScreen(terminal);
@@ -1186,6 +1270,33 @@ describe("TuiAltScreen", () => {
 			terminal.events.some((event) => event.type === "write" && event.data.includes(expectedClipboardSequence)),
 			JSON.stringify(terminal.events.filter((event) => event.type === "write" && event.data.includes("\x1b]52;c;"))),
 		);
+		tui.stop();
+	});
+
+	it("stops selection auto-scroll when Escape cancels the drag", async () => {
+		const terminal = new RecordingTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal);
+		tui.addChild(new Text(Array.from({ length: 10 }, (_, index) => `line ${index + 1}`).join("\n"), 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+		assert.strictEqual(tui.viewportTop, 6);
+
+		terminal.sendInput("\x1b[<0;1;3M");
+		terminal.sendInput("\x1b[<32;1;1M");
+		await new Promise((resolve) => setTimeout(resolve, 130));
+		await terminal.waitForRender();
+		assert.ok(tui.viewportTop < 6);
+
+		terminal.sendInput("\x1b");
+		await terminal.waitForRender();
+		const cancelledViewportTop = tui.viewportTop;
+		await new Promise((resolve) => setTimeout(resolve, 130));
+		await terminal.waitForRender();
+		assert.strictEqual(tui.viewportTop, cancelledViewportTop);
+
+		terminal.sendInput("\x1b[<0;1;1m");
+		await terminal.waitForRender();
+		assert.ok(terminal.events.every((event) => event.type !== "write" || !event.data.includes("\x1b]52;c;")));
 		tui.stop();
 	});
 


### PR DESCRIPTION
I like the auto-copy-to-clipboard but some people (like me), click and select like maniacs while reading. This change allows you to change your mind mid-drag, you can press `Escape` before releasing the mouse to clear the selection without copying it.

This is pretty standard behavior on text editors/inputs.

Changes:
- Add `tui.altScreen.selectionCancel`, bound to Escape by default.
- Cancel active selection and edge auto-scroll without interrupting ongoing agent work.
- Preserve completed selections and existing Escape behavior outside an active drag.
- Add documentation and regression tests.