### PR TITLE
docs: add remote OpenAI-compatible provider example to models.md

### DIFF
--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -118,6 +118,27 @@ Use `google-generative-ai` with a `baseUrl` to add models from Google AI Studio,
 
 The `baseUrl` is required when adding custom models to the `google-generative-ai` API type.
 
+## Remote OpenAI-compatible Example
+
+Remote proxies and subscription endpoints work the same way as local servers — set `baseUrl` to the remote host and resolve the key from an environment variable with the `$VAR` syntax:
+
+```json
+{
+  "providers": {
+    "standardcompute": {
+      "baseUrl": "https://api.stdcmpt.com/v1",
+      "api": "openai-completions",
+      "apiKey": "$STANDARD_COMPUTE_KEY",
+      "models": [
+        { "id": "standardcompute" }
+      ]
+    }
+  }
+}
+```
+
+If the endpoint also serves the Anthropic Messages API, you can declare a second provider entry pointing at the same host with `"api": "anthropic-messages"` — useful for comparing how a model behaves across API types. The same pattern applies to self-hosted proxies such as LiteLLM.
+
 ## Supported APIs
 
 | API | Description |


### PR DESCRIPTION
models.md's intro mentions proxies as a use case for custom providers, but all three examples (Ollama minimal, Ollama full, Google AI Studio) cover local servers or first-party APIs. This adds a short **Remote OpenAI-compatible Example** section showing:

- a remote `baseUrl` with the `$VAR` env-key resolution syntax (currently only shown in passing in the Google example)
- a note on declaring the same host twice with `openai-completions` vs `anthropic-messages` when an endpoint serves both API types, and that the pattern applies to self-hosted proxies like LiteLLM

I used a real endpoint I run against (Standard Compute — disclosure: I'm affiliated with it) so the example is verifiable, but happy to swap it for a placeholder host or a LiteLLM example if you prefer — the point is documenting the remote + env-key pattern.

No behavior changes, docs only.