### PR TITLE
fix(ai): omit Responses tool_choice when no tools are sent

### DIFF
--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -316,7 +316,7 @@ function buildParams(
 		});
 	}
 
-	if (options?.toolChoice !== undefined) {
+	if (options?.toolChoice !== undefined && toolPlacement.immediate.length > 0) {
 		params.tool_choice = options.toolChoice;
 	}
 

--- a/packages/ai/test/openai-responses-compat.test.ts
+++ b/packages/ai/test/openai-responses-compat.test.ts
@@ -154,6 +154,44 @@ describe("openai-responses provider defaults", () => {
 		});
 	});
 
+	it("omits tool_choice when no tools are provided", async () => {
+		let capturedPayload: unknown;
+
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+		);
+
+		const stream = streamOpenAIResponses(
+			getModel("openai", "gpt-5.4"),
+			{
+				messages: [
+					{
+						role: "user",
+						content: "Summarize the conversation",
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				toolChoice: "none",
+				onPayload: (payload) => {
+					capturedPayload = payload;
+				},
+			},
+		);
+
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+
+		expect(capturedPayload).not.toHaveProperty("tool_choice");
+		expect(capturedPayload).not.toHaveProperty("tools");
+	});
+
 	it("sets strict mode explicitly for Cloudflare OpenAI Responses tools", async () => {
 		const model = getModel("cloudflare-ai-gateway", "gpt-5.6-sol");
 		let capturedPayload: CapturedResponsesPayload | undefined;


### PR DESCRIPTION
## Problem

Compaction calls `completeSimple` with `toolChoice: \"none\"` and no tools. xAI's Responses API returns:

`400 A tool_choice was set on the request but no tools were specified`

So `/compact` and overflow compaction fail on Grok. Completions already omits `tool_choice` without tools (#8607). Responses did not.

## Change

In `buildParams`, only send `tool_choice` when immediate tools are present.

Adds a regression test next to the existing \"forwards required tool choice\" case.

## Test

`npx vitest --run test/openai-responses-compat.test.ts` — 34 passed.

Also reproduced against live xAI Grok 4.6: `toolChoice: \"none\"` no longer 400s; official `compact()` succeeds.

Related: https://github.com/earendil-works/pi/issues/8649