### PR TITLE
fix(plan-mode): eliminate false positives in plan mode bash guard and plan extraction

### DIFF
--- a/packages/coding-agent/examples/extensions/plan-mode/index.ts
+++ b/packages/coding-agent/examples/extensions/plan-mode/index.ts
@@ -214,7 +214,9 @@ Restrictions:
 Ask clarifying questions using the questionnaire tool.
 Use brave-search skill via bash for web research.
 
-Create a detailed numbered plan under a "Plan:" header:
+IMPORTANT: Only output a "Plan:" section when the user explicitly asks you to create a plan. Never use "Plan:" format for demonstrations, examples, explanations of how plan mode works, or quoting previous messages - doing so will be mistakenly extracted as a real plan.
+
+When the user does ask for a plan, create a detailed numbered plan under a "Plan:" header:
 
 Plan:
 1. First step description

--- a/packages/coding-agent/examples/extensions/plan-mode/utils.ts
+++ b/packages/coding-agent/examples/extensions/plan-mode/utils.ts
@@ -19,7 +19,7 @@ const DESTRUCTIVE_PATTERNS = [
 	/\btruncate\b/i,
 	/\bdd\b/i,
 	/\bshred\b/i,
-	/(^|[^<])>(?!>)/,
+	/(^|[^<])>(?!>)(?!\s*\/dev\/null)/,
 	/>>/,
 	/\bnpm\s+(install|uninstall|update|ci|link|publish)/i,
 	/\byarn\s+(add|remove|install|publish)/i,
@@ -37,7 +37,7 @@ const DESTRUCTIVE_PATTERNS = [
 	/\bshutdown\b/i,
 	/\bsystemctl\s+(start|stop|restart|enable|disable)/i,
 	/\bservice\s+\S+\s+(start|stop|restart)/i,
-	/\b(vim?|nano|emacs|code|subl)\b/i,
+	/(^|[;&|]\s*)(vim?|nano|emacs|code|subl)(\s|$)/i,
 ];
 
 // Safe read-only commands allowed in plan mode


### PR DESCRIPTION
## Problem

The plan-mode extension's bash guard (`isSafeCommand`) has two false-positive classes that block legitimate read-only commands, and the plan extractor can be fooled by demo text.

### 1. Paths containing the word "code" are blocked

`DESTRUCTIVE_PATTERNS` uses `\b(vim?|nano|emacs|code|subl)\b` to detect editor launches. Because of the `\b...\b` word boundary, any read-only command referencing a path that contains "code" as a word — e.g. `ls /home/user/code/project` or `grep -rn foo /home/user/code/...` — is misclassified as an editor launch and blocked.

### 2. `2>/dev/null` (stderr discard) is blocked as file truncation

The redirect pattern `/(^|[^<])>(?!>)/` matches `2>` too, so the very common read-only idiom `grep foo file 2>/dev/null` is blocked even though discarding stderr is harmless.

### 3. Demo/example "Plan:" text pollutes the plan

`extractTodoItems` (agent_end) extracts any numbered list under a "Plan:" header in the agent's reply. When the agent explains how plan mode works and includes an example `Plan:` block, that demo text is mistaken for a real plan and injected into execution context.

## Fix

- Editor-launch detection now matches only the command-verb position: `/(^|[;&|]\s*)(vim?|nano|emacs|code|subl)(\s|$)/i`
- Redirect detection now exempts `/dev/null`: `/(^|[^<])>(?!>)(?!\s*\/dev\/null)/`
- The `[PLAN MODE ACTIVE]` prompt now instructs the agent to emit "Plan:" sections only when the user explicitly asks, so demo/example text is never extracted as a plan.

## Verification

14-case test harness covering both regressions and no-degradation of real blocks (`rm -rf`, `git reset --hard`, `code .`, `> file`, `npm install`, `sudo`, `touch`):
- `ls /home/abu/code/upstream/pi` → allowed (was blocked)
- `grep x file 2>/dev/null` → allowed (was blocked)
- `rm -rf src`, `code .`, `echo x > file.txt`, `npm install` → still blocked
