### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -2,6 +2,12 @@
 
 Example extensions for pi-coding-agent.
 
+## Pairing device (docs, not a runtime extension)
+
+| File | Description |
+|------|-------------|
+| `gbr-pair.md` | Pair a phone running **Build Remote Agent** (`gbr/1`) to this desktop `pi` session. Spectator via `gbr-agent` loopback `:8788` or `gbr-mcp`. Not affiliated with xAI or SpaceX. |
+
 ## Usage
 
 ```bash

--- a/packages/coding-agent/examples/extensions/gbr-pair.md
+++ b/packages/coding-agent/examples/extensions/gbr-pair.md
@@ -1,0 +1,58 @@
+# Build Remote Agent — pairing device (pi)
+
+Pi can use **Build Remote Agent** as a pairing device: the paid iOS/Android
+app spectates (and can inject into) this desktop `pi` session through the
+free MIT `gbr-agent`. Phone and PC never open ports to each other.
+
+This is documentation, not a runtime TypeScript extension. Prefer a third-party
+[pi package](../docs/packages.md) or [monopi](https://github.com/ifiokjr/monopi)
+over changing pi core.
+
+Website: https://grokbuildremote.com/
+Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT)
+Protocol: `gbr/1` · need agent **v0.6.0+**
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+## Install + pair
+
+```bash
+# macOS / Linux
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # must print v0.6.0 or newer
+gbr-agent pair             # QR in browser + printed 8-char code
+gbr-agent run              # leave running
+```
+
+```powershell
+# Windows
+irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version
+gbr-agent pair
+gbr-agent run
+```
+
+Phone: open Build Remote Agent → **Scan QR from computer** (or type the 8-char
+code). **Unpair** in Settings before changing PCs. Force-close is not enough.
+
+## Attach this `pi` session
+
+After `gbr-agent run`:
+
+- HTTP Bot API: `http://127.0.0.1:8788`
+- MCP stdio: clone the agent repo and run `node mcp/gbr-mcp/bin/gbr-mcp.js`
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+```
+
+Point pi MCP config at that stdio command (absolute path). Phone is spectator.
+Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the
+relay key is copied.


### PR DESCRIPTION
Add **Build Remote Agent** as a pairing device for this desktop agent.

Build Remote Agent is an independent product by Linespotting AB. Not affiliated with xAI or SpaceX. Protocol `gbr/1`. The phone is a spectator + veto, not an orchestrator. Attach surface is only `http://127.0.0.1:8788` after `gbr-agent run`, or MCP stdio `gbr-mcp`.

## How to use

1. Install: `curl -fsSL https://grokbuildremote.com/install.sh | bash` (Windows: `irm https://grokbuildremote.com/install.ps1 | iex`)
2. `gbr-agent version` — need **v0.6.0+**
3. `gbr-agent pair && gbr-agent run` (QR in browser + printed 8-char code)
4. Phone: Build Remote Agent → scan QR **or** type the 8-char code
5. Attach: `curl -sS http://127.0.0.1:8788/health` or MCP stdio `gbr-mcp`

Docs: https://grokbuildremote.com/ · Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents

This PR is docs/config only. No mailbox keys. No product-runtime changes.