### PR TITLE
feat(coding-agent): add per-model compaction profiles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `compaction.profiles` for per-model `reserveTokens` / `keepRecentTokens` overrides keyed by `"provider/modelId"`, so setups spanning models with very different context windows can tune auto-compaction per model ([#8133](https://github.com/earendil-works/pi/issues/8133)).
+
 ## [0.84.3] - 2026-08-24
 
 ### New Features

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -34,6 +34,8 @@ contextTokens > contextWindow - reserveTokens
 
 By default, `reserveTokens` is 16384 tokens (configurable in `~/.pi/agent/settings.json` or `<project-dir>/.pi/settings.json`). This leaves room for the LLM's response.
 
+Both `reserveTokens` and `keepRecentTokens` can be overridden per model with a `compaction.profiles` entry keyed by `"provider/modelId"` (see [settings](./settings.md)); useful when one setup spans models with very different context windows.
+
 You can also trigger manually with `/compact [instructions]`, where optional instructions focus the summary.
 
 ### How It Works

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -116,16 +116,24 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 | `compaction.enabled` | boolean | `true` | Enable auto-compaction |
 | `compaction.reserveTokens` | number | `16384` | Tokens reserved for LLM response |
 | `compaction.keepRecentTokens` | number | `20000` | Recent tokens to keep (not summarized) |
+| `compaction.profiles` | object | - | Per-model overrides of `reserveTokens` / `keepRecentTokens`, keyed by `"provider/modelId"` |
 
 ```json
 {
   "compaction": {
     "enabled": true,
     "reserveTokens": 16384,
-    "keepRecentTokens": 20000
+    "keepRecentTokens": 20000,
+    "profiles": {
+      "some-provider/big-context-model": {
+        "reserveTokens": 400000
+      }
+    }
   }
 }
 ```
+
+A profile may set any subset of the two token fields; each field resolves profile value first, then top-level value, then default. Keys match exactly (`provider/modelId`) — no globs. `compaction.enabled` stays global.
 
 ### Branch Summary
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1875,7 +1875,7 @@ export class AgentSession {
 			const { model: requestModel, apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model);
 
 			const pathEntries = this.sessionManager.getBranch();
-			const settings = this.settingsManager.getCompactionSettings();
+			const settings = this.settingsManager.getCompactionSettings(this.model?.provider, this.model?.id);
 
 			const preparation = prepareCompaction(pathEntries, settings);
 			if (!preparation) {
@@ -2048,7 +2048,7 @@ export class AgentSession {
 	 * @returns Whether the post-run loop should call `agent.continue()` for overflow recovery or queued messages
 	 */
 	private async _checkCompaction(assistantMessage: AssistantMessage, skipAbortedCheck = true): Promise<boolean> {
-		const settings = this.settingsManager.getCompactionSettings();
+		const settings = this.settingsManager.getCompactionSettings(this.model?.provider, this.model?.id);
 		if (!settings.enabled) return false;
 
 		// Skip if message was aborted (user cancelled) - unless skipAbortedCheck is false
@@ -2164,7 +2164,7 @@ export class AgentSession {
 	 * @returns Whether the post-run loop should call `agent.continue()`
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
-		const settings = this.settingsManager.getCompactionSettings();
+		const settings = this.settingsManager.getCompactionSettings(this.model?.provider, this.model?.id);
 		let started = false;
 		let fromExtension = false;
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -10,10 +10,16 @@ import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 
+export interface CompactionProfileSettings {
+	reserveTokens?: number;
+	keepRecentTokens?: number;
+}
+
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
 	reserveTokens?: number; // default: 16384
 	keepRecentTokens?: number; // default: 20000
+	profiles?: Record<string, CompactionProfileSettings>; // per-model token overrides keyed by "provider/modelId"
 }
 
 export interface BranchSummarySettings {
@@ -181,6 +187,11 @@ function parseTimeoutSetting(value: unknown, settingName: string): number | unde
 }
 
 export type SettingsScope = "global" | "project";
+
+/** Non-finite or non-positive token values count as unset so one bad entry can't disable the compaction safety margin. */
+function sanitizeCompactionTokenValue(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
 
 export interface SettingsManagerCreateOptions {
 	projectTrusted?: boolean;
@@ -836,18 +847,34 @@ export class SettingsManager {
 	}
 
 	getCompactionReserveTokens(): number {
-		return this.settings.compaction?.reserveTokens ?? 16384;
+		return sanitizeCompactionTokenValue(this.settings.compaction?.reserveTokens) ?? 16384;
 	}
 
 	getCompactionKeepRecentTokens(): number {
-		return this.settings.compaction?.keepRecentTokens ?? 20000;
+		return sanitizeCompactionTokenValue(this.settings.compaction?.keepRecentTokens) ?? 20000;
 	}
 
-	getCompactionSettings(): { enabled: boolean; reserveTokens: number; keepRecentTokens: number } {
+	/**
+	 * Resolve compaction settings, optionally applying the per-model profile for
+	 * "provider/modelId". Profile values win over top-level values, which win over
+	 * defaults. Without both arguments this returns exactly the global resolution.
+	 */
+	getCompactionSettings(
+		provider?: string,
+		modelId?: string,
+	): { enabled: boolean; reserveTokens: number; keepRecentTokens: number } {
+		let profile: CompactionProfileSettings | undefined;
+		if (provider !== undefined && modelId !== undefined) {
+			const entry = this.settings.compaction?.profiles?.[`${provider}/${modelId}`];
+			if (typeof entry === "object" && entry !== null && !Array.isArray(entry)) {
+				profile = entry;
+			}
+		}
 		return {
 			enabled: this.getCompactionEnabled(),
-			reserveTokens: this.getCompactionReserveTokens(),
-			keepRecentTokens: this.getCompactionKeepRecentTokens(),
+			reserveTokens: sanitizeCompactionTokenValue(profile?.reserveTokens) ?? this.getCompactionReserveTokens(),
+			keepRecentTokens:
+				sanitizeCompactionTokenValue(profile?.keepRecentTokens) ?? this.getCompactionKeepRecentTokens(),
 		};
 	}
 

--- a/packages/coding-agent/test/settings-compaction-profiles.test.ts
+++ b/packages/coding-agent/test/settings-compaction-profiles.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { InMemorySettingsStorage, SettingsManager } from "../src/core/settings-manager.ts";
+
+function storageWithScopes(global: unknown, project?: unknown): InMemorySettingsStorage {
+	const storage = new InMemorySettingsStorage();
+	storage.withLock("global", () => JSON.stringify(global));
+	if (project !== undefined) {
+		storage.withLock("project", () => JSON.stringify(project));
+	}
+	return storage;
+}
+
+describe("SettingsManager compaction profiles", () => {
+	it("returns built-in defaults with no config", () => {
+		const manager = SettingsManager.inMemory();
+		expect(manager.getCompactionSettings()).toEqual({
+			enabled: true,
+			reserveTokens: 16384,
+			keepRecentTokens: 20000,
+		});
+	});
+
+	it("resolves identically without model arguments even when profiles exist", () => {
+		const manager = SettingsManager.inMemory({
+			compaction: {
+				reserveTokens: 1000,
+				profiles: { "faux/big-model": { reserveTokens: 900_000 } },
+			},
+		});
+		expect(manager.getCompactionSettings()).toEqual({
+			enabled: true,
+			reserveTokens: 1000,
+			keepRecentTokens: 20000,
+		});
+	});
+
+	it("profile hit overrides one field while the other falls back to top-level", () => {
+		const manager = SettingsManager.inMemory({
+			compaction: {
+				reserveTokens: 1000,
+				keepRecentTokens: 500,
+				profiles: { "faux/big-model": { reserveTokens: 400_000 } },
+			},
+		});
+		expect(manager.getCompactionSettings("faux", "big-model")).toEqual({
+			enabled: true,
+			reserveTokens: 400_000,
+			keepRecentTokens: 500,
+		});
+	});
+
+	it("top-level values fall back to defaults when unset", () => {
+		const manager = SettingsManager.inMemory({
+			compaction: { profiles: { "faux/big-model": {} } },
+		});
+		expect(manager.getCompactionSettings("faux", "big-model")).toEqual({
+			enabled: true,
+			reserveTokens: 16384,
+			keepRecentTokens: 20000,
+		});
+	});
+
+	it("ignores a profile for the wrong provider or wrong model id", () => {
+		const manager = SettingsManager.inMemory({
+			compaction: {
+				profiles: {
+					"other-provider/big-model": { reserveTokens: 400_000 },
+					"faux/other-model": { reserveTokens: 300_000 },
+				},
+			},
+		});
+		expect(manager.getCompactionSettings("faux", "big-model").reserveTokens).toBe(16384);
+	});
+
+	it("a profile for another model does not alter the queried model (INV4)", () => {
+		const manager = SettingsManager.inMemory({
+			compaction: {
+				reserveTokens: 1000,
+				profiles: { "faux/big-model": { reserveTokens: 400_000, keepRecentTokens: 123 } },
+			},
+		});
+		expect(manager.getCompactionSettings("faux", "small-model")).toEqual({
+			enabled: true,
+			reserveTokens: 1000,
+			keepRecentTokens: 20000,
+		});
+		expect(manager.getCompactionSettings("other-provider", "big-model").reserveTokens).toBe(1000);
+	});
+
+	it.each([
+		["string value", "huge"],
+		["zero", 0],
+		["negative", -1],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+	])("invalid profile field (%s) falls back to top-level", (_name, invalid) => {
+		const manager = SettingsManager.inMemory({
+			compaction: {
+				reserveTokens: 1000,
+				keepRecentTokens: 500,
+				profiles: {
+					"faux/big-model": { reserveTokens: invalid as number, keepRecentTokens: invalid as number },
+				},
+			},
+		});
+		expect(manager.getCompactionSettings("faux", "big-model")).toEqual({
+			enabled: true,
+			reserveTokens: 1000,
+			keepRecentTokens: 500,
+		});
+	});
+
+	it.each([
+		["string value", "huge"],
+		["zero", 0],
+		["negative", -1],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+	])("invalid top-level field (%s) falls back to default", (_name, invalid) => {
+		const manager = SettingsManager.inMemory({
+			compaction: { reserveTokens: invalid as number, keepRecentTokens: invalid as number },
+		});
+		expect(manager.getCompactionSettings("faux", "big-model")).toEqual({
+			enabled: true,
+			reserveTokens: 16384,
+			keepRecentTokens: 20000,
+		});
+	});
+
+	it.each(["not-an-object", 42, [1, 2, 3]])("non-object profile entry %p is ignored", (entry) => {
+		const manager = SettingsManager.inMemory({
+			compaction: {
+				profiles: { "faux/big-model": entry as never },
+			},
+		});
+		expect(manager.getCompactionSettings("faux", "big-model").reserveTokens).toBe(16384);
+	});
+
+	it("merges project profiles into global profiles key-wise instead of clobbering", () => {
+		const storage = storageWithScopes(
+			{
+				compaction: { profiles: { "faux/global-only": { reserveTokens: 111 } } },
+			},
+			{
+				compaction: { profiles: { "faux/project-only": { reserveTokens: 222 } } },
+			},
+		);
+		const manager = SettingsManager.fromStorage(storage);
+		expect(manager.getCompactionSettings("faux", "global-only").reserveTokens).toBe(111);
+		expect(manager.getCompactionSettings("faux", "project-only").reserveTokens).toBe(222);
+	});
+
+	it("project profile values win on key conflicts", () => {
+		const storage = storageWithScopes(
+			{
+				compaction: { profiles: { "faux/shared": { reserveTokens: 111 } } },
+			},
+			{
+				compaction: { profiles: { "faux/shared": { reserveTokens: 222 } } },
+			},
+		);
+		const manager = SettingsManager.fromStorage(storage);
+		expect(manager.getCompactionSettings("faux", "shared").reserveTokens).toBe(222);
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-compaction.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction.test.ts
@@ -714,6 +714,86 @@ describe("AgentSession compaction characterization", () => {
 		expect(runAutoCompactionSpy).not.toHaveBeenCalled();
 	});
 
+	it("applies the per-model compaction profile only to the profiled model", async () => {
+		// Top-level reserveTokens 500 gives "small" (window 1000) a 500-token
+		// trigger. "big" (window 1M) has a profile raising reserveTokens to
+		// 900_000, giving it a 100_000 trigger instead of the global ~999.5k.
+		// Identical message volumes are driven against both; only "small" and
+		// only post-profile boundary usage on "big" may cross their thresholds.
+		const preparations: Array<{ reserveTokens: number; keepRecentTokens: number }> = [];
+		const harness = await createHarness({
+			models: [
+				{ id: "small", contextWindow: 1000, maxTokens: 100 },
+				{ id: "big", contextWindow: 1_000_000, maxTokens: 100 },
+			],
+			settings: {
+				compaction: {
+					reserveTokens: 500,
+					keepRecentTokens: 1,
+					profiles: { "faux/big": { reserveTokens: 900_000 } },
+				},
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						preparations.push({
+							reserveTokens: event.preparation.settings.reserveTokens,
+							keepRecentTokens: event.preparation.settings.keepRecentTokens,
+						});
+						return {
+							compaction: {
+								summary: "profiled compaction",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const assistantFor = (model: Model<any>, totalTokens: number): AssistantMessage => ({
+			...fauxAssistantMessage("", { stopReason: "stop", timestamp: Date.now() }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(totalTokens),
+		});
+
+		// Active model "small" (window 1000, top-level reserveTokens 500): identical
+		// turns of real volume cross its 500-token trigger and auto-compaction fires.
+		await harness.session.prompt("x".repeat(4000));
+		await harness.session.prompt("w".repeat(2000));
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({ reason: "threshold" });
+		// Extension-visible preparation.settings carries the resolved values (INV5).
+		expect(preparations.at(-1)).toEqual({ reserveTokens: 500, keepRecentTokens: 1 });
+
+		// Identical volume on "big": its 900_000 profiled reserveTokens put the
+		// trigger at 100_000, so nothing fires.
+		const bigModel = harness.getModel("big");
+		if (!bigModel) throw new Error("missing faux model 'big'");
+		const eventsBeforeBig = harness.eventsOfType("compaction_end").length;
+		await harness.session.setModel(bigModel);
+		harness.setResponses([fauxAssistantMessage(""), fauxAssistantMessage("")]);
+		await harness.session.prompt("x".repeat(4000));
+		await harness.session.prompt("w".repeat(2000));
+		expect(harness.eventsOfType("compaction_end").length).toBe(eventsBeforeBig);
+
+		// Boundary proof that the profile (not the global value) governs "big":
+		// 600 tokens stays below the 100_000 profiled trigger...
+		await expect(sessionInternals._checkCompaction(assistantFor(bigModel, 600))).resolves.toBe(false);
+		// ...while 100_001 crosses it, though it is far below the ~999_500 trigger
+		// the un-profiled global reserveTokens would give this model. The boolean
+		// return of _checkCompaction only reports queued-message continuation, so
+		// assert on the emitted compaction_end instead.
+		const eventsBeforeBoundary = harness.eventsOfType("compaction_end").length;
+		await sessionInternals._checkCompaction(assistantFor(bigModel, 100_001));
+		expect(harness.eventsOfType("compaction_end").length).toBe(eventsBeforeBoundary + 1);
+		expect(harness.eventsOfType("compaction_end").at(-1)).toMatchObject({ reason: "threshold" });
+	});
+
 	it("does not trigger threshold compaction below the threshold or when disabled", async () => {
 		const belowThresholdHarness = await createHarness({
 			settings: { compaction: { enabled: true, reserveTokens: 1000 } },


### PR DESCRIPTION
Closes #8133

## Problem

The auto-compaction trigger `contextTokens > contextWindow - reserveTokens` uses one global `reserveTokens`. Sessions switching between models with very different context windows (e.g. 200K and 1M) cannot be tuned: a value that suits the large model compacts the small one from the first turn; the default leaves the large model compacting so close to the edge that the summary request itself can overflow.

## Approach

- `compaction.profiles` map in settings.json keyed by exact `"provider/modelId"`, overriding `reserveTokens` / `keepRecentTokens`.
- Resolution chain: profile → top-level values → built-in defaults, inside `getCompactionSettings` — the single accessor used by manual compaction, both automatic compaction paths, and extension-visible `preparation.settings`, so every consumer observes the same values.
- `enabled` stays global. Invalid numeric entries fall back to the next tier instead of disabling the safety margin. No migration needed (unknown keys are harmless).

## Testing

- New unit suite `settings-compaction-profiles.test.ts` (21 tests): resolution chain, sanitization, exact-key isolation.
- New end-to-end suite additions `agent-session-compaction.test.ts` (24 tests incl. boundary: compaction fires at 100_001 tokens under a 900k profile where the global value would not trigger).
- Full `./test.sh`: 11 files / 87 tests passed; `npm run check` clean.

Docs: settings.md, compaction.md, CHANGELOG updated.