### PR TITLE
fix(coding-agent): cap grep and find child output so one line cannot kill the parent

### DIFF
--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -1,4 +1,3 @@
-import { createInterface } from "node:readline";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Text } from "@earendil-works/pi-tui";
 import { spawn } from "child_process";
@@ -6,6 +5,7 @@ import path from "path";
 import { type Static, Type } from "typebox";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.ts";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
+import { attachCappedLineReader } from "../../utils/capped-line-reader.ts";
 import { ensureTool } from "../../utils/tools-manager.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { pathExists, resolveToCwd } from "./path-utils.ts";
@@ -267,9 +267,18 @@ export function createFindToolDefinition(
 						args.push("--", effectivePattern, searchPath);
 
 						const child = spawn(fdPath, args, { stdio: ["ignore", "pipe", "pipe"] });
-						const rl = createInterface({ input: child.stdout });
 						let stderr = "";
 						const lines: string[] = [];
+						// Not readline: it grows one line with an unbounded append, so an
+						// oversized line throws in the parent's `data` handler rather than failing
+						// the tool, and it splits on U+2028/U+2029, which are legal in a filename.
+						const reader = attachCappedLineReader(child.stdout, {
+							onLine: (line) => {
+								lines.push(line);
+							},
+							// A path past the cap is not a path; dropping it loses one result.
+							onOversize: () => {},
+						});
 
 						stopChild = () => {
 							if (!child.killed) {
@@ -278,15 +287,11 @@ export function createFindToolDefinition(
 						};
 
 						const cleanup = () => {
-							rl.close();
+							reader.detach();
 						};
 
 						child.stderr?.on("data", (chunk) => {
 							stderr += chunk.toString();
-						});
-
-						rl.on("line", (line) => {
-							lines.push(line);
 						});
 
 						child.on("error", (error) => {

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -1,5 +1,4 @@
 import { readFile as fsReadFile, stat as fsStat } from "node:fs/promises";
-import { createInterface } from "node:readline";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Text } from "@earendil-works/pi-tui";
 import { spawn } from "child_process";
@@ -7,6 +6,7 @@ import path from "path";
 import { type Static, Type } from "typebox";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.ts";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
+import { attachCappedLineReader } from "../../utils/capped-line-reader.ts";
 import { ensureTool } from "../../utils/tools-manager.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { resolveToCwd } from "./path-utils.ts";
@@ -47,6 +47,8 @@ export interface GrepToolDetails {
 	truncation?: TruncationResult;
 	matchLimitReached?: number;
 	linesTruncated?: boolean;
+	/** Number of `rg --json` events discarded for exceeding the reader's line cap. */
+	eventsDiscarded?: number;
 }
 
 /**
@@ -68,6 +70,12 @@ const defaultGrepOperations: GrepOperations = {
 export interface GrepToolOptions {
 	/** Custom operations for grep. Default: local filesystem plus ripgrep */
 	operations?: GrepOperations;
+	/**
+	 * Max code units held for one `rg --json` event. Default
+	 * `DEFAULT_LINE_CAP_CHARS`. Lowered by tests so an oversized event is reachable
+	 * without writing half a gigabyte.
+	 */
+	lineCapChars?: number;
 }
 
 function formatGrepCall(
@@ -115,11 +123,13 @@ function formatGrepResult(
 	const matchLimit = result.details?.matchLimitReached;
 	const truncation = result.details?.truncation;
 	const linesTruncated = result.details?.linesTruncated;
-	if (matchLimit || truncation?.truncated || linesTruncated) {
+	const eventsDiscarded = result.details?.eventsDiscarded;
+	if (matchLimit || truncation?.truncated || linesTruncated || eventsDiscarded) {
 		const warnings: string[] = [];
 		if (matchLimit) warnings.push(`${matchLimit} matches limit`);
 		if (truncation?.truncated) warnings.push(`${formatSize(truncation.maxBytes ?? DEFAULT_MAX_BYTES)} limit`);
 		if (linesTruncated) warnings.push("some lines truncated");
+		if (eventsDiscarded) warnings.push(`${eventsDiscarded} oversized matches dropped`);
 		text += `\n${theme.fg("warning", `[Truncated: ${warnings.join(", ")}]`)}`;
 	}
 	return text;
@@ -224,17 +234,18 @@ export function createGrepToolDefinition(
 						args.push("--", pattern, searchPath);
 
 						const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
-						const rl = createInterface({ input: child.stdout });
 						let stderr = "";
 						let matchCount = 0;
 						let matchLimitReached = false;
 						let linesTruncated = false;
 						let aborted = false;
 						let killedDueToLimit = false;
+						let eventsDiscarded = 0;
+						const discardedPaths = new Set<string>();
 						const outputLines: string[] = [];
 
 						const cleanup = () => {
-							rl.close();
+							reader.detach();
 							signal?.removeEventListener("abort", onAbort);
 						};
 						const stopChild = (dueToLimit = false) => {
@@ -274,26 +285,49 @@ export function createGrepToolDefinition(
 
 						// Collect matches during streaming, then format them after rg exits.
 						const matches: Array<{ filePath: string; lineNumber: number; lineText?: string }> = [];
-						rl.on("line", (line) => {
-							if (!line.trim() || matchCount >= effectiveLimit) return;
-							let event: any;
-							try {
-								event = JSON.parse(line);
-							} catch {
-								return;
-							}
-							if (event.type === "match") {
-								matchCount++;
-								const filePath = event.data?.path?.text;
-								const lineNumber = event.data?.line_number;
-								const lineText = event.data?.lines?.text;
-								if (filePath && typeof lineNumber === "number")
-									matches.push({ filePath, lineNumber, lineText });
-								if (matchCount >= effectiveLimit) {
-									matchLimitReached = true;
-									stopChild(true);
+						// `rg --json` puts the whole matched line, and one entry per submatch, in a
+						// single event, so one match in a minified bundle is one enormous line and
+						// `--max-columns` cannot bound it - ripgrep documents that flag as having no
+						// effect under `--json`. The cap therefore belongs at the reader, which
+						// discards the event instead of letting the parent process die holding it.
+						const reader = attachCappedLineReader(child.stdout, {
+							capChars: options?.lineCapChars,
+							onLine: (line) => {
+								if (!line.trim() || matchCount >= effectiveLimit) return;
+								let event: any;
+								try {
+									event = JSON.parse(line);
+								} catch {
+									return;
 								}
-							}
+								if (event.type === "match") {
+									matchCount++;
+									const filePath = event.data?.path?.text;
+									const lineNumber = event.data?.line_number;
+									const lineText = event.data?.lines?.text;
+									if (filePath && typeof lineNumber === "number")
+										matches.push({ filePath, lineNumber, lineText });
+									if (matchCount >= effectiveLimit) {
+										matchLimitReached = true;
+										stopChild(true);
+									}
+								}
+							},
+							onOversize: ({ prefix }) => {
+								// A discarded event is a lost match, not a lost byte: report it rather
+								// than return output that reads as complete. The path is sniffed from
+								// the retained head, which is truncated JSON, so it names the file only
+								// when it survived - `rg` emits `path` first.
+								if (!prefix.includes('"type":"match"')) return;
+								eventsDiscarded++;
+								const sniffed = /"path":\{"text":"((?:[^"\\]|\\.)*)"/.exec(prefix);
+								if (!sniffed) return;
+								try {
+									discardedPaths.add(formatPath(JSON.parse(`"${sniffed[1]}"`) as string));
+								} catch {
+									// Undecodable capture: counted, unnamed.
+								}
+							},
 						});
 
 						child.on("error", (error) => {
@@ -311,7 +345,7 @@ export function createGrepToolDefinition(
 								settle(() => reject(new Error(errorMsg)));
 								return;
 							}
-							if (matchCount === 0) {
+							if (matchCount === 0 && eventsDiscarded === 0) {
 								settle(() =>
 									resolve({ content: [{ type: "text", text: "No matches found" }], details: undefined }),
 								);
@@ -357,6 +391,13 @@ export function createGrepToolDefinition(
 									`Some lines truncated to ${GREP_MAX_LINE_LENGTH} chars. Use read tool to see full lines`,
 								);
 								details.linesTruncated = true;
+							}
+							if (eventsDiscarded > 0) {
+								const where = discardedPaths.size > 0 ? ` in ${[...discardedPaths].sort().join(", ")}` : "";
+								notices.push(
+									`${eventsDiscarded} match${eventsDiscarded === 1 ? "" : "es"} MISSING${where}: line too large to read. Use read tool on that file`,
+								);
+								details.eventsDiscarded = eventsDiscarded;
 							}
 							if (notices.length > 0) output += `\n\n[${notices.join(". ")}]`;
 							settle(() =>

--- a/packages/coding-agent/src/utils/capped-line-reader.ts
+++ b/packages/coding-agent/src/utils/capped-line-reader.ts
@@ -1,0 +1,175 @@
+import type { Readable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+/**
+ * Default cap for one line, in UTF-16 code units - the unit `String.length`
+ * counts and the unit V8's maximum string length is expressed in.
+ *
+ * An `rg --json` event is NOT the size of the matched line. It is that line
+ * JSON-escaped, plus one `submatches` entry per occurrence at roughly 53 code
+ * units each, so the pattern - not the file - sets the size. Measured with
+ * ripgrep 15.2.0 on one real 5,089,613-char single-line tracked source file:
+ * `function` gives 5.8M, `"` gives 25,174,363 (363,263 submatches), and `.`
+ * gives 274,009,937. So no cap can be above every legal query, and a cap
+ * justified against a low-submatch pattern alone understates real traffic by
+ * more than an order of magnitude.
+ *
+ * The default therefore has two jobs, and only the second is absolute:
+ *
+ * - Sit above ORDINARY output, so a normal grep never loses a match. Worst
+ *   measured over a whole real tracked repository was 25.2M code units, so this
+ *   default is ~2.7x above it.
+ * - Sit below V8's maximum string length, 536,870,888 on this runtime, which is
+ *   where the append throws and kills the process. This is 8x below it.
+ *
+ * A held line costs two bytes per code unit, so the cap bounds one line's
+ * retention at ~128MB. That is a bound the uncapped append never had: it held
+ * whatever arrived, up to the throw.
+ */
+export const DEFAULT_LINE_CAP_CHARS = 64 * 1024 * 1024;
+
+/** Retained leading slice of a discarded line, for attribution and diagnostics. */
+export const DEFAULT_OVERSIZE_PREFIX_CHARS = 64 * 1024;
+
+export interface OversizedLine {
+	/** Length of the discarded line in code units, terminator excluded, prefix included. */
+	chars: number;
+	/** Leading slice of the discarded line, capped at `prefixChars`. */
+	prefix: string;
+}
+
+export interface CappedLineReaderOptions {
+	/** Max code units held for one line. Default `DEFAULT_LINE_CAP_CHARS`. */
+	capChars?: number;
+	/** Code units retained from a discarded line. Default `DEFAULT_OVERSIZE_PREFIX_CHARS`. */
+	prefixChars?: number;
+	/** Called once per complete line that stayed under the cap. */
+	onLine: (line: string) => void;
+	/** Called once per discarded line, when its terminator arrives or the stream ends. */
+	onOversize: (line: OversizedLine) => void;
+}
+
+export interface CappedLineReader {
+	/** Stop reading. Safe to call more than once. */
+	detach: () => void;
+	/** Code units currently held. Never exceeds `capChars`, mid-oversized-line included. */
+	readonly retainedChars: number;
+}
+
+/**
+ * Read LF-delimited lines from a child process stream, discarding a line that
+ * would grow past a cap.
+ *
+ * Not `node:readline`, for two reasons:
+ *
+ * - Readline grows its line buffer with an unbounded append and offers no line
+ *   cap, so one oversized line throws `RangeError: Invalid string length` inside
+ *   the stream's `data` handler. That throw is in the parent, not the child, and
+ *   no caller-level `try` surrounds it, so it takes the whole process down.
+ * - Readline also splits on U+2028 and U+2029, which are legal inside a JSON
+ *   string. A `rg --json` event containing either is delivered as two fragments
+ *   that both fail to parse, silently losing the match.
+ *
+ * A discarded line is a bad line, not a poisoned stream: framing resynchronises
+ * at the next terminator, so reading continues.
+ */
+export function attachCappedLineReader(stream: Readable, options: CappedLineReaderOptions): CappedLineReader {
+	const capChars = options.capChars ?? DEFAULT_LINE_CAP_CHARS;
+	const prefixChars = Math.min(options.prefixChars ?? DEFAULT_OVERSIZE_PREFIX_CHARS, capChars);
+	const decoder = new StringDecoder("utf8");
+	let buffer = "";
+	// Non-null while a line is being discarded: its retained head, plus how many
+	// code units have passed by since. The rest is never held.
+	let discardPrefix: string | null = null;
+	let discarded = 0;
+
+	const emit = (line: string) => {
+		options.onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+	};
+
+	// Take the head of a line that will not fit, without ever concatenating its tail.
+	const startDiscard = (tail: string) => {
+		const head =
+			buffer.length >= prefixChars
+				? buffer.slice(0, prefixChars)
+				: buffer + tail.slice(0, prefixChars - buffer.length);
+		discarded = buffer.length + tail.length - head.length;
+		buffer = "";
+		discardPrefix = head;
+	};
+
+	const finishDiscard = () => {
+		const prefix = discardPrefix ?? "";
+		discardPrefix = null;
+		const chars = prefix.length + discarded;
+		discarded = 0;
+		options.onOversize({ chars, prefix });
+	};
+
+	const consume = (text: string) => {
+		let rest = text;
+		while (rest.length > 0) {
+			const newlineIndex = rest.indexOf("\n");
+			if (discardPrefix !== null) {
+				if (newlineIndex === -1) {
+					discarded += rest.length;
+					return;
+				}
+				discarded += newlineIndex;
+				finishDiscard();
+				rest = rest.slice(newlineIndex + 1);
+				continue;
+			}
+			if (newlineIndex === -1) {
+				// Held across chunks. The cap is checked before the append, so the
+				// append that would throw never runs.
+				if (buffer.length + rest.length > capChars) {
+					startDiscard(rest);
+					return;
+				}
+				buffer += rest;
+				return;
+			}
+			const lineTail = rest.slice(0, newlineIndex);
+			// Also checked here: one chunk can carry a whole oversized line plus its
+			// terminator, which the buffered path above never sees.
+			if (buffer.length + lineTail.length > capChars) {
+				startDiscard(lineTail);
+				finishDiscard();
+			} else {
+				emit(buffer + lineTail);
+				buffer = "";
+			}
+			rest = rest.slice(newlineIndex + 1);
+		}
+	};
+
+	const onData = (chunk: string | Buffer) => {
+		consume(typeof chunk === "string" ? chunk : decoder.write(chunk));
+	};
+
+	const onEnd = () => {
+		consume(decoder.end());
+		if (discardPrefix !== null) {
+			finishDiscard();
+			return;
+		}
+		if (buffer.length > 0) {
+			emit(buffer);
+			buffer = "";
+		}
+	};
+
+	stream.on("data", onData);
+	stream.on("end", onEnd);
+
+	return {
+		detach: () => {
+			stream.off("data", onData);
+			stream.off("end", onEnd);
+		},
+		get retainedChars() {
+			return buffer.length + (discardPrefix?.length ?? 0);
+		},
+	};
+}

--- a/packages/coding-agent/test/capped-line-reader.test.ts
+++ b/packages/coding-agent/test/capped-line-reader.test.ts
@@ -1,0 +1,159 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import {
+	attachCappedLineReader,
+	DEFAULT_LINE_CAP_CHARS,
+	DEFAULT_OVERSIZE_PREFIX_CHARS,
+	type OversizedLine,
+} from "../src/utils/capped-line-reader.ts";
+
+/**
+ * Policy-level cover for the reader. The real-pipe path, where the parent has to
+ * survive a line past V8's string limit, lives in
+ * test/suite/regressions/grep-oversized-rg-json-event.test.ts.
+ */
+function collect(
+	chunks: Array<string | Buffer>,
+	options?: { capChars?: number; prefixChars?: number },
+): { lines: string[]; oversize: OversizedLine[]; peakRetained: number } {
+	const stream = new Readable({ read() {} });
+	const lines: string[] = [];
+	const oversize: OversizedLine[] = [];
+	let peakRetained = 0;
+	const reader = attachCappedLineReader(stream, {
+		capChars: options?.capChars,
+		prefixChars: options?.prefixChars,
+		onLine: (line) => lines.push(line),
+		onOversize: (drop) => oversize.push(drop),
+	});
+	for (const chunk of chunks) {
+		// Emitted rather than pushed: `push` delivers on a later tick, which would
+		// make the per-chunk retention sample below miss the peak entirely.
+		stream.emit("data", chunk);
+		// Peak, not end state: an end-state assertion passes with the cap deleted,
+		// because a sub-limit line accumulates fine and is only dropped at its
+		// terminator.
+		peakRetained = Math.max(peakRetained, reader.retainedChars);
+	}
+	stream.emit("end");
+	peakRetained = Math.max(peakRetained, reader.retainedChars);
+	reader.detach();
+	return { lines, oversize, peakRetained };
+}
+
+describe("capped line reader", () => {
+	it("splits LF-delimited lines across chunk boundaries", () => {
+		const { lines, oversize } = collect(["al", "pha\nbe", "ta\n"]);
+		expect(lines).toEqual(["alpha", "beta"]);
+		expect(oversize).toEqual([]);
+	});
+
+	it("strips a CR terminator but keeps interior CRs", () => {
+		const { lines } = collect(["alpha\r\nbe\rta\r\n"]);
+		expect(lines).toEqual(["alpha", "be\rta"]);
+	});
+
+	it("emits a trailing unterminated line at end of stream", () => {
+		const { lines } = collect(["alpha\nbeta"]);
+		expect(lines).toEqual(["alpha", "beta"]);
+	});
+
+	it("does not split on U+2028 or U+2029, which are legal inside a JSON string", () => {
+		// node:readline splits on both, which turns one `rg --json` event into two
+		// unparseable fragments and silently loses the match.
+		const record = '{"lines":{"text":"a\u2028b\u2029c"}}';
+		const { lines } = collect([`${record}\n`]);
+		expect(lines).toEqual([record]);
+		expect(JSON.parse(lines[0]).lines.text).toBe("a\u2028b\u2029c");
+	});
+
+	it("does not split a multi-byte character across chunk boundaries", () => {
+		const utf8 = Buffer.from("héllo\n", "utf8");
+		const { lines } = collect([utf8.subarray(0, 2), utf8.subarray(2)]);
+		expect(lines).toEqual(["héllo"]);
+	});
+
+	it("discards a line past the cap and keeps reading after it", () => {
+		const { lines, oversize, peakRetained } = collect(["small\n", `${"x".repeat(50)}\n`, "after\n"], {
+			capChars: 20,
+			prefixChars: 8,
+		});
+		expect(lines).toEqual(["small", "after"]);
+		expect(oversize).toHaveLength(1);
+		expect(oversize[0].chars).toBe(50);
+		expect(oversize[0].prefix).toBe("xxxxxxxx");
+		expect(peakRetained).toBeLessThanOrEqual(20);
+	});
+
+	it("caps a line that arrives whole in one chunk with its terminator", () => {
+		// The buffered path never sees this line: cap and terminator land together.
+		const { lines, oversize, peakRetained } = collect([`${"y".repeat(40)}\nafter\n`], {
+			capChars: 10,
+			prefixChars: 4,
+		});
+		expect(lines).toEqual(["after"]);
+		expect(oversize).toEqual([{ chars: 40, prefix: "yyyy" }]);
+		expect(peakRetained).toBeLessThanOrEqual(10);
+	});
+
+	it("holds only the prefix while an oversized line is still streaming", () => {
+		const { oversize, peakRetained } = collect(["z".repeat(30), "z".repeat(1000), "z".repeat(1000), "\ntail\n"], {
+			capChars: 20,
+			prefixChars: 8,
+		});
+		expect(oversize).toEqual([{ chars: 2030, prefix: "zzzzzzzz" }]);
+		// Retention is the prefix, not the line: 2030 code units passed through.
+		expect(peakRetained).toBeLessThanOrEqual(20);
+	});
+
+	it("reports an oversized line still open at end of stream", () => {
+		const { lines, oversize } = collect(["ok\n", "w".repeat(40)], { capChars: 10, prefixChars: 4 });
+		expect(lines).toEqual(["ok"]);
+		expect(oversize).toEqual([{ chars: 40, prefix: "wwww" }]);
+	});
+
+	it("emits a line exactly at the cap rather than discarding it", () => {
+		const { lines, oversize } = collect([`${"e".repeat(10)}\n`], { capChars: 10 });
+		expect(lines).toEqual(["e".repeat(10)]);
+		expect(oversize).toEqual([]);
+	});
+
+	it("clamps the retained prefix to the cap", () => {
+		const { oversize } = collect([`${"p".repeat(40)}\n`], { capChars: 6, prefixChars: 1000 });
+		expect(oversize[0].prefix).toHaveLength(6);
+		expect(oversize[0].chars).toBe(40);
+	});
+
+	it("stops reading after detach", () => {
+		const stream = new Readable({ read() {} });
+		const lines: string[] = [];
+		const reader = attachCappedLineReader(stream, { onLine: (l) => lines.push(l), onOversize: () => {} });
+		stream.emit("data", "first\n");
+		reader.detach();
+		stream.emit("data", "second\n");
+		expect(lines).toEqual(["first"]);
+	});
+
+	it("defaults sit above measured legitimate output and below V8's string limit", () => {
+		// Worst `rg --json` event measured over a whole real tracked repository,
+		// pattern `"` against a 5,089,613-char single-line source file: 25,174,363.
+		// An event is the escaped line plus ~53 code units per submatch, so the
+		// pattern sets the size and a cap justified against a low-submatch pattern
+		// like `function` (5.8M on that same file) is far too low.
+		expect(DEFAULT_LINE_CAP_CHARS).toBeGreaterThan(25_174_363);
+		// V8 throws past this on Node 24; a held line must never reach it.
+		expect(DEFAULT_LINE_CAP_CHARS).toBeLessThan(536_870_888);
+		expect(DEFAULT_OVERSIZE_PREFIX_CHARS).toBeLessThan(DEFAULT_LINE_CAP_CHARS);
+	});
+
+	it("emits a line the previous 8Mi default would have discarded", () => {
+		// Regression for the cap default itself: an event this size is ordinary
+		// output from a real repository, so discarding it would lose a match that
+		// the uncapped reader delivered.
+		const line = "x".repeat(10 * 1024 * 1024);
+		const { lines, oversize } = collect([`${line}\n`]);
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toHaveLength(line.length);
+		expect(oversize).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/grep-oversized-rg-json-event.test.ts
+++ b/packages/coding-agent/test/suite/regressions/grep-oversized-rg-json-event.test.ts
@@ -1,0 +1,147 @@
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createGrepToolDefinition, type GrepToolDetails } from "../../../src/core/tools/grep.ts";
+
+/**
+ * Regression: the grep tool read `rg --json` through `node:readline`, which grows
+ * one line with an unbounded append and offers no line cap. `rg --json` puts the
+ * whole matched line, plus one entry per submatch, in a single event, so one match
+ * in a minified bundle or a large single-line JSONL record is one enormous line.
+ * Past V8's maximum string length that append throws `RangeError: Invalid string
+ * length` inside the stream's `data` handler - in the parent, where no
+ * tool-level `try` surrounds it, so the whole process exits.
+ *
+ * `--max-columns` cannot fix it: ripgrep documents `-M/--max-columns` as having
+ * no effect under `--json`, and measured output is byte-identical with and
+ * without it. The cap has to go at the reader, which is what
+ * `attachCappedLineReader` does.
+ *
+ * These cases run the real `rg` child over real files, so they exercise the pipe
+ * rather than a synthetic stream.
+ */
+describe("grep survives an oversized rg --json event", () => {
+	let tempRoot: string;
+
+	beforeEach(() => {
+		tempRoot = mkdtempSync(join(tmpdir(), "pi-grep-oversized-"));
+	});
+
+	afterEach(() => {
+		rmSync(tempRoot, { recursive: true, force: true });
+	});
+
+	async function runGrep(
+		args: { pattern: string; limit?: number },
+		capChars?: number,
+	): Promise<{ text: string; details?: GrepToolDetails }> {
+		const def = createGrepToolDefinition(tempRoot, capChars === undefined ? undefined : { lineCapChars: capChars });
+		const ctx = {} as Parameters<typeof def.execute>[4];
+		const result = (await def.execute("call-1", args, undefined, undefined, ctx)) as {
+			content: Array<{ type: string; text?: string }>;
+			details?: GrepToolDetails;
+		};
+		return { text: result.content[0]?.text ?? "", details: result.details };
+	}
+
+	it("drops the oversized match, keeps the others, and says what is missing", async () => {
+		// One line far past the cap, and two ordinary matches around it.
+		writeFileSync(join(tempRoot, "small.txt"), "first NEEDLE\nsecond NEEDLE\n");
+		writeFileSync(join(tempRoot, "huge.txt"), `${"x".repeat(200_000)}NEEDLE${"y".repeat(200_000)}\n`);
+
+		const { text, details } = await runGrep({ pattern: "NEEDLE" }, 50_000);
+
+		expect(text).toContain("small.txt:1: first NEEDLE");
+		expect(text).toContain("small.txt:2: second NEEDLE");
+		expect(details?.eventsDiscarded).toBe(1);
+		// Named, and named as MISSING rather than empty: a model reading grep output
+		// that silently omitted a match would conclude the file has none.
+		expect(text).toContain("1 match MISSING in huge.txt");
+		expect(text).toContain("line too large to read");
+	});
+
+	it("survives a match whose rg event exceeds V8's maximum string length", async () => {
+		// The point of this case: at the default cap, `rg --json` emits this match as a
+		// single event past V8's ceiling (536,870,888 code units on Node 24), so the
+		// uncapped readline append throws and takes the test process with it. If this
+		// case reports a result at all, the parent survived.
+		//
+		// Opt-in because it writes ~600MB: run with `PI_HEAVY_TESTS=1`. The cases above
+		// cover the same reader path at a lowered cap on every run.
+		if (process.env.PI_HEAVY_TESTS !== "1") return;
+		// Appended in chunks: the test process cannot hold this line as one string
+		// either, which is the defect restated.
+		const file = join(tempRoot, "beyond-v8.txt");
+		const chunk = "x".repeat(16 * 1024 * 1024);
+		writeFileSync(file, "");
+		for (let written = 0; written < 600 * 1024 * 1024; written += chunk.length) appendFileSync(file, chunk);
+		appendFileSync(file, "NEEDLE\n");
+		writeFileSync(join(tempRoot, "ordinary.txt"), "ordinary NEEDLE\n");
+
+		const { text, details } = await runGrep({ pattern: "NEEDLE" });
+
+		expect(details?.eventsDiscarded).toBe(1);
+		expect(text).toContain("beyond-v8.txt");
+		expect(text).toContain("ordinary.txt:1: ordinary NEEDLE");
+	}, 600_000);
+
+	it("reports a match whose event is ordinary for a real repository", async () => {
+		// Regression for the cap DEFAULT, not the reader: an event is the escaped line
+		// plus ~53 code units per submatch, so a short pattern on a long line produces
+		// a far bigger event than the line. 200k occurrences on one 200KB line gives a
+		// ~10.2M-char event - above the 8Mi this originally defaulted to, and ordinary
+		// output for a repository holding one minified asset. readline delivered it.
+		writeFileSync(join(tempRoot, "dense.txt"), `${"a".repeat(200_000)}\n`);
+
+		const { text, details } = await runGrep({ pattern: "a" });
+
+		expect(details?.eventsDiscarded).toBeUndefined();
+		expect(text).toContain("dense.txt:1:");
+		expect(text).not.toContain("MISSING");
+	});
+
+	it("reports a discarded match even when it was the only one", async () => {
+		// Otherwise the tool answers "No matches found", which is a false negative.
+		writeFileSync(join(tempRoot, "only.txt"), `${"z".repeat(100_000)}NEEDLE\n`);
+
+		const { text, details } = await runGrep({ pattern: "NEEDLE" }, 20_000);
+
+		expect(text).not.toContain("No matches found");
+		expect(details?.eventsDiscarded).toBe(1);
+		expect(text).toContain("MISSING in only.txt");
+	});
+
+	it("discards an event made oversized by its submatches alone", async () => {
+		// A short line can still produce an enormous event: `rg --json` lists every
+		// submatch, so many matches on one line blow up the event without any one
+		// long line. Measured: 200k matches on a 1.2MB line gave a 12.4M-char event.
+		writeFileSync(join(tempRoot, "many.txt"), `${"NEEDLE".repeat(20_000)}\n`);
+
+		const { text, details } = await runGrep({ pattern: "NEEDLE" }, 60_000);
+
+		expect(details?.eventsDiscarded).toBe(1);
+		expect(text).toContain("MISSING in many.txt");
+	});
+
+	it("leaves ordinary output unmarked", async () => {
+		writeFileSync(join(tempRoot, "plain.txt"), "alpha NEEDLE\nbeta NEEDLE\n");
+
+		const { text, details } = await runGrep({ pattern: "NEEDLE" });
+
+		expect(text).toBe("plain.txt:1: alpha NEEDLE\nplain.txt:2: beta NEEDLE");
+		expect(details?.eventsDiscarded).toBeUndefined();
+	});
+
+	it("does not lose a match on a line containing U+2028", async () => {
+		// readline treats U+2028 and U+2029 as line terminators, but they are legal
+		// inside a JSON string, so the event carrying one was split into two
+		// unparseable fragments and the match vanished.
+		writeFileSync(join(tempRoot, "sep.txt"), "alpha NEEDLE\u2028beta\nplain NEEDLE\n", "utf8");
+
+		const { text } = await runGrep({ pattern: "NEEDLE" });
+
+		expect(text).toContain("sep.txt:1:");
+		expect(text).toContain("sep.txt:2: plain NEEDLE");
+	});
+});


### PR DESCRIPTION
## Problem

The grep and find tools read their `ripgrep`/`fd` child stdout through `node:readline`. Readline grows one line with `this[kLine_buffer] += string` and offers no line cap, so past V8's maximum string length that append throws `RangeError: Invalid string length` **inside the stream's `data` handler** — in the parent process, where no tool-level `try` surrounds it. Node treats it as an uncaught exception and exits, so the whole agent process dies rather than the tool failing.

`rg --json` reaches that size easily: it puts the entire matched line, plus one `submatches` entry per occurrence, in a single event. One match inside a minified bundle, or a large single-line JSONL record, is one enormous line.

Reproduced with ripgrep 15.2.0 on Node 24.18.1 against a real 637,534,215-byte single-line file:

```
node:internal/readline/interface:652
        this[kLine_buffer] += string;
                              ^
RangeError: Invalid string length
    at [_normalWrite] (node:internal/readline/interface:652:31)
    at Socket.ondata (node:internal/readline/interface:263:23)
    at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)
```

`--max-columns` cannot fix it. ripgrep's own help states that `-o/--only-matching`, `--heading`, `-r/--replace`, `-M/--max-columns` "have no effect when `--json` is set", and measured output confirms it: the match event is 8,000,195 chars with and without the flag. `--max-columns-preview` and `-o` do not bound `lines.text` either. The cap has to sit at the reader.

## Change

`attachCappedLineReader` (`src/utils/capped-line-reader.ts`) splits LF-delimited lines from a child pipe and, past a cap, retains a bounded prefix and discards the rest of the line instead of holding it. Framing resynchronises at the next terminator, so reading continues and later matches still arrive. Both tools use it in place of `createInterface`.

Not readline for a second reason as well: readline treats U+2028 and U+2029 as line terminators, but both are legal inside a JSON string, so an `rg --json` event containing either was delivered as two fragments that both failed `JSON.parse` and the match vanished with no error.

**Sizing the default (64Mi code units).** An `rg --json` event is not the size of the matched line: it is that line JSON-escaped, plus ~53 code units per submatch. The *pattern* sets the event size, not the file. Measured against one real 5,089,613-char single-line source file:

| pattern | event chars | submatches |
|---|---|---|
| `function` | 5,826,464 | 3 |
| `"` | 25,174,363 | 363,263 |
| `.` | 274,009,937 | 5,089,612 |

So no cap can be above every legal query, and a cap chosen against a low-submatch pattern alone understates real traffic by more than an order of magnitude. 64Mi sits ~2.7x above the worst event measured over a whole real repository, and 8x below the 536,870,888-char throw. A held line costs two bytes per code unit, so it also bounds one line's retention at ~128MB — a bound the uncapped append never had.

**A discard is a lost match, not a lost byte**, so grep says so: the notice names the count and, where the path survived in the retained prefix, the file, and states the match is `MISSING` rather than absent. Without that a model reading the output would conclude the file has no match. A discard also no longer collapses to `No matches found` when it was the only match. `find` drops a path silently on purpose — a path past the cap is not a path.

## Tests

- `test/capped-line-reader.test.ts` — policy cover: chunk-boundary splitting, CR handling, multi-byte chunk splits, U+2028/U+2029 non-splitting, discard-and-resync, whole-oversized-line-in-one-chunk, prefix clamp, detach, cap-exact emit, and **peak** retention during streaming (an end-state assertion passes with the cap deleted).
- `test/suite/regressions/grep-oversized-rg-json-event.test.ts` — the real `rg` child over real files: oversized match dropped with others kept and named, a discard as the only match, an event oversized by submatches alone, an event ordinary for a real repository emitted intact, ordinary output unmarked, and U+2028 not losing a match. One `PI_HEAVY_TESTS=1` case writes ~600MB and proves the parent survives an event past V8's ceiling.

Mutation-probed: deleting the accumulate-path cap reds 2 cases, deleting the terminated-frame cap arm reds 3, and reverting the default to 8Mi reds 3.

## Validation

- `vitest --run` in `packages/coding-agent`: 1979 passed, 49 skipped, 1 failed — `test/auth-storage.test.ts` "concurrent refresh waits for the lock", which fails identically at the base commit (`a69bef789`) and touches nothing here.
- `tsgo -p tsconfig.build.json --noEmit`: clean.
- `biome check` on the changed files: clean.
