### PR TITLE
fix(ai): unref codex WebSocket idle-cache timer; document extension-side session resource cleanup

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Unref'd the codex WebSocket idle-cache timer so a pooled connection whose server side already closed cannot pin a one-shot process's event loop for the full 5-minute TTL.
+
 ## [0.84.4] - 2026-08-28
 
 ### Added

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -1033,6 +1033,10 @@ function scheduleSessionWebSocketExpiry(sessionId: string, accountId: string, en
 		if (accountEntries?.get(accountId) === entry) accountEntries.delete(accountId);
 		if (accountEntries?.size === 0) websocketSessionCache.delete(sessionId);
 	}, SESSION_WEBSOCKET_CACHE_TTL_MS);
+	// An idle cache entry must not keep a one-shot process alive: when the
+	// server closes its side early the socket handle goes away, but a ref'd
+	// timer would still pin the event loop for the full TTL.
+	entry.idleTimer.unref?.();
 }
 
 async function connectWebSocket(

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -20,6 +20,7 @@ See these complete provider examples:
 - [Quick Reference](#quick-reference)
 - [Override Existing Provider](#override-existing-provider)
 - [Register New Provider](#register-new-provider)
+- [Cleaning Up Session Resources](#cleaning-up-session-resources)
 - [Unregister Provider](#unregister-provider)
 - [OAuth Support](#oauth-support)
 - [Custom Streaming API](#custom-streaming-api)
@@ -184,6 +185,36 @@ pi.registerProvider("my-llm", {
 When `models` is provided, it **replaces** all existing models for that provider.
 
 `apiKey` and custom header values use the same config value syntax as `models.json`: `!command` at the start executes a command for the whole value, `$ENV_VAR` and `${ENV_VAR}` interpolate environment variables, `$$` emits a literal `$`, and `$!` emits a literal `!`.
+
+## Cleaning Up Session Resources
+
+If your extension imports pi-ai **api subpath modules** (for example
+`@earendil-works/pi-ai/api/openai-codex-responses`) they resolve from your
+extension's own `node_modules`, giving you a private pi-ai module instance.
+Pi's session teardown drains the *bundled* pi-ai's session-resource registry,
+but it cannot reach a private instance — so long-lived transports your
+instance pools (like the codex WebSocket cache, which idles connections for
+five minutes) keep a scripted `pi -p` run's process alive after the answer.
+
+Close what your instance owns from a `session_shutdown` handler:
+
+```typescript
+import { closeOpenAICodexWebSocketSessions } from "@earendil-works/pi-ai/api/openai-codex-responses";
+
+export default function (pi: ExtensionAPI) {
+  // ... registerProvider(...) ...
+  pi.on("session_shutdown", () => {
+    try {
+      closeOpenAICodexWebSocketSessions();
+    } catch {
+      /* never block shutdown */
+    }
+  });
+}
+```
+
+The root import (`@earendil-works/pi-ai`) is aliased to the bundled compat
+module and needs no such handler — this only applies to api subpath imports.
 
 ## Unregister Provider
 


### PR DESCRIPTION
## Symptom

A provider extension that streams codex models via pi-ai keeps a scripted `pi -p` run's process alive for ~5 minutes after the final answer is printed.

## Diagnosis

Traced with `diagnostics_channel` (`undici:request:create` stack capture) and `process.getActiveResourcesInfo()`:

1. Codex streams over the pooled WebSocket (`acquireWebSocket`/`processWebSocketStream`). After a stream completes, the connection idles in `websocketSessionCache` with a **ref'd** idle timer (`SESSION_WEBSOCKET_CACHE_TTL_MS` = 5 min).
2. `AgentSession.dispose()` already drains the **bundled** pi-ai's session-resource registry via `cleanupSessionResources()`, so bundled usage is covered.
3. However, an extension importing an **api subpath module** (e.g. `@earendil-works/pi-ai/api/openai-codex-responses`) resolves it from its own `node_modules` — a private pi-ai instance with its own registry and its own WebSocket pool that core's cleanup cannot reach. Post-teardown resource snapshot: `["TCPSocketWrap","Timeout"]` — the pooled socket plus the ref'd idle timer.

## Changes

- **`packages/ai`**: `unref()` the idle-cache timer. This never changes cache behavior, but stops the timer alone from pinning the loop — which is exactly what happens when the server closes its side early (socket handle gone, timer still ref'd for the remaining TTL).
- **`packages/coding-agent/docs/custom-provider.md`**: new "Cleaning Up Session Resources" section documenting that api-subpath imports create a private pi-ai instance, with the `session_shutdown` handler pattern to close pooled transports (e.g. `closeOpenAICodexWebSocketSessions()`).

Verified in a real provider: with the documented handler, `pi -p` exits ~4s after the answer instead of ~300s.

## Deliberately out of scope

- The 5-minute idle TTL is unchanged (it is the right call for interactive reuse).
- No attempt to reach extension-owned pi-ai instances from core; the docs pattern covers it, though aliasing `api/*` subpaths to the bundled modules in the extension loader (as the root import already is) would eliminate the duplicate-instance class entirely — happy to discuss/follow up if that direction is preferred.

`packages/ai` build + codex test suites pass; repo pre-commit checks (biome, tsgo, shrinkwrap, browser smoke) pass.
