### PR TITLE
feat: emit input event for built-in slash commands

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2988,6 +2988,22 @@ export class InteractiveMode {
 			text = text.trim();
 			if (!text) return;
 
+			// Emit input event for built-in slash commands so extensions can observe or intercept them.
+			// Extension and skill commands already flow through session.prompt() which emits input,
+			// so this only fires for builtins to avoid double-emission.
+			if (text.startsWith("/")) {
+				const spaceIndex = text.indexOf(" ");
+				const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+				const isBuiltin = BUILTIN_SLASH_COMMANDS.some((cmd) => cmd.name === commandName);
+				if (isBuiltin && this.session.extensionRunner.hasHandlers("input")) {
+					const inputResult = await this.session.extensionRunner.emitInput(text, undefined, "interactive", undefined);
+					if (inputResult.action === "handled") {
+						this.editor.setText("");
+						return;
+					}
+				}
+			}
+
 			// Handle commands
 			if (text === "/settings") {
 				this.showSettingsSelector();


### PR DESCRIPTION
Built-in slash commands (`/share`, `/export`, `/settings`, etc.) are deterministic TUI operations — they spawn processes, open modals, copy to clipboard. They never reach the LLM and are never expanded like skills. They execute in the TUI input handler and return before `session.prompt()`, so the `input` event never fires for them.

Extension and skill commands already flow through `session.prompt()` which emits `input`. Built-in commands are the only category with zero extension visibility.

This adds a guarded `emitInput` call for built-in commands before the dispatch if-chain. The guard checks `BUILTIN_SLASH_COMMANDS` so extension/skill commands are not double-emitted. Extensions can observe, log, or return `{ action: "handled" }` to suppress.

**Changes:**
- `interactive-mode.ts`: emit `input` event for built-in slash commands before dispatch (16 lines)
- `interactive-mode-builtin-input-event.test.ts`: 10 test cases covering:
  - `/share` blocked when extension returns `handled`
  - `/export` blocked when extension returns `handled`
  - `/settings` blocked when extension returns `handled`
  - `/share` proceeds when extension returns `continue`
  - `/export` with arguments proceeds when extension returns `continue`
  - No emit when no input handlers registered
  - No emit for non-builtin slash commands (avoids double-emission)
  - No emit for non-slash text
  - Full text including arguments passed to `emitInput`
  - `transform` result treated as non-handled (builtins are not transformable)

All 68 existing interactive-mode tests pass. All pre-commit checks pass (`npm run check`).

Closes #8364