### PR TITLE
feat(auth): add Kiro OAuth device login

### DIFF
--- a/packages/ai/src/auth/oauth/kiro.ts
+++ b/packages/ai/src/auth/oauth/kiro.ts
@@ -1,0 +1,303 @@
+import { getKiroEndpoints, resolveKiroApiRegion } from "../../providers/kiro.shared.ts";
+import type { OAuthAuth, OAuthCredential, ProviderAuthInteraction } from "../types.ts";
+import { pollOAuthDeviceCodeFlow } from "./device-code.ts";
+
+const BUILDER_ID_START_URL = "https://view.awsapps.com/start";
+const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+const REFRESH_GRANT = "refresh_token";
+const SSO_SCOPES = [
+	"codewhisperer:completions",
+	"codewhisperer:analysis",
+	"codewhisperer:conversations",
+	"codewhisperer:transformations",
+	"codewhisperer:taskassist",
+];
+const REGION_PROBES = [
+	"us-east-1",
+	"eu-west-1",
+	"eu-central-1",
+	"us-east-2",
+	"eu-west-2",
+	"eu-west-3",
+	"eu-north-1",
+	"ap-southeast-1",
+	"ap-northeast-1",
+	"us-west-2",
+] as const;
+const LOGIN_REQUEST_TIMEOUT_MS = 15_000;
+const TOKEN_EXPIRY_SKEW_MS = 5 * 60 * 1000;
+
+export interface KiroOAuthCredential extends OAuthCredential {
+	clientId: string;
+	clientSecret: string;
+	region: string;
+	authMethod: "idc";
+	profileArn?: string;
+}
+
+type KiroDeviceAuthorization = {
+	deviceCode: string;
+	userCode: string;
+	verificationUri: string;
+	verificationUriComplete: string;
+	interval: number;
+	expiresIn: number;
+};
+
+type KiroTokenResponse = {
+	accessToken?: string;
+	access_token?: string;
+	refreshToken?: string;
+	refresh_token?: string;
+	expiresIn?: number;
+	expires_in?: number;
+	error?: string;
+	error_description?: string;
+};
+
+function requestSignal(signal: AbortSignal): AbortSignal {
+	return AbortSignal.any([signal, AbortSignal.timeout(LOGIN_REQUEST_TIMEOUT_MS)]);
+}
+
+function getField<T>(response: Record<string, unknown>, camel: string, snake: string): T | undefined {
+	const camelValue = response[camel];
+	if (camelValue !== undefined) return camelValue as T;
+	return response[snake] as T | undefined;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+	try {
+		return (await response.json()) as T;
+	} catch {
+		return {} as T;
+	}
+}
+
+async function registerAndAuthorize(
+	startUrl: string,
+	region: string,
+	fetchFn: typeof globalThis.fetch,
+	signal: AbortSignal,
+): Promise<{ clientId: string; clientSecret: string; device: KiroDeviceAuthorization } | undefined> {
+	const oidcEndpoint = `https://oidc.${region}.amazonaws.com`;
+	const registerResponse = await fetchFn(`${oidcEndpoint}/client/register`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+		body: JSON.stringify({
+			clientName: "pi-cli",
+			clientType: "public",
+			scopes: SSO_SCOPES,
+			grantTypes: [DEVICE_CODE_GRANT, REFRESH_GRANT],
+		}),
+		signal: requestSignal(signal),
+	});
+	if (!registerResponse.ok) return undefined;
+	const registration = (await readJson<Record<string, unknown>>(registerResponse)) as Record<string, unknown>;
+	const clientId = getField<string>(registration, "clientId", "client_id");
+	const clientSecret = getField<string>(registration, "clientSecret", "client_secret");
+	if (!clientId || !clientSecret) return undefined;
+
+	const deviceResponse = await fetchFn(`${oidcEndpoint}/device_authorization`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+		body: JSON.stringify({ clientId, clientSecret, startUrl }),
+		signal: requestSignal(signal),
+	});
+	if (!deviceResponse.ok) return undefined;
+	const raw = (await readJson<Record<string, unknown>>(deviceResponse)) as Record<string, unknown>;
+	const deviceCode = getField<string>(raw, "deviceCode", "device_code");
+	const userCode = getField<string>(raw, "userCode", "user_code");
+	const verificationUri = getField<string>(raw, "verificationUri", "verification_uri");
+	const verificationUriComplete = getField<string>(raw, "verificationUriComplete", "verification_uri_complete");
+	const interval = Number(getField<number | string>(raw, "interval", "interval") ?? 5);
+	const expiresIn = Number(getField<number | string>(raw, "expiresIn", "expires_in") ?? 600);
+	if (
+		!deviceCode ||
+		!userCode ||
+		!verificationUri ||
+		!verificationUriComplete ||
+		!Number.isFinite(interval) ||
+		!Number.isFinite(expiresIn)
+	) {
+		return undefined;
+	}
+	return {
+		clientId,
+		clientSecret,
+		device: {
+			deviceCode,
+			userCode,
+			verificationUri,
+			verificationUriComplete,
+			interval: Math.max(1, interval),
+			expiresIn: Math.max(1, expiresIn),
+		},
+	};
+}
+
+async function beginDeviceAuthorization(
+	startUrl: string,
+	preferredRegion: string | undefined,
+	fetchFn: typeof globalThis.fetch,
+	signal: AbortSignal,
+): Promise<{ region: string; clientId: string; clientSecret: string; device: KiroDeviceAuthorization }> {
+	const regions = preferredRegion ? [preferredRegion] : [...REGION_PROBES];
+	for (const region of regions) {
+		try {
+			const result = await registerAndAuthorize(startUrl, region, fetchFn, signal);
+			if (result) return { region, ...result };
+		} catch (error) {
+			if (signal.aborted) throw error;
+			// A region that cannot be reached or does not own the start URL is not
+			// fatal while probing the remaining Identity Center regions.
+		}
+	}
+	throw new Error("Could not find an AWS Identity Center region for the supplied start URL");
+}
+
+async function pollForToken(
+	flow: { region: string; clientId: string; clientSecret: string; device: KiroDeviceAuthorization },
+	fetchFn: typeof globalThis.fetch,
+	signal: AbortSignal,
+): Promise<KiroOAuthCredential> {
+	return pollOAuthDeviceCodeFlow<KiroOAuthCredential>({
+		intervalSeconds: flow.device.interval,
+		expiresInSeconds: flow.device.expiresIn,
+		signal,
+		poll: async () => {
+			const response = await fetchFn(`https://oidc.${flow.region}.amazonaws.com/token`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+				body: JSON.stringify({
+					clientId: flow.clientId,
+					clientSecret: flow.clientSecret,
+					deviceCode: flow.device.deviceCode,
+					grantType: DEVICE_CODE_GRANT,
+				}),
+				signal: requestSignal(signal),
+			});
+			const data = await readJson<KiroTokenResponse>(response);
+			const error = data.error;
+			if (response.ok && !error) {
+				const access = data.accessToken ?? data.access_token;
+				const refresh = data.refreshToken ?? data.refresh_token;
+				const expiresIn = Number(data.expiresIn ?? data.expires_in);
+				if (!access || !refresh || !Number.isFinite(expiresIn)) {
+					return { status: "failed", message: "Kiro token response was missing required fields" };
+				}
+				return {
+					status: "complete",
+					value: {
+						type: "oauth",
+						access,
+						refresh: `${refresh}|${flow.clientId}|${flow.clientSecret}|idc|${flow.region}`,
+						expires: Date.now() + expiresIn * 1000 - TOKEN_EXPIRY_SKEW_MS,
+						clientId: flow.clientId,
+						clientSecret: flow.clientSecret,
+						region: flow.region,
+						authMethod: "idc",
+					},
+				};
+			}
+			if (error === "authorization_pending") return { status: "pending" };
+			if (error === "slow_down") return { status: "slow_down" };
+			return {
+				status: "failed",
+				message: `Kiro authorization failed${error ? `: ${error}` : ` (HTTP ${response.status})`}`,
+			};
+		},
+	});
+}
+
+async function loginKiro(interaction: ProviderAuthInteraction): Promise<KiroOAuthCredential> {
+	interaction.signal.throwIfAborted();
+	const startUrlInput = await interaction.prompt({
+		type: "text",
+		message: "Paste your IAM Identity Center start URL, or leave blank for AWS Builder ID",
+		placeholder: BUILDER_ID_START_URL,
+	});
+	interaction.signal.throwIfAborted();
+	const startUrl = startUrlInput.trim() || BUILDER_ID_START_URL;
+	if (!/^https?:\/\//i.test(startUrl)) throw new Error("Kiro start URL must be an http(s) URL");
+
+	let preferredRegion: string | undefined;
+	if (startUrl !== BUILDER_ID_START_URL) {
+		const regionInput = await interaction.prompt({
+			type: "text",
+			message: "AWS Identity Center region (leave blank to auto-detect)",
+			placeholder: "us-east-1",
+		});
+		preferredRegion = regionInput.trim() || undefined;
+	}
+	const fetchFn = globalThis.fetch;
+	const flow = await beginDeviceAuthorization(startUrl, preferredRegion, fetchFn, interaction.signal);
+	interaction.notify({
+		type: "auth_url",
+		url: flow.device.verificationUriComplete,
+		instructions: `Your code: ${flow.device.userCode}`,
+	});
+	interaction.notify({ type: "progress", message: `Waiting for Kiro authorization in ${flow.region}...` });
+	return pollForToken(flow, fetchFn, interaction.signal);
+}
+
+function parseRefreshCredential(credential: OAuthCredential): {
+	refreshToken: string;
+	clientId: string;
+	clientSecret: string;
+	region: string;
+} {
+	const kiroCredential = credential as KiroOAuthCredential;
+	const parts = credential.refresh.split("|");
+	const refreshToken = parts[0];
+	const clientId = kiroCredential.clientId ?? parts[1];
+	const clientSecret = kiroCredential.clientSecret ?? parts[2];
+	const region = kiroCredential.region ?? (parts[3] === "idc" ? parts[4] : undefined);
+	if (!refreshToken || !clientId || !clientSecret || !region) {
+		throw new Error("Kiro OAuth credential is missing Identity Center refresh metadata; run /login kiro again");
+	}
+	return { refreshToken, clientId, clientSecret, region };
+}
+
+async function refreshKiroToken(credential: OAuthCredential, signal: AbortSignal): Promise<KiroOAuthCredential> {
+	const { refreshToken, clientId, clientSecret, region } = parseRefreshCredential(credential);
+	const response = await fetch(`https://oidc.${region}.amazonaws.com/token`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json", "User-Agent": "pi-cli" },
+		body: JSON.stringify({ clientId, clientSecret, refreshToken, grantType: REFRESH_GRANT }),
+		signal: requestSignal(signal),
+	});
+	const data = await readJson<KiroTokenResponse>(response);
+	if (!response.ok) throw new Error(`Kiro token refresh failed (HTTP ${response.status})`);
+	const access = data.accessToken ?? data.access_token;
+	const refresh = data.refreshToken ?? data.refresh_token ?? refreshToken;
+	const expiresIn = Number(data.expiresIn ?? data.expires_in);
+	if (!access || !Number.isFinite(expiresIn))
+		throw new Error("Kiro token refresh response was missing required fields");
+	return {
+		type: "oauth",
+		access,
+		refresh: `${refresh}|${clientId}|${clientSecret}|idc|${region}`,
+		expires: Date.now() + expiresIn * 1000 - TOKEN_EXPIRY_SKEW_MS,
+		clientId,
+		clientSecret,
+		region,
+		authMethod: "idc",
+		profileArn: (credential as KiroOAuthCredential).profileArn,
+	};
+}
+
+export const kiroOAuth: OAuthAuth = {
+	name: "Kiro (AWS Builder ID / IAM Identity Center)",
+	isSubscription: true,
+	login: loginKiro,
+	refresh: refreshKiroToken,
+	async toAuth(credential: OAuthCredential) {
+		const kiroCredential = credential as KiroOAuthCredential;
+		const region = resolveKiroApiRegion(kiroCredential.region);
+		return {
+			apiKey: credential.access,
+			baseUrl: getKiroEndpoints(region).runtime,
+			headers: kiroCredential.profileArn ? { "x-amzn-kiro-profile-arn": kiroCredential.profileArn } : undefined,
+		};
+	},
+};

--- a/packages/ai/src/auth/oauth/load.ts
+++ b/packages/ai/src/auth/oauth/load.ts
@@ -16,6 +16,7 @@ type OAuthFlowLoaders = {
 	openaiCodex: () => OAuthAuth | Promise<OAuthAuth>;
 	githubCopilot: () => OAuthAuth | Promise<OAuthAuth>;
 	openrouter: () => OAuthAuth | Promise<OAuthAuth>;
+	kiro: () => OAuthAuth | Promise<OAuthAuth>;
 	kimiCoding: () => OAuthAuth | Promise<OAuthAuth>;
 	xai: () => OAuthAuth | Promise<OAuthAuth>;
 	radius: (options: { name: string; gateway: string }) => OAuthAuth | Promise<OAuthAuth>;
@@ -65,4 +66,9 @@ export const loadRadiusOAuth = async (options: { name: string; gateway: string }
 			createRadiusOAuth: (input: { name: string; gateway: string }) => OAuthAuth;
 		}
 	).createRadiusOAuth(options);
+};
+
+export const loadKiroOAuth = async (): Promise<OAuthAuth> => {
+	if (bundledLoaders) return bundledLoaders.kiro();
+	return ((await importOAuthModule("./kiro.ts")) as { kiroOAuth: OAuthAuth }).kiroOAuth;
 };

--- a/packages/ai/src/bun-oauth.ts
+++ b/packages/ai/src/bun-oauth.ts
@@ -1,6 +1,7 @@
 import { anthropicOAuth } from "./auth/oauth/anthropic.ts";
 import { githubCopilotOAuth } from "./auth/oauth/github-copilot.ts";
 import { kimiCodingOAuth } from "./auth/oauth/kimi-coding.ts";
+import { kiroOAuth } from "./auth/oauth/kiro.ts";
 import { registerBundledOAuthFlowLoaders } from "./auth/oauth/load.ts";
 import { openaiCodexOAuth } from "./auth/oauth/openai-codex.ts";
 import { openRouterOAuth } from "./auth/oauth/openrouter.ts";
@@ -14,6 +15,7 @@ export function registerBunOAuthFlows(): void {
 		openaiCodex: () => openaiCodexOAuth,
 		githubCopilot: () => githubCopilotOAuth,
 		openrouter: () => openRouterOAuth,
+		kiro: () => kiroOAuth,
 		kimiCoding: () => kimiCodingOAuth,
 		xai: () => xaiOAuth,
 		radius: createRadiusOAuth,

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -19,6 +19,7 @@ import { googleVertexProvider } from "./google-vertex.ts";
 import { groqProvider } from "./groq.ts";
 import { huggingfaceProvider } from "./huggingface.ts";
 import { kimiCodingProvider } from "./kimi-coding.ts";
+import { kiroProvider } from "./kiro-provider.ts";
 import { minimaxProvider } from "./minimax.ts";
 import { minimaxCnProvider } from "./minimax-cn.ts";
 import { mistralProvider } from "./mistral.ts";
@@ -104,6 +105,7 @@ export function builtinProviders(): Provider[] {
 		groqProvider(),
 		huggingfaceProvider(),
 		kimiCodingProvider(),
+		kiroProvider(),
 		minimaxProvider(),
 		minimaxCnProvider(),
 		mistralProvider(),

--- a/packages/ai/src/providers/kiro-eventstream.ts
+++ b/packages/ai/src/providers/kiro-eventstream.ts
@@ -1,0 +1,169 @@
+const PRELUDE_LENGTH = 12;
+const MESSAGE_CRC_LENGTH = 4;
+const MIN_MESSAGE_LENGTH = PRELUDE_LENGTH + MESSAGE_CRC_LENGTH;
+
+export interface KiroEventStreamMessage {
+	headers: Record<string, string>;
+	payload: Uint8Array;
+}
+
+const CRC_TABLE = new Uint32Array(256);
+for (let index = 0; index < CRC_TABLE.length; index++) {
+	let value = index;
+	for (let bit = 0; bit < 8; bit++) value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+	CRC_TABLE[index] = value >>> 0;
+}
+
+export function crc32(bytes: Uint8Array): number {
+	let value = 0xffffffff;
+	for (const byte of bytes) value = CRC_TABLE[(value ^ byte) & 0xff] ^ (value >>> 8);
+	return (value ^ 0xffffffff) >>> 0;
+}
+
+export function decodeKiroEventStreamMessage(frame: Uint8Array): KiroEventStreamMessage {
+	if (frame.length < MIN_MESSAGE_LENGTH) throw new Error("Kiro event stream frame is too short");
+	const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+	const totalLength = view.getUint32(0, false);
+	const headersLength = view.getUint32(4, false);
+	if (totalLength !== frame.length) {
+		throw new Error(`Kiro event stream framed length ${totalLength} does not match ${frame.length}`);
+	}
+	if (headersLength > totalLength - MIN_MESSAGE_LENGTH) {
+		throw new Error("Kiro event stream header block exceeds frame");
+	}
+	if (crc32(frame.subarray(0, 8)) !== view.getUint32(8, false)) {
+		throw new Error("Kiro event stream prelude CRC mismatch");
+	}
+	if (crc32(frame.subarray(0, totalLength - MESSAGE_CRC_LENGTH)) !== view.getUint32(totalLength - 4, false)) {
+		throw new Error("Kiro event stream message CRC mismatch");
+	}
+
+	const headersStart = PRELUDE_LENGTH;
+	const headersEnd = headersStart + headersLength;
+	return {
+		headers: parseKiroEventStreamHeaders(frame.subarray(headersStart, headersEnd)),
+		payload: frame.subarray(headersEnd, totalLength - MESSAGE_CRC_LENGTH),
+	};
+}
+
+function parseKiroEventStreamHeaders(bytes: Uint8Array): Record<string, string> {
+	const result: Record<string, string> = {};
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const decoder = new TextDecoder();
+	let offset = 0;
+	const requireBytes = (count: number) => {
+		if (offset + count > bytes.length) throw new Error("Truncated Kiro event stream headers");
+	};
+	while (offset < bytes.length) {
+		requireBytes(1);
+		const nameLength = view.getUint8(offset++);
+		requireBytes(nameLength + 1);
+		const name = decoder.decode(bytes.subarray(offset, offset + nameLength));
+		offset += nameLength;
+		const type = view.getUint8(offset++);
+		switch (type) {
+			case 0:
+				result[name] = "true";
+				break;
+			case 1:
+				result[name] = "false";
+				break;
+			case 2:
+				requireBytes(1);
+				result[name] = String(view.getInt8(offset++));
+				break;
+			case 3:
+				requireBytes(2);
+				result[name] = String(view.getInt16(offset, false));
+				offset += 2;
+				break;
+			case 4:
+				requireBytes(4);
+				result[name] = String(view.getInt32(offset, false));
+				offset += 4;
+				break;
+			case 5:
+				requireBytes(8);
+				result[name] = readSignedBigEndian(bytes.subarray(offset, offset + 8)).toString();
+				offset += 8;
+				break;
+			case 6: {
+				requireBytes(2);
+				const length = view.getUint16(offset, false);
+				offset += 2;
+				requireBytes(length);
+				const headerBytes = bytes.subarray(offset, offset + length);
+				let binary = "";
+				for (const byte of headerBytes) binary += String.fromCharCode(byte);
+				result[name] = btoa(binary);
+				offset += length;
+				break;
+			}
+			case 7: {
+				requireBytes(2);
+				const length = view.getUint16(offset, false);
+				offset += 2;
+				requireBytes(length);
+				result[name] = decoder.decode(bytes.subarray(offset, offset + length));
+				offset += length;
+				break;
+			}
+			case 8:
+				requireBytes(8);
+				result[name] = new Date(Number(readSignedBigEndian(bytes.subarray(offset, offset + 8)))).toISOString();
+				offset += 8;
+				break;
+			case 9:
+				requireBytes(16);
+				result[name] = [...bytes.subarray(offset, offset + 16)]
+					.map((byte) => byte.toString(16).padStart(2, "0"))
+					.join("");
+				offset += 16;
+				break;
+			default:
+				throw new Error(`Unknown Kiro event stream header type ${type}`);
+		}
+	}
+	return result;
+}
+
+function readSignedBigEndian(bytes: Uint8Array): bigint {
+	let value = 0n;
+	for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+	if (bytes.length === 8 && (bytes[0] & 0x80) !== 0) value -= 1n << 64n;
+	return value;
+}
+
+export async function* decodeKiroEventStream(
+	source: ReadableStream<Uint8Array>,
+): AsyncGenerator<KiroEventStreamMessage> {
+	const reader = source.getReader();
+	let buffer = new Uint8Array(0);
+	let completed = false;
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (value && value.length > 0) {
+				const next = new Uint8Array(buffer.length + value.length);
+				next.set(buffer);
+				next.set(value, buffer.length);
+				buffer = next;
+			}
+			let offset = 0;
+			while (buffer.length - offset >= 4) {
+				const totalLength = new DataView(buffer.buffer, buffer.byteOffset + offset, 4).getUint32(0, false);
+				if (totalLength < MIN_MESSAGE_LENGTH) throw new Error(`Invalid Kiro event stream length ${totalLength}`);
+				if (buffer.length - offset < totalLength) break;
+				yield decodeKiroEventStreamMessage(buffer.subarray(offset, offset + totalLength));
+				offset += totalLength;
+			}
+			if (offset > 0) buffer = buffer.slice(offset);
+			if (done) break;
+		}
+		if (buffer.length > 0) throw new Error("Truncated Kiro event stream message");
+		completed = true;
+	} finally {
+		if (!completed) await reader.cancel().catch(() => {});
+		reader.releaseLock();
+	}
+}

--- a/packages/ai/src/providers/kiro-provider.ts
+++ b/packages/ai/src/providers/kiro-provider.ts
@@ -1,0 +1,34 @@
+import { lazyOAuth } from "../auth/helpers.ts";
+import { loadKiroOAuth } from "../auth/oauth/load.ts";
+import { createProvider, type Provider } from "../models.ts";
+import { KIRO_MODELS } from "./kiro.catalog.ts";
+import { fetchKiroModelsForCredential, kiroApi } from "./kiro.ts";
+
+export function kiroProvider(): Provider<"kiro-api"> {
+	return createProvider({
+		id: "kiro",
+		name: "Kiro",
+		auth: {
+			oauth: lazyOAuth({
+				name: "Kiro (AWS Builder ID / IAM Identity Center)",
+				isSubscription: true,
+				load: loadKiroOAuth,
+			}),
+		},
+		baseUrl: "https://runtime.us-east-1.kiro.dev/",
+		models: KIRO_MODELS,
+		fetchModels: async (context) => {
+			const credential = context.credential?.type === "oauth" ? context.credential : undefined;
+			if (!credential?.access) return [];
+			return fetchKiroModelsForCredential(
+				{
+					access: credential.access,
+					region: typeof credential.region === "string" ? credential.region : undefined,
+					profileArn: typeof credential.profileArn === "string" ? credential.profileArn : undefined,
+				},
+				context.signal,
+			);
+		},
+		api: kiroApi,
+	});
+}

--- a/packages/ai/src/providers/kiro.catalog.ts
+++ b/packages/ai/src/providers/kiro.catalog.ts
@@ -1,0 +1,111 @@
+import type { Model } from "../types.ts";
+import type { KiroCatalogModel } from "./kiro.shared.ts";
+import { getKiroEndpoints } from "./kiro.shared.ts";
+
+export type KiroModel = Model<"kiro-api"> & {
+	kiroModelId?: string;
+	kiroRegion?: string;
+	kiroProfileArn?: string;
+	additionalModelRequestFieldsSchema?: Record<string, unknown>;
+};
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_MAX_TOKENS = 8_192;
+const KIRO_RUNTIME = getKiroEndpoints("us-east-1").runtime;
+
+function isReasoningModel(id: string): boolean {
+	return /auto|claude-opus|claude-sonnet|deepseek|gpt|glm|qwen/i.test(id);
+}
+
+function createBootstrapModel(
+	id: string,
+	options: Partial<Pick<KiroModel, "reasoning" | "input" | "contextWindow" | "maxTokens" | "thinkingLevelMap">> = {},
+): KiroModel {
+	return {
+		id,
+		name: id
+			.split("-")
+			.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+			.join(" "),
+		api: "kiro-api",
+		provider: "kiro",
+		baseUrl: KIRO_RUNTIME,
+		reasoning: options.reasoning ?? isReasoningModel(id),
+		input: options.input ?? (/^(auto|claude)/i.test(id) ? ["text", "image"] : ["text"]),
+		cost: { ...ZERO_COST },
+		contextWindow: options.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+		maxTokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+		...(options.thinkingLevelMap ? { thinkingLevelMap: options.thinkingLevelMap } : {}),
+		kiroModelId: id,
+	};
+}
+
+/**
+ * Kiro's management catalog is account/profile scoped, so these models are only
+ * a safe bootstrap. A successful List-Available-Models response replaces them.
+ */
+export const KIRO_MODELS: readonly KiroModel[] = [
+	createBootstrapModel("auto", { contextWindow: 1_000_000, maxTokens: 65_536, thinkingLevelMap: { max: "max" } }),
+	createBootstrapModel("claude-opus-5", {
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+	}),
+	createBootstrapModel("claude-sonnet-5", {
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+	}),
+	createBootstrapModel("claude-opus-4.8", {
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+	}),
+	createBootstrapModel("claude-opus-4.7", {
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+	}),
+	createBootstrapModel("claude-opus-4.6", { maxTokens: 32_768, thinkingLevelMap: { max: "max" } }),
+	createBootstrapModel("claude-sonnet-4.6", { maxTokens: 65_536, thinkingLevelMap: { max: "max" } }),
+	createBootstrapModel("claude-opus-4.5", { maxTokens: 65_536 }),
+	createBootstrapModel("claude-sonnet-4.5", { maxTokens: 65_536 }),
+	createBootstrapModel("claude-sonnet-4", { maxTokens: 65_536 }),
+	createBootstrapModel("claude-haiku-4.5", { reasoning: false, maxTokens: 65_536 }),
+	createBootstrapModel("gpt-5.6-sol"),
+	createBootstrapModel("gpt-5.6-terra"),
+	createBootstrapModel("gpt-5.6-luna"),
+	createBootstrapModel("deepseek-3.2"),
+	createBootstrapModel("minimax-m2.5", { reasoning: false }),
+	createBootstrapModel("minimax-m2.1", { reasoning: false }),
+	createBootstrapModel("glm-5"),
+	createBootstrapModel("qwen3-coder-next"),
+];
+
+export function mapKiroCatalogToModels(catalog: readonly KiroCatalogModel[], region: string): KiroModel[] {
+	const seen = new Set<string>();
+	return catalog.map((model) => {
+		const id = model.modelId.trim();
+		if (!id || seen.has(id)) throw new Error(`Kiro management catalog contains duplicate model ID ${id}`);
+		seen.add(id);
+		const existing = KIRO_MODELS.find((candidate) => candidate.kiroModelId === id || candidate.id === id);
+		const limits = model.tokenLimits;
+		const reasoning =
+			model.additionalModelRequestFieldsSchema !== undefined || (existing?.reasoning ?? isReasoningModel(id));
+		return {
+			...(existing ?? createBootstrapModel(id)),
+			id,
+			name: model.displayName?.trim() || existing?.name || id,
+			baseUrl: getKiroEndpoints(region).runtime,
+			reasoning,
+			contextWindow: limits?.maxInputTokens ?? existing?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+			maxTokens: limits?.maxOutputTokens ?? existing?.maxTokens ?? DEFAULT_MAX_TOKENS,
+			kiroModelId: id,
+			kiroRegion: region,
+			...(model.additionalModelRequestFieldsSchema
+				? { additionalModelRequestFieldsSchema: model.additionalModelRequestFieldsSchema }
+				: {}),
+		};
+	});
+}

--- a/packages/ai/src/providers/kiro.shared.ts
+++ b/packages/ai/src/providers/kiro.shared.ts
@@ -1,0 +1,209 @@
+import type { KiroModel } from "./kiro.catalog.ts";
+
+/** AWS SSO regions that map to Kiro's two currently-served API regions. */
+const API_REGION_MAP: Record<string, string> = {
+	"us-west-1": "us-east-1",
+	"us-west-2": "us-east-1",
+	"us-east-2": "us-east-1",
+	"ap-southeast-1": "us-east-1",
+	"ap-southeast-2": "us-east-1",
+	"ap-northeast-1": "us-east-1",
+	"ap-south-1": "us-east-1",
+	"eu-west-1": "eu-central-1",
+	"eu-west-2": "eu-central-1",
+	"eu-west-3": "eu-central-1",
+	"eu-north-1": "eu-central-1",
+	"eu-south-1": "eu-central-1",
+	"eu-south-2": "eu-central-1",
+	"eu-central-2": "eu-central-1",
+};
+
+export interface KiroEndpoints {
+	region: string;
+	management: string;
+	runtime: string;
+}
+
+export function resolveKiroApiRegion(ssoRegion?: string): string {
+	const normalized = ssoRegion?.trim();
+	return normalized ? (API_REGION_MAP[normalized] ?? normalized) : "us-east-1";
+}
+
+export function getKiroEndpoints(region: string): KiroEndpoints {
+	return {
+		region,
+		management: `https://management.${region}.kiro.dev/`,
+		runtime: `https://runtime.${region}.kiro.dev/`,
+	};
+}
+
+export function getKiroRegionFromEndpoint(endpoint: string | undefined): string | undefined {
+	if (!endpoint) return undefined;
+	try {
+		const [service, region, ...suffix] = new URL(endpoint).hostname.split(".");
+		if ((service === "management" || service === "runtime") && suffix.join(".") === "kiro.dev") {
+			return region;
+		}
+	} catch {
+		// The model may have a custom or incomplete base URL. The caller falls back
+		// to the default Kiro region in that case.
+	}
+	return undefined;
+}
+
+export interface KiroManagementAuth {
+	accessToken: string;
+	region: string;
+}
+
+export interface KiroCatalogModel {
+	modelId: string;
+	displayName?: string;
+	tokenLimits?: {
+		maxInputTokens?: number;
+		maxOutputTokens?: number;
+		[key: string]: unknown;
+	};
+	additionalModelRequestFieldsSchema?: Record<string, unknown> | null;
+	[key: string]: unknown;
+}
+
+export interface KiroListAvailableModelsResponse {
+	models: KiroCatalogModel[];
+	[key: string]: unknown;
+}
+
+export class KiroManagementHttpError extends Error {
+	readonly status: number;
+
+	constructor(operation: string, region: string, status: number) {
+		super(`Kiro management ${operation} failed in ${region}: HTTP ${status}`);
+		this.name = "KiroManagementHttpError";
+		this.status = status;
+	}
+}
+
+async function managementRequest<TResponse>(
+	auth: KiroManagementAuth,
+	operation: string,
+	path: string,
+	method: "GET" | "POST",
+	params: Record<string, string | undefined>,
+	fetchFn: typeof globalThis.fetch,
+	signal?: AbortSignal,
+): Promise<TResponse> {
+	const url = new URL(path, getKiroEndpoints(auth.region).management);
+	const request: RequestInit = {
+		method,
+		headers: {
+			Accept: "application/json",
+			Authorization: `Bearer ${auth.accessToken}`,
+		},
+		signal,
+	};
+	if (method === "GET") {
+		for (const [name, value] of Object.entries(params)) {
+			if (value !== undefined) url.searchParams.set(name, value);
+		}
+	} else {
+		request.headers = { ...request.headers, "Content-Type": "application/json" };
+		request.body = JSON.stringify(
+			Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined)),
+		);
+	}
+
+	let response: Response;
+	try {
+		response = await fetchFn(url, request);
+	} catch (error) {
+		if (signal?.aborted) throw error;
+		throw new Error(`Kiro management ${operation} request failed in ${auth.region}`, { cause: error });
+	}
+	if (!response.ok) throw new KiroManagementHttpError(operation, auth.region, response.status);
+	try {
+		return (await response.json()) as TResponse;
+	} catch (error) {
+		throw new Error(`Kiro management ${operation} returned invalid JSON in ${auth.region}`, { cause: error });
+	}
+}
+
+export async function resolveKiroProfileArn(
+	auth: KiroManagementAuth,
+	providedProfileArn: string | undefined,
+	fetchFn: typeof globalThis.fetch = globalThis.fetch,
+	signal?: AbortSignal,
+): Promise<string> {
+	if (providedProfileArn) return providedProfileArn;
+	const response = await managementRequest<{ profiles?: Array<{ arn?: string }> }>(
+		auth,
+		"ListAvailableProfiles",
+		"List-Available-Profiles",
+		"POST",
+		{},
+		fetchFn,
+		signal,
+	);
+	const profileArn = response.profiles?.find(
+		(profile) => typeof profile.arn === "string" && profile.arn.length > 0,
+	)?.arn;
+	if (!profileArn) {
+		throw new Error(`Kiro management ListAvailableProfiles returned no profile in ${auth.region}`);
+	}
+	return profileArn;
+}
+
+export async function fetchKiroModelCatalog(
+	auth: KiroManagementAuth,
+	providedProfileArn?: string,
+	fetchFn: typeof globalThis.fetch = globalThis.fetch,
+	signal?: AbortSignal,
+): Promise<{ profileArn: string; response: KiroListAvailableModelsResponse }> {
+	const profileArn = await resolveKiroProfileArn(auth, providedProfileArn, fetchFn, signal);
+	const response = await managementRequest<KiroListAvailableModelsResponse>(
+		auth,
+		"ListAvailableModels",
+		"List-Available-Models",
+		"GET",
+		{ origin: "KIRO_CLI", profileArn },
+		fetchFn,
+		signal,
+	);
+	if (!Array.isArray(response.models) || response.models.length === 0) {
+		throw new Error(`Kiro management ListAvailableModels returned no models in ${auth.region}`);
+	}
+	if (response.models.some((model) => !model || typeof model.modelId !== "string" || model.modelId.length === 0)) {
+		throw new Error(`Kiro management ListAvailableModels returned an invalid catalog in ${auth.region}`);
+	}
+	return { profileArn, response };
+}
+
+export function mapKiroCatalogModels(catalog: readonly KiroCatalogModel[], region: string): KiroModel[] {
+	const seen = new Set<string>();
+	return catalog.map((model) => {
+		const id = model.modelId.trim();
+		if (!id || seen.has(id)) throw new Error(`Kiro management catalog contains duplicate model ID ${id}`);
+		seen.add(id);
+		const normalizedName = model.displayName?.trim() || id;
+		const limits = model.tokenLimits;
+		const reasoning =
+			model.additionalModelRequestFieldsSchema !== undefined || /auto|claude|deepseek|gpt|glm|qwen/i.test(id);
+		const result: KiroModel = {
+			id,
+			name: normalizedName,
+			api: "kiro-api",
+			provider: "kiro",
+			baseUrl: getKiroEndpoints(region).runtime,
+			reasoning,
+			input: /^(claude|auto)/i.test(id) ? ["text", "image"] : ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: limits?.maxInputTokens ?? 200_000,
+			maxTokens: limits?.maxOutputTokens ?? 8_192,
+			kiroModelId: id,
+			kiroRegion: region,
+			...(model.additionalModelRequestFieldsSchema
+				? { additionalModelRequestFieldsSchema: model.additionalModelRequestFieldsSchema }
+				: {}),
+		};
+		return result;
+	});
+}

--- a/packages/ai/src/providers/kiro.ts
+++ b/packages/ai/src/providers/kiro.ts
@@ -1,0 +1,676 @@
+import { calculateCost } from "../models.ts";
+import type {
+	Api,
+	AssistantMessage,
+	Context,
+	ImageContent,
+	Message,
+	Model,
+	SimpleStreamOptions,
+	StreamOptions,
+	TextContent,
+	Tool,
+	ToolCall,
+	ToolResultMessage,
+	Usage,
+} from "../types.ts";
+import { AssistantMessageEventStream } from "../utils/event-stream.ts";
+import { type KiroModel, mapKiroCatalogToModels } from "./kiro.catalog.ts";
+import {
+	fetchKiroModelCatalog,
+	getKiroRegionFromEndpoint,
+	type KiroCatalogModel,
+	resolveKiroApiRegion,
+	resolveKiroProfileArn,
+} from "./kiro.shared.ts";
+import { decodeKiroEventStream } from "./kiro-eventstream.ts";
+
+export const KIRO_API = "kiro-api" as const;
+const EMPTY_CONTENT_PLACEHOLDER = "Please proceed with the task.";
+const TOOL_RESULT_LIMIT = 250_000;
+const USER_AGENT = "pi-kiro/1.0";
+
+export interface KiroUserInputMessage {
+	content: string;
+	modelId: string;
+	origin: "KIRO_CLI";
+	images?: Array<{ format: string; source: { bytes: string } }>;
+	userInputMessageContext?: {
+		toolResults?: Array<{
+			content: Array<{ text: string }>;
+			status: "success" | "error";
+			toolUseId: string;
+		}>;
+		tools?: Array<{
+			toolSpecification: {
+				name: string;
+				description: string;
+				inputSchema: { json: Record<string, unknown> };
+			};
+		}>;
+	};
+}
+
+export interface KiroHistoryEntry {
+	userInputMessage?: KiroUserInputMessage;
+	assistantResponseMessage?: {
+		content: string;
+		toolUses?: Array<{ name: string; toolUseId: string; input: Record<string, unknown> }>;
+	};
+}
+
+export interface KiroRequest {
+	profileArn: string;
+	conversationState: {
+		chatTriggerType: "MANUAL";
+		agentTaskType: "vibe";
+		conversationId: string;
+		history?: KiroHistoryEntry[];
+		currentMessage: { userInputMessage: KiroUserInputMessage };
+	};
+	additionalModelRequestFields?: Record<string, unknown>;
+	agentMode: "vibe";
+}
+
+type KiroEvent =
+	| { type: "content"; data: string }
+	| { type: "thinkingText"; data: string }
+	| { type: "thinkingSignature"; data: string }
+	| { type: "toolUse"; data: { name: string; toolUseId: string; input: string; stop?: boolean } }
+	| { type: "toolUseInput"; data: { input: string } }
+	| { type: "toolUseStop"; data: { stop: boolean } }
+	| { type: "contextUsage"; data: { contextUsagePercentage: number } }
+	| { type: "usage"; data: { inputTokens?: number; outputTokens?: number } }
+	| { type: "error"; data: { error: string; message?: string } };
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+export function parseKiroEvent(payload: unknown): KiroEvent | undefined {
+	const parsed = asRecord(payload);
+	if (!parsed) return undefined;
+	if (typeof parsed.content === "string") return { type: "content", data: parsed.content };
+	if (typeof parsed.text === "string") return { type: "thinkingText", data: parsed.text };
+	if (typeof parsed.signature === "string") return { type: "thinkingSignature", data: parsed.signature };
+	if (typeof parsed.name === "string" && typeof parsed.toolUseId === "string") {
+		const inputRecord = asRecord(parsed.input);
+		const input =
+			typeof parsed.input === "string"
+				? parsed.input
+				: inputRecord && Object.keys(inputRecord).length > 0
+					? JSON.stringify(inputRecord)
+					: "";
+		return {
+			type: "toolUse",
+			data: { name: parsed.name, toolUseId: parsed.toolUseId, input, stop: parsed.stop === true },
+		};
+	}
+	if (parsed.input !== undefined && typeof parsed.name !== "string") {
+		return {
+			type: "toolUseInput",
+			data: { input: typeof parsed.input === "string" ? parsed.input : JSON.stringify(parsed.input) },
+		};
+	}
+	if (parsed.stop !== undefined && parsed.contextUsagePercentage === undefined) {
+		return { type: "toolUseStop", data: { stop: parsed.stop === true } };
+	}
+	if (typeof parsed.contextUsagePercentage === "number") {
+		return { type: "contextUsage", data: { contextUsagePercentage: parsed.contextUsagePercentage } };
+	}
+	const rawUsage = asRecord(parsed.usage);
+	if (rawUsage) {
+		return {
+			type: "usage",
+			data: {
+				inputTokens: typeof rawUsage.inputTokens === "number" ? rawUsage.inputTokens : undefined,
+				outputTokens: typeof rawUsage.outputTokens === "number" ? rawUsage.outputTokens : undefined,
+			},
+		};
+	}
+	if (parsed.error !== undefined || parsed.Error !== undefined) {
+		const rawError = parsed.error ?? parsed.Error ?? "unknown";
+		return {
+			type: "error",
+			data: {
+				error: typeof rawError === "string" ? rawError : JSON.stringify(rawError),
+				message:
+					typeof parsed.message === "string"
+						? parsed.message
+						: typeof parsed.reason === "string"
+							? parsed.reason
+							: undefined,
+			},
+		};
+	}
+	return undefined;
+}
+
+function textContent(message: Message): string {
+	if (message.role === "user") {
+		return typeof message.content === "string"
+			? message.content
+			: message.content
+					.filter((block): block is TextContent => block.type === "text")
+					.map((block) => block.text)
+					.join("");
+	}
+	if (message.role === "toolResult") {
+		return message.content
+			.filter((block) => block.type === "text")
+			.map((block) => block.text)
+			.join("");
+	}
+	return message.content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join("");
+}
+
+function imagesFromMessage(message: Message): ImageContent[] {
+	if (message.role === "toolResult" || typeof message.content === "string") return [];
+	return message.content.filter((block): block is ImageContent => block.type === "image");
+}
+
+function toKiroImages(images: readonly ImageContent[]): Array<{ format: string; source: { bytes: string } }> {
+	return images.map((image) => ({
+		format: image.mimeType.split("/", 2)[1] || "png",
+		source: { bytes: image.data },
+	}));
+}
+
+type KiroToolSpecification = NonNullable<NonNullable<KiroUserInputMessage["userInputMessageContext"]>["tools"]>[number];
+
+function toKiroTools(tools: readonly Tool[] | undefined): KiroToolSpecification[] | undefined {
+	return tools?.map((tool) => ({
+		toolSpecification: {
+			name: tool.name,
+			description: tool.description,
+			inputSchema: { json: tool.parameters as Record<string, unknown> },
+		},
+	}));
+}
+
+function truncate(value: string): string {
+	return value.length <= TOOL_RESULT_LIMIT ? value : value.slice(0, TOOL_RESULT_LIMIT);
+}
+
+function toKiroToolUse(block: ToolCall): { name: string; toolUseId: string; input: Record<string, unknown> } {
+	let input: Record<string, unknown>;
+	if (typeof block.arguments === "string") {
+		try {
+			input = JSON.parse(block.arguments) as Record<string, unknown>;
+		} catch {
+			input = {};
+		}
+	} else {
+		input = block.arguments;
+	}
+	return { name: block.name, toolUseId: block.id, input };
+}
+
+function assistantHistoryEntry(message: Message): KiroHistoryEntry | undefined {
+	if (message.role !== "assistant") return undefined;
+	let content = "";
+	const toolUses: Array<{ name: string; toolUseId: string; input: Record<string, unknown> }> = [];
+	for (const block of message.content) {
+		if (block.type === "text") content += block.text;
+		if (block.type === "toolCall") toolUses.push(toKiroToolUse(block));
+		// Kiro's history has a separate reasoning field in some CLI versions. Do
+		// not flatten pi thinking into assistant text, which would change replay.
+	}
+	if (!content && toolUses.length === 0 && message.content.length === 0) return undefined;
+	return { assistantResponseMessage: { content, ...(toolUses.length > 0 ? { toolUses } : {}) } };
+}
+
+function addToolResults(
+	entry: KiroHistoryEntry | undefined,
+	messages: readonly ToolResultMessage[],
+	modelId: string,
+): KiroHistoryEntry {
+	const results = messages.map((message) => ({
+		content: [{ text: truncate(textContent(message)) }],
+		status: message.isError ? ("error" as const) : ("success" as const),
+		toolUseId: message.toolCallId,
+	}));
+	if (entry?.userInputMessage) {
+		entry.userInputMessage.userInputMessageContext ??= {};
+		entry.userInputMessage.userInputMessageContext.toolResults = [
+			...(entry.userInputMessage.userInputMessageContext.toolResults ?? []),
+			...results,
+		];
+		return entry;
+	}
+	return {
+		userInputMessage: {
+			content: "",
+			modelId,
+			origin: "KIRO_CLI",
+			userInputMessageContext: { toolResults: results },
+		},
+	};
+}
+
+function buildHistory(
+	messages: readonly Message[],
+	modelId: string,
+	systemPrompt: string | undefined,
+): {
+	history: KiroHistoryEntry[];
+	currentMessages: Message[];
+} {
+	if (messages.length === 0) return { history: [], currentMessages: [] };
+	let currentStart = messages.length - 1;
+	while (currentStart > 0 && messages[currentStart]?.role === "toolResult") currentStart--;
+	const currentCandidate = messages[currentStart];
+	if (currentCandidate?.role === "assistant" && !currentCandidate.content.some((block) => block.type === "toolCall")) {
+		currentStart++;
+	}
+
+	const historyMessages = messages.slice(0, currentStart);
+	const history: KiroHistoryEntry[] = [];
+	let systemAdded = false;
+	for (let index = 0; index < historyMessages.length; index++) {
+		const message = historyMessages[index];
+		if (message.role === "user") {
+			let content = textContent(message);
+			if (systemPrompt && !systemAdded) {
+				content = `${systemPrompt}\n\n${content}`;
+				systemAdded = true;
+			}
+			const images = imagesFromMessage(message);
+			const previous = history.at(-1)?.userInputMessage;
+			if (previous) {
+				previous.content =
+					previous.content && content ? `${previous.content}\n\n${content}` : previous.content || content;
+				if (images.length > 0) previous.images = [...(previous.images ?? []), ...toKiroImages(images)];
+			} else {
+				history.push({
+					userInputMessage: {
+						content,
+						modelId,
+						origin: "KIRO_CLI",
+						...(images.length > 0 ? { images: toKiroImages(images) } : {}),
+					},
+				});
+			}
+		} else if (message.role === "assistant") {
+			const entry = assistantHistoryEntry(message);
+			if (entry) history.push(entry);
+		} else if (message.role === "toolResult") {
+			const results: ToolResultMessage[] = [message];
+			// Consecutive tool results belong to one Kiro user carrier.
+			let next = index + 1;
+			while (next < historyMessages.length && historyMessages[next]?.role === "toolResult") {
+				results.push(historyMessages[next] as ToolResultMessage);
+				next++;
+			}
+			index = next - 1;
+			const previous = history.at(-1);
+			const carrier = previous?.userInputMessage ? previous : undefined;
+			const nextEntry = addToolResults(carrier, results, modelId);
+			if (!carrier) history.push(nextEntry);
+		}
+	}
+	return { history, currentMessages: messages.slice(currentStart) };
+}
+
+function buildAdditionalModelRequestFields(
+	model: KiroModel,
+	reasoning: SimpleStreamOptions["reasoning"],
+): Record<string, unknown> | undefined {
+	if (!reasoning || !model.reasoning) return undefined;
+	const schema = model.additionalModelRequestFieldsSchema;
+	const schemaRecord = asRecord(schema);
+	const properties = asRecord(schemaRecord?.properties);
+	const values = (field: string): string[] => {
+		const fieldSchema = asRecord(properties?.[field]);
+		const effortSchema = asRecord(fieldSchema?.properties) && asRecord(asRecord(fieldSchema?.properties)?.effort);
+		return Array.isArray(effortSchema?.enum)
+			? effortSchema.enum.filter((value): value is string => typeof value === "string")
+			: [];
+	};
+	const requested = reasoning === "minimal" ? "low" : reasoning;
+	const pick = (allowed: string[]) => (allowed.includes(requested) ? requested : (allowed.at(-1) ?? requested));
+	const reasoningValues = values("reasoning");
+	if (reasoningValues.length > 0) return { reasoning: { effort: pick(reasoningValues) } };
+	const outputValues = values("output_config");
+	if (outputValues.length > 0) {
+		return {
+			output_config: { effort: pick(outputValues) },
+			thinking: { type: "adaptive", display: "summarized" },
+		};
+	}
+	return undefined;
+}
+
+export function buildKiroRequest(
+	model: KiroModel,
+	context: Context,
+	profileArn: string,
+	conversationId: string,
+	reasoning?: SimpleStreamOptions["reasoning"],
+): KiroRequest {
+	const modelId = model.kiroModelId ?? model.id;
+	const { history, currentMessages } = buildHistory(context.messages, modelId, context.systemPrompt);
+	const first = currentMessages[0];
+	let content = "";
+	let images: ImageContent[] = [];
+	const toolResults: ToolResultMessage[] = [];
+	if (first?.role === "assistant") {
+		const entry = assistantHistoryEntry(first);
+		if (entry) history.push(entry);
+		for (const message of currentMessages.slice(1)) if (message.role === "toolResult") toolResults.push(message);
+	} else if (first?.role === "toolResult") {
+		for (const message of currentMessages) if (message.role === "toolResult") toolResults.push(message);
+	} else if (first?.role === "user") {
+		content = textContent(first);
+		images = imagesFromMessage(first);
+		if (context.systemPrompt && history.length === 0) content = `${context.systemPrompt}\n\n${content}`;
+	}
+	const tools = toKiroTools(context.tools);
+	const currentContext: KiroUserInputMessage["userInputMessageContext"] = {};
+	if (tools && tools.length > 0) currentContext.tools = tools;
+	if (toolResults.length > 0) {
+		currentContext.toolResults = toolResults.map((message) => ({
+			content: [{ text: truncate(textContent(message)) }],
+			status: message.isError ? "error" : "success",
+			toolUseId: message.toolCallId,
+		}));
+	}
+	if (!content && toolResults.length === 0) content = EMPTY_CONTENT_PLACEHOLDER;
+	const userInputMessage: KiroUserInputMessage = {
+		content,
+		modelId,
+		origin: "KIRO_CLI",
+		...(images.length > 0 ? { images: toKiroImages(images) } : {}),
+		...(Object.keys(currentContext).length > 0 ? { userInputMessageContext: currentContext } : {}),
+	};
+	const additionalModelRequestFields = buildAdditionalModelRequestFields(model, reasoning);
+	return {
+		profileArn,
+		conversationState: {
+			chatTriggerType: "MANUAL",
+			agentTaskType: "vibe",
+			conversationId,
+			...(history.length > 0 ? { history } : {}),
+			currentMessage: { userInputMessage },
+		},
+		...(additionalModelRequestFields ? { additionalModelRequestFields } : {}),
+		agentMode: "vibe",
+	};
+}
+
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function findHeader(headers: Record<string, string | null> | undefined, name: string): string | undefined {
+	if (!headers) return undefined;
+	const lower = name.toLowerCase();
+	return Object.entries(headers).find(([key]) => key.toLowerCase() === lower)?.[1] ?? undefined;
+}
+
+function parseStructuredApiKey(apiKey: string): { token: string; region?: string; profileArn?: string } {
+	if (!apiKey.startsWith("{")) return { token: apiKey };
+	try {
+		const parsed = JSON.parse(apiKey) as { token?: unknown; region?: unknown; profileArn?: unknown };
+		if (typeof parsed.token === "string" && parsed.token.length > 0) {
+			return {
+				token: parsed.token,
+				region: typeof parsed.region === "string" ? parsed.region : undefined,
+				profileArn: typeof parsed.profileArn === "string" ? parsed.profileArn : undefined,
+			};
+		}
+	} catch {
+		// Fall through to treating the input as a raw bearer token.
+	}
+	return { token: apiKey };
+}
+
+function appendText(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	text: string,
+	state: { index?: number },
+): void {
+	if (!text) return;
+	if (state.index === undefined) {
+		state.index = output.content.length;
+		output.content.push({ type: "text", text: "" });
+		stream.push({ type: "text_start", contentIndex: state.index, partial: output });
+	}
+	const block = output.content[state.index];
+	if (block?.type !== "text") return;
+	block.text += text;
+	stream.push({ type: "text_delta", contentIndex: state.index, delta: text, partial: output });
+}
+
+function endText(output: AssistantMessage, stream: AssistantMessageEventStream, state: { index?: number }): void {
+	if (state.index === undefined) return;
+	const block = output.content[state.index];
+	if (block?.type === "text")
+		stream.push({ type: "text_end", contentIndex: state.index, content: block.text, partial: output });
+	state.index = undefined;
+}
+
+function appendThinking(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	text: string,
+	state: { index?: number },
+	textState: { index?: number },
+): void {
+	if (!text) return;
+	endText(output, stream, textState);
+	if (state.index === undefined) {
+		state.index = output.content.length;
+		output.content.push({ type: "thinking", thinking: "" });
+		stream.push({ type: "thinking_start", contentIndex: state.index, partial: output });
+	}
+	const block = output.content[state.index];
+	if (block?.type !== "thinking") return;
+	block.thinking += text;
+	stream.push({ type: "thinking_delta", contentIndex: state.index, delta: text, partial: output });
+}
+
+function endThinking(output: AssistantMessage, stream: AssistantMessageEventStream, state: { index?: number }): void {
+	if (state.index === undefined) return;
+	const block = output.content[state.index];
+	if (block?.type === "thinking")
+		stream.push({ type: "thinking_end", contentIndex: state.index, content: block.thinking, partial: output });
+	state.index = undefined;
+}
+
+function emitToolCall(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	call: { name: string; toolUseId: string; input: string },
+): boolean {
+	const input = call.input.trim() || "{}";
+	let argumentsValue: Record<string, unknown>;
+	try {
+		argumentsValue = JSON.parse(input) as Record<string, unknown>;
+	} catch {
+		argumentsValue = {};
+	}
+	const toolCall: ToolCall = { type: "toolCall", id: call.toolUseId, name: call.name, arguments: argumentsValue };
+	const contentIndex = output.content.length;
+	output.content.push(toolCall);
+	stream.push({ type: "toolcall_start", contentIndex, partial: output });
+	stream.push({ type: "toolcall_delta", contentIndex, delta: input, partial: output });
+	stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
+	return true;
+}
+
+export async function fetchKiroModelsForCredential(
+	credential: { access: string; region?: string; profileArn?: string },
+	signal?: AbortSignal,
+): Promise<readonly KiroModel[]> {
+	const region = resolveKiroApiRegion(credential.region);
+	const { response } = await fetchKiroModelCatalog(
+		{ accessToken: credential.access, region },
+		credential.profileArn,
+		globalThis.fetch,
+		signal,
+	);
+	return mapKiroCatalogToModels(response.models as readonly KiroCatalogModel[], region);
+}
+
+export function streamKiro(
+	model: Model<Api>,
+	context: Context,
+	options: StreamOptions | SimpleStreamOptions = {},
+): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	void (async () => {
+		const output: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage(),
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		try {
+			const structured = parseStructuredApiKey(options.apiKey ?? "");
+			if (!structured.token) throw new Error("Kiro credentials not set. Run /login kiro.");
+			const kiroModel = model as KiroModel;
+			const region = resolveKiroApiRegion(
+				kiroModel.kiroRegion ?? structured.region ?? getKiroRegionFromEndpoint(model.baseUrl),
+			);
+			const fetchFn = options.fetch ?? globalThis.fetch;
+			const profileArn = await resolveKiroProfileArn(
+				{ accessToken: structured.token, region },
+				kiroModel.kiroProfileArn ?? structured.profileArn ?? findHeader(options.headers, "x-amzn-kiro-profile-arn"),
+				fetchFn,
+				options.signal,
+			);
+			const simpleOptions = options as SimpleStreamOptions;
+			const request = buildKiroRequest(
+				kiroModel,
+				context,
+				profileArn,
+				simpleOptions.sessionId ?? crypto.randomUUID(),
+				simpleOptions.reasoning,
+			);
+			await options.onPayload?.(request, model);
+			const endpoint = new URL("generateAssistantResponse", `https://runtime.${region}.kiro.dev/`).toString();
+			const userAgent = `${USER_AGENT} ${crypto.randomUUID()}`;
+			const response = await fetchFn(endpoint, {
+				method: "POST",
+				headers: {
+					...(options.headers ?? {}),
+					"Content-Type": "application/json",
+					Accept: "application/vnd.amazon.eventstream",
+					Authorization: `Bearer ${structured.token}`,
+					"x-amzn-codewhisperer-optout": "true",
+					"amz-sdk-invocation-id": crypto.randomUUID(),
+					"amz-sdk-request": "attempt=1; max=1",
+					"x-amzn-kiro-agent-mode": "vibe",
+					"x-amz-user-agent": userAgent,
+					"user-agent": userAgent,
+				},
+				body: JSON.stringify(request),
+				signal: options.signal,
+			});
+			if (!response.ok) throw new Error(`Kiro API request failed (HTTP ${response.status})`);
+			if (!response.body) throw new Error("Kiro API returned no event stream body");
+			stream.push({ type: "start", partial: output });
+			const textState: { index?: number } = {};
+			const thinkingState: { index?: number } = {};
+			let activeTool: { name: string; toolUseId: string; input: string } | undefined;
+			let emittedToolCalls = 0;
+			let receivedContextUsage = false;
+			let usageEvent: { inputTokens?: number; outputTokens?: number } | undefined;
+			for await (const frame of decodeKiroEventStream(response.body as ReadableStream<Uint8Array>)) {
+				const payloadText = new TextDecoder().decode(frame.payload);
+				let payload: unknown;
+				try {
+					payload = JSON.parse(payloadText);
+				} catch {
+					continue;
+				}
+				const event = parseKiroEvent(payload);
+				if (!event) continue;
+				switch (event.type) {
+					case "content":
+						endThinking(output, stream, thinkingState);
+						appendText(output, stream, event.data, textState);
+						break;
+					case "thinkingText":
+						if (kiroModel.reasoning) appendThinking(output, stream, event.data, thinkingState, textState);
+						break;
+					case "thinkingSignature": {
+						const block = thinkingState.index !== undefined ? output.content[thinkingState.index] : undefined;
+						if (block?.type === "thinking") block.thinkingSignature = event.data;
+						endThinking(output, stream, thinkingState);
+						break;
+					}
+					case "toolUse":
+						if (!activeTool || activeTool.toolUseId !== event.data.toolUseId) {
+							if (activeTool) emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+							activeTool = { name: event.data.name, toolUseId: event.data.toolUseId, input: "" };
+						}
+						activeTool.input += event.data.input;
+						if (event.data.stop) {
+							emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+							activeTool = undefined;
+						}
+						break;
+					case "toolUseInput":
+						if (activeTool) activeTool.input += event.data.input;
+						break;
+					case "toolUseStop":
+						if (event.data.stop && activeTool) {
+							emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+							activeTool = undefined;
+						}
+						break;
+					case "contextUsage":
+						output.usage.input = Math.round((event.data.contextUsagePercentage / 100) * model.contextWindow);
+						receivedContextUsage = true;
+						break;
+					case "usage":
+						usageEvent = event.data;
+						break;
+					case "error":
+						throw new Error(
+							`Kiro API stream error: ${event.data.error}${event.data.message ? `: ${event.data.message}` : ""}`,
+						);
+				}
+			}
+			if (activeTool) emittedToolCalls += emitToolCall(output, stream, activeTool) ? 1 : 0;
+			endThinking(output, stream, thinkingState);
+			endText(output, stream, textState);
+			output.usage.input = usageEvent?.inputTokens ?? output.usage.input;
+			output.usage.output = usageEvent?.outputTokens ?? 0;
+			output.usage.totalTokens = output.usage.input + output.usage.output;
+			if (!receivedContextUsage && output.usage.input === 0) output.usage.input = context.messages.length;
+			calculateCost(model, output.usage);
+			output.stopReason = emittedToolCalls > 0 ? "toolUse" : "stop";
+			stream.push({ type: "done", reason: output.stopReason, message: output });
+		} catch (error) {
+			output.stopReason = options.signal?.aborted ? "aborted" : "error";
+			output.errorMessage = error instanceof Error ? error.message : String(error);
+			stream.push({ type: "error", reason: output.stopReason, error: output });
+		} finally {
+			stream.end();
+		}
+	})();
+	return stream;
+}
+
+export const kiroApi = {
+	stream: streamKiro,
+	streamSimple: streamKiro,
+};

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -64,6 +64,7 @@ export type KnownProvider =
 	| "opencode"
 	| "opencode-go"
 	| "kimi-coding"
+	| "kiro"
 	| "cloudflare-workers-ai"
 	| "cloudflare-ai-gateway"
 	| "qwen-token-plan"

--- a/packages/ai/test/kiro.test.ts
+++ b/packages/ai/test/kiro.test.ts
@@ -1,0 +1,530 @@
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, test, vi } from "vitest";
+import { InMemoryCredentialStore } from "../src/auth/credential-store.ts";
+import { type KiroOAuthCredential, kiroOAuth } from "../src/auth/oauth/kiro.ts";
+import { createModels } from "../src/models.ts";
+import { KIRO_MODELS, mapKiroCatalogToModels } from "../src/providers/kiro.catalog.ts";
+import { fetchKiroModelCatalog } from "../src/providers/kiro.shared.ts";
+import { buildKiroRequest, parseKiroEvent, streamKiro } from "../src/providers/kiro.ts";
+import { crc32, decodeKiroEventStream, decodeKiroEventStreamMessage } from "../src/providers/kiro-eventstream.ts";
+import { kiroProvider } from "../src/providers/kiro-provider.ts";
+import type { AssistantMessage, Context, FetchFunction, ToolResultMessage } from "../src/types.ts";
+
+function jsonResponse(value: unknown, status = 200): Response {
+	return new Response(JSON.stringify(value), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function eventStreamFrame(payload: string): Uint8Array {
+	const payloadBytes = new TextEncoder().encode(payload);
+	const totalLength = 16 + payloadBytes.length;
+	const frame = new Uint8Array(totalLength);
+	const view = new DataView(frame.buffer);
+	view.setUint32(0, totalLength, false);
+	view.setUint32(4, 0, false);
+	view.setUint32(8, crc32(frame.subarray(0, 8)), false);
+	frame.set(payloadBytes, 12);
+	view.setUint32(totalLength - 4, crc32(frame.subarray(0, totalLength - 4)), false);
+	return frame;
+}
+
+function concatFrames(frames: readonly Uint8Array[]): Uint8Array {
+	const result = new Uint8Array(frames.reduce((length, frame) => length + frame.length, 0));
+	let offset = 0;
+	for (const frame of frames) {
+		result.set(frame, offset);
+		offset += frame.length;
+	}
+	return result;
+}
+
+const abortSignal = new AbortController().signal;
+
+function assistantToolCall(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id: "tool-1", name: "lookup", arguments: { query: "x" } }],
+		api: "kiro-api",
+		provider: "kiro",
+		stopReason: "toolUse",
+		timestamp: 2,
+	};
+}
+
+function toolResult(): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "tool-1",
+		toolName: "lookup",
+		content: [{ type: "text", text: "result" }],
+		isError: false,
+		timestamp: 3,
+	};
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe("Kiro OAuth", () => {
+	it("runs Builder ID device authorization and keeps non-secret routing metadata", async () => {
+		const calls: Array<{ url: string; init?: RequestInit }> = [];
+		const fetchMock: FetchFunction = async (input, init) => {
+			const url = String(input);
+			calls.push({ url, init });
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 30,
+				});
+			}
+			if (url.endsWith("/token")) {
+				return jsonResponse({ accessToken: "access-fixture", refreshToken: "refresh-fixture", expiresIn: 3600 });
+			}
+			throw new Error(`unexpected Kiro test URL: ${url}`);
+		};
+		vi.stubGlobal("fetch", fetchMock);
+
+		const notifications: Array<{ type: string; url?: string; message?: string }> = [];
+		const credential = await kiroOAuth.login({
+			signal: abortSignal,
+			prompt: async () => "",
+			notify: (event) => notifications.push(event),
+		});
+
+		expect(credential.type).toBe("oauth");
+		expect(credential.access).toBe("access-fixture");
+		expect(credential.refresh).toContain("|idc|us-east-1");
+		expect((credential as KiroOAuthCredential).region).toBe("us-east-1");
+		expect(notifications).toEqual([
+			{
+				type: "auth_url",
+				url: "https://device.example.test/verify?code=fixture",
+				instructions: "Your code: CODE-FIXTURE",
+			},
+			{ type: "progress", message: "Waiting for Kiro authorization in us-east-1..." },
+		]);
+		expect(calls.map((call) => call.url)).toEqual([
+			"https://oidc.us-east-1.amazonaws.com/client/register",
+			"https://oidc.us-east-1.amazonaws.com/device_authorization",
+			"https://oidc.us-east-1.amazonaws.com/token",
+		]);
+	});
+
+	it("refreshes with the registered device client and preserves profile metadata", async () => {
+		const fetchMock = vi.fn<FetchFunction>(async () =>
+			jsonResponse({ accessToken: "access-refreshed", expiresIn: 1800 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const credential: KiroOAuthCredential = {
+			type: "oauth",
+			access: "access-old",
+			refresh: "refresh-old|client-fixture|secret-fixture|idc|eu-west-1",
+			expires: 0,
+			clientId: "client-fixture",
+			clientSecret: "secret-fixture",
+			region: "eu-west-1",
+			authMethod: "idc",
+			profileArn: "profile-fixture",
+		};
+
+		const refreshed = await kiroOAuth.refresh(credential, abortSignal);
+		expect(refreshed.access).toBe("access-refreshed");
+		expect((refreshed as KiroOAuthCredential).region).toBe("eu-west-1");
+		expect((refreshed as KiroOAuthCredential).profileArn).toBe("profile-fixture");
+		const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		expect(JSON.parse(String(request.body))).toMatchObject({
+			clientId: "client-fixture",
+			clientSecret: "secret-fixture",
+			refreshToken: "refresh-old",
+			grantType: "refresh_token",
+		});
+
+		const auth = await kiroOAuth.toAuth(refreshed);
+		expect(auth.apiKey).toBe("access-refreshed");
+		expect(auth.baseUrl).toBe("https://runtime.eu-central-1.kiro.dev/");
+		expect(auth.headers).toEqual({ "x-amzn-kiro-profile-arn": "profile-fixture" });
+	});
+});
+
+describe("Kiro OAuth error handling", () => {
+	test("fails immediately for fatal HTTP 400 token errors", async () => {
+		const fetchMock: FetchFunction = async (input) => {
+			const url = String(input);
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 30,
+				});
+			}
+			return jsonResponse({ error: "access_denied" }, 400);
+		};
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			kiroOAuth.login({
+				signal: new AbortController().signal,
+				prompt: async () => "",
+				notify: () => {},
+			}),
+		).rejects.toThrow("Kiro authorization failed: access_denied");
+	});
+
+	test("reports slow_down instead of treating it as authorization_pending", async () => {
+		vi.useFakeTimers();
+		try {
+			const fetchMock: FetchFunction = async (input) => {
+				const url = String(input);
+				if (url.endsWith("/client/register")) {
+					return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+				}
+				if (url.endsWith("/device_authorization")) {
+					return jsonResponse({
+						deviceCode: "device-fixture",
+						userCode: "CODE-FIXTURE",
+						verificationUri: "https://device.example.test/verify",
+						verificationUriComplete: "https://device.example.test/verify?code=fixture",
+						interval: 1,
+						expiresIn: 1,
+					});
+				}
+				return jsonResponse({ error: "slow_down" }, 400);
+			};
+			vi.stubGlobal("fetch", fetchMock);
+			const login = kiroOAuth.login({
+				signal: new AbortController().signal,
+				prompt: async () => "",
+				notify: () => {},
+			});
+			const rejection = expect(login).rejects.toThrow("after one or more slow_down responses");
+			await vi.advanceTimersByTimeAsync(1_000);
+			await rejection;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("bounds an in-flight token poll request with the login request timeout", async () => {
+		const timeoutController = new AbortController();
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+		let tokenPollStartedResolve!: () => void;
+		const tokenPollStarted = new Promise<void>((resolve) => {
+			tokenPollStartedResolve = resolve;
+		});
+		const fetchMock: FetchFunction = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 30,
+				});
+			}
+			tokenPollStartedResolve();
+			return new Promise<Response>((_resolve, reject) => {
+				const requestSignal = init?.signal;
+				if (!requestSignal) {
+					reject(new Error("Kiro token poll request did not receive an abort signal"));
+					return;
+				}
+				const rejectOnAbort = () => reject(requestSignal.reason ?? new Error("Kiro token poll aborted"));
+				if (requestSignal.aborted) rejectOnAbort();
+				else requestSignal.addEventListener("abort", rejectOnAbort, { once: true });
+			});
+		};
+		vi.stubGlobal("fetch", fetchMock);
+
+		try {
+			const login = kiroOAuth.login({
+				signal: new AbortController().signal,
+				prompt: async () => "",
+				notify: () => {},
+			});
+			const rejection = expect(login).rejects.toBeDefined();
+			await tokenPollStarted;
+			timeoutController.abort();
+			await rejection;
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	test("rejects a malformed device expiry before starting to poll", async () => {
+		const prompts = ["https://start.example.test", "us-east-1"];
+		let tokenPolls = 0;
+		const fetchMock: FetchFunction = async (input) => {
+			const url = String(input);
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: "not-a-number",
+				});
+			}
+			tokenPolls += 1;
+			return jsonResponse({ accessToken: "unexpected", refreshToken: "unexpected", expiresIn: 3600 });
+		};
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			kiroOAuth.login({
+				signal: new AbortController().signal,
+				prompt: async () => prompts.shift() ?? "",
+				notify: () => {},
+			}),
+		).rejects.toThrow("Could not find an AWS Identity Center region for the supplied start URL");
+		expect(tokenPolls).toBe(0);
+	});
+});
+describe("Kiro management and request transformation", () => {
+	it("discovers a profile and fetches a profile-scoped model catalog", async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const fetchMock: FetchFunction = async (input, init) => {
+			const url = String(input);
+			requests.push({ url, init });
+			if (url.endsWith("/List-Available-Profiles")) {
+				return jsonResponse({ profiles: [{ arn: "profile-fixture" }] });
+			}
+			return jsonResponse({
+				models: [
+					{
+						modelId: "fixture-model",
+						displayName: "Fixture Model",
+						tokenLimits: { maxInputTokens: 1234, maxOutputTokens: 567 },
+					},
+				],
+			});
+		};
+
+		const result = await fetchKiroModelCatalog(
+			{ accessToken: "access-fixture", region: "eu-central-1" },
+			undefined,
+			fetchMock,
+		);
+		expect(result.profileArn).toBe("profile-fixture");
+		expect(result.response.models[0]?.modelId).toBe("fixture-model");
+		expect(requests[0]?.init?.method).toBe("POST");
+		expect(requests[1]?.init?.method).toBe("GET");
+		expect(requests[1]?.url).toContain("origin=KIRO_CLI");
+		expect(requests[1]?.url).toContain("profileArn=profile-fixture");
+		expect(new Headers(requests[1]?.init?.headers).get("authorization")).toBe("Bearer access-fixture");
+
+		const models = mapKiroCatalogToModels(result.response.models, "eu-central-1");
+		expect(models[0]).toMatchObject({
+			id: "fixture-model",
+			contextWindow: 1234,
+			maxTokens: 567,
+			kiroRegion: "eu-central-1",
+		});
+	});
+
+	it("maps system, tool, assistant, and tool-result history into a Kiro request", () => {
+		const model = KIRO_MODELS[0]!;
+		const context: Context = {
+			systemPrompt: "Use concise answers.",
+			tools: [
+				{
+					name: "lookup",
+					description: "Look something up",
+					parameters: Type.Object({ query: Type.String() }),
+				},
+			],
+			messages: [
+				{ role: "user", content: "Earlier", timestamp: 1 },
+				assistantToolCall(),
+				toolResult(),
+				{ role: "user", content: "Current", timestamp: 4 },
+			],
+		};
+
+		const request = buildKiroRequest(model, context, "profile-fixture", "conversation-fixture", "high");
+		expect(request.profileArn).toBe("profile-fixture");
+		expect(request.conversationState.history?.[0]?.userInputMessage?.content).toContain("Earlier");
+		expect(request.conversationState.history?.[1]?.assistantResponseMessage?.toolUses?.[0]?.toolUseId).toBe("tool-1");
+		expect(
+			request.conversationState.history?.[2]?.userInputMessage?.userInputMessageContext?.toolResults?.[0]?.content[0]
+				?.text,
+		).toBe("result");
+		expect(request.conversationState.currentMessage.userInputMessage.content).toBe("Current");
+		expect(
+			request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.tools?.[0]
+				?.toolSpecification.name,
+		).toBe("lookup");
+	});
+});
+
+describe("Kiro EventStream and runtime", () => {
+	it("validates CRCs and reassembles split frames", async () => {
+		const frame = eventStreamFrame(JSON.stringify({ content: "hello" }));
+		expect(new TextDecoder().decode(decodeKiroEventStreamMessage(frame).payload)).toBe(
+			JSON.stringify({ content: "hello" }),
+		);
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(frame.slice(0, 7));
+				controller.enqueue(frame.slice(7));
+				controller.close();
+			},
+		});
+		const messages = [];
+		for await (const message of decodeKiroEventStream(stream)) messages.push(message);
+		expect(messages).toHaveLength(1);
+		expect(new TextDecoder().decode(messages[0]!.payload)).toBe(JSON.stringify({ content: "hello" }));
+		const corrupt = frame.slice();
+		corrupt[8] ^= 1;
+		expect(() => decodeKiroEventStreamMessage(corrupt)).toThrow("prelude CRC");
+	});
+
+	it("parses native events and emits a complete text/tool runtime response", async () => {
+		expect(parseKiroEvent({ content: "hello" })).toEqual({ type: "content", data: "hello" });
+		expect(parseKiroEvent({ text: "reason" })).toEqual({ type: "thinkingText", data: "reason" });
+		expect(parseKiroEvent({ name: "lookup", toolUseId: "tool-1", input: { query: "x" }, stop: true })).toEqual({
+			type: "toolUse",
+			data: { name: "lookup", toolUseId: "tool-1", input: JSON.stringify({ query: "x" }), stop: true },
+		});
+		expect(parseKiroEvent({ usage: { inputTokens: 10, outputTokens: 4 } })).toEqual({
+			type: "usage",
+			data: { inputTokens: 10, outputTokens: 4 },
+		});
+
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const responseBody = concatFrames([
+			eventStreamFrame(JSON.stringify({ text: "reason" })),
+			eventStreamFrame(JSON.stringify({ content: "hello" })),
+			eventStreamFrame(JSON.stringify({ name: "lookup", toolUseId: "tool-1", input: { query: "x" }, stop: true })),
+			eventStreamFrame(JSON.stringify({ usage: { inputTokens: 10, outputTokens: 4 } })),
+		]);
+		const fetchMock: FetchFunction = async (input, init) => {
+			requests.push({ url: String(input), init });
+			return new Response(responseBody, { status: 200 });
+		};
+		const model = KIRO_MODELS[0]!;
+		const context: Context = { messages: [{ role: "user", content: "Current", timestamp: 1 }] };
+		let sentRequest: unknown;
+		const result = await streamKiro(model, context, {
+			apiKey: JSON.stringify({ token: "access-fixture", region: "eu-central-1", profileArn: "profile-fixture" }),
+			fetch: fetchMock,
+			sessionId: "conversation-fixture",
+			onPayload: (payload) => {
+				sentRequest = payload;
+			},
+		}).result();
+
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.errorMessage).toBeUndefined();
+		expect(result.content).toEqual([
+			{ type: "thinking", thinking: "reason" },
+			{ type: "text", text: "hello" },
+			{ type: "toolCall", id: "tool-1", name: "lookup", arguments: { query: "x" } },
+		]);
+		expect(result.usage.input).toBe(10);
+		expect(result.usage.output).toBe(4);
+		expect(requests[0]?.url).toBe("https://runtime.eu-central-1.kiro.dev/generateAssistantResponse");
+		expect(new Headers(requests[0]?.init?.headers).get("authorization")).toBe("Bearer access-fixture");
+		expect(JSON.parse(String(requests[0]?.init?.body))).toMatchObject({
+			profileArn: "profile-fixture",
+			conversationState: { conversationId: "conversation-fixture" },
+		});
+		expect(sentRequest).toMatchObject({ profileArn: "profile-fixture" });
+	});
+});
+
+describe("Kiro provider discovery", () => {
+	it("registers /login-compatible OAuth and refreshes profile-scoped models", async () => {
+		const credentials = new InMemoryCredentialStore();
+		await credentials.modify("kiro", async () => ({
+			type: "oauth",
+			access: "access-fixture",
+			refresh: "refresh-fixture",
+			expires: Date.now() + 60_000,
+			region: "eu-central-1",
+			profileArn: "profile-fixture",
+		}));
+		const fetchMock: FetchFunction = async (input) => {
+			expect(String(input)).toContain("List-Available-Models");
+			return jsonResponse({ models: [{ modelId: "fixture-model", displayName: "Fixture Model" }] });
+		};
+		vi.stubGlobal("fetch", fetchMock);
+
+		const provider = kiroProvider();
+		expect(provider.id).toBe("kiro");
+		expect(provider.auth.oauth?.name).toContain("Kiro");
+		const models = createModels({ credentials });
+		models.setProvider(provider);
+		const refreshResult = await models.refresh({ providers: ["kiro"] });
+		expect(refreshResult.errors.size).toBe(0);
+		expect(models.getModel("kiro", "fixture-model")).toMatchObject({
+			name: "Fixture Model",
+			provider: "kiro",
+			api: "kiro-api",
+		});
+	});
+});
+
+describe("Kiro Models.login wiring", () => {
+	it("persists the device-code credential through the provider login entry", async () => {
+		const fetchMock: FetchFunction = async (input) => {
+			const url = String(input);
+			if (url.endsWith("/client/register")) {
+				return jsonResponse({ clientId: "client-fixture", clientSecret: "secret-fixture" });
+			}
+			if (url.endsWith("/device_authorization")) {
+				return jsonResponse({
+					deviceCode: "device-fixture",
+					userCode: "CODE-FIXTURE",
+					verificationUri: "https://device.example.test/verify",
+					verificationUriComplete: "https://device.example.test/verify?code=fixture",
+					interval: 1,
+					expiresIn: 30,
+				});
+			}
+			if (url.endsWith("/token")) {
+				return jsonResponse({ accessToken: "access-fixture", refreshToken: "refresh-fixture", expiresIn: 3600 });
+			}
+			throw new Error(`unexpected Kiro login URL: ${url}`);
+		};
+		vi.stubGlobal("fetch", fetchMock);
+		const credentials = new InMemoryCredentialStore();
+		const models = createModels({ credentials });
+		models.setProvider(kiroProvider());
+
+		const credential = await models.login("kiro", "oauth", {
+			signal: abortSignal,
+			prompt: async () => "",
+			notify: () => {},
+		});
+
+		expect(credential.type).toBe("oauth");
+		expect((await credentials.read("kiro"))?.type).toBe("oauth");
+		expect(await models.checkAuth("kiro")).toMatchObject({ type: "oauth" });
+	});
+});

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -49,6 +49,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	opencode: "kimi-k2.6",
 	"opencode-go": "kimi-k2.6",
 	"kimi-coding": "kimi-for-coding",
+	kiro: "auto",
 	"cloudflare-workers-ai": "@cf/moonshotai/kimi-k2.6",
 	"cloudflare-ai-gateway": "workers-ai/@cf/moonshotai/kimi-k2.6",
 	"qwen-token-plan": "qwen3.7-max",


### PR DESCRIPTION
## Summary

- Add Kiro OAuth device-code login and refresh support.
- Register Kiro provider, catalog, and runtime routing.
- Handle authorization_pending, slow_down, fatal OAuth errors, request timeouts, and malformed expiresIn responses.
- Add Kiro protocol and login regression coverage.

## Validation

- Kiro/OAuth/model-runtime tests: 56 passed.
- Targeted Biome checks passed.