### PR TITLE
fix(ai): limit codex sse fallback to oversized websocket frames

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -345,18 +345,19 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 						if (aborted || (isCodexNonTransportError(error) && !connectionLimitBeforeStart)) {
 							throw error;
 						}
+						const fallbackToSse = !websocketStarted && isSseRequired(error);
 						appendAssistantMessageDiagnostic(
 							output,
 							createAssistantMessageDiagnostic("provider_transport_failure", error, {
 								configuredTransport: transport,
-								fallbackTransport: websocketStarted ? undefined : "sse",
+								fallbackTransport: fallbackToSse ? "sse" : undefined,
 								eventsEmitted: websocketStarted,
 								phase: websocketStarted ? "after_message_stream_start" : "before_message_stream_start",
 								requestBytes: new TextEncoder().encode(bodyJson).byteLength,
 							}),
 						);
-						recordWebSocketFailure(cacheSessionId, error);
-						if (websocketStarted) {
+						recordWebSocketFailure(cacheSessionId, error, fallbackToSse);
+						if (!fallbackToSse) {
 							throw error;
 						}
 						recordWebSocketSseFallback(cacheSessionId);
@@ -935,14 +936,16 @@ function recordWebSocketSseFallback(sessionId: string | undefined): void {
 	stats.websocketFallbackActive = isWebSocketSseFallbackActive(sessionId);
 }
 
-function recordWebSocketFailure(sessionId: string | undefined, error: unknown): void {
+function recordWebSocketFailure(sessionId: string | undefined, error: unknown, activateSseFallback: boolean): void {
 	if (!sessionId) return;
-	websocketSseFallbackSessions.add(sessionId);
+	if (activateSseFallback) {
+		websocketSseFallbackSessions.add(sessionId);
+	}
 
 	const stats = getOrCreateWebSocketDebugStats(sessionId);
 	stats.websocketFailures++;
 	stats.lastWebSocketError = formatThrownValue(error);
-	stats.websocketFallbackActive = true;
+	stats.websocketFallbackActive = isWebSocketSseFallbackActive(sessionId);
 }
 
 type WebSocketConstructor = new (
@@ -996,6 +999,10 @@ class WebSocketCloseError extends Error {
 		this.reason = options?.reason;
 		this.wasClean = options?.wasClean;
 	}
+}
+
+function isSseRequired(error: unknown): boolean {
+	return error instanceof WebSocketCloseError && error.code === WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE;
 }
 
 function getWebSocketReadyState(socket: WebSocketLike): number | undefined {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -1526,8 +1526,7 @@ describe("openai-codex streaming", () => {
 		expect(global.fetch).not.toHaveBeenCalled();
 	});
 
-	it("falls back to SSE when websocket connect does not open before the connect timeout", async () => {
-		vi.useFakeTimers();
+	it("does not fall back to SSE when a websocket closes with code 1006", async () => {
 		const token = mockToken();
 		const encoder = new TextEncoder();
 		const sse = buildSSEPayload({ status: "completed" });
@@ -1553,6 +1552,10 @@ describe("openai-codex streaming", () => {
 		class MockWebSocket {
 			private listeners = new Map<string, Set<(event: unknown) => void>>();
 
+			constructor() {
+				queueMicrotask(() => this.dispatch("open", {}));
+			}
+
 			addEventListener(type: string, listener: (event: unknown) => void): void {
 				let listeners = this.listeners.get(type);
 				if (!listeners) {
@@ -1567,10 +1570,16 @@ describe("openai-codex streaming", () => {
 			}
 
 			send(): void {
-				throw new Error("send should not be called before websocket open");
+				queueMicrotask(() => this.dispatch("close", { code: 1006, reason: "Connection ended", wasClean: false }));
 			}
 
 			close(): void {}
+
+			private dispatch(type: string, event: unknown): void {
+				for (const listener of this.listeners.get(type) ?? []) {
+					listener(event);
+				}
+			}
 		}
 
 		vi.stubGlobal("WebSocket", MockWebSocket);
@@ -1594,22 +1603,20 @@ describe("openai-codex streaming", () => {
 
 		const resultPromise = streamOpenAICodexResponses(model, context, {
 			apiKey: token,
-			sessionId: "ws-connect-timeout",
+			sessionId: "ws-close-1006",
 			transport: "auto",
 			timeoutMs: 300_000,
 			websocketConnectTimeoutMs: 50,
 		}).result();
 
-		await vi.advanceTimersByTimeAsync(50);
-
 		const result = await resultPromise;
-		expect(result.content.find((content) => content.type === "text")?.text).toBe("Hello");
-		expect(fetchMock).toHaveBeenCalledTimes(1);
-		expect(getOpenAICodexWebSocketDebugStats("ws-connect-timeout")).toMatchObject({
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("WebSocket closed 1006 Connection ended");
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(getOpenAICodexWebSocketDebugStats("ws-close-1006")).toMatchObject({
 			websocketFailures: 1,
-			sseFallbacks: 1,
-			websocketFallbackActive: true,
-			lastWebSocketError: "WebSocket connect timeout after 50ms",
+			websocketFallbackActive: false,
+			lastWebSocketError: "WebSocket closed 1006 Connection ended",
 		});
 	});
 
@@ -1675,7 +1682,7 @@ describe("openai-codex streaming", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
-	it("falls back to SSE when a websocket is idle before the first event", async () => {
+	it("falls back to SSE when a websocket closes with code 1009 before the first event", async () => {
 		vi.useFakeTimers();
 		const token = mockToken();
 		const sentBodies: unknown[] = [];
@@ -1724,6 +1731,7 @@ describe("openai-codex streaming", () => {
 
 			send(data: string): void {
 				sentBodies.push(JSON.parse(data));
+				queueMicrotask(() => this.dispatch("close", { code: 1009 }));
 			}
 
 			close(): void {
@@ -1758,19 +1766,18 @@ describe("openai-codex streaming", () => {
 
 		const resultPromise = streamOpenAICodexResponses(model, context, {
 			apiKey: token,
-			sessionId: "ws-idle-before-start",
+			sessionId: "ws-close-1009",
 			transport: "auto",
 			timeoutMs: 50,
 		}).result();
 
 		await vi.advanceTimersByTimeAsync(0);
 		expect(sentBodies).toHaveLength(1);
-		await vi.advanceTimersByTimeAsync(50);
 
 		const result = await resultPromise;
 		expect(result.content.find((content) => content.type === "text")?.text).toBe("Hello");
 		expect(fetchMock).toHaveBeenCalledTimes(1);
-		expect(getOpenAICodexWebSocketDebugStats("ws-idle-before-start")).toMatchObject({
+		expect(getOpenAICodexWebSocketDebugStats("ws-close-1009")).toMatchObject({
 			websocketFailures: 1,
 			sseFallbacks: 1,
 			websocketFallbackActive: true,
@@ -2226,7 +2233,7 @@ describe("openai-codex streaming", () => {
 						return;
 					}
 					if (sentBodies.length === 3 && recoveryTransport === "sse") {
-						queueMicrotask(() => this.dispatch("error", { message: "retry websocket failed" }));
+						queueMicrotask(() => this.dispatch("close", { code: 1009 }));
 						return;
 					}
 


### PR DESCRIPTION
## Summary

Restrict the automatic Codex WebSocket → SSE fallback to WebSocket close code
`1009` (message too big) only.

- Do not fall back to SSE for other pre-stream WebSocket failures.
- Do not mark the session SSE-only unless the fallback is actually required.
- Add regression coverage for `1006` (no fallback) and `1009` (fallback).

## Motivation

The existing fallback was introduced in #4133 to recover from Codex WebSocket problems. It treated every pre-stream WebSocket error/close as eligible for SSE fallback.

This caused a `1006 Connection ended`, for example from a transient network failure, to silently switch transports. For setups using OpenAI regional processing, the SSE endpoint can then fail because the requested Codex model snapshot is unavailable in that geography. The SSE error obscures the original transient WebSocket failure and makes the session remain SSE-only.

Close code `1009` is the case where SSE is required: the WebSocket request frame is too large. Other failures, including `1000`, `1006`, connection errors, and
timeouts, should remain WebSocket errors and use normal retry handling rather than switching APIs.

In my case, I'm using Codex from EU servers, where apparently the SSE endpoint is not available. When my wifi is temporarily failing the pi session would permanently switch to using SSE for codex. I was forced to switch to another provider for the session to avoid. The error I would get:

```
 Codex error: The requested model snapshot is not available for your project's geography. If
 you need regional processing, consider switching to a model that officially supports it:

https://developers.openai.com/api/docs/guides/your-data#which-models-and-features-are-eligible-for
-data-residency
```

## Validation

I ran this change on my machine for a week or so and haven't run into these kinds of issues anymore.