### PR TITLE
feat: add color values and theme styling

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added theme color values, OKLCH theme definitions, and concise `style()` rendering with direct theme token support and terminal color fallback.
 - Added transcript usage notices for compaction and branch summaries when cache miss notices are enabled.
 
 ### Fixed

--- a/packages/coding-agent/docs/themes.md
+++ b/packages/coding-agent/docs/themes.md
@@ -276,11 +276,12 @@ The `export` section controls colors for `/export` HTML output. If omitted, colo
 
 ## Color Values
 
-Four formats are supported:
+Five formats are supported:
 
 | Format | Example | Description |
 |--------|---------|-------------|
-| Hex | `"#ff0000"` | 6-digit hex RGB |
+| Hex | `"#ff0000"` | 3- or 6-digit sRGB hex |
+| OKLCH | `"oklch(62% 0.1 200)"` | Perceptual lightness, chroma, and hue |
 | 256-color | `39` | xterm 256-color palette index (0-255) |
 | Variable | `"primary"` | Reference to a `vars` entry |
 | Default | `""` | Terminal's default color |
@@ -293,7 +294,7 @@ Four formats are supported:
 
 ### Terminal Compatibility
 
-Pi uses 24-bit RGB colors. Most modern terminals support this (iTerm2, Kitty, WezTerm, Windows Terminal, VS Code). For older terminals with only 256-color support, pi falls back to the nearest approximation.
+Pi uses 24-bit RGB colors when available. It gamut-maps OKLCH to sRGB and falls back to the nearest 256-color or basic ANSI color for less capable terminals.
 
 Check truecolor support:
 

--- a/packages/coding-agent/docs/tui.md
+++ b/packages/coding-agent/docs/tui.md
@@ -413,17 +413,43 @@ pi.registerCommand("pick", {
 
 ## Theming
 
-Components accept theme objects for styling.
+Components accept theme objects for styling. Use `style()` to apply foreground and background colors, text attributes, and terminal fallbacks in one call:
 
-**In `renderCall`/`renderResult`**, use the `theme` parameter:
+```typescript
+import { style } from "@earendil-works/pi-coding-agent";
+
+renderResult(result, options, theme, context) {
+  return new Text(style("Done!", {
+    fg: "success",
+    bg: "toolSuccessBg",
+    bold: true,
+  }), 0, 0);
+}
+```
+
+A style color can be either a token or a concrete color. These are equivalent:
+
+```typescript
+style("Done!", { fg: "toolSuccessBg" });
+style("Done!", { fg: theme.colors.toolSuccessBg });
+```
+
+Use concrete colors for color math:
+
+```typescript
+import { mixColors } from "@earendil-works/pi-tui";
+
+const softer = mixColors(theme.colors.success, theme.colors.toolSuccessBg, 0.2);
+style("Done!", { fg: softer, bg: "toolSuccessBg" });
+```
+
+Any color token can be used as either `fg` or `bg`. The token's name describes its intended role but does not restrict its use. Pi converts concrete colors to truecolor, 256-color, or basic ANSI output based on terminal capabilities.
+
+The existing `theme.fg()` and `theme.bg()` methods remain available for compatibility:
 
 ```typescript
 renderResult(result, options, theme, context) {
-  // Use theme.fg() for foreground colors
   return new Text(theme.fg("success", "Done!"), 0, 0);
-  
-  // Use theme.bg() for background colors
-  const styled = theme.bg("toolPendingBg", theme.fg("accent", "text"));
 }
 ```
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -396,8 +396,13 @@ export {
 	getSettingsListTheme,
 	highlightCode,
 	initTheme,
+	style,
 	Theme,
+	type ThemeBg,
 	type ThemeColor,
+	type ThemeColorValue,
+	type ThemeStyle,
+	type ThemeToken,
 } from "./modes/interactive/theme/theme.ts";
 // Clipboard utilities
 export { copyToClipboard } from "./utils/clipboard.ts";

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -21,7 +21,7 @@
 				"oneOf": [
 					{
 						"type": "string",
-						"description": "Hex color (#RRGGBB), variable reference, or empty string for terminal default"
+						"description": "Hex color (#RGB or #RRGGBB), OKLCH color, variable reference, or empty string for terminal default"
 					},
 					{
 						"type": "integer",
@@ -338,7 +338,7 @@
 			"oneOf": [
 				{
 					"type": "string",
-					"description": "Hex color (#RRGGBB), variable reference, or empty string for terminal default"
+					"description": "Hex color (#RGB or #RRGGBB), OKLCH color, variable reference, or empty string for terminal default"
 				},
 				{
 					"type": "integer",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -2,12 +2,22 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import {
+	backgroundAnsi,
+	type Color,
+	colorToHex,
+	colorToRgb,
 	type EditorTheme,
-	getCapabilities,
+	foregroundAnsi,
+	getTerminalColorMode,
+	indexedColor,
 	type MarkdownTheme,
+	parseColor,
 	type RgbColor,
 	type SelectListTheme,
 	type SettingsListTheme,
+	styleText,
+	type TerminalColorMode,
+	type TextStyle,
 } from "@earendil-works/pi-tui";
 import chalk from "chalk";
 import { type Static, Type } from "typebox";
@@ -23,7 +33,7 @@ import { stripBom } from "../../../utils/text.ts";
 // ============================================================================
 
 const ColorValueSchema = Type.Union([
-	Type.String(), // hex "#ff0000", var ref "primary", or empty ""
+	Type.String(), // hex, OKLCH, var ref "primary", or empty ""
 	Type.Integer({ minimum: 0, maximum: 255 }), // 256-color index
 ]);
 
@@ -169,143 +179,27 @@ export type ThemeBg =
 	| "toolSuccessBg"
 	| "toolErrorBg";
 
+export type ThemeToken = ThemeColor | ThemeBg;
+
+export interface ThemeStyle extends Omit<TextStyle, "fg" | "bg"> {
+	fg?: ThemeToken | Color;
+	bg?: ThemeToken | Color;
+}
+
 type OptionalThemeColor = "thinkingMax" | "searchMatchText";
 type OptionalThemeBg = "scrollbarThumb" | "searchMatchBg";
-
-type ColorMode = "truecolor" | "256color";
+export type ThemeColorValue = string | number | Color;
 
 // ============================================================================
 // Color Utilities
 // ============================================================================
-
-function hexToRgb(hex: string): { r: number; g: number; b: number } {
-	const cleaned = hex.replace("#", "");
-	if (cleaned.length !== 6) {
-		throw new Error(`Invalid hex color: ${hex}`);
-	}
-	const r = parseInt(cleaned.substring(0, 2), 16);
-	const g = parseInt(cleaned.substring(2, 4), 16);
-	const b = parseInt(cleaned.substring(4, 6), 16);
-	if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
-		throw new Error(`Invalid hex color: ${hex}`);
-	}
-	return { r, g, b };
-}
-
-// The 6x6x6 color cube channel values (indices 0-5)
-const CUBE_VALUES = [0, 95, 135, 175, 215, 255];
-
-// Grayscale ramp values (indices 232-255, 24 grays from 8 to 238)
-const GRAY_VALUES = Array.from({ length: 24 }, (_, i) => 8 + i * 10);
-
-function findClosestCubeIndex(value: number): number {
-	let minDist = Infinity;
-	let minIdx = 0;
-	for (let i = 0; i < CUBE_VALUES.length; i++) {
-		const dist = Math.abs(value - CUBE_VALUES[i]);
-		if (dist < minDist) {
-			minDist = dist;
-			minIdx = i;
-		}
-	}
-	return minIdx;
-}
-
-function findClosestGrayIndex(gray: number): number {
-	let minDist = Infinity;
-	let minIdx = 0;
-	for (let i = 0; i < GRAY_VALUES.length; i++) {
-		const dist = Math.abs(gray - GRAY_VALUES[i]);
-		if (dist < minDist) {
-			minDist = dist;
-			minIdx = i;
-		}
-	}
-	return minIdx;
-}
-
-function colorDistance(r1: number, g1: number, b1: number, r2: number, g2: number, b2: number): number {
-	// Weighted Euclidean distance (human eye is more sensitive to green)
-	const dr = r1 - r2;
-	const dg = g1 - g2;
-	const db = b1 - b2;
-	return dr * dr * 0.299 + dg * dg * 0.587 + db * db * 0.114;
-}
-
-function rgbTo256(r: number, g: number, b: number): number {
-	// Find closest color in the 6x6x6 cube
-	const rIdx = findClosestCubeIndex(r);
-	const gIdx = findClosestCubeIndex(g);
-	const bIdx = findClosestCubeIndex(b);
-	const cubeR = CUBE_VALUES[rIdx];
-	const cubeG = CUBE_VALUES[gIdx];
-	const cubeB = CUBE_VALUES[bIdx];
-	const cubeIndex = 16 + 36 * rIdx + 6 * gIdx + bIdx;
-	const cubeDist = colorDistance(r, g, b, cubeR, cubeG, cubeB);
-
-	// Find closest grayscale
-	const gray = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
-	const grayIdx = findClosestGrayIndex(gray);
-	const grayValue = GRAY_VALUES[grayIdx];
-	const grayIndex = 232 + grayIdx;
-	const grayDist = colorDistance(r, g, b, grayValue, grayValue, grayValue);
-
-	// Check if color has noticeable saturation (hue matters)
-	// If max-min spread is significant, prefer cube to preserve tint
-	const maxC = Math.max(r, g, b);
-	const minC = Math.min(r, g, b);
-	const spread = maxC - minC;
-
-	// Only consider grayscale if color is nearly neutral (spread < 10)
-	// AND grayscale is actually closer
-	if (spread < 10 && grayDist < cubeDist) {
-		return grayIndex;
-	}
-
-	return cubeIndex;
-}
-
-function hexTo256(hex: string): number {
-	const { r, g, b } = hexToRgb(hex);
-	return rgbTo256(r, g, b);
-}
-
-function fgAnsi(color: string | number, mode: ColorMode): string {
-	if (color === "") return "\x1b[39m";
-	if (typeof color === "number") return `\x1b[38;5;${color}m`;
-	if (color.startsWith("#")) {
-		if (mode === "truecolor") {
-			const { r, g, b } = hexToRgb(color);
-			return `\x1b[38;2;${r};${g};${b}m`;
-		} else {
-			const index = hexTo256(color);
-			return `\x1b[38;5;${index}m`;
-		}
-	}
-	throw new Error(`Invalid color value: ${color}`);
-}
-
-function bgAnsi(color: string | number, mode: ColorMode): string {
-	if (color === "") return "\x1b[49m";
-	if (typeof color === "number") return `\x1b[48;5;${color}m`;
-	if (color.startsWith("#")) {
-		if (mode === "truecolor") {
-			const { r, g, b } = hexToRgb(color);
-			return `\x1b[48;2;${r};${g};${b}m`;
-		} else {
-			const index = hexTo256(color);
-			return `\x1b[48;5;${index}m`;
-		}
-	}
-	throw new Error(`Invalid color value: ${color}`);
-}
 
 function resolveVarRefs(
 	value: ColorValue,
 	vars: Record<string, ColorValue>,
 	visited = new Set<string>(),
 ): string | number {
-	if (typeof value === "number" || value === "" || value.startsWith("#")) {
+	if (typeof value === "number" || value === "" || value.startsWith("#") || /^oklch\(/i.test(value)) {
 		return value;
 	}
 	if (visited.has(value)) {
@@ -351,53 +245,62 @@ function withThemeColorFallbacks(colors: ThemeJson["colors"]): ThemeJson["colors
 export class Theme {
 	readonly name?: string;
 	readonly sourcePath?: string;
+	readonly colors: Readonly<Record<ThemeToken, Color>>;
 	sourceInfo?: SourceInfo;
-	private fgColors: Map<ThemeColor, string>;
-	private bgColors: Map<ThemeBg, string>;
-	private mode: ColorMode;
+	private mode: TerminalColorMode;
 
 	constructor(
-		fgColors: Record<Exclude<ThemeColor, OptionalThemeColor>, string | number> &
-			Partial<Record<OptionalThemeColor, string | number>>,
-		bgColors: Record<Exclude<ThemeBg, OptionalThemeBg>, string | number> &
-			Partial<Record<OptionalThemeBg, string | number>>,
-		mode: ColorMode,
+		fgColors: Record<Exclude<ThemeColor, OptionalThemeColor>, ThemeColorValue> &
+			Partial<Record<OptionalThemeColor, ThemeColorValue>>,
+		bgColors: Record<Exclude<ThemeBg, OptionalThemeBg>, ThemeColorValue> &
+			Partial<Record<OptionalThemeBg, ThemeColorValue>>,
+		mode: TerminalColorMode,
 		options: { name?: string; sourcePath?: string; sourceInfo?: SourceInfo } = {},
 	) {
 		this.name = options.name;
 		this.sourcePath = options.sourcePath;
 		this.sourceInfo = options.sourceInfo;
 		this.mode = mode;
-		this.fgColors = new Map();
-		const colors = {
+		const values = {
 			...fgColors,
 			thinkingMax: fgColors.thinkingMax ?? fgColors.thinkingXhigh,
 			searchMatchText: fgColors.searchMatchText ?? fgColors.text,
-		};
-		for (const [key, value] of Object.entries(colors) as [ThemeColor, string | number][]) {
-			this.fgColors.set(key, fgAnsi(value, mode));
-		}
-		this.bgColors = new Map();
-		const backgrounds = {
 			...bgColors,
 			scrollbarThumb: bgColors.scrollbarThumb ?? bgColors.selectedBg,
 			searchMatchBg: bgColors.searchMatchBg ?? bgColors.selectedBg,
-		};
-		for (const [key, value] of Object.entries(backgrounds) as [ThemeBg, string | number][]) {
-			this.bgColors.set(key, bgAnsi(value, mode));
+		} as Record<ThemeToken, ThemeColorValue>;
+		const colors = {} as Record<ThemeToken, Color>;
+		for (const [token, value] of Object.entries(values) as [ThemeToken, ThemeColorValue][]) {
+			colors[token] = typeof value === "object" ? value : parseColor(value);
 		}
+		this.colors = Object.freeze(colors);
+	}
+
+	getColor(token: ThemeToken): Color {
+		const color = this.colors[token];
+		if (!color) throw new Error(`Unknown theme color: ${token}`);
+		return color;
+	}
+
+	style(text: string, options: ThemeStyle): string {
+		const { fg, bg, ...attributes } = options;
+		return styleText(
+			text,
+			{
+				...attributes,
+				fg: typeof fg === "string" ? this.getColor(fg) : fg,
+				bg: typeof bg === "string" ? this.getColor(bg) : bg,
+			},
+			this.mode,
+		);
 	}
 
 	fg(color: ThemeColor, text: string): string {
-		const ansi = this.fgColors.get(color);
-		if (!ansi) throw new Error(`Unknown theme color: ${color}`);
-		return `${ansi}${text}\x1b[39m`; // Reset only foreground color
+		return this.style(text, { fg: color });
 	}
 
 	bg(color: ThemeBg, text: string): string {
-		const ansi = this.bgColors.get(color);
-		if (!ansi) throw new Error(`Unknown theme background color: ${color}`);
-		return `${ansi}${text}\x1b[49m`; // Reset only background color
+		return this.style(text, { bg: color });
 	}
 
 	bold(text: string): string {
@@ -421,18 +324,14 @@ export class Theme {
 	}
 
 	getFgAnsi(color: ThemeColor): string {
-		const ansi = this.fgColors.get(color);
-		if (!ansi) throw new Error(`Unknown theme color: ${color}`);
-		return ansi;
+		return foregroundAnsi(this.getColor(color), this.mode);
 	}
 
 	getBgAnsi(color: ThemeBg): string {
-		const ansi = this.bgColors.get(color);
-		if (!ansi) throw new Error(`Unknown theme background color: ${color}`);
-		return ansi;
+		return backgroundAnsi(this.getColor(color), this.mode);
 	}
 
-	getColorMode(): ColorMode {
+	getColorMode(): TerminalColorMode {
 		return this.mode;
 	}
 
@@ -626,8 +525,8 @@ function loadThemeJson(name: string): ThemeJson {
 	return parseThemeJsonContent(name, content);
 }
 
-function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string): Theme {
-	const colorMode = mode ?? (getCapabilities().trueColor ? "truecolor" : "256color");
+function createTheme(themeJson: ThemeJson, mode?: TerminalColorMode, sourcePath?: string): Theme {
+	const colorMode = mode ?? getTerminalColorMode();
 	const resolvedColors = resolveThemeColors(withThemeColorFallbacks(themeJson.colors), themeJson.vars);
 	const fgColors: Record<ThemeColor, string | number> = {} as Record<ThemeColor, string | number>;
 	const bgColors: Record<ThemeBg, string | number> = {} as Record<ThemeBg, string | number>;
@@ -654,13 +553,13 @@ function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string
 	});
 }
 
-export function loadThemeFromPath(themePath: string, mode?: ColorMode): Theme {
+export function loadThemeFromPath(themePath: string, mode?: TerminalColorMode): Theme {
 	const content = fs.readFileSync(themePath, "utf-8");
 	const themeJson = parseThemeJsonContent(themePath, content);
 	return createTheme(themeJson, mode, themePath);
 }
 
-function loadTheme(name: string, mode?: ColorMode): Theme {
+function loadTheme(name: string, mode?: TerminalColorMode): Theme {
 	const registeredTheme = registeredThemes.get(name);
 	if (registeredTheme) {
 		return registeredTheme;
@@ -758,7 +657,7 @@ function getRgbColorLuminance({ r, g, b }: RgbColor): number {
 }
 
 function getAnsiColorLuminance(index: number): number {
-	return getRgbColorLuminance(hexToRgb(ansi256ToHex(index)));
+	return getRgbColorLuminance(colorToRgb(indexedColor(index)));
 }
 
 export function getThemeForRgbColor(rgb: RgbColor): TerminalTheme {
@@ -851,6 +750,11 @@ export const theme: Theme = new Proxy({} as Theme, {
 		return (t as unknown as Record<string | symbol, unknown>)[prop];
 	},
 });
+
+/** Style text with colors from the active theme. */
+export function style(text: string, options: ThemeStyle): string {
+	return theme.style(text, options);
+}
 
 function setGlobalTheme(t: Theme): void {
 	(globalThis as Record<symbol, Theme>)[THEME_KEY] = t;
@@ -1012,52 +916,6 @@ export function stopThemeWatcher(): void {
 // ============================================================================
 
 /**
- * Convert a 256-color index to hex string.
- * Indices 0-15: basic colors (approximate)
- * Indices 16-231: 6x6x6 color cube
- * Indices 232-255: grayscale ramp
- */
-function ansi256ToHex(index: number): string {
-	// Basic colors (0-15) - approximate common terminal values
-	const basicColors = [
-		"#000000",
-		"#800000",
-		"#008000",
-		"#808000",
-		"#000080",
-		"#800080",
-		"#008080",
-		"#c0c0c0",
-		"#808080",
-		"#ff0000",
-		"#00ff00",
-		"#ffff00",
-		"#0000ff",
-		"#ff00ff",
-		"#00ffff",
-		"#ffffff",
-	];
-	if (index < 16) {
-		return basicColors[index];
-	}
-
-	// Color cube (16-231): 6x6x6 = 216 colors
-	if (index < 232) {
-		const cubeIndex = index - 16;
-		const r = Math.floor(cubeIndex / 36);
-		const g = Math.floor((cubeIndex % 36) / 6);
-		const b = cubeIndex % 6;
-		const toHex = (n: number) => (n === 0 ? 0 : 55 + n * 40).toString(16).padStart(2, "0");
-		return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-	}
-
-	// Grayscale (232-255): 24 shades
-	const gray = 8 + (index - 232) * 10;
-	const grayHex = gray.toString(16).padStart(2, "0");
-	return `#${grayHex}${grayHex}${grayHex}`;
-}
-
-/**
  * Get resolved theme colors as CSS-compatible hex strings.
  * Used by HTML export to generate CSS custom properties.
  */
@@ -1072,13 +930,11 @@ export function getResolvedThemeColors(themeName?: string): Record<string, strin
 
 	const cssColors: Record<string, string> = {};
 	for (const [key, value] of Object.entries(resolved)) {
-		if (typeof value === "number") {
-			cssColors[key] = ansi256ToHex(value);
-		} else if (value === "") {
+		if (value === "") {
 			// Empty means default terminal color - use sensible fallback for HTML
 			cssColors[key] = defaultText;
 		} else {
-			cssColors[key] = value;
+			cssColors[key] = colorToHex(parseColor(value));
 		}
 	}
 	return cssColors;
@@ -1111,9 +967,8 @@ export function getThemeExportColors(themeName?: string): {
 		const resolve = (value: ColorValue | undefined): string | undefined => {
 			if (value === undefined) return undefined;
 			const resolved = resolveVarRefs(value, vars);
-			if (typeof resolved === "number") return ansi256ToHex(resolved);
 			if (resolved === "") return undefined;
-			return resolved;
+			return colorToHex(parseColor(resolved));
 		};
 
 		return {

--- a/packages/coding-agent/test/theme-detection.test.ts
+++ b/packages/coding-agent/test/theme-detection.test.ts
@@ -153,6 +153,18 @@ describe("theme color mode", () => {
 		if (!truecolorTheme) throw new Error("dark theme not found");
 		expect(truecolorTheme.getColorMode()).toBe("truecolor");
 		expect(truecolorTheme.getFgAnsi("accent")).toMatch(/^\x1b\[38;2;\d+;\d+;\d+m$/);
+
+		setCapabilities({ images: null, trueColor: false, hyperlinks: false, colorMode: "16color" });
+		const basicColorTheme = getThemeByName("dark");
+		if (!basicColorTheme) throw new Error("dark theme not found");
+		expect(basicColorTheme.getColorMode()).toBe("16color");
+		expect(basicColorTheme.getFgAnsi("accent")).toMatch(/^\x1b\[(?:3\d|9\d)m$/);
+
+		setCapabilities({ images: null, trueColor: false, hyperlinks: false, colorMode: "none" });
+		const colorlessTheme = getThemeByName("dark");
+		if (!colorlessTheme) throw new Error("dark theme not found");
+		expect(colorlessTheme.getColorMode()).toBe("none");
+		expect(colorlessTheme.fg("accent", "text")).toBe("text");
 	});
 });
 

--- a/packages/coding-agent/test/theme-style.test.ts
+++ b/packages/coding-agent/test/theme-style.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resetCapabilitiesCache, setCapabilities } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it } from "vitest";
+import { initTheme, loadThemeFromPath, style, theme } from "../src/modes/interactive/theme/theme.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	resetCapabilitiesCache();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("theme styles", () => {
+	it("accepts theme tokens and concrete colors", () => {
+		setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+		initTheme("dark");
+
+		expect(style("Ready", { fg: "toolSuccessBg" })).toBe(style("Ready", { fg: theme.colors.toolSuccessBg }));
+		expect(theme.style("Ready", { fg: "success", bg: "toolSuccessBg", bold: true })).toContain("Ready");
+	});
+
+	it("keeps the legacy foreground and background helpers", () => {
+		setCapabilities({ images: null, trueColor: true, hyperlinks: false });
+		initTheme("dark");
+
+		expect(theme.fg("success", "Ready")).toBe(`${theme.getFgAnsi("success")}Ready\x1b[39m`);
+		expect(theme.bg("toolSuccessBg", "Ready")).toBe(`${theme.getBgAnsi("toolSuccessBg")}Ready\x1b[49m`);
+	});
+
+	it("loads OKLCH theme values", () => {
+		const themeJson = JSON.parse(
+			readFileSync(new URL("../src/modes/interactive/theme/dark.json", import.meta.url), "utf8"),
+		) as { name: string; colors: Record<string, string | number> };
+		themeJson.name = "oklch-theme";
+		themeJson.colors.accent = "oklch(62% 0.1 200)";
+		const dir = mkdtempSync(join(tmpdir(), "pi-oklch-theme-"));
+		tempDirs.push(dir);
+		const path = join(dir, "oklch-theme.json");
+		writeFileSync(path, JSON.stringify(themeJson));
+
+		const loaded = loadThemeFromPath(path, "truecolor");
+		expect(loaded.colors.accent).toEqual({ kind: "oklch", l: 0.62, c: 0.1, h: 200 });
+		expect(loaded.style("Accent", { fg: "accent" })).toMatch(/^\x1b\[38;2;\d+;\d+;\d+mAccent\x1b\[39m$/);
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added terminal-independent sRGB, OKLCH, and indexed color values with color mixing and truecolor, 256-color, basic ANSI, and colorless style serialization.
+
 ### Fixed
 
 - Fixed duplicate fullscreen right-click paste in VS Code-based terminals on Windows ([#8186](https://github.com/earendil-works/pi/issues/8186)).

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -78,6 +78,31 @@ tui.requestRender(); // Request a re-render
 tui.onDebug = () => console.log("Debug triggered");
 ```
 
+### Colors and terminal styles
+
+Colors are values that can be converted or mixed before terminal rendering:
+
+```typescript
+import {
+  getTerminalColorMode,
+  mixColors,
+  parseColor,
+  styleText,
+} from "@earendil-works/pi-tui";
+
+const accent = parseColor("oklch(70% 0.12 220)");
+const background = parseColor("#20242a");
+const foreground = mixColors(accent, background, 0.2);
+
+const text = styleText(
+  "Ready",
+  { fg: foreground, bg: background, bold: true },
+  getTerminalColorMode(),
+);
+```
+
+`Color` supports terminal defaults, indexed ANSI colors, sRGB, and OKLCH. `styleText()` converts colors to truecolor, 256-color, basic ANSI, or uncolored output based on the requested terminal mode.
+
 ### Alternate-screen viewport layouts
 
 `TuiAltScreen` can render an explicit terminal-height layout. `VStack` and `HStack` allocate constrained regions, while `ScrollView` owns scrolling for one region. These semantics are intentionally unavailable on `TuiMainScreen`, where the terminal owns scrollback.

--- a/packages/tui/src/colors.ts
+++ b/packages/tui/src/colors.ts
@@ -1,0 +1,401 @@
+export interface DefaultColor {
+	readonly kind: "default";
+}
+
+export interface IndexedColor {
+	readonly kind: "indexed";
+	readonly index: number;
+}
+
+export interface RgbColorValue {
+	readonly kind: "rgb";
+	readonly r: number;
+	readonly g: number;
+	readonly b: number;
+}
+
+export interface OklchColorValue {
+	readonly kind: "oklch";
+	readonly l: number;
+	readonly c: number;
+	readonly h: number;
+}
+
+export type Color = DefaultColor | IndexedColor | RgbColorValue | OklchColorValue;
+export type TerminalColorMode = "none" | "16color" | "256color" | "truecolor";
+export type ColorMixSpace = "oklch" | "srgb";
+
+export interface RgbChannels {
+	r: number;
+	g: number;
+	b: number;
+}
+
+export interface OklchChannels {
+	l: number;
+	c: number;
+	h: number;
+}
+
+export interface TextStyle {
+	fg?: Color;
+	bg?: Color;
+	bold?: boolean;
+	dim?: boolean;
+	italic?: boolean;
+	underline?: boolean;
+	inverse?: boolean;
+	strikethrough?: boolean;
+}
+
+export const defaultColor: DefaultColor = Object.freeze({ kind: "default" });
+
+function requireFinite(value: number, name: string): void {
+	if (!Number.isFinite(value)) throw new Error(`${name} must be finite`);
+}
+
+export function indexedColor(index: number): IndexedColor {
+	if (!Number.isInteger(index) || index < 0 || index > 255) {
+		throw new Error(`ANSI color index must be an integer from 0 to 255: ${index}`);
+	}
+	return Object.freeze({ kind: "indexed", index });
+}
+
+export function rgbColor(r: number, g: number, b: number): RgbColorValue {
+	for (const [name, value] of [
+		["r", r],
+		["g", g],
+		["b", b],
+	] as const) {
+		requireFinite(value, name);
+		if (value < 0 || value > 255) throw new Error(`${name} must be between 0 and 255: ${value}`);
+	}
+	return Object.freeze({ kind: "rgb", r, g, b });
+}
+
+export function oklchColor(l: number, c: number, h: number): OklchColorValue {
+	requireFinite(l, "l");
+	requireFinite(c, "c");
+	requireFinite(h, "h");
+	if (l < 0 || l > 1) throw new Error(`l must be between 0 and 1: ${l}`);
+	if (c < 0) throw new Error(`c must not be negative: ${c}`);
+	return Object.freeze({ kind: "oklch", l, c, h: ((h % 360) + 360) % 360 });
+}
+
+const NUMBER_PATTERN = String.raw`[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?`;
+const OKLCH_PATTERN = new RegExp(
+	`^oklch\\(\\s*(${NUMBER_PATTERN})(%)?\\s+(${NUMBER_PATTERN})\\s+(${NUMBER_PATTERN})(?:deg)?\\s*\\)$`,
+	"i",
+);
+
+export function parseColor(value: string | number): Color {
+	if (typeof value === "number") return indexedColor(value);
+	if (value === "") return defaultColor;
+
+	const hex = /^#([\da-f]{3}|[\da-f]{6})$/i.exec(value);
+	if (hex) {
+		const digits = hex[1].length === 3 ? [...hex[1]].map((digit) => digit + digit).join("") : hex[1];
+		return rgbColor(
+			Number.parseInt(digits.slice(0, 2), 16),
+			Number.parseInt(digits.slice(2, 4), 16),
+			Number.parseInt(digits.slice(4, 6), 16),
+		);
+	}
+
+	const oklch = OKLCH_PATTERN.exec(value);
+	if (oklch) {
+		const lightness = Number.parseFloat(oklch[1]) / (oklch[2] ? 100 : 1);
+		return oklchColor(lightness, Number.parseFloat(oklch[3]), Number.parseFloat(oklch[4]));
+	}
+
+	throw new Error(`Invalid color value: ${value}`);
+}
+
+const BASIC_COLORS: readonly RgbChannels[] = [
+	{ r: 0, g: 0, b: 0 },
+	{ r: 128, g: 0, b: 0 },
+	{ r: 0, g: 128, b: 0 },
+	{ r: 128, g: 128, b: 0 },
+	{ r: 0, g: 0, b: 128 },
+	{ r: 128, g: 0, b: 128 },
+	{ r: 0, g: 128, b: 128 },
+	{ r: 192, g: 192, b: 192 },
+	{ r: 128, g: 128, b: 128 },
+	{ r: 255, g: 0, b: 0 },
+	{ r: 0, g: 255, b: 0 },
+	{ r: 255, g: 255, b: 0 },
+	{ r: 0, g: 0, b: 255 },
+	{ r: 255, g: 0, b: 255 },
+	{ r: 0, g: 255, b: 255 },
+	{ r: 255, g: 255, b: 255 },
+];
+const CUBE_VALUES = [0, 95, 135, 175, 215, 255] as const;
+const GRAY_VALUES = Array.from({ length: 24 }, (_, index) => 8 + index * 10);
+
+function indexedToRgb(index: number): RgbChannels {
+	if (index < 16) return BASIC_COLORS[index];
+	if (index < 232) {
+		const cubeIndex = index - 16;
+		return {
+			r: CUBE_VALUES[Math.floor(cubeIndex / 36)],
+			g: CUBE_VALUES[Math.floor((cubeIndex % 36) / 6)],
+			b: CUBE_VALUES[cubeIndex % 6],
+		};
+	}
+	const gray = 8 + (index - 232) * 10;
+	return { r: gray, g: gray, b: gray };
+}
+
+function srgbToLinear(channel: number): number {
+	return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function linearToSrgb(channel: number): number {
+	return channel <= 0.0031308 ? channel * 12.92 : 1.055 * channel ** (1 / 2.4) - 0.055;
+}
+
+interface OklabChannels {
+	l: number;
+	a: number;
+	b: number;
+}
+
+interface LinearRgbChannels {
+	r: number;
+	g: number;
+	b: number;
+}
+
+function rgbToOklab({ r, g, b }: RgbChannels): OklabChannels {
+	const linearR = srgbToLinear(r / 255);
+	const linearG = srgbToLinear(g / 255);
+	const linearB = srgbToLinear(b / 255);
+	const l = Math.cbrt(0.4122214708 * linearR + 0.5363325363 * linearG + 0.0514459929 * linearB);
+	const m = Math.cbrt(0.2119034982 * linearR + 0.6806995451 * linearG + 0.1073969566 * linearB);
+	const s = Math.cbrt(0.0883024619 * linearR + 0.2817188376 * linearG + 0.6299787005 * linearB);
+	return {
+		l: 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+		a: 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+		b: 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+	};
+}
+
+function oklabToLinearRgb({ l, a, b }: OklabChannels): LinearRgbChannels {
+	const lRoot = l + 0.3963377774 * a + 0.2158037573 * b;
+	const mRoot = l - 0.1055613458 * a - 0.0638541728 * b;
+	const sRoot = l - 0.0894841775 * a - 1.291485548 * b;
+	const lValue = lRoot ** 3;
+	const mValue = mRoot ** 3;
+	const sValue = sRoot ** 3;
+	return {
+		r: 4.0767416621 * lValue - 3.3077115913 * mValue + 0.2309699292 * sValue,
+		g: -1.2684380046 * lValue + 2.6097574011 * mValue - 0.3413193965 * sValue,
+		b: -0.0041960863 * lValue - 0.7034186147 * mValue + 1.707614701 * sValue,
+	};
+}
+
+function oklchToOklab({ l, c, h }: OklchChannels): OklabChannels {
+	const radians = (h * Math.PI) / 180;
+	return { l, a: c * Math.cos(radians), b: c * Math.sin(radians) };
+}
+
+function isInSrgbGamut({ r, g, b }: LinearRgbChannels): boolean {
+	const epsilon = 1e-7;
+	return r >= -epsilon && r <= 1 + epsilon && g >= -epsilon && g <= 1 + epsilon && b >= -epsilon && b <= 1 + epsilon;
+}
+
+function linearRgbToChannels({ r, g, b }: LinearRgbChannels): RgbChannels {
+	return {
+		r: Math.round(Math.max(0, Math.min(1, linearToSrgb(r))) * 255),
+		g: Math.round(Math.max(0, Math.min(1, linearToSrgb(g))) * 255),
+		b: Math.round(Math.max(0, Math.min(1, linearToSrgb(b))) * 255),
+	};
+}
+
+function oklchToRgb(color: OklchChannels): RgbChannels {
+	let linear = oklabToLinearRgb(oklchToOklab(color));
+	if (isInSrgbGamut(linear)) return linearRgbToChannels(linear);
+
+	let low = 0;
+	let high = color.c;
+	for (let index = 0; index < 20; index++) {
+		const chroma = (low + high) / 2;
+		const candidate = oklabToLinearRgb(oklchToOklab({ ...color, c: chroma }));
+		if (isInSrgbGamut(candidate)) {
+			low = chroma;
+			linear = candidate;
+		} else {
+			high = chroma;
+		}
+	}
+	return linearRgbToChannels(linear);
+}
+
+export function colorToRgb(color: Color): RgbChannels {
+	switch (color.kind) {
+		case "default":
+			throw new Error("The terminal default color has no concrete RGB value");
+		case "indexed":
+			return indexedToRgb(color.index);
+		case "rgb":
+			return { r: color.r, g: color.g, b: color.b };
+		case "oklch":
+			return oklchToRgb(color);
+	}
+}
+
+export function colorToOklch(color: Color): OklchChannels {
+	if (color.kind === "default") throw new Error("The terminal default color has no concrete OKLCH value");
+	if (color.kind === "oklch") return { l: color.l, c: color.c, h: color.h };
+	const lab = rgbToOklab(colorToRgb(color));
+	return {
+		l: lab.l,
+		c: Math.hypot(lab.a, lab.b),
+		h: ((Math.atan2(lab.b, lab.a) * 180) / Math.PI + 360) % 360,
+	};
+}
+
+export function colorToHex(color: Color): string {
+	const { r, g, b } = colorToRgb(color);
+	const channel = (value: number) => Math.round(value).toString(16).padStart(2, "0");
+	return `#${channel(r)}${channel(g)}${channel(b)}`;
+}
+
+export function mixColors(first: Color, second: Color, amount: number, space: ColorMixSpace = "oklch"): Color {
+	requireFinite(amount, "amount");
+	if (amount < 0 || amount > 1) throw new Error(`amount must be between 0 and 1: ${amount}`);
+
+	if (space === "srgb") {
+		const a = colorToRgb(first);
+		const b = colorToRgb(second);
+		return rgbColor(a.r + (b.r - a.r) * amount, a.g + (b.g - a.g) * amount, a.b + (b.b - a.b) * amount);
+	}
+
+	const a = colorToOklch(first);
+	const b = colorToOklch(second);
+	const firstHue = a.c < 1e-7 ? b.h : a.h;
+	const secondHue = b.c < 1e-7 ? firstHue : b.h;
+	const hueDelta = ((secondHue - firstHue + 540) % 360) - 180;
+	return oklchColor(a.l + (b.l - a.l) * amount, a.c + (b.c - a.c) * amount, firstHue + hueDelta * amount);
+}
+
+function findClosest(values: readonly number[], target: number): number {
+	let closestIndex = 0;
+	let closestDistance = Infinity;
+	for (let index = 0; index < values.length; index++) {
+		const distance = Math.abs(target - values[index]);
+		if (distance < closestDistance) {
+			closestIndex = index;
+			closestDistance = distance;
+		}
+	}
+	return closestIndex;
+}
+
+function colorDistance(first: RgbChannels, second: RgbChannels): number {
+	const dr = first.r - second.r;
+	const dg = first.g - second.g;
+	const db = first.b - second.b;
+	return dr * dr * 0.299 + dg * dg * 0.587 + db * db * 0.114;
+}
+
+function rgbToAnsi256(color: RgbChannels): number {
+	const rIndex = findClosest(CUBE_VALUES, color.r);
+	const gIndex = findClosest(CUBE_VALUES, color.g);
+	const bIndex = findClosest(CUBE_VALUES, color.b);
+	const cubeColor = { r: CUBE_VALUES[rIndex], g: CUBE_VALUES[gIndex], b: CUBE_VALUES[bIndex] };
+	const cubeIndex = 16 + 36 * rIndex + 6 * gIndex + bIndex;
+
+	const gray = Math.round(0.299 * color.r + 0.587 * color.g + 0.114 * color.b);
+	const grayOffset = findClosest(GRAY_VALUES, gray);
+	const grayValue = GRAY_VALUES[grayOffset];
+	const spread = Math.max(color.r, color.g, color.b) - Math.min(color.r, color.g, color.b);
+	if (
+		spread < 10 &&
+		colorDistance(color, { r: grayValue, g: grayValue, b: grayValue }) < colorDistance(color, cubeColor)
+	) {
+		return 232 + grayOffset;
+	}
+	return cubeIndex;
+}
+
+function rgbToAnsi16(color: RgbChannels): number {
+	const target = rgbToOklab(color);
+	let closestIndex = 0;
+	let closestDistance = Infinity;
+	for (let index = 0; index < BASIC_COLORS.length; index++) {
+		const candidate = rgbToOklab(BASIC_COLORS[index]);
+		const distance = (target.l - candidate.l) ** 2 + (target.a - candidate.a) ** 2 + (target.b - candidate.b) ** 2;
+		if (distance < closestDistance) {
+			closestIndex = index;
+			closestDistance = distance;
+		}
+	}
+	return closestIndex;
+}
+
+function basicAnsi(index: number, background: boolean): string {
+	const base = background ? (index < 8 ? 40 : 100) : index < 8 ? 30 : 90;
+	return `\x1b[${base + (index % 8)}m`;
+}
+
+function colorAnsi(color: Color, mode: TerminalColorMode, background: boolean): string {
+	if (mode === "none") return "";
+	if (color.kind === "default") return background ? "\x1b[49m" : "\x1b[39m";
+
+	if (color.kind === "indexed" && mode !== "16color") {
+		return `\x1b[${background ? 48 : 38};5;${color.index}m`;
+	}
+
+	const rgb = colorToRgb(color);
+	if (mode === "truecolor") {
+		return `\x1b[${background ? 48 : 38};2;${Math.round(rgb.r)};${Math.round(rgb.g)};${Math.round(rgb.b)}m`;
+	}
+	if (mode === "256color") {
+		return `\x1b[${background ? 48 : 38};5;${rgbToAnsi256(rgb)}m`;
+	}
+	return basicAnsi(color.kind === "indexed" && color.index < 16 ? color.index : rgbToAnsi16(rgb), background);
+}
+
+export function foregroundAnsi(color: Color, mode: TerminalColorMode): string {
+	return colorAnsi(color, mode, false);
+}
+
+export function backgroundAnsi(color: Color, mode: TerminalColorMode): string {
+	return colorAnsi(color, mode, true);
+}
+
+export function styleText(text: string, options: TextStyle, mode: TerminalColorMode): string {
+	if (mode === "none") return text;
+
+	const prefix: string[] = [];
+	const suffix: string[] = [];
+	if (options.fg) {
+		prefix.push(foregroundAnsi(options.fg, mode));
+		suffix.unshift("\x1b[39m");
+	}
+	if (options.bg) {
+		prefix.push(backgroundAnsi(options.bg, mode));
+		suffix.unshift("\x1b[49m");
+	}
+	if (options.bold) prefix.push("\x1b[1m");
+	if (options.dim) prefix.push("\x1b[2m");
+	if (options.bold || options.dim) suffix.unshift("\x1b[22m");
+	if (options.italic) {
+		prefix.push("\x1b[3m");
+		suffix.unshift("\x1b[23m");
+	}
+	if (options.underline) {
+		prefix.push("\x1b[4m");
+		suffix.unshift("\x1b[24m");
+	}
+	if (options.inverse) {
+		prefix.push("\x1b[7m");
+		suffix.unshift("\x1b[27m");
+	}
+	if (options.strikethrough) {
+		prefix.push("\x1b[9m");
+		suffix.unshift("\x1b[29m");
+	}
+	return `${prefix.join("")}${text}${suffix.join("")}`;
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -9,6 +9,31 @@ export {
 	CombinedAutocompleteProvider,
 	type SlashCommand,
 } from "./autocomplete.ts";
+// Colors and styling
+export {
+	backgroundAnsi,
+	type Color,
+	type ColorMixSpace,
+	colorToHex,
+	colorToOklch,
+	colorToRgb,
+	type DefaultColor,
+	defaultColor,
+	foregroundAnsi,
+	type IndexedColor,
+	indexedColor,
+	mixColors,
+	type OklchChannels,
+	type OklchColorValue,
+	oklchColor,
+	parseColor,
+	type RgbChannels,
+	type RgbColorValue,
+	rgbColor,
+	styleText,
+	type TerminalColorMode,
+	type TextStyle,
+} from "./colors.ts";
 // Components
 export { Box } from "./components/box.ts";
 export { CancellableLoader } from "./components/cancellable-loader.ts";
@@ -101,6 +126,7 @@ export {
 	getImageDimensions,
 	getJpegDimensions,
 	getPngDimensions,
+	getTerminalColorMode,
 	getWebpDimensions,
 	hyperlink,
 	type ImageDimensions,

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import { homedir } from "node:os";
 import { isAbsolute } from "node:path";
 import { pathToFileURL } from "node:url";
+import type { TerminalColorMode } from "./colors.ts";
 
 export type ImageProtocol = "kitty" | "iterm2" | null;
 
@@ -9,6 +10,8 @@ export interface TerminalCapabilities {
 	images: ImageProtocol;
 	trueColor: boolean;
 	hyperlinks: boolean;
+	/** Detailed color support. Omitted capability objects retain the legacy truecolor/256-color behavior. */
+	colorMode?: TerminalColorMode;
 }
 
 export interface CellDimensions {
@@ -72,67 +75,79 @@ export function detectCapabilities(tmuxForwardsHyperlink: () => boolean = probeT
 	const colorTerm = process.env.COLORTERM?.toLowerCase() || "";
 	const hasTrueColorHint = colorTerm === "truecolor" || colorTerm === "24bit";
 	const isWindowsConsole = process.platform === "win32";
+	const capabilities = (images: ImageProtocol, trueColor: boolean, hyperlinks: boolean): TerminalCapabilities => ({
+		images,
+		trueColor,
+		hyperlinks,
+		colorMode: trueColor
+			? "truecolor"
+			: term === "" || term === "dumb"
+				? "none"
+				: term.includes("256color")
+					? "256color"
+					: "16color",
+	});
 
 	// Emit OSC 8 hyperlinks only when tmux confirms it forwards.
 	// Image protocols are unreliable under tmux, so leave `images: null`.
 	if (process.env.TMUX || term.startsWith("tmux")) {
-		return { images: null, trueColor: hasTrueColorHint, hyperlinks: tmuxForwardsHyperlink() };
+		return capabilities(null, hasTrueColorHint, tmuxForwardsHyperlink());
 	}
 
 	// screen does not forward OSC 8 hyperlinks, so keep them off there.
 	if (term.startsWith("screen")) {
-		return { images: null, trueColor: hasTrueColorHint, hyperlinks: false };
+		return capabilities(null, hasTrueColorHint, false);
 	}
 
 	if (process.env.KITTY_WINDOW_ID || termProgram === "kitty") {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
+		return capabilities("kitty", true, true);
 	}
 
 	if (termProgram === "ghostty" || term.includes("ghostty") || process.env.GHOSTTY_RESOURCES_DIR) {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
+		return capabilities("kitty", true, true);
 	}
 
 	if (process.env.WEZTERM_PANE || termProgram === "wezterm") {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
+		return capabilities("kitty", true, true);
 	}
 
 	// Warp supports the Kitty graphics protocol and OSC 8 hyperlinks.
 	if (termProgram === "warpterminal" || process.env.WARP_SESSION_ID || process.env.WARP_TERMINAL_SESSION_UUID) {
-		return { images: "kitty", trueColor: true, hyperlinks: true };
+		return capabilities("kitty", true, true);
 	}
 
 	if (process.env.ITERM_SESSION_ID || termProgram === "iterm.app") {
-		return { images: "iterm2", trueColor: true, hyperlinks: true };
+		return capabilities("iterm2", true, true);
 	}
 
 	if (process.env.WT_SESSION) {
-		return { images: null, trueColor: true, hyperlinks: true };
+		return capabilities(null, true, true);
 	}
 
 	if (termProgram === "vscode") {
-		return { images: null, trueColor: true, hyperlinks: true };
+		return capabilities(null, true, true);
 	}
 
 	if (termProgram === "alacritty") {
-		return { images: null, trueColor: true, hyperlinks: true };
+		return capabilities(null, true, true);
 	}
 
 	if (terminalEmulator === "jetbrains-jediterm") {
-		return { images: null, trueColor: true, hyperlinks: false };
+		return capabilities(null, true, false);
 	}
 
 	// Windows Terminal does not always set WT_SESSION, for example when it hosts
 	// a cmd.exe launched directly from Win+R. Modern Windows consoles support
 	// truecolor; keep hyperlinks off unless we positively detected support above.
 	if (isWindowsConsole) {
-		return { images: null, trueColor: true, hyperlinks: false };
+		return capabilities(null, true, false);
 	}
 
 	// Unknown terminal: be conservative. OSC 8 is rendered invisibly as "just
 	// text" on terminals that swallow it, which means the URL disappears from
 	// the rendered output. Default to the legacy `text (url)` behavior unless we
 	// have positively identified a hyperlink-capable terminal above.
-	return { images: null, trueColor: hasTrueColorHint, hyperlinks: false };
+	return capabilities(null, hasTrueColorHint, false);
 }
 
 export function getCapabilities(): TerminalCapabilities {
@@ -140,6 +155,10 @@ export function getCapabilities(): TerminalCapabilities {
 		cachedCapabilities = detectCapabilities();
 	}
 	return cachedCapabilities;
+}
+
+export function getTerminalColorMode(capabilities: TerminalCapabilities = getCapabilities()): TerminalColorMode {
+	return capabilities.colorMode ?? (capabilities.trueColor ? "truecolor" : "256color");
 }
 
 export function resetCapabilitiesCache(): void {

--- a/packages/tui/test/colors.test.ts
+++ b/packages/tui/test/colors.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+	backgroundAnsi,
+	colorToRgb,
+	foregroundAnsi,
+	indexedColor,
+	mixColors,
+	oklchColor,
+	parseColor,
+	rgbColor,
+	styleText,
+} from "../src/index.ts";
+
+describe("colors", () => {
+	it("parses hex and OKLCH colors", () => {
+		assert.deepStrictEqual(parseColor("#123456"), { kind: "rgb", r: 18, g: 52, b: 86 });
+		assert.deepStrictEqual(parseColor("#abc"), { kind: "rgb", r: 170, g: 187, b: 204 });
+		assert.deepStrictEqual(parseColor("oklch(62% 0.1 200)"), { kind: "oklch", l: 0.62, c: 0.1, h: 200 });
+	});
+
+	it("converts OKLCH to sRGB with gamut mapping", () => {
+		const red = colorToRgb(oklchColor(0.627955, 0.257683, 29.2339));
+		assert.ok(red.r >= 254);
+		assert.ok(red.g <= 1);
+		assert.ok(red.b <= 1);
+	});
+
+	it("mixes colors in OKLCH", () => {
+		const mixed = mixColors(rgbColor(255, 0, 0), rgbColor(0, 0, 255), 0.5);
+		assert.strictEqual(mixed.kind, "oklch");
+		assert.ok(mixed.l > 0 && mixed.l < 1);
+	});
+
+	it("serializes colors for terminal color modes", () => {
+		assert.strictEqual(foregroundAnsi(rgbColor(18, 52, 86), "truecolor"), "\x1b[38;2;18;52;86m");
+		assert.match(foregroundAnsi(rgbColor(18, 52, 86), "256color"), /^\x1b\[38;5;\d+m$/);
+		assert.match(foregroundAnsi(rgbColor(18, 52, 86), "16color"), /^\x1b\[(?:3\d|9\d)m$/);
+		assert.strictEqual(backgroundAnsi(indexedColor(9), "truecolor"), "\x1b[48;5;9m");
+		assert.strictEqual(foregroundAnsi(rgbColor(18, 52, 86), "none"), "");
+	});
+
+	it("applies a complete text style", () => {
+		assert.strictEqual(
+			styleText("Ready", { fg: rgbColor(18, 52, 86), bg: indexedColor(9), bold: true }, "truecolor"),
+			"\x1b[38;2;18;52;86m\x1b[48;5;9m\x1b[1mReady\x1b[22m\x1b[49m\x1b[39m",
+		);
+		assert.strictEqual(styleText("Ready", { fg: rgbColor(18, 52, 86), bold: true }, "none"), "Ready");
+	});
+});

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -370,8 +370,21 @@ describe("detectCapabilities", () => {
 		withEnv({ COLORTERM: "truecolor", TMUX: "/tmp/tmux-1000/default,1234,0", TERM: "tmux-256color" }, () => {
 			const caps = detectCapabilities(() => false);
 			assert.strictEqual(caps.trueColor, true);
+			assert.strictEqual(caps.colorMode, "truecolor");
 			assert.strictEqual(caps.hyperlinks, false);
 			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("detects 256-color, basic-color, and colorless terminals", () => {
+		withEnv({ TERM: "xterm-256color" }, () => {
+			assert.strictEqual(detectCapabilities().colorMode, "256color");
+		});
+		withEnv({ TERM: "linux" }, () => {
+			assert.strictEqual(detectCapabilities().colorMode, "16color");
+		});
+		withEnv({ TERM: "dumb" }, () => {
+			assert.strictEqual(detectCapabilities().colorMode, "none");
 		});
 	});
 });


### PR DESCRIPTION
This greatly refactors the TUI and theme support to expose colors directly.  This is both useful so that an agent can be a bit more adventurous with styling (eg: color math) but also to support non Terminal user interfaces later down the line.

It leaves the old API around for backwards compat.  The API is slightly less concise, but that's because the obvious old names are taken.

**Before:**

```ts
theme.fg("success", "Done")
```

**After:**

```ts
style("Done", { fg: "success" })
```

The old form remains supported and dispatches through the new style system.  We support color tokens everywhere there, but you can now also pass there colors directly.

**Before:**

```ts
theme.bg(
  "toolSuccessBg",
  theme.fg("success", theme.bold("Done")),
)
```

**After:**

```ts
style("Done", {
  fg: "success",
  bg: "toolSuccessBg",
  bold: true,
})
```

You can now intentionally use any token in either position.  Previously, foreground and background tokens were separate types.  That allows you to use them inverse.

```ts
style("Status", {
  fg: "toolSuccessBg",
})
```

The reverse also works:

```ts
style("Status", {
  bg: "success",
})
```

You can nnow use a concrete color.  Previously that wasn't really possible.

**Before:**

```ts
const text = "\x1b[38;2;255;0;128mStatus\x1b[39m";
```

**After:**

```ts
const pink = parseColor("#ff0080");

const text = style("Status", {
  fg: pink,
})
```

This automatically falls back to 256-color, ANSI-16, or uncolored output.

OKLCH works too:

```ts
const pink = parseColor("oklch(65% 0.25 350)");
```

## 5. Use a theme color outside the terminal

Before, the public result was an ANSI sequence:

```ts
const accent = theme.getFgAnsi("accent");
// "\x1b[38;2;138;190;183m"
```

That is not useful for HTML, GUI rendering, image generation, or color calculations.  Now the underlying color is available:

```ts
const accent = theme.colors.accent;
const cssColor = colorToHex(accent);
const rgb = colorToRgb(accent);
```

For example:

```ts
const html = `<span style="color: ${colorToHex(theme.colors.accent)}">Status</span>`;
```

There is now also `mixColors()` which allows color mixing and defaults to perceptual OKLCH mixing:

```ts
const foreground = mixColors(
  theme.colors.success,
  theme.colors.toolSuccessBg,
  0.2,
);

const text = style("Done", {
  fg: foreground,
  bg: "toolSuccessBg",
  bold: true,
});
```

The amount is:

- `0` — entirely the first color
- `0.5` — equal mixture
- `1` — entirely the second color

sRGB mixing is also available:

```ts
const mixed = mixColors(first, second, 0.5, "srgb");
```

The same computed color can be used in non-TUI output:

```ts
const mixed = mixColors(
  theme.colors.accent,
  theme.colors.userMessageBg,
  0.3,
);

const terminalText = style("Accent", { fg: mixed });
const cssColor = colorToHex(mixed);
```

Note that `style` is in `pi-coding-agent` that is theme token aware, but there is a generic `styleText` that does not.