### PR TITLE
fix: expose sleeping llama.cpp models

### DIFF
--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -25,6 +25,11 @@ async function resolveServerUrl(
 	return configured ? normalizeLlamaServerUrl(configured) : undefined;
 }
 
+function modelIsSelectable(model: LlamaModelInfo): boolean {
+	// llama.cpp reports idle-slept models as "sleeping"; requests wake them automatically.
+	return model.status.value === "loaded" || model.status.value === "sleeping";
+}
+
 function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-completions"> {
 	const reportedContextWindow = model.meta?.n_ctx ?? model.meta?.n_ctx_train;
 	const contextWindow = reportedContextWindow && reportedContextWindow > 0 ? reportedContextWindow : 128000;
@@ -59,7 +64,7 @@ export function createLlamaProvider(): LlamaProviderController {
 	let models: readonly Model<"openai-completions">[] = [];
 
 	const setCatalog = (catalog: readonly LlamaModelInfo[], serverUrl: string): void => {
-		models = catalog.filter((model) => model.status.value === "loaded").map((model) => toPiModel(model, serverUrl));
+		models = catalog.filter((model) => modelIsSelectable(model)).map((model) => toPiModel(model, serverUrl));
 	};
 
 	const provider: Provider<"openai-completions"> = {
@@ -133,7 +138,7 @@ export function createLlamaProvider(): LlamaProviderController {
 			const catalog = await new LlamaClient(serverUrl, context.credential.key).list({ signal: context.signal });
 			if (context.signal.aborted) return;
 			const refreshed = catalog
-				.filter((model) => model.status.value === "loaded")
+				.filter((model) => modelIsSelectable(model))
 				.map((model) => toPiModel(model, serverUrl));
 			await context.publish({
 				persist: { models: refreshed, checkedAt: Date.now() },

--- a/packages/coding-agent/test/llama-extension.test.ts
+++ b/packages/coding-agent/test/llama-extension.test.ts
@@ -59,7 +59,7 @@ describe("llama.cpp extension", () => {
 		expect(() => normalizeLlamaServerUrl("file:///tmp/llama")).toThrow("http or https");
 	});
 
-	it("exposes only loaded models with router metadata", () => {
+	it("exposes loaded and sleeping models with router metadata", () => {
 		const controller = createLlamaProvider();
 		controller.setCatalog(
 			[
@@ -69,6 +69,7 @@ describe("llama.cpp extension", () => {
 					architecture: { input_modalities: ["text", "image"] },
 					meta: { n_ctx: 65536, n_ctx_train: 131072 },
 				},
+				{ id: "sleeping", status: { value: "sleeping" } },
 				{ id: "unloaded", status: { value: "unloaded" } },
 				{ id: "loading", status: { value: "loading" } },
 			],
@@ -83,16 +84,21 @@ describe("llama.cpp extension", () => {
 				maxTokens: 65536,
 				input: ["text", "image"],
 			}),
+			expect.objectContaining({
+				id: "sleeping",
+				baseUrl: "http://localhost:8080/v1",
+			}),
 		]);
 	});
 
-	it("persists and restores loaded models for cache-only startup refreshes", async () => {
+	it("persists and restores selectable models for cache-only startup refreshes", async () => {
 		let cachedEntry: ModelsStoreEntry | undefined;
 		const { url } = await listen((request, response) => {
 			if (request.url === "/models") {
 				json(response, {
 					data: [
 						{ id: "loaded", status: { value: "loaded" }, meta: { n_ctx: 32768 } },
+						{ id: "sleeping", status: { value: "sleeping" }, meta: { n_ctx: 32768 } },
 						{ id: "unloaded", status: { value: "unloaded" } },
 					],
 				});
@@ -115,8 +121,8 @@ describe("llama.cpp extension", () => {
 			allowNetwork: true,
 			signal: new AbortController().signal,
 		});
-		expect(first.provider.getModels().map((model) => model.id)).toEqual(["loaded"]);
-		expect(cachedEntry?.models.map((model) => model.id)).toEqual(["loaded"]);
+		expect(first.provider.getModels().map((model) => model.id)).toEqual(["loaded", "sleeping"]);
+		expect(cachedEntry?.models.map((model) => model.id)).toEqual(["loaded", "sleeping"]);
 
 		const second = createLlamaProvider();
 		await second.provider.refreshModels?.({
@@ -128,6 +134,7 @@ describe("llama.cpp extension", () => {
 		});
 		expect(second.provider.getModels()).toEqual([
 			expect.objectContaining({ id: "loaded", baseUrl: `${url}/v1`, contextWindow: 32768 }),
+			expect.objectContaining({ id: "sleeping", baseUrl: `${url}/v1`, contextWindow: 32768 }),
 		]);
 	});
 


### PR DESCRIPTION
Addresses part of #8167. 

llama.cpp router models reported with status `sleeping` were omitted because Pi only exposed `loaded` models.

Fixed by treating `sleeping` as selectable too; [llama.cpp documents](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#sleeping-on-idle) this as idle sleep mode where the model wakes on the next task.

Verified by rerunning repro/unit test covering sleeping model visibility.