### PR TITLE
fix(tui): preserve logical lines when copying soft-wrapped text

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -319,7 +319,7 @@ export class Markdown implements Component {
 			if (isImageLine(line)) {
 				wrappedLines.push(line);
 			} else {
-				for (const wrappedLine of wrapTextWithAnsi(line, contentWidth)) {
+				for (const wrappedLine of wrapTextWithAnsi(line, contentWidth, { softWrapMarkers: true })) {
 					wrappedLines.push(wrappedLine);
 				}
 			}
@@ -591,7 +591,7 @@ export class Markdown implements Component {
 
 				for (const quoteLine of renderedQuoteLines) {
 					const styledLine = applyQuoteStyle(quoteLine);
-					const wrappedLines = wrapTextWithAnsi(styledLine, quoteContentWidth);
+					const wrappedLines = wrapTextWithAnsi(styledLine, quoteContentWidth, { softWrapMarkers: true });
 					for (const wrappedLine of wrappedLines) {
 						lines.push(this.theme.quoteBorder("│ ") + wrappedLine);
 					}
@@ -785,7 +785,7 @@ export class Markdown implements Component {
 
 				const itemLines = this.renderToken(itemToken, itemWidth, undefined, styleContext);
 				for (const line of itemLines) {
-					for (const wrappedLine of wrapTextWithAnsi(line, itemWidth)) {
+					for (const wrappedLine of wrapTextWithAnsi(line, itemWidth, { softWrapMarkers: true })) {
 						const linePrefix = renderedAnyLine ? continuationPrefix : firstPrefix;
 						lines.push(linePrefix + wrappedLine);
 						renderedAnyLine = true;
@@ -858,7 +858,7 @@ export class Markdown implements Component {
 		const availableForCells = availableWidth - borderOverhead;
 		if (availableForCells < numCols) {
 			// Too narrow to render a stable table. Fall back to raw markdown.
-			const fallbackLines = token.raw ? wrapTextWithAnsi(token.raw, availableWidth) : [];
+			const fallbackLines = token.raw ? wrapTextWithAnsi(token.raw, availableWidth, { softWrapMarkers: true }) : [];
 			if (nextTokenType && nextTokenType !== "space") {
 				fallbackLines.push("");
 			}

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -167,7 +167,7 @@ export class SettingsList implements Component {
 		const selectedItem = displayItems[this.selectedIndex];
 		if (selectedItem?.description) {
 			lines.push("");
-			const wrappedDesc = wrapTextWithAnsi(selectedItem.description, width - 4);
+			const wrappedDesc = wrapTextWithAnsi(selectedItem.description, width - 4, { softWrapMarkers: true });
 			for (const line of wrappedDesc) {
 				lines.push(this.theme.description(`  ${line}`));
 			}

--- a/packages/tui/src/components/text.ts
+++ b/packages/tui/src/components/text.ts
@@ -64,8 +64,8 @@ export class Text implements Component {
 		const paddingX = Math.min(this.paddingX, Math.max(0, Math.floor((width - 1) / 2)));
 		const contentWidth = Math.max(1, width - paddingX * 2);
 
-		// Wrap text (this preserves ANSI codes but does NOT pad)
-		const wrappedLines = wrapTextWithAnsi(normalizedText, contentWidth);
+		// Wrap text (this preserves ANSI codes and soft wrap markers but does NOT pad)
+		const wrappedLines = wrapTextWithAnsi(normalizedText, contentWidth, { softWrapMarkers: true });
 
 		// Add margins and background to each line
 		const leftMargin = " ".repeat(paddingX);

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -139,9 +139,12 @@ export { TuiMainScreen, type TuiMainScreenRenderState } from "./tui-main-screen.
 // Utilities
 export {
 	getOsc8LinkAtColumn,
+	SOFT_WRAP_BREAK_MARKER,
+	SOFT_WRAP_SPACE_MARKER,
 	sliceByColumn,
 	stripTerminalSequences,
 	truncateToWidth,
 	visibleWidth,
+	type WrapTextOptions,
 	wrapTextWithAnsi,
 } from "./utils.ts";

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -43,6 +43,8 @@ import {
 	getGraphemeCellRange,
 	getOsc8LinkAtColumn,
 	getWordSegmenter,
+	SOFT_WRAP_BREAK_MARKER,
+	SOFT_WRAP_SPACE_MARKER,
 	sliceByColumn,
 	stripTerminalSequences,
 	visibleWidth,
@@ -1070,17 +1072,35 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 			if (!box?.scrollContentLines) return;
 			sourceLines = box.scrollContentLines;
 		}
-		const lines: string[] = [];
+		let text = "";
+		let previousSoftWrap: "space" | "break" | undefined;
 		for (let row = selection.start.row; row <= selection.end.row; row++) {
 			const line = sourceLines[row] ?? "";
 			const columns = this.getSelectionColumns(line, row, selection);
-			lines.push(
-				stripTerminalSequences(
-					sliceByColumn(line, columns.start, Math.max(0, columns.end - columns.start), true),
-				).trimEnd(),
-			);
+			const sliced = sliceByColumn(line, columns.start, Math.max(0, columns.end - columns.start), true);
+			let extracted = stripTerminalSequences(sliced).trimEnd();
+			if (previousSoftWrap) {
+				extracted = extracted.trimStart();
+			}
+			if (row === selection.start.row) {
+				text = extracted;
+			} else if (previousSoftWrap === "space") {
+				text += (text.length > 0 && extracted.length > 0 ? " " : "") + extracted;
+			} else if (previousSoftWrap === "break") {
+				text += extracted;
+			} else {
+				text += `\n${extracted}`;
+			}
+			if (row < selection.end.row) {
+				if (line.includes(SOFT_WRAP_SPACE_MARKER)) {
+					previousSoftWrap = "space";
+				} else if (line.includes(SOFT_WRAP_BREAK_MARKER)) {
+					previousSoftWrap = "break";
+				} else {
+					previousSoftWrap = undefined;
+				}
+			}
 		}
-		const text = lines.join("\n");
 		if (text.length === 0) return;
 		// Prefer an injected clipboard implementation (native clipboard + platform tools with a
 		// verified success path) when the host app provides one. A bare OSC 52 write can show

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -818,6 +818,13 @@ function splitIntoTokensWithAnsi(text: string): string[] {
 	return tokens;
 }
 
+export const SOFT_WRAP_SPACE_MARKER = "\x1b_pi:ws\x07";
+export const SOFT_WRAP_BREAK_MARKER = "\x1b_pi:wb\x07";
+
+export interface WrapTextOptions {
+	softWrapMarkers?: boolean;
+}
+
 /**
  * Wrap text with ANSI codes preserved.
  *
@@ -827,12 +834,15 @@ function splitIntoTokensWithAnsi(text: string): string[] {
  *
  * @param text - Text to wrap (may contain ANSI codes and newlines)
  * @param width - Maximum visible width per line
+ * @param options - Optional wrapping options (e.g. softWrapMarkers)
  * @returns Array of wrapped lines (NOT padded to width)
  */
-export function wrapTextWithAnsi(text: string, width: number): string[] {
+export function wrapTextWithAnsi(text: string, width: number, options?: WrapTextOptions): string[] {
 	if (!text) {
 		return [""];
 	}
+
+	const softWrapMarkers = options?.softWrapMarkers ?? false;
 
 	// Handle newlines by processing each line separately
 	// Track ANSI state across lines so styles carry over after literal newlines
@@ -843,7 +853,7 @@ export function wrapTextWithAnsi(text: string, width: number): string[] {
 	for (const inputLine of inputLines) {
 		// Prepend active ANSI codes from previous lines (except for first line)
 		const prefix = result.length > 0 ? tracker.getActiveCodes() : "";
-		const wrappedLines = wrapSingleLine(prefix + inputLine, width);
+		const wrappedLines = wrapSingleLine(prefix + inputLine, width, softWrapMarkers);
 		for (const wrappedLine of wrappedLines) {
 			result.push(wrappedLine);
 		}
@@ -854,7 +864,7 @@ export function wrapTextWithAnsi(text: string, width: number): string[] {
 	return result.length > 0 ? result : [""];
 }
 
-function wrapSingleLine(line: string, width: number): string[] {
+function wrapSingleLine(line: string, width: number, softWrapMarkers = false): string[] {
 	if (!line) {
 		return [""];
 	}
@@ -883,17 +893,17 @@ function wrapSingleLine(line: string, width: number): string[] {
 				if (lineEndReset) {
 					currentLine += lineEndReset;
 				}
-				wrapped.push(currentLine);
+				wrapped.push(currentLine + (softWrapMarkers ? SOFT_WRAP_SPACE_MARKER : ""));
 				currentLine = "";
 				currentVisibleLength = 0;
 			}
 
 			// Break long token - breakLongWord handles its own resets
-			const broken = breakLongWord(token, width, tracker);
+			const broken = breakLongWord(token, width, tracker, softWrapMarkers);
 			for (let i = 0; i < broken.length - 1; i++) {
 				wrapped.push(broken[i]!);
 			}
-			currentLine = broken[broken.length - 1];
+			currentLine = broken[broken.length - 1]!;
 			currentVisibleLength = visibleWidth(currentLine);
 			continue;
 		}
@@ -908,7 +918,7 @@ function wrapSingleLine(line: string, width: number): string[] {
 			if (lineEndReset) {
 				lineToWrap += lineEndReset;
 			}
-			wrapped.push(lineToWrap);
+			wrapped.push(lineToWrap + (softWrapMarkers ? SOFT_WRAP_SPACE_MARKER : ""));
 			if (isWhitespace) {
 				// Don't start new line with whitespace
 				currentLine = tracker.getActiveCodes();
@@ -951,7 +961,7 @@ export function isPunctuationChar(char: string): boolean {
 	return PUNCTUATION_REGEX.test(char);
 }
 
-function breakLongWord(word: string, width: number, tracker: AnsiCodeTracker): string[] {
+function breakLongWord(word: string, width: number, tracker: AnsiCodeTracker, softWrapMarkers = false): string[] {
 	const lines: string[] = [];
 	let currentLine = tracker.getActiveCodes();
 	let currentWidth = 0;
@@ -1003,7 +1013,7 @@ function breakLongWord(word: string, width: number, tracker: AnsiCodeTracker): s
 			if (lineEndReset) {
 				currentLine += lineEndReset;
 			}
-			lines.push(currentLine);
+			lines.push(currentLine + (softWrapMarkers ? SOFT_WRAP_BREAK_MARKER : ""));
 			currentLine = tracker.getActiveCodes();
 			currentWidth = 0;
 		}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -6,6 +6,7 @@ import { Markdown, type MarkdownTheme } from "../src/components/markdown.ts";
 import { resetCapabilitiesCache, setCapabilities } from "../src/terminal-image.ts";
 import type { Component, TUI } from "../src/tui.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
+import { stripTerminalSequences } from "../src/utils.ts";
 import { defaultMarkdownTheme } from "./test-themes.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
@@ -23,7 +24,7 @@ function getCell(terminal: VirtualTerminal, row: number, col: number) {
 }
 
 function stripAnsi(line: string): string {
-	return line.replace(/\x1b\[[0-9;]*m/g, "");
+	return stripTerminalSequences(line);
 }
 
 describe("Markdown component", () => {

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { findAltScreenSearchMatches } from "../src/alt-screen-search.ts";
 import { HStack } from "../src/components/h-stack.ts";
 import { Image } from "../src/components/image.ts";
+import { Markdown } from "../src/components/markdown.ts";
 import { ScrollView } from "../src/components/scroll-view.ts";
 import { Text } from "../src/components/text.ts";
 import { VStack } from "../src/components/v-stack.ts";
@@ -15,6 +16,7 @@ import {
 	setCapabilities,
 } from "../src/terminal-image.ts";
 import { TuiAltScreen } from "../src/tui-alt-screen.ts";
+import { defaultMarkdownTheme } from "./test-themes.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
@@ -969,6 +971,120 @@ describe("TuiAltScreen", () => {
 		);
 		assert.ok(terminal.getViewport().some((line) => line.includes("Copied!")));
 
+		tui.stop();
+	});
+
+	it("copies soft-wrapped lines as one logical line", async () => {
+		const terminal = new RecordingTerminal(20, 3);
+		const copied: string[] = [];
+		const tui = new TuiAltScreen(terminal, undefined, undefined, {
+			copySelection: async (text) => {
+				copied.push(text);
+				return true;
+			},
+		});
+		tui.addChild(new Text("alpha beta gamma delta epsilon", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;20;2M");
+		terminal.sendInput("\x1b[<0;20;2m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copied, ["alpha beta gamma delta epsilon"]);
+		tui.stop();
+	});
+
+	it("copies unbroken words broken across lines without inserting spaces", async () => {
+		const terminal = new RecordingTerminal(20, 3);
+		const copied: string[] = [];
+		const tui = new TuiAltScreen(terminal, undefined, undefined, {
+			copySelection: async (text) => {
+				copied.push(text);
+				return true;
+			},
+		});
+		tui.addChild(new Text("https://example.com/very/long/path", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;20;2M");
+		terminal.sendInput("\x1b[<0;20;2m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copied, ["https://example.com/very/long/path"]);
+		tui.stop();
+	});
+
+	it("copies markdown paragraphs with soft-wrapping and preserves explicit paragraph breaks", async () => {
+		const terminal = new RecordingTerminal(25, 6);
+		const copied: string[] = [];
+		const tui = new TuiAltScreen(terminal, undefined, undefined, {
+			copySelection: async (text) => {
+				copied.push(text);
+				return true;
+			},
+		});
+		tui.addChild(
+			new Markdown("First paragraph that is long enough to wrap.\n\nSecond paragraph.", 0, 0, defaultMarkdownTheme),
+		);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;25;4M");
+		terminal.sendInput("\x1b[<0;25;4m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copied, ["First paragraph that is long enough to wrap.\n\nSecond paragraph."]);
+		tui.stop();
+	});
+
+	it("copies code blocks preserving indentation and newlines", async () => {
+		const terminal = new RecordingTerminal(30, 8);
+		const copied: string[] = [];
+		const tui = new TuiAltScreen(terminal, undefined, undefined, {
+			copySelection: async (text) => {
+				copied.push(text);
+				return true;
+			},
+		});
+		tui.addChild(new Markdown("```js\nfunction foo() {\n  return 42;\n}\n```", 0, 0, defaultMarkdownTheme));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;30;5M");
+		terminal.sendInput("\x1b[<0;30;5m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copied, ["```js\n  function foo() {\n    return 42;\n  }\n```"]);
+		tui.stop();
+	});
+
+	it("copies soft-wrapped list items preserving bullet and without continuation indentation", async () => {
+		const terminal = new RecordingTerminal(25, 6);
+		const copied: string[] = [];
+		const tui = new TuiAltScreen(terminal, undefined, undefined, {
+			copySelection: async (text) => {
+				copied.push(text);
+				return true;
+			},
+		});
+		tui.addChild(
+			new Markdown("- First item that is long enough to wrap.\n- Second item.", 0, 0, defaultMarkdownTheme),
+		);
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<0;1;1M");
+		terminal.sendInput("\x1b[<32;25;3M");
+		terminal.sendInput("\x1b[<0;25;3m");
+		await terminal.waitForRender();
+
+		assert.deepStrictEqual(copied, ["- First item that is long enough to wrap.\n- Second item."]);
 		tui.stop();
 	});
 


### PR DESCRIPTION
## Summary

In fullscreen TUI mode (`TuiAltScreen`), copying mouse selections joins visual rows with `lines.join("\n")`. This converts viewport-induced soft line wraps into hard newlines in the clipboard, breaking paragraphs, URLs, and list items.

This PR preserves logical line boundaries during selection copy by tagging soft wraps with zero-width escape markers at the component wrapping layer, while keeping `Component.render(width): string[]` fully backward-compatible.

Addresses the root issue discussed in #5931, #8019, and addresses maintainer feedback from PR #7721.

## Problem & Prior Discussion

- **Issue #5931 / #8019**: Copying wrapped text inserts hard line breaks at visual terminal boundaries.
- **PR #7721 Feedback**: Previous attempts were closed over concerns that changing line representation or requiring custom components to adapt was too disruptive or risky.

## How This PR Solves It

1. **Non-Invasive Zero-Width Markers (`packages/tui/src/utils.ts`)**:
   - `wrapTextWithAnsi(text, width, options?: { softWrapMarkers?: boolean })` optionally embeds zero-width APC sequences:
     - `SOFT_WRAP_SPACE_MARKER` (`\x1b_pi:ws\x07`): soft wrap at whitespace.
     - `SOFT_WRAP_BREAK_MARKER` (`\x1b_pi:wb\x07`): soft wrap mid-token (e.g. unbroken URLs).
   - APC sequences are ignored by terminal emulators and stripped by `visibleWidth()`, `sliceByColumn()`, and `stripTerminalSequences()`.
   - `options` defaults to `{ softWrapMarkers: false }`, ensuring external callers and third-party components receive plain strings.

2. **Built-in Component Opt-In**:
   - `Markdown`, `Text`, and `SettingsList` pass `{ softWrapMarkers: true }` during text rendering.
   - Custom/external components returning plain `string[]` without markers continue to work normally and fall back to visual row breaks.

3. **Intelligent Selection Reconstruction (`packages/tui/src/tui-alt-screen.ts`)**:
   - `copySelectionToClipboard()` inspects row markers:
     - Rows ending with `SOFT_WRAP_SPACE_MARKER` join with a single space, stripping continuation margin/indentation.
     - Rows ending with `SOFT_WRAP_BREAK_MARKER` join without spaces.
     - Hard line breaks (paragraphs, code blocks, explicit `\n`) are preserved as `\n`.

## Testing

- Added unit tests in `packages/tui/test/tui-alt-screen.test.ts`:
  - Single sentences soft-wrapped across lines copy as a single continuous line.
  - Unbroken long URLs wrapped across lines copy without extra spaces.
  - Multi-paragraph Markdown preserves paragraph breaks while joining soft-wrapped lines.
  - Multiline code blocks preserve indentation and newlines.
  - Wrapped list items preserve bullet markers while unwrapping continuation lines.
- Verification:
  - `npm run check`
  - `./test.sh`
