### PR TITLE
fix(tui): detect Zed terminal capabilities

### DIFF
--- a/packages/coding-agent/docs/terminal-setup.md
+++ b/packages/coding-agent/docs/terminal-setup.md
@@ -130,6 +130,21 @@ Add to `keybindings.json`:
 }
 ```
 
+## Zed (Integrated Terminal)
+
+Add these key bindings to your Zed `keymap.json`:
+
+```json
+{
+  "context": "Terminal",
+  "bindings": {
+    "shift-enter": ["terminal::SendText", "\u001b[13;2u"],
+    "ctrl--": ["terminal::SendText", "\u001b[45;5u"],
+    "ctrl-alt-]": ["terminal::SendText", "\u001b[93;7u"]
+  }
+}
+```
+
 ## Windows Terminal
 
 Pi uses Windows-style keybindings when running natively on Windows or in WSL:

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -110,11 +110,7 @@ function detectCapabilitiesFromEnvironment(tmuxForwardsHyperlink: () => boolean)
 		return { images: null, trueColor: true, hyperlinks: true };
 	}
 
-	if (termProgram === "vscode") {
-		return { images: null, trueColor: true, hyperlinks: true };
-	}
-
-	if (termProgram === "alacritty") {
+	if (termProgram === "alacritty" || termProgram === "vscode" || termProgram === "zed") {
 		return { images: null, trueColor: true, hyperlinks: true };
 	}
 

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -401,6 +401,12 @@ describe("detectCapabilities", () => {
 		});
 	});
 
+	it("enables Alacritty capabilities for Zed", () => {
+		withEnv({ TERM_PROGRAM: "zed" }, () => {
+			assert.deepStrictEqual(detectCapabilities(), { images: null, trueColor: true, hyperlinks: true });
+		});
+	});
+
 	it("enables truecolor and hyperlinks for Windows Terminal outside multiplexers", () => {
 		withEnv({ WT_SESSION: "session", TERM: "xterm-256color" }, () => {
 			const caps = detectCapabilities();


### PR DESCRIPTION
This PR implements capability detection for the terminal integrated into [Zed](https://zed.dev/). As of v1.17.2, it uses Alacritty at its core, so it supports the same capabilities: hyperlinks and true color, but not images.

It also documents the keymap settings for the default Pi hotkeys. The Kitty keyboard protocol is not supported AFAIK, because all input handling is done by Zed around the Alacritty core. By default, Zed sends `\x0a` on <kbd>Shift</kbd>+<kbd>Enter</kbd>, which is also what <kbd>Ctrl</kbd>+<kbd>J</kbd> does. Binding a Kitty sequence for <kbd>Shift</kbd>+<kbd>Enter</kbd> allows Pi to differentiate the two hotkeys.