### PR TITLE
fix(agent): end stalled provider streams via idle timeout

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -5,6 +5,7 @@
 
 import {
 	type AssistantMessage,
+	type AssistantMessageEvent,
 	type Context,
 	EventStream,
 	type ToolResultMessage,
@@ -23,6 +24,18 @@ import type {
 } from "./types.ts";
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
+
+/** Default maximum silence between provider-stream events before a turn ends as an error. */
+export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 300_000;
+
+const EMPTY_USAGE = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
 
 /**
  * Start an agent loop with a new prompt message.
@@ -314,50 +327,114 @@ async function streamAssistantResponse(
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;
 
-	for await (const event of response) {
-		switch (event.type) {
-			case "start":
-				partialMessage = event.partial;
-				context.messages.push(partialMessage);
-				addedPartial = true;
-				await emit({ type: "message_start", message: { ...partialMessage } });
-				break;
+	// Watchdog: bound the time the iterator may stay silent. A stalled-but-open
+	// stream would otherwise park the await below forever (no turn end, Escape dead).
+	const idleTimeoutMs = config.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+	const iterator = response[Symbol.asyncIterator]();
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	const clearIdleTimer = () => {
+		if (idleTimer !== undefined) {
+			clearTimeout(idleTimer);
+			idleTimer = undefined;
+		}
+	};
 
-			case "text_start":
-			case "text_delta":
-			case "text_end":
-			case "thinking_start":
-			case "thinking_delta":
-			case "thinking_end":
-			case "toolcall_start":
-			case "toolcall_delta":
-			case "toolcall_end":
-				if (partialMessage) {
-					partialMessage = event.partial;
-					context.messages[context.messages.length - 1] = partialMessage;
-					await emit({
-						type: "message_update",
-						assistantMessageEvent: event,
-						message: { ...partialMessage },
-					});
-				}
-				break;
+	try {
+		while (true) {
+			let settled: IteratorResult<AssistantMessageEvent> | "idle";
+			if (idleTimeoutMs > 0) {
+				const idle = new Promise<"idle">((resolve) => {
+					idleTimer = setTimeout(() => resolve("idle"), idleTimeoutMs);
+				});
+				settled = await Promise.race([iterator.next(), idle]);
+			} else {
+				settled = await iterator.next();
+			}
+			clearIdleTimer();
 
-			case "done":
-			case "error": {
-				const finalMessage = await response.result();
+			if (settled === "idle") {
+				// The producer task stays blocked (bounded leak is accepted), but end()
+				// turns any late push() into a no-op so nothing further is consumed or emitted.
+				response.end();
+				const aborted = signal?.aborted === true;
+				const errorMessage = aborted
+					? undefined
+					: `Provider stream idle for ${idleTimeoutMs}ms; ending turn as a retriable error`;
+				const finalMessage: AssistantMessage = partialMessage
+					? {
+							...sanitizePartialMessage(partialMessage),
+							stopReason: aborted ? "aborted" : "error",
+							errorMessage,
+						}
+					: {
+							role: "assistant",
+							content: [{ type: "text", text: "" }],
+							api: config.model.api,
+							provider: config.model.provider,
+							model: config.model.id,
+							usage: EMPTY_USAGE,
+							stopReason: aborted ? "aborted" : "error",
+							errorMessage,
+							timestamp: Date.now(),
+						};
 				if (addedPartial) {
 					context.messages[context.messages.length - 1] = finalMessage;
 				} else {
 					context.messages.push(finalMessage);
-				}
-				if (!addedPartial) {
 					await emit({ type: "message_start", message: { ...finalMessage } });
 				}
 				await emit({ type: "message_end", message: finalMessage });
 				return finalMessage;
 			}
+
+			if (settled.done) break;
+			const event = settled.value;
+			switch (event.type) {
+				case "start":
+					partialMessage = event.partial;
+					context.messages.push(partialMessage);
+					addedPartial = true;
+					await emit({ type: "message_start", message: { ...partialMessage } });
+					break;
+
+				case "text_start":
+				case "text_delta":
+				case "text_end":
+				case "thinking_start":
+				case "thinking_delta":
+				case "thinking_end":
+				case "toolcall_start":
+				case "toolcall_delta":
+				case "toolcall_end":
+					if (partialMessage) {
+						partialMessage = event.partial;
+						context.messages[context.messages.length - 1] = partialMessage;
+						await emit({
+							type: "message_update",
+							assistantMessageEvent: event,
+							message: { ...partialMessage },
+						});
+					}
+					break;
+
+				case "done":
+				case "error": {
+					const finalMessage = await response.result();
+					if (addedPartial) {
+						context.messages[context.messages.length - 1] = finalMessage;
+					} else {
+						context.messages.push(finalMessage);
+					}
+					if (!addedPartial) {
+						await emit({ type: "message_start", message: { ...finalMessage } });
+					}
+					await emit({ type: "message_end", message: finalMessage });
+					return finalMessage;
+				}
+			}
 		}
+	} finally {
+		clearIdleTimer();
 	}
 
 	const finalMessage = await response.result();
@@ -369,6 +446,22 @@ async function streamAssistantResponse(
 	}
 	await emit({ type: "message_end", message: finalMessage });
 	return finalMessage;
+}
+
+/**
+ * Copy of a partial assistant message with adapter streaming scratch fields
+ * (`index`, `partialJson`) removed so they never persist into history.
+ */
+function sanitizePartialMessage(message: AssistantMessage): AssistantMessage {
+	return {
+		...message,
+		content: message.content.map((block) => {
+			const sanitized = { ...block } as typeof block & { index?: number; partialJson?: string };
+			delete sanitized.index;
+			delete sanitized.partialJson;
+			return sanitized;
+		}),
+	};
 }
 
 /**

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -119,6 +119,8 @@ export interface AgentOptions {
 	thinkingBudgets?: ThinkingBudgets;
 	transport?: Transport;
 	maxRetryDelayMs?: number;
+	/** Optional cap for provider-stream event-level silence before the turn ends as an error. */
+	streamIdleTimeoutMs?: number;
 	toolExecution?: ToolExecutionMode;
 }
 
@@ -210,6 +212,8 @@ export class Agent {
 	public transport: Transport;
 	/** Optional cap for provider-requested retry delays. */
 	public maxRetryDelayMs?: number;
+	/** Optional cap for provider-stream event-level silence. */
+	public streamIdleTimeoutMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
 
@@ -234,6 +238,7 @@ export class Agent {
 		this.thinkingBudgets = runtimeOptions.thinkingBudgets;
 		this.transport = runtimeOptions.transport ?? "auto";
 		this.maxRetryDelayMs = runtimeOptions.maxRetryDelayMs;
+		this.streamIdleTimeoutMs = runtimeOptions.streamIdleTimeoutMs;
 		this.toolExecution = runtimeOptions.toolExecution ?? "parallel";
 	}
 
@@ -454,6 +459,7 @@ export class Agent {
 			transport: this.transport,
 			thinkingBudgets: this.thinkingBudgets,
 			maxRetryDelayMs: this.maxRetryDelayMs,
+			streamIdleTimeoutMs: this.streamIdleTimeoutMs,
 			toolExecution: this.toolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -256,6 +256,9 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 */
 	getFollowUpMessages?: () => Promise<AgentMessage[]>;
 
+	/** Maximum silence in ms between events from the provider stream before the turn ends as a provider error. `0` disables. */
+	streamIdleTimeoutMs?: number;
+
 	/**
 	 * Tool execution mode.
 	 * - "sequential": execute tool calls one by one

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1605,3 +1605,310 @@ describe("agentLoopContinue with AgentMessage", () => {
 		expect(messages[0].role).toBe("assistant");
 	});
 });
+
+describe("stream idle timeout", () => {
+	const IDLE_THRESHOLD_MS = 40;
+
+	function sleep(ms: number): Promise<void> {
+		return new Promise((resolve) => {
+			setTimeout(resolve, ms);
+		});
+	}
+
+	function createPartialMessage(content: AssistantMessage["content"]): AssistantMessage {
+		return { ...createAssistantMessage(content), stopReason: "pending" };
+	}
+
+	function createSilentStallStreamFn(): { streamFn: () => MockAssistantStream; streams: MockAssistantStream[] } {
+		const streams: MockAssistantStream[] = [];
+		return {
+			streams,
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				streams.push(stream);
+				// Never pushes: simulates an open-but-silent provider stream.
+				return stream;
+			},
+		};
+	}
+
+	it("ends the turn as an error when the stream stalls after a partial response", async () => {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamIdleTimeoutMs: IDLE_THRESHOLD_MS,
+		};
+
+		let mockStream: MockAssistantStream | undefined;
+		const streamFn = () => {
+			mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				mockStream!.push({ type: "start", partial: createPartialMessage([{ type: "text", text: "" }]) });
+				mockStream!.push({
+					type: "text_delta",
+					contentIndex: 0,
+					delta: "partial ans",
+					partial: createPartialMessage([{ type: "text", text: "partial ans" }]),
+				});
+				// No further events, no close: stalled.
+			});
+			return mockStream!;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const messages = await stream.result();
+
+		// Turn ends bounded by roughly the threshold plus processing time.
+		const finalMessage = messages[messages.length - 1];
+		expect(finalMessage.role).toBe("assistant");
+		if (finalMessage.role === "assistant") {
+			expect(finalMessage.stopReason).toBe("error");
+			expect(finalMessage.errorMessage).toContain(`${IDLE_THRESHOLD_MS}ms`);
+			// Partial content survives into the finalized error message.
+			expect(finalMessage.content).toContainEqual({ type: "text", text: "partial ans" });
+		}
+
+		// Same observable contract as provider errors: ... message_end -> turn_end -> agent_end.
+		const eventTypes = events.map((e) => e.type);
+		expect(eventTypes.slice(-3)).toEqual(["message_end", "turn_end", "agent_end"]);
+
+		// History ends with the error message: the pending partial became the final message.
+		const lastContextMessage = messages[messages.length - 1];
+		expect(lastContextMessage.role).toBe("assistant");
+		if (lastContextMessage.role === "assistant") {
+			expect(lastContextMessage.stopReason).toBe("error");
+		}
+
+		// Late pushes into the abandoned stream produce no further events (I6).
+		const updateCountBefore = events.filter((e) => e.type === "message_update").length;
+		expect(updateCountBefore).toBeGreaterThan(0);
+		mockStream!.push({
+			type: "text_delta",
+			contentIndex: 0,
+			delta: "late",
+			partial: createPartialMessage([{ type: "text", text: "late" }]),
+		});
+		await sleep(IDLE_THRESHOLD_MS * 2);
+		expect(events.filter((e) => e.type === "message_update").length).toBe(updateCountBefore);
+		expect(
+			messages[messages.length - 1].role === "assistant"
+				? (messages[messages.length - 1] as AssistantMessage).stopReason
+				: undefined,
+		).toBe("error");
+	});
+
+	it("ends the turn with a fresh zero-usage error message when the stream stalls before the first event", async () => {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamIdleTimeoutMs: IDLE_THRESHOLD_MS,
+		};
+		const { streamFn } = createSilentStallStreamFn();
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const messages = await stream.result();
+
+		// Fresh error message appended after the user prompt.
+		expect(messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+		const finalMessage = messages[1];
+		if (finalMessage.role === "assistant") {
+			expect(finalMessage.stopReason).toBe("error");
+			expect(finalMessage.errorMessage).toContain(`${IDLE_THRESHOLD_MS}ms`);
+			expect(finalMessage.usage.totalTokens).toBe(0);
+		}
+
+		// message_start + message_end emitted exactly once for the assistant message.
+		const assistantStarts = events.filter((e) => e.type === "message_start" && e.message.role === "assistant").length;
+		const assistantEnds = events.filter((e) => e.type === "message_end" && e.message.role === "assistant").length;
+		expect(assistantStarts).toBe(1);
+		expect(assistantEnds).toBe(1);
+
+		// Exactly one assistant message in history, no dangling pending partial.
+		const assistantMessages = messages.filter((m) => m.role === "assistant") as AssistantMessage[];
+		expect(assistantMessages.length).toBe(1);
+		expect(assistantMessages.every((m) => m.stopReason !== "pending")).toBe(true);
+	});
+
+	it("strips adapter streaming scratch fields from the finalized partial message", async () => {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamIdleTimeoutMs: IDLE_THRESHOLD_MS,
+		};
+
+		const streamFn = () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				// Adapter partials carry streaming scratch fields that must not reach history.
+				const scratchContent = [
+					{ type: "text", text: "half-written", index: 0 },
+					{ type: "toolCall", id: "tool-1", name: "echo", arguments: {}, partialJson: '{"va' },
+				] as unknown as AssistantMessage["content"];
+				const partial = createPartialMessage(scratchContent);
+				mockStream.push({ type: "start", partial });
+				mockStream.push({ type: "text_delta", contentIndex: 0, delta: "half-written", partial });
+				// Stalled mid-tool-call.
+			});
+			return mockStream;
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, streamFn);
+		for await (const _event of stream) {
+			// consume
+		}
+		const messages = await stream.result();
+
+		// The finalized message (returned and emitted at message_end) carries no scratch fields.
+		const finalMessage = messages[messages.length - 1];
+		expect(finalMessage.role).toBe("assistant");
+		if (finalMessage.role === "assistant") {
+			for (const block of finalMessage.content) {
+				expect(block).not.toHaveProperty("index");
+				expect(block).not.toHaveProperty("partialJson");
+			}
+			expect(finalMessage.content[0]).toMatchObject({ type: "text", text: "half-written" });
+			expect(finalMessage.content[1]).toMatchObject({ type: "toolCall", id: "tool-1", name: "echo" });
+		}
+	});
+
+	it("keeps stopReason aborted when the user aborts while the watchdog is armed", async () => {
+		const controller = new AbortController();
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamIdleTimeoutMs: IDLE_THRESHOLD_MS,
+		};
+		const { streamFn } = createSilentStallStreamFn();
+
+		setTimeout(() => controller.abort(), IDLE_THRESHOLD_MS / 4);
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, controller.signal, streamFn);
+		for await (const _event of stream) {
+			// consume
+		}
+		const messages = await stream.result();
+
+		const finalMessage = messages[messages.length - 1];
+		expect(finalMessage.role).toBe("assistant");
+		if (finalMessage.role === "assistant") {
+			expect(finalMessage.stopReason).toBe("aborted");
+			expect(finalMessage.errorMessage).toBeUndefined();
+		}
+	});
+
+	it("does not end the turn when streamIdleTimeoutMs is 0 (disabled)", async () => {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamIdleTimeoutMs: 0,
+		};
+		const { streams, streamFn } = createSilentStallStreamFn();
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, streamFn);
+		const consumed = (async () => {
+			for await (const event of stream) {
+				events.push(event);
+			}
+		})();
+
+		// Generous real-time bound well past any sane threshold: nothing fires.
+		await sleep(200);
+		expect(events.some((e) => e.type === "turn_end")).toBe(false);
+
+		// Release the stream so the test can settle cleanly.
+		streams[0].push({
+			type: "done",
+			reason: "stop",
+			message: createAssistantMessage([{ type: "text", text: "finally arrived" }]),
+		});
+		await consumed;
+		const messages = await stream.result();
+
+		const finalMessage = messages[messages.length - 1];
+		expect(finalMessage.role).toBe("assistant");
+		expect(finalMessage.role === "assistant" ? finalMessage.stopReason : undefined).toBe("stop");
+	});
+
+	it("completes normally when gaps between events stay below the threshold", async () => {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamIdleTimeoutMs: IDLE_THRESHOLD_MS,
+		};
+
+		const streamFn = () => {
+			const mockStream = new MockAssistantStream();
+			void (async () => {
+				mockStream.push({ type: "start", partial: createPartialMessage([{ type: "text", text: "" }]) });
+				await sleep(IDLE_THRESHOLD_MS / 4);
+				mockStream.push({
+					type: "text_delta",
+					contentIndex: 0,
+					delta: "slow but alive",
+					partial: createPartialMessage([{ type: "text", text: "slow but alive" }]),
+				});
+				await sleep(IDLE_THRESHOLD_MS / 4);
+				mockStream.push({
+					type: "done",
+					reason: "stop",
+					message: createAssistantMessage([{ type: "text", text: "slow but alive" }]),
+				});
+			})();
+			return mockStream;
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, streamFn);
+		for await (const _event of stream) {
+			// consume
+		}
+		const messages = await stream.result();
+
+		const finalMessage = messages[messages.length - 1];
+		expect(finalMessage.role === "assistant" ? finalMessage.stopReason : undefined).toBe("stop");
+		expect(messages.find((m) => m.role === "assistant" && m.stopReason === "error")).toBeUndefined();
+	});
+
+	it("leaves the normal provider-error path unchanged while the watchdog is armed", async () => {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			streamIdleTimeoutMs: IDLE_THRESHOLD_MS,
+		};
+
+		const providerError = createAssistantMessage([{ type: "text", text: "" }], "error");
+		providerError.errorMessage = "provider exploded";
+		const streamFn = () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				mockStream.push({ type: "error", reason: "error", error: providerError });
+			});
+			return mockStream;
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, streamFn);
+		for await (const _event of stream) {
+			// consume
+		}
+		const messages = await stream.result();
+
+		const finalMessage = messages[messages.length - 1];
+		expect(finalMessage.role === "assistant" ? finalMessage.stopReason : undefined).toBe("error");
+		expect(finalMessage.role === "assistant" ? finalMessage.errorMessage : undefined).toBe("provider exploded");
+	});
+});

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -369,6 +369,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		transport: settingsManager.getTransport(),
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
 		maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
+		streamIdleTimeoutMs: settingsManager.getStreamIdleTimeoutMs(),
 	});
 
 	// Restore messages if session has existing data

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -135,6 +135,7 @@ export interface Settings {
 	sessionDir?: string; // Custom session storage directory (same format as --session-dir CLI flag)
 	httpProxy?: string; // Proxy URL applied as HTTP_PROXY and HTTPS_PROXY for Pi-managed HTTP clients
 	httpIdleTimeoutMs?: number; // HTTP header/body idle timeout in milliseconds; 0 disables it
+	streamIdleTimeoutMs?: number; // Provider-stream event idle timeout in milliseconds; 0 disables it
 	websocketConnectTimeoutMs?: number; // WebSocket connect/open handshake timeout in milliseconds; 0 disables it
 	tuiMode?: TuiMode; // default: "regular"
 	fullscreenExitOutput?: FullscreenExitOutput; // default: "transcript"; no effect in regular TUI mode
@@ -893,6 +894,20 @@ export class SettingsManager {
 		}
 		this.globalSettings.httpIdleTimeoutMs = Math.floor(timeoutMs);
 		this.markModified("httpIdleTimeoutMs");
+		this.save();
+	}
+
+	/** Stored value without local default; undefined falls back to the agent package's DEFAULT_STREAM_IDLE_TIMEOUT_MS. */
+	getStreamIdleTimeoutMs(): number | undefined {
+		return parseTimeoutSetting(this.settings.streamIdleTimeoutMs, "streamIdleTimeoutMs");
+	}
+
+	setStreamIdleTimeoutMs(timeoutMs: number): void {
+		if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+			throw new Error(`Invalid streamIdleTimeoutMs setting: ${String(timeoutMs)}`);
+		}
+		this.globalSettings.streamIdleTimeoutMs = Math.floor(timeoutMs);
+		this.markModified("streamIdleTimeoutMs");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -1,4 +1,5 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { DEFAULT_STREAM_IDLE_TIMEOUT_MS } from "@earendil-works/pi-agent-core";
 import { getSupportedThinkingLevels, type Model, type Transport } from "@earendil-works/pi-ai";
 import {
 	type Component,
@@ -25,6 +26,24 @@ import { keyDisplayText } from "./keybinding-hints.ts";
 import { SelectSubmenu, SteppedSubmenu, type SteppedSubmenuStep } from "./settings-submenu.ts";
 
 const MODEL_PICKER_LAYOUT = { minPrimaryColumnWidth: 12, maxPrimaryColumnWidth: 46 };
+
+// Same shape/values as HTTP_IDLE_TIMEOUT_CHOICES; 5 min matches the agent package's effective default.
+const STREAM_IDLE_TIMEOUT_CHOICES = [
+	{ label: "30 sec", timeoutMs: 30_000 },
+	{ label: "1 min", timeoutMs: 60_000 },
+	{ label: "2 min", timeoutMs: 120_000 },
+	{ label: "5 min", timeoutMs: DEFAULT_STREAM_IDLE_TIMEOUT_MS },
+	{ label: "disabled", timeoutMs: 0 },
+] as const;
+
+function formatStreamIdleTimeoutMs(timeoutMs: number): string {
+	const choice = STREAM_IDLE_TIMEOUT_CHOICES.find((item) => item.timeoutMs === timeoutMs);
+	if (choice) {
+		return choice.label;
+	}
+	return `${timeoutMs / 1000} sec`;
+}
+export { formatStreamIdleTimeoutMs };
 
 const THINKING_DESCRIPTIONS: Record<ThinkingLevel, string> = {
 	off: "No reasoning",
@@ -60,6 +79,7 @@ export interface SettingsConfig {
 	followUpMode: "all" | "one-at-a-time";
 	transport: Transport;
 	httpIdleTimeoutMs: number;
+	streamIdleTimeoutMs: number;
 	thinkingLevel: ThinkingLevel;
 	availableThinkingLevels: ThinkingLevel[];
 	modelThinkingLevels: Record<string, ThinkingLevel>;
@@ -98,6 +118,7 @@ export interface SettingsCallbacks {
 	onFollowUpModeChange: (mode: "all" | "one-at-a-time") => void;
 	onTransportChange: (transport: Transport) => void;
 	onHttpIdleTimeoutMsChange: (timeoutMs: number) => void;
+	onStreamIdleTimeoutMsChange: (timeoutMs: number) => void;
 	onModelThinkingLevelChange: (provider: string, modelId: string, level: ThinkingLevel) => void;
 	onModelThinkingLevelRemove: (provider: string, modelId: string) => void;
 	onThemeChange: (theme: string) => void;
@@ -491,6 +512,14 @@ export class SettingsSelectorComponent extends Container {
 				values: HTTP_IDLE_TIMEOUT_CHOICES.map((choice) => choice.label),
 			},
 			{
+				id: "stream-idle-timeout",
+				label: "Stream idle timeout",
+				description:
+					"Maximum silence between provider stream events before the turn ends as a retriable error. Disable to allow unbounded waits.",
+				currentValue: formatStreamIdleTimeoutMs(config.streamIdleTimeoutMs),
+				values: STREAM_IDLE_TIMEOUT_CHOICES.map((choice) => choice.label),
+			},
+			{
 				id: "hide-thinking",
 				label: "Hide thinking",
 				description: "Hide thinking blocks in assistant responses",
@@ -847,6 +876,13 @@ export class SettingsSelectorComponent extends Container {
 						const choice = HTTP_IDLE_TIMEOUT_CHOICES.find((item) => item.label === newValue);
 						if (choice) {
 							callbacks.onHttpIdleTimeoutMsChange(choice.timeoutMs);
+						}
+						break;
+					}
+					case "stream-idle-timeout": {
+						const choice = STREAM_IDLE_TIMEOUT_CHOICES.find((item) => item.label === newValue);
+						if (choice) {
+							callbacks.onStreamIdleTimeoutMsChange(choice.timeoutMs);
 						}
 						break;
 					}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -8,6 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { DEFAULT_STREAM_IDLE_TIMEOUT_MS } from "@earendil-works/pi-agent-core";
 import type { AuthEvent, AuthPrompt } from "@earendil-works/pi-ai";
 import type { AssistantMessage, ImageContent, Message, Model, Usage } from "@earendil-works/pi-ai/compat";
 import type {
@@ -137,7 +138,7 @@ import {
 } from "./components/oauth-selector.ts";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.ts";
 import { SessionSelectorComponent } from "./components/session-selector.ts";
-import { SettingsSelectorComponent } from "./components/settings-selector.ts";
+import { formatStreamIdleTimeoutMs, SettingsSelectorComponent } from "./components/settings-selector.ts";
 import { SkillInvocationMessageComponent } from "./components/skill-invocation-message.ts";
 import {
 	BranchSummaryStatusIndicator,
@@ -4542,6 +4543,7 @@ export class InteractiveMode {
 					followUpMode: this.session.followUpMode,
 					transport: this.settingsManager.getTransport(),
 					httpIdleTimeoutMs: this.settingsManager.getHttpIdleTimeoutMs(),
+					streamIdleTimeoutMs: this.settingsManager.getStreamIdleTimeoutMs() ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS,
 					thinkingLevel: this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL,
 					availableThinkingLevels: [...THINKING_LEVEL_OPTIONS],
 					modelThinkingLevels: this.settingsManager.getAllModelThinkingLevels(),
@@ -4613,6 +4615,12 @@ export class InteractiveMode {
 						this.settingsManager.setHttpIdleTimeoutMs(timeoutMs);
 						configureHttpDispatcher(timeoutMs);
 						this.showStatus(`HTTP idle timeout: ${formatHttpIdleTimeoutMs(timeoutMs)}`);
+					},
+					onStreamIdleTimeoutMsChange: (timeoutMs) => {
+						this.settingsManager.setStreamIdleTimeoutMs(timeoutMs);
+						// Apply live, mirroring the transport knob; the next run reads it via createLoopConfig.
+						this.session.agent.streamIdleTimeoutMs = timeoutMs;
+						this.showStatus(`Stream idle timeout: ${formatStreamIdleTimeoutMs(timeoutMs)}`);
 					},
 					onModelThinkingLevelChange: (provider, modelId, level) => {
 						this.settingsManager.setModelThinkingLevel(provider, modelId, level);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -358,6 +358,49 @@ describe("SettingsManager", () => {
 		});
 	});
 
+	describe("streamIdleTimeoutMs", () => {
+		it("should return undefined when absent (agent package default applies)", () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getStreamIdleTimeoutMs()).toBeUndefined();
+		});
+
+		it("should accept a numeric value from settings", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ streamIdleTimeoutMs: 60000 }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getStreamIdleTimeoutMs()).toBe(60000);
+		});
+
+		it("should accept string forms like the sibling timeout setting", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ streamIdleTimeoutMs: "120000" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getStreamIdleTimeoutMs()).toBe(120000);
+
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ streamIdleTimeoutMs: "disabled" }));
+			const disabledManager = SettingsManager.create(projectDir, agentDir);
+			expect(disabledManager.getStreamIdleTimeoutMs()).toBe(0);
+		});
+
+		it("should reject invalid values", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ streamIdleTimeoutMs: -1 }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(() => manager.getStreamIdleTimeoutMs()).toThrow("Invalid streamIdleTimeoutMs setting");
+		});
+
+		it("should round-trip through the setter and persist", async () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			manager.setStreamIdleTimeoutMs(45000);
+			expect(manager.getStreamIdleTimeoutMs()).toBe(45000);
+			await manager.flush();
+			expect(JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf8")).streamIdleTimeoutMs).toBe(45000);
+
+			manager.setStreamIdleTimeoutMs(0);
+			expect(manager.getStreamIdleTimeoutMs()).toBe(0);
+		});
+	});
+
 	describe("externalEditor", () => {
 		const originalVisual = process.env.VISUAL;
 		const originalEditor = process.env.EDITOR;


### PR DESCRIPTION
Closes #8331

## Problem

During a provider incident (e.g. Anthropic 529 overload), an SSE stream can stay open while stopping event delivery. The `for await` in `streamAssistantResponse` then awaits forever: the turn never ends, Escape does not cancel, queued follow-ups never drain. Byte-level idle timeouts (undici, SDK `timeoutMs`) do not cover this — SSE pings and proxies keep bytes flowing while event-level silence persists.

## Approach

- Arm a watchdog around each awaited `next()` of the provider stream inside `streamAssistantResponse`.
- On expiry, end the stream and finalize exactly like an adapter error: sanitize streaming scratch fields off any partial message, stamp `stopReason` `error` (or `aborted` if the user's signal already fired), replace-or-append into context messages, emit `message_start`/`message_end`, and return before the post-loop `result()` await that would never resolve for an abandoned stream. `runLoop`'s existing error branch then ends the turn as a retryable provider error.
- Configurable via `AgentOptions.streamIdleTimeoutMs` / `AgentLoopConfig.streamIdleTimeoutMs`; 0 disables. coding-agent exposes it as a `streamIdleTimeoutMs` setting with a `/settings` row beside the HTTP idle timeout (live-apply).

## Design decision open for maintainer input

@badlogic raised that local models can legitimately stall far longer (massive prefills), so a low default is unsafe. This change picks **300,000 ms default, enabled**, matching the shipped byte-level HTTP idle default, with per-instance override and 0-disables. If maintainers prefer a higher default (or disabled-by-default for local providers), it is a one-line constant change — happy to adjust.

## Testing

- New `stream idle timeout` block in `agent-loop.test.ts`: 7 cases (expiry fires, partial-message sanitization, aborted-vs-error stopReason, 0-disables, finalize-before-result-await).
- settings-manager tests: 5 new cases (47/47 total). agent-loop suite 30/30.
- Full `./test.sh` green (~3,700 tests); `npm run check` clean.