### PR TITLE
fix(agent,coding-agent): derive branch summary output budget from reserveTokens (#8845)

### DIFF
--- a/packages/agent/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent/src/harness/compaction/branch-summarization.ts
@@ -246,11 +246,19 @@ export async function generateBranchSummary(
 			timestamp: Date.now(),
 		},
 	];
+	// Derive the output budget instead of pinning it at 2048: the input budget is
+	// `contextWindow - reserveTokens`, so a large window feeds hundreds of thousands of
+	// tokens into a 2048-token response. Reasoning tokens share that budget, so reasoning
+	// models hit the cap and the summary comes back incomplete (#8845).
+	const maxTokens = Math.min(
+		Math.floor(0.8 * reserveTokens),
+		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+	);
 	const response = await completeSimpleWithRetries(
 		models,
 		model,
 		{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages },
-		{ signal, maxTokens: 2048 },
+		{ signal, maxTokens },
 		retry,
 		callbacks,
 	);

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -347,7 +347,16 @@ export async function generateBranchSummary(
 	// without running through agent state/events. Retried via completeSummarization
 	// so transient stream drops reuse the configured retry policy.
 	const context = { systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages };
-	const requestOptions: SimpleStreamOptions = { apiKey, headers, env, signal, maxTokens: 2048 };
+	// Derive the output budget instead of pinning it at 2048: the input budget is
+	// `contextWindow - reserveTokens`, so a large window feeds hundreds of thousands of
+	// tokens into a 2048-token response. Reasoning tokens share that budget, so reasoning
+	// models hit the cap and the summary comes back incomplete (#8845). Matches the
+	// compaction summary budget in `generateSummaryWithUsage`.
+	const maxTokens = Math.min(
+		Math.floor(0.8 * reserveTokens),
+		model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+	);
+	const requestOptions: SimpleStreamOptions = { apiKey, headers, env, signal, maxTokens };
 	const response = await completeSummarization(model, context, requestOptions, streamFn, retry, callbacks);
 
 	// Check if aborted or errored

--- a/packages/coding-agent/test/branch-summarization.test.ts
+++ b/packages/coding-agent/test/branch-summarization.test.ts
@@ -43,6 +43,23 @@ function response(content: AssistantMessage["content"]): AssistantMessage {
 	};
 }
 
+/** Captures the stream options the summarization request was issued with. */
+function captureStreamFn(): {
+	streamFn: StreamFn;
+	options: () => SimpleStreamOptions | undefined;
+} {
+	let captured: SimpleStreamOptions | undefined;
+	const streamFn: StreamFn = (_model, _context, options) => {
+		captured = options;
+		const stream = createAssistantMessageEventStream();
+		queueMicrotask(() =>
+			stream.push({ type: "done", reason: "stop", message: response([{ type: "text", text: "summary" }]) }),
+		);
+		return stream;
+	};
+	return { streamFn, options: () => captured };
+}
+
 describe("branch summarization", () => {
 	it("does not override tool choice for branch summaries", async () => {
 		let requestOptions: SimpleStreamOptions | undefined;
@@ -110,5 +127,48 @@ describe("branch summarization", () => {
 		expect(result.error).toBe(
 			"Branch summarization failed: generation hit the token cap and the summary is incomplete",
 		);
+	});
+
+	it("caps the output budget at the model limit when that is the tighter bound", async () => {
+		const { streamFn, options } = captureStreamFn();
+
+		await generateBranchSummary(entries, {
+			model,
+			signal: new AbortController().signal,
+			streamFn,
+		});
+
+		// floor(0.8 * 16384) = 13107, but model.maxTokens is 8192
+		expect(options()?.maxTokens).toBe(8192);
+	});
+
+	/** A 2048-token cap is smaller than most reasoning output, so large branches always hit it (#8845) */
+	it("derives the output budget from reserveTokens instead of pinning it at 2048", async () => {
+		const largeModel = { ...model, maxTokens: 65536 };
+		const { streamFn, options } = captureStreamFn();
+
+		await generateBranchSummary(entries, {
+			model: largeModel,
+			signal: new AbortController().signal,
+			streamFn,
+		});
+
+		expect(options()?.maxTokens).toBe(13107);
+		expect(options()?.maxTokens).toBeGreaterThan(2048);
+	});
+
+	it("scales the output budget with a custom reserveTokens", async () => {
+		const largeModel = { ...model, maxTokens: 65536 };
+		const { streamFn, options } = captureStreamFn();
+
+		await generateBranchSummary(entries, {
+			model: largeModel,
+			reserveTokens: 32768,
+			signal: new AbortController().signal,
+			streamFn,
+		});
+
+		// floor(0.8 * 32768) = 26214
+		expect(options()?.maxTokens).toBe(26214);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #8845 — `/tree` branch summarization failed deterministically on large branches:

```
Branch summarization failed: generation hit the token cap and the summary is incomplete
```

`generateBranchSummary` pinned the response at `maxTokens: 2048`, but the input budget is `contextWindow - reserveTokens` (default reserve 16384). A 400K-window model therefore feeds ~383K tokens of conversation into a 2048-token response — and reasoning tokens share that same output budget, so reasoning models hit the cap easily. The hardcoded cap also had no override.

Compaction's own summary already derives its budget as `min(floor(0.8 * reserveTokens), model.maxTokens)` (`generateSummaryWithUsage`, `compaction.ts:672`), which yields 13,107 with defaults. Branch summarization now uses the same rule, in both copies:

- `packages/coding-agent/src/core/compaction/branch-summarization.ts`
- `packages/agent/src/harness/compaction/branch-summarization.ts`

## Change type

- [x] Bug fix

## Testing

Added to `packages/coding-agent/test/branch-summarization.test.ts`, asserting the `maxTokens` the stream is issued with:

| scenario | `reserveTokens` | `model.maxTokens` | expected |
| --- | --- | --- | --- |
| model limit is the tighter bound | 16384 (default) | 8192 | `8192` |
| budget derived from reserve | 16384 (default) | 65536 | `13107` (was `2048`) |
| scales with custom reserve | 32768 | 65536 | `26214` |

The pre-existing tests (tool choice untouched, tool call rejected, length-limited summary rejected) still apply, and none of them asserted the old hardcoded cap.

The agent-harness copy keeps the identical formula; its test file only covers `collectEntriesForBranchSummary`, and asserting the stream options there would require mocking the `Models` registry, so coverage stays on the coding-agent side.

fixes #8845
