### PR TITLE
fix(ai): omit invalid OpenAI session header

### DIFF
--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -47,7 +47,9 @@ function getClientApiKey(provider: string, apiKey: string | undefined, headers: 
 }
 
 function detectSessionAffinityFormat(model: Pick<Model<"openai-responses">, "provider" | "baseUrl">) {
-	return model.provider === "openrouter" || model.baseUrl.includes("openrouter.ai") ? "openrouter" : "openai";
+	if (model.provider === "openrouter" || model.baseUrl.includes("openrouter.ai")) return "openrouter";
+	if (model.provider === "openai" || model.baseUrl.includes("api.openai.com")) return "openai-nosession";
+	return "openai";
 }
 
 /**

--- a/packages/ai/test/openai-responses-compat.test.ts
+++ b/packages/ai/test/openai-responses-compat.test.ts
@@ -287,10 +287,10 @@ describe("openai-responses provider defaults", () => {
 		},
 	);
 
-	it("sets cache-affinity headers for official OpenAI Responses requests with a sessionId", async () => {
+	it("omits the underscore session header for official OpenAI Responses requests", async () => {
 		const captured = await captureOpenAIResponseHeaders({ sessionId: "session-123" });
 
-		expect(captured.sessionId).toBe("session-123");
+		expect(captured.sessionId).toBeNull();
 		expect(captured.clientRequestId).toBe("session-123");
 	});
 


### PR DESCRIPTION
## Problem

OpenAI Responses requests with a `sessionId` send a `session_id` HTTP header. HTTP/1 proxies that reject underscore-bearing header names terminate these requests before they reach OpenAI. In production this surfaced as an Envoy `400` with `http1.unexpected_underscore`, zero upstream duration, and no upstream host.

The request already carries the same affinity through `prompt_cache_key` and `x-client-request-id`.

## Fix

- Default official OpenAI providers and `api.openai.com` endpoints to the existing `openai-nosession` affinity format.
- Preserve `prompt_cache_key` and `x-client-request-id`.
- Preserve the current behavior for custom proxy providers unless they explicitly select another compatibility format.
- Add a regression assertion that official OpenAI requests omit `session_id`.

## Validation

- `npm run check`
- `packages/ai`: `openai-responses-compat.test.ts` (33 passed)
- `./test.sh` was also run; the affected AI package passed all 899 tests. The repository-wide command later failed in unrelated coding-agent/server tests because a clean worktree has no built workspace `dist` entries and no downloadable `fd` binary.
