### PR TITLE
fix(tui): keep / and - inside fullscreen double-click word selection

### DIFF
--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -67,6 +67,45 @@ const MAX_CACHED_OFFSCREEN_KITTY_TRANSMISSION_BYTES = 32 * 1024 * 1024;
 const MAX_CACHED_OFFSCREEN_KITTY_DECODED_BYTES = 64 * 1024 * 1024;
 const DOUBLE_CLICK_INTERVAL_MS = 500;
 const wordSegmenter = getWordSegmenter();
+/**
+ * Separator runs that count as word constituents for double-click selection,
+ * mirroring how Intl.Segmenter keeps `_` and `.` inside words.
+ */
+const WORD_SEPARATOR_REGEX = /^[-/]+$/;
+
+interface WordRange {
+	start: number;
+	end: number;
+}
+
+/**
+ * Selection ranges (in columns) for double-click and word drags. Intl.Segmenter
+ * splits paths and kebab-case identifiers at `/` and `-`, so double-clicking
+ * `extensions/starline/fixed-editor/compositor.ts` would select one component.
+ * Merge separator runs into the surrounding word; every other non-word
+ * segment stays an individually selectable range.
+ */
+function getWordRanges(line: string): WordRange[] {
+	const ranges: WordRange[] = [];
+	let token: WordRange | undefined;
+	let start = 0;
+	for (const segment of wordSegmenter.segment(line)) {
+		const end = start + visibleWidth(segment.segment);
+		if (segment.isWordLike || WORD_SEPARATOR_REGEX.test(segment.segment)) {
+			if (token) token.end = end;
+			else token = { start, end };
+		} else {
+			if (token) {
+				ranges.push(token);
+				token = undefined;
+			}
+			ranges.push({ start, end });
+		}
+		start = end;
+	}
+	if (token) ranges.push(token);
+	return ranges;
+}
 
 interface CachedKittyImage {
 	transmissionGeneration: number;
@@ -832,16 +871,13 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 	private getWordSelection(point: SelectionPoint): SelectionRange | undefined {
 		const line = stripTerminalSequences(this.getSelectionSourceLine(point));
-		let start = 0;
-		for (const segment of wordSegmenter.segment(line)) {
-			const end = start + visibleWidth(segment.segment);
-			if (point.col >= start && point.col < end) {
+		for (const range of getWordRanges(line)) {
+			if (point.col >= range.start && point.col < range.end) {
 				return {
-					start: { ...point, col: start },
-					end: { ...point, col: end, boundary: true },
+					start: { ...point, col: range.start },
+					end: { ...point, col: range.end, boundary: true },
 				};
 			}
-			start = end;
 		}
 		return undefined;
 	}

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -1056,6 +1056,60 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
+	it("selects whole paths and kebab-case identifiers on double click", async () => {
+		const terminal = new RecordingTerminal(80, 1);
+		const copied: string[] = [];
+		const tui = new TuiAltScreen(terminal, undefined, undefined, {
+			copySelection: async (text) => {
+				copied.push(text);
+				return true;
+			},
+		});
+		tui.addChild(new Text("see extensions/starline/fixed-editor/compositor.ts and @earendil-works/pi-tui", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		// Double-click inside "compositor.ts" selects the whole path.
+		for (const kind of ["M", "m", "M", "m"]) terminal.sendInput(`\x1b[<0;45;1${kind}`);
+		await terminal.waitForRender();
+		assert.strictEqual(copied.at(-1), "extensions/starline/fixed-editor/compositor.ts");
+
+		// Double-click inside "pi-tui" selects the whole scoped package name.
+		for (const kind of ["M", "m", "M", "m"]) terminal.sendInput(`\x1b[<0;61;1${kind}`);
+		await terminal.waitForRender();
+		assert.strictEqual(copied.at(-1), "earendil-works/pi-tui");
+
+		tui.stop();
+	});
+
+	it("keeps spaces and other punctuation as double-click boundaries", async () => {
+		const terminal = new RecordingTerminal(40, 1);
+		const copied: string[] = [];
+		const tui = new TuiAltScreen(terminal, undefined, undefined, {
+			copySelection: async (text) => {
+				copied.push(text);
+				return true;
+			},
+		});
+		tui.addChild(new Text("hello world foo_bar file.ts v1.2.3", 0, 0));
+		tui.start();
+		await terminal.waitForRender();
+
+		for (const [column, expected] of [
+			[2, "hello"],
+			[8, "world"],
+			[14, "foo_bar"],
+			[21, "file.ts"],
+			[29, "v1.2.3"],
+		] as const) {
+			for (const kind of ["M", "m", "M", "m"]) terminal.sendInput(`\x1b[<0;${column};1${kind}`);
+			await terminal.waitForRender();
+			assert.strictEqual(copied.at(-1), expected);
+		}
+
+		tui.stop();
+	});
+
 	it("selects whole words on double click, extends word drags, and selects lines on triple click", async () => {
 		const terminal = new RecordingTerminal(20, 2);
 		const tui = new TuiAltScreen(terminal);


### PR DESCRIPTION
## Summary

Double-click word selection in fullscreen walks `Intl.Segmenter` word segments, which treats `/` and `-` as boundaries, so double-clicking a path selected a single component instead of the whole path:

- `extensions/starline/fixed-editor/compositor.ts` -> "extensions" | "/" | "starline" | ...
- `@earendil-works/pi-tui` -> "@" | "earendil" | "-" | "works" | ...

This coalesces runs of `/` and `-` segments into the surrounding word in `getWordSelection` (packages/tui/src/tui-alt-screen.ts), mirroring how `_` and `.` already stay whole (`foo_bar`, `file.ts`, `v1.2.3`). Every other non-word segment (whitespace, quotes, brackets, `@`) remains an individually selectable range, so word drags over whitespace and triple-click behavior are unchanged.

## Validation

- `node --test test/tui-alt-screen.test.ts`: 44/44 pass, including two new tests:
  - double-click inside `compositor.ts` selects `extensions/starline/fixed-editor/compositor.ts`; inside `pi-tui` selects `earendil-works/pi-tui`
  - `hello` / `world` stay separate tokens; `foo_bar`, `file.ts`, `v1.2.3` remain whole
- Full `npm test` in packages/tui: only 3 pre-existing Windows-environment failures (identical on clean HEAD: home-path shortening x2, imageFallback); all selection tests pass
- `npm run build` (tsgo) and repo pre-commit checks (biome, tsgo --noEmit) pass

Fixes #7746