### PR TITLE
feat(tui): move editor cursor on click

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -902,6 +902,48 @@ export class Editor implements Component, Focusable {
 		}
 	}
 
+	handleClick(x: number, y: number, width: number): void {
+		const visualLines = this.buildVisualLineMap(this.lastWidth);
+		const visibleLineCount = Math.min(
+			Math.max(5, Math.floor(this.tui.terminal.rows * 0.3)),
+			visualLines.length - this.scrollOffset,
+		);
+		if (y < 1 || y > visibleLineCount) return;
+		const visualLineIndex = this.scrollOffset + y - 1;
+		const visualLine = visualLines[visualLineIndex];
+		if (!visualLine) return;
+
+		const paddingX = Math.min(this.paddingX, Math.max(0, Math.floor((width - 1) / 2)));
+		const visualCol = Math.max(0, x - paddingX);
+		const logicalLine = this.state.lines[visualLine.logicalLine] ?? "";
+		const chunk = logicalLine.slice(visualLine.startCol, visualLine.startCol + visualLine.length);
+		const isLastVisualLine =
+			visualLineIndex === visualLines.length - 1 ||
+			visualLines[visualLineIndex + 1]?.logicalLine !== visualLine.logicalLine;
+		let targetCol = isLastVisualLine ? visualLine.startCol + chunk.length : visualLine.startCol;
+		let currentWidth = 0;
+		for (const grapheme of graphemeSegmenter.segment(chunk)) {
+			if (visualCol < currentWidth + visibleWidth(grapheme.segment)) {
+				targetCol = visualLine.startCol + grapheme.index;
+				break;
+			}
+			currentWidth += visibleWidth(grapheme.segment);
+			if (!isLastVisualLine) targetCol = visualLine.startCol + grapheme.index;
+		}
+
+		for (const segment of this.segment(logicalLine, "grapheme")) {
+			if (targetCol > segment.index && targetCol < segment.index + segment.segment.length) {
+				targetCol = segment.index;
+				break;
+			}
+		}
+		this.lastAction = null;
+		this.state.cursorLine = visualLine.logicalLine;
+		this.setCursorCol(targetCol);
+		if (this.autocompleteState) this.updateAutocomplete();
+		this.tui.requestRender();
+	}
+
 	private layoutText(contentWidth: number): LayoutLine[] {
 		const layoutLines: LayoutLine[] = [];
 

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -12,6 +12,7 @@ import {
 	getScrollbarGeometry,
 	getScrollViewBox,
 	getScrollViewsAt,
+	type LayoutBox,
 	type LayoutFrame,
 	renderLayoutFrame,
 	type ScrollbarGeometry,
@@ -30,6 +31,7 @@ import {
 } from "./terminal-image.ts";
 import {
 	type Component,
+	Container,
 	CURSOR_MARKER,
 	compositeTuiLine,
 	type OverlayHandle,
@@ -984,6 +986,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 				this.requestRender();
 				return;
 			}
+			if (!this.getSelectionBounds()) this.handleComponentClick(event.x, event.y);
 			void this.copySelectionToClipboard();
 			this.requestRender();
 			return;
@@ -1020,6 +1023,45 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 					Math.max(0, Math.min(this.terminal.columns - 1, event.x)),
 				);
 		this.requestRender();
+	}
+
+	private getFocusedComponentTarget(x: number, y: number): LayoutBox | undefined {
+		const component = this.getFocusedComponent();
+		if (!component || !this.currentLayout || this.hasOverlay()) return undefined;
+
+		const visit = (box: LayoutBox): LayoutBox | undefined => {
+			if (
+				x < box.rect.x ||
+				x >= box.rect.x + box.rect.width ||
+				y < box.rect.y ||
+				y >= box.rect.y + box.rect.height ||
+				x < box.clip.x ||
+				x >= box.clip.x + box.clip.width ||
+				y < box.clip.y ||
+				y >= box.clip.y + box.clip.height
+			) {
+				return undefined;
+			}
+			for (const child of box.children) {
+				const target = visit(child);
+				if (target) return target;
+			}
+			return box.component === component ||
+				(box.component instanceof Container && this.containsComponent(box.component, component))
+				? box
+				: undefined;
+		};
+		return visit(this.currentLayout.root);
+	}
+
+	private handleComponentClick(x: number, y: number): void {
+		const target = this.getFocusedComponentTarget(x, y);
+		if (!target) return;
+		target.component.handleClick?.(
+			x - target.rect.x,
+			y - target.rect.y + (target.lineOffset ?? 0),
+			target.rect.width,
+		);
 	}
 
 	private getSelectionBounds(): { start: SelectionPoint; end: SelectionPoint } | undefined {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -33,6 +33,9 @@ export interface Component {
 	 */
 	handleInput?(data: string): void;
 
+	/** Handle a primary-button click at component-local terminal coordinates. */
+	handleClick?(x: number, y: number, width: number): void;
+
 	/**
 	 * If true, component receives key release events (Kitty protocol).
 	 * Default is false - release events are filtered out.
@@ -241,6 +244,18 @@ export class Container implements Component {
 			}
 		}
 		return lines;
+	}
+
+	handleClick(x: number, y: number, width: number): void {
+		let offset = 0;
+		for (const child of this.children) {
+			const height = child.render(width).length;
+			if (y >= offset && y < offset + height) {
+				child.handleClick?.(x, y - offset, width);
+				return;
+			}
+			offset += height;
+		}
 	}
 }
 
@@ -536,7 +551,7 @@ export abstract class TuiBase extends Container implements TUI {
 		return this.getMountedRoots().some((child) => this.containsComponent(child, component));
 	}
 
-	private containsComponent(root: Component, target: Component): boolean {
+	protected containsComponent(root: Component, target: Component): boolean {
 		if (root === target) return true;
 		if (!(root instanceof Container)) return false;
 		return root.children.some((child) => this.containsComponent(child, target));

--- a/packages/tui/test/editor-click.test.ts
+++ b/packages/tui/test/editor-click.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+import { test } from "node:test";
+import { Editor } from "../src/components/editor.ts";
+import { Container } from "../src/tui.ts";
+import { TuiAltScreen } from "../src/tui-alt-screen.ts";
+import { defaultEditorTheme } from "./test-themes.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+function click(terminal: VirtualTerminal, x: number, y: number): void {
+	terminal.sendInput(`\x1b[<0;${x};${y}M`);
+	terminal.sendInput(`\x1b[<0;${x};${y}m`);
+}
+
+test("mouse clicks move the editor cursor across wrapped graphemes", async () => {
+	const terminal = new VirtualTerminal(16, 6);
+	const tui = new TuiAltScreen(terminal);
+	const editor = new Editor(tui, defaultEditorTheme, { paddingX: 2 });
+	editor.setText("hello 🙂 world");
+	const root = new Container();
+	root.addChild(editor);
+	tui.setLayoutRoot(root);
+	tui.setFocus(editor);
+	tui.start();
+	await terminal.waitForRender();
+
+	click(terminal, 10, 2);
+	assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 6 });
+
+	click(terminal, 5, 3);
+	assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 11 });
+
+	click(terminal, 15, 3);
+	assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 14 });
+
+	click(terminal, 1, 1);
+	assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 14 });
+
+	tui.stop();
+});


### PR DESCRIPTION
## Summary

Pi supports selecting text with the mouse, but clicking inside the prompt does not move the editor cursor. Editing something already visible therefore still requires navigating back to it with the keyboard, which is surprising in a mouse-enabled terminal.

This PR makes a primary-button click place the cursor at the clicked position in the focused editor. It accounts for wrapped lines, editor padding, and multi-column graphemes, while ignoring clicks outside editable content.

This is a small quality-of-life improvement that makes revising prompts feel more natural without changing keyboard behavior.

## Testing

- `npm run build`
- `npm run check`
- `./test.sh`
