### PR TITLE
Skip project-agent confirm when project is already trusted

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -530,10 +530,12 @@ export default function (pi: ExtensionAPI) {
 				if (projectAgentsRequested.length > 0) {
 					const names = projectAgentsRequested.map((a) => a.name).join(", ");
 					const dir = discovery.projectAgentsDir ?? "(unknown)";
-					const ok = await ctx.ui.confirm(
-						"Run project-local agents?",
-						`Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. Only continue for trusted repositories.`,
-					);
+					if (!ctx.isProjectTrusted()) {
+						const ok = await ctx.ui.confirm(
+							"Run project-local agents?",
+							`Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. Only continue for trusted repositories.`,
+						);
+					}
 					if (!ok)
 						return {
 							content: [{ type: "text", text: "Canceled: project-local agents not approved." }],


### PR DESCRIPTION
## Issue

The subagent extension prompts the user before running any project-local agent (`agentScope: "project"` or `"both"`) regardless of whether the project is already marked as trusted in `~/.pi/agent/trust.json`. Even on a trusted repo this fires a "Run project-local agents?" dialog on **every** subagent call, which contradicts the trust model and the extensions doc that points at `ctx.isProjectTrusted()` as the supported gate for project-local config.

## Root cause

In `packages/coding-agent/examples/extensions/subagent/index.ts`, inside `execute(...)`:

```ts
   if ((agentScope === "project" || agentScope === "both") && confirmProjectAgents && ctx.hasUI) {
       ...
       if (projectAgentsRequested.length > 0) {
           const ok = await ctx.ui.confirm(
               "Run project-local agents?",
               `Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. ...`,
           );
           ...
       }
   }
 ```

The gate on this block is confirmProjectAgents && ctx.hasUI only — it never checks the current trust state. Per the extensions docs, ctx.isProjectTrusted() returns the current decision including saved trust.json, runtime overrides, and CLI flags, and is the documented primitive for "is it OK to honor project-local resources here?"

## Fix

Wrap the `ctx.ui.confirm(...)` call in `if (!ctx.isProjectTrusted())`. The outer collection of `projectAgentsRequested` (and its `params.chain`/`params.tasks`/ `params.agent` walk) is kept as-is — they're informative for the prompt that still fires for untrusted repos. The existing per-call confirmProjectAgents: false escape hatch — allowing the user to choose to never see confirmation dialogs, for both trusted and untrusted repositories — is preserved.

## Behavior matrix

| `confirmProjectAgents` | `agentScope`     | Repo trust | Before            | After      |   |
|------------------------|------------------|------------|-------------------|------------|---|
| `false`                | any              | any        | No prompt         | No prompt  | Retains `confirmProjectAgents` override |
| `true` (default)       | `user`           | any        | No prompt         | No prompt  | Retains user-scope override |
| `true` (default)       | `project`/`both` | Trusted    | Prompt every call | No prompt  |  Removes dialog for trusted repo |
| `true` (default)       | `project`/`both` | Untrusted  | Prompt            | Prompt     |  Retains dialog for untrusted repo |


## To Confirm Before and After Functionality

1. Add a local project agent `.pi/agents/smoke.md`.
2. With the repo path present in `~/.pi/agent/trust.json` set to `true`: call `subagent({ agent: "smoke", task: "...", agentScope: "both" })`. Expect: no UI prompt; agent executes.
3. Remove (or set to false) the entry in `trust.json`, repeat. Expect: prompt appears as before.
4. Keep untrusted, but call with `confirmProjectAgents: false`. Expect: no prompt (escape hatch preserved).