### PR TITLE
fix(ai): hoist Bedrock tool result images out of toolResult for OpenAI models

### DIFF
--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -911,11 +911,14 @@ function sanitizeBedrockDocument(value: DocumentType): DocumentType {
 	return value;
 }
 
-function convertToolResultContent(content: (TextContent | ImageContent)[]): ToolResultContentBlock[] {
+function convertToolResultContent(
+	content: (TextContent | ImageContent)[],
+	hoistImages = false,
+): ToolResultContentBlock[] {
 	const result: ToolResultContentBlock[] = [];
 	for (const c of content) {
 		if (c.type === "image") {
-			result.push({ image: createImageBlock(c.mimeType, c.data) });
+			if (!hoistImages) result.push({ image: createImageBlock(c.mimeType, c.data) });
 		} else {
 			const textBlock = createNonBlankTextBlock(c.text);
 			if (textBlock) result.push(textBlock);
@@ -923,6 +926,21 @@ function convertToolResultContent(content: (TextContent | ImageContent)[]): Tool
 	}
 	if (result.length === 0) result.push({ text: EMPTY_TEXT_PLACEHOLDER });
 	return result;
+}
+
+// OpenAI models on Bedrock reject image blocks nested in toolResult.content
+// ("This model doesn't support the image field for user messages"), but accept
+// the same images as sibling content blocks of the user message that carries
+// the tool results. Model IDs may carry a cross-region inference profile
+// prefix (us./eu./apac.), e.g. "us.openai.gpt-5.6-sol".
+function shouldHoistToolResultImages(model: Model<"bedrock-converse-stream">): boolean {
+	return model.id.startsWith("openai.") || model.id.includes(".openai.");
+}
+
+function convertToolResultImages(content: (TextContent | ImageContent)[]): ContentBlock.ImageMember[] {
+	return content
+		.filter((c): c is ImageContent => c.type === "image")
+		.map((c) => ({ image: createImageBlock(c.mimeType, c.data) }));
 }
 
 function convertMessages(
@@ -1045,15 +1063,18 @@ function convertMessages(
 				// Collect all consecutive toolResult messages into a single user message
 				// Bedrock requires all tool results to be in one message
 				const toolResults: ContentBlock.ToolResultMember[] = [];
+				const toolImages: ContentBlock.ImageMember[] = [];
+				const hoistImages = shouldHoistToolResultImages(model);
 
 				// Add current tool result with all content blocks combined
 				toolResults.push({
 					toolResult: {
 						toolUseId: m.toolCallId,
-						content: convertToolResultContent(m.content),
+						content: convertToolResultContent(m.content, hoistImages),
 						status: m.isError ? ToolResultStatus.ERROR : ToolResultStatus.SUCCESS,
 					},
 				});
+				if (hoistImages) toolImages.push(...convertToolResultImages(m.content));
 
 				// Look ahead for consecutive toolResult messages
 				let j = i + 1;
@@ -1062,10 +1083,11 @@ function convertMessages(
 					toolResults.push({
 						toolResult: {
 							toolUseId: nextMsg.toolCallId,
-							content: convertToolResultContent(nextMsg.content),
+							content: convertToolResultContent(nextMsg.content, hoistImages),
 							status: nextMsg.isError ? ToolResultStatus.ERROR : ToolResultStatus.SUCCESS,
 						},
 					});
+					if (hoistImages) toolImages.push(...convertToolResultImages(nextMsg.content));
 					j++;
 				}
 
@@ -1074,7 +1096,7 @@ function convertMessages(
 
 				result.push({
 					role: ConversationRole.USER,
-					content: toolResults,
+					content: [...toolResults, ...toolImages],
 				});
 				break;
 			}

--- a/packages/ai/test/bedrock-tool-result-images.test.ts
+++ b/packages/ai/test/bedrock-tool-result-images.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeServiceException extends Error {}
+
+	class BedrockRuntimeClient {
+		send(): Promise<unknown> {
+			return Promise.resolve({
+				$metadata: { httpStatusCode: 200 },
+				stream: (async function* () {})(),
+			});
+		}
+	}
+
+	class ConverseStreamCommand {
+		readonly input: unknown;
+
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+
+	return {
+		BedrockRuntimeClient,
+		BedrockRuntimeServiceException,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+import { stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
+import type { AssistantMessage, Context, Model, ToolResultMessage, Usage } from "../src/types.ts";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const openaiModel: Model<"bedrock-converse-stream"> = {
+	id: "us.openai.gpt-5.6-sol",
+	name: "GPT-5.6 Sol (US)",
+	api: "bedrock-converse-stream",
+	provider: "amazon-bedrock",
+	baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 0 },
+	contextWindow: 400000,
+	maxTokens: 128000,
+	compat: undefined,
+};
+
+const anthropicModel: Model<"bedrock-converse-stream"> = {
+	...openaiModel,
+	id: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+	name: "Claude Sonnet 4.5 (US)",
+};
+
+const PNG_DATA = "iVBORw0KGgo=";
+
+function buildAssistantToolCalls(toolCallIds: string[], timestamp: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: toolCallIds.map((id) => ({
+			type: "toolCall",
+			id,
+			name: "read",
+			arguments: { path: "/tmp/chart.png" },
+		})),
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		model: openaiModel.id,
+		usage: emptyUsage,
+		stopReason: "toolUse",
+		timestamp,
+	};
+}
+
+function buildImageToolResult(toolCallId: string, timestamp: number, text?: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [
+			...(text !== undefined ? [{ type: "text" as const, text }] : []),
+			{ type: "image" as const, data: PNG_DATA, mimeType: "image/png" },
+		],
+		isError: false,
+		timestamp,
+	};
+}
+
+async function capturePayload(context: Context, model: Model<"bedrock-converse-stream">): Promise<unknown> {
+	let capturedPayload: unknown;
+	const s = streamBedrock(model, context, {
+		cacheRetention: "none",
+		signal: AbortSignal.abort(),
+		onPayload: (payload) => {
+			capturedPayload = payload;
+			return payload;
+		},
+	});
+	for await (const event of s) {
+		if (event.type === "error") break;
+	}
+	return capturedPayload;
+}
+
+type BedrockMessage = {
+	role: string;
+	content: Array<{
+		text?: string;
+		image?: { format: string; source: { bytes: Uint8Array } };
+		toolResult?: { toolUseId: string; content: Array<{ text?: string; image?: unknown }> };
+	}>;
+};
+
+function buildContext(toolCallIds: string[], resultText?: string): Context {
+	const messages: Context["messages"] = [
+		{ role: "user", content: "Read the chart", timestamp: 1 },
+		buildAssistantToolCalls(toolCallIds, 2),
+	];
+	for (const [index, id] of toolCallIds.entries()) {
+		messages.push(buildImageToolResult(id, 3 + index, resultText));
+	}
+	return { messages };
+}
+
+describe("Bedrock tool result images", () => {
+	it("hoists tool result images to sibling user content blocks for OpenAI models", async () => {
+		const payload = await capturePayload(buildContext(["tool-1"], "rendered chart"), openaiModel);
+		const messages = (payload as { messages: BedrockMessage[] }).messages;
+		const toolResultMessage = messages[messages.length - 1];
+
+		expect(toolResultMessage.role).toBe("user");
+		expect(toolResultMessage.content).toHaveLength(2);
+		expect(toolResultMessage.content[0].toolResult?.content).toEqual([{ text: "rendered chart" }]);
+		expect(toolResultMessage.content[1].image?.format).toBe("png");
+	});
+
+	it("keeps a placeholder in image-only tool results for OpenAI models", async () => {
+		const payload = await capturePayload(buildContext(["tool-1"]), openaiModel);
+		const messages = (payload as { messages: BedrockMessage[] }).messages;
+		const toolResultMessage = messages[messages.length - 1];
+
+		expect(toolResultMessage.content[0].toolResult?.content).toEqual([{ text: "<empty>" }]);
+		expect(toolResultMessage.content[1].image?.format).toBe("png");
+	});
+
+	it("hoists images from consecutive tool results into the same user message", async () => {
+		const payload = await capturePayload(buildContext(["tool-1", "tool-2"], "ok"), openaiModel);
+		const messages = (payload as { messages: BedrockMessage[] }).messages;
+		const toolResultMessage = messages[messages.length - 1];
+
+		expect(toolResultMessage.content.map((block) => Object.keys(block)[0])).toEqual([
+			"toolResult",
+			"toolResult",
+			"image",
+			"image",
+		]);
+	});
+
+	it("keeps images nested in toolResult.content for non-OpenAI models", async () => {
+		const payload = await capturePayload(buildContext(["tool-1"], "rendered chart"), anthropicModel);
+		const messages = (payload as { messages: BedrockMessage[] }).messages;
+		const toolResultMessage = messages[messages.length - 1];
+
+		expect(toolResultMessage.content).toHaveLength(1);
+		expect(toolResultMessage.content[0].toolResult?.content).toHaveLength(2);
+		expect(toolResultMessage.content[0].toolResult?.content[1].image).toBeDefined();
+	});
+});


### PR DESCRIPTION
## For humans

OpenAI models on Bedrock (`us.openai.gpt-5.6-sol` etc.) reject any request with an image nested in `toolResult.content`, which kills the session after any tool returns an image; this moves those images to sibling content blocks of the same user message for OpenAI model IDs only, plus a regression test.

## For agents

Context that isn't visible in the diff:

- The error is `ValidationException: This model doesn't support the image field for user messages.` It fires on the request AFTER the tool returns an image (e.g. `read` on a PNG), so the session becomes permanently wedged: every retry replays the same history and fails again.
- Verified against Bedrock Converse directly with the same model and credentials: image in a user message works, image nested in `toolResult.content` fails, image hoisted beside the toolResult in the same user message works. So the model is image-capable; only the placement is rejected. Anthropic models on Bedrock accept both shapes, which is why nothing else regresses.
- This is the OpenAI-wide restriction (images are only accepted in user-role messages), not a Bedrock quirk. pi already handles it for the direct OpenAI adapters: `openai-completions.ts` hoists tool-result images into a follow-up user message, and `openai-completions-tool-result-images.test.ts` / `openai-responses-tool-result-images.test.ts` cover it. The Bedrock adapter was the gap, likely because OpenAI models only landed on Bedrock in Aug 2026.
- The hoisted images go into the SAME user message as the tool results (not a separate follow-up message) because Bedrock requires all consecutive tool results in one user message, and it accepts extra image blocks alongside them.
- The model ID check (`openai.` prefix or `.openai.` substring) covers cross-region inference profile prefixes (`us.`/`eu.`/`apac.`). There is no existing capability flag for this on Bedrock models; adding one to model compat felt heavier than warranted, but happy to change if you prefer.
- `convertToolResultContent` keeps its `<empty>` placeholder behavior when hoisting leaves a tool result with no content, so image-only tool results still produce a valid non-empty `toolResult.content`.
- `npm run check` passes and the pi-ai suite is green (961 passed / 832 key-gated skips). The new test mirrors the mock setup of `bedrock-convert-messages.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)