### PR TITLE
fix(coding-agent): repair raw control characters in stringified edit args

### DIFF
--- a/packages/agent/src/harness/tools/edit.ts
+++ b/packages/agent/src/harness/tools/edit.ts
@@ -1,3 +1,4 @@
+import { parseJsonWithRepair } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import type { AgentHarnessTool, FileError } from "../types.ts";
 import {
@@ -57,7 +58,9 @@ function prepareEditArguments(input: unknown): EditToolInput {
 	const args = input as Record<string, unknown>;
 	if (typeof args.edits === "string") {
 		try {
-			const parsed: unknown = JSON.parse(args.edits);
+			// parseJsonWithRepair also tolerates raw control characters (real
+			// newlines/tabs) that models sometimes emit unescaped in string values.
+			const parsed: unknown = parseJsonWithRepair(args.edits);
 			if (Array.isArray(parsed)) {
 				args.edits = parsed;
 			} else if (isSingleEditInput(parsed)) {

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -1,4 +1,5 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { parseJsonWithRepair } from "@earendil-works/pi-ai";
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { constants } from "fs";
 import { access as fsAccess, readFile as fsReadFile, writeFile as fsWriteFile } from "fs/promises";
@@ -122,9 +123,11 @@ function prepareEditArguments(input: unknown): EditToolInput {
 
 	// Some models (Opus 4.6, GLM-5.1) send edits as a JSON string instead of an array.
 	// Others send a single edit object instead of a one-element edits array.
+	// parseJsonWithRepair also tolerates raw control characters (real newlines/tabs)
+	// that models sometimes emit unescaped inside string values.
 	if (typeof args.edits === "string") {
 		try {
-			const parsed = JSON.parse(args.edits);
+			const parsed = parseJsonWithRepair(args.edits);
 			if (Array.isArray(parsed)) {
 				args.edits = parsed;
 			} else if (isSingleEditInput(parsed)) {

--- a/packages/coding-agent/test/edit-tool-legacy-input.test.ts
+++ b/packages/coding-agent/test/edit-tool-legacy-input.test.ts
@@ -113,4 +113,19 @@ describe("edit tool stringified edits", () => {
 			edits: "not json",
 		});
 	});
+
+	it("repairs raw control characters inside stringified edits", () => {
+		const definition = createEditToolDefinition(process.cwd());
+		// Models sometimes emit real newlines/tabs unescaped inside string values,
+		// which is invalid JSON and used to fall through to a validation error.
+		const edits = '[{"oldText":"a","newText":"line one\nline\ttwo"}]';
+		const prepared = definition.prepareArguments!({
+			path: "file.txt",
+			edits,
+		});
+		expect(prepared).toEqual({
+			path: "file.txt",
+			edits: [{ oldText: "a", newText: "line one\nline\ttwo" }],
+		});
+	});
 });


### PR DESCRIPTION
## Problem

A follow-up gap in #3370: models that send `edits` as a JSON string sometimes emit **raw control characters** (real newlines/tabs) unescaped inside string values. The bare `JSON.parse` in `prepareEditArguments` throws on those, the `catch {}` silently gives up, and the call still fails schema validation:

```
Validation failed for tool "edit":
  - edits.0: must be object
```

Observed repeatedly in real sessions (pi 0.84.2, claude-opus-5): across 18 days of session logs, 21 `edit` validation errors of this shape; 2 of 3 sampled stringified-`edits` failures contained raw control characters.

## Fix

Use `parseJsonWithRepair` (already exported from `@earendil-works/pi-ai`, used for streaming JSON repair) instead of bare `JSON.parse` in both `prepareEditArguments` copies:

- `packages/coding-agent/src/core/tools/edit.ts`
- `packages/agent/src/harness/tools/edit.ts`

Behavior for valid arrays, single-edit objects, legacy `oldText`/`newText` input, and genuinely malformed strings is unchanged — if repair produces no change, the original error path is preserved (still caught, still passes input through untouched).

## Test plan

- [x] Added regression test: `repairs raw control characters inside stringified edits` in `edit-tool-legacy-input.test.ts` (fails with bare `JSON.parse`, passes with the fix)
- [x] Existing `edit tool prepareArguments` / `stringified edits` suites pass (9/9)
- [ ] Full repo `check` was not runnable locally: `generate-models` requires network access to models.dev (unavailable in my environment); baseline comparison shows zero new type errors. Relying on CI for the full run.