### PR TITLE
Add `--no-ignore` to file autocomplete so ignored files (e.g. `.env`) can be referenced with `@`

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -139,6 +139,7 @@ async function walkDirectoryWithFd(
 		"d",
 		"--follow",
 		"--hidden",
+   		"--no-ignore",
 		"--exclude",
 		".git",
 		"--exclude",


### PR DESCRIPTION
#### Summary

When `@` file autocomplete runs in the TUI, paths are enumerated with `fd`, which by default respects ignore rules (`.gitignore`, `.ignore`, etc.). As a result, files that are gitignored — most notably `.env`, private keys, and other config files that developers often *do* want to reference — never appear in the completion list.

This PR adds `--no-ignore` to the `fd` invocation in `walkDirectoryWithFd` so every file in the working tree is visible to `@` autocomplete. `.git` itself remains excluded via the existing `--exclude` arguments plus the in-code filter.

#### Motivation

Real-world case: a repo keeps `.env` in `.gitignore` (the recommended practice), yet the developer still frequently wants to reference it with `@` — e.g. `@.env` — to have the agent inspect or edit configuration. Today that's impossible: the file is invisible to the autocomplete walker. Ignored files are still real, readable files on disk; hiding them from `@` is surprising and unhelpful.

#### Changes

- `packages/tui/src/autocomplete.ts`: add `--no-ignore` to the `fd` argument list in `walkDirectoryWithFd`.

#### Compatibility / Risks

- `--no-ignore` disables **all** ignore files (`.gitignore`, `.ignore`, `.fdignore`, global gitignore), not just `.gitignore`. The completion list may now include entries from directories that were previously filtered out (e.g. `node_modules`, `vendor`). The existing `--max-results` cap still bounds the result set; if noise becomes a concern, we can scope this down to `--no-ignore-vcs` or make it configurable.
- `.git` is still excluded by both the `--exclude .git*` args and the in-code filter, so repository internals won't surface.

#### Alternatives considered

- `--no-ignore-vcs`: only ignores `.gitignore` rules while still respecting `.ignore` / `.fdignore`. This is a tighter fit if the intent is narrowly "make gitignored files visible". Happy to switch if maintainers prefer.
- Making this a user-facing option instead of hard-coding: the flag is currently always on. If maintainers would prefer a toggle (config / env var), I can wire it up.

#### Test plan

- Manually verified: in a repo where `.env` is gitignored, `@` now lists `.env`, while `.git` contents still do not appear.
