### PR TITLE
fix(coding-agent): flush extension provider registrations before initial model resolution

### DIFF
--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -188,6 +188,28 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		time("resourceLoader.reload");
 	}
 
+	// Extension-registered providers (name+config form) are queued while the
+	// extension runtime is loading and only applied when the AgentSession binds
+	// — after this function has already resolved the initial model. Flush them
+	// here and rehydrate the availability snapshot so session restore and
+	// findInitialModel see extension providers; otherwise fresh sessions
+	// intermittently start on another provider's default model.
+	const extensionRuntime = resourceLoader.getExtensions().runtime;
+	for (const { name, config } of extensionRuntime.pendingProviderRegistrations.splice(0)) {
+		try {
+			modelRuntime.registerProvider(name, config);
+		} catch (error) {
+			console.error(
+				`Failed to register extension provider "${name}":`,
+				error instanceof Error ? error.message : error,
+			);
+		}
+	}
+	for (const { provider } of extensionRuntime.pendingNativeProviderRegistrations.splice(0)) {
+		modelRuntime.registerNativeProvider(provider);
+	}
+	await modelRuntime.refresh({ allowNetwork: false });
+
 	// Check if session has existing data to restore
 	const existingSession = sessionManager.buildSessionContext();
 	const hasExistingSession = existingSession.messages.length > 0;


### PR DESCRIPTION
## Summary

- Extension providers registered via `pi.registerProvider(name, config)` are queued while extensions load (`pendingProviderRegistrations`) and only applied when the `AgentSession` binds — after `createAgentSession` has already resolved the session's initial model.
- When model resolution wins that race, `findInitialModel` misses the extension provider (`getModel` miss or `hasConfiguredAuth` false) and step 4 silently falls back to `defaultModelPerProvider`: the session starts on an unrelated provider's default model, with no warning.
- After `resourceLoader.reload()`, flush both pending registration queues into the model runtime and await a no-network availability refresh, so session restore and `findInitialModel` see extension providers deterministically.

## Verification

- Fresh-session loop against a name+config-registered provider: before the change, 4/10 sessions started on the fallback provider's default; after, 10/10 started on the configured default.
- Restored sessions and first requests resolve through the registered provider.
- `tsgo -p tsconfig.build.json` clean for `packages/coding-agent`.

Close https://github.com/earendil-works/pi/issues/8810