### PR TITLE
feat(tui): edit selected prompt text

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -9,6 +9,7 @@ import {
 	type TUI,
 	type TuiMouseEvent,
 	type TuiMouseEventResult,
+	type TuiSelectionPoint,
 } from "../tui.ts";
 import { UndoStack } from "../undo-stack.ts";
 import {
@@ -219,6 +220,11 @@ interface EditorState {
 	cursorCol: number;
 }
 
+interface EditorPosition {
+	line: number;
+	col: number;
+}
+
 /** Undo snapshot: editor text state plus the paste registry. */
 interface EditorSnapshot {
 	state: EditorState;
@@ -343,6 +349,7 @@ export class Editor implements Component, Focusable {
 	// vertical move can resolve it to a visual column on whatever VL it belongs
 	// to.
 	private snappedFromCursorCol: number | null = null;
+	private selection?: { start: EditorPosition; end: EditorPosition };
 
 	// Undo support
 	private undoStack = new UndoStack<EditorSnapshot>();
@@ -638,37 +645,12 @@ export class Editor implements Component, Focusable {
 		// The renderer synthesizes a click when press and release land on the same
 		// cell without movement, which is the gesture that positions the cursor.
 		if (event.type !== "click" || event.button !== "left") return undefined;
-		if (event.y <= 0 || event.y > this.renderedVisibleLineCount) return { handled: true, focus: true };
+		const position = this.getPositionAt(event.x, event.y, event.width, "start");
+		if (!position) return { handled: true, focus: true };
 
-		const visualLines = this.buildVisualLineMap(this.lastWidth);
-		const visualLineIndex = this.scrollOffset + event.y - 1;
-		const visualLine = visualLines[visualLineIndex];
-		if (!visualLine) return { handled: true, focus: true };
-		const logicalLine = this.state.lines[visualLine.logicalLine] ?? "";
-		const chunkEnd = visualLine.startCol + visualLine.length;
-		const chunk = logicalLine.slice(visualLine.startCol, chunkEnd);
-		const maxPadding = Math.max(0, Math.floor((event.width - 1) / 2));
-		const paddingX = Math.min(this.paddingX, maxPadding);
-		const targetColumn = Math.max(0, event.x - paddingX);
-		let visibleColumn = 0;
-		let targetIndex = chunk.length;
-		let lastGraphemeIndex = 0;
-		for (const grapheme of this.segment(chunk, "grapheme")) {
-			const nextColumn = visibleColumn + visibleWidth(grapheme.segment);
-			lastGraphemeIndex = grapheme.index;
-			if (targetColumn < nextColumn) {
-				targetIndex = grapheme.index;
-				break;
-			}
-			visibleColumn = nextColumn;
-		}
-		const isLastSegment =
-			visualLineIndex === visualLines.length - 1 ||
-			visualLines[visualLineIndex + 1]?.logicalLine !== visualLine.logicalLine;
-		if (!isLastSegment && targetIndex === chunk.length && chunk.length > 0) targetIndex = lastGraphemeIndex;
-
-		this.state.cursorLine = visualLine.logicalLine;
-		this.setCursorCol(visualLine.startCol + targetIndex);
+		this.state.cursorLine = position.line;
+		this.selection = undefined;
+		this.setCursorCol(position.col);
 		this.lastAction = null;
 		this.exitHistoryBrowsing();
 		if (this.autocompleteState) this.updateAutocomplete();
@@ -677,6 +659,24 @@ export class Editor implements Component, Focusable {
 
 	handleInput(data: string): void {
 		const kb = getKeybindings();
+		if (
+			this.selection &&
+			(kb.matches(data, "tui.editor.deleteCharBackward") ||
+				matchesKey(data, "shift+backspace") ||
+				kb.matches(data, "tui.editor.deleteCharForward") ||
+				matchesKey(data, "shift+delete"))
+		) {
+			this.deleteSelection();
+			return;
+		}
+		const selectedTextInput = matchesKey(data, "shift+space")
+			? " "
+			: (decodePrintableKey(data) ?? (data.charCodeAt(0) >= 32 ? data : undefined));
+		if (this.selection && selectedTextInput !== undefined) {
+			this.replaceSelection(selectedTextInput);
+			return;
+		}
+		this.selection = undefined;
 
 		// Handle character jump mode (awaiting next character to jump to)
 		if (this.jumpMode !== null) {
@@ -975,6 +975,123 @@ export class Editor implements Component, Focusable {
 		if (data.charCodeAt(0) >= 32) {
 			this.insertCharacter(data);
 		}
+	}
+
+	handleSelection(start: TuiSelectionPoint, end: TuiSelectionPoint, width: number): boolean {
+		const startPosition = this.getPositionAt(start.x, start.y, width, "start");
+		const endPosition = this.getPositionAt(end.x, end.y, width, end.boundary ? "boundary" : "end");
+		if (!startPosition || !endPosition) return false;
+		if (startPosition.line === endPosition.line && startPosition.col === endPosition.col) return false;
+
+		this.selection = { start: startPosition, end: endPosition };
+		this.lastAction = null;
+		return true;
+	}
+
+	clearSelection(): void {
+		this.selection = undefined;
+	}
+
+	private getPositionAt(
+		x: number,
+		y: number,
+		width: number,
+		mode: "start" | "end" | "boundary",
+	): EditorPosition | undefined {
+		if (y <= 0 || y > this.renderedVisibleLineCount) return undefined;
+		const visualLines = this.buildVisualLineMap(this.lastWidth);
+		const visualLineIndex = this.scrollOffset + y - 1;
+		const visualLine = visualLines[visualLineIndex];
+		if (!visualLine) return undefined;
+
+		const paddingX = Math.min(this.paddingX, Math.max(0, Math.floor((width - 1) / 2)));
+		const visualCol = Math.max(0, x - paddingX);
+		const logicalLine = this.state.lines[visualLine.logicalLine] ?? "";
+		const chunk = logicalLine.slice(visualLine.startCol, visualLine.startCol + visualLine.length);
+		const isLastVisualLine =
+			visualLineIndex === visualLines.length - 1 ||
+			visualLines[visualLineIndex + 1]?.logicalLine !== visualLine.logicalLine;
+		let targetCol = isLastVisualLine || mode !== "start" ? visualLine.startCol + chunk.length : visualLine.startCol;
+		let currentWidth = 0;
+		for (const grapheme of this.segment(chunk, "grapheme")) {
+			if (visualCol < currentWidth + visibleWidth(grapheme.segment)) {
+				targetCol = visualLine.startCol + grapheme.index + (mode === "end" ? grapheme.segment.length : 0);
+				break;
+			}
+			currentWidth += visibleWidth(grapheme.segment);
+			if (!isLastVisualLine && mode === "start") targetCol = visualLine.startCol + grapheme.index;
+		}
+
+		for (const segment of this.segment(logicalLine, "grapheme")) {
+			if (targetCol > segment.index && targetCol < segment.index + segment.segment.length) {
+				targetCol = mode === "end" ? segment.index + segment.segment.length : segment.index;
+				break;
+			}
+		}
+		return { line: visualLine.logicalLine, col: targetCol };
+	}
+
+	private deleteSelection(): void {
+		if (!this.selection) return;
+		this.cancelAutocomplete();
+		this.exitHistoryBrowsing();
+		this.lastAction = null;
+		this.pushUndoSnapshot();
+		this.removeSelection();
+		this.onChange?.(this.getText());
+		this.tui.requestRender();
+	}
+
+	private replaceSelection(text: string): void {
+		if (!this.selection) return;
+		this.cancelAutocomplete();
+		this.exitHistoryBrowsing();
+		this.lastAction = null;
+		this.pushUndoSnapshot();
+		this.removeSelection();
+		this.insertCharacter(text, true);
+		this.lastAction = "type-word";
+	}
+
+	private removeSelection(): void {
+		const selection = this.selection!;
+		this.selection = undefined;
+		const selectedText =
+			selection.start.line === selection.end.line
+				? this.state.lines[selection.start.line]!.slice(selection.start.col, selection.end.col)
+				: [
+						this.state.lines[selection.start.line]!.slice(selection.start.col),
+						...this.state.lines.slice(selection.start.line + 1, selection.end.line),
+						this.state.lines[selection.end.line]!.slice(0, selection.end.col),
+					].join("\n");
+		const before = this.state.lines[selection.start.line]!.slice(0, selection.start.col);
+		const after = this.state.lines[selection.end.line]!.slice(selection.end.col);
+		this.state.lines.splice(selection.start.line, selection.end.line - selection.start.line + 1, before + after);
+		this.state.cursorLine = selection.start.line;
+		this.setCursorCol(selection.start.col);
+		this.removePastes(
+			new Set(
+				[...selectedText.matchAll(PASTE_MARKER_REGEX)]
+					.map((match) => Number(match[1]))
+					.filter((id) => this.pastes.has(id)),
+			),
+		);
+	}
+
+	private removePastes(removedIds: Set<number>): void {
+		if (removedIds.size === 0) return;
+		const remaining = [...this.pastes].filter(([id]) => !removedIds.has(id));
+		const idMap = new Map(remaining.map(([id], index) => [id, index + 1]));
+		const remap = (text: string): string =>
+			text.replace(PASTE_MARKER_REGEX, (fullMatch, idGroup, suffixGroup = "") => {
+				const id = idMap.get(Number(idGroup));
+				return id === undefined ? fullMatch : `[paste #${id}${suffixGroup}]`;
+			});
+		const cursorPrefix = remap(this.state.lines[this.state.cursorLine]!.slice(0, this.state.cursorCol));
+		this.pastes = new Map(remaining.map(([, content], index) => [index + 1, content]));
+		this.pasteCounter = this.pastes.size;
+		this.state.lines = this.state.lines.map(remap);
+		this.setCursorCol(cursorPrefix.length);
 	}
 
 	private layoutText(contentWidth: number): LayoutLine[] {

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -7,7 +7,7 @@ import {
 import { AltScreenFlashContainer } from "./components/alt-screen-flash.ts";
 import { ScrollView } from "./components/scroll-view.ts";
 import { getKeybindings } from "./keybindings.ts";
-import { isKeyRelease } from "./keys.ts";
+import { decodePrintableKey, isKeyRelease, matchesKey } from "./keys.ts";
 import {
 	getLayoutBoxesAt,
 	getScrollbarGeometry,
@@ -201,6 +201,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 	private activeSearch?: ActiveSearch;
 	private pressedUrl?: string;
 	private selectionDragged = false;
+	private componentSelectionOwner?: Component;
 	private mouseCapture?: TuiMouseDispatchTarget;
 	private mousePressTarget?: TuiMouseDispatchTarget;
 	private mousePressPoint?: { x: number; y: number };
@@ -230,6 +231,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		this.implicitDocument = {
 			render: (width) => super.render(width),
 			handleMouse: (event) => super.handleMouse(event),
+			handleSelection: (start, end, width) => super.handleSelection(start, end, width),
+			clearSelection: () => super.clearSelection(),
 			invalidate: () => {
 				for (const child of this.children) child.invalidate();
 			},
@@ -580,6 +583,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 			this.selectionDragged = false;
 			this.clearComponentMouseGesture();
 			this.lastComponentClick = undefined;
+			this.componentSelectionOwner?.clearSelection?.();
+			this.componentSelectionOwner = undefined;
 			if (hadActiveSelection) {
 				this.selectionAnchor = undefined;
 				this.selectionFocus = undefined;
@@ -616,6 +621,24 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 		const keybindings = getKeybindings();
 		const isRelease = isKeyRelease(data);
+		if (!isRelease && this.componentSelectionOwner && this.getSelectionBounds()) {
+			const owner = this.componentSelectionOwner;
+			this.componentSelectionOwner = undefined;
+			this.selectionAnchor = undefined;
+			this.selectionFocus = undefined;
+			this.selectionGranularity = "character";
+			this.selectionInitialRange = undefined;
+			const editsSelection =
+				keybindings.matches(data, "tui.editor.deleteCharBackward") ||
+				matchesKey(data, "shift+backspace") ||
+				keybindings.matches(data, "tui.editor.deleteCharForward") ||
+				matchesKey(data, "shift+delete") ||
+				matchesKey(data, "shift+space") ||
+				decodePrintableKey(data) !== undefined ||
+				data.charCodeAt(0) >= 32;
+			if (!editsSelection) owner.clearSelection?.();
+			this.requestRender();
+		}
 		if (keybindings.matches(data, "tui.altScreen.search")) {
 			if (!isRelease) this.openSearch();
 			return { consume: true };
@@ -777,6 +800,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 	}
 
 	private clearTextSelection(): void {
+		this.componentSelectionOwner?.clearSelection?.();
+		this.componentSelectionOwner = undefined;
 		this.stopSelectionAutoScroll();
 		this.selectionPressActive = false;
 		this.selectionAnchor = undefined;
@@ -1203,6 +1228,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 					return;
 				}
 			}
+			const selection = this.getSelectionBounds();
+			this.componentSelectionOwner = selection ? this.handleComponentSelection(selection) : undefined;
 			void this.copySelectionToClipboard();
 			this.requestRender();
 			return;
@@ -1218,6 +1245,8 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 			return;
 		}
 		this.stopSelectionAutoScroll();
+		this.componentSelectionOwner?.clearSelection?.();
+		this.componentSelectionOwner = undefined;
 		this.selectionPressActive = true;
 		const scrollView =
 			!this.hasOverlay() && this.currentLayout
@@ -1239,6 +1268,50 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 					Math.max(0, Math.min(this.terminal.columns - 1, event.x)),
 				);
 		this.requestRender();
+	}
+
+	private handleComponentSelection(selection: { start: SelectionPoint; end: SelectionPoint }): Component | undefined {
+		if (!this.currentLayout) return undefined;
+		const focused = this.getFocusedComponent();
+		if (!focused?.handleSelection) return undefined;
+		const scrollViewBox = selection.start.scrollView
+			? getScrollViewBox(this.currentLayout, selection.start.scrollView)
+			: undefined;
+		if (selection.start.scrollView && !scrollViewBox) return undefined;
+		if (scrollViewBox) {
+			const target = scrollViewBox.children[0];
+			return target?.component.handleSelection?.(
+				{ x: selection.start.col, y: selection.start.row },
+				{
+					x: selection.end.col,
+					y: selection.end.row,
+					...(selection.end.boundary ? { boundary: true } : {}),
+				},
+				target.rect.width,
+			)
+				? focused
+				: undefined;
+		}
+		const start = { x: selection.start.col, y: selection.start.row };
+		const end = { x: selection.end.col, y: selection.end.row };
+		const startTarget = getLayoutBoxesAt(this.currentLayout, start.x, start.y).find(
+			(box) => box.component === focused,
+		);
+		const endX = selection.end.boundary ? Math.max(0, end.x - 1) : end.x;
+		const endTarget = getLayoutBoxesAt(this.currentLayout, endX, end.y).find((box) => box.component === focused);
+		if (!startTarget || startTarget !== endTarget) return undefined;
+		const offsetY = startTarget.rect.y - (startTarget.lineOffset ?? 0);
+		return focused.handleSelection?.(
+			{ x: start.x - startTarget.rect.x, y: start.y - offsetY },
+			{
+				x: end.x - startTarget.rect.x,
+				y: end.y - offsetY,
+				...(selection.end.boundary ? { boundary: true } : {}),
+			},
+			startTarget.rect.width,
+		)
+			? focused
+			: undefined;
 	}
 
 	private getSelectionBounds(): { start: SelectionPoint; end: SelectionPoint } | undefined {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -59,6 +59,12 @@ export interface TuiMouseEventResult {
 	render?: boolean;
 }
 
+export interface TuiSelectionPoint {
+	x: number;
+	y: number;
+	boundary?: boolean;
+}
+
 /** Internal target metadata used by containers and alternate-screen dispatch. */
 export interface TuiMouseDispatchTarget {
 	component: Component;
@@ -123,6 +129,12 @@ export interface Component {
 
 	/** Optional normalized mouse handler. */
 	handleMouse?(event: TuiMouseEvent): TuiMouseEventResult | undefined;
+
+	/** Optional handler for a completed screen selection within this component. */
+	handleSelection?(start: TuiSelectionPoint, end: TuiSelectionPoint, width: number): boolean;
+
+	/** Clear component-owned selection state. */
+	clearSelection?(): void;
 
 	/**
 	 * If true, component receives key release events (Kitty protocol).
@@ -352,6 +364,24 @@ export class Container implements Component {
 			childY += childHeight;
 		}
 		return undefined;
+	}
+
+	handleSelection(start: TuiSelectionPoint, end: TuiSelectionPoint, width: number): boolean {
+		let childY = 0;
+		for (const child of this.children) {
+			const childHeight = child.render(width).length;
+			if (start.y >= childY && start.y < childY + childHeight && end.y >= childY && end.y < childY + childHeight) {
+				return (
+					child.handleSelection?.({ ...start, y: start.y - childY }, { ...end, y: end.y - childY }, width) ?? false
+				);
+			}
+			childY += childHeight;
+		}
+		return false;
+	}
+
+	clearSelection(): void {
+		for (const child of this.children) child.clearSelection?.();
 	}
 
 	render(width: number): string[] {

--- a/packages/tui/test/mouse-components.test.ts
+++ b/packages/tui/test/mouse-components.test.ts
@@ -176,4 +176,29 @@ describe("mouse-aware components", () => {
 		assert.deepStrictEqual(editor.getCursor(), cursorBefore);
 		tui.stop();
 	});
+
+	for (const { name, input, expected } of [
+		{ name: "deletes", input: "\x7f", expected: " world" },
+		{ name: "replaces", input: "pi", expected: "pi world" },
+	]) {
+		it(`${name} selected editor text`, async () => {
+			const terminal = new VirtualTerminal(20, 6);
+			const tui = new TuiAltScreen(terminal, undefined, undefined, { copySelection: async () => true });
+			const editor = new Editor(tui, editorTheme);
+			editor.setText("hello world");
+			tui.addChild(editor);
+			tui.setFocus(editor);
+			tui.start();
+			await terminal.waitForRender();
+
+			terminal.sendInput("\x1b[<0;1;2M");
+			terminal.sendInput("\x1b[<32;5;2M");
+			terminal.sendInput("\x1b[<0;5;2m");
+			terminal.sendInput(input);
+			await terminal.waitForRender();
+
+			assert.strictEqual(editor.getText(), expected);
+			tui.stop();
+		});
+	}
 });


### PR DESCRIPTION
## Summary

Dragging across text in the prompt already creates a visible selection and copies it, but editing still ignores that selection. This makes a familiar text-editing gesture behave differently from normal input fields.

Let the focused editor receive completed mouse selections so Backspace and Delete remove the selected text, while printable input replaces it at the selection start. Existing terminal selection and clipboard behavior remain unchanged.

## Testing

- `npm run check`
- `node --test test/mouse-components.test.ts` from `packages/tui`
- Full `packages/tui` test suite
