### PR TITLE
feat: add `disabledCommands` setting to block built-in slash commands

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -131,6 +131,7 @@ export interface Settings {
 	markdown?: MarkdownSettings;
 	warnings?: WarningSettings;
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
+	disabledCommands?: string[]; // Built-in slash commands to disable (e.g. ["share", "export"])
 	httpProxy?: string; // Proxy URL applied as HTTP_PROXY and HTTPS_PROXY for Pi-managed HTTP clients
 	httpIdleTimeoutMs?: number; // HTTP header/body idle timeout in milliseconds; 0 disables it
 	websocketConnectTimeoutMs?: number; // WebSocket connect/open handshake timeout in milliseconds; 0 disables it
@@ -1056,6 +1057,13 @@ export class SettingsManager {
 
 	getEnableSkillCommands(): boolean {
 		return this.settings.enableSkillCommands ?? true;
+	}
+
+	getDisabledCommands(): string[] {
+		// Union of global and project disabled commands (project can only add restrictions)
+		const global = this.globalSettings.disabledCommands ?? [];
+		const project = this.projectSettings.disabledCommands ?? [];
+		return [...new Set([...global, ...project])];
 	}
 
 	setEnableSkillCommands(enabled: boolean): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -669,11 +669,14 @@ export class InteractiveMode {
 
 	private createBaseAutocompleteProvider(): AutocompleteProvider {
 		// Define commands for autocomplete
-		const slashCommands: SlashCommand[] = BUILTIN_SLASH_COMMANDS.map((command) => ({
-			name: command.name,
-			description: command.description,
-			...(command.argumentHint && { argumentHint: command.argumentHint }),
-		}));
+		const disabledCommands = new Set(this.settingsManager.getDisabledCommands());
+		const slashCommands: SlashCommand[] = BUILTIN_SLASH_COMMANDS
+			.filter((command) => !disabledCommands.has(command.name))
+			.map((command) => ({
+				name: command.name,
+				description: command.description,
+				...(command.argumentHint && { argumentHint: command.argumentHint }),
+			}));
 
 		const modelCommand = slashCommands.find((command) => command.name === "model");
 		if (modelCommand) {
@@ -2919,6 +2922,17 @@ export class InteractiveMode {
 			if (!text) return;
 
 			// Handle commands
+			if (text.startsWith("/")) {
+				const spaceIndex = text.indexOf(" ");
+				const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+				const disabledCommands = this.settingsManager.getDisabledCommands();
+				if (disabledCommands.includes(commandName)) {
+					this.showError(`The /${commandName} command is disabled by configuration.`);
+					this.editor.setText("");
+					return;
+				}
+			}
+
 			if (text === "/settings") {
 				this.showSettingsSelector();
 				this.editor.setText("");

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -598,4 +598,53 @@ describe("SettingsManager", () => {
 			expect(manager.getShellPath()).toBe(homedir());
 		});
 	});
+
+	describe("disabledCommands", () => {
+		it("should return empty array when no disabled commands configured", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({}));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getDisabledCommands()).toEqual([]);
+		});
+
+		it("should return global disabled commands", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ disabledCommands: ["share", "export"] }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getDisabledCommands()).toEqual(["share", "export"]);
+		});
+
+		it("should union global and project disabled commands", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ disabledCommands: ["share"] }),
+			);
+			writeFileSync(
+				join(projectDir, ".pi", "settings.json"),
+				JSON.stringify({ disabledCommands: ["export"] }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir, { projectTrusted: true });
+			const disabled = manager.getDisabledCommands();
+			expect(disabled).toContain("share");
+			expect(disabled).toContain("export");
+			expect(disabled).toHaveLength(2);
+		});
+
+		it("should deduplicate overlapping entries", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ disabledCommands: ["share"] }),
+			);
+			writeFileSync(
+				join(projectDir, ".pi", "settings.json"),
+				JSON.stringify({ disabledCommands: ["share", "export"] }),
+			);
+			const manager = SettingsManager.create(projectDir, agentDir, { projectTrusted: true });
+			const disabled = manager.getDisabledCommands();
+			expect(disabled).toContain("share");
+			expect(disabled).toContain("export");
+			expect(disabled).toHaveLength(2);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Add a `disabledCommands` setting that allows users and organizations to disable specific built-in slash commands. Disabled commands show an error message and are hidden from autocomplete.

Closes #8325

## Motivation

`/share` uploads full session transcripts to GitHub Gists. `/export` writes complete session data to disk. In enterprise/team environments, sessions contain API keys, proprietary code, and internal architecture details.

Currently there is no way to prevent these commands:
- Extensions cannot override builtins (filtered by `builtinCommandNames`)
- The `input` event only fires for text reaching `session.prompt()` — slash commands return before that
- The permission system gates tool calls but has no visibility into slash commands

## Changes

- **`settings-manager.ts`**: add `disabledCommands?: string[]` to Settings interface; add `getDisabledCommands()` getter with global+project union semantics (project can add restrictions, not remove them)
- **`interactive-mode.ts`**: check `disabledCommands` at the top of `setupEditorSubmitHandler()` before any specific command dispatch
- **`interactive-mode.ts`**: filter disabled commands from the autocomplete provider
- **`settings-manager.test.ts`**: unit tests for the new setting (empty default, global, union, dedup)

## Usage

```json
{ "disabledCommands": ["share", "export"] }
```

Supports both global (`~/.pi/agent/settings.json`) and project (`.pi/settings.json`) scope. Merge semantics: union of both arrays — a project can disable additional commands but cannot re-enable what global disables.

## Design decisions

- Minimal surface area: one setting, one early check, one autocomplete filter
- No new event type or extension hook needed (though a `before_slash_command` event could be a follow-up)
- Consistent with existing patterns (`enableSkillCommands`, `enabledModels`)
- Project-can-only-restrict matches the permission system's merge model