### PR TITLE
fix(ai): expose low reasoning effort for DeepSeek V4 Pro

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -283,7 +283,7 @@ const DEEPSEEK_V4_THINKING_LEVEL_MAP = {
 	high: "high",
 	max: "max",
 } as const;
-const DEEPSEEK_V4_FLASH_THINKING_LEVEL_MAP = {
+const DEEPSEEK_V4_LOW_HIGH_MAX_THINKING_LEVEL_MAP = {
 	...DEEPSEEK_V4_THINKING_LEVEL_MAP,
 	low: "low",
 } as const;
@@ -933,8 +933,8 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 			model.provider === "openrouter"
 				? { ...DEEPSEEK_V4_THINKING_LEVEL_MAP, xhigh: "xhigh", max: null }
 				: (model.provider === "deepseek" || model.provider === "opencode" || model.provider === "opencode-go") &&
-					model.id.includes("deepseek-v4-flash")
-					? DEEPSEEK_V4_FLASH_THINKING_LEVEL_MAP
+					(model.id.includes("deepseek-v4-flash") || model.id.includes("deepseek-v4-pro"))
+					? DEEPSEEK_V4_LOW_HIGH_MAX_THINKING_LEVEL_MAP
 					: DEEPSEEK_V4_THINKING_LEVEL_MAP,
 		);
 	}

--- a/packages/ai/test/supports-xhigh.test.ts
+++ b/packages/ai/test/supports-xhigh.test.ts
@@ -88,8 +88,20 @@ describe("getSupportedThinkingLevels", () => {
 		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "high", "max"]);
 	});
 
+	it("includes low/high/max plus off for DeepSeek V4 Pro on the DeepSeek provider", () => {
+		const model = getModel("deepseek", "deepseek-v4-pro");
+		expect(model).toBeDefined();
+		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "high", "max"]);
+	});
+
 	it("includes low/high/max plus off for DeepSeek V4 Flash on opencode-go", () => {
 		const model = getModel("opencode-go", "deepseek-v4-flash");
+		expect(model).toBeDefined();
+		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "high", "max"]);
+	});
+
+	it("includes low/high/max plus off for DeepSeek V4 Pro on opencode-go", () => {
+		const model = getModel("opencode-go", "deepseek-v4-pro");
 		expect(model).toBeDefined();
 		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "low", "high", "max"]);
 	});
@@ -129,6 +141,12 @@ describe("getSupportedThinkingLevels", () => {
 
 	it("includes only high/xhigh plus off for DeepSeek V4 Flash on OpenRouter", () => {
 		const model = getModel("openrouter", "deepseek/deepseek-v4-flash");
+		expect(model).toBeDefined();
+		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "high", "xhigh"]);
+	});
+
+	it("includes only high/xhigh plus off for DeepSeek V4 Pro on OpenRouter", () => {
+		const model = getModel("openrouter", "deepseek/deepseek-v4-pro");
 		expect(model).toBeDefined();
 		expect(getSupportedThinkingLevels(model!)).toEqual(["off", "high", "xhigh"]);
 	});


### PR DESCRIPTION
## Summary

Enables pi's `low` thinking level for `deepseek-v4-pro` on the native DeepSeek provider and its `opencode` / `opencode-go` mirrors, matching what already exists for `deepseek-v4-flash`.

## Why

DeepSeek's [thinking-mode docs](https://api-docs.deepseek.com/guides/thinking_mode) specify `reasoning_effort` values of `low/high/max`, with the user→actual effort mapping *identical for `deepseek-v4-flash` and `deepseek-v4-pro`* (`low→low`, `medium/high/xhigh→high`, `max→max`). Acceptance of `reasoning_effort=low` for `deepseek-v4-pro` was verified live against the hosted API.

models.dev only lists `high/max` for v4-pro (it lists `low/high/max` for flash), so this is a narrow correction over models.dev metadata, mirroring the approach of #7807 and #8181 for flash.

## Changes

- `packages/ai/scripts/generate-models.ts`
  - Renamed `DEEPSEEK_V4_FLASH_THINKING_LEVEL_MAP` → `DEEPSEEK_V4_LOW_HIGH_MAX_THINKING_LEVEL_MAP` since it now applies to both flash and pro.
  - The low-enabled map is now applied to `deepseek-v4-flash` **and** `deepseek-v4-pro` on the `deepseek`, `opencode`, and `opencode-go` providers.
- `packages/ai/test/supports-xhigh.test.ts`
  - Added: `deepseek/deepseek-v4-pro` and `opencode-go/deepseek-v4-pro` now expose `["off", "low", "high", "max"]`.
  - Regression guard: `openrouter/deepseek-v4-pro` stays `["off", "high", "xhigh"]`.

## Unchanged

- OpenRouter (`high`/`xhigh` only, per its verified metadata)
- `qwen-token-plan` / `qwen-token-plan-cn` / `qwen-token-plan-individual` (separate thinking map, same as #8181)
- Together

## Testing

- `vitest` on `supports-xhigh`, `together-models`, `qwen-token-plan-models`, `openai-completions-tool-choice`, `max-thinking`, `stream`: 168 pass.
- `biome check` clean on both changed files.