### PR TITLE
fix(extensions): contain widget render failures and tear down ctx-owned widgets on invalidation

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -4,7 +4,7 @@
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Model, Provider, ProviderHeaders } from "@earendil-works/pi-ai";
-import type { KeyId } from "@earendil-works/pi-tui";
+import type { Component, KeyId, TUI } from "@earendil-works/pi-tui";
 import { type Theme, theme } from "../../modes/interactive/theme/theme.ts";
 import type { ResourceDiagnostic } from "../diagnostics.ts";
 import type { KeybindingsConfig } from "../keybindings.ts";
@@ -35,6 +35,7 @@ import type {
 	ExtensionRuntime,
 	ExtensionShortcut,
 	ExtensionUIContext,
+	ExtensionWidgetOptions,
 	InputEvent,
 	InputEventResult,
 	InputSource,
@@ -295,6 +296,8 @@ export class ExtensionRunner {
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
 	private staleMessage: string | undefined;
+	/** Widget keys registered through this runner's ui context; released on invalidate. */
+	private ownedWidgetKeys: Set<string> = new Set();
 
 	constructor(
 		extensions: Extension[],
@@ -431,8 +434,46 @@ export class ExtensionRunner {
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext, mode: ExtensionMode = "print"): void {
-		this.uiContext = uiContext ?? noOpUIContext;
+		this.uiContext = uiContext ? this.trackOwnedWidgets(uiContext) : noOpUIContext;
 		this.mode = mode;
+	}
+
+	/**
+	 * Wrap a ui context so widgets registered through this runner are tracked
+	 * and force-removed when the runner is invalidated. Extensions capture ctx
+	 * in widget render closures (a documented contract violation, but a common
+	 * one); without ownership tracking those closures keep rendering against a
+	 * stale ctx after session replacement or reload. Prototype-based wrapping
+	 * keeps getters (e.g. theme) lazy.
+	 */
+	private trackOwnedWidgets(uiContext: ExtensionUIContext): ExtensionUIContext {
+		const wrapped = Object.create(uiContext) as ExtensionUIContext;
+		const track = (key: string, content: unknown): void => {
+			if (content === undefined) this.ownedWidgetKeys.delete(key);
+			else this.ownedWidgetKeys.add(key);
+		};
+		wrapped.setWidget = (
+			key: string,
+			content: string[] | ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined,
+			options?: ExtensionWidgetOptions,
+		) => {
+			track(key, content);
+			return uiContext.setWidget(key, content as never, options);
+		};
+		return wrapped;
+	}
+
+	/** Remove all widgets this runner registered. Best-effort by design. */
+	private releaseOwnedWidgets(): void {
+		const keys = [...this.ownedWidgetKeys];
+		this.ownedWidgetKeys.clear();
+		for (const key of keys) {
+			try {
+				this.uiContext.setWidget(key, undefined);
+			} catch {
+				// Widget teardown must never turn invalidation into a crash.
+			}
+		}
 	}
 
 	getUIContext(): ExtensionUIContext {
@@ -546,6 +587,7 @@ export class ExtensionRunner {
 		if (!this.staleMessage) {
 			this.staleMessage = message;
 			this.runtime.invalidate(message);
+			this.releaseOwnedWidgets();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/extension-widget-boundary.ts
+++ b/packages/coding-agent/src/modes/interactive/extension-widget-boundary.ts
@@ -1,0 +1,66 @@
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import type { Theme } from "./theme/theme.ts";
+
+/**
+ * Wraps an extension widget component with a render error boundary.
+ *
+ * The TUI render timer has no error boundary of its own: an exception thrown
+ * from any widget's render() escapes into an uncaughtException and kills the
+ * whole process. That is the worst possible failure mode for UI chrome — a
+ * single buggy extension widget takes down an interactive session, including
+ * all unsaved operator state in flight.
+ *
+ * A widget that throws during render is disabled (removed via `onDisable`)
+ * and renders no lines from then on. Returning an empty array is
+ * contract-safe: Container.render simply concatenates child lines.
+ */
+export function createExtensionWidgetBoundary(options: {
+	key: string;
+	component: Component & { dispose?(): void };
+	onDisable: (key: string, component: Component & { dispose?(): void }, error: unknown) => void;
+}): Component & { dispose?(): void } {
+	const { key, component, onDisable } = options;
+	let disabled = false;
+
+	const disable = (error: unknown): void => {
+		if (disabled) return;
+		disabled = true;
+		try {
+			onDisable(key, component, error);
+		} catch {
+			// The disabler itself must not turn a widget failure into a crash.
+		}
+	};
+
+	return {
+		render(width: number): string[] {
+			if (disabled) return [];
+			try {
+				return component.render(width);
+			} catch (error) {
+				disable(error);
+				return [];
+			}
+		},
+		invalidate(): void {
+			if (disabled) return;
+			try {
+				component.invalidate?.();
+			} catch {
+				// A throwing invalidate must not escalate either; keep the widget
+				// installed and let the render boundary handle persistent failure.
+			}
+		},
+		dispose(): void {
+			disabled = true;
+			try {
+				component.dispose?.();
+			} catch {
+				// Best-effort cleanup.
+			}
+		},
+	};
+}
+
+/** Utility type re-export so callers can reference the widget factory shape. */
+export type ExtensionWidgetFactory = (tui: TUI, theme: Theme) => Component & { dispose?(): void };

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -151,6 +151,7 @@ import { TreeSelectorComponent } from "./components/tree-selector.ts";
 import { TrustSelectorComponent } from "./components/trust-selector.ts";
 import { UserMessageComponent } from "./components/user-message.ts";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.ts";
+import { createExtensionWidgetBoundary } from "./extension-widget-boundary.ts";
 import { editInExternalEditor } from "./external-editor.ts";
 import { refreshModelCatalogs } from "./model-catalog-refresh.ts";
 import { getModelSearchText } from "./model-search.ts";
@@ -2249,8 +2250,29 @@ export class InteractiveMode {
 		if (leadingSpacer) {
 			container.addChild(new Spacer(1));
 		}
-		for (const component of widgets.values()) {
-			container.addChild(component);
+		for (const [key, component] of widgets.entries()) {
+			// Render error boundary: a throwing widget must be disabled, not fatal.
+			// The TUI render timer has no error boundary of its own, so an
+			// exception here would otherwise escape as an uncaughtException and
+			// exit the process.
+			container.addChild(
+				createExtensionWidgetBoundary({
+					key,
+					component,
+					onDisable: (widgetKey, widget, error) => {
+						console.error(
+							`${APP_NAME}: extension widget "${widgetKey}" threw during render and was disabled:`,
+							error,
+						);
+						try {
+							widget.dispose?.();
+						} catch {}
+						this.extensionWidgetsAbove.delete(widgetKey);
+						this.extensionWidgetsBelow.delete(widgetKey);
+						this.ui.requestRender();
+					},
+				}),
+			);
 		}
 	}
 

--- a/packages/coding-agent/test/extension-widget-boundary.test.ts
+++ b/packages/coding-agent/test/extension-widget-boundary.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { createExtensionWidgetBoundary } from "../src/modes/interactive/extension-widget-boundary.ts";
+
+function makeComponent(behavior: { render?: (width: number) => string[] }): {
+	component: { render: (width: number) => string[]; invalidate: () => void; dispose?: () => void };
+	renders: number;
+} {
+	const renders = { count: 0 };
+	const component = {
+		render(width: number): string[] {
+			renders.count += 1;
+			return behavior.render ? behavior.render(width) : ["ok"];
+		},
+		invalidate: vi.fn(),
+		dispose: vi.fn(),
+	};
+	return { component, renders: renders.count, ...renders } as never;
+}
+
+describe("extension widget render boundary", () => {
+	it("passes render and invalidate through unchanged for a healthy widget", () => {
+		const onDisable = vi.fn();
+		const { component } = makeComponent({});
+		const bounded = createExtensionWidgetBoundary({ key: "w", component, onDisable });
+
+		expect(bounded.render(80)).toEqual(["ok"]);
+		bounded.invalidate();
+		expect(component.invalidate).toHaveBeenCalled();
+		expect(onDisable).not.toHaveBeenCalled();
+	});
+
+	it("disables the widget instead of throwing on a render exception", () => {
+		const onDisable = vi.fn();
+		const boom = new Error("stale ctx");
+		const { component } = makeComponent({
+			render: () => {
+				throw boom;
+			},
+		});
+		const bounded = createExtensionWidgetBoundary({ key: "w", component, onDisable });
+
+		expect(bounded.render(80)).toEqual([]);
+		expect(onDisable).toHaveBeenCalledWith("w", component, boom);
+		// Subsequent renders stay empty and do not re-enter the broken widget.
+		expect(bounded.render(80)).toEqual([]);
+		expect(onDisable).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders empty (not throwing) after dispose", () => {
+		const onDisable = vi.fn();
+		const { component } = makeComponent({});
+		const bounded = createExtensionWidgetBoundary({ key: "w", component, onDisable });
+
+		bounded.dispose?.();
+		expect(bounded.render(80)).toEqual([]);
+		expect(component.dispose).toHaveBeenCalled();
+		expect(onDisable).not.toHaveBeenCalled(); // dispose is not a failure
+	});
+
+	it("contains a throwing disposer and a throwing invalidator", () => {
+		const onDisable = vi.fn();
+		const component = {
+			render: () => ["x"],
+			invalidate: () => {
+				throw new Error("invalidate boom");
+			},
+			dispose: () => {
+				throw new Error("dispose boom");
+			},
+		};
+		const bounded = createExtensionWidgetBoundary({ key: "w", component, onDisable });
+
+		expect(() => bounded.invalidate()).not.toThrow();
+		expect(bounded.render(80)).toEqual(["x"]); // invalidate failure does not disable
+		expect(() => bounded.dispose?.()).not.toThrow();
+	});
+
+	it("keeps the widget if onDisable itself throws", () => {
+		const onDisable = () => {
+			throw new Error("disabler broken");
+		};
+		const { component } = makeComponent({
+			render: () => {
+				throw new Error("render boom");
+			},
+		});
+		const bounded = createExtensionWidgetBoundary({ key: "w", component, onDisable });
+
+		expect(bounded.render(80)).toEqual([]); // disabled locally even though disabler threw
+	});
+});

--- a/packages/coding-agent/test/extensions-runner-widget-ownership.test.ts
+++ b/packages/coding-agent/test/extensions-runner-widget-ownership.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExtensionRunner } from "../src/core/extensions/runner.ts";
+import type { ExtensionUIContext } from "../src/core/extensions/types.ts";
+
+function createUIContext(): ExtensionUIContext & {
+	setWidget: ReturnType<typeof vi.fn>;
+	themeValue: string;
+} {
+	const setWidget = vi.fn();
+	const context = {
+		setWidget,
+		notify: vi.fn(),
+		setStatus: vi.fn(),
+		get theme() {
+			return context.themeValue;
+		},
+		themeValue: "base-theme",
+	} as unknown as ExtensionUIContext & { setWidget: ReturnType<typeof vi.fn>; themeValue: string };
+	return context;
+}
+
+function createRuntime(): Record<string, ReturnType<typeof vi.fn>> {
+	return {
+		invalidate: vi.fn(),
+		getActiveTools: vi.fn(() => []),
+		on: vi.fn(),
+	};
+}
+
+function createRunner(): ExtensionRunner {
+	return new ExtensionRunner([], createRuntime() as never, "/tmp", vi.fn() as never, vi.fn() as never);
+}
+
+describe("extension widget ownership teardown", () => {
+	it("force-removes widgets registered through the ctx when the runner is invalidated", () => {
+		const runner = createRunner();
+		const ui = createUIContext();
+		runner.setUIContext(ui, "tui");
+
+		const ctxUI = runner.getUIContext();
+		ctxUI.setWidget("usage", ["line"], { placement: "belowEditor" });
+		ctxUI.setWidget("status-extra", ["x"]);
+
+		expect(ui.setWidget).toHaveBeenCalledTimes(2);
+		expect(runner.hasUI()).toBe(true);
+
+		runner.invalidate();
+
+		// Two explicit registrations, then one removal per owned widget on invalidate.
+		const registrations = ui.setWidget.mock.calls.filter(([, content]) => content !== undefined);
+		expect(registrations.length).toBe(2);
+		const removals = ui.setWidget.mock.calls.filter(([, content]) => content === undefined);
+		expect(removals.length).toBe(2);
+		expect(removals.map(([key]) => key).sort()).toEqual(["status-extra", "usage"]);
+	});
+
+	it("deregistering a widget stops tracking it", () => {
+		const runner = createRunner();
+		const ui = createUIContext();
+		runner.setUIContext(ui, "tui");
+
+		const ctxUI = runner.getUIContext();
+		ctxUI.setWidget("usage", ["line"]);
+		ctxUI.setWidget("usage", undefined);
+
+		runner.invalidate();
+
+		const removals = ui.setWidget.mock.calls.filter(([, content]) => content === undefined);
+		expect(removals.length).toBe(1); // the explicit deregistration only
+	});
+
+	it("keeps getters lazy through the wrapper and preserves invalidation idempotency", () => {
+		const runner = createRunner();
+		const ui = createUIContext();
+		runner.setUIContext(ui, "tui");
+
+		const ctxUI = runner.getUIContext() as unknown as { theme: string };
+		ui.themeValue = "changed-after-wrapping";
+		expect(ctxUI.theme).toBe("changed-after-wrapping");
+
+		runner.invalidate();
+		runner.invalidate(); // second call must not re-remove or throw
+		expect(ui.setWidget).toHaveBeenCalledTimes(0);
+	});
+
+	it("invalidation survives a throwing ui context", () => {
+		const runner = createRunner();
+		const ui = createUIContext();
+		ui.setWidget = vi.fn(() => {
+			throw new Error("ui gone");
+		}) as never;
+		runner.setUIContext(ui, "tui");
+
+		const ctxUI = runner.getUIContext();
+		expect(() => ctxUI.setWidget("usage", ["line"])).toThrow("ui gone");
+
+		expect(() => runner.invalidate()).not.toThrow();
+	});
+});


### PR DESCRIPTION
Closes #8150.

## Problem

A third-party extension (`@marckrenn/pi-sub-bar`, fix filed upstream at marckrenn/pi-sub#76) captured the extension ctx inside its widget `render()` closure. On `/reload`:

1. the runner is invalidated (correct, deliberate fence),
2. but the widget registration survives in the TUI (its render timer keeps ticking),
3. the orphaned closure touches the stale ctx → `assertActive` throws,
4. the throw escapes into the TUI render timer → **uncaughtException → process exit**.

The full session dies because one cosmetic status widget had a bug. Repro stack in #8150.

## Fix — two independent layers

**1. Per-widget render error boundary** (`extension-widget-boundary.ts`, new): every extension widget added to a widget container is wrapped so that a `render()` exception disables that widget (logged, disposed, removed) instead of crashing the process. Returning `[]` is contract-safe — `Container.render` concatenates child lines. Throwing `invalidate()`/`dispose()` are contained too; `dispose` sets a terminal disabled state.

**2. Widget ownership tracking** (`ExtensionRunner.setUIContext`): the ui context is wrapped (prototype-based, so getters like `theme` stay lazy) so every widget registered through a runner is tracked and **force-removed when that runner is invalidated**. Extensions that capture ctx in render closures — a documented contract violation, but a common one — can no longer leave live rendering obligations running against invalidated authority.

Either layer alone prevents the reported crash; together they make the failure class structurally impossible.

## Testing

- `test/extension-widget-boundary.test.ts` — 5 cases: healthy passthrough, render-throw disables once and stays empty, post-dispose renders empty, throwing invalidate/dispose contained, throwing disabler doesn't break local disabling.
- `test/extensions-runner-widget-ownership.test.ts` — 4 cases: force-removal of all owned widgets on invalidate, deregistration stops tracking, lazy getters preserved + idempotent invalidate, throwing ui context doesn't crash invalidation.
- Full local suite delta vs stashed baseline: **0 new failures** (14 pre-existing local failures reproduce identically on clean upstream `main`; environment-dependent CLI tests).
- Passes the repo pre-commit chain: biome, pinned-deps, ts-imports, shrinkwrap, install-lock, `tsgo --noEmit`, browser-smoke.

## Notes

- Widget teardown is best-effort by design: a throwing `setWidget(key, undefined)` during invalidation is swallowed (teardown must never turn invalidation into a crash).
- The boundary lives in `modes/interactive/` because `renderWidgetContainer` is the single choke point where widget components enter containers.