### PR TITLE
fix(coding-agent): llama.cpp try /v1/models then /models when listing models

### DIFF
--- a/packages/coding-agent/src/extensions/llama/client.ts
+++ b/packages/coding-agent/src/extensions/llama/client.ts
@@ -180,13 +180,28 @@ export class LlamaClient {
 	}
 
 	async list(options: { reload?: boolean; signal?: AbortSignal } = {}): Promise<LlamaModelInfo[]> {
-		const payload = await this.request(`/models${options.reload ? "?reload=1" : ""}`, { signal: options.signal });
-		if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
-			throw new Error("llama.cpp returned an invalid model catalog");
+		const reloadQuery = options.reload ? "?reload=1" : "";
+		const candidates = [`/v1/models${reloadQuery}`, `/models${reloadQuery}`];
+		let lastError: unknown;
+		for (const candidate of candidates) {
+			try {
+				const payload = await this.request(candidate, { signal: options.signal });
+				if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
+					lastError = new Error("llama.cpp returned an invalid model catalog");
+					continue;
+				}
+				const data = (payload as { data: unknown[] }).data;
+				if (!data.every(isModelInfo)) {
+					lastError = new Error("Server is not running in llama.cpp router mode");
+					continue;
+				}
+				return data;
+			} catch (err) {
+				lastError = err;
+				// try next candidate
+			}
 		}
-		const data = (payload as { data: unknown[] }).data;
-		if (!data.every(isModelInfo)) throw new Error("Server is not running in llama.cpp router mode");
-		return data;
+		throw lastError instanceof Error ? lastError : new Error("Failed to list models");
 	}
 
 	async load(model: string, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
## Summary

Attempt to improve compatibility when listing models from llama-based servers by trying `/v1/models` first (OpenAI-compatible style) and falling back to `/models` (native style). This is a single, minimal change: only the `list()` method in `packages/coding-agent/src/extensions/llama/client.ts` is modified. All other behavior and URL normalization remain unchanged.

## Problem / Motivation

Some llama.cpp frontends and wrappers expose the model list at `/v1/models` (to be OpenAI-compatible), while others expose `/models`. The existing implementation requested only `/models`, causing failures against servers that require `/v1/models` (for example LMStudio). Rather than changing global URL normalization or request logic, this PR makes the smallest possible change to improve compatibility.

## What changed

- File: `packages/coding-agent/src/extensions/llama/client.ts`
- Change: Replace the `list()` implementation to:
  1. Try `/v1/models` (with optional `?reload=1` when requested).
  2. If that fails, try `/models` (with optional `?reload=1`).
  3. Return the first successful model list; if both fail, propagate an error.
- No other functions were modified (`normalize`, `request`, `watch`, etc. remain unchanged).

Expected behavior:
- If the server implements `/v1/models`, `list()` succeeds using that endpoint.
- If not, `list()` falls back to `/models`.
- If neither returns a valid model list, the same error behavior as before occurs.