### PR TITLE
fix(ai): match subdomains and root domains in NO_PROXY

### DIFF
--- a/packages/ai/src/utils/node-http-proxy.ts
+++ b/packages/ai/src/utils/node-http-proxy.ts
@@ -34,6 +34,43 @@ function parseProxyTargetUrl(targetUrl: string | URL): URL | undefined {
 	}
 }
 
+function stripBrackets(host: string): string {
+	return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}
+
+function parseNoProxyEntry(entry: string): { host: string; port: number } | undefined {
+	const trimmed = entry.trim().toLowerCase();
+	if (!trimmed) return undefined;
+
+	if (trimmed.startsWith("[")) {
+		const closingBracket = trimmed.indexOf("]");
+		if (closingBracket !== -1) {
+			const host = trimmed.slice(1, closingBracket);
+			const rest = trimmed.slice(closingBracket + 1);
+			if (rest.startsWith(":")) {
+				const port = Number.parseInt(rest.slice(1), 10);
+				return { host, port: Number.isNaN(port) ? 0 : port };
+			}
+			return { host, port: 0 };
+		}
+	}
+
+	if (trimmed.includes(":") && trimmed.split(":").length > 2) {
+		return { host: trimmed, port: 0 };
+	}
+
+	const colonIndex = trimmed.lastIndexOf(":");
+	if (colonIndex !== -1 && colonIndex === trimmed.indexOf(":")) {
+		const host = trimmed.slice(0, colonIndex);
+		const port = Number.parseInt(trimmed.slice(colonIndex + 1), 10);
+		if (!Number.isNaN(port)) {
+			return { host, port };
+		}
+	}
+
+	return { host: trimmed, port: 0 };
+}
+
 function shouldProxyHostname(hostname: string, port: number, env?: ProviderEnv): boolean {
 	const noProxy = getProxyEnv("no_proxy", env).toLowerCase();
 	if (!noProxy) {
@@ -43,26 +80,38 @@ function shouldProxyHostname(hostname: string, port: number, env?: ProviderEnv):
 		return false;
 	}
 
-	return noProxy.split(/[,\s]/).every((proxy) => {
-		if (!proxy) {
+	const normalizedTargetHost = stripBrackets(hostname.toLowerCase());
+
+	return noProxy.split(/[,\s]/).every((entry) => {
+		const parsed = parseNoProxyEntry(entry);
+		if (!parsed) {
 			return true;
 		}
 
-		const parsedProxy = proxy.match(/^(.+):(\d+)$/);
-		let proxyHostname = parsedProxy ? parsedProxy[1] : proxy;
-		const proxyPort = parsedProxy ? Number.parseInt(parsedProxy[2]!, 10) : 0;
-		if (proxyPort && proxyPort !== port) {
+		if (parsed.port && parsed.port !== port) {
 			return true;
 		}
 
-		if (!/^[.*]/.test(proxyHostname)) {
-			return hostname !== proxyHostname;
+		let domain = stripBrackets(parsed.host);
+		if (domain.startsWith("*.")) {
+			domain = domain.slice(2);
+		} else if (domain.startsWith(".") || domain.startsWith("*")) {
+			domain = domain.slice(1);
 		}
 
-		if (proxyHostname.startsWith("*")) {
-			proxyHostname = proxyHostname.slice(1);
+		if (!domain) {
+			return true;
 		}
-		return !hostname.endsWith(proxyHostname);
+
+		if (normalizedTargetHost === domain) {
+			return false;
+		}
+
+		if (normalizedTargetHost.endsWith(`.${domain}`)) {
+			return false;
+		}
+
+		return true;
 	});
 }
 
@@ -73,7 +122,7 @@ function getProxyForUrl(targetUrl: string | URL, env?: ProviderEnv): string {
 	}
 
 	const protocol = parsedUrl.protocol.split(":", 1)[0]!;
-	const hostname = parsedUrl.host.replace(/:\d*$/, "");
+	const hostname = stripBrackets(parsedUrl.hostname || parsedUrl.host.replace(/:\d*$/, ""));
 	const port = Number.parseInt(parsedUrl.port, 10) || DEFAULT_PROXY_PORTS[protocol] || 0;
 	if (!shouldProxyHostname(hostname, port, env)) {
 		return "";

--- a/packages/ai/test/node-http-proxy.test.ts
+++ b/packages/ai/test/node-http-proxy.test.ts
@@ -73,4 +73,23 @@ describe("node HTTP proxy resolution", () => {
 			UNSUPPORTED_PROXY_PROTOCOL_MESSAGE,
 		);
 	});
+
+	it("handles subdomain wildcards, IPv6, and ports in NO_PROXY", () => {
+		resetProxyEnv();
+		process.env.HTTPS_PROXY = "http://proxy.example:8080";
+		process.env.NO_PROXY = "example.com, .wildcard.org, *.star.net, ::1, [2001:db8::1], 127.0.0.1:8080";
+
+		expect(resolveHttpProxyUrlForTarget("https://example.com")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://api.example.com")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://wildcard.org")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://api.wildcard.org")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://star.net")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://api.star.net")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://notexample.com")?.toString()).toBe("http://proxy.example:8080/");
+
+		expect(resolveHttpProxyUrlForTarget("https://[::1]:80")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://[2001:db8::1]")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://127.0.0.1:8080")).toBeUndefined();
+		expect(resolveHttpProxyUrlForTarget("https://127.0.0.1:3000")?.toString()).toBe("http://proxy.example:8080/");
+	});
 });


### PR DESCRIPTION
Fixes #8736

### Summary of Changes
- Fix `NO_PROXY` parsing to handle wildcard domains (`*.example.com`, `.example.com`) and bare domains (`example.com`) consistently across subdomains and root domains.
- Properly parse IPv6 entries (both bracketed `[::1]:8080` / `[::1]` and unbracketed `::1`), preventing misinterpretation of colons as host-port separators.
- Normalize target URLs to compare hostnames without bracket delimiters.
- Add regression test suite in `packages/ai/test/node-http-proxy.test.ts`.

### Verification
- Targeted unit tests:
  ```bash
  bun test packages/ai/test/node-http-proxy.test.ts
  ```
  All 5 test suites passed cleanly (15 assertions).
