### PR TITLE
feat: add startup composer

### DIFF
--- a/packages/coding-agent/src/cli/project-trust.ts
+++ b/packages/coding-agent/src/cli/project-trust.ts
@@ -1,14 +1,17 @@
+import type { Terminal } from "@earendil-works/pi-tui";
 import chalk from "chalk";
 import type { ProjectTrustContext } from "../core/extensions/types.ts";
 import type { AppMode } from "../core/project-trust.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";
-import { showStartupInput, showStartupSelector } from "./startup-ui.ts";
+import { type StartupComposerHandoff, showStartupInput, showStartupSelector } from "./startup-ui.ts";
 
 export function createProjectTrustContext(options: {
 	cwd: string;
 	mode: AppMode;
 	settingsManager: SettingsManager;
 	hasUI: boolean;
+	terminal?: Terminal;
+	startupComposer?: StartupComposerHandoff;
 }): ProjectTrustContext {
 	return {
 		cwd: options.cwd,
@@ -26,6 +29,11 @@ export function createProjectTrustContext(options: {
 					options.settingsManager,
 					title,
 					selectOptions.map((option) => ({ label: option, value: option })),
+					{
+						terminal: options.terminal,
+						ui: options.startupComposer?.ui,
+						handoff: options.startupComposer,
+					},
 				);
 			},
 			confirm: async (title, message) => {
@@ -36,10 +44,19 @@ export function createProjectTrustContext(options: {
 					return false;
 				}
 				return (
-					(await showStartupSelector(options.settingsManager, `${title}\n${message}`, [
-						{ label: "Yes", value: true },
-						{ label: "No", value: false },
-					])) ?? false
+					(await showStartupSelector(
+						options.settingsManager,
+						`${title}\n${message}`,
+						[
+							{ label: "Yes", value: true },
+							{ label: "No", value: false },
+						],
+						{
+							terminal: options.terminal,
+							ui: options.startupComposer?.ui,
+							handoff: options.startupComposer,
+						},
+					)) ?? false
 				);
 			},
 			input: async (title, placeholder) => {
@@ -49,7 +66,11 @@ export function createProjectTrustContext(options: {
 				if (options.mode !== "interactive") {
 					return undefined;
 				}
-				return showStartupInput(options.settingsManager, title, placeholder);
+				return showStartupInput(options.settingsManager, title, placeholder, {
+					terminal: options.terminal,
+					ui: options.startupComposer?.ui,
+					handoff: options.startupComposer,
+				});
 			},
 			notify: (message, type = "info") => {
 				if (options.mode !== "interactive") {

--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -1,9 +1,15 @@
 import {
+	Editor,
+	type EditorOptions,
+	type EditorState,
+	getKeybindings,
 	ProcessTerminal,
 	setCapabilityOverrides,
 	setKeybindings,
+	type Terminal,
 	type TUI,
 	TuiMainScreen,
+	type TuiStopOptions,
 } from "@earendil-works/pi-tui";
 import { existsSync } from "fs";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, getAgentDir, getSettingsPath, PACKAGE_NAME } from "../config.ts";
@@ -20,6 +26,7 @@ import {
 import {
 	detectTerminalBackgroundFromEnv,
 	detectTerminalThemeForAuto,
+	getEditorTheme,
 	initTheme,
 	loadThemeFromPath,
 	parseAutoThemeSetting,
@@ -32,6 +39,90 @@ import {
 const OFFICIAL_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
 const OFFICIAL_APP_NAME = "pi";
 const OFFICIAL_CONFIG_DIR_NAME = ".pi";
+
+export type StartupComposerCancelReason = "interrupt" | "clear" | "exit";
+
+export interface StartupComposerOptions extends EditorOptions {
+	onCancel?: (reason: StartupComposerCancelReason) => void;
+}
+
+/** UI handoff used while a startup dialog temporarily owns the terminal. */
+export interface StartupComposerHandoff {
+	readonly ui: TUI;
+	pause(): void;
+	resume(): void;
+	isCancelled?(): boolean;
+	isRunning?(): boolean;
+}
+
+export interface StartupComposerSession extends StartupComposerHandoff {
+	readonly composer: StartupComposer;
+	readonly terminal: Terminal;
+	getState(): EditorState;
+	stop(options?: TuiStopOptions): void;
+	isRunning(): boolean;
+}
+
+/**
+ * The runtime-independent editor shown while the session runtime is loading.
+ * It deliberately forwards only editing input to Editor; runtime actions are
+ * handled after the normal InteractiveMode has taken over.
+ */
+function captureEditorState(editor: Editor): EditorState {
+	return (
+		editor.getState?.() ?? {
+			text: editor.getText(),
+			cursor: editor.getCursor(),
+			pasteRegistry: new Map(),
+			pasteCounter: 0,
+			pasteBuffer: "",
+			isInPaste: false,
+		}
+	);
+}
+
+export class StartupComposer extends Editor {
+	private readonly cancelCallback?: (reason: StartupComposerCancelReason) => void;
+
+	constructor(tui: TUI, options: StartupComposerOptions = {}) {
+		super(tui, getEditorTheme(), options);
+		this.cancelCallback = options.onCancel;
+	}
+
+	override handleInput(data: string): void {
+		const keybindings = getKeybindings();
+		if (keybindings.matches(data, "app.interrupt")) {
+			this.cancelCallback?.("interrupt");
+			return;
+		}
+		if (keybindings.matches(data, "app.clear") || keybindings.matches(data, "tui.input.copy")) {
+			this.cancelCallback?.("clear");
+			return;
+		}
+		if (keybindings.matches(data, "app.exit") && this.getText().length === 0) {
+			this.cancelCallback?.("exit");
+			return;
+		}
+		if (keybindings.matches(data, "tui.input.submit")) {
+			// Submission is intentionally disabled until the normal editor is ready.
+			return;
+		}
+
+		// No autocomplete provider or app handlers are installed here. Slash
+		// input and runtime shortcuts therefore remain plain editable text.
+		super.handleInput(data);
+	}
+}
+
+export interface StartupComposerCreateOptions extends StartupComposerOptions {
+	terminal?: Terminal;
+}
+
+export interface StartupTuiOptions {
+	terminal?: Terminal;
+	ui?: TUI;
+	handoff?: StartupComposerHandoff;
+}
 
 interface DistributionMetadata {
 	packageName: string;
@@ -80,27 +171,40 @@ async function loadStartupThemes(settingsManager: SettingsManager): Promise<Them
 	return loadThemes(resolvedPaths.themes);
 }
 
-export async function createStartupTui(settingsManager: SettingsManager): Promise<TUI> {
+function createConfiguredStartupTui(settingsManager: SettingsManager, terminal: Terminal): TUI {
 	setCapabilityOverrides(settingsManager.getTerminalCapabilityOverrides());
-	setRegisteredThemes(await loadStartupThemes(settingsManager));
 	const terminalTheme = detectTerminalBackgroundFromEnv().theme;
 	initTheme(resolveThemeSetting(settingsManager.getThemeSetting(), terminalTheme) ?? terminalTheme);
 	setKeybindings(KeybindingsManager.create());
-	const ui: TUI = new TuiMainScreen(new ProcessTerminal(), settingsManager.getShowHardwareCursor(), getAgentDir());
+	const ui: TUI = new TuiMainScreen(terminal, settingsManager.getShowHardwareCursor(), getAgentDir());
 	ui.setClearOnShrink(settingsManager.getClearOnShrink());
 	return ui;
 }
 
-export function startStartupTui(ui: TUI, settingsManager: SettingsManager): void {
-	ui.start();
-	void applyDetectedStartupTheme(ui, settingsManager);
+export async function createStartupTui(
+	settingsManager: SettingsManager,
+	terminal: Terminal = new ProcessTerminal(),
+): Promise<TUI> {
+	setCapabilityOverrides(settingsManager.getTerminalCapabilityOverrides());
+	setRegisteredThemes(await loadStartupThemes(settingsManager));
+	return createConfiguredStartupTui(settingsManager, terminal);
 }
 
-async function applyDetectedStartupTheme(ui: TUI, settingsManager: SettingsManager): Promise<void> {
+export function startStartupTui(ui: TUI, settingsManager: SettingsManager, isActive: () => boolean = () => true): void {
+	ui.start();
+	void applyDetectedStartupTheme(ui, settingsManager, isActive);
+}
+
+async function applyDetectedStartupTheme(
+	ui: TUI,
+	settingsManager: SettingsManager,
+	isActive: () => boolean,
+): Promise<void> {
 	const themeSetting = settingsManager.getThemeSetting();
 	if (themeSetting && !parseAutoThemeSetting(themeSetting)) return;
 
 	const terminalTheme = await detectTerminalThemeForAuto({ ui, timeoutMs: 100 });
+	if (!isActive()) return;
 	setTheme(resolveThemeSetting(themeSetting, terminalTheme) ?? terminalTheme);
 	ui.invalidate();
 	ui.requestRender();
@@ -110,6 +214,89 @@ async function clearStartupTui(ui: TUI): Promise<void> {
 	ui.clear();
 	ui.requestRender();
 	await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+/**
+ * Start the runtime-independent composer on a terminal immediately.
+ *
+ * The returned session owns the renderer until the runtime is ready. Dialogs
+ * can pause it and reuse the same renderer and terminal through the handoff
+ * methods, keeping the draft out of selector/input components.
+ */
+export function createStartupComposer(
+	settingsManager: SettingsManager,
+	options: StartupComposerCreateOptions = {},
+): StartupComposerSession {
+	const { terminal: configuredTerminal, ...composerOptions } = options;
+	const terminal = configuredTerminal ?? new ProcessTerminal();
+	const ui = createConfiguredStartupTui(settingsManager, terminal);
+	let running = false;
+	let paused = false;
+	let stopped = false;
+	let cancelled = false;
+	let pausedState: EditorState | undefined;
+
+	const composer = new StartupComposer(ui, {
+		...composerOptions,
+		onCancel: (reason) => {
+			cancelled = true;
+			composerOptions.onCancel?.(reason);
+		},
+	});
+
+	ui.addChild(composer);
+	ui.setFocus(composer);
+	running = true;
+	startStartupTui(ui, settingsManager, () => running && !stopped);
+	ui.renderNow();
+
+	const session: StartupComposerSession = {
+		ui,
+		composer,
+		terminal,
+		getState: () => captureEditorState(composer),
+		pause: () => {
+			if (!running || paused || stopped) return;
+			pausedState = captureEditorState(composer);
+			ui.removeChild(composer);
+			ui.setFocus(null);
+			ui.stop({ preserveScreen: true });
+			running = false;
+			paused = true;
+		},
+		resume: () => {
+			if (!paused || stopped) return;
+			if (pausedState) {
+				composer.setState?.(pausedState);
+			}
+			ui.clear();
+			ui.addChild(composer);
+			ui.setFocus(composer);
+			running = true;
+			paused = false;
+			startStartupTui(ui, settingsManager, () => running && !stopped);
+			ui.renderNow(true);
+			pausedState = undefined;
+		},
+		stop: (stopOptions) => {
+			if (running || paused) {
+				ui.removeChild(composer);
+				ui.setFocus(null);
+				ui.stop(stopOptions);
+				running = false;
+			}
+			stopped = true;
+			paused = false;
+			pausedState = undefined;
+			if (stopOptions?.preserveScreen !== true) {
+				terminal.clearScreen();
+			}
+		},
+		isRunning: () => running,
+		isCancelled: () => cancelled,
+	};
+
+	return session;
 }
 
 /**
@@ -142,8 +329,22 @@ export async function showStartupSelector<T>(
 	settingsManager: SettingsManager,
 	title: string,
 	options: Array<{ label: string; value: T }>,
+	startupOptions: StartupTuiOptions = {},
 ): Promise<T | undefined> {
-	const ui = await createStartupTui(settingsManager);
+	if (startupOptions.handoff?.isCancelled?.()) {
+		return undefined;
+	}
+
+	const handoff = startupOptions.handoff;
+	handoff?.pause();
+	let ui: TUI;
+	try {
+		ui = startupOptions.ui ?? handoff?.ui ?? (await createStartupTui(settingsManager, startupOptions.terminal));
+	} catch (error) {
+		handoff?.resume();
+		throw error;
+	}
+
 	return new Promise((resolve) => {
 		let settled = false;
 		const finish = async (result: T | undefined) => {
@@ -151,8 +352,12 @@ export async function showStartupSelector<T>(
 				return;
 			}
 			settled = true;
+			ui.setFocus(null);
+			ui.removeChild(selector);
+			selector.dispose();
 			await clearStartupTui(ui);
 			ui.stop();
+			handoff?.resume();
 			resolve(result);
 		};
 
@@ -165,7 +370,7 @@ export async function showStartupSelector<T>(
 		);
 		ui.addChild(selector);
 		ui.setFocus(selector);
-		startStartupTui(ui, settingsManager);
+		startStartupTui(ui, settingsManager, () => handoff?.isRunning?.() ?? true);
 	});
 }
 
@@ -215,8 +420,22 @@ export async function showStartupInput(
 	settingsManager: SettingsManager,
 	title: string,
 	placeholder?: string,
+	startupOptions: StartupTuiOptions = {},
 ): Promise<string | undefined> {
-	const ui = await createStartupTui(settingsManager);
+	if (startupOptions.handoff?.isCancelled?.()) {
+		return undefined;
+	}
+
+	const handoff = startupOptions.handoff;
+	handoff?.pause();
+	let ui: TUI;
+	try {
+		ui = startupOptions.ui ?? handoff?.ui ?? (await createStartupTui(settingsManager, startupOptions.terminal));
+	} catch (error) {
+		handoff?.resume();
+		throw error;
+	}
+
 	return new Promise((resolve) => {
 		let settled = false;
 		const finish = async (result: string | undefined) => {
@@ -225,8 +444,11 @@ export async function showStartupInput(
 			}
 			settled = true;
 			input.dispose();
+			ui.setFocus(null);
+			ui.removeChild(input);
 			await clearStartupTui(ui);
 			ui.stop();
+			handoff?.resume();
 			resolve(result);
 		};
 
@@ -241,6 +463,6 @@ export async function showStartupInput(
 		);
 		ui.addChild(input);
 		ui.setFocus(input);
-		startStartupTui(ui, settingsManager);
+		startStartupTui(ui, settingsManager, () => handoff?.isRunning?.() ?? true);
 	});
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -32,7 +32,13 @@ import { buildInitialMessage } from "./cli/initial-message.ts";
 import { listModels } from "./cli/list-models.ts";
 import { createProjectTrustContext } from "./cli/project-trust.ts";
 import { selectSession } from "./cli/session-picker.ts";
-import { shouldRunFirstTimeSetup, showFirstTimeSetup, showStartupSelector } from "./cli/startup-ui.ts";
+import {
+	createStartupComposer,
+	type StartupComposerSession,
+	shouldRunFirstTimeSetup,
+	showFirstTimeSetup,
+	showStartupSelector,
+} from "./cli/startup-ui.ts";
 import { APP_NAME, ENV_SESSION_DIR, expandTildePath, getAgentDir, getPackageDir, VERSION } from "./config.ts";
 import { type CreateAgentSessionRuntimeFactory, createAgentSessionRuntime } from "./core/agent-session-runtime.ts";
 import {
@@ -704,6 +710,10 @@ export async function main(args: string[], options?: MainOptions) {
 			: undefined;
 	const trustPromptMode: AppMode = parsed.help || parsed.listModels !== undefined ? "print" : appMode;
 	const projectTrustByCwd = new Map<string, boolean>();
+	let startupComposer: StartupComposerSession | undefined;
+	const startupCancellation = { value: false };
+	let startupCancellationPromise: Promise<void> | undefined;
+	let resolveStartupCancellation: (() => void) | undefined;
 
 	const resolvedExtensionPaths = resolveCliPaths(cwd, parsed.extensions);
 	const resolvedSkillPaths = resolveCliPaths(cwd, parsed.skills);
@@ -749,7 +759,10 @@ export async function main(args: string[], options?: MainOptions) {
 										cwd,
 										mode: isInitialRuntime ? trustPromptMode : appMode,
 										settingsManager: startupSettingsManager,
-										hasUI: isInitialRuntime && trustPromptMode === "interactive",
+										hasUI:
+											isInitialRuntime && trustPromptMode === "interactive" && !startupCancellation.value,
+										terminal: startupComposer?.terminal,
+										startupComposer,
 									}),
 								onExtensionError: (message) => projectTrustDiagnostics.push({ type: "warning", message }),
 							});
@@ -837,12 +850,54 @@ export async function main(args: string[], options?: MainOptions) {
 		};
 	};
 	time("createRuntime");
-	const runtime = await createAgentSessionRuntime(createRuntime, {
+
+	const shouldStartStartupComposer = appMode === "interactive" && !isPlainRuntimeMetadataCommand(parsed);
+	if (shouldStartStartupComposer) {
+		startupCancellationPromise = new Promise<void>((resolve) => {
+			resolveStartupCancellation = resolve;
+		});
+		startupComposer = createStartupComposer(startupSettingsManager, {
+			onCancel: () => {
+				startupCancellation.value = true;
+				startupComposer?.stop();
+				resolveStartupCancellation?.();
+			},
+		});
+	}
+
+	const runtimePromise = createAgentSessionRuntime(createRuntime, {
 		cwd: sessionManager.getCwd(),
 		agentDir,
 		sessionManager,
 	});
+	let runtime: Awaited<ReturnType<typeof createAgentSessionRuntime>>;
+	if (startupComposer && startupCancellationPromise) {
+		try {
+			const result = await Promise.race([
+				runtimePromise.then((value) => ({ kind: "ready" as const, value })),
+				startupCancellationPromise.then(() => ({ kind: "cancelled" as const })),
+			]);
+			if (result.kind === "cancelled") {
+				void runtimePromise.then((resolvedRuntime) => resolvedRuntime.dispose()).catch(() => {});
+				stopThemeWatcher();
+				return;
+			}
+			runtime = result.value;
+		} catch (error) {
+			startupComposer.stop();
+			throw error;
+		}
+	} else {
+		try {
+			runtime = await runtimePromise;
+		} catch (error) {
+			startupComposer?.stop();
+			throw error;
+		}
+	}
 	time("createAgentSessionRuntime");
+	const initialEditorState = startupComposer?.getState();
+	startupComposer?.stop();
 	const { services, session, modelFallbackMessage } = runtime;
 	const { settingsManager, modelRuntime, resourceLoader } = services;
 	setCapabilityOverrides(settingsManager.getTerminalCapabilityOverrides());
@@ -939,6 +994,8 @@ export async function main(args: string[], options?: MainOptions) {
 			verbose: parsed.verbose,
 			tuiMode: parsed.tuiMode,
 			initialThemeSetting: parsed.useTheme,
+			terminal: startupComposer?.terminal,
+			initialEditorState,
 		});
 		if (startupBenchmark) {
 			await interactiveMode.init();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -14,6 +14,7 @@ import type {
 	AutocompleteItem,
 	AutocompleteProvider,
 	EditorComponent,
+	EditorState,
 	Keybinding,
 	KeyId,
 	MarkdownTheme,
@@ -354,6 +355,10 @@ export interface InteractiveModeOptions {
 	tuiMode?: TuiMode;
 	/** Initial interactive theme setting for this invocation. */
 	initialThemeSetting?: string;
+	/** Terminal to reuse from startup UI. */
+	terminal?: Terminal;
+	/** Draft state captured by the startup composer. */
+	initialEditorState?: EditorState;
 }
 
 interface InteractiveTuiOptions {
@@ -582,6 +587,7 @@ export class InteractiveMode {
 			tuiMode,
 			showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
 			logDirectory: getAgentDir(),
+			terminal: options.terminal,
 			onRightClickPaste: this.onRightClickPaste,
 			fullscreenCopyOnSelect: this.settingsManager.getFullscreenCopyOnSelect(),
 		});
@@ -606,6 +612,9 @@ export class InteractiveMode {
 			paddingX: editorPaddingX,
 			autocompleteMaxVisible,
 		});
+		if (options.initialEditorState) {
+			this.defaultEditor.setState(options.initialEditorState);
+		}
 		this.editor = this.defaultEditor;
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor as Component);
@@ -951,6 +960,10 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.clear", () => this.handleCtrlC());
 		this.defaultEditor.onCtrlD = () => this.handleCtrlD();
 		this.defaultEditor.onSubmit = (text) => this.handleStartupSubmit(text);
+		// Do not let Enter clear or submit the draft while managed tools are loading.
+		// The submit handler is installed only after startup completes, so the
+		// editor's cursor and paste registry remain intact during this phase.
+		this.defaultEditor.disableSubmit = true;
 		this.ui.setFocus(this.editor);
 
 		// Start the UI before initializing extensions so session_start handlers can use interactive dialogs
@@ -1031,6 +1044,7 @@ export class InteractiveMode {
 		this.fdPath = fdPath;
 
 		// Enable the remaining input handlers only after managed-tool setup completes.
+		this.defaultEditor.disableSubmit = false;
 		this.setupKeyHandlers();
 		this.setupEditorSubmitHandler();
 		this.ui.requestRender();
@@ -2675,8 +2689,10 @@ export class InteractiveMode {
 	private setCustomEditorComponent(factory: EditorFactory | undefined): void {
 		this.editorComponentFactory = factory;
 
-		// Save text from current editor before switching
-		const currentText = this.editor.getText();
+		// Save the complete draft before switching. Custom editors that do not
+		// implement state transfer still receive the text-only fallback.
+		const currentState = this.editor.getState?.();
+		const currentText = currentState?.text ?? this.editor.getText();
 
 		this.disposeActiveSelector();
 		this.editorContainer.clear();
@@ -2689,8 +2705,12 @@ export class InteractiveMode {
 			newEditor.onSubmit = this.defaultEditor.onSubmit;
 			newEditor.onChange = this.defaultEditor.onChange;
 
-			// Copy text from previous editor
-			newEditor.setText(currentText);
+			// Copy the complete state when both editors support the transfer API.
+			if (currentState && newEditor.setState) {
+				newEditor.setState(currentState);
+			} else {
+				newEditor.setText(currentText);
+			}
 
 			// Copy appearance settings if supported
 			if (newEditor.borderColor !== undefined) {
@@ -2732,8 +2752,12 @@ export class InteractiveMode {
 
 			this.editor = newEditor;
 		} else {
-			// Restore default editor with text from custom editor
-			this.defaultEditor.setText(currentText);
+			// Restore default editor with the complete state when available.
+			if (currentState) {
+				this.defaultEditor.setState(currentState);
+			} else {
+				this.defaultEditor.setText(currentText);
+			}
 			this.editor = this.defaultEditor;
 		}
 
@@ -4004,13 +4028,19 @@ export class InteractiveMode {
 		this.isShuttingDown = true;
 		try {
 			this.unregisterSignalHandlers();
-		} catch {}
+		} catch {
+			// Best-effort cleanup while handling the original crash.
+		}
 		try {
 			killTrackedDetachedChildren();
-		} catch {}
+		} catch {
+			// Best-effort cleanup while handling the original crash.
+		}
 		try {
 			this.ui.stop();
-		} catch {}
+		} catch {
+			// Best-effort cleanup while handling the original crash.
+		}
 		console.error(`${APP_NAME} exiting due to uncaughtException:`);
 		console.error(error);
 		process.exit(1);

--- a/packages/coding-agent/test/startup-composer.test.ts
+++ b/packages/coding-agent/test/startup-composer.test.ts
@@ -1,0 +1,82 @@
+import type { Terminal, TUI } from "@earendil-works/pi-tui";
+import { setKeybindings, TuiMainScreen } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal.ts";
+import { createStartupComposer, StartupComposer, showStartupSelector } from "../src/cli/startup-ui.ts";
+import { KeybindingsManager } from "../src/core/keybindings.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+
+class RecordingTerminal extends VirtualTerminal implements Terminal {
+	startCount = 0;
+	stopCount = 0;
+
+	override start(onInput: (data: string) => void, onResize: () => void): void {
+		this.startCount += 1;
+		super.start(onInput, onResize);
+	}
+
+	override stop(): void {
+		this.stopCount += 1;
+		super.stop();
+	}
+}
+
+function createComposerTui(terminal: VirtualTerminal): TUI {
+	return new TuiMainScreen(terminal);
+}
+
+describe("StartupComposer", () => {
+	// Regression coverage for #8689.
+	it("keeps draft text when Enter is pressed and reports cancellation", () => {
+		setKeybindings(new KeybindingsManager());
+		const terminal = new VirtualTerminal();
+		const ui = createComposerTui(terminal);
+		const onCancel = vi.fn();
+		const composer = new StartupComposer(ui, { onCancel });
+		ui.addChild(composer);
+		ui.setFocus(composer);
+		ui.start();
+
+		try {
+			terminal.sendInput("draft /model");
+			terminal.sendInput("\r");
+			expect(composer.getText()).toBe("draft /model");
+
+			terminal.sendInput("\x1b");
+			expect(onCancel).toHaveBeenCalledWith("interrupt");
+		} finally {
+			ui.stop();
+		}
+	});
+
+	// Regression coverage for #8689.
+	it("pauses the composer while a selector uses the same terminal", async () => {
+		setKeybindings(new KeybindingsManager());
+		const terminal = new RecordingTerminal();
+		const settingsManager = SettingsManager.inMemory();
+		const startup = createStartupComposer(settingsManager, { terminal });
+		terminal.sendInput("draft");
+
+		const selectedPromise = showStartupSelector(
+			settingsManager,
+			"Trust project folder?",
+			[{ label: "Trust", value: true }],
+			{ handoff: startup },
+		);
+		expect(startup.isRunning()).toBe(false);
+		expect(startup.ui.terminal).toBe(terminal);
+
+		// Selector input must not be appended to the hidden composer.
+		terminal.sendInput("wrong");
+		terminal.sendInput("\r");
+
+		expect(await selectedPromise).toBe(true);
+		expect(startup.isRunning()).toBe(true);
+		expect(startup.composer.getText()).toBe("draft");
+		expect(terminal.startCount).toBe(3);
+		expect(terminal.stopCount).toBe(2);
+
+		startup.stop();
+		expect(terminal.stopCount).toBe(3);
+	});
+});

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -206,7 +206,22 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 }
 
 // Kitty CSI-u sequences for printable keys, including optional shifted/base codepoints.
-interface EditorState {
+/**
+ * Transferable editor state for handing a draft to another editor instance.
+ *
+ * The paste registry and bracketed-paste fields are included so large pastes
+ * remain atomic and can still be expanded after a renderer handoff.
+ */
+export interface EditorState {
+	text: string;
+	cursor: { line: number; col: number };
+	pasteRegistry: Map<number, string>;
+	pasteCounter: number;
+	pasteBuffer: string;
+	isInPaste: boolean;
+}
+
+interface EditorTextState {
 	lines: string[];
 	cursorLine: number;
 	cursorCol: number;
@@ -214,7 +229,7 @@ interface EditorState {
 
 /** Undo snapshot: editor text state plus the paste registry. */
 interface EditorSnapshot {
-	state: EditorState;
+	state: EditorTextState;
 	pastes: Map<number, string>;
 	pasteCounter: number;
 }
@@ -268,7 +283,7 @@ function createScrollBorder(direction: "↑" | "↓", hiddenLineCount: number, w
 }
 
 export class Editor implements Component, Focusable {
-	private state: EditorState = {
+	private state: EditorTextState = {
 		lines: [""],
 		cursorLine: 0,
 		cursorCol: 0,
@@ -316,7 +331,7 @@ export class Editor implements Component, Focusable {
 	// Prompt history for up/down navigation
 	private history: string[] = [];
 	private historyIndex: number = -1; // -1 = not browsing, 0 = most recent, 1 = older, etc.
-	private historyDraft: EditorState | null = null;
+	private historyDraft: EditorTextState | null = null;
 
 	// Kill ring for Emacs-style kill/yank operations
 	private killRing = new KillRing();
@@ -1017,6 +1032,68 @@ export class Editor implements Component, Focusable {
 
 	getCursor(): { line: number; col: number } {
 		return { line: this.state.cursorLine, col: this.state.cursorCol };
+	}
+
+	/**
+	 * Capture all draft state needed to continue editing in another editor.
+	 * Copies are returned so the source editor can continue changing safely.
+	 */
+	getState(): EditorState {
+		return {
+			text: this.getText(),
+			cursor: this.getCursor(),
+			pasteRegistry: new Map(this.pastes),
+			pasteCounter: this.pasteCounter,
+			pasteBuffer: this.pasteBuffer,
+			isInPaste: this.isInPaste,
+		};
+	}
+
+	/**
+	 * Restore a previously captured draft state without submitting or adding an
+	 * undo entry. Invalid cursor values are clamped to the transferred text.
+	 */
+	setState(state: EditorState): void {
+		this.cancelAutocomplete();
+		this.lastAction = null;
+		this.exitHistoryBrowsing();
+
+		const lines = state.text.split("\n");
+		const requestedLine = Number.isInteger(state.cursor.line) ? state.cursor.line : 0;
+		const cursorLine = Math.max(0, Math.min(lines.length - 1, requestedLine));
+		const requestedCol = Number.isInteger(state.cursor.col) ? state.cursor.col : 0;
+		const cursorCol = Math.max(0, Math.min(lines[cursorLine]?.length ?? 0, requestedCol));
+		this.state = { lines, cursorLine, cursorCol };
+
+		const pastes = new Map<number, string>();
+		let maxPasteId = 0;
+		for (const [pasteId, pasteContent] of state.pasteRegistry) {
+			if (!Number.isInteger(pasteId) || pasteId <= 0 || typeof pasteContent !== "string") continue;
+			pastes.set(pasteId, pasteContent);
+			maxPasteId = Math.max(maxPasteId, pasteId);
+		}
+		this.pastes = pastes;
+		const requestedCounter = Number.isInteger(state.pasteCounter) ? state.pasteCounter : 0;
+		this.pasteCounter = Math.max(0, requestedCounter, maxPasteId);
+		this.pasteBuffer = state.pasteBuffer;
+		this.isInPaste = state.isInPaste;
+
+		this.scrollOffset = 0;
+		this.preferredVisualCol = null;
+		this.snappedFromCursorCol = null;
+		this.undoStack.clear();
+		this.onChange?.(this.getText());
+		this.tui.requestRender();
+	}
+
+	/** Alias for integrations that prefer an explicit editor-state name. */
+	getEditorState(): EditorState {
+		return this.getState();
+	}
+
+	/** Alias for integrations that prefer an explicit editor-state name. */
+	setEditorState(state: EditorState): void {
+		this.setState(state);
 	}
 
 	setText(text: string): void {

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -1,4 +1,5 @@
 import type { AutocompleteProvider } from "./autocomplete.ts";
+import type { EditorState } from "./components/editor.ts";
 import type { Component } from "./tui.ts";
 
 /**
@@ -51,6 +52,12 @@ export interface EditorComponent extends Component {
 	 * Falls back to getText() if not implemented.
 	 */
 	getExpandedText?(): string;
+
+	/** Capture transferable text, cursor, paste, and bracketed-paste state. */
+	getState?(): EditorState;
+
+	/** Restore transferable text, cursor, paste, and bracketed-paste state. */
+	setState?(state: EditorState): void;
 
 	// =========================================================================
 	// Autocomplete support (optional)

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -12,7 +12,7 @@ export {
 // Components
 export { Box } from "./components/box.ts";
 export { CancellableLoader } from "./components/cancellable-loader.ts";
-export { Editor, type EditorOptions, type EditorTheme } from "./components/editor.ts";
+export { Editor, type EditorOptions, type EditorState, type EditorTheme } from "./components/editor.ts";
 export { HStack } from "./components/h-stack.ts";
 export { Image, type ImageOptions, type ImageTheme } from "./components/image.ts";
 export { Input } from "./components/input.ts";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -311,6 +311,57 @@ describe("Editor component", () => {
 			lines[0] = "mutated";
 			assert.deepStrictEqual(editor.getLines(), ["a", "b"]);
 		});
+
+		// Regression coverage for #8689.
+		it("transfers cursor and large-paste state between editors", () => {
+			const source = new Editor(createTestTUI(), defaultEditorTheme);
+			source.setText("before ");
+			const pastedText = "x".repeat(1001);
+			source.handleInput(`\x1b[200~${pastedText}\x1b[201~`);
+			source.handleInput("\x1b[D");
+
+			const state = source.getState();
+			assert.strictEqual(state.text, `before [paste #1 1001 chars]`);
+			assert.strictEqual(state.pasteRegistry.get(1), pastedText);
+
+			const target = new Editor(createTestTUI(), defaultEditorTheme);
+			target.setState(state);
+
+			assert.strictEqual(target.getText(), source.getText());
+			assert.strictEqual(target.getExpandedText(), `before ${pastedText}`);
+			assert.deepStrictEqual(target.getCursor(), source.getCursor());
+			assert.deepStrictEqual(target.getState().pasteRegistry, state.pasteRegistry);
+		});
+
+		it("transfers an in-progress bracketed paste buffer", () => {
+			const source = new Editor(createTestTUI(), defaultEditorTheme);
+			source.handleInput("\x1b[200~partial");
+			const target = new Editor(createTestTUI(), defaultEditorTheme);
+
+			target.setState(source.getState());
+			target.handleInput(" content\x1b[201~");
+
+			assert.strictEqual(target.getText(), "partial content");
+			assert.strictEqual(target.getState().isInPaste, false);
+		});
+
+		// Regression coverage for #8689.
+		it("transfers multiline draft text without expanding paste markers", () => {
+			const source = new Editor(createTestTUI(), defaultEditorTheme);
+			const pastedText = "x".repeat(1001);
+			source.setText("prefix\n");
+			source.handleInput(`\x1b[200~${pastedText}\x1b[201~`);
+			source.handleInput("\x1b[D");
+
+			const state = source.getState();
+			const target = new Editor(createTestTUI(), defaultEditorTheme);
+			target.setState(state);
+
+			assert.strictEqual(target.getText(), "prefix\n[paste #1 1001 chars]");
+			assert.strictEqual(target.getExpandedText(), `prefix\n${pastedText}`);
+			assert.deepStrictEqual(target.getCursor(), { line: 1, col: 0 });
+			assert.deepStrictEqual(target.getState().pasteRegistry, state.pasteRegistry);
+		});
 	});
 
 	describe("Backslash+Enter newline workaround", () => {
@@ -3956,7 +4007,7 @@ describe("Editor component", () => {
 			editor.render(80);
 
 			const text = editor.getText();
-			const _marker = text.match(/\[paste #\d+ \d+ chars\]/)![0];
+			assert.match(text, /\[paste #\d+ \d+ chars\]/);
 			// Line 0: "12345678901234567890"
 			// Line 1: "" (empty)
 			// Line 2: "hello [paste #1 2000 chars]"


### PR DESCRIPTION
## Summary
- Added `StartupComposer`, which accepts input while startup is in progress and carries that input state into normal interactive mode.
- Enabled startup project trust checks, selection, and input dialogs to use the shared UI/terminal.
- Extended editor state capture and restoration to support handoff between the startup composer and the regular editor.
- Added and updated tests for the startup composer and editor state restoration.

## Verification
- Added `packages/coding-agent/test/startup-composer.test.ts`.
- Updated `packages/tui/test/editor.test.ts`.
- No completed check runs are present for the target commit on the GitHub API (CI has not run).
