### PR TITLE
FD-2120: Normalize kimi-coding thinking signatures to base64url

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -1117,6 +1117,18 @@ function normalizeToolCallId(id: string): string {
 	return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
+/**
+ * Convert a standard base64 string to unpadded base64url.
+ *
+ * Some Anthropic-compatible providers (notably kimi-coding) return thinking
+ * signatures as standard base64, but their request validator expects
+ * base64url on replay. The bytes are identical; only the textual encoding
+ * differs. This helper is idempotent for strings that are already base64url.
+ */
+function base64ToBase64Url(base64: string): string {
+	return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
 function convertToolResult(
 	msg: ToolResultMessage,
 	isOAuthToken: boolean,
@@ -1219,7 +1231,7 @@ function convertMessages(
 					if (block.redacted) {
 						blocks.push({
 							type: "redacted_thinking",
-							data: block.thinkingSignature!,
+							data: base64ToBase64Url(block.thinkingSignature!),
 						});
 						continue;
 					}
@@ -1246,7 +1258,7 @@ function convertMessages(
 						blocks.push({
 							type: "thinking",
 							thinking: sanitizeSurrogates(block.thinking),
-							signature: thinkingSignature,
+							signature: base64ToBase64Url(thinkingSignature),
 						});
 					}
 				} else if (block.type === "toolCall") {

--- a/packages/ai/test/kimi-coding-thinking-signature.test.ts
+++ b/packages/ai/test/kimi-coding-thinking-signature.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import type { Context, Model } from "../src/types.ts";
+
+const mockState = vi.hoisted(() => ({
+	createParams: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	function createSseResponse(): Response {
+		const body = [
+			`event: message_start\ndata: ${JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "msg_test",
+					usage: { input_tokens: 10, output_tokens: 0 },
+				},
+			})}\n`,
+			`event: content_block_start\ndata: ${JSON.stringify({
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "text", text: "ok" },
+			})}\n`,
+			`event: content_block_delta\ndata: ${JSON.stringify({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "ok" },
+			})}\n`,
+			`event: content_block_stop\ndata: ${JSON.stringify({
+				type: "content_block_stop",
+				index: 0,
+			})}\n`,
+			`event: message_delta\ndata: ${JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 1 },
+			})}\n`,
+		].join("\n");
+
+		return new Response(body, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	}
+
+	class FakeAnthropic {
+		messages = {
+			create: (params: Record<string, unknown>) => {
+				mockState.createParams = params;
+				return {
+					asResponse: async () => createSseResponse(),
+				};
+			},
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+describe("kimi-coding thinking signature encoding", () => {
+	const model = {
+		id: "kimi-for-coding",
+		name: "Kimi For Coding",
+		api: "anthropic-messages",
+		provider: "kimi-coding",
+		baseUrl: "https://api.kimi.com/coding",
+		reasoning: true,
+		input: ["text"],
+		output: ["text"],
+		contextWindow: 200000,
+		maxTokens: 8192,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		compat: {
+			supportsEagerToolInputStreaming: true,
+			supportsLongCacheRetention: false,
+			supportsCacheControlOnTools: true,
+			supportsTemperature: true,
+			allowEmptySignature: false,
+			supportsStrictTools: false,
+			supportsToolReferences: false,
+		},
+	} as Model<"anthropic-messages">;
+
+	it("converts thinking signatures from base64 to base64url on replay", async () => {
+		const base64Signature = "F31Ns+5lg+HZ/B2HKQwlNw==";
+		const base64UrlSignature = "F31Ns-5lg-HZ_B2HKQwlNw";
+
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "text", text: "Do something" }],
+					timestamp: 1,
+				},
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "thinking",
+							thinking: "planning...",
+							thinkingSignature: base64Signature,
+						},
+						{
+							type: "toolCall",
+							id: "tool_1",
+							name: "bash",
+							arguments: { command: "echo hi" },
+						},
+					],
+					api: "anthropic-messages",
+					provider: "kimi-coding",
+					model: "kimi-for-coding",
+					usage: {
+						input: 10,
+						output: 5,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 15,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "toolUse",
+					timestamp: 2,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "tool_1",
+					toolName: "bash",
+					content: [{ type: "text", text: "hi" }],
+					isError: false,
+					timestamp: 3,
+				},
+			],
+		};
+
+		const s = streamAnthropic(model, context, {
+			apiKey: "kimi_api_key_test",
+			thinkingEnabled: true,
+			thinkingBudgetTokens: 1024,
+		});
+		for await (const event of s) {
+			if (event.type === "error") break;
+		}
+
+		const params = mockState.createParams!;
+		expect(params).toBeDefined();
+
+		const messages = params.messages as Array<{ role: string; content: unknown }>;
+		const assistantMessage = messages.find((m) => m.role === "assistant");
+		expect(assistantMessage).toBeDefined();
+
+		const content = assistantMessage!.content as Array<{ type: string; signature?: string; data?: string }>;
+		const thinkingBlock = content.find((c) => c.type === "thinking");
+		expect(thinkingBlock).toBeDefined();
+		expect(thinkingBlock!.signature).toBe(base64UrlSignature);
+	});
+
+	it("converts redacted thinking signatures from base64 to base64url on replay", async () => {
+		const base64Signature = "a+b/c==";
+		const base64UrlSignature = "a-b_c";
+
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "thinking",
+							thinking: "[Reasoning redacted]",
+							thinkingSignature: base64Signature,
+							redacted: true,
+						},
+					],
+					api: "anthropic-messages",
+					provider: "kimi-coding",
+					model: "kimi-for-coding",
+					usage: {
+						input: 10,
+						output: 5,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 15,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: 1,
+				},
+				{
+					role: "user",
+					content: [{ type: "text", text: "Next" }],
+					timestamp: 2,
+				},
+			],
+		};
+
+		const s = streamAnthropic(model, context, {
+			apiKey: "kimi_api_key_test",
+			thinkingEnabled: true,
+			thinkingBudgetTokens: 1024,
+		});
+		for await (const event of s) {
+			if (event.type === "error") break;
+		}
+
+		const params = mockState.createParams!;
+		const messages = params.messages as Array<{ role: string; content: unknown }>;
+		const assistantMessage = messages.find((m) => m.role === "assistant");
+		expect(assistantMessage).toBeDefined();
+
+		const content = assistantMessage!.content as Array<{ type: string; signature?: string; data?: string }>;
+		const redactedBlock = content.find((c) => c.type === "redacted_thinking");
+		expect(redactedBlock).toBeDefined();
+		expect(redactedBlock!.data).toBe(base64UrlSignature);
+	});
+});


### PR DESCRIPTION
## Problem

The `kimi-coding` provider frequently fails on the second+ turn of a reasoning-enabled conversation with:

```
Error: 400 {"error":{"type":"invalid_request_error","message":"messages.1.content.0.signature: malformed encrypted reasoning content: invalid base64url encoding"},"type":"error"}
```

This happens after a tool result is returned and the assistant's previous `thinking` block (with its `thinkingSignature`) is replayed to the API.

## Root cause

The Kimi coding endpoint returns thinking signatures as standard **base64** (`+`, `/`), but its request validator expects **base64url** (`-`, `_`) on replay. pi's `anthropic-messages` converter passed the signature through unchanged.

## Fix

Convert standard base64 signatures to unpadded base64url when building Anthropic Messages params for both `thinking` and `redacted_thinking` blocks. The byte content is identical; only the textual encoding changes. The helper is idempotent for strings already in base64url.

```ts
function base64ToBase64Url(base64: string): string {
  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
}
```

## Tests

Added `packages/ai/test/kimi-coding-thinking-signature.test.ts` covering:
- A standard `thinking` block with a base64 signature is normalized to base64url.
- A `redacted_thinking` block with a base64 signature is normalized to base64url.

## Related

- Linear: [FD-2120](https://linear.app/foragedata/issue/FD-2120/fix-kimi-coding-thinking-signature-base64url-error)
