### PR TITLE
fix(tui): match skill commands by bare name in slash autocomplete

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -327,11 +327,15 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					};
 				});
 
-				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name).map((item) => ({
-					value: item.name,
-					label: item.label,
-					...(item.description && { description: item.description }),
-				}));
+				// Match skill commands against the bare skill name (without the "skill:" prefix),
+				// so characters in the prefix (e.g. the 'i' in "skill") can't steal the first query character
+				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name.replace(/^skill:/, "")).map(
+					(item) => ({
+						value: item.name,
+						label: item.label,
+						...(item.description && { description: item.description }),
+					}),
+				);
 
 				if (filtered.length === 0) return null;
 

--- a/packages/tui/test/autocomplete-skill-slash.test.ts
+++ b/packages/tui/test/autocomplete-skill-slash.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { CombinedAutocompleteProvider } from "../src/autocomplete.ts";
+
+describe("CombinedAutocompleteProvider slash-command filter", () => {
+	const commands = [
+		{ name: "skill:deep-research", description: "Multi-agent deep research" },
+		{ name: "skill:research-idea", description: "Refine a raw idea into a falsifiable seed" },
+		{ name: "skill:to-sidecar", description: "Route work to a sidecar" },
+		{ name: "model", description: "Select the active model" },
+	];
+
+	async function suggestionsFor(prefix: string): Promise<string[]> {
+		const provider = new CombinedAutocompleteProvider(commands, process.cwd());
+		const line = `/${prefix}`;
+		const result = await provider.getSuggestions([line], 0, line.length, { signal: new AbortController().signal });
+		assert.ok(result, `expected suggestions for "/${prefix}"`);
+		return result.items.map((item) => item.value);
+	}
+
+	it("ranks skill:research-idea first for query 'idea' (bare-name matching)", async () => {
+		const items = await suggestionsFor("idea");
+		assert.equal(items[0], "skill:research-idea");
+		assert.ok(
+			!items.includes("skill:deep-research"),
+			"'deep-research' has no 'i' in its bare name, so it must not match 'idea'",
+		);
+	});
+
+	it("non-skill commands are unaffected by the prefix strip", async () => {
+		const items = await suggestionsFor("mod");
+		assert.ok(items.includes("model"), "model command still matches 'mod'");
+	});
+
+	it("skill commands still match their own name characters", async () => {
+		const items = await suggestionsFor("side");
+		assert.ok(items.includes("skill:to-sidecar"), "'to-sidecar' should match 'side' via its bare name");
+	});
+});


### PR DESCRIPTION
## Problem

Typing `/idea` in the slash-command menu ranked `skill:deep-research` above `skill:research-idea`. The slash branch of `CombinedAutocompleteProvider.getSuggestions` runs `fuzzyFilter` against the full command name, i.e. the `skill:<name>` string. Fuzzy matching is a greedy earliest-occurrence subsequence scorer, so the `i` in the `skill:` prefix consumes the first character of the query "idea", leaving `deep-research` with only "dea" to score on. Result: deep-research scores better (lower is better) than research-idea.

Concrete trace for query "idea":
- `skill:deep-research`: the `i` in the `skill:` prefix matches, then "dea" matches inside "deep-research" (d-e-e-p... has d, e, a) -> better score
- `skill:research-idea`: the prefix `i` matches, but then "dea" must match inside the bare name "research-idea" with larger gaps -> worse score

## Fix

Match skill commands against the bare skill name (strip the `skill:` prefix) in the slash autocomplete branch of `packages/tui/src/autocomplete.ts`:

```ts
const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name.replace(/^skill:/, "")).map(...)
```

This is a no-op for non-skill commands (built-in slash commands, templates, extension commands), so their ranking is unchanged.

## Verification

- New regression test `packages/tui/test/autocomplete-skill-slash.test.ts` asserts:
  - query "idea": `skill:research-idea` ranks first, `skill:deep-research` drops out entirely (no "i" in the bare name "deep-research")
  - non-skill command "model" still matches query "mod"
  - `skill:to-sidecar` still matches query "side" via its bare name
- Full `packages/tui` test suite passes.