### PR TITLE
fix(tui): preserve scrollback on offscreen changes

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed above-viewport content changes clearing and replaying regular-mode terminal scrollback; off-screen lines now remain historical snapshots while visible changes render differentially.
 - Fixed main-screen rendering crashing when image-heavy output exceeded V8's string length limit ([#8028](https://github.com/earendil-works/pi/issues/8028)).
 - Fixed autocomplete ordering for nested results ([#8669](https://github.com/earendil-works/pi/pull/8669)).
 - Fixed fullscreen double-click word selection splitting paths and kebab-case tokens on `/` and `-` ([#7746](https://github.com/earendil-works/pi/issues/7746)).

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -654,8 +654,8 @@ if (matchesKey(data, Key.enter)) {
 `TuiMainScreen` uses three rendering strategies:
 
 1. **First Render**: Output all lines without clearing scrollback
-2. **Width Changed or Change Above Viewport**: Clear screen and fully re-render
-3. **Normal Update**: Move the cursor to the first changed line, clear to the end, and render changed lines
+2. **Width/Height Changed or Unsafe Shrink/Image Update**: Clear screen and fully re-render
+3. **Normal Update**: Move the cursor to the first changed visible line and render the changed range. Changes already above the viewport remain as historical terminal-scrollback snapshots; a change spanning into the viewport is clamped to its first visible row.
 
 `TuiAltScreen` owns a terminal-height viewport. Without an explicit layout root it preserves the legacy single-document scrolling behavior. With `setLayoutRoot()`, `VStack`, `HStack`, and nested `ScrollView` components can reserve fixed regions and independently scroll constrained regions. It updates changed viewport rows in place, follows streaming output while at the bottom, and preserves a manually selected scroll position while content grows. Mouse-wheel and configurable keyboard navigation scroll without modifying terminal scrollback, including jumps between OSC 133 semantic prompt markers. Clicking an OSC 8 hyperlink opens it with the configured URL handler. Dragging with the primary mouse button selects text and copies it to the clipboard with OSC 52; holding the drag at a scroll view's top or bottom edge auto-scrolls and extends the selection into off-screen content. Kitty images support vertical viewport cropping; iTerm2 inline images fall back to text because the iTerm2 protocol cannot delete or crop placements during viewport repainting.
 

--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -206,6 +206,14 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		return reservedRows;
 	}
 
+	private hasKittyImageStraddlingViewport(lines: string[], viewportTop: number): boolean {
+		for (let i = 0; i < viewportTop && i < lines.length; i++) {
+			if (extractKittyImageIds(lines[i] ?? "").length === 0) continue;
+			if (i + this.getKittyImageReservedRows(lines, i) > viewportTop) return true;
+		}
+		return false;
+	}
+
 	private expandChangedRangeForKittyImages(
 		firstChanged: number,
 		lastChanged: number,
@@ -445,12 +453,40 @@ export class TuiMainScreen extends TuiBase implements TUI {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible.
-		// If the first changed line is above the previous viewport, we need a full redraw.
+		// Lines above the viewport have already become terminal scrollback and cannot be
+		// updated in place. Keep those lines as historical snapshots instead of clearing
+		// scrollback and replaying the entire document. If the change reaches the visible
+		// viewport, clamp the differential update to its first visible row.
+		let preservePreviousKittyImageIds = false;
 		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
-			return;
+			// A transient component may have made the terminal working area taller than
+			// the current document. In that case clamping would leave stale rows behind.
+			if (this.maxLinesRendered > newLines.length) {
+				logRedraw(`above-viewport change with stale rows (max=${this.maxLinesRendered}, new=${newLines.length})`);
+				fullRender(true);
+				return;
+			}
+			const kittyImageStraddlesViewport =
+				this.hasKittyImageStraddlingViewport(this.previousLines, prevViewportTop) ||
+				this.hasKittyImageStraddlingViewport(newLines, prevViewportTop);
+			if (kittyImageStraddlesViewport) {
+				logRedraw(`kitty image straddles viewport (${firstChanged} < ${prevViewportTop})`);
+				fullRender(true);
+				return;
+			}
+			preservePreviousKittyImageIds = true;
+			if (lastChanged < prevViewportTop) {
+				this.positionHardwareCursor(cursorPos, newLines.length);
+				this.previousLines = newLines;
+				const nextKittyImageIds = this.collectKittyImageIds(newLines);
+				for (const id of this.previousKittyImageIds) nextKittyImageIds.add(id);
+				this.previousKittyImageIds = nextKittyImageIds;
+				this.previousWidth = width;
+				this.previousHeight = height;
+				this.previousViewportTop = prevViewportTop;
+				return;
+			}
+			firstChanged = prevViewportTop;
 		}
 
 		// Render from first changed line to end
@@ -609,7 +645,11 @@ export class TuiMainScreen extends TuiBase implements TUI {
 		this.positionHardwareCursor(cursorPos, newLines.length);
 
 		this.previousLines = newLines;
-		this.previousKittyImageIds = this.collectKittyImageIds(newLines);
+		const nextKittyImageIds = this.collectKittyImageIds(newLines);
+		if (preservePreviousKittyImageIds) {
+			for (const id of this.previousKittyImageIds) nextKittyImageIds.add(id);
+		}
+		this.previousKittyImageIds = nextKittyImageIds;
 		this.previousWidth = width;
 		this.previousHeight = height;
 	}

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -333,6 +333,60 @@ describe("TUI Kitty image cleanup", () => {
 		}
 	});
 
+	it("retains off-screen snapshot image ids for a later forced redraw", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 3);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const image = encodeKitty("AAAA", { columns: 2, rows: 1, imageId: 90, moveCursor: false });
+		component.lines = [image, "Line 1", "Line 2", "Line 3"];
+		tui.start();
+		await terminal.waitForRender();
+		const redrawsBeforeChange = tui.fullRedraws;
+		terminal.clearWrites();
+
+		component.lines = ["historical snapshot", "Line 1", "Line 2", "Line 3"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, redrawsBeforeChange);
+		assert.ok(!terminal.getWrites().includes(deleteKittyImage(90)), "the off-screen snapshot should remain intact");
+		terminal.clearWrites();
+
+		tui.requestRender(true);
+		await terminal.waitForRender();
+
+		assert.ok(
+			terminal.getWrites().includes(deleteKittyImage(90)),
+			"a forced redraw should delete the snapshot image",
+		);
+		tui.stop();
+	});
+
+	it("keeps the full-redraw fallback when an image straddles the viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 3);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		const image = encodeKitty("AAAA", { columns: 2, rows: 3, imageId: 91, moveCursor: false });
+		component.lines = [image, "", "", "after"];
+		tui.start();
+		await terminal.waitForRender();
+		const redrawsBeforeChange = tui.fullRedraws;
+		terminal.clearWrites();
+
+		component.lines = ["removed", "", "", "after"];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.ok(tui.fullRedraws > redrawsBeforeChange, "a straddling image should force a full redraw");
+		assert.ok(terminal.getWrites().includes("\x1b[2J"), "the fallback should clear the viewport");
+
+		tui.stop();
+	});
+
 	it("does not use cursor-up placement for Kitty images taller than the viewport", async () => {
 		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
 		setCellDimensions({ widthPx: 10, heightPx: 10 });
@@ -618,6 +672,91 @@ describe("TUI content shrinkage", () => {
 });
 
 describe("TUI differential rendering", () => {
+	it("keeps an off-screen-only change as a scrollback snapshot", async () => {
+		const terminal = new LoggingVirtualTerminal(20, 5);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 10 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+		const redrawsAfterInitialRender = tui.fullRedraws;
+		terminal.clearWrites();
+
+		component.lines = Array.from({ length: 10 }, (_, i) => (i === 2 ? "CHANGED OFFSCREEN" : `Line ${i}`));
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, redrawsAfterInitialRender);
+		assert.ok(!terminal.getWrites().includes("\x1b[2J"), "off-screen changes must not clear the viewport");
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "off-screen changes must not clear scrollback");
+		assert.deepStrictEqual(terminal.getViewport(), ["Line 5", "Line 6", "Line 7", "Line 8", "Line 9"]);
+		assert.ok(
+			terminal.getScrollBuffer().some((line) => line.includes("Line 2")),
+			"native scrollback should retain the original historical snapshot",
+		);
+
+		tui.stop();
+	});
+
+	it("clamps changes spanning scrollback and the visible viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(20, 5);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 10 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+		const redrawsAfterInitialRender = tui.fullRedraws;
+		terminal.clearWrites();
+
+		component.lines = Array.from({ length: 10 }, (_, i) => {
+			if (i === 2) return "CHANGED OFFSCREEN";
+			if (i === 8) return "CHANGED VISIBLE";
+			return `Line ${i}`;
+		});
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, redrawsAfterInitialRender);
+		assert.ok(!terminal.getWrites().includes("\x1b[2J"), "spanning changes must not clear the viewport");
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "spanning changes must not clear scrollback");
+		assert.deepStrictEqual(terminal.getViewport(), ["Line 5", "Line 6", "Line 7", "CHANGED VISIBLE", "Line 9"]);
+
+		tui.stop();
+	});
+
+	it("keeps following appended output when an earlier line reflows above the viewport", async () => {
+		const terminal = new LoggingVirtualTerminal(20, 5);
+		const tui: TUI = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		tui.addChild(component);
+
+		component.lines = Array.from({ length: 10 }, (_, i) => `Line ${i}`);
+		tui.start();
+		await terminal.waitForRender();
+		const redrawsAfterInitialRender = tui.fullRedraws;
+		terminal.clearWrites();
+
+		component.lines = [
+			...Array.from({ length: 10 }, (_, i) => (i === 2 ? "REFLOWED OFFSCREEN" : `Line ${i}`)),
+			"Line 10",
+			"Line 11",
+			"Line 12",
+		];
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		assert.strictEqual(tui.fullRedraws, redrawsAfterInitialRender);
+		assert.ok(!terminal.getWrites().includes("\x1b[2J"), "streaming reflow must not clear the viewport");
+		assert.ok(!terminal.getWrites().includes("\x1b[3J"), "streaming reflow must not clear scrollback");
+		assert.deepStrictEqual(terminal.getViewport(), ["Line 8", "Line 9", "Line 10", "Line 11", "Line 12"]);
+
+		tui.stop();
+	});
+
 	it("tracks cursor correctly when content shrinks with unchanged remaining lines", async () => {
 		const terminal = new VirtualTerminal(40, 10);
 		const tui: TUI = new TuiMainScreen(terminal);


### PR DESCRIPTION
## Summary

- keep above-viewport main-screen changes as historical native-scrollback snapshots instead of clearing and replaying the full transcript
- clamp changes that extend into the visible viewport so streaming output continues to update and follow the tail
- retain full-redraw fallbacks for stale working-area rows and Kitty images that straddle the viewport
- preserve off-screen Kitty image IDs so a later forced redraw (including `/reload`) still cleans them up

## Motivation

Streaming Markdown can reflow an earlier line after it has moved above the viewport (tables are a common case). The regular renderer currently responds with `fullRender(true)`, which clears native terminal scrollback and replays the entire transcript. This makes long sessions flicker and destroys useful iTerm/Kitty scrollback.

## Tests

- `npm test --workspace=@earendil-works/pi-tui`
- `npm run build --workspace=@earendil-works/pi-tui`
- `npx biome check packages/tui/src/tui-main-screen.ts packages/tui/test/tui-render.test.ts packages/tui/README.md packages/tui/CHANGELOG.md`

The repository-wide `tsgo --noEmit` remains blocked by pre-existing generated model-catalog type errors; the TUI workspace build passes.