### PR TITLE
fix(ai): round-trip Bedrock redacted reasoning

### DIFF
--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -101,9 +101,17 @@ export interface BedrockOptions extends StreamOptions {
 	bearerToken?: string;
 }
 
-type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
+type Block = (TextContent | ThinkingContent | ToolCall) & {
+	index?: number;
+	partialJson?: string;
+	/** Scratch buffer for encrypted reasoning deltas, joined into `thinkingSignature`. */
+	redactedChunks?: Uint8Array[];
+};
 
 const EMPTY_TEXT_PLACEHOLDER = "<empty>";
+
+/** Matches the placeholder the Anthropic API path uses for redacted thinking. */
+const REDACTED_THINKING_PLACEHOLDER = "[Reasoning redacted]";
 
 export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> = (
 	model: Model<"bedrock-converse-stream">,
@@ -313,13 +321,13 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 				throw new Error(output.errorMessage || "An unknown error occurred");
 			}
 
+			// A stream can settle without stopping every block, so finalize here too.
+			for (const block of output.content) finalizeStreamingBlock(block as Block);
 			stream.push({ type: "done", reason: output.stopReason, message: output });
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) {
-				delete (block as Block).index;
-				// partialJson is only a streaming scratch buffer; never persist it.
-				delete (block as Block).partialJson;
+				finalizeStreamingBlock(block as Block);
 			}
 			output.stopReason = options.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = formatBedrockError(error);
@@ -624,12 +632,54 @@ function handleContentBlockDelta(
 					partial: output,
 				});
 			}
-			if (delta.reasoningContent.signature) {
+			// `thinkingSignature` holds either an Anthropic signature or an opaque redacted
+			// payload, never both: mixing them would corrupt whichever arrived first.
+			if (delta.reasoningContent.signature && !thinkingBlock.redacted) {
 				thinkingBlock.thinkingSignature =
 					(thinkingBlock.thinkingSignature || "") + delta.reasoningContent.signature;
 			}
+			if (delta.reasoningContent.redactedContent?.length) {
+				// Encrypted reasoning from non-Anthropic models on Bedrock (e.g. OpenAI GPT-5.6).
+				// The payload is opaque, so keep it verbatim in `thinkingSignature` the way the
+				// Anthropic path stores redacted thinking, and replay it on the next turn.
+				if (!thinkingBlock.redacted) {
+					thinkingBlock.redacted = true;
+					thinkingBlock.thinkingSignature = "";
+					thinkingBlock.thinking += REDACTED_THINKING_PLACEHOLDER;
+					stream.push({
+						type: "thinking_delta",
+						contentIndex: thinkingIndex,
+						delta: REDACTED_THINKING_PLACEHOLDER,
+						partial: output,
+					});
+				}
+				thinkingBlock.redactedChunks ??= [];
+				thinkingBlock.redactedChunks.push(delta.reasoningContent.redactedContent);
+			}
 		}
 	}
+}
+
+/**
+ * Encodes buffered encrypted reasoning into `thinkingSignature` and drops the scratch
+ * buffer, which must never reach a persisted message: `Uint8Array` serializes to an
+ * index-keyed object roughly ten times the size of the base64 payload.
+ */
+function flushRedactedContent(block: Block): void {
+	if (block.type !== "thinking" || !block.redactedChunks) return;
+	block.thinkingSignature = bytesToBase64(block.redactedChunks);
+	delete block.redactedChunks;
+}
+
+/**
+ * Strips every streaming scratch field. Runs from the terminal paths as well as
+ * `contentBlockStop`, because a stream can settle without stopping each block.
+ */
+function finalizeStreamingBlock(block: Block): void {
+	delete block.index;
+	// partialJson is only a streaming scratch buffer; never persist it.
+	delete block.partialJson;
+	flushRedactedContent(block);
 }
 
 function handleMetadata(
@@ -663,6 +713,7 @@ function handleContentBlockStop(
 			stream.push({ type: "text_end", contentIndex: index, content: block.text, partial: output });
 			break;
 		case "thinking":
+			flushRedactedContent(block);
 			stream.push({ type: "thinking_end", contentIndex: index, content: block.thinking, partial: output });
 			break;
 		case "toolCall":
@@ -936,6 +987,15 @@ function convertMessages(
 							});
 							break;
 						case "thinking": {
+							// Encrypted reasoning is opaque: replay the stored payload as the
+							// `redactedContent` member instead of lowering it to reasoning text.
+							if (c.redacted) {
+								const redactedContent = decodeRedactedContent(c.thinkingSignature);
+								if (redactedContent?.length) {
+									contentBlocks.push({ reasoningContent: { redactedContent } });
+								}
+								continue;
+							}
 							// Skip empty thinking blocks
 							const thinking = sanitizeSurrogates(c.thinking);
 							if (thinking.trim().length === 0) continue;
@@ -1223,11 +1283,43 @@ function createImageBlock(mimeType: string, data: string) {
 			throw new Error(`Unknown image type: ${mimeType}`);
 	}
 
+	return { source: { bytes: base64ToBytes(data) }, format };
+}
+
+function base64ToBytes(data: string): Uint8Array {
 	const binaryString = atob(data);
 	const bytes = new Uint8Array(binaryString.length);
 	for (let i = 0; i < binaryString.length; i++) {
 		bytes[i] = binaryString.charCodeAt(i);
 	}
+	return bytes;
+}
 
-	return { source: { bytes }, format };
+/**
+ * Decodes a stored redacted payload. The AWS SDK hands the blob over as bytes, but a
+ * persisted session carries it as base64. A hand-edited or externally produced session
+ * can hold a signature that is not base64; drop that block instead of failing the
+ * whole request.
+ */
+function decodeRedactedContent(signature: string | undefined): Uint8Array | undefined {
+	if (!signature) return undefined;
+	try {
+		return base64ToBytes(signature);
+	} catch {
+		return undefined;
+	}
+}
+
+function bytesToBase64(chunks: Uint8Array[]): string {
+	// Encrypted reasoning runs to tens of KB, so build the binary string in slices
+	// rather than one concatenation per byte. The window stays under the engine's
+	// argument-count limit for spread calls.
+	const WINDOW = 0x8000;
+	let binary = "";
+	for (const chunk of chunks) {
+		for (let i = 0; i < chunk.length; i += WINDOW) {
+			binary += String.fromCharCode(...chunk.subarray(i, i + WINDOW));
+		}
+	}
+	return btoa(binary);
 }

--- a/packages/ai/test/bedrock-redacted-reasoning.test.ts
+++ b/packages/ai/test/bedrock-redacted-reasoning.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * OpenAI models served through Bedrock Converse (e.g. `global.openai.gpt-5.6-terra`)
+ * return encrypted reasoning as the opaque `redactedContent` member of
+ * `reasoningContent`, not as `reasoningText`. The AWS SDK decodes the wire blob to
+ * `Uint8Array`.
+ * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html
+ */
+const bedrockMock = vi.hoisted(() => {
+	const redactedBase64 = "cnNuXzVaVnJpZjRKMGJYSXFtV2RsZWRqN1FJRmVOaWtSUWJF";
+	return {
+		redactedBase64,
+		redactedBytes: new Uint8Array(Buffer.from(redactedBase64, "base64")),
+		streamEvents: undefined as unknown[] | undefined,
+	};
+});
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+
+	class BedrockRuntimeClient {
+		send(): Promise<unknown> {
+			if (bedrockMock.streamEvents) {
+				const events = bedrockMock.streamEvents;
+				return Promise.resolve({
+					$metadata: { httpStatusCode: 200 },
+					stream: (async function* () {
+						yield* events;
+					})(),
+				});
+			}
+			return Promise.reject(new Error("mock send"));
+		}
+	}
+
+	class ConverseStreamCommand {
+		readonly input: unknown;
+
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+import { stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
+import type { Context, Message, Model, ThinkingContent } from "../src/types.ts";
+
+const gptModel: Model<"bedrock-converse-stream"> = {
+	id: "global.openai.gpt-5.6-terra",
+	name: "GPT-5.6 Terra (Global)",
+	api: "bedrock-converse-stream",
+	provider: "amazon-bedrock",
+	baseUrl: "https://bedrock-runtime.ap-northeast-1.amazonaws.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+};
+
+const emptyUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+/** Mirrors the ConverseStream frames GPT-5.6 emits: encrypted reasoning, then text. */
+function redactedReasoningEvents(): unknown[] {
+	return [
+		{ messageStart: { role: "assistant" } },
+		{
+			contentBlockDelta: {
+				contentBlockIndex: 0,
+				delta: { reasoningContent: { redactedContent: bedrockMock.redactedBytes } },
+			},
+		},
+		{ contentBlockStop: { contentBlockIndex: 0 } },
+		{ contentBlockDelta: { contentBlockIndex: 1, delta: { text: "done" } } },
+		{ contentBlockStop: { contentBlockIndex: 1 } },
+		{ messageStop: { stopReason: "end_turn" } },
+	];
+}
+
+interface BedrockRequestPayload {
+	messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+}
+
+async function capturePayload(context: Context): Promise<BedrockRequestPayload> {
+	let capturedPayload: BedrockRequestPayload | undefined;
+	const s = streamBedrock(gptModel, context, {
+		cacheRetention: "none",
+		signal: AbortSignal.abort(),
+		onPayload: (payload) => {
+			capturedPayload = payload as BedrockRequestPayload;
+			return payload;
+		},
+	});
+	for await (const event of s) {
+		if (event.type === "error") break;
+	}
+	if (!capturedPayload) {
+		throw new Error("Expected Bedrock payload to be captured before request abort");
+	}
+	return capturedPayload;
+}
+
+describe("Bedrock redacted reasoning", () => {
+	beforeEach(() => {
+		bedrockMock.streamEvents = undefined;
+	});
+
+	it("does not fail the stream when reasoning arrives as redactedContent", async () => {
+		bedrockMock.streamEvents = redactedReasoningEvents();
+
+		const response = await streamBedrock(gptModel, {
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		}).result();
+
+		expect(response.stopReason, response.errorMessage).not.toBe("error");
+		// Reasoning precedes the answer, matching the order Bedrock streamed it.
+		expect(response.content.map((c) => c.type)).toEqual(["thinking", "text"]);
+		expect(response.content[1]).toEqual({ type: "text", text: "done" });
+	});
+
+	it("preserves the encrypted reasoning payload on the assistant message", async () => {
+		bedrockMock.streamEvents = redactedReasoningEvents();
+
+		const response = await streamBedrock(gptModel, {
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		}).result();
+
+		const thinking = response.content.find((c): c is ThinkingContent => c.type === "thinking");
+		expect(thinking).toBeDefined();
+		// Same representation Anthropic redacted thinking already uses: the opaque
+		// payload rides in `thinkingSignature` with `redacted: true`.
+		expect(thinking?.redacted).toBe(true);
+		expect(thinking?.thinkingSignature).toBe(bedrockMock.redactedBase64);
+		// The byte buffer is streaming scratch state: persisting it would bloat the
+		// session, since a Uint8Array serializes to an index-keyed object.
+		expect("redactedChunks" in thinking!).toBe(false);
+	});
+
+	it("encodes the payload when the stream never sends contentBlockStop", async () => {
+		bedrockMock.streamEvents = [
+			{ messageStart: { role: "assistant" } },
+			{
+				contentBlockDelta: {
+					contentBlockIndex: 0,
+					delta: { reasoningContent: { redactedContent: bedrockMock.redactedBytes } },
+				},
+			},
+			{ messageStop: { stopReason: "end_turn" } },
+		];
+
+		const response = await streamBedrock(gptModel, {
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		}).result();
+
+		const thinking = response.content.find((c): c is ThinkingContent => c.type === "thinking");
+		expect(thinking?.thinkingSignature).toBe(bedrockMock.redactedBase64);
+		// Streaming scratch state must not survive into the persisted message.
+		expect("redactedChunks" in thinking!).toBe(false);
+		expect("index" in thinking!).toBe(false);
+	});
+
+	it("joins encrypted reasoning split across deltas", async () => {
+		const [head, tail] = [bedrockMock.redactedBytes.slice(0, 7), bedrockMock.redactedBytes.slice(7)];
+		bedrockMock.streamEvents = [
+			{ messageStart: { role: "assistant" } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { redactedContent: head } } } },
+			{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { redactedContent: tail } } } },
+			{ contentBlockStop: { contentBlockIndex: 0 } },
+			{ messageStop: { stopReason: "end_turn" } },
+		];
+
+		const response = await streamBedrock(gptModel, {
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+		}).result();
+
+		const thinking = response.content.find((c): c is ThinkingContent => c.type === "thinking");
+		expect(thinking?.thinkingSignature).toBe(bedrockMock.redactedBase64);
+		// The placeholder marks the block once, not once per delta.
+		expect(thinking?.thinking).toBe("[Reasoning redacted]");
+	});
+
+	it("replays redacted reasoning as reasoningContent.redactedContent", async () => {
+		const messages: Message[] = [
+			{ role: "user", content: "hello", timestamp: Date.now() },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "", thinkingSignature: bedrockMock.redactedBase64, redacted: true },
+					{ type: "text", text: "done" },
+				],
+				api: "bedrock-converse-stream",
+				provider: "amazon-bedrock",
+				model: gptModel.id,
+				usage: emptyUsage,
+				stopReason: "stop",
+				timestamp: Date.now(),
+			},
+			{ role: "user", content: "continue", timestamp: Date.now() },
+		];
+
+		const payload = await capturePayload({ messages });
+
+		const assistant = payload.messages.find((m: any) => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(assistant!.content).toEqual([
+			{ reasoningContent: { redactedContent: bedrockMock.redactedBytes } },
+			{ text: "done" },
+		]);
+	});
+
+	it("replays redacted reasoning before the toolUse block it belongs to", async () => {
+		// Bedrock rejects a tool continuation whose reasoning block is missing or
+		// reordered, so the opaque payload must land ahead of the matching toolUse.
+		const messages: Message[] = [
+			{ role: "user", content: "read the file", timestamp: Date.now() },
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "", thinkingSignature: bedrockMock.redactedBase64, redacted: true },
+					{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "/tmp/a.txt" } },
+				],
+				api: "bedrock-converse-stream",
+				provider: "amazon-bedrock",
+				model: gptModel.id,
+				usage: emptyUsage,
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			},
+			{
+				role: "toolResult",
+				toolCallId: "tool-1",
+				toolName: "read",
+				content: [{ type: "text", text: "file body" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		];
+
+		const payload = await capturePayload({ messages });
+
+		const assistant = payload.messages.find((m: any) => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(assistant!.content).toEqual([
+			{ reasoningContent: { redactedContent: bedrockMock.redactedBytes } },
+			{ toolUse: { toolUseId: "tool-1", name: "read", input: { path: "/tmp/a.txt" } } },
+		]);
+	});
+});


### PR DESCRIPTION
Bedrock Converse returns encrypted reasoning as the opaque `redactedContent` member of `reasoningContent`, documented on both [`ReasoningContentBlock`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html) and the streaming [`ReasoningContentBlockDelta`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html). OpenAI models served on Bedrock (e.g. `global.openai.gpt-5.6-terra`) return reasoning in this shape.

The stream handler only read `reasoningContent.text` and `.signature`, so the payload was dropped. The persisted thinking block kept an empty `thinkingSignature`, and `convertMessages` then skipped it via the `thinking.trim().length === 0` guard, so replayed history lost the reasoning block entirely — including tool continuations, which Bedrock validates against the reasoning block that precedes the matching `toolUse`.

Fixed by buffering the delta bytes and encoding them into `thinkingSignature` with `redacted: true`, the representation the Anthropic path already uses for `redacted_thinking`, then lowering them back to `reasoningContent.redactedContent` on replay. Scratch state is stripped from every terminal path, since a stream can settle without a `contentBlockStop` for each block.

Added `test/bedrock-redacted-reasoning.test.ts` covering stream survival, payload preservation, missing `contentBlockStop`, deltas split across frames, and replay ordering ahead of both text and `toolUse`.

Verification:

- `npm test --workspace @earendil-works/pi-ai -- test/bedrock-redacted-reasoning.test.ts` (6 passed)
- `npm run check`
- `./test.sh`
