### PR TITLE
fix(ai): cap Baseten DeepSeek V4 Flash output at 384k tokens

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1203,6 +1203,11 @@ function processBasetenModels(provider: ModelsDevProvider | undefined): Model<Ap
 				? toggleThinkingLevelMap
 				: getEffortThinkingLevelMap(reasoningOptions);
 
+		// models.dev reports 1M output here, but Baseten serves a 384k max output.
+		// https://docs.baseten.co/inference/model-apis/overview.md#supported-models
+		const maxTokens =
+			modelId === "deepseek-ai/DeepSeek-V4-Flash-0731" ? 384000 : (model.limit?.output || 4096);
+
 		models.push({
 			id: modelId,
 			name: model.name || modelId,
@@ -1220,7 +1225,7 @@ function processBasetenModels(provider: ModelsDevProvider | undefined): Model<Ap
 			},
 			compat,
 			contextWindow: model.limit?.context || 4096,
-			maxTokens: model.limit?.output || 4096,
+			maxTokens,
 		});
 	}
 

--- a/packages/ai/test/baseten-models.test.ts
+++ b/packages/ai/test/baseten-models.test.ts
@@ -54,6 +54,13 @@ describe("Baseten models", () => {
 		});
 	});
 
+	it("caps DeepSeek V4 Flash output tokens below its context window", () => {
+		const model = getModel("baseten", "deepseek-ai/DeepSeek-V4-Flash-0731");
+
+		expect(model.contextWindow).toBe(1_048_576);
+		expect(model.maxTokens).toBe(384_000);
+	});
+
 	it("models Kimi K2.6 reasoning as an explicit off/on toggle", async () => {
 		const model = getModel("baseten", "moonshotai/Kimi-K2.6");
 		let payload: Record<string, unknown> | undefined;


### PR DESCRIPTION
models.dev reports a 1,048,576-token output limit for `deepseek-ai/DeepSeek-V4-Flash-0731` on Baseten, but Baseten serves a 384k max output ([docs](https://docs.baseten.co/inference/model-apis/overview.md#supported-models)). Requests above 384k fail.

Caps `maxTokens` at 384,000 for this model in `scripts/generate-models.ts`, preserving the 1,048,576-token context window. Adds a test asserting `contextWindow` stays 1,048,576 and `maxTokens` is 384,000.

Verified locally: `npm run generate-models` produces the capped value, the new test passes, and `npm run check` plus `./test.sh` are green.
