### PR TITLE
fix(ai): preserve Codex thread affinity headers

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -272,13 +272,24 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 				body = nextBody as RequestBody;
 			}
 			const websocketRequestId = codexSessionId || uuidv7();
-			const sseHeaders = buildSSEHeaders(model.headers, options?.headers, accountId, apiKey, codexSessionId);
+			// Pi has one stable session identity for both the cache session and the
+			// provider conversation thread. Send it through every Codex affinity field.
+			const codexThreadId = codexSessionId;
+			const sseHeaders = buildSSEHeaders(
+				model.headers,
+				options?.headers,
+				accountId,
+				apiKey,
+				codexSessionId,
+				codexThreadId,
+			);
 			const websocketHeaders = buildWebSocketHeaders(
 				model.headers,
 				options?.headers,
 				accountId,
 				apiKey,
 				websocketRequestId,
+				codexThreadId,
 			);
 			const bodyJson = JSON.stringify(body);
 			const httpTimeoutMs = normalizeTimeoutMs(options?.timeoutMs);
@@ -1617,6 +1628,7 @@ function buildSSEHeaders(
 	accountId: string,
 	token: string,
 	sessionId?: string,
+	threadId?: string,
 ): Headers {
 	const headers = buildBaseCodexHeaders(initHeaders, additionalHeaders, accountId, token);
 	headers.set("OpenAI-Beta", "responses=experimental");
@@ -1625,6 +1637,11 @@ function buildSSEHeaders(
 
 	if (sessionId) {
 		headers.set("session-id", sessionId);
+	}
+	if (threadId) {
+		headers.set("thread-id", threadId);
+		headers.set("x-client-request-id", threadId);
+	} else if (sessionId) {
 		headers.set("x-client-request-id", sessionId);
 	}
 
@@ -1637,6 +1654,7 @@ function buildWebSocketHeaders(
 	accountId: string,
 	token: string,
 	requestId: string,
+	threadId?: string,
 ): Headers {
 	const headers = buildBaseCodexHeaders(initHeaders, additionalHeaders, accountId, token);
 	headers.delete("accept");
@@ -1644,7 +1662,10 @@ function buildWebSocketHeaders(
 	headers.delete("OpenAI-Beta");
 	headers.delete("openai-beta");
 	headers.set("OpenAI-Beta", OPENAI_BETA_RESPONSES_WEBSOCKETS);
-	headers.set("x-client-request-id", requestId);
+	headers.set("x-client-request-id", threadId ?? requestId);
 	headers.set("session-id", requestId);
+	if (threadId) {
+		headers.set("thread-id", threadId);
+	}
 	return headers;
 }

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -11,7 +11,7 @@ import {
 	stream as streamOpenAICodexResponses,
 	streamSimple as streamSimpleOpenAICodexResponses,
 } from "../src/api/openai-codex-responses.ts";
-import type { Context, Model } from "../src/types.ts";
+import type { AssistantMessage, Context, Model } from "../src/types.ts";
 
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 
@@ -554,8 +554,9 @@ describe("openai-codex streaming", () => {
 			}
 			if (url === "https://chatgpt.com/backend-api/codex/responses") {
 				const headers = init?.headers instanceof Headers ? init.headers : undefined;
-				// Verify sessionId is set in headers
+				// Verify all Codex affinity headers use the stable Pi session identity.
 				expect(headers?.get("session-id")).toBe(sessionId);
+				expect(headers?.get("thread-id")).toBe(sessionId);
 				expect(headers?.has("session_id")).toBe(false);
 				expect(headers?.get("x-client-request-id")).toBe(sessionId);
 
@@ -593,6 +594,145 @@ describe("openai-codex streaming", () => {
 
 		const streamResult = streamOpenAICodexResponses(model, context, { apiKey: token, sessionId, transport: "sse" });
 		await streamResult.result();
+	});
+
+	it("preserves Codex cache affinity across retries and tool-result continuations", async () => {
+		const token = mockToken();
+		const sessionId = "stable-cache-session";
+		const requestSnapshots: Array<{
+			affinity: {
+				promptCacheKey: unknown;
+				sessionId: string | null;
+				threadId: string | null;
+				clientRequestId: string | null;
+			};
+			shape: Record<string, unknown>;
+			input: unknown[];
+		}> = [];
+		let fetchCount = 0;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_input: string | URL, init?: RequestInit) => {
+				fetchCount++;
+				const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+				const body = decodeCodexRequestBody(init?.body);
+				if (!body) throw new Error("Expected a Codex request body");
+				const { input, ...shape } = body;
+				requestSnapshots.push({
+					affinity: {
+						promptCacheKey: body.prompt_cache_key,
+						sessionId: headers.get("session-id"),
+						threadId: headers.get("thread-id"),
+						clientRequestId: headers.get("x-client-request-id"),
+					},
+					shape,
+					input: Array.isArray(input) ? input : [],
+				});
+
+				if (fetchCount === 1) return new Response("retry", { status: 503 });
+				const encoder = new TextEncoder();
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(encoder.encode(buildSSEPayload({ status: "completed" })));
+							controller.close();
+						},
+					}),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}),
+		);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.6-luna",
+			name: "GPT-5.6 Luna",
+			api: "openai-codex-responses",
+			provider: "clawrouter",
+			baseUrl: "http://gateway.invalid/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const tool = {
+			name: "sample_tool",
+			description: "Sample tool",
+			parameters: Type.Object({ payload: Type.String() }),
+		};
+		const firstContext: Context = {
+			systemPrompt: "Stable system prompt",
+			messages: [{ role: "user", content: "Use the tool", timestamp: 1 }],
+			tools: [tool],
+		};
+		const toolCall: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "call_1", name: "sample_tool", arguments: { payload: "x" } }],
+			api: "openai-codex-responses",
+			provider: "clawrouter",
+			model: "gpt-5.6-luna",
+			usage: {
+				input: 10,
+				output: 3,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 13,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: 2,
+		};
+		const secondContext: Context = {
+			...firstContext,
+			messages: [
+				...firstContext.messages,
+				toolCall,
+				{
+					role: "toolResult",
+					toolCallId: "call_1",
+					toolName: "sample_tool",
+					content: [{ type: "text", text: "result" }],
+					isError: false,
+					timestamp: 3,
+				},
+				{ role: "user", content: "Continue", timestamp: 4 },
+			],
+		};
+		const finalAssistant: AssistantMessage = {
+			...toolCall,
+			content: [{ type: "text", text: "Finished" }],
+			stopReason: "stop",
+			timestamp: 5,
+		};
+		const thirdContext: Context = {
+			...secondContext,
+			messages: [...secondContext.messages, finalAssistant, { role: "user", content: "Next", timestamp: 6 }],
+		};
+		const options = { apiKey: token, sessionId, transport: "sse" as const, maxRetries: 1 };
+
+		await streamOpenAICodexResponses(model, firstContext, options).result();
+		await streamOpenAICodexResponses(model, secondContext, options).result();
+		await streamOpenAICodexResponses(model, thirdContext, options).result();
+
+		expect(fetchCount).toBe(4);
+		expect(requestSnapshots).toHaveLength(4);
+		const [retry, first, continuation, subsequent] = requestSnapshots;
+		expect(retry).toEqual(first);
+		expect(first.affinity).toEqual({
+			promptCacheKey: sessionId,
+			sessionId,
+			threadId: sessionId,
+			clientRequestId: sessionId,
+		});
+		expect(continuation.affinity).toEqual(first.affinity);
+		expect(subsequent.affinity).toEqual(first.affinity);
+		expect(continuation.shape).toEqual(first.shape);
+		expect(subsequent.shape).toEqual(first.shape);
+		expect(continuation.input.slice(0, first.input.length)).toEqual(first.input);
+		expect(subsequent.input.slice(0, continuation.input.length)).toEqual(continuation.input);
+		expect(continuation.input.length).toBeGreaterThan(first.input.length);
+		expect(subsequent.input.length).toBeGreaterThan(continuation.input.length);
 	});
 
 	it("omits SSE cache affinity when cacheRetention is none", async () => {
@@ -1332,6 +1472,7 @@ describe("openai-codex streaming", () => {
 		expect(result.endTurn).toBe(false);
 		expect(sentBodies).toHaveLength(1);
 		expect(capturedWebSocketHeaders?.["session-id"]).toBe("session-auto");
+		expect(capturedWebSocketHeaders?.["thread-id"]).toBe("session-auto");
 		expect(capturedWebSocketHeaders?.session_id).toBeUndefined();
 		expect(capturedWebSocketHeaders?.["x-client-request-id"]).toBe("session-auto");
 		expect(global.fetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Adds the missing `thread-id` affinity header to OpenAI Codex Responses requests. Pi already sends a stable `prompt_cache_key`, `session-id`, and `x-client-request-id` derived from `StreamOptions.sessionId`; the upstream Codex client also sends the stable `session-id` + `thread-id` pair. The header is now sent on both SSE and WebSocket transports.

This is a narrow follow-up to the pre-TTL miss report in #8463. It does not add `prompt_cache_retention` (ChatGPT Codex Responses rejects that parameter), change cache TTLs, alter retries, or mutate prompt history.

## Proven behavior

- `SessionManager.getSessionId()` is created once per Pi session and is passed through `Agent`/`AgentLoop` into every ordinary turn, tool-result continuation, and retry.
- Before this change, `packages/ai/src/api/openai-codex-responses.ts` omitted `thread-id` entirely.
- The live vanilla lane reproduced a zero-cache request at:
  - assistant JSONL entry: `bcc767db`
  - response ID: `resp_022df271c75ee198016a8c56662dc087d2b87215b478546887`
  - timestamp: `2026-08-24T14:34:22.296Z`
  - model: `gpt-5.6-luna`
  - input: `56,908`, cache read: `0`, cache write: `0`
  - preceding request: entry `677d61ec` at `2026-08-24T14:34:13.532Z`, input `784`, cache read `33,280`; gap `8.764s`
  - next request recovered with cache read `55,808`
- Only five assistant requests occurred in the preceding 60 seconds, so the documented approximate 15-requests/minute per-key guidance does not explain this event.
- The regression test captures only request metadata and serialized shapes. It asserts stable cache/header affinity across a retry, an assistant tool-call + tool-result continuation, and a subsequent user turn, while asserting append-only input prefixes.

## Remaining proof gap

The local evidence proves a same-session pre-TTL miss and proves the client-side key/header gap. It does not expose the provider-side route/cache decision. ClawRouter may still drop or rewrite `thread-id`/other affinity headers, or the upstream provider may evict/route away from the cache despite correct request metadata. Those are external runtime/provider hypotheses and were not changed by this PR.

Primary references:

- OpenAI prompt caching: https://developers.openai.com/api/docs/guides/prompt-caching
- OpenAI Codex session headers: https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/requests/headers.rs
- Related report: #8463
- Related cross-session key override PR: #6654 (not assumed to solve this same-session miss)

## Validation

- `npm run check` passes.
- `./test.sh` passes: all workspace suites green, with expected skips.
- `npm run build` passes.
- Focused `packages/ai/test/openai-codex-stream.test.ts`: 39/39 passed.

## Candidate handoff

Candidate commit: `497811d35`

Build outside the active worktree:

```bash
git fetch fork fix/codex-pre-ttl-cache-misses
git worktree add /tmp/pi-codex-cache-candidate 497811d35
cd /tmp/pi-codex-cache-candidate
npm ci --ignore-scripts
npm run build
npm pack --pack-destination /tmp/pi-codex-cache-package packages/coding-agent
```

Captain-approved install of the generated tarball:

```bash
npm install --global /tmp/pi-codex-cache-package/earendil-works-pi-coding-agent-0.84.3.tgz --ignore-scripts
```

Rollback to the shipped package:

```bash
npm uninstall --global @earendil-works/pi-coding-agent
npm install --global @earendil-works/pi-coding-agent@0.84.3 --ignore-scripts
```

No install, global package change, ClawRouter change, or active-session change was performed in this lane.
