### PR TITLE
fix(coding-agent): restore continuation after retry and compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2222,8 +2222,28 @@ export class AgentSession {
 			this.sessionManager.appendCompaction(summary, firstKeptEntryId, tokensBefore, details, fromExtension, usage);
 			const newEntries = this.sessionManager.getEntries();
 			const sessionContext = this.sessionManager.buildSessionContext();
-			this.agent.state.messages = sessionContext.messages;
-			const estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
+			let messages = sessionContext.messages;
+			if (willRetry) {
+				// Failed attempts are persisted before being removed from live context. Rebuilding can
+				// restore multiple consecutive attempts (for example, retryable error then length stop),
+				// so remove the whole failed suffix from live context while preserving session history.
+				let failedTailStart = messages.length;
+				while (failedTailStart > 0) {
+					const message = messages[failedTailStart - 1];
+					if (
+						message.role !== "assistant" ||
+						(message.stopReason !== "error" && message.stopReason !== "length")
+					) {
+						break;
+					}
+					failedTailStart--;
+				}
+				if (failedTailStart < messages.length) {
+					messages = messages.slice(0, failedTailStart);
+				}
+			}
+			this.agent.state.messages = messages;
+			const estimatedTokensAfter = estimateMessagesTokens(messages);
 
 			// Get the saved compaction entry for the extension event
 			const savedCompactionEntry = newEntries.find((e) => e.type === "compaction" && e.summary === summary) as
@@ -2251,15 +2271,6 @@ export class AgentSession {
 			this._emit({ type: "compaction_end", reason, result, aborted: false, willRetry });
 
 			if (willRetry) {
-				const messages = this.agent.state.messages;
-				const lastMsg = messages[messages.length - 1];
-				// The overflow response was persisted on message_end before _checkCompaction() removed it
-				// from agent state. Rebuilding state from the new compaction can restore that kept entry,
-				// leaving an assistant as the final message. agent.continue() rejects that state, so remove
-				// the retriable error or truncated-length response again before continuing the interrupted turn.
-				if (lastMsg?.role === "assistant" && (lastMsg.stopReason === "error" || lastMsg.stopReason === "length")) {
-					this.agent.state.messages = messages.slice(0, -1);
-				}
 				return true;
 			}
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -356,6 +356,66 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.session.getLastAssistantText()).toBe("completed response");
 	});
 
+	it("resumes the interrupted turn when compaction restores multiple failed attempts", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 1000, maxTokens: 100 }],
+			settings: {
+				retry: { enabled: true, maxRetries: 3, baseDelayMs: 0 },
+				compaction: { enabled: true, keepRecentTokens: 100, reserveTokens: 0 },
+			},
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage("seed response"),
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "server_error: transient failure",
+			}),
+			fauxAssistantMessage("partial reasoning", { stopReason: "length" }),
+			fauxAssistantMessage("default pi compaction summary"),
+			fauxAssistantMessage("completed response"),
+		]);
+
+		const session = harness.session;
+		let liveTailRoleAtCompactionEnd: string | undefined;
+		session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.reason === "overflow" && event.willRetry) {
+				liveTailRoleAtCompactionEnd = session.messages.at(-1)?.role;
+			}
+		});
+
+		await session.prompt("seed prompt");
+		await expect(session.prompt("x".repeat(5000))).resolves.toBeUndefined();
+
+		expect(harness.faux.state.callCount).toBe(5);
+		expect(harness.getPendingResponseCount()).toBe(0);
+		expect(harness.eventsOfType("auto_retry_start")).toHaveLength(1);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(1);
+		expect(harness.eventsOfType("compaction_end")).toEqual([
+			expect.objectContaining({
+				reason: "overflow",
+				result: expect.objectContaining({ summary: "default pi compaction summary" }),
+				aborted: false,
+				willRetry: true,
+			}),
+		]);
+		expect(liveTailRoleAtCompactionEnd).toBe("user");
+
+		const entries = harness.sessionManager.getEntries();
+		expect(entries.filter((entry) => entry.type === "compaction")).toEqual([
+			expect.objectContaining({ fromHook: false }),
+		]);
+		expect(
+			entries.flatMap((entry) => {
+				if (entry.type !== "message" || entry.message.role !== "assistant") return [];
+				const { stopReason } = entry.message;
+				return stopReason === "error" || stopReason === "length" ? [stopReason] : [];
+			}),
+		).toEqual(["error", "length"]);
+		expect(harness.session.getLastAssistantText()).toBe("completed response");
+	});
+
 	it("does not compact when a length stop reaches the desired output limit", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1", contextWindow: 1_000_000, maxTokens: 100 }],


### PR DESCRIPTION
I ran into an edge case with the recovery flow introduced in [`32850ef7`](https://github.com/earendil-works/pi/commit/32850ef7c5edff7a6eee0214516fbb7382bf292d).

Basically, if Pi hits a temporary error and the retry also gets cut short, it compacts the conversation but accidentally leaves the first error as the last message. When it tries to continue, it fails with:

>   Cannot continue from message role: assistant

I included a regression test that walks through the whole sequence, which should make the problem easier to see, but I'm happy to provide more details if anything is unclear.

I wasn't sure whether I needed to open an issue first since I'm already approved to send PRs, so I went ahead and sent the fix directly. If you'd prefer an issue too, please let me know.

(I used my clanker for the rest of this, but I vetted/edited myself)

 To reproduce, you need to:

 1. Enable automatic retry and compaction.
 2. Start a turn with enough history for compaction.
 3. Have the first attempt return a retryable error, such as server_error.
 4. Have the retry end with a recoverable length response.

 Pi then compacts the conversation and fails when it tries to continue the interrupted turn.

 This PR:

 - removes all failed attempts restored at the end of the active conversation before Pi continues
 - keeps those attempts in the saved session history
 - adds a faux-provider regression test covering the full error, retry, truncation, compaction, and resume sequence