### PR TITLE
feat: emit input event for built-in slash commands

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -284,7 +284,10 @@ pi starts
       ▼
 user sends prompt ─────────────────────────────────────────┐
   │                                                        │
-  ├─► (extension commands checked first, bypass if found)  │
+  ├─► (built-in slash commands: input event fires first)   │
+  │     ├─► if handled: command is suppressed              │
+  │     └─► if continue: built-in handler runs normally    │
+  ├─► (extension commands checked, bypass if found)        │
   ├─► input (can intercept, transform, or handle)          │
   ├─► (skill/template expansion if not handled)            │
   ├─► before_agent_start (can inject message, modify system prompt)
@@ -892,14 +895,18 @@ pi.on("user_bash", (event, ctx) => {
 
 #### input
 
-Fired when user input is received, after extension commands are checked but before skill and template expansion. The event sees the raw input text, so `/skill:foo` and `/template` are not yet expanded.
+Fired when user input is received, before skill and template expansion. For built-in slash commands (`/share`, `/export`, `/settings`, etc.), the event fires before the command is dispatched — returning `handled` suppresses the command. For extension and skill commands, the event fires inside `session.prompt()` after extension command dispatch but before expansion.
 
 **Processing order:**
-1. Extension commands (`/cmd`) checked first - if found, handler runs and input event is skipped
-2. `input` event fires - can intercept, transform, or handle
-3. If not handled: skill commands (`/skill:name`) expanded to skill content
-4. If not handled: prompt templates (`/template`) expanded to template content
-5. Agent processing begins (`before_agent_start`, etc.)
+1. Built-in slash commands: `input` event fires — can intercept or observe
+2. If not handled: built-in handler runs (if matched)
+3. Extension commands (`/cmd`) checked — if found, handler runs via `session.prompt()`
+4. `input` event fires again (inside `session.prompt()`) — this covers non-builtin input
+5. If not handled: skill commands (`/skill:name`) expanded to skill content
+6. If not handled: prompt templates (`/template`) expanded to template content
+7. Agent processing begins (`before_agent_start`, etc.)
+
+The `input` event does **not** double-fire for the same input. Built-in commands fire it in the TUI before dispatch; all other input fires it inside `session.prompt()`. These are mutually exclusive paths.
 
 ```typescript
 pi.on("input", async (event, ctx) => {
@@ -922,6 +929,12 @@ pi.on("input", async (event, ctx) => {
 
   // Route by source: skip processing for extension-injected messages
   if (event.source === "extension") return { action: "continue" };
+
+  // Block specific built-in commands (e.g. prevent session data export)
+  if (event.text === "/share" || event.text.startsWith("/export")) {
+    ctx.ui.notify("Session export is disabled by policy", "warning");
+    return { action: "handled" };
+  }
 
   // Intercept skill commands before expansion
   if (event.text.startsWith("/skill:")) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2988,6 +2988,27 @@ export class InteractiveMode {
 			text = text.trim();
 			if (!text) return;
 
+			// Emit input event for built-in slash commands so extensions can observe or intercept them.
+			// Extension and skill commands already flow through session.prompt() which emits input,
+			// so this only fires for builtins to avoid double-emission.
+			if (text.startsWith("/")) {
+				const spaceIndex = text.indexOf(" ");
+				const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+				const isBuiltin = BUILTIN_SLASH_COMMANDS.some((cmd) => cmd.name === commandName);
+				if (isBuiltin && this.session.extensionRunner.hasHandlers("input")) {
+					const inputResult = await this.session.extensionRunner.emitInput(
+						text,
+						undefined,
+						"interactive",
+						undefined,
+					);
+					if (inputResult.action === "handled") {
+						this.editor.setText("");
+						return;
+					}
+				}
+			}
+
 			// Handle commands
 			if (text === "/settings") {
 				this.showSettingsSelector();

--- a/packages/coding-agent/test/interactive-mode-builtin-input-event.test.ts
+++ b/packages/coding-agent/test/interactive-mode-builtin-input-event.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type BuiltinInputEventContext = {
+	defaultEditor: { onSubmit?: (text: string) => Promise<void> };
+	editor: {
+		addToHistory?: (text: string) => void;
+		setText: (text: string) => void;
+	};
+	session: {
+		isCompacting: boolean;
+		isStreaming: boolean;
+		isBashRunning: boolean;
+		extensionRunner: {
+			hasHandlers: (event: string) => boolean;
+			emitInput: (
+				text: string,
+				images: undefined,
+				source: string,
+				streamingBehavior: undefined,
+			) => Promise<{ action: string }>;
+		};
+		prompt: (text: string, options?: unknown) => Promise<void>;
+	};
+	flushPendingBashComponents: () => void;
+	showSettingsSelector: () => void;
+	showModelsSelector: () => Promise<void>;
+	handleShareCommand: () => Promise<void>;
+	handleExportCommand: (text: string) => Promise<void>;
+	handleImportCommand: (text: string) => Promise<void>;
+	handleModelCommand: (searchTerm?: string, options?: unknown) => Promise<void>;
+	handleCopyCommand: (options?: unknown) => Promise<void>;
+	handleNameCommand: (text: string) => void;
+	handleSessionCommand: () => void;
+	handleChangelogCommand: () => void;
+	handleHotkeysCommand: () => void;
+	handleCloneCommand: () => Promise<void>;
+	handleClearCommand: () => Promise<void>;
+	handleReloadCommand: () => Promise<void>;
+	handleLoginCommand: (providerRef?: string) => Promise<void>;
+	handleCompactCommand: (instructions?: string) => Promise<void>;
+	handleBashCommand: (command: string, excludeFromContext: boolean) => Promise<void>;
+	showUserMessageSelector: () => void;
+	showTreeSelector: () => void;
+	showTrustSelector: () => void;
+	showOAuthSelector: (mode: string) => void;
+	showSessionSelector: () => void;
+	handleDebugCommand: () => void;
+	handleArminSaysHi: () => void;
+	handleDementedDelves: () => void;
+	isExtensionCommand: (text: string) => boolean;
+	isBashMode: boolean;
+	updateEditorBorderColor: () => void;
+	updatePendingMessagesDisplay: () => void;
+	pendingMessagesContainer: { addChild: () => void };
+	pendingBashComponents: unknown[];
+	onInputCallback?: (text: string) => void;
+	pendingUserInputs: string[];
+	settingsManager: { getEnableSkillCommands: () => boolean };
+	sessionManager: { getCwd: () => string };
+};
+
+type InteractiveModePrivate = {
+	setupEditorSubmitHandler(this: BuiltinInputEventContext): void;
+};
+
+const proto = InteractiveMode.prototype as unknown as InteractiveModePrivate;
+
+function createContext(overrides?: Partial<BuiltinInputEventContext>): BuiltinInputEventContext {
+	return {
+		defaultEditor: {},
+		editor: {
+			addToHistory: vi.fn(),
+			setText: vi.fn(),
+		},
+		session: {
+			isCompacting: false,
+			isStreaming: false,
+			isBashRunning: false,
+			extensionRunner: {
+				hasHandlers: vi.fn(() => false),
+				emitInput: vi.fn(async () => ({ action: "continue" })),
+			},
+			prompt: vi.fn(async () => {}),
+		},
+		flushPendingBashComponents: vi.fn(),
+		showSettingsSelector: vi.fn(),
+		showModelsSelector: vi.fn(async () => {}),
+		handleShareCommand: vi.fn(async () => {}),
+		handleExportCommand: vi.fn(async () => {}),
+		handleImportCommand: vi.fn(async () => {}),
+		handleModelCommand: vi.fn(async () => {}),
+		handleCopyCommand: vi.fn(async () => {}),
+		handleNameCommand: vi.fn(),
+		handleSessionCommand: vi.fn(),
+		handleChangelogCommand: vi.fn(),
+		handleHotkeysCommand: vi.fn(),
+		handleCloneCommand: vi.fn(async () => {}),
+		handleClearCommand: vi.fn(async () => {}),
+		handleReloadCommand: vi.fn(async () => {}),
+		handleLoginCommand: vi.fn(async () => {}),
+		handleCompactCommand: vi.fn(async () => {}),
+		handleBashCommand: vi.fn(async () => {}),
+		showUserMessageSelector: vi.fn(),
+		showTreeSelector: vi.fn(),
+		showTrustSelector: vi.fn(),
+		showOAuthSelector: vi.fn(),
+		showSessionSelector: vi.fn(),
+		handleDebugCommand: vi.fn(),
+		handleArminSaysHi: vi.fn(),
+		handleDementedDelves: vi.fn(),
+		isExtensionCommand: vi.fn(() => false),
+		isBashMode: false,
+		updateEditorBorderColor: vi.fn(),
+		updatePendingMessagesDisplay: vi.fn(),
+		pendingMessagesContainer: { addChild: vi.fn() },
+		pendingBashComponents: [],
+		onInputCallback: undefined,
+		pendingUserInputs: [],
+		settingsManager: { getEnableSkillCommands: () => true },
+		sessionManager: { getCwd: () => "/tmp" },
+		...overrides,
+	};
+}
+
+describe("InteractiveMode builtin slash command input event", () => {
+	it("emits input event for /share and blocks when extension returns handled", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		(ctx.session.extensionRunner.emitInput as ReturnType<typeof vi.fn>).mockResolvedValue({ action: "handled" });
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/share");
+
+		expect(ctx.session.extensionRunner.emitInput).toHaveBeenCalledWith("/share", undefined, "interactive", undefined);
+		expect(ctx.handleShareCommand).not.toHaveBeenCalled();
+		expect(ctx.editor.setText).toHaveBeenCalledWith("");
+	});
+
+	it("emits input event for /export and blocks when extension returns handled", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		(ctx.session.extensionRunner.emitInput as ReturnType<typeof vi.fn>).mockResolvedValue({ action: "handled" });
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/export");
+
+		expect(ctx.session.extensionRunner.emitInput).toHaveBeenCalledWith(
+			"/export",
+			undefined,
+			"interactive",
+			undefined,
+		);
+		expect(ctx.handleExportCommand).not.toHaveBeenCalled();
+		expect(ctx.editor.setText).toHaveBeenCalledWith("");
+	});
+
+	it("emits input event for /settings and blocks when extension returns handled", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		(ctx.session.extensionRunner.emitInput as ReturnType<typeof vi.fn>).mockResolvedValue({ action: "handled" });
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/settings");
+
+		expect(ctx.session.extensionRunner.emitInput).toHaveBeenCalledWith(
+			"/settings",
+			undefined,
+			"interactive",
+			undefined,
+		);
+		expect(ctx.showSettingsSelector).not.toHaveBeenCalled();
+	});
+
+	it("proceeds with /share when extension returns continue", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		(ctx.session.extensionRunner.emitInput as ReturnType<typeof vi.fn>).mockResolvedValue({ action: "continue" });
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/share");
+
+		expect(ctx.session.extensionRunner.emitInput).toHaveBeenCalledWith("/share", undefined, "interactive", undefined);
+		expect(ctx.handleShareCommand).toHaveBeenCalled();
+	});
+
+	it("proceeds with /export when extension returns continue", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		(ctx.session.extensionRunner.emitInput as ReturnType<typeof vi.fn>).mockResolvedValue({ action: "continue" });
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/export session.html");
+
+		expect(ctx.session.extensionRunner.emitInput).toHaveBeenCalledWith(
+			"/export session.html",
+			undefined,
+			"interactive",
+			undefined,
+		);
+		expect(ctx.handleExportCommand).toHaveBeenCalledWith("/export session.html");
+	});
+
+	it("does not emit input event when no handlers are registered", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/share");
+
+		expect(ctx.session.extensionRunner.emitInput).not.toHaveBeenCalled();
+		expect(ctx.handleShareCommand).toHaveBeenCalled();
+	});
+
+	it("does not emit input event for non-builtin slash commands", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		// /my-extension-command is not a builtin — it should NOT trigger emitInput here
+		// (it flows through session.prompt() later which has its own emitInput)
+		await ctx.defaultEditor.onSubmit!("/my-extension-command");
+
+		expect(ctx.session.extensionRunner.emitInput).not.toHaveBeenCalled();
+	});
+
+	it("does not emit input event for non-slash text", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("hello world");
+
+		expect(ctx.session.extensionRunner.emitInput).not.toHaveBeenCalled();
+	});
+
+	it("passes full text including arguments to emitInput", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		(ctx.session.extensionRunner.emitInput as ReturnType<typeof vi.fn>).mockResolvedValue({ action: "continue" });
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/model anthropic/claude-sonnet-4");
+
+		expect(ctx.session.extensionRunner.emitInput).toHaveBeenCalledWith(
+			"/model anthropic/claude-sonnet-4",
+			undefined,
+			"interactive",
+			undefined,
+		);
+	});
+
+	it("handles transform result by proceeding with original text (no transformation for builtins)", async () => {
+		const ctx = createContext();
+		(ctx.session.extensionRunner.hasHandlers as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		// transform is treated as "not handled" — the builtin dispatch uses the original text
+		(ctx.session.extensionRunner.emitInput as ReturnType<typeof vi.fn>).mockResolvedValue({
+			action: "transform",
+			text: "something else",
+		});
+
+		proto.setupEditorSubmitHandler.call(ctx);
+		await ctx.defaultEditor.onSubmit!("/share");
+
+		// transform !== "handled", so the command proceeds
+		expect(ctx.handleShareCommand).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Built-in slash commands (`/share`, `/export`, `/settings`, etc.) are deterministic TUI operations that execute before `session.prompt()`. Extension and skill commands already flow through `session.prompt()` which emits the `input` event. Built-in commands are the only category with zero extension visibility.

This emits the existing `input` event for built-in commands before dispatch, guarded to `BUILTIN_SLASH_COMMANDS` to avoid double-emission. Extensions can observe, log, or return `{ action: "handled" }` to suppress.

**Changes:**
- `interactive-mode.ts`: 16-line guarded `emitInput` call before the builtin if-chain
- `interactive-mode-builtin-input-event.test.ts`: 10 test cases (handled, continue, no-handler, non-builtin, non-slash, args, transform)
- `docs/extensions.md`: updated lifecycle diagram, processing order, and added blocking example

All existing tests pass. All pre-commit checks pass.

Closes #8364