### PR TITLE
fix(coding-agent): scope the bash PI_* guideline to session questions

### DIFF
--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -45,7 +45,9 @@ const bashSchema = Type.Object({
 
 export const bashToolSystemPromptContribution = {
 	snippet: "Execute bash commands (ls, grep, find, etc.)",
-	guidelines: ["You can inspect PI_* environment variables for current model and session details."],
+	guidelines: [
+		"When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.",
+	],
 } as const;
 
 export type BashToolInput = Static<typeof bashSchema>;

--- a/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
@@ -74,7 +74,7 @@ describe("AgentSession dynamic tool registration", () => {
 
 		const bashTool = session.agent.state.tools.find((tool) => tool.name === "bash")!;
 		expect(session.systemPrompt).toContain(
-			"You can inspect PI_* environment variables for current model and session details.",
+			"When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.",
 		);
 		await bashTool.execute("bash-env", { command: "printf ok" });
 		expect(sessionEnv).toMatchObject({

--- a/packages/coding-agent/test/sdk-session-manager.test.ts
+++ b/packages/coding-agent/test/sdk-session-manager.test.ts
@@ -105,7 +105,7 @@ describe("createAgentSession session manager defaults", () => {
 		});
 		expect(session.sessionFile).toBeTruthy();
 		expect(session.systemPrompt).toContain(
-			"You can inspect PI_* environment variables for current model and session details.",
+			"When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.",
 		);
 
 		const bashTool = session.agent.state.tools.find((tool) => tool.name === "bash");

--- a/packages/coding-agent/test/server/create-harness.test.ts
+++ b/packages/coding-agent/test/server/create-harness.test.ts
@@ -52,7 +52,7 @@ function createPromptTool(name: string, promptSnippet?: string, promptGuidelines
 const defaultPromptTools = [
 	createPromptTool("read", "Read file contents", ["Use read to examine files instead of cat or sed."]),
 	createPromptTool("bash", "Execute bash commands (ls, grep, find, etc.)", [
-		"You can inspect PI_* environment variables for current model and session details.",
+		"When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.",
 	]),
 	createPromptTool("edit", "Edit files", ["Edit carefully."]),
 	createPromptTool("write", "Create or overwrite files", ["Use write only for new files or complete rewrites."]),
@@ -96,9 +96,11 @@ describe("coding-agent Harness construction", () => {
 		expect(prompt).toContain("- read: Read file contents");
 		expect(prompt).toContain("- bash: Execute bash commands (ls, grep, find, etc.)");
 		expect(prompt).toContain("Use read to examine files instead of cat or sed.");
-		expect(prompt).toContain("You can inspect PI_* environment variables for current model and session details.");
+		expect(prompt).toContain(
+			"When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.",
+		);
 		expect(prompt.indexOf("Use read to examine files")).toBeLessThan(
-			prompt.indexOf("You can inspect PI_* environment variables"),
+			prompt.indexOf("inspect the relevant PI_* environment variables"),
 		);
 	});
 
@@ -290,7 +292,7 @@ describe("coding-agent Harness construction", () => {
 		[
 			"bash",
 			"Execute bash commands (ls, grep, find, etc.)",
-			"You can inspect PI_* environment variables for current model and session details.",
+			"When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.",
 		],
 		["read", "Read file contents", "Use read to examine files instead of cat or sed."],
 		[
@@ -342,7 +344,7 @@ describe("coding-agent Harness construction", () => {
 		expect(prompt).toContain("- write: Create or overwrite files");
 		expect(prompt).toContain("- read: Read file contents");
 		expect(prompt).not.toContain("- bash:");
-		expect(prompt).not.toContain("You can inspect PI_* environment variables");
+		expect(prompt).not.toContain("inspect the relevant PI_* environment variables");
 		expect(prompt).toContain('<project_instructions path="/workspace/AGENTS.md">');
 		expect(prompt).toContain("<name>review</name>");
 		expect(prompt.indexOf("Use write only for new files or complete rewrites.")).toBeLessThan(

--- a/packages/coding-agent/test/tool-system-prompt-contributions.test.ts
+++ b/packages/coding-agent/test/tool-system-prompt-contributions.test.ts
@@ -33,4 +33,14 @@ describe("built-in tool system prompt contributions", () => {
 
 		expect(definition.promptGuidelines).toBeUndefined();
 	});
+
+	test("scopes the bash PI_* guideline to questions about the active model or session", () => {
+		const definition = createBashToolDefinition("/workspace");
+		const guideline = (definition.promptGuidelines ?? []).find((entry) => entry.includes("PI_*"));
+
+		expect(guideline).toBe(
+			"When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.",
+		);
+		expect(guideline?.startsWith("When the user asks")).toBe(true);
+	});
 });


### PR DESCRIPTION
Fixes #7787

## Problem

With the default `exposeSessionEnvironment: true`, the bash tool contributed an unconditional guideline:

> You can inspect PI_* environment variables for current model and session details.

Models read this as startup work and run `env` during tasks that have nothing to do with the active model or session. Where `env` is gated by a permission extension, that produces permission prompts in the middle of unrelated work.

## Change

Prompt-only. The guideline now states the condition under which the variables matter:

> When the user asks which model, provider, reasoning level, or Pi session is active, inspect the relevant PI_* environment variables instead of inferring the answer.

`PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, and `PI_REASONING_LEVEL` are still injected exactly as before — `resolveSpawnContext` is untouched, and `exposeSessionEnvironment: false` still omits the guideline entirely. This matches `packages/coding-agent/docs/environment-variables.md`, which already scopes inspection to relevant questions.

## Tests

- New regression test in `tool-system-prompt-contributions.test.ts` asserting the guideline is conditional.
- Updated the four suites that assert the guideline text verbatim.
- `npm run check` passes. `./test.sh`: the coding-agent suite passes except `6999-models-json-hot-reload` and `7209-model-selector-filter-resets-selection`, which fail identically on a clean `main` here and are unrelated to this change.

No CHANGELOG edit, per CONTRIBUTING.md.