### PR TITLE
feat(ai): add GLM-5.3 Flash to Z.AI catalogs

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -258,6 +258,24 @@ const NVIDIA_NIM_UNSUPPORTED_MODELS = new Set([
 	"upstage/solar-10.7b-instruct",
 ]);
 const ZAI_TOOL_STREAM_UNSUPPORTED_MODELS = new Set(["glm-4.5", "glm-4.5-air", "glm-4.5-flash", "glm-4.5v"]);
+const ZAI_CODING_PLAN_MODEL_OVERRIDES = {
+	"glm-5.3-flash": {
+		id: "glm-5.3-flash",
+		name: "GLM-5.3 Flash",
+		tool_call: true,
+		reasoning: true,
+		reasoning_options: [{ type: "effort", values: ["low", "high", "max"] }],
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 1_000_000,
+			output: 131_072,
+		},
+	},
+} satisfies Record<string, ModelsDevModel>;
+
 const OPENCODE_GO_GLM52_THINKING_LEVEL_MAP = {
 	off: null,
 	minimal: null,
@@ -1209,7 +1227,10 @@ function processZaiModels(data: ModelsDevCatalog): Model<Api>[] {
 	const models: Model<Api>[] = [];
 
 	for (const { source, provider, baseUrl } of variants) {
-		for (const [modelId, model] of Object.entries(data[source]?.models ?? {})) {
+		for (const [modelId, model] of Object.entries({
+			...data[source]?.models,
+			...ZAI_CODING_PLAN_MODEL_OVERRIDES,
+		})) {
 			const m = model as ModelsDevModel;
 			if (m.tool_call !== true) continue;
 			const supportsImage = m.modalities?.input?.includes("image");

--- a/packages/ai/test/generate-models-strict.test.ts
+++ b/packages/ai/test/generate-models-strict.test.ts
@@ -83,4 +83,67 @@ describe("strict model generation", () => {
 		);
 		expect(generatedPaths.map((path) => readFileSync(join(packageRoot, path), "utf8"))).toEqual(sourceBefore);
 	});
+
+	it("includes GLM-5.3 Flash in both Z.AI Coding Plan catalogs", () => {
+		const fixtureRoot = mkdtempSync(join(tmpdir(), "pi-generate-models-"));
+		temporaryRoots.push(fixtureRoot);
+		const outputDir = join(fixtureRoot, "catalog");
+		const preloadPath = join(fixtureRoot, "mock-models-dev.mjs");
+		writeFileSync(
+			preloadPath,
+			`globalThis.fetch = async (input) => {\n` +
+				`  if (String(input) === "https://models.dev/api.json") {\n` +
+				`    return new Response(JSON.stringify({}), { status: 200 });\n` +
+				`  }\n` +
+				`  return new Response("", { status: 500 });\n` +
+				`};\n`,
+		);
+
+		const result = spawnSync(
+			process.execPath,
+			[
+				"--import",
+				pathToFileURL(preloadPath).href,
+				"scripts/generate-models.ts",
+				"--json-only",
+				"--json-output",
+				outputDir,
+			],
+			{
+				cwd: packageRoot,
+				encoding: "utf8",
+				timeout: 10_000,
+			},
+		);
+
+		expect(result.status).toBe(0);
+		for (const [provider, baseUrl] of Object.entries({
+			zai: "https://api.z.ai/api/coding/paas/v4",
+			"zai-coding-cn": "https://open.bigmodel.cn/api/coding/paas/v4",
+		})) {
+			const catalog = JSON.parse(readFileSync(join(outputDir, "providers", `${provider}.json`), "utf8"));
+			expect(catalog["glm-5.3-flash"]).toMatchObject({
+				id: "glm-5.3-flash",
+				name: "GLM-5.3 Flash",
+				api: "openai-completions",
+				provider,
+				baseUrl,
+				reasoning: true,
+				input: ["text", "image"],
+				contextWindow: 1_000_000,
+				maxTokens: 131_072,
+				thinkingLevelMap: {
+					off: null,
+					low: "low",
+					high: "high",
+					max: "max",
+				},
+				compat: {
+					thinkingFormat: "zai",
+					supportsReasoningEffort: true,
+					zaiToolStream: true,
+				},
+			});
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- Add a durable GLM-5.3 Flash override to both Z.AI Coding Plan catalogs.
- Preserve Z.AI OpenAI Completions endpoints and GLM-5.3 reasoning compatibility, including text/image input, a 1,000,000-token context window, and a 131,072-token output limit.
- Add a generator regression for both Z.AI catalog variants.

## Reference
- Official Z.AI release notes: https://docs.z.ai/release-notes/new-released

## Verification
- Generated the JSON model catalog and inspected both Z.AI entries.
- Tests were not run; validation is coordinated separately.