### PR TITLE
fix(coding-agent): getStats tokens.total = billable only (exclude cache)

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3164,7 +3164,9 @@ export class AgentSession {
 				output: usageTotals.output,
 				cacheRead: usageTotals.cacheRead,
 				cacheWrite: usageTotals.cacheWrite,
-				total: usageTotals.input + usageTotals.output + usageTotals.cacheRead + usageTotals.cacheWrite,
+				// BILLABLE only: cache is billed at 1/120th the input rate; including it
+				// inflates totals and skews compaction budgets + consumer write-backs.
+				total: usageTotals.input + usageTotals.output,
 			},
 			cost: usageTotals.cost,
 			contextUsage: this.getContextUsage(),


### PR DESCRIPTION
## Problem

`AgentSession.getStats()` computes `tokens.total` as input + output + cacheRead + cacheWrite. Cache tokens are billed at **1/120th** the input rate (DeepSeek/OpenAI cache pricing), so including them inflates the total ~120x. Consequences:

- compaction budgets trigger far too early (a 150K-context session reports ~18M 'total')
- status/stats displays show wrong numbers
- consumers writing totals back to their own accounting get ~120x inflated values (observed: 146K vs 11K real in an external consumer)

## Fix

`total` = input + output only (billable). Individual cacheRead/cacheWrite fields remain available for consumers that want them.