### PR TITLE
fix(coding-agent): surface + bound the torn-append replay loss in session JSONL files

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1,11 +1,13 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { type ImageContent, type Message, type TextContent, type Usage, uuidv7 } from "@earendil-works/pi-ai";
+import chalk from "chalk";
 import { randomUUID } from "crypto";
 import {
 	appendFileSync,
 	closeSync,
 	createReadStream,
 	existsSync,
+	fstatSync,
 	mkdirSync,
 	openSync,
 	readdirSync,
@@ -500,6 +502,33 @@ class SessionHeaderScanLimitError extends Error {
 	}
 }
 
+/**
+ * Best-effort line-boundary repair after a failed session-file write.
+ *
+ * A failed append (e.g. ENOSPC mid-write) can leave a partial entry at the
+ * file tail with no trailing newline. If the next successful append is then
+ * written at EOF, it lands on the SAME physical line — and the loader skips
+ * that whole line, silently costing TWO entries (the torn remainder plus the
+ * complete entry concatenated after it). Re-establishing the newline boundary
+ * keeps the damage to the one entry that was already lost.
+ */
+function repairTornTail(file: string): void {
+	try {
+		const fd = openSync(file, "r");
+		try {
+			const { size } = fstatSync(fd);
+			if (size === 0) return;
+			const last = Buffer.alloc(1);
+			readSync(fd, last, 0, 1, size - 1);
+			if (last[0] !== 0x0a) appendFileSync(file, "\n");
+		} finally {
+			closeSync(fd);
+		}
+	} catch {
+		// Best-effort: the original write error is what must propagate.
+	}
+}
+
 function parseSessionEntryLine(line: string): FileEntry | null {
 	if (!line.trim()) return null;
 	try {
@@ -516,6 +545,7 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 	if (!existsSync(resolvedFilePath)) return [];
 
 	const entries: FileEntry[] = [];
+	let skippedMalformedLines = 0;
 	const fd = openSync(resolvedFilePath, "r");
 	try {
 		const decoder = new StringDecoder("utf8");
@@ -530,8 +560,10 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 			let lineStart = 0;
 			let newlineIndex = pending.indexOf("\n", lineStart);
 			while (newlineIndex !== -1) {
-				const entry = parseSessionEntryLine(pending.slice(lineStart, newlineIndex));
+				const line = pending.slice(lineStart, newlineIndex);
+				const entry = parseSessionEntryLine(line);
 				if (entry) entries.push(entry);
+				else if (line.trim()) skippedMalformedLines++;
 				lineStart = newlineIndex + 1;
 				newlineIndex = pending.indexOf("\n", lineStart);
 			}
@@ -539,10 +571,23 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 		}
 
 		pending += decoder.end();
-		const finalEntry = parseSessionEntryLine(pending);
-		if (finalEntry) entries.push(finalEntry);
+		if (pending.trim()) {
+			const finalEntry = parseSessionEntryLine(pending);
+			if (finalEntry) entries.push(finalEntry);
+			else skippedMalformedLines++;
+		}
 	} finally {
 		closeSync(fd);
+	}
+	if (skippedMalformedLines > 0) {
+		// Never silent: a skipped line is missing from replay, and a torn-append
+		// artifact (a partial write followed by a later append on the same line)
+		// costs TWO entries — the loader drops both with the malformed line.
+		console.error(
+			chalk.yellow(
+				`Warning: ${resolvedFilePath}: skipped ${skippedMalformedLines} malformed session line(s); those entries are missing from this session's replay.`,
+			),
+		);
 	}
 
 	// Validate session header
@@ -983,6 +1028,9 @@ export class SessionManager {
 			for (const entry of this.fileEntries) {
 				writeFileSync(fd, `${JSON.stringify(entry)}\n`);
 			}
+		} catch (error) {
+			repairTornTail(this.sessionFile);
+			throw error;
 		} finally {
 			closeSync(fd);
 		}
@@ -1018,7 +1066,12 @@ export class SessionManager {
 		const hasAssistant = this.fileEntries.some((e) => e.type === "message" && e.message.role === "assistant");
 		if (!hasAssistant) {
 			if (this.flushed) {
-				appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+				try {
+					appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+				} catch (error) {
+					repairTornTail(this.sessionFile);
+					throw error;
+				}
 			} else {
 				// Mark as not flushed so when assistant arrives, all entries get written
 				this.flushed = false;
@@ -1032,12 +1085,20 @@ export class SessionManager {
 				for (const e of this.fileEntries) {
 					writeFileSync(fd, `${JSON.stringify(e)}\n`);
 				}
+			} catch (error) {
+				repairTornTail(this.sessionFile);
+				throw error;
 			} finally {
 				closeSync(fd);
 			}
 			this.flushed = true;
 		} else {
-			appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+			try {
+				appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+			} catch (error) {
+				repairTornTail(this.sessionFile);
+				throw error;
+			}
 		}
 	}
 
@@ -1621,10 +1682,15 @@ export class SessionManager {
 		writeFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`, { flag: "wx" });
 
 		// Copy all non-header entries from source
-		for (const entry of sourceEntries) {
-			if (entry.type !== "session") {
-				appendFileSync(newSessionFile, `${JSON.stringify(entry)}\n`);
+		try {
+			for (const entry of sourceEntries) {
+				if (entry.type !== "session") {
+					appendFileSync(newSessionFile, `${JSON.stringify(entry)}\n`);
+				}
 			}
+		} catch (error) {
+			repairTornTail(newSessionFile);
+			throw error;
 		}
 
 		return new SessionManager(resolvedTargetCwd, dir, newSessionFile, true);

--- a/packages/coding-agent/test/session-manager-malformed-lines.test.ts
+++ b/packages/coding-agent/test/session-manager-malformed-lines.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the #279313 torn-append artifact class in session loading:
+ * a malformed line that carries BOTH a torn entry prefix AND a complete
+ * following entry on one physical line is silently skipped by
+ * parseSessionEntryLine — costing TWO replay entries with no signal.
+ *
+ * These tests verify:
+ * - loadEntriesFromFile counts skipped malformed lines and surfaces a
+ *   single visible WARNING per load (never silent).
+ * - A clean file produces no warning.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadEntriesFromFile } from "../src/core/session-manager.ts";
+
+const header = {
+	type: "session",
+	version: 3,
+	id: "00000000-0000-0000-0000-000000000000",
+	timestamp: "2026-01-01T00:00:00.000Z",
+	cwd: "/tmp",
+};
+
+function entry(id: string, role: string): string {
+	return JSON.stringify({
+		type: "message",
+		id,
+		parentId: null,
+		timestamp: `2026-01-01T00:00:0${id.charCodeAt(0) % 10}.000Z`,
+		message: { role, content: [{ type: "text", text: `hello ${id}` }] },
+	});
+}
+
+describe("loadEntriesFromFile malformed-line warning", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = join(tmpdir(), `pi-jsonl-warn-${process.pid}-${Date.now()}`);
+		mkdirSync(dir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("counts a torn-append line as skipped and warns once (the swallowed complete entry is visible as a loss)", () => {
+		const file = join(dir, "session.jsonl");
+		// torn entry `a` (prefix only) + COMPLETE entry `b` concatenated on the same physical line
+		const torn = `${entry("a", "assistant").slice(0, 40)}${entry("b", "user")}`;
+		writeFileSync(file, `${JSON.stringify(header)}\n${torn}\n${entry("c", "user")}\n`);
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const entries = loadEntriesFromFile(file);
+			// header + c only: `a` was already torn, and `b` is swallowed with the malformed line
+			expect(entries.map((e) => (e as { id?: string }).id)).toEqual(["00000000-0000-0000-0000-000000000000", "c"]);
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			expect(String(errorSpy.mock.calls[0][0])).toContain("skipped 1 malformed session line");
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("counts a torn final fragment (no trailing newline) as skipped", () => {
+		const file = join(dir, "session.jsonl");
+		const torn = entry("a", "assistant").slice(0, 40); // no trailing \n at EOF
+		writeFileSync(file, `${JSON.stringify(header)}\n${torn}`);
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const entries = loadEntriesFromFile(file);
+			expect(entries).toHaveLength(1); // header only
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			expect(String(errorSpy.mock.calls[0][0])).toContain("skipped 1 malformed session line");
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("does not warn for a clean file (blank lines included)", () => {
+		const file = join(dir, "session.jsonl");
+		writeFileSync(file, `${JSON.stringify(header)}\n\n${entry("a", "user")}\n\n`);
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const entries = loadEntriesFromFile(file);
+			expect(entries).toHaveLength(2);
+			expect(errorSpy).not.toHaveBeenCalled();
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/session-manager-torn-tail-repair.test.ts
+++ b/packages/coding-agent/test/session-manager-torn-tail-repair.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the torn-tail repair on session-file write failure (#279313):
+ * when an append fails partway (e.g. ENOSPC persists a prefix of the buffer
+ * and then throws), the file tail must be repaired to a line boundary so the
+ * NEXT successful append cannot concatenate onto the torn fragment — a
+ * concatenation the loader would silently swallow as one malformed line,
+ * costing TWO replay entries.
+ */
+
+import * as realFs from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock "fs" so appendFileSync on the victim file persists only the FIRST HALF
+// of the payload and then throws ENOSPC — exactly the observed artifact shape.
+// The repair's own appendFileSync(file, "\n") is short and passes through.
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	const victimTag = "victim-jsonl";
+	return {
+		...actual,
+		appendFileSync: ((file: realFs.PathOrFileDescriptor, data: string, ...rest: unknown[]) => {
+			const path = typeof file === "string" ? file : "";
+			if (path.includes(victimTag) && typeof data === "string" && data.length > 64) {
+				actual.appendFileSync(file, data.slice(0, Math.floor(data.length / 2)));
+				const err = new Error("ENOSPC: no space left on device, write") as NodeJS.ErrnoException;
+				err.code = "ENOSPC";
+				throw err;
+			}
+			return (actual.appendFileSync as (...args: unknown[]) => void)(file, data, ...rest);
+		}) as typeof actual.appendFileSync,
+	};
+});
+
+import { SessionManager } from "../src/core/session-manager.ts";
+
+const header = {
+	type: "session",
+	version: 3,
+	id: "00000000-0000-0000-0000-000000000000",
+	timestamp: "2026-01-01T00:00:00.000Z",
+	cwd: "/tmp",
+};
+
+function entryLine(id: string, role: string): string {
+	return JSON.stringify({
+		type: "message",
+		id,
+		parentId: null,
+		timestamp: `2026-01-01T00:00:0${id.charCodeAt(0) % 10}.000Z`,
+		message: { role, content: [{ type: "text", text: `hello ${id} ${"x".repeat(200)}` }] },
+	});
+}
+
+describe("session-file torn-tail repair on write failure", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = join(tmpdir(), `pi-jsonl-repair-${process.pid}-${Date.now()}`);
+		mkdirSync(dir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("repairs the torn tail so the next append starts on a fresh line (error still propagates)", () => {
+		const file = join(dir, "victim-jsonl.jsonl");
+		// Seed a flushed session (header + assistant message => hasAssistant, flushed)
+		writeFileSync(file, `${JSON.stringify(header)}\n${entryLine("a", "assistant")}\n`);
+		const mgr = SessionManager.open(file);
+
+		// The next append hits the mocked ENOSPC partial: half the entry lands, then throw.
+		expect(() => mgr.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }] })).toThrow(/ENOSPC/);
+
+		// The file tail must now end at a line boundary (the repair appended \n).
+		const raw = realFs.readFileSync(file, "utf8");
+		expect(raw.endsWith("\n")).toBe(true);
+
+		// The torn fragment exists as its own (malformed) line, NOT concatenated
+		// with a later complete entry.
+		const lines = raw.split("\n").filter((l) => l.length > 0);
+		expect(lines).toHaveLength(3); // header + seeded assistant entry + torn fragment
+	});
+});


### PR DESCRIPTION
## Summary

Session JSONL files can end up with a line that carries BOTH a torn entry prefix AND a complete following entry concatenated on one physical line. `parseSessionEntryLine` skips the whole malformed line, so one storage event silently costs **two** replay entries — with no signal anywhere.

## Mechanism (root-caused from a fleet of ~150 session files)

A failed append under **ENOSPC** persists a **prefix** of the entry and then throws (writeback under block exhaustion persists what it can; the retry loop advances past the persisted prefix, gets `-ENOSPC`, and throws **after the partial bytes landed**). The in-memory session state (updated before `_persist`) stays complete, so the session survives with a torn file **tail** — no trailing newline. The next successful append lands at EOF on the **same physical line** as the fragment, and the loader later skips that whole line.

Evidence: all observed torn-entry timestamps fall inside two disk-full windows in the system journal (`No space left on device` storms), with entry-timestamp gaps of seconds-to-hours between the torn fragment and the concatenated entry (the file sat torn until the next successful append). A single `write(2)` to a regular file cannot tear on its own — the error path is the mechanism.

## The fix (two halves)

- **Loader — never silent:** `loadEntriesFromFile` counts skipped non-blank malformed lines per load and emits one visible warning (file, count, replay consequence). Still never fatal.
- **Writer — bound the damage:** on any write error in the persist paths (append, initial flush, rewrite, fork copy), best-effort re-establish the newline boundary at the file tail before rethrowing (if the last byte is not `\n`, append one). The next append then starts on a fresh line, and the loss stays bounded to the single entry that was already lost.

## Tests

- `session-manager-malformed-lines.test.ts`: torn line counted + warned once; torn EOF fragment counted; clean file silent.
- `session-manager-torn-tail-repair.test.ts`: ENOSPC partial-write simulation (fs mock) — the error propagates AND the tail ends at a line boundary.

Found while investigating silent replay loss in resumed sessions (fleet scan: 14/148 sessions carried the artifact after two disk-full windows). Companion tooling (repair + standing detector) on our side; this PR is the upstream cure.
