### PR TITLE
fix(extension-examples): use agent_settled instead of end

### DIFF
--- a/packages/coding-agent/examples/extensions/border-status-editor.ts
+++ b/packages/coding-agent/examples/extensions/border-status-editor.ts
@@ -92,7 +92,7 @@ export default function (pi: ExtensionAPI) {
 		activeTui?.requestRender();
 	});
 
-	pi.on("agent_end", () => {
+	pi.on("agent_settled", () => {
 		isWorking = false;
 		stopSpinner();
 		activeTui?.requestRender();

--- a/packages/coding-agent/examples/extensions/git-checkpoint.ts
+++ b/packages/coding-agent/examples/extensions/git-checkpoint.ts
@@ -46,8 +46,8 @@ export default function (pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("agent_end", async () => {
-		// Clear checkpoints after agent completes
+	pi.on("agent_settled", async () => {
+		// Clear checkpoints after the full agent run completes
 		checkpoints.clear();
 	});
 }

--- a/packages/coding-agent/examples/extensions/notify.ts
+++ b/packages/coding-agent/examples/extensions/notify.ts
@@ -49,7 +49,9 @@ function notify(title: string, body: string): void {
 }
 
 export default function (pi: ExtensionAPI) {
-	pi.on("agent_end", async () => {
+	// `agent_end` fires after each low-level run; Pi may still retry, compact,
+	// or continue with queued follow-ups. Notify only after the full run settles.
+	pi.on("agent_settled", async () => {
 		notify("Pi", "Ready for input");
 	});
 }

--- a/packages/coding-agent/examples/extensions/titlebar-spinner.ts
+++ b/packages/coding-agent/examples/extensions/titlebar-spinner.ts
@@ -48,7 +48,7 @@ export default function (pi: ExtensionAPI) {
 		startAnimation(ctx);
 	});
 
-	pi.on("agent_end", async (_event, ctx) => {
+	pi.on("agent_settled", async (_event, ctx) => {
 		stopAnimation(ctx);
 	});
 

--- a/packages/coding-agent/examples/rpc-extension-ui.ts
+++ b/packages/coding-agent/examples/rpc-extension-ui.ts
@@ -576,7 +576,7 @@ async function main() {
 			return;
 		}
 
-		if (data.type === "agent_end") {
+		if (data.type === "agent_settled") {
 			isStreaming = false;
 			hideLoading();
 			outputLog.append("");

--- a/packages/coding-agent/examples/sdk/06-extensions.ts
+++ b/packages/coding-agent/examples/sdk/06-extensions.ts
@@ -71,7 +71,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("agent_end", async (event) => {
-		console.log(\`[Extension] Done, \${event.messages.length} messages\`);
+		console.log(\`[Extension] Low-level run ended, \${event.messages.length} messages\`);
 	});
 
 	// Register a custom tool

--- a/packages/coding-agent/examples/sdk/README.md
+++ b/packages/coding-agent/examples/sdk/README.md
@@ -132,7 +132,7 @@ session.subscribe((event) => {
     case "tool_execution_end":
       console.log(`Result: ${event.result}`);
       break;
-    case "agent_end":
+    case "agent_settled":
       console.log("Done");
       break;
   }


### PR DESCRIPTION
Adresses #7350.

Reproduced the premature “done/idle” behavior in status-like examples using `agent_end`: that event fires after a low-level run, while Pi may still retry, compact, or continue queued follow-ups.

Fixed those examples to use `agent_settled`, which fires only after Pi will not continue automatically.

 Changed:
- `notify.ts, titlebar-spinner.ts, border-status-editor.ts, rpc-extension-ui.ts, git-checkpoint.ts`
- SDK README “Done” example
- SDK extension log wording: kept `agent_end`, but clarified it means low-level run ended

Not changed:
- `plan-mode`: needs `agent_end` messages and may queue follow-ups
- `git-merge-and-resolve`: intentionally runs after each low-level run to merge and queue conflict resolution