### PR TITLE
fix(tui): render markdown soft line breaks as spaces, not hard breaks

### DIFF
--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -639,6 +639,10 @@ export class Markdown implements Component {
 			const segments: string[] = text.split("\n");
 			return segments.map((segment: string) => applyText(segment)).join("\n");
 		};
+		// Soft line breaks inside paragraphs render as spaces per CommonMark,
+		// so wrapped source lines reflow into one paragraph instead of breaking.
+		// (Hard breaks arrive as separate "br" tokens; rendered LaTeX keeps real newlines.)
+		const applyTextWithSoftBreaks = (text: string): string => applyText(text.replace(/\s*\n\s*/g, " "));
 
 		for (const token of tokens) {
 			switch (token.type) {
@@ -653,7 +657,7 @@ export class Markdown implements Component {
 				}
 
 				case "escape":
-					result += applyTextWithNewlines(this.options.preserveBackslashEscapes ? token.raw : token.text);
+					result += applyTextWithSoftBreaks(this.options.preserveBackslashEscapes ? token.raw : token.text);
 					break;
 
 				case "text":
@@ -661,7 +665,7 @@ export class Markdown implements Component {
 					if (token.tokens && token.tokens.length > 0) {
 						result += this.renderInlineTokens(token.tokens, resolvedStyleContext);
 					} else {
-						result += applyTextWithNewlines(token.text);
+						result += applyTextWithSoftBreaks(token.text);
 					}
 					break;
 
@@ -721,14 +725,14 @@ export class Markdown implements Component {
 				case "html":
 					// Render inline HTML as plain text
 					if ("raw" in token && typeof token.raw === "string") {
-						result += applyTextWithNewlines(token.raw);
+						result += applyTextWithSoftBreaks(token.raw);
 					}
 					break;
 
 				default:
 					// Handle any other inline token types as plain text
 					if ("text" in token && typeof token.text === "string") {
-						result += applyTextWithNewlines(token.text);
+						result += applyTextWithSoftBreaks(token.text);
 					}
 			}
 		}

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1300,16 +1300,14 @@ bar`,
 
 			const lines = markdown.render(80);
 
-			// Both lines should have the quote border
+			// Lazy continuation: one paragraph joined at the soft break.
 			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
 			const quotedLines = plainLines.filter((line) => line.startsWith("│ "));
-			assert.strictEqual(quotedLines.length, 2, `Expected 2 quoted lines, got: ${JSON.stringify(plainLines)}`);
+			assert.strictEqual(quotedLines.length, 1, `Expected 1 quoted line, got: ${JSON.stringify(plainLines)}`);
 
 			// Both lines should have italic (from theme.quote styling)
 			const fooLine = lines.find((line) => line.includes("Foo"));
 			const barLine = lines.find((line) => line.includes("bar"));
-			assert.ok(fooLine, "Should have Foo line");
-			assert.ok(barLine, "Should have bar line");
 
 			// Check that both have italic (\x1b[3m) - blockquotes use theme styling, not default message color
 			assert.ok(fooLine?.includes("\x1b[3m"), `Foo line should have italic: ${fooLine}`);
@@ -1334,10 +1332,10 @@ bar`,
 
 			const lines = markdown.render(80);
 
-			// Both lines should have the quote border
+			// Explicit multiline quote: still one paragraph joined at the soft break.
 			const plainLines = lines.map((line) => line.replace(/\x1b\[[0-9;]*m/g, ""));
 			const quotedLines = plainLines.filter((line) => line.startsWith("│ "));
-			assert.strictEqual(quotedLines.length, 2, `Expected 2 quoted lines, got: ${JSON.stringify(plainLines)}`);
+			assert.strictEqual(quotedLines.length, 1, `Expected 1 quoted line, got: ${JSON.stringify(plainLines)}`);
 
 			// Both lines should have italic (from theme.quote styling)
 			const fooLine = lines.find((line) => line.includes("Foo"));
@@ -1712,6 +1710,34 @@ bar`,
 				joinedPlain.includes("<div>") && joinedPlain.includes("</div>"),
 				"Should render HTML in code blocks",
 			);
+		});
+	});
+
+	describe("Soft line breaks", () => {
+		it("should reflow single-newline paragraphs instead of breaking lines", () => {
+			// Soft breaks (single \n inside a paragraph) must render as spaces per CommonMark,
+			// so wrapped source lines flow into one paragraph.
+			const markdown = new Markdown(
+				"First, I check the parse tree.\nThen I trace how tokens flow.\nFinally, I conclude.",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+			const joined = lines.filter((line) => line.length > 0).join(" ");
+			assert.ok(
+				joined.includes("parse tree. Then I trace how tokens flow."),
+				`Soft breaks must render as spaces, got: ${JSON.stringify(joined)}`,
+			);
+		});
+
+		it("should keep explicit hard breaks (br tokens) as line breaks", () => {
+			const markdown = new Markdown("line one  \nline two", 0, 0, defaultMarkdownTheme);
+
+			const lines = markdown.render(80).map((line) => stripAnsi(line).trimEnd());
+			const nonEmpty = lines.filter((line) => line.length > 0);
+			assert.strictEqual(nonEmpty.length, 2);
 		});
 	});
 


### PR DESCRIPTION
## Problem

Thinking blocks (and any markdown paragraph) written with single `\n` line breaks rendered as one ragged fragment per line instead of flowing into a paragraph — very hard to read. Fixes #8673.

## Root cause

`marked` keeps CommonMark *soft* breaks as literal `\n` inside paragraph `text` tokens. `Markdown.renderInlineTokens()` styled text via `applyTextWithNewlines()`, which splits on `\n` and re-joins with `"\n"` — turning every soft break into a hard terminal line break. Per CommonMark, soft breaks must render as a space so the paragraph reflows.

## Fix

Add `applyTextWithSoftBreaks()` (collapses `\n` to one space before styling) and use it for plain-text inline tokens (`escape`, `text`, inline `html`, default). Untouched on purpose:

- rendered LaTeX output, which legitimately contains newlines
- explicit hard breaks (`br` tokens)

## Test plan

- New `Soft line breaks` tests in `packages/tui/test/markdown.test.ts`: single-newline paragraph flows into one paragraph; explicit `br` still breaks.
- Updated two blockquote tests that pinned the old hard-break behavior for lazy continuations (`>Foo\nbar`) to the spec-correct joined output.
- Full tui suite passes (83/83); `npm run check` passes.