### PR TITLE
fix(coding-agent): scan past non-EXIF APP1 segments

### DIFF
--- a/packages/coding-agent/src/utils/exif-orientation.ts
+++ b/packages/coding-agent/src/utils/exif-orientation.ts
@@ -50,8 +50,7 @@ function findJpegTiffOffset(bytes: Uint8Array): number {
 			if (offset + 4 >= bytes.length) return -1;
 			const segmentStart = offset + 4;
 			if (segmentStart + 6 > bytes.length) return -1;
-			if (!hasExifHeader(bytes, segmentStart)) return -1;
-			return segmentStart + 6;
+			if (hasExifHeader(bytes, segmentStart)) return segmentStart + 6;
 		}
 
 		if (offset + 4 > bytes.length) return -1;

--- a/packages/coding-agent/test/image-processing.test.ts
+++ b/packages/coding-agent/test/image-processing.test.ts
@@ -14,6 +14,9 @@ const TINY_PNG =
 const TINY_JPEG =
 	"/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAACAAIDAREAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAVAQEBAAAAAAAAAAAAAAAAAAAGCf/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AD3VTB3/2Q==";
 
+const TINY_JPEG_2X1 =
+	"/9j/4AAQSkZJRgABAgAAAQABAAD/wAARCAABAAIDAREAAhEBAxEB/9sAQwADAgIDAgIDAwMDBAMDBAUIBQUEBAUKBwcGCAwKDAwLCgsLDQ4SEA0OEQ4LCxAWEBETFBUVFQwPFxgWFBgSFBUU/9sAQwEDBAQFBAUJBQUJFA0LDRQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD4H8Q/8h/Uv+vmX/0M1/o1wJ/ySWU/9g1D/wBNRMOM/wDkp8z/AOv9b/05I//Z";
+
 // 100x100 gray PNG
 const MEDIUM_PNG_100x100 =
 	"iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAAAAABVicqIAAAAAmJLR0QA/4ePzL8AAAAHdElNRQfqAQ4AMzkN2iH/AAAAP0lEQVRo3u3NQQEAAAQEMASXXYrz2gqst/Lm4ZBIJBKJRCKRSCQSiUQikUgkEolEIpFIJBKJRCKRSCQSiSTsAP1cAUZeKtreAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI2LTAxLTE0VDAwOjUxOjU3KzAwOjAw6crMeAAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyNi0wMS0xNFQwMDo1MTo1NyswMDowMJiXdMQAAAAodEVYdGRhdGU6dGltZXN0YW1wADIwMjYtMDEtMTRUMDA6NTE6NTcrMDA6MDDPglUbAAAAAElFTkSuQmCC";
@@ -24,6 +27,27 @@ const LARGE_PNG_200x200 =
 
 function imageBytes(base64Data: string): Uint8Array {
 	return Buffer.from(base64Data, "base64");
+}
+
+function app1Segment(payload: Uint8Array): Buffer {
+	const segment = Buffer.alloc(payload.length + 4);
+	segment[0] = 0xff;
+	segment[1] = 0xe1;
+	segment.writeUInt16BE(payload.length + 2, 2);
+	segment.set(payload, 4);
+	return segment;
+}
+
+function jpegWithXmpBeforeOrientation(): string {
+	const jpeg = Buffer.from(TINY_JPEG_2X1, "base64");
+	const xmp = app1Segment(Buffer.from('http://ns.adobe.com/xap/1.0/\0<x:xmpmeta xmlns:x="adobe:ns:meta/"/>'));
+	const orientation6 = app1Segment(
+		Buffer.concat([
+			Buffer.from("Exif\0\0"),
+			Buffer.from("49492a0008000000010012010300010000000600000000000000", "hex"),
+		]),
+	);
+	return Buffer.concat([jpeg.subarray(0, 2), xmp, orientation6, jpeg.subarray(2)]).toString("base64");
 }
 
 describe("convertToPng", () => {
@@ -46,6 +70,15 @@ describe("convertToPng", () => {
 		expect(buffer[1]).toBe(0x50); // 'P'
 		expect(buffer[2]).toBe(0x4e); // 'N'
 		expect(buffer[3]).toBe(0x47); // 'G'
+	});
+
+	it("should apply EXIF orientation after an XMP APP1 segment", async () => {
+		const result = await convertToPng(jpegWithXmpBeforeOrientation(), "image/jpeg");
+
+		expect(result).not.toBeNull();
+		const png = Buffer.from(result!.data, "base64");
+		expect(png.readUInt32BE(16)).toBe(1);
+		expect(png.readUInt32BE(20)).toBe(2);
 	});
 });
 


### PR DESCRIPTION
## Summary

- continue scanning JPEG segments when an APP1 segment is not EXIF
- preserve the existing bounds and segment-length handling
- cover an XMP-before-EXIF JPEG through `convertToPng()`

## Testing

- focused image-processing regression test
- `npm run check`
- `./test.sh`

Fixes #8571
