### PR TITLE
fix(tui): yield long markdown rendering

### DIFF
--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -208,18 +208,23 @@ tui.hasOverlay();
 All components implement:
 
 ```typescript
+interface RenderContext {
+  deadline: number;
+  requestRender: () => void;
+}
+
 interface Component {
-  render(width: number): string[];
+  render(width: number, context?: RenderContext): string[];
   handleInput?(data: string): void;
-  invalidate?(): void;
+  invalidate(): void;
 }
 ```
 
 | Method | Description |
 |--------|-------------|
-| `render(width)` | Returns an array of strings, one per line. Each line **must not exceed `width`** or the TUI will error. Use `truncateToWidth()` or manual wrapping to ensure this. |
+| `render(width, context?)` | Returns an array of strings, one per line. Each line **must not exceed `width`** or the TUI will error. Use `truncateToWidth()` or manual wrapping to ensure this. When `context` is present, a component with deferred work must stop at `deadline`, return its completed prefix, preserve its progress, and call `requestRender()` to resume in a later frame. |
 | `handleInput?(data)` | Called when the component has focus and receives keyboard input. The `data` string contains raw terminal input (may include ANSI escape sequences). |
-| `invalidate?()` | Called to clear any cached render state. Components should re-render from scratch on the next `render()` call. |
+| `invalidate()` | Called to clear any cached render state. Components should re-render from scratch on the next `render()` call. |
 
 The TUI appends a full SGR reset and OSC 8 reset at the end of each rendered line. Styles do not carry across lines. If you emit multi-line text with styling, reapply styles per line or use `wrapTextWithAnsi()` so styles are preserved for each wrapped line.
 
@@ -442,6 +447,9 @@ md.setText("Updated markdown");
 - Optional syntax highlighting via `highlightCode`
 - Padding support
 - Render caching for performance
+- Cooperative rendering when called by a TUI frame: token rendering, wrapping, and styling resume across 8 ms frames for large documents
+
+`Markdown.render(width)` remains synchronous for direct callers. TUI-managed rendering supplies a `RenderContext`. Markdown returns the rendered prefix and schedules a later frame until the document is complete.
 
 ### Loader
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1,7 +1,8 @@
+import { performance } from "node:perf_hooks";
 import { Marked, type Token, Tokenizer, type TokenizerExtension, type Tokens } from "marked";
 import { renderLatex } from "../latex.ts";
 import { getCapabilities, hyperlink, isImageLine } from "../terminal-image.ts";
-import type { Component } from "../tui.ts";
+import type { Component, RenderContext } from "../tui.ts";
 import { applyBackgroundToLine, visibleWidth, wrapTextWithAnsi } from "../utils.ts";
 
 const STRICT_STRIKETHROUGH_REGEX = /^(~~)(?=[^\s~])((?:\\.|[^\\])*?(?:\\.|[^\s~\\]))\1(?=[^~]|$)/;
@@ -233,6 +234,18 @@ interface InlineStyleContext {
 	stylePrefix: string;
 }
 
+interface ProgressiveRender {
+	text: string;
+	width: number;
+	tokens: Token[];
+	tokenIndex: number;
+	renderedLines: string[];
+	wrapIndex: number;
+	wrappedLines: string[];
+	styleIndex: number;
+	contentLines: string[];
+}
+
 export class Markdown implements Component {
 	private text: string;
 	private paddingX: number; // Left/right padding
@@ -246,6 +259,7 @@ export class Markdown implements Component {
 	private cachedText?: string;
 	private cachedWidth?: number;
 	private cachedLines?: string[];
+	private progressiveRender?: ProgressiveRender;
 
 	constructor(
 		text: string,
@@ -272,100 +286,105 @@ export class Markdown implements Component {
 		this.cachedText = undefined;
 		this.cachedWidth = undefined;
 		this.cachedLines = undefined;
+		this.progressiveRender = undefined;
 	}
 
-	render(width: number): string[] {
-		// Check cache
+	render(width: number, context?: RenderContext): string[] {
 		if (this.cachedLines && this.cachedText === this.text && this.cachedWidth === width) {
 			return this.cachedLines;
 		}
 
-		// Calculate available width for content (subtract horizontal padding)
 		const contentWidth = Math.max(1, width - this.paddingX * 2);
 		const text = this.options.transform?.(this.text, contentWidth) ?? this.text;
-
-		// Don't render anything if there's no actual text
 		if (!text || text.trim() === "") {
 			const result: string[] = [];
-			// Update cache
 			this.cachedText = this.text;
 			this.cachedWidth = width;
 			this.cachedLines = result;
 			return result;
 		}
 
-		// Replace tabs with 3 spaces for consistent rendering
 		const normalizedText = text.replace(/\t/g, "   ");
-
-		// Parse markdown to HTML-like tokens
-		const tokens = markdownParser.lexer(normalizedText);
-		trimPartialClosingFences(tokens);
-
-		// Convert tokens to styled terminal output
-		const renderedLines: string[] = [];
-
-		for (let i = 0; i < tokens.length; i++) {
-			const token = tokens[i];
-			const nextToken = tokens[i + 1];
-			const tokenLines = this.renderToken(token, contentWidth, nextToken?.type);
-			for (const tokenLine of tokenLines) {
-				renderedLines.push(tokenLine);
-			}
+		if (
+			!this.progressiveRender ||
+			this.progressiveRender.text !== normalizedText ||
+			this.progressiveRender.width !== width
+		) {
+			const tokens = markdownParser.lexer(normalizedText);
+			trimPartialClosingFences(tokens);
+			this.progressiveRender = {
+				text: normalizedText,
+				width,
+				tokens,
+				tokenIndex: 0,
+				renderedLines: [],
+				wrapIndex: 0,
+				wrappedLines: [],
+				styleIndex: 0,
+				contentLines: [],
+			};
 		}
 
-		// Wrap lines (NO padding, NO background yet)
-		const wrappedLines: string[] = [];
-		for (const line of renderedLines) {
-			if (isImageLine(line)) {
-				wrappedLines.push(line);
-			} else {
-				for (const wrappedLine of wrapTextWithAnsi(line, contentWidth)) {
-					wrappedLines.push(wrappedLine);
-				}
-			}
+		const state = this.progressiveRender;
+		const deadline = context?.deadline ?? Number.POSITIVE_INFINITY;
+		while (state.tokenIndex < state.tokens.length && performance.now() < deadline) {
+			const index = state.tokenIndex++;
+			state.renderedLines.push(
+				...this.renderToken(state.tokens[index], contentWidth, state.tokens[index + 1]?.type),
+			);
+		}
+		while (
+			state.tokenIndex === state.tokens.length &&
+			state.wrapIndex < state.renderedLines.length &&
+			performance.now() < deadline
+		) {
+			const line = state.renderedLines[state.wrapIndex++];
+			state.wrappedLines.push(...(isImageLine(line) ? [line] : wrapTextWithAnsi(line, contentWidth)));
 		}
 
-		// Add margins and background to each wrapped line
 		const leftMargin = " ".repeat(this.paddingX);
 		const rightMargin = " ".repeat(this.paddingX);
 		const bgFn = this.defaultTextStyle?.bgColor;
-		const contentLines: string[] = [];
-
-		for (const line of wrappedLines) {
+		while (
+			state.wrapIndex === state.renderedLines.length &&
+			state.styleIndex < state.wrappedLines.length &&
+			performance.now() < deadline
+		) {
+			const line = state.wrappedLines[state.styleIndex++];
 			if (isImageLine(line)) {
-				contentLines.push(line);
+				state.contentLines.push(line);
 				continue;
 			}
-
 			const lineWithMargins = leftMargin + line + rightMargin;
-
-			if (bgFn) {
-				contentLines.push(applyBackgroundToLine(lineWithMargins, width, bgFn));
-			} else {
-				// No background - just pad to width
-				const visibleLen = visibleWidth(lineWithMargins);
-				const paddingNeeded = Math.max(0, width - visibleLen);
-				contentLines.push(lineWithMargins + " ".repeat(paddingNeeded));
-			}
+			state.contentLines.push(
+				bgFn
+					? applyBackgroundToLine(lineWithMargins, width, bgFn)
+					: lineWithMargins + " ".repeat(Math.max(0, width - visibleWidth(lineWithMargins))),
+			);
 		}
 
-		// Add top/bottom padding (empty lines)
-		const emptyLine = " ".repeat(width);
-		const emptyLines: string[] = [];
-		for (let i = 0; i < this.paddingY; i++) {
-			const line = bgFn ? applyBackgroundToLine(emptyLine, width, bgFn) : emptyLine;
-			emptyLines.push(line);
+		if (
+			state.tokenIndex < state.tokens.length ||
+			state.wrapIndex < state.renderedLines.length ||
+			state.styleIndex < state.wrappedLines.length
+		) {
+			context?.requestRender();
+			return this.withPadding(state.contentLines, width, bgFn);
 		}
 
-		// Combine top padding, content, and bottom padding
-		const result = emptyLines.concat(contentLines, emptyLines);
-
-		// Update cache
+		const result = this.withPadding(state.contentLines, width, bgFn);
 		this.cachedText = this.text;
 		this.cachedWidth = width;
 		this.cachedLines = result;
-
+		this.progressiveRender = undefined;
 		return result.length > 0 ? result : [""];
+	}
+
+	private withPadding(contentLines: readonly string[], width: number, bgFn: DefaultTextStyle["bgColor"]): string[] {
+		const emptyLine = " ".repeat(width);
+		const paddingLine = bgFn ? applyBackgroundToLine(emptyLine, width, bgFn) : emptyLine;
+		const padding = Array.from({ length: this.paddingY }, () => paddingLine);
+		return [...padding, ...contentLines, ...padding];
 	}
 
 	/**

--- a/packages/tui/src/layout.ts
+++ b/packages/tui/src/layout.ts
@@ -1,8 +1,9 @@
+import { performance } from "node:perf_hooks";
 import type { ScrollView } from "./components/scroll-view.ts";
 import { allocateStackSizes, visibleStackEntries } from "./components/stack.ts";
 import { getLayoutNode } from "./layout-node.ts";
 import { cropKittyImageLine, getKittyImageMetadata, isImageLine } from "./terminal-image.ts";
-import { type Component, CURSOR_MARKER, compositeTuiLine } from "./tui.ts";
+import { type Component, CURSOR_MARKER, compositeTuiLine, type RenderContext } from "./tui.ts";
 import { extractAnsiCode, getGraphemeCellRange, sliceByColumn, visibleWidth } from "./utils.ts";
 
 const OSC133_ZONE_PREFIX = /^(?:\x1b\]133;[ABC](?:\x07|\x1b\\))+/;
@@ -68,7 +69,11 @@ function renderCached(context: LayoutContext, component: Component, width: numbe
 	}
 	let lines = widths.get(safeWidth);
 	if (!lines) {
-		lines = component.render(safeWidth);
+		const renderContext: RenderContext = {
+			requestRender: context.requestRender,
+			deadline: performance.now() + 8,
+		};
+		lines = component.render(safeWidth, renderContext);
 		widths.set(safeWidth, lines);
 	}
 	return lines;

--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { performance } from "node:perf_hooks";
 import { deleteKittyImage, isImageLine } from "./terminal-image.ts";
 import { type TUI, TuiBase, type TuiStopOptions } from "./tui.ts";
 import { visibleWidth } from "./utils.ts";
@@ -194,7 +195,10 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		};
 
 		// Render all components to get new lines
-		let newLines = this.render(width);
+		let newLines = this.render(width, {
+			deadline: performance.now() + 8,
+			requestRender: () => this.requestRender(),
+		});
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.hasOverlayEntries) {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -20,13 +20,21 @@ import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth
 /**
  * Component interface - all components must implement this
  */
+export interface RenderContext {
+	/** Request another frame after yielding from a long render. */
+	requestRender: () => void;
+	/** Monotonic deadline for cooperative work in the current frame. */
+	deadline: number;
+}
+
 export interface Component {
 	/**
 	 * Render the component to lines for the given viewport width
 	 * @param width - Current viewport width
+	 * @param context - Optional cooperative rendering budget
 	 * @returns Array of strings, each representing a line
 	 */
-	render(width: number): string[];
+	render(width: number, context?: RenderContext): string[];
 
 	/**
 	 * Optional handler for keyboard input when component has focus
@@ -232,10 +240,10 @@ export class Container implements Component {
 		}
 	}
 
-	render(width: number): string[] {
+	render(width: number, context?: RenderContext): string[] {
 		const lines: string[] = [];
 		for (const child of this.children) {
-			const childLines = child.render(width);
+			const childLines = child.render(width, context);
 			for (const line of childLines) {
 				lines.push(line);
 			}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -38,6 +38,30 @@ function stripAnsi(line: string): string {
 
 describe("Markdown component", () => {
 	describe("Transforms", () => {
+		it("yields large Markdown rendering and resumes on a later frame", () => {
+			const source = Array.from({ length: 10_000 }, (_, index) => `line ${index}`).join("\n");
+			const markdown = new Markdown(source, 0, 0, defaultMarkdownTheme);
+			let requestedFrames = 0;
+
+			const partial = markdown.render(80, {
+				deadline: Number.NEGATIVE_INFINITY,
+				requestRender: () => {
+					requestedFrames++;
+				},
+			});
+			assert.deepStrictEqual(partial, []);
+			assert.equal(requestedFrames, 1);
+
+			const complete = markdown.render(80, {
+				deadline: Number.POSITIVE_INFINITY,
+				requestRender: () => {
+					requestedFrames++;
+				},
+			});
+			assert.equal(complete.length, 10_000);
+			assert.equal(stripAnsi(complete[9_999]).trim(), "line 9999");
+		});
+
 		it("caches transformed Markdown by source and available width", () => {
 			const calls: Array<{ source: string; availableWidth: number }> = [];
 			const markdown = new Markdown("source", 2, 0, defaultMarkdownTheme, undefined, {


### PR DESCRIPTION
## Problem

Large Markdown rendering can monopolize the interactive TUI event loop. In a reproduced session, Node repeatedly measured a large UTF-16 string for UTF-8 output while the terminal stopped responding.

## Solution

- Add an optional `RenderContext` with a monotonic deadline and a callback that schedules another frame.
- Give main-screen and layout rendering an 8 ms cooperative budget.
- Preserve Markdown token, wrapping, and styling progress across frames. Markdown returns its completed prefix and resumes on the requested frame.
- Keep `Markdown.render(width)` synchronous for direct callers.
- Document the component contract and Markdown behavior.

## Verification

- `npm run build` in `packages/tui`
- `node --import tsx --test test/markdown.test.ts` in `packages/tui`

The Markdown suite includes a 10,000-line regression that forces a yield, confirms another frame is requested, and verifies the same component resumes to complete output.

## Limitation

Markdown tokenization remains synchronous. Callers should continue to bound untrusted input before rendering.
