### PR TITLE
fix(ai): surface stream errors and support toolless models

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1169,6 +1169,7 @@ The `openai-completions` API is implemented by many providers with minor differe
 
 ```typescript
 interface OpenAICompletionsCompat {
+  supportsTools?: boolean;           // Whether provider supports tool calling; false omits tools and tool_choice from requests (default: true)
   supportsStore?: boolean;           // Whether provider supports the `store` field (default: true)
   supportsDeveloperRole?: boolean;   // Whether provider supports `developer` role vs `system` (default: true)
   supportsReasoningEffort?: boolean; // Whether provider supports `reasoning_effort` (default: true)
@@ -1193,6 +1194,7 @@ interface OpenAICompletionsCompat {
 }
 
 interface OpenAIResponsesCompat {
+  supportsTools?: boolean;           // Whether provider supports tool calling; false omits tools and tool_choice from requests (default: true)
   supportsDeveloperRole?: boolean;   // Whether provider supports `developer` role vs `system` (default: true)
   sessionAffinityFormat?: 'openai' | 'openai-nosession' | 'openrouter'; // Session-affinity header format: 'openai' sends `session_id` and `x-client-request-id`; 'openai-nosession' sends `x-client-request-id`; 'openrouter' sends `x-session-id`. Does not affect the `prompt_cache_key` body param (default: auto-detected)
   supportsLongCacheRetention?: boolean; // Whether provider supports `prompt_cache_retention: "24h"` (default: true)

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -567,6 +567,7 @@ function isAnthropicTemperatureUnsupportedModel(modelId: string): boolean {
 }
 
 const OPENAI_COMPLETIONS_DEFAULT_COMPAT = {
+	supportsTools: true,
 	supportsStore: true,
 	supportsDeveloperRole: true,
 	supportsReasoningEffort: true,

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -184,6 +184,7 @@ function getAnthropicCompat(
 	model: Model<"anthropic-messages">,
 ): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking" | "allowedFallbackModels">> {
 	return {
+		supportsTools: model.compat?.supportsTools ?? true,
 		supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? true,
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
 		sendSessionAffinityHeaders: model.compat?.sendSessionAffinityHeaders ?? false,
@@ -1038,7 +1039,7 @@ function buildParams(
 		params.temperature = options.temperature;
 	}
 
-	if (immediateTools.length > 0 || deferredTools.length > 0) {
+	if (compat.supportsTools && (immediateTools.length > 0 || deferredTools.length > 0)) {
 		params.tools = [
 			...convertTools(
 				immediateTools,
@@ -1096,7 +1097,7 @@ function buildParams(
 		}
 	}
 
-	if (options?.toolChoice) {
+	if (compat.supportsTools && options?.toolChoice) {
 		if (typeof options.toolChoice === "string") {
 			params.tool_choice = { type: options.toolChoice };
 		} else {
@@ -1320,7 +1321,8 @@ function convertMessages(
 }
 
 function shouldUseFineGrainedToolStreamingBeta(model: Model<"anthropic-messages">, context: Context): boolean {
-	return !!context.tools?.length && !getAnthropicCompat(model).supportsEagerToolInputStreaming;
+	const compat = getAnthropicCompat(model);
+	return compat.supportsTools && !!context.tools?.length && !compat.supportsEagerToolInputStreaming;
 }
 
 function convertTools(

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -235,6 +235,7 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 
 		try {
 			const supportsStrictMode = model.compat?.supportsStrictMode ?? false;
+			const supportsTools = model.compat?.supportsTools ?? true;
 			const client = new BedrockRuntimeClient(config);
 			let observedRawResponse = false;
 			if (options.onResponse) {
@@ -256,7 +257,7 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 					...(inferenceMaxTokens !== undefined && { maxTokens: inferenceMaxTokens }),
 					...(options.temperature !== undefined && { temperature: options.temperature }),
 				},
-				toolConfig: convertToolConfig(context.tools, options.toolChoice, supportsStrictMode),
+				toolConfig: convertToolConfig(context.tools, options.toolChoice, supportsStrictMode, supportsTools),
 				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
 				...(options.requestMetadata !== undefined && { requestMetadata: options.requestMetadata }),
 			};
@@ -1103,7 +1104,9 @@ function convertToolConfig(
 	tools: Tool[] | undefined,
 	toolChoice: BedrockOptions["toolChoice"],
 	supportsStrictMode: boolean,
+	supportsTools = true,
 ): ToolConfiguration | undefined {
+	if (!supportsTools) return undefined;
 	if (!tools?.length) return undefined;
 	if (toolChoice === "none") return undefined;
 

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -805,25 +805,27 @@ function buildParams(
 		params.temperature = options.temperature;
 	}
 
-	const deferredToolNames =
-		compat.deferredToolsMode === "kimi" ? getDeferredToolNames(context.messages) : new Set<string>();
-	const activeTools = context.tools?.filter((tool) => !deferredToolNames.has(tool.name));
-	if (activeTools && activeTools.length > 0) {
-		params.tools = convertTools(activeTools, compat);
-		if (compat.zaiToolStream) {
-			(params as any).tool_stream = true;
+	if (compat.supportsTools) {
+		const deferredToolNames =
+			compat.deferredToolsMode === "kimi" ? getDeferredToolNames(context.messages) : new Set<string>();
+		const activeTools = context.tools?.filter((tool) => !deferredToolNames.has(tool.name));
+		if (activeTools && activeTools.length > 0) {
+			params.tools = convertTools(activeTools, compat);
+			if (compat.zaiToolStream) {
+				(params as any).tool_stream = true;
+			}
+		} else if (hasToolHistory(context.messages)) {
+			// Anthropic (via LiteLLM/proxy) requires tools param when conversation has tool_calls/tool_results
+			params.tools = [];
 		}
-	} else if (hasToolHistory(context.messages)) {
-		// Anthropic (via LiteLLM/proxy) requires tools param when conversation has tool_calls/tool_results
-		params.tools = [];
+
+		if (options?.toolChoice) {
+			params.tool_choice = options.toolChoice;
+		}
 	}
 
 	if (cacheControl) {
 		applyAnthropicCacheControl(messages, params.tools, cacheControl);
-	}
-
-	if (options?.toolChoice) {
-		params.tool_choice = options.toolChoice;
 	}
 
 	const thinkingTokenBudgetField = resolveThinkingTokenBudgetField(compat);

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -509,6 +509,12 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			for await (const chunk of openaiStream) {
 				if (!chunk || typeof chunk !== "object") continue;
 
+				if ("error" in chunk && (chunk as any).error) {
+					const errObj = (chunk as any).error;
+					const msg = typeof errObj === "string" ? errObj : errObj.message || JSON.stringify(errObj);
+					throw new Error(msg);
+				}
+
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
 				// and each chunk in a streamed completion carries the same id.
 				output.responseId ||= chunk.id;
@@ -522,15 +528,22 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
 				if (!choice) continue;
 
+				if ("error" in choice && (choice as any).error) {
+					const errObj = (choice as any).error;
+					const msg = typeof errObj === "string" ? errObj : errObj.message || JSON.stringify(errObj);
+					throw new Error(msg);
+				}
+
 				// Fallback: some providers (e.g., Moonshot) return usage
 				// in choice.usage instead of the standard chunk.usage
 				if (!chunk.usage && (choice as any).usage) {
 					output.usage = parseChunkUsage((choice as any).usage, model);
 				}
 
-				if (choice.finish_reason) {
-					output.rawStopReason = choice.finish_reason;
-					const finishReasonResult = mapStopReason(choice.finish_reason);
+				const nativeFinishReason = (choice as any).native_finish_reason;
+				if (choice.finish_reason || nativeFinishReason) {
+					output.rawStopReason = nativeFinishReason ?? choice.finish_reason;
+					const finishReasonResult = mapStopReason(choice.finish_reason, nativeFinishReason);
 					output.stopReason = finishReasonResult.stopReason;
 					if (finishReasonResult.errorMessage) {
 						output.errorMessage = finishReasonResult.errorMessage;
@@ -1500,10 +1513,16 @@ function parseChunkUsage(
 	return usage;
 }
 
-function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | string): {
+function mapStopReason(
+	reason: ChatCompletionChunk.Choice["finish_reason"] | string,
+	nativeReason?: string | null,
+): {
 	stopReason: StopReason;
 	errorMessage?: string;
 } {
+	if (nativeReason === "network_error" || nativeReason === "error") {
+		return { stopReason: "error", errorMessage: `Provider native_finish_reason: ${nativeReason}` };
+	}
 	if (reason === null) return { stopReason: "stop" };
 	switch (reason) {
 		case "stop":
@@ -1583,6 +1602,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const cacheControlFormat = provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
 	return {
+		supportsTools: true,
 		supportsStore: !isNonStandard,
 		supportsDeveloperRole: isOpenRouterDeveloperRoleModel || (!isNonStandard && !isOpenRouter),
 		supportsReasoningEffort:
@@ -1637,6 +1657,7 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
 	if (!model.compat) return detected;
 
 	return {
+		supportsTools: model.compat.supportsTools ?? detected.supportsTools,
 		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
 		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
 		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -67,6 +67,7 @@ function resolveCacheRetention(cacheRetention?: CacheRetention, env?: ProviderEn
 
 function getCompat(model: Model<"openai-responses">): Required<OpenAIResponsesCompat> {
 	return {
+		supportsTools: model.compat?.supportsTools ?? true,
 		supportsDeveloperRole: model.compat?.supportsDeveloperRole ?? true,
 		sessionAffinityFormat: model.compat?.sessionAffinityFormat ?? detectSessionAffinityFormat(model),
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
@@ -269,11 +270,13 @@ function buildParams(
 		compat.supportsOpenAIGrammarTools,
 	),
 ) {
-	const deferredToolsMode = compat.supportsAdditionalTools
-		? "additional-tools"
-		: compat.supportsToolSearch
-			? "tool-search"
-			: undefined;
+	const deferredToolsMode = compat.supportsTools
+		? compat.supportsAdditionalTools
+			? "additional-tools"
+			: compat.supportsToolSearch
+				? "tool-search"
+				: undefined
+		: undefined;
 	const toolPlacement = splitDeferredTools(context, deferredToolsMode !== undefined);
 	const messages = convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS, {
 		grammarToolInputProperties,
@@ -309,14 +312,14 @@ function buildParams(
 		params.service_tier = options.serviceTier;
 	}
 
-	if (toolPlacement.immediate.length > 0) {
+	if (compat.supportsTools && toolPlacement.immediate.length > 0) {
 		params.tools = convertResponsesTools(toolPlacement.immediate, {
 			supportsStrictMode: compat.supportsStrictMode,
 			supportsOpenAIGrammarTools: compat.supportsOpenAIGrammarTools,
 		});
 	}
 
-	if (options?.toolChoice !== undefined) {
+	if (compat.supportsTools && options?.toolChoice !== undefined) {
 		params.tool_choice = options.toolChoice;
 	}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -555,6 +555,8 @@ export type AssistantMessageEvent =
  * Use this to override URL-based auto-detection for custom providers.
  */
 export interface OpenAICompletionsCompat {
+	/** Whether the provider supports tool calling. When false, tools and tool_choice are omitted from requests. Default: true. */
+	supportsTools?: boolean;
 	/** Whether the provider supports the `store` field. Default: auto-detected from URL. */
 	supportsStore?: boolean;
 	/** Whether the provider supports the `developer` role (vs `system`). Default: auto-detected from URL. */
@@ -626,6 +628,8 @@ export interface OpenAICompletionsCompat {
 
 /** Compatibility settings for OpenAI Responses APIs. */
 export interface OpenAIResponsesCompat {
+	/** Whether the provider supports tool calling. When false, tools and tool_choice are omitted from requests. Default: true. */
+	supportsTools?: boolean;
 	/** Whether the provider supports the `developer` role (vs `system`). Default: true. */
 	supportsDeveloperRole?: boolean;
 	/** Session-affinity header format: `openai` sends `session_id` and `x-client-request-id`; `openai-nosession` sends `x-client-request-id`; `openrouter` sends `x-session-id`. Does not affect the `prompt_cache_key` body param, which is governed by cache retention. Default: auto-detected. */
@@ -646,6 +650,8 @@ export interface OpenAIResponsesCompat {
 
 /** Compatibility settings for Anthropic Messages-compatible APIs. */
 export interface AnthropicMessagesCompat {
+	/** Whether the provider supports tool calling. When false, tools and tool_choice are omitted from requests. Default: true. */
+	supportsTools?: boolean;
 	/**
 	 * Whether the provider accepts per-tool `eager_input_streaming`.
 	 * When false, the Anthropic provider omits `tools[].eager_input_streaming`
@@ -709,6 +715,8 @@ export interface AnthropicMessagesCompat {
 
 /** Compatibility settings for Amazon Bedrock models. */
 export interface BedrockCompat {
+	/** Whether the model supports tool calling. When false, tools are omitted from requests. Default: true. */
+	supportsTools?: boolean;
 	/** Whether the model supports Bedrock strict tool schemas. Default: false. */
 	supportsStrictMode?: boolean;
 }

--- a/packages/ai/test/deferred-tools.test.ts
+++ b/packages/ai/test/deferred-tools.test.ts
@@ -362,6 +362,7 @@ describe("deferred tools", () => {
 		});
 
 		const messages = convertMessages(makeKimiModel("kimi"), context, {
+			supportsTools: true,
 			supportsStore: false,
 			supportsDeveloperRole: false,
 			supportsReasoningEffort: false,

--- a/packages/ai/test/openai-completions-empty-tools.test.ts
+++ b/packages/ai/test/openai-completions-empty-tools.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getModel, streamSimple } from "../src/compat.ts";
+import type { Tool } from "../src/types.ts";
 
 // Empty tools arrays must NOT be serialized as `tools: []` — some OpenAI-compatible
 // backends (e.g. DashScope / Aliyun Qwen via compatible-mode) reject the request with
@@ -300,5 +301,88 @@ describe("openai-completions empty tools handling", () => {
 		const params = mockState.lastParams as { tools?: unknown[] };
 		expect(Array.isArray(params.tools)).toBe(true);
 		expect(params.tools).toEqual([]);
+	});
+
+	it("omits tools and tool_choice when compat.supportsTools is false", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = {
+			...baseModel,
+			api: "openai-completions",
+			compat: { supportsTools: false },
+		} as const;
+
+		const dummyTool: Tool = {
+			name: "test_tool",
+			description: "A test tool",
+			parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+		};
+
+		await streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+				tools: [dummyTool],
+			},
+			{ apiKey: "test", toolChoice: "auto" },
+		).result();
+
+		const params = mockState.lastParams as { tools?: unknown; tool_choice?: unknown };
+		expect("tools" in (params as object)).toBe(false);
+		expect("tool_choice" in (params as object)).toBe(false);
+	});
+
+	it("omits tools even with tool history when compat.supportsTools is false", async () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini")!;
+		const model = {
+			...baseModel,
+			api: "openai-completions",
+			compat: { supportsTools: false },
+		} as const;
+
+		await streamSimple(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "use the tool", timestamp: Date.now() },
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "toolCall",
+								id: "t1",
+								name: "noop",
+								arguments: {},
+							},
+						],
+						stopReason: "toolUse",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						api: "openai-completions",
+						provider: "openai",
+						model: "gpt-4o-mini",
+						timestamp: Date.now(),
+					},
+					{
+						role: "toolResult",
+						toolCallId: "t1",
+						toolName: "noop",
+						content: [{ type: "text", text: "done" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+				tools: [],
+			},
+			{ apiKey: "test" },
+		).result();
+
+		const params = mockState.lastParams as { tools?: unknown };
+		expect("tools" in (params as object)).toBe(false);
 	});
 });

--- a/packages/ai/test/openai-completions-raw-stop-reason.test.ts
+++ b/packages/ai/test/openai-completions-raw-stop-reason.test.ts
@@ -76,4 +76,87 @@ describe("OpenAI completions raw stop reasons", () => {
 		expect(message.rawStopReason).toBe("content_filter");
 		expect(message.errorMessage).toBe("Provider finish_reason: content_filter");
 	});
+
+	it("surfaces error when native_finish_reason is network_error even if finish_reason is stop", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-3",
+				choices: [{ index: 0, delta: {}, finish_reason: "stop", native_finish_reason: "network_error" }],
+			},
+		];
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.rawStopReason).toBe("network_error");
+		expect(message.errorMessage).toBe("Provider native_finish_reason: network_error");
+	});
+
+	it("surfaces error when native_finish_reason is error", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-4",
+				choices: [{ index: 0, delta: {}, finish_reason: "stop", native_finish_reason: "error" }],
+			},
+		];
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.rawStopReason).toBe("error");
+		expect(message.errorMessage).toBe("Provider native_finish_reason: error");
+	});
+
+	it("surfaces error when chunk contains an error payload", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-5",
+				error: { message: "Model does not support tools", code: 400 },
+			},
+		];
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("Model does not support tools");
+	});
+
+	it("surfaces error when choice contains an error payload", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-6",
+				choices: [
+					{
+						index: 0,
+						error: { message: "Internal server error" },
+					},
+				],
+			},
+		];
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toContain("Internal server error");
+	});
+
+	it("preserves partial text when stream terminates with abnormal native finish reason", async () => {
+		mockState.chunks = [
+			{
+				id: "chatcmpl-7",
+				choices: [{ index: 0, delta: { content: "Partial response before failure" } }],
+			},
+			{
+				id: "chatcmpl-7",
+				choices: [{ index: 0, delta: {}, finish_reason: "stop", native_finish_reason: "network_error" }],
+			},
+		];
+
+		const message = await streamOpenAICompletions(model, context, { apiKey: "test" }).result();
+
+		expect(message.stopReason).toBe("error");
+		expect(message.rawStopReason).toBe("network_error");
+		expect(message.errorMessage).toBe("Provider native_finish_reason: network_error");
+		expect(message.content).toEqual([{ type: "text", text: "Partial response before failure" }]);
+	});
 });

--- a/packages/ai/test/openai-completions-thinking-as-text.test.ts
+++ b/packages/ai/test/openai-completions-thinking-as-text.test.ts
@@ -22,6 +22,7 @@ const emptyUsage: Usage = {
 };
 
 const compat = {
+	supportsTools: true,
 	supportsStore: true,
 	supportsDeveloperRole: true,
 	supportsReasoningEffort: true,

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -1297,6 +1297,7 @@ describe("openai-completions tool_choice", () => {
 			},
 			{
 				...model.compat,
+				supportsTools: true,
 				supportsStore: false,
 				supportsDeveloperRole: false,
 				supportsReasoningEffort: true,

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -23,6 +23,7 @@ const compat: Omit<Required<OpenAICompletionsCompat>, "deferredToolsMode" | "thi
 	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
 	thinkingTokenBudgetField?: OpenAICompletionsCompat["thinkingTokenBudgetField"];
 } = {
+	supportsTools: true,
 	supportsStore: true,
 	supportsDeveloperRole: true,
 	supportsReasoningEffort: true,

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -38,6 +38,8 @@ The `apiKey` value is a placeholder because Ollama ignores it. pi still treats m
 
 Some OpenAI-compatible servers do not understand the `developer` role used for reasoning-capable models. For those providers, set `compat.supportsDeveloperRole` to `false` so pi sends the system prompt as a `system` message instead. If the server also does not support `reasoning_effort`, set `compat.supportsReasoningEffort` to `false` too.
 
+Models without tool-calling support (or servers that error on `tools` payloads) should set `compat.supportsTools` to `false`. pi then omits `tools` and `tool_choice` from outgoing requests entirely instead of sending them.
+
 You can set `compat` at the provider level to apply to all models, or at the model level to override a specific model. This commonly applies to Ollama, vLLM, SGLang, and similar OpenAI-compatible servers.
 
 ```json
@@ -458,6 +460,7 @@ For providers with partial OpenAI compatibility, use the `compat` field.
 
 | Field | Description |
 |-------|-------------|
+| `supportsTools` | Whether the model/provider supports tool calling; when `false`, `tools` and `tool_choice` are omitted from requests (default: `true`) |
 | `supportsStore` | Provider supports `store` field |
 | `supportsDeveloperRole` | Use `developer` vs `system` role |
 | `supportsReasoningEffort` | Support for `reasoning_effort` parameter |

--- a/packages/coding-agent/src/core/model-config.ts
+++ b/packages/coding-agent/src/core/model-config.ts
@@ -71,6 +71,7 @@ const ChatTemplateKwargVariableSchema = Type.Object({
 const ChatTemplateKwargSchema = Type.Union([ChatTemplateKwargScalarSchema, ChatTemplateKwargVariableSchema]);
 
 const OpenAICompletionsCompatSchema = Type.Object({
+	supportsTools: Type.Optional(Type.Boolean()),
 	supportsStore: Type.Optional(Type.Boolean()),
 	supportsDeveloperRole: Type.Optional(Type.Boolean()),
 	supportsReasoningEffort: Type.Optional(Type.Boolean()),
@@ -111,6 +112,7 @@ const OpenAICompletionsCompatSchema = Type.Object({
 });
 
 const OpenAIResponsesCompatSchema = Type.Object({
+	supportsTools: Type.Optional(Type.Boolean()),
 	supportsDeveloperRole: Type.Optional(Type.Boolean()),
 	sessionAffinityFormat: Type.Optional(
 		Type.Union([Type.Literal("openai"), Type.Literal("openai-nosession"), Type.Literal("openrouter")]),
@@ -123,6 +125,7 @@ const OpenAIResponsesCompatSchema = Type.Object({
 });
 
 const AnthropicMessagesCompatSchema = Type.Object({
+	supportsTools: Type.Optional(Type.Boolean()),
 	supportsEagerToolInputStreaming: Type.Optional(Type.Boolean()),
 	supportsLongCacheRetention: Type.Optional(Type.Boolean()),
 	sendSessionAffinityHeaders: Type.Optional(Type.Boolean()),

--- a/packages/coding-agent/test/suite/regressions/8499-openrouter-tools-compat-error.test.ts
+++ b/packages/coding-agent/test/suite/regressions/8499-openrouter-tools-compat-error.test.ts
@@ -1,0 +1,57 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("issue #8499 openrouter stream error surfacing", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("surfaces error when stream terminates with abnormal native finish reason", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: false } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "Provider native_finish_reason: network_error",
+			}),
+		]);
+
+		await harness.session.prompt("test prompt");
+
+		const assistantMessages = harness.session.messages.filter((m): m is AssistantMessage => m.role === "assistant");
+		const lastAssistant = assistantMessages[assistantMessages.length - 1];
+		expect(lastAssistant).toBeDefined();
+		expect(lastAssistant.stopReason).toBe("error");
+		expect(lastAssistant.errorMessage).toBe("Provider native_finish_reason: network_error");
+	});
+
+	it("preserves partial content when stream terminates with error", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: false } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("Partial text before abort", {
+				stopReason: "error",
+				errorMessage: "Provider native_finish_reason: network_error",
+			}),
+		]);
+
+		await harness.session.prompt("test prompt");
+
+		const assistantMessages = harness.session.messages.filter((m): m is AssistantMessage => m.role === "assistant");
+		const lastAssistant = assistantMessages[assistantMessages.length - 1];
+		expect(lastAssistant).toBeDefined();
+		expect(lastAssistant.stopReason).toBe("error");
+		expect(lastAssistant.errorMessage).toBe("Provider native_finish_reason: network_error");
+		expect(lastAssistant.content).toEqual([{ type: "text", text: "Partial text before abort" }]);
+	});
+});


### PR DESCRIPTION
Fixes #8499

## Problem

A response from `openrouter/stealth/ox-alpha` with `finish_reason: "stop"`, `native_finish_reason: "network_error"`, and 0 output tokens was previously treated as a clean stop. The agent session ended silently mid-task with no error surfaced.

## Fix

Abnormal native finish reasons (e.g. `network_error`) are now mapped to a retryable error instead of `stop`. When such an error surfaces, the session automatically retries and continues. Also adds a `supportsTools` compatibility option so toolless models can be configured without sending `tools`/`tool_choice` payloads.

## Real-world reproduction

Reproduced in a long-running Three.js coding session against `openrouter/stealth/ox-alpha` via OpenRouter: the pre-fix build stopped mid-task on a provider failure; the fixed build hit the same failure, retried, and continued to completion.

## Verification

- Regression tests added for abnormal native stop reasons and OpenRouter stream error surfacing
- All 52 logic tests pass
- Production build compiles (`npm run check`)
