### PR TITLE
feat: Add eager tool execution

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -19,10 +19,174 @@ import type {
 	AgentTool,
 	AgentToolCall,
 	AgentToolResult,
+	SpeculativeToolExecutionConfig,
+	SpeculativeToolTelemetry,
 	StreamFn,
 } from "./types.ts";
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
+
+type SpeculativeRawOutcome = {
+	result: AgentToolResult<any>;
+	isError: boolean;
+	executionArgs: unknown;
+};
+
+type SpeculativeToolCandidate = {
+	toolCall: AgentToolCall;
+	tool: AgentTool<any>;
+	executionArgs: unknown;
+	fingerprint: string;
+	startedAt: number;
+	finishedAt?: number;
+	dispatchReachedAt?: number;
+	state: "running" | "completed" | "committed" | "discarded";
+	controller: AbortController;
+	promise: Promise<SpeculativeRawOutcome>;
+	reported: boolean;
+};
+
+type SpeculativeCandidateRegistry = Map<string, SpeculativeToolCandidate>;
+
+const speculativeCandidateRegistries = new WeakMap<AssistantMessage, SpeculativeCandidateRegistry>();
+
+function canonicalJson(value: unknown, ancestors = new Set<object>()): string {
+	if (value === null) return "null";
+	if (typeof value === "string" || typeof value === "boolean") return JSON.stringify(value);
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) throw new Error("Non-finite numbers are not JSON values");
+		return JSON.stringify(value);
+	}
+	if (Array.isArray(value)) {
+		if (ancestors.has(value)) throw new Error("Circular values are not JSON values");
+		ancestors.add(value);
+		try {
+			return `[${value.map((entry) => canonicalJson(entry, ancestors)).join(",")}]`;
+		} finally {
+			ancestors.delete(value);
+		}
+	}
+	if (
+		typeof value !== "object" ||
+		value === null ||
+		Array.isArray(value) ||
+		Object.getPrototypeOf(value) !== Object.prototype
+	) {
+		throw new Error("Non-JSON value");
+	}
+	const objectValue = value as Record<string, unknown>;
+	if (ancestors.has(objectValue)) throw new Error("Circular values are not JSON values");
+	ancestors.add(objectValue);
+	try {
+		return `{${Object.keys(objectValue)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${canonicalJson(objectValue[key], ancestors)}`)
+			.join(",")}}`;
+	} finally {
+		ancestors.delete(objectValue);
+	}
+}
+
+function createExecutionFingerprint(toolCall: AgentToolCall, executionArgs: unknown): string {
+	return canonicalJson({ name: toolCall.name, args: executionArgs });
+}
+
+function emitSpeculationTelemetry(config: SpeculativeToolExecutionConfig, telemetry: SpeculativeToolTelemetry): void {
+	try {
+		config.onTelemetry?.(telemetry);
+	} catch {
+		// Observability must not affect agent execution.
+	}
+	console.debug("speculative-tool-execution", {
+		toolCallId: telemetry.toolCallId,
+		toolName: telemetry.toolName,
+		outcome: telemetry.outcome,
+		reason: telemetry.reason,
+		executionDurationMs: telemetry.executionDurationMs,
+		overlapMs: telemetry.overlapMs,
+	});
+}
+
+function reportCandidate(
+	config: SpeculativeToolExecutionConfig,
+	candidate: SpeculativeToolCandidate,
+	outcome: Exclude<SpeculativeToolTelemetry["outcome"], "ineligible">,
+	reason?: string,
+): void {
+	if (candidate.reported) return;
+	candidate.reported = true;
+	const executionDurationMs =
+		candidate.finishedAt === undefined ? undefined : candidate.finishedAt - candidate.startedAt;
+	const overlapMs =
+		outcome === "committed" && executionDurationMs !== undefined && candidate.dispatchReachedAt !== undefined
+			? Math.min(executionDurationMs, Math.max(0, candidate.dispatchReachedAt - candidate.startedAt))
+			: undefined;
+	emitSpeculationTelemetry(config, {
+		toolName: candidate.tool.name,
+		toolCallId: candidate.toolCall.id,
+		candidateStartedAt: candidate.startedAt,
+		candidateFinishedAt: candidate.finishedAt,
+		dispatchReachedAt: candidate.dispatchReachedAt,
+		outcome,
+		reason,
+		executionDurationMs,
+		overlapMs,
+	});
+}
+
+function reportIneligibleCandidate(
+	config: SpeculativeToolExecutionConfig,
+	toolCall: AgentToolCall,
+	reason: string,
+): void {
+	emitSpeculationTelemetry(config, {
+		toolName: toolCall.name,
+		toolCallId: toolCall.id,
+		outcome: "ineligible",
+		reason,
+	});
+}
+
+function createCandidateSignal(
+	runSignal: AbortSignal | undefined,
+	controller: AbortController,
+): { signal: AbortSignal; dispose: () => void } {
+	const abort = () => controller.abort();
+	if (runSignal?.aborted) {
+		abort();
+		return { signal: controller.signal, dispose: () => {} };
+	}
+	runSignal?.addEventListener("abort", abort, { once: true });
+	return {
+		signal: controller.signal,
+		dispose: () => runSignal?.removeEventListener("abort", abort),
+	};
+}
+
+function discardCandidate(
+	config: SpeculativeToolExecutionConfig,
+	candidate: SpeculativeToolCandidate,
+	outcome: "discarded" | "fingerprint_mismatch" | "aborted",
+	reason: string,
+): void {
+	if (candidate.reported || candidate.state === "committed") return;
+	candidate.state = "discarded";
+	candidate.controller.abort();
+	reportCandidate(config, candidate, outcome, reason);
+}
+
+function discardAllCandidates(
+	config: SpeculativeToolExecutionConfig,
+	registry: SpeculativeCandidateRegistry | undefined,
+	reason: string,
+	outcome: "discarded" | "aborted" = "discarded",
+): void {
+	if (!registry) return;
+	for (const candidate of registry.values()) {
+		discardCandidate(config, candidate, outcome, reason);
+	}
+	registry.clear();
+}
 
 /**
  * Start an agent loop with a new prompt message.
@@ -285,90 +449,137 @@ async function streamAssistantResponse(
 	emit: AgentEventSink,
 	streamFunction: StreamFn,
 ): Promise<AssistantMessage> {
-	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
 		messages = await config.transformContext(messages, signal);
 	}
 
-	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
 	const llmMessages = await config.convertToLlm(messages);
-
-	// Build LLM context
 	const llmContext: Context = {
 		systemPrompt: context.systemPrompt,
 		messages: llmMessages,
 		tools: context.tools,
 	};
-
-	// Resolve API key (important for expiring tokens)
 	const resolvedApiKey =
 		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
-
 	const response = await streamFunction(config.model, llmContext, {
 		...config,
 		apiKey: resolvedApiKey,
 		signal,
 	});
-
+	const speculationConfig =
+		config.speculativeToolExecution?.enabled === true ? config.speculativeToolExecution : undefined;
+	const candidates = speculationConfig ? new Map<string, SpeculativeToolCandidate>() : undefined;
+	let speculationBarrier = false;
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;
+	let completed = false;
 
-	for await (const event of response) {
-		switch (event.type) {
-			case "start":
-				partialMessage = event.partial;
-				context.messages.push(partialMessage);
-				addedPartial = true;
-				await emit({ type: "message_start", message: { ...partialMessage } });
+	try {
+		let finalMessage: AssistantMessage | undefined;
+		for await (const event of response) {
+			if (event.type === "done" || event.type === "error") {
+				finalMessage = await response.result();
 				break;
+			}
 
-			case "text_start":
-			case "text_delta":
-			case "text_end":
-			case "thinking_start":
-			case "thinking_delta":
-			case "thinking_end":
-			case "toolcall_start":
-			case "toolcall_delta":
-			case "toolcall_end":
-				if (partialMessage) {
+			switch (event.type) {
+				case "start":
 					partialMessage = event.partial;
-					context.messages[context.messages.length - 1] = partialMessage;
-					await emit({
-						type: "message_update",
-						assistantMessageEvent: event,
-						message: { ...partialMessage },
-					});
-				}
-				break;
+					context.messages.push(partialMessage);
+					addedPartial = true;
+					await emit({ type: "message_start", message: { ...partialMessage } });
+					break;
 
-			case "done":
-			case "error": {
-				const finalMessage = await response.result();
-				if (addedPartial) {
-					context.messages[context.messages.length - 1] = finalMessage;
-				} else {
-					context.messages.push(finalMessage);
-				}
-				if (!addedPartial) {
-					await emit({ type: "message_start", message: { ...finalMessage } });
-				}
-				await emit({ type: "message_end", message: finalMessage });
-				return finalMessage;
+				case "text_start":
+				case "text_delta":
+				case "text_end":
+				case "thinking_start":
+				case "thinking_delta":
+				case "thinking_end":
+				case "toolcall_start":
+				case "toolcall_delta":
+					if (partialMessage) {
+						partialMessage = event.partial;
+						context.messages[context.messages.length - 1] = partialMessage;
+						await emit({
+							type: "message_update",
+							assistantMessageEvent: event,
+							message: { ...partialMessage },
+						});
+					}
+					break;
+
+				case "toolcall_end":
+					if (partialMessage) {
+						partialMessage = event.partial;
+						context.messages[context.messages.length - 1] = partialMessage;
+						await emit({
+							type: "message_update",
+							assistantMessageEvent: event,
+							message: { ...partialMessage },
+						});
+					}
+					if (speculationConfig && candidates) {
+						if (speculationBarrier) {
+							reportIneligibleCandidate(speculationConfig, event.toolCall, "preceding speculation barrier");
+						} else {
+							const eligible = await maybeStartSpeculativeCandidate(
+								context,
+								event.toolCall,
+								config,
+								signal,
+								candidates,
+							);
+							if (!eligible) speculationBarrier = true;
+						}
+					}
+					break;
 			}
 		}
-	}
 
-	const finalMessage = await response.result();
-	if (addedPartial) {
-		context.messages[context.messages.length - 1] = finalMessage;
-	} else {
-		context.messages.push(finalMessage);
-		await emit({ type: "message_start", message: { ...finalMessage } });
+		const settledMessage = finalMessage ?? (await response.result());
+		if (addedPartial) {
+			context.messages[context.messages.length - 1] = settledMessage;
+		} else {
+			context.messages.push(settledMessage);
+			await emit({ type: "message_start", message: { ...settledMessage } });
+		}
+
+		if (speculationConfig && candidates) {
+			if (
+				signal?.aborted ||
+				settledMessage.stopReason === "error" ||
+				settledMessage.stopReason === "aborted" ||
+				settledMessage.stopReason === "length"
+			) {
+				discardAllCandidates(
+					speculationConfig,
+					candidates,
+					signal?.aborted ? "run aborted" : `final message stop reason: ${settledMessage.stopReason}`,
+					signal?.aborted ? "aborted" : "discarded",
+				);
+			} else {
+				reconcileSpeculativeCandidates(settledMessage, candidates, speculationConfig, context);
+				if (candidates.size > 0) {
+					speculativeCandidateRegistries.set(settledMessage, candidates);
+				}
+			}
+		}
+
+		await emit({ type: "message_end", message: settledMessage });
+		completed = true;
+		return settledMessage;
+	} finally {
+		if (!completed && speculationConfig) {
+			discardAllCandidates(
+				speculationConfig,
+				candidates,
+				signal?.aborted ? "run aborted" : "stream did not produce a runnable message",
+				signal?.aborted ? "aborted" : "discarded",
+			);
+		}
 	}
-	await emit({ type: "message_end", message: finalMessage });
-	return finalMessage;
 }
 
 /**
@@ -416,13 +627,15 @@ async function executeToolCalls(
 	emit: AgentEventSink,
 ): Promise<ExecutedToolCallBatch> {
 	const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
+	const candidates = speculativeCandidateRegistries.get(assistantMessage);
+	speculativeCandidateRegistries.delete(assistantMessage);
 	const hasSequentialToolCall = toolCalls.some(
 		(tc) => currentContext.tools?.find((t) => t.name === tc.name)?.executionMode === "sequential",
 	);
 	if (config.toolExecution === "sequential" || hasSequentialToolCall) {
-		return executeToolCallsSequential(currentContext, assistantMessage, toolCalls, config, signal, emit);
+		return executeToolCallsSequential(currentContext, assistantMessage, toolCalls, config, signal, emit, candidates);
 	}
-	return executeToolCallsParallel(currentContext, assistantMessage, toolCalls, config, signal, emit);
+	return executeToolCallsParallel(currentContext, assistantMessage, toolCalls, config, signal, emit, candidates);
 }
 
 type ExecutedToolCallBatch = {
@@ -437,6 +650,7 @@ async function executeToolCallsSequential(
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
+	candidates: SpeculativeCandidateRegistry | undefined,
 ): Promise<ExecutedToolCallBatch> {
 	const finalizedCalls: FinalizedToolCallOutcome[] = [];
 	const messages: ToolResultMessage[] = [];
@@ -458,7 +672,7 @@ async function executeToolCallsSequential(
 				isError: preparation.isError,
 			};
 		} else {
-			const executed = await executePreparedToolCall(preparation, signal, emit);
+			const executed = await executePreparedToolCall(preparation, signal, emit, candidates, config);
 			finalized = await finalizeExecutedToolCall(
 				currentContext,
 				assistantMessage,
@@ -493,6 +707,7 @@ async function executeToolCallsParallel(
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
+	candidates: SpeculativeCandidateRegistry | undefined,
 ): Promise<ExecutedToolCallBatch> {
 	const finalizedCalls: FinalizedToolCallEntry[] = [];
 
@@ -520,7 +735,7 @@ async function executeToolCallsParallel(
 		}
 
 		finalizedCalls.push(async () => {
-			const executed = await executePreparedToolCall(preparation, signal, emit);
+			const executed = await executePreparedToolCall(preparation, signal, emit, candidates, config);
 			const finalized = await finalizeExecutedToolCall(
 				currentContext,
 				assistantMessage,
@@ -597,14 +812,11 @@ function prepareToolCallArguments(tool: AgentTool<any>, toolCall: AgentToolCall)
 	};
 }
 
-async function prepareToolCall(
+function prepareToolCallWithoutHook(
 	currentContext: AgentContext,
-	assistantMessage: AssistantMessage,
 	toolCall: AgentToolCall,
-	config: AgentLoopConfig,
-	signal: AbortSignal | undefined,
-): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
-	const tool = currentContext.tools?.find((t) => t.name === toolCall.name);
+): PreparedToolCall | ImmediateToolCallOutcome {
+	const tool = currentContext.tools?.find((candidate) => candidate.name === toolCall.name);
 	if (!tool) {
 		return {
 			kind: "immediate",
@@ -615,48 +827,11 @@ async function prepareToolCall(
 
 	try {
 		const preparedToolCall = prepareToolCallArguments(tool, toolCall);
-		const validatedArgs = validateToolArguments(tool, preparedToolCall);
-		if (config.beforeToolCall) {
-			const beforeResult = await config.beforeToolCall(
-				{
-					assistantMessage,
-					toolCall,
-					args: validatedArgs,
-					context: currentContext,
-				},
-				signal,
-			);
-			if (signal?.aborted) {
-				return {
-					kind: "immediate",
-					result: createErrorToolResult("Operation aborted"),
-					isError: true,
-				};
-			}
-			if (beforeResult?.block) {
-				const result = createErrorToolResult(beforeResult.reason || "Tool execution was blocked");
-				if (beforeResult.terminate === true) {
-					result.terminate = true;
-				}
-				return {
-					kind: "immediate",
-					result,
-					isError: true,
-				};
-			}
-		}
-		if (signal?.aborted) {
-			return {
-				kind: "immediate",
-				result: createErrorToolResult("Operation aborted"),
-				isError: true,
-			};
-		}
 		return {
 			kind: "prepared",
 			toolCall,
 			tool,
-			args: validatedArgs,
+			args: validateToolArguments(tool, preparedToolCall),
 		};
 	} catch (error) {
 		return {
@@ -667,46 +842,279 @@ async function prepareToolCall(
 	}
 }
 
+async function prepareToolCall(
+	currentContext: AgentContext,
+	assistantMessage: AssistantMessage,
+	toolCall: AgentToolCall,
+	config: AgentLoopConfig,
+	signal: AbortSignal | undefined,
+): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
+	const preparation = prepareToolCallWithoutHook(currentContext, toolCall);
+	if (preparation.kind === "immediate") return preparation;
+
+	if (config.beforeToolCall) {
+		const beforeResult = await config.beforeToolCall(
+			{
+				assistantMessage,
+				toolCall,
+				args: preparation.args,
+				context: currentContext,
+			},
+			signal,
+		);
+		if (signal?.aborted) {
+			return {
+				kind: "immediate",
+				result: createErrorToolResult("Operation aborted"),
+				isError: true,
+			};
+		}
+		if (beforeResult?.block) {
+			const result = createErrorToolResult(beforeResult.reason || "Tool execution was blocked");
+			if (beforeResult.terminate === true) {
+				result.terminate = true;
+			}
+			return {
+				kind: "immediate",
+				result,
+				isError: true,
+			};
+		}
+	}
+	if (signal?.aborted) {
+		return {
+			kind: "immediate",
+			result: createErrorToolResult("Operation aborted"),
+			isError: true,
+		};
+	}
+	return preparation;
+}
+
+async function executePreparedToolRaw(
+	prepared: PreparedToolCall,
+	signal: AbortSignal | undefined,
+	onUpdate: (partialResult: AgentToolResult<any>) => void,
+): Promise<SpeculativeRawOutcome> {
+	try {
+		const result = await prepared.tool.execute(prepared.toolCall.id, prepared.args as never, signal, onUpdate);
+		return { result, isError: false, executionArgs: prepared.args };
+	} catch (error) {
+		return {
+			result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
+			isError: true,
+			executionArgs: prepared.args,
+		};
+	}
+}
+
+async function maybeStartSpeculativeCandidate(
+	currentContext: AgentContext,
+	toolCall: AgentToolCall,
+	config: AgentLoopConfig,
+	signal: AbortSignal | undefined,
+	registry: SpeculativeCandidateRegistry,
+): Promise<boolean> {
+	const speculationConfig = config.speculativeToolExecution as SpeculativeToolExecutionConfig;
+	if (signal?.aborted) {
+		reportIneligibleCandidate(speculationConfig, toolCall, "run aborted");
+		return false;
+	}
+	if (config.toolExecution === "sequential") {
+		reportIneligibleCandidate(speculationConfig, toolCall, "sequential tool execution");
+		return false;
+	}
+	const maxInFlight =
+		typeof speculationConfig.maxInFlight === "number" && Number.isFinite(speculationConfig.maxInFlight)
+			? Math.max(1, Math.floor(speculationConfig.maxInFlight))
+			: 2;
+	if (registry.size >= maxInFlight) {
+		reportIneligibleCandidate(speculationConfig, toolCall, "speculation capacity exhausted");
+		return false;
+	}
+	const tool = currentContext.tools?.find((candidate) => candidate.name === toolCall.name);
+	if (!tool) {
+		reportIneligibleCandidate(speculationConfig, toolCall, "tool not directly advertised");
+		return false;
+	}
+	if (tool.executionMode === "sequential") {
+		reportIneligibleCandidate(speculationConfig, toolCall, "sequential tool");
+		return false;
+	}
+	if (!tool.speculation || tool.speculation.safe !== true) {
+		reportIneligibleCandidate(speculationConfig, toolCall, "tool is not speculation-safe");
+		return false;
+	}
+	if (config.beforeToolCall) {
+		reportIneligibleCandidate(speculationConfig, toolCall, "beforeToolCall is configured");
+		return false;
+	}
+	const preparation = prepareToolCallWithoutHook(currentContext, toolCall);
+	if (preparation.kind === "immediate") {
+		reportIneligibleCandidate(speculationConfig, toolCall, "tool arguments could not be prepared");
+		return false;
+	}
+	if (typeof preparation.args !== "object" || preparation.args === null || Array.isArray(preparation.args)) {
+		reportIneligibleCandidate(speculationConfig, toolCall, "validated arguments are not an object");
+		return false;
+	}
+	let fingerprint: string;
+	try {
+		fingerprint = createExecutionFingerprint(toolCall, preparation.args);
+	} catch {
+		reportIneligibleCandidate(speculationConfig, toolCall, "execution arguments are not canonical JSON");
+		return false;
+	}
+	try {
+		if (
+			tool.speculation.canExecute &&
+			!(await tool.speculation.canExecute({
+				toolCall,
+				args: preparation.args as Record<string, unknown>,
+			}))
+		) {
+			reportIneligibleCandidate(speculationConfig, toolCall, "tool speculation policy vetoed execution");
+			return false;
+		}
+		if (speculationConfig.canExecute && !(await speculationConfig.canExecute(tool, toolCall))) {
+			reportIneligibleCandidate(speculationConfig, toolCall, "host speculation policy vetoed execution");
+			return false;
+		}
+	} catch {
+		reportIneligibleCandidate(speculationConfig, toolCall, "speculation policy failed");
+		return false;
+	}
+
+	const controller = new AbortController();
+	const candidateSignal = createCandidateSignal(signal, controller);
+	const startedAt = Date.now();
+	let candidate: SpeculativeToolCandidate;
+	const promise = executePreparedToolRaw(preparation, candidateSignal.signal, () => {}).then((outcome) => {
+		candidateSignal.dispose();
+		candidate.finishedAt = Date.now();
+		if (candidate.state === "running") candidate.state = "completed";
+		return outcome;
+	});
+	candidate = {
+		toolCall,
+		tool,
+		executionArgs: preparation.args,
+		fingerprint,
+		startedAt,
+		state: "running",
+		controller,
+		promise,
+		reported: false,
+	};
+	registry.set(toolCall.id, candidate);
+	return true;
+}
+
+function takeMatchingCandidate(
+	prepared: PreparedToolCall,
+	registry: SpeculativeCandidateRegistry | undefined,
+	speculationConfig: SpeculativeToolExecutionConfig | undefined,
+): SpeculativeToolCandidate | undefined {
+	const candidate = registry?.get(prepared.toolCall.id);
+	if (!candidate || !speculationConfig) return undefined;
+	registry?.delete(prepared.toolCall.id);
+	candidate.dispatchReachedAt = Date.now();
+	let fingerprint: string;
+	try {
+		fingerprint = createExecutionFingerprint(prepared.toolCall, prepared.args);
+	} catch {
+		discardCandidate(
+			speculationConfig,
+			candidate,
+			"fingerprint_mismatch",
+			"final execution arguments are not canonical JSON",
+		);
+		return undefined;
+	}
+	if (candidate.fingerprint !== fingerprint) {
+		discardCandidate(speculationConfig, candidate, "fingerprint_mismatch", "final execution arguments changed");
+		return undefined;
+	}
+	if (candidate.state === "discarded") return undefined;
+	candidate.state = "committed";
+	return candidate;
+}
+
+function reconcileSpeculativeCandidates(
+	assistantMessage: AssistantMessage,
+	registry: SpeculativeCandidateRegistry,
+	config: SpeculativeToolExecutionConfig,
+	context: AgentContext,
+): void {
+	for (const [toolCallId, candidate] of registry) {
+		const finalToolCall = assistantMessage.content.find(
+			(content): content is AgentToolCall => content.type === "toolCall" && content.id === toolCallId,
+		);
+		if (!finalToolCall) {
+			registry.delete(toolCallId);
+			discardCandidate(config, candidate, "discarded", "final message removed tool call");
+			continue;
+		}
+		const preparation = prepareToolCallWithoutHook(context, finalToolCall);
+		if (preparation.kind === "immediate") {
+			registry.delete(toolCallId);
+			discardCandidate(config, candidate, "fingerprint_mismatch", "final tool call could not be prepared");
+			continue;
+		}
+		try {
+			if (candidate.fingerprint === createExecutionFingerprint(finalToolCall, preparation.args)) continue;
+		} catch {
+			// The mismatch path below aborts the candidate and preserves ordinary dispatch.
+		}
+		registry.delete(toolCallId);
+		discardCandidate(config, candidate, "fingerprint_mismatch", "final execution arguments changed");
+	}
+}
+
 async function executePreparedToolCall(
 	prepared: PreparedToolCall,
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
+	candidates: SpeculativeCandidateRegistry | undefined,
+	config: AgentLoopConfig,
 ): Promise<ExecutedToolCallOutcome> {
+	const candidate = takeMatchingCandidate(prepared, candidates, config.speculativeToolExecution);
+	if (candidate) {
+		const outcome = await candidate.promise;
+		reportCandidate(
+			config.speculativeToolExecution as SpeculativeToolExecutionConfig,
+			candidate,
+			signal?.aborted ? "aborted" : "committed",
+			signal?.aborted ? "run aborted before candidate commit" : undefined,
+		);
+		return outcome;
+	}
+
 	const updateEvents: Promise<void>[] = [];
 	let acceptingUpdates = true;
-
-	try {
-		const result = await prepared.tool.execute(
-			prepared.toolCall.id,
-			prepared.args as never,
-			signal,
-			(partialResult) => {
-				if (!acceptingUpdates) return;
-				updateEvents.push(
-					Promise.resolve(
-						emit({
-							type: "tool_execution_update",
-							toolCallId: prepared.toolCall.id,
-							toolName: prepared.toolCall.name,
-							args: prepared.toolCall.arguments,
-							partialResult,
-						}),
-					),
-				);
-			},
+	const outcome = await executePreparedToolRaw(prepared, signal, (partialResult) => {
+		if (!acceptingUpdates) return;
+		updateEvents.push(
+			Promise.resolve(
+				emit({
+					type: "tool_execution_update",
+					toolCallId: prepared.toolCall.id,
+					toolName: prepared.toolCall.name,
+					args: prepared.toolCall.arguments,
+					partialResult,
+				}),
+			),
 		);
-		acceptingUpdates = false;
+	});
+	acceptingUpdates = false;
+	try {
 		await Promise.all(updateEvents);
-		return { result, isError: false };
+		return outcome;
 	} catch (error) {
-		acceptingUpdates = false;
-		await Promise.all(updateEvents);
 		return {
 			result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
 			isError: true,
 		};
-	} finally {
-		acceptingUpdates = false;
 	}
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -120,6 +120,7 @@ export interface AgentOptions {
 	transport?: Transport;
 	maxRetryDelayMs?: number;
 	toolExecution?: ToolExecutionMode;
+	speculativeToolExecution?: AgentLoopConfig["speculativeToolExecution"];
 }
 
 class PendingMessageQueue {
@@ -212,6 +213,7 @@ export class Agent {
 	public maxRetryDelayMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
+	private readonly speculativeToolExecution?: AgentLoopConfig["speculativeToolExecution"];
 
 	constructor(options: AgentOptions) {
 		// Older compiled consumers may omit options or streamFn even though the current API requires them.
@@ -235,6 +237,7 @@ export class Agent {
 		this.transport = runtimeOptions.transport ?? "auto";
 		this.maxRetryDelayMs = runtimeOptions.maxRetryDelayMs;
 		this.toolExecution = runtimeOptions.toolExecution ?? "parallel";
+		this.speculativeToolExecution = runtimeOptions.speculativeToolExecution;
 	}
 
 	/**
@@ -455,6 +458,7 @@ export class Agent {
 			thinkingBudgets: this.thinkingBudgets,
 			maxRetryDelayMs: this.maxRetryDelayMs,
 			toolExecution: this.toolExecution,
+			speculativeToolExecution: this.speculativeToolExecution,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
 			shouldStopAfterTurn: shouldStopAfterTurn

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -53,6 +53,48 @@ export type QueueMode = "all" | "one-at-a-time";
 export type AgentToolCall = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
 
 /**
+ * Immutable call data provided to a tool-owned speculation policy.
+ *
+ * `args` are the validated arguments that would be passed to `execute()`.
+ */
+export interface ToolSpeculationContext {
+	toolCall: AgentToolCall;
+	args: Record<string, unknown>;
+}
+
+/**
+ * Explicit opt-in for physical execution before the provider response finishes.
+ *
+ * A speculative result remains invisible until ordinary tool dispatch commits it.
+ */
+export interface ToolSpeculationPolicy {
+	safe: true;
+	mode?: "finalized";
+	canExecute?: (context: ToolSpeculationContext) => boolean | Promise<boolean>;
+}
+
+/** Diagnostic information for one speculative execution candidate. */
+export interface SpeculativeToolTelemetry {
+	toolName: string;
+	toolCallId: string;
+	candidateStartedAt?: number;
+	candidateFinishedAt?: number;
+	dispatchReachedAt?: number;
+	outcome: "committed" | "discarded" | "ineligible" | "fingerprint_mismatch" | "aborted";
+	reason?: string;
+	executionDurationMs?: number;
+	overlapMs?: number;
+}
+
+/** Opt-in configuration for finalized, discard-safe tool execution. */
+export interface SpeculativeToolExecutionConfig {
+	enabled: boolean;
+	maxInFlight?: number;
+	canExecute?: (tool: AgentTool, toolCall: AgentToolCall) => boolean | Promise<boolean>;
+	onTelemetry?: (event: SpeculativeToolTelemetry) => void;
+}
+
+/**
  * Result returned from `beforeToolCall`.
  *
  * Returning `{ block: true }` prevents the tool from executing. The loop emits an error tool result instead.
@@ -265,6 +307,14 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 *
 	 * Default: "parallel"
 	 */
+
+	/**
+	 * Opt-in speculative execution for finalized, discard-safe tool calls.
+	 *
+	 * Disabled by default. Candidates do not emit normal tool lifecycle events or
+	 * alter the transcript until ordinary dispatch commits their result.
+	 */
+	speculativeToolExecution?: SpeculativeToolExecutionConfig;
 	toolExecution?: ToolExecutionMode;
 
 	/**
@@ -406,6 +456,12 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 	 * If omitted, the default execution mode applies.
 	 */
 	executionMode?: ToolExecutionMode;
+
+	/**
+	 * Opt-in declaration that this tool may be physically executed after its
+	 * streamed call arguments are finalized, before ordinary dispatch commits it.
+	 */
+	speculation?: ToolSpeculationPolicy;
 }
 
 /** Context snapshot passed into the low-level agent loop. */

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -10,7 +10,14 @@ import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { agentLoop, agentLoopContinue } from "../src/agent-loop.ts";
 import { setDefaultStreamFn } from "../src/index.ts";
-import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
+import type {
+	AgentContext,
+	AgentEvent,
+	AgentLoopConfig,
+	AgentMessage,
+	AgentTool,
+	AgentToolCall,
+} from "../src/types.ts";
 
 // Mock stream for testing - mimics MockAssistantStream
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -1603,5 +1610,229 @@ describe("agentLoopContinue with AgentMessage", () => {
 		const messages = await stream.result();
 		expect(messages.length).toBe(1);
 		expect(messages[0].role).toBe("assistant");
+	});
+});
+
+describe("speculative tool execution", () => {
+	it("starts after toolcall_end, commits exactly once, and preserves lifecycle events", async () => {
+		const schema = Type.Object({ value: Type.String() });
+		let signalStarted = () => {};
+		const started = new Promise<void>((resolve) => {
+			signalStarted = resolve;
+		});
+		let releaseExecution = () => {};
+		const release = new Promise<void>((resolve) => {
+			releaseExecution = resolve;
+		});
+		const telemetry: Array<{ outcome: string; overlapMs?: number }> = [];
+		let executions = 0;
+		const tool: AgentTool<typeof schema, { value: string }> = {
+			name: "sleep_read",
+			label: "Sleep read",
+			description: "Discard-safe controlled read",
+			parameters: schema,
+			speculation: { safe: true, mode: "finalized" },
+			async execute(_toolCallId, params) {
+				executions++;
+				signalStarted();
+				await release;
+				return { content: [{ type: "text", text: params.value }], details: { value: params.value } };
+			},
+		};
+		const call: AgentToolCall = {
+			type: "toolCall",
+			id: "speculative-1",
+			name: "sleep_read",
+			arguments: { value: "early" },
+		};
+		const partial = createAssistantMessage([call], "toolUse");
+		const firstResponse = new MockAssistantStream();
+		let providerCalls = 0;
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(
+			[createUserMessage("read")],
+			{ systemPrompt: "", messages: [], tools: [tool] },
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				speculativeToolExecution: { enabled: true, onTelemetry: (event) => telemetry.push(event) },
+			},
+			undefined,
+			() => {
+				providerCalls++;
+				if (providerCalls === 1) return firstResponse;
+				const response = new MockAssistantStream();
+				queueMicrotask(() => {
+					response.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					});
+				});
+				return response;
+			},
+		);
+		const consume = (async () => {
+			for await (const event of stream) events.push(event);
+		})();
+
+		firstResponse.push({ type: "start", partial });
+		firstResponse.push({ type: "toolcall_end", contentIndex: 0, toolCall: call, partial });
+		await started;
+		expect(executions).toBe(1);
+		expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(0);
+
+		firstResponse.push({ type: "done", reason: "toolUse", message: partial });
+		await Promise.resolve();
+		releaseExecution();
+		const messages = await stream.result();
+		await consume;
+
+		expect(executions).toBe(1);
+		expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(1);
+		expect(events.filter((event) => event.type === "tool_execution_end")).toHaveLength(1);
+		expect(messages.filter((message) => message.role === "toolResult")).toHaveLength(1);
+		expect(telemetry).toContainEqual(expect.objectContaining({ outcome: "committed" }));
+	});
+
+	it("enforces barriers and re-executes only a changed final fingerprint", async () => {
+		const schema = Type.Object({ value: Type.String() });
+		const starts: string[] = [];
+		const telemetry: Array<{ outcome: string }> = [];
+		let signalCandidatesStarted = () => {};
+		const candidatesStarted = new Promise<void>((resolve) => {
+			signalCandidatesStarted = resolve;
+		});
+		const safeTool: AgentTool<typeof schema, { value: string }> = {
+			name: "safe",
+			label: "Safe",
+			description: "Discard-safe test tool",
+			parameters: schema,
+			speculation: { safe: true },
+			async execute(_toolCallId, params) {
+				starts.push(`safe:${params.value}`);
+				if (starts.length === 2) signalCandidatesStarted();
+				return { content: [{ type: "text", text: params.value }], details: { value: params.value } };
+			},
+		};
+		const unsafeTool: AgentTool<typeof schema, { value: string }> = {
+			name: "unsafe",
+			label: "Unsafe",
+			description: "Unsafe test tool",
+			parameters: schema,
+			executionMode: "sequential",
+			async execute(_toolCallId, params) {
+				starts.push(`unsafe:${params.value}`);
+				return { content: [{ type: "text", text: params.value }], details: { value: params.value } };
+			},
+		};
+		const initialCalls: AgentToolCall[] = [
+			{ type: "toolCall", id: "safe-a", name: "safe", arguments: { value: "a" } },
+			{ type: "toolCall", id: "safe-b", name: "safe", arguments: { value: "b" } },
+			{ type: "toolCall", id: "unsafe-c", name: "unsafe", arguments: { value: "c" } },
+			{ type: "toolCall", id: "safe-d", name: "safe", arguments: { value: "d" } },
+		];
+		const partial = createAssistantMessage(initialCalls, "toolUse");
+		const firstResponse = new MockAssistantStream();
+		let providerCalls = 0;
+		const stream = agentLoop(
+			[createUserMessage("read")],
+			{ systemPrompt: "", messages: [], tools: [safeTool, unsafeTool] },
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				speculativeToolExecution: { enabled: true, maxInFlight: 2, onTelemetry: (event) => telemetry.push(event) },
+			},
+			undefined,
+			() => {
+				providerCalls++;
+				if (providerCalls === 1) return firstResponse;
+				const response = new MockAssistantStream();
+				queueMicrotask(() => {
+					response.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					});
+				});
+				return response;
+			},
+		);
+
+		firstResponse.push({ type: "start", partial });
+		for (const [contentIndex, toolCall] of initialCalls.entries()) {
+			firstResponse.push({ type: "toolcall_end", contentIndex, toolCall, partial });
+		}
+		await candidatesStarted;
+		expect(starts).toEqual(["safe:a", "safe:b"]);
+
+		const finalCalls = initialCalls.map((toolCall) =>
+			toolCall.id === "safe-b" ? { ...toolCall, arguments: { value: "changed" } } : toolCall,
+		);
+		firstResponse.push({
+			type: "done",
+			reason: "toolUse",
+			message: createAssistantMessage(finalCalls, "toolUse"),
+		});
+		await stream.result();
+
+		expect(starts).toEqual(["safe:a", "safe:b", "safe:changed", "unsafe:c", "safe:d"]);
+		expect(telemetry).toContainEqual(expect.objectContaining({ outcome: "fingerprint_mismatch" }));
+	});
+
+	it("leaves unmarked tools disabled until ordinary dispatch", async () => {
+		const schema = Type.Object({ value: Type.String() });
+		let executions = 0;
+		const tool: AgentTool<typeof schema, { value: string }> = {
+			name: "unmarked",
+			label: "Unmarked",
+			description: "No speculation declaration",
+			parameters: schema,
+			async execute(_toolCallId, params) {
+				executions++;
+				return { content: [{ type: "text", text: params.value }], details: { value: params.value } };
+			},
+		};
+		const call: AgentToolCall = {
+			type: "toolCall",
+			id: "unmarked-1",
+			name: "unmarked",
+			arguments: { value: "ordinary" },
+		};
+		const partial = createAssistantMessage([call], "toolUse");
+		const firstResponse = new MockAssistantStream();
+		let providerCalls = 0;
+		const stream = agentLoop(
+			[createUserMessage("run")],
+			{ systemPrompt: "", messages: [], tools: [tool] },
+			{
+				model: createModel(),
+				convertToLlm: identityConverter,
+				speculativeToolExecution: { enabled: true },
+			},
+			undefined,
+			() => {
+				providerCalls++;
+				if (providerCalls === 1) return firstResponse;
+				const response = new MockAssistantStream();
+				queueMicrotask(() => {
+					response.push({
+						type: "done",
+						reason: "stop",
+						message: createAssistantMessage([{ type: "text", text: "done" }]),
+					});
+				});
+				return response;
+			},
+		);
+
+		firstResponse.push({ type: "start", partial });
+		firstResponse.push({ type: "toolcall_end", contentIndex: 0, toolCall: call, partial });
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(executions).toBe(0);
+		firstResponse.push({ type: "done", reason: "toolUse", message: partial });
+		await stream.result();
+		expect(executions).toBe(1);
 	});
 });

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -14,6 +14,7 @@ import type {
 	AgentToolUpdateCallback,
 	ThinkingLevel,
 	ToolExecutionMode,
+	ToolSpeculationPolicy,
 } from "@earendil-works/pi-agent-core";
 import type {
 	Api,
@@ -477,6 +478,9 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	 * If omitted, the default execution mode applies.
 	 */
 	executionMode?: ToolExecutionMode;
+
+	/** Explicit opt-in for finalized, discard-safe speculative execution. */
+	speculation?: ToolSpeculationPolicy;
 
 	/** Execute the tool. */
 	execute(

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -3,7 +3,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { Api, ImageContent, Model, TextContent } from "@earendil-works/pi-ai";
 import { Text } from "@earendil-works/pi-tui";
 import { constants } from "fs";
-import { access as fsAccess, readFile as fsReadFile } from "fs/promises";
+import { access as fsAccess, readFile as fsReadFile, realpath, stat } from "fs/promises";
 import { type Static, Type } from "typebox";
 import { getReadmePath } from "../../config.ts";
 import { keyHint, keyText } from "../../modes/interactive/components/keybinding-hints.ts";
@@ -66,6 +66,51 @@ export interface ReadToolOptions {
 	autoResizeImages?: boolean;
 	/** Custom operations for file reading. Default: local filesystem */
 	operations?: ReadOperations;
+}
+
+async function canSpeculateLocalRead(cwd: string, path: string): Promise<boolean> {
+	if (
+		path.startsWith("www.") ||
+		/^[a-z][a-z0-9+.-]*:\/\//i.test(path) ||
+		path.includes(":") ||
+		path.includes("?") ||
+		path.includes("#")
+	) {
+		return false;
+	}
+
+	try {
+		const workspacePath = await realpath(cwd);
+		const requestedPath = resolveToCwd(path, cwd);
+		const resolvedPath = await realpath(requestedPath);
+		const workspaceRelativePath = relative(workspacePath, resolvedPath);
+		if (
+			workspaceRelativePath === "" ||
+			workspaceRelativePath === ".." ||
+			workspaceRelativePath.startsWith(`..${sep}`) ||
+			isAbsolute(workspaceRelativePath)
+		) {
+			return false;
+		}
+
+		const target = await stat(resolvedPath);
+		if (target.isDirectory()) return true;
+		if (!target.isFile()) return false;
+		if (await detectSupportedImageMimeTypeFromFile(resolvedPath)) return false;
+
+		const content = await fsReadFile(resolvedPath);
+		if (
+			content.includes(0) ||
+			content.subarray(0, 5).toString("ascii") === "%PDF-" ||
+			content.subarray(0, 15).toString("ascii") === "SQLite format 3\u0000"
+		) {
+			return false;
+		}
+		new TextDecoder("utf-8", { fatal: true }).decode(content);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 type ReadRenderArgs = { path?: string; file_path?: string; offset?: number; limit?: number };
@@ -220,6 +265,14 @@ export function createReadToolDefinition(
 		promptGuidelines: [...readToolSystemPromptContribution.guidelines],
 		parameters: readSchema,
 		constrainedSampling: getExperimentalToolSampling(),
+		speculation: {
+			safe: true,
+			mode: "finalized",
+			canExecute: async ({ args }) =>
+				ops === defaultReadOperations &&
+				typeof args.path === "string" &&
+				(await canSpeculateLocalRead(cwd, args.path)),
+		},
 		async execute(
 			_toolCallId,
 			{ path, offset, limit }: { path: string; offset?: number; limit?: number },

--- a/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
+++ b/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
@@ -14,6 +14,7 @@ export function wrapToolDefinition<TDetails = unknown>(
 		constrainedSampling: definition.constrainedSampling,
 		prepareArguments: definition.prepareArguments,
 		executionMode: definition.executionMode,
+		speculation: definition.speculation,
 		execute: (toolCallId, params, signal, onUpdate, ctx?: ExtensionContext) =>
 			definition.execute(toolCallId, params, signal, onUpdate, ctx ?? (ctxFactory?.() as ExtensionContext)),
 	};
@@ -42,6 +43,7 @@ export function createToolDefinitionFromAgentTool(tool: AgentTool<any>): ToolDef
 		constrainedSampling: tool.constrainedSampling,
 		prepareArguments: tool.prepareArguments,
 		executionMode: tool.executionMode,
+		speculation: tool.speculation,
 		execute: async (toolCallId, params, signal, onUpdate) => tool.execute(toolCallId, params, signal, onUpdate),
 	};
 }

--- a/packages/coding-agent/test/read-speculation.test.ts
+++ b/packages/coding-agent/test/read-speculation.test.ts
@@ -1,0 +1,218 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, type Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createReadTool } from "../src/core/tools/read.ts";
+
+const temporaryPaths: string[] = [];
+
+function createTemporaryDirectory(prefix: string): string {
+	const directory = mkdtempSync(join(tmpdir(), prefix));
+	temporaryPaths.push(directory);
+	return directory;
+}
+
+afterEach(() => {
+	for (const directory of temporaryPaths.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+	vi.useRealTimers();
+});
+
+describe("read speculation policy", () => {
+	it("permits only direct local workspace targets that stay on the filesystem branch", async () => {
+		const workspace = createTemporaryDirectory("read-speculation-workspace-");
+		const outsideWorkspace = createTemporaryDirectory("read-speculation-outside-");
+		writeFileSync(join(workspace, "plain.txt"), "plain UTF-8 text\n");
+		mkdirSync(join(workspace, "directory"));
+		writeFileSync(
+			join(workspace, "image.png"),
+			Buffer.from(
+				"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9JXz0AAAAASUVORK5CYII=",
+				"base64",
+			),
+		);
+		writeFileSync(join(workspace, "document.pdf"), "%PDF-1.7\n");
+		writeFileSync(join(workspace, "database.sqlite"), Buffer.from("SQLite format 3\u0000", "ascii"));
+		writeFileSync(join(outsideWorkspace, "outside.txt"), "outside\n");
+
+		const tool = createReadTool(workspace);
+		const canExecute = tool.speculation?.canExecute;
+		expect(canExecute).toBeDefined();
+		if (!canExecute) throw new Error("Read tool must expose speculation policy");
+
+		const check = async (path: string) =>
+			await canExecute({
+				toolCall: { type: "toolCall", id: `call-${path}`, name: "read", arguments: { path } },
+				args: { path },
+			});
+
+		await expect(check("plain.txt")).resolves.toBe(true);
+		await expect(check("directory")).resolves.toBe(true);
+		await expect(check("https://example.invalid/readme.txt")).resolves.toBe(false);
+		await expect(check("mcp://tool/readme.txt")).resolves.toBe(false);
+		await expect(check("archive.zip:entry.txt")).resolves.toBe(false);
+		await expect(check("database.sqlite?query=SELECT%201")).resolves.toBe(false);
+		await expect(check("document.pdf")).resolves.toBe(false);
+		await expect(check("image.png")).resolves.toBe(false);
+		await expect(check("plain.txt:conflicts")).resolves.toBe(false);
+		await expect(check(join(outsideWorkspace, "outside.txt"))).resolves.toBe(false);
+		await expect(check("missing.txt")).resolves.toBe(false);
+	});
+});
+
+describe("read speculative execution", () => {
+	it("overlaps a real local read with provider generation and commits its sole physical result", async () => {
+		vi.useFakeTimers();
+		const workspace = createTemporaryDirectory("read-speculation-agent-");
+		writeFileSync(join(workspace, "fixture.txt"), "fixture content\n");
+		const model: Model<"openai-responses"> = {
+			id: "mock",
+			name: "mock",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8192,
+			maxTokens: 2048,
+		};
+		const run = async (enabled: boolean, path = "fixture.txt") => {
+			const tool = createReadTool(workspace);
+			const execute = tool.execute;
+			let physicalExecutions = 0;
+			let providerFinished = false;
+			let executedBeforeProviderFinished = false;
+			let signalPhysicalExecution = () => {};
+			const physicalExecution = new Promise<void>((resolve) => {
+				signalPhysicalExecution = resolve;
+			});
+			let signalProviderTailScheduled = () => {};
+			const providerTailScheduled = new Promise<void>((resolve) => {
+				signalProviderTailScheduled = resolve;
+			});
+			tool.execute = async (toolCallId, params, signal, onUpdate) => {
+				physicalExecutions++;
+				executedBeforeProviderFinished ||= !providerFinished;
+				signalPhysicalExecution();
+				return await execute(toolCallId, params, signal, onUpdate);
+			};
+			const telemetry: Array<{ outcome: string; overlapMs?: number }> = [];
+			let providerCalls = 0;
+			const agent = new Agent({
+				initialState: { model, tools: [tool] },
+				streamFn: () => {
+					const response = new EventStream<AssistantMessageEvent, AssistantMessage>(
+						(event) => event.type === "done" || event.type === "error",
+						(event) => {
+							if (event.type === "done") return event.message;
+							if (event.type === "error") return event.error;
+							throw new Error("Unexpected response event");
+						},
+					);
+					providerCalls++;
+					queueMicrotask(() => {
+						if (providerCalls === 1) {
+							const assistantMessage: AssistantMessage = {
+								role: "assistant",
+								content: [{ type: "toolCall", id: "read-1", name: "read", arguments: { path } }],
+								api: "openai-responses",
+								provider: "openai",
+								model: "mock",
+								usage: {
+									input: 0,
+									output: 0,
+									cacheRead: 0,
+									cacheWrite: 0,
+									totalTokens: 0,
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+								},
+								stopReason: "toolUse",
+								timestamp: Date.now(),
+							};
+							response.push({ type: "start", partial: assistantMessage });
+							response.push({
+								type: "toolcall_end",
+								contentIndex: 0,
+								toolCall: assistantMessage.content[0] as Extract<
+									AssistantMessage["content"][number],
+									{ type: "toolCall" }
+								>,
+								partial: assistantMessage,
+							});
+							setTimeout(() => {
+								providerFinished = true;
+								response.push({ type: "done", reason: "toolUse", message: assistantMessage });
+							}, 400);
+							signalProviderTailScheduled();
+							return;
+						}
+						response.push({
+							type: "done",
+							reason: "stop",
+							message: {
+								role: "assistant",
+								content: [{ type: "text", text: "done" }],
+								api: "openai-responses",
+								provider: "openai",
+								model: "mock",
+								usage: {
+									input: 0,
+									output: 0,
+									cacheRead: 0,
+									cacheWrite: 0,
+									totalTokens: 0,
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+								},
+								stopReason: "stop",
+								timestamp: Date.now(),
+							},
+						});
+					});
+					return response;
+				},
+				...(enabled
+					? { speculativeToolExecution: { enabled: true, onTelemetry: (event) => telemetry.push(event) } }
+					: {}),
+			});
+			const completion = agent.prompt("read fixture");
+			await providerTailScheduled;
+			if (enabled && path === "fixture.txt") {
+				await physicalExecution;
+			} else {
+				await Promise.resolve();
+				await Promise.resolve();
+			}
+			vi.advanceTimersByTime(400);
+			await completion;
+			return {
+				executedBeforeProviderFinished,
+				physicalExecutions,
+				telemetry,
+				history: agent.state.messages.map((message) => {
+					const { timestamp: _timestamp, ...stableMessage } = message;
+					return stableMessage;
+				}),
+			};
+		};
+
+		const enabled = await run(true);
+		const disabled = await run(false);
+
+		expect(enabled.executedBeforeProviderFinished).toBe(true);
+		expect(disabled.executedBeforeProviderFinished).toBe(false);
+		expect(enabled.physicalExecutions).toBe(1);
+		expect(disabled.physicalExecutions).toBe(1);
+		expect(enabled.telemetry).toContainEqual(
+			expect.objectContaining({ outcome: "committed", overlapMs: expect.any(Number) }),
+		);
+		expect(enabled.history).toEqual(disabled.history);
+		const http = await run(true, "https://example.invalid/fixture.txt");
+
+		expect(http.executedBeforeProviderFinished).toBe(false);
+		expect(http.telemetry).toContainEqual(expect.objectContaining({ outcome: "ineligible" }));
+	});
+});


### PR DESCRIPTION
## Summary

Adds opt-in eager execution for finalized, explicitly discard-safe tool calls. V1 starts eligible local `read` calls at `toolcall_end`, reuses the exact candidate outcome at normal dispatch, and otherwise discards it without normal lifecycle events or transcript history.

## Safety boundary

- Disabled by default.
- Candidates require a tool-owned `safe: true`, `mode: "finalized"` policy.
- The coding agent marks only direct, in-workspace local filesystem `read` calls eligible.
- URL-shaped, internal, archive, database, image, converted, missing, outside-workspace, and custom-operation reads remain on ordinary dispatch.
- Candidate fingerprints, cancellation, effect barriers, hooks, and result normalization preserve current execution semantics.

## Verification

- `npm run check`
- `packages/agent`: `npm test` — 420 passed, 1 skipped
- `packages/agent/test/agent-loop.test.ts` — 26 passed
- `packages/coding-agent/test/read-speculation.test.ts` — 2 passed

The full coding-agent suite has unrelated failures when its workspace `dist` artifacts are absent.

## Benchmark

Controlled production `Agent` plus real `ReadTool`, seven alternating samples, with a fixed 400 ms provider tail:

- 16 MiB local read: 402.46 ms eager median vs. 415.93 ms ordinary median, saving 13.47 ms (3.24%).
- Local reads began before provider completion and committed exactly once in 7/7 samples.
- URL-shaped targets were ineligible in 3/3 control samples and never began early.

## Future work

- V2: stable partial arguments from `toolcall_delta`, with candidate fingerprints, argument-stability tracking, and mismatch cancellation.
- V3: structured effects and information-flow properties.
- V4: dependency-aware tool-program scheduling with effect barriers and concurrency constraints.
- V5: restricted shadow execution for partially generated programs.