### PR TITLE
fix(coding-agent): cap agent retry backoff

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -141,6 +141,7 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 | `retry.enabled` | boolean | `true` | Enable automatic agent-level retry on transient errors |
 | `retry.maxRetries` | number | `3` | Maximum agent-level retry attempts |
 | `retry.baseDelayMs` | number | `2000` | Base delay for agent-level exponential backoff (2s, 4s, 8s) |
+| `retry.maxAgentDelayMs` | number | `30000` | Maximum agent-level retry delay; later exponential delays are capped |
 | `retry.provider.timeoutMs` | number | SDK default | Provider/SDK request timeout in milliseconds |
 | `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
@@ -155,6 +156,7 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
     "enabled": true,
     "maxRetries": 3,
     "baseDelayMs": 2000,
+    "maxAgentDelayMs": 30000,
     "provider": {
       "timeoutMs": 3600000,
       "maxRetries": 0,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2822,7 +2822,7 @@ export class AgentSession {
 			return false;
 		}
 
-		const delayMs = settings.baseDelayMs * 2 ** (this._retryAttempt - 1);
+		const delayMs = Math.min(settings.baseDelayMs * 2 ** (this._retryAttempt - 1), settings.maxAgentDelayMs);
 
 		this._emit({
 			type: "auto_retry_start",

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -31,6 +31,7 @@ export interface RetrySettings {
 	enabled?: boolean; // default: true
 	maxRetries?: number; // default: 3
 	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
+	maxAgentDelayMs?: number; // default: 30000 (maximum agent-level retry delay)
 	provider?: ProviderRetrySettings;
 }
 
@@ -875,11 +876,12 @@ export class SettingsManager {
 		this.save();
 	}
 
-	getRetrySettings(): { enabled: boolean; maxRetries: number; baseDelayMs: number } {
+	getRetrySettings(): { enabled: boolean; maxRetries: number; baseDelayMs: number; maxAgentDelayMs: number } {
 		return {
 			enabled: this.getRetryEnabled(),
 			maxRetries: this.settings.retry?.maxRetries ?? 3,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
+			maxAgentDelayMs: this.settings.retry?.maxAgentDelayMs ?? 30000,
 		};
 	}
 

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -71,10 +71,12 @@ describe("AgentSession retry", () => {
 	async function createSession(options?: {
 		failCount?: number;
 		maxRetries?: number;
+		maxAgentDelayMs?: number;
 		delayAssistantMessageEndMs?: number;
 	}) {
 		const failCount = options?.failCount ?? 1;
 		const maxRetries = options?.maxRetries ?? 3;
+		const maxAgentDelayMs = options?.maxAgentDelayMs;
 		const delayAssistantMessageEndMs = options?.delayAssistantMessageEndMs ?? 0;
 		let callCount = 0;
 
@@ -108,7 +110,7 @@ describe("AgentSession retry", () => {
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
 		const modelRegistry = await createModelRegistry(authStorage, tempDir);
 		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
-		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1 } });
+		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1, maxAgentDelayMs } });
 
 		session = new AgentSession({
 			agent,
@@ -146,6 +148,18 @@ describe("AgentSession retry", () => {
 		expect(created.getCallCount()).toBe(2);
 		expect(events).toEqual(["start:1", "end:success=true"]);
 		expect(created.session.isRetrying).toBe(false);
+	});
+
+	it("caps exponential retry delays", async () => {
+		const created = await createSession({ failCount: 4, maxRetries: 4, maxAgentDelayMs: 3 });
+		const delays: number[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "auto_retry_start") delays.push(event.delayMs);
+		});
+
+		await created.session.prompt("Test");
+
+		expect(delays).toEqual([1, 2, 3, 3]);
 	});
 
 	it("exhausts max retries and emits failure", async () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -335,6 +335,25 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("retry", () => {
+		it("should default agent retry delays to 2 seconds and cap them at 30 seconds", () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getRetrySettings()).toEqual({
+				enabled: true,
+				maxRetries: 3,
+				baseDelayMs: 2000,
+				maxAgentDelayMs: 30000,
+			});
+		});
+
+		it("should use a configured retry delay cap", () => {
+			expect(SettingsManager.inMemory({ retry: { maxAgentDelayMs: 5000 } }).getRetrySettings().maxAgentDelayMs).toBe(
+				5000,
+			);
+		});
+	});
+
 	describe("httpIdleTimeoutMs", () => {
 		it("should default to 5 minutes", () => {
 			const manager = SettingsManager.create(projectDir, agentDir);


### PR DESCRIPTION
## Summary

Add `retry.maxAgentDelayMs` for Pi's outer agent retry loop. It preserves exponential backoff while capping each wait at 30 seconds by default.

With this configuration:

```json
{
  "retry": {
    "maxRetries": 10,
    "baseDelayMs": 2000,
    "maxAgentDelayMs": 30000
  }
}
```

retry waits are `2s, 4s, 8s, 16s, 30s, 30s, ...`.

`retry.maxAgentDelayMs` is deliberately distinct from `retry.provider.maxRetryDelayMs`, which limits server-requested provider retry delays.

## Validation

- `npm run check`
- Targeted tests: `settings-manager.test.ts`, `agent-session-retry.test.ts`
- `./test.sh` ran but has four existing failures in unrelated coding-agent tests (`agent-session-concurrent`, `experimental-cli-command`, `footer-data-provider`); the modified retry tests passed.

This PR is AI-generated by `/wr`.
