### PR TITLE
feat(tui): add editor-scroll capture and verification tooling

### DIFF
--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -6,6 +6,16 @@ import { visibleWidth } from "./utils.ts";
 
 const KITTY_SEQUENCE_PREFIX = "\x1b_G";
 
+// Autowrap control: with autowrap enabled, terminals commit the wrap when the
+// last column of a row is written (Windows ConPTY eagerly, xterm as pending
+// wrap). Relative cursor navigation between full-width lines (borders, editor
+// rows) then drifts by one row per full-width line, desyncing
+// hardwareCursorRow and shifting the rendered frame down on every repaint.
+// Disable autowrap around each render so `\r\n` row navigation is exact on
+// every terminal (same approach as tui-alt-screen).
+const DISABLE_AUTOWRAP = "\x1b[?7l";
+const ENABLE_AUTOWRAP = "\x1b[?7h";
+
 interface KittyImageHeader {
 	ids: number[];
 	rows: number;
@@ -209,7 +219,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// Helper to clear scrollback and viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
-			let buffer = "\x1b[?2026h"; // Begin synchronized output
+			let buffer = "\x1b[?2026h" + DISABLE_AUTOWRAP; // Begin synchronized output, disable autowrap
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
@@ -231,7 +241,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 				}
 				buffer += line;
 			}
-			buffer += "\x1b[?2026l"; // End synchronized output
+			buffer += ENABLE_AUTOWRAP + "\x1b[?2026l"; // Re-enable autowrap, end synchronized output
 			this.terminal.write(buffer);
 			this.cursorRow = Math.max(0, newLines.length - 1);
 			this.hardwareCursorRow = this.cursorRow;
@@ -331,7 +341,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		// All changes are in deleted lines (nothing to render, just clear)
 		if (firstChanged >= newLines.length) {
 			if (this.previousLines.length > newLines.length) {
-				let buffer = "\x1b[?2026h";
+				let buffer = "\x1b[?2026h" + DISABLE_AUTOWRAP;
 				buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
 				// Move to end of new content (clamp to 0 for empty content)
 				const targetRow = Math.max(0, newLines.length - 1);
@@ -363,7 +373,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 				if (moveBack > 0) {
 					buffer += `\x1b[${moveBack}A`;
 				}
-				buffer += "\x1b[?2026l";
+				buffer += ENABLE_AUTOWRAP + "\x1b[?2026l";
 				this.terminal.write(buffer);
 				this.cursorRow = targetRow;
 				this.hardwareCursorRow = targetRow;
@@ -387,7 +397,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 
 		// Render from first changed line to end
 		// Build buffer with all updates wrapped in synchronized output
-		let buffer = "\x1b[?2026h"; // Begin synchronized output
+		let buffer = "\x1b[?2026h" + DISABLE_AUTOWRAP; // Begin synchronized output, disable autowrap
 		buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
 		const prevViewportBottom = prevViewportTop + height - 1;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
@@ -494,7 +504,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 			buffer += `\x1b[${extraLines}A`;
 		}
 
-		buffer += "\x1b[?2026l"; // End synchronized output
+		buffer += ENABLE_AUTOWRAP + "\x1b[?2026l"; // Re-enable autowrap, end synchronized output
 
 		if (process.env.PI_TUI_DEBUG === "1") {
 			const debugDir = "/tmp/tui";

--- a/packages/tui/test/editor-scroll-demo.ts
+++ b/packages/tui/test/editor-scroll-demo.ts
@@ -1,0 +1,118 @@
+/**
+ * editor-scroll-demo.ts
+ *
+ * Scriptable minimal TUI app for capturing/verifying Editor scroll behavior.
+ * Built on the same TuiMainScreen + Editor stack as pi's interactive mode so
+ * layout/render behavior matches the real app.
+ *
+ * Usage:
+ *   EDITOR_DEMO_TEXT_FILE=prompt.txt \
+ *   EDITOR_DEMO_EVENT_LOG=/tmp/demo-events.jsonl \
+ *   PI_TUI_WRITE_LOG=/tmp/demo-ansi.log \
+ *   node test/editor-scroll-demo.ts
+ *
+ * Environment:
+ *   EDITOR_DEMO_TEXT_FILE    initial editor text (default: generated 45-line text)
+ *   EDITOR_DEMO_REWRITE_FILE text used by the F5 rewrite trigger (default: same as initial)
+ *   EDITOR_DEMO_EVENT_LOG    JSONL event log (triggers, cursor/scroll observations)
+ *   PI_TUI_WRITE_LOG         set by capture harness; terminal.ts records raw ANSI here
+ *
+ * Trigger keys (simulate app-level events that interactive-mode performs on the editor):
+ *   F5  editor.setText(rewriteText)                     — fork/navigate/extension rewrite
+ *   F6  addToHistory + Up/Down cycle                    — prompt history browsing
+ *   F7  tui.setFocus(null) then setFocus(editor)        — focus churn
+ *   F8  save/restore getText()/setText(saved)           — custom-UI restore path
+ *   F9  onSubmit (submits and stops the app)
+ *   Ctrl+C  exit
+ *
+ * All other keys are forwarded to the normal Editor handling.
+ */
+import * as fs from "node:fs";
+import { Editor } from "../src/components/editor.ts";
+import { ProcessTerminal } from "../src/terminal.ts";
+import { TuiMainScreen } from "../src/tui-main-screen.ts";
+import { defaultEditorTheme } from "./test-themes.ts";
+
+const EVENT_LOG = process.env.EDITOR_DEMO_EVENT_LOG || "/tmp/editor-scroll-demo-events.jsonl";
+
+function logEvent(event: string, detail: Record<string, unknown> = {}): void {
+	try {
+		fs.appendFileSync(EVENT_LOG, `${JSON.stringify({ t: Date.now(), event, ...detail })}\n`);
+	} catch {
+		// Event log is best-effort; never crash the app over it.
+	}
+}
+
+function readTextFile(path: string | undefined, fallback: string): string {
+	if (!path) return fallback;
+	try {
+		return fs.readFileSync(path, "utf8");
+	} catch {
+		return fallback;
+	}
+}
+
+const generatedText = Array.from({ length: 45 }, (_, i) => `line-${String(i).padStart(2, "0")} payload`).join("\n");
+const initialText = readTextFile(process.env.EDITOR_DEMO_TEXT_FILE, generatedText);
+const rewriteText = readTextFile(process.env.EDITOR_DEMO_REWRITE_FILE, initialText);
+
+class ScrollDemoEditor extends Editor {
+	private f5Count = 0;
+
+	override handleInput(data: string): void {
+		// Legacy F-key sequences (dumb PTY: no kitty protocol in effect).
+		if (data === "\x1b[15~") {
+			this.f5Count++;
+			logEvent("trigger", { name: "f5-setText", count: this.f5Count, textLen: rewriteText.length });
+			this.setText(rewriteText);
+			return;
+		}
+		if (data === "\x1b[17~") {
+			logEvent("trigger", { name: "f6-history-cycle" });
+			this.addToHistory(initialText);
+			this.handleInput("\x1b[A"); // Up → history entry
+			this.handleInput("\x1b[B"); // Down → draft restore
+			return;
+		}
+		if (data === "\x1b[18~") {
+			logEvent("trigger", { name: "f7-focus-churn" });
+			const tui = (this as unknown as { tui: TuiMainScreen }).tui;
+			tui.setFocus(null);
+			tui.setFocus(this);
+			return;
+		}
+		if (data === "\x1b[19~") {
+			logEvent("trigger", { name: "f8-save-restore", textLen: this.getText().length });
+			const saved = this.getText();
+			this.setText(saved);
+			return;
+		}
+		if (data === "\x1b[20~") {
+			logEvent("trigger", { name: "f9-submit", textLen: this.getText().length });
+			this.onSubmit?.(this.getText());
+			return;
+		}
+		super.handleInput(data);
+	}
+}
+
+const terminal = new ProcessTerminal();
+const tui = new TuiMainScreen(terminal);
+const editor = new ScrollDemoEditor(tui, defaultEditorTheme);
+
+tui.addChild(editor);
+tui.setFocus(editor);
+editor.setText(initialText);
+
+logEvent("start", { textLines: initialText.split("\n").length });
+
+editor.onSubmit = (text: string) => {
+	logEvent("submitted", { textLen: text.length });
+	tui.stop();
+	process.exit(0);
+};
+
+tui.start();
+
+// Ctrl+C is handled by TuiMainScreen (stop); exit cleanly when stopped.
+process.on("exit", () => logEvent("exit"));

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -830,3 +830,49 @@ describe("TUI differential rendering", () => {
 		tui.stop();
 	});
 });
+
+describe("TUI autowrap guard", () => {
+	it("disables and re-enables autowrap around every render (regression: ConPTY autowrap drift)", async () => {
+		// Windows ConPTY commits autowrap eagerly after writing the last column,
+		// while pi tracks the cursor without accounting for it. Without disabling
+		// autowrap around renders, relative `\r\n` navigation between full-width
+		// lines (e.g. the Editor's borders) drifts one row per line, shifting the
+		// frame down and hiding the cursor below the fold.
+		const terminal = new LoggingVirtualTerminal(40, 10);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		// Full-width lines (borders) trigger the wrap on eager-wrap terminals.
+		component.lines = ["─".repeat(40), "editor line", "─".repeat(40)];
+		tui.addChild(component);
+		tui.start();
+		await terminal.waitForRender();
+
+		const firstRender = terminal.getWrites();
+		assert.ok(
+			firstRender.includes("\x1b[?2026h\x1b[?7l"),
+			"first render should disable autowrap after starting synchronized output",
+		);
+		assert.ok(
+			firstRender.includes("\x1b[?7h\x1b[?2026l"),
+			"first render should re-enable autowrap before ending synchronized output",
+		);
+
+		// Incremental renders must carry the same guard.
+		terminal.clearWrites();
+		component.lines = ["─".repeat(40), "editor line changed", "─".repeat(40)];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const incremental = terminal.getWrites();
+		assert.ok(
+			incremental.includes("\x1b[?2026h\x1b[?7l"),
+			"incremental render should disable autowrap",
+		);
+		assert.ok(
+			incremental.includes("\x1b[?7h\x1b[?2026l"),
+			"incremental render should re-enable autowrap",
+		);
+
+		tui.stop();
+	});
+});

--- a/scripts/editor-scroll-capture/README.md
+++ b/scripts/editor-scroll-capture/README.md
@@ -1,0 +1,72 @@
+# editor-scroll-capture
+
+Capture and verification tooling for the pi Editor's scroll behavior (see issue #8484).
+
+Three pieces:
+
+- **`packages/tui/test/editor-scroll-demo.ts`** — scriptable minimal TUI app on the real
+  `TuiMainScreen` + `Editor` stack. Trigger keys simulate app-level editor events:
+  `F5` = `setText` rewrite, `F6` = history cycle, `F7` = focus churn,
+  `F8` = save/restore, `F9` = submit. Writes a JSONL event log
+  (`EDITOR_DEMO_EVENT_LOG`).
+- **`capture.py`** — PTY harness. Spawns the demo (or any command) in a
+  pseudo-terminal, feeds a scripted scenario, and records the raw ANSI stream
+  (via `PI_TUI_WRITE_LOG`), a timed `timeline.jsonl` (in/out bytes), and the
+  app event log.
+- **`analyze.mjs`** — ANSI virtual-terminal analyzer. Reconstructs the screen
+  from `timeline.jsonl`, locates the editor box from its scroll-indicator
+  borders (`─── ↑ N more` / `─── ↓ N more`), and reports any frame where the
+  editor view jumped to the top while the cursor remained below (scroll-jump
+  anomaly).
+- **`fuzz-scroll.mts`** — property check: after every random editor operation,
+  the rendered output must still contain the reverse-video cursor cell
+  whenever the editor holds text (cursor must never be scrolled out of view).
+
+## Requirements
+
+- Node >= 22.19 (type stripping) for the demo and analyzer
+- Python 3 (stdlib only) for the capture harness
+- The TUI deps installed: `npm install --workspace packages/tui --ignore-scripts`
+
+## Usage
+
+```bash
+# 1. capture a scenario (default demo, 100x30 PTY)
+python3 scripts/editor-scroll-capture/capture.py \
+  --scenario scripts/editor-scroll-capture/scenarios/scroll-attempt1.txt \
+  --out /tmp/esc
+
+# 2. analyze the capture
+node scripts/editor-scroll-capture/analyze.mjs /tmp/esc
+
+# optional: dump the reconstructed screen (debugging)
+node scripts/editor-scroll-capture/analyze.mjs /tmp/esc --dump-screen
+node scripts/editor-scroll-capture/analyze.mjs /tmp/esc --dump-at=800
+
+# 3. property-fuzz the editor scroll invariant
+node scripts/editor-scroll-capture/fuzz-scroll.mts 2000 42
+```
+
+Capture any other command with `--cmd` (e.g. the real `pi`):
+
+```bash
+python3 scripts/editor-scroll-capture/capture.py \
+  --cmd "pi" --scenario my-scenario.txt --out /tmp/pi-capture
+```
+
+## Scenario format
+
+One directive per line (`#` comments allowed):
+
+| directive | meaning |
+|-----------|---------|
+| `wait <seconds>` | sleep |
+| `key <name> [x<count>]` | named key (`up`, `down`, `enter`, `f5`…), repeated |
+| `raw <hex>` | raw bytes, e.g. `1b5b41` = CSI A |
+| `type <text>` | literal text (`\n` escape = newline) |
+
+## Notes
+
+The analyzer's virtual terminal models DEC autowrap (wrap-pending) so that
+full-width lines — the editor borders — are positioned exactly like a real
+xterm-style terminal.

--- a/scripts/editor-scroll-capture/analyze.mjs
+++ b/scripts/editor-scroll-capture/analyze.mjs
@@ -1,0 +1,642 @@
+#!/usr/bin/env node
+/**
+ * analyze.mjs — ANSI capture analyzer for the pi Editor scroll bug.
+ *
+ * Reads a capture directory produced by capture.py:
+ *   timeline.jsonl   { t, dir: "in"|"out", hex }  (authoritative, has timing)
+ *   events.jsonl     demo app trigger log (optional, for correlation)
+ *
+ * Reconstructs a virtual terminal screen from the "out" stream and watches
+ * the pi Editor's scroll indicators:
+ *   top border    "─── ↑ N more "  → editor scrolled down by N
+ *   top border    "───────..."     → editor at top
+ *   bottom border "─── ↓ M more "  → M lines hidden below
+ *
+ * Detects "scroll jumped to top" anomalies (symptom b):
+ *   - top border ↑N (N>0) → plain, while content still exists below the
+ *     visible editor area (bottom ↓ present), or the cursor was below the
+ *     top content row and stays there
+ *   - cursor cell disappears from the visible editor area while the editor
+ *     still has text below (cursor scrolled out of view)
+ *
+ * Usage:
+ *   node scripts/editor-scroll-capture/analyze.mjs /tmp/editor-scroll-capture
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Minimal virtual terminal (enough for the TUI output stream)
+// ---------------------------------------------------------------------------
+
+class VirtualTerminal {
+	constructor(cols, rows) {
+		this.cols = cols;
+		this.rows = rows;
+		this.screen = [];
+		for (let r = 0; r < rows; r++) this.screen.push(newRow(cols));
+		this.row = 0;
+		this.col = 0;
+		this.wrapPending = false;
+		this.savedRow = 0;
+		this.savedCol = 0;
+		this.scrollTop = 0;
+		this.scrollBottom = rows - 1;
+		this.reverse = false;
+		this.alt = false;
+	}
+
+	get rowsCount() {
+		return this.rows;
+	}
+
+	text() {
+		return this.screen.map((row) => row.map((c) => c.ch).join(""));
+	}
+
+	cursorCell() {
+		return this.screen[this.row][this.col];
+	}
+
+	feed(data) {
+		let i = 0;
+		const s = data;
+		while (i < s.length) {
+			const ch = s[i];
+			if (ch === "\x1b") {
+				i = this.consumeEscape(s, i + 1);
+			} else if (ch === "\r") {
+				this.col = 0;
+				this.wrapPending = false;
+				i++;
+			} else if (ch === "\n") {
+				this.wrapPending = false;
+				this.lineFeed();
+				i++;
+			} else if (ch === "\b") {
+				this.col = Math.max(0, this.col - 1);
+				i++;
+			} else if (ch === "\t") {
+				this.col = Math.min(this.cols - 1, this.col + 8 - (this.col % 8));
+				i++;
+			} else if (ch === "\x07" || ch === "\x0b" || ch === "\x0c") {
+				if (ch === "\x0b" || ch === "\x0c") this.lineFeed();
+				i++;
+			} else {
+				this.put(ch);
+				i++;
+			}
+		}
+	}
+
+	consumeEscape(s, i) {
+		// C1 / CSI / OSC / APC / DCS / generic ESC sequences
+		if (i >= s.length) return i;
+		const c = s[i];
+		if (c === "[") return this.consumeCsi(s, i + 1);
+		if (c === "]") return this.consumeOsc(s, i + 1);
+		if (c === "_" || c === "^" || c === "P" || c === "X") return this.consumeStringTerminated(s, i + 1);
+		if (c === "7") {
+			this.savedRow = this.row;
+			this.savedCol = this.col;
+			return i + 1;
+		}
+		if (c === "8") {
+			this.row = this.savedRow;
+			this.col = this.savedCol;
+			return i + 1;
+		}
+		if (c === "c") {
+			// RIS - full reset
+			this.screen = [];
+			for (let r = 0; r < this.rows; r++) this.screen.push(newRow(this.cols));
+			this.row = 0;
+			this.col = 0;
+			return i + 1;
+		}
+		if (c === "D") {
+			this.lineFeed();
+			return i + 1;
+		}
+		if (c === "M") {
+			this.reverseLineFeed();
+			return i + 1;
+		}
+		if (c === "E") {
+			this.col = 0;
+			this.lineFeed();
+			return i + 1;
+		}
+		if (c === "=" || c === ">") return i + 1; // keypad modes - ignore
+		// bare ESC + printable: treat as literal (ignore)
+		return i + 1;
+	}
+
+	consumeStringTerminated(s, i) {
+		// OSC/APC/DCS: skip until BEL or ST (\x1b\\)
+		while (i < s.length) {
+			if (s[i] === "\x07") return i + 1;
+			if (s[i] === "\x1b" && s[i + 1] === "\\") return i + 2;
+			i++;
+		}
+		return i;
+	}
+
+	consumeOsc(s, i) {
+		return this.consumeStringTerminated(s, i);
+	}
+
+	consumeCsi(s, i) {
+		// Parse params up to final byte (0x40-0x7E); ignore intermediates.
+		let params = "";
+		let final = "";
+		let j = i;
+		while (j < s.length) {
+			const code = s.charCodeAt(j);
+			if (code >= 0x40 && code <= 0x7e) {
+				final = s[j];
+				break;
+			}
+			if (code >= 0x20 && code <= 0x3f) {
+				params += s[j];
+				j++;
+			} else {
+				break;
+			}
+		}
+		if (final === "") return j; // unterminated - ignore rest
+		this.applyCsi(params, final);
+		return j + 1;
+	}
+
+	applyCsi(params, final) {
+		this.wrapPending = false;
+		const nums = params
+			.split(";")
+			.map((p) => parseInt(p, 10))
+			.map((n) => (Number.isNaN(n) ? 0 : n));
+		const n = (idx, def) => (nums[idx] === 0 || nums[idx] === undefined ? def : nums[idx]);
+		const isPrivate = params.startsWith("?") || params.startsWith(">") || params.startsWith("<") || params.startsWith("=");
+		const p = isPrivate ? params.slice(1) : params;
+		const pnums = p
+			.split(";")
+			.map((x) => parseInt(x, 10))
+			.map((x) => (Number.isNaN(x) ? 0 : x));
+
+		switch (final) {
+			case "A":
+				this.row = Math.max(0, this.row - n(0, 1));
+				break;
+			case "B":
+				this.row = Math.min(this.rows - 1, this.row + n(0, 1));
+				break;
+			case "C":
+				this.col = Math.min(this.cols - 1, this.col + n(0, 1));
+				break;
+			case "D":
+				this.col = Math.max(0, this.col - n(0, 1));
+				break;
+			case "E":
+				this.row = Math.min(this.rows - 1, this.row + n(0, 1));
+				this.col = 0;
+				break;
+			case "F":
+				this.row = Math.max(0, this.row - n(0, 1));
+				this.col = 0;
+				break;
+			case "G":
+				this.col = Math.max(0, Math.min(this.cols - 1, n(0, 1) - 1));
+				break;
+			case "d":
+				this.row = Math.max(0, Math.min(this.rows - 1, n(0, 1) - 1));
+				break;
+			case "H":
+			case "f":
+				this.row = Math.max(0, Math.min(this.rows - 1, n(0, 1) - 1));
+				this.col = Math.max(0, Math.min(this.cols - 1, n(1, 1) - 1));
+				break;
+			case "J":
+				this.eraseDisplay(n(0, 0));
+				break;
+			case "K":
+				this.eraseLine(n(0, 0));
+				break;
+			case "X":
+				this.eraseChars(n(0, 1));
+				break;
+			case "P": {
+				const row = this.screen[this.row];
+				const cnt = Math.min(n(0, 1), this.cols - this.col);
+				row.splice(this.col, cnt);
+				while (row.length < this.cols) row.push(newCell());
+				break;
+			}
+			case "@": {
+				const row = this.screen[this.row];
+				const cnt = Math.min(n(0, 1), this.cols - this.col);
+				for (let k = 0; k < cnt; k++) row.splice(this.col, 0, newCell());
+				row.length = this.cols;
+				break;
+			}
+			case "S":
+				this.scrollUp(n(0, 1));
+				break;
+			case "T":
+				this.scrollDown(n(0, 1));
+				break;
+			case "r":
+				this.scrollTop = Math.max(0, n(0, 1) - 1);
+				this.scrollBottom = Math.min(this.rows - 1, n(1, this.rows) - 1);
+				this.row = 0;
+				this.col = 0;
+				break;
+			case "s":
+				this.savedRow = this.row;
+				this.savedCol = this.col;
+				break;
+			case "u":
+				this.row = this.savedRow;
+				this.col = this.savedCol;
+				break;
+			case "m":
+				this.applySgr(pnums);
+				break;
+			case "n":
+			case "c":
+				// DSR/DA queries: the app writes these; no terminal in this
+				// analyzer responds, so nothing to do.
+				break;
+			default:
+				break;
+		}
+	}
+
+	applySgr(nums) {
+		if (nums.length === 0 || nums[0] === 0) {
+			this.reverse = false;
+			return;
+		}
+		for (const num of nums) {
+			if (num === 7) this.reverse = true;
+			else if (num === 27) this.reverse = false;
+		}
+	}
+
+	put(ch) {
+		if (this.row >= this.rows) return;
+		if (this.wrapPending) {
+			this.wrapPending = false;
+			this.col = 0;
+			this.lineFeed();
+		}
+		const cell = this.screen[this.row][this.col];
+		cell.ch = ch;
+		cell.reverse = this.reverse;
+		this.col++;
+		if (this.col >= this.cols) {
+			this.col = this.cols - 1; // stay at last column, wrap pending
+			this.wrapPending = true;
+		}
+	}
+
+	lineFeed() {
+		if (this.row === this.scrollBottom) {
+			this.screen.splice(this.scrollTop, 1);
+			this.screen.splice(this.scrollBottom, 0, newRow(this.cols));
+		} else if (this.row < this.rows - 1) {
+			this.row++;
+		}
+	}
+
+	reverseLineFeed() {
+		if (this.row === this.scrollTop) {
+			this.screen.splice(this.scrollTop, 0, newRow(this.cols));
+			this.screen.splice(this.scrollBottom + 1, 1);
+		} else if (this.row > 0) {
+			this.row--;
+		}
+	}
+
+	scrollUp(n) {
+		for (let k = 0; k < n; k++) {
+			this.screen.splice(this.scrollTop, 1);
+			this.screen.splice(this.scrollBottom, 0, newRow(this.cols));
+		}
+	}
+
+	scrollDown(n) {
+		for (let k = 0; k < n; k++) {
+			this.screen.splice(this.scrollBottom, 0, newRow(this.cols));
+			this.screen.splice(this.scrollTop, 1);
+		}
+	}
+
+	eraseDisplay(mode) {
+		if (mode === 2 || mode === 3) {
+			for (let r = 0; r < this.rows; r++) {
+				this.screen[r] = newRow(this.cols);
+			}
+		} else if (mode === 1) {
+			for (let r = 0; r <= this.row; r++) {
+				const row = this.screen[r];
+				const upto = r === this.row ? this.col + 1 : this.cols;
+				for (let c = 0; c < upto; c++) row[c] = newCell();
+			}
+		} else {
+			for (let r = this.row; r < this.rows; r++) {
+				const row = this.screen[r];
+				const from = r === this.row ? this.col : 0;
+				for (let c = from; c < this.cols; c++) row[c] = newCell();
+			}
+		}
+	}
+
+	eraseLine(mode) {
+		const row = this.screen[this.row];
+		if (mode === 2) {
+			for (let c = 0; c < this.cols; c++) row[c] = newCell();
+		} else if (mode === 1) {
+			for (let c = 0; c <= this.col; c++) row[c] = newCell();
+		} else {
+			for (let c = this.col; c < this.cols; c++) row[c] = newCell();
+		}
+	}
+
+	eraseChars(n) {
+		const row = this.screen[this.row];
+		for (let c = this.col; c < Math.min(this.cols, this.col + n); c++) row[c] = newCell();
+	}
+}
+
+function newCell() {
+	return { ch: " ", reverse: false };
+}
+
+function newRow(cols) {
+	const row = [];
+	for (let c = 0; c < cols; c++) row.push(newCell());
+	return row;
+}
+
+// ---------------------------------------------------------------------------
+// Editor state extraction from a screen snapshot
+// ---------------------------------------------------------------------------
+
+const BORDER_RE = /^─*─── (↑|↓) (\d+) more ─*$/;
+
+/**
+ * Locate the editor box (bottom-most bordered region) and extract:
+ *   topIndicator / bottomIndicator, cursor row/col within the editor box,
+ *   content rows (visible text).
+ */
+function extractEditor(screenText) {
+	const rows = screenText;
+	const lastNonEmpty = (() => {
+		for (let r = rows.length - 1; r >= 0; r--) {
+			if (rows[r].trim() !== "") return r;
+		}
+		return -1;
+	})();
+	if (lastNonEmpty < 0) return null;
+
+	// Bottom border: last non-empty row; may be plain dashes or a ↓ indicator.
+	const bottomRow = lastNonEmpty;
+	const bottomText = rows[bottomRow].trim();
+	const bottomMatch = bottomText.match(BORDER_RE);
+	if (!bottomText.includes("─") && !bottomMatch) return null;
+
+	// Walk up from the bottom border to find the top border.
+	let topRow = -1;
+	for (let r = bottomRow - 1; r >= 0; r--) {
+		const t = rows[r].trim();
+		if (t.includes("─") && (t.startsWith("─") || t.includes("───"))) {
+			topRow = r;
+			break;
+		}
+	}
+	if (topRow < 0) return null;
+
+	const topMatch = rows[topRow].trim().match(BORDER_RE);
+	const botMatch = bottomText.match(BORDER_RE);
+
+	// Cursor: reverse-video cell within the editor box rows.
+	const screen = null; // replaced below by caller for reverse scan
+	return {
+		topRow,
+		bottomRow,
+		topIndicator: topMatch ? { dir: topMatch[1], n: parseInt(topMatch[2], 10) } : null,
+		bottomIndicator: botMatch ? { dir: botMatch[1], n: parseInt(botMatch[2], 10) } : null,
+		content: rows.slice(topRow + 1, bottomRow),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Analysis
+// ---------------------------------------------------------------------------
+
+function readTimeline(dir) {
+	const p = path.join(dir, "timeline.jsonl");
+	if (!fs.existsSync(p)) return [];
+	return fs
+		.readFileSync(p, "utf8")
+		.split("\n")
+		.filter((l) => l.trim())
+		.map((l) => JSON.parse(l));
+}
+
+function main() {
+	const args = process.argv.slice(2);
+	const dumpScreen = args.includes("--dump-screen");
+	let dumpAt = null;
+	const dumpAtArg = args.find((a) => a.startsWith("--dump-at="));
+	if (dumpAtArg) dumpAt = parseFloat(dumpAtArg.split("=")[1]);
+	const dir = args.find((a) => !a.startsWith("--"));
+	if (!dir) {
+		console.error("usage: node analyze.mjs <capture-dir> [--dump-screen]");
+		process.exit(1);
+	}
+	const timeline = readTimeline(dir);
+	const decoder = new TextDecoder();
+
+	let cols = 100;
+	let rows = 30;
+	// Determine size from the first full-screen render if possible (fall back to defaults)
+	const vt = new VirtualTerminal(cols, rows);
+	const states = [];
+	let lastAnomaly = null;
+	const anomalies = [];
+	let pendingInput = "";
+	const inputEvents = [];
+
+	// Track editor state over time (sampled after each input and every 50ms of output)
+	let lastSampleT = -1;
+	let lastInHex = "";
+
+	for (const ev of timeline) {
+		if (ev.dir === "in") {
+			lastInHex = ev.hex;
+			inputEvents.push({ t: ev.t, hex: ev.hex });
+		} else {
+			const buf = Buffer.from(ev.hex, "hex");
+			const text = decoder.decode(buf, { stream: true });
+			if (text) vt.feed(text);
+			// sample
+			const sample = () => {
+				const screenText = vt.text();
+				const editor = extractEditor(screenText);
+				const cursor = findCursorCell(vt, editor);
+				const state = {
+					t: ev.t,
+					input: lastInHex,
+					top: editor?.topIndicator ?? null,
+					bottom: editor?.bottomIndicator ?? null,
+					cursorInEditor: cursor !== null,
+					cursorRow: cursor?.row ?? -1,
+					cursorCol: cursor?.col ?? -1,
+					editorRows: editor ? editor.bottomRow - editor.topRow - 1 : 0,
+				};
+				states.push(state);
+				detectAnomaly(state, states, anomalies);
+			};
+			if (lastSampleT < 0 || ev.t - lastSampleT >= 50) {
+				sample();
+				lastSampleT = ev.t;
+			}
+		}
+	}
+	// flush any partial UTF-8 sequence, then final sample
+	vt.feed(decoder.decode());
+	{
+		const screenText = vt.text();
+		const editor = extractEditor(screenText);
+		const cursor = findCursorCell(vt, editor);
+		states.push({
+			t: timeline.at(-1)?.t ?? 0,
+			input: lastInHex,
+			top: editor?.topIndicator ?? null,
+			bottom: editor?.bottomIndicator ?? null,
+			cursorInEditor: cursor !== null,
+			cursorRow: cursor?.row ?? -1,
+			cursorCol: cursor?.col ?? -1,
+			editorRows: editor ? editor.bottomRow - editor.topRow - 1 : 0,
+		});
+	}
+
+	if (dumpScreen) {
+		console.log("==== final screen dump ====");
+		const rows = vt.text();
+		rows.forEach((r, i) => console.log(String(i).padStart(3) + "|" + r.replace(/\s+$/, "") + "|"));
+		console.log("==========================");
+	}
+
+	if (dumpAt !== null) {
+		const target = states.find((s) => s.t >= dumpAt);
+		if (target) {
+			console.log(`==== screen dump at t=${target.t}ms ====`);
+			// Replay up to that timestamp
+			const vt2 = new VirtualTerminal(cols, rows);
+			const dec2 = new TextDecoder();
+			for (const ev of timeline) {
+				if (ev.dir === "out" && ev.t <= target.t) {
+					vt2.feed(dec2.decode(Buffer.from(ev.hex, "hex"), { stream: true }));
+				}
+			}
+			vt2.feed(dec2.decode());
+			vt2.text().forEach((r, i) => console.log(String(i).padStart(3) + "|" + r.replace(/\s+$/, "") + "|"));
+			console.log("==========================");
+		}
+	}
+
+
+	// ---- report ----
+	console.log(`timeline events: ${timeline.length} (in=${inputEvents.length})`);
+	console.log(`samples: ${states.length}`);
+	console.log(`anomalies detected: ${anomalies.length}`);
+	console.log("");
+	if (anomalies.length === 0) {
+		console.log("No scroll-jump anomalies detected in this capture.");
+		console.log("Sample editor states (every few frames):");
+		for (const s of states.filter((_, i) => i % Math.max(1, Math.floor(states.length / 8)) === 0)) {
+			console.log(`  t=${String(s.t).padEnd(7)} ${describeState(s)}`);
+		}
+		return;
+	}
+	for (const a of anomalies) {
+		console.log("=".repeat(70));
+		console.log(`ANOMALY at t=${a.t}ms  (after input: ${describeInput(a.input)})`);
+		console.log(`  ${a.reason}`);
+		console.log(`  before: ${describeState(a.before)}`);
+		console.log(`  after : ${describeState(a.after)}`);
+	}
+}
+
+function findCursorCell(vt, editor) {
+	if (!editor) return null;
+	for (let r = editor.topRow + 1; r < editor.bottomRow; r++) {
+		const row = vt.screen[r];
+		for (let c = 0; c < row.length; c++) {
+			if (row[c].reverse) return { row: r, col: c };
+		}
+	}
+	return null;
+}
+
+function describeState(s) {
+	if (!s) return "n/a";
+	const top = s.top ? `${s.top.dir}${s.top.n}` : "top(plain)";
+	const bottom = s.bottom ? `${s.bottom.dir}${s.bottom.n}` : "bottom(plain)";
+	return `top=${top} bottom=${bottom} cursor=${s.cursorInEditor ? `r${s.cursorRow}c${s.cursorCol}` : "LOST"} editorRows=${s.editorRows}`;
+}
+
+function describeInput(hex) {
+	if (!hex) return "(none)";
+	const b = Buffer.from(hex, "hex");
+	const s = b.toString("latin1");
+	if (s === "\x1b[A") return "Up";
+	if (s === "\x1b[B") return "Down";
+	if (s === "\x1b[15~") return "F5(setText)";
+	if (s === "\x1b[17~") return "F6(history)";
+	if (s === "\x1b[18~") return "F7(focus)";
+	if (s === "\x1b[19~") return "F8(save/restore)";
+	if (s === "\x1b[20~") return "F9(submit)";
+	if (s === "\r") return "Enter";
+	if (s.length > 1) return JSON.stringify(s.slice(0, 30));
+	return s;
+}
+
+function detectAnomaly(state, states, anomalies) {
+	if (states.length < 2) return;
+	const prev = states[states.length - 2];
+	// Only compare states separated by an input event boundary (or new frames)
+	// Jump to top: top indicator was ↑N (N>0) and becomes plain/absent,
+	// while the editor still has content below (bottom ↓ present) — or the
+	// cursor is below the first editor content row.
+	const wasScrolled = prev.top && prev.top.dir === "↑" && prev.top.n > 0;
+	const nowTop = !state.top || state.top.dir !== "↑" || state.top.n === 0;
+	if (wasScrolled && nowTop) {
+		const hasContentBelow = state.bottom && state.bottom.dir === "↓";
+		const cursorBelowTop = state.cursorInEditor && state.cursorRow > (state.editorRows > 0 ? 0 : 0);
+		if (hasContentBelow || cursorBelowTop) {
+			anomalies.push({
+				t: state.t,
+				input: state.input,
+				reason: "editor scroll jumped to top (top indicator ↑N → plain) while content/cursor remained below",
+				before: prev,
+				after: state,
+			});
+			return;
+		}
+	}
+	// Cursor lost: was in editor, now gone, while bottom still shows content below
+	if (prev.cursorInEditor && !state.cursorInEditor && state.bottom && state.bottom.dir === "↓") {
+		anomalies.push({
+			t: state.t,
+			input: state.input,
+			reason: "editor cursor cell vanished from view while lines remain below (cursor scrolled out)",
+			before: prev,
+			after: state,
+		});
+	}
+}
+
+main();

--- a/scripts/editor-scroll-capture/capture.py
+++ b/scripts/editor-scroll-capture/capture.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+capture.py — PTY capture harness for the pi Editor scroll bug.
+
+Spawns a TUI app (default: the editor-scroll-demo) inside a pseudo-terminal,
+feeds scripted keystrokes, and captures:
+  - the raw ANSI stream pi writes (via PI_TUI_WRITE_LOG, pi's built-in logger)
+  - the raw PTY output bytes (belt-and-braces fallback)
+  - app-level event log (demo app writes JSONL to EDITOR_DEMO_EVENT_LOG)
+
+Scenario format (one directive per line, '#' comments allowed):
+  wait <seconds>            sleep
+  key <name> [x<count>]     send a named key (see KEY_SEQUENCES) count times
+  raw <hex>                 send raw bytes (hex, e.g. 1b5b41 = CSI A)
+  type <text>               type literal text (UTF-8, newlines as \\n escape)
+
+Example scenario (repro the suspected rewrite/scroll interaction):
+  wait 0.5
+  key end
+  key up x10
+  wait 0.2
+  key f5
+  wait 0.5
+  key f8
+  wait 0.5
+  key ctrl+c
+
+Usage:
+  python3 scripts/editor-scroll-capture/capture.py \
+      --scenario scenarios/scroll-rewrite.txt \
+      --out /tmp/editor-scroll-capture
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import pty
+import select
+import signal
+import sys
+import time
+
+KEY_SEQUENCES = {
+    "up": b"\x1b[A",
+    "down": b"\x1b[B",
+    "right": b"\x1b[C",
+    "left": b"\x1b[D",
+    "enter": b"\r",
+    "tab": b"\t",
+    "esc": b"\x1b",
+    "home": b"\x1b[H",
+    "end": b"\x1b[F",
+    "pgup": b"\x1b[5~",
+    "pgdn": b"\x1b[6~",
+    "f5": b"\x1b[15~",
+    "f6": b"\x1b[17~",
+    "f7": b"\x1b[18~",
+    "f8": b"\x1b[19~",
+    "f9": b"\x1b[20~",
+    "ctrl+c": b"\x03",
+    "ctrl+z": b"\x1a",
+    "ctrl+l": b"\x0c",
+    "backspace": b"\x7f",
+    "delete": b"\x1b[3~",
+}
+
+
+def parse_scenario(path: str) -> list[tuple[str, ...]]:
+    directives: list[tuple[str, ...]] = []
+    with open(path, encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            directives.append(tuple(line.split()))
+    return directives
+
+
+def encode_directive(directive: tuple[str, ...]) -> bytes:
+    kind = directive[0]
+    if kind == "key":
+        name = directive[1]
+        count = 1
+        for tok in directive[2:]:
+            if tok.startswith("x") and tok[1:].isdigit():
+                count = int(tok[1:])
+        seq = KEY_SEQUENCES.get(name)
+        if seq is None:
+            raise ValueError(f"unknown key: {name}")
+        return seq * count
+    if kind == "raw":
+        return bytes.fromhex(directive[1])
+    if kind == "type":
+        text = " ".join(directive[1:]).replace("\\n", "\n")
+        return text.encode("utf-8")
+    raise ValueError(f"unknown directive: {kind}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PTY capture harness for pi editor scroll bug")
+    parser.add_argument("--scenario", required=True, help="scenario file")
+    parser.add_argument("--out", default="/tmp/editor-scroll-capture", help="output directory")
+    parser.add_argument(
+        "--cmd",
+        default=None,
+        help="command to run (default: demo app via node22 + ts-strip)",
+    )
+    parser.add_argument("--cols", type=int, default=100)
+    parser.add_argument("--rows", type=int, default=30)
+    parser.add_argument("--timeout", type=float, default=30.0, help="hard timeout seconds")
+    parser.add_argument("--demo-text", default=None, help="initial editor text file for the demo")
+    parser.add_argument("--demo-rewrite", default=None, help="F5 rewrite text file for the demo")
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    ansi_log = os.path.join(args.out, "ansi.log")
+    pty_log = os.path.join(args.out, "pty-raw.log")
+    event_log = os.path.join(args.out, "events.jsonl")
+    timeline_log = os.path.join(args.out, "timeline.jsonl")
+    scenario_log = os.path.join(args.out, "scenario.txt")
+
+    with open(scenario_log, "w", encoding="utf-8") as f:
+        f.write(open(args.scenario, encoding="utf-8").read())
+
+    if args.cmd:
+        cmd = args.cmd
+    else:
+        node = os.environ.get("PI_NODE", "node")
+        repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        demo = os.path.join(repo, "packages", "tui", "test", "editor-scroll-demo.ts")
+        cmd = f"{node} {demo}"
+
+    env = os.environ.copy()
+    env["PI_TUI_WRITE_LOG"] = ansi_log
+    env["EDITOR_DEMO_EVENT_LOG"] = event_log
+    if args.demo_text:
+        env["EDITOR_DEMO_TEXT_FILE"] = args.demo_text
+    if args.demo_rewrite:
+        env["EDITOR_DEMO_REWRITE_FILE"] = args.demo_rewrite
+    env["TERM"] = env.get("TERM", "xterm-256color")
+    env["COLORTERM"] = env.get("COLORTERM", "truecolor")
+
+    directives = parse_scenario(args.scenario)
+    print(f"[capture] cmd: {cmd}")
+    print(f"[capture] out: {args.out}")
+
+    tl_start = time.monotonic()
+
+    def tl(kind: str, hexdata: str) -> None:
+        with open(timeline_log, "a", encoding="utf-8") as f:
+            f.write(f'{{"t": {round((time.monotonic() - tl_start) * 1000, 1)}, "dir": "{kind}", "hex": "{hexdata}"}}\n')
+
+
+    pid, fd = pty.fork()
+    if pid == 0:  # child
+        os.environ.update(env)
+        # window size
+        import fcntl
+        import struct
+        import termios
+
+        winsize = struct.pack("HHHH", args.rows, args.cols, 0, 0)
+        fcntl.ioctl(sys.stdout.fileno(), termios.TIOCSWINSZ, winsize)
+        os.execvp("/bin/sh", ["/bin/sh", "-c", cmd])
+        os._exit(127)
+
+    # parent
+    with open(pty_log, "wb") as ptyf:
+        start = time.monotonic()
+        deadline = start + args.timeout
+        for directive in directives:
+            if time.monotonic() > deadline:
+                print("[capture] TIMEOUT reached; aborting scenario")
+                break
+            kind = directive[0]
+            if kind == "wait":
+                time.sleep(float(directive[1]))
+                continue
+            payload = encode_directive(directive)
+            print(f"[capture] -> {directive}")
+            os.write(fd, payload)
+            tl("in", payload.hex())
+            # drain available output for a short window so renders settle
+            drain_for(fd, ptyf, 0.05, tl)
+        # give the app a moment to settle, then terminate
+        drain_for(fd, ptyf, 0.5, tl)
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+
+    print(f"[capture] done. ANSI log: {ansi_log} ({os.path.getsize(ansi_log)} bytes)")
+    print(f"[capture] PTY log: {pty_log} ({os.path.getsize(pty_log)} bytes)")
+    print(f"[capture] timeline: {timeline_log}")
+    if os.path.exists(event_log):
+        print(f"[capture] event log: {event_log} ({os.path.getsize(event_log)} bytes)")
+    return 0
+
+
+def drain_for(fd: int, ptyf, seconds: float, tl=None) -> None:
+    end = time.monotonic() + seconds
+    while time.monotonic() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if fd in r:
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            ptyf.write(data)
+            ptyf.flush()
+            if tl is not None:
+                tl("out", data.hex())
+        else:
+            # idle wait consumed the remainder of the window
+            break
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/editor-scroll-capture/fuzz-scroll.mts
+++ b/scripts/editor-scroll-capture/fuzz-scroll.mts
@@ -1,0 +1,207 @@
+/**
+ * fuzz-scroll.mts — property-based search for the editor scroll-jump bug.
+ *
+ * Invariant: after every operation + render(), if the editor holds any text,
+ * the rendered output MUST contain the reverse-video cursor cell somewhere.
+ * A missing cursor means the view is showing a scroll position where the
+ * cursor is not visible (symptom: "editor scroll returned to top, cursor lost").
+ *
+ * Prints the first failing operation sequence (for deterministic replay).
+ *
+ * Run: node scripts/editor-scroll-capture/fuzz-scroll.mts [iterations] [seed]
+ */
+import { Editor } from "../../packages/tui/src/components/editor.ts";
+import { TuiMainScreen } from "../../packages/tui/src/tui-main-screen.ts";
+import { VirtualTerminal } from "../../packages/tui/test/virtual-terminal.ts";
+import { defaultEditorTheme } from "../../packages/tui/test/test-themes.ts";
+
+const ITER = Number(process.argv[2] ?? 2000);
+const SEED = Number(process.argv[3] ?? 42);
+
+// Deterministic PRNG (mulberry32)
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a |= 0;
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+const rand = mulberry32(SEED);
+const ri = (n: number): number => Math.floor(rand() * n);
+const pick = <T,>(arr: T[]): T => arr[ri(arr.length)]!;
+
+const WORDS = ["foo", "bar", "baz", "word", "longword", "あいう", "日本語", "x", "y", "zz", "🚀", "ab", "cd"];
+const PUNCT = [" ", "  ", "   ", ", ", ".\n", "\n", "\n\n", "", " - "];
+
+function randomLine(maxLen: number): string {
+	const line: string[] = [];
+	let len = 0;
+	while (len < maxLen && rand() < 0.9) {
+		const w = pick(WORDS);
+		line.push(w);
+		len += w.length;
+		if (len < maxLen) {
+			const p = pick(PUNCT);
+			line.push(p);
+			len += p.length;
+		}
+	}
+	return line.join("");
+}
+
+function randomText(): string {
+	const n = 1 + ri(40);
+	const lines: string[] = [];
+	for (let i = 0; i < n; i++) {
+		lines.push(ri(4) === 0 ? "" : randomLine(20 + ri(120)));
+	}
+	return lines.join("\n");
+}
+
+const KEYS = [
+	"\x1b[A", // up
+	"\x1b[B", // down
+	"\x1b[C", // right
+	"\x1b[D", // left
+	"\x1b[H", // home (line start)
+	"\x1b[F", // end (line end)
+	"\x1b[5~", // pgup
+	"\x1b[6~", // pgdn
+	"\x01", // ctrl+a (line start)
+	"\x05", // ctrl+e (line end)
+	"\x7f", // backspace
+	"\x1b[3~", // delete
+	"\x15", // ctrl+u (delete to line start)
+	"\x0b", // ctrl+k (delete to line end)
+	"\x17", // ctrl+w (delete word back)
+	"\x1a", // ctrl+z... actually ctrl+- is undo; use \x1f? test below
+];
+
+function randomOp(editor: Editor, tui: TuiMainScreen): string {
+	const r = rand();
+	if (r < 0.45) {
+		const k = pick(KEYS);
+		editor.handleInput(k);
+		return `key ${JSON.stringify(k)}`;
+	}
+	if (r < 0.55) {
+		// type a printable char / word
+		const s = rand() < 0.7 ? pick(WORDS) : pick(PUNCT);
+		editor.handleInput(s);
+		return `type ${JSON.stringify(s)}`;
+	}
+	if (r < 0.65) {
+		// setText (app-level rewrite)
+		editor.setText(randomText());
+		return "setText(random)";
+	}
+	if (r < 0.7) {
+		// setText(same) — save/restore
+		const t = editor.getText();
+		editor.setText(t);
+		return "setText(same)";
+	}
+	if (r < 0.75) {
+		// insertTextAtCursor
+		editor.insertTextAtCursor(randomText());
+		return "insertTextAtCursor(random)";
+	}
+	if (r < 0.8) {
+		// history cycle
+		editor.addToHistory(randomText());
+		editor.handleInput("\x1b[A");
+		editor.handleInput("\x1b[B");
+		return "history-cycle";
+	}
+	if (r < 0.85) {
+		// focus churn
+		tui.setFocus(null);
+		tui.setFocus(editor);
+		return "focus-churn";
+	}
+	if (r < 0.9) {
+		// undo (ctrl+-)
+		editor.handleInput("\x1f");
+		return "undo";
+	}
+	if (r < 0.95) {
+		// bracketed paste (single-line only to keep it simple)
+		editor.handleInput(`\x1b[200~${randomLine(60)}\x1b[201~`);
+		return "paste";
+	}
+	// multiline paste
+	editor.handleInput(`\x1b[200~${randomText()}\x1b[201~`);
+	return "paste-multi";
+}
+
+function cursorVisible(editor: Editor, width: number): { visible: boolean; lines: string[] } {
+	const lines = editor.render(width);
+	for (const l of lines) {
+		if (l.includes("\x1b[7m")) return { visible: true, lines };
+	}
+	return { visible: false, lines };
+}
+
+const COLS = 100;
+const ROWS = 30;
+const WIDTH = COLS - 2; // editor render width (matches app padding)
+
+let failures = 0;
+let lastFailingOps: string[] = [];
+let lastFailWidth = WIDTH;
+
+for (let iter = 0; iter < ITER; iter++) {
+	const vt = new VirtualTerminal(COLS, ROWS);
+	const tui = new TuiMainScreen(vt);
+	const editor = new Editor(tui, defaultEditorTheme);
+	tui.addChild(editor);
+	tui.setFocus(editor);
+
+	const ops: string[] = [];
+	const text = randomText();
+	editor.setText(text);
+	ops.push("setText(initial)");
+
+	let width = WIDTH;
+	for (let step = 0; step < 60; step++) {
+		const op = randomOp(editor, tui);
+		ops.push(op);
+
+		// occasional resize (changes wrapping + maxVisibleLines)
+		if (rand() < 0.08) {
+			width = 20 + ri(90);
+			ops.push(`resize-width ${width}`);
+		}
+
+		if (editor.getText().trim() !== "") {
+			const { visible, lines } = cursorVisible(editor, width);
+			if (!visible) {
+				failures++;
+				lastFailingOps = [...ops];
+				lastFailWidth = width;
+				if (failures <= 3) {
+					console.log(`\nFAIL #${failures} iter=${iter} step=${step} width=${width}`);
+					console.log(`  ops: ${ops.join(" | ")}`);
+					console.log(`  cursor missing; rendered rows=${lines.length}`);
+					console.log(`  top=${JSON.stringify(stripAnsi(lines[0] ?? ""))}`);
+					console.log(`  bottom=${JSON.stringify(stripAnsi(lines.at(-1) ?? ""))}`);
+				}
+				break;
+			}
+		}
+	}
+}
+
+console.log(`\n=== fuzz done: ${ITER} iterations, ${failures} failures (seed=${SEED}) ===`);
+if (failures > 0) {
+	console.log("first failing sequence:");
+	for (const op of lastFailingOps) console.log(`  ${op}`);
+}
+
+function stripAnsi(s: string): string {
+	return s.replace(/\x1b\[[0-9;]*m/g, "").replace(/\x1b_[^\x07]*\x07/g, "");
+}

--- a/scripts/editor-scroll-capture/scenarios/scroll-attempt1.txt
+++ b/scripts/editor-scroll-capture/scenarios/scroll-attempt1.txt
@@ -1,0 +1,21 @@
+# Editor scroll repro attempts — real render pipeline (PTY)
+# Initial: 45-line generated text, cursor at end (bottom, scrolled)
+wait 0.8
+key end
+wait 0.3
+key up x10
+wait 0.3
+key f5
+wait 0.4
+key f8
+wait 0.4
+key f7
+wait 0.4
+key f6
+wait 0.4
+key up x3
+wait 0.3
+key down x3
+wait 0.3
+key ctrl+c
+wait 0.5


### PR DESCRIPTION
## Summary

Capture and verification tooling for Editor scroll behavior (see #8484). Adds:

- **`packages/tui/test/editor-scroll-demo.ts`** — scriptable minimal TUI app on the real `TuiMainScreen` + `Editor` stack. Trigger keys simulate app-level editor events (F5 `setText` rewrite, F6 history cycle, F7 focus churn, F8 save/restore, F9 submit).
- **`scripts/editor-scroll-capture/capture.py`** — PTY harness: runs the demo (or any command, e.g. the real `pi`) with `PI_TUI_WRITE_LOG`, feeds a scripted scenario, records a timed byte timeline.
- **`scripts/editor-scroll-capture/analyze.mjs`** — ANSI virtual-terminal analyzer (DEC autowrap-aware) that locates the editor box from its scroll-indicator borders and detects scroll-jump anomalies.
- **`scripts/editor-scroll-capture/fuzz-scroll.mts`** — property check that the cursor cell never disappears from rendered output after any editor operation.
- README + sample scenario.

## Motivation

#8484 was diagnosed on the render layer (ConPTY autowrap drift) rather than the editor state — editor scroll offset survives every operation we could construct (unit probes, fuzz, real-app tmux runs). This tooling is what made that verification possible and is reusable for capturing/reproducing scroll behavior on affected platforms (Windows Terminal) where the bug cannot be observed on Linux.

## Verification

- `fuzz-scroll.mts 2000 42` — 0 failures.
- Demo + capture + analyze end-to-end run against the TUI source; screen reconstruction matches xterm.js viewport.
- Not wired into the test suite (requires a PTY); run on demand.
