### PR TITLE
fix(ai): treat whitespace-only tool results as empty output

### DIFF
--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -227,7 +227,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 				? msg.content.filter((c): c is ImageContent => c.type === "image")
 				: [];
 
-			const hasText = textResult.length > 0;
+			const hasText = textResult.trim().length > 0;
 			const hasImages = imageContent.length > 0;
 
 			// Gemini 3+ models support multimodal function responses with images nested inside

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1380,7 +1380,7 @@ export function convertMessages(
 				const hasImages = toolMsg.content.some((c) => c.type === "image");
 
 				// Always send tool result with text (or placeholder if only images)
-				const hasText = textResult.length > 0;
+				const hasText = textResult.trim().length > 0;
 				const toolResultText = hasText ? textResult : hasImages ? "(see attached image)" : "(no tool output)";
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -83,7 +83,7 @@ function convertToolResultOutput<TApi extends Api>(
 		.map((c) => c.text)
 		.join("\n");
 	const images = content.filter((c): c is ImageContent => c.type === "image");
-	const hasText = textResult.length > 0;
+	const hasText = textResult.trim().length > 0;
 
 	if (images.length === 0 || !model.input.includes("image")) {
 		return sanitizeSurrogates(hasText ? textResult : images.length > 0 ? "(see attached image)" : "(no tool output)");

--- a/packages/ai/test/google-shared-image-tool-result-routing.test.ts
+++ b/packages/ai/test/google-shared-image-tool-result-routing.test.ts
@@ -99,4 +99,44 @@ describe("google-shared image tool result routing", () => {
 		expect(imageResponse?.parts).toHaveLength(1);
 		expect(imageResponse?.parts?.[0]?.inlineData).toBeTruthy();
 	});
+
+	it("treats whitespace-only tool result text as empty output", () => {
+		const model = makeModel("google-generative-ai", "google", "gemini-2.5-flash");
+		const now = Date.now();
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "run the command", timestamp: now },
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call_ws", name: "bash", arguments: { command: "true" } }],
+					api: "google-generative-ai",
+					provider: "google",
+					model: "gemini-2.5-flash",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "toolUse",
+					timestamp: now,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_ws",
+					toolName: "bash",
+					content: [{ type: "text", text: "\r\n" }],
+					isError: false,
+					timestamp: now,
+				},
+			],
+		};
+
+		const contents = convertMessages(model, context);
+		const functionResponse = contents[2]?.parts?.[0]?.functionResponse;
+		expect(functionResponse).toBeTruthy();
+		expect(functionResponse?.response).toEqual({ output: "" });
+	});
 });

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -74,6 +74,17 @@ function buildEmptyToolResult(toolCallId: string, timestamp: number): ToolResult
 	};
 }
 
+function buildWhitespaceToolResult(toolCallId: string, timestamp: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "bash",
+		content: [{ type: "text", text: "\r\n" }],
+		isError: false,
+		timestamp,
+	};
+}
+
 describe("openai-completions convertMessages", () => {
 	it("batches tool-result images after consecutive tool results", () => {
 		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
@@ -146,6 +157,41 @@ describe("openai-completions convertMessages", () => {
 				{ role: "user", content: "Run the command", timestamp: now - 1 },
 				assistantMessage,
 				buildEmptyToolResult("tool-1", now + 1),
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const toolMessage = messages.find((m) => m.role === "tool") as { role: "tool"; content: string } | undefined;
+		expect(toolMessage).toBeTruthy();
+		expect(toolMessage?.content).toBe("(no tool output)");
+		expect(toolMessage?.content).not.toContain("see attached image");
+	});
+
+	it("uses '(no tool output)' placeholder for whitespace-only tool results", () => {
+		const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text", "image"],
+		};
+
+		const now = Date.now();
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "true" } }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Run the command", timestamp: now - 1 },
+				assistantMessage,
+				buildWhitespaceToolResult("tool-1", now + 1),
 			],
 		};
 

--- a/packages/ai/test/openai-responses-empty-tool-result.test.ts
+++ b/packages/ai/test/openai-responses-empty-tool-result.test.ts
@@ -55,4 +55,43 @@ describe("OpenAI Responses convertResponsesMessages empty tool result", () => {
 		expect(functionCallOutput?.output).toBe("(no tool output)");
 		expect(functionCallOutput?.output).not.toContain("see attached image");
 	});
+
+	it("uses '(no tool output)' placeholder for whitespace-only tool results", () => {
+		const model = getModel("openai", "gpt-4o-mini");
+		const now = Date.now();
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "true" } }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage,
+			stopReason: "toolUse",
+			timestamp: now,
+		};
+
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Run the command", timestamp: now - 1 },
+				assistant,
+				{
+					role: "toolResult",
+					toolCallId: "tool-1",
+					toolName: "bash",
+					content: [{ type: "text", text: "\r\n" }],
+					isError: false,
+					timestamp: now + 1,
+				},
+			],
+		};
+
+		const input = convertResponsesMessages(model, context, new Set(["openai", "openai-codex", "opencode"]));
+		const functionCallOutput = input.find((item) => item.type === "function_call_output") as
+			| { type: "function_call_output"; output: string }
+			| undefined;
+
+		expect(functionCallOutput).toBeTruthy();
+		expect(functionCallOutput?.output).toBe("(no tool output)");
+		expect(functionCallOutput?.output).not.toContain("see attached image");
+	});
 });


### PR DESCRIPTION
## Problem

Tool results whose text consists only of whitespace (e.g. `"\r\n"` from a Windows shell) pass the `textResult.length > 0` check and are sent verbatim to the provider. OpenAI-compatible providers reject tool message content that is empty or whitespace-only with HTTP 400. Because the offending message stays in the conversation history, **every subsequent request in that session fails**, permanently bricking the session with no way to recover without editing the session file.

## Fix

Switch the check to `textResult.trim().length > 0` in the three tool-result conversion paths so whitespace-only output falls back to the existing empty-output handling:

- `openai-completions.ts` / `openai-responses-shared.ts` → `"(no tool output)"` placeholder
- `google-shared.ts` → empty `output` value (same as the already-handled empty-string case)

## Tests

Added regression tests covering whitespace-only (`"\r\n"`) tool results for all three conversion paths. Verified red before the fix and green after.

## Repro

1. A tool (e.g. `bash` on Windows) returns output that is only a line break (`"\r\n"`)
2. The next request fails with `400 ... content string cannot be empty or only whitespace`
3. All further turns in that session fail the same way