### PR TITLE
feat(coding-agent): add agent_recovery_exhausted extension hook

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -309,7 +309,8 @@ user sends prompt ────────────────────�
   │   └─► turn_end                                 │       │
   │                                                        │
   ├─► agent_end                                            │
-  └─► agent_settled (no retry/compaction/follow-up left)   │
+  ├─► agent_recovery_exhausted (native retry/overflow done; can request one continue)
+  └─► agent_settled (no retry/compaction/follow-up/hook continue left) │
                                                            │
 user sends another prompt ◄────────────────────────────────┘
 
@@ -566,7 +567,7 @@ Inside `before_agent_start`, `event.systemPrompt` and `ctx.getSystemPrompt()` bo
 
 #### agent_start / agent_end / agent_settled
 
-`agent_start` fires when a low-level agent run begins. `agent_end` fires when that run ends, but Pi may still auto-retry, auto-compact and retry, or continue with queued follow-up messages. Use `agent_settled` for status integrations that need to know Pi will not continue running automatically.
+`agent_start` fires when a low-level agent run begins. `agent_end` fires when that run ends, but Pi may still auto-retry, auto-compact and retry, continue with queued follow-up messages, or honor `agent_recovery_exhausted`. Use `agent_settled` for status integrations that need to know Pi will not continue running automatically.
 
 ```typescript
 pi.on("agent_start", async (_event, ctx) => {});
@@ -579,6 +580,36 @@ pi.on("agent_settled", async (_event, ctx) => {
   // ctx.isIdle() is true here unless another extension started a new run.
 });
 ```
+
+#### agent_recovery_exhausted
+
+Fires after native retry and overflow compact-and-retry are exhausted, and after queued follow-up/steering continuations, when the last assistant still failed. It does not fire on success, `stopReason: "aborted"`, mid-ladder retry, successful overflow recovery, or after the per-prompt continuation cap (`MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS`, 8).
+
+Detect support at runtime with `pi.features`:
+
+```typescript
+const supported =
+  pi.features != null &&
+  Object.prototype.hasOwnProperty.call(pi.features, "agent_recovery_exhausted") &&
+  pi.features.agent_recovery_exhausted === true;
+```
+
+Return `{ retry: true }` to request one in-session continuation. Pi then removes the trailing failed assistant from active context (session history is unchanged) and calls `agent.continue()`. Any other result, a throw, or an aborted signal is a decline. Later handlers still run and cannot cancel an earlier retry vote.
+
+```typescript
+pi.on("agent_recovery_exhausted", async (event, ctx) => {
+  // event.message - failed assistant (includes stopReason / errorMessage)
+  // event.nativeRetryAttempts - completed native retries for this cycle
+  // event.overflowRecoveryAttempted - true after the single overflow compact-and-retry
+  // event.signal - abort signal for this prompt
+  if (event.signal.aborted) return;
+  const applied = await pi.setModel(fallbackModel);
+  if (!applied) return;
+  return { retry: true };
+});
+```
+
+`agent_settled` still fires exactly once per prompt, after native recovery and any accepted hook continuations finish.
 
 #### turn_start / turn_end
 
@@ -1339,6 +1370,10 @@ export default function (pi: ExtensionAPI) {
 ```
 
 ## ExtensionAPI Methods
+
+### pi.features
+
+Frozen runtime feature flags. On current hosts this is `{ agent_recovery_exhausted: true }`. Treat a missing `features` object, a missing key, or a value other than `true` as unsupported.
 
 ### pi.on(event, handler)
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -76,6 +76,7 @@ import {
 	ExtensionRunner,
 	type ExtensionUIContext,
 	type InputSource,
+	MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS,
 	type MessageEndEvent,
 	type MessageStartEvent,
 	type MessageUpdateEvent,
@@ -336,6 +337,8 @@ export class AgentSession {
 	// Retry state
 	private _retryAbortController: AbortController | undefined = undefined;
 	private _retryAttempt = 0;
+	private _promptAbortController: AbortController | undefined = undefined;
+	private _recoveryExhaustedContinuations = 0;
 
 	// Bash execution state
 	private readonly _bashAbortControllers = new Set<AbortController>();
@@ -1070,16 +1073,88 @@ export class AgentSession {
 
 	private async _runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void> {
 		this._isAgentRunActive = true;
+		this._recoveryExhaustedContinuations = 0;
+		this._promptAbortController = new AbortController();
 		try {
 			await this.agent.prompt(messages);
-			while (await this._handlePostAgentRun()) {
-				await this.agent.continue();
+			while (true) {
+				const lastAssistant = this._lastAssistantMessage;
+				const nativeRetryAttempts = this._retryAttempt;
+				const overflowRecoveryAttempted = this._overflowRecoveryAttempted;
+				if (await this._handlePostAgentRun()) {
+					await this.agent.continue();
+					continue;
+				}
+				if (
+					await this._tryAgentRecoveryExhaustedContinuation(
+						lastAssistant,
+						nativeRetryAttempts,
+						overflowRecoveryAttempted,
+					)
+				) {
+					await this.agent.continue();
+					continue;
+				}
+				break;
 			}
 		} finally {
+			this._promptAbortController = undefined;
 			this._systemPromptOverride = undefined;
 			this._flushPendingBashMessages();
 			await this._emitAgentSettled();
 		}
+	}
+
+	private _isAgentRecoveryExhaustedCandidate(message: AssistantMessage, overflowRecoveryAttempted: boolean): boolean {
+		if (message.stopReason === "aborted") {
+			return false;
+		}
+		if (message.stopReason === "error") {
+			return true;
+		}
+		return overflowRecoveryAttempted && message.stopReason === "length";
+	}
+
+	private async _tryAgentRecoveryExhaustedContinuation(
+		message: AssistantMessage | undefined,
+		nativeRetryAttempts: number,
+		overflowRecoveryAttempted: boolean,
+	): Promise<boolean> {
+		const signal = this._promptAbortController?.signal;
+		if (!message || !signal || signal.aborted) {
+			return false;
+		}
+		if (!this._isAgentRecoveryExhaustedCandidate(message, overflowRecoveryAttempted)) {
+			return false;
+		}
+		if (this._recoveryExhaustedContinuations >= MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS) {
+			return false;
+		}
+		if (!this._extensionRunner.hasHandlers("agent_recovery_exhausted")) {
+			return false;
+		}
+
+		const retry = await this._extensionRunner.emitAgentRecoveryExhausted({
+			type: "agent_recovery_exhausted",
+			message,
+			nativeRetryAttempts,
+			overflowRecoveryAttempted,
+			signal,
+		});
+
+		if (!retry || signal.aborted) {
+			return false;
+		}
+		if (this._recoveryExhaustedContinuations >= MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS) {
+			return false;
+		}
+
+		this._recoveryExhaustedContinuations++;
+		const messages = this.agent.state.messages;
+		if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+			this.agent.state.messages = messages.slice(0, -1);
+		}
+		return true;
 	}
 
 	private async _handlePostAgentRun(): Promise<boolean> {
@@ -1556,6 +1631,7 @@ export class AgentSession {
 	 * Abort current operation and wait for agent to become idle.
 	 */
 	async abort(): Promise<void> {
+		this._promptAbortController?.abort();
 		this.abortRetry();
 		this.agent.abort();
 		await this.waitForIdle();
@@ -2833,6 +2909,7 @@ export class AgentSession {
 	 */
 	abortRetry(): void {
 		this._retryAbortController?.abort();
+		this._promptAbortController?.abort();
 	}
 
 	/** Whether auto-retry is currently in progress */

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -22,6 +22,8 @@ export { ExtensionRunner } from "./runner.ts";
 export type {
 	AfterProviderResponseEvent,
 	AgentEndEvent,
+	AgentRecoveryExhaustedEvent,
+	AgentRecoveryExhaustedResult,
 	AgentSettledEvent,
 	AgentStartEvent,
 	// Re-exports
@@ -69,6 +71,7 @@ export type {
 	ExtensionError,
 	ExtensionEvent,
 	ExtensionFactory,
+	ExtensionFeatures,
 	ExtensionFlag,
 	ExtensionHandler,
 	ExtensionMode,
@@ -183,5 +186,6 @@ export {
 	isReadToolResult,
 	isToolCallEventType,
 	isWriteToolResult,
+	MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS,
 } from "./types.ts";
 export { wrapRegisteredTool, wrapRegisteredTools } from "./wrapper.ts";

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -256,6 +256,10 @@ function createExtensionAPI(
 	eventBus: EventBus,
 ): ExtensionAPI {
 	const api = {
+		features: Object.freeze({
+			agent_recovery_exhausted: true,
+		}),
+
 		// Registration methods - write to extension
 		on(event: string, handler: HandlerFn): void {
 			runtime.assertActive();

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -13,6 +13,8 @@ import type { ScopedModel } from "../model-resolver.ts";
 import type { SessionManager } from "../session-manager.ts";
 import type { BuildSystemPromptOptions } from "../system-prompt.ts";
 import type {
+	AgentRecoveryExhaustedEvent,
+	AgentRecoveryExhaustedResult,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	BeforeProviderHeadersEvent,
@@ -135,6 +137,7 @@ type RunnerEmitEvent = Exclude<
 	| MessageEndEvent
 	| ResourcesDiscoverEvent
 	| InputEvent
+	| AgentRecoveryExhaustedEvent
 >;
 
 type SessionBeforeEvent = Extract<
@@ -830,6 +833,36 @@ export class ExtensionRunner {
 		}
 
 		return result as RunnerEmitResult<TEvent>;
+	}
+
+	async emitAgentRecoveryExhausted(event: AgentRecoveryExhaustedEvent): Promise<boolean> {
+		const ctx = this.createContext();
+		let retry = false;
+
+		for (const ext of this.extensions) {
+			const handlers = ext.handlers.get("agent_recovery_exhausted");
+			if (!handlers || handlers.length === 0) continue;
+
+			for (const handler of handlers) {
+				try {
+					const handlerResult = (await handler(event, ctx)) as AgentRecoveryExhaustedResult | undefined;
+					if (handlerResult?.retry === true) {
+						retry = true;
+					}
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					const stack = err instanceof Error ? err.stack : undefined;
+					this.emitError({
+						extensionPath: ext.path,
+						event: event.type,
+						error: message,
+						stack,
+					});
+				}
+			}
+		}
+
+		return retry;
 	}
 
 	async emitMessageEnd(event: MessageEndEvent): Promise<AgentMessage | undefined> {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -17,6 +17,7 @@ import type {
 } from "@earendil-works/pi-agent-core";
 import type {
 	Api,
+	AssistantMessage,
 	AssistantMessageEvent,
 	AssistantMessageEventStream,
 	ConstrainedSamplingConfig,
@@ -740,6 +741,30 @@ export interface AgentSettledEvent {
 	type: "agent_settled";
 }
 
+/** Per-prompt cap on hook-driven continuations after native recovery is exhausted. */
+export const MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS = 8;
+
+/** Fired after native retry and overflow recovery are exhausted, before agent_settled. */
+export interface AgentRecoveryExhaustedEvent {
+	type: "agent_recovery_exhausted";
+	/** Failed assistant that exhausted native recovery. */
+	message: AssistantMessage;
+	/**
+	 * Completed native retry attempts for this post-run cycle, captured
+	 * before `_handlePostAgentRun` resets `_retryAttempt`. `0` when native
+	 * retry never started (disabled, non-retryable, or 401/403).
+	 */
+	nativeRetryAttempts: number;
+	/** True when this cycle already consumed the single overflow compact-and-retry. */
+	overflowRecoveryAttempted: boolean;
+	/** Abort signal for this `_runAgentPrompt` invocation. */
+	signal: AbortSignal;
+}
+
+export interface AgentRecoveryExhaustedResult {
+	retry?: boolean;
+}
+
 /** Fired at the start of each turn */
 export interface TurnStartEvent {
 	type: "turn_start";
@@ -1059,6 +1084,7 @@ export type ExtensionEvent =
 	| AgentStartEvent
 	| AgentEndEvent
 	| AgentSettledEvent
+	| AgentRecoveryExhaustedEvent
 	| TurnStartEvent
 	| TurnEndEvent
 	| MessageStartEvent
@@ -1208,10 +1234,22 @@ export interface ResolvedCommand extends RegisteredCommand {
 // biome-ignore lint/suspicious/noConfusingVoidType: void allows bare return statements
 export type ExtensionHandler<E, R = undefined> = (event: E, ctx: ExtensionContext) => Promise<R | void> | R | void;
 
+/** Runtime feature flags advertised on hook-bearing hosts. */
+export interface ExtensionFeatures {
+	readonly agent_recovery_exhausted: true;
+}
+
 /**
  * ExtensionAPI passed to extension factory functions.
  */
 export interface ExtensionAPI {
+	/**
+	 * Runtime feature flags. Present on hosts that implement this surface.
+	 * Detect `agent_recovery_exhausted` by checking that `features` is a non-null
+	 * object whose own enumerable data property `agent_recovery_exhausted` is `true`.
+	 */
+	readonly features?: ExtensionFeatures;
+
 	// =========================================================================
 	// Event Subscription
 	// =========================================================================
@@ -1245,6 +1283,10 @@ export interface ExtensionAPI {
 	on(event: "agent_start", handler: ExtensionHandler<AgentStartEvent>): void;
 	on(event: "agent_end", handler: ExtensionHandler<AgentEndEvent>): void;
 	on(event: "agent_settled", handler: ExtensionHandler<AgentSettledEvent>): void;
+	on(
+		event: "agent_recovery_exhausted",
+		handler: ExtensionHandler<AgentRecoveryExhaustedEvent, AgentRecoveryExhaustedResult>,
+	): void;
 	on(event: "turn_start", handler: ExtensionHandler<TurnStartEvent>): void;
 	on(event: "turn_end", handler: ExtensionHandler<TurnEndEvent>): void;
 	on(event: "message_start", handler: ExtensionHandler<MessageStartEvent>): void;

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -32,6 +32,8 @@ export { areExperimentalFeaturesEnabled } from "./experimental.ts";
 // Extensions system
 export {
 	type AgentEndEvent,
+	type AgentRecoveryExhaustedEvent,
+	type AgentRecoveryExhaustedResult,
 	type AgentSettledEvent,
 	type AgentStartEvent,
 	type AgentToolResult,
@@ -51,6 +53,7 @@ export {
 	type ExtensionError,
 	type ExtensionEvent,
 	type ExtensionFactory,
+	type ExtensionFeatures,
 	type ExtensionFlag,
 	type ExtensionHandler,
 	ExtensionRunner,
@@ -58,6 +61,7 @@ export {
 	type ExtensionUIContext,
 	type InlineExtension,
 	type LoadExtensionsResult,
+	MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS,
 	type MessageRenderer,
 	type RegisteredCommand,
 	type SessionBeforeCompactEvent,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -53,6 +53,8 @@ export { createEventBus, type EventBus, type EventBusController } from "./core/e
 // Extension system
 export type {
 	AgentEndEvent,
+	AgentRecoveryExhaustedEvent,
+	AgentRecoveryExhaustedResult,
 	AgentSettledEvent,
 	AgentStartEvent,
 	AgentToolResult,
@@ -85,6 +87,7 @@ export type {
 	ExtensionError,
 	ExtensionEvent,
 	ExtensionFactory,
+	ExtensionFeatures,
 	ExtensionFlag,
 	ExtensionHandler,
 	ExtensionRuntime,
@@ -163,6 +166,7 @@ export {
 	isReadToolResult,
 	isToolCallEventType,
 	isWriteToolResult,
+	MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS,
 	wrapRegisteredTool,
 	wrapRegisteredTools,
 } from "./core/extensions/index.ts";

--- a/packages/coding-agent/test/suite/agent-session-recovery-exhausted.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-recovery-exhausted.test.ts
@@ -1,0 +1,357 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type AgentRecoveryExhaustedEvent,
+	type ExtensionAPI,
+	MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS,
+} from "../../src/index.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+function historyAssistants(harness: Harness): AssistantMessage[] {
+	return harness.sessionManager.getBranch().flatMap((entry) => {
+		if (entry.type !== "message" || entry.message.role !== "assistant") {
+			return [];
+		}
+		return [entry.message];
+	});
+}
+
+function activeAssistants(harness: Harness): AssistantMessage[] {
+	return harness.session.messages.filter((message): message is AssistantMessage => message.role === "assistant");
+}
+
+describe("AgentSession agent_recovery_exhausted", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("advertises the hook on pi.features as an own enumerable true flag", async () => {
+		let api: ExtensionAPI | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					api = pi;
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		expect(api?.features).toEqual({ agent_recovery_exhausted: true });
+		expect(Object.isFrozen(api?.features)).toBe(true);
+		const descriptor = Object.getOwnPropertyDescriptor(api?.features, "agent_recovery_exhausted");
+		expect(descriptor).toMatchObject({ enumerable: true, value: true });
+	});
+
+	it("fires after native retry exhaustion and continues when a handler returns retry", async () => {
+		const payloads: AgentRecoveryExhaustedEvent[] = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async (event) => {
+						payloads.push(event);
+						return { retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("recovered after hook"),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(payloads).toHaveLength(1);
+		expect(payloads[0]?.nativeRetryAttempts).toBe(2);
+		expect(payloads[0]?.overflowRecoveryAttempted).toBe(false);
+		expect(payloads[0]?.message.stopReason).toBe("error");
+		expect(harness.faux.state.callCount).toBe(4);
+		expect(harness.session.getLastAssistantText()).toBe("recovered after hook");
+		expect(activeAssistants(harness).map((message) => message.stopReason)).toEqual(["stop"]);
+		expect(historyAssistants(harness).map((message) => message.stopReason)).toEqual([
+			"error",
+			"error",
+			"error",
+			"stop",
+		]);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+
+	it("fires after failed overflow recovery for a truncated response", async () => {
+		const payloads: AgentRecoveryExhaustedEvent[] = [];
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 1_000_000, maxTokens: 100 }],
+			settings: { compaction: { keepRecentTokens: 1, reserveTokens: 0 }, retry: { enabled: false } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "overflow compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+					pi.on("agent_recovery_exhausted", async (event) => {
+						payloads.push(event);
+						return { retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			() => fauxAssistantMessage("x".repeat(64), { stopReason: "length", timestamp: Date.now() + 10_000 }),
+			() => fauxAssistantMessage("y".repeat(64), { stopReason: "length", timestamp: Date.now() + 10_000 }),
+			fauxAssistantMessage("recovered on larger path"),
+		]);
+
+		await harness.session.prompt("x".repeat(5000));
+
+		expect(payloads).toHaveLength(1);
+		expect(payloads[0]?.overflowRecoveryAttempted).toBe(true);
+		expect(payloads[0]?.message.stopReason).toBe("length");
+		expect(harness.faux.state.callCount).toBe(3);
+		expect(harness.session.getLastAssistantText()).toBe("recovered on larger path");
+		expect(activeAssistants(harness).at(-1)?.stopReason).toBe("stop");
+		expect(historyAssistants(harness).some((message) => message.stopReason === "length")).toBe(true);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+
+	it("does not fire on success, abort, or mid-ladder retry", async () => {
+		const successFires: number[] = [];
+		const success = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async () => {
+						successFires.push(1);
+					});
+				},
+			],
+		});
+		harnesses.push(success);
+		success.setResponses([fauxAssistantMessage("ok")]);
+		await success.session.prompt("hi");
+		expect(successFires).toEqual([]);
+		expect(success.eventsOfType("agent_settled")).toHaveLength(1);
+
+		const midLadderFires: number[] = [];
+		const midLadder = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async () => {
+						midLadderFires.push(1);
+						return { retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(midLadder);
+		midLadder.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("recovered natively"),
+		]);
+		await midLadder.session.prompt("hi");
+		expect(midLadderFires).toEqual([]);
+		expect(midLadder.faux.state.callCount).toBe(2);
+		expect(midLadder.session.getLastAssistantText()).toBe("recovered natively");
+
+		const abortFires: number[] = [];
+		const aborted = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async () => {
+						abortFires.push(1);
+						return { retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(aborted);
+		aborted.setResponses([fauxAssistantMessage("x".repeat(20_000))]);
+		const sawMessageUpdate = new Promise<void>((resolve) => {
+			const unsubscribe = aborted.session.subscribe((event) => {
+				if (event.type === "message_update") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = aborted.session.prompt("hi");
+		await sawMessageUpdate;
+		await aborted.session.abort();
+		await promptPromise;
+		expect(abortFires).toEqual([]);
+		expect(aborted.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+
+	it("does not fire after abortRetry cancels native retry sleep", async () => {
+		const fires: number[] = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 100 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async () => {
+						fires.push(1);
+						return { retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("should not run"),
+		]);
+
+		const sawRetryStart = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "auto_retry_start") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("test");
+		await sawRetryStart;
+		harness.session.abortRetry();
+		await promptPromise;
+
+		expect(fires).toEqual([]);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+
+	it("ignores retry when the handler aborts the prompt signal", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: false } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async (event, ctx) => {
+						ctx.abort();
+						expect(event.signal.aborted).toBe(true);
+						return { retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_api_key" }),
+			fauxAssistantMessage("should not run"),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+
+	it("treats a thrown handler as no vote and still honors a later retry", async () => {
+		const order: string[] = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: false } },
+			extensionFactories: [
+				{
+					path: "<inline:throws>",
+					factory: (pi) => {
+						pi.on("agent_recovery_exhausted", async () => {
+							order.push("throw");
+							throw new Error("handler failed");
+						});
+					},
+				},
+				{
+					path: "<inline:retry>",
+					factory: (pi) => {
+						pi.on("agent_recovery_exhausted", async () => {
+							order.push("retry");
+							return { retry: true };
+						});
+					},
+				},
+				{
+					path: "<inline:decline>",
+					factory: (pi) => {
+						pi.on("agent_recovery_exhausted", async () => {
+							order.push("decline");
+							return { retry: false };
+						});
+					},
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_api_key" }),
+			fauxAssistantMessage("continued after throw"),
+		]);
+
+		await harness.session.prompt("test");
+
+		expect(order).toEqual(["throw", "retry", "decline"]);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.session.getLastAssistantText()).toBe("continued after throw");
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+
+	it("caps hook-driven continuations at 8 and settles exactly once", async () => {
+		const fires: number[] = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: false } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async () => {
+						fires.push(1);
+						return { retry: true };
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses(
+			Array.from({ length: MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS + 2 }, () =>
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_api_key" }),
+			),
+		);
+
+		await harness.session.prompt("test");
+
+		expect(fires).toHaveLength(MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS);
+		expect(harness.faux.state.callCount).toBe(MAX_AGENT_RECOVERY_EXHAUSTED_CONTINUATIONS + 1);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+		expect(activeAssistants(harness).at(-1)?.stopReason).toBe("error");
+	});
+
+	it("settles exactly once when the handler declines", async () => {
+		const fires: number[] = [];
+		const harness = await createHarness({
+			settings: { retry: { enabled: false } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("agent_recovery_exhausted", async () => {
+						fires.push(1);
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_api_key" })]);
+
+		await harness.session.prompt("test");
+
+		expect(fires).toEqual([1]);
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Problem

After native retry and overflow compact-and-retry are exhausted, Pi settles. Extensions have no public way to switch model and continue in the same session.

Example: the current model returns a retryable 5xx until `maxRetries` is spent, or overflow recovery already compact-and-retried once and failed. Today that ends the turn. An extension that has another configured model cannot continue without sending a new user message.

## Solution

Add `agent_recovery_exhausted`. It fires once per exhausted native post-run cycle, after retry/overflow/queued continuations and before `agent_settled`.

- Payload: failed assistant, completed native retry count, overflow-recovery flag, abort signal
- `{ retry: true }` slices the trailing failed assistant from active context (history unchanged) and calls `agent.continue()`
- Per-prompt cap of 8 hook-driven continuations
- Does not fire on success, abort, mid-ladder retry, or successful overflow recovery
- Detect support with `pi.features.agent_recovery_exhausted === true` (own enumerable data property)

This does not change retry defaults, overflow policy, or backoff.

## Tests

`packages/coding-agent/test/suite/agent-session-recovery-exhausted.test.ts` covers retry exhaustion, failed overflow recovery, success/abort/mid-ladder non-fire, accepted continuation, abort during the handler, cap 8, and exactly-once settlement.
