### PR TITLE
fix: expose unloaded llama.cpp presets

### DIFF
--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -27,7 +27,7 @@ async function resolveServerUrl(
 
 function modelIsSelectable(model: LlamaModelInfo): boolean {
 	// llama.cpp reports idle-slept models as "sleeping"; requests wake them automatically.
-	return model.status.value === "loaded" || model.status.value === "sleeping";
+	return model.status.value === "loaded" || model.status.value === "sleeping" || model.source !== "cache";
 }
 
 function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-completions"> {

--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -26,8 +26,15 @@ async function resolveServerUrl(
 }
 
 function modelIsSelectable(model: LlamaModelInfo): boolean {
-	// llama.cpp reports idle-slept models as "sleeping"; requests wake them automatically.
-	return model.status.value === "loaded" || model.status.value === "sleeping" || model.source !== "cache";
+	return (
+		model.status.value === "loaded" ||
+		// llama.cpp reports idle-slept models as "sleeping"; requests wake them automatically.
+		model.status.value === "sleeping" ||
+		// presets from --models-preset should always be available
+		model.source === "preset" ||
+		// llama-swap doesn't set "source", treat as presets
+		!model.source
+	);
 }
 
 function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-completions"> {


### PR DESCRIPTION
Related: #8167

I use `llama-server --models-preset ./llama-models.ini` not `--models-dir --no-models-autoload`, I always want my presets to be selectable as they will be loaded on request.

[llama-swap](https://github.com/mostlygeek/llama-swap) also mostly works with this provider but it doesn't set `source` at all, these can also always be selectable as llama-swap handles loading and unloading itself.