### PR TITLE
fix(ai): normalize tool-result history for strict OpenAI-compatible providers

### DIFF
--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -160,6 +160,14 @@ export function transformMessages<TApi extends Api>(
 	const result: Message[] = [];
 	let pendingToolCalls: ToolCall[] = [];
 	let existingToolResultIds = new Set<string>();
+	// Tool results belonging to skipped errored/aborted assistant messages must be
+	// dropped too, or providers that validate message order (e.g. Kimi) reject the
+	// request: "messages with role 'tool' must be a response to a preceding message
+	// with 'tool_calls'".
+	const droppedToolCallIds = new Set<string>();
+	// Synthetic "No result provided" results inserted below, tracked so they can be
+	// dropped when the real result arrives later (see dedupe pass at the end).
+	const syntheticToolCallIds = new Set<string>();
 	const insertSyntheticToolResults = () => {
 		if (pendingToolCalls.length > 0) {
 			for (const tc of pendingToolCalls) {
@@ -172,6 +180,7 @@ export function transformMessages<TApi extends Api>(
 						isError: true,
 						timestamp: Date.now(),
 					} as ToolResultMessage);
+					syntheticToolCallIds.add(tc.id);
 				}
 			}
 			pendingToolCalls = [];
@@ -193,6 +202,12 @@ export function transformMessages<TApi extends Api>(
 			// - The model should retry from the last valid state
 			const assistantMsg = msg as AssistantMessage;
 			if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
+				// Its tool results must not be replayed either: a `tool` message
+				// without a preceding assistant `tool_calls` message is rejected by
+				// providers that validate message order (e.g. Kimi).
+				for (const block of assistantMsg.content) {
+					if (block.type === "toolCall") droppedToolCallIds.add(block.id);
+				}
 				continue;
 			}
 
@@ -205,6 +220,7 @@ export function transformMessages<TApi extends Api>(
 
 			result.push(msg);
 		} else if (msg.role === "toolResult") {
+			if (droppedToolCallIds.has(msg.toolCallId)) continue;
 			existingToolResultIds.add(msg.toolCallId);
 			result.push(msg);
 		} else if (msg.role === "user") {
@@ -218,6 +234,62 @@ export function transformMessages<TApi extends Api>(
 
 	// If the conversation ends with unresolved tool calls, synthesize results now.
 	insertSyntheticToolResults();
+
+	// Dedupe tool results: a synthetic "No result provided" may have been inserted
+	// for a tool call whose real result arrives later (interrupted by a custom/user
+	// message). Duplicate tool_call_ids make strict providers (e.g. Kimi) reject the
+	// request with "Invalid request: tokenization failed".
+	{
+		const seen = new Set<string>();
+		for (let i = result.length - 1; i >= 0; i--) {
+			const msg = result[i];
+			if (msg.role !== "toolResult") continue;
+			if (seen.has(msg.toolCallId)) {
+				if (syntheticToolCallIds.has(msg.toolCallId)) result.splice(i, 1);
+				continue;
+			}
+			seen.add(msg.toolCallId);
+		}
+	}
+	// Normalize tool-result placement. Providers that validate message order
+	// (e.g. Kimi) reject requests where a `tool` message follows a `user` message
+	// instead of the assistant message that issued the tool call. Session history
+	// can interleave custom messages (e.g. background-task notifications) between
+	// an assistant tool call and its result. Move each assistant's tool results to
+	// immediately after it, before any interleaved user messages.
+	for (let i = 0; i < result.length; i++) {
+		const assistant = result[i];
+		if (assistant.role !== "assistant") continue;
+		const toolCallIds = new Set<string>(assistant.content.filter((b) => b.type === "toolCall").map((b) => b.id));
+		if (toolCallIds.size === 0) continue;
+		let k = i + 1;
+		let interrupted = false;
+		while (k < result.length) {
+			const next = result[k];
+			if (next.role === "toolResult" && toolCallIds.has(next.toolCallId)) {
+				k++;
+				continue;
+			}
+			if (next.role === "user") {
+				interrupted = true;
+				k++;
+				continue;
+			}
+			break;
+		}
+		if (!interrupted) {
+			i = k - 1;
+			continue;
+		}
+		const segment = result.splice(i + 1, k - (i + 1));
+		result.splice(
+			i + 1,
+			0,
+			...segment.filter((m): m is ToolResultMessage => m.role === "toolResult"),
+			...segment.filter((m) => m.role === "user"),
+		);
+		i = k - 1;
+	}
 
 	return result;
 }

--- a/packages/ai/test/transform-messages-tool-result-history.test.ts
+++ b/packages/ai/test/transform-messages-tool-result-history.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "../src/api/transform-messages.ts";
+import type { AssistantMessage, Message, Model, ToolCall } from "../src/types.ts";
+
+function makeKimiModel(): Model<"openai-completions"> {
+	return {
+		id: "kimi-k3",
+		name: "Kimi K3",
+		api: "openai-completions",
+		provider: "moonshotai-cn",
+		baseUrl: "https://api.moonshot.cn/v1",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1048576,
+		maxTokens: 131072,
+	};
+}
+
+function userMessage(content: string): Message {
+	return { role: "user", content, timestamp: Date.now() };
+}
+
+function assistantToolCall(
+	id: string,
+	name: string,
+	stopReason: AssistantMessage["stopReason"] = "toolUse",
+): AssistantMessage {
+	const toolCall: ToolCall = { type: "toolCall", id, name, arguments: {} };
+	return {
+		role: "assistant",
+		content: [toolCall],
+		api: "openai-completions",
+		provider: "moonshotai-cn",
+		model: "kimi-k3",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function toolResult(toolCallId: string, text: string): Message {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "bash",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+const roles = (messages: Message[]): string => messages.map((m) => m.role).join(",");
+
+describe("transformMessages: tool result history normalization", () => {
+	const model = makeKimiModel();
+
+	it("drops tool results belonging to skipped errored/aborted assistant messages", () => {
+		const out = transformMessages(
+			[userMessage("go"), assistantToolCall("c1", "bash", "error"), toolResult("c1", "output"), userMessage("next")],
+			model,
+		);
+		expect(roles(out)).toBe("user,user");
+	});
+
+	it("drops the errored assistant but keeps healthy tool round-trips intact", () => {
+		const out = transformMessages(
+			[userMessage("go"), assistantToolCall("c2", "bash"), toolResult("c2", "output"), userMessage("next")],
+			model,
+		);
+		expect(roles(out)).toBe("user,assistant,toolResult,user");
+	});
+
+	it("moves a tool result before an interleaved user message and removes the synthetic duplicate", () => {
+		// Session order when a custom message (e.g. background-task notification)
+		// lands between the assistant tool call and its result.
+		const out = transformMessages(
+			[
+				userMessage("go"),
+				assistantToolCall("c3", "subagent_wait"),
+				userMessage("Background task notification"),
+				toolResult("c3", "done"),
+				userMessage("next"),
+			],
+			model,
+		);
+		// assistant, real tool result, then the interleaved user messages.
+		// The synthetic "No result provided" duplicate must not be present.
+		expect(roles(out)).toBe("user,assistant,toolResult,user,user");
+		const resultIds = out
+			.filter((m) => m.role === "toolResult")
+			.map((m) => (m as Message & { toolCallId: string }).toolCallId);
+		expect(resultIds).toEqual(["c3"]);
+	});
+
+	it("handles multiple tool calls with several interruptions", () => {
+		const assistant = assistantToolCall("a", "bash");
+		assistant.content = [
+			{ type: "toolCall", id: "a", name: "bash", arguments: {} },
+			{ type: "toolCall", id: "b", name: "bash", arguments: {} },
+		];
+		const out = transformMessages(
+			[
+				userMessage("go"),
+				assistant,
+				userMessage("note1"),
+				toolResult("a", "A"),
+				userMessage("note2"),
+				toolResult("b", "B"),
+				userMessage("next"),
+			],
+			model,
+		);
+		expect(roles(out)).toBe("user,assistant,toolResult,toolResult,user,user,user");
+	});
+
+	it("keeps the synthetic result when the real result never arrives", () => {
+		const out = transformMessages([userMessage("go"), assistantToolCall("c5", "bash"), userMessage("next")], model);
+		const resultIds = out
+			.filter((m) => m.role === "toolResult")
+			.map((m) => (m as Message & { toolCallId: string }).toolCallId);
+		expect(resultIds).toEqual(["c5"]);
+	});
+
+	it("never emits duplicate tool_call_ids", () => {
+		const out = transformMessages(
+			[
+				userMessage("go"),
+				assistantToolCall("c6", "subagent_wait"),
+				userMessage("notify"),
+				toolResult("c6", "real"),
+				userMessage("next"),
+			],
+			model,
+		);
+		const ids = out
+			.filter((m) => m.role === "toolResult")
+			.map((m) => (m as Message & { toolCallId: string }).toolCallId);
+		expect(ids).toEqual(["c6"]);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});


### PR DESCRIPTION
## Problem

Replaying session history to OpenAI-compatible providers that strictly validate message order (reproduced with Moonshot/Kimi `kimi-k3` and `kimi-k2`, via `openai-completions`) fails with two API errors. Lenient providers (DeepSeek, OpenAI) never surfaced these, so sessions that work on one model break on another.

### 1. `messages with role 'tool' must be a response to a preceding message with 'tool_calls'`

`transformMessages` skips assistant messages with `stopReason === "error" | "aborted"`, but keeps their tool results. If such a turn had already emitted tool calls (aborted mid-stream, network error), the replay contains a `tool` message with no preceding assistant `tool_calls` message. Kimi rejects this with a 400.

### 2. Interleaved user messages break the `tool_calls → tool` sequence

Session history can interleave custom messages (e.g. background-task notifications from `subagent_wait`) between an assistant tool call and its tool result. These are serialized as `user` messages, so the replay contains `assistant(tool_calls) → user → tool`. Kimi rejects this with the same 400.

### 3. Duplicate `tool_call_id`s → `Invalid request: tokenization failed`

For the interrupted case above, the synthetic "No result provided" result (inserted when a user message interrupts pending tool calls) remains next to the real result that arrives later, emitting two `tool` messages with the same `tool_call_id`. Kimi rejects this with `Invalid request: tokenization failed`.

## Fix

All three fixed in `transformMessages`:

1. When skipping an errored/aborted assistant message, record its tool call ids and drop their tool results too.
2. After the synthetic-result pass, move each assistant's tool results to immediately after it, before any interleaved user messages (order of user messages preserved).
3. Track synthetic "No result provided" insertions and drop them when the real result for the same `tool_call_id` arrives later.

## Verification

- New unit tests: `packages/ai/test/transform-messages-tool-result-history.test.ts` (6 cases, all passing).
- Replayed the exact failing session history (275 messages) against the real Moonshot API: before the fix → 400 `tokenization failed`; after → HTTP 200.
- `biome check` and `tsgo --noEmit` clean for the changed files.

## Notes

- Behavior change: tool results of errored/aborted assistant turns are no longer replayed (previously they were orphaned, which strict providers rejected anyway).
- If a real result never arrives, the synthetic "No result provided" result is still kept, preserving the existing behavior for providers that require a result per tool call.
