### PR TITLE
fix(ai): bedrock response to include smithy headers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Amazon Bedrock `after_provider_response`/`onResponse` to forward the raw response headers instead of only the synthesized request id header ([#8234](https://github.com/earendil-works/pi/issues/8234)).
 - Fixed Kimi OpenAI-compatible usage reporting so top-level `cached_tokens` count as cache reads instead of normal input tokens ([#8075](https://github.com/earendil-works/pi/issues/8075)).
 
 ## [0.84.2] - 2026-08-14

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -23,7 +23,7 @@ import {
 	ToolResultStatus,
 } from "@aws-sdk/client-bedrock-runtime";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
-import type { BuildMiddleware, DocumentType, MetadataBearer } from "@smithy/types";
+import type { BuildMiddleware, DeserializeMiddleware, DocumentType, HttpResponse, MetadataBearer } from "@smithy/types";
 import { HttpProxyAgent } from "http-proxy-agent";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { calculateCost } from "../models.ts";
@@ -35,6 +35,7 @@ import type {
 	ImageContent,
 	Model,
 	ProviderEnv,
+	ProviderResponse,
 	SimpleStreamOptions,
 	StopReason,
 	StreamFunction,
@@ -227,6 +228,12 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 		try {
 			const supportsStrictMode = model.compat?.supportsStrictMode ?? false;
 			const client = new BedrockRuntimeClient(config);
+			let observedRawResponse = false;
+			if (options.onResponse) {
+				addResponseHeadersMiddleware(client, options.onResponse, model, () => {
+					observedRawResponse = true;
+				});
+			}
 			const customHeaders = providerHeadersToRecord(options.headers);
 			if (customHeaders) {
 				addCustomHeadersMiddleware(client, customHeaders);
@@ -253,7 +260,7 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 
 			const response = await client.send(command, { abortSignal: options.signal });
 			responseRequestId = normalizeDiagnosticValue(response.$metadata.requestId);
-			if (response.$metadata.httpStatusCode !== undefined) {
+			if (!observedRawResponse && response.$metadata.httpStatusCode !== undefined) {
 				const responseHeaders: Record<string, string> = {};
 				if (response.$metadata.requestId) {
 					responseHeaders["x-amzn-requestid"] = response.$metadata.requestId;
@@ -456,6 +463,41 @@ function addCustomHeadersMiddleware(client: BedrockRuntimeClient, headers: Recor
 		return next(args);
 	};
 	client.middlewareStack.add(middleware, { step: "build", name: "pi-ai-custom-headers", priority: "low" });
+}
+
+function isSmithyHttpResponse(response: unknown): response is HttpResponse {
+	if (!response || typeof response !== "object") return false;
+	const candidate = response as Partial<HttpResponse>;
+	return typeof candidate.statusCode === "number" && !!candidate.headers && typeof candidate.headers === "object";
+}
+
+function toProviderResponse(response: unknown): ProviderResponse | undefined {
+	if (!isSmithyHttpResponse(response)) return undefined;
+	return { status: response.statusCode, headers: { ...response.headers } };
+}
+
+/**
+ * Bedrock's modeled `$metadata` only preserves selected HTTP metadata (for example
+ * requestId), so custom gateway headers are otherwise lost before callers see
+ * `onResponse`. Capture the raw Smithy HTTP response at the deserialize step,
+ * after the SDK receives the response but before the event stream is consumed.
+ */
+function addResponseHeadersMiddleware(
+	client: BedrockRuntimeClient,
+	onResponse: NonNullable<BedrockOptions["onResponse"]>,
+	model: Model<"bedrock-converse-stream">,
+	onObserved: () => void,
+): void {
+	const middleware: DeserializeMiddleware<object, MetadataBearer> = (next) => async (args) => {
+		const result = await next(args);
+		const providerResponse = toProviderResponse(result.response);
+		if (providerResponse) {
+			onObserved();
+			await onResponse(providerResponse, model);
+		}
+		return result;
+	};
+	client.middlewareStack.add(middleware, { step: "deserialize", name: "pi-ai-response-headers" });
 }
 
 export const streamSimple: StreamFunction<"bedrock-converse-stream", SimpleStreamOptions> = (

--- a/packages/ai/test/bedrock-response-headers.test.ts
+++ b/packages/ai/test/bedrock-response-headers.test.ts
@@ -1,0 +1,63 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
+import { getModel } from "../src/compat.ts";
+import type { Model, ProviderResponse } from "../src/types.ts";
+
+const MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+let server: Server | undefined;
+
+afterEach(async () => {
+	if (!server) return;
+	await new Promise<void>((resolve, reject) => {
+		server?.close((error) => (error ? reject(error) : resolve()));
+	});
+	server = undefined;
+});
+
+async function startBedrockResponseServer(): Promise<string> {
+	server = createServer((_req, res) => {
+		res.writeHead(200, {
+			"content-type": "application/vnd.amazon.eventstream",
+			"x-bifrost-provider": "bedrock",
+			"x-bifrost-resolved-model": MODEL_ID,
+			"x-amzn-requestid": "req-123",
+		});
+		res.end();
+	});
+
+	await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("Expected TCP test server address");
+	return `http://127.0.0.1:${address.port}`;
+}
+
+describe("bedrock response headers", () => {
+	it("forwards raw Smithy response headers to onResponse", async () => {
+		const baseModel = getModel("amazon-bedrock", MODEL_ID) as Model<"bedrock-converse-stream">;
+		const model = { ...baseModel, baseUrl: await startBedrockResponseServer() };
+		const responses: ProviderResponse[] = [];
+
+		const result = await streamBedrock(
+			model,
+			{ messages: [{ role: "user", content: "hello", timestamp: Date.now() }] },
+			{
+				cacheRetention: "none",
+				env: { AWS_BEDROCK_FORCE_HTTP1: "1", AWS_BEDROCK_SKIP_AUTH: "1" },
+				onResponse: (response) => {
+					responses.push(response);
+				},
+			},
+		).result();
+
+		// The fake server intentionally returns an empty event stream; this assertion
+		// documents that the header callback still fires before stream consumption.
+		expect(result.stopReason).toBe("error");
+		expect(responses).toHaveLength(1);
+		expect(responses[0].status).toBe(200);
+		expect(responses[0].headers["x-amzn-requestid"]).toBe("req-123");
+		expect(responses[0].headers["x-bifrost-provider"]).toBe("bedrock");
+		expect(responses[0].headers["x-bifrost-resolved-model"]).toBe(MODEL_ID);
+	});
+});


### PR DESCRIPTION
Addresses #8234.

Reproed locally: Bedrock `onResponse`/`after_provider_response` only exposed $metadata-derived headers, so gateway headers like `x-bifrost-provider` were dropped.

Fixed by capturing the raw Smithy HTTP response in a Bedrock deserialize middleware and forwarding its real status/headers, with the old $metadata path kept as a fallback.

Added a regression test and reran the local repro to verify: `x-bifrost-provider` / `x-bifrost-resolved-model` now reach `onResponse`:

```jsonl
{"status":200,"headers":{"content-type":"application/vnd.amazon.eventstream","x-bifrost-provider":"bedrock","x-bifrost-resolved-model":"us.anthropic.claude-haiku-4-5-20251001-v1:0","x-amzn-requestid":"req-123", ...}}
```