### PR TITLE
Establish PiQuest foundation and update documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,101 @@
 # Development Rules
 
+## Project Identity
+
+PiQuest is a game-development-focused derivative of Pi, built on the Pi monorepo (currently plain upstream Pi, version 0.84.2). The goal is not to rewrite Pi or build a generic agent framework from scratch: preserve as much of upstream Pi as practical and add a game-development product layer on top.
+
+- Long-term CLI identity is `piquest`, not `pi`. Do not perform a repository-wide Pi to PiQuest string replacement.
+- Do not rename packages, binaries, config directories, or namespaces yet.
+- Keep upstream mergeability a first-class concern. This repository should remain capable of absorbing upstream Pi changes.
+
+## Architecture Boundaries
+
+Three tiers, in decreasing order of mergeability with upstream.
+
+### Upstream-owned packages
+
+Keep these as close to upstream Pi as reasonably possible:
+
+- `packages/agent`, `packages/ai`, `packages/tui`, `packages/client`, `packages/protocol`, `packages/server`, `packages/session-backends`, `packages/telemetry`, `packages/evals`
+
+Do not introduce game-specific concepts into these packages unless there is a demonstrated architectural need.
+
+### `packages/coding-agent`
+
+This is the primary Pi integration surface. Prefer its public SDK, session APIs, extension APIs, tool factories, and presentation infrastructure:
+
+- Programmatic SDK: `createAgentSession`, `createAgentSessionRuntime`, `createCodingTools` and per-tool factories in `src/core/sdk.ts`.
+- Extension API (`src/core/extensions/types.ts`): register tools, commands, shortcuts, CLI flags, providers, message/entry renderers, markdown transformers. UI hooks include `setHeader`, `setFooter`, `setWidget`, `setStatus`, `setTheme`, `setTitle`, custom editors/overlays.
+- Identity: `package.json` `piConfig` (name, configDir) already drives `APP_NAME`, `APP_TITLE`, `CONFIG_DIR_NAME`, env-var prefixes, and the terminal title (`src/config.ts`). A rebranded package automatically skips upstream-specific first-time-setup branding (`src/cli/startup-ui.ts`).
+- Shipping resources: `package.json` `pi` manifest field lists extensions/skills/prompts/themes (`src/core/pi-manifest.ts`).
+- Extensions load from `.pi/extensions/` (project), `~/.pi/agent/` (global), and packages; extension modules resolve bundled packages (`typebox`, `@earendil-works/pi-*`, `@earendil-works/pi-coding-agent`) via the loader's virtual modules.
+
+Avoid scattering PiQuest conditionals throughout `packages/coding-agent`. Bad direction:
+
+```
+if (isPiQuest) ...
+if (gameMode) ...
+if (engine === "godot") ...
+```
+
+through many unrelated Pi files. Prefer explicit extension points and dependency injection.
+
+### PiQuest-owned code
+
+PiQuest-specific functionality lives in a future `packages/piquest/` package. This should eventually own: the `piquest` CLI entry point, PiQuest branding and presentation, game-development system behavior, project/game context, engine detection, engine adapters, game-specific tools, and run/playtest/verification workflows.
+
+- Keep it one coherent package. Split into multiple packages only when real architectural pressure appears.
+- Do not fork generic TUI primitives for PiQuest branding; compose above `@earendil-works/pi-tui`.
+- Do not duplicate the entire Pi interactive UI; make presentation configurable and supply a PiQuest presentation layer.
+
+## Upstream Policy
+
+"Do not modify Pi core merely because a feature is game-development-related. First prove that the feature cannot cleanly live in PiQuest-owned code."
+
+- Minimize edits to upstream-owned files.
+- Keep PiQuest-specific code isolated.
+- Avoid large cosmetic rewrites of inherited Pi code.
+- Avoid unrelated formatting churn.
+- Separate upstream/core refactors from PiQuest feature work when practical.
+- Prefer small, reviewable integration patches.
+- Preserve existing Pi behavior unless a PiQuest requirement explicitly changes it.
+- Check whether an existing Pi extension point already solves a problem before modifying core code.
+- Small upstream-friendly refactors are acceptable when necessary to expose clean extension points (for example, making branding/presentation configurable). Keep such extension points generic enough that they could plausibly be useful outside PiQuest, and document important deviations from upstream.
+
+## Engine Policy
+
+- Do not tightly couple PiQuest core to one engine.
+- Engine-specific functionality lives behind explicit engine adapter boundaries.
+- Prove the architecture with one engine before expanding. Unity is the first target. Do not add speculative multi-engine support.
+- Do not select or implement an engine without a demonstrated need.
+
+## Development Discipline
+
+- Inspect before editing. Read files in full before wide-ranging changes.
+- Follow existing repository conventions. Keep changes scoped to the current task.
+- Do not redesign unrelated Pi systems.
+- Do not create abstractions before they have a real caller.
+- Avoid speculative multi-agent orchestration.
+- Prefer tests for architectural boundaries and behavior.
+- If a new `packages/piquest` package is created, it must satisfy the same root checks as every other package (see Commands) and be added to the root `package.json` workspaces and `tsconfig.json` `paths`.
+
 ## Conversational Style
 
-- Keep answers short and concise
-- No emojis in commits, issues, PR comments, or code
-- No fluff or cheerful filler text (e.g., "Thanks @user" not "Thanks so much @user!")
-- Technical prose only, be direct
+- Keep answers short and concise.
+- No emojis in commits, issues, PR comments, or code.
+- No fluff or cheerful filler text.
+- Technical prose only, be direct.
 - Use concise, clear, simple language. Define unavoidable jargon before using it.
 - Explain non-trivial designs and problems as: problem, concrete example or short trace, then solution. State why the solution is necessary and distinguish it from optional complexity.
-- Prefer concrete behavior and small illustrations over abstract summaries, dense terminology, or unexplained lists of changes.
 - When the user asks a question, answer it first before making edits or running implementation commands.
 - When responding to user feedback or an analysis, explicitly say whether you agree or disagree before saying what you changed.
 
 ## Code Quality
 
-- Read files in full before wide-ranging changes, before editing files you have not fully inspected, and when asked to investigate or audit. Do not rely on search snippets for broad changes.
 - No `any` unless absolutely necessary.
 - Inline single-line helpers that have only one call site.
 - Check node_modules for external API types; don't guess.
-- **No inline imports** (`await import()`, `import("pkg").Type`, dynamic type imports). Top-level imports only.
+- No inline imports (`await import()`, `import("pkg").Type`, dynamic type imports). Top-level imports only.
 - Never remove or downgrade code to fix type errors from outdated deps; upgrade the dep instead.
 - Use only erasable TypeScript syntax (Node strip-only mode) in code checked by the root config (`packages/*/src`, `packages/*/test`, `packages/coding-agent/examples`): no parameter properties, `enum`, `namespace`/`module`, `import =`, `export =`, or other constructs needing JS emit. Use explicit fields with constructor assignments.
 - Always ask before removing functionality or code that appears intentional.
@@ -28,7 +105,7 @@
 
 ## Commands
 
-- After code changes (not docs): `npm run check` (full output, no tail). Fix all errors, warnings, and infos before committing. Does not run tests.
+- After code changes (not docs): `npm run check` (full output, no tail). Fix all errors, warnings, and infos before committing. Runs biome (with `--write`), pinned-dep/import/shrinkwrap/install-lock checks, `tsgo --noEmit`, and a browser smoke test. Does not run tests.
 - Never run `npm run build` or `npm test` unless requested by the user.
 - Never run the full vitest suite directly: it includes e2e tests that activate when endpoint/auth env vars are present. For all non-e2e tests, run `./test.sh` from the repo root. Otherwise run specific tests from the package root:
   - Vitest: `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/specific.test.ts`
@@ -58,7 +135,7 @@ Committing:
 - Stage explicit paths (`git add <path1> <path2>`); never `git add -A` / `git add .`.
 - Before committing, run `git status` and verify you are only staging your files.
 - `packages/ai/src/models.generated.ts` may always be included alongside your files.
-- Message format: `{feat,fix,docs}[(ai,tui,agent,coding-agent)]: <commit message> (optionally multiple lines)`. Message is informative and concise.
+- Message format: `{feat,fix,docs}[(ai,tui,agent,coding-agent,piquest)]: <commit message> (optionally multiple lines)`. Message is informative and concise.
 
 Never run (destroys other agents' work or bypasses checks):
 
@@ -70,31 +147,7 @@ If rebase conflicts occur:
 - If a conflict is in a file you did not modify, abort and ask the user.
 - Never force push.
 
-## Issues and PRs
-
-See `CONTRIBUTING.md` for the contributor gate (auto-close workflows, `lgtm`/`lgtmi`, quality bar).
-
-When reviewing PRs:
-
-- Do not run `gh pr checkout`, `git switch`, or otherwise move the worktree to the PR branch unless the user explicitly asks.
-- Use `gh pr view`, `gh pr diff`, `gh api`, and local `git show`/`git diff` against fetched refs to inspect PR metadata, commits, and patches without changing branches.
-- If you need PR file contents, fetch/read them into temporary files or use `git show <ref>:<path>` without switching branches.
-
-When creating issues:
-
-- Add `pkg:*` labels for affected packages (`pkg:agent`, `pkg:ai`, `pkg:coding-agent`, `pkg:tui`); use all that apply.
-
-When posting issue/PR comments:
-
-- Write the comment to a temp file and post with `gh issue/pr comment --body-file` (never multi-line markdown via `--body`).
-- Keep comments concise, technical, in the user's tone.
-- End every AI-posted comment with the AI-generated disclaimer line specified by the originating prompt (e.g. `This comment is AI-generated by `/wr``).
-
-When closing issues via commit:
-
-- Include `fixes #<number>` or `closes #<number>` in the message so merging auto-closes the issue. For multiple issues, repeat the keyword per issue (`closes #1, closes #2`); a shared keyword (`closes #1, #2`) only closes the first.
-
-## Testing pi Interactive Mode with tmux
+## Testing Interactive Mode with tmux
 
 Run the TUI in a controlled terminal (from the repo root):
 
@@ -117,52 +170,16 @@ Rules:
 
 - All new entries go under `## [Unreleased]`. Read the full section first and append to existing subsections; never duplicate them.
 - Released version sections (e.g. `## [0.12.2]`) are immutable; never modify them.
-- Do not create changelog entries when working on a branch other than `main` or pull request
-
-Attribution:
-
-- Internal (from issues): `Fixed foo bar ([#123](https://github.com/earendil-works/pi-mono/issues/123))`
-- External contributions: `Added feature X ([#456](https://github.com/earendil-works/pi-mono/pull/456) by [@username](https://github.com/username))`
+- Do not create changelog entries when working on a branch other than `main`.
 
 ## Releasing
 
-**Lockstep versioning**: all packages share one version; every release updates all together. `patch` = fixes + additions, `minor` = breaking changes. No major releases.
+**Lockstep versioning**: all packages share one version; every release updates all together. `patch` = fixes + additions, `minor` = breaking changes.
 
-1. **Update CHANGELOGs**: ask the user whether they ran the `/cl` prompt on the latest commit on `main`. If not, they must run `/cl` first to audit and update each package's `[Unreleased]` section before releasing.
+The upstream release flow (`scripts/release.mjs`, local smoke via `npm run release:local`, CI publish/announcement in `.github/workflows/build-binaries.yml`) is inherited from upstream Pi and assumes upstream infrastructure. Before publishing this fork:
 
-2. **Local smoke test**: build an unpublished release and smoke test from outside the repo (so it can't resolve workspace files):
-   ```bash
-   npm run release:local -- --out /tmp/pi-local-release --force
-   cd /tmp
-
-   # Node package install smoke tests
-   /tmp/pi-local-release/node/pi --help
-   /tmp/pi-local-release/node/pi --version
-   /tmp/pi-local-release/node/pi --list-models
-   /tmp/pi-local-release/node/pi -p "Say exactly: ok"
-   /tmp/pi-local-release/node/pi
-
-   # Bun binary smoke tests
-   /tmp/pi-local-release/bun/pi --help
-   /tmp/pi-local-release/bun/pi --version
-   /tmp/pi-local-release/bun/pi --list-models
-   /tmp/pi-local-release/bun/pi -p "Say exactly: ok"
-   /tmp/pi-local-release/bun/pi
-   ```
-   Verify both Node and Bun startup, model/account listing, interactive startup, and at least one real prompt with the intended default provider. The bare commands `/tmp/pi-local-release/node/pi` and `/tmp/pi-local-release/bun/pi` start interactive mode; run each in tmux, submit a prompt, and wait for the model reply before considering the interactive smoke test passed. Failures are release blockers unless the user explicitly accepts the risk.
-
-3. **Run the release script**:
-   ```bash
-   PI_ALLOW_LOCKFILE_CHANGE=1 npm_config_min_release_age=0 npm run release:patch    # fixes + additions
-   PI_ALLOW_LOCKFILE_CHANGE=1 npm_config_min_release_age=0 npm run release:minor    # breaking changes
-   ```
-   Use `npm_config_min_release_age=0` only for the release command. The repo's normal npm age gate can otherwise block the release lockfile refresh when the current workspace package version was published recently. Review any lockfile or shrinkwrap diffs the release creates before push.
-
-   The release script bumps all package versions, updates changelogs, regenerates release artifacts, runs `npm run check`, commits `Release vX.Y.Z`, tags `vX.Y.Z`, adds fresh `## [Unreleased]` changelog sections, commits `Add [Unreleased] section for next cycle`, then pushes `main` and the tag. Do not rerun the release script after a tag was pushed.
-
-4. **CI verifies and announces the npm release**: pushing the `vX.Y.Z` tag triggers `.github/workflows/build-binaries.yml`. The `publish-npm` job uses npm trusted publishing through GitHub Actions OIDC with environment `npm-publish`; no local `npm publish`, `npm whoami`, OTP, or WebAuthn flow is required. After publishing, `announce-pi-dev-release` verifies every public workspace package resolves at the exact release version and that its npm tarball is available, then writes the verified release marker to R2. `pi.dev/api/latest-version` reads that marker; it must never announce a release from npm before this job succeeds.
-
-5. **If CI publish or announcement fails**: inspect the failed job. The publish helper is idempotent and skips package versions already present on npm; the announcement job rechecks availability before updating the R2 marker. Rerun the failed job or workflow after fixing CI or transient npm issues. Do not rerun `npm run release:patch` or `npm run release:minor` for the same version.
+- Revalidate the release scripts, npm package scope, OIDC publish environment, and announcement flow for PiQuest's own publishing targets.
+- Do not assume `pi.dev`, R2 markers, or upstream npm accounts apply to PiQuest.
 
 ## User Override
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,34 @@
+# PiQuest
+
+PiQuest는 Pi(`pi-mono` 모노레포)를 기반으로 하는 게임 개발 전용 코딩 에이전트입니다. Pi를 다시 작성하거나 범용 에이전트 프레임워크를 처음부터 만드는 것이 목표가 아닙니다. 업스트림 Pi의 에이전트, 모델/프로바이더, 세션, 도구, TUI 인프라를 최대한 보존하면서 그 위에 게임 개발 특화 동작을 얹는 것이 목표입니다.
+
+현재 저장소는 업스트림 Pi(v0.84.2)를 그대로 추적합니다. 업스트림과의 병합성을 최우선으로 유지하며, PiQuest 전용 코드는 PiQuest 소유 패키지에 격리합니다.
+
+## 상태
+
+기반 구축 단계입니다. 저장소는 순수 업스트림 Pi 클론이며 `AGENTS.md`에 PiQuest 개발 규칙이 정리되어 있습니다. 게임 개발 기능은 아직 구현되지 않았습니다.
+
+## 아키텍처
+
+업스트림과의 병합성 수준에 따라 세 계층으로 나뉩니다.
+
+- **업스트림 소유 패키지**(`packages/agent`, `packages/ai`, `packages/tui`, `packages/client`, `packages/protocol`, `packages/server`, `packages/session-backends`, `packages/telemetry`, `packages/evals`): 가능한 한 업스트림과 동일하게 유지합니다.
+- **`packages/coding-agent`**: 주요 Pi 통합 지점입니다. 프로그래매틱 SDK, 세션 API, 확장 API, 도구 팩토리, 프레젠테이션 훅을 제공합니다.
+- **PiQuest 소유 코드**: `packages/piquest/`에 위치합니다. `piquest` CLI 진입점, 브랜딩/프레젠테이션, 프로젝트/게임 컨텍스트, 엔진 감지 및 어댑터, 게임 전용 도구, 실행/플레이테스트/검증 워크플로우를 담당합니다.
+
+엔진 특화 기능은 명시적인 엔진 어댑터 경계 뒤에 구현됩니다. 첫 번째 엔진 타겟은 Unity이며, 섣부른 다중 엔진 지원은 하지 않습니다.
+
+## 개발
+
+```bash
+npm install --ignore-scripts  # 라이프사이클 스크립트 없이 의존성 설치
+npm run check         # 린트, 포맷, 타입체크, 의존성 검사
+./test.sh             # API 키 없이 테스트 실행
+./pi-test.sh          # 소스에서 에이전트 실행
+```
+
+자세한 개발 규칙(아키텍처 경계, 업스트림 정책, 커맨드, 테스트)은 `AGENTS.md`를 참고하세요.
+
+## 라이선스
+
+MIT. PiQuest는 MIT 라이선스의 [Pi](https://github.com/earendil-works/pi)에서 파생되었습니다.

--- a/README.md
+++ b/README.md
@@ -1,114 +1,34 @@
-<p align="center">
-  <a href="https://pi.dev">
-    <img alt="pi logo" src="https://pi.dev/logo-auto.svg" width="128">
-  </a>
-</p>
-<p align="center">
-  <a href="https://discord.com/invite/3cU7Bz4UPx"><img alt="Discord" src="https://img.shields.io/badge/discord-community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
-  <a href="https://www.npmjs.com/package/@earendil-works/pi-coding-agent"><img alt="npm" src="https://img.shields.io/npm/v/@earendil-works/pi-coding-agent?style=flat-square" /></a>
-</p>
+# PiQuest
 
-> New issues and PRs from new contributors are auto-closed by default. Maintainers review auto-closed issues daily. See [CONTRIBUTING.md](CONTRIBUTING.md).
+PiQuest is a game-development-focused coding agent built on Pi (the `pi-mono` monorepo). It does not rewrite Pi or build a generic agent framework from scratch: it preserves upstream Pi's agent, model/provider, session, tool, and TUI infrastructure and layers game-development behavior on top.
 
-# Pi Agent Harness
+The repository currently tracks upstream Pi (v0.84.2). Upstream mergeability is a first-class concern; PiQuest-specific code is isolated in PiQuest-owned packages.
 
-This is the home of the Pi agent harness project including our self extensible coding agent.
+## Status
 
-* **[@earendil-works/pi-coding-agent](packages/coding-agent)**: Interactive coding agent CLI
-* **[@earendil-works/pi-agent-core](packages/agent)**: Agent runtime with tool calling and state management
-* **[@earendil-works/pi-ai](packages/ai)**: Unified multi-provider LLM API (OpenAI, Anthropic, Google, …)
+Foundation stage. The repo is a plain upstream Pi clone with the PiQuest development rules established in `AGENTS.md`. Game-development features are not implemented yet.
 
-To learn more about Pi:
+## Architecture
 
-* [Visit pi.dev](https://pi.dev), the project website with demos
-* [Read the documentation](https://pi.dev/docs/latest), but you can also ask the agent to explain itself
+Three tiers, in decreasing order of mergeability with upstream:
 
-## All Packages
+- **Upstream-owned packages** (`packages/agent`, `packages/ai`, `packages/tui`, `packages/client`, `packages/protocol`, `packages/server`, `packages/session-backends`, `packages/telemetry`, `packages/evals`) stay as close to upstream as possible.
+- **`packages/coding-agent`** is the primary Pi integration surface: programmatic SDK, session APIs, extension APIs, tool factories, and presentation hooks.
+- **PiQuest-owned code** will live in `packages/piquest/`: the `piquest` CLI entry point, branding and presentation, project/game context, engine detection and adapters, game-specific tools, and run/playtest/verification workflows.
 
-| Package | Description |
-|---------|-------------|
-| **[@earendil-works/pi-telemetry](packages/telemetry)** | Vendor-neutral telemetry contracts, reference adapter, conformance tests, and typed schemas |
-| **[@earendil-works/pi-ai](packages/ai)** | Unified multi-provider LLM API (OpenAI, Anthropic, Google, etc.) |
-| **[@earendil-works/pi-agent-core](packages/agent)** | Agent runtime with tool calling and state management |
-| **[@earendil-works/pi-coding-agent](packages/coding-agent)** | Interactive coding agent CLI |
-| **[@earendil-works/pi-tui](packages/tui)** | Terminal UI library with differential rendering |
-
-For Slack/chat automation and workflows see [earendil-works/pi-chat](https://github.com/earendil-works/pi-chat).
-
-## Permissions & Containerization
-
-Pi does not include a built-in permission system for restricting filesystem, process, network, or credential access. By default, it runs with the permissions of the user and process that launched it.
-
-If you need stronger boundaries, containerize or sandbox Pi. See [packages/coding-agent/docs/containerization.md](packages/coding-agent/docs/containerization.md) for three patterns:
-
-- **Gondolin extension**: keep `pi` and provider auth on the host while routing built-in tools and `!` commands into a local Linux micro-VM.
-- **Plain Docker**: run the whole `pi` process in a local container for simple isolation.
-- **OpenShell**: run the whole `pi` process in a policy-controlled sandbox.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and [AGENTS.md](AGENTS.md) for project-specific rules (for both humans and agents).  Longer term plans for Pi can also be found in [RFCs](https://rfc.earendil.com/keyword/pi/).
+Engine-specific functionality lives behind explicit engine adapter boundaries. Unity is the first target; there is no speculative multi-engine support.
 
 ## Development
 
 ```bash
-npm install --ignore-scripts  # Install all dependencies without running lifecycle scripts
-npm run build         # Refresh model data, then build all packages
-npm run build:offline # Rebuild using existing model data without network access
-npm run check         # Lint, format, and type check
-./test.sh            # Run tests (skips LLM-dependent tests without API keys)
-./pi-test.sh         # Run pi from sources (can be run from any directory)
+npm install --ignore-scripts  # Install dependencies without lifecycle scripts
+npm run check         # Lint, format, typecheck, and dependency checks
+./test.sh             # Run tests without API keys
+./pi-test.sh          # Run the agent from sources
 ```
 
-## Building standalone binaries from release source
-
-GitHub releases include a versioned source archive covered by the release's `SHA256SUMS` file. Extract it and run the same build script used for the official standalone binaries:
-
-```bash
-VERSION="<release-version>"
-tar -xzf "pi-${VERSION}-source.tar.gz"
-cd "pi-${VERSION}"
-./scripts/build-binaries.sh --offline-model-data --platform linux-x64 --out "$PWD/out"
-```
-
-The source archive includes the generated provider model data used for the release. `--offline-model-data` builds with that snapshot instead of refreshing it from live provider catalogs. The script still installs dependencies, builds the monorepo, compiles the Bun executable, and stages its runtime assets. Package maintainers who provide dependencies separately can pass `--skip-install --skip-deps`.
-
-## Supply-chain hardening
-
-We treat npm dependency changes as reviewed code changes.
-
-- Direct external dependencies are pinned to exact versions. Internal workspace packages remain version-ranged.
-- `.npmrc` sets `save-exact=true` and `min-release-age=2` to avoid same-day dependency releases during npm resolution.
-- `package-lock.json` is the dependency ground truth. Pre-commit blocks accidental lockfile commits unless `PI_ALLOW_LOCKFILE_CHANGE=1` is set.
-- `npm run check` verifies pinned direct deps, native TypeScript import compatibility, and the generated coding-agent shrinkwrap.
-- The published CLI package includes `packages/coding-agent/npm-shrinkwrap.json`, generated from the root lockfile, to pin transitive deps for npm users.
-- Release smoke tests use `npm run release:local` to build, pack, and create isolated npm and Bun installs outside the repo before tagging a release.
-- Local release installs, documented npm installs, and `pi update --self` use `--ignore-scripts` where supported.
-- CI installs with `npm ci --ignore-scripts`, and a scheduled GitHub workflow runs `npm audit --omit=dev` plus `npm audit signatures --omit=dev`.
-- Shrinkwrap generation has an explicit allowlist for dependency lifecycle scripts; new lifecycle-script deps fail checks until reviewed.
-
-## Share your OSS coding agent sessions
-
-If you use Pi or other coding agents for open source work, please share your sessions.
-
-Public OSS session data helps improve coding agents with real-world tasks, tool use, failures, and fixes instead of toy benchmarks.
-
-For the full explanation, see [this post on X](https://x.com/badlogicgames/status/2037811643774652911).
-
-To publish sessions, use [`badlogic/pi-share-hf`](https://github.com/badlogic/pi-share-hf). Read its README.md for setup instructions. All you need is a Hugging Face account, the Hugging Face CLI, and `pi-share-hf`.
-
-You can also watch [this video](https://x.com/badlogicgames/status/2041151967695634619), where I show how I publish my `pi-mono` sessions.
-
-I regularly publish my own `pi-mono` work sessions here:
-
-- [badlogicgames/pi-mono on Hugging Face](https://huggingface.co/datasets/badlogicgames/pi-mono)
+See `AGENTS.md` for detailed development rules (architecture boundaries, upstream policy, commands, testing).
 
 ## License
 
-MIT
-
-<p align="center">
-  <a href="https://pi.dev">pi.dev</a> domain graciously donated by
-  <br /><br />
-  <a href="https://exe.dev"><img src="packages/coding-agent/docs/images/exy.png" alt="Exy mascot" width="48" /><br />exe.dev</a>
-</p>
+MIT. PiQuest is derived from [Pi](https://github.com/earendil-works/pi), MIT licensed.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "linear": {
+      "type": "remote",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}


### PR DESCRIPTION
- Rewrite AGENTS.md with PiQuest identity, architecture boundaries, upstream policy, engine policy, and dev rules
- Replace upstream README with PiQuest English intro; add Korean README.ko.md
- Add opencode.json with Linear remote MCP server