### PR TITLE
Load skills when bash is available

### DIFF
--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -352,16 +352,21 @@ function loadSkillFromFile(
  * Skills with disableModelInvocation=true are excluded from the prompt
  * (they can only be invoked explicitly via /skill:name commands).
  */
-export function formatSkillsForPrompt(skills: Skill[]): string {
+export function formatSkillsForPrompt(skills: Skill[], loadingTool: "read" | "bash" = "read"): string {
 	const visibleSkills = skills.filter((s) => !s.disableModelInvocation);
 
 	if (visibleSkills.length === 0) {
 		return "";
 	}
 
+	const loadInstruction =
+		loadingTool === "bash"
+			? "Use bash to load a skill's file when the task matches its description."
+			: "Use the read tool to load a skill's file when the task matches its description.";
+
 	const lines = [
 		"\n\nThe following skills provide specialized instructions for specific tasks.",
-		"Use the read tool to load a skill's file when the task matches its description.",
+		loadInstruction,
 		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
 		"",
 		"<available_skills>",

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -60,10 +60,15 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 			prompt += "</project_context>\n";
 		}
 
-		// Append skills section (only if read tool is available)
-		const customPromptHasRead = !selectedTools || selectedTools.includes("read");
-		if (customPromptHasRead && skills.length > 0) {
-			prompt += formatSkillsForPrompt(skills);
+		// Append skills section when a file-loading tool is available.
+		const customPromptTools = selectedTools || ["read", "bash", "edit", "write"];
+		const customPromptSkillLoader = customPromptTools.includes("read")
+			? "read"
+			: customPromptTools.includes("bash")
+				? "bash"
+				: null;
+		if (customPromptSkillLoader && skills.length > 0) {
+			prompt += formatSkillsForPrompt(skills, customPromptSkillLoader);
 		}
 
 		prompt += `\nCurrent working directory: ${promptCwd}\n`;
@@ -158,9 +163,10 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 		prompt += "</project_context>\n";
 	}
 
-	// Append skills section (only if read tool is available)
-	if (hasRead && skills.length > 0) {
-		prompt += formatSkillsForPrompt(skills);
+	// Append skills section when a file-loading tool is available.
+	const skillLoader = hasRead ? "read" : hasBash ? "bash" : null;
+	if (skillLoader && skills.length > 0) {
+		prompt += formatSkillsForPrompt(skills, skillLoader);
 	}
 
 	prompt += `\nCurrent working directory: ${promptCwd}`;

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, test } from "vitest";
+import type { Skill } from "../src/core/skills.ts";
 import { buildSystemPrompt } from "../src/core/system-prompt.ts";
+
+const testSkill: Skill = {
+	name: "test-skill",
+	description: "A test skill.",
+	filePath: "/path/to/skill/SKILL.md",
+	baseDir: "/path/to/skill",
+	disableModelInvocation: false,
+	sourceInfo: {
+		path: "/path/to/skill/SKILL.md",
+		source: "test",
+		scope: "temporary",
+		origin: "top-level",
+	},
+};
 
 describe("buildSystemPrompt", () => {
 	describe("empty tools", () => {
@@ -71,6 +86,44 @@ describe("buildSystemPrompt", () => {
 				"- When reading pi docs or examples, resolve docs/... under Additional docs and examples/... under Examples, not the current working directory",
 			);
 			expect(prompt).toContain("environment variables (docs/environment-variables.md)");
+		});
+	});
+
+	describe("skills", () => {
+		test("includes skills when read is selected", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: ["read"],
+				contextFiles: [],
+				skills: [testSkill],
+				cwd: process.cwd(),
+			});
+
+			expect(prompt).toContain("<available_skills>");
+			expect(prompt).toContain("Use the read tool to load a skill's file");
+		});
+
+		test("includes skills when bash is selected without read", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: ["bash"],
+				contextFiles: [],
+				skills: [testSkill],
+				cwd: process.cwd(),
+			});
+
+			expect(prompt).toContain("<available_skills>");
+			expect(prompt).toContain("Use bash to load a skill's file");
+			expect(prompt).not.toContain("Use the read tool to load a skill's file");
+		});
+
+		test("omits skills when neither read nor bash is selected", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: ["edit"],
+				contextFiles: [],
+				skills: [testSkill],
+				cwd: process.cwd(),
+			});
+
+			expect(prompt).not.toContain("<available_skills>");
 		});
 	});
 


### PR DESCRIPTION
Fixes #8551.

## Summary
- Include the skills section when `bash` is available even if `read` is disabled.
- Adjust skill-loading guidance to say `bash` when `read` is unavailable.
- Add system prompt regression tests for read, bash-only, and no file-loading-tool cases.

## Tests
- `npx vitest run packages/coding-agent/test/system-prompt.test.ts packages/coding-agent/test/skills.test.ts`
- `npm run check`