### PR TITLE
feat(coding-agent): For llama.cpp, also show unloaded models in `/model`

### DIFF
--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -27,7 +27,8 @@ async function resolveServerUrl(
 
 function modelIsSelectable(model: LlamaModelInfo): boolean {
 	// llama.cpp reports idle-slept models as "sleeping"; requests wake them automatically.
-	return model.status.value === "loaded" || model.status.value === "sleeping";
+	// Unloaded models are auto-loaded by the router when a request is sent, so they are selectable too.
+	return model.status.value === "loaded" || model.status.value === "sleeping" || model.status.value === "unloaded";
 }
 
 function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-completions"> {

--- a/packages/coding-agent/test/llama-extension.test.ts
+++ b/packages/coding-agent/test/llama-extension.test.ts
@@ -59,7 +59,7 @@ describe("llama.cpp extension", () => {
 		expect(() => normalizeLlamaServerUrl("file:///tmp/llama")).toThrow("http or https");
 	});
 
-	it("exposes loaded and sleeping models with router metadata", () => {
+	it("exposes loaded, sleeping, and unloaded models with router metadata", () => {
 		const controller = createLlamaProvider();
 		controller.setCatalog(
 			[
@@ -86,6 +86,10 @@ describe("llama.cpp extension", () => {
 			}),
 			expect.objectContaining({
 				id: "sleeping",
+				baseUrl: "http://localhost:8080/v1",
+			}),
+			expect.objectContaining({
+				id: "unloaded",
 				baseUrl: "http://localhost:8080/v1",
 			}),
 		]);
@@ -121,8 +125,8 @@ describe("llama.cpp extension", () => {
 			allowNetwork: true,
 			signal: new AbortController().signal,
 		});
-		expect(first.provider.getModels().map((model) => model.id)).toEqual(["loaded", "sleeping"]);
-		expect(cachedEntry?.models.map((model) => model.id)).toEqual(["loaded", "sleeping"]);
+		expect(first.provider.getModels().map((model) => model.id)).toEqual(["loaded", "sleeping", "unloaded"]);
+		expect(cachedEntry?.models.map((model) => model.id)).toEqual(["loaded", "sleeping", "unloaded"]);
 
 		const second = createLlamaProvider();
 		await second.provider.refreshModels?.({
@@ -135,6 +139,7 @@ describe("llama.cpp extension", () => {
 		expect(second.provider.getModels()).toEqual([
 			expect.objectContaining({ id: "loaded", baseUrl: `${url}/v1`, contextWindow: 32768 }),
 			expect.objectContaining({ id: "sleeping", baseUrl: `${url}/v1`, contextWindow: 32768 }),
+			expect.objectContaining({ id: "unloaded", baseUrl: `${url}/v1`, contextWindow: 128000 }),
 		]);
 	});
 


### PR DESCRIPTION
Related: https://github.com/earendil-works/pi/pull/8479

The llama.cpp router exposes unloaded models, and when a prompt is sent targeting one of those unloaded models, it will automatically load the model.

This way, we don't need to manually load them with `/llama` in order to use them.

`/llama` is still useful for unloading currently loaded models.