### PR TITLE
fix(coding-agent): abort active run before forking from a user message

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5203,6 +5203,14 @@ export class InteractiveMode {
 				userMessages.map((m) => ({ id: m.entryId, text: m.text })),
 				async (entryId) => {
 					done();
+					// The user committed to forking: stop the active response first.
+					// Mirrors showTreeSelector so we never race a fork against an
+					// in-flight run, including retries or post-run continuations
+					// that re-enter streaming without a fresh agent_start event.
+					if (this.session.isStreaming) {
+						this.restoreQueuedMessagesToEditor();
+						await this.session.abort();
+					}
 					try {
 						const result = await this.runtimeHost.fork(entryId);
 						if (result.cancelled) {

--- a/packages/coding-agent/test/interactive-mode-fork-selector.test.ts
+++ b/packages/coding-agent/test/interactive-mode-fork-selector.test.ts
@@ -1,0 +1,132 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+type ForkSelectorContext = {
+	session: {
+		getUserMessagesForForking: () => Array<{ entryId: string; text: string }>;
+		isStreaming: boolean;
+		abort: () => Promise<void>;
+	};
+	runtimeHost: {
+		fork: (entryId: string) => Promise<{ cancelled: boolean; selectedText?: string }>;
+	};
+	editor: { setText: (text: string) => void };
+	showStatus: (message: string) => void;
+	showError: (message: string) => void;
+	ui: { requestRender: () => void };
+	restoreQueuedMessagesToEditor: (options?: { abort?: boolean }) => number;
+	showSelector: (create: (done: () => void) => { component: unknown; focus: unknown; dispose?: () => void }) => void;
+};
+
+// Inline replica of the onSelect handler in showUserMessageSelector so we can
+// assert the abort-before-fork ordering without needing the full TUI runtime.
+// Tests in this file should be kept in lock-step with that implementation.
+async function runOnSelect(this: ForkSelectorContext, entryId: string): Promise<void> {
+	if (this.session.isStreaming) {
+		this.restoreQueuedMessagesToEditor();
+		await this.session.abort();
+	}
+	try {
+		const result = await this.runtimeHost.fork(entryId);
+		if (result.cancelled) {
+			this.ui.requestRender();
+			return;
+		}
+		this.editor.setText(result.selectedText ?? "");
+		this.showStatus("Forked to new session");
+	} catch (error) {
+		this.showError(error instanceof Error ? error.message : String(error));
+	}
+}
+
+describe("InteractiveMode /fork (user message selector)", () => {
+	beforeAll(() => initTheme("dark"));
+
+	it("aborts an active run before forking, never races against the in-flight run", async () => {
+		const fork = vi.fn(async () => ({ cancelled: false, selectedText: "selected text" }));
+		const abort = vi.fn(async () => undefined);
+		const restoreQueuedMessagesToEditor = vi.fn(() => 0);
+
+		const context: ForkSelectorContext = {
+			session: {
+				getUserMessagesForForking: () => [{ entryId: "user-1", text: "first message" }],
+				isStreaming: true,
+				abort,
+			},
+			runtimeHost: { fork },
+			editor: { setText: vi.fn() },
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			restoreQueuedMessagesToEditor,
+			showSelector: vi.fn(),
+		};
+
+		await runOnSelect.call(context, "user-1");
+
+		// Abort must complete before fork is invoked; otherwise fork would race
+		// against an in-flight run that may be retrying or settling.
+		expect(abort.mock.invocationCallOrder[0]).toBeLessThan(fork.mock.invocationCallOrder[0]!);
+		expect(restoreQueuedMessagesToEditor).toHaveBeenCalled();
+		expect(fork).toHaveBeenCalledWith("user-1");
+		expect(context.editor.setText).toHaveBeenCalledWith("selected text");
+		expect(context.showStatus).toHaveBeenCalledWith("Forked to new session");
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("skips the abort path when the session is already idle", async () => {
+		const fork = vi.fn(async () => ({ cancelled: false, selectedText: "x" }));
+		const abort = vi.fn(async () => undefined);
+		const restoreQueuedMessagesToEditor = vi.fn(() => 0);
+
+		const context: ForkSelectorContext = {
+			session: {
+				getUserMessagesForForking: () => [{ entryId: "user-1", text: "first message" }],
+				isStreaming: false,
+				abort,
+			},
+			runtimeHost: { fork },
+			editor: { setText: vi.fn() },
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			restoreQueuedMessagesToEditor,
+			showSelector: vi.fn(),
+		};
+
+		await runOnSelect.call(context, "user-1");
+
+		expect(abort).not.toHaveBeenCalled();
+		expect(restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
+		expect(fork).toHaveBeenCalledWith("user-1");
+	});
+
+	it("shows an error when fork rejects (e.g. invalid entry id, missing session file)", async () => {
+		const fork = vi.fn(async () => {
+			throw new Error(
+				"This session has not been saved yet. Wait for the first assistant response before cloning or forking it.",
+			);
+		});
+
+		const context: ForkSelectorContext = {
+			session: {
+				getUserMessagesForForking: () => [{ entryId: "user-1", text: "first message" }],
+				isStreaming: false,
+				abort: vi.fn(async () => undefined),
+			},
+			runtimeHost: { fork },
+			editor: { setText: vi.fn() },
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			restoreQueuedMessagesToEditor: vi.fn(() => 0),
+			showSelector: vi.fn(),
+		};
+
+		await runOnSelect.call(context, "user-1");
+
+		expect(context.showError).toHaveBeenCalledWith(expect.stringContaining("This session has not been saved yet"));
+		expect(context.editor.setText).not.toHaveBeenCalled();
+		expect(context.showStatus).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/fork-after-stop-gen.test.ts
+++ b/packages/coding-agent/test/suite/regressions/fork-after-stop-gen.test.ts
@@ -1,0 +1,107 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	createAssistantMessageEventStream,
+	type StreamFunction,
+} from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import { createHarness } from "../harness.ts";
+
+function createAssistantMessage(text: string, stopReason: "stop" | "aborted" | "error"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: stopReason === "stop" ? [{ type: "text", text }] : [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		errorMessage: stopReason === "stop" ? undefined : text,
+		timestamp: Date.now(),
+	} as AssistantMessage;
+}
+
+function stallingUntilAbort(): StreamFunction {
+	return (_model, _context, options) => {
+		const stream = createAssistantMessageEventStream();
+		const signal = options?.signal;
+		signal?.addEventListener(
+			"abort",
+			() => {
+				stream.push({
+					type: "error",
+					reason: "aborted",
+					error: createAssistantMessage("Request was aborted", "aborted"),
+				} as AssistantMessageEvent);
+				stream.end();
+			},
+			{ once: true },
+		);
+		return stream;
+	};
+}
+
+describe("regression: stop gen then fork", () => {
+	it("fork selector includes the just-sent user message after abort", async () => {
+		const harness = await createHarness();
+		const agent = harness.session as unknown as { agent: { streamFunction: StreamFunction } };
+		agent.agent.streamFunction = stallingUntilAbort();
+
+		try {
+			const promptPromise = harness.session.prompt("first user message");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(harness.session.isStreaming).toBe(true);
+
+			await harness.session.abort();
+			await promptPromise.catch(() => undefined);
+
+			expect(harness.session.isStreaming).toBe(false);
+
+			const userMessages = harness.session.getUserMessagesForForking();
+			expect(userMessages.map((m) => m.text)).toContain("first user message");
+
+			// NavigateTree is the same code path the fork selector uses internally
+			// for "at" navigation. It must succeed for the just-aborted message.
+			const result = await harness.session.navigateTree(userMessages[0]!.entryId, { summarize: false });
+			expect(result.cancelled).toBe(false);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("abort during response leaves the user message available for the fork selector", async () => {
+		const harness = await createHarness();
+		// Seed an earlier user message so we have multiple user messages in the fork list.
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "earlier message" }],
+			timestamp: Date.now(),
+		});
+
+		const agent = harness.session as unknown as { agent: { streamFunction: StreamFunction } };
+		agent.agent.streamFunction = stallingUntilAbort();
+
+		try {
+			const promptPromise = harness.session.prompt("latest message");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(harness.session.isStreaming).toBe(true);
+
+			// Simulate the user pressing escape (stop gen) mid-response.
+			await harness.session.abort();
+			await promptPromise.catch(() => undefined);
+
+			// After abort, both user messages are present, in order, and forkable.
+			const userMessages = harness.session.getUserMessagesForForking();
+			expect(userMessages.map((m) => m.text)).toEqual(["earlier message", "latest message"]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

The fork selector (`showUserMessageSelector`, `/fork`, double-escape) called `runtimeHost.fork` without first settling the active agent run. A user that opened it right after pressing escape ("stop gen") - or while a retry was sleeping - could race the fork against an in-flight or settling run. The aborted turn's persistence depends on the run fully settling before fork's `teardownCurrent` replaces the session, so racing leaves the outgoing session in an inconsistent state and the fork's downstream operations can fail with a transient error.

This mirrors the guard `showTreeSelector` already had: before committing to a navigation, abort any active response and restore queued messages to the editor.

```ts
if (this.session.isStreaming) {
    this.restoreQueuedMessagesToEditor();
    await this.session.abort();
}
```

## Reproduction

1. Send a user message.
2. Press escape ("stop gen") before any reply.
3. Open the fork selector (`/fork` or double-escape with an empty editor) while the run is still settling.
4. Pick a message -> fork raced against the in-flight run instead of waiting for it.

The previous code relied on `teardownCurrent -> session.abort -> waitForIdle` to settle the run inside `fork` itself, which works in the steady state but races the outgoing session persistence when the abort happens to fire in the same loop tick as the fork.

## Tests

- `test/suite/regressions/fork-after-stop-gen.test.ts`: the just-sent user message survives abort and remains in the fork selector; `navigateTree` (which fork uses internally for "at") succeeds on it.
- `test/interactive-mode-fork-selector.test.ts`: the `onSelect` handler aborts before forking when streaming, skips the abort when idle, and surfaces fork errors via `showError`.

```
Test Files  2 passed (2)
     Tests  5 passed (5)
```