### PR TITLE
fix(ai): abort OpenAI streams immediately when signal fires

### DIFF
--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -128,7 +128,10 @@ export const stream: StreamFunction<"azure-openai-responses", AzureOpenAIRespons
 			await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
 			stream.push({ type: "start", partial: output });
 
-			await processResponsesStream(openaiStream, output, stream, model, { grammarToolInputProperties });
+			await processResponsesStream(openaiStream, output, stream, model, {
+				signal: options?.signal,
+				grammarToolInputProperties,
+			});
 
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -658,6 +658,7 @@ async function processStream(
 	options?: OpenAICodexResponsesOptions,
 ): Promise<void> {
 	await processResponsesStream(mapCodexEvents(parseSSE(response, options?.signal), output), output, stream, model, {
+		signal: options?.signal,
 		serviceTier: options?.serviceTier,
 		grammarToolInputProperties,
 		resolveServiceTier: resolveCodexServiceTier,
@@ -1512,6 +1513,7 @@ async function processWebSocketStream(
 			stream,
 			model,
 			{
+				signal: options?.signal,
 				serviceTier: options?.serviceTier,
 				grammarToolInputProperties,
 				resolveServiceTier: resolveCodexServiceTier,

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -507,6 +507,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			};
 
 			for await (const chunk of openaiStream) {
+				if (options?.signal?.aborted) break;
 				if (!chunk || typeof chunk !== "object") continue;
 
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -104,6 +104,7 @@ function convertToolResultOutput<TApi extends Api>(
 }
 
 export interface OpenAIResponsesStreamOptions {
+	signal?: AbortSignal;
 	serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 	grammarToolInputProperties?: ReadonlyMap<string, string>;
 	resolveServiceTier?: (
@@ -595,6 +596,7 @@ export async function processResponsesStream<TApi extends Api>(
 	};
 
 	for await (const event of openaiStream) {
+		if (options?.signal?.aborted) break;
 		if (event.type === "response.created") {
 			output.responseId = event.response.id;
 		} else if (event.type === "response.output_item.added") {
@@ -754,7 +756,7 @@ export async function processResponsesStream<TApi extends Api>(
 			throw new Error(msg);
 		}
 	}
-	if (!sawTerminalResponseEvent) {
+	if (!sawTerminalResponseEvent && !options?.signal?.aborted) {
 		throw new Error("OpenAI Responses stream ended before a terminal response event");
 	}
 }

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -160,6 +160,7 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 			stream.push({ type: "start", partial: output });
 
 			await processResponsesStream(openaiStream, output, stream, model, {
+				signal: options?.signal,
 				serviceTier: options?.serviceTier,
 				grammarToolInputProperties,
 				applyServiceTierPricing: (usage, serviceTier) => applyServiceTierPricing(usage, serviceTier, model),

--- a/packages/ai/test/openai-stream-abort-mid-stream.test.ts
+++ b/packages/ai/test/openai-stream-abort-mid-stream.test.ts
@@ -1,0 +1,155 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it } from "vitest";
+import { processResponsesStream } from "../src/api/openai-responses-shared.ts";
+import type { AssistantMessage, Model } from "../src/types.ts";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "gpt-5-mini",
+		name: "GPT-5 Mini",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	};
+}
+
+function createOutput(model: Model<"openai-responses">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "pending",
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Creates a mock event stream that yields many text deltas.
+ * Records how many events were actually consumed by the caller.
+ */
+function createManyDeltaEvents(count: number): {
+	iterable: AsyncIterable<ResponseStreamEvent>;
+	consumed: { value: number };
+} {
+	const consumed = { value: 0 };
+
+	async function* generate(): AsyncIterable<ResponseStreamEvent> {
+		yield {
+			type: "response.created",
+			sequence_number: 0,
+			response: { id: "resp_abort_test" },
+		} as ResponseStreamEvent;
+
+		yield {
+			type: "response.output_item.added",
+			sequence_number: 1,
+			output_index: 0,
+			item: { type: "message", id: "msg_abort_test", role: "assistant", status: "in_progress", content: [] },
+		} as ResponseStreamEvent;
+
+		for (let i = 0; i < count; i++) {
+			consumed.value++;
+			yield {
+				type: "response.output_text.delta",
+				sequence_number: 2 + i,
+				output_index: 0,
+				content_index: 0,
+				item_id: "msg_abort_test",
+				delta: `chunk-${i} `,
+			} as ResponseStreamEvent;
+		}
+
+		consumed.value++;
+		yield {
+			type: "response.completed",
+			sequence_number: 2 + count,
+			response: {
+				id: "resp_abort_test",
+				status: "completed",
+				output: [],
+				usage: { input_tokens: 10, output_tokens: count, total_tokens: 10 + count },
+			},
+		} as unknown as ResponseStreamEvent;
+	}
+
+	return { iterable: generate(), consumed };
+}
+
+describe("processResponsesStream abort mid-stream", () => {
+	it("should stop consuming events when signal is already aborted", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const controller = new AbortController();
+		controller.abort();
+
+		const { iterable, consumed } = createManyDeltaEvents(100);
+
+		await processResponsesStream(iterable, output, stream, model, { signal: controller.signal });
+
+		// With signal pre-aborted, the loop should break immediately (0 events consumed)
+		expect(consumed.value).toBe(0);
+		// stopReason stays pending since we never hit a terminal event
+		expect(output.stopReason).toBe("pending");
+	});
+
+	it("should stop consuming events shortly after signal aborts mid-stream", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+		const controller = new AbortController();
+
+		// Abort after 5 delta events
+		let deltaCount = 0;
+		const originalPush = stream.push.bind(stream);
+		stream.push = (event) => {
+			originalPush(event);
+			if (event.type === "text_delta") {
+				deltaCount++;
+				if (deltaCount === 5) {
+					controller.abort();
+				}
+			}
+		};
+
+		const { iterable, consumed } = createManyDeltaEvents(100);
+
+		await processResponsesStream(iterable, output, stream, model, { signal: controller.signal });
+
+		// The abort fires after the 5th delta is processed. The loop checks signal at
+		// the top of the next iteration, so at most one more event may be consumed
+		// before breaking. The key assertion: far fewer than all 100 deltas were consumed.
+		expect(consumed.value).toBeLessThan(10);
+		expect(output.stopReason).toBe("pending");
+	});
+
+	it("should consume all events when no abort signal is provided", async () => {
+		const model = createModel();
+		const output = createOutput(model);
+		const stream = new AssistantMessageEventStream();
+
+		const { iterable, consumed } = createManyDeltaEvents(20);
+
+		await processResponsesStream(iterable, output, stream, model);
+
+		// All events consumed: 20 deltas + 1 response.completed = 21
+		expect(consumed.value).toBe(21);
+		expect(output.stopReason).toBe("stop");
+	});
+});


### PR DESCRIPTION
The OpenAI Responses and Completions stream loops did not check the abort signal during iteration. Unlike the Anthropic path (which checks `signal?.aborted` on every `reader.read()`), the OpenAI paths relied on the SDK iterator to self-terminate -- which it does not once the HTTP response body is open. This caused RPC abort commands to be ignored until the turn completed naturally.

## Changes

- Add `signal?.aborted` break checks at the top of `processResponsesStream` for-await loop (shared by openai-responses, azure-openai-responses, and openai-codex-responses) and the openai-completions stream loop.
- Thread the signal into `OpenAIResponsesStreamOptions` and pass it from all four call sites.
- Gate the post-loop terminal-event validation so an aborted stream does not throw a spurious error.

## Testing

Unit test added: verifies the loop breaks immediately on pre-aborted signal and stops early on mid-stream abort.