### PR TITLE
fix(coding-agent): prevent TUI crash on large diffs by avoiding spread in push

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -243,16 +243,16 @@ export class ToolExecutionComponent extends Container {
 			const lines: string[] = [];
 			if (contentLines.length > 0) {
 				lines.push("");
-				lines.push(...contentLines);
+				for (const line of contentLines) lines.push(line);
 			}
 			for (let i = 0; i < this.imageComponents.length; i++) {
 				const spacer = this.imageSpacers[i];
 				if (spacer) {
-					lines.push(...spacer.render(width));
+					for (const line of spacer.render(width)) lines.push(line);
 				}
 				const imageComponent = this.imageComponents[i];
 				if (imageComponent) {
-					lines.push(...imageComponent.render(width));
+					for (const line of imageComponent.render(width)) lines.push(line);
 				}
 			}
 			return lines;


### PR DESCRIPTION
## Summary

Fixes #8036: The edit tool crashes the TUI when rendering large diffs (~14.5MB) because `lines.push(...contentLines)` exceeds V8's maximum call stack size when contentLines contains many elements.

## Changes

Replace spread operator with a loop in `ToolExecutionComponent.render()` to safely push large arrays:

```typescript
// Before (crashes on large arrays)
lines.push(...contentLines);

// After (safe for any array size)
for (const line of contentLines) lines.push(line);
```

This fix applies to three locations in the render method:
1. `contentLines` - the main content being rendered
2. `spacer.render(width)` - spacer elements between images
3. `imageComponent.render(width)` - image components

## Testing

All existing tests pass (25/25 in tool-execution-component.test.ts).

## Related Issues

- Fixes #8036 (Edit tool crashes TUI when rendering a large diff)
- May also help with #8028 (RangeError: Invalid string length in fullRender)

Signed-off-by: Battleplus <battleplus@proton.me>