### PR TITLE
fix(ai): keep zai thinking enabled for forced-thinking models (off === null)

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -859,7 +859,13 @@ function buildParams(
 			thinking?: { type: "enabled" | "disabled"; clear_thinking?: boolean };
 			reasoning_effort?: string;
 		};
-		zaiParams.thinking = options?.reasoningEffort ? { type: "enabled", clear_thinking: false } : { type: "disabled" };
+		// Forced-thinking models (thinkingLevelMap.off === null, e.g. GLM-5.3 / GLM-5.3-Flash)
+		// ignore `disabled` and fold their mandatory reasoning into `content`, so keep thinking on.
+		// Mirrors the guard used by the deepseek/openrouter handlers below.
+		const forcedThinking = model.thinkingLevelMap?.off === null;
+		zaiParams.thinking = (options?.reasoningEffort || forcedThinking)
+			? { type: "enabled", clear_thinking: false }
+			: { type: "disabled" };
 		if (options?.reasoningEffort && compat.supportsReasoningEffort) {
 			const mappedEffort = model.thinkingLevelMap?.[options.reasoningEffort];
 			const effort = mappedEffort === undefined ? options.reasoningEffort : mappedEffort;


### PR DESCRIPTION
## Summary
When `reasoningEffort` is undefined (thinking level = off), the `zai` thinking-format branch in `openai-completions.ts` unconditionally sends `thinking: { type: "disabled" }`. For **forced-thinking** Z.AI models whose `thinkingLevelMap.off === null` (e.g. `glm-5.3` and `glm-5.3-flash`), the API does not honor `disabled` and folds the mandatory reasoning into the `content` field, which pi then renders as the final answer.

This mirrors the guard already present in the `deepseek` (line 908) and `openrouter` (line 922) handlers: only send `disabled` when the model actually supports turning thinking off.

## Fix
```ts
const forcedThinking = model.thinkingLevelMap?.off === null;
zaiParams.thinking = (options?.reasoningEffort || forcedThinking)
  ? { type: "enabled", clear_thinking: false }
  : { type: "disabled" };
```

Models that support disabling thinking (e.g. `glm-5.2`, `thinkingLevelMap.off = "none"") are unchanged.

## Test plan
- [ ] Select `glm-5.3` / `glm-5.3-flash` (provider `zai-coding-cn`), toggle thinking to off, confirm the request sends `thinking.type = enabled` and reasoning is returned in `reasoning_content` (hidden thinking block) rather than folded into `content`.
- [ ] Select `glm-5.2`, toggle thinking off, confirm `disabled` is still sent (unchanged behavior).

Closes #8706