### PR TITLE
fix(coding-agent): repair unterminated session tails

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -11,6 +11,7 @@ import {
 	readdirSync,
 	readSync,
 	statSync,
+	truncateSync,
 	writeFileSync,
 } from "fs";
 import { readdir, stat } from "fs/promises";
@@ -510,12 +511,22 @@ function parseSessionEntryLine(line: string): FileEntry | null {
 	}
 }
 
-/** Exported for testing */
-export function loadEntriesFromFile(filePath: string): FileEntry[] {
+type SessionTailRepair = { kind: "append-newline" } | { kind: "truncate"; length: number };
+
+interface LoadedSessionFile {
+	entries: FileEntry[];
+	tailRepair: SessionTailRepair | null;
+}
+
+function loadSessionFile(filePath: string): LoadedSessionFile {
 	const resolvedFilePath = normalizePath(filePath);
-	if (!existsSync(resolvedFilePath)) return [];
+	if (!existsSync(resolvedFilePath)) return { entries: [], tailRepair: null };
 
 	const entries: FileEntry[] = [];
+	let lastNewlineEnd = 0;
+	let totalBytesRead = 0;
+	let hasUnterminatedTail = false;
+	let finalEntry: FileEntry | null = null;
 	const fd = openSync(resolvedFilePath, "r");
 	try {
 		const decoder = new StringDecoder("utf8");
@@ -526,7 +537,14 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 			const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
 			if (bytesRead === 0) break;
 
-			pending += decoder.write(buffer.subarray(0, bytesRead));
+			const chunk = buffer.subarray(0, bytesRead);
+			const lastNewlineIndex = chunk.lastIndexOf(0x0a);
+			if (lastNewlineIndex !== -1) {
+				lastNewlineEnd = totalBytesRead + lastNewlineIndex + 1;
+			}
+			totalBytesRead += bytesRead;
+
+			pending += decoder.write(chunk);
 			let lineStart = 0;
 			let newlineIndex = pending.indexOf("\n", lineStart);
 			while (newlineIndex !== -1) {
@@ -539,20 +557,31 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 		}
 
 		pending += decoder.end();
-		const finalEntry = parseSessionEntryLine(pending);
+		hasUnterminatedTail = pending.length > 0;
+		finalEntry = parseSessionEntryLine(pending);
 		if (finalEntry) entries.push(finalEntry);
 	} finally {
 		closeSync(fd);
 	}
 
 	// Validate session header
-	if (entries.length === 0) return entries;
+	if (entries.length === 0) return { entries, tailRepair: null };
 	const header = entries[0];
 	if (header.type !== "session" || typeof (header as { id?: unknown }).id !== "string") {
-		return [];
+		return { entries: [], tailRepair: null };
 	}
 
-	return entries;
+	const tailRepair: SessionTailRepair | null = hasUnterminatedTail
+		? finalEntry
+			? { kind: "append-newline" }
+			: { kind: "truncate", length: lastNewlineEnd }
+		: null;
+	return { entries, tailRepair };
+}
+
+/** Exported for testing */
+export function loadEntriesFromFile(filePath: string): FileEntry[] {
+	return loadSessionFile(filePath).entries;
 }
 
 /**
@@ -864,6 +893,7 @@ export class SessionManager {
 	private labelsById: Map<string, string> = new Map();
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
+	private tailRepair: SessionTailRepair | null = null;
 
 	private constructor(
 		cwd: string,
@@ -871,7 +901,7 @@ export class SessionManager {
 		sessionFile: string | undefined,
 		persist: boolean,
 		newSessionOptions?: NewSessionOptions,
-		preloadedFileEntries?: FileEntry[],
+		preloadedSessionFile?: LoadedSessionFile,
 	) {
 		this.cwd = resolvePath(cwd);
 		this.sessionDir = normalizePath(sessionDir);
@@ -881,7 +911,7 @@ export class SessionManager {
 		}
 
 		if (sessionFile) {
-			this._setSessionFile(sessionFile, preloadedFileEntries);
+			this._setSessionFile(sessionFile, preloadedSessionFile);
 		} else {
 			this.newSession(newSessionOptions);
 		}
@@ -892,10 +922,12 @@ export class SessionManager {
 		this._setSessionFile(sessionFile);
 	}
 
-	private _setSessionFile(sessionFile: string, preloadedFileEntries?: FileEntry[]): void {
+	private _setSessionFile(sessionFile: string, preloadedSessionFile?: LoadedSessionFile): void {
 		this.sessionFile = resolvePath(sessionFile);
 		if (existsSync(this.sessionFile)) {
-			this.fileEntries = preloadedFileEntries ?? loadEntriesFromFile(this.sessionFile);
+			const loadedSessionFile = preloadedSessionFile ?? loadSessionFile(this.sessionFile);
+			this.fileEntries = loadedSessionFile.entries;
+			this.tailRepair = loadedSessionFile.tailRepair;
 
 			// If file was empty, initialize it with a valid session header. If it was
 			// non-empty but did not parse as a pi session, fail without modifying it.
@@ -947,6 +979,7 @@ export class SessionManager {
 		this.labelTimestampsById.clear();
 		this.leafId = null;
 		this.flushed = false;
+		this.tailRepair = null;
 
 		if (this.persist) {
 			const fileTimestamp = timestamp.replace(/[:.]/g, "-");
@@ -986,6 +1019,18 @@ export class SessionManager {
 		} finally {
 			closeSync(fd);
 		}
+		this.tailRepair = null;
+	}
+
+	private _repairTailBeforeAppend(): void {
+		if (!this.sessionFile || !this.tailRepair) return;
+
+		if (this.tailRepair.kind === "append-newline") {
+			appendFileSync(this.sessionFile, "\n");
+		} else {
+			truncateSync(this.sessionFile, this.tailRepair.length);
+		}
+		this.tailRepair = null;
 	}
 
 	isPersisted(): boolean {
@@ -1014,6 +1059,7 @@ export class SessionManager {
 
 	_persist(entry: SessionEntry): void {
 		if (!this.persist || !this.sessionFile) return;
+		this._repairTailBeforeAppend();
 
 		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
 		if (!hasAssistant) {
@@ -1472,6 +1518,7 @@ export class SessionManager {
 			this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
 			this.sessionId = newSessionId;
 			this.sessionFile = newSessionFile;
+			this.tailRepair = null;
 			this._buildIndex();
 
 			// Only write the file now if it contains an assistant message.
@@ -1530,7 +1577,7 @@ export class SessionManager {
 	static open(path: string, sessionDir?: string, cwdOverride?: string): SessionManager {
 		const resolvedPath = resolvePath(path);
 		let header: SessionHeader | null = null;
-		let preloadedFileEntries: FileEntry[] | undefined;
+		let preloadedSessionFile: LoadedSessionFile | undefined;
 		if (cwdOverride === undefined && existsSync(resolvedPath)) {
 			try {
 				header = readSessionHeader(resolvedPath);
@@ -1538,15 +1585,15 @@ export class SessionManager {
 				if (!(error instanceof SessionHeaderScanLimitError)) throw error;
 				// The bounded scan is only a discovery optimization. A full load remains
 				// authoritative for legacy files with very large headers or prefixes.
-				preloadedFileEntries = loadEntriesFromFile(resolvedPath);
-				const firstEntry = preloadedFileEntries[0];
+				preloadedSessionFile = loadSessionFile(resolvedPath);
+				const firstEntry = preloadedSessionFile.entries[0];
 				header = firstEntry?.type === "session" ? firstEntry : null;
 			}
 		}
 		const cwd = cwdOverride ?? (header ? getSessionHeaderCwd(header) : undefined) ?? process.cwd();
 		// If no sessionDir provided, derive from file's parent directory
 		const dir = sessionDir ? normalizePath(sessionDir) : resolve(resolvedPath, "..");
-		return new SessionManager(cwd, dir, resolvedPath, true, undefined, preloadedFileEntries);
+		return new SessionManager(cwd, dir, resolvedPath, true, undefined, preloadedSessionFile);
 	}
 
 	/**

--- a/packages/coding-agent/test/suite/regressions/8345-session-manager-torn-tail.test.ts
+++ b/packages/coding-agent/test/suite/regressions/8345-session-manager-torn-tail.test.ts
@@ -1,0 +1,145 @@
+import { appendFileSync, chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+
+function userMessage(text: string) {
+	return { role: "user" as const, content: text, timestamp: Date.now() };
+}
+
+function assistantMessage(text: string) {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic",
+		model: "test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: Date.now(),
+	};
+}
+
+describe("regression #8345: unterminated session tail", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "pi-session-tail-"));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function createPersistedSession(): { manager: SessionManager; file: string } {
+		const manager = SessionManager.create(tempDir, tempDir);
+		manager.appendMessage(userMessage("你好"));
+		manager.appendMessage(assistantMessage("hello"));
+		const file = manager.getSessionFile();
+		if (!file) throw new Error("Expected a persisted session file");
+		return { manager, file };
+	}
+
+	function expectValidJsonl(file: string): void {
+		const content = readFileSync(file, "utf8");
+		expect(content.endsWith("\n")).toBe(true);
+		for (const line of content.split("\n").filter(Boolean)) {
+			expect(() => JSON.parse(line)).not.toThrow();
+		}
+	}
+
+	it("removes an invalid final fragment before the next append", () => {
+		const { file } = createPersistedSession();
+		const intactContent = readFileSync(file);
+		appendFileSync(file, '{"type":"message","content":"残');
+		const tornContent = readFileSync(file);
+
+		const recovered = SessionManager.open(file, tempDir);
+		expect(readFileSync(file)).toEqual(tornContent);
+
+		recovered.appendMessage(userMessage("u2"));
+		expect(readFileSync(file).subarray(0, intactContent.length)).toEqual(intactContent);
+		recovered.appendMessage(assistantMessage("a2"));
+		recovered.appendMessage(userMessage("u3"));
+		expect(recovered.getBranch()).toHaveLength(5);
+
+		const restored = SessionManager.open(file, tempDir);
+		expect(restored.getBranch()).toHaveLength(5);
+		expect(restored.getBranch().map((entry) => (entry.type === "message" ? entry.message.role : entry.type))).toEqual(
+			["user", "assistant", "user", "assistant", "user"],
+		);
+		expectValidJsonl(file);
+	});
+
+	it("terminates a valid final record before the next append", () => {
+		const { file } = createPersistedSession();
+		const content = readFileSync(file);
+		expect(content.at(-1)).toBe(0x0a);
+		const unterminatedContent = content.subarray(0, content.length - 1);
+		writeFileSync(file, unterminatedContent);
+
+		const recovered = SessionManager.open(file, tempDir);
+		expect(readFileSync(file)).toEqual(unterminatedContent);
+		recovered.appendMessage(userMessage("u2"));
+
+		const restored = SessionManager.open(file, tempDir);
+		expect(restored.getBranch()).toHaveLength(3);
+		expect(restored.getBranch().map((entry) => (entry.type === "message" ? entry.message.role : entry.type))).toEqual(
+			["user", "assistant", "user"],
+		);
+		expectValidJsonl(file);
+	});
+
+	it("opens a read-only file without repairing its invalid tail", () => {
+		const { file } = createPersistedSession();
+		appendFileSync(file, '{"type":"message"');
+		const tornContent = readFileSync(file);
+		chmodSync(file, 0o444);
+
+		try {
+			const recovered = SessionManager.open(file, tempDir);
+			expect(recovered.getBranch()).toHaveLength(2);
+			expect(readFileSync(file)).toEqual(tornContent);
+		} finally {
+			chmodSync(file, 0o644);
+		}
+	});
+
+	it("does not repair the source file when forking", () => {
+		const { file } = createPersistedSession();
+		appendFileSync(file, '{"type":"message"');
+		const tornContent = readFileSync(file);
+		const targetDir = join(tempDir, "fork");
+		mkdirSync(targetDir);
+
+		const forked = SessionManager.forkFrom(file, targetDir, targetDir);
+		expect(forked.getBranch()).toHaveLength(2);
+		expect(readFileSync(file)).toEqual(tornContent);
+		expectValidJsonl(forked.getSessionFile()!);
+	});
+
+	it("repairs an invalid fragment after a header before the first message append", () => {
+		const { file } = createPersistedSession();
+		const content = readFileSync(file);
+		const headerEnd = content.indexOf(0x0a) + 1;
+		const tornContent = Buffer.concat([content.subarray(0, headerEnd), Buffer.from('{"type":"message"')]);
+		writeFileSync(file, tornContent);
+
+		const recovered = SessionManager.open(file, tempDir);
+		expect(recovered.getBranch()).toHaveLength(0);
+		expect(readFileSync(file)).toEqual(tornContent);
+
+		recovered.appendMessage(userMessage("u1"));
+		const restored = SessionManager.open(file, tempDir);
+		expect(restored.getBranch()).toHaveLength(1);
+		expectValidJsonl(file);
+	});
+});


### PR DESCRIPTION
## Summary

- detect malformed or unterminated JSONL tails without changing the file during load
- repair the tail before the next append by truncating an invalid fragment or adding the missing delimiter
- keep read-only loads and fork sources unchanged

Fixes #8345

## Verification

- `npm run check`
- `vitest --run test/suite/regressions/8345-session-manager-torn-tail.test.ts` (5 passed)
