### PR TITLE
feat(ai): use pi user-agent for kimi-coding requests

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -148,8 +148,11 @@ const COPILOT_STATIC_HEADERS = {
 	"Copilot-Integration-Id": "vscode-chat",
 } as const;
 
+const aiPackageVersion = (JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as { version: string })
+	.version;
+
 const KIMI_STATIC_HEADERS = {
-	"User-Agent": "KimiCLI/1.5",
+	"User-Agent": `pi/${aiPackageVersion}`,
 } as const;
 
 const TOGETHER_BASE_URL = "https://api.together.ai/v1";


### PR DESCRIPTION
## What

Change the static `User-Agent` header on generated `kimi-coding` models from `KimiCLI/1.5` to `pi/<version>`, with the version read from `packages/ai/package.json` at codegen time. Only `scripts/generate-models.ts` changes; the new header lands in the regenerated model data.

## Why

`KimiCLI/1.5` was added for #3586 because the Kimi For Coding endpoint expected the Kimi CLI client identity. The endpoint now accepts arbitrary user agents, so pi no longer needs to present itself as another client. Identifying as `pi/<version>` gives the provider accurate attribution and is consistent with the Codex adapter, which already self-identifies via `originator: pi` and a `pi (...)` user agent.

## Testing

`npm run check` passes and the `packages/ai` vitest suite passes. A full `./test.sh` run in my environment has pre-existing failures in the `coding-agent` and `pi-protocol` suites (unresolved workspace dist entries without a build) that reproduce identically on `main`; they are unrelated to this change.
