### PR TITLE
feat(ai): add ChatGPT OAuth image generation

### DIFF
--- a/packages/ai/src/api/openai-codex-images.lazy.ts
+++ b/packages/ai/src/api/openai-codex-images.lazy.ts
@@ -1,0 +1,10 @@
+import type { ImagesModel, ProviderImages } from "../types.ts";
+
+export const openAICodexImagesApi = (): ProviderImages => ({
+	generateImages: async (model, context, options) =>
+		(await import("./openai-codex-images.ts")).generateImages(
+			model as ImagesModel<"openai-codex-images">,
+			context,
+			options,
+		),
+});

--- a/packages/ai/src/api/openai-codex-images.ts
+++ b/packages/ai/src/api/openai-codex-images.ts
@@ -1,4 +1,4 @@
-import type { Tool as OpenAITool } from "openai/resources/responses/responses.js";
+import type { Tool as OpenAITool, ToolChoiceTypes } from "openai/resources/responses/responses.js";
 import type {
 	AssistantImages,
 	AssistantMessage,
@@ -32,6 +32,15 @@ export const generateImages: ImagesFunction<"openai-codex-images", ImagesOptions
 	};
 
 	const images = new Map<number, ImageContent>();
+	let imageGenerationFailed = false;
+	const collectImage = (outputIndex: number, data: string): void => {
+		if (!isValidBase64(data)) throw new Error("ChatGPT returned malformed image data");
+		images.set(outputIndex, { type: "image", data, mimeType: "image/png" });
+		if ([...images.values()].reduce((total, image) => total + image.data.length, 0) > MAX_IMAGE_BASE64_CHARS) {
+			images.clear();
+			throw new Error("ChatGPT image generation output exceeds the 24 MiB base64 limit");
+		}
+	};
 	const driver: Model<"openai-codex-responses"> = {
 		id: OPENAI_CODEX_IMAGE_DRIVER_MODEL_ID,
 		name: "GPT-5.4 mini",
@@ -41,7 +50,7 @@ export const generateImages: ImagesFunction<"openai-codex-images", ImagesOptions
 		reasoning: true,
 		input: ["text", "image"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 272_000,
+		contextWindow: 400_000,
 		maxTokens: 128_000,
 	};
 	const responsesContext: Context = {
@@ -83,22 +92,22 @@ export const generateImages: ImagesFunction<"openai-codex-images", ImagesOptions
 					store: false,
 					stream: true,
 					tools: [{ type: "image_generation", action }] satisfies OpenAITool[],
-					tool_choice: "required",
+					tool_choice: { type: "image_generation" } satisfies ToolChoiceTypes,
 					parallel_tool_calls: false,
 				};
 			},
+			onImageGenerationPartialImage: (outputIndex, image) => {
+				// Codex can emit the only image bytes as a partial-image event and leave terminal output empty.
+				collectImage(outputIndex, image);
+			},
 			onImageGenerationCall: (outputIndex, item) => {
+				if (item.status === "failed") {
+					images.delete(outputIndex);
+					imageGenerationFailed = true;
+					return;
+				}
 				if (item.status !== "completed") return;
-				if (typeof item.result !== "string" || !isValidBase64(item.result)) {
-					throw new Error("ChatGPT returned malformed image data");
-				}
-				images.set(outputIndex, { type: "image", data: item.result, mimeType: "image/png" });
-				// Senpi found that native results can be repeated across item-done and terminal events; cap the
-				// deduplicated aggregate so a provider response cannot retain unbounded base64 payloads.
-				if ([...images.values()].reduce((total, image) => total + image.data.length, 0) > MAX_IMAGE_BASE64_CHARS) {
-					images.clear();
-					throw new Error("ChatGPT image generation output exceeds the 24 MiB base64 limit");
-				}
+				if (item.result) collectImage(outputIndex, item.result);
 			},
 		}).result();
 	} finally {
@@ -115,7 +124,9 @@ export const generateImages: ImagesFunction<"openai-codex-images", ImagesOptions
 	}
 	if (images.size === 0) {
 		output.stopReason = "error";
-		output.errorMessage = "ChatGPT image generation completed without an image";
+		output.errorMessage = imageGenerationFailed
+			? "ChatGPT image generation failed"
+			: "ChatGPT image generation completed without an image";
 		return output;
 	}
 

--- a/packages/ai/src/api/openai-codex-images.ts
+++ b/packages/ai/src/api/openai-codex-images.ts
@@ -1,0 +1,128 @@
+import type { Tool as OpenAITool } from "openai/resources/responses/responses.js";
+import type {
+	AssistantImages,
+	AssistantMessage,
+	Context,
+	ImageContent,
+	ImagesContext,
+	ImagesFunction,
+	ImagesModel,
+	ImagesOptions,
+	Model,
+} from "../types.ts";
+import { combineAbortSignals } from "../utils/abort-signals.ts";
+import { stream } from "./openai-codex-responses.ts";
+
+export const OPENAI_CODEX_IMAGE_DRIVER_MODEL_ID = "gpt-5.4-mini";
+const DEFAULT_IMAGE_TIMEOUT_MS = 150_000;
+const MAX_IMAGE_BASE64_CHARS = 24 * 1024 * 1024;
+
+export const generateImages: ImagesFunction<"openai-codex-images", ImagesOptions> = async (
+	model: ImagesModel<"openai-codex-images">,
+	context: ImagesContext,
+	options?: ImagesOptions,
+) => {
+	const output: AssistantImages = {
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		output: [],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+
+	const images = new Map<number, ImageContent>();
+	const driver: Model<"openai-codex-responses"> = {
+		id: OPENAI_CODEX_IMAGE_DRIVER_MODEL_ID,
+		name: "GPT-5.4 mini",
+		api: "openai-codex-responses",
+		provider: model.provider,
+		baseUrl: model.baseUrl,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 272_000,
+		maxTokens: 128_000,
+	};
+	const responsesContext: Context = {
+		systemPrompt: "Use the image generation tool exactly once to fulfill the user's request.",
+		messages: [{ role: "user", content: context.input, timestamp: Date.now() }],
+	};
+	const action = context.input.some((item) => item.type === "image") ? "edit" : "generate";
+	const timeoutMs = options?.timeoutMs ?? DEFAULT_IMAGE_TIMEOUT_MS;
+	const timeoutSignal = timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+	const requestSignal = combineAbortSignals([options?.signal, timeoutSignal]);
+
+	let result: AssistantMessage;
+	try {
+		result = await stream(driver, responsesContext, {
+			apiKey: options?.apiKey,
+			fetch: options?.fetch,
+			env: options?.env,
+			headers: options?.headers,
+			signal: requestSignal.signal,
+			timeoutMs,
+			maxRetryDelayMs: options?.maxRetryDelayMs,
+			telemetryContext: options?.telemetryContext,
+			transport: "sse",
+			// Image requests are isolated and billable, so never persist state or retry an ambiguous failure.
+			cacheRetention: "none",
+			maxRetries: 0,
+			onResponse: async (response) => await options?.onResponse?.(response, model),
+			onPayload: async (payload) => {
+				const inspected = (await options?.onPayload?.(payload, model)) ?? payload;
+				if (typeof inspected !== "object" || inspected === null || Array.isArray(inspected)) {
+					throw new Error("Codex image generation payload hook must return an object");
+				}
+				const body = { ...(inspected as Record<string, unknown>) };
+				delete body.previous_response_id;
+				delete body.prompt_cache_key;
+				return {
+					...body,
+					model: OPENAI_CODEX_IMAGE_DRIVER_MODEL_ID,
+					store: false,
+					stream: true,
+					tools: [{ type: "image_generation", action }] satisfies OpenAITool[],
+					tool_choice: "required",
+					parallel_tool_calls: false,
+				};
+			},
+			onImageGenerationCall: (outputIndex, item) => {
+				if (item.status !== "completed") return;
+				if (typeof item.result !== "string" || !isValidBase64(item.result)) {
+					throw new Error("ChatGPT returned malformed image data");
+				}
+				images.set(outputIndex, { type: "image", data: item.result, mimeType: "image/png" });
+				// Senpi found that native results can be repeated across item-done and terminal events; cap the
+				// deduplicated aggregate so a provider response cannot retain unbounded base64 payloads.
+				if ([...images.values()].reduce((total, image) => total + image.data.length, 0) > MAX_IMAGE_BASE64_CHARS) {
+					images.clear();
+					throw new Error("ChatGPT image generation output exceeds the 24 MiB base64 limit");
+				}
+			},
+		}).result();
+	} finally {
+		requestSignal.cleanup();
+	}
+
+	output.responseId = result.responseId;
+	output.usage = result.usage;
+	if (result.stopReason === "error" || result.stopReason === "aborted") {
+		const timedOut = timeoutSignal?.aborted && !options?.signal?.aborted;
+		output.stopReason = timedOut ? "error" : result.stopReason;
+		output.errorMessage = timedOut ? `ChatGPT image generation timed out after ${timeoutMs}ms` : result.errorMessage;
+		return output;
+	}
+	if (images.size === 0) {
+		output.stopReason = "error";
+		output.errorMessage = "ChatGPT image generation completed without an image";
+		return output;
+	}
+
+	output.output = [...images.values()];
+	return output;
+};
+
+function isValidBase64(value: string): boolean {
+	return value.length > 0 && value.length % 4 === 0 && /^[A-Za-z0-9+/]*={0,2}$/.test(value);
+}

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -3,6 +3,7 @@ import type {
 	Tool as OpenAITool,
 	ResponseCreateParamsStreaming,
 	ResponseInput,
+	ResponseOutputItem,
 	ResponseStreamEvent,
 } from "openai/resources/responses/responses.js";
 
@@ -75,6 +76,8 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	textVerbosity?: "low" | "medium" | "high";
 	toolChoice?: "auto" | "none" | "required";
+	/** Internal native-tool output hook used by the dedicated image transport. */
+	onImageGenerationCall?: (outputIndex: number, item: ResponseOutputItem.ImageGenerationCall) => void;
 }
 
 type CodexResponseStatus = "completed" | "incomplete" | "failed" | "cancelled" | "queued" | "in_progress";
@@ -657,6 +660,7 @@ async function processStream(
 	await processResponsesStream(mapCodexEvents(parseSSE(response, options?.signal), output), output, stream, model, {
 		serviceTier: options?.serviceTier,
 		grammarToolInputProperties,
+		onImageGenerationCall: options?.onImageGenerationCall,
 		resolveServiceTier: resolveCodexServiceTier,
 		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 	});
@@ -1511,6 +1515,7 @@ async function processWebSocketStream(
 			{
 				serviceTier: options?.serviceTier,
 				grammarToolInputProperties,
+				onImageGenerationCall: options?.onImageGenerationCall,
 				resolveServiceTier: resolveCodexServiceTier,
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 			},

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -78,6 +78,7 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	toolChoice?: "auto" | "none" | "required";
 	/** Internal native-tool output hook used by the dedicated image transport. */
 	onImageGenerationCall?: (outputIndex: number, item: ResponseOutputItem.ImageGenerationCall) => void;
+	onImageGenerationPartialImage?: (outputIndex: number, image: string) => void;
 }
 
 type CodexResponseStatus = "completed" | "incomplete" | "failed" | "cancelled" | "queued" | "in_progress";
@@ -661,6 +662,7 @@ async function processStream(
 		serviceTier: options?.serviceTier,
 		grammarToolInputProperties,
 		onImageGenerationCall: options?.onImageGenerationCall,
+		onImageGenerationPartialImage: options?.onImageGenerationPartialImage,
 		resolveServiceTier: resolveCodexServiceTier,
 		applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 	});
@@ -1516,6 +1518,7 @@ async function processWebSocketStream(
 				serviceTier: options?.serviceTier,
 				grammarToolInputProperties,
 				onImageGenerationCall: options?.onImageGenerationCall,
+				onImageGenerationPartialImage: options?.onImageGenerationPartialImage,
 				resolveServiceTier: resolveCodexServiceTier,
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),
 			},

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -107,6 +107,7 @@ export interface OpenAIResponsesStreamOptions {
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	grammarToolInputProperties?: ReadonlyMap<string, string>;
 	onImageGenerationCall?: (outputIndex: number, item: ResponseOutputItem.ImageGenerationCall) => void;
+	onImageGenerationPartialImage?: (outputIndex: number, image: string) => void;
 	resolveServiceTier?: (
 		responseServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
 		requestServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
@@ -609,6 +610,8 @@ export async function processResponsesStream<TApi extends Api>(
 				options?.onImageGenerationCall?.(event.output_index, event.item);
 			}
 			createSlot(event.output_index, event.item);
+		} else if (event.type === "response.image_generation_call.partial_image") {
+			options?.onImageGenerationPartialImage?.(event.output_index, event.partial_image_b64);
 		} else if (event.type === "response.reasoning_summary_text.delta") {
 			const slot = getSlot(event.output_index, "thinking");
 			if (!slot) continue;

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -106,6 +106,7 @@ function convertToolResultOutput<TApi extends Api>(
 export interface OpenAIResponsesStreamOptions {
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	grammarToolInputProperties?: ReadonlyMap<string, string>;
+	onImageGenerationCall?: (outputIndex: number, item: ResponseOutputItem.ImageGenerationCall) => void;
 	resolveServiceTier?: (
 		responseServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
 		requestServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
@@ -553,6 +554,12 @@ export async function processResponsesStream<TApi extends Api>(
 	): void => {
 		sawTerminalResponseEvent = true;
 		backfillReasoningSignatures(response.output ?? []);
+		// Some Responses transports omit output_item.done. Surface terminal image items as a final backfill,
+		// following Senpi's native-tool reconciliation strategy:
+		// https://github.com/code-yeongyu/senpi/blob/main/packages/ai/src/api/openai-responses-shared.ts
+		for (const [outputIndex, item] of (response.output ?? []).entries()) {
+			if (item.type === "image_generation_call") options?.onImageGenerationCall?.(outputIndex, item);
+		}
 		if (response?.id) {
 			output.responseId = response.id;
 		}
@@ -598,6 +605,9 @@ export async function processResponsesStream<TApi extends Api>(
 		if (event.type === "response.created") {
 			output.responseId = event.response.id;
 		} else if (event.type === "response.output_item.added") {
+			if (event.item.type === "image_generation_call") {
+				options?.onImageGenerationCall?.(event.output_index, event.item);
+			}
 			createSlot(event.output_index, event.item);
 		} else if (event.type === "response.reasoning_summary_text.delta") {
 			const slot = getSlot(event.output_index, "thinking");
@@ -679,6 +689,9 @@ export async function processResponsesStream<TApi extends Api>(
 			pushToolCallDelta(slot, appendCustomToolCallInput(slot.block, event.input, true));
 		} else if (event.type === "response.output_item.done") {
 			const item = event.item;
+			if (item.type === "image_generation_call") {
+				options?.onImageGenerationCall?.(event.output_index, item);
+			}
 			applyMessagePhaseStopReason(item);
 			const slot = getOrCreateSlot(event.output_index, item);
 

--- a/packages/ai/src/image-models.ts
+++ b/packages/ai/src/image-models.ts
@@ -1,5 +1,7 @@
 import { IMAGE_MODELS } from "./image-models.generated.ts";
-import type { ImagesApi, ImagesModel, KnownImagesProvider } from "./types.ts";
+import type { ImagesApi, ImagesModel } from "./types.ts";
+
+export type BuiltinImagesProvider = keyof typeof IMAGE_MODELS;
 
 const imageModelRegistry: Map<string, Map<string, ImagesModel<ImagesApi>>> = new Map();
 
@@ -12,7 +14,7 @@ for (const [provider, models] of Object.entries(IMAGE_MODELS)) {
 }
 
 type ImageModelApi<
-	TProvider extends KnownImagesProvider,
+	TProvider extends BuiltinImagesProvider,
 	TModelId extends keyof (typeof IMAGE_MODELS)[TProvider],
 > = (typeof IMAGE_MODELS)[TProvider][TModelId] extends { api: infer TApi }
 	? TApi extends ImagesApi
@@ -21,18 +23,18 @@ type ImageModelApi<
 	: never;
 
 export function getImageModel<
-	TProvider extends KnownImagesProvider,
+	TProvider extends BuiltinImagesProvider,
 	TModelId extends keyof (typeof IMAGE_MODELS)[TProvider],
 >(provider: TProvider, modelId: TModelId): ImagesModel<ImageModelApi<TProvider, TModelId>> {
 	const providerModels = imageModelRegistry.get(provider);
 	return providerModels?.get(modelId as string) as ImagesModel<ImageModelApi<TProvider, TModelId>>;
 }
 
-export function getImageProviders(): KnownImagesProvider[] {
-	return Array.from(imageModelRegistry.keys()) as KnownImagesProvider[];
+export function getImageProviders(): BuiltinImagesProvider[] {
+	return Array.from(imageModelRegistry.keys()) as BuiltinImagesProvider[];
 }
 
-export function getImageModels<TProvider extends KnownImagesProvider>(
+export function getImageModels<TProvider extends BuiltinImagesProvider>(
 	provider: TProvider,
 ): ImagesModel<ImageModelApi<TProvider, keyof (typeof IMAGE_MODELS)[TProvider]>>[] {
 	const models = imageModelRegistry.get(provider);

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -27,6 +27,7 @@ import { moonshotaiCnProvider } from "./moonshotai-cn.ts";
 import { nvidiaProvider } from "./nvidia.ts";
 import { openaiProvider } from "./openai.ts";
 import { openaiCodexProvider } from "./openai-codex.ts";
+import { openaiCodexImagesProvider } from "./openai-codex-images.ts";
 import { opencodeProvider } from "./opencode.ts";
 import { opencodeGoProvider } from "./opencode-go.ts";
 import { openrouterProvider } from "./openrouter.ts";
@@ -142,7 +143,7 @@ export function builtinModels(options?: CreateModelsOptions): MutableModels {
 
 /** All built-in image-generation providers, freshly constructed. */
 export function builtinImagesProviders(): ImagesProvider[] {
-	return [openrouterImagesProvider()];
+	return [openaiCodexImagesProvider(), openrouterImagesProvider()];
 }
 
 /** An `ImagesModels` collection with every built-in image-generation provider registered. */

--- a/packages/ai/src/providers/images/register-builtins.ts
+++ b/packages/ai/src/providers/images/register-builtins.ts
@@ -1,14 +1,27 @@
+import type { generateImages as generateImagesOpenAICodexFunction } from "../../api/openai-codex-images.ts";
 import type { generateImages as generateImagesOpenRouterFunction } from "../../api/openrouter-images.ts";
 import { registerImagesApiProvider } from "../../images-api-registry.ts";
-import type { AssistantImages, ImagesContext, ImagesFunction, ImagesModel, ImagesOptions } from "../../types.ts";
+import type {
+	AssistantImages,
+	ImagesApi,
+	ImagesContext,
+	ImagesFunction,
+	ImagesModel,
+	ImagesOptions,
+} from "../../types.ts";
+
+interface OpenAICodexImagesProviderModule {
+	generateImages: typeof generateImagesOpenAICodexFunction;
+}
 
 interface OpenRouterImagesProviderModule {
 	generateImages: typeof generateImagesOpenRouterFunction;
 }
 
+let openAICodexImagesProviderModulePromise: Promise<OpenAICodexImagesProviderModule> | undefined;
 let openRouterImagesProviderModulePromise: Promise<OpenRouterImagesProviderModule> | undefined;
 
-function createLazyLoadErrorImages(model: ImagesModel<"openrouter-images">, error: unknown): AssistantImages {
+function createLazyLoadErrorImages(model: ImagesModel<ImagesApi>, error: unknown): AssistantImages {
 	return {
 		api: model.api,
 		provider: model.provider,
@@ -27,6 +40,26 @@ function loadOpenRouterImagesProviderModule(): Promise<OpenRouterImagesProviderM
 	return openRouterImagesProviderModulePromise;
 }
 
+function loadOpenAICodexImagesProviderModule(): Promise<OpenAICodexImagesProviderModule> {
+	openAICodexImagesProviderModulePromise ||= import("../../api/openai-codex-images.ts").then(
+		(module) => module as OpenAICodexImagesProviderModule,
+	);
+	return openAICodexImagesProviderModulePromise;
+}
+
+export const generateImagesOpenAICodex: ImagesFunction<"openai-codex-images", ImagesOptions> = async (
+	model: ImagesModel<"openai-codex-images">,
+	context: ImagesContext,
+	options?: ImagesOptions,
+) => {
+	try {
+		const module = await loadOpenAICodexImagesProviderModule();
+		return await module.generateImages(model, context, options);
+	} catch (error) {
+		return createLazyLoadErrorImages(model, error);
+	}
+};
+
 export const generateImagesOpenRouter: ImagesFunction<"openrouter-images", ImagesOptions> = async (
 	model: ImagesModel<"openrouter-images">,
 	context: ImagesContext,
@@ -41,6 +74,10 @@ export const generateImagesOpenRouter: ImagesFunction<"openrouter-images", Image
 };
 
 export function registerBuiltInImagesApiProviders(): void {
+	registerImagesApiProvider({
+		api: "openai-codex-images",
+		generateImages: generateImagesOpenAICodex,
+	});
 	registerImagesApiProvider({
 		api: "openrouter-images",
 		generateImages: generateImagesOpenRouter,

--- a/packages/ai/src/providers/openai-codex-images.ts
+++ b/packages/ai/src/providers/openai-codex-images.ts
@@ -1,0 +1,25 @@
+import { openAICodexImagesApi } from "../api/openai-codex-images.lazy.ts";
+import { createImagesProvider, type ImagesProvider } from "../images-models.ts";
+import type { ImagesModel } from "../types.ts";
+import { OPENAI_CODEX_BASE_URL, openaiCodexProvider } from "./openai-codex.ts";
+
+const CHATGPT_IMAGE_GENERATION_MODEL = {
+	id: "chatgpt-image-generation",
+	name: "ChatGPT Image Generation",
+	api: "openai-codex-images",
+	provider: "openai-codex",
+	baseUrl: OPENAI_CODEX_BASE_URL,
+	input: ["text", "image"],
+	output: ["image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+} satisfies ImagesModel<"openai-codex-images">;
+
+export function openaiCodexImagesProvider(): ImagesProvider {
+	return createImagesProvider({
+		id: "openai-codex",
+		name: "ChatGPT",
+		auth: openaiCodexProvider().auth,
+		models: [CHATGPT_IMAGE_GENERATION_MODEL],
+		api: openAICodexImagesApi(),
+	});
+}

--- a/packages/ai/src/providers/openai-codex.ts
+++ b/packages/ai/src/providers/openai-codex.ts
@@ -4,11 +4,13 @@ import { loadOpenAICodexOAuth } from "../auth/oauth/load.ts";
 import { createProvider, type Provider } from "../models.ts";
 import { OPENAI_CODEX_MODELS } from "./openai-codex.models.ts";
 
+export const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
+
 export function openaiCodexProvider(): Provider<"openai-codex-responses"> {
 	return createProvider({
 		id: "openai-codex",
 		name: "OpenAI Codex",
-		baseUrl: "https://chatgpt.com/backend-api",
+		baseUrl: OPENAI_CODEX_BASE_URL,
 		auth: {
 			oauth: lazyOAuth({
 				name: "OpenAI (ChatGPT Plus/Pro)",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -28,7 +28,7 @@ export type KnownApi =
 
 export type Api = KnownApi | (string & {});
 
-export type KnownImagesApi = "openrouter-images";
+export type KnownImagesApi = "openai-codex-images" | "openrouter-images";
 
 export type ImagesApi = KnownImagesApi | (string & {});
 
@@ -75,7 +75,7 @@ export type KnownProvider =
 	| "xiaomi-token-plan-sgp";
 export type ProviderId = KnownProvider | string;
 
-export type KnownImagesProvider = "openrouter";
+export type KnownImagesProvider = "openai-codex" | "openrouter";
 
 export type ImagesProviderId = KnownImagesProvider | string;
 

--- a/packages/ai/test/openai-codex-images.test.ts
+++ b/packages/ai/test/openai-codex-images.test.ts
@@ -88,6 +88,31 @@ describe("OpenAI Codex images", () => {
 				completedResponse([{ type: "image_generation_call", id: "ig_1", status: "completed", result: IMAGE_DATA }]),
 			],
 		},
+		{
+			name: "Codex partial-only output",
+			action: "generate",
+			context: { input: [{ type: "text" as const, text: "Draw a circle" }] },
+			events: [
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "image_generation_call", id: "ig_1", status: "in_progress", result: null },
+				},
+				{
+					type: "response.image_generation_call.partial_image",
+					item_id: "ig_1",
+					output_index: 0,
+					partial_image_index: 0,
+					partial_image_b64: IMAGE_DATA,
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "image_generation_call", id: "ig_1", status: "generating", result: null },
+				},
+				completedResponse([{ type: "image_generation_call", id: "ig_1", status: "completed", result: null }]),
+			],
+		},
 	])("handles $name", async ({ action, context, events }) => {
 		let requestBody: Record<string, unknown> | undefined;
 		const fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -115,7 +140,7 @@ describe("OpenAI Codex images", () => {
 			store: false,
 			stream: true,
 			tools: [{ type: "image_generation", action }],
-			tool_choice: "required",
+			tool_choice: { type: "image_generation" },
 			parallel_tool_calls: false,
 		});
 		expect(requestBody).not.toHaveProperty("previous_response_id");
@@ -138,7 +163,7 @@ describe("OpenAI Codex images", () => {
 		expect(fetch).toHaveBeenCalledOnce();
 	});
 
-	it("rejects malformed or oversized output and honors cancellation", async () => {
+	it("handles provider failures without retries and honors in-flight cancellation", async () => {
 		const malformed = await generateImages(
 			MODEL,
 			{ input: [{ type: "text", text: "Draw" }] },
@@ -153,6 +178,38 @@ describe("OpenAI Codex images", () => {
 			},
 		);
 		expect(malformed).toMatchObject({ stopReason: "error", errorMessage: "ChatGPT returned malformed image data" });
+
+		const failed = await generateImages(
+			MODEL,
+			{ input: [{ type: "text", text: "Draw" }] },
+			{
+				apiKey: mockToken(),
+				fetch: async () =>
+					sse([
+						completedResponse([{ type: "image_generation_call", id: "ig_1", status: "failed", result: null }]),
+					]),
+			},
+		);
+		expect(failed).toMatchObject({ stopReason: "error", errorMessage: "ChatGPT image generation failed" });
+
+		const retryableFetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ error: { message: "unavailable" } }), {
+					status: 503,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		const unavailable = await generateImages(
+			MODEL,
+			{ input: [{ type: "text", text: "Draw" }] },
+			{
+				apiKey: mockToken(),
+				fetch: retryableFetch,
+				maxRetries: 9,
+			},
+		);
+		expect(unavailable.stopReason).toBe("error");
+		expect(retryableFetch).toHaveBeenCalledOnce();
 
 		const oversized = await generateImages(
 			MODEL,
@@ -178,17 +235,26 @@ describe("OpenAI Codex images", () => {
 		});
 
 		const controller = new AbortController();
-		controller.abort();
+		const inFlightFetch = vi.fn(
+			(_input: string | URL | Request, init?: RequestInit) =>
+				new Promise<Response>((_resolve, reject) => {
+					const signal = init?.signal;
+					if (!signal) throw new Error("Expected a request signal");
+					signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+					queueMicrotask(() => controller.abort());
+				}),
+		);
 		const aborted = await generateImages(
 			MODEL,
 			{ input: [{ type: "text", text: "Draw" }] },
 			{
 				apiKey: mockToken(),
-				fetch: vi.fn(),
+				fetch: inFlightFetch,
 				signal: controller.signal,
 			},
 		);
 		expect(aborted.stopReason).toBe("aborted");
+		expect(inFlightFetch).toHaveBeenCalledOnce();
 	});
 
 	it("registers ChatGPT before OpenRouter in the built-in image inventory", () => {

--- a/packages/ai/test/openai-codex-images.test.ts
+++ b/packages/ai/test/openai-codex-images.test.ts
@@ -1,0 +1,197 @@
+import { zstdDecompressSync } from "node:zlib";
+import { describe, expect, it, vi } from "vitest";
+import { generateImages } from "../src/api/openai-codex-images.ts";
+import { builtinImagesProviders } from "../src/providers/all.ts";
+import type { ImagesContext, ImagesModel } from "../src/types.ts";
+
+const MODEL: ImagesModel<"openai-codex-images"> = {
+	id: "chatgpt-image-generation",
+	name: "ChatGPT Image Generation",
+	api: "openai-codex-images",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api",
+	input: ["text", "image"],
+	output: ["image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+};
+const IMAGE_DATA = "aW1hZ2U=";
+
+function mockToken(): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
+	).toString("base64");
+	return `header.${payload}.signature`;
+}
+
+function decodeRequestBody(body: RequestInit["body"] | undefined): Record<string, unknown> {
+	if (typeof body === "string") return JSON.parse(body) as Record<string, unknown>;
+	if (body instanceof Uint8Array) {
+		return JSON.parse(Buffer.from(zstdDecompressSync(body)).toString("utf8")) as Record<string, unknown>;
+	}
+	throw new Error("Expected a Codex request body");
+}
+
+function sse(events: readonly object[]): Response {
+	return new Response(`${events.map((event) => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\n`, {
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function completedResponse(output: readonly object[]) {
+	return {
+		type: "response.completed",
+		response: {
+			id: "resp_image",
+			status: "completed",
+			output,
+			usage: {
+				input_tokens: 5,
+				output_tokens: 3,
+				total_tokens: 8,
+				input_tokens_details: { cached_tokens: 0 },
+				output_tokens_details: { reasoning_tokens: 0 },
+			},
+		},
+	};
+}
+
+describe("OpenAI Codex images", () => {
+	it.each([
+		{
+			name: "generation with a terminal-only result",
+			action: "generate",
+			context: { input: [{ type: "text" as const, text: "Draw a fox" }] },
+			events: [
+				completedResponse([{ type: "image_generation_call", id: "ig_1", status: "completed", result: IMAGE_DATA }]),
+			],
+		},
+		{
+			name: "editing with item-done and terminal deduplication",
+			action: "edit",
+			context: {
+				input: [
+					{ type: "text" as const, text: "Add a hat" },
+					{ type: "image" as const, data: IMAGE_DATA, mimeType: "image/png" },
+				],
+			},
+			events: [
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "image_generation_call", id: "ig_1", status: "in_progress", result: null },
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "image_generation_call", id: "ig_1", status: "completed", result: IMAGE_DATA },
+				},
+				completedResponse([{ type: "image_generation_call", id: "ig_1", status: "completed", result: IMAGE_DATA }]),
+			],
+		},
+	])("handles $name", async ({ action, context, events }) => {
+		let requestBody: Record<string, unknown> | undefined;
+		const fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			requestBody = decodeRequestBody(init?.body);
+			const headers = new Headers(init?.headers);
+			expect(headers.get("authorization")).toBe(`Bearer ${mockToken()}`);
+			expect(headers.get("chatgpt-account-id")).toBe("acc_test");
+			expect(init?.signal).toBeInstanceOf(AbortSignal);
+			return sse(events);
+		});
+
+		const result = await generateImages(MODEL, context satisfies ImagesContext, {
+			apiKey: mockToken(),
+			fetch,
+			maxRetries: 9,
+		});
+
+		expect(result).toMatchObject({
+			responseId: "resp_image",
+			stopReason: "stop",
+			output: [{ type: "image", data: IMAGE_DATA, mimeType: "image/png" }],
+		});
+		expect(requestBody).toMatchObject({
+			model: "gpt-5.4-mini",
+			store: false,
+			stream: true,
+			tools: [{ type: "image_generation", action }],
+			tool_choice: "required",
+			parallel_tool_calls: false,
+		});
+		expect(requestBody).not.toHaveProperty("previous_response_id");
+		expect(requestBody).not.toHaveProperty("prompt_cache_key");
+		if (action === "edit") {
+			expect(requestBody).toMatchObject({
+				input: [
+					{
+						role: "user",
+						content: expect.arrayContaining([
+							expect.objectContaining({
+								type: "input_image",
+								image_url: `data:image/png;base64,${IMAGE_DATA}`,
+							}),
+						]),
+					},
+				],
+			});
+		}
+		expect(fetch).toHaveBeenCalledOnce();
+	});
+
+	it("rejects malformed or oversized output and honors cancellation", async () => {
+		const malformed = await generateImages(
+			MODEL,
+			{ input: [{ type: "text", text: "Draw" }] },
+			{
+				apiKey: mockToken(),
+				fetch: async () =>
+					sse([
+						completedResponse([
+							{ type: "image_generation_call", id: "ig_1", status: "completed", result: "not base64" },
+						]),
+					]),
+			},
+		);
+		expect(malformed).toMatchObject({ stopReason: "error", errorMessage: "ChatGPT returned malformed image data" });
+
+		const oversized = await generateImages(
+			MODEL,
+			{ input: [{ type: "text", text: "Draw" }] },
+			{
+				apiKey: mockToken(),
+				fetch: async () =>
+					sse([
+						completedResponse([
+							{
+								type: "image_generation_call",
+								id: "ig_1",
+								status: "completed",
+								result: "a".repeat(24 * 1024 * 1024 + 4),
+							},
+						]),
+					]),
+			},
+		);
+		expect(oversized).toMatchObject({
+			stopReason: "error",
+			errorMessage: "ChatGPT image generation output exceeds the 24 MiB base64 limit",
+		});
+
+		const controller = new AbortController();
+		controller.abort();
+		const aborted = await generateImages(
+			MODEL,
+			{ input: [{ type: "text", text: "Draw" }] },
+			{
+				apiKey: mockToken(),
+				fetch: vi.fn(),
+				signal: controller.signal,
+			},
+		);
+		expect(aborted.stopReason).toBe("aborted");
+	});
+
+	it("registers ChatGPT before OpenRouter in the built-in image inventory", () => {
+		expect(builtinImagesProviders().map((provider) => provider.id)).toEqual(["openai-codex", "openrouter"]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a native ChatGPT image-generation transport to `@earendil-works/pi-ai`, reusing the existing OpenAI Codex OAuth and Responses infrastructure.

Consumers can generate or edit images through a user’s ChatGPT entitlement without requiring an OpenAI API key or sending the OAuth credential to another service.

## Implementation

- Adds the `openai-codex-images` image API and `openai-codex` image provider.
- Exposes one model:
  - ID: `chatgpt-image-generation`
  - Name: `ChatGPT Image Generation`
  - Internal driver: `gpt-5.4-mini`
- Reuses the existing Codex backend URL, OAuth/account headers, refresh behavior, and SSE processing.
- Sends an isolated Responses request with:
  - `store: false`
  - no `previous_response_id` or main-agent transcript
  - only the forced native `image_generation` tool
  - `generate` or `edit` selected from reference-image presence
  - no automatic retries
  - caller cancellation and a 150-second timeout
- Reconciles image output across partial-image, item-added/item-done, and terminal response events.
- Deduplicates output, validates base64, and enforces a 24 MiB aggregate base64 ceiling.
- Registers ChatGPT before OpenRouter in the built-in image-provider inventory.
- Leaves normal Codex text Responses behavior unchanged.

The event-reconciliation approach follows Senpi’s native-image implementation where Codex may emit image bytes through a partial event while leaving terminal output empty.

## Security and billing

- The OAuth token is sent only to the existing ChatGPT Codex backend.
- Requests are stateless and are not attached to the main agent conversation.
- Prompts, reference images, generated payloads, and credentials are not logged.
- Usage is covered by the user’s ChatGPT entitlement; this transport does not introduce API-key billing.

## Verification

- New ChatGPT image transport suite: 5 tests passed.
- Existing Codex streaming regression suite: 38 tests passed.
- `npm run check` passed.
- `@earendil-works/pi-ai` production build passed.
- Generation was manually verified through Aside Canary with an eligible Codex OAuth account.