### PR TITLE
feat(ai): bedrock mantle anthropic messages

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -360,6 +360,17 @@ const BEDROCK_MANTLE_OPENAI_RESPONSES_MODEL_IDS = new Set([
 	"xai.grok-4.6",
 ]);
 const BEDROCK_MANTLE_OPENAI_RESPONSES_V1_MODEL_IDS = new Set(["openai.gpt-oss-120b", "openai.gpt-oss-20b"]);
+const BEDROCK_MANTLE_ANTHROPIC_MESSAGES_MODEL_IDS = new Set([
+	"anthropic.claude-opus-5",
+	"anthropic.claude-sonnet-5",
+	"anthropic.claude-mythos-5",
+	"anthropic.claude-fable-5",
+	"anthropic.claude-opus-4-8",
+	"anthropic.claude-opus-4-7",
+	"anthropic.claude-haiku-4-5",
+	"anthropic.claude-mythos-preview",
+]);
+const BEDROCK_MANTLE_ANTHROPIC_MESSAGES_ROOT_MODEL_IDS = new Set(["anthropic.claude-mythos-preview"]);
 const MODELS_DEV_OPENAI_UNSUPPORTED_MODEL_IDS = new Set(["gpt-5.6"]);
 const OPENAI_TOOL_SEARCH_MODEL_IDS = new Set([
 	"gpt-5.4",
@@ -1023,8 +1034,57 @@ function isBedrockMantleOpenAIResponsesModelId(modelId: string): boolean {
 	return BEDROCK_MANTLE_OPENAI_RESPONSES_MODEL_IDS.has(modelId);
 }
 
+function getBedrockMantleAnthropicMessagesBaseUrl(modelId: string): string {
+	return BEDROCK_MANTLE_ANTHROPIC_MESSAGES_ROOT_MODEL_IDS.has(modelId)
+		? "https://bedrock-mantle.us-east-1.api.aws"
+		: "https://bedrock-mantle.us-east-1.api.aws/anthropic";
+}
+
+function isBedrockMantleAnthropicMessagesModelId(modelId: string): boolean {
+	return BEDROCK_MANTLE_ANTHROPIC_MESSAGES_MODEL_IDS.has(modelId);
+}
+
 // These model-card entries are not yet present in models.dev's Bedrock catalog. Keep the normal
 // models.dev metadata for IDs that upstream already publishes; only supplement missing model IDs here.
+const BEDROCK_MANTLE_ANTHROPIC_MESSAGES_SUPPLEMENTAL_MODELS: Model<"anthropic-messages">[] = [
+	{
+		id: "anthropic.claude-mythos-5",
+		name: "Claude Mythos 5",
+		api: "anthropic-messages",
+		provider: "amazon-bedrock",
+		baseUrl: getBedrockMantleAnthropicMessagesBaseUrl("anthropic.claude-mythos-5"),
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	},
+	{
+		id: "anthropic.claude-haiku-4-5",
+		name: "Claude Haiku 4.5",
+		api: "anthropic-messages",
+		provider: "amazon-bedrock",
+		baseUrl: getBedrockMantleAnthropicMessagesBaseUrl("anthropic.claude-haiku-4-5"),
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	},
+	{
+		id: "anthropic.claude-mythos-preview",
+		name: "Claude Mythos Preview",
+		api: "anthropic-messages",
+		provider: "amazon-bedrock",
+		baseUrl: getBedrockMantleAnthropicMessagesBaseUrl("anthropic.claude-mythos-preview"),
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 128_000,
+	},
+];
+
 const BEDROCK_MANTLE_OPENAI_RESPONSES_SUPPLEMENTAL_MODELS: Model<"openai-responses">[] = [
 	{
 		id: "google.gemma-4-31b",
@@ -1516,9 +1576,30 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 			for (const [modelId, model] of Object.entries(data["amazon-bedrock"].models)) {
 				const m = model as ModelsDevModel;
 				if (m.tool_call !== true) continue;
-				if (BEDROCK_INFERENCE_PROFILE_ONLY_MODEL_IDS.has(modelId)) continue;
 
 				let id = modelId;
+
+				if (isBedrockMantleAnthropicMessagesModelId(id)) {
+					models.push({
+						id,
+						name: m.name || id,
+						api: "anthropic-messages" as const,
+						provider: "amazon-bedrock" as const,
+						baseUrl: getBedrockMantleAnthropicMessagesBaseUrl(id),
+						reasoning: m.reasoning === true,
+						input: (m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"]) as ("text" | "image")[],
+						cost: {
+							input: m.cost?.input || 0,
+							output: m.cost?.output || 0,
+							cacheRead: m.cost?.cache_read || 0,
+							cacheWrite: m.cost?.cache_write || 0,
+						},
+						contextWindow: m.limit?.context || 4096,
+						maxTokens: m.limit?.output || 4096,
+					});
+					recordModelsDevReasoningOptions("amazon-bedrock" as const, id, m);
+					continue;
+				}
 
 				if (isBedrockMantleOpenAIResponsesModelId(id)) {
 					models.push({
@@ -1546,6 +1627,8 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 					recordModelsDevReasoningOptions("amazon-bedrock" as const, id, m);
 					continue;
 				}
+
+				if (BEDROCK_INFERENCE_PROFILE_ONLY_MODEL_IDS.has(modelId)) continue;
 
 				if (id.startsWith("ai21.jamba")) {
 					// These models doesn't support tool use in streaming mode
@@ -1579,6 +1662,11 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 			}
 
 			const bedrockModelIds = new Set(models.filter((model) => model.provider === "amazon-bedrock").map((model) => model.id));
+			for (const model of BEDROCK_MANTLE_ANTHROPIC_MESSAGES_SUPPLEMENTAL_MODELS) {
+				if (!bedrockModelIds.has(model.id)) {
+					models.push(model);
+				}
+			}
 			for (const model of BEDROCK_MANTLE_OPENAI_RESPONSES_SUPPLEMENTAL_MODELS) {
 				if (!bedrockModelIds.has(model.id)) {
 					models.push(model);

--- a/packages/ai/src/api/bedrock-mantle-anthropic-messages.lazy.ts
+++ b/packages/ai/src/api/bedrock-mantle-anthropic-messages.lazy.ts
@@ -1,0 +1,30 @@
+import type { ProviderStreams } from "../types.ts";
+import { lazyApi } from "./lazy.ts";
+
+/**
+ * Loads the Bedrock Mantle Anthropic Messages implementation through a variable
+ * specifier so browser bundlers cannot follow the import into Node-only AWS token modules.
+ * The `.ts`/`.js` rewrite keeps the trick working from both source and built output.
+ */
+const importNodeOnlyApi = (specifier: string): Promise<unknown> => {
+	const runtimeSpecifier = import.meta.url.endsWith(".js") ? specifier.replace(/\.ts$/, ".js") : specifier;
+	return import(runtimeSpecifier);
+};
+
+let bedrockMantleAnthropicMessagesModuleOverride: ProviderStreams | undefined;
+
+/**
+ * Overrides the dynamically imported Bedrock Mantle Anthropic Messages implementation.
+ * Used by the Bun binary build, where the variable-specifier import cannot be bundled;
+ * the build registers a statically imported module instead.
+ */
+export function setBedrockMantleAnthropicMessagesProviderModule(module: ProviderStreams): void {
+	bedrockMantleAnthropicMessagesModuleOverride = module;
+}
+
+export const bedrockMantleAnthropicMessagesApi = (): ProviderStreams =>
+	lazyApi(
+		async () =>
+			bedrockMantleAnthropicMessagesModuleOverride ??
+			((await importNodeOnlyApi("./bedrock-mantle-anthropic-messages.ts")) as ProviderStreams),
+	);

--- a/packages/ai/src/api/bedrock-mantle-anthropic-messages.ts
+++ b/packages/ai/src/api/bedrock-mantle-anthropic-messages.ts
@@ -1,0 +1,69 @@
+import type { Model, SimpleStreamOptions, StreamFunction } from "../types.ts";
+import {
+	type AnthropicOptions,
+	stream as anthropicMessagesStream,
+	streamSimple as anthropicMessagesStreamSimple,
+} from "./anthropic-messages.ts";
+import {
+	type BedrockMantleAuthOptions,
+	getRegionFromBedrockMantleBaseUrl,
+	prepareBedrockMantleAuth,
+} from "./bedrock-mantle-auth.ts";
+
+export interface BedrockMantleAnthropicMessagesOptions extends AnthropicOptions, BedrockMantleAuthOptions {}
+
+function getMantleAnthropicMessagesBaseUrl(region: string, modelBaseUrl: string | undefined): string {
+	const path = modelBaseUrl ? new URL(modelBaseUrl).pathname.replace(/\/$/, "") : "/anthropic";
+	return `https://bedrock-mantle.${region}.api.aws${path}`;
+}
+
+function withMantleAnthropicMessagesOptions(
+	model: Model<"anthropic-messages">,
+	options: BedrockMantleAnthropicMessagesOptions | undefined,
+): { model: Model<"anthropic-messages">; options: AnthropicOptions } {
+	const auth = prepareBedrockMantleAuth(options, {
+		modelBaseUrl: model.baseUrl,
+		headers: model.headers,
+		baseUrlForRegion: (region) => getMantleAnthropicMessagesBaseUrl(region, model.baseUrl),
+		regionFromBaseUrl: getRegionFromBedrockMantleBaseUrl,
+	});
+	const requestModel = { ...model, baseUrl: auth.baseUrl };
+
+	if (auth.type === "bearer") {
+		return {
+			model: requestModel,
+			options: {
+				...options,
+				apiKey: undefined,
+				headers: { ...auth.headers, authorization: `Bearer ${auth.token}` },
+			},
+		};
+	}
+
+	return {
+		model: requestModel,
+		options: {
+			...options,
+			apiKey: auth.apiKey,
+			headers: auth.headers,
+			fetch: auth.fetch,
+		},
+	};
+}
+
+export const stream: StreamFunction<"anthropic-messages", BedrockMantleAnthropicMessagesOptions> = (
+	model,
+	context,
+	options,
+) => {
+	const prepared = withMantleAnthropicMessagesOptions(model as Model<"anthropic-messages">, options);
+	return anthropicMessagesStream(prepared.model, context, prepared.options);
+};
+
+export const streamSimple: StreamFunction<"anthropic-messages", SimpleStreamOptions> = (model, context, options) => {
+	const prepared = withMantleAnthropicMessagesOptions(
+		model as Model<"anthropic-messages">,
+		options as BedrockMantleAnthropicMessagesOptions | undefined,
+	);
+	return anthropicMessagesStreamSimple(prepared.model, context, prepared.options as SimpleStreamOptions);
+};

--- a/packages/ai/src/bedrock-provider.ts
+++ b/packages/ai/src/bedrock-provider.ts
@@ -3,6 +3,10 @@ import {
 	streamSimple as bedrockConverseStreamSimple,
 } from "./api/bedrock-converse-stream.ts";
 import {
+	stream as bedrockMantleAnthropicMessagesStream,
+	streamSimple as bedrockMantleAnthropicMessagesStreamSimple,
+} from "./api/bedrock-mantle-anthropic-messages.ts";
+import {
 	stream as bedrockMantleOpenAIResponsesStream,
 	streamSimple as bedrockMantleOpenAIResponsesStreamSimple,
 } from "./api/bedrock-mantle-openai-responses.ts";
@@ -15,4 +19,9 @@ export const bedrockProviderModule = {
 export const bedrockMantleOpenAIResponsesProviderModule = {
 	stream: bedrockMantleOpenAIResponsesStream,
 	streamSimple: bedrockMantleOpenAIResponsesStreamSimple,
+};
+
+export const bedrockMantleAnthropicMessagesProviderModule = {
+	stream: bedrockMantleAnthropicMessagesStream,
+	streamSimple: bedrockMantleAnthropicMessagesStreamSimple,
 };

--- a/packages/ai/src/compat.ts
+++ b/packages/ai/src/compat.ts
@@ -13,6 +13,7 @@
 export * from "./api/anthropic-messages.lazy.ts";
 export * from "./api/azure-openai-responses.lazy.ts";
 export * from "./api/bedrock-converse-stream.lazy.ts";
+export * from "./api/bedrock-mantle-anthropic-messages.lazy.ts";
 export * from "./api/bedrock-mantle-openai-responses.lazy.ts";
 export * from "./api/google-generative-ai.lazy.ts";
 export * from "./api/google-vertex.lazy.ts";

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1,4 +1,5 @@
 import { bedrockConverseStreamApi } from "../api/bedrock-converse-stream.lazy.ts";
+import { bedrockMantleAnthropicMessagesApi } from "../api/bedrock-mantle-anthropic-messages.lazy.ts";
 import { bedrockMantleOpenAIResponsesApi } from "../api/bedrock-mantle-openai-responses.lazy.ts";
 import type { ApiKeyAuth } from "../auth/types.ts";
 import { createProvider, type Provider } from "../models.ts";
@@ -80,8 +81,10 @@ export const bedrockAuth: ApiKeyAuth = {
 	},
 };
 
-export function amazonBedrockProvider(): Provider<"bedrock-converse-stream" | "openai-responses"> {
-	return createProvider<"bedrock-converse-stream" | "openai-responses">({
+export function amazonBedrockProvider(): Provider<
+	"bedrock-converse-stream" | "openai-responses" | "anthropic-messages"
+> {
+	return createProvider<"bedrock-converse-stream" | "openai-responses" | "anthropic-messages">({
 		id: "amazon-bedrock",
 		name: "Amazon Bedrock",
 		auth: { apiKey: bedrockAuth },
@@ -89,6 +92,7 @@ export function amazonBedrockProvider(): Provider<"bedrock-converse-stream" | "o
 		api: {
 			"bedrock-converse-stream": bedrockConverseStreamApi(),
 			"openai-responses": bedrockMantleOpenAIResponsesApi(),
+			"anthropic-messages": bedrockMantleAnthropicMessagesApi(),
 		},
 	});
 }

--- a/packages/ai/test/bedrock-models.test.ts
+++ b/packages/ai/test/bedrock-models.test.ts
@@ -29,9 +29,14 @@ describe("Amazon Bedrock Models", () => {
 		console.log(`Found ${models.length} Bedrock models`);
 	});
 
-	it("exposes Claude Opus 5 through an inference profile only", () => {
-		expect(models.some((model) => model.id === "global.anthropic.claude-opus-5")).toBe(true);
-		expect(models.some((model) => model.id === "anthropic.claude-opus-5")).toBe(false);
+	it("exposes Claude Opus 5 runtime inference profiles and the Mantle Messages base model", () => {
+		expect(getModel("amazon-bedrock", "global.anthropic.claude-opus-5")).toMatchObject({
+			api: "bedrock-converse-stream",
+		});
+		expect(getModel("amazon-bedrock", "anthropic.claude-opus-5")).toMatchObject({
+			api: "anthropic-messages",
+			baseUrl: "https://bedrock-mantle.us-east-1.api.aws/anthropic",
+		});
 	});
 
 	it("routes Bedrock Responses-compatible models through Mantle under the Bedrock provider", () => {
@@ -65,11 +70,37 @@ describe("Amazon Bedrock Models", () => {
 		}
 	});
 
+	it("routes Bedrock Messages-compatible models through Mantle under the Bedrock provider", () => {
+		for (const id of [
+			"anthropic.claude-opus-5",
+			"anthropic.claude-sonnet-5",
+			"anthropic.claude-mythos-5",
+			"anthropic.claude-fable-5",
+			"anthropic.claude-opus-4-8",
+			"anthropic.claude-opus-4-7",
+			"anthropic.claude-haiku-4-5",
+		] as const) {
+			expect(getModel("amazon-bedrock", id)).toMatchObject({
+				api: "anthropic-messages",
+				provider: "amazon-bedrock",
+				baseUrl: "https://bedrock-mantle.us-east-1.api.aws/anthropic",
+			});
+		}
+
+		expect(getModel("amazon-bedrock", "anthropic.claude-mythos-preview")).toMatchObject({
+			api: "anthropic-messages",
+			provider: "amazon-bedrock",
+			baseUrl: "https://bedrock-mantle.us-east-1.api.aws",
+		});
+	});
+
 	it("keeps non-Mantle Bedrock Runtime models on Converse", () => {
 		for (const id of [
 			"us.anthropic.claude-opus-4-6-v1",
 			"openai.gpt-oss-120b-1:0",
 			"global.openai.gpt-5.6-sol",
+			"anthropic.claude-haiku-4-5-20251001-v1:0",
+			"global.anthropic.claude-fable-5",
 		] as const) {
 			expect(getModel("amazon-bedrock", id)).toMatchObject({
 				api: "bedrock-converse-stream",
@@ -79,9 +110,9 @@ describe("Amazon Bedrock Models", () => {
 	});
 
 	if (hasBedrockCredentials() && process.env.BEDROCK_EXTENSIVE_MODEL_TEST) {
-		const extensiveModels = process.env.BEDROCK_MANTLE_OPENAI_RESPONSES_TEST
+		const extensiveModels = process.env.BEDROCK_MANTLE_TEST
 			? models
-			: models.filter((model) => model.api !== "openai-responses");
+			: models.filter((model) => model.api !== "openai-responses" && model.api !== "anthropic-messages");
 
 		for (const model of extensiveModels) {
 			it(`should make a simple request with ${model.id}`, { timeout: 10_000 }, async () => {

--- a/packages/coding-agent/src/bun/register-bedrock.ts
+++ b/packages/coding-agent/src/bun/register-bedrock.ts
@@ -1,8 +1,14 @@
 import {
+	bedrockMantleAnthropicMessagesProviderModule,
 	bedrockMantleOpenAIResponsesProviderModule,
 	bedrockProviderModule,
 } from "@earendil-works/pi-ai/bedrock-provider";
-import { setBedrockMantleOpenAIResponsesProviderModule, setBedrockProviderModule } from "@earendil-works/pi-ai/compat";
+import {
+	setBedrockMantleAnthropicMessagesProviderModule,
+	setBedrockMantleOpenAIResponsesProviderModule,
+	setBedrockProviderModule,
+} from "@earendil-works/pi-ai/compat";
 
 setBedrockProviderModule(bedrockProviderModule);
 setBedrockMantleOpenAIResponsesProviderModule(bedrockMantleOpenAIResponsesProviderModule);
+setBedrockMantleAnthropicMessagesProviderModule(bedrockMantleAnthropicMessagesProviderModule);


### PR DESCRIPTION
Follow up to #8572, addresses #5363.

Adds Amazon Bedrock Mantle Anthropic Messages routing under the existing public `amazon-bedrock` provider, using the existing Anthropic Messages adapter behind a Bedrock Mantle shared auth wrapper.

As per [docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html), routes Messages-compatible Mantle IDs to `anthropic-messages` internally:

- `anthropic.claude-opus-5`
- `anthropic.claude-sonnet-5`
- `anthropic.claude-mythos-5`
- `anthropic.claude-fable-5`
- `anthropic.claude-opus-4-8`
- `anthropic.claude-opus-4-7`
- `anthropic.claude-haiku-4-5`
- `anthropic.claude-mythos-preview`

Keeps Bedrock Runtime/global IDs on Converse.

