### PR TITLE
feat(coding-agent): extensions changelog

### DIFF
--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -32,7 +32,7 @@ function getEnv(): NodeJS.ProcessEnv {
 	}
 }
 
-import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import type { Readable } from "node:stream";
 import ignore from "ignore";
 import { minimatch } from "minimatch";
@@ -69,6 +69,7 @@ export interface PathMetadata {
 	scope: SourceScope;
 	origin: "package" | "top-level";
 	baseDir?: string;
+	changelogPath?: string;
 }
 
 export interface ResolvedResource {
@@ -650,6 +651,35 @@ function collectResourceFiles(dir: string, resourceType: ResourceType): string[]
 		return collectAutoExtensionEntries(dir);
 	}
 	return collectFiles(dir, FILE_PATTERNS[resourceType]);
+}
+
+function hasManifestResourceFields(manifest: PiManifest): boolean {
+	return RESOURCE_TYPES.some((resourceType) => manifest[resourceType] !== undefined);
+}
+
+function isPathInside(parent: string, child: string): boolean {
+	const relativePath = relative(parent, child);
+	return (
+		relativePath !== "" && relativePath !== ".." && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath)
+	);
+}
+
+function resolvePackageChangelogPath(packageRoot: string, manifest: PiManifest | null): string | undefined {
+	const changelogPath = manifest?.changelogPath ?? "CHANGELOG.md";
+	if (!changelogPath) return undefined;
+
+	const resolvedPath = resolve(packageRoot, changelogPath);
+	if (!existsSync(resolvedPath)) return undefined;
+
+	const canonicalPackageRoot = canonicalizePath(packageRoot);
+	const canonicalChangelogPath = canonicalizePath(resolvedPath);
+	if (!isPathInside(canonicalPackageRoot, canonicalChangelogPath)) return undefined;
+
+	try {
+		return statSync(resolvedPath).isFile() ? resolvedPath : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 function matchesAnyPattern(filePath: string, patterns: string[], baseDir: string): boolean {
@@ -2156,6 +2186,14 @@ export class DefaultPackageManager implements PackageManager {
 		filter: PackageFilter | undefined,
 		metadata: PathMetadata,
 	): boolean {
+		const manifest = readPiManifest(join(packageRoot, "package.json"));
+		const changelogPath = resolvePackageChangelogPath(packageRoot, manifest);
+		if (changelogPath) {
+			metadata.changelogPath = changelogPath;
+		} else {
+			delete metadata.changelogPath;
+		}
+
 		if (filter) {
 			for (const resourceType of RESOURCE_TYPES) {
 				const patterns = filter[resourceType];
@@ -2171,10 +2209,9 @@ export class DefaultPackageManager implements PackageManager {
 			return true;
 		}
 
-		const manifest = readPiManifest(join(packageRoot, "package.json"));
-		if (manifest) {
+		if (manifest && hasManifestResourceFields(manifest)) {
 			for (const resourceType of RESOURCE_TYPES) {
-				const entries = manifest[resourceType as keyof PiManifest];
+				const entries = manifest[resourceType];
 				this.addManifestEntries(
 					entries,
 					packageRoot,
@@ -2208,7 +2245,7 @@ export class DefaultPackageManager implements PackageManager {
 		metadata: PathMetadata,
 	): void {
 		const manifest = readPiManifest(join(packageRoot, "package.json"));
-		const entries = manifest?.[resourceType as keyof PiManifest];
+		const entries = manifest?.[resourceType];
 		if (entries) {
 			this.addManifestEntries(entries, packageRoot, resourceType, target, metadata);
 			return;
@@ -2277,7 +2314,7 @@ export class DefaultPackageManager implements PackageManager {
 		resourceType: ResourceType,
 	): { allFiles: string[]; enabledByManifest: Set<string> } {
 		const manifest = readPiManifest(join(packageRoot, "package.json"));
-		const entries = manifest?.[resourceType as keyof PiManifest];
+		const entries = manifest?.[resourceType];
 		if (entries && entries.length > 0) {
 			const allFiles = this.collectFilesFromManifestEntries(entries, packageRoot, resourceType);
 			const manifestPatterns = entries.filter(isOverridePattern);

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -103,6 +103,14 @@ export interface PackageUpdate {
 	scope: Exclude<SourceScope, "temporary">;
 }
 
+export interface PackageUpdateResult extends PackageUpdate {
+	installedPath: string;
+	baseDir: string;
+	fromVersion?: string;
+	toVersion?: string;
+	changelogPath?: string;
+}
+
 export interface ConfiguredPackage {
 	source: string;
 	scope: "user" | "project";
@@ -116,7 +124,7 @@ export interface PackageManager {
 	installAndPersist(source: string, options?: { local?: boolean }): Promise<void>;
 	remove(source: string, options?: { local?: boolean }): Promise<void>;
 	removeAndPersist(source: string, options?: { local?: boolean }): Promise<boolean>;
-	update(source?: string): Promise<void>;
+	update(source?: string): Promise<PackageUpdateResult[]>;
 	listConfiguredPackages(): ConfiguredPackage[];
 	resolveExtensionSources(
 		sources: string[],
@@ -1086,7 +1094,7 @@ export class DefaultPackageManager implements PackageManager {
 		return this.removeSourceFromSettings(source, options);
 	}
 
-	async update(source?: string): Promise<void> {
+	async update(source?: string): Promise<PackageUpdateResult[]> {
 		const globalSettings = this.settingsManager.getGlobalSettings();
 		const projectSettings = this.settingsManager.getProjectSettings();
 		const identity = source ? this.getPackageIdentity(source) : undefined;
@@ -1115,12 +1123,12 @@ export class DefaultPackageManager implements PackageManager {
 			);
 		}
 
-		await this.updateConfiguredSources(updateSources);
+		return await this.updateConfiguredSources(updateSources);
 	}
 
-	private async updateConfiguredSources(sources: ConfiguredUpdateSource[]): Promise<void> {
+	private async updateConfiguredSources(sources: ConfiguredUpdateSource[]): Promise<PackageUpdateResult[]> {
 		if (isOfflineModeEnabled() || sources.length === 0) {
-			return;
+			return [];
 		}
 
 		const npmCandidates: NpmUpdateTarget[] = [];
@@ -1157,7 +1165,7 @@ export class DefaultPackageManager implements PackageManager {
 			}
 		}
 
-		const tasks: Promise<void>[] = [];
+		const tasks: Promise<PackageUpdateResult[]>[] = [];
 		if (userNpmUpdates.length > 0) {
 			tasks.push(this.updateNpmBatch(userNpmUpdates, "user"));
 		}
@@ -1165,16 +1173,16 @@ export class DefaultPackageManager implements PackageManager {
 			tasks.push(this.updateNpmBatch(projectNpmUpdates, "project"));
 		}
 		if (gitCandidates.length > 0) {
-			const gitTasks = gitCandidates.map(
-				(entry) => async () =>
-					this.withProgress("update", entry.source, `Updating ${entry.source}...`, async () => {
-						await this.updateGit(entry.parsed, entry.scope);
-					}),
+			const gitTasks = gitCandidates.map((entry) => async () => this.updateGitWithResult(entry));
+			tasks.push(
+				this.runWithConcurrency(gitTasks, GIT_UPDATE_CONCURRENCY).then((results) =>
+					results.filter((result): result is PackageUpdateResult => result !== undefined),
+				),
 			);
-			tasks.push(this.runWithConcurrency(gitTasks, GIT_UPDATE_CONCURRENCY).then(() => {}));
 		}
 
-		await Promise.all(tasks);
+		const results = await Promise.all(tasks);
+		return results.flat();
 	}
 
 	private async shouldUpdateNpmSource(source: NpmSource, scope: InstalledSourceScope): Promise<boolean> {
@@ -1193,9 +1201,21 @@ export class DefaultPackageManager implements PackageManager {
 		}
 	}
 
-	private async updateNpmBatch(sources: NpmUpdateTarget[], scope: InstalledSourceScope): Promise<void> {
+	private async updateNpmBatch(
+		sources: NpmUpdateTarget[],
+		scope: InstalledSourceScope,
+	): Promise<PackageUpdateResult[]> {
 		if (sources.length === 0) {
-			return;
+			return [];
+		}
+
+		const beforeVersions = new Map<string, { installedPath: string; version?: string }>();
+		for (const entry of sources) {
+			const installedPath = this.getNpmInstallPath(entry.parsed, scope);
+			beforeVersions.set(entry.source, {
+				installedPath,
+				version: existsSync(installedPath) ? this.getInstalledNpmVersion(installedPath) : undefined,
+			});
 		}
 
 		const sourceLabel = sources.length === 1 ? sources[0].source : `${scope} npm packages`;
@@ -1204,6 +1224,22 @@ export class DefaultPackageManager implements PackageManager {
 
 		await this.withProgress("update", sourceLabel, message, async () => {
 			await this.installNpmBatch(specs, scope);
+		});
+
+		return sources.map((entry) => {
+			const installedPath = this.getNpmInstallPath(entry.parsed, scope);
+			const before = beforeVersions.get(entry.source);
+			return {
+				source: entry.source,
+				displayName: entry.parsed.name,
+				type: "npm" as const,
+				scope,
+				installedPath,
+				baseDir: installedPath,
+				fromVersion: before?.version,
+				toVersion: this.getInstalledNpmVersion(installedPath),
+				changelogPath: this.getPackageChangelogPath(installedPath),
+			};
 		});
 	}
 
@@ -1536,6 +1572,10 @@ export class DefaultPackageManager implements PackageManager {
 		} catch {
 			return undefined;
 		}
+	}
+
+	private getPackageChangelogPath(packageRoot: string): string | undefined {
+		return resolvePackageChangelogPath(packageRoot, readPiManifest(join(packageRoot, "package.json")));
 	}
 
 	private async getLatestNpmVersion(packageSpec: string, range?: string): Promise<string> {
@@ -1890,6 +1930,36 @@ export class DefaultPackageManager implements PackageManager {
 			this.pruneEmptyGitParents(targetDir, gitRoot);
 			throw error;
 		}
+	}
+
+	private async updateGitWithResult(entry: GitUpdateTarget): Promise<PackageUpdateResult | undefined> {
+		const installedPath = this.getGitInstallPath(entry.parsed, entry.scope);
+		const fromVersion = existsSync(installedPath) ? this.getInstalledNpmVersion(installedPath) : undefined;
+		let result: PackageUpdateResult | undefined;
+
+		await this.withProgress("update", entry.source, `Updating ${entry.source}...`, async () => {
+			await this.updateGit(entry.parsed, entry.scope);
+			const toVersion = this.getInstalledNpmVersion(installedPath);
+			if (fromVersion === undefined && toVersion === undefined) {
+				return;
+			}
+			if (fromVersion === toVersion) {
+				return;
+			}
+			result = {
+				source: entry.source,
+				displayName: `${entry.parsed.host}/${entry.parsed.path}`,
+				type: "git",
+				scope: entry.scope,
+				installedPath,
+				baseDir: installedPath,
+				fromVersion,
+				toVersion,
+				changelogPath: this.getPackageChangelogPath(installedPath),
+			};
+		});
+
+		return result;
 	}
 
 	private async updateGit(source: GitSource, scope: SourceScope): Promise<void> {

--- a/packages/coding-agent/src/core/pi-manifest.ts
+++ b/packages/coding-agent/src/core/pi-manifest.ts
@@ -6,6 +6,7 @@ export interface PiManifest {
 	skills?: string[];
 	prompts?: string[];
 	themes?: string[];
+	changelogPath?: string;
 }
 
 const RESOURCE_FIELDS = ["extensions", "skills", "prompts", "themes"] as const;
@@ -28,6 +29,12 @@ export function readPiManifest(packageJsonPath: string): PiManifest | null {
 				manifest[field] = entries;
 			}
 		}
+
+		const changelogPath = pkg.pi.changelogPath;
+		if (typeof changelogPath === "string") {
+			manifest.changelogPath = changelogPath;
+		}
+
 		return manifest;
 	} catch {
 		return null;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -93,6 +93,7 @@ export type PackageSource =
 
 export interface Settings {
 	lastChangelogVersion?: string;
+	extensionChangelogVersions?: Record<string, string>;
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: ThinkingLevel;
@@ -706,6 +707,19 @@ export class SettingsManager {
 	setLastChangelogVersion(version: string): void {
 		this.globalSettings.lastChangelogVersion = version;
 		this.markModified("lastChangelogVersion");
+		this.save();
+	}
+
+	getExtensionChangelogVersion(key: string): string | undefined {
+		return this.settings.extensionChangelogVersions?.[key];
+	}
+
+	setExtensionChangelogVersion(key: string, version: string): void {
+		this.globalSettings.extensionChangelogVersions = {
+			...(this.globalSettings.extensionChangelogVersions ?? {}),
+			[key]: version,
+		};
+		this.markModified("extensionChangelogVersions", key);
 		this.save();
 	}
 

--- a/packages/coding-agent/src/core/source-info.ts
+++ b/packages/coding-agent/src/core/source-info.ts
@@ -12,6 +12,18 @@ export interface SourceInfo {
 	changelogPath?: string;
 }
 
+export interface SourcePackageIdentity {
+	source: string;
+	scope: SourceScope;
+}
+
+export function getSourcePackageKey(identity: SourcePackageIdentity): string {
+	return JSON.stringify({
+		source: identity.source,
+		scope: identity.scope,
+	});
+}
+
 export function createSourceInfo(path: string, metadata: PathMetadata): SourceInfo {
 	return {
 		path,

--- a/packages/coding-agent/src/core/source-info.ts
+++ b/packages/coding-agent/src/core/source-info.ts
@@ -9,6 +9,7 @@ export interface SourceInfo {
 	scope: SourceScope;
 	origin: SourceOrigin;
 	baseDir?: string;
+	changelogPath?: string;
 }
 
 export function createSourceInfo(path: string, metadata: PathMetadata): SourceInfo {
@@ -18,6 +19,7 @@ export function createSourceInfo(path: string, metadata: PathMetadata): SourceIn
 		scope: metadata.scope,
 		origin: metadata.origin,
 		baseDir: metadata.baseDir,
+		...(metadata.changelogPath ? { changelogPath: metadata.changelogPath } : {}),
 	};
 }
 
@@ -28,6 +30,7 @@ export function createSyntheticSourceInfo(
 		scope?: SourceScope;
 		origin?: SourceOrigin;
 		baseDir?: string;
+		changelogPath?: string;
 	},
 ): SourceInfo {
 	return {
@@ -36,5 +39,6 @@ export function createSyntheticSourceInfo(
 		scope: options.scope ?? "temporary",
 		origin: options.origin ?? "top-level",
 		baseDir: options.baseDir,
+		...(options.changelogPath ? { changelogPath: options.changelogPath } : {}),
 	};
 }

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -191,6 +191,7 @@ export {
 } from "./core/model-runtime.ts";
 export type {
 	PackageManager,
+	PackageUpdateResult,
 	PathMetadata,
 	ProgressCallback,
 	ProgressEvent,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -96,12 +96,19 @@ import { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../cor
 import { type SessionEntry, SessionManager, sessionEntryToContextMessages } from "../../core/session-manager.ts";
 import type { FullscreenExitOutput, TuiMode } from "../../core/settings-manager.ts";
 import { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.ts";
-import type { SourceInfo } from "../../core/source-info.ts";
+import { getSourcePackageKey, type SourceInfo } from "../../core/source-info.ts";
 import { isInstallTelemetryEnabled } from "../../core/telemetry.ts";
 import type { TruncationResult } from "../../core/tools/truncate.ts";
 import { hasTrustRequiringProjectResources, ProjectTrustStore } from "../../core/trust-manager.ts";
 import { getUsageCostBreakdown } from "../../core/usage-totals.ts";
-import { getChangelogPath, getNewEntries, normalizeChangelogLinks, parseChangelog } from "../../utils/changelog.ts";
+import {
+	type ChangelogEntry,
+	compareVersions,
+	getChangelogPath,
+	getNewEntries,
+	normalizeChangelogLinks,
+	parseChangelog,
+} from "../../utils/changelog.ts";
 import { copyToClipboard, readClipboardText } from "../../utils/clipboard.ts";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.ts";
 import { parseGitUrl } from "../../utils/git.ts";
@@ -110,8 +117,9 @@ import { getCwdRelativePath } from "../../utils/paths.ts";
 import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
 import { killTrackedDetachedChildren } from "../../utils/shell.ts";
 import { loadAllHighlightLanguages } from "../../utils/syntax-highlight.ts";
+import { stripBom } from "../../utils/text.ts";
 import { ensureTool, type ToolStatus } from "../../utils/tools-manager.ts";
-import { checkForNewPiVersion, type LatestPiRelease } from "../../utils/version-check.ts";
+import { checkForNewPiVersion, comparePackageVersions, type LatestPiRelease } from "../../utils/version-check.ts";
 import { ArminComponent } from "./components/armin.ts";
 import { AssistantMessageComponent } from "./components/assistant-message.ts";
 import { BashExecutionComponent } from "./components/bash-execution.ts";
@@ -462,6 +470,7 @@ export class InteractiveMode {
 	private lastSigintTime = 0;
 	private lastEscapeTime = 0;
 	private changelogMarkdown: string | undefined = undefined;
+	private extensionChangelogMarkdown: string | undefined = undefined;
 	private startupNoticesShown = false;
 	private anthropicSubscriptionWarningShown = false;
 
@@ -801,7 +810,7 @@ export class InteractiveMode {
 		}
 		this.startupNoticesShown = true;
 
-		if (!this.changelogMarkdown) {
+		if (!this.changelogMarkdown && !this.extensionChangelogMarkdown) {
 			return;
 		}
 
@@ -809,16 +818,29 @@ export class InteractiveMode {
 			this.chatContainer.addChild(new Spacer(1));
 		}
 		this.chatContainer.addChild(new DynamicBorder());
-		if (this.settingsManager.getCollapseChangelog()) {
-			const versionMatch = this.changelogMarkdown.match(/##\s+\[?(\d+\.\d+\.\d+)\]?/);
-			const latestVersion = versionMatch ? versionMatch[1] : this.version;
-			const condensedText = `Updated to v${latestVersion}. Use ${theme.bold("/changelog")} to view full changelog.`;
-			this.chatContainer.addChild(new Text(condensedText, 1, 0));
-		} else {
-			this.chatContainer.addChild(new Text(theme.bold(theme.fg("accent", "What's New")), 1, 0));
+		if (this.changelogMarkdown) {
+			if (this.settingsManager.getCollapseChangelog()) {
+				const versionMatch = this.changelogMarkdown.match(/##\s+\[?(\d+\.\d+\.\d+)\]?/);
+				const latestVersion = versionMatch ? versionMatch[1] : this.version;
+				const condensedText = `Updated to v${latestVersion}. Use ${theme.bold("/changelog")} to view full changelog.`;
+				this.chatContainer.addChild(new Text(condensedText, 1, 0));
+			} else {
+				this.chatContainer.addChild(new Text(theme.bold(theme.fg("accent", "What's New")), 1, 0));
+				this.chatContainer.addChild(new Spacer(1));
+				this.chatContainer.addChild(
+					new Markdown(this.changelogMarkdown.trim(), 1, 0, this.getMarkdownThemeWithSettings()),
+				);
+				this.chatContainer.addChild(new Spacer(1));
+			}
+		}
+		if (this.extensionChangelogMarkdown) {
+			if (this.changelogMarkdown) {
+				this.chatContainer.addChild(new Spacer(1));
+			}
+			this.chatContainer.addChild(new Text(theme.bold(theme.fg("accent", "Extension Updates")), 1, 0));
 			this.chatContainer.addChild(new Spacer(1));
 			this.chatContainer.addChild(
-				new Markdown(this.changelogMarkdown.trim(), 1, 0, this.getMarkdownThemeWithSettings()),
+				new Markdown(this.extensionChangelogMarkdown.trim(), 1, 0, this.getMarkdownThemeWithSettings()),
 			);
 			this.chatContainer.addChild(new Spacer(1));
 		}
@@ -899,8 +921,9 @@ export class InteractiveMode {
 
 		this.registerSignalHandlers();
 
-		// Load changelog (only show new entries, skip for resumed sessions)
+		// Load changelogs (only show new entries, skip for resumed sessions)
 		this.changelogMarkdown = this.getChangelogForDisplay();
+		this.extensionChangelogMarkdown = this.getExtensionChangelogForDisplay();
 
 		if (this.session.scopedModels.length > 0 && (this.options.verbose || !this.settingsManager.getQuietStartup())) {
 			const modelList = this.session.scopedModels
@@ -1285,6 +1308,98 @@ export class InteractiveMode {
 		}
 
 		return undefined;
+	}
+
+	private getExtensionChangelogForDisplay(): string | undefined {
+		// Skip changelog for resumed/continued sessions (already have messages)
+		if (this.session.state.messages.length > 0) {
+			return undefined;
+		}
+
+		const seenKeys = new Set<string>();
+		const notices: string[] = [];
+		for (const extension of this.session.resourceLoader.getExtensions().extensions) {
+			const sourceInfo = extension.sourceInfo;
+			if (sourceInfo.origin !== "package" || !sourceInfo.baseDir || !sourceInfo.changelogPath) {
+				continue;
+			}
+
+			const key = getSourcePackageKey(sourceInfo);
+			if (seenKeys.has(key)) {
+				continue;
+			}
+			seenKeys.add(key);
+
+			const currentVersion = this.getPackageVersion(sourceInfo.baseDir);
+			if (!currentVersion) {
+				continue;
+			}
+
+			const lastVersion = this.settingsManager.getExtensionChangelogVersion(key);
+			if (!lastVersion) {
+				// Fresh extension install - record the version, don't show changelog.
+				this.settingsManager.setExtensionChangelogVersion(key, currentVersion);
+				continue;
+			}
+
+			const comparison = comparePackageVersions(currentVersion, lastVersion);
+			const isNewerVersion = comparison === undefined ? currentVersion !== lastVersion : comparison > 0;
+			if (!isNewerVersion) {
+				continue;
+			}
+
+			const currentEntry = this.parseChangelogEntryVersion(currentVersion);
+			const newEntries = getNewEntries(parseChangelog(sourceInfo.changelogPath), lastVersion).filter(
+				(entry) => !currentEntry || compareVersions(entry, currentEntry) <= 0,
+			);
+			if (newEntries.length === 0) {
+				continue;
+			}
+
+			this.settingsManager.setExtensionChangelogVersion(key, currentVersion);
+			notices.push(
+				[
+					`### ${this.getPackageDisplayName(sourceInfo.baseDir, sourceInfo.source)} ${lastVersion} → ${currentVersion}`,
+				]
+					.concat(newEntries.map((entry) => entry.content))
+					.join("\n\n"),
+			);
+		}
+
+		return notices.length > 0 ? notices.join("\n\n") : undefined;
+	}
+
+	private getPackageVersion(packageRoot: string): string | undefined {
+		try {
+			const content = fs.readFileSync(path.join(packageRoot, "package.json"), "utf-8");
+			const pkg = JSON.parse(stripBom(content)) as { version?: unknown };
+			return typeof pkg.version === "string" ? pkg.version : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private getPackageDisplayName(packageRoot: string, fallback: string): string {
+		try {
+			const content = fs.readFileSync(path.join(packageRoot, "package.json"), "utf-8");
+			const pkg = JSON.parse(stripBom(content)) as { name?: unknown };
+			return typeof pkg.name === "string" && pkg.name ? pkg.name : fallback;
+		} catch {
+			return fallback;
+		}
+	}
+
+	private parseChangelogEntryVersion(version: string): ChangelogEntry | undefined {
+		const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+		if (!match) {
+			return undefined;
+		}
+		return {
+			major: Number.parseInt(match[1], 10),
+			minor: Number.parseInt(match[2], 10),
+			patch: Number.parseInt(match[3], 10),
+			content: "",
+		};
 	}
 
 	private reportInstallTelemetry(version: string): void {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -29,10 +29,11 @@ import {
 } from "./config.ts";
 import type { InlineExtension } from "./core/extensions/types.ts";
 import { ModelRuntime } from "./core/model-runtime.ts";
-import { DefaultPackageManager } from "./core/package-manager.ts";
+import { DefaultPackageManager, type PackageUpdateResult } from "./core/package-manager.ts";
 import { type AppMode, resolveProjectTrusted } from "./core/project-trust.ts";
 import { DefaultResourceLoader } from "./core/resource-loader.ts";
 import { SettingsManager } from "./core/settings-manager.ts";
+import { getSourcePackageKey } from "./core/source-info.ts";
 import { hasTrustRequiringProjectResources, ProjectTrustStore } from "./core/trust-manager.ts";
 import { spawnProcess, spawnProcessSync, waitForChildProcess } from "./utils/child-process.ts";
 import { canonicalizePath, getCwdRelativePath } from "./utils/paths.ts";
@@ -580,6 +581,25 @@ function updateTargetIncludesExtensions(target: UpdateTarget): boolean {
 	return target.type === "all" || target.type === "extensions";
 }
 
+function rememberExtensionChangelogVersions(
+	settingsManager: SettingsManager,
+	updates: readonly PackageUpdateResult[],
+): void {
+	for (const update of updates) {
+		if (!update.changelogPath || !update.fromVersion || !update.toVersion) {
+			continue;
+		}
+		if (!isNewerPackageVersion(update.toVersion, update.fromVersion)) {
+			continue;
+		}
+
+		const key = getSourcePackageKey(update);
+		if (!settingsManager.getExtensionChangelogVersion(key)) {
+			settingsManager.setExtensionChangelogVersion(key, update.fromVersion);
+		}
+	}
+}
+
 async function refreshModelCatalogs(agentDir: string): Promise<void> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), 15_000);
@@ -1012,7 +1032,9 @@ export async function handlePackageCommand(
 				}
 				if (updateTargetIncludesExtensions(target)) {
 					const updateSource = target.type === "extensions" ? target.source : undefined;
-					await packageManager.update(updateSource);
+					const updates = await packageManager.update(updateSource);
+					rememberExtensionChangelogVersions(settingsManager, updates);
+					await settingsManager.flush();
 					if (updateSource) {
 						console.log(chalk.green(`Updated ${updateSource}`));
 					} else {

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -17,6 +17,7 @@ import { ENV_AGENT_DIR, PACKAGE_NAME, VERSION } from "../src/config.ts";
 import { ModelRuntime } from "../src/core/model-runtime.ts";
 import type { ResolvedPaths } from "../src/core/package-manager.ts";
 import { InMemorySettingsStorage, SettingsManager } from "../src/core/settings-manager.ts";
+import { getSourcePackageKey } from "../src/core/source-info.ts";
 import { ProjectTrustStore } from "../src/core/trust-manager.ts";
 import { main } from "../src/main.ts";
 import { ConfigSelectorComponent } from "../src/modes/interactive/components/config-selector.ts";
@@ -387,6 +388,58 @@ if (process.platform !== "win32") fs.chmodSync(piPath, 0o755);
 			await expect(main(["update", "--extensions"])).resolves.toBeUndefined();
 
 			expect(existsSync(recordPath)).toBe(true);
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("records extension changelog baseline versions during package update", async () => {
+		const packageRoot = join(agentDir, "npm", "node_modules", "fake-changelog-package");
+		const fakeNpmPath = join(tempDir, "fake-changelog-npm.cjs");
+		const changelogPath = join(packageRoot, "CHANGELOG.md");
+		mkdirSync(packageRoot, { recursive: true });
+		writeFileSync(
+			join(packageRoot, "package.json"),
+			JSON.stringify({ name: "fake-changelog-package", version: "1.0.0" }),
+		);
+		writeFileSync(changelogPath, "## [1.1.0]\n\n- Updated");
+		writeFileSync(
+			fakeNpmPath,
+			`const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args[0] === "view") {
+	console.log(JSON.stringify("1.1.0"));
+	process.exit(0);
+}
+if (args[0] === "install") {
+	fs.writeFileSync(
+		path.join(${JSON.stringify(packageRoot)}, "package.json"),
+		JSON.stringify({ name: "fake-changelog-package", version: "1.1.0" })
+	);
+	process.exit(0);
+}
+throw new Error("Unexpected npm args: " + args.join(" "));
+`,
+		);
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ packages: ["npm:fake-changelog-package"], npmCommand: [originalExecPath, fakeNpmPath] }),
+		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await expect(runPackageCommandDirectly(["update", "--extensions"])).resolves.toBeUndefined();
+
+			const settings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf-8")) as {
+				extensionChangelogVersions?: Record<string, string>;
+			};
+			const key = getSourcePackageKey({
+				source: "npm:fake-changelog-package",
+				scope: "user",
+			});
+			expect(settings.extensionChangelogVersions?.[key]).toBe("1.0.0");
 			expect(process.exitCode).toBeUndefined();
 		} finally {
 			logSpy.mockRestore();

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -2371,6 +2371,50 @@ export default function(api) { api.registerTool({ name: "test", description: "te
 			);
 		});
 
+		it("should return changelog metadata for updated npm packages", async () => {
+			const installedPath = join(tempDir, ".pi", "npm", "node_modules", "example");
+			const changelogPath = join(installedPath, "docs", "CHANGELOG.md");
+			mkdirSync(join(installedPath, "docs"), { recursive: true });
+			writeFileSync(
+				join(installedPath, "package.json"),
+				JSON.stringify({
+					name: "example",
+					version: "1.0.0",
+					pi: { changelogPath: "docs/CHANGELOG.md" },
+				}),
+			);
+			writeFileSync(changelogPath, "## [1.1.0]\n\n- Updated");
+			settingsManager.setProjectPackages(["npm:example"]);
+
+			vi.spyOn(packageManager as any, "runCommandCapture").mockResolvedValue('"1.1.0"');
+			vi.spyOn(packageManager as any, "runCommand").mockImplementation(async () => {
+				writeFileSync(
+					join(installedPath, "package.json"),
+					JSON.stringify({
+						name: "example",
+						version: "1.1.0",
+						pi: { changelogPath: "docs/CHANGELOG.md" },
+					}),
+				);
+			});
+
+			const updates = await packageManager.update("npm:example");
+
+			expect(updates).toEqual([
+				{
+					source: "npm:example",
+					displayName: "example",
+					type: "npm",
+					scope: "project",
+					installedPath,
+					baseDir: installedPath,
+					fromVersion: "1.0.0",
+					toVersion: "1.1.0",
+					changelogPath,
+				},
+			]);
+		});
+
 		it("should skip project npm update when installed version matches latest", async () => {
 			const installedPath = join(tempDir, ".pi", "npm", "node_modules", "example");
 			mkdirSync(installedPath, { recursive: true });

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -640,6 +640,92 @@ Content`,
 			expect(result.skills.some((r) => r.path === slashSkillPath && r.enabled)).toBe(true);
 		});
 
+		it("should expose manifest changelogPath on package resources", async () => {
+			const pkgDir = join(tempDir, "changelog-manifest-package");
+			const extensionPath = join(pkgDir, "src", "index.ts");
+			const changelogPath = join(pkgDir, "docs", "CHANGELOG.md");
+			mkdirSync(join(pkgDir, "src"), { recursive: true });
+			mkdirSync(join(pkgDir, "docs"), { recursive: true });
+			writeFileSync(extensionPath, "export default function() {}");
+			writeFileSync(changelogPath, "## [1.0.0]\n\n- Initial release");
+			writeFileSync(
+				join(pkgDir, "package.json"),
+				JSON.stringify({
+					name: "changelog-manifest-package",
+					pi: {
+						extensions: ["src/index.ts"],
+						changelogPath: "docs/CHANGELOG.md",
+					},
+				}),
+			);
+
+			const result = await packageManager.resolveExtensionSources([pkgDir]);
+			const extension = result.extensions.find((r) => r.path === extensionPath);
+
+			expect(extension?.metadata.changelogPath).toBe(changelogPath);
+		});
+
+		it("should expose package CHANGELOG.md by convention", async () => {
+			const pkgDir = join(tempDir, "changelog-convention-package");
+			const extensionPath = join(pkgDir, "extensions", "index.ts");
+			const changelogPath = join(pkgDir, "CHANGELOG.md");
+			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
+			writeFileSync(extensionPath, "export default function() {}");
+			writeFileSync(changelogPath, "## [1.0.0]\n\n- Initial release");
+
+			const result = await packageManager.resolveExtensionSources([pkgDir]);
+			const extension = result.extensions.find((r) => r.path === extensionPath);
+
+			expect(extension?.metadata.changelogPath).toBe(changelogPath);
+		});
+
+		it("should still auto-discover resources when pi manifest only declares changelogPath", async () => {
+			const pkgDir = join(tempDir, "changelog-only-manifest-package");
+			const extensionPath = join(pkgDir, "extensions", "index.ts");
+			const changelogPath = join(pkgDir, "CHANGELOG.md");
+			mkdirSync(join(pkgDir, "extensions"), { recursive: true });
+			writeFileSync(extensionPath, "export default function() {}");
+			writeFileSync(changelogPath, "## [1.0.0]\n\n- Initial release");
+			writeFileSync(
+				join(pkgDir, "package.json"),
+				JSON.stringify({
+					name: "changelog-only-manifest-package",
+					pi: {
+						changelogPath: "CHANGELOG.md",
+					},
+				}),
+			);
+
+			const result = await packageManager.resolveExtensionSources([pkgDir]);
+			const extension = result.extensions.find((r) => r.path === extensionPath);
+
+			expect(extension?.metadata.changelogPath).toBe(changelogPath);
+		});
+
+		it("should ignore manifest changelogPath outside the package root", async () => {
+			const pkgDir = join(tempDir, "unsafe-changelog-package");
+			const extensionPath = join(pkgDir, "src", "index.ts");
+			mkdirSync(join(pkgDir, "src"), { recursive: true });
+			writeFileSync(extensionPath, "export default function() {}");
+			writeFileSync(join(tempDir, "CHANGELOG.md"), "## [1.0.0]\n\n- Outside");
+			writeFileSync(join(pkgDir, "CHANGELOG.md"), "## [1.0.0]\n\n- Fallback should not be used");
+			writeFileSync(
+				join(pkgDir, "package.json"),
+				JSON.stringify({
+					name: "unsafe-changelog-package",
+					pi: {
+						extensions: ["src/index.ts"],
+						changelogPath: "../CHANGELOG.md",
+					},
+				}),
+			);
+
+			const result = await packageManager.resolveExtensionSources([pkgDir]);
+			const extension = result.extensions.find((r) => r.path === extensionPath);
+
+			expect(extension?.metadata.changelogPath).toBeUndefined();
+		});
+
 		it("should handle directories with auto-discovery layout", async () => {
 			const pkgDir = join(tempDir, "auto-pkg");
 			mkdirSync(join(pkgDir, "extensions"), { recursive: true });


### PR DESCRIPTION
Addresses #5958.

Adds `changelogPath` to `PiManifest`. Safe package-relative changelog resolution, with `CHANGELOG.md` fallback, and carries it through `PathMetadata`/`SourceInfo`.

Added extension changelog handling like Pi’s own changelog.

If the package exposes `pi.changelogPath` or has `CHANGELOG.md`, Pi stores the last seen package version in settings. When an extension update runs, we record the pre-update version, and on the next fresh interactive launch compare the stored version to the installed package version. Then parses the changelog entries in between, shows an Extension Updates section, then marks the current version as seen.

Any cmd that updates etensions can show this, which are:
```bash
 pi update --extensions
 pi update --all
 pi update <extension-source>
 pi update --extension <extension-source>
 pi update --self --extensions
 pi update pi --extensions
 pi update self --extensions
```

<img width="798" height="626" alt="Screenshot 2026-08-28 at 16 34 15" src="https://github.com/user-attachments/assets/c882f01c-94b9-4857-b9b7-243d88c0d437" />
