### PR TITLE
fix(ai): expose low thinking level for DeepSeek V4 Flash on opencode/opencode-go

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -875,7 +875,8 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 			model,
 			model.provider === "openrouter"
 				? { ...DEEPSEEK_V4_THINKING_LEVEL_MAP, xhigh: "xhigh", max: null }
-				: model.provider === "deepseek" && model.id === "deepseek-v4-flash"
+				: (model.provider === "deepseek" || model.provider === "opencode" || model.provider === "opencode-go") &&
+					model.id.includes("deepseek-v4-flash")
 					? DEEPSEEK_V4_FLASH_THINKING_LEVEL_MAP
 					: DEEPSEEK_V4_THINKING_LEVEL_MAP,
 		);

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -88,10 +88,10 @@ describe("getSupportedThinkingLevels", () => {
 		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "high", "max"]);
 	});
 
-	it("includes only high/max plus off for DeepSeek V4 Flash on opencode-go", () => {
+	it("includes low/high/max plus off for DeepSeek V4 Flash on opencode-go", () => {
 		const model = getModel("opencode-go", "deepseek-v4-flash");
 		expect(model).toBeDefined();
-		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "high", "max"]);
+		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "high", "max"]);
 	});
 
 	it("includes only high plus off for OpenCode Go Kimi K2.6", () => {


### PR DESCRIPTION
## Problem

`DEEPSEEK_V4_FLASH_THINKING_LEVEL_MAP` (which enables the `low` reasoning-effort level) was only applied to `deepseek/deepseek-v4-flash`. The same model served through **opencode** and **opencode-go** fell back to `DEEPSEEK_V4_THINKING_LEVEL_MAP`, which sets `low: null`, so those providers only offered `off` / `high` / `max`.

Verified:
- models.dev reports `reasoning_options: [{type: "effort", values: ["low", "high", "max"]}]` for `opencode-go/deepseek-v4-flash`, `opencode/deepseek-v4-flash`, and `opencode/deepseek-v4-flash-free`.
- Live test against `https://opencode.ai/zen/go/v1` (opencode-go): `reasoning_effort=low` returns 200 for both `deepseek-v4-flash` and `deepseek-v4-pro`.
- DeepSeek's official docs (api-docs.deepseek.com/guides/thinking_mode) state `low`/`high`/`max` are the supported OpenAI-format effort values (medium/xhigh map to high).

## Change

Apply `DEEPSEEK_V4_FLASH_THINKING_LEVEL_MAP` to every `deepseek-v4-flash` variant on the `deepseek`, `opencode`, and `opencode-go` providers (not just `deepseek`).

`qwen-token-plan` is intentionally left unchanged — its gateway support for the `low` effort level is not verified.

## Verification

- `npm run hydrate:model-data` regenerates `opencode-go.json` / `opencode.json` with `low: "low"` in `thinkingLevelMap` for `deepseek-v4-flash` (and `deepseek-v4-flash-free` on opencode).
- Updated `test/supports-xhigh.test.ts` to expect `["off", "low", "high", "max"]` for `opencode-go/deepseek-v4-flash`.
- `vitest` passes for `supports-xhigh`, `qwen-token-plan-models`, and `max-thinking` suites.
