### PR TITLE
Tolerate non-session entries before the session header

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -545,12 +545,11 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 		closeSync(fd);
 	}
 
-	// Validate session header before repairing the file.
+	// Validate a session header exists before repairing the file. Forks may
+	// prepend non-session entries (e.g. a title record) before the header.
 	if (entries.length === 0) return entries;
-	const header = entries[0];
-	if (header.type !== "session" || typeof (header as { id?: unknown }).id !== "string") {
-		return [];
-	}
+	const header = entries.find((entry) => entry.type === "session" && "id" in entry && typeof entry.id === "string");
+	if (!header) return [];
 
 	if (pending) appendFileSync(resolvedFilePath, "\n");
 	return entries;
@@ -558,14 +557,17 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
 
 /**
  * Inspect a physical line while searching for the first parsed session entry.
- * Blank and malformed lines are skipped to match loadEntriesFromFile().
- * Returns undefined to keep scanning, null for a parsed non-header entry, or the header.
+ * Blank, malformed, and non-header entries are skipped so forks that prepend
+ * metadata lines (e.g. a title record) still resolve their session header.
+ * Returns undefined to keep scanning, or the header.
  */
-function parseSessionHeaderCandidate(line: string): SessionHeader | null | undefined {
+function parseSessionHeaderCandidate(line: string): SessionHeader | undefined {
 	if (!line.trim()) return undefined;
 	const entry = parseSessionEntryLine(line);
 	if (!entry) return undefined;
-	if (entry.type !== "session" || typeof (entry as { id?: unknown }).id !== "string") return null;
+	if (entry.type !== "session" || !("id" in entry) || typeof entry.id !== "string") {
+		return undefined;
+	}
 	return entry;
 }
 
@@ -705,7 +707,9 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			if (!entry) continue;
 
 			if (!header) {
-				if (entry.type !== "session") return null;
+				// Tolerate non-session entries before the header (e.g. a
+				// title record written ahead of it by forks).
+				if (entry.type !== "session") continue;
 				header = entry;
 				continue;
 			}

--- a/packages/coding-agent/test/session-manager/session-header-position.test.ts
+++ b/packages/coding-agent/test/session-manager/session-header-position.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findMostRecentSession, loadEntriesFromFile, SessionManager } from "../../src/core/session-manager.ts";
+
+const SESSION_ID = "0199ffff-0000-7000-8000-000000000001";
+
+describe("entries before the session header", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `session-header-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function writeTitleLine(file: string): void {
+		writeFileSync(
+			file,
+			`${JSON.stringify({
+				type: "title",
+				v: 1,
+				title: "Fork-written title",
+				source: "auto",
+				updatedAt: "2025-01-01T00:00:00Z",
+			})}\n`,
+		);
+	}
+
+	function writeHeaderLine(file: string): void {
+		writeFileSync(
+			file,
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: SESSION_ID,
+				timestamp: "2025-01-01T00:00:00Z",
+				cwd: tempDir,
+			})}\n`,
+			{ flag: "a" },
+		);
+	}
+
+	function writeSessionFile(name: string, { withTitle = true } = {}): string {
+		const file = join(tempDir, name);
+		if (withTitle) writeTitleLine(file);
+		writeHeaderLine(file);
+		return file;
+	}
+
+	it("loadEntriesFromFile reads entries when a title record precedes the header", () => {
+		const file = writeSessionFile("prefixed.jsonl");
+		const entries = loadEntriesFromFile(file);
+		expect(entries.length).toBe(2);
+		expect(entries[0].type).toBe("title");
+		expect(entries[1].type).toBe("session");
+	});
+
+	it("loadEntriesFromFile still rejects files without any session header", () => {
+		const file = join(tempDir, "no-header.jsonl");
+		writeTitleLine(file);
+		writeFileSync(file, `${JSON.stringify({ type: "session_info", name: "x" })}\n`, { flag: "a" });
+		expect(loadEntriesFromFile(file)).toEqual([]);
+	});
+
+	it("findMostRecentSession resolves sessions with pre-header entries", () => {
+		const file = writeSessionFile("2025-01-01T00-00-00-000Z_test.jsonl");
+		expect(findMostRecentSession(tempDir)).toBe(file);
+	});
+
+	it("SessionManager.listAll lists sessions with pre-header entries", async () => {
+		writeSessionFile("2025-01-01T00-00-00-000Z_test.jsonl");
+		const sessions = await SessionManager.listAll(tempDir);
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].id).toBe(SESSION_ID);
+	});
+});


### PR DESCRIPTION
Forks prepend metadata entries (e.g. a title record) ahead of the session header. Discovery previously rejected such files outright: parseSessionHeaderCandidate aborted on the first parsed non-header entry, buildSessionInfo returned null, and loadEntriesFromFile required entries[0] to be the header. Scan past non-session entries instead. Files written by pi always lead with the header, so behavior for them is unchanged; files with no header anywhere are still rejected.