### PR TITLE
feat(coding-agent): add experimental append compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -54,6 +54,8 @@ import { normalizeToolResultImages } from "../utils/tool-result-images.ts";
 import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.ts";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.ts";
 import {
+	type AppendCompactionRequest,
+	buildAppendCompactionContextPrefix,
 	type CompactionResult,
 	calculateContextTokens,
 	collectEntriesForBranchSummary,
@@ -65,6 +67,7 @@ import {
 	shouldCompact,
 } from "./compaction/index.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
+import { areExperimentalFeaturesEnabled } from "./experimental.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
 import {
@@ -1783,6 +1786,30 @@ export class AgentSession {
 	// =========================================================================
 
 	/**
+	 * Build an experimental append-compaction request that reuses the active prompt, tools,
+	 * routing session, and context transforms so the provider can reuse the cached request prefix.
+	 */
+	private async _createCompactionRequest(
+		signal: AbortSignal,
+		pathEntries: SessionEntry[],
+		firstKeptEntryId: string,
+	): Promise<AppendCompactionRequest | null> {
+		if (!areExperimentalFeaturesEnabled()) {
+			return null;
+		}
+		const contextPrefixMessages = buildAppendCompactionContextPrefix(pathEntries, firstKeptEntryId);
+		const transformedMessages = this.agent.transformContext
+			? await this.agent.transformContext(contextPrefixMessages, signal)
+			: contextPrefixMessages;
+		return {
+			systemPrompt: this.agent.state.systemPrompt,
+			tools: this.agent.state.tools,
+			sessionId: this.agent.sessionId,
+			contextPrefixMessages: await this.agent.convertToLlm(transformedMessages),
+		};
+	}
+
+	/**
 	 * Manually compact the session context.
 	 * Aborts current agent operation first.
 	 * @param customInstructions Optional instructions for the compaction summary
@@ -1855,6 +1882,11 @@ export class AgentSession {
 					preparation,
 					requestModel,
 					apiKey,
+					await this._createCompactionRequest(
+						this._compactionAbortController.signal,
+						pathEntries,
+						preparation.firstKeptEntryId,
+					),
 					headers,
 					customInstructions,
 					this._compactionAbortController.signal,
@@ -2127,6 +2159,11 @@ export class AgentSession {
 					preparation,
 					requestModel,
 					apiKey,
+					await this._createCompactionRequest(
+						this._autoCompactionAbortController.signal,
+						pathEntries,
+						preparation.firstKeptEntryId,
+					),
 					headers,
 					undefined,
 					this._autoCompactionAbortController.signal,

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -129,6 +129,13 @@ export interface CompactionSettings {
 	keepRecentTokens: number;
 }
 
+export interface AppendCompactionRequest {
+	systemPrompt: string;
+	tools: Context["tools"];
+	sessionId?: string;
+	contextPrefixMessages: Context["messages"];
+}
+
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 	enabled: true,
 	reserveTokens: 16384,
@@ -788,9 +795,52 @@ export function prepareCompaction(
 	};
 }
 
+/** Build the exact active-context prefix replaced by an append compaction summary. */
+export function buildAppendCompactionContextPrefix(
+	pathEntries: SessionEntry[],
+	firstKeptEntryId: string,
+): AgentMessage[] {
+	let previousCompactionIndex = -1;
+	for (let index = pathEntries.length - 1; index >= 0; index--) {
+		if (pathEntries[index].type === "compaction") {
+			previousCompactionIndex = index;
+			break;
+		}
+	}
+
+	let boundaryStart = 0;
+	const contextPrefixMessages: AgentMessage[] = [];
+	if (previousCompactionIndex >= 0) {
+		const previousCompaction = pathEntries[previousCompactionIndex] as CompactionEntry;
+		const previousFirstKeptIndex = pathEntries.findIndex((entry) => entry.id === previousCompaction.firstKeptEntryId);
+		boundaryStart = previousFirstKeptIndex >= 0 ? previousFirstKeptIndex : previousCompactionIndex + 1;
+		contextPrefixMessages.push(...sessionEntryToContextMessages(previousCompaction));
+	}
+
+	const firstKeptEntryIndex = pathEntries.findIndex((entry) => entry.id === firstKeptEntryId);
+	if (firstKeptEntryIndex < 0) {
+		throw new Error(`Compaction kept entry not found: ${firstKeptEntryId}`);
+	}
+	for (let index = boundaryStart; index < firstKeptEntryIndex; index++) {
+		const entry = pathEntries[index];
+		if (entry.type !== "compaction") {
+			contextPrefixMessages.push(...sessionEntryToContextMessages(entry));
+		}
+	}
+	return contextPrefixMessages;
+}
+
 // ============================================================================
 // Main compaction function
 // ============================================================================
+
+const APPEND_SUMMARIZATION_PROMPT = `Do not continue the task and do not call tools. Only produce the requested summary.
+
+The conversation before this message is the history being compacted. A recent suffix has been temporarily omitted and will be restored after your summary. Create a structured context checkpoint that preserves everything needed to understand and continue that suffix.
+
+${SUMMARIZATION_PROMPT}`;
+
+const SPLIT_TURN_CONTEXT_INSTRUCTION = `The retained suffix begins in the middle of the latest turn. Make sure the summary preserves the original request and the early progress needed to understand that retained suffix.`;
 
 const TURN_PREFIX_SUMMARIZATION_PROMPT = `This is the PREFIX of a turn that was too large to keep. The SUFFIX (recent work) is retained.
 
@@ -807,6 +857,20 @@ Summarize the prefix to provide context for the retained suffix:
 
 Be concise. Focus on what's needed to understand the kept suffix.`;
 
+interface CompactModeOptions {
+	readonly preparation: CompactionPreparation;
+	readonly model: Model<any>;
+	readonly apiKey: string | undefined;
+	readonly headers?: Record<string, string>;
+	readonly customInstructions?: string;
+	readonly signal?: AbortSignal;
+	readonly thinkingLevel?: ThinkingLevel;
+	readonly streamFn?: StreamFn;
+	readonly env?: Record<string, string>;
+	readonly retry?: RetryPolicy;
+	readonly callbacks?: RetryCallbacks;
+}
+
 /**
  * Generate summaries for compaction using prepared data.
  * Returns CompactionResult - SessionManager adds uuid/parentUuid when saving.
@@ -818,6 +882,7 @@ export async function compact(
 	preparation: CompactionPreparation,
 	model: Model<any>,
 	apiKey: string | undefined,
+	request: AppendCompactionRequest | null,
 	headers?: Record<string, string>,
 	customInstructions?: string,
 	signal?: AbortSignal,
@@ -827,43 +892,76 @@ export async function compact(
 	retry?: RetryPolicy,
 	callbacks?: RetryCallbacks,
 ): Promise<CompactionResult> {
-	const {
-		firstKeptEntryId,
-		messagesToSummarize,
-		turnPrefixMessages,
-		isSplitTurn,
-		tokensBefore,
-		previousSummary,
-		fileOps,
-		settings,
-	} = preparation;
+	const compactOptions = {
+		preparation,
+		model,
+		apiKey,
+		headers,
+		customInstructions,
+		signal,
+		thinkingLevel,
+		streamFn,
+		env,
+		retry,
+		callbacks,
+	} satisfies CompactModeOptions;
+	const result = request
+		? await compactAppend({ ...compactOptions, request })
+		: await compactStandalone(compactOptions);
 
-	// Generate summaries and merge into one
-	let summary: string;
-	let summaryUsage: Usage;
+	const { firstKeptEntryId, tokensBefore, fileOps } = preparation;
+	const { readFiles, modifiedFiles } = computeFileLists(fileOps);
+	const summary = result.text + formatFileOperations(readFiles, modifiedFiles);
+
+	if (!firstKeptEntryId) {
+		throw new Error("First kept entry has no UUID - session may need migration");
+	}
+
+	return {
+		summary,
+		firstKeptEntryId,
+		tokensBefore,
+		usage: result.usage,
+		details: { readFiles, modifiedFiles } as CompactionDetails,
+	};
+}
+
+/** Compact with isolated summary requests that do not reuse the active conversation prefix. */
+async function compactStandalone(options: CompactModeOptions): Promise<{ text: string; usage: Usage }> {
+	const {
+		preparation,
+		model,
+		apiKey,
+		headers,
+		customInstructions,
+		signal,
+		thinkingLevel,
+		streamFn,
+		env,
+		retry,
+		callbacks,
+	} = options;
+	const { messagesToSummarize, turnPrefixMessages, isSplitTurn, previousSummary, settings } = preparation;
 
 	if (isSplitTurn && turnPrefixMessages.length > 0) {
-		let historyText = "No prior history.";
-		let historyUsage: Usage | undefined;
-		if (messagesToSummarize.length > 0) {
-			const historyResult = await generateSummaryWithUsage(
-				messagesToSummarize,
-				model,
-				settings.reserveTokens,
-				apiKey,
-				headers,
-				signal,
-				customInstructions,
-				previousSummary,
-				thinkingLevel,
-				streamFn,
-				env,
-				retry,
-				callbacks,
-			);
-			historyText = historyResult.text;
-			historyUsage = historyResult.usage;
-		}
+		const historyResult =
+			messagesToSummarize.length > 0
+				? await generateSummaryWithUsage(
+						messagesToSummarize,
+						model,
+						settings.reserveTokens,
+						apiKey,
+						headers,
+						signal,
+						customInstructions,
+						previousSummary,
+						thinkingLevel,
+						streamFn,
+						env,
+						retry,
+						callbacks,
+					)
+				: undefined;
 		const turnPrefixResult = await generateTurnPrefixSummary(
 			turnPrefixMessages,
 			model,
@@ -877,45 +975,97 @@ export async function compact(
 			retry,
 			callbacks,
 		);
-		// Merge into single summary
-		summary = `${historyText}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.text}`;
-		summaryUsage = historyUsage ? combineUsage(historyUsage, turnPrefixResult.usage) : turnPrefixResult.usage;
-	} else {
-		// Just generate history summary
-		const result = await generateSummaryWithUsage(
-			messagesToSummarize,
-			model,
-			settings.reserveTokens,
-			apiKey,
-			headers,
-			signal,
-			customInstructions,
-			previousSummary,
-			thinkingLevel,
-			streamFn,
-			env,
-			retry,
-			callbacks,
-		);
-		summary = result.text;
-		summaryUsage = result.usage;
+		return {
+			text: `${historyResult?.text ?? "No prior history."}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.text}`,
+			usage: historyResult ? combineUsage(historyResult.usage, turnPrefixResult.usage) : turnPrefixResult.usage,
+		};
 	}
 
-	// Compute file lists and append to summary
-	const { readFiles, modifiedFiles } = computeFileLists(fileOps);
-	summary += formatFileOperations(readFiles, modifiedFiles);
+	return generateSummaryWithUsage(
+		messagesToSummarize,
+		model,
+		settings.reserveTokens,
+		apiKey,
+		headers,
+		signal,
+		customInstructions,
+		previousSummary,
+		thinkingLevel,
+		streamFn,
+		env,
+		retry,
+		callbacks,
+	);
+}
 
-	if (!firstKeptEntryId) {
-		throw new Error("First kept entry has no UUID - session may need migration");
+interface CompactAppendOptions extends CompactModeOptions {
+	readonly request: AppendCompactionRequest;
+}
+
+/** Compact by appending a summary request to the active prefix so provider caches remain reusable. */
+async function compactAppend(options: CompactAppendOptions): Promise<{ text: string; usage: Usage }> {
+	const {
+		preparation,
+		request,
+		model,
+		apiKey,
+		headers,
+		customInstructions,
+		signal,
+		thinkingLevel,
+		streamFn,
+		env,
+		retry,
+		callbacks,
+	} = options;
+	const maxTokens = Math.min(
+		Math.floor(0.8 * preparation.settings.reserveTokens),
+		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+	);
+	let promptText = APPEND_SUMMARIZATION_PROMPT;
+	if (preparation.isSplitTurn) {
+		promptText += `\n\n${SPLIT_TURN_CONTEXT_INSTRUCTION}`;
+	}
+	if (customInstructions) {
+		promptText += `\n\nAdditional focus: ${customInstructions}`;
 	}
 
-	return {
-		summary,
-		firstKeptEntryId,
-		tokensBefore,
-		usage: summaryUsage,
-		details: { readFiles, modifiedFiles } as CompactionDetails,
+	const summarizationMessage = {
+		role: "user" as const,
+		content: [{ type: "text" as const, text: promptText }],
+		timestamp: Date.now(),
 	};
+	const context: Context = {
+		systemPrompt: request.systemPrompt,
+		messages: [...request.contextPrefixMessages, summarizationMessage],
+		tools: request.tools,
+	};
+	const streamOptions = {
+		...createSummarizationOptions(model, maxTokens, apiKey, headers, env, signal, thinkingLevel),
+		sessionId: request.sessionId,
+	};
+	const produce = async (): Promise<AssistantMessage> =>
+		streamFn
+			? (await streamFn(model, context, streamOptions)).result()
+			: completeSimple(model, context, streamOptions);
+	const response = await retryAssistantCall(produce, retry, signal, callbacks);
+
+	if (response.stopReason === "aborted") {
+		const error = new Error("Compaction cancelled");
+		error.name = "AbortError";
+		throw error;
+	}
+	if (response.stopReason === "error") {
+		throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);
+	}
+	if (response.content.some((block) => block.type === "toolCall")) {
+		throw new Error("Append compaction attempted to call a tool");
+	}
+	const text = contentText(response.content);
+	if (!text.trim()) {
+		throw new Error("Append compaction returned an empty summary");
+	}
+	return { text, usage: response.usage };
 }
 
 /**

--- a/packages/coding-agent/test/compaction-summary-reasoning.test.ts
+++ b/packages/coding-agent/test/compaction-summary-reasoning.test.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage, Model } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Context, Model } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	type CompactionPreparation,
@@ -153,7 +154,7 @@ describe("generateSummary reasoning options", () => {
 			settings: { enabled: true, reserveTokens: 500000, keepRecentTokens: 20000 },
 		};
 
-		const result = await compact(preparation, createModel(false, 128000), "test-key");
+		const result = await compact(preparation, createModel(false, 128000), "test-key", null);
 
 		expect(result.usage).toEqual({
 			...mockSummaryResponse.usage,
@@ -164,4 +165,57 @@ describe("generateSummary reasoning options", () => {
 		});
 		expect(completeSimpleMock.mock.calls.map((call) => call[2]?.maxTokens)).toEqual([128000, 128000]);
 	});
+
+	it("summarizes a split turn with one append request", async () => {
+		const prefixMessages: Context["messages"] = [
+			{ role: "user", content: "old request", timestamp: Date.now() },
+			createAssistantMessageForPrefix("old response"),
+		];
+		const preparation: CompactionPreparation = {
+			firstKeptEntryId: "entry-keep",
+			messagesToSummarize: [prefixMessages[0]],
+			turnPrefixMessages: [prefixMessages[1]],
+			isSplitTurn: true,
+			tokensBefore: 1000,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: { enabled: true, reserveTokens: 2000, keepRecentTokens: 100 },
+		};
+		const tools = [{ name: "read", description: "Read a file", parameters: Type.Object({}) }];
+
+		const result = await compact(
+			preparation,
+			createModel(false),
+			"test-key",
+			{
+				systemPrompt: "normal coding system prompt",
+				tools,
+				sessionId: "existing-session",
+				contextPrefixMessages: prefixMessages,
+			},
+			undefined,
+			"focus on decisions",
+		);
+
+		expect(result.summary).toContain("## Goal");
+		expect(completeSimpleMock).toHaveBeenCalledTimes(1);
+		const [, context, options] = completeSimpleMock.mock.calls[0];
+		expect(context.systemPrompt).toBe("normal coding system prompt");
+		expect(context.tools).toBe(tools);
+		expect(context.messages.slice(0, -1)).toEqual(prefixMessages);
+		const summaryRequest = JSON.stringify(context.messages.at(-1));
+		expect(context.messages.at(-1)?.role).toBe("user");
+		expect(summaryRequest).toContain("Do not continue the task");
+		expect(summaryRequest).toContain("middle of the latest turn");
+		expect(summaryRequest).toContain("Additional focus: focus on decisions");
+		expect(options).toMatchObject({ sessionId: "existing-session", apiKey: "test-key" });
+		expect(options).not.toHaveProperty("cacheRetention");
+	});
 });
+
+function createAssistantMessageForPrefix(text: string): AssistantMessage {
+	return {
+		...mockSummaryResponse,
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+	buildAppendCompactionContextPrefix,
 	type CompactionSettings,
 	calculateContextTokens,
 	compact,
@@ -502,6 +503,16 @@ describe("prepareCompaction with previous compaction", () => {
 		expect(summarizedText).toContain("user msg 3 - kept by compaction1");
 		expect(summarizedText).not.toContain("First summary");
 		expect(preparation!.previousSummary).toBe("First summary");
+
+		const contextPrefixMessages = buildAppendCompactionContextPrefix(
+			[u1, a1, u2, a2, u3, a3, compaction1, u4, a4],
+			preparation!.firstKeptEntryId,
+		);
+		const contextPrefixText = extractText(contextPrefixMessages);
+		expect(contextPrefixMessages[0]?.role).toBe("compactionSummary");
+		expect(contextPrefixText).toContain("First summary");
+		expect(contextPrefixText).toContain("user msg 2 - kept by compaction1");
+		expect(contextPrefixText).toContain("user msg 3 - kept by compaction1");
 	});
 });
 
@@ -549,7 +560,7 @@ describe.skipIf(!process.env.ANTHROPIC_OAUTH_TOKEN)("LLM summarization", () => {
 		const preparation = prepareCompaction(entries, DEFAULT_COMPACTION_SETTINGS);
 		expect(preparation).toBeDefined();
 
-		const compactionResult = await compact(preparation!, model, process.env.ANTHROPIC_OAUTH_TOKEN!);
+		const compactionResult = await compact(preparation!, model, process.env.ANTHROPIC_OAUTH_TOKEN!, null);
 
 		expect(compactionResult.summary.length).toBeGreaterThan(100);
 		expect(compactionResult.firstKeptEntryId).toBeTruthy();
@@ -570,7 +581,7 @@ describe.skipIf(!process.env.ANTHROPIC_OAUTH_TOKEN)("LLM summarization", () => {
 		const preparation = prepareCompaction(entries, DEFAULT_COMPACTION_SETTINGS);
 		expect(preparation).toBeDefined();
 
-		const compactionResult = await compact(preparation!, model, process.env.ANTHROPIC_OAUTH_TOKEN!);
+		const compactionResult = await compact(preparation!, model, process.env.ANTHROPIC_OAUTH_TOKEN!, null);
 
 		// Simulate appending compaction to entries by creating a proper entry
 		const lastEntry = entries[entries.length - 1];


### PR DESCRIPTION
Use append compaction when PI_EXPERIMENTAL=1. Append mode reuses the active system prompt, tools, transformed context, and routing session so the compacted prefix can reuse provider prompt caches. Standalone remains the default.