### PR TITLE
fix(agent): stop the loop when the run is aborted during tool execution

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -223,6 +223,17 @@ async function runLoop(
 
 			await emit({ type: "turn_end", message, toolResults });
 
+			// The run was aborted while a tool was executing (user pressed Stop).
+			// Stop the loop here instead of continuing: the signal is already
+			// cancelled, so the next LLM call would fail immediately and produce a
+			// second spurious "aborted" result — one Stop click appearing as two
+			// cancellations. (The streamAssistantResponse path above already exits
+			// on error/aborted; the tool-execution path needs the same guard.)
+			if (signal.aborted) {
+				await emit({ type: "agent_end", messages: newMessages });
+				return;
+			}
+
 			const nextTurnContext = {
 				message,
 				toolResults,

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1480,6 +1480,86 @@ describe("agentLoop with AgentMessage", () => {
 
 		expect(llmCalls).toBe(1);
 	});
+
+	it("stops the loop when the run is aborted during tool execution (no second LLM call)", async () => {
+		const toolSchema = Type.Object({});
+		let toolStarted = false;
+		let releaseTool: (() => void) | undefined;
+		const abortController = new AbortController();
+
+		const slowTool: AgentTool<typeof toolSchema> = {
+			name: "slow",
+			label: "Slow",
+			description: "Slow tool",
+			parameters: toolSchema,
+			async execute(_id, _params, signal) {
+				toolStarted = true;
+				await new Promise<void>((resolve) => {
+					releaseTool = resolve;
+					signal?.addEventListener("abort", () => resolve(), { once: true });
+				});
+				return {
+					content: [{ type: "text", text: "aborted" }],
+					details: {},
+					isError: true,
+				};
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [slowTool] };
+		let llmCalls = 0;
+		let queuedDelivered = false;
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "sequential",
+			getSteeringMessages: async () => {
+				// A second message sits in the queue while the tool runs.
+				if (toolStarted && !queuedDelivered) {
+					queuedDelivered = true;
+					return [createUserMessage("second message")];
+				}
+				return [];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop(
+			[createUserMessage("start")],
+			context,
+			config,
+			abortController.signal,
+			(_model, _ctx, _options) => {
+				llmCalls++;
+				const mockStream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "slow", arguments: {} }],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+				});
+				return mockStream;
+			},
+		);
+
+		// Wait until the tool has started executing, then abort mid-execution.
+		while (!toolStarted) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		abortController.abort();
+		releaseTool?.();
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		// Exactly one stop: the aborted tool run, not a second spurious one.
+		const agentEnds = events.filter((e) => e.type === "agent_end");
+		expect(agentEnds.length).toBe(1);
+		// The queue must not be drained into a cancelled signal (second LLM call).
+		expect(llmCalls).toBe(1);
+	});
 });
 
 describe("agentLoopContinue with AgentMessage", () => {


### PR DESCRIPTION
## Problem

When the user presses **Stop** while a tool call is still executing, **one click produces two "cancelled" results**:

1. the running tool is aborted (expected), and
2. a **second** spurious failure appears for the queued steering/follow-up message (unexpected).

### Reproduction (deterministic)

1. Send a prompt that starts a long tool call (e.g. `sleep 300`).
2. While the tool is running, send a second message (it enters the steering queue).
3. Press Stop.

Observed message list: `base...` → `aborted` → `second message` → `aborted` — two aborts for a single Stop.

## Root cause

`runLoop` in `packages/agent/src/agent-loop.ts` only exits on an aborted/error result coming back from `streamAssistantResponse`. When the abort signal fires **during tool execution**, `executeToolCalls` returns normally (the tools observe `signal.aborted`), and `runLoop` continues into the queued-message handling with the **already-cancelled signal**. The next `streamAssistantResponse` call fails immediately on the dead signal, which surfaces as a second `agent_end`/aborted result.

This also happens without a queued message: after the tool is aborted `hasMoreToolCalls` is still true, so the loop asks the LLM again with a cancelled signal.

## Fix

After the tool-execution turn (right after `turn_end`), check `signal.aborted` and exit the loop — mirroring the existing `streamAssistantResponse` error/aborted path:

```ts
if (signal.aborted) {
  await emit({ type: "agent_end", messages: newMessages });
  return;
}
```

One Stop = one abort. Queued steering/follow-up messages are left untouched for the caller's next turn (they are no longer drained into a dead signal).

## Test

Adds a regression test that aborts mid-tool-execution with a queued steering message and asserts exactly **one** `agent_end` and exactly **one** LLM call.

Verified against both the `dist` build (0.84.2, reproduced the double abort, confirmed the fix removes it) and the source in this repo (red before / green after).