### PR TITLE
fix(ai): detect api.kimi.com as a Moonshot endpoint

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1452,7 +1452,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		baseUrl.includes("open.bigmodel.cn");
 	const isTogether =
 		provider === "together" || baseUrl.includes("api.together.ai") || baseUrl.includes("api.together.xyz");
-	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
+	const isMoonshot = provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.") || baseUrl.includes("api.kimi.com");
 	const isOpenRouter = provider === "openrouter" || baseUrl.includes("openrouter.ai");
 	const isCloudflareWorkersAI = provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
 	const isCloudflareAiGateway = provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");

--- a/packages/ai/test/kimi-coding-compat.test.ts
+++ b/packages/ai/test/kimi-coding-compat.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import type { Model } from "../src/types.ts";
+
+/**
+ * Regression test: api.kimi.com (Kimi Coding, OpenAI-compatible endpoint)
+ * must be detected as a Moonshot endpoint. Without that detection the system
+ * prompt is sent with role "developer", which Kimi rejects with
+ * 400: role 'developer' is not allowed.
+ */
+function buildKimiModel(): Model<"openai-completions"> {
+	return {
+		id: "k3",
+		name: "Kimi K3 1M",
+		api: "openai-completions",
+		provider: "kimi-code",
+		baseUrl: "https://api.kimi.com/coding/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1048576,
+		maxTokens: 1048576,
+		// Mirrors custom-provider configs (e.g. DeepSeek Harness llm-pi-ai):
+		// only reasoning-effort is declared explicitly, so supportsDeveloperRole
+		// must fall back to the baseUrl-based detection.
+		compat: { supportsReasoningEffort: true },
+	};
+}
+
+describe("kimi coding endpoint compat", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("sends the system prompt with role system (not developer) and max_tokens", async () => {
+		let capturedBody: { messages: Array<{ role: string }>; max_tokens?: number; max_completion_tokens?: number } | undefined;
+		const encoder = new TextEncoder();
+		vi.stubGlobal("fetch", async (_url: unknown, init: RequestInit) => {
+			capturedBody = JSON.parse(String(init.body));
+			const sse =
+				'data: {"id":"x","object":"chat.completion.chunk","created":1,"model":"k3","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}\n\n' +
+				"data: [DONE]\n\n";
+			return new Response(
+				new ReadableStream({
+					start(controller) {
+						controller.enqueue(encoder.encode(sse));
+						controller.close();
+					},
+				}),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		});
+
+		const stream = streamOpenAICompletions(
+			buildKimiModel(),
+			{ messages: [], systemPrompt: "You are a helpful assistant.", tools: undefined },
+			{ apiKey: "test-key", reasoningEffort: "high", maxTokens: 8192 },
+		);
+		for await (const event of stream) {
+			if (event.type === "error") {
+				throw new Error(JSON.stringify(event));
+			}
+		}
+
+		expect(capturedBody).toBeDefined();
+		expect(capturedBody!.messages[0].role).toBe("system");
+		expect(capturedBody!.max_tokens).toBe(8192);
+		expect(capturedBody!.max_completion_tokens).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

Custom OpenAI-compatible providers pointing at **Kimi Coding** (`https://api.kimi.com/coding/v1`) fail with:

```
400: {"message":"role 'developer' is not allowed","type":"invalid_request_error"}
```

`detectCompat` only recognizes `api.moonshot.*` hosts as Moonshot, so `api.kimi.com` falls through to the default "standard OpenAI endpoint" detection. With reasoning enabled, the system prompt is then sent with role `"developer"` (see `convertMessages`), which Kimi's API rejects.

## Fix

Add `api.kimi.com` to the `isMoonshot` detection. This makes the same compat behavior as the built-in moonshot providers apply to Kimi Coding endpoints:

- system prompt sent with role `"system"` instead of `"developer"`
- `max_tokens` field used instead of `max_completion_tokens`
- `supportsStore` / `supportsStrictMode` correctly disabled

## Test

Added `kimi-coding-compat.test.ts`, a regression test that runs a request through `stream` for a `kimi.com` model (custom-provider style, no explicit `supportsDeveloperRole`) and asserts the payload uses `role: "system"` and the `max_tokens` field.

Verified: test fails before the fix (`expected 'developer' to be 'system'`) and passes after.