### PR TITLE
fix(tui): handle Apple Terminal meta arrows

### DIFF
--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -478,6 +478,10 @@ const LEGACY_SEQUENCE_KEY_IDS: Record<string, KeyId> = {
 	"\x1bf": "alt+right",
 	"\x1bp": "alt+up",
 	"\x1bn": "alt+down",
+	"\x1b\x1b[A": "alt+up",
+	"\x1b\x1b[B": "alt+down",
+	"\x1b\x1b[C": "alt+right",
+	"\x1b\x1b[D": "alt+left",
 } as const;
 
 type LegacyModifierKey = keyof typeof LEGACY_SHIFT_SEQUENCES;
@@ -1043,7 +1047,10 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 
 		case "up":
 			if (modifier === MODIFIERS.alt) {
-				return data === "\x1bp" || matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt);
+				return (
+					LEGACY_SEQUENCE_KEY_IDS[data] === "alt+up" ||
+					matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt)
+				);
 			}
 			if (modifier === 0) {
 				return (
@@ -1058,7 +1065,10 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 
 		case "down":
 			if (modifier === MODIFIERS.alt) {
-				return data === "\x1bn" || matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt);
+				return (
+					LEGACY_SEQUENCE_KEY_IDS[data] === "alt+down" ||
+					matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt)
+				);
 			}
 			if (modifier === 0) {
 				return (
@@ -1076,7 +1086,7 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 				return (
 					data === "\x1b[1;3D" ||
 					(!_kittyProtocolActive && data === "\x1bB") ||
-					data === "\x1bb" ||
+					LEGACY_SEQUENCE_KEY_IDS[data] === "alt+left" ||
 					matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS.alt)
 				);
 			}
@@ -1103,7 +1113,7 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
 				return (
 					data === "\x1b[1;3C" ||
 					(!_kittyProtocolActive && data === "\x1bF") ||
-					data === "\x1bf" ||
+					LEGACY_SEQUENCE_KEY_IDS[data] === "alt+right" ||
 					matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS.alt)
 				);
 			}

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -198,6 +198,21 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 	while (pos < buffer.length) {
 		const remaining = buffer.slice(pos);
 
+		// A second ESC may be the prefix for an Option-modified escape sequence.
+		// Wait briefly for the next byte instead of finalizing Ctrl+Alt+[ early.
+		if (remaining === `${ESC}${ESC}`) return { sequences, remainder: remaining };
+
+		// Apple Terminal prefixes the ordinary arrow sequence with ESC for
+		// Option+arrow. Preserve it as one event so key matching sees Alt+arrow.
+		if (remaining.startsWith(`${ESC}${ESC}[`)) {
+			if (remaining.length < 4) return { sequences, remainder: remaining };
+			if (/[ABCD]/.test(remaining[3]!)) {
+				sequences.push(remaining.slice(0, 4));
+				pos += 4;
+				continue;
+			}
+		}
+
 		// Try to extract a sequence starting at this position
 		if (remaining.startsWith(ESC)) {
 			// Find the end of this escape sequence

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -500,6 +500,16 @@ describe("matchesKey", () => {
 		it("should match alt+arrows", () => {
 			assert.strictEqual(matchesKey("\x1bp", "alt+up"), true);
 			assert.strictEqual(matchesKey("\x1bp", "up"), false);
+			for (const [sequence, key] of [
+				["\x1b\x1b[A", "up"],
+				["\x1b\x1b[B", "down"],
+				["\x1b\x1b[C", "right"],
+				["\x1b\x1b[D", "left"],
+			] as const) {
+				assert.strictEqual(matchesKey(sequence, `alt+${key}`), true);
+				assert.strictEqual(matchesKey(sequence, key), false);
+				assert.strictEqual(parseKey(sequence), `alt+${key}`);
+			}
 		});
 
 		it("should match rxvt modifier sequences", () => {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -64,6 +64,13 @@ describe("StdinBuffer", () => {
 			assert.deepStrictEqual(emittedSequences, [upArrow]);
 		});
 
+		it("should preserve Apple Terminal Option+arrow sequences", () => {
+			for (const sequence of ["\x1b\x1b[A", "\x1b\x1b[B", "\x1b\x1b[C", "\x1b\x1b[D"]) {
+				processInput(sequence);
+			}
+			assert.deepStrictEqual(emittedSequences, ["\x1b\x1b[A", "\x1b\x1b[B", "\x1b\x1b[C", "\x1b\x1b[D"]);
+		});
+
 		it("should pass through complete function key sequences", () => {
 			const f1 = "\x1b[11~";
 			processInput(f1);
@@ -107,6 +114,22 @@ describe("StdinBuffer", () => {
 
 			processInput("5H");
 			assert.deepStrictEqual(emittedSequences, ["\x1b[1;5H"]);
+		});
+
+		it("should preserve Apple Terminal Option+arrow sequences split across chunks", () => {
+			processInput("\x1b");
+			processInput("\x1b[");
+			processInput("A");
+
+			assert.deepStrictEqual(emittedSequences, ["\x1b\x1b[A"]);
+		});
+
+		it("should preserve Apple Terminal Option+arrow when each escape arrives separately", () => {
+			processInput("\x1b");
+			processInput("\x1b");
+			processInput("[A");
+
+			assert.deepStrictEqual(emittedSequences, ["\x1b\x1b[A"]);
 		});
 
 		it("should buffer split across many chunks", () => {
@@ -269,9 +292,11 @@ describe("StdinBuffer", () => {
 			assert.deepStrictEqual(emittedSequences, ["\x1b", "\x1b[27;1:3u"]);
 		});
 
-		it("should still emit ESC+ESC as a single sequence when not followed by a new escape", () => {
+		it("should still emit ESC+ESC as a single sequence when not followed by a new escape", async () => {
 			// \x1b\x1b alone (no following CSI) stays as-is — e.g. ctrl+alt+[
 			processInput("\x1b\x1b");
+			assert.deepStrictEqual(emittedSequences, []);
+			await wait(15);
 			assert.deepStrictEqual(emittedSequences, ["\x1b\x1b"]);
 		});
 


### PR DESCRIPTION
## Summary

- recognize Apple Terminal's legacy Option+arrow sequences (`ESC ESC [ A-D`) as Alt+arrow
- keep the two-ESC prefix buffered so fragmented stdin chunks are emitted as one key event
- preserve the existing WezTerm Escape-plus-Kitty-sequence handling

## Reproduction

With Terminal.app's **Use Option as Meta key** enabled, Option+Up produces:

```text
1b 1b 5b 41
```

Pi previously split this into separate Escape/CSI input, so bindings such as `app.message.dequeue: alt+up` did not fire.

## Testing

- `node --test packages/tui/test/keys.test.ts packages/tui/test/stdin-buffer.test.ts`
- `npm --workspace=@earendil-works/pi-tui test`
- `./node_modules/.bin/biome check packages/tui/src/keys.ts packages/tui/src/stdin-buffer.ts packages/tui/test/keys.test.ts packages/tui/test/stdin-buffer.test.ts`
- `./node_modules/.bin/tsgo -p packages/tui/tsconfig.build.json --noEmit`

No changelog entry is included.
