### PR TITLE
feat(coding-agent): attach clipboard images as atomic markers

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -104,6 +104,8 @@ import { getChangelogPath, getNewEntries, normalizeChangelogLinks, parseChangelo
 import { copyToClipboard, readClipboardText } from "../../utils/clipboard.ts";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.ts";
 import { parseGitUrl } from "../../utils/git.ts";
+import { processImage } from "../../utils/image-process.ts";
+import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.ts";
 import { openBrowser } from "../../utils/open-browser.ts";
 import { getCwdRelativePath } from "../../utils/paths.ts";
 import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
@@ -205,6 +207,7 @@ class ExpandableText extends Text implements Expandable {
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
+	images: ImageContent[];
 };
 
 type CompactionCostNotice = {
@@ -445,8 +448,11 @@ export class InteractiveMode {
 	private keybindings: KeybindingsManager;
 	private version: string;
 	private isInitialized = false;
-	private onInputCallback?: (text: string) => void;
-	private pendingUserInputs: string[] = [];
+	private onInputCallback?: (input: { text: string; images: ImageContent[] }) => void;
+
+	/** Currently pending editor image attachments, keyed by marker ID. */
+	private pendingImageAttachments = new Map<number, { path: string; hash: string }>();
+	private pendingUserInputs: Array<{ text: string; images: ImageContent[] }> = [];
 	private activeStatusIndicator: StatusIndicator | undefined = undefined;
 	private readonly idleStatus = new IdleStatus();
 	private workingMessage: string | undefined = undefined;
@@ -1175,9 +1181,9 @@ export class InteractiveMode {
 
 		// Main interactive loop
 		while (true) {
-			const userInput = await this.getUserInput();
+			const { text: userInput, images } = await this.getUserInput();
 			try {
-				await this.session.prompt(userInput);
+				await this.session.prompt(userInput, { images });
 			} catch (error: unknown) {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 				this.showError(errorMessage);
@@ -2674,7 +2680,6 @@ export class InteractiveMode {
 			// Wire up callbacks from the default editor
 			newEditor.onSubmit = this.defaultEditor.onSubmit;
 			newEditor.onChange = this.defaultEditor.onChange;
-
 			// Copy text from previous editor
 			newEditor.setText(currentText);
 
@@ -2907,11 +2912,55 @@ export class InteractiveMode {
 			}
 		};
 
-		// Handle clipboard paste (triggered on Ctrl+V). Images are attached by path;
+		// Handle clipboard paste (triggered on Ctrl+V). Images are attached as [Image N] markers;
 		// otherwise, paste plain text from the system clipboard.
 		this.defaultEditor.onPasteImage = () => {
 			void this.handleClipboardPaste();
 		};
+	}
+
+	private async takeEditorImages(): Promise<ImageContent[] | undefined> {
+		const attachments = this.editor.getImageAttachments?.() ?? [];
+		const images: ImageContent[] = [];
+		for (const { id, path: filePath } of attachments) {
+			try {
+				const mimeType = await detectSupportedImageMimeTypeFromFile(filePath);
+				if (!mimeType) {
+					this.showError(`[Image ${id}] is not a supported image file`);
+					return undefined;
+				}
+				const content = await fs.promises.readFile(filePath);
+				const processed = await processImage(content, mimeType);
+				if (!processed.ok) {
+					this.showError(`[Image ${id}] ${processed.message}`);
+					return undefined;
+				}
+				images.push({ type: "image", mimeType: processed.mimeType, data: processed.data });
+			} catch (error) {
+				this.showError(
+					`[Image ${id}] could not be read: ${error instanceof Error ? error.message : String(error)}`,
+				);
+				return undefined;
+			}
+		}
+		this.editor.clearImages?.();
+		for (const { path: filePath } of this.pendingImageAttachments.values())
+			fs.rm(filePath, { force: true }, () => {});
+		this.pendingImageAttachments.clear();
+		return images;
+	}
+
+	private restoreSubmittedEditorText(text: string): void {
+		if (this.editor.insertTextAtCursor) this.editor.insertTextAtCursor(text);
+		else this.editor.setText(text);
+	}
+
+	private submitUserInput(text: string, images: ImageContent[]): void {
+		this.flushPendingBashComponents();
+		const input = { text, images };
+		if (this.onInputCallback) this.onInputCallback(input);
+		else this.pendingUserInputs.push(input);
+		this.editor.addToHistory?.(text);
 	}
 
 	private async handleRightClickPaste(): Promise<void> {
@@ -2932,13 +2981,30 @@ export class InteractiveMode {
 		try {
 			const image = await readClipboardImage();
 			if (image) {
+				const hash = crypto.createHash("sha256").update(image.bytes).digest("hex");
+				const activeIds = new Set(this.editor.getImageAttachments?.().map(({ id }) => id));
+				if (
+					[...this.pendingImageAttachments].some(
+						([id, attachment]) => activeIds.has(id) && attachment.hash === hash,
+					)
+				) {
+					this.showStatus("Image is already attached");
+					return;
+				}
+
 				const tmpDir = os.tmpdir();
 				const ext = extensionForImageMimeType(image.mimeType) ?? "png";
 				const fileName = `pi-clipboard-${crypto.randomUUID()}.${ext}`;
 				const filePath = path.join(tmpDir, fileName);
 				fs.writeFileSync(filePath, Buffer.from(image.bytes));
 
-				this.editor.insertTextAtCursor?.(filePath);
+				const markerId = this.editor.insertImageMarker?.(filePath);
+				if (markerId === undefined) {
+					this.editor.insertTextAtCursor?.(filePath);
+				} else {
+					this.pendingImageAttachments.set(markerId, { path: filePath, hash });
+					this.showStatus(`[Image ${markerId}] attached`);
+				}
 				this.ui.requestRender();
 				return;
 			}
@@ -3124,7 +3190,12 @@ export class InteractiveMode {
 					this.editor.setText("");
 					await this.session.prompt(text);
 				} else {
-					this.queueCompactionMessage(text, "steer");
+					const images = await this.takeEditorImages();
+					if (!images) {
+						this.restoreSubmittedEditorText(text);
+						return;
+					}
+					this.queueCompactionMessage(text, "steer", images);
 				}
 				return;
 			}
@@ -3133,23 +3204,24 @@ export class InteractiveMode {
 			// This handles extension commands (execute immediately), prompt template expansion, and queueing
 			if (this.session.isStreaming) {
 				this.editor.addToHistory?.(text);
+				const images = await this.takeEditorImages();
+				if (!images) {
+					this.restoreSubmittedEditorText(text);
+					return;
+				}
 				this.editor.setText("");
-				await this.session.prompt(text, { streamingBehavior: "steer" });
+				await this.session.prompt(text, { streamingBehavior: "steer", images });
 				this.updatePendingMessagesDisplay();
 				this.ui.requestRender();
 				return;
 			}
 
-			// Normal message submission
-			// First, move any pending bash components to chat
-			this.flushPendingBashComponents();
-
-			if (this.onInputCallback) {
-				this.onInputCallback(text);
-			} else {
-				this.pendingUserInputs.push(text);
+			const images = await this.takeEditorImages();
+			if (!images) {
+				this.restoreSubmittedEditorText(text);
+				return;
 			}
-			this.editor.addToHistory?.(text);
+			this.submitUserInput(text, images);
 		};
 	}
 
@@ -3875,16 +3947,16 @@ export class InteractiveMode {
 		);
 	}
 
-	async getUserInput(): Promise<string> {
+	async getUserInput(): Promise<{ text: string; images: ImageContent[] }> {
 		const queuedInput = this.pendingUserInputs.shift();
 		if (queuedInput !== undefined) {
 			return queuedInput;
 		}
 
 		return new Promise((resolve) => {
-			this.onInputCallback = (text: string) => {
+			this.onInputCallback = (input) => {
 				this.onInputCallback = undefined;
-				resolve(text);
+				resolve(input);
 			};
 		});
 	}
@@ -4103,7 +4175,9 @@ export class InteractiveMode {
 				this.editor.setText("");
 				await this.session.prompt(text);
 			} else {
-				this.queueCompactionMessage(text, "followUp");
+				const images = await this.takeEditorImages();
+				if (!images) return;
+				this.queueCompactionMessage(text, "followUp", images);
 			}
 			return;
 		}
@@ -4112,15 +4186,19 @@ export class InteractiveMode {
 		// This handles extension commands (execute immediately), prompt template expansion, and queueing
 		if (this.session.isStreaming) {
 			this.editor.addToHistory?.(text);
+			const images = await this.takeEditorImages();
+			if (!images) return;
 			this.editor.setText("");
-			await this.session.prompt(text, { streamingBehavior: "followUp" });
+			await this.session.prompt(text, { streamingBehavior: "followUp", images });
 			this.updatePendingMessagesDisplay();
 			this.ui.requestRender();
 		}
 		// If not streaming, Alt+Enter acts like regular Enter (trigger onSubmit)
-		else if (this.editor.onSubmit) {
+		else {
+			const images = await this.takeEditorImages();
+			if (!images) return;
 			this.editor.setText("");
-			this.editor.onSubmit(text);
+			this.submitUserInput(text, images);
 		}
 	}
 
@@ -4375,8 +4453,8 @@ export class InteractiveMode {
 		return allQueued.length;
 	}
 
-	private queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
-		this.compactionQueuedMessages.push({ text, mode });
+	private queueCompactionMessage(text: string, mode: "steer" | "followUp", images: ImageContent[]): void {
+		this.compactionQueuedMessages.push({ text, mode, images });
 		this.editor.addToHistory?.(text);
 		this.editor.setText("");
 		this.updatePendingMessagesDisplay();
@@ -4420,9 +4498,9 @@ export class InteractiveMode {
 					if (this.isExtensionCommand(message.text)) {
 						await this.session.prompt(message.text);
 					} else if (message.mode === "followUp") {
-						await this.session.followUp(message.text);
+						await this.session.followUp(message.text, message.images);
 					} else {
-						await this.session.steer(message.text);
+						await this.session.steer(message.text, message.images);
 					}
 				}
 				this.updatePendingMessagesDisplay();
@@ -4450,7 +4528,7 @@ export class InteractiveMode {
 
 			// Start a prompt when idle, or queue it into a run still finishing compaction.
 			const promptPromise = this.session
-				.prompt(firstPrompt.text, { streamingBehavior: firstPrompt.mode })
+				.prompt(firstPrompt.text, { streamingBehavior: firstPrompt.mode, images: firstPrompt.images })
 				.catch((error) => {
 					restoreQueue(error);
 				});
@@ -4460,9 +4538,9 @@ export class InteractiveMode {
 				if (this.isExtensionCommand(message.text)) {
 					await this.session.prompt(message.text);
 				} else if (message.mode === "followUp") {
-					await this.session.followUp(message.text);
+					await this.session.followUp(message.text, message.images);
 				} else {
-					await this.session.steer(message.text);
+					await this.session.steer(message.text, message.images);
 				}
 			}
 			this.updatePendingMessagesDisplay();

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -1,5 +1,8 @@
+import type { ImageContent } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type UserInput = { text: string; images: ImageContent[] };
 
 type SubmitContext = {
 	defaultEditor: { onSubmit?: (text: string) => void };
@@ -7,20 +10,23 @@ type SubmitContext = {
 		addToHistory?: (text: string) => void;
 		setText: (text: string) => void;
 	};
-	session: {
-		isCompacting: boolean;
-		isStreaming: boolean;
-		isBashRunning: boolean;
-		prompt: (text: string, options?: unknown) => Promise<void>;
+	runtimeHost: {
+		session: {
+			isCompacting: boolean;
+			isStreaming: boolean;
+			isBashRunning: boolean;
+			prompt: (text: string, options?: unknown) => Promise<void>;
+		};
 	};
 	flushPendingBashComponents: () => void;
-	onInputCallback?: (text: string) => void;
-	pendingUserInputs: string[];
+	onInputCallback?: (input: UserInput) => void;
+	pendingImageAttachments: Map<number, { path: string; hash: string }>;
+	pendingUserInputs: UserInput[];
 };
 
 type InputContext = {
-	onInputCallback?: (text: string) => void;
-	pendingUserInputs: string[];
+	onInputCallback?: (input: UserInput) => void;
+	pendingUserInputs: UserInput[];
 };
 
 type StartupSubmitContext = {
@@ -31,27 +37,30 @@ type StartupSubmitContext = {
 type InteractiveModePrivate = {
 	handleStartupSubmit(this: StartupSubmitContext, text: string): void;
 	setupEditorSubmitHandler(this: SubmitContext): void;
-	getUserInput(this: InputContext): Promise<string>;
+	getUserInput(this: InputContext): Promise<UserInput>;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
 
 function createSubmitContext(): SubmitContext {
-	return {
+	return Object.assign(Object.create(InteractiveMode.prototype), {
 		defaultEditor: {},
 		editor: {
 			addToHistory: vi.fn(),
 			setText: vi.fn(),
 		},
-		session: {
-			isCompacting: false,
-			isStreaming: false,
-			isBashRunning: false,
-			prompt: vi.fn(async () => {}),
+		runtimeHost: {
+			session: {
+				isCompacting: false,
+				isStreaming: false,
+				isBashRunning: false,
+				prompt: vi.fn(async () => {}),
+			},
 		},
 		flushPendingBashComponents: vi.fn(),
+		pendingImageAttachments: new Map(),
 		pendingUserInputs: [],
-	};
+	}) as SubmitContext;
 }
 
 describe("InteractiveMode startup input", () => {
@@ -73,17 +82,18 @@ describe("InteractiveMode startup input", () => {
 
 		await context.defaultEditor.onSubmit?.(" early prompt ");
 
-		expect(context.pendingUserInputs).toEqual(["early prompt"]);
+		expect(context.pendingUserInputs).toEqual([{ text: "early prompt", images: [] }]);
 		expect(context.flushPendingBashComponents).toHaveBeenCalledTimes(1);
 		expect(context.editor.addToHistory).toHaveBeenCalledWith("early prompt");
 	});
 
 	it("returns queued startup input before installing a new input callback", async () => {
+		const input = { text: "queued prompt", images: [] };
 		const context: InputContext = {
-			pendingUserInputs: ["queued prompt"],
+			pendingUserInputs: [input],
 		};
 
-		await expect(interactiveModePrototype.getUserInput.call(context)).resolves.toBe("queued prompt");
+		await expect(interactiveModePrototype.getUserInput.call(context)).resolves.toBe(input);
 		expect(context.onInputCallback).toBeUndefined();
 		expect(context.pendingUserInputs).toEqual([]);
 	});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -24,9 +24,23 @@ const PASTE_MARKER_REGEX = /\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]/g;
 /** Non-global version for single-segment testing. */
 const PASTE_MARKER_SINGLE = /^\[paste #(\d+)( (\+\d+ lines|\d+ chars))?\]$/;
 
+/** Regex matching attached-image markers like `[Image 1]`. */
+const IMAGE_MARKER_REGEX = /\[Image (\d+)\]/g;
+
+const IMAGE_MARKER_SINGLE = /^\[Image (\d+)\]$/;
+
 /** Check if a segment is a paste marker (i.e. was merged by segmentWithMarkers). */
 function isPasteMarker(segment: string): boolean {
 	return segment.length >= 10 && PASTE_MARKER_SINGLE.test(segment);
+}
+
+function isAtomicMarker(segment: string): boolean {
+	return isPasteMarker(segment) || IMAGE_MARKER_SINGLE.test(segment);
+}
+
+interface MarkerRule {
+	regex: RegExp;
+	isValid(id: number): boolean;
 }
 
 /**
@@ -39,23 +53,26 @@ function isPasteMarker(segment: string): boolean {
 function segmentWithMarkers(
 	text: string,
 	baseSegmenter: Intl.Segmenter,
-	validIds: Set<number>,
+	rules: MarkerRule[],
 ): Iterable<Intl.SegmentData> {
-	// Fast path: no paste markers in the text or no valid IDs.
-	if (validIds.size === 0 || !text.includes("[paste #")) {
+	// Fast path: no markers in the text or no valid IDs.
+	if (rules.length === 0 || (!text.includes("[paste #") && !text.includes("[Image "))) {
 		return baseSegmenter.segment(text);
 	}
 
 	// Find all marker spans with valid IDs.
 	const markers: Array<{ start: number; end: number }> = [];
-	for (const m of text.matchAll(PASTE_MARKER_REGEX)) {
-		const id = Number.parseInt(m[1]!, 10);
-		if (!validIds.has(id)) continue;
-		markers.push({ start: m.index, end: m.index + m[0].length });
+	for (const rule of rules) {
+		for (const m of text.matchAll(rule.regex)) {
+			const id = Number.parseInt(m[1]!, 10);
+			if (!rule.isValid(id)) continue;
+			markers.push({ start: m.index, end: m.index + m[0].length });
+		}
 	}
 	if (markers.length === 0) {
 		return baseSegmenter.segment(text);
 	}
+	markers.sort((a, b) => a.start - b.start);
 
 	// Build merged segment list.
 	const baseSegments = baseSegmenter.segment(text);
@@ -217,6 +234,8 @@ interface EditorSnapshot {
 	state: EditorState;
 	pastes: Map<number, string>;
 	pasteCounter: number;
+	images: Map<number, string>;
+	imageCounter: number;
 }
 
 interface LayoutLine {
@@ -309,6 +328,10 @@ export class Editor implements Component, Focusable {
 	private pastes: Map<number, string> = new Map();
 	private pasteCounter: number = 0;
 
+	/** Attached images: marker ID -> temp file path. */
+	private images: Map<number, string> = new Map();
+	private imageCounter: number = 0;
+
 	// Bracketed paste mode buffering
 	private pasteBuffer: string = "";
 	private isInPaste: boolean = false;
@@ -357,9 +380,18 @@ export class Editor implements Component, Focusable {
 		return new Set(this.pastes.keys());
 	}
 
-	/** Segment text with paste-marker awareness, only merging markers with valid IDs. */
+	private markerRules(): MarkerRule[] {
+		const pastes = this.validPasteIds();
+		const images = new Set(this.images.keys());
+		const rules: MarkerRule[] = [];
+		if (pastes.size > 0) rules.push({ regex: PASTE_MARKER_REGEX, isValid: (id) => pastes.has(id) });
+		if (images.size > 0) rules.push({ regex: IMAGE_MARKER_REGEX, isValid: (id) => images.has(id) });
+		return rules;
+	}
+
+	/** Segment text with marker awareness, only merging markers with valid IDs. */
 	private segment(text: string, mode: "word" | "grapheme"): Iterable<Intl.SegmentData> {
-		return segmentWithMarkers(text, mode === "word" ? wordSegmenter : graphemeSegmenter, this.validPasteIds());
+		return segmentWithMarkers(text, mode === "word" ? wordSegmenter : graphemeSegmenter, this.markerRules());
 	}
 
 	getPaddingX(): number {
@@ -1028,6 +1060,7 @@ export class Editor implements Component, Focusable {
 		if (this.getText() !== normalized) {
 			this.pushUndoSnapshot();
 		}
+		this.removeImages([...this.images.keys()]);
 		this.pastes.clear();
 		this.pasteCounter = 0;
 		this.setTextInternal(normalized);
@@ -1045,6 +1078,50 @@ export class Editor implements Component, Focusable {
 		this.lastAction = null;
 		this.exitHistoryBrowsing();
 		this.insertTextAtCursorInternal(text);
+	}
+
+	/** Register an attached image and insert its atomic `[Image N]` marker. */
+	insertImageMarker(filePath: string): number {
+		this.cancelAutocomplete();
+		this.pushUndoSnapshot();
+		this.lastAction = null;
+		this.exitHistoryBrowsing();
+		this.imageCounter++;
+		const id = this.imageCounter;
+		this.images.set(id, filePath);
+		this.insertTextAtCursorInternal(`[Image ${id}]`);
+		return id;
+	}
+
+	/** Currently pending image attachments, ordered by marker position. */
+	getImageAttachments(): Array<{ id: number; path: string }> {
+		const seen = new Set<number>();
+		return [...this.getText().matchAll(IMAGE_MARKER_REGEX)].flatMap((match) => {
+			const id = Number(match[1]);
+			const path = this.images.get(id);
+			if (!path || seen.has(id)) return [];
+			seen.add(id);
+			return [{ id, path }];
+		});
+	}
+
+	/** Drop all pending image attachments. */
+	clearImages(): void {
+		this.images.clear();
+		this.imageCounter = 0;
+	}
+
+	private removeImages(removedIds: number[]): void {
+		for (const id of removedIds) this.images.delete(id);
+	}
+
+	private removeImagesFromText(text: string): void {
+		const remainingText = this.getText();
+		this.removeImages(
+			[...text.matchAll(IMAGE_MARKER_REGEX)]
+				.map((match) => Number(match[1]))
+				.filter((id) => this.images.has(id) && !remainingText.includes(`[Image ${id}]`)),
+		);
 	}
 
 	/**
@@ -1301,6 +1378,7 @@ export class Editor implements Component, Focusable {
 			const lastGrapheme = graphemes[graphemes.length - 1];
 			const graphemeLength = lastGrapheme ? lastGrapheme.segment.length : 1;
 			const isPastedSegmented = PASTE_MARKER_SINGLE.exec(lastGrapheme.segment);
+			const removedImageId = IMAGE_MARKER_SINGLE.exec(lastGrapheme.segment)?.[1];
 
 			if (isPastedSegmented) {
 				// This contains the id part e.g 4 from [paste #4 +123 lines]
@@ -1334,6 +1412,7 @@ export class Editor implements Component, Focusable {
 
 			this.state.lines[this.state.cursorLine] = before + after;
 			this.setCursorCol(this.state.cursorCol - graphemeLength);
+			if (removedImageId) this.removeImages([Number(removedImageId)]);
 		} else if (this.state.cursorLine > 0) {
 			this.pushUndoSnapshot();
 
@@ -1546,6 +1625,7 @@ export class Editor implements Component, Focusable {
 			// Delete from start of line up to cursor
 			this.state.lines[this.state.cursorLine] = currentLine.slice(this.state.cursorCol);
 			this.setCursorCol(0);
+			this.removeImagesFromText(deletedText);
 		} else if (this.state.cursorLine > 0) {
 			this.pushUndoSnapshot();
 
@@ -1580,6 +1660,7 @@ export class Editor implements Component, Focusable {
 
 			// Delete from cursor to end of line
 			this.state.lines[this.state.cursorLine] = currentLine.slice(0, this.state.cursorCol);
+			this.removeImagesFromText(deletedText);
 		} else if (this.state.cursorLine < this.state.lines.length - 1) {
 			this.pushUndoSnapshot();
 
@@ -1635,6 +1716,7 @@ export class Editor implements Component, Focusable {
 			this.state.lines[this.state.cursorLine] =
 				currentLine.slice(0, deleteFrom) + currentLine.slice(this.state.cursorCol);
 			this.setCursorCol(deleteFrom);
+			this.removeImagesFromText(deletedText);
 		}
 
 		if (this.onChange) {
@@ -1677,6 +1759,7 @@ export class Editor implements Component, Focusable {
 
 			this.state.lines[this.state.cursorLine] =
 				currentLine.slice(0, this.state.cursorCol) + currentLine.slice(deleteTo);
+			this.removeImagesFromText(deletedText);
 		}
 
 		if (this.onChange) {
@@ -1700,10 +1783,12 @@ export class Editor implements Component, Focusable {
 			const graphemes = [...this.segment(afterCursor, "grapheme")];
 			const firstGrapheme = graphemes[0];
 			const graphemeLength = firstGrapheme ? firstGrapheme.segment.length : 1;
+			const deletedImageId = firstGrapheme ? IMAGE_MARKER_SINGLE.exec(firstGrapheme.segment)?.[1] : undefined;
 
 			const before = currentLine.slice(0, this.state.cursorCol);
 			const after = currentLine.slice(this.state.cursorCol + graphemeLength);
 			this.state.lines[this.state.cursorLine] = before + after;
+			if (deletedImageId) this.removeImages([Number(deletedImageId)]);
 		} else if (this.state.cursorLine < this.state.lines.length - 1) {
 			this.pushUndoSnapshot();
 
@@ -1895,7 +1980,7 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(
 			findWordBackward(currentLine, this.state.cursorCol, {
 				segment: (text) => this.segment(text, "word"),
-				isAtomicSegment: isPasteMarker,
+				isAtomicSegment: isAtomicMarker,
 			}),
 		);
 	}
@@ -2022,7 +2107,13 @@ export class Editor implements Component, Focusable {
 	}
 
 	private pushUndoSnapshot(): void {
-		this.undoStack.push({ state: this.state, pastes: this.pastes, pasteCounter: this.pasteCounter });
+		this.undoStack.push({
+			state: this.state,
+			pastes: this.pastes,
+			pasteCounter: this.pasteCounter,
+			images: new Map(this.images),
+			imageCounter: this.imageCounter,
+		});
 	}
 
 	private undo(): void {
@@ -2032,6 +2123,8 @@ export class Editor implements Component, Focusable {
 		Object.assign(this.state, snapshot.state);
 		this.pastes = snapshot.pastes;
 		this.pasteCounter = snapshot.pasteCounter;
+		this.images = new Map(snapshot.images);
+		this.imageCounter = Math.max(snapshot.imageCounter, ...this.images.keys(), 0);
 		this.lastAction = null;
 		this.preferredVisualCol = null;
 		if (this.onChange) {
@@ -2089,7 +2182,7 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(
 			findWordForward(currentLine, this.state.cursorCol, {
 				segment: (text) => this.segment(text, "word"),
-				isAtomicSegment: isPasteMarker,
+				isAtomicSegment: isAtomicMarker,
 			}),
 		);
 	}

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -46,6 +46,15 @@ export interface EditorComponent extends Component {
 	/** Insert text at current cursor position */
 	insertTextAtCursor?(text: string): void;
 
+	/** Register an attached image and insert its atomic `[Image N]` marker. */
+	insertImageMarker?(filePath: string): number;
+
+	/** Currently pending image attachments, ordered by marker position. */
+	getImageAttachments?(): Array<{ id: number; path: string }>;
+
+	/** Drop all pending image attachments. */
+	clearImages?(): void;
+
 	/**
 	 * Get text with any markers expanded (e.g., paste markers).
 	 * Falls back to getText() if not implemented.

--- a/packages/tui/test/editor-image-marker.test.ts
+++ b/packages/tui/test/editor-image-marker.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import { Editor } from "../src/components/editor.ts";
+import type { TUI } from "../src/tui.ts";
+import { TuiMainScreen } from "../src/tui-main-screen.ts";
+import { defaultEditorTheme } from "./test-themes.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+function createTestTUI(cols = 80, rows = 24): TUI {
+	return new TuiMainScreen(new VirtualTerminal(cols, rows));
+}
+
+function tempImage(): { path: string; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "pi-image-marker-"));
+	const path = join(dir, "img.png");
+	writeFileSync(path, "png");
+	return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("Editor image markers", () => {
+	it("inserts and tracks an image marker", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const image = tempImage();
+		try {
+			editor.setText("hello ");
+			const id = editor.insertImageMarker(image.path);
+			assert.strictEqual(editor.getText(), "hello [Image 1]");
+			assert.deepStrictEqual(editor.getImageAttachments(), [{ id, path: image.path }]);
+		} finally {
+			image.cleanup();
+		}
+	});
+
+	it("moves across the marker as one unit", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const image = tempImage();
+		try {
+			editor.insertImageMarker(image.path);
+			editor.handleInput("\x1b[D");
+			assert.strictEqual(editor.getCursor().col, 0);
+			editor.handleInput("\x1b[C");
+			assert.strictEqual(editor.getCursor().col, "[Image 1]".length);
+		} finally {
+			image.cleanup();
+		}
+	});
+
+	for (const [name, keys] of [
+		["backspace", ["\x7f"]],
+		["forward delete", ["\x1b[H", "\x1b[3~"]],
+		["delete to line start", ["\x15"]],
+		["delete to line end", ["\x1b[H", "\x0b"]],
+		["delete word backward", ["\x17"]],
+		["delete word forward", ["\x1b[H", "\x1bd"]],
+	] as const) {
+		it(`${name} removes the attachment with the marker`, () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const image = tempImage();
+			try {
+				editor.insertImageMarker(image.path);
+				for (const key of keys) editor.handleInput(key);
+				assert.strictEqual(editor.getText(), "");
+				assert.deepStrictEqual(editor.getImageAttachments(), []);
+			} finally {
+				image.cleanup();
+			}
+		});
+	}
+
+	it("undoing insertion removes the attachment with the marker", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const image = tempImage();
+		try {
+			editor.insertImageMarker(image.path);
+			editor.handleInput("\x1b[45;5u");
+			assert.strictEqual(editor.getText(), "");
+			assert.deepStrictEqual(editor.getImageAttachments(), []);
+		} finally {
+			image.cleanup();
+		}
+	});
+
+	it("undoing deletion restores the attachment with the marker", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const image = tempImage();
+		try {
+			const id = editor.insertImageMarker(image.path);
+			editor.handleInput("\x7f");
+			editor.handleInput("\x1b[45;5u");
+			assert.strictEqual(editor.getText(), `[Image ${id}]`);
+			assert.deepStrictEqual(editor.getImageAttachments(), [{ id, path: image.path }]);
+		} finally {
+			image.cleanup();
+		}
+	});
+
+	it("returns attachments in marker position order", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const first = tempImage();
+		const second = tempImage();
+		try {
+			const firstId = editor.insertImageMarker(first.path);
+			editor.handleInput("\x1b[H");
+			const secondId = editor.insertImageMarker(second.path);
+			assert.strictEqual(editor.getText(), `[Image ${secondId}][Image ${firstId}]`);
+			assert.deepStrictEqual(editor.getImageAttachments(), [
+				{ id: secondId, path: second.path },
+				{ id: firstId, path: first.path },
+			]);
+		} finally {
+			first.cleanup();
+			second.cleanup();
+		}
+	});
+
+	it("clearImages drops attachments", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const image = tempImage();
+		try {
+			editor.insertImageMarker(image.path);
+			editor.clearImages();
+			assert.deepStrictEqual(editor.getImageAttachments(), []);
+		} finally {
+			image.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Pasting an image into Pi currently inserts its temporary file path into the prompt. That exposes an implementation detail and makes it hard to see which parts of the input are actual image attachments.

This PR makes pasted images feel like attachments in the editor. Each image appears as an `[Image N]` marker that the cursor and deletion commands treat as a single item. The attachment remains paired with that marker through normal prompts, steering, follow-ups, and compaction queues.

Duplicate images are ignored, and if an image cannot be processed, Pi leaves the draft intact so the user can correct it instead of losing the prompt.

## Testing

- `npm run check`
- `node --test test/editor-image-marker.test.ts`
- TUI workspace suite via `./test.sh`
