### PR TITLE
fix: compact at safe turn boundaries

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -244,6 +244,11 @@ async function runLoop(
 				};
 			}
 
+			if (signal?.aborted) {
+				await emit({ type: "agent_end", messages: newMessages });
+				return;
+			}
+
 			if (
 				await config.shouldStopAfterTurn?.({
 					message,

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1101,6 +1101,69 @@ describe("agentLoop with AgentMessage", () => {
 		expect(convertedSecondTurnSystemPrompt).toBe("second prompt");
 	});
 
+	it("should stop before another provider request when prepareNextTurn aborts the run", async () => {
+		const controller = new AbortController();
+		const toolSchema = Type.Object({ value: Type.String() });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			prepareNextTurn: async () => {
+				controller.abort();
+				return undefined;
+			},
+		};
+
+		let llmCalls = 0;
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("echo something")], context, config, controller.signal, () => {
+			llmCalls++;
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (llmCalls === 1) {
+					mockStream.push({
+						type: "done",
+						reason: "toolUse",
+						message: createAssistantMessage(
+							[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+							"toolUse",
+						),
+					});
+				} else {
+					mockStream.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "should not run" }]),
+					});
+				}
+			});
+			return mockStream;
+		});
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(llmCalls).toBe(1);
+		expect(events.at(-1)?.type).toBe("agent_end");
+	});
+
 	it("should stop after the current turn when shouldStopAfterTurn returns true", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executed: string[] = [];

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -68,6 +68,7 @@ import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
 import {
+	type BoundaryCompactionOptions,
 	type ContextUsage,
 	type ExtensionCommandContextActions,
 	type ExtensionErrorListener,
@@ -313,6 +314,7 @@ export class AgentSession {
 	private _unsubscribeAgent?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _isAgentRunActive = false;
+	private _abortRequested = false;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
 
@@ -326,6 +328,8 @@ export class AgentSession {
 	// Compaction state
 	private _compactionAbortController: AbortController | undefined = undefined;
 	private _autoCompactionAbortController: AbortController | undefined = undefined;
+	private _pendingBoundaryCompaction: BoundaryCompactionOptions | undefined;
+	private _boundaryCompactionInProgress = false;
 	private _overflowRecoveryAttempted = false;
 
 	// Branch summarization state
@@ -541,11 +545,23 @@ export class AgentSession {
 		this.agent.prepareNextTurnWithContext = async (turn, signal) => {
 			const previousSnapshot = await previousPrepareNextTurnWithContext?.(turn, signal);
 			const previousContext = previousSnapshot?.context ?? turn.context;
+			const boundaryRequest = this._pendingBoundaryCompaction;
+			this._pendingBoundaryCompaction = undefined;
+
+			if (boundaryRequest && !signal?.aborted) {
+				this._boundaryCompactionInProgress = true;
+				try {
+					await this._runAutoCompaction(boundaryRequest.reason, false, boundaryRequest.customInstructions, signal);
+				} finally {
+					this._boundaryCompactionInProgress = false;
+				}
+			}
 
 			return {
 				...previousSnapshot,
 				context: {
 					...previousContext,
+					messages: this.agent.state.messages.slice(),
 					systemPrompt: this._systemPromptOverride ?? this._baseSystemPrompt,
 					tools: this.agent.state.tools.slice(),
 				},
@@ -595,6 +611,7 @@ export class AgentSession {
 
 	private async _emitAgentSettled(): Promise<void> {
 		this._isAgentRunActive = false;
+		this._pendingBoundaryCompaction = undefined;
 		try {
 			await this._extensionRunner.emit({ type: "agent_settled" });
 			this._emit({ type: "agent_settled" });
@@ -610,6 +627,14 @@ export class AgentSession {
 	private _handleAgentEvent = async (event: AgentEvent): Promise<void> => {
 		// When a user message starts, check if it's from either queue and remove it BEFORE emitting
 		// This ensures the UI sees the updated queue state
+		if (event.type === "agent_start") {
+			this._pendingBoundaryCompaction = undefined;
+		}
+
+		if (event.type === "agent_end") {
+			this._pendingBoundaryCompaction = undefined;
+		}
+
 		if (event.type === "message_start" && event.message.role === "user") {
 			this._overflowRecoveryAttempted = false;
 			const messageText = contentText(event.message.content, "");
@@ -1062,15 +1087,18 @@ export class AgentSession {
 
 	private async _runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void> {
 		this._isAgentRunActive = true;
+		this._abortRequested = false;
 		try {
 			await this.agent.prompt(messages);
 			while (await this._handlePostAgentRun()) {
+				if (this._abortRequested) break;
 				await this.agent.continue();
 			}
 		} finally {
 			this._systemPromptOverride = undefined;
 			this._flushPendingBashMessages();
 			await this._emitAgentSettled();
+			this._abortRequested = false;
 		}
 	}
 
@@ -1548,7 +1576,10 @@ export class AgentSession {
 	 * Abort current operation and wait for agent to become idle.
 	 */
 	async abort(): Promise<void> {
+		this._abortRequested = true;
 		this.abortRetry();
+		this._pendingBoundaryCompaction = undefined;
+		this._autoCompactionAbortController?.abort();
 		this.agent.abort();
 		await this.waitForIdle();
 	}
@@ -1936,8 +1967,34 @@ export class AgentSession {
 	 * Cancel in-progress compaction (manual or auto).
 	 */
 	abortCompaction(): void {
+		this._pendingBoundaryCompaction = undefined;
 		this._compactionAbortController?.abort();
 		this._autoCompactionAbortController?.abort();
+		if (this._boundaryCompactionInProgress) {
+			this.agent.abort();
+		}
+	}
+
+	/**
+	 * Request compaction after the current assistant/tool turn completes.
+	 */
+	requestCompactionAtTurnBoundary(options: BoundaryCompactionOptions): boolean {
+		if (!this._isAgentRunActive || this.agent.signal?.aborted || this._boundaryCompactionInProgress) {
+			return false;
+		}
+
+		const existing = this._pendingBoundaryCompaction;
+		if (!existing) {
+			this._pendingBoundaryCompaction = { ...options };
+			return true;
+		}
+
+		if (existing.reason === "threshold" && options.reason === "manual") {
+			this._pendingBoundaryCompaction = { ...options };
+		} else if (!existing.customInstructions && options.customInstructions) {
+			existing.customInstructions = options.customInstructions;
+		}
+		return true;
 	}
 
 	/**
@@ -2055,12 +2112,19 @@ export class AgentSession {
 	/**
 	 * Internal: Run auto-compaction with events.
 	 */
-	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
+	private async _runAutoCompaction(
+		reason: "manual" | "overflow" | "threshold",
+		willRetry: boolean,
+		customInstructions?: string,
+		runSignal?: AbortSignal,
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		let started = false;
+		let runAbortListener: (() => void) | undefined;
+		let compactionAbortController: AbortController | undefined;
 
 		try {
-			if (!this.model) {
+			if (!this.model || runSignal?.aborted) {
 				return false;
 			}
 
@@ -2074,7 +2138,17 @@ export class AgentSession {
 			}
 
 			this._emit({ type: "compaction_start", reason });
-			this._autoCompactionAbortController = new AbortController();
+			const activeCompactionAbortController = new AbortController();
+			compactionAbortController = activeCompactionAbortController;
+			this._autoCompactionAbortController = activeCompactionAbortController;
+			if (runSignal) {
+				runAbortListener = () => activeCompactionAbortController.abort();
+				if (runSignal.aborted) {
+					activeCompactionAbortController.abort();
+				} else {
+					runSignal.addEventListener("abort", runAbortListener, { once: true });
+				}
+			}
 			started = true;
 
 			let extensionCompaction: CompactionResult | undefined;
@@ -2085,10 +2159,10 @@ export class AgentSession {
 					type: "session_before_compact",
 					preparation,
 					branchEntries: pathEntries,
-					customInstructions: undefined,
+					customInstructions,
 					reason,
 					willRetry,
-					signal: this._autoCompactionAbortController.signal,
+					signal: activeCompactionAbortController.signal,
 				})) as SessionBeforeCompactResult | undefined;
 
 				if (extensionResult?.cancel) {
@@ -2128,8 +2202,8 @@ export class AgentSession {
 					requestModel,
 					apiKey,
 					headers,
-					undefined,
-					this._autoCompactionAbortController.signal,
+					customInstructions,
+					activeCompactionAbortController.signal,
 					this.thinkingLevel,
 					this.agent.streamFunction,
 					env,
@@ -2143,7 +2217,7 @@ export class AgentSession {
 				details = compactResult.details;
 			}
 
-			if (this._autoCompactionAbortController.signal.aborted) {
+			if (activeCompactionAbortController.signal.aborted) {
 				this._emit({
 					type: "compaction_end",
 					reason,
@@ -2203,21 +2277,26 @@ export class AgentSession {
 			return this.agent.hasQueuedMessages();
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
+			const aborted = compactionAbortController?.signal.aborted === true || runSignal?.aborted === true;
 			if (started) {
 				this._emit({
 					type: "compaction_end",
 					reason,
 					result: undefined,
-					aborted: false,
+					aborted,
 					willRetry: false,
-					errorMessage:
-						reason === "overflow"
+					errorMessage: aborted
+						? undefined
+						: reason === "overflow"
 							? `Context overflow recovery failed: ${errorMessage}`
 							: `Auto-compaction failed: ${errorMessage}`,
 				});
 			}
 			return false;
 		} finally {
+			if (runSignal && runAbortListener) {
+				runSignal.removeEventListener("abort", runAbortListener);
+			}
 			this._autoCompactionAbortController = undefined;
 		}
 	}
@@ -2440,6 +2519,7 @@ export class AgentSession {
 						}
 					})();
 				},
+				requestCompactionAtTurnBoundary: (options) => this.requestCompactionAtTurnBoundary(options),
 				getSystemPrompt: () => this.systemPrompt,
 				getSystemPromptOptions: () => this._baseSystemPromptOptions,
 			},

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -39,6 +39,7 @@ export type {
 	BeforeProviderHeadersEvent,
 	BeforeProviderRequestEvent,
 	BeforeProviderRequestEventResult,
+	BoundaryCompactionOptions,
 	BuildSystemPromptOptions,
 	// Context
 	CompactOptions,

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -17,6 +17,7 @@ import type {
 	BeforeAgentStartEventResult,
 	BeforeProviderHeadersEvent,
 	BeforeProviderRequestEvent,
+	BoundaryCompactionOptions,
 	CompactOptions,
 	ContextEvent,
 	ContextEventResult,
@@ -284,6 +285,7 @@ export class ExtensionRunner {
 	private hasPendingMessagesFn: () => boolean = () => false;
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
+	private requestCompactionAtTurnBoundaryFn: (options: BoundaryCompactionOptions) => boolean = () => false;
 	private getSystemPromptFn: () => string = () => "";
 	private getSystemPromptOptionsFn: () => BuildSystemPromptOptions = () => ({ cwd: this.cwd });
 	private newSessionHandler: NewSessionHandler = async () => ({ cancelled: false });
@@ -347,6 +349,7 @@ export class ExtensionRunner {
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
+		this.requestCompactionAtTurnBoundaryFn = contextActions.requestCompactionAtTurnBoundary;
 		this.getSystemPromptFn = contextActions.getSystemPrompt;
 		this.getSystemPromptOptionsFn = contextActions.getSystemPromptOptions ?? (() => ({ cwd: this.cwd }));
 
@@ -742,6 +745,10 @@ export class ExtensionRunner {
 			compact: (options) => {
 				runner.assertActive();
 				runner.compactFn(options);
+			},
+			requestCompactionAtTurnBoundary: (options) => {
+				runner.assertActive();
+				return runner.requestCompactionAtTurnBoundaryFn(options);
 			},
 			getSystemPrompt: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -299,6 +299,12 @@ export interface CompactOptions {
 	onError?: (error: Error) => void;
 }
 
+/** Request context compaction after the current agent turn reaches its safe boundary. */
+export interface BoundaryCompactionOptions {
+	reason: "manual" | "threshold";
+	customInstructions?: string;
+}
+
 /**
  * Context passed to extension event handlers.
  */
@@ -342,6 +348,8 @@ export interface ExtensionContext {
 	getContextUsage(): ContextUsage | undefined;
 	/** Trigger compaction without awaiting completion. */
 	compact(options?: CompactOptions): void;
+	/** Request compaction after the current assistant/tool turn completes. */
+	requestCompactionAtTurnBoundary(options: BoundaryCompactionOptions): boolean;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
 }
@@ -1656,6 +1664,7 @@ export interface ExtensionContextActions {
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;
+	requestCompactionAtTurnBoundary: (options: BoundaryCompactionOptions) => boolean;
 	getSystemPrompt: () => string;
 	getSystemPromptOptions?: () => BuildSystemPromptOptions;
 }

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -160,6 +160,9 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 						timestamp: m.timestamp,
 					};
 				case "custom": {
+					// Historical pi-vcc continuation records are inert compatibility data.
+					// Never expose them to a provider after session reload.
+					if (m.customType === "pi-vcc-continuation") return undefined;
 					const content = typeof m.content === "string" ? [{ type: "text" as const, text: m.content }] : m.content;
 					return {
 						role: "user",

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2041,6 +2041,7 @@ export class InteractiveMode {
 					}
 				})();
 			},
+			requestCompactionAtTurnBoundary: (options) => this.session.requestCompactionAtTurnBoundary(options),
 			getSystemPrompt: () => this.session.systemPrompt,
 		});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -98,6 +98,7 @@ describe("ExtensionRunner", () => {
 		shutdown: () => {},
 		getContextUsage: () => undefined,
 		compact: () => {},
+		requestCompactionAtTurnBoundary: () => false,
 		getSystemPrompt: () => "",
 		getScopedModels: () => [],
 	};

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -2,8 +2,10 @@ import {
 	type AssistantMessage,
 	createAssistantMessageEventStream,
 	fauxAssistantMessage,
+	fauxToolCall,
 	type Model,
 } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { estimateTokens } from "../../src/core/compaction/index.ts";
 import { createHarness, getUserTexts, type Harness } from "./harness.ts";
@@ -276,6 +278,155 @@ describe("AgentSession compaction characterization", () => {
 		expect(compactionEntries).toHaveLength(1);
 		expect(compactionEnd?.result?.estimatedTokensAfter).toBeGreaterThan(0);
 		expect(getStreamCallCount()).toBe(1);
+	});
+
+	it("requests boundary compaction and continues in the same agent run", async () => {
+		let accepted: boolean | undefined;
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 20 } },
+			extensionFactories: [
+				(pi) => {
+					pi.registerTool({
+						name: "request_compaction",
+						label: "Request compaction",
+						description: "Request a test compaction",
+						parameters: Type.Object({}),
+						execute: async (_toolCallId, _params, _signal, _onUpdate, ctx) => {
+							accepted = ctx.requestCompactionAtTurnBoundary({
+								reason: "manual",
+								customInstructions: "preserve the active task",
+							});
+							return { content: [{ type: "text", text: "requested" }], details: {} };
+						},
+					});
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "boundary summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("seed answer"),
+			fauxAssistantMessage([fauxToolCall("request_compaction", {})], { stopReason: "toolUse" }),
+			fauxAssistantMessage("completed after compaction"),
+		]);
+
+		await harness.session.prompt("seed");
+		harness.events.length = 0;
+		await harness.session.prompt(`start ${"x".repeat(100)}`);
+
+		expect(accepted).toBe(true);
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.eventsOfType("agent_start")).toHaveLength(1);
+		expect(harness.eventsOfType("agent_end")).toHaveLength(1);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(1);
+		expect(harness.session.getLastAssistantText()).toBe("completed after compaction");
+	});
+
+	it("aborts the active agent when Escape cancels boundary compaction", async () => {
+		let compactionStarted: (() => void) | undefined;
+		const compactionReady = new Promise<void>((resolve) => {
+			compactionStarted = resolve;
+		});
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 20 } },
+			extensionFactories: [
+				(pi) => {
+					pi.registerTool({
+						name: "request_compaction",
+						label: "Request compaction",
+						description: "Request a test compaction",
+						parameters: Type.Object({}),
+						execute: async (_toolCallId, _params, _signal, _onUpdate, ctx) => {
+							ctx.requestCompactionAtTurnBoundary({ reason: "manual" });
+							return { content: [{ type: "text", text: "requested" }], details: {} };
+						},
+					});
+					pi.on("session_before_compact", async (event) => {
+						compactionStarted?.();
+						return await new Promise<{ cancel: true }>((resolve) => {
+							event.signal.addEventListener("abort", () => resolve({ cancel: true }), { once: true });
+						});
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("seed answer"),
+			() => fauxAssistantMessage([fauxToolCall("request_compaction", {})], { stopReason: "toolUse" }),
+			fauxAssistantMessage("must not run"),
+		]);
+
+		await harness.session.prompt("seed");
+		const callsBeforePrompt = harness.faux.state.callCount;
+		harness.events.length = 0;
+		const prompt = harness.session.prompt(`start ${"x".repeat(100)}`);
+		await compactionReady;
+		harness.session.abortCompaction();
+		await prompt;
+
+		expect(harness.faux.state.callCount - callsBeforePrompt, JSON.stringify(harness.events)).toBe(1);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({ aborted: true });
+	});
+
+	it("does not retry after aborting post-run overflow compaction", async () => {
+		let compactionStarted!: () => void;
+		const compactionReady = new Promise<void>((resolve) => {
+			compactionStarted = resolve;
+		});
+		let releaseCompaction!: () => void;
+		const release = new Promise<void>((resolve) => {
+			releaseCompaction = resolve;
+		});
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 1000, maxTokens: 100 }],
+			settings: { compaction: { keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						if (event.reason !== "overflow") return;
+						compactionStarted();
+						await Promise.race([
+							release,
+							new Promise<void>((resolve) => event.signal.addEventListener("abort", () => resolve(), { once: true })),
+						]);
+						if (event.signal.aborted) return { cancel: true };
+						return {
+							compaction: {
+								summary: "overflow compacted",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("partial response", { stopReason: "length" })]);
+
+		const prompt = harness.session.prompt("x".repeat(5000));
+		await compactionReady;
+		const abort = harness.session.abort();
+		releaseCompaction();
+		await abort;
+		await prompt;
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction")).toHaveLength(0);
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({
+			reason: "overflow",
+			aborted: true,
+		});
 	});
 
 	it("compacts and resumes after a length stop below the desired output limit", async () => {

--- a/packages/coding-agent/test/suite/agent-session-runtime.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-runtime.test.ts
@@ -200,7 +200,7 @@ describe("AgentSessionRuntime characterization", () => {
 		expect(switchResult.cancelled).toBe(false);
 		expect(runtime.session.sessionFile).toBe(firstSessionFile);
 		// The outgoing session settled before replacement: the interrupted tool
-		// call has a persisted tool result instead of dangling forever.
+		// call has a persisted tool result and no post-abort provider turn.
 		const outgoingEntries = SessionManager.open(outgoingSession.sessionFile!)
 			.getEntries()
 			.filter((entry) => entry.type === "message");
@@ -208,7 +208,6 @@ describe("AgentSessionRuntime characterization", () => {
 			"user",
 			"assistant",
 			"toolResult",
-			"assistant",
 		]);
 	});
 

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -20,6 +20,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		shutdown: vi.fn(),
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,
+		requestCompactionAtTurnBoundary: () => false,
 		getSystemPrompt: () => "",
 	};
 }


### PR DESCRIPTION
## Summary
- Add a run-scoped boundary-compaction request API and consume it between completed Pi turns.
- Rebuild the live context in the same run, preserve the native recent tail, and stop before another provider turn when the active signal is aborted.
- Keep core overflow recovery bounded and prevent RPC/session abort from starting its post-run retry.
- Add regression coverage for same-run compaction, Escape cancellation, persistence, session replacement, and post-run overflow abort.

## Verification
- `npx vitest --run packages/coding-agent/test/suite/agent-session-compaction.test.ts packages/coding-agent/test/suite/agent-session-runtime.test.ts packages/coding-agent/test/extensions-runner.test.ts packages/coding-agent/test/trigger-compact-extension.test.ts` — 72 passed.
- `npx vitest --run packages/agent/test/agent-loop.test.ts` — 24 passed.
- `git diff --check` — passed.

## Notes
- The branch is based on the current upstream `main`; the dependent ai-configs change is in a separate PR/branch.