### PR TITLE
fix(coding-agent): re-pair tool results when rebuilding session context

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `streamProxy()` dropping finalized tool-call metadata such as OpenAI Responses namespaces ([#7709](https://github.com/earendil-works/pi/issues/7709)).
+- Re-pair tool results with the assistant message that issued their tool calls when rebuilding v4 harness session context, so custom messages projected between an assistant `tool_calls` message and its tool results no longer produce an invalid message sequence.
 
 ## [0.84.1] - 2026-08-07
 

--- a/packages/agent/src/harness/session/context.ts
+++ b/packages/agent/src/harness/session/context.ts
@@ -1,3 +1,4 @@
+import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
 import type { AgentMessage } from "../../types.ts";
 import { createBranchSummaryMessage, createCompactionSummaryMessage } from "../messages.ts";
 import type { CompactionEntry, CustomEntry, Entry } from "./types.ts";
@@ -87,14 +88,65 @@ export function sessionEntryToContextMessages(
 	return [];
 }
 
+/**
+ * Re-pair tool results with the assistant message that issued their tool calls.
+ *
+ * Session trees can chain custom entries (extension notices, etc.) between an
+ * assistant tool-call message and its results, because appends always chain to
+ * the current leaf. Flattening such a path emits user messages between the
+ * assistant message and its tool results, which providers reject with
+ * "Messages with role 'tool' must be a response to a preceding message with
+ * 'tool_calls'". Hoist each tool result directly after its owning assistant
+ * message, preserving result order; drop results whose tool call is not in the
+ * rebuilt context (e.g. compacted away or removed by session edits).
+ */
+export function normalizeToolResults(messages: AgentMessage[]): AgentMessage[] {
+	const ownerByCallId = new Map<string, AssistantMessage>();
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const part of message.content) {
+			if (part.type === "toolCall") ownerByCallId.set(part.id, message);
+		}
+	}
+
+	const resultsByOwner = new Map<AssistantMessage, ToolResultMessage[]>();
+	const normalized: AgentMessage[] = [];
+	for (const message of messages) {
+		if (message.role === "toolResult") {
+			const owner = ownerByCallId.get(message.toolCallId);
+			if (!owner) continue;
+			const results = resultsByOwner.get(owner);
+			if (results) {
+				results.push(message);
+			} else {
+				resultsByOwner.set(owner, [message]);
+			}
+			continue;
+		}
+		normalized.push(message);
+	}
+
+	// Emit each owner's results right after it. Results may precede or follow
+	// their owner in the flattened input, so flush them in a second walk.
+	const result: AgentMessage[] = [];
+	for (const message of normalized) {
+		result.push(message);
+		if (message.role === "assistant") {
+			const results = resultsByOwner.get(message);
+			if (results) result.push(...results);
+		}
+	}
+	return result;
+}
+
 export function buildSessionContext(
 	pathEntries: readonly Entry[],
 	options: SessionContextBuildOptions = {},
 ): SessionContext {
 	const state = deriveSessionContextState(pathEntries);
 	const contextEntries = buildContextEntries(pathEntries, options);
-	const messages = contextEntries.flatMap((entry, index) =>
-		sessionEntryToContextMessages(entry, index, contextEntries, options),
+	const messages = normalizeToolResults(
+		contextEntries.flatMap((entry, index) => sessionEntryToContextMessages(entry, index, contextEntries, options)),
 	);
 	return { ...state, messages };
 }

--- a/packages/agent/test/harness/session/context.test.ts
+++ b/packages/agent/test/harness/session/context.test.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { buildSessionContext } from "../../../src/harness/session/context.ts";
 import type { Entry } from "../../../src/harness/session/types.ts";
@@ -24,6 +24,28 @@ function assistantMessage(text: string): AssistantMessage {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function toolCallMessage(callIds: string[]): AssistantMessage {
+	return {
+		...assistantMessage("running tools"),
+		content: [
+			{ type: "text", text: "running tools" },
+			...callIds.map((callId) => ({ type: "toolCall" as const, id: callId, name: "bash", arguments: {} })),
+		],
+		stopReason: "toolUse",
+	};
+}
+
+function toolResultMessage(callId: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: callId,
+		toolName: "bash",
+		content: [{ type: "text", text: "done" }],
+		isError: false,
 		timestamp: 1,
 	};
 }
@@ -120,5 +142,47 @@ describe("v4 session context", () => {
 		});
 		expect(context.messages.map((message) => message.role)).toEqual(["user", "user"]);
 		expect(context.messages[1]).toMatchObject({ content: [{ type: "text", text: "note: project me" }] });
+	});
+
+	it("hoists tool results past projected custom entries", () => {
+		// Extensions can append custom entries between the assistant tool-call
+		// message and its results; flattening must keep the result adjacent to
+		// its tool_calls message or providers reject the sequence.
+		const entries: Entry[] = [
+			entry({ type: "message", id: "user", parentId: null, message: userMessage("go") }, 1),
+			entry({ type: "message", id: "assistant", parentId: "user", message: toolCallMessage(["call_X"]) }, 2),
+			entry({ type: "custom", id: "notice", parentId: "assistant", customType: "notice", data: "attention" }, 3),
+			entry({ type: "message", id: "result", parentId: "notice", message: toolResultMessage("call_X") }, 4),
+			entry({ type: "message", id: "next", parentId: "result", message: userMessage("next") }, 5),
+		];
+
+		const context = buildSessionContext(entries, {
+			entryProjectors: {
+				notice: (custom) => [userMessage(`notice: ${String(custom.data)}`)],
+			},
+		});
+		expect(context.messages.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+			"toolResult",
+			"user",
+			"user",
+		]);
+		expect(context.messages[1]).toMatchObject({
+			content: expect.arrayContaining([expect.objectContaining({ type: "toolCall", id: "call_X" })]),
+		});
+		expect(context.messages[2]).toMatchObject({ toolCallId: "call_X" });
+		expect(context.messages[3]).toMatchObject({ content: [{ type: "text", text: "notice: attention" }] });
+	});
+
+	it("drops tool results whose tool call is missing from context", () => {
+		const entries: Entry[] = [
+			entry({ type: "message", id: "user", parentId: null, message: userMessage("go") }, 1),
+			entry({ type: "message", id: "result", parentId: "user", message: toolResultMessage("call_GONE") }, 2),
+			entry({ type: "message", id: "next", parentId: "result", message: userMessage("next") }, 3),
+		];
+
+		const context = buildSessionContext(entries);
+		expect(context.messages.map((message) => message.role)).toEqual(["user", "user"]);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed inherited GitHub Copilot login triggering API rate limits while enabling model policies by limiting concurrent policy updates ([#6187](https://github.com/earendil-works/pi/issues/6187)).
 - Fixed fullscreen transcript search snapping back to the current match during manual scrolling and fragmented mouse input leaking into the search query.
 - Fixed inherited required LaTeX arguments starting on a new line being parsed as empty ([#7760](https://github.com/earendil-works/pi/issues/7760)).
+- Re-pair tool results with the assistant message that issued their tool calls when rebuilding session context on resume, compaction, or branch navigation. Custom messages injected by extensions between an assistant `tool_calls` message and its tool results previously flattened into an invalid `assistant(tool_calls) → user → tool` sequence that strict OpenAI-compatible providers reject with a 400; orphaned tool results are dropped instead of being sent ([#8166](https://github.com/earendil-works/pi/issues/8166)).
 
 ## [0.84.1] - 2026-08-07
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,5 +1,13 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { type ImageContent, type Message, type TextContent, type Usage, uuidv7 } from "@earendil-works/pi-ai";
+import {
+	type AssistantMessage,
+	type ImageContent,
+	type Message,
+	type TextContent,
+	type ToolResultMessage,
+	type Usage,
+	uuidv7,
+} from "@earendil-works/pi-ai";
 import { randomUUID } from "crypto";
 import {
 	appendFileSync,
@@ -454,6 +462,57 @@ export function buildContextEntries(
 }
 
 /**
+ * Re-pair tool results with the assistant message that issued their tool calls.
+ *
+ * Session trees can chain custom entries (extension notices, etc.) between an
+ * assistant tool-call message and its results, because appends always chain to
+ * the current leaf. Flattening such a path emits user messages between the
+ * assistant message and its tool results, which providers reject with
+ * "Messages with role 'tool' must be a response to a preceding message with
+ * 'tool_calls'". Hoist each tool result directly after its owning assistant
+ * message, preserving result order; drop results whose tool call is not in the
+ * rebuilt context (e.g. compacted away or removed by session edits).
+ */
+export function normalizeToolResults(messages: AgentMessage[]): AgentMessage[] {
+	const ownerByCallId = new Map<string, AssistantMessage>();
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const part of message.content) {
+			if (part.type === "toolCall") ownerByCallId.set(part.id, message);
+		}
+	}
+
+	const resultsByOwner = new Map<AssistantMessage, ToolResultMessage[]>();
+	const normalized: AgentMessage[] = [];
+	for (const message of messages) {
+		if (message.role === "toolResult") {
+			const owner = ownerByCallId.get(message.toolCallId);
+			if (!owner) continue;
+			const results = resultsByOwner.get(owner);
+			if (results) {
+				results.push(message);
+			} else {
+				resultsByOwner.set(owner, [message]);
+			}
+			continue;
+		}
+		normalized.push(message);
+	}
+
+	// Emit each owner's results right after it. Results may precede or follow
+	// their owner in the flattened input, so flush them in a second walk.
+	const result: AgentMessage[] = [];
+	for (const message of normalized) {
+		result.push(message);
+		if (message.role === "assistant") {
+			const results = resultsByOwner.get(message);
+			if (results) result.push(...results);
+		}
+	}
+	return result;
+}
+
+/**
  * Build the session context from entries using tree traversal.
  * If leafId is provided, walks from that entry to root.
  * Handles compaction and branch summaries along the path.
@@ -465,7 +524,9 @@ export function buildSessionContext(
 ): SessionContext {
 	const path = buildSessionPath(entries, leafId, byId);
 	const { thinkingLevel, model } = getSessionContextSettings(path);
-	const messages = buildContextEntries(entries, leafId, byId).flatMap(sessionEntryToContextMessages);
+	const messages = normalizeToolResults(
+		buildContextEntries(entries, leafId, byId).flatMap(sessionEntryToContextMessages),
+	);
 	return { messages, thinkingLevel, model };
 }
 

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -5,6 +5,7 @@ import {
 	buildSessionContext,
 	type CompactionEntry,
 	type CustomEntry,
+	type CustomMessageEntry,
 	type ModelChangeEntry,
 	type SessionEntry,
 	type SessionMessageEntry,
@@ -58,12 +59,70 @@ function custom(id: string, parentId: string | null, customType: string, data?: 
 	return { type: "custom", id, parentId, timestamp: "2025-01-01T00:00:00Z", customType, data };
 }
 
+function customMessage(id: string, parentId: string | null, customType: string): CustomMessageEntry {
+	return {
+		type: "custom_message",
+		id,
+		parentId,
+		timestamp: "2025-01-01T00:00:00Z",
+		customType,
+		content: `notice: ${customType}`,
+		display: true,
+	};
+}
+
 function thinkingLevel(id: string, parentId: string | null, level: string): ThinkingLevelChangeEntry {
 	return { type: "thinking_level_change", id, parentId, timestamp: "2025-01-01T00:00:00Z", thinkingLevel: level };
 }
 
 function modelChange(id: string, parentId: string | null, provider: string, modelId: string): ModelChangeEntry {
 	return { type: "model_change", id, parentId, timestamp: "2025-01-01T00:00:00Z", provider, modelId };
+}
+
+function toolCallMsg(id: string, parentId: string | null, callIds: string[]): SessionMessageEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: "2025-01-01T00:00:00Z",
+		message: {
+			role: "assistant",
+			content: [
+				{ type: "text", text: "running tools" },
+				...callIds.map((callId) => ({ type: "toolCall" as const, id: callId, name: "bash", arguments: {} })),
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-test",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: 1,
+		},
+	};
+}
+
+function toolResultMsg(id: string, parentId: string | null, callId: string): SessionMessageEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: "2025-01-01T00:00:00Z",
+		message: {
+			role: "toolResult",
+			toolCallId: callId,
+			toolName: "bash",
+			content: [{ type: "text", text: "done" }],
+			isError: false,
+			timestamp: 1,
+		},
+	};
 }
 
 describe("buildSessionContext", () => {
@@ -300,6 +359,83 @@ describe("buildSessionContext", () => {
 			const ctx = buildSessionContext(entries, "2");
 			// Should only get the orphan since parent chain is broken
 			expect(ctx.messages).toHaveLength(1);
+		});
+	});
+
+	describe("tool result ordering", () => {
+		it("hoists tool results past interleaved custom entries", () => {
+			// Extensions can append custom entries between the assistant tool-call
+			// message and its results; flattening must keep the result adjacent to
+			// its tool_calls message or providers reject the sequence.
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "go"),
+				toolCallMsg("2", "1", ["call_X"]),
+				customMessage("3", "2", "notice"),
+				toolResultMsg("4", "3", "call_X"),
+				msg("5", "4", "user", "next"),
+			];
+			const ctx = buildSessionContext(entries);
+			expect(ctx.messages.map((m) => m.role)).toEqual(["user", "assistant", "toolResult", "custom", "user"]);
+			expect((ctx.messages[1] as any).content[1]).toMatchObject({ type: "toolCall", id: "call_X" });
+			expect((ctx.messages[2] as any).toolCallId).toBe("call_X");
+		});
+
+		it("drops tool results whose tool call is missing from context", () => {
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "go"),
+				toolResultMsg("2", "1", "call_GONE"),
+				msg("3", "2", "user", "next"),
+			];
+			const ctx = buildSessionContext(entries);
+			expect(ctx.messages.map((m) => m.role)).toEqual(["user", "user"]);
+		});
+
+		it("groups parallel tool results under their shared assistant message", () => {
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "go"),
+				toolCallMsg("2", "1", ["call_X", "call_Y"]),
+				customMessage("3", "2", "notice"),
+				toolResultMsg("4", "3", "call_X"),
+				customMessage("5", "4", "notice2"),
+				toolResultMsg("6", "5", "call_Y"),
+				msg("7", "6", "user", "next"),
+			];
+			const ctx = buildSessionContext(entries);
+			expect(ctx.messages.map((m) => m.role)).toEqual([
+				"user",
+				"assistant",
+				"toolResult",
+				"toolResult",
+				"custom",
+				"custom",
+				"user",
+			]);
+			expect((ctx.messages[2] as any).toolCallId).toBe("call_X");
+			expect((ctx.messages[3] as any).toolCallId).toBe("call_Y");
+		});
+
+		it("pairs results with the assistant that declared their tool call", () => {
+			const entries: SessionEntry[] = [
+				msg("1", null, "user", "go"),
+				toolCallMsg("2", "1", ["call_X"]),
+				toolCallMsg("3", "2", ["call_Y"]),
+				toolResultMsg("4", "3", "call_X"),
+				toolResultMsg("5", "4", "call_Y"),
+				msg("6", "5", "user", "next"),
+			];
+			const ctx = buildSessionContext(entries);
+			expect(ctx.messages.map((m) => m.role)).toEqual([
+				"user",
+				"assistant",
+				"toolResult",
+				"assistant",
+				"toolResult",
+				"user",
+			]);
+			expect((ctx.messages[1] as any).content[1]).toMatchObject({ type: "toolCall", id: "call_X" });
+			expect((ctx.messages[2] as any).toolCallId).toBe("call_X");
+			expect((ctx.messages[3] as any).content[1]).toMatchObject({ type: "toolCall", id: "call_Y" });
+			expect((ctx.messages[4] as any).toolCallId).toBe("call_Y");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the rebuild path of the session-corruption bug described in #8166: when a session context is rebuilt from the persisted session tree (resume, compaction, branch navigation), tool results are re-paired with the assistant message that issued their tool calls, and orphaned results (whose tool call is no longer in the rebuilt context) are dropped instead of being sent.

## Problem

The session tree is append-only and always chains new entries to the current leaf. Extension hooks run after an assistant `tool_calls` message is persisted but before the tool result lands, so extensions that inject custom messages there (e.g. informational notices sent mid-turn) produce a tree like:

```
assistant (tool_calls: call_a)
custom_message (extension notice)   <- appended between the two
toolResult (call_a)
```

This is a perfectly valid tree. But `buildSessionContext` flattens the tree in entry order and `convertToLlm` converts custom messages to `user` role, so the rebuilt context contains `assistant(tool_calls) -> user -> tool`. Strict OpenAI-compatible providers reject this with:

```
400: "Messages with role 'tool' must be a response to a preceding message with 'tool_calls'"
```

Because the bad ordering is persisted, the session is permanently wedged on every subsequent turn. Two independent extensions (both of which only use the documented extension APIs) triggered this on different sessions. The live path is unaffected: in-memory messages accumulate in the correct order and custom messages are not injected into them mid-turn.

Note: #8209 addresses the live-injection variant of the same bug (extensions that raw-push into `agent.state.messages` mid-turn). This PR is complementary — it fixes the rebuild path, which #8209 does not cover, and it makes already-corrupted session files recover automatically on resume (previously the only remedy was hand-editing the JSONL to rewire `parentId`s).

## Fix

`normalizeToolResults(messages)` in `packages/coding-agent/src/core/session-manager.ts`:

1. Indexes every `toolCall` id to the assistant message that declared it.
2. Collects each assistant's `toolResult`s in encounter order; results without a declaring tool call in the rebuilt context are dropped.
3. Re-emits the sequence with each assistant's results directly after it, so `custom`/`user` messages no longer sit between `tool_calls` and their results.

`buildSessionContext` now runs the flat-mapped entries through this normalization. The same fix is mirrored in the v4 harness session context builder (`packages/agent/src/harness/session/context.ts`).

## Test plan

- New regression tests in `packages/coding-agent/test/session-manager/build-context.test.ts` (20 passed):
  - hoists tool results past interleaved custom entries
  - drops tool results whose tool call is missing from context
  - groups parallel tool results under their shared assistant message
  - pairs results with the assistant that declared their tool call
- New regression tests in `packages/agent/test/harness/session/context.test.ts` (5 passed), including projection of custom entries.
- Verified against a real corrupted session file: rebuilding its context before the fix produced the `assistant(tool_calls) -> user -> tool` sequence; after the fix, zero violations and the tool result sits directly after its `tool_calls` message.
