### PR TITLE
feat(coding-agent): add pi.registerToolRenderer for external tool rendering

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1617,6 +1617,24 @@ pi.registerEntryRenderer("status-card", (entry, { expanded }, theme) => {
 pi.appendEntry("status-card", { title: "Indexed files", count: 17 });
 ```
 
+### pi.registerToolRenderer(toolName, renderer)
+
+Register an external custom renderer for a tool. This overrides the tool definition's `renderCall`, `renderResult`, and `renderShell` in the interactive TUI and HTML session export without re-registering or wrapping the tool.
+
+```typescript
+import { Text } from "@earendil-works/pi-tui";
+
+pi.registerToolRenderer("mcpScript", {
+  renderCall(args, theme) {
+    return new Text(theme.fg("accent", "MCP Script: ") + (args.code?.slice(0, 50) ?? ""));
+  },
+  renderResult(result, { expanded }, theme) {
+    const text = result.content?.find((c) => c.type === "text")?.text ?? "";
+    return new Text(theme.fg("toolOutput", expanded ? text : text.slice(0, 100)));
+  },
+});
+```
+
 ### pi.registerShortcut(shortcut, options)
 
 Register a keyboard shortcut. See [keybindings.md](keybindings.md) for the shortcut format and built-in keybindings.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -924,7 +924,34 @@ export class AgentSession {
 	}
 
 	getToolDefinition(name: string): ToolDefinition | undefined {
-		return this._toolDefinitions.get(name)?.definition;
+		const baseDef = this._toolDefinitions.get(name)?.definition;
+		const customRenderer = this._extensionRunner?.getToolRenderer(name);
+		if (!customRenderer) {
+			return baseDef;
+		}
+
+		if (!baseDef) {
+			return {
+				name,
+				label: name,
+				description: "",
+				parameters: undefined as any,
+				execute: async () => ({
+					content: [{ type: "text", text: "" }],
+					details: {},
+				}),
+				renderShell: customRenderer.renderShell,
+				renderCall: customRenderer.renderCall,
+				renderResult: customRenderer.renderResult,
+			};
+		}
+
+		return {
+			...baseDef,
+			renderShell: customRenderer.renderShell ?? baseDef.renderShell,
+			renderCall: customRenderer.renderCall ?? baseDef.renderCall,
+			renderResult: customRenderer.renderResult ?? baseDef.renderResult,
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -158,6 +158,7 @@ export type {
 	ToolExecutionStartEvent,
 	ToolExecutionUpdateEvent,
 	ToolInfo,
+	ToolRenderer,
 	ToolRenderResultOptions,
 	ToolResultEvent,
 	ToolResultEventResult,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -44,6 +44,7 @@ import type {
 	ProviderConfig,
 	RegisteredCommand,
 	ToolDefinition,
+	ToolRenderer,
 } from "./types.ts";
 
 /** Modules available to extensions via virtualModules (for compiled binaries) */
@@ -325,6 +326,12 @@ function createExtensionAPI(
 			extension.entryRenderers.set(customType, renderer as EntryRenderer);
 		},
 
+		registerToolRenderer(toolName: string, renderer: ToolRenderer): void {
+			runtime.assertActive();
+			extension.toolRenderers ??= new Map();
+			extension.toolRenderers.set(toolName, renderer as ToolRenderer);
+		},
+
 		// Flag access - checks extension registered it, reads from runtime
 		getFlag(name: string): boolean | string | undefined {
 			runtime.assertActive();
@@ -489,6 +496,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		tools: new Map(),
 		messageRenderers: new Map(),
 		entryRenderers: new Map(),
+		toolRenderers: new Map(),
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -60,6 +60,7 @@ import type {
 	SessionShutdownEvent,
 	ToolCallEvent,
 	ToolCallEventResult,
+	ToolRenderer,
 	ToolResultEvent,
 	ToolResultEventResult,
 	UserBashEvent,
@@ -593,6 +594,16 @@ export class ExtensionRunner {
 	getEntryRenderer(customType: string): EntryRenderer | undefined {
 		for (const ext of this.extensions) {
 			const renderer = ext.entryRenderers?.get(customType);
+			if (renderer) {
+				return renderer;
+			}
+		}
+		return undefined;
+	}
+
+	getToolRenderer(toolName: string): ToolRenderer | undefined {
+		for (const ext of this.extensions) {
+			const renderer = ext.toolRenderers?.get(toolName);
 			if (renderer) {
 				return renderer;
 			}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1184,6 +1184,20 @@ export type EntryRenderer<T = unknown> = (
 	theme: Theme,
 ) => Component | undefined;
 
+export interface ToolRenderer<TParams extends TSchema = TSchema, TDetails = unknown, TState = any> {
+	/** Controls whether ToolExecutionComponent renders the standard colored shell or the tool renders its own framing. */
+	renderShell?: "default" | "self";
+	/** Custom rendering for tool call display */
+	renderCall?: (args: Static<TParams>, theme: Theme, context: ToolRenderContext<TState, Static<TParams>>) => Component;
+	/** Custom rendering for tool result display */
+	renderResult?: (
+		result: AgentToolResult<TDetails>,
+		options: ToolRenderResultOptions,
+		theme: Theme,
+		context: ToolRenderContext<TState, Static<TParams>>,
+	) => Component;
+}
+
 // ============================================================================
 // Command Registration
 // ============================================================================
@@ -1316,6 +1330,12 @@ export interface ExtensionAPI {
 
 	/** Register a custom renderer for CustomEntry. Custom entries do not participate in LLM context. */
 	registerEntryRenderer<T = unknown>(customType: string, renderer: EntryRenderer<T>): void;
+
+	/** Register an external custom renderer for a tool (overrides tool definition rendering in TUI and export). */
+	registerToolRenderer<TParams extends TSchema = TSchema, TDetails = unknown, TState = any>(
+		toolName: string,
+		renderer: ToolRenderer<TParams, TDetails, TState>,
+	): void;
 
 	// =========================================================================
 	// Actions
@@ -1726,6 +1746,7 @@ export interface Extension {
 	messageRenderers: Map<string, MessageRenderer>;
 	markdownTransformer?: MarkdownTransformer;
 	entryRenderers?: Map<string, EntryRenderer>;
+	toolRenderers?: Map<string, ToolRenderer>;
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -140,6 +140,7 @@ export type {
 	ToolExecutionStartEvent,
 	ToolExecutionUpdateEvent,
 	ToolInfo,
+	ToolRenderer,
 	ToolRenderResultOptions,
 	ToolResultEvent,
 	TurnEndEvent,

--- a/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
+++ b/packages/coding-agent/test/agent-session-dynamic-tools.test.ts
@@ -253,4 +253,59 @@ describe("AgentSession dynamic tool registration", () => {
 
 		session.dispose();
 	});
+
+	it("overrides tool definition rendering with registered tool renderer", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: tempDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [
+				(pi) => {
+					pi.registerTool({
+						name: "my_custom_tool",
+						label: "My Custom Tool",
+						description: "Tool with built-in renderer",
+						parameters: Type.Object({}),
+						renderShell: "default",
+						renderCall: () => undefined as any,
+						renderResult: () => undefined as any,
+						execute: async () => ({
+							content: [{ type: "text", text: "ok" }],
+							details: {},
+						}),
+					});
+				},
+				(pi) => {
+					pi.registerToolRenderer("my_custom_tool", {
+						renderShell: "self",
+						renderCall: () => "external_call" as any,
+						renderResult: () => "external_result" as any,
+					});
+				},
+			],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir,
+			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		await session.bindExtensions({});
+
+		const toolDef = session.getToolDefinition("my_custom_tool");
+		expect(toolDef).toBeDefined();
+		expect(toolDef?.renderShell).toBe("self");
+		expect(toolDef?.renderCall?.({} as any, {} as any, {} as any)).toBe("external_call");
+		expect(toolDef?.renderResult?.({} as any, {} as any, {} as any, {} as any)).toBe("external_result");
+
+		session.dispose();
+	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -640,6 +640,24 @@ describe("ExtensionRunner", () => {
 			expect(runner.getEntryRenderer("my-entry")).toBeDefined();
 			expect(runner.getEntryRenderer("not-exists")).toBeUndefined();
 		});
+
+		it("gets tool renderer by tool name", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.registerToolRenderer("custom-tool", {
+						renderCall: () => null,
+						renderResult: () => null,
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-renderer.ts"), extCode);
+
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			expect(runner.getToolRenderer("custom-tool")).toBeDefined();
+			expect(runner.getToolRenderer("not-exists")).toBeUndefined();
+		});
 	});
 
 	describe("flags", () => {


### PR DESCRIPTION
## Summary
Adds `pi.registerToolRenderer(toolName, renderer)` to `ExtensionAPI`.

This allows extensions (such as UI/theme polish extensions like `pi-pretty-tui`) to customize `renderCall`, `renderResult`, and `renderShell` for tools registered by other extensions (e.g. MCP tools) or built-ins without re-registering the tool or encountering tool name conflicts.

## Motivation
Currently, Pi enforces strict uniqueness across extension-registered tools (`Tool conflict with ...`). Built-in tools can be overridden by full tool re-registration, but extension tools (like `mcp` / `mcpScript` from `pi-mcp-adapter` or LSP tools) cannot be overridden by other extensions.

Extensions that focus purely on terminal UI aesthetics/formatting need a way to customize the display of third-party tools without touching the execution logic or package internals of those extensions.

## Changes
- **`ExtensionAPI` & Types**: Added `registerToolRenderer` method and `ToolRenderer` interface with `renderCall`, `renderResult`, and optional `renderShell`.
- **Loader & Runner**: Captured `toolRenderers` per extension and exposed `extensionRunner.getToolRenderer(toolName)`.
- **AgentSession**: `getToolDefinition(name)` merges registered tool renderers with tool definitions, taking precedence over tool-defined rendering slots while preserving underlying execution.
- **Documentation**: Documented `pi.registerToolRenderer` in `docs/extensions.md`.
- **Tests**: Added unit tests in `extensions-runner.test.ts` and `agent-session-dynamic-tools.test.ts`.

## Test Plan
- Unit tests pass: `npx vitest run test/extensions-runner.test.ts` and `test/agent-session-dynamic-tools.test.ts`
- Monorepo build and pre-commit checks pass (`biome check`, typecheck, all tests)
- Verified locally in interactive session with external UI extensions.
