### PR TITLE
fix(tui): disable autowrap around main-screen renders to prevent ConPTY drift

### DIFF
--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -6,6 +6,16 @@ import { visibleWidth } from "./utils.ts";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
+// Autowrap control: with autowrap enabled, terminals commit the wrap when the
+// last column of a row is written (Windows ConPTY eagerly, xterm as pending
+// wrap). Relative cursor navigation between full-width lines (borders, editor
+// rows) then drifts by one row per full-width line, desyncing
+// hardwareCursorRow and shifting the rendered frame down on every repaint.
+// Disable autowrap around each render so `\r\n` row navigation is exact on
+// every terminal (same approach as tui-alt-screen).
+const DISABLE_AUTOWRAP = "\x1b[?7l";
+const ENABLE_AUTOWRAP = "\x1b[?7h";
+
 interface KittyImageHeader {
 	ids: number[];
 	rows: number;
@@ -209,7 +219,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
-			let buffer = "\x1b[?2026h"; // Begin synchronized output
+			let buffer = "\x1b[?2026h" + DISABLE_AUTOWRAP; // Begin synchronized output, disable autowrap
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
@@ -231,7 +241,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 				}
 				buffer += line;
 			}
-			buffer += "\x1b[?2026l"; // End synchronized output
+			buffer += ENABLE_AUTOWRAP + "\x1b[?2026l"; // Re-enable autowrap, end synchronized output
 			this.terminal.write(buffer);
 			this.cursorRow = Math.max(0, newLines.length - 1);
 			this.hardwareCursorRow = this.cursorRow;
@@ -331,7 +341,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// All changes are in deleted lines (nothing to render, just clear)
 		if (firstChanged >= newLines.length) {
 			if (this.previousLines.length > newLines.length) {
-				let buffer = "\x1b[?2026h";
+				let buffer = "\x1b[?2026h" + DISABLE_AUTOWRAP;
 				buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
 				// Move to end of new content (clamp to 0 for empty content)
 				const targetRow = Math.max(0, newLines.length - 1);
@@ -363,7 +373,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 				if (moveBack > 0) {
 					buffer += `\x1b[${moveBack}A`;
 				}
-				buffer += "\x1b[?2026l";
+				buffer += ENABLE_AUTOWRAP + "\x1b[?2026l";
 				this.terminal.write(buffer);
 				this.cursorRow = targetRow;
 				this.hardwareCursorRow = targetRow;
@@ -387,7 +397,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 
 		// Render from first changed line to end
 		// Build buffer with all updates wrapped in synchronized output
-		let buffer = "\x1b[?2026h"; // Begin synchronized output
+		let buffer = "\x1b[?2026h" + DISABLE_AUTOWRAP; // Begin synchronized output, disable autowrap
 		buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
 		const prevViewportBottom = prevViewportTop + height - 1;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
@@ -494,7 +504,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 			buffer += `\x1b[${extraLines}A`;
 		}
 
-		buffer += "\x1b[?2026l"; // End synchronized output
+		buffer += ENABLE_AUTOWRAP + "\x1b[?2026l"; // Re-enable autowrap, end synchronized output
 
 		if (process.env.PI_TUI_DEBUG === "1") {
 			const debugDir = "/tmp/tui";

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -830,3 +830,49 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI autowrap guard", () => {
+	it("disables and re-enables autowrap around every render (regression: ConPTY autowrap drift)", async () => {
+		// Windows ConPTY commits autowrap eagerly after writing the last column,
+		// while pi tracks the cursor without accounting for it. Without disabling
+		// autowrap around renders, relative `\r\n` navigation between full-width
+		// lines (e.g. the Editor's borders) drifts one row per line, shifting the
+		// frame down and hiding the cursor below the fold.
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		// Full-width lines (borders) trigger the wrap on eager-wrap terminals.
+		component.lines = ["─".repeat(40), "editor line", "─".repeat(40)];
+		tui.addChild(component);
+		tui.start();
+		await terminal.waitForRender();
+
+		const firstRender = terminal.getWrites();
+		assert.ok(
+			firstRender.includes("\x1b[?2026h\x1b[?7l"),
+			"first render should disable autowrap after starting synchronized output",
+		);
+		assert.ok(
+			firstRender.includes("\x1b[?7h\x1b[?2026l"),
+			"first render should re-enable autowrap before ending synchronized output",
+		);
+
+		// Incremental renders must carry the same guard.
+		terminal.clearWrites();
+		component.lines = ["─".repeat(40), "editor line changed", "─".repeat(40)];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const incremental = terminal.getWrites();
+		assert.ok(
+			incremental.includes("\x1b[?2026h\x1b[?7l"),
+			"incremental render should disable autowrap",
+		);
+		assert.ok(
+			incremental.includes("\x1b[?7h\x1b[?2026l"),
+			"incremental render should re-enable autowrap",
+		);
+
+		tui.stop();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #8484. On Windows/ConPTY, `TuiMainScreen` renders full-width lines (editor borders, `DynamicBorder`, etc.) with autowrap enabled. ConPTY commits the wrap eagerly when the last column is written, so relative `\r\n` navigation between full-width lines advances two rows instead of one; `hardwareCursorRow` tracking drifts by one row per full-width line and every repaint shifts the frame down. The editor box slides below the fold — its top (and `↑ N` indicator) stays visible while the cursor is pushed off-screen, perceived as "the editor scrolled back to top".

The fullscreen renderer (`tui-alt-screen`) already disables autowrap (`\x1b[?7l`) for this reason; this PR applies the same guard to the main screen.

## Changes

- `packages/tui/src/tui-main-screen.ts`: wrap all three render buffers (full redraw, deleted-lines clear, incremental diff) in `\x1b[?7l` / `\x1b[?7h` (disable/re-enable autowrap), matching the alt-screen approach.
- `packages/tui/test/tui-render.test.ts`: regression test asserting the autowrap guard is present in both full and incremental render output.

## Verification

- `node --test packages/tui/test/tui-render.test.ts` — 26 tests pass (including the new regression test).
- Full `packages/tui` suite: 917 tests pass.
- ANSI capture of the demo TUI confirms the guard is emitted and the screen stays aligned across renders (0 scroll anomalies in analysis).
- Editor scroll logic itself was verified separately (unit probes, 1500-iteration fuzz, real-app tmux testing) — the drift is purely in the render layer.

This is untestable on Linux (xterm keeps autowrap pending, so `\r\n` navigation is already exact); the fix is a no-op for xterm-style terminals and only changes behavior where the eager wrap was causing drift.
