### PR TITLE
fix(coding-agent): use neutral wording for repeated ambiguous length stops

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1999,14 +1999,17 @@ export class AgentSession {
 			}
 
 			if (this._overflowRecoveryAttempted) {
+				// A repeated ambiguous length stop (recoverable but not a detected overflow) must not be
+				// labeled as context overflow: reserve that wording for responses matching isContextOverflow().
 				this._emit({
 					type: "compaction_end",
 					reason: "overflow",
 					result: undefined,
 					aborted: false,
 					willRetry: false,
-					errorMessage:
-						"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
+					errorMessage: isContextOverflow(assistantMessage, contextWindow)
+						? "Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model."
+						: "Truncated response recovery failed after one compact-and-retry attempt.",
 				});
 				return false;
 			}

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -353,7 +353,7 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.faux.state.callCount).toBe(2);
 		expect(harness.eventsOfType("compaction_start").filter((event) => event.reason === "overflow")).toHaveLength(1);
 		expect(harness.eventsOfType("compaction_end").at(-1)?.errorMessage).toBe(
-			"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
+			"Truncated response recovery failed after one compact-and-retry attempt.",
 		);
 	});
 
@@ -436,6 +436,35 @@ describe("AgentSession compaction characterization", () => {
 
 		await sessionInternals._checkCompaction(overflowMessage);
 		await sessionInternals._checkCompaction({ ...overflowMessage, timestamp: Date.now() + 1 });
+
+		expect(runAutoCompactionSpy).toHaveBeenCalledTimes(1);
+		expect(compactionErrors).toContain(
+			"Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.",
+		);
+	});
+
+	it("keeps overflow wording when a repeated length stop fills the context window", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 100, maxTokens: 100 }],
+		});
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		// MiMo-style overflow: length stop with zero output while input fills the context window.
+		const lengthOverflowMessage = createAssistant(harness, {
+			stopReason: "length",
+			totalTokens: 100,
+			timestamp: Date.now(),
+		});
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
+		const compactionErrors: string[] = [];
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.errorMessage) {
+				compactionErrors.push(event.errorMessage);
+			}
+		});
+
+		await sessionInternals._checkCompaction(lengthOverflowMessage);
+		await sessionInternals._checkCompaction({ ...lengthOverflowMessage, timestamp: Date.now() + 1 });
 
 		expect(runAutoCompactionSpy).toHaveBeenCalledTimes(1);
 		expect(compactionErrors).toContain(


### PR DESCRIPTION
Fixes #8130

## Problem

A second recoverable `length` stop (output below the model's desired limit) always emitted:

```
Context overflow recovery failed after one compact-and-retry attempt. Try reducing context or switching to a larger-context model.
```

even when neither response matched `isContextOverflow()`. Per #7540, a recoverable `length` stop is intentionally ambiguous — it may be context pressure *or* provider-side truncation — and the normal UI message already uses neutral wording ("Response was truncated before completion."). Only this terminal recovery path still labeled it as overflow.

## Change

In `AgentSession._checkCompaction`, when the single bounded compact-and-retry attempt is exhausted, pick the terminal message based on the current response:

- `isContextOverflow(assistantMessage, contextWindow)` → keep the existing overflow wording
- otherwise (repeated ambiguous `length`) → new neutral wording: "Truncated response recovery failed after one compact-and-retry attempt."

The recovery behavior itself is unchanged: still exactly one compact-and-retry attempt.

## Tests

- Updated "stops after one compact-and-retry when a second response is also truncated" — two `length` stops with output below `maxTokens` and a large context window now expect the neutral message (this was the buggy assertion matching the old behavior).
- Added "keeps overflow wording when a repeated length stop fills the context window" — MiMo-style overflow (`length` stop, zero output, input filling the context window) still reports the context-overflow message.
- Existing error-based overflow test ("does not retry overflow recovery more than once") and the auto-compaction queue suite still pass unchanged.

## Validation

- `npx vitest --run` in `packages/coding-agent`: compaction suites pass (pre-existing environment-related failures on `main` unrelated to this change, verified via stash)
- `tsgo --noEmit`, `biome check`, and the repo's pre-commit `npm run check` all pass
