### PR TITLE
fix(tui): avoid full-screen flashing when content changes above the v…

### DIFF
--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -206,16 +206,26 @@ export class TuiMainScreen extends TuiBase implements TUI {
 
 		newLines = this.applyLineResets(newLines);
 
-		// Helper to clear scrollback and viewport and render all new lines
-		const fullRender = (clear: boolean): void => {
+		// Helper to clear scrollback and viewport and render all new lines.
+		// When `clear` is false and `fromRow` is > 0, only the screen is cleared and
+		// the tail (fromRow onward) is reprinted. Rows above fromRow are unchanged
+		// and stay in the terminal's scrollback, which is the only way to repair a
+		// change above the viewport: cursor movement cannot enter the scrollback.
+		const fullRender = (options: { clear: boolean; fromRow?: number }): void => {
+			const { clear, fromRow = 0 } = options;
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
+			} else if (fromRow > 0) {
+				// Tail repair: replace everything from fromRow down without touching
+				// the unchanged rows above it. Delete only images in that range.
+				buffer += this.deleteChangedKittyImages(fromRow, this.previousLines.length - 1);
+				buffer += "\x1b[2J\x1b[H"; // Clear screen, home (keep scrollback)
 			}
-			for (let i = 0; i < newLines.length; i++) {
-				if (i > 0) buffer += "\r\n";
+			for (let i = fromRow; i < newLines.length; i++) {
+				if (i > fromRow) buffer += "\r\n";
 				const line = newLines[i];
 				const isImage = isImageLine(line);
 				const imageReservedRows = isImage ? this.getKittyImageReservedRows(newLines, i) : 1;
@@ -262,14 +272,14 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// First render - just output everything without clearing (assumes clean screen)
 		if (this.previousLines.length === 0 && !widthChanged && !heightChanged) {
 			logRedraw("first render");
-			fullRender(false);
+			fullRender({ clear: false });
 			return;
 		}
 
 		// Width changes always need a full re-render because wrapping changes.
 		if (widthChanged) {
 			logRedraw(`terminal width changed (${this.previousWidth} -> ${width})`);
-			fullRender(true);
+			fullRender({ clear: true });
 			return;
 		}
 
@@ -278,7 +288,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// In that environment, a full redraw causes the entire history to replay on every toggle.
 		if (heightChanged && !isTermuxSession()) {
 			logRedraw(`terminal height changed (${this.previousHeight} -> ${height})`);
-			fullRender(true);
+			fullRender({ clear: true });
 			return;
 		}
 
@@ -287,7 +297,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.getClearOnShrink() && newLines.length < this.maxLinesRendered && !this.hasOverlayEntries) {
 			logRedraw(`clearOnShrink (maxLinesRendered=${this.maxLinesRendered})`);
-			fullRender(true);
+			fullRender({ clear: true });
 			return;
 		}
 
@@ -337,7 +347,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 				const targetRow = Math.max(0, newLines.length - 1);
 				if (targetRow < prevViewportTop) {
 					logRedraw(`deleted lines moved viewport up (${targetRow} < ${prevViewportTop})`);
-					fullRender(true);
+					fullRender({ clear: true });
 					return;
 				}
 				const lineDiff = computeLineDiff(targetRow);
@@ -348,7 +358,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 				const extraLines = this.previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true);
+					fullRender({ clear: true });
 					return;
 				}
 				const clearStartOffset = newLines.length === 0 ? 0 : 1;
@@ -377,11 +387,24 @@ export class TuiMainScreen extends TuiBase implements TUI {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible.
-		// If the first changed line is above the previous viewport, we need a full redraw.
+		// A change above the viewport cannot be reached by cursor movement (cursor-up
+		// at the screen edge scrolls the viewport instead of entering the scrollback).
+		// Repair it by clearing the screen and reprinting the tail, keeping the
+		// unchanged rows above it in the scrollback. Long transcripts hit this
+		// constantly when tool results update above the streaming content; clearing
+		// the scrollback and reprinting 10k+ lines each time visibly flashes the
+		// whole screen.
 		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
+			logRedraw(`tail repair above viewport (${firstChanged} < ${prevViewportTop})`);
+			// The reprinted tail must fill the whole screen: a stale viewport top
+			// can make the first change land inside the final viewport, in which
+			// case start from the viewport top instead.
+			const fromRow = Math.min(firstChanged, Math.max(0, newLines.length - height));
+			if (fromRow === 0) {
+				fullRender({ clear: true });
+			} else {
+				fullRender({ clear: false, fromRow });
+			}
 			return;
 		}
 
@@ -428,7 +451,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 					logRedraw(
 						`kitty image pre-clear would scroll (${imageStartScreenRow} + ${imageReservedRows} > ${height})`,
 					);
-					fullRender(true);
+					fullRender({ clear: true });
 					return;
 				}
 

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -830,3 +830,114 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI long transcript repairs", () => {
+	it("repairs changes just above the viewport without clearing the scrollback", async () => {
+		const terminal = new LoggingVirtualTerminal(80, 30);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const line = (i: number): string => `line ${i} ${"x".repeat(60)}`;
+		component.lines = Array.from({ length: 10000 }, (_, i) => line(i));
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		// Tool-result-like update ~50 rows above the bottom, while streaming
+		// continues appending below it. This used to clear screen and scrollback
+		// and reprint all 10k lines on every such update in long transcripts.
+		component.lines = [...component.lines];
+		component.lines[9950] = `updated result ${"y".repeat(60)}`;
+		component.lines.push(line(10000), line(10001));
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(!writes.includes("\x1b[3J"), "scrollback must not be cleared");
+		assert.ok(writes.includes("\x1b[2J\x1b[H"), "screen is cleared for the tail reprint");
+		assert.ok(!writes.includes("line 100 "), "unchanged rows above the repair are not reprinted");
+		assert.ok(writes.includes("updated result"), "the repaired tail is written");
+
+		// The emulator only retains the last 1000 rows; verify the repaired tail
+		// relative to the end of the scroll buffer.
+		const scrollback = terminal.getScrollBuffer();
+		const last = scrollback.length - 1;
+		assert.match(scrollback[last] ?? "", /line 10001/);
+		assert.match(scrollback[last - 1] ?? "", /line 10000/);
+		assert.match(scrollback[last - 51] ?? "", /updated result/);
+		assert.match(scrollback[last - 50] ?? "", /line 9951/);
+		assert.match(scrollback[last - 72] ?? "", /line 9949/);
+
+		tui.stop();
+	});
+
+	it("tail-reprints far-above-viewport changes without clearing the scrollback", async () => {
+		const terminal = new LoggingVirtualTerminal(80, 30);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const line = (i: number): string => `line ${i} ${"x".repeat(60)}`;
+		component.lines = Array.from({ length: 10000 }, (_, i) => line(i));
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		// A change thousands of rows up is repaired the same way: clear the screen
+		// and reprint everything from the change down. The scrollback above it is
+		// unchanged and must be preserved.
+		component.lines = [...component.lines];
+		component.lines[100] = `updated top ${"y".repeat(60)}`;
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(writes.includes("\x1b[2J\x1b[H"), "screen is cleared for the tail reprint");
+		assert.ok(!writes.includes("\x1b[3J"), "scrollback must not be cleared");
+		assert.ok(writes.includes("updated top"), "the changed row is written");
+		assert.ok(!writes.includes("line 0 "), "rows above the change are not reprinted");
+
+		// The emulator trims old rows out of its scrollback; the final viewport
+		// must show the last rows of the transcript.
+		const viewport = terminal.getViewport();
+		assert.match(viewport[0] ?? "", /line 9970/);
+		assert.match(viewport[29] ?? "", /line 9999/);
+
+		tui.stop();
+	});
+
+	it("tail-repairs a shrink above the viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(80, 30);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const line = (i: number): string => `line ${i} ${"x".repeat(60)}`;
+		component.lines = Array.from({ length: 10000 }, (_, i) => line(i));
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		// A component above the viewport shrinks by several lines and its first
+		// line changes. The tail below must shift up and stay aligned.
+		component.lines = [...component.lines];
+		component.lines.splice(9950, 5, `shrunk ${"z".repeat(60)}`);
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const writes = terminal.getWrites();
+		assert.ok(writes.includes("\x1b[2J\x1b[H"), "screen is cleared for the tail reprint");
+		assert.ok(!writes.includes("\x1b[3J"), "scrollback must not be cleared");
+
+		// 9996 lines remain (five removed, one inserted). The last row is the old
+		// row 9999; the shrunk row sits 45 rows above the bottom.
+		const scrollback = terminal.getScrollBuffer();
+		const last = scrollback.length - 1;
+		assert.match(scrollback[last] ?? "", /line 9999/);
+		assert.match(scrollback[last - 45] ?? "", /shrunk/);
+		assert.match(scrollback[last - 44] ?? "", /line 9955/);
+
+		tui.stop();
+	});
+});


### PR DESCRIPTION
…iewport in long transcripts

Differential rendering could only touch the visible viewport, so any change above it (e.g. a tool result updating above streaming content in 10k+ line transcripts) cleared the screen and scrollback and reprinted every line, visibly flashing each time. Clear only the screen and reprint the tail from the first changed line, keeping the unchanged rows in the scrollback.