### PR TITLE
Add pi user-agent to most api adapters

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -281,18 +281,8 @@ function mergeHeaders(...headerSources: (ProviderHeaders | undefined)[]): Provid
 	return merged;
 }
 
-function mergeClientHeaders(
-	model: Model<"anthropic-messages">,
-	...headerSources: (ProviderHeaders | undefined)[]
-): ProviderHeaders {
-	const merged = mergeHeaders(...headerSources);
-	if (model.provider === "kimi-coding") {
-		for (const name of Object.keys(merged)) {
-			if (name.toLowerCase() === "user-agent") delete merged[name];
-		}
-		merged["User-Agent"] = getPiUserAgent();
-	}
-	return merged;
+function mergeClientHeaders(...headerSources: (ProviderHeaders | undefined)[]): ProviderHeaders {
+	return mergeHeaders({ "User-Agent": getPiUserAgent() }, ...headerSources);
 }
 
 function hasHeader(headers: ProviderHeaders | undefined, name: string): boolean {
@@ -917,7 +907,6 @@ function createClient(
 			dangerouslyAllowBrowser: true,
 			fetch,
 			defaultHeaders: mergeClientHeaders(
-				model,
 				{
 					accept: "application/json",
 					"anthropic-dangerous-direct-browser-access": "true",
@@ -941,7 +930,6 @@ function createClient(
 			dangerouslyAllowBrowser: true,
 			fetch,
 			defaultHeaders: mergeClientHeaders(
-				model,
 				{
 					accept: "application/json",
 					"anthropic-dangerous-direct-browser-access": "true",
@@ -961,7 +949,6 @@ function createClient(
 	const sessionAffinityHeaders: ProviderHeaders =
 		sessionId && getAnthropicCompat(model).sendSessionAffinityHeaders ? { "x-session-affinity": sessionId } : {};
 	const defaultHeaders = mergeClientHeaders(
-		model,
 		{
 			accept: "application/json",
 			"anthropic-dangerous-direct-browser-access": "true",

--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -13,6 +13,7 @@ import type {
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
+import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { createGrammarToolInputProperties } from "./constrained-sampling.ts";
@@ -253,7 +254,7 @@ function resolveAzureConfig(
 }
 
 function createClient(model: Model<"azure-openai-responses">, apiKey: string, options?: AzureOpenAIResponsesOptions) {
-	const headers = { ...model.headers };
+	const headers = { "User-Agent": getPiUserAgent(), ...model.headers };
 
 	if (options?.headers) {
 		Object.assign(headers, options.headers);

--- a/packages/ai/src/api/google-generative-ai.ts
+++ b/packages/ai/src/api/google-generative-ai.ts
@@ -22,6 +22,7 @@ import type {
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
+import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import type { GoogleApiThinkingLevel, ResolvedGoogleThinkingLevel } from "./google-shared.ts";
 import {
@@ -344,7 +345,7 @@ function createClient(
 		httpOptions.baseUrl = model.baseUrl;
 		httpOptions.apiVersion = ""; // baseUrl already includes version path, don't append
 	}
-	const headers = providerHeadersToRecord({ ...model.headers, ...optionsHeaders });
+	const headers = providerHeadersToRecord({ "User-Agent": getPiUserAgent(), ...model.headers, ...optionsHeaders });
 	if (headers) {
 		httpOptions.headers = headers;
 	}

--- a/packages/ai/src/api/google-vertex.ts
+++ b/packages/ai/src/api/google-vertex.ts
@@ -26,6 +26,7 @@ import type {
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
+import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import type { GoogleApiThinkingLevel, ResolvedGoogleThinkingLevel } from "./google-shared.ts";
@@ -391,7 +392,7 @@ function buildHttpOptions(model: Model<"google-vertex">, optionsHeaders?: Provid
 		}
 	}
 
-	const headers = providerHeadersToRecord({ ...model.headers, ...optionsHeaders });
+	const headers = providerHeadersToRecord({ "User-Agent": getPiUserAgent(), ...model.headers, ...optionsHeaders });
 	if (headers) {
 		httpOptions.headers = headers;
 	}

--- a/packages/ai/src/api/mistral-conversations.ts
+++ b/packages/ai/src/api/mistral-conversations.ts
@@ -17,6 +17,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
+import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { getJsonSchemaToolParameters, resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import { buildBaseOptions } from "./simple-options.ts";
@@ -329,6 +330,7 @@ class MistralHttpError extends Error {
 
 function buildMistralHeaders(model: Model<"mistral-conversations">, apiKey: string, options?: MistralOptions): Headers {
 	const headers = new Headers({
+		"User-Agent": getPiUserAgent(),
 		accept: "text/event-stream",
 		authorization: `Bearer ${apiKey}`,
 		"content-type": "application/json",

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -40,7 +40,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
-import { forcePiUserAgent } from "../utils/pi-user-agent.ts";
+import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
@@ -647,7 +647,7 @@ function createClient(
 	sessionId?: string,
 	compat: ResolvedOpenAICompletionsCompat = getCompat(model),
 ) {
-	const headers: ProviderHeaders = { ...model.headers };
+	const headers: ProviderHeaders = { "User-Agent": getPiUserAgent(), ...model.headers };
 	if (model.provider === "github-copilot") {
 		const hasImages = hasCopilotVisionInput(context.messages);
 		const copilotHeaders = buildCopilotDynamicHeaders({
@@ -672,10 +672,6 @@ function createClient(
 	// Merge options headers last so they can override defaults
 	if (optionsHeaders) {
 		Object.assign(headers, optionsHeaders);
-	}
-
-	if (model.provider === "xai") {
-		forcePiUserAgent(headers);
 	}
 
 	return new OpenAI({

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -19,7 +19,7 @@ import { splitDeferredTools } from "../utils/deferred-tools.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
-import { forcePiUserAgent } from "../utils/pi-user-agent.ts";
+import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { createGrammarToolInputProperties } from "./constrained-sampling.ts";
@@ -224,7 +224,7 @@ function createClient(
 	sessionId?: string,
 ) {
 	const compat = getCompat(model);
-	const headers: ProviderHeaders = { ...model.headers };
+	const headers: ProviderHeaders = { "User-Agent": getPiUserAgent(), ...model.headers };
 	if (model.provider === "github-copilot") {
 		const hasImages = hasCopilotVisionInput(context.messages);
 		const copilotHeaders = buildCopilotDynamicHeaders({
@@ -248,10 +248,6 @@ function createClient(
 	// Merge options headers last so they can override defaults
 	if (optionsHeaders) {
 		Object.assign(headers, optionsHeaders);
-	}
-
-	if (model.provider === "xai") {
-		forcePiUserAgent(headers);
 	}
 
 	return new OpenAI({

--- a/packages/ai/src/utils/pi-user-agent.ts
+++ b/packages/ai/src/utils/pi-user-agent.ts
@@ -1,5 +1,4 @@
 import type * as NodeOs from "node:os";
-import type { ProviderHeaders } from "../types.ts";
 
 type ProcessWithOsBuiltinModule = typeof process & {
 	getBuiltinModule?: (id: "node:os") => typeof NodeOs;
@@ -17,11 +16,4 @@ const nodeOs = loadNodeOs();
 
 export function getPiUserAgent(): string {
 	return nodeOs ? `pi (${nodeOs.platform()} ${nodeOs.release()}; ${nodeOs.arch()})` : "pi (browser)";
-}
-
-export function forcePiUserAgent(headers: ProviderHeaders): void {
-	for (const name of Object.keys(headers)) {
-		if (name.toLowerCase() === "user-agent") delete headers[name];
-	}
-	headers["User-Agent"] = getPiUserAgent();
 }

--- a/packages/ai/test/anthropic-auth-token.test.ts
+++ b/packages/ai/test/anthropic-auth-token.test.ts
@@ -52,6 +52,7 @@ vi.mock("@anthropic-ai/sdk", () => {
 	return { default: FakeAnthropic };
 });
 
+const PI_USER_AGENT = `pi (${platform()} ${release()}; ${arch()})`;
 const neverAbortedSignal = new AbortController().signal;
 
 const context: Context = {
@@ -196,21 +197,20 @@ describe("Anthropic auth token env", () => {
 });
 
 describe("Anthropic-compatible user agents", () => {
-	it("enforces the pi runtime user agent for Kimi Coding", async () => {
-		await streamAnthropic(kimiCodingModel, context, {
-			apiKey: "kimi-key",
-			headers: { "user-agent": "custom-client" },
-		}).result();
-
-		const headers = mockState.constructorOpts?.defaultHeaders as Record<string, string>;
-		const userAgentHeaders = Object.entries(headers).filter(([name]) => name.toLowerCase() === "user-agent");
-		expect(userAgentHeaders).toEqual([["User-Agent", `pi (${platform()} ${release()}; ${arch()})`]]);
-	});
-
-	it("does not apply the pi runtime user agent to Anthropic", async () => {
+	it("uses pi's User-Agent by default for Anthropic Messages requests", async () => {
 		await streamAnthropic(anthropicModel, context, { apiKey: "anthropic-key" }).result();
 
 		const headers = mockState.constructorOpts?.defaultHeaders as Record<string, string>;
-		expect(Object.keys(headers).some((name) => name.toLowerCase() === "user-agent")).toBe(false);
+		expect(headers["User-Agent"]).toBe(PI_USER_AGENT);
+	});
+
+	it("lets explicit headers override the default Anthropic Messages User-Agent", async () => {
+		await streamAnthropic(kimiCodingModel, context, {
+			apiKey: "kimi-key",
+			headers: { "User-Agent": "custom-client" },
+		}).result();
+
+		const headers = mockState.constructorOpts?.defaultHeaders as Record<string, string>;
+		expect(headers["User-Agent"]).toBe("custom-client");
 	});
 });

--- a/packages/ai/test/azure-openai-base-url.test.ts
+++ b/packages/ai/test/azure-openai-base-url.test.ts
@@ -1,3 +1,4 @@
+import { arch, platform, release } from "node:os";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stream as streamAzureOpenAIResponses } from "../src/api/azure-openai-responses.ts";
@@ -39,6 +40,8 @@ vi.mock("openai", () => {
 
 	return { AzureOpenAI };
 });
+
+const PI_USER_AGENT = `pi (${platform()} ${release()}; ${arch()})`;
 
 const context: Context = {
 	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
@@ -90,6 +93,17 @@ async function captureClientBaseUrl(baseUrl: string): Promise<string> {
 	await streamAzureOpenAIResponses(model, context, { apiKey: "test-api-key" }).result();
 	expect(azureMock.constructorCalls).toHaveLength(1);
 	return azureMock.constructorCalls[0].baseURL;
+}
+
+async function captureClientHeaders(headers?: Record<string, string>): Promise<Record<string, string>> {
+	const model = getModel("azure-openai-responses", "gpt-4o-mini");
+	await streamAzureOpenAIResponses(model, context, {
+		apiKey: "test-api-key",
+		azureBaseUrl: "https://my-resource.openai.azure.com",
+		headers,
+	}).result();
+	expect(azureMock.constructorCalls).toHaveLength(1);
+	return azureMock.constructorCalls[0].defaultHeaders ?? {};
 }
 
 describe("azure-openai-responses base URL normalization", () => {
@@ -199,5 +213,15 @@ describe("azure-openai-responses base URL normalization", () => {
 		await streamAzureOpenAIResponses(model, context, { apiKey: "test-api-key" }).result();
 		expect(azureMock.constructorCalls).toHaveLength(1);
 		expect(azureMock.constructorCalls[0].baseURL).toBe("https://my-resource.openai.azure.com/openai/v1");
+	});
+});
+
+describe("azure-openai-responses user agent", () => {
+	it("uses pi's User-Agent by default", async () => {
+		expect((await captureClientHeaders())["User-Agent"]).toBe(PI_USER_AGENT);
+	});
+
+	it("lets explicit headers override the default User-Agent", async () => {
+		expect((await captureClientHeaders({ "User-Agent": "custom-agent" }))["User-Agent"]).toBe("custom-agent");
 	});
 });

--- a/packages/ai/test/google-raw-stop-reason.test.ts
+++ b/packages/ai/test/google-raw-stop-reason.test.ts
@@ -1,12 +1,18 @@
+import { arch, platform, release } from "node:os";
 import { describe, expect, it, vi } from "vitest";
 
 const googleGenAiMock = vi.hoisted(() => ({
+	constructorCalls: [] as Array<Record<string, unknown>>,
 	finishReason: "MALFORMED_FUNCTION_CALL",
 	includeFunctionCall: false,
 }));
 
 vi.mock("@google/genai", () => {
 	class GoogleGenAI {
+		constructor(config: Record<string, unknown>) {
+			googleGenAiMock.constructorCalls.push(config);
+		}
+
 		models = {
 			generateContentStream: async function* () {
 				yield {
@@ -84,9 +90,25 @@ import { stream as streamGoogleVertex } from "../src/api/google-vertex.ts";
 import { getModel } from "../src/compat.ts";
 import type { Context } from "../src/types.ts";
 
+const PI_USER_AGENT = `pi (${platform()} ${release()}; ${arch()})`;
+
 const context: Context = {
 	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
 };
+
+async function captureGoogleHeaders(headers?: Record<string, string>): Promise<Record<string, string>> {
+	googleGenAiMock.constructorCalls.length = 0;
+	googleGenAiMock.finishReason = "STOP";
+	googleGenAiMock.includeFunctionCall = false;
+	await streamGoogleGenerativeAi(getModel("google", "gemini-2.5-flash"), context, {
+		apiKey: "test-api-key",
+		headers,
+	}).result();
+
+	expect(googleGenAiMock.constructorCalls).toHaveLength(1);
+	const httpOptions = googleGenAiMock.constructorCalls[0].httpOptions as { headers?: Record<string, string> };
+	return httpOptions.headers ?? {};
+}
 
 describe("Google raw stop reasons", () => {
 	it("preserves raw Gemini finish reasons for Google Generative AI errors", async () => {
@@ -158,5 +180,15 @@ describe("Google raw stop reasons", () => {
 		expect(message.stopReason).toBe("toolUse");
 		expect(message.rawStopReason).toBe("STOP");
 		expect(message.content.some((block) => block.type === "toolCall")).toBe(true);
+	});
+});
+
+describe("Google Generative AI user agent", () => {
+	it("uses pi's User-Agent by default", async () => {
+		expect((await captureGoogleHeaders())["User-Agent"]).toBe(PI_USER_AGENT);
+	});
+
+	it("lets explicit headers override the default User-Agent", async () => {
+		expect((await captureGoogleHeaders({ "User-Agent": "custom-agent" }))["User-Agent"]).toBe("custom-agent");
 	});
 });

--- a/packages/ai/test/google-vertex-api-key-resolution.test.ts
+++ b/packages/ai/test/google-vertex-api-key-resolution.test.ts
@@ -1,3 +1,4 @@
+import { arch, platform, release } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const googleGenAiMock = vi.hoisted(() => ({
@@ -49,6 +50,7 @@ import { stream as streamGoogleVertex } from "../src/api/google-vertex.ts";
 import { getModel } from "../src/compat.ts";
 import type { Context, Model } from "../src/types.ts";
 
+const PI_USER_AGENT = `pi (${platform()} ${release()}; ${arch()})`;
 const model = getModel("google-vertex", "gemini-3-flash-preview");
 const context: Context = {
 	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
@@ -154,7 +156,24 @@ describe("google-vertex api key resolution", () => {
 		await stream.result();
 
 		expect(googleGenAiMock.constructorCalls).toHaveLength(1);
-		expect(googleGenAiMock.constructorCalls[0]?.httpOptions).toBeUndefined();
+		expect(googleGenAiMock.constructorCalls[0]?.httpOptions).toEqual({
+			headers: { "User-Agent": PI_USER_AGENT },
+		});
+	});
+
+	it("lets explicit headers override the default User-Agent", async () => {
+		const stream = streamGoogleVertex(model, context, {
+			project: "test-project",
+			location: "us-central1",
+			headers: { "User-Agent": "custom-agent" },
+		});
+
+		await stream.result();
+
+		expect(googleGenAiMock.constructorCalls).toHaveLength(1);
+		expect(googleGenAiMock.constructorCalls[0]?.httpOptions).toEqual({
+			headers: { "User-Agent": "custom-agent" },
+		});
 	});
 
 	it("forwards custom baseUrl to the ADC client", async () => {

--- a/packages/ai/test/mistral-http-transport.test.ts
+++ b/packages/ai/test/mistral-http-transport.test.ts
@@ -1,8 +1,11 @@
+import { arch, platform, release } from "node:os";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { stream as streamMistral } from "../src/api/mistral-conversations.ts";
 import { getModel } from "../src/compat.ts";
 import type { Context, FetchFunction, ProviderResponse } from "../src/types.ts";
+
+const PI_USER_AGENT = `pi (${platform()} ${release()}; ${arch()})`;
 
 function createSseResponse(events: unknown[], headers?: Record<string, string>): Response {
 	const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join("\r\n\r\n")}\r\n\r\ndata: [DONE]\r\n\r\n`;
@@ -109,6 +112,7 @@ describe("Mistral HTTP transport", () => {
 		expect(headers.get("accept")).toBe("text/event-stream");
 		expect(headers.get("x-affinity")).toBe("session-1");
 		expect(headers.get("x-custom")).toBe("value");
+		expect(headers.get("user-agent")).toBe(PI_USER_AGENT);
 		expect(callbackPayload?.maxTokens).toBe(123);
 		expect(callbackPayload?.promptMode).toBe("reasoning");
 		expect(callbackPayload?.promptCacheKey).toBe("session-1");
@@ -356,11 +360,12 @@ describe("Mistral HTTP transport", () => {
 			apiKey: "request-key",
 			fetch,
 			sessionId: "automatic-affinity",
-			headers: { authorization: null, "x-affinity": null },
+			headers: { authorization: null, "x-affinity": null, "User-Agent": "custom-agent" },
 		}).result();
 
 		expect(requestHeaders?.has("authorization")).toBe(false);
 		expect(requestHeaders?.has("x-affinity")).toBe(false);
+		expect(requestHeaders?.get("user-agent")).toBe("custom-agent");
 	});
 
 	it("aborts while waiting for an SSE chunk", async () => {

--- a/packages/ai/test/xai-responses.test.ts
+++ b/packages/ai/test/xai-responses.test.ts
@@ -184,7 +184,7 @@ describe("xAI Responses provider", () => {
 		});
 	});
 
-	it("keeps the SDK User-Agent for non-xAI Responses requests", async () => {
+	it("uses pi's User-Agent by default for Responses requests", async () => {
 		let userAgent: string | null = null;
 		vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
 			userAgent = new Request(input, init).headers.get("user-agent");
@@ -203,8 +203,17 @@ describe("xAI Responses provider", () => {
 		).result();
 
 		expect(result.stopReason, result.errorMessage).toBe("stop");
-		expect(userAgent).not.toBeNull();
-		expect(userAgent).not.toBe(PI_USER_AGENT);
+		expect(userAgent).toBe(PI_USER_AGENT);
+	});
+
+	it("lets explicit headers override the default Responses User-Agent", async () => {
+		const captured = await captureRequest(
+			XAI_MODELS["grok-4.5"],
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{ apiKey: "xai-test-token", headers: { "User-Agent": "custom-agent" } },
+		);
+
+		expect(captured.headers.get("user-agent")).toBe("custom-agent");
 	});
 
 	it("forces pi's User-Agent on custom xAI Completions models over caller headers", async () => {

--- a/packages/ai/test/xai-responses.test.ts
+++ b/packages/ai/test/xai-responses.test.ts
@@ -38,6 +38,53 @@ function completedResponse(): Response {
 	});
 }
 
+const customCompletionsModel: Model<"openai-completions"> = {
+	id: "grok-custom",
+	name: "Grok Custom",
+	api: "openai-completions",
+	provider: "xai",
+	baseUrl: "https://api.x.ai/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 16384,
+};
+
+async function captureCompletionsUserAgent(headers?: Record<string, string>): Promise<string | null> {
+	let userAgent: string | null = null;
+	vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+		userAgent = new Request(input, init).headers.get("user-agent");
+		const chunks = [
+			{ id: "chatcmpl-ua", choices: [{ delta: { content: "ok" }, finish_reason: null, index: 0 }] },
+			{
+				id: "chatcmpl-ua",
+				choices: [{ delta: {}, finish_reason: "stop", index: 0 }],
+				usage: {
+					prompt_tokens: 1,
+					completion_tokens: 1,
+					prompt_tokens_details: { cached_tokens: 0 },
+					completion_tokens_details: { reasoning_tokens: 0 },
+				},
+			},
+		];
+		const body = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}`).join("\n\n")}\n\ndata: [DONE]\n\n`;
+		return new Response(body, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	});
+
+	const result = await streamOpenAICompletions(
+		customCompletionsModel,
+		{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+		{ apiKey: "xai-test-token", headers },
+	).result();
+
+	expect(result.stopReason, result.errorMessage).toBe("stop");
+	return userAgent;
+}
+
 async function captureRequest(
 	model: Model<"openai-responses">,
 	context: Context,
@@ -216,49 +263,11 @@ describe("xAI Responses provider", () => {
 		expect(captured.headers.get("user-agent")).toBe("custom-agent");
 	});
 
-	it("forces pi's User-Agent on custom xAI Completions models over caller headers", async () => {
-		let userAgent: string | null = null;
-		vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-			userAgent = new Request(input, init).headers.get("user-agent");
-			const chunks = [
-				{ id: "chatcmpl-ua", choices: [{ delta: { content: "ok" }, finish_reason: null, index: 0 }] },
-				{
-					id: "chatcmpl-ua",
-					choices: [{ delta: {}, finish_reason: "stop", index: 0 }],
-					usage: {
-						prompt_tokens: 1,
-						completion_tokens: 1,
-						prompt_tokens_details: { cached_tokens: 0 },
-						completion_tokens_details: { reasoning_tokens: 0 },
-					},
-				},
-			];
-			const body = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}`).join("\n\n")}\n\ndata: [DONE]\n\n`;
-			return new Response(body, {
-				status: 200,
-				headers: { "content-type": "text/event-stream" },
-			});
-		});
+	it("uses pi's User-Agent by default for Completions requests", async () => {
+		expect(await captureCompletionsUserAgent()).toBe(PI_USER_AGENT);
+	});
 
-		const customModel: Model<"openai-completions"> = {
-			id: "grok-custom",
-			name: "Grok Custom",
-			api: "openai-completions",
-			provider: "xai",
-			baseUrl: "https://api.x.ai/v1",
-			reasoning: false,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 128000,
-			maxTokens: 16384,
-		};
-		const result = await streamOpenAICompletions(
-			customModel,
-			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
-			{ apiKey: "xai-test-token", headers: { "User-Agent": "custom-agent" } },
-		).result();
-
-		expect(result.stopReason, result.errorMessage).toBe("stop");
-		expect(userAgent).toBe(PI_USER_AGENT);
+	it("lets explicit headers override the default Completions User-Agent", async () => {
+		expect(await captureCompletionsUserAgent({ "User-Agent": "custom-agent" })).toBe("custom-agent");
 	});
 });


### PR DESCRIPTION
added Pi’s default User-Agent to seven adapters:

 - openai-responses
 - openai-completions
 - anthropic-messages
 - azure-openai-responses
 - google-generative-ai
 - google-vertex
 - mistral-conversations

Closes #8305