### PR TITLE
fix(coding-agent): collapse tool result images until output is expanded

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -343,7 +343,7 @@ export class ToolExecutionComponent extends Container {
 			const caps = getCapabilities();
 			for (let i = 0; i < imageBlocks.length; i++) {
 				const img = imageBlocks[i];
-				if (caps.images && this.showImages && img.data && img.mimeType) {
+				if (caps.images && this.showImages && this.expanded && img.data && img.mimeType) {
 					const converted = this.convertedImages.get(i);
 					const imageData = converted?.data ?? img.data;
 					const imageMimeType = converted?.mimeType ?? img.mimeType;

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -1,7 +1,7 @@
 import { join, resolve } from "node:path";
-import { Text, type TUI } from "@earendil-works/pi-tui";
+import { resetCapabilitiesCache, setCapabilities, setCellDimensions, Text, type TUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { beforeAll, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
 import { getReadmePath } from "../src/config.ts";
 import type { ToolDefinition } from "../src/core/extensions/types.ts";
 import { type BashOperations, createBashToolDefinition } from "../src/core/tools/bash.ts";
@@ -33,6 +33,11 @@ function createFakeTui(): TUI {
 describe("ToolExecutionComponent parity", () => {
 	beforeAll(() => {
 		initTheme("dark");
+	});
+
+	afterEach(() => {
+		resetCapabilitiesCache();
+		setCellDimensions({ widthPx: 9, heightPx: 18 });
 	});
 
 	test("stacks custom call and result renderers like the old implementation", () => {
@@ -427,6 +432,45 @@ describe("ToolExecutionComponent parity", () => {
 		const rendered = component.render(120).join("\n");
 		expect(stripAnsi(rendered)).toContain(error);
 		expect(rendered).toContain(theme.fg("toolOutput", error));
+	});
+
+	test("does not reserve terminal image rows for collapsed read results", () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+
+		const component = new ToolExecutionComponent(
+			"read",
+			"tool-image-read-collapsed",
+			{ path: "page.png" },
+			{ showImages: true },
+			createReadToolDefinition(process.cwd()),
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult(
+			{
+				content: [
+					{ type: "text", text: "Read image file [image/png]" },
+					{
+						type: "image",
+						data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+						mimeType: "image/png",
+					},
+				],
+				details: undefined,
+				isError: false,
+			},
+			false,
+		);
+
+		const collapsed = component.render(120);
+		expect(stripAnsi(collapsed.join("\n"))).toContain("page.png");
+		expect(collapsed.join("\n")).not.toContain("\x1b_G");
+		expect(collapsed.filter((line) => line === "").length).toBeLessThan(5);
+
+		component.setExpanded(true);
+		const expanded = component.render(120);
+		expect(expanded.join("\n")).toContain("\x1b_G");
 	});
 
 	test("collapses ordinary read results until expanded", () => {


### PR DESCRIPTION
Fixes https://github.com/earendil-works/pi/issues/8304

## Summary
- Collapsed tool output hid image *text* (`formatReadResult` returns `""` when not expanded) but still mounted Kitty/iTerm `Image` children whenever `showImages` was on (the default settings toggle, unrelated to Ctrl+O).
- That left full images visible in collapsed view on terminals that paint graphics, and reserved the same height as blank rows in hosts that do not.
- Gate image mounting on `this.expanded` so images only appear after expanding tool output.


Screenshots below rendered in a terminal that doesn't support rendering images (herdr), but also tested on ghostty where images get rendered. Having inline images rendered any time an agent reads them is not a great UX and should only show if un-collapsed.

Before:
<img width="804" height="1057" alt="Screenshot 2026-08-17 at 00 14 41" src="https://github.com/user-attachments/assets/18839900-507e-4314-9eaf-2e804456a6cd" />

After:
<img width="991" height="206" alt="Screenshot 2026-08-17 at 00 13 29" src="https://github.com/user-attachments/assets/89ac0b4a-4ca8-4c49-8608-c153bd2cf636" />
