### PR TITLE
fix(agent): prevent duplicate JSONL writers

### DIFF
--- a/packages/agent/docs/harness.md
+++ b/packages/agent/docs/harness.md
@@ -572,8 +572,10 @@ stops renewal after the queue drains and deletes only its matching `(owner_id,
 fence)` pair — so a stale owner cannot release the replacement that succeeded it.
 This is what makes "one process owns one session" an enforced property rather than
 a convention the serving layer is trusted to uphold. Memory and JSONL have no
-equivalent and rely on process ownership; a JSONL session opened twice is corrupt
-and undetected.
+cross-process equivalent and rely on process ownership. Within one process, opening
+a JSONL session transfers writer ownership to the new instance; superseded instances
+reject later writes. Two processes opening the same file remains unsupported and
+undetected.
 
 Atomicity itself needs no special handling. A multi-write transaction is all-or-none
 by the file format: WAL frames become visible only when the commit record lands, so a

--- a/packages/agent/src/harness/session/jsonl/repo.ts
+++ b/packages/agent/src/harness/session/jsonl/repo.ts
@@ -86,14 +86,25 @@ export async function listJsonlSessionMetadata(
 	return metadata.sort((left, right) => right.modifiedAt - left.modifiedAt);
 }
 
+/** Load a read-only snapshot without superseding the active in-process writer. */
 export async function loadJsonlSessionStorage(
 	options: JsonlSessionRepoOptions,
 	metadata: JsonlSessionMetadata,
 ): Promise<JsonlSessionStorage> {
+	return openJsonlSessionStorage(options, metadata, false);
+}
+
+async function openJsonlSessionStorage(
+	options: JsonlSessionRepoOptions,
+	metadata: JsonlSessionMetadata,
+	writable: boolean,
+): Promise<JsonlSessionStorage> {
 	if (!fileResult(await options.fs.exists(metadata.path), `Failed to check session ${metadata.path}`)) {
 		throw new SessionError("not_found", `Session not found: ${metadata.id}`);
 	}
-	const storage = await JsonlSessionStorage.load(options.fs, metadata.path);
+	const storage = await (writable
+		? JsonlSessionStorage.open(options.fs, metadata.path, metadata.id)
+		: JsonlSessionStorage.load(options.fs, metadata.path));
 	const loadedMetadata = await storage.getMetadata();
 	if (loadedMetadata.id !== metadata.id) {
 		throw new SessionError("invalid_entry", `Session id does not match header: ${metadata.id}`);
@@ -128,7 +139,7 @@ export class JsonlSessionRepo
 	}
 
 	async open(metadata: JsonlSessionMetadata): Promise<Session<JsonlSessionMetadata>> {
-		return new Session(await this.loadStorage(metadata));
+		return new Session(await this.loadStorage(metadata, true));
 	}
 
 	async list(options: JsonlSessionListOptions = {}): Promise<JsonlSessionMetadata[]> {
@@ -155,8 +166,8 @@ export class JsonlSessionRepo
 		});
 	}
 
-	private async loadStorage(metadata: JsonlSessionMetadata): Promise<JsonlSessionStorage> {
-		return loadJsonlSessionStorage({ fs: this.fs, sessionsRoot: this.sessionsRootInput }, metadata);
+	private async loadStorage(metadata: JsonlSessionMetadata, writable = false): Promise<JsonlSessionStorage> {
+		return openJsonlSessionStorage({ fs: this.fs, sessionsRoot: this.sessionsRootInput }, metadata, writable);
 	}
 
 	private async resolveCreateDestination(options: JsonlSessionCreateOptions): Promise<{ id: string; cwd: string }> {

--- a/packages/agent/src/harness/session/jsonl/storage.ts
+++ b/packages/agent/src/harness/session/jsonl/storage.ts
@@ -20,6 +20,44 @@ import { encodeHeader, encodeMutation, metadataFromHeader, parseHeader, parseMut
 import { fileResult, invalidFile, JsonlDecodeError } from "./errors.ts";
 import type { JsonlSessionMetadata, JsonlSessionRepoFileSystem, JsonlV4Header } from "./types.ts";
 
+const fileOperationTails = new Map<string, Promise<void>>();
+
+/**
+ * Serializes writer handoff and mutations for one JSONL path in this JavaScript
+ * realm. JSONL still relies on the caller to enforce single-process ownership.
+ */
+function enqueueFileOperation<T>(path: string, operation: () => Promise<T>): Promise<T> {
+	const result = (fileOperationTails.get(path) ?? Promise.resolve()).then(operation);
+	const tail = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	fileOperationTails.set(path, tail);
+	void tail.then(() => {
+		if (fileOperationTails.get(path) === tail) fileOperationTails.delete(path);
+	});
+	return result;
+}
+
+interface WriterClaim {
+	path: string;
+}
+
+// Claims are weakly tied to storage lifetime because the current Session API has no explicit close operation.
+const activeWriterClaims = new Map<string, WriterClaim>();
+const writerClaimFinalizer = new FinalizationRegistry<WriterClaim>((claim) => {
+	if (activeWriterClaims.get(claim.path) === claim) activeWriterClaims.delete(claim.path);
+});
+
+function invalidateWriter(path: string): void {
+	activeWriterClaims.delete(path);
+}
+
+async function resolveCoordinationPath(fs: JsonlSessionRepoFileSystem, path: string): Promise<string> {
+	if (fs.canonicalPath === undefined) return path;
+	return fileResult(await fs.canonicalPath(path), `Failed to resolve session path ${path}`);
+}
+
 /**
  * Build a complete sibling temporary file, then atomically rename it over the destination.
  * The populate callback must create or overwrite `tempPath` with the complete file. The
@@ -48,12 +86,15 @@ async function publishFileAtomically(
 export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata> {
 	private readonly fs: JsonlSessionRepoFileSystem;
 	private readonly metadata: JsonlSessionMetadata;
+	private readonly coordinationPath: string;
 	private readonly state = new SessionState();
+	private writerClaim: WriterClaim | undefined;
 	private tail: Promise<void> = Promise.resolve();
 
-	constructor(fs: JsonlSessionRepoFileSystem, metadata: JsonlSessionMetadata) {
+	constructor(fs: JsonlSessionRepoFileSystem, metadata: JsonlSessionMetadata, coordinationPath = metadata.path) {
 		this.fs = fs;
 		this.metadata = structuredClone(metadata);
+		this.coordinationPath = coordinationPath;
 	}
 
 	static async create(
@@ -61,12 +102,50 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 		path: string,
 		header: JsonlV4Header,
 	): Promise<JsonlSessionStorage> {
-		fileResult(await fs.writeFile(path, encodeHeader(header)), `Failed to initialize session ${path}`);
-		const fileInfo = fileResult(await fs.fileInfo(path), `Failed to read session metadata ${path}`);
-		return new JsonlSessionStorage(fs, metadataFromHeader(header, path, fileInfo.mtimeMs));
+		await enqueueFileOperation(path, async () => {
+			fileResult(await fs.writeFile(path, encodeHeader(header)), `Failed to initialize session ${path}`);
+		});
+		const canonicalPath = await resolveCoordinationPath(fs, path);
+		return enqueueFileOperation(canonicalPath, async () => {
+			const fileInfo = fileResult(
+				await fs.fileInfo(canonicalPath),
+				`Failed to read session metadata ${canonicalPath}`,
+			);
+			return new JsonlSessionStorage(
+				fs,
+				metadataFromHeader(header, path, fileInfo.mtimeMs),
+				canonicalPath,
+			).activateWriter();
+		});
 	}
 
+	/** Load an unclaimed snapshot for read-only consumers such as search indexing. */
 	static async load(fs: JsonlSessionRepoFileSystem, path: string): Promise<JsonlSessionStorage> {
+		const canonicalPath = await resolveCoordinationPath(fs, path);
+		return enqueueFileOperation(canonicalPath, () => JsonlSessionStorage.loadUnlocked(fs, path, canonicalPath));
+	}
+
+	/** Load a writable session and supersede any older writer for the same path in this process. */
+	static async open(
+		fs: JsonlSessionRepoFileSystem,
+		path: string,
+		expectedSessionId: string,
+	): Promise<JsonlSessionStorage> {
+		const canonicalPath = await resolveCoordinationPath(fs, path);
+		return enqueueFileOperation(canonicalPath, async () => {
+			const storage = await JsonlSessionStorage.loadUnlocked(fs, path, canonicalPath);
+			if (storage.metadata.id !== expectedSessionId) {
+				throw new SessionError("invalid_entry", `Session id does not match header: ${expectedSessionId}`);
+			}
+			return storage.activateWriter();
+		});
+	}
+
+	private static async loadUnlocked(
+		fs: JsonlSessionRepoFileSystem,
+		path: string,
+		coordinationPath: string,
+	): Promise<JsonlSessionStorage> {
 		const content = fileResult(await fs.readTextFile(path), `Failed to read session ${path}`);
 		const physicalLines = content.split("\n");
 		if (physicalLines.at(-1) === "") physicalLines.pop();
@@ -76,7 +155,11 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 		const headerResult = parseHeader(physicalLines[0]);
 		if (!headerResult.ok) throw invalidFile(path, 1, headerResult.error);
 		const fileInfo = fileResult(await fs.fileInfo(path), `Failed to read session metadata ${path}`);
-		const storage = new JsonlSessionStorage(fs, metadataFromHeader(headerResult.value, path, fileInfo.mtimeMs));
+		const storage = new JsonlSessionStorage(
+			fs,
+			metadataFromHeader(headerResult.value, path, fileInfo.mtimeMs),
+			coordinationPath,
+		);
 		for (let index = 1; index < physicalLines.length; index++) {
 			const line = physicalLines[index]!;
 			const mutationResult = parseMutation(line);
@@ -88,6 +171,7 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 					await publishFileAtomically(fs, path, async (tempPath) => {
 						fileResult(await fs.writeFile(tempPath, validPrefix), `Failed to stage torn-tail repair ${path}`);
 					});
+					invalidateWriter(coordinationPath);
 					return storage;
 				}
 				throw invalidFile(path, index + 1, mutationResult.error);
@@ -103,20 +187,24 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 		}
 		if (!content.endsWith("\n")) {
 			fileResult(await fs.appendFile(path, "\n"), `Failed to repair unterminated session tail ${path}`);
+			invalidateWriter(coordinationPath);
 		}
 		return storage;
 	}
 
-	async fork(path: string, header: JsonlV4Header, options: ForkOptions): Promise<JsonlSessionStorage> {
-		const mutations = this.state.createForkMutations(options);
-		await publishFileAtomically(this.fs, path, async (tempPath) => {
-			const targetStorage = await JsonlSessionStorage.create(this.fs, tempPath, header);
-			for (const mutation of mutations) {
-				await targetStorage.appendMutation(mutation);
-				targetStorage.applyMutation(mutation);
-			}
+	fork(path: string, header: JsonlV4Header, options: ForkOptions): Promise<JsonlSessionStorage> {
+		return this.enqueueRead(async () => {
+			const current = await JsonlSessionStorage.loadUnlocked(this.fs, this.metadata.path, this.coordinationPath);
+			const mutations = current.state.createForkMutations(options);
+			await publishFileAtomically(this.fs, path, async (tempPath) => {
+				const targetStorage = await JsonlSessionStorage.create(this.fs, tempPath, header);
+				for (const mutation of mutations) {
+					await targetStorage.appendMutation(mutation);
+					targetStorage.applyMutation(mutation);
+				}
+			});
+			return JsonlSessionStorage.open(this.fs, path, header.id);
 		});
-		return JsonlSessionStorage.load(this.fs, path);
 	}
 
 	async drain(): Promise<void> {
@@ -256,7 +344,12 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 	}
 
 	private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-		const result = this.tail.then(operation);
+		const result = this.tail.then(() =>
+			enqueueFileOperation(this.coordinationPath, async () => {
+				this.assertActiveWriter();
+				return operation();
+			}),
+		);
 		this.tail = result.then(
 			() => undefined,
 			() => undefined,
@@ -273,5 +366,31 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 
 	private applyMutation(mutation: SessionMutation): void {
 		this.state.applyMutation(mutation);
+	}
+
+	private activateWriter(): this {
+		const claim = { path: this.coordinationPath };
+		activeWriterClaims.set(claim.path, claim);
+		writerClaimFinalizer.register(this, claim, claim);
+		this.writerClaim = claim;
+		return this;
+	}
+
+	private assertActiveWriter(): void {
+		if (this.writerClaim === undefined || activeWriterClaims.get(this.coordinationPath) !== this.writerClaim) {
+			throw new SessionError(
+				"storage",
+				`JSONL session ${this.metadata.id} writer was superseded; reopen before writing`,
+			);
+		}
+	}
+
+	private enqueueRead<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.tail.then(() => enqueueFileOperation(this.coordinationPath, operation));
+		this.tail = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
 	}
 }

--- a/packages/agent/src/harness/session/jsonl/types.ts
+++ b/packages/agent/src/harness/session/jsonl/types.ts
@@ -15,7 +15,8 @@ export type JsonlSessionRepoFileSystem = Pick<
 	| "exists"
 	| "createDir"
 	| "remove"
->;
+> &
+	Partial<Pick<FileSystem, "canonicalPath">>;
 
 export interface JsonlSessionRepoOptions {
 	fs: JsonlSessionRepoFileSystem;

--- a/packages/agent/test/harness/session/jsonl-storage.test.ts
+++ b/packages/agent/test/harness/session/jsonl-storage.test.ts
@@ -439,6 +439,86 @@ describe("JSONL v4 per-session storage", () => {
 		expect((await restored.getLog()).map((item) => item.seq)).toEqual([1, 2, 3, 4, 5, 6]);
 	});
 
+	it("transfers writer ownership to a newly opened session", async () => {
+		const root = createTempDir();
+		const firstRepository = createRepository(root);
+		const firstWriter = await firstRepository.create({ id: "single-writer", cwd: root });
+		const secondRepository = createRepository(root);
+		const secondWriter = await secondRepository.open(await firstWriter.getMetadata());
+
+		await expect(firstWriter.appendCustomEntry("stale")).rejects.toMatchObject({
+			code: "storage",
+			message: expect.stringContaining("reopen"),
+		});
+		const committedId = await secondWriter.appendCustomEntry("current");
+
+		const restored = await reopen(root, secondWriter);
+		expect(await restored.getEntry(committedId)).toMatchObject({ id: committedId, seq: 1 });
+		expect((await restored.getLog()).map((item) => item.seq)).toEqual([1]);
+	});
+
+	it("does not transfer writer ownership when metadata validation fails", async () => {
+		const root = createTempDir();
+		const firstWriter = await createRepository(root).create({ id: "valid-id", cwd: root });
+		const metadata = await firstWriter.getMetadata();
+
+		await expect(createRepository(root).open({ ...metadata, id: "wrong-id" })).rejects.toMatchObject({
+			code: "invalid_entry",
+		});
+		const committedId = await firstWriter.appendCustomEntry("still-current");
+
+		expect(await firstWriter.getEntry(committedId)).toMatchObject({ id: committedId, seq: 1 });
+	});
+
+	it("waits for an admitted append before transferring writer ownership", async () => {
+		const root = createTempDir();
+		const firstEnv = new NodeExecutionEnv({ cwd: root });
+		const firstRepository = new JsonlSessionRepo({ fs: firstEnv, sessionsRoot: root });
+		const firstWriter = await firstRepository.create({ id: "writer-handoff", cwd: root });
+		const metadata = await firstWriter.getMetadata();
+		const appendFile = firstEnv.appendFile.bind(firstEnv);
+		let notifyAppendStarted = () => {};
+		let releaseAppend = () => {};
+		const appendStarted = new Promise<void>((resolve) => {
+			notifyAppendStarted = resolve;
+		});
+		const appendGate = new Promise<void>((resolve) => {
+			releaseAppend = resolve;
+		});
+		vi.spyOn(firstEnv, "appendFile").mockImplementationOnce(async (...args) => {
+			notifyAppendStarted();
+			await appendGate;
+			return appendFile(...args);
+		});
+
+		const firstWrite = firstWriter.appendEntry({ type: "custom", id: "first", customType: "note" }, "main");
+		await appendStarted;
+		const secondWriterPromise = createRepository(root).open(metadata);
+		releaseAppend();
+
+		const first = await firstWrite;
+		const secondWriter = await secondWriterPromise;
+		const second = await secondWriter.appendEntry({ type: "custom", id: "second", customType: "note" }, "main");
+
+		expect([first.seq, second.seq]).toEqual([1, 2]);
+		expect((await reopen(root, secondWriter)).getLog()).resolves.toEqual([
+			{ kind: "entry", seq: 1, entry: first },
+			{ kind: "entry", seq: 2, entry: second },
+		]);
+	});
+
+	it("does not transfer source writer ownership when forking", async () => {
+		const root = createTempDir();
+		const repository = createRepository(root);
+		const source = await repository.create({ id: "source-writer", cwd: root });
+		await source.appendMessage(userMessage("before fork"));
+
+		await repository.fork(await source.getMetadata(), { id: "fork", cwd: root });
+		const committedId = await source.appendCustomEntry("after-fork");
+
+		expect(await source.getEntry(committedId)).toMatchObject({ id: committedId, seq: 2 });
+	});
+
 	it("rejects non-JSON payloads without changing the durable prefix", async () => {
 		const root = createTempDir();
 		const session = await createRepository(root).create({ id: "validation", cwd: root });


### PR DESCRIPTION
Serialize writable opens and mutations by canonical session path. A new writable open supersedes older in-process writers, which now fail before sequence allocation or append, while read-only loads and forks preserve ownership.\n\nTesting: session test suite (123 tests)