### PR TITLE
add fullscreen wheel scroll lines setting

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -68,6 +68,7 @@ Use `/trust` in interactive mode to save a project trust decision for future ses
 | `tuiMode` | string | `"regular"` | Interactive TUI mode: `"regular"` or experimental `"fullscreen"`. Changes from `/settings` apply immediately; `--tui-mode` overrides this setting at startup |
 | `fullscreenExitOutput` | string | `"transcript"` | Fullscreen exit output: `"transcript"` prints the final transcript and resume hint, while `"resume-hint"` restores the previous screen and prints only the resume hint. Has no effect in regular TUI mode |
 | `fullscreenScrollbar` | string | `"auto"` | Fullscreen transcript scrollbar: `"auto"` shows it temporarily while scrolling, `"always"` reserves the rightmost column and keeps it visible, and `"hidden"` hides it. Has no effect in regular TUI mode |
+| `fullscreenWheelScrollLines` | number | `1` | Lines scrolled per mouse-wheel event in fullscreen mode. Has no effect in regular TUI mode |
 
 For VS Code, include `--wait` so pi resumes after the editor exits:
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -139,6 +139,7 @@ export interface Settings {
 	tuiMode?: TuiMode; // default: "regular"
 	fullscreenExitOutput?: FullscreenExitOutput; // default: "transcript"; no effect in regular TUI mode
 	fullscreenScrollbar?: ScrollViewScrollbar; // default: "auto"; no effect in regular TUI mode
+	fullscreenWheelScrollLines?: number; // default: 1; no effect in regular TUI mode
 }
 
 function isMergeableObject(value: unknown): value is Record<string, unknown> {
@@ -1213,6 +1214,17 @@ export class SettingsManager {
 	setFullscreenScrollbar(mode: ScrollViewScrollbar): void {
 		this.globalSettings.fullscreenScrollbar = mode;
 		this.markModified("fullscreenScrollbar");
+		this.save();
+	}
+
+	getFullscreenWheelScrollLines(): number {
+		const n = this.settings.fullscreenWheelScrollLines;
+		return typeof n === "number" && Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
+	}
+
+	setFullscreenWheelScrollLines(lines: number): void {
+		this.globalSettings.fullscreenWheelScrollLines = Math.max(1, Math.floor(lines));
+		this.markModified("fullscreenWheelScrollLines");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -84,6 +84,7 @@ export interface SettingsConfig {
 	tuiMode: TuiMode;
 	fullscreenExitOutput: FullscreenExitOutput;
 	fullscreenScrollbar: ScrollViewScrollbar;
+	fullscreenWheelScrollLines: number;
 	warnings: WarningSettings;
 }
 
@@ -122,6 +123,7 @@ export interface SettingsCallbacks {
 	onTuiModeChange: (mode: TuiMode) => void;
 	onFullscreenExitOutputChange: (output: FullscreenExitOutput) => void;
 	onFullscreenScrollbarChange: (mode: ScrollViewScrollbar) => void;
+	onFullscreenWheelScrollLinesChange: (lines: number) => void;
 	onWarningsChange: (warnings: WarningSettings) => void;
 	onCancel: () => void;
 }
@@ -778,6 +780,13 @@ export class SettingsSelectorComponent extends Container {
 				values: ["auto", "always", "hidden"],
 			},
 			{
+				id: "fullscreen-wheel-scroll-lines",
+				label: "Fullscreen wheel scroll lines",
+				description: "Lines scrolled per mouse-wheel event in fullscreen mode; has no effect in regular mode",
+				currentValue: String(config.fullscreenWheelScrollLines),
+				values: ["1", "2", "3", "4", "5", "6", "8", "10"],
+			},
+			{
 				id: "theme",
 				label: "Theme",
 				description: "Color theme for the interface",
@@ -997,6 +1006,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "fullscreen-scrollbar":
 						callbacks.onFullscreenScrollbarChange(newValue as ScrollViewScrollbar);
+						break;
+					case "fullscreen-wheel-scroll-lines":
+						callbacks.onFullscreenWheelScrollLinesChange(parseInt(newValue, 10));
 						break;
 					case "theme":
 						callbacks.onThemeChange(newValue);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -398,6 +398,8 @@ interface InteractiveTuiOptions {
 	logDirectory: string;
 	terminal?: Terminal;
 	onRightClickPaste?: () => void;
+	/** Lines scrolled per mouse-wheel event in fullscreen mode. */
+	wheelScrollLines?: number;
 }
 
 /** Composition root for selecting the interactive terminal renderer. */
@@ -410,6 +412,7 @@ export function createInteractiveTui(options: InteractiveTuiOptions): TuiMainScr
 			searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
 			openUrl: openBrowser,
 			onRightClickPaste: options.onRightClickPaste,
+			wheelScrollLines: options.wheelScrollLines,
 			copySelection: async (text) => {
 				try {
 					await copyToClipboard(text);
@@ -616,6 +619,7 @@ export class InteractiveMode {
 			showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
 			logDirectory: getAgentDir(),
 			onRightClickPaste: this.onRightClickPaste,
+			wheelScrollLines: this.settingsManager.getFullscreenWheelScrollLines(),
 		});
 		this.ui = createInteractiveTuiReference(() => this.renderer);
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
@@ -896,6 +900,7 @@ export class InteractiveMode {
 			logDirectory: getAgentDir(),
 			terminal,
 			onRightClickPaste: this.onRightClickPaste,
+			wheelScrollLines: this.settingsManager.getFullscreenWheelScrollLines(),
 		});
 		nextUi.setClearOnShrink(clearOnShrink);
 		nextUi.onDebug = onDebug;
@@ -2004,6 +2009,13 @@ export class InteractiveMode {
 
 	private applyFullscreenScrollbarSetting(): void {
 		this.transcriptScrollView?.setScrollbar(this.settingsManager.getFullscreenScrollbar());
+	}
+
+	private applyFullscreenWheelScrollLinesSetting(): void {
+		const tui = this.renderer;
+		if (tui instanceof TuiAltScreen) {
+			tui.setWheelScrollLines(this.settingsManager.getFullscreenWheelScrollLines());
+		}
 	}
 
 	private applyRuntimeSettings(): void {
@@ -4588,6 +4600,7 @@ export class InteractiveMode {
 					tuiMode: this.ui.mode,
 					fullscreenExitOutput: this.settingsManager.getFullscreenExitOutput(),
 					fullscreenScrollbar: this.settingsManager.getFullscreenScrollbar(),
+					fullscreenWheelScrollLines: this.settingsManager.getFullscreenWheelScrollLines(),
 					warnings: this.settingsManager.getWarnings(),
 				},
 				{
@@ -4782,6 +4795,10 @@ export class InteractiveMode {
 					onFullscreenScrollbarChange: (mode) => {
 						this.settingsManager.setFullscreenScrollbar(mode);
 						this.applyFullscreenScrollbarSetting();
+					},
+					onFullscreenWheelScrollLinesChange: (lines) => {
+						this.settingsManager.setFullscreenWheelScrollLines(lines);
+						this.applyFullscreenWheelScrollLinesSetting();
 					},
 					onWarningsChange: (warnings) => {
 						this.settingsManager.setWarnings(warnings);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -436,21 +436,29 @@ describe("SettingsManager", () => {
 		const manager = SettingsManager.create(projectDir, agentDir);
 		expect(manager.getFullscreenExitOutput()).toBe("transcript");
 		expect(manager.getFullscreenScrollbar()).toBe("auto");
+		expect(manager.getFullscreenWheelScrollLines()).toBe(1);
 
 		manager.setFullscreenExitOutput("resume-hint");
 		manager.setFullscreenScrollbar("hidden");
+		manager.setFullscreenWheelScrollLines(6);
 		await manager.flush();
 		const savedSettings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8"));
 		expect(savedSettings.fullscreenExitOutput).toBe("resume-hint");
 		expect(savedSettings.fullscreenScrollbar).toBe("hidden");
+		expect(savedSettings.fullscreenWheelScrollLines).toBe(6);
 
 		writeFileSync(
 			join(agentDir, "settings.json"),
-			JSON.stringify({ fullscreenExitOutput: "nothing", fullscreenScrollbar: "sometimes" }),
+			JSON.stringify({
+				fullscreenExitOutput: "nothing",
+				fullscreenScrollbar: "sometimes",
+				fullscreenWheelScrollLines: 0,
+			}),
 		);
 		const reloadedManager = SettingsManager.create(projectDir, agentDir);
 		expect(reloadedManager.getFullscreenExitOutput()).toBe("transcript");
 		expect(reloadedManager.getFullscreenScrollbar()).toBe("auto");
+		expect(reloadedManager.getFullscreenWheelScrollLines()).toBe(1);
 	});
 
 	describe("outputPad", () => {

--- a/packages/coding-agent/test/settings-selector.test.ts
+++ b/packages/coding-agent/test/settings-selector.test.ts
@@ -17,9 +17,11 @@ describe("SettingsSelectorComponent", () => {
 	it("cycles through fullscreen settings", () => {
 		const onExitOutputChange = vi.fn();
 		const onScrollbarChange = vi.fn();
+		const onWheelScrollLinesChange = vi.fn();
 		const config = {
 			fullscreenExitOutput: "transcript",
 			fullscreenScrollbar: "auto",
+			fullscreenWheelScrollLines: 1,
 			warnings: {},
 			defaultModel: "not set",
 			availableDefaultModels: [],
@@ -30,6 +32,7 @@ describe("SettingsSelectorComponent", () => {
 		const callbacks = {
 			onFullscreenExitOutputChange: onExitOutputChange,
 			onFullscreenScrollbarChange: onScrollbarChange,
+			onFullscreenWheelScrollLinesChange: onWheelScrollLinesChange,
 		} as unknown as SettingsCallbacks;
 
 		const cycle = (label: string, count: number) => {
@@ -42,5 +45,7 @@ describe("SettingsSelectorComponent", () => {
 		expect(onExitOutputChange.mock.calls.flat()).toEqual(["resume-hint", "transcript"]);
 		cycle("Fullscreen scrollbar", 3);
 		expect(onScrollbarChange.mock.calls.flat()).toEqual(["always", "hidden", "auto"]);
+		cycle("Fullscreen wheel scroll lines", 3);
+		expect(onWheelScrollLinesChange.mock.calls.flat()).toEqual([2, 3, 4]);
 	});
 });

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -191,7 +191,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 	private activeSearch?: ActiveSearch;
 	private pressedUrl?: string;
 	private selectionDragged = false;
-	private readonly wheelScrollLines: number;
+	private wheelScrollLines: number;
 	private readonly mouseEnabled: boolean;
 	private readonly searchMatchStyle: (text: string) => string;
 	private readonly searchCurrentMatchStyle: (text: string) => string;
@@ -237,6 +237,14 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		this.layoutRoot = component;
 		this.currentLayout = undefined;
 		this.requestRender();
+	}
+
+	/**
+	 * Update how many logical lines each mouse-wheel event scrolls at runtime,
+	 * so a settings change takes effect without recreating the renderer.
+	 */
+	setWheelScrollLines(lines: number): void {
+		this.wheelScrollLines = Math.max(1, Math.floor(lines));
 	}
 
 	override render(width: number): string[] {

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -364,6 +364,26 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
+	it("applies wheelScrollLines at runtime via setWheelScrollLines", async () => {
+		const terminal = new VirtualTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal);
+		tui.setWheelScrollLines(3);
+		const inner = new ScrollView(new Text("i1\ni2\ni3\ni4\ni5\ni6", 0, 0));
+		const outer = new ScrollView(
+			new VStack([{ component: inner, basis: 2 }, new Text("tail1\ntail2\ntail3\ntail4\ntail5", 0, 0)]),
+			{ primary: true },
+		);
+		tui.setLayoutRoot(outer);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<65;1;1M");
+		await terminal.waitForRender();
+		assert.strictEqual(inner.scrollTop, 3);
+		assert.strictEqual(outer.scrollTop, 0);
+		tui.stop();
+	});
+
 	it("supports configurable keyboard viewport navigation with four rows of page overlap", async () => {
 		const terminal = new VirtualTerminal(20, 8);
 		const tui = new TuiAltScreen(terminal);


### PR DESCRIPTION
## Problem

In fullscreen TUI mode, each SGR mouse-wheel event scrolls the transcript by a fixed
single line (`wheelScrollLines` defaults to 1). On terminals that coalesce an
accelerated trackpad gesture into very few wheel events (observed on Termius), a fast
scroll moves only a line or two, making it tedious to review a long transcript.

## Change

Adds a `fullscreenWheelScrollLines` setting (default `1`, so behavior is unchanged for
existing users) wired through:

- the settings manager (validated, persisted getter/setter)
- the `/settings` UI ("Fullscreen wheel scroll lines", selectable 1/2/3/4/5/6/8/10)
- the fullscreen TUI, via the existing `TuiAltScreenOptions.wheelScrollLines` knob

A new `TuiAltScreen.setWheelScrollLines()` applies the value at runtime without
recreating the renderer, so a `/settings` change takes effect immediately. The setting
mirrors the existing `fullscreenScrollbar` plumbing and has no effect in regular mode.

## Tests

- `settings-manager.test.ts`: default, persist, and out-of-range validation
- `settings-selector.test.ts`: `/settings` cycles the new option
- `tui-alt-screen.test.ts`: `setWheelScrollLines()` applies the multiplier at runtime

## Future work

Normalize scroll event density (fractional accumulation + inter-event timing) so scroll
distance per physical gesture is consistent across terminals. Note that magnitude a
terminal emulator already drops cannot be recovered client-side.
