### PR TITLE
fix(coding-agent): retry hung pi.dev catalog refreshes

### DIFF
--- a/packages/coding-agent/src/core/remote-catalog-provider.ts
+++ b/packages/coding-agent/src/core/remote-catalog-provider.ts
@@ -5,6 +5,7 @@ import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 
 const DEFAULT_CATALOG_BASE_URL = "https://pi.dev";
 export const REMOTE_CATALOG_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const REMOTE_CATALOG_ATTEMPT_TIMEOUT_MS = 3_000;
 
 function mergeModels(baseline: readonly Model<Api>[], dynamic: readonly Model<Api>[]): Model<Api>[] {
 	const merged = [...baseline];
@@ -75,17 +76,33 @@ export function withRemoteCatalog(
 			}
 
 			// Only revalidate when a cached body backs the validator, so a 304 can never
-			// leave the overlay empty.
+			// leave the overlay empty. Revalidation is one attempt: a hang or transport
+			// failure falls back to a full download instead of retrying If-None-Match.
 			const validator = stored?.models.length ? stored.etag : undefined;
 			const url = new URL(`/api/models/providers/${encodeURIComponent(provider.id)}`, catalogBaseUrl);
-			const response = await fetchWithRetry(url, {
-				headers: {
-					accept: "application/json",
-					"User-Agent": getPiUserAgent(VERSION),
-					...(validator ? { "if-none-match": validator } : {}),
-				},
-				signal: context.signal,
-			});
+			const fetchCatalog = (revalidate: string | undefined) =>
+				fetchWithRetry(
+					url,
+					{
+						headers: {
+							accept: "application/json",
+							"User-Agent": getPiUserAgent(VERSION),
+							...(revalidate ? { "if-none-match": revalidate } : {}),
+						},
+						signal: context.signal,
+					},
+					{
+						attemptTimeoutMs: REMOTE_CATALOG_ATTEMPT_TIMEOUT_MS,
+						...(revalidate ? { maxRetries: 0 } : {}),
+					},
+				);
+			let response: Response;
+			try {
+				response = await fetchCatalog(validator);
+			} catch (error) {
+				if (!validator || context.signal.aborted) throw error;
+				response = await fetchCatalog(undefined);
+			}
 			if (context.signal.aborted) return;
 			const checkedAt = Date.now();
 			// Unchanged: dynamicModels already holds the stored overlay, so only the

--- a/packages/coding-agent/src/utils/management-http.ts
+++ b/packages/coding-agent/src/utils/management-http.ts
@@ -7,8 +7,17 @@ export interface FetchRetryOptions {
 	maxRetries?: number;
 	/** Retry transient HTTP responses as well as transport failures. Defaults to true. */
 	retryOnStatus?: boolean;
-	/** Per-attempt timeout. A new timeout is created for every attempt. */
+	/** Overall time budget shared by all attempts. */
 	timeoutMs?: number;
+	/** Per-attempt timeout. A new timeout is created for every attempt. */
+	attemptTimeoutMs?: number;
+}
+
+function combineSignals(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+	const active = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+	if (active.length === 0) return undefined;
+	if (active.length === 1) return active[0];
+	return AbortSignal.any(active);
 }
 
 /**
@@ -19,8 +28,9 @@ export interface FetchRetryOptions {
  * agent/model operations: those can fail after the HTTP request starts and are
  * retried by their semantic caller instead.
  *
- * Caller cancellation is terminal. When timeoutMs is supplied, it is the
- * overall time budget shared by all attempts.
+ * Caller cancellation is terminal. timeoutMs is the overall time budget shared
+ * by all attempts. attemptTimeoutMs aborts only the current attempt so a hung
+ * connection can be retried.
  */
 export async function fetchWithRetry(
 	input: FetchInput,
@@ -32,17 +42,17 @@ export async function fetchWithRetry(
 			? 2
 			: Math.max(0, Math.floor(options.maxRetries));
 	const retryOnStatus = options.retryOnStatus ?? true;
-	const parentSignal = init?.signal;
+	const parentSignal = init?.signal ?? undefined;
 	const timeoutSignal =
 		options.timeoutMs !== undefined && options.timeoutMs > 0 ? AbortSignal.timeout(options.timeoutMs) : undefined;
-	const signal = timeoutSignal
-		? parentSignal
-			? AbortSignal.any([parentSignal, timeoutSignal])
-			: timeoutSignal
-		: parentSignal;
+	const attemptTimeoutMs =
+		options.attemptTimeoutMs !== undefined && options.attemptTimeoutMs > 0 ? options.attemptTimeoutMs : undefined;
 
 	for (let attempt = 0; ; attempt++) {
-		signal?.throwIfAborted();
+		parentSignal?.throwIfAborted();
+		timeoutSignal?.throwIfAborted();
+		const attemptTimeoutSignal = attemptTimeoutMs !== undefined ? AbortSignal.timeout(attemptTimeoutMs) : undefined;
+		const signal = combineSignals([parentSignal, timeoutSignal, attemptTimeoutSignal]);
 
 		try {
 			const response = await fetch(input, signal ? { ...init, signal } : init);
@@ -55,10 +65,16 @@ export async function fetchWithRetry(
 				// do if cancelling its body also fails.
 			}
 		} catch (error) {
+			const attemptTimedOut = Boolean(
+				attemptTimeoutSignal?.aborted && !parentSignal?.aborted && !timeoutSignal?.aborted,
+			);
 			if (
 				parentSignal?.aborted ||
 				timeoutSignal?.aborted ||
-				(error instanceof Error && error.name === "AbortError" && timeoutSignal === undefined) ||
+				(error instanceof Error &&
+					error.name === "AbortError" &&
+					!attemptTimedOut &&
+					timeoutSignal === undefined) ||
 				attempt >= maxRetries
 			) {
 				throw error;

--- a/packages/coding-agent/test/management-http.test.ts
+++ b/packages/coding-agent/test/management-http.test.ts
@@ -49,4 +49,75 @@ describe("fetchWithRetry", () => {
 		await expect(fetchWithRetry("https://example.test", { signal: controller.signal })).rejects.toThrow();
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
+
+	it("retries a hung attempt when attemptTimeoutMs is set", async () => {
+		const signals: AbortSignal[] = [];
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			if (init?.signal) signals.push(init.signal);
+			if (signals.length === 1) {
+				await new Promise<never>((_, reject) => {
+					init?.signal?.addEventListener("abort", () => {
+						reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+					});
+				});
+			}
+			return Response.json({ ok: true });
+		});
+
+		const response = await fetchWithRetry("https://example.test", undefined, {
+			attemptTimeoutMs: 20,
+			maxRetries: 1,
+		});
+		expect(response.ok).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(signals[0]).not.toBe(signals[1]);
+	});
+
+	it("does not retry an overall timeout", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			await new Promise<Response>((_, reject) => {
+				init?.signal?.addEventListener("abort", () => {
+					reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+				});
+			});
+			return Response.json({ ok: true });
+		});
+
+		await expect(
+			fetchWithRetry("https://example.test", undefined, { timeoutMs: 20, maxRetries: 2 }),
+		).rejects.toThrow();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not retry caller cancellation when attemptTimeoutMs is set", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const fetchMock = vi.spyOn(globalThis, "fetch");
+
+		await expect(
+			fetchWithRetry("https://example.test", { signal: controller.signal }, { attemptTimeoutMs: 20 }),
+		).rejects.toThrow();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("retries attempt timeouts until the overall timeout", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			await new Promise<Response>((_, reject) => {
+				init?.signal?.addEventListener("abort", () => {
+					reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+				});
+			});
+			return Response.json({ ok: true });
+		});
+
+		await expect(
+			fetchWithRetry("https://example.test", undefined, {
+				attemptTimeoutMs: 15,
+				timeoutMs: 40,
+				maxRetries: 10,
+			}),
+		).rejects.toThrow();
+		expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+		expect(fetchMock.mock.calls.length).toBeLessThan(6);
+	});
 });

--- a/packages/coding-agent/test/remote-catalog-provider.test.ts
+++ b/packages/coding-agent/test/remote-catalog-provider.test.ts
@@ -48,6 +48,15 @@ function testProvider(localGeneratedAt?: number) {
 	);
 }
 
+function headerRecord(init: RequestInit | undefined): Record<string, string> {
+	return (init?.headers ?? {}) as Record<string, string>;
+}
+
+function shortenCatalogAttemptTimeouts(): void {
+	const timeout = AbortSignal.timeout.bind(AbortSignal);
+	vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => timeout(ms > 100 ? 20 : ms));
+}
+
 async function refreshProvider(
 	provider: Provider,
 	store: InMemoryModelsStore,
@@ -143,6 +152,85 @@ describe("remote catalog provider", () => {
 		expect(stored?.checkedAt).toBeGreaterThanOrEqual(checkedAt ?? 0);
 	});
 
+	it("retries a hung If-None-Match revalidation without the validator", async () => {
+		shortenCatalogAttemptTimeouts();
+		let downloads = 0;
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			if (headerRecord(init)["if-none-match"]) {
+				await new Promise<Response>((_, reject) => {
+					init?.signal?.addEventListener("abort", () => {
+						reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+					});
+				});
+			}
+			downloads++;
+			const id = downloads === 1 ? "dynamic" : "refreshed";
+			return new Response(JSON.stringify({ [id]: model(id) }), {
+				headers: { "content-type": "application/json", etag: `"${id}"` },
+			});
+		});
+		const provider = testProvider();
+		const store = new InMemoryModelsStore();
+
+		await refreshProvider(provider, store);
+		await refreshProvider(provider, store, { force: true });
+
+		const revalidations = fetchSpy.mock.calls.filter((call) => headerRecord(call[1])["if-none-match"]);
+		const fallbacks = fetchSpy.mock.calls.filter((call) => !headerRecord(call[1])["if-none-match"]);
+		expect(revalidations.length).toBe(1);
+		expect(fallbacks.length).toBe(2);
+		expect(provider.getModels().map((entry) => entry.id)).toEqual(["static", "refreshed"]);
+	});
+
+	it("falls back to a full download after a transport error on revalidation", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			if (headerRecord(init)["if-none-match"]) throw new Error("fetch failed");
+			return new Response(JSON.stringify({ refreshed: model("refreshed") }), {
+				headers: { "content-type": "application/json", etag: '"catalog-2"' },
+			});
+		});
+		const provider = testProvider();
+		const store = new InMemoryModelsStore();
+		await store.write(provider.id, {
+			models: [model("dynamic")],
+			checkedAt: Date.now(),
+			lastModified: Date.now(),
+			etag: '"catalog-1"',
+		});
+
+		await refreshProvider(provider, store, { force: true });
+
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		expect(headerRecord(fetchSpy.mock.calls[0]?.[1])["if-none-match"]).toBe('"catalog-1"');
+		expect(headerRecord(fetchSpy.mock.calls[1]?.[1])["if-none-match"]).toBeUndefined();
+		expect(provider.getModels().map((entry) => entry.id)).toEqual(["static", "refreshed"]);
+	});
+
+	it("does not fall back when the caller aborts revalidation", async () => {
+		const controller = new AbortController();
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			if (headerRecord(init)["if-none-match"]) {
+				controller.abort();
+				throw Object.assign(new Error("This operation was aborted"), { name: "AbortError" });
+			}
+			return new Response(JSON.stringify({ dynamic: model("dynamic") }), {
+				headers: { "content-type": "application/json", etag: '"catalog-1"' },
+			});
+		});
+		const provider = testProvider();
+		const store = new InMemoryModelsStore();
+		await store.write(provider.id, {
+			models: [model("dynamic")],
+			checkedAt: Date.now(),
+			lastModified: Date.now(),
+			etag: '"catalog-1"',
+		});
+
+		await expect(refreshProvider(provider, store, { force: true, signal: controller.signal })).rejects.toThrow();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(headerRecord(fetchSpy.mock.calls[0]?.[1])["if-none-match"]).toBe('"catalog-1"');
+	});
+
 	it("drops a stale etag when the overlay becomes unavailable", async () => {
 		const responses = [
 			new Response(JSON.stringify({ dynamic: model("dynamic") }), {
@@ -166,8 +254,6 @@ describe("remote catalog provider", () => {
 				headers: { "content-type": "application/json", etag: '"catalog-1"' },
 			}),
 			new Response("rate limited", { status: 429 }),
-			new Response("rate limited", { status: 429 }),
-			new Response("rate limited", { status: 429 }),
 			new Response(null, { status: 304, headers: { etag: '"catalog-1"' } }),
 		];
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => responses.shift() as Response);
@@ -182,7 +268,7 @@ describe("remote catalog provider", () => {
 		expect(stored?.models.map((entry) => entry.id)).toEqual(["dynamic"]);
 
 		await refreshProvider(provider, store, { force: true });
-		expect(fetchSpy.mock.calls[4]?.[1]?.headers).toMatchObject({ "if-none-match": '"catalog-1"' });
+		expect(fetchSpy.mock.calls[2]?.[1]?.headers).toMatchObject({ "if-none-match": '"catalog-1"' });
 		expect(provider.getModels().map((entry) => entry.id)).toEqual(["static", "dynamic"]);
 	});
 


### PR DESCRIPTION
pi.dev `/api/models/providers/*` intermittently accepts TLS and returns no bytes. That is a recurrence of #8065 (server-side 304/hang). The catalog server is not in this repo.

`pi update --models` uses one 15s abort for the whole refresh. Catalog fetches had no per-attempt timeout, so one hung provider consumed the budget and failed with `Model catalog refresh timed out.` `fetchWithRetry` already retries transport errors, but parent abort is terminal, so a hang never retried.

This is a client workaround, not a server fix.

- Add `attemptTimeoutMs` to `fetchWithRetry`. A hung attempt is aborted and retried. `timeoutMs` stays an overall budget. Caller abort stays terminal.
- Catalog refreshes use a 3s per-attempt timeout.
- Keep `If-None-Match`. Revalidation is one attempt. On hang or transport error, fall back to a full download instead of retrying the broken 304 path.
- Do not fall back when the caller aborts.

Unconditional GETs hang too, so dropping validators would not fix this. Worst case after this change is one 3s revalidation plus three 3s downloads (12s), inside the existing 15s refresh budget.

fixes #8198
