### PR TITLE
fix(ai): omit reasoning effort for xAI Grok Build

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1194,6 +1194,7 @@ interface OpenAICompletionsCompat {
 
 interface OpenAIResponsesCompat {
   supportsDeveloperRole?: boolean;   // Whether provider supports `developer` role vs `system` (default: true)
+  supportsReasoningEffort?: boolean; // Whether provider supports `reasoning.effort` (default: true)
   sessionAffinityFormat?: 'openai' | 'openai-nosession' | 'openrouter'; // Session-affinity header format: 'openai' sends `session_id` and `x-client-request-id`; 'openai-nosession' sends `x-client-request-id`; 'openrouter' sends `x-session-id`. Does not affect the `prompt_cache_key` body param (default: auto-detected)
   supportsLongCacheRetention?: boolean; // Whether provider supports `prompt_cache_retention: "24h"` (default: true)
   supportsStrictMode?: boolean;      // Whether provider supports strict JSON-schema function tools (default: false; enabled in metadata for built-in OpenAI models)

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -855,9 +855,12 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	) {
 		mergeThinkingLevelMap(model, { off: "none" });
 	}
-	// xAI models without verified effort options (e.g. grok-build-0.1) must not
-	// send the undocumented "none"/"minimal" efforts.
-	if (model.provider === "xai" && model.api === "openai-responses" && model.thinkingLevelMap === undefined) {
+	if (model.provider === "xai" && model.api === "openai-responses" && model.id === "grok-build-0.1") {
+		// Grok Build reasons at a fixed level and rejects explicit reasoning effort.
+		mergeThinkingLevelMap(model, { off: null, minimal: null, low: null, medium: null });
+	} else if (model.provider === "xai" && model.api === "openai-responses" && model.thinkingLevelMap === undefined) {
+		// xAI models without verified effort options must not send undocumented
+		// "none"/"minimal" efforts.
 		mergeThinkingLevelMap(model, { off: null, minimal: null });
 	}
 	if (supportsOpenAiXhigh(model.id)) {
@@ -1734,7 +1737,10 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					api: "openai-responses",
 					provider: "xai",
 					baseUrl: "https://api.x.ai/v1",
-					compat: { ...XAI_RESPONSES_COMPAT },
+					compat: {
+						...XAI_RESPONSES_COMPAT,
+						...(modelId === "grok-build-0.1" ? { supportsReasoningEffort: false } : {}),
+					},
 					reasoning: m.reasoning === true,
 					input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
 					cost: {

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -68,6 +68,7 @@ function resolveCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEn
 function getCompat(model: Model<"openai-responses">): Required<OpenAIResponsesCompat> {
 	return {
 		supportsDeveloperRole: model.compat?.supportsDeveloperRole ?? true,
+		supportsReasoningEffort: model.compat?.supportsReasoningEffort ?? true,
 		sessionAffinityFormat: model.compat?.sessionAffinityFormat ?? detectSessionAffinityFormat(model),
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
 		supportsStrictMode: model.compat?.supportsStrictMode ?? false,
@@ -322,15 +323,21 @@ function buildParams(
 
 	if (model.reasoning) {
 		if (options?.reasoningEffort || options?.reasoningSummary) {
-			const effort = options?.reasoningEffort
-				? (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort)
-				: "medium";
+			const effort = (
+				options?.reasoningEffort
+					? (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort)
+					: "medium"
+			) as NonNullable<typeof params.reasoning>["effort"];
 			params.reasoning = {
-				effort: effort as NonNullable<typeof params.reasoning>["effort"],
+				...(compat.supportsReasoningEffort ? { effort } : {}),
 				summary: options?.reasoningSummary || "auto",
 			};
 			params.include = ["reasoning.encrypted_content"];
-		} else if (model.provider !== "github-copilot" && model.thinkingLevelMap?.off !== null) {
+		} else if (
+			compat.supportsReasoningEffort &&
+			model.provider !== "github-copilot" &&
+			model.thinkingLevelMap?.off !== null
+		) {
 			params.reasoning = {
 				effort: (model.thinkingLevelMap?.off ?? "none") as NonNullable<typeof params.reasoning>["effort"],
 			};

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -628,6 +628,8 @@ export interface OpenAICompletionsCompat {
 export interface OpenAIResponsesCompat {
 	/** Whether the provider supports the `developer` role (vs `system`). Default: true. */
 	supportsDeveloperRole?: boolean;
+	/** Whether the provider supports `reasoning.effort`. Default: true. */
+	supportsReasoningEffort?: boolean;
 	/** Session-affinity header format: `openai` sends `session_id` and `x-client-request-id`; `openai-nosession` sends `x-client-request-id`; `openrouter` sends `x-session-id`. Does not affect the `prompt_cache_key` body param, which is governed by cache retention. Default: auto-detected. */
 	sessionAffinityFormat?: SessionAffinityFormat;
 	/** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */

--- a/packages/ai/test/xai-responses.test.ts
+++ b/packages/ai/test/xai-responses.test.ts
@@ -6,7 +6,7 @@ import { stream as streamOpenAIResponses } from "../src/api/openai-responses.ts"
 import { getSupportedThinkingLevels } from "../src/models.ts";
 import { XAI_MODELS } from "../src/providers/xai.models.ts";
 import { xaiProvider } from "../src/providers/xai.ts";
-import type { Context, Model } from "../src/types.ts";
+import type { Context, Model, SimpleStreamOptions } from "../src/types.ts";
 
 const PI_USER_AGENT = `pi (${platform()} ${release()}; ${arch()})`;
 
@@ -107,6 +107,28 @@ async function captureRequest(
 	return captured!;
 }
 
+async function captureSimpleRequest(
+	model: Model<"openai-responses">,
+	context: Context,
+	options: SimpleStreamOptions,
+): Promise<CapturedRequest> {
+	let captured: CapturedRequest | undefined;
+	vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+		const request = new Request(input, init);
+		captured = {
+			url: request.url,
+			headers: request.headers,
+			body: JSON.parse(await request.clone().text()) as Record<string, unknown>,
+		};
+		return completedResponse();
+	});
+
+	const result = await xaiProvider().streamSimple(model, context, options).result();
+	expect(result.stopReason, result.errorMessage).toBe("stop");
+	expect(captured).toBeDefined();
+	return captured!;
+}
+
 describe("xAI Responses provider", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -131,7 +153,7 @@ describe("xAI Responses provider", () => {
 		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.5"])).toEqual(["low", "medium", "high"]);
 		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.6"])).toEqual(["low", "medium", "high", "xhigh"]);
 		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.3"])).toEqual(["off", "low", "medium", "high"]);
-		expect(getSupportedThinkingLevels(XAI_MODELS["grok-build-0.1"])).toEqual(["low", "medium", "high"]);
+		expect(getSupportedThinkingLevels(XAI_MODELS["grok-build-0.1"])).toEqual(["high"]);
 	});
 
 	it("uses /responses with bearer auth and xAI-compatible request fields", async () => {
@@ -185,6 +207,36 @@ describe("xAI Responses provider", () => {
 			include: ["reasoning.encrypted_content"],
 		});
 		expect(captured.body).not.toHaveProperty("reasoning");
+	});
+
+	it("omits reasoning effort for Grok Build while requesting encrypted reasoning", async () => {
+		const captured = await captureSimpleRequest(
+			XAI_MODELS["grok-build-0.1"],
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{ apiKey: "xai-test-token", reasoning: "high" },
+		);
+
+		expect(captured.body).toMatchObject({
+			model: "grok-build-0.1",
+			reasoning: { summary: "auto" },
+			include: ["reasoning.encrypted_content"],
+		});
+		expect(captured.body).not.toHaveProperty("reasoning.effort");
+	});
+
+	it("omits the default reasoning effort when the Responses provider does not support it", async () => {
+		const model = {
+			...XAI_MODELS["grok-build-0.1"],
+			id: "grok-build-without-thinking-map",
+			thinkingLevelMap: undefined,
+		} satisfies Model<"openai-responses">;
+		const captured = await captureRequest(
+			model,
+			{ messages: [{ role: "user", content: "hello", timestamp: 1 }] },
+			{ apiKey: "xai-test-token" },
+		);
+
+		expect(captured.body).not.toHaveProperty("reasoning.effort");
 	});
 
 	it("uses /responses for Grok 4.6 with xhigh effort and encrypted reasoning", async () => {


### PR DESCRIPTION
## Problem

xAI rejects `grok-build-0.1` requests that include `reasoning.effort`. Pi currently includes this field for explicit reasoning levels and may also send `"none"` through the default path, causing the request to fail with HTTP 400.

## Change

- Add a Responses compatibility flag for models that do not accept `reasoning.effort`.
- Disable the field for xAI `grok-build-0.1` while keeping reasoning, summaries, and encrypted reasoning content enabled.
- Cover both explicit reasoning levels and the default effort path.
- Document the compatibility flag.

## Testing

- `npm run check`
- `npm run build`
- `./test.sh`
- Focused Responses compatibility tests: 45 passed

## Limitations

This was not validated against the live xAI Grok Build endpoint because no xAI API key was available. The regression tests verify the payload generated by Pi; the reported live HTTP 400 is documented in #8381.

Related: #8381
