### PR TITLE
feat(coding-agent): enable experimental cache-friendly compaction

### DIFF
--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -20,7 +20,9 @@ Pi has two summarization mechanisms:
 | Compaction | Context exceeds threshold, or `/compact` | Summarize old messages to free up context |
 | Branch summarization | `/tree` navigation | Preserve context when switching branches |
 
-Both use the same structured summary format and track file operations cumulatively. Compaction and branch-summary requests use fresh routing session IDs and, where supported by the provider, disable prompt-cache writes because these one-off prompts are unlikely to be reused.
+Both use the same structured summary format and track file operations cumulatively. By default, compaction and branch-summary requests use fresh routing session IDs and disable prompt-cache writes because these one-off prompts are unlikely to be reused.
+
+With `PI_EXPERIMENTAL=1`, built-in compaction instead preserves the active provider-context prefix and routing options with short prompt-cache retention, allowing providers to reuse the active prefix. Each summary uses this path only when context transformation preserves an exact provider-visible prefix of the active context and the source leaves room for the requested summary budget. Split-turn compaction also requires the provider-visible turn prefix to remain the context suffix. Otherwise, the affected summary falls back to standalone summarization without prompt caching.
 
 ## Compaction
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -15,6 +15,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type {
 	Agent,
 	AgentEvent,
@@ -28,6 +29,7 @@ import { contentText } from "@earendil-works/pi-ai";
 import type {
 	AssistantMessage,
 	AuthResult,
+	Context,
 	ImageContent,
 	Model,
 	ProviderHeaders,
@@ -66,6 +68,7 @@ import {
 	shouldCompact,
 } from "./compaction/index.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
+import { areExperimentalFeaturesEnabled } from "./experimental.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
 import {
@@ -1801,6 +1804,88 @@ export class AgentSession {
 		env: Record<string, string> | undefined,
 		reason: "manual" | "threshold" | "overflow",
 	): Promise<CompactionResult> {
+		// Preserve standalone summarization outside experimental mode.
+		if (!areExperimentalFeaturesEnabled()) {
+			return compact(
+				preparation,
+				requestModel,
+				apiKey,
+				headers,
+				customInstructions,
+				signal,
+				this.thinkingLevel,
+				this.agent.streamFunction,
+				env,
+				this.settingsManager.getRetrySettings(),
+				this._summarizationRetryCallbacks({ source: "compaction", reason }),
+				undefined, // cacheFriendly
+			);
+		}
+
+		// Snapshot request-level context so every candidate uses the same system prompt and tool set.
+		const systemPrompt = this.agent.state.systemPrompt;
+		const tools = this.agent.state.tools.slice();
+		const buildSourceContext = async (messages: AgentMessage[]) =>
+			this.agent.buildProviderContext({ systemPrompt, messages: messages.slice(), tools: tools.slice() }, signal);
+		const fullContext = await buildSourceContext(this.agent.state.messages);
+		const isExactActiveMessagePrefix = (candidate: Context): boolean =>
+			candidate.messages.length > 0 &&
+			candidate.messages.length <= fullContext.messages.length &&
+			isDeepStrictEqual(candidate.messages, fullContext.messages.slice(0, candidate.messages.length));
+
+		// Context transforms may not preserve prefixes when run on truncated history.
+		// Keep this undefined unless the candidate remains an exact prefix; compact()
+		// treats an undefined source as a request for standalone, non-cached summarization.
+		let sourceContext: Context | undefined;
+		if (preparation.messagesToSummarize.length > 0 && preparation.sourceMessages) {
+			const candidateContext = await buildSourceContext(preparation.sourceMessages);
+			if (isExactActiveMessagePrefix(candidateContext)) {
+				sourceContext = candidateContext;
+			}
+		}
+
+		// A split-turn instruction identifies the turn at the end of its source context.
+		// Require both an exact active-context prefix and the provider-visible turn
+		// prefix as its suffix; otherwise use standalone summarization.
+		let turnPrefixSourceContext: Context | undefined;
+		if (
+			preparation.isSplitTurn &&
+			preparation.turnPrefixMessages.length > 0 &&
+			preparation.turnPrefixSourceMessages
+		) {
+			const candidateContext = await buildSourceContext(preparation.turnPrefixSourceMessages);
+			const providerTurnPrefix = await this.agent.convertToLlm(preparation.turnPrefixMessages.slice());
+			if (
+				isExactActiveMessagePrefix(candidateContext) &&
+				providerTurnPrefix.length > 0 &&
+				providerTurnPrefix.length <= candidateContext.messages.length &&
+				isDeepStrictEqual(candidateContext.messages.slice(-providerTurnPrefix.length), providerTurnPrefix)
+			) {
+				turnPrefixSourceContext = candidateContext;
+			}
+		}
+
+		// Split-turn compaction can make separate history and turn-prefix summary requests.
+		// If none of the summary requests compact() will make has a cache-safe provider-context prefix,
+		// run the whole compaction through standalone summarization.
+		if (sourceContext === undefined && turnPrefixSourceContext === undefined) {
+			return compact(
+				preparation,
+				requestModel,
+				apiKey,
+				headers,
+				customInstructions,
+				signal,
+				this.thinkingLevel,
+				this.agent.streamFunction,
+				env,
+				this.settingsManager.getRetrySettings(),
+				this._summarizationRetryCallbacks({ source: "compaction", reason }),
+				undefined, // cacheFriendly
+			);
+		}
+
+		// For split turns, either source may remain undefined so only that summary falls back.
 		return compact(
 			preparation,
 			requestModel,
@@ -1813,7 +1898,18 @@ export class AgentSession {
 			env,
 			this.settingsManager.getRetrySettings(),
 			this._summarizationRetryCallbacks({ source: "compaction", reason }),
-			undefined, // cacheFriendly
+			{
+				sourceContext,
+				turnPrefixSourceContext,
+				requestOptions: {
+					sessionId: this.agent.sessionId,
+					onPayload: this.agent.onPayload,
+					onResponse: this.agent.onResponse,
+					transport: this.agent.transport,
+					thinkingBudgets: this.agent.thinkingBudgets,
+					maxRetryDelayMs: this.agent.maxRetryDelayMs,
+				},
+			},
 		);
 	}
 

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -7,8 +7,8 @@ import {
 	type Model,
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { estimateTokens } from "../../src/core/compaction/index.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { estimateTokens, prepareCompaction } from "../../src/core/compaction/index.ts";
 import { createHarness, getUserTexts, type Harness } from "./harness.ts";
 
 type SessionWithCompactionInternals = {
@@ -95,8 +95,18 @@ function seedCompactableSession(harness: Harness): void {
 
 describe("AgentSession compaction characterization", () => {
 	const harnesses: Harness[] = [];
+	const originalPiExperimental = process.env.PI_EXPERIMENTAL;
+
+	beforeEach(() => {
+		delete process.env.PI_EXPERIMENTAL;
+	});
 
 	afterEach(() => {
+		if (originalPiExperimental === undefined) {
+			delete process.env.PI_EXPERIMENTAL;
+		} else {
+			process.env.PI_EXPERIMENTAL = originalPiExperimental;
+		}
 		vi.useRealTimers();
 		vi.restoreAllMocks();
 		while (harnesses.length > 0) {
@@ -254,7 +264,7 @@ describe("AgentSession compaction characterization", () => {
 		expect(harness.faux.state.callCount).toBe(1);
 	});
 
-	it("uses the standalone compaction request context", async () => {
+	it("uses the standalone compaction request context outside experimental mode", async () => {
 		const harness = await createHarness({ settings: { compaction: { keepRecentTokens: 1 } } });
 		harnesses.push(harness);
 		seedCompactableSession(harness);
@@ -280,6 +290,174 @@ describe("AgentSession compaction characterization", () => {
 		expect(requestOptions).toMatchObject({ cacheRetention: "none" });
 		expect(requestOptions?.sessionId).not.toBe("active-routing-session");
 		expect(requestOptions?.transport).toBeUndefined();
+	});
+
+	it.each([
+		{ mode: "manual", keepRecentTokens: 2, expectedCalls: 1 },
+		{ mode: "automatic", keepRecentTokens: 1, expectedCalls: 2 },
+	] as const)("builds $mode compaction contexts through the active agent request pipeline", async (testCase) => {
+		process.env.PI_EXPERIMENTAL = "1";
+		const harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: testCase.keepRecentTokens } },
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "old request ".repeat(20) }],
+			timestamp: now - 4000,
+		});
+		harness.sessionManager.appendMessage({
+			...createAssistant(harness, { stopReason: "stop", totalTokens: 100, timestamp: now - 3000 }),
+			content: [{ type: "text", text: "old response ".repeat(20) }],
+		});
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "new" }],
+			timestamp: now - 2000,
+		});
+		harness.sessionManager.appendMessage({
+			...createAssistant(harness, { stopReason: "stop", totalTokens: 200, timestamp: now - 1000 }),
+			content: [{ type: "text", text: "ok" }],
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		const preparation = prepareCompaction(
+			harness.sessionManager.getBranch(),
+			harness.settingsManager.getCompactionSettings(),
+		);
+		if (!preparation?.sourceMessages || !preparation.turnPrefixSourceMessages) {
+			throw new Error("Expected compaction source messages");
+		}
+		const activeMessages = harness.session.agent.state.messages.slice();
+
+		const transformMarker: AgentMessage = {
+			role: "custom",
+			customType: "compaction-transform-marker",
+			content: "transformed context",
+			display: false,
+			timestamp: now - 5000,
+		};
+		harness.session.agent.transformContext = async (messages) => [transformMarker, ...messages];
+		const originalConvertToLlm = harness.session.agent.convertToLlm;
+		const convertedInputs: AgentMessage[][] = [];
+		harness.session.agent.convertToLlm = async (messages) => {
+			convertedInputs.push(messages);
+			return await originalConvertToLlm(messages);
+		};
+
+		const onPayload = async (payload: unknown) => payload;
+		const onResponse = async () => {};
+		harness.session.agent.sessionId = "compaction-routing-session";
+		harness.session.agent.onPayload = onPayload;
+		harness.session.agent.onResponse = onResponse;
+		harness.session.agent.transport = "websocket";
+		harness.session.agent.thinkingBudgets = { low: 1234 };
+		harness.session.agent.maxRetryDelayMs = 4321;
+
+		const requestContexts: Context[] = [];
+		const requestOptions: Array<SimpleStreamOptions | undefined> = [];
+		useSummaryStreamFn(harness, "pipeline summary", (context, options) => {
+			requestContexts.push(context);
+			requestOptions.push(options);
+		});
+
+		if (testCase.mode === "manual") {
+			await harness.session.compact();
+		} else {
+			const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+			await sessionInternals._runAutoCompaction("threshold", false);
+		}
+
+		const sourcePrefixes = preparation.isSplitTurn
+			? [preparation.sourceMessages, preparation.turnPrefixSourceMessages]
+			: [preparation.sourceMessages];
+		expect(sourcePrefixes).toHaveLength(testCase.expectedCalls);
+		expect(requestContexts).toHaveLength(testCase.expectedCalls);
+		expect(convertedInputs).toHaveLength(testCase.expectedCalls + 1 + (preparation.isSplitTurn ? 1 : 0));
+		expect(convertedInputs[0]).toEqual([transformMarker, ...activeMessages]);
+
+		for (let i = 0; i < sourcePrefixes.length; i++) {
+			const transformedSource = [transformMarker, ...sourcePrefixes[i]];
+			expect(convertedInputs[i + 1]).toEqual(transformedSource);
+			expect(requestContexts[i].systemPrompt).toBe(harness.session.agent.state.systemPrompt);
+			expect(requestContexts[i].tools).toEqual(harness.session.agent.state.tools);
+			expect(requestContexts[i].messages.slice(0, -1)).toEqual(await originalConvertToLlm(transformedSource));
+			expect(requestOptions[i]).toMatchObject({
+				cacheRetention: "short",
+				sessionId: "compaction-routing-session",
+				transport: "websocket",
+				thinkingBudgets: { low: 1234 },
+				maxRetryDelayMs: 4321,
+			});
+			expect(requestOptions[i]?.onPayload).toBe(onPayload);
+			expect(requestOptions[i]?.onResponse).toBe(onResponse);
+		}
+		if (preparation.isSplitTurn) {
+			expect(convertedInputs.at(-1)).toEqual(preparation.turnPrefixMessages);
+		}
+	});
+
+	it("uses standalone summarization when a context transform breaks source prefixes", async () => {
+		process.env.PI_EXPERIMENTAL = "1";
+		const harness = await createHarness({ settings: { compaction: { keepRecentTokens: 1 } } });
+		harnesses.push(harness);
+
+		const now = Date.now();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "old request ".repeat(20) }],
+			timestamp: now - 4000,
+		});
+		harness.sessionManager.appendMessage({
+			...createAssistant(harness, { stopReason: "stop", totalTokens: 100, timestamp: now - 3000 }),
+			content: [{ type: "text", text: "old response ".repeat(20) }],
+		});
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "large final request" }],
+			timestamp: now - 2000,
+		});
+		harness.sessionManager.appendMessage({
+			...createAssistant(harness, { stopReason: "stop", totalTokens: 200, timestamp: now - 1000 }),
+			content: [{ type: "text", text: "kept suffix" }],
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		const preparation = prepareCompaction(
+			harness.sessionManager.getBranch(),
+			harness.settingsManager.getCompactionSettings(),
+		);
+		expect(preparation?.isSplitTurn).toBe(true);
+
+		const appendedContext: AgentMessage = {
+			role: "custom",
+			customType: "appended-context",
+			content: "provider-only context",
+			display: false,
+			timestamp: now,
+		};
+		harness.session.agent.transformContext = async (messages) => [...messages, appendedContext];
+
+		const requestContexts: Context[] = [];
+		const requestOptions: Array<SimpleStreamOptions | undefined> = [];
+		useSummaryStreamFn(harness, "summary", (context, options) => {
+			requestContexts.push(context);
+			requestOptions.push(options);
+		});
+
+		await harness.session.compact();
+
+		expect(requestContexts).toHaveLength(2);
+		for (let i = 0; i < requestContexts.length; i++) {
+			expect(requestContexts[i].systemPrompt).not.toBe(harness.session.agent.state.systemPrompt);
+			expect(requestContexts[i].tools).toBeUndefined();
+			expect(JSON.stringify(requestContexts[i].messages)).toContain("<conversation>");
+			expect(JSON.stringify(requestContexts[i].messages)).not.toContain("provider-only context");
+			expect(requestOptions[i]).toMatchObject({ cacheRetention: "none" });
+			expect(requestOptions[i]?.sessionId).not.toBe(harness.session.agent.sessionId);
+		}
 	});
 
 	it("persists usage from pi-generated manual compaction", async () => {


### PR DESCRIPTION
This will enable "cache friendly compaction", i.e. caching that appends the compaction request to the main session. Currently Pi will only do standalone requests for compaction, which is a lot more expensive than reusing the current session cache (if it is warm).

This only enables it for auto compaction and `/compact`, not yet for thread summarization, which is also important.

Confirmed to use cache reads on OpenAI.

Preparatory plumbing commits https://github.com/earendil-works/pi/commit/ef8dc7385b1ed41c40cd0a4bbf612326ec18bd23 and https://github.com/earendil-works/pi/commit/cff1cf52c6c73ef873dcb6148238ed68f69e1ead