### PR TITLE
fix(coding-agent): expose https-proxy-agent named export

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed resumed sessions corrupting the next appended entry when their JSONL file lacks a trailing newline ([#8345](https://github.com/earendil-works/pi/issues/8345)).
 - Fixed extension messages sent with `triggerTurn: false` while the agent is running being inserted between a tool call and its result, which made providers that validate message order reject the replayed history. They are now appended once the turn's tool results are in ([#8537](https://github.com/earendil-works/pi/issues/8537)).
 - Fixed compaction and branch summaries forcing `toolChoice: "none"` ([#8649](https://github.com/earendil-works/pi/issues/8649), [#8638](https://github.com/earendil-works/pi/issues/8638)).
+- Fixed Google Vertex requests failing with `HttpsProxyAgent is not a constructor` when the bundled Node.js runtime uses an HTTP(S) proxy ([#8610](https://github.com/earendil-works/pi/issues/8610)).
 
 ## [0.84.3] - 2026-08-24
 

--- a/scripts/build-coding-agent-bundle.mjs
+++ b/scripts/build-coding-agent-bundle.mjs
@@ -49,6 +49,30 @@ export function createJiti(...args) {
 	},
 };
 
+const httpsProxyAgentNamedExportPlugin = {
+	name: "https-proxy-agent-named-export",
+	setup(build) {
+		build.onResolve({ filter: /^https-proxy-agent$/ }, (args) => {
+			if (args.kind !== "dynamic-import") return undefined;
+			return {
+				namespace: "https-proxy-agent-named-export",
+				path: args.path,
+			};
+		});
+		build.onLoad(
+			{
+				filter: /^https-proxy-agent$/,
+				namespace: "https-proxy-agent-named-export",
+			},
+			() => ({
+				contents: 'export { HttpsProxyAgent } from "https-proxy-agent";',
+				loader: "js",
+				resolveDir: repoRoot,
+			}),
+		);
+	},
+};
+
 function commonBuildOptions() {
 	return {
 		absWorkingDir: repoRoot,
@@ -67,7 +91,7 @@ function commonBuildOptions() {
 		// package replaces it with a synchronous lazy require so jiti loads only
 		// when importing an extension; Babel remains deferred until a cache miss
 		// needs transformation.
-		plugins: [lazyJitiPlugin],
+		plugins: [lazyJitiPlugin, httpsProxyAgentNamedExportPlugin],
 		sourcemap: false,
 		target: "node22.19",
 		// Do not apply the monorepo's source-oriented path aliases while bundling


### PR DESCRIPTION
**Description**

- add a plugin to `build-coding-agent-bundle` script, which exposes a named export for `https-proxy-agent` (as part of a `https-proxy-agent-*.js` chunk)
- closes #8610

**Tested with (AI generated):**

```bash
(node scripts/build-coding-agent-bundle.mjs || exit 1

     proxy_chunk="$(
       find packages/coding-agent/dist/bundle/chunks \
         -name 'https-proxy-agent-*.js' -print -quit
     )"

     if [ -z "$proxy_chunk" ]; then
       echo "Proxy-agent chunk not found" >&2
       exit 1
     fi

     PROXY_CHUNK="$PWD/$proxy_chunk" node --input-type=module --eval '
       import { pathToFileURL } from "node:url";

       const module = await import(
         pathToFileURL(process.env.PROXY_CHUNK).href
       );

       console.log("exports:", Object.keys(module));
       console.log(
         "HttpsProxyAgent type:",
         typeof module.HttpsProxyAgent
       );

       if (typeof module.HttpsProxyAgent !== "function") {
         throw new Error("HttpsProxyAgent named export is missing");
       }
     '
   )
```

**Results after fix**

```
exports: [ 'HttpsProxyAgent' ]
HttpsProxyAgent type: function
```