### PR TITLE
fix(coding-agent): enforce session writer ownership and audit provider lineage

### DIFF
--- a/packages/coding-agent/docs/environment-variables.md
+++ b/packages/coding-agent/docs/environment-variables.md
@@ -85,10 +85,17 @@ These variables are read by Pi itself:
 | `PI_SKIP_VERSION_CHECK` | Disable the `pi.dev` latest-version request |
 | `PI_TELEMETRY` | Override install/update telemetry and provider attribution headers: `1`/`true`/`yes` or `0`/`false`/`no` |
 | `PI_CACHE_RETENTION` | Set to `long` for extended provider prompt caching where supported |
+| `PI_PROVIDER_PAYLOAD_AUDIT` | Set to `1`, `true`, or `yes` to append provider-payload lineage hashes (not raw payload content) to the persistent session |
 | `PI_SHARE_VIEWER_URL` | Override the base URL used by `/share` |
 | `PI_HARDWARE_CURSOR` | Set to `1` to show the hardware cursor; see [Terminal setup](terminal-setup.md) |
 | `PI_TUI_ESC_TIMEOUT` | How long to wait after a lone ESC before treating it as Escape, in milliseconds; defaults to `100` over SSH and `10` otherwise. Increase if Alt-key input is misread as Escape |
 | `VISUAL`, `EDITOR` | External editor fallback when `externalEditor` is unset |
 | `HTTP_PROXY`, `HTTPS_PROXY` | Proxy outbound HTTP requests |
+
+### Provider Payload Audit
+
+`PI_PROVIDER_PAYLOAD_AUDIT` records a `provider-payload-audit` custom entry immediately before each provider request. The entry contains SHA-256 hashes, byte counts, array-item prefix comparisons, provider/model identity, and the corresponding session-context lineage. It does not contain the payload or retain payload object references.
+
+The classification distinguishes linear appends and retries from changed earlier sections, model changes, compaction, and explicit session-path transitions. Custom entries do not participate in provider context, so enabling the audit does not add content to the request. It does add diagnostic entries to the persistent session JSONL and is therefore disabled by default.
 
 Provider credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and cloud-provider configuration are listed in [Providers](providers.md#environment-variables-or-auth-file).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -861,6 +861,7 @@ export class AgentSession {
 		this._disconnectFromAgent();
 		this._eventListeners = [];
 		cleanupSessionResources(this.sessionId);
+		this.sessionManager.dispose();
 	}
 
 	// =========================================================================
@@ -1069,6 +1070,9 @@ export class AgentSession {
 	// =========================================================================
 
 	private async _runAgentPrompt(messages: AgentMessage | AgentMessage[]): Promise<void> {
+		// Every provider turn must prove exclusive ownership of the persisted
+		// session before the agent can construct or issue a request.
+		this.sessionManager.assertWriterOwnership();
 		this._isAgentRunActive = true;
 		try {
 			await this.agent.prompt(messages);
@@ -1276,6 +1280,12 @@ export class AgentSession {
 			return;
 		}
 
+		try {
+			this.sessionManager.assertWriterOwnership();
+		} catch (error) {
+			preflightResult?.(false);
+			throw error;
+		}
 		preflightResult?.(true);
 		await this._runAgentPrompt(messages);
 	}

--- a/packages/coding-agent/src/core/provider-payload-audit.ts
+++ b/packages/coding-agent/src/core/provider-payload-audit.ts
@@ -1,0 +1,308 @@
+import { createHash } from "node:crypto";
+import type { Model } from "@earendil-works/pi-ai";
+import { getLatestCompactionEntry, type SessionManager, sessionEntryToContextMessages } from "./session-manager.ts";
+
+export const PROVIDER_PAYLOAD_AUDIT_CUSTOM_TYPE = "provider-payload-audit";
+
+interface PayloadSectionSnapshot {
+	key: string;
+	bytes: number;
+	sha256: string;
+	itemSha256?: string[];
+}
+
+interface PayloadSnapshot {
+	bytes: number;
+	sha256: string;
+	sections: PayloadSectionSnapshot[];
+}
+
+interface ProviderPayloadLineage {
+	payload: PayloadSnapshot;
+	contextEntryIds: string[];
+	latestCompactionEntryId?: string;
+}
+
+interface SequenceContinuity {
+	change: "initial" | "unchanged" | "appended" | "rewritten";
+	previousCount: number;
+	currentCount: number;
+	commonPrefixCount: number;
+}
+
+interface SectionContinuity {
+	key: string;
+	change: "added" | "removed" | "unchanged" | "appended" | "rewritten";
+	previousBytes?: number;
+	currentBytes?: number;
+	commonPrefixItems?: number;
+}
+
+export interface ProviderPayloadAuditRecord {
+	version: 1;
+	requestIndex: number;
+	provider: string;
+	modelId: string;
+	api: string;
+	contextKey: string;
+	classification:
+		| "initial-context"
+		| "new-model-context"
+		| "linear-append-or-retry"
+		| "linear-prefix-break"
+		| "explicit-compaction"
+		| "explicit-session-path-transition";
+	payloadPrefixBroken: boolean;
+	payload: PayloadSnapshot;
+	sectionContinuity: SectionContinuity[];
+	sectionOrder: SequenceContinuity;
+	sessionContext: SequenceContinuity;
+	latestCompactionEntryId?: string;
+}
+
+function jsonBytes(value: unknown): Buffer | undefined {
+	const json = JSON.stringify(value);
+	return json === undefined ? undefined : Buffer.from(json);
+}
+
+function sha256(bytes: Buffer): string {
+	return createHash("sha256").update(bytes).digest("hex");
+}
+
+const DIRECT_CONTEXT_SECTION_KEYS = new Set([
+	"system",
+	"system_instruction",
+	"systemInstruction",
+	"instructions",
+	"messages",
+	"input",
+	"contents",
+	"tools",
+	"toolConfig",
+	"tool_config",
+]);
+const NESTED_CONTEXT_SECTION_KEYS = new Map([
+	["config", new Set(["systemInstruction", "tools", "toolConfig"])],
+	["context", new Set(["systemPrompt", "messages", "tools"])],
+]);
+const LINEAR_APPEND_SECTION_KEYS = new Set(["messages", "input", "contents", "context.messages"]);
+
+function addSection(sections: PayloadSectionSnapshot[], key: string, value: unknown): void {
+	const bytes = jsonBytes(value);
+	if (!bytes) return;
+	sections.push({
+		key,
+		bytes: bytes.byteLength,
+		sha256: sha256(bytes),
+		itemSha256: Array.isArray(value)
+			? value.map((item) => sha256(jsonBytes(item) ?? Buffer.from("null")))
+			: undefined,
+	});
+}
+
+function snapshotPayload(payload: unknown): PayloadSnapshot {
+	const wholeBytes = jsonBytes(payload) ?? Buffer.from("null");
+	const sections: PayloadSectionSnapshot[] = [];
+
+	if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
+		for (const [key, value] of Object.entries(payload)) {
+			if (DIRECT_CONTEXT_SECTION_KEYS.has(key)) {
+				addSection(sections, key, value);
+				continue;
+			}
+			const nestedKeys = NESTED_CONTEXT_SECTION_KEYS.get(key);
+			if (nestedKeys && typeof value === "object" && value !== null && !Array.isArray(value)) {
+				for (const [nestedKey, nestedValue] of Object.entries(value)) {
+					if (nestedKeys.has(nestedKey)) addSection(sections, `${key}.${nestedKey}`, nestedValue);
+				}
+			}
+		}
+		if (sections.length === 0) addSection(sections, "$payload", payload);
+	} else {
+		addSection(sections, "$payload", payload);
+	}
+
+	return { bytes: wholeBytes.byteLength, sha256: sha256(wholeBytes), sections };
+}
+
+function sequenceContinuity(previous: readonly string[] | undefined, current: readonly string[]): SequenceContinuity {
+	if (!previous) {
+		return {
+			change: "initial",
+			previousCount: 0,
+			currentCount: current.length,
+			commonPrefixCount: 0,
+		};
+	}
+
+	let commonPrefixCount = 0;
+	while (
+		commonPrefixCount < previous.length &&
+		commonPrefixCount < current.length &&
+		previous[commonPrefixCount] === current[commonPrefixCount]
+	) {
+		commonPrefixCount++;
+	}
+	const change =
+		commonPrefixCount === previous.length && commonPrefixCount === current.length
+			? "unchanged"
+			: commonPrefixCount === previous.length
+				? "appended"
+				: "rewritten";
+	return {
+		change,
+		previousCount: previous.length,
+		currentCount: current.length,
+		commonPrefixCount,
+	};
+}
+
+function compareSections(
+	previous: readonly PayloadSectionSnapshot[] | undefined,
+	current: readonly PayloadSectionSnapshot[],
+): SectionContinuity[] {
+	if (!previous) {
+		return current.map((section) => ({ key: section.key, change: "added", currentBytes: section.bytes }));
+	}
+
+	const previousByKey = new Map(previous.map((section) => [section.key, section]));
+	const currentByKey = new Map(current.map((section) => [section.key, section]));
+	const result: SectionContinuity[] = [];
+
+	for (const previousSection of previous) {
+		const currentSection = currentByKey.get(previousSection.key);
+		if (!currentSection) {
+			result.push({ key: previousSection.key, change: "removed", previousBytes: previousSection.bytes });
+			continue;
+		}
+		if (previousSection.sha256 === currentSection.sha256) {
+			result.push({
+				key: previousSection.key,
+				change: "unchanged",
+				previousBytes: previousSection.bytes,
+				currentBytes: currentSection.bytes,
+			});
+			continue;
+		}
+
+		if (previousSection.itemSha256 && currentSection.itemSha256) {
+			const continuity = sequenceContinuity(previousSection.itemSha256, currentSection.itemSha256);
+			result.push({
+				key: previousSection.key,
+				change: continuity.change === "appended" ? "appended" : "rewritten",
+				previousBytes: previousSection.bytes,
+				currentBytes: currentSection.bytes,
+				commonPrefixItems: continuity.commonPrefixCount,
+			});
+			continue;
+		}
+
+		result.push({
+			key: previousSection.key,
+			change: "rewritten",
+			previousBytes: previousSection.bytes,
+			currentBytes: currentSection.bytes,
+		});
+	}
+
+	for (const currentSection of current) {
+		if (!previousByKey.has(currentSection.key)) {
+			result.push({ key: currentSection.key, change: "added", currentBytes: currentSection.bytes });
+		}
+	}
+	return result;
+}
+
+function contextKey(model: Model<any>): string {
+	return `${model.provider}\u0000${model.id}\u0000${model.api}`;
+}
+
+function environmentEnablesAudit(value: string | undefined): boolean {
+	return value === "1" || value === "true" || value === "yes";
+}
+
+/**
+ * Records hashes and sequence-prefix comparisons for the final payload returned
+ * by before_provider_request handlers. It never mutates or retains the payload.
+ */
+export class ProviderPayloadAudit {
+	private readonly previousByContext = new Map<string, ProviderPayloadLineage>();
+	private readonly sessionManager: SessionManager;
+	private readonly enabled: boolean;
+	private lastContextKey: string | undefined;
+	private requestIndex = 0;
+
+	constructor(
+		sessionManager: SessionManager,
+		enabled = environmentEnablesAudit(process.env.PI_PROVIDER_PAYLOAD_AUDIT),
+	) {
+		this.sessionManager = sessionManager;
+		this.enabled = enabled;
+	}
+
+	record(payload: unknown, model: Model<any>): void {
+		if (!this.enabled) return;
+
+		const key = contextKey(model);
+		const previous = this.previousByContext.get(key);
+		const payloadSnapshot = snapshotPayload(payload);
+		const contextEntries = this.sessionManager
+			.buildContextEntries()
+			.filter((entry) => sessionEntryToContextMessages(entry).length > 0);
+		const contextEntryIds = contextEntries.map((entry) => entry.id);
+		const latestCompactionEntryId = getLatestCompactionEntry(this.sessionManager.getBranch())?.id;
+		const sectionContinuity = compareSections(previous?.payload.sections, payloadSnapshot.sections);
+		const sectionOrder = sequenceContinuity(
+			previous?.payload.sections.map((section) => section.key),
+			payloadSnapshot.sections.map((section) => section.key),
+		);
+		const sessionContext = sequenceContinuity(previous?.contextEntryIds, contextEntryIds);
+		const payloadPrefixBroken =
+			previous !== undefined &&
+			(sectionOrder.change === "rewritten" ||
+				sectionContinuity.some(
+					(section) =>
+						section.change === "added" ||
+						section.change === "removed" ||
+						section.change === "rewritten" ||
+						(section.change === "appended" && !LINEAR_APPEND_SECTION_KEYS.has(section.key)),
+				));
+
+		let classification: ProviderPayloadAuditRecord["classification"];
+		if (!previous) {
+			classification = this.lastContextKey && this.lastContextKey !== key ? "new-model-context" : "initial-context";
+		} else if (
+			sessionContext.change === "rewritten" &&
+			latestCompactionEntryId !== undefined &&
+			latestCompactionEntryId !== previous.latestCompactionEntryId
+		) {
+			classification = "explicit-compaction";
+		} else if (sessionContext.change === "rewritten") {
+			classification = "explicit-session-path-transition";
+		} else if (payloadPrefixBroken) {
+			classification = "linear-prefix-break";
+		} else {
+			classification = "linear-append-or-retry";
+		}
+
+		const record: ProviderPayloadAuditRecord = {
+			version: 1,
+			requestIndex: ++this.requestIndex,
+			provider: model.provider,
+			modelId: model.id,
+			api: model.api,
+			contextKey: key,
+			classification,
+			payloadPrefixBroken,
+			payload: payloadSnapshot,
+			sectionContinuity,
+			sectionOrder,
+			sessionContext,
+			latestCompactionEntryId,
+		};
+
+		this.sessionManager.appendCustomEntry(PROVIDER_PAYLOAD_AUDIT_CUSTOM_TYPE, record);
+		this.previousByContext.set(key, { payload: payloadSnapshot, contextEntryIds, latestCompactionEntryId });
+		this.lastContextKey = key;
+	}
+}

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -11,6 +11,7 @@ import { convertToLlm } from "./messages.ts";
 import { findInitialModel } from "./model-resolver.ts";
 import { ModelRuntime } from "./model-runtime.ts";
 import { mergeProviderAttributionHeaders } from "./provider-attribution.ts";
+import { ProviderPayloadAudit } from "./provider-payload-audit.ts";
 import type { ResourceLoader } from "./resource-loader.ts";
 import { DefaultResourceLoader } from "./resource-loader.ts";
 import { getDefaultSessionDir, SessionManager } from "./session-manager.ts";
@@ -293,6 +294,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	};
 
 	const extensionRunnerRef: { current?: ExtensionRunner } = {};
+	const providerPayloadAudit = new ProviderPayloadAudit(sessionManager);
 
 	agent = new Agent({
 		initialState: {
@@ -331,12 +333,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				},
 			});
 		},
-		onPayload: async (payload, _model) => {
+		onPayload: async (payload, payloadModel) => {
+			// This is the final common boundary for normal turns, compaction,
+			// summarization, and conforming custom providers.
+			sessionManager.assertWriterOwnership();
 			const runner = extensionRunnerRef.current;
-			if (!runner?.hasHandlers("before_provider_request")) {
-				return payload;
-			}
-			return runner.emitBeforeProviderRequest(payload);
+			const finalPayload = runner?.hasHandlers("before_provider_request")
+				? await runner.emitBeforeProviderRequest(payload)
+				: payload;
+			providerPayloadAudit.record(finalPayload, payloadModel);
+			return finalPayload;
 		},
 		onResponse: async (response, _model) => {
 			const runner = extensionRunnerRef.current;

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -9,11 +9,14 @@ import {
 	mkdirSync,
 	openSync,
 	readdirSync,
+	readFileSync,
 	readSync,
 	statSync,
+	unlinkSync,
 	writeFileSync,
 } from "fs";
 import { readdir, stat } from "fs/promises";
+import { hostname } from "os";
 import { join, resolve } from "path";
 import { createInterface } from "readline";
 import { StringDecoder } from "string_decoder";
@@ -841,6 +844,228 @@ async function listSessionsFromDir(
 	return sessions;
 }
 
+interface SessionWriterOwner {
+	pid: number;
+	host: string;
+	token: string;
+	sessionId: string;
+	acquiredAt: string;
+}
+
+interface SessionWriterLock {
+	path: string;
+	token: string;
+	exitHandler: () => void;
+}
+
+const SESSION_WRITER_LOCK_SUFFIX = ".writer.lock";
+const SESSION_WRITER_RECOVERY_SUFFIX = ".recovery";
+const SESSION_TAIL_READ_BUFFER_SIZE = 64 * 1024;
+
+export class SessionWriterOwnershipError extends Error {
+	readonly sessionFile: string;
+	readonly owner?: SessionWriterOwner;
+
+	constructor(sessionFile: string, owner?: SessionWriterOwner) {
+		const ownerDescription = owner
+			? `pid ${owner.pid} on ${owner.host}`
+			: "an unknown writer whose lock cannot be safely recovered";
+		super(
+			`Session ${sessionFile} is owned by another live process (${ownerDescription}). ` +
+				"Close that process or explicitly hand off ownership before continuing.",
+		);
+		this.name = "SessionWriterOwnershipError";
+		this.sessionFile = sessionFile;
+		this.owner = owner;
+	}
+}
+
+export class SessionDurableTailError extends Error {
+	readonly sessionFile: string;
+
+	constructor(sessionFile: string, message: string) {
+		super(`Session ${sessionFile} changed outside its owning process: ${message}`);
+		this.name = "SessionDurableTailError";
+		this.sessionFile = sessionFile;
+	}
+}
+
+function errorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? String((error as { code?: unknown }).code)
+		: undefined;
+}
+
+function parseSessionWriterOwner(content: string): SessionWriterOwner | undefined {
+	try {
+		const value = JSON.parse(content) as Partial<SessionWriterOwner>;
+		if (
+			typeof value.pid !== "number" ||
+			!Number.isInteger(value.pid) ||
+			value.pid <= 0 ||
+			typeof value.host !== "string" ||
+			typeof value.token !== "string" ||
+			typeof value.sessionId !== "string" ||
+			typeof value.acquiredAt !== "string"
+		) {
+			return undefined;
+		}
+		return value as SessionWriterOwner;
+	} catch {
+		return undefined;
+	}
+}
+
+function readSessionWriterOwner(lockPath: string): SessionWriterOwner | undefined {
+	try {
+		return parseSessionWriterOwner(readFileSync(lockPath, "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+function processIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return errorCode(error) !== "ESRCH";
+	}
+}
+
+function removeOwnedLock(lockPath: string, token: string): void {
+	const owner = readSessionWriterOwner(lockPath);
+	if (!owner || owner.token !== token) return;
+	try {
+		unlinkSync(lockPath);
+	} catch (error) {
+		if (errorCode(error) !== "ENOENT") throw error;
+	}
+}
+
+function tryRecoverDeadWriter(lockPath: string, expectedOwner: SessionWriterOwner): boolean {
+	if (expectedOwner.host !== hostname() || processIsAlive(expectedOwner.pid)) return false;
+
+	const recoveryPath = `${lockPath}${SESSION_WRITER_RECOVERY_SUFFIX}`;
+	const recoveryToken = randomUUID();
+	try {
+		writeFileSync(recoveryPath, recoveryToken, { encoding: "utf8", flag: "wx" });
+	} catch {
+		return false;
+	}
+
+	try {
+		const currentOwner = readSessionWriterOwner(lockPath);
+		if (
+			!currentOwner ||
+			currentOwner.token !== expectedOwner.token ||
+			currentOwner.host !== hostname() ||
+			processIsAlive(currentOwner.pid)
+		) {
+			return false;
+		}
+		unlinkSync(lockPath);
+		return true;
+	} finally {
+		try {
+			if (readFileSync(recoveryPath, "utf8") === recoveryToken) {
+				unlinkSync(recoveryPath);
+			}
+		} catch {
+			// A failed recovery remains fail-closed for the next owner.
+		}
+	}
+}
+
+function acquireSessionWriterLock(sessionFile: string, sessionId: string): SessionWriterLock {
+	const lockPath = `${sessionFile}${SESSION_WRITER_LOCK_SUFFIX}`;
+	const owner: SessionWriterOwner = {
+		pid: process.pid,
+		host: hostname(),
+		token: randomUUID(),
+		sessionId,
+		acquiredAt: new Date().toISOString(),
+	};
+
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			writeFileSync(lockPath, JSON.stringify(owner), { encoding: "utf8", flag: "wx" });
+			const exitHandler = () => removeOwnedLock(lockPath, owner.token);
+			process.once("exit", exitHandler);
+			return { path: lockPath, token: owner.token, exitHandler };
+		} catch (error) {
+			if (errorCode(error) !== "EEXIST") throw error;
+			const currentOwner = readSessionWriterOwner(lockPath);
+			if (attempt === 0 && currentOwner && tryRecoverDeadWriter(lockPath, currentOwner)) {
+				continue;
+			}
+			throw new SessionWriterOwnershipError(sessionFile, currentOwner);
+		}
+	}
+
+	throw new SessionWriterOwnershipError(sessionFile, readSessionWriterOwner(lockPath));
+}
+
+function getLastSessionEntryId(entries: FileEntry[]): string | null {
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry.type !== "session" && typeof entry.id === "string") return entry.id;
+	}
+	return null;
+}
+
+function parseDurableTailLine(line: Buffer, sessionFile: string): FileEntry | undefined {
+	const text = line.toString("utf8");
+	if (!text.trim()) return undefined;
+	const entry = parseSessionEntryLine(text);
+	if (!entry) {
+		throw new SessionDurableTailError(sessionFile, "the physical tail is not valid JSONL");
+	}
+	if (entry.type !== "session" && typeof entry.id !== "string") {
+		throw new SessionDurableTailError(sessionFile, "the physical tail entry has no stable id");
+	}
+	return entry;
+}
+
+function readDurableTailId(sessionFile: string): string | null {
+	if (!existsSync(sessionFile)) return null;
+	const size = statSync(sessionFile).size;
+	if (size === 0) return null;
+
+	const fd = openSync(sessionFile, "r");
+	try {
+		let offset = size;
+		let lineChunks: Buffer[] = [];
+		while (offset > 0) {
+			const length = Math.min(SESSION_TAIL_READ_BUFFER_SIZE, offset);
+			const start = offset - length;
+			const buffer = Buffer.allocUnsafe(length);
+			const bytesRead = readSync(fd, buffer, 0, length, start);
+			if (bytesRead !== length) {
+				throw new SessionDurableTailError(sessionFile, "the physical tail changed while it was being verified");
+			}
+			let segmentEnd = bytesRead;
+
+			for (let index = bytesRead - 1; index >= 0; index--) {
+				if (buffer[index] !== 0x0a) continue;
+				lineChunks.unshift(buffer.subarray(index + 1, segmentEnd));
+				const entry = parseDurableTailLine(Buffer.concat(lineChunks), sessionFile);
+				if (entry) return entry.type === "session" ? null : entry.id;
+				lineChunks = [];
+				segmentEnd = index;
+			}
+
+			lineChunks.unshift(buffer.subarray(0, segmentEnd));
+			offset = start;
+		}
+
+		const entry = parseDurableTailLine(Buffer.concat(lineChunks), sessionFile);
+		return !entry || entry.type === "session" ? null : entry.id;
+	} finally {
+		closeSync(fd);
+	}
+}
+
 /**
  * Manages conversation sessions as append-only trees stored in JSONL files.
  *
@@ -864,6 +1089,9 @@ export class SessionManager {
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
+	private durableTailId: string | null = null;
+	private writerLock: SessionWriterLock | undefined;
+	private writerOwnershipInvalid: SessionDurableTailError | undefined;
 
 	private constructor(
 		cwd: string,
@@ -893,6 +1121,10 @@ export class SessionManager {
 	}
 
 	private _setSessionFile(sessionFile: string, preloadedFileEntries?: FileEntry[]): void {
+		this._releaseWriterOwnership();
+		this.writerOwnershipInvalid = undefined;
+		this.durableTailId = null;
+		this.flushed = false;
 		this.sessionFile = resolvePath(sessionFile);
 		if (existsSync(this.sessionFile)) {
 			this.fileEntries = preloadedFileEntries ?? loadEntriesFromFile(this.sessionFile);
@@ -907,19 +1139,31 @@ export class SessionManager {
 				this.newSession();
 				this.sessionFile = explicitPath;
 				this._rewriteFile();
-				this.flushed = true;
 				return;
 			}
 
-			const header = this.fileEntries.find((e) => e.type === "session") as SessionHeader | undefined;
+			let header = this.fileEntries.find((e) => e.type === "session") as SessionHeader | undefined;
 			this.sessionId = header?.id ?? createSessionId();
-
-			if (migrateToCurrentVersion(this.fileEntries)) {
-				this._rewriteFile();
-			}
-
-			this._buildIndex();
+			this.durableTailId = getLastSessionEntryId(this.fileEntries);
 			this.flushed = true;
+
+			if ((header?.version ?? 1) < CURRENT_SESSION_VERSION) {
+				// Acquire ownership, then reload under that ownership so migration can
+				// never rewrite entries appended between the initial read and the lock.
+				this.assertWriterOwnership();
+				this.fileEntries = loadEntriesFromFile(this.sessionFile);
+				header = this.fileEntries.find((e) => e.type === "session") as SessionHeader | undefined;
+				if (!header || header.id !== this.sessionId) {
+					throw new SessionDurableTailError(this.sessionFile, "its header changed while ownership was acquired");
+				}
+				this.durableTailId = getLastSessionEntryId(this.fileEntries);
+				if (migrateToCurrentVersion(this.fileEntries)) {
+					this._buildIndex();
+					this._rewriteFile();
+				}
+			} else {
+				this._buildIndex();
+			}
 		} else {
 			const explicitPath = this.sessionFile;
 			this.newSession();
@@ -928,6 +1172,9 @@ export class SessionManager {
 	}
 
 	newSession(options?: NewSessionOptions): string | undefined {
+		this._releaseWriterOwnership();
+		this.writerOwnershipInvalid = undefined;
+		this.durableTailId = null;
 		if (options?.id !== undefined) {
 			assertValidSessionId(options.id);
 		}
@@ -976,8 +1223,82 @@ export class SessionManager {
 		}
 	}
 
+	private _releaseWriterOwnership(): void {
+		const lock = this.writerLock;
+		if (!lock) return;
+		removeOwnedLock(lock.path, lock.token);
+		process.removeListener("exit", lock.exitHandler);
+		this.writerLock = undefined;
+	}
+
+	private _ensureWriterOwnership(): void {
+		if (!this.persist || !this.sessionFile) return;
+		if (this.writerOwnershipInvalid) throw this.writerOwnershipInvalid;
+
+		const expectedLockPath = `${this.sessionFile}${SESSION_WRITER_LOCK_SUFFIX}`;
+		if (this.writerLock) {
+			if (this.writerLock.path !== expectedLockPath) {
+				this._releaseWriterOwnership();
+			} else {
+				const owner = readSessionWriterOwner(this.writerLock.path);
+				if (owner?.token === this.writerLock.token) return;
+				throw new SessionWriterOwnershipError(this.sessionFile, owner);
+			}
+		}
+
+		this.writerLock = acquireSessionWriterLock(this.sessionFile, this.sessionId);
+	}
+
+	private _verifyDurableTail(): void {
+		if (!this.persist || !this.sessionFile) return;
+		if (!existsSync(this.sessionFile)) {
+			if (this.flushed || this.durableTailId !== null) {
+				throw new SessionDurableTailError(this.sessionFile, "the persisted file disappeared");
+			}
+			return;
+		}
+
+		if (statSync(this.sessionFile).size === 0 && !this.flushed && this.durableTailId === null) {
+			return;
+		}
+
+		const header = readSessionHeader(this.sessionFile);
+		if (!header || header.id !== this.sessionId) {
+			throw new SessionDurableTailError(this.sessionFile, "the session header no longer matches");
+		}
+		const actualTailId = readDurableTailId(this.sessionFile);
+		if (actualTailId !== this.durableTailId) {
+			throw new SessionDurableTailError(
+				this.sessionFile,
+				`expected durable tail ${this.durableTailId ?? "<header>"}, found ${actualTailId ?? "<header>"}`,
+			);
+		}
+	}
+
+	/**
+	 * Require this process to own the persisted session and prove that the file's
+	 * physical tail still matches the last entry this manager observed.
+	 */
+	assertWriterOwnership(): void {
+		this._ensureWriterOwnership();
+		try {
+			this._verifyDurableTail();
+		} catch (error) {
+			if (error instanceof SessionDurableTailError) {
+				this.writerOwnershipInvalid = error;
+			}
+			throw error;
+		}
+	}
+
+	/** Release persisted-session ownership so another process can explicitly take over. */
+	dispose(): void {
+		this._releaseWriterOwnership();
+	}
+
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
+		this.assertWriterOwnership();
 		const fd = openSync(this.sessionFile, "w");
 		try {
 			for (const entry of this.fileEntries) {
@@ -986,6 +1307,8 @@ export class SessionManager {
 		} finally {
 			closeSync(fd);
 		}
+		this.durableTailId = getLastSessionEntryId(this.fileEntries);
+		this.flushed = true;
 	}
 
 	isPersisted(): boolean {
@@ -1014,13 +1337,18 @@ export class SessionManager {
 
 	_persist(entry: SessionEntry): void {
 		if (!this.persist || !this.sessionFile) return;
+		this.assertWriterOwnership();
 
-		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
+		const hasAssistant =
+			this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant") ||
+			(entry.type === "message" && entry.message.role === "assistant");
 		if (!hasAssistant) {
 			if (this.flushed) {
 				appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+				this.durableTailId = entry.id;
 			} else {
-				// Mark as not flushed so when assistant arrives, all entries get written
+				// Keep pre-assistant entries in memory. The writer lock still reserves
+				// this session path until the first assistant response flushes them.
 				this.flushed = false;
 			}
 			return;
@@ -1029,23 +1357,28 @@ export class SessionManager {
 		if (!this.flushed) {
 			const fd = openSync(this.sessionFile, "wx");
 			try {
-				for (const e of this.fileEntries) {
-					writeFileSync(fd, `${JSON.stringify(e)}\n`);
+				for (const existingEntry of this.fileEntries) {
+					writeFileSync(fd, `${JSON.stringify(existingEntry)}\n`);
 				}
+				writeFileSync(fd, `${JSON.stringify(entry)}\n`);
 			} finally {
 				closeSync(fd);
 			}
 			this.flushed = true;
+			this.durableTailId = entry.id;
 		} else {
 			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+			this.durableTailId = entry.id;
 		}
 	}
 
 	private _appendEntry(entry: SessionEntry): void {
+		// Persist first so a failed ownership or durable-tail check cannot leave a
+		// losing writer's divergent entry in its in-memory provider context.
+		this._persist(entry);
 		this.fileEntries.push(entry);
 		this.byId.set(entry.id, entry);
 		this.leafId = entry.id;
-		this._persist(entry);
 	}
 
 	/** Append a message as child of current leaf, then advance leaf. Returns entry id.
@@ -1469,6 +1802,10 @@ export class SessionManager {
 				parentId = labelEntry.id;
 			}
 
+			this._releaseWriterOwnership();
+			this.writerOwnershipInvalid = undefined;
+			this.durableTailId = null;
+			this.flushed = false;
 			this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
 			this.sessionId = newSessionId;
 			this.sessionFile = newSessionFile;
@@ -1507,6 +1844,7 @@ export class SessionManager {
 		}
 		this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
 		this.sessionId = newSessionId;
+		this.durableTailId = null;
 		this._buildIndex();
 		return undefined;
 	}

--- a/packages/coding-agent/test/fixtures/session-writer-process.ts
+++ b/packages/coding-agent/test/fixtures/session-writer-process.ts
@@ -1,0 +1,134 @@
+import { Agent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai/compat";
+import { AgentSession } from "../../src/core/agent-session.ts";
+import type { ModelRuntime } from "../../src/core/model-runtime.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { createTestResourceLoader } from "../utilities.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function assistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function send(message: Record<string, unknown>): void {
+	process.send?.(message);
+}
+
+const [mode, sessionFile, tempDir] = process.argv.slice(2);
+if (!mode || !sessionFile || !tempDir) {
+	throw new Error("Expected mode, session file, and temp directory");
+}
+
+if (mode === "owner") {
+	const manager = SessionManager.open(sessionFile);
+	const entryId = manager.appendCustomEntry("writer-owner", { pid: process.pid });
+	send({ type: "owned", entryId });
+
+	process.on("message", (message) => {
+		if (message === "release") {
+			manager.dispose();
+			send({ type: "released" });
+			process.exit(0);
+		}
+	});
+} else if (mode === "contender") {
+	const manager = SessionManager.open(sessionFile);
+	const entriesBefore = manager.getEntries().length;
+	let appendError: string | undefined;
+	try {
+		manager.appendCustomEntry("contender-append", { pid: process.pid });
+	} catch (error) {
+		appendError = error instanceof Error ? error.message : String(error);
+	}
+	const entriesAfterAppend = manager.getEntries().length;
+
+	let providerCalled = false;
+	const model = getModel("anthropic", "claude-sonnet-4-5")!;
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: {
+			model,
+			systemPrompt: "Test",
+			tools: [],
+		},
+		streamFn: () => {
+			providerCalled = true;
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				const message = assistantMessage("provider response");
+				stream.push({ type: "start", partial: { ...message, content: [] } });
+				stream.push({ type: "done", reason: "stop", message });
+			});
+			return stream;
+		},
+	});
+
+	const modelRuntime = {
+		hasConfiguredAuth: () => true,
+		checkAuth: async () => ({ type: "api_key", key: "test-key" }),
+		isUsingOAuth: () => false,
+	} as unknown as ModelRuntime;
+	const session = new AgentSession({
+		agent,
+		sessionManager: manager,
+		settingsManager: SettingsManager.create(tempDir, tempDir),
+		cwd: tempDir,
+		modelRuntime,
+		resourceLoader: createTestResourceLoader(),
+	});
+
+	let promptError: string | undefined;
+	try {
+		await session.prompt("contender provider turn");
+	} catch (error) {
+		promptError = error instanceof Error ? error.message : String(error);
+	}
+
+	send({
+		type: "contender-result",
+		appendError,
+		entriesBefore,
+		entriesAfterAppend,
+		promptError,
+		providerCalled,
+	});
+	session.dispose();
+	process.exit(0);
+} else if (mode === "handoff") {
+	const manager = SessionManager.open(sessionFile);
+	const entryId = manager.appendCustomEntry("handoff-owner", { pid: process.pid });
+	manager.dispose();
+	send({ type: "handoff-result", entryId });
+	process.exit(0);
+} else {
+	throw new Error(`Unknown mode: ${mode}`);
+}

--- a/packages/coding-agent/test/provider-payload-audit.test.ts
+++ b/packages/coding-agent/test/provider-payload-audit.test.ts
@@ -1,0 +1,199 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	PROVIDER_PAYLOAD_AUDIT_CUSTOM_TYPE,
+	ProviderPayloadAudit,
+	type ProviderPayloadAuditRecord,
+} from "../src/core/provider-payload-audit.ts";
+import { type CustomEntry, SessionManager } from "../src/core/session-manager.ts";
+
+const anthropicModel = {
+	id: "claude-test",
+	name: "Claude Test",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://example.invalid",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 100_000,
+	maxTokens: 4096,
+} as Model<any>;
+
+function deepFreeze<T>(value: T): T {
+	if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+	Object.freeze(value);
+	for (const child of Object.values(value)) deepFreeze(child);
+	return value;
+}
+
+function records(manager: SessionManager): ProviderPayloadAuditRecord[] {
+	return manager
+		.getEntries()
+		.filter(
+			(entry): entry is CustomEntry =>
+				entry.type === "custom" && entry.customType === PROVIDER_PAYLOAD_AUDIT_CUSTOM_TYPE,
+		)
+		.map((entry) => entry.data as ProviderPayloadAuditRecord);
+}
+
+function section(record: ProviderPayloadAuditRecord, key: string) {
+	return record.sectionContinuity.find((value) => value.key === key);
+}
+
+describe("ProviderPayloadAudit", () => {
+	it("hashes the final payload without mutation and distinguishes linear appends from rewrites", () => {
+		const manager = SessionManager.inMemory();
+		const audit = new ProviderPayloadAudit(manager, true);
+		manager.appendMessage({ role: "user", content: [{ type: "text", text: "first secret" }], timestamp: 1 });
+
+		const firstPayload = deepFreeze({
+			model: anthropicModel.id,
+			system: "stable system secret",
+			tools: [{ name: "read", input_schema: { type: "object" } }],
+			messages: [{ role: "user", content: "first secret" }],
+			max_tokens: 4096,
+		});
+		const firstBytes = JSON.stringify(firstPayload);
+		audit.record(firstPayload, anthropicModel);
+		expect(JSON.stringify(firstPayload)).toBe(firstBytes);
+
+		manager.appendCustomMessageEntry("test-reply", "reply", false);
+		const appendedPayload = deepFreeze({
+			...firstPayload,
+			messages: [...firstPayload.messages, { role: "assistant", content: "reply" }],
+			max_tokens: 8192,
+		});
+		audit.record(appendedPayload, anthropicModel);
+
+		manager.appendMessage({ role: "user", content: [{ type: "text", text: "next" }], timestamp: 2 });
+		const rewrittenPayload = deepFreeze({
+			...appendedPayload,
+			messages: [
+				{ role: "user", content: "changed earlier content" },
+				...appendedPayload.messages.slice(1),
+				{ role: "user", content: "next" },
+			],
+		});
+		audit.record(rewrittenPayload, anthropicModel);
+
+		const [initial, appended, rewritten] = records(manager);
+		expect(initial.classification).toBe("initial-context");
+		expect(initial.payloadPrefixBroken).toBe(false);
+		expect(JSON.stringify(initial)).not.toContain("secret");
+
+		expect(appended.classification).toBe("linear-append-or-retry");
+		expect(appended.sessionContext.change).toBe("appended");
+		expect(section(appended, "messages")).toMatchObject({ change: "appended", commonPrefixItems: 1 });
+
+		expect(rewritten.classification).toBe("linear-prefix-break");
+		expect(rewritten.payloadPrefixBroken).toBe(true);
+		expect(rewritten.sessionContext.change).toBe("appended");
+		expect(section(rewritten, "messages")).toMatchObject({ change: "rewritten", commonPrefixItems: 0 });
+	});
+
+	it("tracks nested provider context while ignoring non-context request options", () => {
+		const manager = SessionManager.inMemory();
+		const audit = new ProviderPayloadAudit(manager, true);
+		const googleModel = {
+			...anthropicModel,
+			id: "gemini-test",
+			provider: "google",
+			api: "google-generative-ai",
+		} as Model<any>;
+		manager.appendMessage({ role: "user", content: [{ type: "text", text: "first" }], timestamp: 1 });
+		audit.record(
+			{
+				model: googleModel.id,
+				contents: [{ role: "user", parts: [{ text: "first" }] }],
+				config: {
+					systemInstruction: "stable",
+					tools: [{ functionDeclarations: [{ name: "read" }] }],
+					thinkingConfig: { thinkingLevel: "LOW" },
+				},
+			},
+			googleModel,
+		);
+
+		manager.appendMessage({ role: "user", content: [{ type: "text", text: "second" }], timestamp: 2 });
+		audit.record(
+			{
+				model: googleModel.id,
+				contents: [
+					{ role: "user", parts: [{ text: "first" }] },
+					{ role: "user", parts: [{ text: "second" }] },
+				],
+				config: {
+					systemInstruction: "stable",
+					tools: [{ functionDeclarations: [{ name: "read" }] }],
+					thinkingConfig: { thinkingLevel: "HIGH" },
+				},
+			},
+			googleModel,
+		);
+
+		manager.appendMessage({ role: "user", content: [{ type: "text", text: "third" }], timestamp: 3 });
+		audit.record(
+			{
+				model: googleModel.id,
+				contents: [
+					{ role: "user", parts: [{ text: "first" }] },
+					{ role: "user", parts: [{ text: "second" }] },
+					{ role: "user", parts: [{ text: "third" }] },
+				],
+				config: {
+					systemInstruction: "stable",
+					tools: [{ functionDeclarations: [{ name: "read" }] }, { functionDeclarations: [{ name: "write" }] }],
+					thinkingConfig: { thinkingLevel: "HIGH" },
+				},
+			},
+			googleModel,
+		);
+
+		const [, appended, toolsChanged] = records(manager);
+		expect(appended.classification).toBe("linear-append-or-retry");
+		expect(appended.payload.sections.map((value) => value.key)).toEqual([
+			"contents",
+			"config.systemInstruction",
+			"config.tools",
+		]);
+		expect(section(appended, "contents")).toMatchObject({ change: "appended" });
+		expect(toolsChanged.classification).toBe("linear-prefix-break");
+		expect(section(toolsChanged, "config.tools")).toMatchObject({ change: "appended" });
+	});
+
+	it("classifies compaction and model changes as explicit context transitions", () => {
+		const manager = SessionManager.inMemory();
+		const audit = new ProviderPayloadAudit(manager, true);
+		const firstId = manager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "first" }],
+			timestamp: 1,
+		});
+		audit.record({ model: anthropicModel.id, messages: [{ role: "user", content: "first" }] }, anthropicModel);
+
+		manager.appendCompaction("summary", firstId, 100);
+		audit.record({ model: anthropicModel.id, messages: [{ role: "user", content: "compacted" }] }, anthropicModel);
+
+		const openAiModel = {
+			...anthropicModel,
+			id: "gpt-test",
+			provider: "openai",
+			api: "openai-responses",
+		} as Model<any>;
+		audit.record({ model: openAiModel.id, input: [{ role: "user", content: "new model" }] }, openAiModel);
+
+		const [, compacted, newModel] = records(manager);
+		expect(compacted.classification).toBe("explicit-compaction");
+		expect(compacted.latestCompactionEntryId).toEqual(expect.any(String));
+		expect(compacted.sessionContext.change).toBe("rewritten");
+		expect(newModel.classification).toBe("new-model-context");
+	});
+
+	it("does nothing when auditing is disabled", () => {
+		const manager = SessionManager.inMemory();
+		const audit = new ProviderPayloadAudit(manager, false);
+		audit.record({ messages: [] }, anthropicModel);
+		expect(records(manager)).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/session-info-modified-timestamp.test.ts
+++ b/packages/coding-agent/test/session-info-modified-timestamp.test.ts
@@ -20,23 +20,27 @@ function createSessionFile(path: string): void {
 	// SessionManager only persists once it has seen at least one assistant message.
 	// Add a minimal assistant entry so subsequent appends are persisted.
 	const mgr = SessionManager.open(path);
-	mgr.appendMessage({
-		role: "assistant",
-		content: [{ type: "text", text: "hi" }],
-		api: "openai-completions",
-		provider: "openai",
-		model: "test",
-		usage: {
-			input: 1,
-			output: 1,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 2,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-		stopReason: "stop",
-		timestamp: Date.now(),
-	});
+	try {
+		mgr.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "hi" }],
+			api: "openai-completions",
+			provider: "openai",
+			model: "test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+	} finally {
+		mgr.dispose();
+	}
 }
 
 describe("SessionInfo.modified", () => {

--- a/packages/coding-agent/test/session-manager-writer-ownership.test.ts
+++ b/packages/coding-agent/test/session-manager-writer-ownership.test.ts
@@ -1,0 +1,167 @@
+import { type ChildProcess, fork } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadEntriesFromFile, SessionDurableTailError, SessionManager } from "../src/core/session-manager.ts";
+
+interface ChildMessage {
+	type: string;
+	[key: string]: unknown;
+}
+
+const childModule = fileURLToPath(new URL("./fixtures/session-writer-process.ts", import.meta.url));
+
+describe("persisted session writer ownership", () => {
+	let tempDir: string;
+	let sessionFile: string;
+	const children = new Set<ChildProcess>();
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-session-writer-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+		sessionFile = join(tempDir, "shared.jsonl");
+		const timestamp = new Date().toISOString();
+		writeFileSync(
+			sessionFile,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: "shared-session",
+				timestamp,
+				cwd: tempDir,
+			})}\n${JSON.stringify({
+				type: "message",
+				id: "root-entry",
+				parentId: null,
+				timestamp,
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "root" }],
+					timestamp: Date.now(),
+				},
+			})}\n`,
+		);
+	});
+
+	afterEach(() => {
+		for (const child of children) {
+			child.kill("SIGKILL");
+		}
+		children.clear();
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	function spawnChild(mode: "owner" | "contender" | "handoff"): ChildProcess {
+		const child = fork(childModule, [mode, sessionFile, tempDir], {
+			cwd: join(dirname(childModule), "../../../.."),
+			execArgv: ["--import", "tsx"],
+			stdio: ["ignore", "pipe", "pipe", "ipc"],
+		});
+		children.add(child);
+		child.once("exit", () => children.delete(child));
+		return child;
+	}
+
+	async function waitForMessage(child: ChildProcess, type: string): Promise<ChildMessage> {
+		return await new Promise<ChildMessage>((resolve, reject) => {
+			let stderr = "";
+			const timeout = setTimeout(() => {
+				cleanup();
+				reject(new Error(`Timed out waiting for ${type}. stderr: ${stderr}`));
+			}, 10_000);
+
+			const onMessage = (message: ChildMessage) => {
+				if (message.type !== type) return;
+				cleanup();
+				resolve(message);
+			};
+			const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+				cleanup();
+				reject(new Error(`Child exited before ${type}: code=${code} signal=${signal}. stderr: ${stderr}`));
+			};
+			const onStderr = (chunk: Buffer | string) => {
+				stderr += chunk.toString();
+			};
+			const cleanup = () => {
+				clearTimeout(timeout);
+				child.off("message", onMessage);
+				child.off("exit", onExit);
+				child.stderr?.off("data", onStderr);
+			};
+
+			child.on("message", onMessage);
+			child.once("exit", onExit);
+			child.stderr?.on("data", onStderr);
+		});
+	}
+
+	it("allows one live writer, blocks a second append and provider turn, then permits handoff", async () => {
+		const owner = spawnChild("owner");
+		const owned = await waitForMessage(owner, "owned");
+		expect(owned.entryId).toEqual(expect.any(String));
+
+		const contender = spawnChild("contender");
+		const result = await waitForMessage(contender, "contender-result");
+		expect(result.appendError).toMatch(/owned by another live process/i);
+		expect(result.entriesAfterAppend).toBe(result.entriesBefore);
+		expect(result.promptError).toMatch(/owned by another live process/i);
+		expect(result.providerCalled).toBe(false);
+
+		owner.send("release");
+		await waitForMessage(owner, "released");
+
+		const handoff = spawnChild("handoff");
+		const handoffResult = await waitForMessage(handoff, "handoff-result");
+		expect(handoffResult.entryId).toEqual(expect.any(String));
+
+		const entries = loadEntriesFromFile(sessionFile).filter((entry) => entry.type !== "session");
+		expect(entries.map((entry) => entry.type === "custom" && entry.customType)).toEqual([
+			false,
+			"writer-owner",
+			"handoff-owner",
+		]);
+		for (let index = 1; index < entries.length; index++) {
+			expect(entries[index].parentId).toBe(entries[index - 1].id);
+		}
+	});
+
+	it("recovers an abandoned writer lock only after the owning process exits", async () => {
+		const owner = spawnChild("owner");
+		await waitForMessage(owner, "owned");
+		const exited = new Promise<void>((resolve) => owner.once("exit", () => resolve()));
+		owner.kill("SIGKILL");
+		await exited;
+
+		const handoff = spawnChild("handoff");
+		const handoffResult = await waitForMessage(handoff, "handoff-result");
+		expect(handoffResult.entryId).toEqual(expect.any(String));
+	});
+
+	it("fails closed before mutating memory when the durable tail changes behind the owner", () => {
+		const manager = SessionManager.open(sessionFile);
+		try {
+			const ownerEntryId = manager.appendCustomEntry("owner-entry");
+			const entriesBefore = manager.getEntries();
+			appendFileSync(
+				sessionFile,
+				`${JSON.stringify({
+					type: "custom",
+					customType: "foreign-entry",
+					id: "foreign-tail",
+					parentId: ownerEntryId,
+					timestamp: new Date().toISOString(),
+				})}\n`,
+			);
+
+			expect(() => manager.appendCustomEntry("must-not-land")).toThrow(SessionDurableTailError);
+			expect(manager.getEntries()).toEqual(entriesBefore);
+			expect(loadEntriesFromFile(sessionFile).at(-1)).toMatchObject({ id: "foreign-tail" });
+		} finally {
+			manager.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- enforce one live writer per persisted session and verify the durable physical tail before provider turns
- fail closed on competing/abandoned writer ownership and keep persistence ahead of in-memory mutation
- add opt-in provider-payload lineage auditing without retaining raw payloads

## Verification
- 19 focused coding-agent tests pass:
  - session-manager-writer-ownership
  - agent-session-concurrent
  - provider-payload-audit
  - session-info-modified-timestamp
  - sdk-session-manager
- full monorepo build passes
- earlier full coding-agent run: 1,941 passing; five unrelated environment/TUI failures remained
