### PR TITLE
fix(tui): make alt screen not segment on - and /

### DIFF
--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -66,6 +66,9 @@ const MAX_CACHED_OFFSCREEN_KITTY_IMAGES = 16;
 const MAX_CACHED_OFFSCREEN_KITTY_TRANSMISSION_BYTES = 32 * 1024 * 1024;
 const MAX_CACHED_OFFSCREEN_KITTY_DECODED_BYTES = 64 * 1024 * 1024;
 const DOUBLE_CLICK_INTERVAL_MS = 500;
+// Regular mode delegates double-click selection to the terminal emulator. Fullscreen owns mouse selection,
+// so mirror common terminal word-selection behavior by keeping paths and kebab-case tokens whole.
+const TERMINAL_WORD_SELECTION_JOINERS = new Set(["/", "-"]);
 const wordSegmenter = getWordSegmenter();
 
 interface CachedKittyImage {
@@ -832,18 +835,38 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 	private getWordSelection(point: SelectionPoint): SelectionRange | undefined {
 		const line = stripTerminalSequences(this.getSelectionSourceLine(point));
+		const segments: Array<{ start: number; end: number; isWordLike: boolean; isTerminalJoiner: boolean }> = [];
 		let start = 0;
 		for (const segment of wordSegmenter.segment(line)) {
 			const end = start + visibleWidth(segment.segment);
-			if (point.col >= start && point.col < end) {
-				return {
-					start: { ...point, col: start },
-					end: { ...point, col: end, boundary: true },
-				};
-			}
+			segments.push({
+				start,
+				end,
+				isWordLike: segment.isWordLike === true,
+				isTerminalJoiner: TERMINAL_WORD_SELECTION_JOINERS.has(segment.segment),
+			});
 			start = end;
 		}
-		return undefined;
+		const clickedSegmentIndex = segments.findIndex(
+			(segment) => point.col >= segment.start && point.col < segment.end,
+		);
+		if (clickedSegmentIndex < 0) return undefined;
+		const canCoalesce = (leftIndex: number, rightIndex: number): boolean => {
+			const left = segments[leftIndex];
+			const right = segments[rightIndex];
+			if (!left || !right) return false;
+			const leftSelectable = left.isWordLike || left.isTerminalJoiner;
+			const rightSelectable = right.isWordLike || right.isTerminalJoiner;
+			return leftSelectable && rightSelectable && (left.isTerminalJoiner || right.isTerminalJoiner);
+		};
+		let rangeStartIndex = clickedSegmentIndex;
+		let rangeEndIndex = clickedSegmentIndex;
+		while (rangeStartIndex > 0 && canCoalesce(rangeStartIndex - 1, rangeStartIndex)) rangeStartIndex--;
+		while (rangeEndIndex < segments.length - 1 && canCoalesce(rangeEndIndex, rangeEndIndex + 1)) rangeEndIndex++;
+		return {
+			start: { ...point, col: segments[rangeStartIndex]?.start ?? 0 },
+			end: { ...point, col: segments[rangeEndIndex]?.end ?? 0, boundary: true },
+		};
 	}
 
 	private getLineSelection(point: SelectionPoint): SelectionRange {

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -835,37 +835,38 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 	private getWordSelection(point: SelectionPoint): SelectionRange | undefined {
 		const line = stripTerminalSequences(this.getSelectionSourceLine(point));
-		const segments: Array<{ start: number; end: number; isWordLike: boolean; isTerminalJoiner: boolean }> = [];
+		const segments: Array<{ start: number; end: number; selectable: boolean; joiner: boolean }> = [];
 		let start = 0;
 		for (const segment of wordSegmenter.segment(line)) {
 			const end = start + visibleWidth(segment.segment);
-			segments.push({
-				start,
-				end,
-				isWordLike: segment.isWordLike === true,
-				isTerminalJoiner: TERMINAL_WORD_SELECTION_JOINERS.has(segment.segment),
-			});
+			const joiner = TERMINAL_WORD_SELECTION_JOINERS.has(segment.segment);
+			segments.push({ start, end, selectable: segment.isWordLike === true || joiner, joiner });
 			start = end;
 		}
 		const clickedSegmentIndex = segments.findIndex(
 			(segment) => point.col >= segment.start && point.col < segment.end,
 		);
 		if (clickedSegmentIndex < 0) return undefined;
-		const canCoalesce = (leftIndex: number, rightIndex: number): boolean => {
-			const left = segments[leftIndex];
-			const right = segments[rightIndex];
-			if (!left || !right) return false;
-			const leftSelectable = left.isWordLike || left.isTerminalJoiner;
-			const rightSelectable = right.isWordLike || right.isTerminalJoiner;
-			return leftSelectable && rightSelectable && (left.isTerminalJoiner || right.isTerminalJoiner);
-		};
-		let rangeStartIndex = clickedSegmentIndex;
-		let rangeEndIndex = clickedSegmentIndex;
-		while (rangeStartIndex > 0 && canCoalesce(rangeStartIndex - 1, rangeStartIndex)) rangeStartIndex--;
-		while (rangeEndIndex < segments.length - 1 && canCoalesce(rangeEndIndex, rangeEndIndex + 1)) rangeEndIndex++;
+
+		const canJoin = (
+			left: { selectable: boolean; joiner: boolean },
+			right: { selectable: boolean; joiner: boolean },
+		): boolean => left.selectable && right.selectable && (left.joiner || right.joiner);
+		let selectionStart = segments[clickedSegmentIndex].start;
+		let selectionEnd = segments[clickedSegmentIndex].end;
+		for (let index = clickedSegmentIndex; index > 0 && canJoin(segments[index - 1], segments[index]); index--) {
+			selectionStart = segments[index - 1].start;
+		}
+		for (
+			let index = clickedSegmentIndex;
+			index < segments.length - 1 && canJoin(segments[index], segments[index + 1]);
+			index++
+		) {
+			selectionEnd = segments[index + 1].end;
+		}
 		return {
-			start: { ...point, col: segments[rangeStartIndex]?.start ?? 0 },
-			end: { ...point, col: segments[rangeEndIndex]?.end ?? 0, boundary: true },
+			start: { ...point, col: selectionStart },
+			end: { ...point, col: selectionEnd, boundary: true },
 		};
 	}
 

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -1039,6 +1039,35 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
+	it("coalesces slash and hyphen separated segments for double-click word selection", async () => {
+		for (const { line, needle } of [
+			{ line: "extensions/starline/fixed-editor/compositor.ts", needle: "starline" },
+			{ line: "earendil-works/pi-tui", needle: "works" },
+		]) {
+			const copied: string[] = [];
+			const terminal = new RecordingTerminal(80, 1);
+			const tui = new TuiAltScreen(terminal, undefined, undefined, {
+				copySelection: async (text) => {
+					copied.push(text);
+					return true;
+				},
+			});
+			tui.addChild(new Text(line, 0, 0));
+			tui.start();
+			await terminal.waitForRender();
+
+			const oneBasedClickColumn = line.indexOf(needle) + 1;
+			terminal.sendInput(`\x1b[<0;${oneBasedClickColumn};1M`);
+			terminal.sendInput(`\x1b[<0;${oneBasedClickColumn};1m`);
+			terminal.sendInput(`\x1b[<0;${oneBasedClickColumn};1M`);
+			terminal.sendInput(`\x1b[<0;${oneBasedClickColumn};1m`);
+			await terminal.waitForRender();
+
+			assert.deepStrictEqual(copied, [line]);
+			tui.stop();
+		}
+	});
+
 	it("highlights a complete whitespace segment during a word drag", async () => {
 		const terminal = new RecordingTerminal(20, 1);
 		const tui = new TuiAltScreen(terminal);


### PR DESCRIPTION
Addresses #7746.

Fullscreen double-click selection used `Intl.Segmenter` directly, splitting paths/kebab-case (so boundaries `/` and `-`), unlike regular terminal selection.

Fixed by joining adjacent word segments on fullscreen when the boundary is `/` or `-`, preserving existing Unicode/width handling.

Re-ran the repro test and TUI tests to verify paths/package names now select as a full token.

https://github.com/user-attachments/assets/05de1486-da05-49e1-accd-b850ea8f8a80

