### PR TITLE
fix(ai): normalize OpenAI-compatible tool call IDs

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1136,30 +1136,32 @@ export function convertMessages(
 ): ChatCompletionMessageParam[] {
 	const params: ChatCompletionMessageParam[] = [];
 
+	const maxToolCallIdLength = 40;
+	const fitToolCallIdWithHash = (candidate: string, hashSource: string): string => {
+		if (candidate.length <= maxToolCallIdLength) return candidate;
+		const hash = shortHash(hashSource);
+		const prefix = candidate.slice(0, Math.max(1, maxToolCallIdLength - hash.length - 1));
+		return `${prefix}_${hash}`;
+	};
 	const normalizeToolCallId = (id: string): string => {
-		// Handle pipe-separated IDs from OpenAI Responses API
-		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =)
-		// These come from providers like github-copilot, openai-codex, opencode
-		// Extract just the call_id part and normalize it
-		// Multiple tool calls in the same turn can share call_id but differ by item_id.
-		// Preserve item-level uniqueness when replaying into Chat Completions, which
-		// requires distinct tool call ids.
+		// Handle pipe-separated IDs from OpenAI Responses API.
+		// Format: {call_id}|{id} where {id} can be 400+ chars with special chars (+, /, =).
+		// Multiple tool calls in the same turn can share call_id but differ by item_id,
+		// so retain both parts before applying the Chat Completions length limit.
 		if (id.includes("|")) {
-			// Sanitize to allowed chars and truncate to 40 chars (OpenAI limit)
 			const separatorIndex = id.indexOf("|");
 			const callId = id.slice(0, separatorIndex).replace(/[^a-zA-Z0-9_-]/g, "_");
 			const itemId = id.slice(separatorIndex + 1).replace(/[^a-zA-Z0-9_-]/g, "_");
 			const combinedId = itemId.length > 0 ? `${callId}_${itemId}` : callId;
-			if (combinedId.length <= 40) {
-				return combinedId;
-			}
-			const hash = shortHash(id).slice(0, 8);
-			const prefix = callId.slice(0, Math.max(1, 40 - hash.length - 1));
-			return `${prefix}_${hash}`;
+			return fitToolCallIdWithHash(combinedId, id);
 		}
 
-		if (model.provider === "openai") return id.length > 40 ? id.slice(0, 40) : id;
-		return id;
+		// OpenAI-compatible gateways can forward Chat Completions history to a
+		// Responses backend, where call_id is capped. Normalize foreign IDs for every
+		// OpenAI-compatible provider, not only the provider named "openai".
+		if (id.length <= maxToolCallIdLength) return id;
+		const sanitizedId = id.replace(/[^a-zA-Z0-9_-]/g, "_");
+		return fitToolCallIdWithHash(sanitizedId, id);
 	};
 
 	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));

--- a/packages/ai/test/openai-completions-tool-call-id.test.ts
+++ b/packages/ai/test/openai-completions-tool-call-id.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages } from "../src/api/openai-completions.ts";
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	OpenAICompletionsCompat,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.ts";
+
+const usage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const compat = {
+	supportsStore: false,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	supportsFinishReason: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	chatTemplateKwargs: {},
+	chatTemplateArgs: {},
+	zaiToolStream: false,
+	supportsThinkingTokenBudget: false,
+	thinkingTokenBudgetField: undefined,
+	supportsStrictMode: true,
+	supportsOpenAIGrammarTools: false,
+	cacheControlFormat: undefined,
+	sendSessionAffinityHeaders: false,
+	sessionAffinityFormat: "openai",
+	supportsLongCacheRetention: true,
+} satisfies Omit<
+	Required<OpenAICompletionsCompat>,
+	"cacheControlFormat" | "deferredToolsMode" | "thinkingTokenBudgetField"
+> & {
+	cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+	thinkingTokenBudgetField?: OpenAICompletionsCompat["thinkingTokenBudgetField"];
+};
+
+const targetModel: Model<"openai-completions"> = {
+	id: "gpt-proxy-model",
+	name: "GPT Proxy Model",
+	api: "openai-completions",
+	provider: "custom-gateway",
+	baseUrl: "https://gateway.example/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 4096,
+	compat,
+};
+
+function buildContext(toolCallIds: string[]): Context {
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: toolCallIds.map((id, index) => ({
+			type: "toolCall",
+			id,
+			name: "read",
+			arguments: { path: `file-${index}.txt` },
+		})),
+		api: "cursor-sdk",
+		provider: "cursor",
+		model: "composer",
+		usage,
+		stopReason: "toolUse",
+		timestamp: 2,
+	};
+	const results: ToolResultMessage[] = toolCallIds.map((toolCallId, index) => ({
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [{ type: "text", text: `result-${index}` }],
+		isError: false,
+		timestamp: 3 + index,
+	}));
+	return {
+		messages: [{ role: "user", content: "Read the files", timestamp: 1 }, assistant, ...results],
+	};
+}
+
+function getSerializedIds(context: Context): { calls: string[]; results: string[] } {
+	const messages = convertMessages(targetModel, context, compat);
+	const assistant = messages.find((message) => message.role === "assistant");
+	if (!assistant || assistant.role !== "assistant") throw new Error("Expected assistant message");
+	return {
+		calls: assistant.tool_calls?.map((call) => call.id) ?? [],
+		results: messages.filter((message) => message.role === "tool").map((message) => message.tool_call_id),
+	};
+}
+
+describe("OpenAI-compatible Chat Completions tool call ID normalization", () => {
+	it("bounds foreign IDs for custom gateways and preserves result pairing", () => {
+		const ids = [
+			"cursor-pi-bridge-run-c2417032-9686-40f2-bd3c-a763fbaa7693-tool-10",
+			`call_246256__thought__${"A+/=".repeat(1_300)}`,
+		];
+
+		const serialized = getSerializedIds(buildContext(ids));
+
+		expect(serialized.calls).toEqual(serialized.results);
+		expect(serialized.calls).toHaveLength(ids.length);
+		for (const id of serialized.calls) {
+			expect(id.length).toBeLessThanOrEqual(40);
+			expect(id).toMatch(/^[A-Za-z0-9_-]+$/);
+		}
+	});
+
+	it("keeps distinct long IDs unique instead of truncating them to the same prefix", () => {
+		const prefix = "cursor-pi-bridge-run-c2417032-9686-40f2-bd3c-a763fbaa7693-tool-";
+		const serialized = getSerializedIds(buildContext([`${prefix}10`, `${prefix}11`]));
+
+		expect(new Set(serialized.calls).size).toBe(2);
+		expect(serialized.calls).toEqual(serialized.results);
+	});
+
+	it("preserves short provider-native IDs verbatim", () => {
+		const serialized = getSerializedIds(buildContext(["call.native:1"]));
+
+		expect(serialized.calls).toEqual(["call.native:1"]);
+		expect(serialized.results).toEqual(serialized.calls);
+	});
+});


### PR DESCRIPTION
### Problem

   OpenAI-compatible gateways can route Chat Completions requests to an OpenAI Responses backend. Historical tool calls from another provider may then violate the backend's `call_id` constraints.

   For example, `pi-cursor-sdk` previously produced this 65-character ID:

   ```text
   cursor-pi-bridge-run-c2417032-9686-40f2-bd3c-a763fbaa7693-tool-10
 ```

 When replayed through a custom OpenAI-compatible provider such as LiteLLM, OpenAI rejects the request:

 ```text
   Invalid 'input[71].call_id': string too long.
   Expected a string with maximum length 64, but got a string with length 65 instead.
 ```

 openai-completions.ts already normalized pipe-separated Responses IDs and long IDs for the provider named openai. Non-pipe IDs sent through other OpenAI-compatible providers were left unchanged.

 This is related to the replay problems previously addressed in #1022 and #2328, but covers the remaining custom-gateway/Chat-Completions path.

### Change

 Normalize long historical tool-call IDs for every openai-completions target:

 - preserve short provider-native IDs verbatim;
 - sanitize long IDs to the accepted character set;
 - shorten long IDs using a bounded prefix and deterministic hash;
 - preserve uniqueness for IDs with a common prefix;
 - rely on the existing transformation map to apply the same normalized ID to the matching tool result.

 This is provider-neutral and does not add LiteLLM-specific behavior.

 ### Tests

 Added regression coverage for:

 - the observed 65-character Cursor bridge ID;
 - multi-kilobyte foreign tool-call IDs;
 - distinct long IDs sharing the same prefix;
 - matching assistant tool calls and tool results;
 - preservation of short provider-native IDs.