### PR TITLE
feat(coding-agent): add artifact verification repair gate

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2975,6 +2975,7 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `trigger-compact.ts` | Trigger compaction manually | `compact()` |
 | `git-checkpoint.ts` | Git stash on turns | `on("turn_start")`, `on("session_before_fork")`, `exec` |
 | `git-merge-and-resolve.ts` | Fetch, merge, and resolve conflicts | `on("agent_end")`, `exec`, `sendUserMessage` |
+| `artifact-verifier.ts` | Gate a configured success token on deterministic artifact verification and bounded repair | `on("message_end")`, `on("agent_end")`, `exec`, `sendUserMessage` |
 | `auto-commit-on-exit.ts` | Commit on shutdown | `on("session_shutdown")`, `exec` |
 | **UI Components** |||
 | `status-line.ts` | Footer status indicator | `setStatus`, session events |
@@ -3018,3 +3019,42 @@ All examples in [examples/extensions/](../examples/extensions/).
 | `inline-bash.ts` | Inline bash in tool calls | `on("tool_call")` |
 | `bash-spawn-hook.ts` | Adjust bash command, cwd, and env before execution | `createBashTool`, `spawnHook` |
 | `with-deps/` | Extension with npm dependencies | Package structure with `package.json` |
+
+### Artifact verifier contract
+
+The `artifact-verifier.ts` example is inert unless the trusted project root
+contains `.pi-artifact-verifier.json`:
+
+```json
+{
+  "version": 1,
+  "command": "node",
+  "args": ["./verify-artifact.mjs"],
+  "timeoutMs": 120000,
+  "maxRepairs": 2,
+  "successToken": "ARTIFACT_OK"
+}
+```
+
+The command runs without a shell in the project root. It must print one JSON
+object to stdout:
+
+```json
+{
+  "ok": false,
+  "summary": "Keyboard activation failed",
+  "issues": [
+    {
+      "code": "keyboard_activation",
+      "message": "Enter did not activate Move Left"
+    }
+  ]
+}
+```
+
+A zero exit code plus `"ok": true` releases the configured success token.
+Otherwise the extension sends the report back as a follow-up repair request.
+After `maxRepairs` failures it replaces later occurrences of the success token
+with `ARTIFACT_VERIFICATION_FAILED`. This keeps project-specific verification
+outside Pi while preventing a model from claiming success before the verifier
+accepts the artifact.

--- a/packages/coding-agent/examples/extensions/artifact-verifier.ts
+++ b/packages/coding-agent/examples/extensions/artifact-verifier.ts
@@ -1,0 +1,176 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/index.ts";
+
+const CONFIG_FILE = ".pi-artifact-verifier.json";
+const PENDING_TOKEN = "ARTIFACT_VERIFICATION_PENDING";
+const FAILED_TOKEN = "ARTIFACT_VERIFICATION_FAILED";
+
+interface ArtifactVerifierConfig {
+	args: string[];
+	command: string;
+	maxRepairs: number;
+	successToken: string;
+	timeoutMs: number;
+	version: 1;
+}
+
+interface VerificationReport {
+	issues: unknown[];
+	ok: boolean;
+	summary: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseConfig(value: unknown): ArtifactVerifierConfig {
+	if (
+		!isRecord(value) ||
+		value.version !== 1 ||
+		typeof value.command !== "string" ||
+		value.command.length === 0 ||
+		!Array.isArray(value.args) ||
+		!value.args.every((arg) => typeof arg === "string") ||
+		typeof value.timeoutMs !== "number" ||
+		!Number.isInteger(value.timeoutMs) ||
+		value.timeoutMs <= 0 ||
+		typeof value.maxRepairs !== "number" ||
+		!Number.isInteger(value.maxRepairs) ||
+		value.maxRepairs < 0 ||
+		typeof value.successToken !== "string" ||
+		value.successToken.length === 0
+	) {
+		throw new Error(`Invalid ${CONFIG_FILE}`);
+	}
+	return {
+		args: value.args,
+		command: value.command,
+		maxRepairs: value.maxRepairs,
+		successToken: value.successToken,
+		timeoutMs: value.timeoutMs,
+		version: 1,
+	};
+}
+
+function parseReport(stdout: string): VerificationReport {
+	let value: unknown;
+	try {
+		value = JSON.parse(stdout);
+	} catch {
+		value = undefined;
+	}
+	if (
+		!isRecord(value) ||
+		typeof value.ok !== "boolean" ||
+		typeof value.summary !== "string" ||
+		!Array.isArray(value.issues)
+	) {
+		return {
+			issues: [{ code: "verifier_protocol_error", message: "Verifier returned invalid JSON" }],
+			ok: false,
+			summary: "Artifact verifier protocol failed",
+		};
+	}
+	return { issues: value.issues, ok: value.ok, summary: value.summary };
+}
+
+function replaceToken(message: AgentMessage, token: string, replacement: string): AgentMessage | undefined {
+	if (message.role !== "assistant") {
+		return;
+	}
+	let changed = false;
+	const content = message.content.map((part) => {
+		if (part.type !== "text" || !part.text.includes(token)) {
+			return part;
+		}
+		changed = true;
+		return { ...part, text: part.text.replaceAll(token, replacement) };
+	});
+	return changed ? { ...message, content } : undefined;
+}
+
+export default function artifactVerifier(pi: ExtensionAPI): void {
+	let config: ArtifactVerifierConfig | undefined;
+	let configCwd: string | undefined;
+	let exhausted = false;
+	let repairs = 0;
+	let running = false;
+	let verified = false;
+
+	async function loadConfig(ctx: ExtensionContext): Promise<ArtifactVerifierConfig | undefined> {
+		if (!ctx.isProjectTrusted()) {
+			return;
+		}
+		if (configCwd === ctx.cwd) {
+			return config;
+		}
+		configCwd = ctx.cwd;
+		exhausted = false;
+		repairs = 0;
+		verified = false;
+		try {
+			config = parseConfig(JSON.parse(await readFile(join(ctx.cwd, CONFIG_FILE), "utf8")));
+		} catch (error) {
+			if (isRecord(error) && error.code === "ENOENT") {
+				config = undefined;
+				return;
+			}
+			throw error;
+		}
+		return config;
+	}
+
+	pi.on("message_end", async (event, ctx) => {
+		const active = await loadConfig(ctx);
+		if (active === undefined || verified) {
+			return;
+		}
+		const message = replaceToken(event.message, active.successToken, exhausted ? FAILED_TOKEN : PENDING_TOKEN);
+		return message === undefined ? undefined : { message };
+	});
+
+	pi.on("agent_end", async (_event, ctx) => {
+		const active = await loadConfig(ctx);
+		if (active === undefined || exhausted || running || verified) {
+			return;
+		}
+		running = true;
+		try {
+			const execution = await pi.exec(active.command, active.args, {
+				cwd: ctx.cwd,
+				timeout: active.timeoutMs,
+			});
+			const report = parseReport(execution.stdout);
+			if (execution.code === 0 && report.ok) {
+				verified = true;
+				pi.sendUserMessage(`Artifact verification passed. Reply with exactly ${active.successToken}`, {
+					deliverAs: "followUp",
+				});
+				return;
+			}
+			if (repairs < active.maxRepairs) {
+				repairs += 1;
+				pi.sendUserMessage(
+					[
+						`Artifact verification failed. Repair attempt ${repairs} of ${active.maxRepairs}.`,
+						"Repair the artifact from this machine-readable report, then re-run your normal read check.",
+						JSON.stringify(report),
+						`Do not emit ${active.successToken} until verification passes.`,
+					].join("\n"),
+					{ deliverAs: "followUp" },
+				);
+				return;
+			}
+			exhausted = true;
+			pi.sendUserMessage(
+				`${FAILED_TOKEN}: repair budget exhausted. Report the verifier failure without claiming success.\n${JSON.stringify(report)}`,
+				{ deliverAs: "followUp" },
+			);
+		} finally {
+			running = false;
+		}
+	});
+}

--- a/packages/coding-agent/test/artifact-verifier-extension.test.ts
+++ b/packages/coding-agent/test/artifact-verifier-extension.test.ts
@@ -1,0 +1,180 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import artifactVerifier from "../examples/extensions/artifact-verifier.ts";
+import type { ExecResult, ExtensionAPI, ExtensionContext } from "../src/core/extensions/index.ts";
+import type { MessageEndEventResult } from "../src/core/extensions/types.ts";
+
+type AgentEndHandler = (event: { type: "agent_end" }, ctx: ExtensionContext) => Promise<void>;
+type MessageEndHandler = (
+	event: { type: "message_end"; message: AgentMessage },
+	ctx: ExtensionContext,
+) => Promise<MessageEndEventResult | undefined> | MessageEndEventResult | undefined;
+
+const CONFIG = {
+	version: 1,
+	command: "node",
+	args: ["verify.mjs"],
+	timeoutMs: 30_000,
+	maxRepairs: 2,
+	successToken: "PI_FLASH_TETRIS_OK",
+};
+
+function assistant(text: string): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+	} as AgentMessage;
+}
+
+function textOf(message: AgentMessage | undefined): string {
+	if (message?.role !== "assistant") {
+		return "";
+	}
+	return message.content
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("");
+}
+
+function setup(cwd: string, results: ExecResult[]) {
+	let agentEnd: AgentEndHandler | undefined;
+	let messageEnd: MessageEndHandler | undefined;
+	const sendUserMessage = vi.fn();
+	const exec = vi.fn<ExtensionAPI["exec"]>().mockImplementation(async () => {
+		return results.shift() ?? { stdout: "", stderr: "missing result", code: 1, killed: false };
+	});
+	const pi = {
+		on(event: string, handler: AgentEndHandler | MessageEndHandler) {
+			if (event === "agent_end") {
+				agentEnd = handler as AgentEndHandler;
+			}
+			if (event === "message_end") {
+				messageEnd = handler as MessageEndHandler;
+			}
+		},
+		exec,
+		sendUserMessage,
+	} as unknown as ExtensionAPI;
+	artifactVerifier(pi);
+	const ctx = {
+		cwd,
+		isProjectTrusted: () => true,
+	} as unknown as ExtensionContext;
+	return {
+		exec,
+		sendUserMessage,
+		message: async (text: string) => messageEnd?.({ type: "message_end", message: assistant(text) }, ctx),
+		settle: async () => agentEnd?.({ type: "agent_end" }, ctx),
+	};
+}
+
+function result(payload: unknown, code = 0): ExecResult {
+	return {
+		stdout: JSON.stringify(payload),
+		stderr: "",
+		code,
+		killed: false,
+	};
+}
+
+describe("artifact verifier example", () => {
+	let cwd: string;
+
+	afterEach(() => {
+		if (cwd) {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	function project(): string {
+		cwd = mkdtempSync(join(tmpdir(), "pi-artifact-verifier-"));
+		writeFileSync(join(cwd, ".pi-artifact-verifier.json"), JSON.stringify(CONFIG));
+		return cwd;
+	}
+
+	it("withholds the configured success token until verification passes", async () => {
+		const harness = setup(project(), []);
+
+		const pending = await harness.message("done\nPI_FLASH_TETRIS_OK");
+
+		expect(textOf(pending?.message)).toBe("done\nARTIFACT_VERIFICATION_PENDING");
+	});
+
+	it("sends a machine-readable verifier failure back as a bounded repair", async () => {
+		const harness = setup(project(), [
+			result(
+				{
+					ok: false,
+					summary: "Keyboard activation failed",
+					issues: [
+						{
+							code: "keyboard_activation",
+							message: "Enter on Move Left did not dispatch click",
+						},
+					],
+				},
+				1,
+			),
+		]);
+
+		await harness.settle();
+
+		expect(harness.exec).toHaveBeenCalledWith("node", ["verify.mjs"], {
+			cwd,
+			timeout: 30_000,
+		});
+		expect(harness.sendUserMessage).toHaveBeenCalledTimes(1);
+		expect(harness.sendUserMessage.mock.calls[0]?.[0]).toContain('"code":"keyboard_activation"');
+		expect(harness.sendUserMessage.mock.calls[0]?.[0]).toContain("Repair attempt 1 of 2");
+		expect(harness.sendUserMessage.mock.calls[0]?.[1]).toEqual({
+			deliverAs: "followUp",
+		});
+	});
+
+	it("releases the success token only after a repaired artifact verifies", async () => {
+		const harness = setup(project(), [
+			result({ ok: false, summary: "broken", issues: [] }, 1),
+			result({ ok: true, summary: "all checks passed", issues: [] }),
+		]);
+
+		await harness.settle();
+		await harness.settle();
+		expect(harness.sendUserMessage.mock.calls[1]?.[0]).toContain("Reply with exactly PI_FLASH_TETRIS_OK");
+
+		const verified = await harness.message("PI_FLASH_TETRIS_OK");
+		expect(verified).toBeUndefined();
+	});
+
+	it("fails closed when the repair budget is exhausted", async () => {
+		const config = { ...CONFIG, maxRepairs: 1 };
+		const dir = project();
+		writeFileSync(join(dir, ".pi-artifact-verifier.json"), JSON.stringify(config));
+		const harness = setup(dir, [
+			result({ ok: false, summary: "first failure", issues: [] }, 1),
+			result({ ok: false, summary: "still broken", issues: [] }, 1),
+		]);
+
+		await harness.settle();
+		await harness.settle();
+
+		expect(harness.sendUserMessage).toHaveBeenCalledTimes(2);
+		expect(harness.sendUserMessage.mock.calls[1]?.[0]).toContain("ARTIFACT_VERIFICATION_FAILED");
+		const blocked = await harness.message("PI_FLASH_TETRIS_OK");
+		expect(textOf(blocked?.message)).toBe("ARTIFACT_VERIFICATION_FAILED");
+	});
+
+	it("does nothing when no artifact verifier contract exists", async () => {
+		cwd = mkdtempSync(join(tmpdir(), "pi-artifact-verifier-"));
+		const harness = setup(cwd, []);
+
+		await harness.settle();
+		const untouched = await harness.message("PI_FLASH_TETRIS_OK");
+
+		expect(harness.exec).not.toHaveBeenCalled();
+		expect(harness.sendUserMessage).not.toHaveBeenCalled();
+		expect(untouched).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- add an opt-in trusted-project artifact verifier extension
- withhold a configured success token until deterministic verification passes
- feed machine-readable failures back as bounded repair turns and fail closed on exhaustion

## RED
- 4 behavior tests failed against a no-op scaffold; the no-contract case passed

## GREEN
- offline monorepo build: pass
- whole-tree typecheck: pass
- policy checks: pass
- artifact verifier tests: 5/5
- extension regressions: 52/52

The verifier command is project-owned and runs without a shell. Pi does not inspect project artifacts itself.
