### PR TITLE
fix(coding-agent): honor settings.shellPath for config/header '!' command resolution

### DIFF
--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,7 +1,7 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { spawn, spawnSync } from "child_process";
-import { getBinDir } from "../config.ts";
+import { getBinDir, getSettingsPath } from "../config.ts";
 
 export interface ShellConfig {
 	shell: string;
@@ -19,6 +19,43 @@ function isLegacyWslBashPath(path: string): boolean {
 
 function getBashShellConfig(shell: string): ShellConfig {
 	return isLegacyWslBashPath(shell) ? { shell, args: ["-s"], commandTransport: "stdin" } : { shell, args: ["-c"] };
+}
+
+/**
+ * Read the shellPath configured by the user in settings.json.
+ * The bash tool already honors `settings.shellPath`; making shell resolution
+ * here read the same value keeps header/API-key `!command` resolution
+ * consistent and avoids silently auto-selecting a broken shell (e.g. the
+ * WSL `bash.exe` shim) when the user has explicitly configured a working one.
+ */
+function getConfiguredShellPath(): string | undefined {
+	try {
+		const settingsPath = getSettingsPath();
+		if (!existsSync(settingsPath)) return undefined;
+		const settings: unknown = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		const shellPath =
+			settings && typeof settings === "object" ? (settings as Record<string, unknown>)["shellPath"] : undefined;
+		if (typeof shellPath !== "string" || shellPath.trim() === "") return undefined;
+		const normalized = shellPath.replace(/\\/g, "/");
+		return existsSync(normalized) ? normalized : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Windows system32 / WindowsApps "bash" are the WSL or Windows Subsystem for
+ * Linux shims, not real bash. When no distro is installed they exit non-zero
+ * with no output (and the WindowsApps shim may open the Store). Skip them so
+ * auto-detection never selects a shell that is not a functioning bash.
+ */
+function isWslShimBashPath(path: string): boolean {
+	const normalized = path.replace(/\\/g, "/").toLowerCase();
+	return (
+		normalized.endsWith("/system32/bash.exe") ||
+		normalized.endsWith("/sysnative/bash.exe") ||
+		normalized.includes("/windowsapps/bash.exe")
+	);
 }
 
 function findExecutableOnPath(executable: string): string | null {
@@ -65,12 +102,19 @@ function findExecutableOnPath(executable: string): string | null {
  * 3. On Unix: /bin/bash, then bash on PATH, then fallback to sh
  */
 export function getShellConfig(customShellPath?: string): ShellConfig {
-	// 1. Check user-specified shell path
+	// 1. Check the user-specified shell path: an explicit arg first, then the
+	//    shellPath configured in settings.json (used by the bash tool), so that
+	//    `!`-prefixed config/header commands don't silently fall back to an
+	//    auto-detected broken shell on Windows.
 	if (customShellPath) {
 		if (existsSync(customShellPath)) {
 			return getBashShellConfig(customShellPath);
 		}
 		throw new Error(`Custom shell path not found: ${customShellPath}`);
+	}
+	const configuredShellPath = getConfiguredShellPath();
+	if (configuredShellPath) {
+		return getBashShellConfig(configuredShellPath);
 	}
 
 	if (process.platform === "win32") {
@@ -91,9 +135,10 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 			}
 		}
 
-		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
+		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, etc.), skipping
+		//    WSL / WindowsApps shims that are not a functioning bash.
 		const bashOnPath = findExecutableOnPath("bash.exe");
-		if (bashOnPath) {
+		if (bashOnPath && !isWslShimBashPath(bashOnPath)) {
 			return getBashShellConfig(bashOnPath);
 		}
 

--- a/packages/coding-agent/test/resolve-config-value.test.ts
+++ b/packages/coding-agent/test/resolve-config-value.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.ts";
 import {
 	clearConfigValueCache,
 	resolveConfigValue,
@@ -52,6 +53,19 @@ describe("resolveConfigValue", () => {
 		expect(resolveConfigValue("!echo '  spaced-key  '")).toBe("spaced-key");
 		expect(resolveConfigValue("!printf 'line1\\nline2'")).toBe("line1\nline2");
 		expect(resolveConfigValue("!echo 'hello world' | tr ' ' '-'")).toBe("hello-world");
+	});
+
+	test("honors shellPath configured in settings.json for command resolution", () => {
+		const prior = process.env[ENV_AGENT_DIR];
+		process.env[ENV_AGENT_DIR] = tempDir;
+		writeFileSync(join(tempDir, "settings.json"), JSON.stringify({ shellPath: "/bin/bash" }));
+		try {
+			expect(resolveConfigValue("!echo 'via-configured-shell'")).toBe("via-configured-shell");
+		} finally {
+			if (prior === undefined) delete process.env[ENV_AGENT_DIR];
+			else process.env[ENV_AGENT_DIR] = prior;
+			rmSync(join(tempDir, "settings.json"), { force: true });
+		}
 	});
 
 	test.each(["!exit 1", "!nonexistent-command-12345", "!printf ''"])(


### PR DESCRIPTION
Fixes #8763

## Problem

On Windows, `!`-prefixed values (API keys / provider headers that run a shell command) resolved from `resolve-config-value.ts` call `getShellConfig()` with **no argument**. `getShellConfig()` only honored the explicit `customShellPath` arg, so it **ignored `settings.shellPath`** — even though the bash tool already uses it.

As a result, auto-detection could pick a non-real bash (WSL `C:\Windows\System32\bash.exe` shim or the `...\WindowsApps\bash.exe` App Execution Alias). The shim exits `status !== 0` with empty stdout; `executeWithConfiguredShell` treats that as `{ executed: true }` and does **not** fall back to the default shell, so a `!command` header/API-key value silently fails to resolve. For example a user sees an error like:

```
Error: API key auth failed for provider <name>:
Failed to resolve provider "<name>" header "Authorization" from shell command: ...
```

## Change

In `packages/coding-agent/src/utils/shell.ts`:

1. `getShellConfig()` now honors the user-configured `settings.shellPath` (read from `settings.json` via `getSettingsPath()`) when no explicit shell is passed — consistent with the bash tool. The `existsSync` guard keeps it safe in remote/explicit contexts.
2. During PATH auto-detection, skip known **WSL / WindowsApps bash shims** (`system32\bash.exe`, `sysnative\bash.exe`, `WindowsApps\bash.exe`) so a nonfunctioning shim is never silently selected.

Adds a test in `resolve-config-value.test.ts` verifying a command is resolved via the shell configured in `settings.json`.

## Tests

`cd packages/coding-agent && npx vitest run test/resolve-config-value.test.ts`
