### PR TITLE
fix(coding-agent): stop counting trailing newline as a line in read tool (#7329)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed read tool line counts being one higher than the actual number of lines for files ending with a newline, which made truncation notices report a phantom extra line and let `offset` one past the end of file return an empty success instead of an error ([#7329](https://github.com/earendil-works/pi/issues/7329)).
-
 ## [0.84.3] - 2026-08-24
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed read tool line counts being one higher than the actual number of lines for files ending with a newline, which made truncation notices report a phantom extra line and let `offset` one past the end of file return an empty success instead of an error ([#7329](https://github.com/earendil-works/pi/issues/7329)).
+
 ## [0.84.3] - 2026-08-24
 
 ### New Features

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -273,6 +273,10 @@ export function createReadToolDefinition(
 								const buffer = await ops.readFile(absolutePath);
 								const textContent = buffer.toString("utf-8");
 								const allLines = textContent.split("\n");
+								// A trailing newline produces a phantom empty element; it is not a line.
+								if (allLines.length > 1 && allLines[allLines.length - 1] === "") {
+									allLines.pop();
+								}
 								const totalFileLines = allLines.length;
 								// Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.
 								const startLine = offset ? Math.max(0, offset - 1) : 0;

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -170,6 +170,26 @@ describe("Coding Agent Tools", () => {
 			);
 		});
 
+		it("should not count a trailing newline as an extra line", async () => {
+			const testFile = join(testDir, "trailing-newline.txt");
+			writeFileSync(testFile, "Line 1\nLine 2\nLine 3\n");
+
+			const result = await readTool.execute("test-call-trailing-newline", { path: testFile });
+			const output = getTextOutput(result);
+
+			expect(output).toBe("Line 1\nLine 2\nLine 3");
+			expect(output).not.toContain("Use offset=");
+		});
+
+		it("should show error when offset is one past the last line of a file ending with a newline", async () => {
+			const testFile = join(testDir, "trailing-newline-offset.txt");
+			writeFileSync(testFile, "Line 1\nLine 2\nLine 3\n");
+
+			await expect(
+				readTool.execute("test-call-trailing-newline-offset", { path: testFile, offset: 4 }),
+			).rejects.toThrow(/Offset 4 is beyond end of file \(3 lines total\)/);
+		});
+
 		it("should include truncation details when truncated", async () => {
 			const testFile = join(testDir, "large-file.txt");
 			const lines = Array.from({ length: 2500 }, (_, i) => `Line ${i + 1}`);


### PR DESCRIPTION
Fixes #7329

`read` splits file content with `split("\n")`, which keeps a phantom empty
element when the file ends with a newline (i.e. most files). Every reported
line count is one too high.

Three visible symptoms:
- truncation notice says "of N+1" instead of "of N"
- the continuation hint `Use offset=N+1 to continue.` points at a line that
  does not exist
- `offset = lines + 1` returns an empty success instead of erroring; the
  "beyond end of file" error also overstates the total

Why this matters beyond cosmetics: the wrong counts make the tool's output
self-inconsistent, so models that notice the mismatch spend an extra
verification round-trip on it (e.g. running `wc -l` or PowerShell to get the
real count) — wasted tokens and latency on every occurrence. Weaker models
instead trust the numbers and report wrong line counts back to the user, or
interpret the silent empty result at `offset = lines + 1` as "this line
exists but is empty". I hit this in practice: while verifying this bug, the
agent interrupted its answer to run a shell command just to double-check the
real number of lines.

Fix: drop the trailing empty element after the split, so counts match
`wc -l` semantics and the existing bounds check triggers correctly.

## Testing
- added two regression tests (full read of trailing-newline file; offset past
  EOF throws with correct total)
- existing tools.test.ts passes; the 3 failures I saw locally are pre-existing
  Windows environment issues that also fail on pristine HEAD (2x EACCES edit
  permission tests, 1x grep flag-like pattern), unrelated to this change