### PR TITLE
fix: detect reasoning_content via proxy/gateway routes + guard conten…

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -80,7 +80,7 @@ function hasToolHistory(messages: Message[]): boolean {
 			return true;
 		}
 		if (msg.role === "assistant") {
-			if (msg.content.some((block) => block.type === "toolCall")) {
+			if ((msg.content ?? []).some((block) => block.type === "toolCall")) {
 				return true;
 			}
 		}
@@ -239,14 +239,46 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
 				maxRetries: 0,
 			};
-			const { data: openaiStream, response } = await retryProviderRequest(
-				() => client.chat.completions.create(params, requestOptions).withResponse(),
-				{
-					maxRetries: options?.maxRetries,
-					maxRetryDelayMs: options?.maxRetryDelayMs,
-					signal: options?.signal,
-				},
-			);
+			// Error recovery for DeepSeek reasoning_content 400 errors.
+			// If the backend requires reasoning_content on all assistant messages but
+			// some are missing it (e.g. when routing through a proxy/gateway that doesn't
+			// match the `isDeepSeek` URL check), inject empty reasoning_content and retry.
+			const isReasoningContentError = (err: unknown) => {
+				const msg = (err as any)?.message || (err as any)?.error?.message || String(err);
+				return typeof msg === "string" && msg.includes("reasoning_content") && msg.includes("must be passed back");
+			};
+			const injectReasoningContentOnParams = (msgs: any[]) =>
+				msgs.map((m) => {
+					if (m.role === "assistant" && m.reasoning_content === undefined) {
+						return { ...m, reasoning_content: "" };
+					}
+					return m;
+				});
+			let openaiStream: any, response: any;
+			try {
+				({ data: openaiStream, response } = await retryProviderRequest(
+					() => client.chat.completions.create(params, requestOptions).withResponse(),
+					{
+						maxRetries: options?.maxRetries,
+						maxRetryDelayMs: options?.maxRetryDelayMs,
+						signal: options?.signal,
+					},
+				));
+			} catch (firstError) {
+				if (isReasoningContentError(firstError)) {
+					params.messages = injectReasoningContentOnParams(params.messages);
+					({ data: openaiStream, response } = await retryProviderRequest(
+						() => client.chat.completions.create(params, requestOptions).withResponse(),
+						{
+							maxRetries: options?.maxRetries,
+							maxRetryDelayMs: options?.maxRetryDelayMs,
+							signal: options?.signal,
+						},
+					));
+				} else {
+					throw firstError;
+				}
+			}
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
@@ -1030,6 +1062,17 @@ export function convertMessages(
 	};
 
 	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));
+	// Detect conversations that use reasoning_content thinking blocks (e.g. DeepSeek
+	// via a proxy/gateway that doesn't match the `isDeepSeek` URL check). If any
+	// assistant message carries a reasoning_content thinking signature, inject empty
+	// reasoning_content on all assistant messages to prevent 400 errors.
+	const conversationUsesReasoningContent = transformedMessages.some(
+		(msg) =>
+			msg.role === "assistant" &&
+			(msg.content ?? []).some(
+				(block) => block.type === "thinking" && block.thinkingSignature === "reasoning_content",
+			),
+	);
 
 	if (context.systemPrompt) {
 		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
@@ -1173,8 +1216,8 @@ export function convertMessages(
 				}
 			}
 			if (
-				compat.requiresReasoningContentOnAssistantMessages &&
-				model.reasoning &&
+				(compat.requiresReasoningContentOnAssistantMessages ||
+					conversationUsesReasoningContent) &&
 				(assistantMsg as { reasoning_content?: string }).reasoning_content === undefined
 			) {
 				(assistantMsg as { reasoning_content?: string }).reasoning_content = "";
@@ -1201,11 +1244,12 @@ export function convertMessages(
 				const toolMsg = transformedMessages[j] as ToolResultMessage;
 
 				// Extract text and image content
-				const textResult = toolMsg.content
+				const toolMsgContent = toolMsg.content ?? [];
+				const textResult = toolMsgContent
 					.filter(isTextContentBlock)
 					.map((block) => block.text)
 					.join("\n");
-				const hasImages = toolMsg.content.some((c) => c.type === "image");
+				const hasImages = toolMsgContent.some((c) => c.type === "image");
 
 				// Always send tool result with text (or placeholder if only images)
 				const hasText = textResult.length > 0;
@@ -1228,7 +1272,7 @@ export function convertMessages(
 				}
 
 				if (hasImages && model.input.includes("image")) {
-					for (const block of toolMsg.content) {
+					for (const block of toolMsgContent) {
 						if (isImageContentBlock(block)) {
 							imageBlocks.push({
 								type: "image_url",

--- a/packages/coding-agent/src/core/tools/render-utils.ts
+++ b/packages/coding-agent/src/core/tools/render-utils.ts
@@ -42,8 +42,9 @@ export function getTextOutput(
 ): string {
 	if (!result) return "";
 
-	const textBlocks = result.content.filter((c) => c.type === "text");
-	const imageBlocks = result.content.filter((c) => c.type === "image");
+	const content = result.content ?? [];
+	const textBlocks = content.filter((c) => c.type === "text");
+	const imageBlocks = content.filter((c) => c.type === "image");
 
 	let output = textBlocks.map((c) => sanitizeBinaryOutput(stripAnsi(c.text || "")).replace(/\r/g, "")).join("\n");
 

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -180,7 +180,7 @@ export class ToolExecutionComponent extends Container {
 		if (caps.images !== "kitty") return;
 		if (!this.result) return;
 
-		const imageBlocks = this.result.content.filter((c) => c.type === "image");
+		const imageBlocks = (this.result.content ?? []).filter((c) => c.type === "image");
 		for (let i = 0; i < imageBlocks.length; i++) {
 			const img = imageBlocks[i];
 			if (!img.data || !img.mimeType) continue;
@@ -294,7 +294,7 @@ export class ToolExecutionComponent extends Container {
 				} else {
 					try {
 						const component = resultRenderer(
-							{ content: this.result.content as any, details: this.result.details },
+							{ content: (this.result.content ?? []) as any, details: this.result.details },
 							{ expanded: this.expanded, isPartial: this.isPartial },
 							theme,
 							this.getRenderContext(this.resultRendererComponent),
@@ -328,7 +328,7 @@ export class ToolExecutionComponent extends Container {
 		this.imageSpacers = [];
 
 		if (this.result) {
-			const imageBlocks = this.result.content.filter((c) => c.type === "image");
+			const imageBlocks = (this.result.content ?? []).filter((c) => c.type === "image");
 			const caps = getCapabilities();
 			for (let i = 0; i < imageBlocks.length; i++) {
 				const img = imageBlocks[i];


### PR DESCRIPTION
…t iteration

Problem
=======
When DeepSeek is accessed through a proxy or gateway (e.g. LiteLLM, opencode zen), the isDeepSeek detection in openai-completions.ts only checks provider === "deepseek" || baseUrl.includes("deepseek.com"). This misses routes where the proxy URL doesn't contain "deepseek" but the backend still requires reasoning_content on all assistant messages.

The result: a 400 error ("reasoning_content must be passed back") whenever the conversation contains assistant messages with thinking blocks but the proxy/gateway URL doesn't match the isDeepSeek check.

This is upstream issue #7702.

Fix
===
1. Pre-scan conversation for reasoning_content thinking blocks After transformMessages, detect if any assistant message carries a thinking block with thinkingSignature === "reasoning_content". If so, set conversationUsesReasoningContent = true and inject empty reasoning_content on all assistant messages — independent of the isDeepSeek URL check.

2. Error recovery with retry If the API call fails with a "reasoning_content must be passed back" error, inject empty reasoning_content on all assistant messages and retry once. This catches cases where the pre-scan doesn't trigger but the backend still requires it.

3. Guard content iteration (defense-in-depth)
   - hasToolHistory: msg.content -> msg.content ?? []
   - render-utils.ts: result.content -> result.content ?? []
   - tool-execution.ts: this.result.content -> this.result.content ?? []
   - convertMessages toolResult: toolMsg.content -> toolMsg.content ?? []

   These match the existing normalization in transform-messages.ts (line 73)
   and agent-loop.ts (line 780) which already guard content == null.

Testing
=======
TypeScript type-check passes (0 errors in modified source files). Pre-existing test-file errors about model manifest typing are unrelated.