### PR TITLE
feat(coding-agent): drop extra vertical padding on tool rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Tightened tool-row chrome: no leading spacer, no vertical box padding, and no extra blank line above self-rendered tool shells.
+
 ## [0.84.3] - 2026-08-24
 
 ### New Features

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -63,13 +63,11 @@ export class ToolExecutionComponent extends Container {
 		this.ui = ui;
 		this.cwd = cwd;
 
-		this.addChild(new Spacer(1));
-
 		// Always create all shell variants. contentBox is used for default renderer-based composition.
 		// selfRenderContainer is used when the tool renders its own framing.
 		// contentText is reserved for generic fallback rendering when no tool definition exists.
-		this.contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
-		this.contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		this.contentBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
+		this.contentText = new Text("", 1, 0, (text: string) => theme.bg("toolPendingBg", text));
 		this.selfRenderContainer = new Container();
 
 		if (this.hasRendererDefinition()) {
@@ -242,7 +240,6 @@ export class ToolExecutionComponent extends Container {
 
 			const lines: string[] = [];
 			if (contentLines.length > 0) {
-				lines.push("");
 				lines.push(...contentLines);
 			}
 			for (let i = 0; i < this.imageComponents.length; i++) {

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -65,6 +65,7 @@ describe("ToolExecutionComponent parity", () => {
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rendered).toContain("custom call");
 		expect(rendered).toContain("custom result");
+		expect(rendered.split("\n")[0]?.trim().length).toBeGreaterThan(0);
 	});
 
 	test("self-rendered empty tool rows take no layout space", () => {


### PR DESCRIPTION
## Summary
- Remove the leading spacer on every tool row, the extra vertical box padding, and the blank line above self-rendered tool shells.
- Transcripts were spending 2-3 empty lines per tool call before any command or output appeared.

## Test plan
- [x] `vitest --run test/tool-execution-component.test.ts` (25 passed)
- [ ] Reload an interactive session and confirm tool cards sit flush without overlapping neighboring rows