### PR TITLE
feat(coding-agent): preview long read lines

### DIFF
--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -18,10 +18,14 @@ import { getTextOutput, renderToolPath, replaceTabs, str } from "./render-utils.
 import { wrapToolDefinition } from "./tool-definition-wrapper.ts";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.ts";
 
+const READ_LINE_PREVIEW_CHARACTERS = 2000;
+
 const readSchema = Type.Object({
 	path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
 	offset: Type.Optional(Type.Number({ description: "Line number to start reading from (1-indexed)" })),
-	limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
+	limit: Type.Optional(
+		Type.Number({ description: "Maximum number of lines to read. Use 1 to return a complete long line." }),
+	),
 });
 
 export const readToolSystemPromptContribution = {
@@ -33,6 +37,35 @@ export type ReadToolInput = Static<typeof readSchema>;
 
 export interface ReadToolDetails {
 	truncation?: TruncationResult;
+	longLinesShortened?: number;
+}
+
+interface LongReadLinePreviewResult {
+	content: string;
+	notices: string[];
+}
+
+function previewLongReadLines(content: string, startLine: number): LongReadLinePreviewResult {
+	const notices: string[] = [];
+	const previewedContent = content
+		.split("\n")
+		.map((line, index) => {
+			const lineEnding = line.endsWith("\r") ? "\r" : "";
+			const lineText = lineEnding ? line.slice(0, -1) : line;
+			const characters = Array.from(lineText);
+			if (characters.length <= READ_LINE_PREVIEW_CHARACTERS) {
+				return line;
+			}
+
+			const lineNumber = startLine + index;
+			notices.push(
+				`[Line ${lineNumber} shortened: showing ${READ_LINE_PREVIEW_CHARACTERS.toLocaleString("en-US")} of ${characters.length.toLocaleString("en-US")} characters. Use offset=${lineNumber}, limit=1 to read the complete line.]`,
+			);
+			return `${characters.slice(0, READ_LINE_PREVIEW_CHARACTERS).join("")}${lineEnding}`;
+		})
+		.join("\n");
+
+	return { content: previewedContent, notices };
 }
 
 interface CompactReadClassification {
@@ -203,6 +236,11 @@ function formatReadResult(
 			text += `\n${theme.fg("warning", `[Truncated: ${truncation.outputLines} lines shown (${formatSize(truncation.maxBytes ?? DEFAULT_MAX_BYTES)} limit)]`)}`;
 		}
 	}
+	const longLinesShortened = result.details?.longLinesShortened;
+	if (longLinesShortened) {
+		const lineLabel = longLinesShortened === 1 ? "line" : "lines";
+		text += `\n${theme.fg("warning", `[${longLinesShortened} long ${lineLabel} shortened to ${READ_LINE_PREVIEW_CHARACTERS.toLocaleString("en-US")} characters]`)}`;
+	}
 	return text;
 }
 
@@ -215,7 +253,7 @@ export function createReadToolDefinition(
 	return {
 		name: "read",
 		label: "read",
-		description: `Read the contents of a file. Supports text files and images (jpg, png, gif, webp, bmp). Images are sent as attachments. For text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Use offset/limit for large files. When you need the full file, continue with offset until complete.`,
+		description: `Read the contents of a file. Supports text files and images (jpg, png, gif, webp, bmp). Images are sent as attachments. For text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). In ordinary reads, lines longer than ${READ_LINE_PREVIEW_CHARACTERS.toLocaleString("en-US")} characters are shortened; use offset with limit=1 to read one in full. Use offset/limit for large files. When you need the full file, continue with offset until complete.`,
 		promptSnippet: readToolSystemPromptContribution.snippet,
 		promptGuidelines: [...readToolSystemPromptContribution.guidelines],
 		parameters: readSchema,
@@ -293,6 +331,10 @@ export function createReadToolDefinition(
 								}
 								// Apply truncation, respecting both line and byte limits.
 								const truncation = truncateHead(selectedContent);
+								const linePreview =
+									limit === 1
+										? { content: truncation.content, notices: [] }
+										: previewLongReadLines(truncation.content, startLineDisplay);
 								let outputText: string;
 								if (truncation.firstLineExceedsLimit) {
 									// First line alone exceeds the byte limit. Point the model at a bash fallback.
@@ -303,7 +345,7 @@ export function createReadToolDefinition(
 									// Truncation occurred. Build an actionable continuation notice.
 									const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
 									const nextOffset = endLineDisplay + 1;
-									outputText = truncation.content;
+									outputText = linePreview.content;
 									if (truncation.truncatedBy === "lines") {
 										outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
 									} else {
@@ -314,10 +356,14 @@ export function createReadToolDefinition(
 									// User-specified limit stopped early, but the file still has more content.
 									const remaining = allLines.length - (startLine + userLimitedLines);
 									const nextOffset = startLine + userLimitedLines + 1;
-									outputText = `${truncation.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
+									outputText = `${linePreview.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
 								} else {
 									// No truncation and no remaining user-limited content.
-									outputText = truncation.content;
+									outputText = linePreview.content;
+								}
+								if (linePreview.notices.length > 0) {
+									outputText += `\n\n${linePreview.notices.join("\n")}`;
+									details = { ...details, longLinesShortened: linePreview.notices.length };
 								}
 								content = [{ type: "text", text: outputText }];
 							}

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -79,6 +79,118 @@ describe("Coding Agent Tools", () => {
 			expect(result.details).toBeUndefined();
 		});
 
+		it("should preview long lines during normal reads", async () => {
+			const testFile = join(testDir, "long-line.txt");
+			const longLine = "x".repeat(3000);
+			writeFileSync(testFile, longLine);
+
+			const result = await readTool.execute("test-call-long-line", { path: testFile });
+
+			expect(getTextOutput(result)).toBe(
+				`${"x".repeat(2000)}\n\n[Line 1 shortened: showing 2,000 of 3,000 characters. Use offset=1, limit=1 to read the complete line.]`,
+			);
+			expect(result.details?.longLinesShortened).toBe(1);
+		});
+
+		it("should preserve a line at the preview boundary", async () => {
+			const testFile = join(testDir, "preview-boundary-line.txt");
+			const boundaryLine = "😀".repeat(2000);
+			writeFileSync(testFile, boundaryLine);
+
+			const result = await readTool.execute("test-call-preview-boundary", { path: testFile });
+
+			expect(getTextOutput(result)).toBe(boundaryLine);
+			expect(result.details).toBeUndefined();
+		});
+
+		it("should return a complete long line when limit is one", async () => {
+			const testFile = join(testDir, "focused-long-line.txt");
+			const longLine = "x".repeat(3000);
+			writeFileSync(testFile, longLine);
+
+			const result = await readTool.execute("test-call-focused-long-line", {
+				path: testFile,
+				offset: 1,
+				limit: 1,
+			});
+
+			expect(getTextOutput(result)).toBe(longLine);
+			expect(result.details).toBeUndefined();
+		});
+
+		it("should count Unicode code points and preserve CRLF line endings", async () => {
+			const testFile = join(testDir, "unicode-crlf-long-line.txt");
+			const longLine = "😀".repeat(2001);
+			writeFileSync(testFile, `before\r\n${longLine}\r\nafter`);
+
+			const result = await readTool.execute("test-call-unicode-crlf-long-line", {
+				path: testFile,
+				offset: 2,
+			});
+			const focusedResult = await readTool.execute("test-call-unicode-crlf-focused-line", {
+				path: testFile,
+				offset: 2,
+				limit: 1,
+			});
+
+			expect(getTextOutput(result)).toBe(
+				`${"😀".repeat(2000)}\r\nafter\n\n[Line 2 shortened: showing 2,000 of 2,001 characters. Use offset=2, limit=1 to read the complete line.]`,
+			);
+			expect(result.details?.longLinesShortened).toBe(1);
+			expect(getTextOutput(focusedResult)).toBe(
+				`${longLine}\r\n\n[1 more lines in file. Use offset=3 to continue.]`,
+			);
+		});
+
+		it("should report every shortened line", async () => {
+			const testFile = join(testDir, "multiple-long-lines.txt");
+			writeFileSync(testFile, `${"a".repeat(2001)}\nshort\n${"b".repeat(2002)}`);
+
+			const result = await readTool.execute("test-call-multiple-long-lines", { path: testFile });
+			const output = getTextOutput(result);
+
+			expect(output).toContain("a".repeat(2000));
+			expect(output).not.toContain("a".repeat(2001));
+			expect(output).toContain("b".repeat(2000));
+			expect(output).not.toContain("b".repeat(2001));
+			expect(output).toContain(
+				"[Line 1 shortened: showing 2,000 of 2,001 characters. Use offset=1, limit=1 to read the complete line.]",
+			);
+			expect(output).toContain(
+				"[Line 3 shortened: showing 2,000 of 2,002 characters. Use offset=3, limit=1 to read the complete line.]",
+			);
+			expect(result.details?.longLinesShortened).toBe(2);
+		});
+
+		it("should preview a line at the exact byte limit and preserve focused recovery", async () => {
+			const testFile = join(testDir, "byte-boundary-long-line.txt");
+			const longLine = "x".repeat(50 * 1024);
+			writeFileSync(testFile, longLine);
+
+			const previewResult = await readTool.execute("test-call-byte-boundary-preview", { path: testFile });
+			const focusedResult = await readTool.execute("test-call-byte-boundary-focused", {
+				path: testFile,
+				limit: 1,
+			});
+
+			expect(getTextOutput(previewResult)).toBe(
+				`${"x".repeat(2000)}\n\n[Line 1 shortened: showing 2,000 of 51,200 characters. Use offset=1, limit=1 to read the complete line.]`,
+			);
+			expect(getTextOutput(focusedResult)).toBe(longLine);
+		});
+
+		it("should preserve core handling for lines above the byte limit", async () => {
+			const testFile = join(testDir, "over-byte-limit-long-line.txt");
+			writeFileSync(testFile, "x".repeat(50 * 1024 + 1));
+
+			const result = await readTool.execute("test-call-over-byte-limit", { path: testFile });
+
+			expect(getTextOutput(result)).toMatch(/^\[Line 1 is .* exceeds 50\.0KB limit\. Use bash:/);
+			expect(getTextOutput(result)).not.toContain("shortened");
+			expect(result.details?.truncation?.firstLineExceedsLimit).toBe(true);
+			expect(result.details?.longLinesShortened).toBeUndefined();
+		});
+
 		it("should handle non-existent files", async () => {
 			const testFile = join(testDir, "nonexistent.txt");
 


### PR DESCRIPTION
## Context

This PR is mainly a concrete reference for #8140. The issue records the data I gathered about a rare `read` edge case; this patch makes the proposed behavior and its maintenance cost easier to inspect.

I do not have a strong expectation that this should merge into core. The behavior is uncommon, and my tests did not show a reliable improvement in whole-run token use or task performance. I am sharing the implementation in case the research or approach is useful to the maintainers.

## Summary

- Show the first 2,000 Unicode characters of long lines during normal reads.
- Tell the model which line was shortened and how to retrieve it in full.
- Treat `offset=<line>, limit=1` as an explicit full-line read.
- Preserve the existing 2,000-line and 50 KB limits, image handling, errors, cancellation, and rendering.

Related: #8140

## Research summary

The read tool protects against large files, but a single generated or malformed line can still add thousands of potentially irrelevant tokens to the model context. Common examples from real sessions were base64 data, source maps, serialized logs, generated fixtures, and malformed edits.

This behavior is rare:

- Personal Pi history: 394 activations among 50,959 ordinary reads (0.77%).
- Clean-stock DeepSWE history: 15 activations among 10,325 reads (0.15%).

When it happens, the payload can be large. Across 393 reconstructable personal-history reads, the median possible saving was 1,044 tokens, the mean was 3,008, and the maximum was 30,030. These figures assume the model did not request the complete line afterward.

A targeted DeepSWE comparison produced five activations across 48 trajectories. The five affected read results were 7,795 characters smaller in total, an 8.2% reduction. No focused recovery read occurred. Whole-run token use and task results varied too much to attribute an improvement to this change.

Pi previously capped read lines at 2,000 characters. Commit `de77cd14` removed that behavior when read truncation moved into the shared line/byte helper.

## Behavior

A normal read of a 3,000-character line returns its first 2,000 characters and an actionable notice:

```text
[Line 12 shortened: showing 2,000 of 3,000 characters. Use offset=12, limit=1 to read the complete line.]
```

A subsequent read with `offset=12, limit=1` returns the complete line unless it exceeds Pi's existing 50 KB limit.

## Tradeoff

Some long lines contain useful information. The preview therefore identifies every shortened line and provides a recovery path using existing parameters. Near the 2,000-character boundary, the notice can make the result slightly larger; historical replay found 26 such cases, adding 433 tokens in total.

## Tests

- `npm run check`
- `npm run build:offline`
- `./test.sh`

