### PR TITLE
fix(tui): avoid resetting cursor blink during renders

### DIFF
--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -287,7 +287,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 				? ENABLE_BUTTON_MOTION_MOUSE
 				: ENABLE_ALL_MOTION_MOUSE;
 		this.terminal.write(
-			`${ENTER_ALT_SCREEN}${DISABLE_AUTOWRAP}${this.mouseEnabled ? mouseSequence : ""}\x1b[2J\x1b[H\x1b[?25l`,
+			`${ENTER_ALT_SCREEN}${DISABLE_AUTOWRAP}${this.mouseEnabled ? mouseSequence : ""}\x1b[2J\x1b[H${this.transitionTerminalCursorVisibility(false)}`,
 		);
 	}
 
@@ -308,8 +308,10 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 	protected override afterTerminalStop(options: TuiStopOptions): void {
 		if (!this.altScreenActive) return;
 		this.altScreenActive = false;
+		this.invalidateTerminalCursorVisibility();
+		const showCursor = this.transitionTerminalCursorVisibility(true);
 		if (options.preserveScreen) {
-			this.terminal.write(`${BEGIN_SYNCHRONIZED_OUTPUT}${EXIT_ALT_SCREEN}\x1b[?25h${END_SYNCHRONIZED_OUTPUT}`);
+			this.terminal.write(`${BEGIN_SYNCHRONIZED_OUTPUT}${EXIT_ALT_SCREEN}${showCursor}${END_SYNCHRONIZED_OUTPUT}`);
 		} else {
 			const width = Math.max(1, this.terminal.columns);
 			const documentLines = this.render(width).map((line) => line.replace(OSC133_ZONE_PREFIX, ""));
@@ -321,7 +323,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 				if (row > 0) buffer += "\r\n";
 				buffer += `\r\x1b[2K${this.lastDocument[row] ?? ""}`;
 			}
-			buffer += `\x1b[0m${ENABLE_AUTOWRAP}\r\n\x1b[?25h${END_SYNCHRONIZED_OUTPUT}`;
+			buffer += `\x1b[0m${ENABLE_AUTOWRAP}\r\n${showCursor}${END_SYNCHRONIZED_OUTPUT}`;
 			this.terminal.write(buffer);
 		}
 		if (this.savedCapabilities) {
@@ -1299,10 +1301,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 		if (cursorPos) {
 			buffer += `\x1b[${cursorPos.row + 1};${Math.min(width, cursorPos.col) + 1}H`;
-			buffer += this.getShowHardwareCursor() ? "\x1b[?25h" : "\x1b[?25l";
-		} else {
-			buffer += "\x1b[?25l";
 		}
+		buffer += this.transitionTerminalCursorVisibility(cursorPos !== null && this.getShowHardwareCursor());
 		buffer += END_SYNCHRONIZED_OUTPUT;
 		this.terminal.write(buffer);
 

--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -571,7 +571,9 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		}
 		// Move to absolute column (1-indexed)
 		buffer += `\x1b[${targetCol + 1}G`;
-		this.terminal.write(buffer);
+		if (buffer) {
+			this.terminal.write(buffer);
+		}
 		this.writeTerminalCursorVisibility(this.getShowHardwareCursor());
 
 		this.hardwareCursorRow = targetRow;

--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -553,7 +553,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 	 */
 	private positionHardwareCursor(cursorPos: { row: number; col: number } | null, totalLines: number): void {
 		if (!cursorPos || totalLines <= 0) {
-			this.terminal.hideCursor();
+			this.writeTerminalCursorVisibility(false);
 			return;
 		}
 
@@ -571,16 +571,9 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		}
 		// Move to absolute column (1-indexed)
 		buffer += `\x1b[${targetCol + 1}G`;
-
-		if (buffer) {
-			this.terminal.write(buffer);
-		}
+		this.terminal.write(buffer);
+		this.writeTerminalCursorVisibility(this.getShowHardwareCursor());
 
 		this.hardwareCursorRow = targetRow;
-		if (this.getShowHardwareCursor()) {
-			this.terminal.showCursor();
-		} else {
-			this.terminal.hideCursor();
-		}
 	}
 }

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -248,6 +248,10 @@ export class Container implements Component {
  * TUI - Main class for managing terminal UI with differential rendering
  */
 const SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";
+const SHOW_CURSOR = "\x1b[?25h";
+const HIDE_CURSOR = "\x1b[?25l";
+
+type TerminalCursorVisibility = "unknown" | "visible" | "hidden";
 
 /** Composite overlay content into a terminal line at a fixed column. */
 export function compositeTuiLine(
@@ -342,6 +346,7 @@ export abstract class TuiBase extends Container implements TUI {
 	private lastRenderAt = 0;
 	private static readonly MIN_RENDER_INTERVAL_MS = 16;
 	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
+	private terminalCursorVisibility: TerminalCursorVisibility = "unknown";
 	private clearOnShrink = process.env.PI_CLEAR_ON_SHRINK === "1";
 	protected fullRedrawCount = 0;
 	protected stopped = false;
@@ -381,6 +386,28 @@ export abstract class TuiBase extends Container implements TUI {
 
 	protected afterTerminalStop(_options: TuiStopOptions): void {}
 
+	protected invalidateTerminalCursorVisibility(): void {
+		this.terminalCursorVisibility = "unknown";
+	}
+
+	private updateTerminalCursorVisibility(visible: boolean): boolean {
+		const nextVisibility = visible ? "visible" : "hidden";
+		if (this.terminalCursorVisibility === nextVisibility) return false;
+		this.terminalCursorVisibility = nextVisibility;
+		return true;
+	}
+
+	protected transitionTerminalCursorVisibility(visible: boolean): string {
+		return this.updateTerminalCursorVisibility(visible) ? (visible ? SHOW_CURSOR : HIDE_CURSOR) : "";
+	}
+
+	protected writeTerminalCursorVisibility(visible: boolean, { force = false }: { force?: boolean } = {}): void {
+		const changed = this.updateTerminalCursorVisibility(visible);
+		if (!changed && !force) return;
+		if (visible) this.terminal.showCursor();
+		else this.terminal.hideCursor();
+	}
+
 	get fullRedraws(): number {
 		return this.fullRedrawCount;
 	}
@@ -393,7 +420,7 @@ export abstract class TuiBase extends Container implements TUI {
 		if (this.showHardwareCursor === enabled) return;
 		this.showHardwareCursor = enabled;
 		if (!enabled) {
-			this.terminal.hideCursor();
+			this.writeTerminalCursorVisibility(false, { force: true });
 		}
 		this.requestRender();
 	}
@@ -559,7 +586,7 @@ export abstract class TuiBase extends Container implements TUI {
 		if (!options?.nonCapturing && this.isOverlayVisible(entry)) {
 			this.setFocus(component);
 		}
-		this.terminal.hideCursor();
+		this.writeTerminalCursorVisibility(false, { force: true });
 		this.requestRender();
 
 		// Return handle for controlling this overlay
@@ -575,7 +602,9 @@ export abstract class TuiBase extends Container implements TUI {
 						const topVisible = this.getTopmostVisibleOverlay();
 						this.setFocus(topVisible?.component ?? entry.preFocus);
 					}
-					if (this.overlayStack.length === 0) this.terminal.hideCursor();
+					if (this.overlayStack.length === 0) {
+						this.writeTerminalCursorVisibility(false, { force: true });
+					}
 					this.requestRender();
 				}
 			},
@@ -653,7 +682,9 @@ export abstract class TuiBase extends Container implements TUI {
 			const topVisible = this.getTopmostVisibleOverlay();
 			this.setFocus(topVisible?.component ?? overlay.preFocus);
 		}
-		if (this.overlayStack.length === 0) this.terminal.hideCursor();
+		if (this.overlayStack.length === 0) {
+			this.writeTerminalCursorVisibility(false, { force: true });
+		}
 		this.requestRender();
 	}
 
@@ -697,13 +728,14 @@ export abstract class TuiBase extends Container implements TUI {
 
 	start(): void {
 		this.stopped = false;
+		this.invalidateTerminalCursorVisibility();
 		this.beforeTerminalStart();
 		this.terminal.start(
 			(data) => this.handleTerminalInput(data),
 			() => this.requestRender(),
 		);
 		this.afterTerminalStart();
-		this.terminal.hideCursor();
+		this.writeTerminalCursorVisibility(false, { force: true });
 		if (this.terminalColorSchemeNotificationsEnabled) {
 			this.terminal.write("\x1b[?2031h");
 		}
@@ -756,7 +788,7 @@ export abstract class TuiBase extends Container implements TUI {
 			this.terminal.write("\x1b[?2031l");
 		}
 		this.beforeTerminalStop(options);
-		this.terminal.showCursor();
+		this.writeTerminalCursorVisibility(true, { force: true });
 		this.terminal.stop();
 		this.afterTerminalStop(options);
 	}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -378,6 +378,11 @@ export abstract class TuiBase extends Container implements TUI {
 
 	protected resetRenderState(): void {}
 
+	private resetAllRenderState(): void {
+		this.resetRenderState();
+		this.invalidateTerminalCursorVisibility();
+	}
+
 	protected beforeTerminalStart(): void {}
 
 	protected afterTerminalStart(): void {}
@@ -397,6 +402,7 @@ export abstract class TuiBase extends Container implements TUI {
 		return true;
 	}
 
+	// Fullscreen appends the sequence to synchronized output; direct callers preserve Terminal method overrides.
 	protected transitionTerminalCursorVisibility(visible: boolean): string {
 		return this.updateTerminalCursorVisibility(visible) ? (visible ? SHOW_CURSOR : HIDE_CURSOR) : "";
 	}
@@ -586,7 +592,7 @@ export abstract class TuiBase extends Container implements TUI {
 		if (!options?.nonCapturing && this.isOverlayVisible(entry)) {
 			this.setFocus(component);
 		}
-		this.writeTerminalCursorVisibility(false, { force: true });
+		this.writeTerminalCursorVisibility(false);
 		this.requestRender();
 
 		// Return handle for controlling this overlay
@@ -603,7 +609,7 @@ export abstract class TuiBase extends Container implements TUI {
 						this.setFocus(topVisible?.component ?? entry.preFocus);
 					}
 					if (this.overlayStack.length === 0) {
-						this.writeTerminalCursorVisibility(false, { force: true });
+						this.writeTerminalCursorVisibility(false);
 					}
 					this.requestRender();
 				}
@@ -683,7 +689,7 @@ export abstract class TuiBase extends Container implements TUI {
 			this.setFocus(topVisible?.component ?? overlay.preFocus);
 		}
 		if (this.overlayStack.length === 0) {
-			this.writeTerminalCursorVisibility(false, { force: true });
+			this.writeTerminalCursorVisibility(false);
 		}
 		this.requestRender();
 	}
@@ -735,7 +741,7 @@ export abstract class TuiBase extends Container implements TUI {
 			() => this.requestRender(),
 		);
 		this.afterTerminalStart();
-		this.writeTerminalCursorVisibility(false, { force: true });
+		this.writeTerminalCursorVisibility(false);
 		if (this.terminalColorSchemeNotificationsEnabled) {
 			this.terminal.write("\x1b[?2031h");
 		}
@@ -794,7 +800,7 @@ export abstract class TuiBase extends Container implements TUI {
 	}
 
 	renderNow(force = false): void {
-		if (force) this.resetRenderState();
+		if (force) this.resetAllRenderState();
 		this.renderRequested = false;
 		this.cancelRenderTimer();
 		this.lastRenderAt = performance.now();
@@ -803,7 +809,7 @@ export abstract class TuiBase extends Container implements TUI {
 
 	requestRender(force = false): void {
 		if (force) {
-			this.resetRenderState();
+			this.resetAllRenderState();
 			this.requestImmediateRender();
 			return;
 		}

--- a/packages/tui/test/cursor-visibility-state.test.ts
+++ b/packages/tui/test/cursor-visibility-state.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { Terminal } from "../src/terminal.ts";
+import { type Component, CURSOR_MARKER, type TUI } from "../src/tui.ts";
+import { TuiAltScreen } from "../src/tui-alt-screen.ts";
+import { TuiMainScreen } from "../src/tui-main-screen.ts";
+
+const SHOW_CURSOR = "\x1b[?25h";
+const HIDE_CURSOR = "\x1b[?25l";
+const ENTER_ALT_SCREEN = "\x1b[?1049h";
+const EXIT_ALT_SCREEN = "\x1b[?1049l";
+const BEGIN_SYNCHRONIZED_OUTPUT = "\x1b[?2026h";
+const END_SYNCHRONIZED_OUTPUT = "\x1b[?2026l";
+
+class RecordingTerminal implements Terminal {
+	readonly writes: string[] = [];
+	hideCursorCalls = 0;
+	showCursorCalls = 0;
+
+	start(_onInput: (data: string) => void, _onResize: () => void): void {}
+
+	stop(): void {}
+
+	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {}
+
+	write(data: string): void {
+		this.writes.push(data);
+	}
+
+	get columns(): number {
+		return 80;
+	}
+
+	get rows(): number {
+		return 24;
+	}
+
+	get kittyProtocolActive(): boolean {
+		return true;
+	}
+
+	moveBy(lines: number): void {
+		if (lines > 0) this.write(`\x1b[${lines}B`);
+		else if (lines < 0) this.write(`\x1b[${-lines}A`);
+	}
+
+	hideCursor(): void {
+		this.hideCursorCalls += 1;
+		this.write(HIDE_CURSOR);
+	}
+
+	showCursor(): void {
+		this.showCursorCalls += 1;
+		this.write(SHOW_CURSOR);
+	}
+
+	clearLine(): void {
+		this.write("\x1b[K");
+	}
+
+	clearFromCursor(): void {
+		this.write("\x1b[J");
+	}
+
+	clearScreen(): void {
+		this.write("\x1b[2J\x1b[H");
+	}
+
+	setTitle(title: string): void {
+		this.write(`\x1b]0;${title}\x07`);
+	}
+
+	setProgress(_active: boolean): void {}
+
+	clearWrites(): void {
+		this.writes.length = 0;
+	}
+
+	async waitForRender(): Promise<void> {
+		await new Promise<void>((resolve) => setTimeout(resolve, 25));
+	}
+}
+
+class CursorComponent implements Component {
+	frame = 0;
+	showCursor = true;
+
+	render(): string[] {
+		return [`streamed chunk ${this.frame}`, `> draft${this.showCursor ? CURSOR_MARKER : ""}`];
+	}
+
+	invalidate(): void {}
+}
+
+interface RendererCase {
+	name: string;
+	create(terminal: Terminal): TUI;
+}
+
+const rendererCases: RendererCase[] = [
+	{
+		name: "regular renderer",
+		create: (terminal) => new TuiMainScreen(terminal, true),
+	},
+	{
+		name: "fullscreen renderer",
+		create: (terminal) => new TuiAltScreen(terminal, true),
+	},
+];
+
+function countSequence(terminal: RecordingTerminal, sequence: string): number {
+	return terminal.writes.reduce((count, write) => count + write.split(sequence).length - 1, 0);
+}
+
+async function renderNextFrame(tui: TUI, terminal: RecordingTerminal, component: CursorComponent): Promise<void> {
+	component.frame += 1;
+	tui.requestRender();
+	await terminal.waitForRender();
+}
+
+for (const rendererCase of rendererCases) {
+	describe(rendererCase.name, () => {
+		it("emits cursor visibility only when the state changes", async () => {
+			const terminal = new RecordingTerminal();
+			const tui = rendererCase.create(terminal);
+			const component = new CursorComponent();
+			tui.addChild(component);
+			tui.start();
+			await terminal.waitForRender();
+
+			try {
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), tui.mode === "fullscreen" ? 2 : 1);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
+				assert.strictEqual(terminal.hideCursorCalls, 1);
+				assert.strictEqual(terminal.showCursorCalls, tui.mode === "regular" ? 1 : 0);
+
+				terminal.clearWrites();
+				tui.renderNow(true);
+				await renderNextFrame(tui, terminal, component);
+				await renderNextFrame(tui, terminal, component);
+				await renderNextFrame(tui, terminal, component);
+
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+
+				terminal.clearWrites();
+				component.showCursor = false;
+				await renderNextFrame(tui, terminal, component);
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 1);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+
+				if (tui.mode === "fullscreen") {
+					const transitionWrite = terminal.writes.find((write) => write.includes(HIDE_CURSOR));
+					assert.ok(transitionWrite?.startsWith(BEGIN_SYNCHRONIZED_OUTPUT));
+					assert.ok(transitionWrite?.endsWith(END_SYNCHRONIZED_OUTPUT));
+				}
+
+				terminal.clearWrites();
+				await renderNextFrame(tui, terminal, component);
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+
+				terminal.clearWrites();
+				component.showCursor = true;
+				await renderNextFrame(tui, terminal, component);
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("applies hardware cursor setting changes once", async () => {
+			const terminal = new RecordingTerminal();
+			const tui = rendererCase.create(terminal);
+			const component = new CursorComponent();
+			tui.addChild(component);
+			tui.start();
+			await terminal.waitForRender();
+
+			try {
+				terminal.clearWrites();
+				const hideCursorCalls = terminal.hideCursorCalls;
+				tui.setShowHardwareCursor(false);
+				await terminal.waitForRender();
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 1);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+				assert.strictEqual(terminal.hideCursorCalls, hideCursorCalls + 1);
+
+				terminal.clearWrites();
+				tui.setShowHardwareCursor(true);
+				await terminal.waitForRender();
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
+
+				terminal.clearWrites();
+				await renderNextFrame(tui, terminal, component);
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+}
+
+describe("fullscreen renderer lifecycle", () => {
+	it("restores cursor visibility after leaving the alternate screen", async () => {
+		const terminal = new RecordingTerminal();
+		const tui = new TuiAltScreen(terminal, true);
+		const component = new CursorComponent();
+		tui.addChild(component);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		tui.stop({ preserveScreen: true });
+
+		const exitWrite = terminal.writes.find((write) => write.includes(EXIT_ALT_SCREEN));
+		assert.ok(exitWrite?.includes(`${EXIT_ALT_SCREEN}${SHOW_CURSOR}`));
+		assert.ok(exitWrite?.startsWith(BEGIN_SYNCHRONIZED_OUTPUT));
+		assert.ok(exitWrite?.endsWith(END_SYNCHRONIZED_OUTPUT));
+		assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 2);
+		assert.strictEqual(terminal.showCursorCalls, 1);
+		assert.strictEqual(countSequence(terminal, ENTER_ALT_SCREEN), 0);
+	});
+});

--- a/packages/tui/test/cursor-visibility-state.test.ts
+++ b/packages/tui/test/cursor-visibility-state.test.ts
@@ -75,10 +75,6 @@ class RecordingTerminal implements Terminal {
 	clearWrites(): void {
 		this.writes.length = 0;
 	}
-
-	async waitForRender(): Promise<void> {
-		await new Promise<void>((resolve) => setTimeout(resolve, 25));
-	}
 }
 
 class CursorComponent implements Component {
@@ -118,40 +114,42 @@ function countSequence(terminal: RecordingTerminal, sequence: string): number {
 	return terminal.writes.reduce((count, write) => count + write.split(sequence).length - 1, 0);
 }
 
-async function renderNextFrame(tui: TUI, terminal: RecordingTerminal, component: CursorComponent): Promise<void> {
+function renderNextFrame(tui: TUI, component: CursorComponent): void {
 	component.frame += 1;
-	tui.requestRender();
-	await terminal.waitForRender();
+	tui.renderNow();
 }
 
 for (const rendererCase of rendererCases) {
 	describe(rendererCase.name, () => {
-		it("emits cursor visibility only when the state changes", async () => {
+		it("emits cursor visibility only when the state changes", () => {
 			const terminal = new RecordingTerminal();
 			const tui = rendererCase.create(terminal);
 			const component = new CursorComponent();
 			tui.addChild(component);
 			tui.start();
-			await terminal.waitForRender();
+			tui.renderNow();
 
 			try {
-				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), tui.mode === "fullscreen" ? 2 : 1);
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 1);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
-				assert.strictEqual(terminal.hideCursorCalls, 1);
+				assert.strictEqual(terminal.hideCursorCalls, tui.mode === "regular" ? 1 : 0);
 				assert.strictEqual(terminal.showCursorCalls, tui.mode === "regular" ? 1 : 0);
 
 				terminal.clearWrites();
 				tui.renderNow(true);
-				await renderNextFrame(tui, terminal, component);
-				await renderNextFrame(tui, terminal, component);
-				await renderNextFrame(tui, terminal, component);
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
 
+				terminal.clearWrites();
+				renderNextFrame(tui, component);
+				renderNextFrame(tui, component);
+				renderNextFrame(tui, component);
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
 
 				terminal.clearWrites();
 				component.showCursor = false;
-				await renderNextFrame(tui, terminal, component);
+				renderNextFrame(tui, component);
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 1);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
 
@@ -162,13 +160,13 @@ for (const rendererCase of rendererCases) {
 				}
 
 				terminal.clearWrites();
-				await renderNextFrame(tui, terminal, component);
+				renderNextFrame(tui, component);
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
 
 				terminal.clearWrites();
 				component.showCursor = true;
-				await renderNextFrame(tui, terminal, component);
+				renderNextFrame(tui, component);
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
 			} finally {
@@ -176,19 +174,19 @@ for (const rendererCase of rendererCases) {
 			}
 		});
 
-		it("does not re-emit visibility when the cursor moves during streaming", async () => {
+		it("does not re-emit visibility when the cursor moves during streaming", () => {
 			const terminal = new RecordingTerminal();
 			const tui = rendererCase.create(terminal);
 			const component = new CursorComponent();
 			tui.addChild(component);
 			tui.start();
-			await terminal.waitForRender();
+			tui.renderNow();
 
 			try {
 				terminal.clearWrites();
 				for (const cursorOffset of [3, 0, 4, 1]) {
 					component.cursorOffset = cursorOffset;
-					await renderNextFrame(tui, terminal, component);
+					renderNextFrame(tui, component);
 				}
 
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
@@ -198,33 +196,53 @@ for (const rendererCase of rendererCases) {
 			}
 		});
 
-		it("applies hardware cursor setting changes once", async () => {
+		it("applies hardware cursor setting changes once", () => {
 			const terminal = new RecordingTerminal();
 			const tui = rendererCase.create(terminal);
 			const component = new CursorComponent();
 			tui.addChild(component);
 			tui.start();
-			await terminal.waitForRender();
+			tui.renderNow();
 
 			try {
 				terminal.clearWrites();
 				const hideCursorCalls = terminal.hideCursorCalls;
 				tui.setShowHardwareCursor(false);
-				await terminal.waitForRender();
+				tui.renderNow();
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 1);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
 				assert.strictEqual(terminal.hideCursorCalls, hideCursorCalls + 1);
 
 				terminal.clearWrites();
 				tui.setShowHardwareCursor(true);
-				await terminal.waitForRender();
+				tui.renderNow();
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
 
 				terminal.clearWrites();
-				await renderNextFrame(tui, terminal, component);
+				renderNextFrame(tui, component);
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("reasserts cursor visibility after restart", () => {
+			const terminal = new RecordingTerminal();
+			const tui = rendererCase.create(terminal);
+			const component = new CursorComponent();
+			tui.addChild(component);
+			tui.start();
+			tui.renderNow();
+			tui.stop({ preserveScreen: true });
+			terminal.clearWrites();
+
+			tui.start();
+			tui.renderNow();
+			try {
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 1);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
 			} finally {
 				tui.stop();
 			}
@@ -233,13 +251,13 @@ for (const rendererCase of rendererCases) {
 }
 
 describe("fullscreen renderer lifecycle", () => {
-	it("restores cursor visibility after leaving the alternate screen", async () => {
+	it("restores cursor visibility after leaving the alternate screen", () => {
 		const terminal = new RecordingTerminal();
 		const tui = new TuiAltScreen(terminal, true);
 		const component = new CursorComponent();
 		tui.addChild(component);
 		tui.start();
-		await terminal.waitForRender();
+		tui.renderNow();
 		terminal.clearWrites();
 
 		tui.stop({ preserveScreen: true });

--- a/packages/tui/test/cursor-visibility-state.test.ts
+++ b/packages/tui/test/cursor-visibility-state.test.ts
@@ -110,6 +110,17 @@ const rendererCases: RendererCase[] = [
 	},
 ];
 
+const defaultRendererCases: RendererCase[] = [
+	{
+		name: "regular renderer",
+		create: (terminal) => new TuiMainScreen(terminal),
+	},
+	{
+		name: "fullscreen renderer",
+		create: (terminal) => new TuiAltScreen(terminal),
+	},
+];
+
 function countSequence(terminal: RecordingTerminal, sequence: string): number {
 	return terminal.writes.reduce((count, write) => count + write.split(sequence).length - 1, 0);
 }
@@ -249,6 +260,33 @@ for (const rendererCase of rendererCases) {
 		});
 	});
 }
+
+describe("default hidden hardware cursor", () => {
+	for (const rendererCase of defaultRendererCases) {
+		it(`does not re-emit hide while ${rendererCase.name} streams`, () => {
+			const terminal = new RecordingTerminal();
+			const tui = rendererCase.create(terminal);
+			const component = new CursorComponent();
+			tui.addChild(component);
+			tui.start();
+			tui.renderNow();
+
+			try {
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 1);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+
+				terminal.clearWrites();
+				renderNextFrame(tui, component);
+				renderNextFrame(tui, component);
+				renderNextFrame(tui, component);
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
+			} finally {
+				tui.stop();
+			}
+		});
+	}
+});
 
 describe("fullscreen renderer lifecycle", () => {
 	it("restores cursor visibility after leaving the alternate screen", () => {

--- a/packages/tui/test/cursor-visibility-state.test.ts
+++ b/packages/tui/test/cursor-visibility-state.test.ts
@@ -84,9 +84,15 @@ class RecordingTerminal implements Terminal {
 class CursorComponent implements Component {
 	frame = 0;
 	showCursor = true;
+	cursorOffset = 5;
 
 	render(): string[] {
-		return [`streamed chunk ${this.frame}`, `> draft${this.showCursor ? CURSOR_MARKER : ""}`];
+		const draft = "draft";
+		const cursor = this.showCursor ? CURSOR_MARKER : "";
+		return [
+			`streamed chunk ${this.frame}`,
+			`> ${draft.slice(0, this.cursorOffset)}${cursor}${draft.slice(this.cursorOffset)}`,
+		];
 	}
 
 	invalidate(): void {}
@@ -165,6 +171,28 @@ for (const rendererCase of rendererCases) {
 				await renderNextFrame(tui, terminal, component);
 				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
 				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 1);
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("does not re-emit visibility when the cursor moves during streaming", async () => {
+			const terminal = new RecordingTerminal();
+			const tui = rendererCase.create(terminal);
+			const component = new CursorComponent();
+			tui.addChild(component);
+			tui.start();
+			await terminal.waitForRender();
+
+			try {
+				terminal.clearWrites();
+				for (const cursorOffset of [3, 0, 4, 1]) {
+					component.cursorOffset = cursorOffset;
+					await renderNextFrame(tui, terminal, component);
+				}
+
+				assert.strictEqual(countSequence(terminal, HIDE_CURSOR), 0);
+				assert.strictEqual(countSequence(terminal, SHOW_CURSOR), 0);
 			} finally {
 				tui.stop();
 			}


### PR DESCRIPTION
## Summary

- track terminal cursor visibility in `TuiBase` and emit visibility commands only on state transitions during renders
- apply the same behavior to regular and fullscreen renderers while preserving lifecycle, overlay, and settings calls through the public `Terminal` methods
- reassert cursor state on forced redraws and alternate-screen lifecycle boundaries
- cover enabled and default-hidden hardware cursors, cursor movement, settings changes, and renderer restart behavior

Related to #8003

## Reporter validation

This removes repeated `DECTCEM` visibility commands. The report says default settings, where the hardware cursor is normally hidden, so confirmation is still pending on whether `showHardwareCursor`/`PI_HARDWARE_CURSOR=1` or fullscreen mode was active and whether this branch resolves the visual flicker. If the default software cursor still flickers, its repaint path should be investigated separately.

## Validation

- `npm run check`
- `node --test test/cursor-visibility-state.test.ts` (11 tests)
- existing TUI renderer, shrink, and overlay suites
- GitHub CI `build-check-test`
