### PR TITLE
fix(settings,retry,sdk): settings concurrency, quota-error retryability, provider-failure visibility, model warnings

### DIFF
--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -90,12 +90,28 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
 ]);
 
 /**
+ * Optional per-call overrides for {@link isRetryableAssistantError} and
+ * {@link retryAssistantCall}. Patterns are case-insensitive regular-expression
+ * sources; an error message matching any override is treated as retryable even
+ * when it matches the built-in non-retryable limit patterns (e.g. usage/quota
+ * exhaustion), giving callers a way to keep running through provider limits.
+ */
+export interface RetryOverrides {
+	nonRetryableOverrides?: string[];
+}
+
+function matchesAnyPattern(message: string, patterns: readonly string[]): boolean {
+	if (patterns.length === 0) return false;
+	return new RegExp(patterns.join("|"), "i").test(message);
+}
+
+/**
  * Retry policy: bounded attempts with exponential backoff (`baseDelayMs * 2^(attempt-1)`).
  * Matches `settings.retry` (`enabled`, `maxRetries`, `baseDelayMs`) in coding-agent; kept
  * here so the classifier and the policy-driven retry loop live together and stay reusable
  * by the SDK and other callers.
  */
-export interface RetryPolicy {
+export interface RetryPolicy extends RetryOverrides {
 	enabled: boolean;
 	/** Max retry attempts (0 = no retries). The initial call never counts as a retry. */
 	maxRetries: number;
@@ -186,7 +202,7 @@ export async function retryAssistantCall(
 		}
 
 		// Non-retryable, or budget exhausted: return the final error message.
-		if (attempt >= maxAttempts || !isRetryableAssistantError(response)) {
+		if (attempt >= maxAttempts || !isRetryableAssistantError(response, policy)) {
 			if (lastRetry) await callbacks?.onRetryFinished?.(false, lastRetry.attempt, response.errorMessage);
 			return response;
 		}
@@ -219,10 +235,14 @@ export async function retryAssistantCall(
  * This does not implement retry policy. Callers should first handle context
  * overflow separately, then apply their own retry budget, backoff, and reporting
  * before restarting the assistant turn.
+ *
+ * Error messages matching `overrides.nonRetryableOverrides` are downgraded to
+ * retryable even when they match the built-in non-retryable limit patterns.
  */
-export function isRetryableAssistantError(message: AssistantMessage): boolean {
+export function isRetryableAssistantError(message: AssistantMessage, overrides?: RetryOverrides): boolean {
 	if (message.stopReason !== "error" || !message.errorMessage) return false;
 	const errorMessage = message.errorMessage;
+	if (matchesAnyPattern(errorMessage, overrides?.nonRetryableOverrides ?? [])) return true;
 	if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) return false;
 	return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage);
 }

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -76,6 +76,12 @@ describe("provider retry classification", () => {
 		).toBe(false);
 	});
 
+	it("downgrades limit errors matching nonRetryableOverrides to retryable", () => {
+		const message = fauxAssistantMessage("", { stopReason: "error", errorMessage: "429 quota exceeded" });
+		expect(isRetryableAssistantError(message, { nonRetryableOverrides: ["quota.?exceeded"] })).toBe(true);
+		expect(isRetryableAssistantError(message, { nonRetryableOverrides: ["unrelated-pattern"] })).toBe(false);
+	});
+
 	it("classifies assistant error messages", () => {
 		expect(
 			isRetryableAssistantError(fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" })),
@@ -120,6 +126,18 @@ describe("retryAssistantCall", () => {
 		expect(produce).toHaveBeenCalledTimes(1);
 		expect(onRetryScheduled).not.toHaveBeenCalled();
 		expect(onRetryFinished).not.toHaveBeenCalled();
+	});
+
+	it("retries a quota error downgraded by nonRetryableOverrides", async () => {
+		const produce = vi.fn(async () =>
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "insufficient_quota" }),
+		);
+		const onRetryScheduled = vi.fn();
+		const policy: RetryPolicy = { enabled: true, maxRetries: 2, baseDelayMs: 0, nonRetryableOverrides: ["quota"] };
+		const res = await retryAssistantCall(produce, policy, undefined, { onRetryScheduled });
+		expect(res.stopReason).toBe("error");
+		expect(produce).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+		expect(onRetryScheduled).toHaveBeenCalledTimes(2);
 	});
 
 	it("retries a transient error up to maxRetries then returns the final error", async () => {

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -298,6 +298,7 @@ user sends prompt ────────────────────�
   │   ├─► before_provider_headers (can mutate headers)     |
   │   ├─► before_provider_request (can inspect or replace payload)
   │   ├─► after_provider_response (status + headers, before stream consume)
+  │   ├─► provider_error (failed provider call, per attempt)
   │   │                                            │       │
   │   │   LLM responds, may call tools:            │       │
   │   │     ├─► tool_execution_start               │       │
@@ -716,6 +717,19 @@ pi.on("after_provider_response", (event, ctx) => {
 ```
 
 Header availability depends on provider and transport. Providers that abstract HTTP responses may not expose headers.
+
+#### provider_error
+
+Fired when a provider call fails (assistant message with stopReason `"error"`). Unlike `after_provider_response`, this also covers failures with no HTTP response, such as network errors and mid-stream failures. Fired once per failed attempt, including attempts that an automatic retry will reschedule.
+
+```typescript
+pi.on("provider_error", async (event, ctx) => {
+  // event.provider - provider id (e.g. "anthropic")
+  // event.modelId - model id that failed
+  // event.error - error message from the provider
+  ctx.ui.notify(`${event.provider}/${event.modelId} failed: ${event.error}`, "warning");
+});
+```
 
 ### Model Events
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -141,11 +141,14 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 | `retry.enabled` | boolean | `true` | Enable automatic agent-level retry on transient errors |
 | `retry.maxRetries` | number | `3` | Maximum agent-level retry attempts |
 | `retry.baseDelayMs` | number | `2000` | Base delay for agent-level exponential backoff (2s, 4s, 8s) |
+| `retry.nonRetryableOverrides` | string[] | `[]` | Error-message regex sources treated as retryable even when they match built-in non-retryable limits (e.g. usage/quota exhaustion) |
 | `retry.provider.timeoutMs` | number | SDK default | Provider/SDK request timeout in milliseconds |
 | `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
 
 When a provider requests a retry delay longer than `retry.provider.maxRetryDelayMs`, the request fails immediately with an informative error instead of waiting silently. Set it to `0` to disable the limit.
+
+By default, quota/usage-limit errors are non-retryable so deterministic failures fail fast. Add patterns to `retry.nonRetryableOverrides` to keep retrying through specific limits, e.g. `"nonRetryableOverrides": ["usage.?limit", "insufficient_quota"]`.
 
 Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explicitly needed. Setting it above `0` can make SDK/provider retries handle out-of-usage-limit errors before Pi sees them, which may block the agent until the provider quota resets in some circumstances.
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2770,7 +2770,9 @@ export class AgentSession {
 	private _isRetryableError(message: AssistantMessage): boolean {
 		// Context overflow is handled by compaction, not retry.
 		if (isContextOverflow(message, this.model?.contextWindow ?? 0)) return false;
-		return isRetryableAssistantError(message);
+		return isRetryableAssistantError(message, {
+			nonRetryableOverrides: this.settingsManager.getNonRetryableOverrides(),
+		});
 	}
 
 	/**

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -112,6 +112,7 @@ export type {
 	ProjectTrustHandler,
 	// Provider Registration
 	ProviderConfig,
+	ProviderErrorEvent,
 	ProviderModelConfig,
 	ReadToolCallEvent,
 	ReadToolResultEvent,

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -711,6 +711,18 @@ export interface AfterProviderResponseEvent {
 	headers: Record<string, string>;
 }
 
+/**
+ * Fired when a provider call fails (stopReason "error"). Unlike
+ * `after_provider_response`, this also covers failures with no HTTP response,
+ * such as network errors and mid-stream failures.
+ */
+export interface ProviderErrorEvent {
+	type: "provider_error";
+	provider: string;
+	modelId: string;
+	error: string;
+}
+
 /** Fired after user submits prompt but before agent loop. */
 export interface BeforeAgentStartEvent {
 	type: "before_agent_start";
@@ -1055,6 +1067,7 @@ export type ExtensionEvent =
 	| BeforeProviderRequestEvent
 	| BeforeProviderHeadersEvent
 	| AfterProviderResponseEvent
+	| ProviderErrorEvent
 	| BeforeAgentStartEvent
 	| AgentStartEvent
 	| AgentEndEvent
@@ -1241,6 +1254,7 @@ export interface ExtensionAPI {
 	): void;
 	on(event: "before_provider_headers", handler: ExtensionHandler<BeforeProviderHeadersEvent>): void;
 	on(event: "after_provider_response", handler: ExtensionHandler<AfterProviderResponseEvent>): void;
+	on(event: "provider_error", handler: ExtensionHandler<ProviderErrorEvent>): void;
 	on(event: "before_agent_start", handler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>): void;
 	on(event: "agent_start", handler: ExtensionHandler<AgentStartEvent>): void;
 	on(event: "agent_end", handler: ExtensionHandler<AgentEndEvent>): void;

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -656,7 +656,7 @@ export async function findInitialModel(options: {
 			process.exit(1);
 		}
 		if (resolved.model) {
-			return { model: resolved.model, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: undefined };
+			return { model: resolved.model, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: resolved.warning };
 		}
 	}
 

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { Agent, type AgentMessage, setDefaultStreamFn, type ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import { clampThinkingLevel, type Message, type Model, streamSimple } from "@earendil-works/pi-ai/compat";
 import { getAgentDir } from "../config.ts";
 import { resolvePath } from "../utils/paths.ts";
@@ -319,7 +320,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const websocketConnectTimeoutMs =
 				options?.websocketConnectTimeoutMs ?? settingsManager.getWebSocketConnectTimeoutMs();
 			const headerRunner = extensionRunnerRef.current;
-			return modelRuntime.streamSimple(model, context, {
+			const stream = modelRuntime.streamSimple(model, context, {
 				...options,
 				timeoutMs,
 				websocketConnectTimeoutMs,
@@ -337,6 +338,31 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						: (headers ?? {});
 				},
 			});
+			const runner = extensionRunnerRef.current;
+			if (!runner?.hasHandlers("provider_error")) {
+				return stream;
+			}
+			// Provider failures are encoded in the returned stream as error events
+			// (pi-ai contract), so tee the stream to surface each failed attempt.
+			const wrapped = createAssistantMessageEventStream();
+			void (async () => {
+				try {
+					for await (const event of stream) {
+						if (event.type === "error" && event.error.stopReason === "error") {
+							await runner.emit({
+								type: "provider_error",
+								provider: model.provider,
+								modelId: model.id,
+								error: event.error.errorMessage || "Unknown provider error",
+							});
+						}
+						wrapped.push(event);
+					}
+				} finally {
+					wrapped.end();
+				}
+			})();
+			return wrapped;
 		},
 		onPayload: async (payload, _model) => {
 			const runner = extensionRunnerRef.current;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -220,6 +220,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		model = result.model;
 		if (!model) {
 			modelFallbackMessage = formatNoModelsAvailableMessage();
+		} else if (result.fallbackMessage) {
+			modelFallbackMessage = result.fallbackMessage;
 		} else if (modelFallbackMessage) {
 			modelFallbackMessage += `. Using ${model.provider}/${model.id}`;
 		}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -2,11 +2,11 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Transport } from "@earendil-works/pi-ai";
 import type { TuiMode as RendererTuiMode, ScrollViewScrollbar } from "@earendil-works/pi-tui";
 import { randomUUID } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
-import { normalizePath, resolvePath } from "../utils/paths.ts";
+import { getFileRevision, normalizePath, resolvePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 
@@ -265,7 +265,20 @@ export class FileSettingsStorage implements SettingsStorage {
 				if (!release) {
 					release = this.acquireLockSyncWithRetry(path);
 				}
-				writeFileSync(path, next, "utf-8");
+				// Write to a temp file in the same directory and rename so readers never
+				// observe a partially written settings file (rename is atomic on POSIX).
+				const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+				try {
+					writeFileSync(tempPath, next, "utf-8");
+					renameSync(tempPath, path);
+				} catch (error) {
+					try {
+						unlinkSync(tempPath);
+					} catch {
+						// Temp file already gone; nothing to clean up.
+					}
+					throw error;
+				}
 			}
 		} finally {
 			if (release) {
@@ -307,6 +320,7 @@ export class SettingsManager {
 	private writeQueue: Promise<void> = Promise.resolve();
 	private errors: SettingsError[];
 	private settingsPaths: SettingsPaths;
+	private fileRevisions: Partial<Record<SettingsScope, string | undefined>> = {};
 
 	private constructor(
 		storage: SettingsStorage,
@@ -327,6 +341,7 @@ export class SettingsManager {
 		this.errors = [...initialErrors];
 		this.settingsPaths = settingsPaths;
 		this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+		this.syncFileRevisions();
 	}
 
 	/** Create a SettingsManager that loads from files */
@@ -513,6 +528,7 @@ export class SettingsManager {
 			this.recordError("project", projectLoad.error);
 		}
 		this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+		this.fileRevisions.project = this.settingsPaths.project ? getFileRevision(this.settingsPaths.project) : undefined;
 	}
 
 	async reload(): Promise<void> {
@@ -541,6 +557,7 @@ export class SettingsManager {
 		}
 
 		this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+		this.syncFileRevisions();
 	}
 
 	/** Apply additional overrides on top of current settings */
@@ -591,13 +608,13 @@ export class SettingsManager {
 		this.modifiedProjectNestedFields.clear();
 	}
 
-	private enqueueWrite(scope: SettingsScope, task: () => void): void {
+	private enqueueWrite(scope: SettingsScope, task: () => void | Promise<void>): void {
 		this.writeQueue = this.writeQueue
-			.then(() => {
+			.then(async () => {
 				if (scope === "project") {
 					this.assertProjectTrustedForWrite();
 				}
-				task();
+				await task();
 				this.clearModifiedScope(scope);
 			})
 			.catch((error) => {
@@ -611,6 +628,45 @@ export class SettingsManager {
 			snapshot.set(key, new Set(value));
 		}
 		return snapshot;
+	}
+
+	private syncFileRevisions(): void {
+		for (const scope of ["global", "project"] as const) {
+			const path = this.settingsPaths[scope];
+			this.fileRevisions[scope] = path ? getFileRevision(path) : undefined;
+		}
+	}
+
+	/**
+	 * Reload in-memory settings for a scope when the file changed on disk since we
+	 * last read or wrote it. Without this, a long-running session would merge its
+	 * stale snapshot over concurrent edits (e.g. another pi session changing
+	 * defaultProvider/defaultModel). External values win for unmodified fields;
+	 * fields explicitly modified in this session are merged on top by the caller.
+	 */
+	private reloadScopeIfChanged(scope: SettingsScope): void {
+		const path = this.settingsPaths[scope];
+		if (!path) return;
+		if (getFileRevision(path) === this.fileRevisions[scope]) return;
+
+		const load = SettingsManager.tryLoadFromStorage(
+			this.storage,
+			scope,
+			scope === "project" ? this.projectTrusted : true,
+		);
+		if (load.error) {
+			this.recordError(scope, load.error);
+			this.fileRevisions[scope] = getFileRevision(path);
+			return;
+		}
+		if (scope === "global") {
+			this.globalSettings = load.settings;
+			this.globalSettingsLoadError = null;
+		} else {
+			this.projectSettings = load.settings;
+			this.projectSettingsLoadError = null;
+		}
+		this.fileRevisions[scope] = getFileRevision(path);
 	}
 
 	private persistScopedSettings(
@@ -655,8 +711,11 @@ export class SettingsManager {
 		const modifiedFields = new Set(this.modifiedFields);
 		const modifiedNestedFields = this.cloneModifiedNestedFields(this.modifiedNestedFields);
 
-		this.enqueueWrite("global", () => {
+		this.enqueueWrite("global", async () => {
+			this.reloadScopeIfChanged("global");
 			this.persistScopedSettings("global", snapshotGlobalSettings, modifiedFields, modifiedNestedFields);
+			this.syncFileRevisions();
+			this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
 		});
 	}
 
@@ -672,8 +731,11 @@ export class SettingsManager {
 		const snapshotProjectSettings = structuredClone(this.projectSettings);
 		const modifiedFields = new Set(this.modifiedProjectFields);
 		const modifiedNestedFields = this.cloneModifiedNestedFields(this.modifiedProjectNestedFields);
-		this.enqueueWrite("project", () => {
+		this.enqueueWrite("project", async () => {
+			this.reloadScopeIfChanged("project");
 			this.persistScopedSettings("project", snapshotProjectSettings, modifiedFields, modifiedNestedFields);
+			this.syncFileRevisions();
+			this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
 		});
 	}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -31,6 +31,7 @@ export interface RetrySettings {
 	enabled?: boolean; // default: true
 	maxRetries?: number; // default: 3
 	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
+	nonRetryableOverrides?: string[]; // error-message regex sources treated as retryable despite matching built-in non-retryable limits (e.g. usage-limit errors)
 	provider?: ProviderRetrySettings;
 }
 
@@ -943,6 +944,10 @@ export class SettingsManager {
 			maxRetries: this.settings.retry?.maxRetries ?? 3,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
 		};
+	}
+
+	getNonRetryableOverrides(): string[] {
+		return [...(this.settings.retry?.nonRetryableOverrides ?? [])];
 	}
 
 	getHttpIdleTimeoutMs(): number {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -113,6 +113,7 @@ export type {
 	ProjectTrustEventResult,
 	ProjectTrustHandler,
 	ProviderConfig,
+	ProviderErrorEvent,
 	ProviderModelConfig,
 	ReadToolCallEvent,
 	RegisteredCommand,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3378,6 +3378,13 @@ export class InteractiveMode {
 
 			case "agent_settled":
 				await this.checkShutdownRequested();
+				for (const { scope, path, error } of this.settingsManager.drainErrors()) {
+					this.showWarning(
+						path
+							? `Invalid settings file ${path}: ${error.message}`
+							: `Invalid ${scope} settings: ${error.message}`,
+					);
+				}
 				break;
 
 			case "compaction_start": {

--- a/packages/coding-agent/test/agent-session-runtime-events.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-events.test.ts
@@ -14,6 +14,7 @@ import { ModelRuntime } from "../src/core/model-runtime.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import type {
 	ExtensionFactory,
+	ProviderErrorEvent,
 	SessionBeforeForkEvent,
 	SessionBeforeSwitchEvent,
 	SessionShutdownEvent,
@@ -253,5 +254,22 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		const cancelAtResult = await runtimeHost.fork("missing-entry", { position: "at" });
 		expect(cancelAtResult).toEqual({ cancelled: true });
 		expect(events).toEqual([{ type: "session_before_fork", entryId: "missing-entry", position: "at" }]);
+	});
+
+	it("emits provider_error when a provider call fails", async () => {
+		const errors: ProviderErrorEvent[] = [];
+		const { runtimeHost, faux } = await createRuntimeHost((pi) => {
+			pi.on("provider_error", (event) => {
+				errors.push(event);
+			});
+		});
+
+		faux.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: "quota exceeded" })]);
+		await runtimeHost.session.prompt("hello");
+
+		const model = faux.getModel();
+		expect(errors).toEqual([
+			{ type: "provider_error", provider: model.provider, modelId: model.id, error: "quota exceeded" },
+		]);
 	});
 });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -748,6 +748,22 @@ describe("default model selection", () => {
 		expect(result.model?.id).toBe("openai/ghost-model");
 	});
 
+	test("findInitialModel surfaces the custom-model-id warning as fallbackMessage", async () => {
+		const registry = {
+			getModels: () => allModels,
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
+
+		const result = await findInitialModel({
+			cliProvider: "openrouter",
+			cliModel: "openrouter/openai/ghost-model",
+			scopedModels: [],
+			isContinuing: false,
+			modelRuntime: registry,
+		});
+
+		expect(result.fallbackMessage).toContain('Model "openai/ghost-model" not found for provider "openrouter"');
+	});
+
 	test("findInitialModel selects ai-gateway default when available", async () => {
 		const aiGatewayModel: Model<"anthropic-messages"> = {
 			id: "anthropic/claude-opus-4-6",

--- a/packages/coding-agent/test/settings-manager-bug.test.ts
+++ b/packages/coding-agent/test/settings-manager-bug.test.ts
@@ -144,4 +144,42 @@ describe("SettingsManager - External Edit Preservation", () => {
 		const savedProjectSettings = JSON.parse(readFileSync(projectSettingsPath, "utf-8"));
 		expect(savedProjectSettings.extensions).toEqual(["./in-memory-extension.ts"]);
 	});
+
+	it("should pick up concurrent default model edits when saving an unrelated setting", async () => {
+		const settingsPath = join(agentDir, "settings.json");
+
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				defaultProvider: "anthropic",
+				defaultModel: "claude-from-startup",
+			}),
+		);
+
+		const manager = SettingsManager.create(projectDir, agentDir);
+
+		// Another pi session persists a different default while this one runs.
+		writeFileSync(
+			settingsPath,
+			JSON.stringify(
+				{
+					defaultProvider: "openai",
+					defaultModel: "gpt-from-other-session",
+				},
+				null,
+				2,
+			),
+		);
+
+		manager.setTheme("light");
+		await manager.flush();
+
+		const savedSettings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(savedSettings.defaultProvider).toBe("openai");
+		expect(savedSettings.defaultModel).toBe("gpt-from-other-session");
+		expect(savedSettings.theme).toBe("light");
+
+		expect(manager.getDefaultProvider()).toBe("openai");
+		expect(manager.getDefaultModel()).toBe("gpt-from-other-session");
+	});
 });


### PR DESCRIPTION
Five defects observed in production with pi v0.84.2 across long-running multi-session harness operation, with fixes for the four that remain on `main`.

**1. Settings: stale-snapshot merge, non-atomic writes, silent late errors** (65aecc0)
Any save could merge stale state over concurrent edits, and writes were non-atomic `writeFileSync`; settings errors recorded after startup were never drained. Observed live: an operator's `defaultProvider`/`defaultModel` reverted while sessions ran concurrently. Now: file-revision check (mtime/size/ctime via `getFileRevision`, the same mechanism `auth.json` uses) triggers a reload before every scoped merge; writes go through temp-file+rename; queued errors surface in the TUI on `agent_settled`.

**2. Volatile/durable model split** — already fixed on main by #8356; included here for incident traceability, no code change. The shipped 0.84.2 persisted every runtime model switch as the durable default; we observed an operator's saved default revert ~16h later when a long-lived session re-persisted its choice.

**3. Quota-terminal silent deaths** (0cfc73e)
`NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN` is a module constant checked before retryability, so usage-limit errors terminate runs with no recourse. Measured across our fleet: 23 crashed subagent sessions traced to terminal quota-classified errors operators expected to ride out. New `retry.nonRetryableOverrides` setting downgrades specific patterns (e.g. `"usage.?limit"`) to retryable, wired through both `isRetryableAssistantError` and `retryAssistantCall`.

**4. Headless provider-failure blindness** (0b33e27)
`after_provider_response` fires only after a successful HTTP response; failed provider calls (network errors, mid-stream deaths) were invisible to extensions. New `provider_error` event emits `{provider, modelId, error}` once per failed attempt from the single stream chokepoint in `createAgentSession`.

**5. Fabricated-model warnings dropped on the SDK path** (d303fa7)
`buildFallbackModel` fabricates `{id: requested}` for unknown `--model`/`--provider` and produces a warning, but `findInitialModel` discarded it. The warning now flows through `InitialModelResult.fallbackMessage` and is surfaced as a diagnostic.

**Testing:** new unit tests per patch (settings concurrency preservation, retry-override classification, `provider_error` emission via faux provider, fallbackMessage propagation); full coding-agent suite green except pre-existing environment-dependent failures identical on base; repo-wide `tsgo --noEmit` clean.