### PR TITLE
fix(ai): align Qwen Token Plan model catalogs

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -301,6 +301,17 @@ const QWEN_TOKEN_PLAN_PROVIDER_IDS = new Set<string>([
 	"qwen-token-plan-cn",
 	"qwen-token-plan-individual",
 ]);
+// International and China Token Plans expose the same text-model catalog.
+const QWEN_TOKEN_PLAN_MODEL_IDS = new Set<string>([
+	"deepseek-v4-pro",
+	"deepseek-v4-pro-0813",
+	"deepseek-v4-flash-0731",
+	"glm-5.2",
+	"qwen3.6-flash",
+	"qwen3.7-max",
+	"qwen3.7-plus",
+	"qwen3.8-max",
+]);
 // QwenCloud Token Plan Individual text-model allowlist, verified 2026-08-05.
 // Retired models remain excluded above even if the public catalog lags.
 // https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview
@@ -2198,7 +2209,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 				source: "alibaba-token-plan",
 				provider: "qwen-token-plan",
 				baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
-				modelIds: undefined,
+				modelIds: QWEN_TOKEN_PLAN_MODEL_IDS,
 			},
 			{
 				source: "alibaba-token-plan",
@@ -2210,7 +2221,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 				source: "alibaba-token-plan-cn",
 				provider: "qwen-token-plan-cn",
 				baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
-				modelIds: undefined,
+				modelIds: QWEN_TOKEN_PLAN_MODEL_IDS,
 			},
 		] as const;
 

--- a/packages/ai/test/generate-models-strict.test.ts
+++ b/packages/ai/test/generate-models-strict.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 });
 
 describe("strict model generation", () => {
-	it("fails before mutating generated data when an Individual model loses tool support", () => {
+	it("fails before mutating generated data when a shared Token Plan model loses tool support", () => {
 		const fixtureRoot = mkdtempSync(join(tmpdir(), "pi-generate-models-"));
 		temporaryRoots.push(fixtureRoot);
 		const isolatedPackageRoot = join(fixtureRoot, "package");
@@ -25,6 +25,7 @@ describe("strict model generation", () => {
 		const modelIds = [
 			"deepseek-v4-flash-0731",
 			"deepseek-v4-pro",
+			"deepseek-v4-pro-0813",
 			"glm-5.2",
 			"qwen3.6-flash",
 			"qwen3.7-max",
@@ -75,7 +76,7 @@ describe("strict model generation", () => {
 
 		expect(result.status).toBe(1);
 		expect(`${result.stdout}\n${result.stderr}`).toContain(
-			"qwen-token-plan-individual model IDs do not match (missing: deepseek-v4-flash-0731)",
+			"qwen-token-plan model IDs do not match (missing: deepseek-v4-flash-0731)",
 		);
 		expect(generatedPaths.map((path) => readFileSync(join(isolatedPackageRoot, path), "utf8"))).toEqual(
 			isolatedBefore,

--- a/packages/ai/test/qwen-token-plan-models.test.ts
+++ b/packages/ai/test/qwen-token-plan-models.test.ts
@@ -40,18 +40,11 @@ vi.mock("openai", () => {
 });
 
 const TEXT_MODELS = [
-	"MiniMax-M2.5",
-	"deepseek-v3.2",
-	"deepseek-v4-flash",
 	"deepseek-v4-pro",
-	"glm-5",
-	"glm-5.1",
+	"deepseek-v4-pro-0813",
+	"deepseek-v4-flash-0731",
 	"glm-5.2",
-	"kimi-k2.5",
-	"kimi-k2.6",
-	"kimi-k2.7-code",
 	"qwen3.6-flash",
-	"qwen3.6-plus",
 	"qwen3.7-max",
 	"qwen3.7-plus",
 	"qwen3.8-max",
@@ -69,22 +62,7 @@ const INDIVIDUAL_TEXT_MODELS = [
 
 const IMAGE_MODELS = ["qwen-image-2.0", "qwen-image-2.0-pro", "wan2.7-image", "wan2.7-image-pro"];
 
-const QWEN_THINKING_MODELS = [
-	"deepseek-v3.2",
-	"deepseek-v4-flash",
-	"deepseek-v4-pro",
-	"glm-5",
-	"glm-5.1",
-	"glm-5.2",
-	"kimi-k2.5",
-	"kimi-k2.6",
-	"kimi-k2.7-code",
-	"qwen3.6-flash",
-	"qwen3.6-plus",
-	"qwen3.7-max",
-	"qwen3.7-plus",
-	"qwen3.8-max",
-] as const;
+const QWEN_THINKING_MODELS = TEXT_MODELS;
 
 type QwenTokenPlanProvider = "qwen-token-plan" | "qwen-token-plan-cn" | "qwen-token-plan-individual";
 type QwenTokenPlanModelCase = { provider: QwenTokenPlanProvider; modelId: string };
@@ -96,7 +74,12 @@ const QWEN_THINKING_MODEL_CASES: QwenTokenPlanModelCase[] = [
 	...INDIVIDUAL_TEXT_MODELS.map((modelId) => ({ provider: "qwen-token-plan-individual" as const, modelId })),
 ];
 
-const QWEN_REASONING_EFFORT_MODELS = ["deepseek-v4-flash", "deepseek-v4-pro", "glm-5", "glm-5.1", "glm-5.2"] as const;
+const QWEN_REASONING_EFFORT_MODELS = [
+	"deepseek-v4-pro",
+	"deepseek-v4-pro-0813",
+	"deepseek-v4-flash-0731",
+	"glm-5.2",
+] as const;
 
 const QWEN_REASONING_EFFORT_MODEL_CASES: QwenTokenPlanModelCase[] = [
 	...(["qwen-token-plan", "qwen-token-plan-cn"] as const).flatMap((provider) =>
@@ -123,12 +106,15 @@ describe("Qwen Token Plan models", () => {
 		]);
 	});
 
-	it.each(["qwen-token-plan", "qwen-token-plan-cn"] as const)("exposes all text models on %s", (provider) => {
-		const modelIds = getModels(provider).map((model) => model.id);
-		for (const expected of TEXT_MODELS) {
-			expect(modelIds, `${provider} should include ${expected}`).toContain(expected);
-		}
-	});
+	it.each(["qwen-token-plan", "qwen-token-plan-cn"] as const)(
+		"exposes exactly the shared text-model catalog on %s",
+		(provider) => {
+			const modelIds = getModels(provider)
+				.map((model) => model.id)
+				.sort();
+			expect(modelIds).toEqual([...TEXT_MODELS].sort());
+		},
+	);
 
 	it.each(["qwen-token-plan", "qwen-token-plan-cn"] as const)("omits image models from %s", (provider) => {
 		const modelIds = getModels(provider).map((model) => model.id);
@@ -167,6 +153,7 @@ describe("Qwen Token Plan models", () => {
 			).result();
 
 			expect(payload).toHaveProperty("enable_thinking", true);
+			expect(payload).toHaveProperty("model", modelId);
 			expect(payload).not.toHaveProperty("thinking");
 		},
 	);
@@ -244,6 +231,7 @@ describe("Qwen Token Plan models", () => {
 			).result();
 
 			expect(payload).toHaveProperty("reasoning_effort", "high");
+			expect(payload).toHaveProperty("model", modelId);
 		},
 	);
 


### PR DESCRIPTION
## Summary

- Use one shared text-model allowlist for `qwen-token-plan` and `qwen-token-plan-cn`.
- Expose the same eight current models on both providers, including `deepseek-v4-pro-0813` and `deepseek-v4-flash-0731`.
- Keep `qwen-token-plan-individual` on its separate seven-model catalog.
- Tighten generator and request-payload tests so catalog drift fails before generated data is written.

## Why

The international and China Token Plans expose the same text-model catalog, but pi previously accepted every tool-capable model returned for each models.dev provider. That exposed stale or unavailable entries and allowed the two catalogs to diverge.

The shared allowlist makes the product catalog explicit while still sourcing model metadata from models.dev. `deepseek-v4-pro-0813` is now available natively after [anomalyco/models.dev#4771](https://github.com/anomalyco/models.dev/pull/4771), so no local metadata fallback is needed.

## Impact

Both Token Plan providers now expose exactly:

- `deepseek-v4-pro`
- `deepseek-v4-pro-0813`
- `deepseek-v4-flash-0731`
- `glm-5.2`
- `qwen3.6-flash`
- `qwen3.7-max`
- `qwen3.7-plus`
- `qwen3.8-max`

## Checks

- `NODE_USE_ENV_PROXY=1 npm run generate-models`
- Focused pi-ai tests: 61 passed
- `npm run check`
- `./test.sh`

Closes #8194

AI disclosure: This PR was prepared with Codex at @sunner's request. The requested model list, provider scope, and final changes were reviewed by @sunner.
