### PR TITLE
fix(ai): omit Responses tool_choice without tools

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed OpenAI-compatible Chat Completions requests sending `tool_choice` without tools, which gateways can reject during compaction ([#8607](https://github.com/earendil-works/pi/issues/8607)).
+- Fixed OpenAI Responses and Azure OpenAI Responses requests sending `tool_choice` without tools, which providers can reject during compaction.
 
 ## [0.84.3] - 2026-08-24
 

--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -308,7 +308,7 @@ function buildParams(
 			supportsOpenAIGrammarTools: model.compat?.supportsOpenAIGrammarTools ?? false,
 		});
 	}
-	if (options?.toolChoice !== undefined) {
+	if (options?.toolChoice !== undefined && params.tools?.length) {
 		params.tool_choice = options.toolChoice;
 	}
 

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -316,7 +316,7 @@ function buildParams(
 		});
 	}
 
-	if (options?.toolChoice !== undefined) {
+	if (options?.toolChoice !== undefined && params.tools?.length) {
 		params.tool_choice = options.toolChoice;
 	}
 

--- a/packages/ai/test/azure-openai-tool-choice.test.ts
+++ b/packages/ai/test/azure-openai-tool-choice.test.ts
@@ -76,4 +76,27 @@ describe("Azure OpenAI tool choice", () => {
 		expect(payload).toMatchObject({ tool_choice: "none" });
 		expect((payload as { tools?: unknown[] }).tools).toHaveLength(1);
 	});
+
+	it("omits toolChoice when no tools are provided", async () => {
+		let payload: unknown;
+		const result = streamSimple(
+			model,
+			{
+				messages: [{ role: "user", content: "Summarize this", timestamp: 1 }],
+			},
+			{
+				apiKey: "test-key",
+				toolChoice: "none",
+				onPayload: (requestPayload) => {
+					payload = requestPayload;
+					throw new Error("payload captured");
+				},
+			},
+		);
+
+		await result.result();
+
+		expect(payload).not.toHaveProperty("tool_choice");
+		expect(payload).not.toHaveProperty("tools");
+	});
 });

--- a/packages/ai/test/openai-responses-compat.test.ts
+++ b/packages/ai/test/openai-responses-compat.test.ts
@@ -154,6 +154,38 @@ describe("openai-responses provider defaults", () => {
 		});
 	});
 
+	it("omits toolChoice when no tools are provided", async () => {
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			getModel("xai", "grok-4.6"),
+			{
+				messages: [{ role: "user", content: "Summarize the conversation", timestamp: Date.now() }],
+			},
+			{
+				apiKey: "test-key",
+				toolChoice: "none",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).not.toHaveProperty("tool_choice");
+		expect(capturedPayload).not.toHaveProperty("tools");
+	});
+
 	it("sets strict mode explicitly for Cloudflare OpenAI Responses tools", async () => {
 		const model = getModel("cloudflare-ai-gateway", "gpt-5.6-sol");
 		let capturedPayload: CapturedResponsesPayload | undefined;


### PR DESCRIPTION
Compaction sends toolChoice none without tools. Chat Completions already omitted that; OpenAI Responses and Azure OpenAI Responses still sent it, which providers can reject.

See also #8607.