### PR TITLE
fix(ai): preserve reasoning_content on cross-model replay into DeepSeek-family endpoints

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1587,6 +1587,10 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 	const isNvidia = provider === "nvidia" || baseUrl.includes("integrate.api.nvidia.com");
 	const isAntLing = provider === "ant-ling" || baseUrl.includes("api.ant-ling.com");
 	const isDeepSeek = provider === "deepseek" || baseUrl.toLowerCase().includes("deepseek.com");
+	// DeepSeek-family models served by other gateways (api.b.ai, token.sensenova.cn,
+	// openrouter-hosted `deepseek/*`, ...) share the api.deepseek.com requirement that
+	// assistant messages carry `reasoning_content` back in thinking mode.
+	const isDeepSeekFamily = isDeepSeek || model.id.toLowerCase().includes("deepseek");
 
 	const isNonStandard =
 		isNvidia ||
@@ -1631,7 +1635,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 		requiresToolResultName: false,
 		requiresAssistantAfterToolResult: false,
 		requiresThinkingAsText: false,
-		requiresReasoningContentOnAssistantMessages: isDeepSeek,
+		requiresReasoningContentOnAssistantMessages: isDeepSeekFamily,
 		thinkingFormat: isDeepSeek
 			? "deepseek"
 			: isZai

--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -57,6 +57,21 @@ function downgradeUnsupportedImages<TApi extends Api>(messages: Message[], model
 }
 
 /**
+ * Whether the target model is a DeepSeek-family thinking endpoint that requires
+ * `reasoning_content` to be passed back on assistant messages: the official
+ * api.deepseek.com route, and DeepSeek-compatible gateways serving deepseek
+ * models under a different provider/baseUrl (e.g. api.b.ai, token.sensenova.cn,
+ * or openrouter-hosted `deepseek/*` models).
+ */
+function isDeepSeekFamilyTarget<TApi extends Api>(model: Model<TApi>): boolean {
+	return (
+		model.provider === "deepseek" ||
+		model.baseUrl.toLowerCase().includes("deepseek.com") ||
+		model.id.toLowerCase().includes("deepseek")
+	);
+}
+
+/**
  * Normalize tool call ID for cross-provider compatibility.
  * OpenAI Responses API generates IDs that are 450+ chars with special characters like `|`.
  * Anthropic APIs require IDs matching ^[a-zA-Z0-9_-]+$ (max 64 chars).
@@ -110,6 +125,18 @@ export function transformMessages<TApi extends Api>(
 					// Skip empty thinking blocks, convert others to plain text
 					if (!block.thinking || block.thinking.trim() === "") return [];
 					if (isSameModel) return block;
+					// Cross-model replay into a DeepSeek-family thinking endpoint: the API
+					// rejects assistant messages that omit `reasoning_content` in thinking
+					// mode (e.g. "The `reasoning_content` in the thinking mode must be passed
+					// back to the API"). Keep the text in a thinking block carrying the field
+					// DeepSeek expects instead of folding it into `content`.
+					if (isDeepSeekFamilyTarget(model)) {
+						return {
+							type: "thinking" as const,
+							thinking: block.thinking,
+							thinkingSignature: "reasoning_content",
+						};
+					}
 					return {
 						type: "text" as const,
 						text: block.thinking,

--- a/packages/ai/test/transform-messages-cross-model-deepseek-reasoning.test.ts
+++ b/packages/ai/test/transform-messages-cross-model-deepseek-reasoning.test.ts
@@ -1,0 +1,189 @@
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
+import { transformMessages } from "../src/api/transform-messages.ts";
+import type { AssistantMessage, Context, Model, Usage } from "../src/types.ts";
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function buildModel(overrides: Partial<Model<"openai-completions">>): Model<"openai-completions"> {
+	return {
+		id: "repro-model",
+		name: "Repro Model",
+		api: "openai-completions",
+		provider: "repro-provider",
+		baseUrl: "http://127.0.0.1:1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+		...overrides,
+	};
+}
+
+function buildForeignAssistant(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "thinking", thinking: "internal reasoning from another provider", thinkingSignature: "reasoning" },
+			{ type: "text", text: "visible answer" },
+			{
+				type: "toolCall",
+				id: "call_1",
+				name: "repro",
+				arguments: {},
+				thoughtSignature: "some-thought-signature",
+			},
+		],
+		api: "openai-completions",
+		provider: "openrouter",
+		model: "stealth/ox-alpha",
+		usage: emptyUsage,
+		stopReason: "toolUse",
+		timestamp: 2,
+	};
+}
+
+function buildContext(assistant: AssistantMessage): Context {
+	return {
+		messages: [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{ role: "user", content: "continue", timestamp: 3 },
+		],
+	};
+}
+
+describe("transform-messages cross-model DeepSeek reasoning replay", () => {
+	it("keeps cross-model thinking as reasoning_content when the target is a DeepSeek-family model", () => {
+		const model = buildModel({
+			id: "deepseek-v4-flash",
+			provider: "b-ai",
+			baseUrl: "https://api.b.ai/v1",
+		});
+
+		const [assistant] = transformMessages(buildContext(buildForeignAssistant()).messages, model).filter(
+			(msg): msg is AssistantMessage => msg.role === "assistant",
+		);
+
+		expect(assistant.content).toContainEqual({
+			type: "thinking",
+			thinking: "internal reasoning from another provider",
+			thinkingSignature: "reasoning_content",
+		});
+	});
+
+	it("still downgrades cross-model thinking to text for non-DeepSeek targets", () => {
+		const model = buildModel({ id: "repro-model", provider: "repro-provider" });
+
+		const [assistant] = transformMessages(buildContext(buildForeignAssistant()).messages, model).filter(
+			(msg): msg is AssistantMessage => msg.role === "assistant",
+		);
+
+		expect(assistant.content).toContainEqual({ type: "text", text: "internal reasoning from another provider" });
+		expect(assistant.content.some((block) => block.type === "thinking")).toBe(false);
+	});
+});
+
+describe("openai-completions cross-model DeepSeek reasoning replay", () => {
+	async function captureRequest(model: Model<"openai-completions">): Promise<{
+		messages: Array<Record<string, unknown>>;
+	}> {
+		const requestBodies: Array<Record<string, unknown>> = [];
+		const server = http.createServer(async (req, res) => {
+			let body = "";
+			for await (const chunk of req) {
+				body += chunk.toString();
+			}
+			requestBodies.push(JSON.parse(body) as Record<string, unknown>);
+
+			res.writeHead(200, {
+				"content-type": "text/event-stream",
+				"cache-control": "no-cache",
+				connection: "keep-alive",
+			});
+			res.write(
+				`data: ${JSON.stringify({
+					id: "chatcmpl-repro",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }],
+				})}\n\n`,
+			);
+			res.write(
+				`data: ${JSON.stringify({
+					id: "chatcmpl-repro",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: model.id,
+					choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+					usage: { prompt_tokens: 1, completion_tokens: 1 },
+				})}\n\n`,
+			);
+			res.write("data: [DONE]\n\n");
+			res.end();
+		});
+
+		server.listen(0, "127.0.0.1");
+		await once(server, "listening");
+
+		try {
+			const { port } = server.address() as AddressInfo;
+			const stream = streamOpenAICompletions(
+				{ ...model, baseUrl: `http://127.0.0.1:${port}` },
+				buildContext(buildForeignAssistant()),
+				{ apiKey: "test-key" },
+			);
+			for await (const _event of stream) {
+				// drain
+			}
+		} finally {
+			server.close();
+			await once(server, "close");
+		}
+
+		return requestBodies[0] as { messages: Array<Record<string, unknown>> };
+	}
+
+	it("emits reasoning_content on cross-model assistant messages for a DeepSeek-family target", async () => {
+		const request = await captureRequest(
+			buildModel({
+				id: "deepseek-v4-flash",
+				provider: "b-ai",
+				baseUrl: "https://api.b.ai/v1",
+			}),
+		);
+
+		const assistant = request.messages.find((msg) => msg.role === "assistant");
+		expect(assistant).toEqual(
+			expect.objectContaining({
+				role: "assistant",
+				reasoning_content: "internal reasoning from another provider",
+			}),
+		);
+	});
+
+	it("keeps the text-only downgrade for non-DeepSeek targets", async () => {
+		const request = await captureRequest(buildModel({ id: "repro-model", provider: "repro-provider" }));
+
+		const assistant = request.messages.find((msg) => msg.role === "assistant");
+		expect(assistant).toEqual(
+			expect.objectContaining({
+				role: "assistant",
+				content: "internal reasoning from another providervisible answer",
+			}),
+		);
+		expect(assistant?.reasoning_content).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

DeepSeek-family thinking endpoints (api.deepseek.com, and DeepSeek-compatible gateways such as `api.b.ai` / `token.sensenova.cn`, or openrouter-hosted `deepseek/*` models) reject requests in thinking mode when an assistant message that originally carried reasoning is replayed without `reasoning_content`:

```
400: The `reasoning_content` in the thinking mode must be passed back to the API.
```

This triggers on cross-provider history replay: assistant turns produced by another provider (e.g. openrouter with `thinkingSignature: "reasoning"`) are replayed into a DeepSeek-family route, `transformMessages` downgrades the cross-model `thinking` blocks to plain text, and the resulting wire message has `tool_calls` but no `reasoning_content`. `INVALID_REQUEST` is not retried, so the whole turn fails. See #8728 for the full report (also reproduced in DeepSeek Harness, which bundles pi-ai).

## Fix

1. `transformMessages`: when downgrading cross-model `thinking` blocks, keep them as `thinking` blocks with `thinkingSignature: "reasoning_content"` when the target model is a DeepSeek-family endpoint, instead of folding the text into `content`. The completions serializer already writes `reasoning_content` from a signed thinking block.
2. `detectCompat`: auto-enable `requiresReasoningContentOnAssistantMessages` for DeepSeek-family models (provider `deepseek`, `deepseek.com` base URL, or model id containing `deepseek`), so assistant messages that end up without `reasoning_content` get the empty-field fallback. `thinkingFormat` detection is unchanged, so non-DeepSeek gateways are not affected.

Non-DeepSeek targets keep the previous text-only downgrade behavior.

## Tests

Added `packages/ai/test/transform-messages-cross-model-deepseek-reasoning.test.ts`:

- cross-model thinking is kept as `reasoning_content` for DeepSeek-family targets
- non-DeepSeek targets still downgrade to text (no regression)
- full `stream` round-trip against a local HTTP server: the wire assistant message carries `reasoning_content` for a `b-ai`/`deepseek-v4-flash` model (via auto-detected compat), and stays text-only for a generic model

Verified: new tests 4/4 pass; related existing tests (`transform-messages-copilot-openai-to-anthropic`, `openai-completions-thinking-as-text`, `openai-completions-reasoning-details`) 11/11 pass; `biome check` clean; `tsgo --noEmit` clean for the touched files.

Fixes #8728
