### PR TITLE
fix(ai): prevent copilot policy login rate limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -37,6 +37,7 @@
 ### Fixed
 
 - Fixed GitHub Copilot login triggering API rate limits while enabling model policies by limiting concurrent policy updates ([#6187](https://github.com/earendil-works/pi/issues/6187)).
+- Fixed GitHub Copilot login still triggering API rate limits by updating only account models with unconfigured policies and honoring server retry delays ([#7850](https://github.com/earendil-works/pi/issues/7850)).
 - Fixed upstream request buffer limit failures to trigger automatic assistant retries.
 - Fixed OpenAI Responses function and custom tool calls to preserve namespaces during streaming, proxying, and replay ([#7709](https://github.com/earendil-works/pi/issues/7709)).
 - Fixed built-in and custom DeepSeek API models to send output limits through the supported `max_tokens` field.

--- a/packages/ai/src/auth/oauth/github-copilot.ts
+++ b/packages/ai/src/auth/oauth/github-copilot.ts
@@ -407,6 +407,10 @@ async function enableGitHubCopilotModel(
 	return response.ok;
 }
 
+/**
+ * Enable the requested GitHub Copilot models and return the successful IDs.
+ * Policy updates are best effort; exhausted rate limiting stops the batch.
+ */
 async function enableGitHubCopilotModels(
 	token: string,
 	modelIds: readonly string[],

--- a/packages/ai/src/auth/oauth/github-copilot.ts
+++ b/packages/ai/src/auth/oauth/github-copilot.ts
@@ -3,6 +3,7 @@
  */
 
 import { GITHUB_COPILOT_MODELS } from "../../providers/github-copilot.models.ts";
+import { sleep } from "../../utils/sleep.ts";
 import type { OAuthAuth, OAuthCredential, ProviderAuthInteraction } from "../types.ts";
 import { abortableSleep, pollOAuthDeviceCodeFlow } from "./device-code.ts";
 
@@ -16,8 +17,6 @@ const COPILOT_HEADERS = {
 	"Copilot-Integration-Id": "vscode-chat",
 } as const;
 const COPILOT_API_VERSION = "2026-06-01";
-const MAX_RETRY_AFTER_MS = 10_000;
-const DEFAULT_RETRY_AFTER_MS = 1_000;
 
 type DeviceCodeResponse = {
 	device_code: string;
@@ -91,66 +90,108 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 	return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
 
-function parseAvailableCopilotModelIds(raw: unknown, allowPolicyFallback: boolean): string[] {
+function parseGitHubCopilotModelCatalog(raw: unknown, allowPolicyFallback: boolean) {
 	const data = asRecord(raw)?.data;
 	if (!Array.isArray(data)) {
 		throw new Error("Invalid Copilot models response");
 	}
 
-	const pickerIds: string[] = [];
-	const policyEnabledIds: string[] = [];
-	for (const rawItem of data) {
+	const accountModels = data.flatMap((rawItem) => {
 		const item = asRecord(rawItem);
 		const id = item?.id;
-		if (!item || typeof id !== "string") continue;
+		if (!item || typeof id !== "string") return [];
 
 		const capabilities = asRecord(item.capabilities);
 		const supports = asRecord(capabilities?.supports);
-		if (supports?.tool_calls === false) continue;
-		const policy = asRecord(item.policy);
-		if (item.model_picker_enabled === true && policy?.state !== "disabled") pickerIds.push(id);
-		if (policy?.state === "enabled") policyEnabledIds.push(id);
-	}
-	return pickerIds.length > 0 || !allowPolicyFallback ? pickerIds : policyEnabledIds;
+		if (supports?.tool_calls === false) return [];
+
+		return [
+			{
+				id,
+				pickerEnabled: item.model_picker_enabled === true,
+				policyState: asRecord(item.policy)?.state,
+			},
+		];
+	});
+	const pickerModelIds = accountModels
+		.filter((model) => model.pickerEnabled && model.policyState !== "disabled")
+		.map((model) => model.id);
+	const usePolicyFallback = allowPolicyFallback && pickerModelIds.length === 0;
+	const availableModelIds =
+		pickerModelIds.length > 0 || !allowPolicyFallback
+			? pickerModelIds
+			: accountModels.filter((model) => model.policyState === "enabled").map((model) => model.id);
+	const policyModelIds = accountModels
+		.filter(
+			(model) =>
+				model.policyState === "unconfigured" &&
+				Object.hasOwn(GITHUB_COPILOT_MODELS, model.id) &&
+				(model.pickerEnabled || usePolicyFallback),
+		)
+		.map((model) => model.id);
+	return { availableModelIds, policyModelIds };
 }
 
-async function fetchAvailableGitHubCopilotModelIds(
+async function fetchWithRateLimitRetry(
+	url: string,
+	init: RequestInit,
+	signal: AbortSignal,
+	retryPolicy: { maxRetries: number; maxElapsedMs: number },
+): Promise<Response> {
+	const retryBudgetSignal =
+		retryPolicy.maxRetries > 0 && retryPolicy.maxElapsedMs > 0
+			? AbortSignal.timeout(retryPolicy.maxElapsedMs)
+			: undefined;
+	const requestSignal = retryBudgetSignal ? AbortSignal.any([signal, retryBudgetSignal]) : signal;
+	const retryDeadline = retryBudgetSignal ? Date.now() + retryPolicy.maxElapsedMs : undefined;
+	for (let retry = 0; ; retry++) {
+		const response = await fetch(url, {
+			...init,
+			signal: AbortSignal.any([requestSignal, AbortSignal.timeout(5000)]),
+		});
+		if (response.status !== 429 || retry === retryPolicy.maxRetries) return response;
+
+		const retryAfter = response.headers.get("retry-after");
+		let delayMs = 500 * 2 ** retry;
+		if (retryAfter) {
+			const seconds = Number.parseFloat(retryAfter);
+			delayMs = Number.isNaN(seconds) ? Date.parse(retryAfter) - Date.now() : seconds * 1000;
+			if (!Number.isFinite(delayMs)) return response;
+		}
+		delayMs = Math.max(0, delayMs);
+		if (retryDeadline !== undefined && delayMs >= retryDeadline - Date.now()) return response;
+		await response.body?.cancel();
+		await sleep(delayMs, requestSignal);
+	}
+}
+
+async function fetchGitHubCopilotModels(
 	copilotToken: string,
 	enterpriseDomain: string | undefined,
 	signal: AbortSignal,
-): Promise<string[]> {
+	retryPolicy: { maxRetries: number; maxElapsedMs: number },
+) {
 	const baseUrl = getGitHubCopilotBaseUrl(copilotToken, enterpriseDomain);
 	// Some Individual accounts return false for every picker flag despite explicit enabled policies.
 	// Limit the fallback to that endpoint so other account types keep strict picker semantics.
 	const allowPolicyFallback = baseUrl === "https://api.individual.githubcopilot.com";
-	const request = () =>
-		fetch(`${baseUrl}/models`, {
+	const response = await fetchWithRateLimitRetry(
+		`${baseUrl}/models`,
+		{
 			headers: {
 				Accept: "application/json",
 				Authorization: `Bearer ${copilotToken}`,
 				...COPILOT_HEADERS,
 				"X-GitHub-Api-Version": COPILOT_API_VERSION,
 			},
-			signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
-		});
-
-	// The login-time policy updates can drain the Copilot API rate-limit bucket, in which case
-	// this request is rejected with 429. Honor Retry-After and retry once instead of failing.
-	let response = await request();
-	if (response.status === 429) {
-		const retryAfterSeconds = Number(response.headers.get("retry-after"));
-		const waitMs =
-			Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
-				? Math.min(retryAfterSeconds * 1000, MAX_RETRY_AFTER_MS)
-				: DEFAULT_RETRY_AFTER_MS;
-		await abortableSleep(waitMs, signal, "Login cancelled");
-		response = await request();
-	}
+		},
+		signal,
+		retryPolicy,
+	);
 	if (!response.ok) {
-		const text = await response.text();
-		throw new Error(`${response.status} ${response.statusText}: ${text}`);
+		throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`);
 	}
-	return parseAvailableCopilotModelIds(await response.json(), allowPolicyFallback);
+	return parseGitHubCopilotModelCatalog(await response.json(), allowPolicyFallback);
 }
 
 async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
@@ -315,9 +356,13 @@ async function refreshGitHubCopilotToken(
 	signal: AbortSignal,
 ): Promise<OAuthCredential> {
 	const credentials = await refreshGitHubCopilotAccessToken(refreshToken, enterpriseDomain, signal);
+	const { availableModelIds } = await fetchGitHubCopilotModels(credentials.access, enterpriseDomain, signal, {
+		maxRetries: 0,
+		maxElapsedMs: 0,
+	});
 	return {
 		...credentials,
-		availableModelIds: await fetchAvailableGitHubCopilotModelIds(credentials.access, enterpriseDomain, signal),
+		availableModelIds,
 	};
 }
 
@@ -334,38 +379,52 @@ async function enableGitHubCopilotModel(
 	const baseUrl = getGitHubCopilotBaseUrl(token, enterpriseDomain);
 	const url = `${baseUrl}/models/${modelId}/policy`;
 
+	let response: Response;
 	try {
-		const response = await fetch(url, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${token}`,
-				...COPILOT_HEADERS,
-				"openai-intent": "chat-policy",
-				"x-interaction-type": "chat-policy",
+		response = await fetchWithRateLimitRetry(
+			url,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+					...COPILOT_HEADERS,
+					"openai-intent": "chat-policy",
+					"x-interaction-type": "chat-policy",
+				},
+				body: JSON.stringify({ state: "enabled" }),
 			},
-			body: JSON.stringify({ state: "enabled" }),
 			signal,
-		});
-		return response.ok;
+			{ maxRetries: 2, maxElapsedMs: 5000 },
+		);
 	} catch (error) {
 		if (signal.aborted) throw error;
 		return false;
 	}
+	if (response.status === 429) {
+		throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`);
+	}
+	return response.ok;
 }
 
-/**
- * Enable all known GitHub Copilot models that may require policy acceptance.
- * Called after successful login to ensure all models are available.
- */
-async function enableAllGitHubCopilotModels(
+async function enableGitHubCopilotModels(
 	token: string,
+	modelIds: readonly string[],
 	enterpriseDomain: string | undefined,
 	signal: AbortSignal,
-): Promise<void> {
-	for (const model of Object.values(GITHUB_COPILOT_MODELS)) {
-		await enableGitHubCopilotModel(token, model.id, enterpriseDomain, signal);
+): Promise<string[]> {
+	const enabledModelIds: string[] = [];
+	for (const modelId of modelIds) {
+		try {
+			if (await enableGitHubCopilotModel(token, modelId, enterpriseDomain, signal)) {
+				enabledModelIds.push(modelId);
+			}
+		} catch (error) {
+			if (signal.aborted) throw error;
+			break;
+		}
 	}
+	return enabledModelIds;
 }
 
 async function loginGitHubCopilot(interaction: ProviderAuthInteraction): Promise<OAuthCredential> {
@@ -396,15 +455,28 @@ async function loginGitHubCopilot(interaction: ProviderAuthInteraction): Promise
 		enterpriseDomain ?? undefined,
 		interaction.signal,
 	);
-	interaction.notify({ type: "progress", message: "Enabling models..." });
-	await enableAllGitHubCopilotModels(credentials.access, enterpriseDomain ?? undefined, interaction.signal);
-	return {
-		...credentials,
-		availableModelIds: await fetchAvailableGitHubCopilotModelIds(
+	const models = await fetchGitHubCopilotModels(
+		credentials.access,
+		enterpriseDomain ?? undefined,
+		interaction.signal,
+		{
+			maxRetries: 2,
+			maxElapsedMs: 5000,
+		},
+	);
+	let enabledModelIds: string[] = [];
+	if (models.policyModelIds.length > 0) {
+		interaction.notify({ type: "progress", message: "Enabling models..." });
+		enabledModelIds = await enableGitHubCopilotModels(
 			credentials.access,
+			models.policyModelIds,
 			enterpriseDomain ?? undefined,
 			interaction.signal,
-		),
+		);
+	}
+	return {
+		...credentials,
+		availableModelIds: [...new Set([...models.availableModelIds, ...enabledModelIds])],
 	};
 }
 

--- a/packages/ai/src/auth/oauth/github-copilot.ts
+++ b/packages/ai/src/auth/oauth/github-copilot.ts
@@ -5,7 +5,7 @@
 import { GITHUB_COPILOT_MODELS } from "../../providers/github-copilot.models.ts";
 import { sleep } from "../../utils/sleep.ts";
 import type { OAuthAuth, OAuthCredential, ProviderAuthInteraction } from "../types.ts";
-import { abortableSleep, pollOAuthDeviceCodeFlow } from "./device-code.ts";
+import { pollOAuthDeviceCodeFlow } from "./device-code.ts";
 
 const decode = (s: string) => atob(s);
 const CLIENT_ID = decode("SXYxLmI1MDdhMDhjODdlY2ZlOTg=");

--- a/packages/ai/src/auth/oauth/kimi-coding.ts
+++ b/packages/ai/src/auth/oauth/kimi-coding.ts
@@ -7,6 +7,7 @@
  */
 
 import { getProviderEnvValue } from "../../utils/provider-env.ts";
+import { sleep } from "../../utils/sleep.ts";
 import type { OAuthAuth, OAuthCredential, ProviderAuthInteraction } from "../types.ts";
 import { pollOAuthDeviceCodeFlow } from "./device-code.ts";
 
@@ -203,21 +204,6 @@ async function pollForToken(
 				message: `Kimi Code device token request failed (status ${response.status})${typeof error === "string" ? `: ${error}${description}` : ""}`,
 			};
 		},
-	});
-}
-
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
-	return new Promise((resolve, reject) => {
-		signal.throwIfAborted();
-		const onAbort = () => {
-			clearTimeout(timeout);
-			reject(signal.reason);
-		};
-		const timeout = setTimeout(() => {
-			signal.removeEventListener("abort", onAbort);
-			resolve();
-		}, ms);
-		signal.addEventListener("abort", onAbort, { once: true });
 	});
 }
 

--- a/packages/ai/src/utils/sleep.ts
+++ b/packages/ai/src/utils/sleep.ts
@@ -1,0 +1,14 @@
+export function sleep(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		signal.throwIfAborted();
+		const onAbort = () => {
+			clearTimeout(timeout);
+			reject(signal.reason);
+		};
+		const timeout = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+}

--- a/packages/ai/test/github-copilot-oauth.test.ts
+++ b/packages/ai/test/github-copilot-oauth.test.ts
@@ -6,11 +6,15 @@ import { githubCopilotProvider } from "../src/providers/github-copilot.ts";
 
 const neverAbortedSignal = new AbortController().signal;
 
-function jsonResponse(body: unknown, status: number = 200): Response {
+const testCopilotAccessToken = "tid=test;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;";
+const testCopilotModelsUrl = "https://api.individual.githubcopilot.com/models";
+
+function jsonResponse(body: unknown, status: number = 200, headers?: Record<string, string>): Response {
 	return new Response(JSON.stringify(body), {
 		status,
 		headers: {
 			"Content-Type": "application/json",
+			...headers,
 		},
 	});
 }
@@ -26,6 +30,37 @@ function getUrl(input: unknown): string {
 		return input.url;
 	}
 	throw new Error(`Unsupported fetch input: ${String(input)}`);
+}
+
+function stubGitHubCopilotLoginFetch(options: {
+	models: () => Response;
+	policy?: (modelId: string) => Response;
+}): void {
+	const fetchMock = vi.fn(async (input: string | URL | Request): Promise<Response> => {
+		const url = getUrl(input);
+		if (url.endsWith("/login/device/code")) {
+			return jsonResponse({
+				device_code: "device-code",
+				user_code: "ABCD-EFGH",
+				verification_uri: "https://github.com/login/device",
+				interval: 1,
+				expires_in: 900,
+			});
+		}
+		if (url.endsWith("/login/oauth/access_token")) {
+			return jsonResponse({ access_token: "ghu_refresh_token" });
+		}
+		if (url.includes("/copilot_internal/v2/token")) {
+			return jsonResponse({ token: testCopilotAccessToken, expires_at: 9999999999 });
+		}
+		if (url === testCopilotModelsUrl) return options.models();
+		if (url.startsWith(`${testCopilotModelsUrl}/`) && url.endsWith("/policy")) {
+			if (!options.policy) throw new Error(`Unexpected policy request: ${url}`);
+			return options.policy(url.slice(`${testCopilotModelsUrl}/`.length, -"/policy".length));
+		}
+		throw new Error(`Unexpected fetch URL: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
 }
 
 function loginGitHubCopilotForTest(options: {
@@ -180,6 +215,37 @@ describe("GitHub Copilot OAuth device flow", () => {
 		expect(credentials.availableModelIds).toEqual([]);
 	});
 
+	it("does not retry model catalog throttling during credential refresh", async () => {
+		let catalogRequestCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: unknown): Promise<Response> => {
+				const url = getUrl(input);
+				if (url.includes("/copilot_internal/v2/token")) {
+					return jsonResponse({ token: testCopilotAccessToken, expires_at: 9999999999 });
+				}
+				if (url === testCopilotModelsUrl) {
+					catalogRequestCount += 1;
+					return jsonResponse({ error: "too many requests" }, 429, { "Retry-After": "0" });
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			}),
+		);
+
+		await expect(
+			githubCopilotOAuth.refresh(
+				{
+					type: "oauth",
+					access: "old-access-token",
+					refresh: "ghu_refresh_token",
+					expires: 0,
+				},
+				neverAbortedSignal,
+			),
+		).rejects.toThrow("429");
+		expect(catalogRequestCount).toBe(1);
+	});
+
 	it("reports device-code details through onDeviceCode", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-03-09T00:00:00Z"));
@@ -239,125 +305,150 @@ describe("GitHub Copilot OAuth device flow", () => {
 		await loginPromise;
 	});
 
-	it("enables model policies sequentially during login", async () => {
+	it("updates only known, tool-capable, unconfigured account model policies", async () => {
 		vi.useFakeTimers();
 
-		let activePolicyRequests = 0;
-		let maxActivePolicyRequests = 0;
-		let policyRequestCount = 0;
-		const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
-			const url = getUrl(input);
-
-			if (url.endsWith("/login/device/code")) {
+		let catalogRequestCount = 0;
+		const policyModelIds: string[] = [];
+		stubGitHubCopilotLoginFetch({
+			models: () => {
+				catalogRequestCount += 1;
 				return jsonResponse({
-					device_code: "device-code",
-					user_code: "ABCD-EFGH",
-					verification_uri: "https://github.com/login/device",
-					interval: 1,
-					expires_in: 900,
+					data: [
+						{
+							id: "gpt-4.1",
+							model_picker_enabled: true,
+							policy: { state: "enabled" },
+							capabilities: { supports: { tool_calls: true } },
+						},
+						{
+							id: "claude-sonnet-4.5",
+							model_picker_enabled: true,
+							policy: { state: "unconfigured" },
+							capabilities: { supports: { tool_calls: true } },
+						},
+						{
+							id: "remote-only-model",
+							model_picker_enabled: true,
+							policy: { state: "unconfigured" },
+							capabilities: { supports: { tool_calls: true } },
+						},
+						{
+							id: "gpt-5.4",
+							model_picker_enabled: true,
+							policy: { state: "unconfigured" },
+							capabilities: { supports: { tool_calls: false } },
+						},
+					],
 				});
-			}
-
-			if (url.endsWith("/login/oauth/access_token")) {
-				return jsonResponse({ access_token: "ghu_refresh_token" });
-			}
-
-			if (url.includes("/copilot_internal/v2/token")) {
-				return jsonResponse({
-					token: "tid=test;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;",
-					expires_at: 9999999999,
-				});
-			}
-
-			if (url.endsWith("/models")) {
-				return jsonResponse({ data: [] });
-			}
-
-			if (url.includes("/models/") && url.endsWith("/policy")) {
-				policyRequestCount += 1;
-				activePolicyRequests += 1;
-				maxActivePolicyRequests = Math.max(maxActivePolicyRequests, activePolicyRequests);
-				await new Promise<void>((resolve) => setTimeout(resolve, 10));
-				activePolicyRequests -= 1;
+			},
+			policy: (modelId) => {
+				policyModelIds.push(modelId);
 				return new Response("", { status: 200 });
-			}
-
-			throw new Error(`Unexpected fetch URL: ${url}`);
+			},
 		});
-
-		vi.stubGlobal("fetch", fetchMock);
 
 		const loginPromise = loginGitHubCopilotForTest({
 			onDeviceCode: () => {},
 			onPrompt: async () => "",
 		});
-
-		await vi.advanceTimersByTimeAsync(0);
-		await vi.advanceTimersByTimeAsync(1000);
 		await vi.advanceTimersByTimeAsync(1000);
 		await loginPromise;
 
-		expect(policyRequestCount).toBeGreaterThan(1);
-		expect(maxActivePolicyRequests).toBe(1);
+		expect(catalogRequestCount).toBe(1);
+		expect(policyModelIds).toEqual(["claude-sonnet-4.5"]);
 	});
 
-	it("retries GET /models once after a 429, honoring Retry-After", async () => {
+	it("retries a throttled policy update after Retry-After", async () => {
 		vi.useFakeTimers();
 
-		let modelsRequestCount = 0;
-		const fetchMock = vi.fn(async (input: unknown): Promise<Response> => {
-			const url = getUrl(input);
-
-			if (url.endsWith("/login/device/code")) {
-				return jsonResponse({
-					device_code: "device-code",
-					user_code: "ABCD-EFGH",
-					verification_uri: "https://github.com/login/device",
-					interval: 1,
-					expires_in: 900,
-				});
-			}
-
-			if (url.endsWith("/login/oauth/access_token")) {
-				return jsonResponse({ access_token: "ghu_refresh_token" });
-			}
-
-			if (url.includes("/copilot_internal/v2/token")) {
-				return jsonResponse({
-					token: "tid=test;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;",
-					expires_at: 9999999999,
-				});
-			}
-
-			if (url.endsWith("/models")) {
-				modelsRequestCount += 1;
-				if (modelsRequestCount === 1) {
-					return new Response("too many requests", { status: 429, headers: { "retry-after": "1" } });
-				}
-				return jsonResponse({ data: [{ id: "gpt-5.4", model_picker_enabled: true }] });
-			}
-
-			if (url.includes("/models/") && url.endsWith("/policy")) {
-				return new Response("", { status: 200 });
-			}
-
-			throw new Error(`Unexpected fetch URL: ${url}`);
+		let policyRequestCount = 0;
+		stubGitHubCopilotLoginFetch({
+			models: () =>
+				jsonResponse({
+					data: [{ id: "claude-sonnet-4.5", model_picker_enabled: true, policy: { state: "unconfigured" } }],
+				}),
+			policy: () => {
+				policyRequestCount += 1;
+				return policyRequestCount === 1
+					? jsonResponse({ error: "too many requests" }, 429, { "Retry-After": "1" })
+					: new Response("", { status: 200 });
+			},
 		});
-
-		vi.stubGlobal("fetch", fetchMock);
 
 		const loginPromise = loginGitHubCopilotForTest({
 			onDeviceCode: () => {},
 			onPrompt: async () => "",
 		});
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(policyRequestCount).toBe(1);
+		await vi.advanceTimersByTimeAsync(999);
+		expect(policyRequestCount).toBe(1);
+		await vi.advanceTimersByTimeAsync(1);
+		await loginPromise;
 
-		await vi.advanceTimersByTimeAsync(0);
-		await vi.advanceTimersByTimeAsync(1000); // device poll
-		await vi.advanceTimersByTimeAsync(1000); // Retry-After wait
-		const credentials = await loginPromise;
+		expect(policyRequestCount).toBe(2);
+	});
 
-		expect(modelsRequestCount).toBe(2);
-		expect(credentials.availableModelIds).toEqual(["gpt-5.4"]);
+	it("continues policy updates after a transport failure", async () => {
+		vi.useFakeTimers();
+
+		const modelIds = ["gpt-4.1", "claude-sonnet-4.5"];
+		const policyModelIds: string[] = [];
+		stubGitHubCopilotLoginFetch({
+			models: () =>
+				jsonResponse({
+					data: modelIds.map((id) => ({ id, model_picker_enabled: true, policy: { state: "unconfigured" } })),
+				}),
+			policy: (modelId) => {
+				policyModelIds.push(modelId);
+				if (policyModelIds.length === 1) throw new Error("fetch failed");
+				return new Response("", { status: 200 });
+			},
+		});
+
+		const loginPromise = loginGitHubCopilotForTest({
+			onDeviceCode: () => {},
+			onPrompt: async () => "",
+		});
+		await vi.advanceTimersByTimeAsync(1000);
+		await loginPromise;
+
+		expect(policyModelIds).toEqual(modelIds);
+	});
+
+	it("stops policy updates and persists authentication when the retry delay exceeds the login budget", async () => {
+		vi.useFakeTimers();
+
+		const policyModelIds: string[] = [];
+		stubGitHubCopilotLoginFetch({
+			models: () =>
+				jsonResponse({
+					data: [
+						{ id: "gpt-4.1", model_picker_enabled: true, policy: { state: "unconfigured" } },
+						{ id: "claude-sonnet-4.5", model_picker_enabled: true, policy: { state: "unconfigured" } },
+					],
+				}),
+			policy: (modelId) => {
+				policyModelIds.push(modelId);
+				return jsonResponse({ error: "too many requests" }, 429, { "Retry-After": "5" });
+			},
+		});
+
+		const store = new InMemoryCredentialStore();
+		const models = createModels({ credentials: store });
+		models.setProvider(githubCopilotProvider());
+		const loginPromise = models.login("github-copilot", "oauth", {
+			signal: neverAbortedSignal,
+			prompt: async () => "",
+			notify: () => {},
+		});
+
+		await vi.advanceTimersByTimeAsync(1000);
+		const credential = await loginPromise;
+		expect(credential).toMatchObject({ type: "oauth", access: testCopilotAccessToken });
+		expect(policyModelIds).toEqual(["gpt-4.1"]);
+		expect(await store.read("github-copilot")).toEqual(credential);
 	});
 
 	it("rejects a non-http(s) verification_uri before it reaches onDeviceCode", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -50,7 +50,6 @@
 - Fixed managed-tool downloads delaying TUI startup and hiding diagnostics in fullscreen mode by mounting the TUI first and showing download progress and warnings inside it.
 - Fixed opening a model selector immediately after startup cancelling and restarting the in-progress model catalog refresh.
 - Fixed inherited GitHub Copilot login triggering API rate limits while enabling model policies by limiting concurrent policy updates ([#6187](https://github.com/earendil-works/pi/issues/6187)).
-- Fixed inherited GitHub Copilot login still triggering API rate limits by updating only account models with unconfigured policies and honoring server retry delays ([#7850](https://github.com/earendil-works/pi/issues/7850)).
 - Fixed fullscreen transcript search snapping back to the current match during manual scrolling and fragmented mouse input leaking into the search query.
 - Fixed inherited required LaTeX arguments starting on a new line being parsed as empty ([#7760](https://github.com/earendil-works/pi/issues/7760)).
 - Updated the transitive `nanoid` development dependency to address a denial-of-service vulnerability.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Fixed managed-tool downloads delaying TUI startup and hiding diagnostics in fullscreen mode by mounting the TUI first and showing download progress and warnings inside it.
 - Fixed opening a model selector immediately after startup cancelling and restarting the in-progress model catalog refresh.
 - Fixed inherited GitHub Copilot login triggering API rate limits while enabling model policies by limiting concurrent policy updates ([#6187](https://github.com/earendil-works/pi/issues/6187)).
+- Fixed inherited GitHub Copilot login still triggering API rate limits by updating only account models with unconfigured policies and honoring server retry delays ([#7850](https://github.com/earendil-works/pi/issues/7850)).
 - Fixed fullscreen transcript search snapping back to the current match during manual scrolling and fragmented mouse input leaking into the search query.
 - Fixed inherited required LaTeX arguments starting on a new line being parsed as empty ([#7760](https://github.com/earendil-works/pi/issues/7760)).
 - Updated the transitive `nanoid` development dependency to address a denial-of-service vulnerability.


### PR DESCRIPTION
**Description**

- fixes #7850
- fetch the account model catalog before policy updates
- update only known, tool-capable, **unconfigured** models
- retry throttled login requests within a bounded delay
  - refresh behavior is preserved as non-retry
- extract `sleep` into a util 