### PR TITLE
[CLOSED] fix(coding-agent): expose host keybinding access on the extension API

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2315,24 +2315,30 @@ If a slot intentionally has no visible content, return an empty `Component` such
 
 #### Keybinding Hints
 
-Use `keyHint()` to display keybinding hints that respect the active keybinding configuration:
+Use `pi.keyHint()` to display keybinding hints that respect the active keybinding configuration:
 
 ```typescript
-import { keyHint } from "@earendil-works/pi-coding-agent";
-
-renderResult(result, { expanded }, theme, context) {
-  let text = theme.fg("success", "✓ Done");
-  if (!expanded) {
-    text += ` (${keyHint("app.tools.expand", "to expand")})`;
-  }
-  return new Text(text, 0, 0);
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    // ...
+    renderResult(result, { expanded }, theme, context) {
+      let text = theme.fg("success", "✓ Done");
+      if (!expanded) {
+        text += ` (${pi.keyHint("app.tools.expand", "to expand")})`;
+      }
+      return new Text(text, 0, 0);
+    },
+  });
 }
 ```
 
-Available functions:
-- `keyHint(keybinding, description)` - Formats a configured keybinding id such as `"app.tools.expand"` or `"tui.select.confirm"`
-- `keyText(keybinding)` - Returns the raw configured key text for a keybinding id
-- `rawKeyHint(key, description)` - Format a raw key string
+Available on the `ExtensionAPI` instance:
+- `pi.keyHint(keybinding, description)` - Formats a configured keybinding id such as `"app.tools.expand"` or `"tui.select.confirm"`
+- `pi.keyText(keybinding)` - Returns the raw configured key text for a keybinding id
+- `pi.keyDisplayText(keybinding)` - Like `keyText` with capitalized key parts
+- `pi.getKeybindings()` - The host's keybindings manager, for `getKeys()` and `matches()`. Resolved on every call; do not cache the returned instance.
+
+Do not import `keyHint`/`keyText`/`getKeybindings` from `@earendil-works/pi-coding-agent` or `@earendil-works/pi-tui` in an extension. An installed extension can resolve its own copy of those packages, and that copy's module-local keybindings manager never receives the host's `app.*` bindings, so hints render with an empty key. The `pi.*` methods above are bound to the host and always see the merged bindings.
 
 Use namespaced keybinding ids:
 - Coding-agent ids use the `app.*` namespace, for example `app.tools.expand`, `app.editor.external`, `app.session.rename`

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -12,8 +12,8 @@ import type { Provider } from "@earendil-works/pi-ai";
 import * as _bundledPiAiCompat from "@earendil-works/pi-ai/compat";
 import * as _bundledPiAiOauth from "@earendil-works/pi-ai/oauth";
 import * as _bundledPiAiProviders from "@earendil-works/pi-ai/providers/all";
-import type { KeyId } from "@earendil-works/pi-tui";
 import * as _bundledPiTui from "@earendil-works/pi-tui";
+import { getKeybindings as getHostKeybindings, type Keybinding, type KeyId } from "@earendil-works/pi-tui";
 import { createJiti } from "jiti/static";
 // Static imports of packages that extensions may use.
 // These MUST be static so Bun bundles them into the compiled binary.
@@ -25,6 +25,7 @@ import { CONFIG_DIR_NAME, getAgentDir, isBunBinary } from "../../config.ts";
 // NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 // avoiding a circular dependency. Extensions can import from @earendil-works/pi-coding-agent.
 import * as _bundledPiCodingAgent from "../../index.ts";
+import { keyDisplayText, keyHint, keyText } from "../../modes/interactive/components/keybinding-hints.ts";
 import { resolvePath } from "../../utils/paths.ts";
 import { createEventBus, type EventBus } from "../event-bus.ts";
 import type { ExecOptions } from "../exec.ts";
@@ -412,6 +413,28 @@ function createExtensionAPI(
 		getCommands() {
 			assertActive();
 			return runtime.getCommands();
+		},
+
+		// Keybindings - host-bound so extensions see the host's merged app.*
+		// bindings even when they resolve their own copy of the pi packages (#4748)
+		getKeybindings() {
+			assertActive();
+			return getHostKeybindings();
+		},
+
+		keyText(keybinding: Keybinding) {
+			assertActive();
+			return keyText(keybinding);
+		},
+
+		keyDisplayText(keybinding: Keybinding) {
+			assertActive();
+			return keyDisplayText(keybinding);
+		},
+
+		keyHint(keybinding: Keybinding, description: string) {
+			assertActive();
+			return keyHint(keybinding, description);
 		},
 
 		setModel(model) {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -39,10 +39,12 @@ import type {
 	Component,
 	EditorComponent,
 	EditorTheme,
+	Keybinding,
 	KeyId,
 	OverlayHandle,
 	OverlayOptions,
 	TUI,
+	KeybindingsManager as TuiKeybindingsManager,
 } from "@earendil-works/pi-tui";
 import type { Static, TSchema } from "typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
@@ -1407,6 +1409,32 @@ export interface ExtensionAPI {
 
 	/** Get available slash commands in the current session. */
 	getCommands(): SlashCommandInfo[];
+
+	// =========================================================================
+	// Keybindings
+	// =========================================================================
+
+	/**
+	 * Get the host's keybindings manager: app and TUI definitions merged with
+	 * the user's keybindings.json once the interactive UI has initialized.
+	 *
+	 * Extensions must use this (or the formatting helpers below) instead of
+	 * importing `getKeybindings()`/`keyText()` from their own copy of the pi
+	 * packages: an extension can resolve a separate module instance whose
+	 * module-local manager never sees the host's `app.*` bindings, so lookups
+	 * come back empty. The host manager is resolved on every call, so do not
+	 * cache the returned instance.
+	 */
+	getKeybindings(): TuiKeybindingsManager;
+
+	/** Bound keys of a keybinding formatted for display (e.g. "ctrl+o"); empty string when unbound. */
+	keyText(keybinding: Keybinding): string;
+
+	/** Like `keyText` with capitalized key parts (e.g. "Ctrl+O"). */
+	keyDisplayText(keybinding: Keybinding): string;
+
+	/** Themed hint combining the bound key and a description (e.g. "ctrl+o to expand"). */
+	keyHint(keybinding: Keybinding, description: string): string;
 
 	// =========================================================================
 	// Model and Thinking Level

--- a/packages/coding-agent/test/suite/regressions/4748-extension-keybindings.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4748-extension-keybindings.test.ts
@@ -1,0 +1,83 @@
+// Regression test for https://github.com/earendil-works/pi/issues/4748
+//
+// Extensions can resolve their own module instance of the pi packages, so the
+// module-local keybindings manager they reach via getKeybindings()/keyText()
+// never sees the host's app.* bindings and lookups come back empty. The
+// ExtensionAPI exposes host-bound keybinding access instead; these tests pin
+// that the API resolves the host manager at call time.
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadExtensions } from "../../../src/core/extensions/loader.ts";
+import type { ExtensionAPI } from "../../../src/core/extensions/types.ts";
+import { KeybindingsManager } from "../../../src/core/keybindings.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+
+interface CaptureState {
+	api?: ExtensionAPI;
+}
+
+function capturedApi(): ExtensionAPI {
+	const state = (globalThis as typeof globalThis & { __keybindingRealmTest?: CaptureState }).__keybindingRealmTest;
+	if (!state?.api) throw new Error("Extension did not capture its API");
+	return state.api;
+}
+
+describe("extension keybinding access (#4748)", () => {
+	let root: string;
+	let previousKeybindings: ReturnType<typeof getKeybindings>;
+
+	beforeEach(async () => {
+		initTheme("dark");
+		previousKeybindings = getKeybindings();
+		root = join(tmpdir(), `pi-keybinding-realm-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(root, { recursive: true });
+		const extensionPath = join(root, "capture.ts");
+		writeFileSync(
+			extensionPath,
+			`export default function (pi) {
+	(globalThis.__keybindingRealmTest ??= {}).api = pi;
+}
+`,
+			"utf-8",
+		);
+		const result = await loadExtensions([extensionPath], root);
+		expect(result.errors).toEqual([]);
+	});
+
+	afterEach(() => {
+		setKeybindings(previousKeybindings);
+		delete (globalThis as typeof globalThis & { __keybindingRealmTest?: CaptureState }).__keybindingRealmTest;
+		if (existsSync(root)) rmSync(root, { recursive: true, force: true });
+	});
+
+	it("resolves app.* bindings through the host manager", () => {
+		setKeybindings(new KeybindingsManager());
+		const api = capturedApi();
+
+		expect(api.keyText("app.tools.expand")).toBe("ctrl+o");
+		expect(api.getKeybindings().getKeys("app.tools.expand")).toEqual(["ctrl+o"]);
+	});
+
+	it("reflects host keybinding changes at call time", () => {
+		const api = capturedApi();
+
+		setKeybindings(new KeybindingsManager());
+		expect(api.keyText("app.tools.expand")).toBe("ctrl+o");
+
+		setKeybindings(new KeybindingsManager({ "app.tools.expand": "ctrl+y" }));
+		expect(api.keyText("app.tools.expand")).toBe("ctrl+y");
+		expect(api.keyDisplayText("app.tools.expand")).toBe("Ctrl+Y");
+	});
+
+	it("formats themed hints with the host's bound key", () => {
+		setKeybindings(new KeybindingsManager());
+		const hint = capturedApi().keyHint("app.tools.expand", "to expand");
+
+		expect(hint).toContain("ctrl+o");
+		expect(hint).toContain("to expand");
+	});
+});


### PR DESCRIPTION
Fixes #4748.

Extensions loaded from their own install can resolve a private copy of the pi packages. That copy's module-local keybindings manager in pi-tui never receives the host's `setKeybindings(merged)`, so `keyText("app.tools.expand")` returns an empty string and hints render as `( to expand)`.

Following the review direction in #7011 (host-owned state should be exposed on the ExtensionAPI instance rather than forced through module resolution), this adds host-bound keybinding access to `ExtensionAPI`:

- `pi.getKeybindings()` - the host's manager, resolved at call time
- `pi.keyText(keybinding)` / `pi.keyDisplayText(keybinding)` - formatted bound keys
- `pi.keyHint(keybinding, description)` - themed key + description hint

Docs updated to route extension keybinding hints through the API instance and warn against importing the module-local helpers.

Regression test: `test/suite/regressions/4748-extension-keybindings.test.ts` loads an extension through the loader and asserts `app.*` bindings resolve through the host manager, including after a `setKeybindings` swap (call-time resolution).

`npm run check` and `./test.sh` pass.

Prepared with AI assistance (Claude); I reviewed the change and understand it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKTAVZntZKG9UoTCZWTQ8h