### PR TITLE
fix(ai): pin createProvider TApi for xAI Responses provider

### DIFF
--- a/packages/ai/src/providers/xai.ts
+++ b/packages/ai/src/providers/xai.ts
@@ -5,7 +5,7 @@ import { createProvider, type Provider } from "../models.ts";
 import { XAI_MODELS } from "./xai.models.ts";
 
 export function xaiProvider(): Provider<"openai-responses"> {
-	return createProvider({
+	return createProvider<"openai-responses">({
 		id: "xai",
 		name: "xAI",
 		baseUrl: "https://api.x.ai/v1",


### PR DESCRIPTION
After #8124 routed the built-in xAI catalog through the OpenAI Responses API, the ai workspace stopped building:

\`\`\`
src/providers/xai.ts(8,2): error TS2322: Type 'Provider<"openai-completions" | "openai-responses">' is not assignable to type 'Provider<"openai-responses">'.
\`\`\`

\`xaiProvider()\` declares its return type as \`Provider<"openai-responses">\` and passes \`api: openAIResponsesApi()\`. \`createProvider\`'s generic widens back to \`Api\` because the \`api\` field is a single \`ProviderStreams\` value rather than a literal-keyed \`Partial<Record<TApi, ProviderStreams>>\` map, so TS infers \`Provider<Api>\` instead of \`Provider<"openai-responses">\`.

Pass the literal generic explicitly so the call matches the declared signature.

## Repro (on v0.84.3 tag)

\`\`\`
$ cd packages/ai && npm run build:offline
...
src/providers/xai.ts(8,2): error TS2322: ...
\`\`\`

## Verification

After this patch:

- \`packages/ai\` (\`npm run build:offline\`) and \`packages/coding-agent\` (\`npm run build\`) both build clean.
- \`packages/ai/test/xai-responses.test.ts\` — 10/10 pass.
- \`packages/coding-agent/test/model-resolver.test.ts\` — 48/48 pass.
- \`packages/coding-agent/test/compaction.test.ts\` + \`agent-session-compaction.test.ts\` — 24 passed / 7 skipped (pre-existing skips).
- \`node packages/coding-agent/dist/bundle/cli.js --version\` → \`0.84.3\`.
- \`node packages/coding-agent/dist/bundle/cli.js update\` → \`pi is already up to date (v0.84.3)\`, exit 0.

## Diff

\`\`\`diff
--- a/packages/ai/src/providers/xai.ts
+++ b/packages/ai/src/providers/xai.ts
@@
 export function xaiProvider(): Provider<"openai-responses"> {
-       return createProvider({
+       return createProvider<"openai-responses">({
                id: "xai",
                name: "xAI",
                baseUrl: "https://api.x.ai/v1",