### PR TITLE
fix(coding-agent): print mode misses final output on tool-call tails

### DIFF
--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -138,20 +138,40 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 
 		if (mode === "text") {
 			const state = session.state;
-			const lastMessage = state.messages[state.messages.length - 1];
-
-			if (lastMessage?.role === "assistant") {
-				const assistantMsg = lastMessage as AssistantMessage;
+			// Walk BACKWARDS to the last assistant message that carries text.
+			// A long agentic run can legitimately end on a tool-call-only
+			// assistant message, or on a non-assistant entry (compaction,
+			// extension injection) — the previous behaviour printed "the
+			// literal last entry or nothing", which emitted ZERO bytes with
+			// exit 0 on exactly those tails, silently losing the run's report.
+			// An error/abort on the terminal assistant message still reports
+			// as an error; a session with no printable text anywhere is a
+			// FAILED print, not a silent success.
+			let printedText = false;
+			let reportedError = false;
+			for (let i = state.messages.length - 1; i >= 0; i--) {
+				const candidate = state.messages[i];
+				if (candidate?.role !== "assistant") continue;
+				const assistantMsg = candidate as AssistantMessage;
 				if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
 					console.error(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
 					exitCode = 1;
-				} else {
-					for (const content of assistantMsg.content) {
-						if (content.type === "text") {
-							writeRawStdout(`${content.text}\n`);
-						}
-					}
+					reportedError = true;
+					break;
 				}
+				const textParts = assistantMsg.content.filter((content) => content.type === "text");
+				if (textParts.length === 0) continue;
+				for (const content of textParts) {
+					writeRawStdout(`${content.text}\n`);
+				}
+				printedText = true;
+				break;
+			}
+			if (!printedText && !reportedError) {
+				console.error(
+					"pi: print mode produced no text output (no assistant message with text content in the session)",
+				);
+				exitCode = 1;
 			}
 		}
 

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -1,5 +1,13 @@
 import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/core/output-guard.ts", () => ({
+	writeRawStdout: vi.fn(),
+	flushRawStdout: vi.fn(async () => {}),
+	waitForRawStdoutBackpressure: vi.fn(async () => {}),
+}));
+
+import { writeRawStdout } from "../src/core/output-guard.ts";
 import type { SessionShutdownEvent } from "../src/index.ts";
 import { runPrintMode } from "../src/modes/print-mode.ts";
 
@@ -121,6 +129,47 @@ describe("runPrintMode", () => {
 		expect(session.prompt).toHaveBeenCalledWith("hello");
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
+	});
+
+	it("KHA-346a: prints the last assistant TEXT even when the final assistant message is tool-call-only", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "the real report" }));
+		// Simulate a long agentic run's tail: the final assistant message carries
+		// no text content (it ended on tool calls) — the previous one has the report.
+		runtimeHost.session.state.messages.push(createAssistantMessage({}));
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(writeRawStdout).toHaveBeenCalledWith("the real report\n");
+	});
+
+	it("KHA-346b: prints the last assistant TEXT even when the session tail is a non-assistant entry", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "the real report" }));
+		runtimeHost.session.state.messages.push({
+			role: "user",
+			content: "injected tail",
+		} as unknown as AssistantMessage);
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(0);
+		expect(writeRawStdout).toHaveBeenCalledWith("the real report\n");
+	});
+
+	it("KHA-346c: a print run with NO printable text anywhere exits non-zero and says so on stderr", async () => {
+		const runtimeHost = createRuntimeHost(createAssistantMessage({}));
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+			mode: "text",
+		});
+
+		expect(exitCode).toBe(1);
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("no text output"));
 	});
 
 	it("emits session_shutdown and returns non-zero on assistant error", async () => {


### PR DESCRIPTION
…empty print exits non-zero

Print mode's text output only fired when the literal last session entry was an assistant message with text content. Long agentic runs routinely end on a tool-call-only assistant message or a non-assistant entry (compaction, extension injection) — in exactly those cases pi printed NOTHING and exited 0, silently losing the run's final report. Observed three times in one day driving headless builds.

Text mode now walks backwards to the last assistant message carrying text and prints that; a terminal error/abort still reports as before; and a print run with no printable text anywhere writes a diagnostic to stderr and exits 1 — a print that printed nothing is a failure, not a silent success.

Three new tests reproduce each failure shape (tool-call tail, non-assistant tail, genuinely-empty session), red against the previous code, green with the fix; existing print-mode tests unchanged.