### PR TITLE
feat(settings-selector): show & make default searchable for model and thinking

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -28,6 +28,11 @@ interface ScopedModelItem {
 	thinkingLevel?: string;
 }
 
+interface DefaultModelReference {
+	provider: string;
+	id: string;
+}
+
 type ModelScope = "all" | "scoped";
 
 /**
@@ -61,6 +66,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private refreshStatusSuccess = false;
 	private tui: TUI;
 	private scopedModels: ReadonlyArray<ScopedModelItem>;
+	private defaultModel?: DefaultModelReference;
 	private scope: ModelScope = "all";
 	private scopeText?: Text;
 	private scopeHintText?: Text;
@@ -77,6 +83,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		onCancel: () => void,
 		initialSearchInput?: string,
 		onSelectAsDefault?: (model: Model<any>) => void,
+		defaultModel?: DefaultModelReference,
 	) {
 		super();
 
@@ -84,6 +91,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.currentModel = currentModel;
 		this.modelRuntime = modelRuntime;
 		this.scopedModels = scopedModels;
+		this.defaultModel = defaultModel;
 		this.scope = scopedModels.length > 0 ? "scoped" : "all";
 		this.onSelectCallback = onSelect;
 		this.onSelectAsDefaultCallback = onSelectAsDefault;
@@ -237,6 +245,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		return keyHint("tui.input.tab", "scope") + theme.fg("muted", " (all/scoped)");
 	}
 
+	private isDefaultModel(model: Model<any>): boolean {
+		return this.defaultModel?.provider === model.provider && this.defaultModel.id === model.id;
+	}
+
 	private setScope(scope: ModelScope): void {
 		if (this.scope === scope) return;
 		this.scope = scope;
@@ -250,11 +262,24 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private filterModels(query: string): void {
-		this.filteredModels = query
-			? fuzzyFilter(this.activeModels, query, ({ id, provider, model }) =>
-					getModelSelectorSearchText({ id, provider, name: model.name }),
-				)
-			: this.activeModels;
+		if (query) {
+			const filtered = fuzzyFilter(this.activeModels, query, (item) => {
+				const defaultText = this.isDefaultModel(item.model) ? " default startup" : "";
+				return `${getModelSelectorSearchText({ id: item.id, provider: item.provider, name: item.model.name })}${defaultText}`;
+			});
+			if (/\b(default|startup)\b/iu.test(query)) {
+				const defaultItems = this.activeModels.filter((item) => this.isDefaultModel(item.model));
+				const defaultKeys = new Set(defaultItems.map((item) => `${item.provider}\0${item.id}`));
+				this.filteredModels = [
+					...defaultItems,
+					...filtered.filter((item) => !defaultKeys.has(`${item.provider}\0${item.id}`)),
+				];
+			} else {
+				this.filteredModels = filtered;
+			}
+		} else {
+			this.filteredModels = this.activeModels;
+		}
 		// When filtering by a query, move the selector to the top row so the best
 		// match is highlighted. When the query is cleared, keep the current position
 		// clamped to the (restored) list length.
@@ -279,6 +304,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 			const isSelected = i === this.selectedIndex;
 			const isCurrent = modelsAreEqual(this.currentModel, item.model);
+			const isDefault = this.isDefaultModel(item.model);
+			const defaultBadge = isDefault ? theme.fg("muted", " · default") : "";
 
 			let line = "";
 			if (isSelected) {
@@ -286,12 +313,12 @@ export class ModelSelectorComponent extends Container implements Focusable {
 				const modelText = `${item.id}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
-				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${checkmark}`;
+				line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${defaultBadge}${checkmark}`;
 			} else {
 				const modelText = `  ${item.id}`;
 				const providerBadge = theme.fg("muted", `[${item.provider}]`);
 				const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
-				line = `${modelText} ${providerBadge}${checkmark}`;
+				line = `${modelText} ${providerBadge}${defaultBadge}${checkmark}`;
 			}
 
 			this.listContainer.addChild(new Text(line, 0, 0));

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -2,6 +2,9 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import {
 	Container,
 	type Focusable,
+	fuzzyFilter,
+	getKeybindings,
+	Input,
 	matchesKey,
 	type SelectItem,
 	SelectList,
@@ -32,7 +35,12 @@ const LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
  * Component that renders a thinking level selector with borders
  */
 export class ThinkingSelectorComponent extends Container implements Focusable {
+	private searchInput: Input;
 	private selectList: SelectList;
+	private selectListChildIndex: number;
+	private allItems: SelectItem[];
+	private onSelect: (level: ThinkingLevel) => void;
+	private onCancel: () => void;
 	private onSelectAsDefault?: (level: ThinkingLevel) => void;
 	private _focused = false;
 
@@ -42,6 +50,7 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 
 	set focused(value: boolean) {
 		this._focused = value;
+		this.searchInput.focused = value;
 	}
 
 	constructor(
@@ -50,14 +59,18 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 		onSelect: (level: ThinkingLevel) => void,
 		onCancel: () => void,
 		onSelectAsDefault?: (level: ThinkingLevel) => void,
+		defaultThinkingLevel?: ThinkingLevel,
 	) {
 		super();
+		this.onSelect = onSelect;
+		this.onCancel = onCancel;
 		this.onSelectAsDefault = onSelectAsDefault;
 
-		const thinkingLevels: SelectItem[] = availableLevels.map((level) => ({
+		this.allItems = availableLevels.map((level) => ({
 			value: level,
 			label: level,
-			description: LEVEL_DESCRIPTIONS[level],
+			description:
+				level === defaultThinkingLevel ? `${LEVEL_DESCRIPTIONS[level]} · default` : LEVEL_DESCRIPTIONS[level],
 		}));
 
 		// Add top border
@@ -68,34 +81,41 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 		this.addChild(new Text(`${keyDisplayText("app.thinking.cycle")} cycles thinking levels in-session`, 0, 0));
 		this.addChild(new Spacer(1));
 
+		this.searchInput = new Input();
+		this.searchInput.onSubmit = () => this.selectList.handleInput("\r");
+		this.addChild(this.searchInput);
+		this.addChild(new Spacer(1));
+
 		// Create selector
-		this.selectList = new SelectList(
-			thinkingLevels,
-			thinkingLevels.length,
-			getSelectListTheme(),
-			THINKING_SELECT_LIST_LAYOUT,
-		);
-
-		// Preselect current level
-		const currentIndex = thinkingLevels.findIndex((item) => item.value === currentLevel);
-		if (currentIndex !== -1) {
-			this.selectList.setSelectedIndex(currentIndex);
-		}
-
-		this.selectList.onSelect = (item) => {
-			onSelect(item.value as ThinkingLevel);
-		};
-
-		this.selectList.onCancel = () => {
-			onCancel();
-		};
-
+		this.selectList = this.buildSelectList(this.allItems, currentLevel);
+		this.selectListChildIndex = this.children.length;
 		this.addChild(this.selectList);
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("dim", "  Enter to select · Ctrl+S to set as default · Esc to cancel"), 0, 0));
 
 		// Add bottom border
 		this.addChild(new DynamicBorder());
+	}
+
+	private buildSelectList(items: SelectItem[], preselect?: ThinkingLevel): SelectList {
+		const list = new SelectList(items, Math.max(1, items.length), getSelectListTheme(), THINKING_SELECT_LIST_LAYOUT);
+		const currentIndex = items.findIndex((item) => item.value === preselect);
+		if (currentIndex !== -1) {
+			list.setSelectedIndex(currentIndex);
+		}
+		list.onSelect = (item) => this.onSelect(item.value as ThinkingLevel);
+		list.onCancel = () => this.onCancel();
+		return list;
+	}
+
+	private applyFilter(query: string): void {
+		const filtered = query
+			? fuzzyFilter(this.allItems, query, (item) => `${item.label} ${item.description ?? ""}`)
+			: this.allItems;
+		const selectedValue = this.selectList.getSelectedItem()?.value as ThinkingLevel | undefined;
+		const newList = this.buildSelectList(filtered, selectedValue);
+		this.children[this.selectListChildIndex] = newList;
+		this.selectList = newList;
 	}
 
 	handleInput(keyData: string): void {
@@ -105,7 +125,19 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 			return;
 		}
 
-		this.selectList.handleInput(keyData);
+		const kb = getKeybindings();
+		const isNav =
+			kb.matches(keyData, "tui.select.up") ||
+			kb.matches(keyData, "tui.select.down") ||
+			kb.matches(keyData, "tui.select.confirm") ||
+			kb.matches(keyData, "tui.select.cancel");
+		if (isNav) {
+			this.selectList.handleInput(keyData);
+			return;
+		}
+
+		this.searchInput.handleInput(keyData);
+		this.applyFilter(this.searchInput.getValue());
 	}
 
 	getSelectList(): SelectList {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4791,6 +4791,7 @@ export class InteractiveMode {
 					this.ui.requestRender();
 				},
 				(level) => selectLevel(level, true),
+				this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL,
 			);
 			return { component: selector, focus: selector };
 		});
@@ -4961,6 +4962,8 @@ export class InteractiveMode {
 					this.showError(error instanceof Error ? error.message : String(error));
 				}
 			};
+			const defaultProvider = this.settingsManager.getDefaultProvider();
+			const defaultModel = this.settingsManager.getDefaultModel();
 			const selector = new ModelSelectorComponent(
 				this.ui,
 				this.session.model,
@@ -4973,6 +4976,7 @@ export class InteractiveMode {
 				},
 				initialSearchInput,
 				(model) => selectModel(model, true),
+				defaultProvider && defaultModel ? { provider: defaultProvider, id: defaultModel } : undefined,
 			);
 			return { component: selector, focus: selector, dispose: () => selector.dispose() };
 		});


### PR DESCRIPTION
Since we now use ctrl + S hotkey to save/ persist model and thinking to settings, I added a default label in `/model` and `/thinking` to make it clear, and made default searchable as a word.

https://github.com/user-attachments/assets/2fba4b49-444c-49b3-9af2-b715f7e86c23

