### PR TITLE
fix(ai): keep Baseten GLM-5.2 text-only

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1219,6 +1219,8 @@ function processBasetenModels(provider: ModelsDevProvider | undefined): Model<Ap
 			: supportsToggle
 				? toggleThinkingLevelMap
 				: getEffortThinkingLevelMap(reasoningOptions);
+		// Baseten's GLM-5.2 endpoints are text-only despite models.dev reporting image input.
+		const supportsImageInput = !isGlm52 && model.modalities?.input?.includes("image");
 
 		models.push({
 			id: modelId,
@@ -1228,7 +1230,7 @@ function processBasetenModels(provider: ModelsDevProvider | undefined): Model<Ap
 			baseUrl,
 			reasoning,
 			...(thinkingLevelMap ? { thinkingLevelMap } : {}),
-			input: model.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
+			input: supportsImageInput ? ["text", "image"] : ["text"],
 			cost: {
 				input: model.cost?.input || 0,
 				output: model.cost?.output || 0,

--- a/packages/ai/test/baseten-models.test.ts
+++ b/packages/ai/test/baseten-models.test.ts
@@ -54,6 +54,11 @@ describe("Baseten models", () => {
 		});
 	});
 
+	it("keeps both GLM 5.2 endpoints text-only", () => {
+		expect(getModel("baseten", "zai-org/GLM-5.2").input).toEqual(["text"]);
+		expect(getModel("baseten", "zai-org/GLM-5.2-Fast").input).toEqual(["text"]);
+	});
+
 	it("models Kimi K2.6 reasoning as an explicit off/on toggle", async () => {
 		const model = getModel("baseten", "moonshotai/Kimi-K2.6");
 		let payload: Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

- override incorrect models.dev image-input metadata for Baseten GLM-5.2 and GLM-5.2-Fast
- keep both endpoints text-only during model catalog generation
- add regression coverage for both endpoints

## Testing

- `npm run build`
- `npm run check`
- `./test.sh`
