### PR TITLE
feat(coding-agent): make write and edit output easier to scan

### DIFF
--- a/packages/coding-agent/docs/themes.md
+++ b/packages/coding-agent/docs/themes.md
@@ -114,6 +114,9 @@ vim ~/.pi/agent/themes/my-theme.json
     "toolDiffAdded": "#00ff00",
     "toolDiffRemoved": "#ff0000",
     "toolDiffContext": "secondary",
+    "toolDiffText": "",
+    "toolDiffAddedBg": "#1e2e1e",
+    "toolDiffRemovedBg": "#2e1e1e",
     "syntaxComment": "secondary",
     "syntaxKeyword": "primary",
     "syntaxFunction": "#00aaff",
@@ -160,13 +163,13 @@ vim ~/.pi/agent/themes/my-theme.json
 
 - `name` is required, must be unique, and must not contain `/`.
 - `vars` is optional. Define reusable colors here, then reference them in `colors`.
-- `colors` must define all 51 required tokens. `thinkingMax`, `scrollbarThumb`, and the two search highlight tokens are optional and use the fallbacks listed below.
+- `colors` must define all 51 required tokens. `thinkingMax`, `scrollbarThumb`, the two search highlight tokens, and the three changed-row diff tokens are optional and use the fallbacks listed below.
 
 The `$schema` field enables editor auto-completion and validation.
 
 ## Color Tokens
 
-Every theme must define all 51 required color tokens. The optional tokens preserve compatibility with existing themes: `thinkingMax` falls back to `thinkingXhigh`, `scrollbarThumb` and `searchMatchBg` fall back to `selectedBg`, and `searchMatchText` falls back to `text`. Other search matches use `searchMatchText` on `searchMatchBg` with an underline; the current match reverses that foreground/background pair and uses bold text.
+Every theme must define all 51 required color tokens. The optional tokens preserve compatibility with existing themes: `thinkingMax` falls back to `thinkingXhigh`, `scrollbarThumb` and `searchMatchBg` fall back to `selectedBg`, `searchMatchText` and `toolDiffText` fall back to `text`, and the added/removed diff backgrounds fall back to `toolSuccessBg`/`toolErrorBg`. Other search matches use `searchMatchText` on `searchMatchBg` with an underline; the current match reverses that foreground/background pair and uses bold text.
 
 ### Core UI (11 colors)
 
@@ -218,13 +221,16 @@ Every theme must define all 51 required color tokens. The optional tokens preser
 | `mdHr` | Horizontal rule |
 | `mdListBullet` | List bullets |
 
-### Tool Diffs (3 colors)
+### Tool Diffs (3 required, 3 optional)
 
 | Token | Purpose |
 |-------|---------|
 | `toolDiffAdded` | Added lines |
 | `toolDiffRemoved` | Removed lines |
 | `toolDiffContext` | Context lines |
+| `toolDiffText` | Changed-line text; optional, falls back to `text` |
+| `toolDiffAddedBg` | Added-line background; optional, falls back to `toolSuccessBg` |
+| `toolDiffRemovedBg` | Removed-line background; optional, falls back to `toolErrorBg` |
 
 ### Syntax Highlighting (9 colors)
 

--- a/packages/coding-agent/src/core/tools/renderers/edit.ts
+++ b/packages/coding-agent/src/core/tools/renderers/edit.ts
@@ -7,7 +7,7 @@
  */
 
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
-import { renderDiff } from "../../../modes/interactive/components/diff.ts";
+import { BODY_JOINT, DiffRowsComponent, parseDiffRows } from "../../../modes/interactive/components/diff.ts";
 import type { Theme } from "../../../modes/interactive/theme/theme.ts";
 import type { ToolDefinition } from "../../extensions/types.ts";
 import type { EditToolDetails } from "../edit.ts";
@@ -82,7 +82,19 @@ function getRenderablePreviewInput(args: RenderableEditArgs | undefined): { path
 }
 function formatEditCall(args: RenderableEditArgs | undefined, theme: Theme, cwd: string): string {
 	const pathDisplay = renderToolPath(str(args?.file_path ?? args?.path), theme, cwd);
-	return `${theme.fg("toolTitle", theme.bold("edit"))} ${pathDisplay}`;
+	return `${theme.fg("toolTitle", theme.bold("Edit"))}${theme.fg("toolTitle", "(")}${pathDisplay}${theme.fg("toolTitle", ")")}`;
+}
+function formatDiffSummary(added: number, removed: number, theme: Theme): string {
+	const lines = (count: number): string => `line${count === 1 ? "" : "s"}`;
+	let text = "No changes";
+	if (added > 0 && removed > 0) {
+		text = `Added ${theme.bold(String(added))} ${lines(added)} and Removed ${theme.bold(String(removed))} ${lines(removed)}`;
+	} else if (added > 0) {
+		text = `Added ${theme.bold(String(added))} ${lines(added)}`;
+	} else if (removed > 0) {
+		text = `Removed ${theme.bold(String(removed))} ${lines(removed)}`;
+	}
+	return theme.fg("toolOutput", `${BODY_JOINT}${text}`);
 }
 function formatEditResult(
 	args: RenderableEditArgs | undefined,
@@ -90,7 +102,7 @@ function formatEditResult(
 	result: EditToolResultLike,
 	theme: Theme,
 	isError: boolean,
-): string | undefined {
+): DiffRowsComponent | string | undefined {
 	const rawPath = str(args?.file_path ?? args?.path);
 	const previewDiff = preview && !("error" in preview) ? preview.diff : undefined;
 	const previewError = preview && "error" in preview ? preview.error : undefined;
@@ -107,7 +119,7 @@ function formatEditResult(
 
 	const resultDiff = result.details?.diff;
 	if (resultDiff && resultDiff !== previewDiff) {
-		return renderDiff(resultDiff, { filePath: rawPath ?? undefined });
+		return new DiffRowsComponent(parseDiffRows(resultDiff).rows, rawPath ?? undefined);
 	}
 
 	return undefined;
@@ -116,17 +128,11 @@ function getEditHeaderBg(
 	preview: EditPreview | undefined,
 	settledError: boolean | undefined,
 	theme: Theme,
-): (text: string) => string {
-	if (preview) {
-		if ("error" in preview) {
-			return (text: string) => theme.bg("toolErrorBg", text);
-		}
-		return (text: string) => theme.bg("toolSuccessBg", text);
-	}
-	if (settledError) {
+): ((text: string) => string) | undefined {
+	if (settledError || (preview && "error" in preview)) {
 		return (text: string) => theme.bg("toolErrorBg", text);
 	}
-	return (text: string) => theme.bg("toolPendingBg", text);
+	return undefined;
 }
 function buildEditCallComponent(
 	component: EditCallRenderComponent,
@@ -134,7 +140,7 @@ function buildEditCallComponent(
 	theme: Theme,
 	cwd: string,
 ): EditCallRenderComponent {
-	component.setBgFn(getEditHeaderBg(component.preview, component.settledError, theme));
+	component.setBgFn(getEditHeaderBg(component.preview, component.settledError, theme) ?? ((text) => text));
 	component.clear();
 	component.addChild(new Text(formatEditCall(args, theme, cwd), 0, 0));
 
@@ -142,10 +148,16 @@ function buildEditCallComponent(
 		return component;
 	}
 
-	const body =
-		"error" in component.preview ? theme.fg("error", component.preview.error) : renderDiff(component.preview.diff);
+	if ("error" in component.preview) {
+		component.addChild(new Spacer(1));
+		component.addChild(new Text(theme.fg("error", component.preview.error), 0, 0));
+		return component;
+	}
+
+	const { rows, added, removed } = parseDiffRows(component.preview.diff);
 	component.addChild(new Spacer(1));
-	component.addChild(new Text(body, 0, 0));
+	component.addChild(new Text(formatDiffSummary(added, removed, theme), 0, 0));
+	component.addChild(new DiffRowsComponent(rows, str(args?.file_path ?? args?.path) ?? undefined));
 	return component;
 }
 function setEditPreview(
@@ -232,7 +244,7 @@ export const editRenderers: Pick<ToolDefinition<any, any>, "renderCall" | "rende
 			return component;
 		}
 		component.addChild(new Spacer(1));
-		component.addChild(new Text(output, 1, 0));
+		component.addChild(output instanceof DiffRowsComponent ? output : new Text(output, 1, 0));
 		return component;
 	},
 };

--- a/packages/coding-agent/src/core/tools/renderers/write.ts
+++ b/packages/coding-agent/src/core/tools/renderers/write.ts
@@ -7,6 +7,7 @@
  */
 
 import { Container, Text } from "@earendil-works/pi-tui";
+import { BODY_JOINT, BODY_JOINT_WIDTH } from "../../../modes/interactive/components/diff.ts";
 import { keyHint } from "../../../modes/interactive/components/keybinding-hints.ts";
 import { getLanguageFromPath, highlightCode, type Theme } from "../../../modes/interactive/theme/theme.ts";
 import type { ToolDefinition, ToolRenderResultOptions } from "../../extensions/types.ts";
@@ -103,7 +104,7 @@ function formatWriteCall(
 	const rawPath = str(args?.file_path ?? args?.path);
 	const fileContent = str(args?.content);
 	const pathDisplay = renderToolPath(rawPath, theme, cwd);
-	let text = `${theme.fg("toolTitle", theme.bold("write"))} ${pathDisplay}`;
+	let text = `${theme.fg("toolTitle", theme.bold("Write"))}${theme.fg("toolTitle", "(")}${pathDisplay}${theme.fg("toolTitle", ")")}`;
 
 	if (fileContent === null) {
 		text += `\n\n${theme.fg("error", "[invalid content arg - expected string]")}`;
@@ -117,7 +118,17 @@ function formatWriteCall(
 		const maxLines = options.expanded ? lines.length : 10;
 		const displayLines = lines.slice(0, maxLines);
 		const remaining = lines.length - maxLines;
-		text += `\n\n${displayLines.map((line) => (lang ? line : theme.fg("toolOutput", replaceTabs(line)))).join("\n")}`;
+		const numWidth = String(totalLines).length;
+		const bodyIndent = " ".repeat(BODY_JOINT_WIDTH);
+		const body = displayLines
+			.map((line, index) => {
+				const number = theme.fg("toolDiffContext", String(index + 1).padStart(numWidth, " "));
+				const prefix = index === 0 ? BODY_JOINT : bodyIndent;
+				const content = lang ? line : theme.fg("toolOutput", replaceTabs(line));
+				return `${prefix}${number}  ${content}`;
+			})
+			.join("\n");
+		text += `\n\n${body}`;
 		if (remaining > 0) {
 			text += `${theme.fg("muted", `\n... (${remaining} more lines, ${totalLines} total,`)} ${keyHint("app.tools.expand", "to expand")}${theme.fg("muted", ")")}`;
 		}

--- a/packages/coding-agent/src/modes/interactive/components/diff.ts
+++ b/packages/coding-agent/src/modes/interactive/components/diff.ts
@@ -1,5 +1,6 @@
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import * as Diff from "diff";
-import { theme } from "../theme/theme.ts";
+import { getLanguageFromPath, highlightCode, theme } from "../theme/theme.ts";
 
 /**
  * Parse diff line to extract prefix, line number, and content.
@@ -144,4 +145,69 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
 	}
 
 	return result.join("\n");
+}
+
+export type DiffRowKind = "context" | "removed" | "added";
+
+export interface DiffRow {
+	kind: DiffRowKind;
+	lineNum: string;
+	content: string;
+}
+
+export const BODY_JOINT = "└ ";
+export const BODY_JOINT_WIDTH = 2;
+
+export function parseDiffRows(diffText: string): { rows: DiffRow[]; added: number; removed: number } {
+	const rows: DiffRow[] = [];
+	let added = 0;
+	let removed = 0;
+
+	for (const line of diffText.split("\n")) {
+		const parsed = parseDiffLine(line);
+		if (!parsed) continue;
+
+		const kind: DiffRowKind = parsed.prefix === "+" ? "added" : parsed.prefix === "-" ? "removed" : "context";
+		if (kind === "added") added++;
+		if (kind === "removed") removed++;
+		rows.push({ kind, lineNum: parsed.lineNum.trim(), content: parsed.content });
+	}
+
+	return { rows, added, removed };
+}
+
+export class DiffRowsComponent implements Component {
+	private readonly rows: DiffRow[];
+	private readonly highlightedContents?: string[];
+
+	constructor(rows: DiffRow[], filePath?: string) {
+		this.rows = rows;
+		const lang = filePath ? getLanguageFromPath(filePath) : undefined;
+		if (lang) {
+			this.highlightedContents = highlightCode(rows.map((row) => replaceTabs(row.content)).join("\n"), lang);
+		}
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const numWidth = Math.max(1, ...this.rows.map((row) => row.lineNum.length));
+		const indentWidth = Math.min(BODY_JOINT_WIDTH, Math.max(0, width));
+		const regionWidth = Math.max(0, width - indentWidth);
+		const indent = " ".repeat(indentWidth);
+
+		return this.rows.map((row, index) => {
+			if (regionWidth === 0) return indent;
+
+			const marker = row.kind === "context" ? "  " : row.kind === "removed" ? " -" : " +";
+			const color = row.kind === "context" ? "toolDiffContext" : "toolDiffText";
+			const prefix = theme.fg(color, `${row.lineNum.padStart(numWidth, " ")}${marker}`);
+			const content = this.highlightedContents?.[index] ?? theme.fg(color, replaceTabs(row.content));
+			const styled = truncateToWidth(prefix + content, regionWidth, "");
+			const padded = styled + " ".repeat(regionWidth - visibleWidth(styled));
+			if (row.kind === "context") return indent + padded;
+
+			return indent + theme.bg(row.kind === "removed" ? "toolDiffRemovedBg" : "toolDiffAddedBg", padded);
+		});
+	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -295,18 +295,20 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	private updateDisplay(): void {
-		const bgFn = this.isPartial
-			? (text: string) => theme.bg("toolPendingBg", text)
-			: this.result?.isError
-				? (text: string) => theme.bg("toolErrorBg", text)
-				: (text: string) => theme.bg("toolSuccessBg", text);
+		const bgFn = this.result?.isError
+			? (text: string) => theme.bg("toolErrorBg", text)
+			: this.toolName === "write" || this.toolName === "edit"
+				? undefined
+				: this.isPartial
+					? (text: string) => theme.bg("toolPendingBg", text)
+					: (text: string) => theme.bg("toolSuccessBg", text);
 
 		let hasContent = false;
 		this.hideComponent = false;
 		if (this.hasRendererDefinition()) {
 			const renderContainer = this.getRenderShell() === "self" ? this.selfRenderContainer : this.contentBox;
 			if (renderContainer instanceof Box) {
-				renderContainer.setBgFn(bgFn);
+				renderContainer.setBgFn(bgFn ?? ((text) => text));
 			}
 			renderContainer.clear();
 
@@ -357,7 +359,7 @@ export class ToolExecutionComponent extends Container {
 				}
 			}
 		} else {
-			this.contentText.setCustomBgFn(bgFn);
+			this.contentText.setCustomBgFn(bgFn ?? ((text) => text));
 			this.contentText.setText(this.formatToolExecution());
 			hasContent = true;
 		}

--- a/packages/coding-agent/src/modes/interactive/theme/dark.json
+++ b/packages/coding-agent/src/modes/interactive/theme/dark.json
@@ -17,6 +17,8 @@
 		"toolPendingBg": "#282832",
 		"toolSuccessBg": "#283228",
 		"toolErrorBg": "#3c2828",
+		"toolDiffAddedBg": "#1d3a1d",
+		"toolDiffRemovedBg": "#3d1d1d",
 		"customMsgBg": "#2d2838"
 	},
 	"colors": {
@@ -61,6 +63,9 @@
 		"toolDiffAdded": "green",
 		"toolDiffRemoved": "red",
 		"toolDiffContext": "gray",
+		"toolDiffText": "#ffffff",
+		"toolDiffAddedBg": "toolDiffAddedBg",
+		"toolDiffRemovedBg": "toolDiffRemovedBg",
 
 		"syntaxComment": "#6A9955",
 		"syntaxKeyword": "#569CD6",

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -16,6 +16,8 @@
 		"toolPendingBg": "#e8e8f0",
 		"toolSuccessBg": "#e8f0e8",
 		"toolErrorBg": "#f0e8e8",
+		"toolDiffAddedBg": "#d9ead3",
+		"toolDiffRemovedBg": "#f4cccc",
 		"customMsgBg": "#ede7f6"
 	},
 	"colors": {
@@ -60,6 +62,9 @@
 		"toolDiffAdded": "green",
 		"toolDiffRemoved": "red",
 		"toolDiffContext": "mediumGray",
+		"toolDiffText": "text",
+		"toolDiffAddedBg": "toolDiffAddedBg",
+		"toolDiffRemovedBg": "toolDiffRemovedBg",
 
 		"syntaxComment": "#008000",
 		"syntaxKeyword": "#0000FF",

--- a/packages/coding-agent/src/modes/interactive/theme/theme-json.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-json.ts
@@ -58,10 +58,13 @@ const ThemeJsonSchema = Type.Object({
 		mdQuoteBorder: ColorValueSchema,
 		mdHr: ColorValueSchema,
 		mdListBullet: ColorValueSchema,
-		// Tool Diffs (3 colors)
+		// Tool Diffs (3 required, 3 optional)
 		toolDiffAdded: ColorValueSchema,
 		toolDiffRemoved: ColorValueSchema,
 		toolDiffContext: ColorValueSchema,
+		toolDiffText: Type.Optional(ColorValueSchema),
+		toolDiffAddedBg: Type.Optional(ColorValueSchema),
+		toolDiffRemovedBg: Type.Optional(ColorValueSchema),
 		// Syntax Highlighting (9 colors)
 		syntaxComment: ColorValueSchema,
 		syntaxKeyword: ColorValueSchema,

--- a/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-schema.json
@@ -34,7 +34,7 @@
 		},
 		"colors": {
 			"type": "object",
-			"description": "Theme color definitions (thinkingMax, scrollbarThumb, and search highlight colors are optional and use compatible fallbacks)",
+			"description": "Theme color definitions (thinkingMax, scrollbarThumb, search highlight, and diff row colors are optional and use compatible fallbacks)",
 			"required": [
 				"accent",
 				"border",
@@ -240,6 +240,18 @@
 				"toolDiffContext": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Context lines in tool diffs"
+				},
+				"toolDiffText": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Changed-line text in tool diffs (falls back to text when omitted)"
+				},
+				"toolDiffAddedBg": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Added-line background in tool diffs (falls back to toolSuccessBg when omitted)"
+				},
+				"toolDiffRemovedBg": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Removed-line background in tool diffs (falls back to toolErrorBg when omitted)"
 				},
 				"syntaxComment": {
 					"$ref": "#/$defs/colorValue",

--- a/packages/coding-agent/src/modes/interactive/theme/theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme.ts
@@ -69,6 +69,7 @@ export type ThemeColor =
 	| "toolDiffAdded"
 	| "toolDiffRemoved"
 	| "toolDiffContext"
+	| "toolDiffText"
 	| "syntaxComment"
 	| "syntaxKeyword"
 	| "syntaxFunction"
@@ -95,10 +96,12 @@ export type ThemeBg =
 	| "customMessageBg"
 	| "toolPendingBg"
 	| "toolSuccessBg"
-	| "toolErrorBg";
+	| "toolErrorBg"
+	| "toolDiffAddedBg"
+	| "toolDiffRemovedBg";
 
-type OptionalThemeColor = "thinkingMax" | "searchMatchText";
-type OptionalThemeBg = "scrollbarThumb" | "searchMatchBg";
+type OptionalThemeColor = "thinkingMax" | "searchMatchText" | "toolDiffText";
+type OptionalThemeBg = "scrollbarThumb" | "searchMatchBg" | "toolDiffAddedBg" | "toolDiffRemovedBg";
 
 type ColorMode = "truecolor" | "256color";
 
@@ -262,6 +265,9 @@ function withThemeColorFallbacks(colors: ThemeJson["colors"]): ThemeJson["colors
 	scrollbarThumb: ColorValue;
 	searchMatchBg: ColorValue;
 	searchMatchText: ColorValue;
+	toolDiffText: ColorValue;
+	toolDiffAddedBg: ColorValue;
+	toolDiffRemovedBg: ColorValue;
 } {
 	return {
 		...colors,
@@ -269,6 +275,9 @@ function withThemeColorFallbacks(colors: ThemeJson["colors"]): ThemeJson["colors
 		scrollbarThumb: colors.scrollbarThumb ?? colors.selectedBg,
 		searchMatchBg: colors.searchMatchBg ?? colors.selectedBg,
 		searchMatchText: colors.searchMatchText ?? colors.text,
+		toolDiffText: colors.toolDiffText ?? colors.text,
+		toolDiffAddedBg: colors.toolDiffAddedBg ?? colors.toolSuccessBg,
+		toolDiffRemovedBg: colors.toolDiffRemovedBg ?? colors.toolErrorBg,
 	};
 }
 
@@ -301,6 +310,7 @@ export class Theme {
 			...fgColors,
 			thinkingMax: fgColors.thinkingMax ?? fgColors.thinkingXhigh,
 			searchMatchText: fgColors.searchMatchText ?? fgColors.text,
+			toolDiffText: fgColors.toolDiffText ?? fgColors.text,
 		};
 		for (const [key, value] of Object.entries(colors) as [ThemeColor, string | number][]) {
 			this.fgColors.set(key, fgAnsi(value, mode));
@@ -310,6 +320,8 @@ export class Theme {
 			...bgColors,
 			scrollbarThumb: bgColors.scrollbarThumb ?? bgColors.selectedBg,
 			searchMatchBg: bgColors.searchMatchBg ?? bgColors.selectedBg,
+			toolDiffAddedBg: bgColors.toolDiffAddedBg ?? bgColors.toolSuccessBg,
+			toolDiffRemovedBg: bgColors.toolDiffRemovedBg ?? bgColors.toolErrorBg,
 		};
 		for (const [key, value] of Object.entries(backgrounds) as [ThemeBg, string | number][]) {
 			this.bgColors.set(key, bgAnsi(value, mode));
@@ -535,6 +547,8 @@ function createTheme(themeJson: ThemeJson, mode?: ColorMode, sourcePath?: string
 		"toolPendingBg",
 		"toolSuccessBg",
 		"toolErrorBg",
+		"toolDiffAddedBg",
+		"toolDiffRemovedBg",
 	]);
 	for (const [key, value] of Object.entries(resolvedColors)) {
 		if (bgColorKeys.has(key)) {

--- a/packages/coding-agent/test/diff-rows.test.ts
+++ b/packages/coding-agent/test/diff-rows.test.ts
@@ -1,0 +1,50 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, test } from "vitest";
+import { DiffRowsComponent, parseDiffRows } from "../src/modes/interactive/components/diff.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+
+describe("tool diff rows", () => {
+	test("parses rows and counts changes", () => {
+		expect(parseDiffRows("+1 foo\n 2 bar\n-3 baz\n   ...")).toEqual({
+			rows: [
+				{ kind: "added", lineNum: "1", content: "foo" },
+				{ kind: "context", lineNum: "2", content: "bar" },
+				{ kind: "removed", lineNum: "3", content: "baz" },
+				{ kind: "context", lineNum: "", content: "..." },
+			],
+			added: 1,
+			removed: 1,
+		});
+	});
+
+	test("renders changed rows with full-width backgrounds", () => {
+		initTheme("dark");
+		const lines = new DiffRowsComponent([
+			{ kind: "context", lineNum: "1", content: "plain" },
+			{ kind: "removed", lineNum: "2", content: "gone" },
+			{ kind: "added", lineNum: "3", content: "한글🙂".repeat(10) },
+		]).render(20);
+
+		expect(lines.every((line) => visibleWidth(line) === 20)).toBe(true);
+		expect(lines[0]).not.toContain(theme.getBgAnsi("toolDiffAddedBg"));
+		expect(lines[0]).not.toContain(theme.getBgAnsi("toolDiffRemovedBg"));
+		expect(lines[1]).toContain(theme.getBgAnsi("toolDiffRemovedBg"));
+		expect(lines[2]).toContain(theme.getBgAnsi("toolDiffAddedBg"));
+		expect(lines[2]).toContain(theme.getFgAnsi("toolDiffText"));
+	});
+
+	test("syntax-highlights diff content from the file path", () => {
+		initTheme("dark");
+		const lines = new DiffRowsComponent(
+			[
+				{ kind: "removed", lineNum: "1", content: "const value = 1;" },
+				{ kind: "added", lineNum: "1", content: "const value = 2;" },
+			],
+			"example.ts",
+		).render(40);
+
+		expect(lines.every((line) => line.includes(theme.getFgAnsi("syntaxKeyword")))).toBe(true);
+		expect(lines[0]).toContain(theme.getBgAnsi("toolDiffRemovedBg"));
+		expect(lines[1]).toContain(theme.getBgAnsi("toolDiffAddedBg"));
+	});
+});

--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -124,7 +124,7 @@ describe("edit tool TUI rendering", () => {
 			"line 50 changed",
 			() => tui.requestRender(true),
 		);
-		expect(callOnlyRender).toContain("edit");
+		expect(callOnlyRender).toContain("Edit");
 		expect(callOnlyRender).toContain("line 950 changed");
 
 		const redrawsBeforeResult = tui.fullRedraws;

--- a/packages/coding-agent/test/scrollbar-theme.test.ts
+++ b/packages/coding-agent/test/scrollbar-theme.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 	}
 });
 
-describe("optional fullscreen theme colors", () => {
+describe("optional theme colors", () => {
 	it("falls back to selectedBg when scrollbarThumb is omitted", () => {
 		const themeJson = loadDarkTheme();
 		themeJson.name = "legacy-scrollbar-theme";
@@ -66,5 +66,18 @@ describe("optional fullscreen theme colors", () => {
 		const loadedTheme = loadThemeFromPath(writeTheme(themeJson), "truecolor");
 		expect(loadedTheme.getBgAnsi("searchMatchBg")).toBe("\x1b[48;2;17;34;51m");
 		expect(loadedTheme.getFgAnsi("searchMatchText")).toBe("\x1b[38;2;34;51;68m");
+	});
+
+	it("falls back to existing tool colors for diff rows", () => {
+		const themeJson = loadDarkTheme();
+		themeJson.name = "legacy-diff-theme";
+		delete themeJson.colors.toolDiffText;
+		delete themeJson.colors.toolDiffAddedBg;
+		delete themeJson.colors.toolDiffRemovedBg;
+
+		const loadedTheme = loadThemeFromPath(writeTheme(themeJson), "truecolor");
+		expect(loadedTheme.getFgAnsi("toolDiffText")).toBe(loadedTheme.getFgAnsi("text"));
+		expect(loadedTheme.getBgAnsi("toolDiffAddedBg")).toBe(loadedTheme.getBgAnsi("toolSuccessBg"));
+		expect(loadedTheme.getBgAnsi("toolDiffRemovedBg")).toBe(loadedTheme.getBgAnsi("toolErrorBg"));
 	});
 });

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -115,9 +115,33 @@ describe("ToolExecutionComponent parity", () => {
 		);
 		component.updateResult({ content: [], details: { diff: "+1 after", firstChangedLine: 1 }, isError: false });
 		const rendered = stripAnsi(component.render(120).join("\n"));
-		expect(rendered).toContain("edit");
+		expect(rendered).toContain("Edit(");
 		expect(rendered).toContain("README.md");
 		expect(rendered).not.toContain(":1");
+	});
+
+	test("syntax-highlights edit previews based on the edited file path", () => {
+		const component = new ToolExecutionComponent(
+			"edit",
+			"tool-edit-syntax",
+			{ path: "example.ts", oldText: "const value = 1;", newText: "const value = 2;" },
+			{},
+			withBuiltInRenderers("edit", createBaseToolDefinition("edit")),
+			createFakeTui(),
+			process.cwd(),
+		);
+		component.updateResult(
+			{
+				content: [],
+				details: { diff: "-1 const value = 1;\n+1 const value = 2;", firstChangedLine: 1 },
+				isError: false,
+			},
+			false,
+		);
+
+		const rendered = component.render(120).join("\n");
+		expect(rendered).toContain(theme.getFgAnsi("syntaxKeyword"));
+		expect(rendered).toContain(theme.getFgAnsi("syntaxNumber"));
 	});
 
 	test("preserves legacy file_path rendering compatibility for built-in tools", () => {
@@ -386,9 +410,32 @@ describe("ToolExecutionComponent parity", () => {
 			process.cwd(),
 		);
 		const rendered = stripAnsi(component.render(120).join("\n"));
-		expect(rendered).toContain("one");
-		expect(rendered).toContain("two");
+		expect(rendered).toContain("Write(");
+		expect(rendered).toContain("└ 1  one");
+		expect(rendered).toContain("  2  two");
 		expect(rendered).not.toContain("two\n\n");
+	});
+
+	test("keeps write previews transparent while retaining the error background", () => {
+		const component = new ToolExecutionComponent(
+			"write",
+			"tool-write-background",
+			{ path: "README.md", content: "one" },
+			{},
+			createWriteToolDefinition(process.cwd()),
+			createFakeTui(),
+			process.cwd(),
+		);
+		expect(component.render(120).join("\n")).not.toContain(theme.getBgAnsi("toolPendingBg"));
+
+		component.updateResult({ content: [], details: undefined, isError: false }, false);
+		expect(component.render(120).join("\n")).not.toContain(theme.getBgAnsi("toolSuccessBg"));
+
+		component.updateResult(
+			{ content: [{ type: "text", text: "write failed" }], details: undefined, isError: true },
+			false,
+		);
+		expect(component.render(120).join("\n")).toContain(theme.getBgAnsi("toolErrorBg"));
 	});
 
 	test("trims trailing blank display lines from read results", () => {


### PR DESCRIPTION
## Summary

Write and edit output is where I spend most of my time checking what Pi actually changed. The current generic tool blocks make that harder to scan, especially across larger file changes.

This gives those tools a compact, file-focused presentation:

- `Write(path)` previews add line numbers while retaining file-aware syntax highlighting.
- `Edit(path)` previews show added and removed counts, syntax highlighting, and full-width backgrounds for changed lines.

Pending and successful file changes no longer use the generic tool background. Errors remain visually distinct, click-to-expand behavior is unchanged, and the new diff colors fall back to existing theme tokens so custom themes continue to work.

This is part of the series of small, pi-idiomatic UI improvements I am contributing, focused on making the interface clearer without adding interaction complexity.

## Testing

- `npm run check`
- `./test.sh`
- Focused coding-agent renderer and theme tests: 39 passed
