### PR TITLE
feat(coding-agent): add --exclude-extensions to skip named extensions

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -32,6 +32,7 @@ See [examples/extensions/](../examples/extensions/) for working implementations.
 
 - [Quick Start](#quick-start)
 - [Extension Locations](#extension-locations)
+  - [Skipping Extensions](#skipping-extensions)
 - [Available Imports](#available-imports)
 - [Writing an Extension](#writing-an-extension)
   - [Extension Styles](#extension-styles)
@@ -133,6 +134,18 @@ Additional paths via `settings.json`:
   ]
 }
 ```
+
+### Skipping Extensions
+
+`--no-extensions` (`-ne`) disables discovery entirely. To keep your normal set minus a few entries, use `--exclude-extensions` (`-xe`) with a comma-separated list:
+
+```bash
+pi --exclude-extensions subagents,mcp
+```
+
+An entry matches an extension's name — the file stem for `foo.ts`, the directory name for `foo/index.ts`, case-insensitive — or its absolute or relative path. Exclusions apply to auto-discovered extensions and to explicit `-e` paths, so an exclusion always wins over an inclusion. An entry that matches nothing prints a warning rather than failing silently.
+
+This is useful when an extension spawns child pi processes: the child can inherit the user's real configuration while suppressing the spawning extension itself (so children do not spawn grandchildren) and any extension whose startup cost is not worth paying per child.
 
 To share extensions via npm or git as pi packages, see [packages.md](packages.md).
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -629,6 +629,14 @@ const { session } = await createAgentSession({ resourceLoader: loader });
 
 Extensions can register tools, subscribe to events, add commands, and more. See [extensions.md](extensions.md) for the full API.
 
+**Skipping extensions:** `noExtensions: true` disables discovery entirely. `excludeExtensions` keeps discovery on but drops named entries — the CLI `--exclude-extensions` flag. Each entry matches an extension's name (the file stem for `foo.ts`, the directory name for `foo/index.ts`, case-insensitive) or its path, and applies to `additionalExtensionPaths` as well as discovered ones.
+
+```typescript
+const loader = new DefaultResourceLoader({
+  excludeExtensions: ["subagents", "mcp"],
+});
+```
+
 **Named inline extensions:** By default, inline factories display as `<inline:1>`, `<inline:2>`, etc. in the startup Extensions list. To show a descriptive name instead, wrap the factory:
 
 ```typescript

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -220,6 +220,7 @@ Built-in tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`.
 | Option | Description |
 |--------|-------------|
 | `-e`, `--extension <source>` | Load an extension from path, npm, or git; repeatable |
+| `--exclude-extensions <list>`, `-xe <list>` | Skip specific extensions by name or path |
 | `--no-extensions` | Disable extension discovery |
 | `--skill <path>` | Load a skill; repeatable |
 | `--no-skills` | Disable skill discovery |
@@ -233,6 +234,13 @@ Combine `--no-*` with explicit flags to load exactly what you need, ignoring set
 
 ```bash
 pi --no-extensions -e ./my-extension.ts
+```
+
+Use `--exclude-extensions` when you want your normal extension set minus a few entries, rather than an all-or-nothing switch. An entry matches an extension's name (the file stem for `foo.ts`, the directory name for `foo/index.ts`, case-insensitive) or its path. It applies to auto-discovered extensions and to explicit `-e` paths, so an exclusion always wins over an inclusion. Entries that match nothing print a warning.
+
+```bash
+# Normal configuration, minus two extensions
+pi --exclude-extensions subagents,mcp
 ```
 
 ### Other Options
@@ -295,6 +303,9 @@ pi --tools read,grep,find,ls -p "Review the code"
 
 # Disable one extension or built-in tool while keeping the rest available
 pi --exclude-tools ask_question
+
+# Keep the normal extension set minus two extensions
+pi --exclude-extensions subagents,mcp
 ```
 
 ## Design Principles

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -34,6 +34,7 @@ export interface Args {
 	noTools?: boolean;
 	noBuiltinTools?: boolean;
 	extensions?: string[];
+	excludeExtensions?: string[];
 	noExtensions?: boolean;
 	print?: boolean;
 	export?: string;
@@ -157,6 +158,11 @@ export function parseArgs(args: string[]): Args {
 		} else if ((arg === "--extension" || arg === "-e") && i + 1 < args.length) {
 			result.extensions = result.extensions ?? [];
 			result.extensions.push(args[++i]);
+		} else if ((arg === "--exclude-extensions" || arg === "-xe") && i + 1 < args.length) {
+			result.excludeExtensions = args[++i]
+				.split(",")
+				.map((s) => s.trim())
+				.filter((name) => name.length > 0);
 		} else if (arg === "--no-extensions" || arg === "-ne") {
 			result.noExtensions = true;
 		} else if (arg === "--skill" && i + 1 < args.length) {
@@ -291,6 +297,9 @@ ${chalk.bold("Options:")}
                                  Applies to built-in, extension, and custom tools
   --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh, max
   --extension, -e <path>         Load an extension file (can be used multiple times)
+  --exclude-extensions, -xe <names>
+                                 Comma-separated denylist of extension names or paths to skip
+                                 Matches the file stem (foo.ts) or directory name (foo/index.ts)
   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)
   --skill <path>                 Load a skill file or directory (can be used multiple times)
   --no-skills, -ns               Disable skills discovery and loading
@@ -366,6 +375,9 @@ ${chalk.bold("Examples:")}
 
   # Disable one tool while keeping the rest available
   ${APP_NAME} --exclude-tools ask_question
+
+  # Keep the normal extension set minus two extensions
+  ${APP_NAME} --exclude-extensions subagents,mcp
 
   # Export a session file to HTML
   ${APP_NAME} --export ~/${CONFIG_DIR_NAME}/agent/sessions/--path--/session.jsonl

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -68,6 +68,17 @@ function resolvePromptInput(input: string | undefined, description: string): str
 	return input;
 }
 
+/**
+ * The name a user would type for an extension path: the file stem for `foo.ts`, the
+ * directory name for `foo/index.ts`. Used by --exclude-extensions so a denylist entry
+ * does not have to spell out an absolute path.
+ */
+function extensionName(extensionPath: string): string {
+	const base = basename(extensionPath);
+	const stem = base.replace(/\.[cm]?[jt]sx?$/, "");
+	return stem === "index" ? basename(dirname(extensionPath)) : stem;
+}
+
 function loadContextFileFromDir(dir: string): { path: string; content: string } | null {
 	const candidates = ["AGENTS.override.md", "AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"];
 	for (const filename of candidates) {
@@ -167,6 +178,8 @@ export interface DefaultResourceLoaderOptions {
 	additionalThemePaths?: string[];
 	extensionFactories?: InlineExtension[];
 	noExtensions?: boolean;
+	/** Extension names (file stem or directory name, case-insensitive) or paths to skip. */
+	excludeExtensions?: string[];
 	noSkills?: boolean;
 	noPromptTemplates?: boolean;
 	noThemes?: boolean;
@@ -205,6 +218,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private additionalThemePaths: string[];
 	private extensionFactories: InlineExtension[];
 	private noExtensions: boolean;
+	private excludeExtensions: string[];
 	private noSkills: boolean;
 	private noPromptTemplates: boolean;
 	private noThemes: boolean;
@@ -267,6 +281,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.additionalThemePaths = options.additionalThemePaths ?? [];
 		this.extensionFactories = options.extensionFactories ?? [];
 		this.noExtensions = options.noExtensions ?? false;
+		this.excludeExtensions = options.excludeExtensions ?? [];
 		this.noSkills = options.noSkills ?? false;
 		this.noPromptTemplates = options.noPromptTemplates ?? false;
 		this.noThemes = options.noThemes ?? false;
@@ -449,9 +464,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const cliEnabledPrompts = getEnabledPaths(cliExtensionPaths.prompts);
 		const cliEnabledThemes = getEnabledPaths(cliExtensionPaths.themes);
 
-		const extensionPaths = this.noExtensions
-			? cliEnabledExtensions
-			: this.mergePaths(cliEnabledExtensions, enabledExtensions);
+		const extensionPaths = this.applyExtensionExclusions(
+			this.noExtensions ? cliEnabledExtensions : this.mergePaths(cliEnabledExtensions, enabledExtensions),
+			// noExtensions already suppressed discovery, so an entry naming a discovered
+			// extension legitimately matches nothing. Warning there would be noise.
+			{ warnUnmatched: !this.noExtensions },
+		);
 
 		const extensionsResult = await this.loadFinalExtensionSet(extensionPaths, preTrustExtensions);
 		for (const p of this.additionalExtensionPaths) {
@@ -553,9 +571,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 		});
 		const enabledExtensions = resolvedPaths.extensions.filter((r) => r.enabled).map((r) => r.path);
 		const cliEnabledExtensions = cliExtensionPaths.extensions.filter((r) => r.enabled).map((r) => r.path);
-		const extensionPaths = this.noExtensions
-			? cliEnabledExtensions
-			: this.mergePaths(cliEnabledExtensions, enabledExtensions);
+		const extensionPaths = this.applyExtensionExclusions(
+			this.noExtensions ? cliEnabledExtensions : this.mergePaths(cliEnabledExtensions, enabledExtensions),
+			{ warnUnmatched: false },
+		);
 		const extensionsResult = await loadExtensionsCached(extensionPaths, this.cwd, this.eventBus);
 		if (!options.includeInlineFactories) {
 			return extensionsResult;
@@ -841,6 +860,47 @@ export class DefaultResourceLoader implements ResourceLoader {
 			origin: "top-level",
 			baseDir: statSync(normalizedPath).isDirectory() ? normalizedPath : resolve(normalizedPath, ".."),
 		};
+	}
+
+	/**
+	 * Drop extension paths named by --exclude-extensions. An entry matches either the
+	 * extension's name (file stem, or directory name for `foo/index.ts`) case-insensitively,
+	 * or its path. Explicit -e paths are filtered too: an exclusion is the more specific
+	 * instruction, so it wins over an inclusion.
+	 *
+	 * Callers set `warnUnmatched` only when the extension set is the complete one, so a
+	 * pass that deliberately sees fewer extensions (the pre-trust pass, or `noExtensions`)
+	 * cannot warn about an entry that would have matched otherwise.
+	 */
+	private applyExtensionExclusions(extensionPaths: string[], options: { warnUnmatched: boolean }): string[] {
+		if (this.excludeExtensions.length === 0) {
+			return extensionPaths;
+		}
+
+		const matched = new Set<string>();
+		const kept = extensionPaths.filter((extensionPath) => {
+			const name = extensionName(extensionPath).toLowerCase();
+			const canonical = canonicalizePath(extensionPath);
+			const entry = this.excludeExtensions.find(
+				(candidate) =>
+					candidate.toLowerCase() === name || canonicalizePath(this.resolveResourcePath(candidate)) === canonical,
+			);
+			if (entry === undefined) {
+				return true;
+			}
+			matched.add(entry);
+			return false;
+		});
+
+		if (options.warnUnmatched) {
+			for (const entry of this.excludeExtensions) {
+				if (!matched.has(entry)) {
+					console.error(chalk.yellow(`Warning: --exclude-extensions matched no extension: ${entry}`));
+				}
+			}
+		}
+
+		return kept;
 	}
 
 	private mergePaths(primary: string[], additional: string[]): string[] {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -762,6 +762,7 @@ export async function main(args: string[], options?: MainOptions) {
 				additionalPromptTemplatePaths: resolvedPromptTemplatePaths,
 				additionalThemePaths: resolvedThemePaths,
 				noExtensions: parsed.noExtensions,
+				excludeExtensions: parsed.excludeExtensions,
 				noSkills: parsed.noSkills,
 				noPromptTemplates: parsed.noPromptTemplates,
 				noThemes: parsed.noThemes,

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -244,6 +244,40 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--exclude-extensions flag", () => {
+		test("parses a single name", () => {
+			const result = parseArgs(["--exclude-extensions", "mcp"]);
+			expect(result.excludeExtensions).toEqual(["mcp"]);
+		});
+
+		test("parses -xe shorthand", () => {
+			const result = parseArgs(["-xe", "mcp"]);
+			expect(result.excludeExtensions).toEqual(["mcp"]);
+		});
+
+		test("parses multiple comma-separated names", () => {
+			const result = parseArgs(["--exclude-extensions", "subagents,mcp"]);
+			expect(result.excludeExtensions).toEqual(["subagents", "mcp"]);
+		});
+
+		test("trims whitespace and drops empty entries", () => {
+			const result = parseArgs(["--exclude-extensions", " subagents , , mcp ,"]);
+			expect(result.excludeExtensions).toEqual(["subagents", "mcp"]);
+		});
+
+		test("accepts paths as entries", () => {
+			const result = parseArgs(["--exclude-extensions", "./ext/mcp.ts,/abs/subagents/index.ts"]);
+			expect(result.excludeExtensions).toEqual(["./ext/mcp.ts", "/abs/subagents/index.ts"]);
+		});
+
+		test("parses alongside --no-extensions and -e", () => {
+			const result = parseArgs(["--no-extensions", "-e", "foo.ts", "-xe", "foo"]);
+			expect(result.noExtensions).toBe(true);
+			expect(result.extensions).toEqual(["foo.ts"]);
+			expect(result.excludeExtensions).toEqual(["foo"]);
+		});
+	});
+
 	describe("--skill flag", () => {
 		test("parses single --skill", () => {
 			const result = parseArgs(["--skill", "./skill-dir"]);

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
@@ -757,6 +757,154 @@ Extension prompt content`,
 			expect(loader.getThemes().themes.find((theme) => theme.name === "extension-theme")?.sourceInfo).toMatchObject(
 				extensionMetadata,
 			);
+		});
+	});
+
+	describe("excludeExtensions option", () => {
+		// Two auto-discovered user extensions, one per supported layout: `alpha.ts` (name is
+		// the file stem) and `beta/index.ts` (name is the directory).
+		const writeDiscoveredExtensions = () => {
+			const userExtDir = join(agentDir, "extensions");
+			const betaDir = join(userExtDir, "beta");
+			mkdirSync(betaDir, { recursive: true });
+			const alphaPath = join(userExtDir, "alpha.ts");
+			const betaPath = join(betaDir, "index.ts");
+			writeFileSync(alphaPath, "export default function() {}");
+			writeFileSync(betaPath, "export default function() {}");
+			return { alphaPath, betaPath };
+		};
+
+		const loadedPaths = (loader: DefaultResourceLoader) =>
+			loader.getExtensions().extensions.map((extension) => extension.path);
+
+		it("should exclude an auto-discovered extension by file stem", async () => {
+			const { alphaPath, betaPath } = writeDiscoveredExtensions();
+
+			const loader = new DefaultResourceLoader({ cwd, agentDir, excludeExtensions: ["alpha"] });
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([betaPath]);
+			expect(loadedPaths(loader)).not.toContain(alphaPath);
+		});
+
+		it("should exclude an auto-discovered extension by directory name", async () => {
+			const { alphaPath } = writeDiscoveredExtensions();
+
+			const loader = new DefaultResourceLoader({ cwd, agentDir, excludeExtensions: ["beta"] });
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([alphaPath]);
+		});
+
+		it("should match names case-insensitively", async () => {
+			const { betaPath } = writeDiscoveredExtensions();
+
+			const loader = new DefaultResourceLoader({ cwd, agentDir, excludeExtensions: ["ALPHA"] });
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([betaPath]);
+		});
+
+		it("should exclude by absolute path", async () => {
+			const { alphaPath, betaPath } = writeDiscoveredExtensions();
+
+			const loader = new DefaultResourceLoader({ cwd, agentDir, excludeExtensions: [alphaPath] });
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([betaPath]);
+		});
+
+		it("should exclude by path relative to cwd", async () => {
+			const { betaPath } = writeDiscoveredExtensions();
+			const relativeAlpha = relative(cwd, join(agentDir, "extensions", "alpha.ts"));
+
+			const loader = new DefaultResourceLoader({ cwd, agentDir, excludeExtensions: [relativeAlpha] });
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([betaPath]);
+		});
+
+		it("should exclude an explicitly requested -e extension", async () => {
+			// An explicit exclusion is the more specific instruction, so it wins over -e.
+			const explicitPath = join(tempDir, "explicit.ts");
+			writeFileSync(explicitPath, "export default function() {}");
+
+			const loader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				additionalExtensionPaths: [explicitPath],
+				excludeExtensions: ["explicit"],
+			});
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([]);
+			expect(loader.getExtensions().errors).toEqual([]);
+		});
+
+		it("should also exclude from the pre-trust extension pass", async () => {
+			// loadProjectTrustExtensions() resolves extensions on its own path; a filter that
+			// only ran on the final pass would still let the excluded extension run its
+			// project_trust handler.
+			writeDiscoveredExtensions();
+			const betaPath = join(agentDir, "extensions", "beta", "index.ts");
+
+			const loader = new DefaultResourceLoader({ cwd, agentDir, excludeExtensions: ["alpha"] });
+			const preTrust = await loader.loadProjectTrustExtensions();
+
+			expect(preTrust.extensions.map((extension) => extension.path)).toEqual([betaPath]);
+		});
+
+		it("should warn once about an entry that matched nothing", async () => {
+			writeDiscoveredExtensions();
+			const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			const loader = new DefaultResourceLoader({ cwd, agentDir, excludeExtensions: ["alpha", "typo"] });
+			await loader.reload();
+
+			const warnings = consoleError.mock.calls
+				.map(([message]) => String(message))
+				.filter((message) => message.includes("--exclude-extensions"));
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0]).toContain("typo");
+			consoleError.mockRestore();
+		});
+
+		it("should still exclude an -e path when noExtensions is set", async () => {
+			const explicitPath = join(tempDir, "explicit.ts");
+			writeFileSync(explicitPath, "export default function() {}");
+
+			const loader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				noExtensions: true,
+				additionalExtensionPaths: [explicitPath],
+				excludeExtensions: ["explicit"],
+			});
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([]);
+		});
+
+		it("should be a no-op alongside noExtensions", async () => {
+			writeDiscoveredExtensions();
+			const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			const loader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				noExtensions: true,
+				excludeExtensions: ["alpha"],
+			});
+			await loader.reload();
+
+			expect(loadedPaths(loader)).toEqual([]);
+			// noExtensions already dropped alpha, so the unmatched warning would be noise.
+			expect(
+				consoleError.mock.calls
+					.map(([message]) => String(message))
+					.filter((message) => message.includes("--exclude-extensions")),
+			).toEqual([]);
+			consoleError.mockRestore();
 		});
 	});
 


### PR DESCRIPTION
Extension loading was all-or-nothing: full auto-discovery, or --no-extensions.
There was no way to express "my normal extension set, minus these". Guarding
inside an extension only works for extensions you own, since the guard must live
in the extension being denied, so a third-party extension could not be
suppressed at all.

--exclude-extensions <names> (-xe) is the direct analogue of --exclude-tools
(-xt) and copies its parse shape: comma-separated, trimmed, empties dropped.
Filtering happens in DefaultResourceLoader where extensionPaths is computed, so
both the pre-trust pass and the final pass honour it.

An entry matches an extension's name -- the file stem for foo.ts, the directory
name for foo/index.ts, case-insensitive -- or its absolute or relative path.
Exclusions apply to explicit -e paths too: an exclusion is the more specific
instruction, so it wins over an inclusion. An entry matching nothing warns on
stderr rather than silently denying nothing, except when --no-extensions already
suppressed discovery.

closes #8431
