### PR TITLE
fix(ai): fall back to the legacy Gemini tool schema when endpoints reject unknown fields

### DIFF
--- a/packages/ai/src/api/google-generative-ai.ts
+++ b/packages/ai/src/api/google-generative-ai.ts
@@ -29,6 +29,7 @@ import {
 	convertMessages,
 	convertTools,
 	isThinkingPart,
+	isUnknownSchemaFieldError,
 	mapStopReason,
 	resolveGoogleFunctionCallingMode,
 	retainThoughtSignature,
@@ -89,7 +90,18 @@ export const stream: StreamFunction<"google-generative-ai", GoogleOptions> = (
 			if (nextParams !== undefined) {
 				params = nextParams as GenerateContentParameters;
 			}
-			const googleStream = await retryGoogleRequest(() => client.models.generateContentStream(params), options);
+			const googleStream = await retryGoogleRequest(
+				() => client.models.generateContentStream(params),
+				options,
+			).catch((error) => {
+				// Endpoints on older serving stacks reject tool schemas that use fields
+				// they do not know; rebuild once with the legacy `parameters` subset.
+				if (!context.tools?.length || !isUnknownSchemaFieldError(error)) throw error;
+				return retryGoogleRequest(
+					() => client.models.generateContentStream(buildParams(model, context, options, true)),
+					options,
+				);
+			});
 
 			stream.push({ type: "start", partial: output });
 			let currentBlock: TextContent | ThinkingContent | null = null;
@@ -356,6 +368,7 @@ function buildParams(
 	model: Model<"google-generative-ai">,
 	context: Context,
 	options: GoogleOptions = {},
+	useLegacyParameters = false,
 ): GenerateContentParameters {
 	const contents = convertMessages(model, context);
 
@@ -376,7 +389,7 @@ function buildParams(
 		...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
 		...(context.tools &&
 			context.tools.length > 0 && {
-				tools: convertTools(context.tools, false, supportsStrictMode),
+				tools: convertTools(context.tools, useLegacyParameters, supportsStrictMode),
 			}),
 		...(functionCallingMode !== undefined && {
 			toolConfig: { functionCallingConfig: { mode: functionCallingMode } },

--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -247,28 +247,72 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 	return contents;
 }
 
-const JSON_SCHEMA_META_DECLARATIONS = new Set([
-	"$schema",
-	"$id",
-	"$anchor",
-	"$dynamicAnchor",
-	"$vocabulary",
-	"$comment",
-	"$defs",
-	"definitions", // pre-draft-2019-09 equivalent of $defs
+/**
+ * Fields of the Gemini legacy Schema message (mirrors the Schema interface in
+ * @google/genai). Endpoints that only accept the legacy subset reject any field
+ * outside this list, so emit exactly these and nothing else.
+ */
+const GEMINI_LEGACY_SCHEMA_KEYS = new Set([
+	"anyOf",
+	"default",
+	"description",
+	"enum",
+	"example",
+	"format",
+	"items",
+	"maximum",
+	"maxItems",
+	"maxLength",
+	"maxProperties",
+	"minimum",
+	"minItems",
+	"minLength",
+	"minProperties",
+	"nullable",
+	"pattern",
+	"properties",
+	"propertyOrdering",
+	"required",
+	"title",
+	"type",
 ]);
 
 /**
- * Strip meta-declarations from a schema obj
+ * Downgrade a JSON Schema to the Gemini legacy Schema subset: keep only fields
+ * the legacy Schema message defines, fold `const` into `enum`, and recurse into
+ * arrays (e.g. anyOf entries).
  */
 function sanitizeForOpenApi(schema: unknown): unknown {
-	if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
+	if (typeof schema !== "object" || schema === null) {
 		return schema;
+	}
+	if (Array.isArray(schema)) {
+		return schema.map(sanitizeForOpenApi);
 	}
 
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(schema)) {
-		if (JSON_SCHEMA_META_DECLARATIONS.has(key)) continue;
+		if (key === "const") {
+			result.enum = [value];
+			continue;
+		}
+		if (key === "$ref") {
+			// Deliberately preserved: dropping a $ref silently breaks the schema
+			// worse than passing it through.
+			result.$ref = value;
+			continue;
+		}
+		if (key === "properties" && typeof value === "object" && value !== null && !Array.isArray(value)) {
+			// `properties` is keyed by arbitrary property names, not schema keywords;
+			// keep every entry and sanitize each property schema.
+			const props: Record<string, unknown> = {};
+			for (const [propName, propSchema] of Object.entries(value)) {
+				props[propName] = sanitizeForOpenApi(propSchema);
+			}
+			result.properties = props;
+			continue;
+		}
+		if (!GEMINI_LEGACY_SCHEMA_KEYS.has(key)) continue;
 		result[key] = sanitizeForOpenApi(value);
 	}
 	return result;
@@ -395,6 +439,18 @@ export function mapStopReasonString(reason: string): StopReason {
  * both, so normalize the error by adding the missing `headers` before
  * rethrowing.
  */
+/**
+ * True when a Gemini endpoint rejected the request because the tool schema used
+ * JSON Schema fields the endpoint does not know (e.g. `parametersJsonSchema`,
+ * `patternProperties`, `const`). These 400s are fixed by retrying with legacy
+ * `parameters`, so callers should not surface them as model errors.
+ */
+export function isUnknownSchemaFieldError(error: unknown): boolean {
+	if ((error as { status?: unknown })?.status !== 400) return false;
+	const message = String((error as { message?: unknown })?.message ?? error);
+	return /Unknown name|Cannot find field/i.test(message);
+}
+
 export function retryGoogleRequest<T>(
 	request: () => Promise<T>,
 	options?: Pick<StreamOptions, "maxRetries" | "maxRetryDelayMs" | "signal">,

--- a/packages/ai/test/google-shared-convert-tools.test.ts
+++ b/packages/ai/test/google-shared-convert-tools.test.ts
@@ -201,3 +201,74 @@ describe("google-shared convertTools", () => {
 		expect(convertTools([], true)).toBeUndefined();
 	});
 });
+
+describe("google-shared legacy parameters subset", () => {
+	it("folds const into enum, including inside anyOf arrays", () => {
+		const tools = [
+			makeTool({
+				type: "object",
+				properties: {
+					mode: { anyOf: [{ const: "auto" }, { const: "json" }] },
+				},
+			}),
+		];
+		const decl = convertTools(tools, true)?.[0]?.functionDeclarations?.[0];
+		expect(decl?.parameters).toEqual({
+			type: "object",
+			properties: { mode: { anyOf: [{ enum: ["auto"] }, { enum: ["json"] }] } },
+		});
+	});
+
+	it("drops keywords the legacy Schema message does not define", () => {
+		const tools = [
+			makeTool({
+				type: "object",
+				properties: {
+					map: {
+						type: "object",
+						patternProperties: { "^.*$": { type: "string" } },
+						additionalProperties: false,
+					},
+					pick: { oneOf: [{ type: "string" }, { type: "number" }] },
+					n: { type: "number", exclusiveMinimum: 0 },
+				},
+			}),
+		];
+		const decl = convertTools(tools, true)?.[0]?.functionDeclarations?.[0];
+		expect(decl?.parameters).toEqual({
+			type: "object",
+			properties: {
+				map: { type: "object" },
+				pick: {},
+				n: { type: "number" },
+			},
+		});
+	});
+
+	it("keeps legacy Schema fields such as propertyOrdering", () => {
+		const tools = [
+			makeTool({
+				type: "object",
+				properties: { command: { type: "string" } },
+				required: ["command"],
+				propertyOrdering: ["command"],
+			}),
+		];
+		const decl = convertTools(tools, true)?.[0]?.functionDeclarations?.[0];
+		expect(decl?.parameters).toEqual({
+			type: "object",
+			properties: { command: { type: "string" } },
+			required: ["command"],
+			propertyOrdering: ["command"],
+		});
+	});
+
+	it("emits parametersJsonSchema untouched when useParameters=false", () => {
+		const schema = {
+			type: "object",
+			properties: { mode: { anyOf: [{ const: "auto" }] } },
+		};
+		const decl = convertTools([makeTool(schema)], false)?.[0]?.functionDeclarations?.[0];
+		expect(decl?.parametersJsonSchema).toEqual(schema);
+	});
+});

--- a/packages/ai/test/google-shared-retry.test.ts
+++ b/packages/ai/test/google-shared-retry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { retryGoogleRequest } from "../src/api/google-shared.ts";
+import { isUnknownSchemaFieldError, retryGoogleRequest } from "../src/api/google-shared.ts";
 
 /** Shaped like @google/genai's ApiError: has `status`, but no `headers`. */
 function googleApiError(status: number): Error {
@@ -36,5 +36,27 @@ describe("google request retries", () => {
 
 		await expect(retryGoogleRequest(request, { maxRetries: 2 })).rejects.toBe(error);
 		expect(request).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("isUnknownSchemaFieldError", () => {
+	it("matches the gemini invalid-argument unknown-schema-field payload", () => {
+		const error = Object.assign(
+			new Error(
+				"Invalid JSON payload received. Unknown name \"parametersJsonSchema\" at 'tools[0].function_declarations[0]': Cannot find field.",
+			),
+			{ status: 400 },
+		);
+		expect(isUnknownSchemaFieldError(error)).toBe(true);
+	});
+
+	it("rejects non-400 errors even when the message matches", () => {
+		const error = Object.assign(new Error('Unknown name "parametersJsonSchema"'), { status: 429 });
+		expect(isUnknownSchemaFieldError(error)).toBe(false);
+	});
+
+	it("rejects unrelated 400s", () => {
+		const error = Object.assign(new Error("Invalid argument: temperature out of range"), { status: 400 });
+		expect(isUnknownSchemaFieldError(error)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Problem

Some generativelanguage endpoints reject tool-calling requests whose schemas use JSON Schema fields outside the legacy Schema message:

- `parametersJsonSchema` itself: `400 INVALID_ARGUMENT: Unknown name "parametersJsonSchema" at 'tools[0].function_declarations[0]'`
- inside legacy `parameters`: `patternProperties`, `const`, and any other keyword the legacy message does not define

Observed with `gemini-3.6-flash` on the public generativelanguage endpoint: every tool call 400s, while the same model answers fine without tools.

## Fix

1. **`sanitizeForOpenApi` becomes a whitelist** of the legacy Schema message fields (mirroring `@google/genai`'s `Schema` interface) instead of a meta-key blacklist: unknown keywords are dropped, `const: X` folds to `enum: [X]`, `$ref` is preserved, `properties` maps keep their arbitrary keys, and arrays (e.g. `anyOf` entries) are descended into. A blacklist encodes the bugs you have seen; the whitelist encodes the server's contract, so future TypeBox keywords cannot 400.
2. **`google-generative-ai` retries once with legacy `parameters`** when a request fails with a schema-field 400 (`isUnknownSchemaFieldError`: status 400 + "Unknown name"/"Cannot find field"). Endpoints on older serving stacks self-heal; endpoints that accept `parametersJsonSchema` see no behavior change.

## Verification

- New unit tests: whitelist drops non-legacy keywords, const folds into enum (including inside `anyOf`), `properties`/`propertyOrdering`/`$ref` preserved, `parametersJsonSchema` path untouched, detector matches the real 400 payload and rejects unrelated 400s/429s. 18/18 green in the two touched suites; other suite failures reproduce on clean `main` (missing generated provider data) and are unrelated.
- Live end-to-end against `gemini-3.6-flash` with a tool schema containing `patternProperties` + `const`: completes with `stopReason: "toolUse"` and a valid tool call. On this endpoint the default `parametersJsonSchema` path always 400s, so success can only come via the new fallback; the model also correctly used an enum-folded value.

## Scope note

`onPayload`-modified params are not reapplied on the fallback retry; the fallback rebuilds via `buildParams`. `google-vertex` is untouched (Vertex accepts `parametersJsonSchema`).