### PR TITLE
fix(coding-agent): exclude superseded retry attempts from restored context

### DIFF
--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -210,6 +210,14 @@ A message in the conversation. The `message` field contains an `AgentMessage`.
 {"type":"message","id":"c3d4e5f6","parentId":"b2c3d4e5","timestamp":"2024-12-03T14:00:03.000Z","message":{"role":"toolResult","toolCallId":"call_123","toolName":"bash","content":[{"type":"text","text":"output"}],"isError":false}}
 ```
 
+A replacement produced by automatic retry may include `supersedesEntryIds`. The referenced assistant attempts remain in the JSONL history and rendered transcript, but are omitted from model context on branches containing the replacement.
+
+```json
+{"type":"message","id":"d4e5f6a7","parentId":"b2c3d4e5","timestamp":"2024-12-03T14:00:04.000Z","supersedesEntryIds":["b2c3d4e5"],"message":{"role":"assistant","content":[{"type":"text","text":"Recovered response"}],"provider":"anthropic","model":"claude-sonnet-4-5","usage":{...},"stopReason":"stop"}}
+```
+
+This is an additive version 3 field and does not require migration. Older readers ignore it and retain the previous replay behavior. Existing sessions without supersession metadata are unchanged because replacement relationships cannot be inferred safely.
+
 ### ModelChangeEntry
 
 Emitted when the user switches models mid-session.
@@ -327,12 +335,13 @@ Entries form a tree:
    - If `retainedTail` is present, it acts as a self-contained checkpoint and entries after the compaction are included
    - Otherwise entries from `firstKeptEntryId` to the compaction are included
    - Then entries after compaction are included
-3. Preserves non-message entries in the selected range so interactive mode can render them
+3. Preserves non-message and superseded entries in the selected range so interactive mode can render them
 
-`buildSessionContext()` builds on that entry list to produce the message list for the LLM:
+`buildSessionContext()` follows the same branch to produce the message list for the LLM:
 
-1. Extracts current model and thinking level settings from the full path
-2. Converts selected entries to messages:
+1. Omits assistant entries referenced by a later entry's `supersedesEntryIds`
+2. Extracts current model and thinking level settings from the filtered path
+3. Converts selected entries to messages:
    - `message` -> stored `AgentMessage`
    - `compaction` -> `compactionSummary` plus `retainedTail` when present
    - `branch_summary` -> `branchSummary`
@@ -404,7 +413,7 @@ Key methods for working with sessions programmatically.
 - `createBranchedSession(leafId)` - Extract branch to new session file
 
 ### Instance Methods - Appending (all return entry ID)
-- `appendMessage(message)` - Add message
+- `appendMessage(message, supersedesEntryIds?)` - Add message
 - `appendThinkingLevelChange(level)` - Record thinking change
 - `appendModelChange(provider, modelId)` - Record model change
 - `appendCompaction(summary, firstKeptEntryId, tokensBefore, details?, fromHook?)` - Add compaction

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -335,6 +335,7 @@ export class AgentSession {
 	// Retry state
 	private _retryAbortController: AbortController | undefined = undefined;
 	private _retryAttempt = 0;
+	private _pendingSupersededEntryIds: string[] = [];
 
 	// Bash execution state
 	private readonly _bashAbortControllers = new Set<AbortController>();
@@ -610,8 +611,8 @@ export class AgentSession {
 		}
 	}
 
-	// Track last assistant message for auto-compaction check
-	private _lastAssistantMessage: AssistantMessage | undefined = undefined;
+	// Track the persisted assistant entry for post-run retry and compaction checks.
+	private _lastAssistantEntry: { message: AssistantMessage; entryId: string } | undefined = undefined;
 
 	/** Internal handler for agent events - shared by subscribe and reconnect */
 	private _handleAgentEvent = async (event: AgentEvent): Promise<void> => {
@@ -645,6 +646,7 @@ export class AgentSession {
 
 		// Handle session persistence
 		if (event.type === "message_end") {
+			let messageEntryId: string | undefined;
 			// Check if this is a custom message from extensions
 			if (event.message.role === "custom") {
 				// Persist as CustomMessageEntry
@@ -660,13 +662,17 @@ export class AgentSession {
 				event.message.role === "toolResult"
 			) {
 				// Regular LLM message - persist as SessionMessageEntry
-				this.sessionManager.appendMessage(event.message);
+				const supersedesEntryIds = event.message.role === "assistant" ? this._pendingSupersededEntryIds : [];
+				messageEntryId = this.sessionManager.appendMessage(event.message, supersedesEntryIds);
+				if (supersedesEntryIds.length > 0) {
+					this._pendingSupersededEntryIds = [];
+				}
 			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 
 			// Track assistant message for auto-compaction (checked on agent_end)
-			if (event.message.role === "assistant") {
-				this._lastAssistantMessage = event.message;
+			if (event.message.role === "assistant" && messageEntryId) {
+				this._lastAssistantEntry = { message: event.message, entryId: messageEntryId };
 
 				const assistantMsg = event.message as AssistantMessage;
 				if (assistantMsg.stopReason !== "error" && assistantMsg.stopReason !== "length") {
@@ -712,6 +718,31 @@ export class AgentSession {
 			}
 		}
 		return undefined;
+	}
+
+	private _findMessageEntryId(message: AgentMessage): string | undefined {
+		const branch = this.sessionManager.getBranch();
+		for (let i = branch.length - 1; i >= 0; i--) {
+			const entry = branch[i];
+			if (entry.type === "message" && entry.message === message) {
+				return entry.id;
+			}
+		}
+		return undefined;
+	}
+
+	private _removeAssistantMessage(message: AssistantMessage): void {
+		const messages = this.agent.state.messages;
+		const messageIndex = messages.lastIndexOf(message);
+		if (messageIndex >= 0) {
+			this.agent.state.messages = [...messages.slice(0, messageIndex), ...messages.slice(messageIndex + 1)];
+		}
+	}
+
+	private _markEntrySuperseded(entryId: string): void {
+		if (!this._pendingSupersededEntryIds.includes(entryId)) {
+			this._pendingSupersededEntryIds.push(entryId);
+		}
 	}
 
 	private _replaceMessageInPlace(target: AgentMessage, replacement: AgentMessage): void {
@@ -1082,13 +1113,14 @@ export class AgentSession {
 	}
 
 	private async _handlePostAgentRun(): Promise<boolean> {
-		const msg = this._lastAssistantMessage;
-		this._lastAssistantMessage = undefined;
-		if (!msg) {
+		const assistantEntry = this._lastAssistantEntry;
+		this._lastAssistantEntry = undefined;
+		if (!assistantEntry) {
 			return false;
 		}
+		const { message: msg, entryId } = assistantEntry;
 
-		if (this._isRetryableError(msg) && (await this._prepareRetry(msg))) {
+		if (this._isRetryableError(msg) && (await this._prepareRetry(msg, entryId))) {
 			return true;
 		}
 
@@ -1102,7 +1134,7 @@ export class AgentSession {
 			this._retryAttempt = 0;
 		}
 
-		if (await this._checkCompaction(msg)) {
+		if (await this._checkCompaction(msg, true, entryId)) {
 			return true;
 		}
 
@@ -1994,7 +2026,11 @@ export class AgentSession {
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
 	 * @returns Whether the post-run loop should call `agent.continue()` for overflow recovery or queued messages
 	 */
-	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
+	private async _checkCompaction(
+		assistantMessage: AssistantMessage,
+		skipAbortedCheck = true,
+		assistantEntryId?: string,
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		if (!settings.enabled) return false;
 
@@ -2056,14 +2092,18 @@ export class AgentSession {
 				return false;
 			}
 
-			// Case 1: remove the failed or truncated message from agent state, compact, and
-			// retry once. The message remains in session history but is excluded from retry context.
-			this._overflowRecoveryAttempted = true;
-			const messages = this.agent.state.messages;
-			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
-				this.agent.state.messages = messages.slice(0, -1);
+			// Case 1: compact without the failed or truncated message, then retry once.
+			// The replacement assistant entry records which persisted attempt it supersedes.
+			const supersededEntryId = assistantEntryId ?? this._findMessageEntryId(assistantMessage);
+			if (!supersededEntryId) {
+				return false;
 			}
-			return await this._runAutoCompaction("overflow", willRetry);
+			this._overflowRecoveryAttempted = true;
+			const shouldContinue = await this._runAutoCompaction("overflow", willRetry, [supersededEntryId]);
+			if (shouldContinue) {
+				this._markEntrySuperseded(supersededEntryId);
+			}
+			return shouldContinue;
 		}
 
 		// Case 3: threshold compaction without retry.
@@ -2107,7 +2147,11 @@ export class AgentSession {
 	 * @param willRetry Whether to continue the interrupted turn after overflow compaction
 	 * @returns Whether the post-run loop should call `agent.continue()`
 	 */
-	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
+	private async _runAutoCompaction(
+		reason: "overflow" | "threshold",
+		willRetry: boolean,
+		additionalSupersededEntryIds: readonly string[] = [],
+	): Promise<boolean> {
 		const settings = this.settingsManager.getCompactionSettings();
 		let started = false;
 		let fromExtension = false;
@@ -2121,7 +2165,7 @@ export class AgentSession {
 
 			const pathEntries = this.sessionManager.getBranch();
 
-			const preparation = prepareCompaction(pathEntries, settings);
+			const preparation = prepareCompaction(pathEntries, settings, additionalSupersededEntryIds);
 			if (!preparation) {
 				return false;
 			}
@@ -2221,7 +2265,7 @@ export class AgentSession {
 
 			this.sessionManager.appendCompaction(summary, firstKeptEntryId, tokensBefore, details, fromExtension, usage);
 			const newEntries = this.sessionManager.getEntries();
-			const sessionContext = this.sessionManager.buildSessionContext();
+			const sessionContext = this.sessionManager.buildSessionContext(additionalSupersededEntryIds);
 			this.agent.state.messages = sessionContext.messages;
 			const estimatedTokensAfter = estimateMessagesTokens(sessionContext.messages);
 
@@ -2251,15 +2295,6 @@ export class AgentSession {
 			this._emit({ type: "compaction_end", reason, result, aborted: false, willRetry });
 
 			if (willRetry) {
-				const messages = this.agent.state.messages;
-				const lastMsg = messages[messages.length - 1];
-				// The overflow response was persisted on message_end before _checkCompaction() removed it
-				// from agent state. Rebuilding state from the new compaction can restore that kept entry,
-				// leaving an assistant as the final message. agent.continue() rejects that state, so remove
-				// the retriable error or truncated-length response again before continuing the interrupted turn.
-				if (lastMsg?.role === "assistant" && (lastMsg.stopReason === "error" || lastMsg.stopReason === "length")) {
-					this.agent.state.messages = messages.slice(0, -1);
-				}
 				return true;
 			}
 
@@ -2756,7 +2791,7 @@ export class AgentSession {
 	 * Prepare a retryable error for continuation with exponential backoff.
 	 * @returns true if the caller should continue the agent, false otherwise
 	 */
-	private async _prepareRetry(message: AssistantMessage): Promise<boolean> {
+	private async _prepareRetry(message: AssistantMessage, entryId: string): Promise<boolean> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
 			return false;
@@ -2780,12 +2815,6 @@ export class AgentSession {
 			errorMessage: message.errorMessage || "Unknown error",
 		});
 
-		// Remove error message from agent state (keep in session for history)
-		const messages = this.agent.state.messages;
-		if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
-			this.agent.state.messages = messages.slice(0, -1);
-		}
-
 		// Wait with exponential backoff (abortable)
 		this._retryAbortController = new AbortController();
 		try {
@@ -2805,6 +2834,8 @@ export class AgentSession {
 			this._retryAbortController = undefined;
 		}
 
+		this._removeAssistantMessage(message);
+		this._markEntrySuperseded(entryId);
 		return true;
 	}
 

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -15,7 +15,7 @@ import {
 	createCompactionSummaryMessage,
 	createCustomMessage,
 } from "../messages.ts";
-import type { ReadonlySessionManager, SessionEntry } from "../session-manager.ts";
+import { filterSupersededSessionEntries, type ReadonlySessionManager, type SessionEntry } from "../session-manager.ts";
 import { completeSummarization, estimateTokens } from "./compaction.ts";
 import {
 	computeFileLists,
@@ -193,6 +193,7 @@ function getMessageFromEntry(entry: SessionEntry): AgentMessage | undefined {
  * @param tokenBudget - Maximum tokens to include (0 = no limit)
  */
 export function prepareBranchEntries(entries: SessionEntry[], tokenBudget: number = 0): BranchPreparation {
+	const projectedEntries = filterSupersededSessionEntries(entries);
 	const messages: AgentMessage[] = [];
 	const fileOps = createFileOps();
 	let totalTokens = 0;
@@ -200,7 +201,7 @@ export function prepareBranchEntries(entries: SessionEntry[], tokenBudget: numbe
 	// First pass: collect file ops from ALL entries (even if they don't fit in token budget)
 	// This ensures we capture cumulative file tracking from nested branch summaries
 	// Only extract from pi-generated summaries (fromHook !== true), not extension-generated ones
-	for (const entry of entries) {
+	for (const entry of projectedEntries) {
 		if (entry.type === "branch_summary" && !entry.fromHook && entry.details) {
 			const details = entry.details as BranchSummaryDetails;
 			if (Array.isArray(details.readFiles)) {
@@ -216,8 +217,8 @@ export function prepareBranchEntries(entries: SessionEntry[], tokenBudget: numbe
 	}
 
 	// Second pass: walk from newest to oldest, adding messages until token budget
-	for (let i = entries.length - 1; i >= 0; i--) {
-		const entry = entries[i];
+	for (let i = projectedEntries.length - 1; i >= 0; i--) {
+		const entry = projectedEntries[i];
 		const message = getMessageFromEntry(entry);
 		if (!message) continue;
 

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -13,6 +13,7 @@ import { convertToLlm } from "../messages.ts";
 import {
 	buildSessionContext,
 	type CompactionEntry,
+	filterSupersededSessionEntries,
 	type SessionEntry,
 	sessionEntryToContextMessages,
 } from "../session-manager.ts";
@@ -88,8 +89,14 @@ function extractFileOperations(
  * Extract AgentMessage from an entry if it produces one.
  * Returns undefined for entries that don't contribute to LLM context.
  */
-function getMessageFromEntryForCompaction(entry: SessionEntry): AgentMessage | undefined {
+function getMessageFromEntryForCompaction(
+	entry: SessionEntry,
+	additionalSupersededEntryIds: ReadonlySet<string> = new Set(),
+): AgentMessage | undefined {
 	if (entry.type === "compaction") {
+		return undefined;
+	}
+	if (entry.type === "message" && entry.message.role === "assistant" && additionalSupersededEntryIds.has(entry.id)) {
 		return undefined;
 	}
 	return sessionEntryToContextMessages(entry)[0];
@@ -417,6 +424,16 @@ export function findCutPoint(
 	endIndex: number,
 	keepRecentTokens: number,
 ): CutPointResult {
+	return findCutPointForCompaction(entries, startIndex, endIndex, keepRecentTokens, new Set());
+}
+
+function findCutPointForCompaction(
+	entries: SessionEntry[],
+	startIndex: number,
+	endIndex: number,
+	keepRecentTokens: number,
+	additionalSupersededEntryIds: ReadonlySet<string>,
+): CutPointResult {
 	const cutPoints = findValidCutPoints(entries, startIndex, endIndex);
 
 	if (cutPoints.length === 0) {
@@ -429,10 +446,8 @@ export function findCutPoint(
 
 	for (let i = endIndex - 1; i >= startIndex; i--) {
 		const entry = entries[i];
-		const messageTokens = sessionEntryToContextMessages(entry).reduce(
-			(sum, message) => sum + estimateTokens(message),
-			0,
-		);
+		const message = getMessageFromEntryForCompaction(entry, additionalSupersededEntryIds);
+		const messageTokens = message ? estimateTokens(message) : 0;
 		if (messageTokens === 0) continue;
 		accumulatedTokens += messageTokens;
 
@@ -445,6 +460,25 @@ export function findCutPoint(
 					break;
 				}
 			}
+
+			// If the visible part of one interrupted turn exceeds the budget, keep its
+			// excluded final assistant as a structural split point. This lets compaction
+			// summarize the turn prefix without counting or sending the failed attempt.
+			if (isTurnStartEntry(entries[cutIndex])) {
+				const structuralCutPoint = cutPoints.find((candidate) => {
+					if (candidate <= cutIndex) return false;
+					const candidateEntry = entries[candidate];
+					return (
+						candidateEntry.type === "message" &&
+						candidateEntry.message.role === "assistant" &&
+						additionalSupersededEntryIds.has(candidateEntry.id) &&
+						findTurnStartIndex(entries, candidate, startIndex) === cutIndex
+					);
+				});
+				if (structuralCutPoint !== undefined) {
+					cutIndex = structuralCutPoint;
+				}
+			}
 			break;
 		}
 	}
@@ -453,7 +487,10 @@ export function findCutPoint(
 	while (cutIndex > startIndex) {
 		const prevEntry = entries[cutIndex - 1];
 		// Stop at compaction boundaries or context-visible entries.
-		if (prevEntry.type === "compaction" || sessionEntryToContextMessages(prevEntry).length > 0) {
+		if (
+			prevEntry.type === "compaction" ||
+			getMessageFromEntryForCompaction(prevEntry, additionalSupersededEntryIds) !== undefined
+		) {
 			break;
 		}
 		cutIndex--;
@@ -737,9 +774,15 @@ export interface CompactionPreparation {
 }
 
 export function prepareCompaction(
-	pathEntries: SessionEntry[],
+	branchEntries: SessionEntry[],
 	settings: CompactionSettings,
+	additionalSupersededEntryIds: readonly string[] = [],
 ): CompactionPreparation | undefined {
+	// Keep the current failed attempt as a structural cut point, but never include it
+	// in token accounting or summarization input. Durable superseded attempts can be
+	// removed entirely because their replacements already exist on the branch.
+	const pathEntries = filterSupersededSessionEntries(branchEntries);
+	const additionalSupersededEntryIdSet = new Set(additionalSupersededEntryIds);
 	if (pathEntries.length > 0 && pathEntries[pathEntries.length - 1].type === "compaction") {
 		return undefined;
 	}
@@ -762,9 +805,17 @@ export function prepareCompaction(
 	}
 	const boundaryEnd = pathEntries.length;
 
-	const tokensBefore = estimateContextTokens(buildSessionContext(pathEntries).messages).tokens;
+	const tokensBefore = estimateContextTokens(
+		buildSessionContext(branchEntries, undefined, undefined, additionalSupersededEntryIds).messages,
+	).tokens;
 
-	const cutPoint = findCutPoint(pathEntries, boundaryStart, boundaryEnd, settings.keepRecentTokens);
+	const cutPoint = findCutPointForCompaction(
+		pathEntries,
+		boundaryStart,
+		boundaryEnd,
+		settings.keepRecentTokens,
+		additionalSupersededEntryIdSet,
+	);
 
 	// Get UUID of first kept entry
 	const firstKeptEntry = pathEntries[cutPoint.firstKeptEntryIndex];
@@ -778,7 +829,7 @@ export function prepareCompaction(
 	// Messages to summarize (will be discarded after summary)
 	const messagesToSummarize: AgentMessage[] = [];
 	for (let i = boundaryStart; i < historyEnd; i++) {
-		const msg = getMessageFromEntryForCompaction(pathEntries[i]);
+		const msg = getMessageFromEntryForCompaction(pathEntries[i], additionalSupersededEntryIdSet);
 		if (msg) messagesToSummarize.push(msg);
 	}
 
@@ -786,7 +837,7 @@ export function prepareCompaction(
 	const turnPrefixMessages: AgentMessage[] = [];
 	if (cutPoint.isSplitTurn) {
 		for (let i = cutPoint.turnStartIndex; i < cutPoint.firstKeptEntryIndex; i++) {
-			const msg = getMessageFromEntryForCompaction(pathEntries[i]);
+			const msg = getMessageFromEntryForCompaction(pathEntries[i], additionalSupersededEntryIdSet);
 			if (msg) turnPrefixMessages.push(msg);
 		}
 	}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -53,6 +53,8 @@ export interface SessionEntryBase {
 export interface SessionMessageEntry extends SessionEntryBase {
 	type: "message";
 	message: AgentMessage;
+	/** Earlier assistant attempts replaced by this entry and omitted from model context. */
+	supersedesEntryIds?: string[];
 }
 
 export interface ThinkingLevelChangeEntry extends SessionEntryBase {
@@ -407,20 +409,27 @@ export function sessionEntryToContextMessages(entry: SessionEntry): AgentMessage
 	return [];
 }
 
-/**
- * Build the active, compaction-aware session entry list.
- *
- * This follows the current leaf path. If the path contains compaction entries,
- * the latest compaction is represented by the compaction entry itself, followed
- * by the kept entries starting at firstKeptEntryId and all entries after the
- * compaction entry. Older summarized entries are omitted.
- */
-export function buildContextEntries(
-	entries: SessionEntry[],
-	leafId?: string | null,
-	byId?: Map<string, SessionEntry>,
+/** Remove assistant attempts explicitly superseded on one session branch. */
+export function filterSupersededSessionEntries(
+	path: SessionEntry[],
+	additionalSupersededEntryIds: readonly string[] = [],
 ): SessionEntry[] {
-	const path = buildSessionPath(entries, leafId, byId);
+	const supersededEntryIds = new Set(additionalSupersededEntryIds);
+	for (const entry of path) {
+		if (entry.type !== "message" || !Array.isArray(entry.supersedesEntryIds)) continue;
+		for (const entryId of entry.supersedesEntryIds) {
+			if (typeof entryId === "string") {
+				supersededEntryIds.add(entryId);
+			}
+		}
+	}
+
+	return path.filter(
+		(entry) => entry.type !== "message" || entry.message.role !== "assistant" || !supersededEntryIds.has(entry.id),
+	);
+}
+
+function buildCompactionAwareContextEntries(path: SessionEntry[]): SessionEntry[] {
 	let compaction: CompactionEntry | null = null;
 
 	for (const entry of path) {
@@ -454,6 +463,23 @@ export function buildContextEntries(
 }
 
 /**
+ * Build the active, compaction-aware session entry list.
+ *
+ * This follows the current leaf path. If the path contains compaction entries,
+ * the latest compaction is represented by the compaction entry itself, followed
+ * by the kept entries starting at firstKeptEntryId and all entries after the
+ * compaction entry. Older summarized entries are omitted.
+ */
+export function buildContextEntries(
+	entries: SessionEntry[],
+	leafId?: string | null,
+	byId?: Map<string, SessionEntry>,
+): SessionEntry[] {
+	const path = buildSessionPath(entries, leafId, byId);
+	return buildCompactionAwareContextEntries(path);
+}
+
+/**
  * Build the session context from entries using tree traversal.
  * If leafId is provided, walks from that entry to root.
  * Handles compaction and branch summaries along the path.
@@ -462,10 +488,11 @@ export function buildSessionContext(
 	entries: SessionEntry[],
 	leafId?: string | null,
 	byId?: Map<string, SessionEntry>,
+	additionalSupersededEntryIds: readonly string[] = [],
 ): SessionContext {
-	const path = buildSessionPath(entries, leafId, byId);
+	const path = filterSupersededSessionEntries(buildSessionPath(entries, leafId, byId), additionalSupersededEntryIds);
 	const { thinkingLevel, model } = getSessionContextSettings(path);
-	const messages = buildContextEntries(entries, leafId, byId).flatMap(sessionEntryToContextMessages);
+	const messages = buildCompactionAwareContextEntries(path).flatMap(sessionEntryToContextMessages);
 	return { messages, thinkingLevel, model };
 }
 
@@ -1054,13 +1081,17 @@ export class SessionManager {
 	 * so it is easier to find them.
 	 * These need to be appended via appendCompaction() and appendBranchSummary() methods.
 	 */
-	appendMessage(message: Message | CustomMessage | BashExecutionMessage): string {
+	appendMessage(
+		message: Message | CustomMessage | BashExecutionMessage,
+		supersedesEntryIds: readonly string[] = [],
+	): string {
 		const entry: SessionMessageEntry = {
 			type: "message",
 			id: generateId(this.byId),
 			parentId: this.leafId,
 			timestamp: new Date().toISOString(),
 			message,
+			...(supersedesEntryIds.length > 0 ? { supersedesEntryIds: [...new Set(supersedesEntryIds)] } : {}),
 		};
 		this._appendEntry(entry);
 		return entry.id;
@@ -1270,7 +1301,7 @@ export class SessionManager {
 	}
 
 	/**
-	 * Build the active, compaction-aware entry list for context/rendering.
+	 * Build the active, compaction-aware entry list for rendering.
 	 * Uses tree traversal from current leaf.
 	 */
 	buildContextEntries(): SessionEntry[] {
@@ -1281,8 +1312,8 @@ export class SessionManager {
 	 * Build the session context (what gets sent to the LLM).
 	 * Uses tree traversal from current leaf.
 	 */
-	buildSessionContext(): SessionContext {
-		return buildSessionContext(this.getEntries(), this.leafId, this.byId);
+	buildSessionContext(additionalSupersededEntryIds: readonly string[] = []): SessionContext {
+		return buildSessionContext(this.getEntries(), this.leafId, this.byId, additionalSupersededEntryIds);
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -156,11 +156,15 @@ describe("AgentSession auto-compaction queue resume", () => {
 		const runAutoCompactionSpy = vi
 			.spyOn(
 				session as unknown as {
-					_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<void>;
+					_runAutoCompaction: (
+						reason: "overflow" | "threshold",
+						willRetry: boolean,
+						additionalSupersededEntryIds?: readonly string[],
+					) => Promise<boolean>;
 				},
 				"_runAutoCompaction",
 			)
-			.mockResolvedValue();
+			.mockResolvedValue(false);
 
 		const events: Array<{ type: string; reason: string; errorMessage?: string }> = [];
 		session.subscribe((event) => {
@@ -171,11 +175,15 @@ describe("AgentSession auto-compaction queue resume", () => {
 
 		const checkCompaction = (
 			session as unknown as {
-				_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<void>;
+				_checkCompaction: (
+					assistantMessage: AssistantMessage,
+					skipAbortedCheck?: boolean,
+					assistantEntryId?: string,
+				) => Promise<boolean>;
 			}
 		)._checkCompaction.bind(session);
 
-		await checkCompaction(overflowMessage);
+		await checkCompaction(overflowMessage, true, "overflow-entry");
 		await checkCompaction({ ...overflowMessage, timestamp: Date.now() + 1 });
 
 		expect(runAutoCompactionSpy).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -7,7 +7,7 @@ import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentSession } from "../src/core/agent-session.ts";
 import { AuthStorage } from "../src/core/auth-storage.ts";
-import { SessionManager } from "../src/core/session-manager.ts";
+import { SessionManager, type SessionMessageEntry } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
 import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 import { createTestResourceLoader } from "./utilities.ts";
@@ -146,6 +146,19 @@ describe("AgentSession retry", () => {
 		expect(created.getCallCount()).toBe(2);
 		expect(events).toEqual(["start:1", "end:success=true"]);
 		expect(created.session.isRetrying).toBe(false);
+		const assistantEntries = created.session.sessionManager
+			.getEntries()
+			.filter(
+				(entry): entry is SessionMessageEntry => entry.type === "message" && entry.message.role === "assistant",
+			);
+		expect(assistantEntries).toHaveLength(2);
+		expect(assistantEntries[1]?.supersedesEntryIds).toEqual([assistantEntries[0]?.id]);
+		expect(
+			created.session.sessionManager
+				.buildSessionContext()
+				.messages.filter((message) => message.role === "assistant")
+				.map((message) => (message.content[0]?.type === "text" ? message.content[0].text : "")),
+		).toEqual(["Success"]);
 	});
 
 	it("exhausts max retries and emits failure", async () => {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -12,6 +12,7 @@ import {
 	estimateContextTokens,
 	findCutPoint,
 	getLastAssistantUsage,
+	prepareBranchEntries,
 	prepareCompaction,
 	shouldCompact,
 } from "../src/core/compaction/index.ts";
@@ -372,6 +373,58 @@ describe("findCutPoint", () => {
 		expect(customFitsBudget.firstKeptEntryIndex).toBe(2);
 		expect(customFitsBudget.isSplitTurn).toBe(false);
 		expect(customFitsBudget.turnStartIndex).toBe(-1);
+	});
+});
+
+describe("prepareCompaction with pending supersession", () => {
+	it("should not include the failed attempt in the recent-token budget", () => {
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("old turn ".repeat(100))),
+			createMessageEntry(createAssistantMessage("old response")),
+			createMessageEntry(createUserMessage("recent turn ".repeat(100))),
+			createMessageEntry(createAssistantMessage("recent response")),
+			createMessageEntry(createUserMessage("current turn")),
+			createMessageEntry(createAssistantMessage("failed attempt ".repeat(100))),
+		];
+		const failedEntry = entries[5];
+		const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 100 };
+
+		const preparation = prepareCompaction(entries, settings, [failedEntry.id]);
+
+		expect(preparation).toBeDefined();
+		expect(preparation!.firstKeptEntryId).toBe(entries[2].id);
+		expect(preparation!.isSplitTurn).toBe(false);
+		expect(extractText(preparation!.messagesToSummarize)).not.toContain("failed attempt");
+	});
+
+	it("should keep the failed assistant as a structural split point", () => {
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("oversized turn ".repeat(100))),
+			createMessageEntry(createAssistantMessage("failed attempt")),
+		];
+		const failedEntry = entries[1];
+		const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 100 };
+
+		const preparation = prepareCompaction(entries, settings, [failedEntry.id]);
+
+		expect(preparation).toBeDefined();
+		expect(preparation!.firstKeptEntryId).toBe(failedEntry.id);
+		expect(preparation!.isSplitTurn).toBe(true);
+		expect(extractText(preparation!.turnPrefixMessages)).toContain("oversized turn");
+		expect(extractText(preparation!.turnPrefixMessages)).not.toContain("failed attempt");
+	});
+});
+
+describe("prepareBranchEntries", () => {
+	it("should omit assistant attempts superseded on the branch", () => {
+		const userEntry = createMessageEntry(createUserMessage("hello"));
+		const failedEntry = createMessageEntry(createAssistantMessage("failed attempt"));
+		const replacementEntry = createMessageEntry(createAssistantMessage("replacement"));
+		replacementEntry.supersedesEntryIds = [failedEntry.id];
+
+		const preparation = prepareBranchEntries([userEntry, failedEntry, replacementEntry]);
+
+		expect(extractText(preparation.messages)).toBe("hello\nreplacement");
 	});
 });
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -9,7 +9,11 @@ import { estimateTokens } from "../../src/core/compaction/index.ts";
 import { createHarness, getUserTexts, type Harness } from "./harness.ts";
 
 type SessionWithCompactionInternals = {
-	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
+	_checkCompaction: (
+		assistantMessage: AssistantMessage,
+		skipAbortedCheck?: boolean,
+		assistantEntryId?: string,
+	) => Promise<boolean>;
 	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
 };
 
@@ -420,7 +424,7 @@ describe("AgentSession compaction characterization", () => {
 			}
 		});
 
-		await sessionInternals._checkCompaction(lengthOverflowMessage);
+		await sessionInternals._checkCompaction(lengthOverflowMessage, true, "length-overflow-entry");
 		await sessionInternals._checkCompaction({ ...lengthOverflowMessage, timestamp: Date.now() + 1 });
 
 		expect(runAutoCompactionSpy).toHaveBeenCalledTimes(1);
@@ -506,7 +510,7 @@ describe("AgentSession compaction characterization", () => {
 			}
 		});
 
-		await sessionInternals._checkCompaction(overflowMessage);
+		await sessionInternals._checkCompaction(overflowMessage, true, "overflow-entry");
 		await sessionInternals._checkCompaction({ ...overflowMessage, timestamp: Date.now() + 1 });
 
 		expect(runAutoCompactionSpy).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/suite/regressions/7724-cold-restore-overflow-replay.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7724-cold-restore-overflow-replay.test.ts
@@ -1,0 +1,209 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AssistantMessage, Context, Message } from "@earendil-works/pi-ai/compat";
+import {
+	type FauxProviderRegistration,
+	fauxAssistantMessage,
+	registerFauxProvider,
+} from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../../../src/core/auth-storage.ts";
+import { convertToLlm } from "../../../src/core/messages.ts";
+import { createAgentSession } from "../../../src/core/sdk.ts";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import { SettingsManager } from "../../../src/core/settings-manager.ts";
+import { createInMemoryModelRegistry, getModelRuntime } from "../../model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "../../utilities.ts";
+
+type Scenario = {
+	name: string;
+	stopReason: "error" | "length";
+	errorMessage?: string;
+	contextWindow: number;
+	seed: boolean;
+};
+
+function captureResponse(
+	requests: Message[][],
+	content: string,
+	options: { stopReason?: AssistantMessage["stopReason"]; errorMessage?: string } = {},
+) {
+	return (context: Context) => {
+		requests.push(structuredClone(context.messages));
+		return fauxAssistantMessage(content, options);
+	};
+}
+
+function isOverflowAssistant(message: Message, scenario: Scenario): boolean {
+	return (
+		message.role === "assistant" &&
+		message.stopReason === scenario.stopReason &&
+		message.content.some((part) => part.type === "text" && part.text === `${scenario.name} overflow response`)
+	);
+}
+
+describe("#7724 cold restore after overflow recovery", () => {
+	const cleanups: Array<() => void> = [];
+
+	afterEach(() => {
+		while (cleanups.length > 0) {
+			cleanups.pop()?.();
+		}
+	});
+
+	it("applies chained supersessions only on branches containing their replacements", () => {
+		const manager = SessionManager.inMemory();
+		const userEntryId = manager.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+		const firstAttemptId = manager.appendMessage(
+			fauxAssistantMessage("first attempt", { stopReason: "error", errorMessage: "overloaded" }),
+		);
+		const secondAttemptId = manager.appendMessage(
+			fauxAssistantMessage("second attempt", { stopReason: "error", errorMessage: "overloaded" }),
+			[firstAttemptId],
+		);
+		const recoveredEntryId = manager.appendMessage(fauxAssistantMessage("recovered"), [secondAttemptId]);
+
+		expect(manager.buildContextEntries().map((entry) => entry.id)).toEqual([
+			userEntryId,
+			firstAttemptId,
+			secondAttemptId,
+			recoveredEntryId,
+		]);
+
+		expect(
+			manager
+				.buildSessionContext()
+				.messages.filter((message) => message.role === "assistant")
+				.map((message) => (message.content[0]?.type === "text" ? message.content[0].text : "")),
+		).toEqual(["recovered"]);
+
+		manager.branch(firstAttemptId);
+		expect(
+			manager
+				.buildSessionContext()
+				.messages.filter((message) => message.role === "assistant")
+				.map((message) => (message.content[0]?.type === "text" ? message.content[0].text : "")),
+		).toEqual(["first attempt"]);
+	});
+
+	it.each<Scenario>([
+		{
+			name: "length",
+			stopReason: "length",
+			contextWindow: 1000,
+			seed: false,
+		},
+		{
+			name: "error",
+			stopReason: "error",
+			errorMessage: "prompt is too long",
+			contextWindow: 100_000,
+			seed: true,
+		},
+	])("does not replay the superseded $name response", async (scenario) => {
+		const tempDir = join(tmpdir(), `pi-7724-${scenario.name}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		cleanups.push(() => {
+			if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		const faux: FauxProviderRegistration = registerFauxProvider({
+			models: [{ id: "faux-1", contextWindow: scenario.contextWindow, maxTokens: 100 }],
+		});
+		cleanups.push(() => faux.unregister());
+		const model = faux.getModel();
+		const authStorage = AuthStorage.inMemory();
+		await authStorage.modify(model.provider, async () => ({ type: "api_key", key: "faux-key" }));
+		const modelRegistry = await createInMemoryModelRegistry(authStorage);
+		modelRegistry.registerProvider(model.provider, {
+			baseUrl: model.baseUrl,
+			apiKey: "faux-key",
+			api: faux.api,
+			models: faux.models,
+		});
+		const modelRuntime = getModelRuntime(modelRegistry);
+		const settings = { compaction: { keepRecentTokens: 1, reserveTokens: 0 } };
+		const requests: Message[][] = [];
+		const responses = [
+			captureResponse(requests, `${scenario.name} overflow response`, {
+				stopReason: scenario.stopReason,
+				errorMessage: scenario.errorMessage,
+			}),
+			captureResponse(requests, `${scenario.name} compaction summary`),
+			captureResponse(requests, `${scenario.name} recovered response`),
+			captureResponse(requests, `${scenario.name} cold response`),
+		];
+		if (scenario.seed) {
+			responses.unshift(captureResponse(requests, `${scenario.name} seed response`));
+			responses.splice(3, 0, captureResponse(requests, `${scenario.name} split-turn summary`));
+		}
+		faux.setResponses(responses);
+
+		const liveManager = SessionManager.create(tempDir, tempDir);
+		const { session: liveSession } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			model,
+			modelRuntime,
+			noTools: "all",
+			resourceLoader: createTestResourceLoader(),
+			sessionManager: liveManager,
+			settingsManager: SettingsManager.inMemory(settings),
+		});
+		cleanups.push(() => liveSession.dispose());
+
+		if (scenario.seed) {
+			await liveSession.prompt("seed turn");
+		}
+		await liveSession.prompt("x".repeat(5000));
+
+		const liveHistory = structuredClone(convertToLlm(liveSession.messages));
+		expect(liveHistory.some((message) => isOverflowAssistant(message, scenario))).toBe(false);
+		const overflowEntry = liveManager
+			.getEntries()
+			.find(
+				(entry) =>
+					entry.type === "message" &&
+					entry.message.role === "assistant" &&
+					isOverflowAssistant(entry.message, scenario),
+			);
+		expect(overflowEntry?.type).toBe("message");
+		expect(
+			liveManager
+				.getEntries()
+				.some(
+					(entry) =>
+						entry.type === "message" &&
+						entry.message.role === "assistant" &&
+						entry.supersedesEntryIds?.includes(overflowEntry!.id),
+				),
+		).toBe(true);
+
+		const sessionFile = liveManager.getSessionFile();
+		expect(sessionFile).toBeDefined();
+		liveSession.dispose();
+
+		const coldManager = SessionManager.open(sessionFile!, tempDir);
+		const { session: coldSession } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			model,
+			modelRuntime,
+			noTools: "all",
+			resourceLoader: createTestResourceLoader(),
+			sessionManager: coldManager,
+			settingsManager: SettingsManager.inMemory(settings),
+		});
+		cleanups.push(() => coldSession.dispose());
+		expect(convertToLlm(coldSession.messages)).toEqual(liveHistory);
+
+		await coldSession.prompt("after cold restore");
+
+		const coldRequest = requests.at(-1);
+		expect(coldRequest).toBeDefined();
+		const coldHistory = coldRequest!.slice(0, -1);
+		expect(coldHistory.some((message) => isOverflowAssistant(message, scenario))).toBe(false);
+		expect(coldHistory).toEqual(liveHistory);
+	});
+});


### PR DESCRIPTION
## Summary

- record the assistant entry IDs replaced by successful retries
- exclude superseded attempts from provider context, compaction input and token budgets, branch summaries, and cold restores
- retain superseded attempts in JSONL history and the rendered transcript
- cover length and explicit overflow recovery, retry chains, and branch-local behavior
- use one additional summarization request when the active turn alone exceeds the retained-token budget, rather than retrying the same oversized input unchanged

## Design

A failed assistant response cannot be identified as superseded from its stop reason alone, because terminal failures use the same values. The replacement entry therefore records the relationship explicitly, and provider-context consumers apply the same branch-local projection. The original attempt remains in JSONL and the rendered transcript.

## Related work

#8283 fixes a live continuation failure in the same retry and compaction path. This PR also covers that sequence, while preserving the replacement relationship so cold restore reconstructs the same provider context.

## Compatibility

`supersedesEntryIds` is optional in session format v3. Older readers ignore it and retain the previous replay behavior. Existing sessions without this metadata are unchanged because replacement relationships cannot be inferred safely.

Fixes #7724.

## Verification

- `npm run check`
- `./test.sh` (coding-agent: 1928 passed, 49 skipped)
