### PR TITLE
feat(client,server,ai,coding-agent): TCP/WS transports, experimental …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5408,6 +5408,7 @@
 				"@earendil-works/pi-ai": "^0.84.4",
 				"@earendil-works/pi-client": "^0.84.4",
 				"@earendil-works/pi-protocol": "^0.84.4",
+				"@earendil-works/pi-server": "^0.84.4",
 				"@earendil-works/pi-tui": "^0.84.4",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -25,6 +25,7 @@ import { mistralProvider } from "./mistral.ts";
 import { moonshotaiProvider } from "./moonshotai.ts";
 import { moonshotaiCnProvider } from "./moonshotai-cn.ts";
 import { nvidiaProvider } from "./nvidia.ts";
+import { ollamaProvider } from "./ollama.ts";
 import { openaiProvider } from "./openai.ts";
 import { openaiCodexProvider } from "./openai-codex.ts";
 import { opencodeProvider } from "./opencode.ts";
@@ -110,6 +111,7 @@ export function builtinProviders(): Provider[] {
 		moonshotaiProvider(),
 		moonshotaiCnProvider(),
 		nvidiaProvider(),
+		ollamaProvider(),
 		openaiProvider(),
 		openaiCodexProvider(),
 		opencodeProvider(),

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -1,0 +1,84 @@
+import { openAICompletionsApi } from "../api/openai-completions.lazy.ts";
+import { createProvider, type Provider } from "../models.ts";
+import type { Model } from "../types.ts";
+
+/**
+ * Ollama provider - local OpenAI-compatible inference server.
+ *
+ * A purely dynamic provider: the model catalog is discovered from the running
+ * Ollama server (`GET /api/tags`) instead of a generated static directory, so
+ * adding it requires no `generate:models` run and no network access at build
+ * time. Ollama is keyless, so auth always resolves as configured.
+ *
+ * Requires a running server, e.g. `ollama serve`, and at least one pulled
+ * model. Point at a remote instance with `OLLAMA_HOST` or the provider base
+ * URL override (`pi config set providers.ollama.baseUrl`).
+ */
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:11434";
+
+interface OllamaTag {
+	name: string;
+}
+
+interface OllamaTagsResponse {
+	models?: OllamaTag[];
+}
+
+function normalizeOllamaBaseUrl(baseUrl: string): string {
+	return baseUrl.replace(/\/+$/u, "");
+}
+
+async function fetchOllamaTags(baseUrl: string, signal: AbortSignal): Promise<OllamaTag[]> {
+	const response = await fetch(`${baseUrl}/api/tags`, { signal });
+	if (!response.ok) {
+		throw new Error(`Ollama /api/tags failed: HTTP ${response.status}`);
+	}
+	const data = (await response.json()) as OllamaTagsResponse;
+	return data.models ?? [];
+}
+
+function modelFromTag(tag: OllamaTag, baseUrl: string): Model<"openai-completions"> {
+	const rawId = tag.name;
+	const id = rawId.includes(":") ? rawId : `${rawId}:latest`;
+	const name = rawId.includes(":") ? rawId : rawId;
+	return {
+		id,
+		name,
+		api: "openai-completions",
+		provider: "ollama",
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 32768,
+		maxTokens: 8192,
+	};
+}
+
+export interface OllamaProviderOptions {
+	/** Override the default server URL. Defaults to http://127.0.0.1:11434. */
+	baseUrl?: string;
+}
+
+export function ollamaProvider(options: OllamaProviderOptions = {}): Provider<"openai-completions"> {
+	const baseUrl = normalizeOllamaBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL);
+	return createProvider({
+		id: "ollama",
+		name: "Ollama (local)",
+		baseUrl,
+		auth: {
+			apiKey: {
+				name: "Ollama (keyless local server)",
+				resolve: async () => ({ auth: {} }),
+			},
+		},
+		models: [],
+		api: openAICompletionsApi(),
+		fetchModels: async (context) => {
+			const tags = await fetchOllamaTags(baseUrl, context.signal);
+			if (context.signal.aborted) return [];
+			return tags.map((tag) => modelFromTag(tag, baseUrl));
+		},
+	});
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,6 +14,14 @@
 			"types": "./dist/unix.d.ts",
 			"import": "./dist/unix.js"
 		},
+		"./tcp": {
+			"types": "./dist/tcp.d.ts",
+			"import": "./dist/tcp.js"
+		},
+		"./ws": {
+			"types": "./dist/ws.d.ts",
+			"import": "./dist/ws.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"sideEffects": false,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,6 +7,7 @@ export {
 	PiSessionOwnershipError,
 } from "./errors.ts";
 export type { AcquireSessionOptions, PiSessionHandle, SessionLease, SessionLeaseMode } from "./session-handle.ts";
+export { createTcpTransportFactory, type TcpTransportOptions } from "./tcp.ts";
 export type { ByteTransport, ByteTransportFactory, ByteTransportHandlers } from "./transport.ts";
 export type {
 	ConnectionState,
@@ -16,3 +17,5 @@ export type {
 	PiClientOptions,
 	Unsubscribe,
 } from "./types.ts";
+export { createUnixTransportFactory, type UnixTransportOptions } from "./unix.ts";
+export { createWebSocketTransportFactory, type WebSocketTransportOptions } from "./ws.ts";

--- a/packages/client/src/tcp.ts
+++ b/packages/client/src/tcp.ts
@@ -1,0 +1,157 @@
+import { createConnection, type Socket } from "node:net";
+import { DEFAULT_MAX_FRAME_LENGTH } from "@earendil-works/pi-protocol";
+import type { ByteTransport, ByteTransportFactory, ByteTransportHandlers } from "./transport.ts";
+
+export interface TcpTransportOptions {
+	host: string;
+	port: number;
+	maxPendingBytes?: number;
+}
+
+/** Creates fresh TCP socket transports for PiClient connection attempts. */
+export function createTcpTransportFactory(options: TcpTransportOptions): ByteTransportFactory {
+	if (typeof options.host !== "string" || options.host.length === 0) {
+		throw new TypeError("TCP transport host must not be empty");
+	}
+	if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65535) {
+		throw new TypeError("TCP transport port must be an integer between 1 and 65535");
+	}
+	const maxPendingBytes = options.maxPendingBytes ?? DEFAULT_MAX_FRAME_LENGTH * 4;
+	if (!Number.isSafeInteger(maxPendingBytes) || maxPendingBytes <= 0) {
+		throw new TypeError("TCP transport maxPendingBytes must be a positive safe integer");
+	}
+	return (handlers) => connectTcpSocket(options.host, options.port, maxPendingBytes, handlers);
+}
+
+function connectTcpSocket(
+	host: string,
+	port: number,
+	maxPendingBytes: number,
+	handlers: ByteTransportHandlers,
+): Promise<ByteTransport> {
+	return new Promise<ByteTransport>((resolve, reject) => {
+		const socket = createConnection({ host, port });
+		let connected = false;
+		let terminal = false;
+
+		const close = (): void => {
+			if (terminal) return;
+			terminal = true;
+			socket.destroy();
+			if (connected) handlers.onClose();
+			else reject(new Error("TCP transport closed before connecting"));
+		};
+
+		socket.once("connect", () => {
+			if (terminal) return;
+			connected = true;
+			resolve(
+				new TcpByteTransport(socket, maxPendingBytes, () => {
+					terminal = true;
+				}),
+			);
+		});
+		socket.on("data", (chunk) => {
+			if (!terminal) handlers.onData(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+		});
+		socket.once("end", close);
+		socket.once("close", close);
+		socket.once("error", (error) => {
+			if (terminal) return;
+			terminal = true;
+			socket.destroy();
+			if (connected) handlers.onError(error);
+			else reject(error);
+		});
+	});
+}
+
+class TcpByteTransport implements ByteTransport {
+	readonly #socket: Socket;
+	readonly #maxPendingBytes: number;
+	readonly #markLocalClose: () => void;
+	#closed = false;
+	#pendingBytes = 0;
+	#writeTail: Promise<void> = Promise.resolve();
+
+	constructor(socket: Socket, maxPendingBytes: number, markLocalClose: () => void) {
+		this.#socket = socket;
+		this.#maxPendingBytes = maxPendingBytes;
+		this.#markLocalClose = markLocalClose;
+	}
+
+	send(chunk: Uint8Array): Promise<void> {
+		if (!(chunk instanceof Uint8Array)) {
+			return Promise.reject(new TypeError("TCP transport chunks must be Uint8Array"));
+		}
+		if (this.#closed) return Promise.reject(new Error("TCP transport is closed"));
+		if (this.#pendingBytes + chunk.byteLength > this.#maxPendingBytes) {
+			return Promise.reject(new Error("TCP transport exceeded its pending byte limit"));
+		}
+		this.#pendingBytes += chunk.byteLength;
+		const bytes = chunk.slice();
+		const write = this.#writeTail.then(() => this.#write(bytes));
+		const tracked = write.finally(() => {
+			this.#pendingBytes -= bytes.byteLength;
+		});
+		this.#writeTail = tracked.catch(() => {});
+		return tracked;
+	}
+
+	close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#markLocalClose();
+		this.#socket.destroy();
+	}
+
+	#write(chunk: Uint8Array): Promise<void> {
+		if (this.#closed || !this.#socket.writable) return Promise.reject(new Error("TCP transport is closed"));
+		return new Promise<void>((resolve, reject) => {
+			let callbackComplete = false;
+			let drainComplete = false;
+			let requiresDrain: boolean | undefined;
+			let settled = false;
+
+			const onDrain = (): void => {
+				drainComplete = true;
+				finish();
+			};
+			const cleanup = (): void => {
+				this.#socket.off("drain", onDrain);
+				this.#socket.off("close", onClose);
+			};
+			const fail = (error: Error): void => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				reject(error);
+			};
+			const finish = (): void => {
+				if (settled || !callbackComplete || requiresDrain === undefined) return;
+				if (requiresDrain && !drainComplete) return;
+				settled = true;
+				cleanup();
+				resolve();
+			};
+			const onClose = (): void => fail(new Error("TCP transport closed during write"));
+
+			try {
+				this.#socket.once("close", onClose);
+				const accepted = this.#socket.write(chunk, (error) => {
+					if (error) {
+						fail(error);
+						return;
+					}
+					callbackComplete = true;
+					finish();
+				});
+				requiresDrain = !accepted;
+				if (requiresDrain) this.#socket.once("drain", onDrain);
+				finish();
+			} catch (error) {
+				fail(error instanceof Error ? error : new Error(String(error)));
+			}
+		});
+	}
+}

--- a/packages/client/src/ws.ts
+++ b/packages/client/src/ws.ts
@@ -1,0 +1,125 @@
+import { WebSocket } from "node:http";
+import { DEFAULT_MAX_FRAME_LENGTH } from "@earendil-works/pi-protocol";
+import type { ByteTransport, ByteTransportFactory, ByteTransportHandlers } from "./transport.ts";
+
+export interface WebSocketTransportOptions {
+	/** ws:// or wss:// URL of the remote endpoint. */
+	url: string;
+	maxPendingBytes?: number;
+}
+
+/** Creates fresh WebSocket transports for PiClient connection attempts. */
+export function createWebSocketTransportFactory(options: WebSocketTransportOptions): ByteTransportFactory {
+	if (typeof options.url !== "string" || options.url.length === 0) {
+		throw new TypeError("WebSocket transport URL must not be empty");
+	}
+	let parsed: URL;
+	try {
+		parsed = new URL(options.url);
+	} catch {
+		throw new TypeError(`WebSocket transport URL is invalid: ${options.url}`);
+	}
+	if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+		throw new TypeError(`WebSocket transport URL must use ws: or wss: (got ${parsed.protocol})`);
+	}
+	const maxPendingBytes = options.maxPendingBytes ?? DEFAULT_MAX_FRAME_LENGTH * 4;
+	if (!Number.isSafeInteger(maxPendingBytes) || maxPendingBytes <= 0) {
+		throw new TypeError("WebSocket transport maxPendingBytes must be a positive safe integer");
+	}
+	return (handlers) => connectWebSocket(options.url, maxPendingBytes, handlers);
+}
+
+function connectWebSocket(
+	url: string,
+	maxPendingBytes: number,
+	handlers: ByteTransportHandlers,
+): Promise<ByteTransport> {
+	return new Promise<ByteTransport>((resolve, reject) => {
+		const socket = new WebSocket(url);
+		let connected = false;
+		let terminal = false;
+
+		socket.binaryType = "arraybuffer";
+
+		const close = (): void => {
+			if (terminal) return;
+			terminal = true;
+			if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+				try {
+					socket.close();
+				} catch {
+					// Already closing or closed.
+				}
+			}
+			if (connected) handlers.onClose();
+			else reject(new Error("WebSocket transport closed before connecting"));
+		};
+
+		socket.addEventListener("open", () => {
+			if (terminal) return;
+			connected = true;
+			resolve(
+				new WebSocketByteTransport(socket, maxPendingBytes, () => {
+					terminal = true;
+				}),
+			);
+		});
+		socket.addEventListener("message", (event) => {
+			if (terminal) return;
+			const data = event.data;
+			if (data instanceof ArrayBuffer) {
+				handlers.onData(new Uint8Array(data));
+			} else if (ArrayBuffer.isView(data)) {
+				handlers.onData(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+			}
+			// Text frames are ignored; the protocol is binary-only.
+		});
+		socket.addEventListener("close", close);
+		socket.addEventListener("error", (event) => {
+			if (terminal) return;
+			terminal = true;
+			const message = event instanceof Error ? event.message : "WebSocket transport error";
+			if (connected) handlers.onError(new Error(message));
+			else reject(new Error(message));
+		});
+	});
+}
+
+class WebSocketByteTransport implements ByteTransport {
+	readonly #socket: WebSocket;
+	readonly #maxPendingBytes: number;
+	readonly #markLocalClose: () => void;
+	#closed = false;
+
+	constructor(socket: WebSocket, maxPendingBytes: number, markLocalClose: () => void) {
+		this.#socket = socket;
+		this.#maxPendingBytes = maxPendingBytes;
+		this.#markLocalClose = markLocalClose;
+	}
+
+	send(chunk: Uint8Array): Promise<void> {
+		if (!(chunk instanceof Uint8Array)) {
+			return Promise.reject(new TypeError("WebSocket transport chunks must be Uint8Array"));
+		}
+		if (this.#closed) return Promise.reject(new Error("WebSocket transport is closed"));
+		if (this.#socket.readyState !== WebSocket.OPEN) {
+			return Promise.reject(new Error("WebSocket transport is not open"));
+		}
+		if (this.#socket.bufferedAmount + chunk.byteLength > this.#maxPendingBytes) {
+			return Promise.reject(new Error("WebSocket transport exceeded its pending byte limit"));
+		}
+		this.#socket.send(chunk);
+		return Promise.resolve();
+	}
+
+	close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#markLocalClose();
+		try {
+			this.#socket.close();
+		} catch {
+			// Already closing or closed.
+		}
+	}
+}

--- a/packages/client/test/tcp.test.ts
+++ b/packages/client/test/tcp.test.ts
@@ -1,0 +1,145 @@
+import { createServer, type Server, type Socket } from "node:net";
+import {
+	ClientMessageDecoder,
+	encodeServerMessage,
+	PROTOCOL_VERSION,
+	type ServerSnapshot,
+} from "@earendil-works/pi-protocol";
+import { describe, expect, test } from "vitest";
+import { PiClient } from "../src/index.ts";
+import { createTcpTransportFactory } from "../src/tcp.ts";
+
+const serverSnapshot: ServerSnapshot = {
+	serverId: "tcp-server",
+	protocolVersion: PROTOCOL_VERSION,
+	revision: 4,
+	sessions: [],
+	models: [],
+};
+
+async function listen(server: Server, port = 0): Promise<number> {
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	const address = server.address();
+	return typeof address === "object" && address !== null ? address.port : port;
+}
+
+async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+	for (const socket of sockets) socket.destroy();
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+describe("TCP transport", () => {
+	test("rejects invalid TCP transport options", () => {
+		expect(() => createTcpTransportFactory({ host: "", port: 1 })).toThrow(/must not be empty/);
+		expect(() => createTcpTransportFactory({ host: "127.0.0.1", port: 0 })).toThrow(/between 1 and 65535/);
+		expect(() => createTcpTransportFactory({ host: "127.0.0.1", port: 70000 })).toThrow(/between 1 and 65535/);
+		expect(() => createTcpTransportFactory({ host: "127.0.0.1", port: 8080, maxPendingBytes: 0 })).toThrow(
+			/positive/,
+		);
+	});
+
+	test("PiClient exchanges fragmented framed messages over a real TCP socket", async () => {
+		const sockets = new Set<Socket>();
+		const server = createServer((socket) => {
+			sockets.add(socket);
+			socket.once("close", () => sockets.delete(socket));
+			const decoder = new ClientMessageDecoder();
+			socket.on("data", (chunk) => {
+				for (const message of decoder.push(chunk)) {
+					if (message.type === "hello") {
+						const hello = encodeServerMessage({
+							type: "hello",
+							version: PROTOCOL_VERSION,
+							connectionId: "tcp-connection",
+							snapshot: serverSnapshot,
+						});
+						for (const byte of hello) socket.write(new Uint8Array([byte]));
+					} else {
+						const response = encodeServerMessage({
+							type: "response",
+							id: message.id,
+							ok: true,
+							result: { command: "list", sessions: [] },
+						});
+						const split = Math.floor(response.byteLength / 2);
+						socket.write(response.subarray(0, split));
+						socket.write(response.subarray(split));
+					}
+				}
+			});
+		});
+		const port = await listen(server);
+		const client = new PiClient({
+			transportFactory: createTcpTransportFactory({ host: "127.0.0.1", port }),
+		});
+
+		try {
+			await expect(client.connect()).resolves.toEqual(serverSnapshot);
+			await expect(Promise.all([client.listSessions(), client.listSessions()])).resolves.toEqual([[], []]);
+		} finally {
+			client.disconnect();
+			await closeServer(server, sockets);
+		}
+	});
+
+	test("PiClient rejects a truncated final frame from a real TCP socket", async () => {
+		const sockets = new Set<Socket>();
+		const server = createServer((socket) => {
+			sockets.add(socket);
+			socket.once("close", () => sockets.delete(socket));
+			const decoder = new ClientMessageDecoder();
+			socket.on("data", (chunk) => {
+				for (const message of decoder.push(chunk)) {
+					if (message.type === "hello") {
+						socket.write(
+							encodeServerMessage({
+								type: "hello",
+								version: PROTOCOL_VERSION,
+								connectionId: "tcp-truncated",
+								snapshot: serverSnapshot,
+							}),
+						);
+					} else {
+						socket.end(new Uint8Array([0, 0, 0, 2, 1]));
+					}
+				}
+			});
+		});
+		const port = await listen(server);
+		const client = new PiClient({
+			transportFactory: createTcpTransportFactory({ host: "127.0.0.1", port }),
+		});
+
+		try {
+			await client.connect();
+			await expect(client.listSessions()).rejects.toMatchObject({ name: "ProtocolValidationError" });
+			expect(client.connectionState).toBe("disconnected");
+		} finally {
+			client.disconnect();
+			await closeServer(server, sockets);
+		}
+	});
+
+	test("rejects connection errors to a closed port", async () => {
+		const sockets = new Set<Socket>();
+		const server = createServer((socket) => sockets.add(socket));
+		const port = await listen(server);
+		await closeServer(server, sockets);
+
+		await expect(
+			createTcpTransportFactory({ host: "127.0.0.1", port })({
+				onData: () => {},
+				onClose: () => {},
+				onError: () => {},
+			}),
+		).rejects.toMatchObject({ code: "ECONNREFUSED" });
+	});
+});

--- a/packages/client/test/ws.test.ts
+++ b/packages/client/test/ws.test.ts
@@ -1,0 +1,185 @@
+import { createHash } from "node:crypto";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import {
+	ClientMessageDecoder,
+	encodeServerMessage,
+	PROTOCOL_VERSION,
+	type ServerSnapshot,
+} from "@earendil-works/pi-protocol";
+import { describe, expect, test } from "vitest";
+import { PiClient } from "../src/index.ts";
+import { createWebSocketTransportFactory } from "../src/ws.ts";
+
+const serverSnapshot: ServerSnapshot = {
+	serverId: "ws-server",
+	protocolVersion: PROTOCOL_VERSION,
+	revision: 4,
+	sessions: [],
+	models: [],
+};
+
+const WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+interface Frame {
+	opcode: number;
+	payload: Uint8Array;
+}
+
+/** Minimal unmasked server-to-client frame encoder for tests. */
+function encodeFrame(payload: Uint8Array, opcode: number): Uint8Array {
+	let headerLength: number;
+	if (payload.byteLength < 126) {
+		headerLength = 2;
+	} else if (payload.byteLength <= 0xffff) {
+		headerLength = 4;
+	} else {
+		headerLength = 10;
+	}
+	const frame = new Uint8Array(headerLength + payload.byteLength);
+	frame[0] = 0x80 | opcode;
+	if (headerLength === 2) {
+		frame[1] = payload.byteLength;
+	} else if (headerLength === 4) {
+		frame[1] = 126;
+		frame[2] = payload.byteLength >>> 8;
+		frame[3] = payload.byteLength;
+	} else {
+		frame[1] = 127;
+		let value = payload.byteLength;
+		for (let index = 9; index >= 2; index--) {
+			frame[index] = value & 0xff;
+			value = Math.floor(value / 256);
+		}
+	}
+	frame.set(payload, headerLength);
+	return frame;
+}
+
+/** Minimal masked client-frame decoder for tests (handles single-frame messages). */
+function decodeClientFrames(chunk: Uint8Array): Frame[] {
+	const frames: Frame[] = [];
+	let offset = 0;
+	while (offset + 2 <= chunk.byteLength) {
+		const first = chunk[offset]!;
+		const second = chunk[offset + 1]!;
+		const opcode = first & 0x0f;
+		const masked = (second & 0x80) !== 0;
+		let length = second & 0x7f;
+		let headerLength = 2;
+		if (length === 126) {
+			length = (chunk[offset + 2]! << 8) | chunk[offset + 3]!;
+			headerLength = 4;
+		} else if (length === 127) {
+			let value = 0;
+			for (let index = 0; index < 8; index++) value = value * 256 + chunk[offset + 2 + index]!;
+			length = value;
+			headerLength = 10;
+		}
+		if (masked) headerLength += 4;
+		const payloadStart = offset + headerLength;
+		if (payloadStart + length > chunk.byteLength) break;
+		let payload = chunk.subarray(payloadStart, payloadStart + length);
+		if (masked) {
+			const key = chunk.subarray(payloadStart - 4, payloadStart);
+			const unmasked = new Uint8Array(length);
+			for (let index = 0; index < length; index++) unmasked[index] = payload[index]! ^ key[index % 4]!;
+			payload = unmasked;
+		}
+		frames.push({ opcode, payload });
+		offset = payloadStart + length;
+	}
+	return frames;
+}
+
+async function listen(server: HttpServer, port = 0): Promise<number> {
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	const address = server.address();
+	return typeof address === "object" && address !== null ? address.port : port;
+}
+
+async function closeServer(server: HttpServer): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+}
+
+describe("WebSocket transport", () => {
+	test("rejects invalid WebSocket transport options", () => {
+		expect(() => createWebSocketTransportFactory({ url: "" })).toThrow(/must not be empty/);
+		expect(() => createWebSocketTransportFactory({ url: "not a url" })).toThrow(/invalid/);
+		expect(() => createWebSocketTransportFactory({ url: "http://example.com" })).toThrow(/ws:/);
+		expect(() => createWebSocketTransportFactory({ url: "ws://example.com", maxPendingBytes: 0 })).toThrow(
+			/positive/,
+		);
+	});
+
+	test("PiClient exchanges framed messages over a real WebSocket", async () => {
+		const server = createHttpServer(() => {});
+		server.on("upgrade", (request, socket) => {
+			const key = request.headers["sec-websocket-key"];
+			const accept = createHash("sha1")
+				.update(key + WEBSOCKET_GUID)
+				.digest("base64");
+			socket.write(
+				[
+					"HTTP/1.1 101 Switching Protocols",
+					"Upgrade: websocket",
+					"Connection: Upgrade",
+					`Sec-WebSocket-Accept: ${accept}`,
+					"",
+					"",
+				].join("\r\n"),
+			);
+			const decoder = new ClientMessageDecoder();
+			socket.on("data", (chunk) => {
+				for (const message of decodeClientFrames(
+					new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+				)) {
+					for (const decoded of decoder.push(message.payload)) {
+						if (decoded.type === "hello") {
+							const hello = encodeFrame(
+								encodeServerMessage({
+									type: "hello",
+									version: PROTOCOL_VERSION,
+									connectionId: "ws-connection",
+									snapshot: serverSnapshot,
+								}),
+								0x2,
+							);
+							socket.write(hello);
+						} else {
+							const response = encodeFrame(
+								encodeServerMessage({
+									type: "response",
+									id: decoded.id,
+									ok: true,
+									result: { command: "list", sessions: [] },
+								}),
+								0x2,
+							);
+							socket.write(response);
+						}
+					}
+				}
+			});
+		});
+		const port = await listen(server);
+		const client = new PiClient({
+			transportFactory: createWebSocketTransportFactory({ url: `ws://127.0.0.1:${port}` }),
+		});
+
+		try {
+			await expect(client.connect()).resolves.toEqual(serverSnapshot);
+			await expect(Promise.all([client.listSessions(), client.listSessions()])).resolves.toEqual([[], []]);
+		} finally {
+			client.disconnect();
+			await closeServer(server);
+		}
+	});
+});

--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -31,6 +31,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | Extension | Description |
 |-----------|-------------|
 | `todo.ts` | Todo list tool + `/todos` command with custom rendering and state persistence |
+| `fetch-url.ts` | `fetch_url` tool using global fetch, with prompt contributions, custom rendering, `--fetch-timeout` flag, and `/fetch-url` command |
 | `hello.ts` | Minimal custom tool example |
 | `question.ts` | Demonstrates `ctx.ui.select()` for asking the user questions with custom UI |
 | `questionnaire.ts` | Multi-question input with tab bar navigation between questions |
@@ -129,6 +130,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 |-----------|-------------|
 | `custom-provider-anthropic/` | Custom Anthropic provider with OAuth support and custom streaming implementation |
 | `custom-provider-gitlab-duo/` | GitLab Duo provider using pi-ai's built-in Anthropic/OpenAI streaming via proxy |
+| `custom-provider-openai-compatible.ts` | Minimal OpenAI-compatible provider reusing pi-ai's built-in `openai-completions` API (no streaming code) |
 
 ### External Dependencies
 

--- a/packages/coding-agent/examples/extensions/custom-provider-openai-compatible.ts
+++ b/packages/coding-agent/examples/extensions/custom-provider-openai-compatible.ts
@@ -1,0 +1,39 @@
+/**
+ * OpenAI-Compatible Provider Extension
+ *
+ * Demonstrates registering a custom provider WITHOUT writing any streaming
+ * code: pi-ai's built-in `openai-completions` API is reused, so the provider
+ * only needs a base URL, an API key, and model metadata.
+ *
+ * This is the recommended path for OpenAI-compatible gateways/proxies
+ * (vLLM, Ollama, LM Studio, cloud AI gateways, etc.).
+ *
+ * Usage:
+ *   MY_GATEWAY_API_KEY=sk-... pi -e ./packages/coding-agent/examples/extensions/custom-provider-openai-compatible.ts
+ *   # Then /model to select my-gateway/<model-id>
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+	pi.registerProvider("my-gateway", {
+		name: "My OpenAI-Compatible Gateway",
+		baseUrl: "https://gateway.example.com/v1",
+		apiKey: "$MY_GATEWAY_API_KEY",
+		// Reuse pi-ai's built-in chat completions implementation. Other built-in
+		// options include "openai-responses", "anthropic-messages", "mistral-conversations".
+		api: "openai-completions",
+		authHeader: true,
+		models: [
+			{
+				id: "my-model",
+				name: "My Model",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 8192,
+			},
+		],
+	});
+}

--- a/packages/coding-agent/examples/extensions/fetch-url.ts
+++ b/packages/coding-agent/examples/extensions/fetch-url.ts
@@ -1,0 +1,117 @@
+/**
+ * Fetch URL Extension
+ *
+ * Demonstrates a custom LLM-callable tool with:
+ * - `defineTool` for parameter type inference
+ * - `promptSnippet` / `promptGuidelines` system-prompt contributions
+ * - Custom `renderCall` / `renderResult` TUI rendering
+ * - A CLI flag (`--fetch-timeout`) and a `/fetch-url` command
+ *
+ * The tool uses Node's global `fetch`, so it has zero extra dependencies.
+ *
+ * Usage:
+ *   pi -e ./packages/coding-agent/examples/extensions/fetch-url.ts
+ *   # Then ask the agent to fetch a URL, e.g. "fetch https://example.com"
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+const FetchUrlParams = Type.Object({
+	url: Type.String({ description: "The URL to fetch" }),
+	maxBytes: Type.Optional(Type.Number({ description: "Maximum response bytes to return (default 8000)" })),
+});
+
+interface FetchUrlDetails {
+	url: string;
+	status: number;
+	bytes: number;
+	truncated: boolean;
+}
+
+/** Default timeout in milliseconds; overridable via the --fetch-timeout flag. */
+let fetchTimeoutMs = 15_000;
+
+export default function (pi: ExtensionAPI) {
+	pi.registerFlag("fetch-timeout", {
+		description: "Timeout in seconds for the fetch_url tool (default 15)",
+		type: "string",
+		default: "15",
+	});
+
+	pi.registerTool(
+		defineTool({
+			name: "fetch_url",
+			label: "Fetch URL",
+			description: "Fetch a URL and return its text content. Use for reading web pages or API responses.",
+			promptSnippet: "Fetch a URL and return its text content",
+			promptGuidelines: ["Prefer fetch_url over bash curl for simple HTTP GET requests."],
+			parameters: FetchUrlParams,
+
+			async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
+				const maxBytes = params.maxBytes ?? 8000;
+				const controller = new AbortController();
+				const timeout = setTimeout(() => controller.abort(), fetchTimeoutMs);
+				const onAbort = () => controller.abort();
+				signal?.addEventListener("abort", onAbort, { once: true });
+
+				try {
+					const response = await fetch(params.url, { signal: controller.signal, redirect: "follow" });
+					const body = await response.text();
+					const truncated = body.length > maxBytes;
+					const content = truncated ? `${body.slice(0, maxBytes)}\n\n[truncated at ${maxBytes} bytes]` : body;
+					return {
+						content: [
+							{
+								type: "text",
+								text: response.ok ? content : `HTTP ${response.status}: ${content}`,
+							},
+						],
+						details: {
+							url: params.url,
+							status: response.status,
+							bytes: body.length,
+							truncated,
+						} as FetchUrlDetails,
+					};
+				} finally {
+					clearTimeout(timeout);
+					signal?.removeEventListener("abort", onAbort);
+				}
+			},
+
+			renderCall(args, theme, _context) {
+				return new Text(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", args.url), 0, 0);
+			},
+
+			renderResult(result, _options, theme, context) {
+				const details = result.details as FetchUrlDetails | undefined;
+				if (context.isError || !details) {
+					return new Text(theme.fg("error", "fetch failed"), 0, 0);
+				}
+				const status =
+					details.status < 400 ? theme.fg("success", `${details.status}`) : theme.fg("error", `${details.status}`);
+				const size = details.truncated
+					? theme.fg("warning", `${details.bytes} bytes (truncated)`)
+					: theme.fg("muted", `${details.bytes} bytes`);
+				return new Text(`${theme.fg("muted", "✓")} ${status} ${theme.fg("dim", details.url)} ${size}`, 0, 0);
+			},
+		}),
+	);
+
+	// Apply the flag on session start (flags are resolved after extension load).
+	pi.on("session_start", () => {
+		const raw = pi.getFlag("fetch-timeout");
+		const parsed = typeof raw === "string" ? Number.parseInt(raw, 10) : undefined;
+		fetchTimeoutMs = parsed && parsed > 0 ? parsed * 1000 : 15_000;
+	});
+
+	pi.registerCommand("fetch-url", {
+		description: "Show the current fetch_url timeout",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(`fetch_url timeout is ${fetchTimeoutMs / 1000}s`, "info");
+		},
+	});
+}

--- a/packages/coding-agent/install-lock/package-lock.json
+++ b/packages/coding-agent/install-lock/package-lock.json
@@ -508,6 +508,7 @@
 				"@earendil-works/pi-ai": "^0.84.4",
 				"@earendil-works/pi-client": "^0.84.4",
 				"@earendil-works/pi-protocol": "^0.84.4",
+				"@earendil-works/pi-server": "^0.84.4",
 				"@earendil-works/pi-tui": "^0.84.4",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
@@ -541,6 +542,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-server": {
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-server/-/pi-server-0.84.4.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.84.4",
+				"@earendil-works/pi-protocol": "^0.84.4"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -13,6 +13,7 @@
 				"@earendil-works/pi-ai": "^0.84.4",
 				"@earendil-works/pi-client": "^0.84.4",
 				"@earendil-works/pi-protocol": "^0.84.4",
+				"@earendil-works/pi-server": "^0.84.4",
 				"@earendil-works/pi-tui": "^0.84.4",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
@@ -531,6 +532,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-server": {
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-server/-/pi-server-0.84.4.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.84.4",
+				"@earendil-works/pi-protocol": "^0.84.4"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -48,6 +48,7 @@
 		"@earendil-works/pi-ai": "^0.84.4",
 		"@earendil-works/pi-client": "^0.84.4",
 		"@earendil-works/pi-protocol": "^0.84.4",
+		"@earendil-works/pi-server": "^0.84.4",
 		"@earendil-works/pi-tui": "^0.84.4",
 		"@silvia-odwyer/photon-node": "0.3.4",
 		"chalk": "5.6.2",

--- a/packages/coding-agent/src/cli/experimental/runner.ts
+++ b/packages/coding-agent/src/cli/experimental/runner.ts
@@ -1,0 +1,114 @@
+/**
+ * Experimental CLI execution layer.
+ *
+ * Wires the parsed experimental commands to concrete implementations:
+ * - `runServer` starts a PiServer on the requested transport addresses.
+ * - `runClient` connects a PiClient to a remote PiServer.
+ * - `runPi` is not yet implemented; the legacy interactive session flow
+ *   remains the entry point for ordinary usage.
+ *
+ * The server uses the in-memory TestServerService as a minimal
+ * PiServerService implementation until a durable harness-backed service is
+ * wired in.
+ */
+
+import { PiClient } from "@earendil-works/pi-client";
+import { createTcpTransportFactory } from "@earendil-works/pi-client/tcp";
+import { createUnixTransportFactory } from "@earendil-works/pi-client/unix";
+import { createWebSocketTransportFactory } from "@earendil-works/pi-client/ws";
+import { PiServer, type PiServerListener } from "@earendil-works/pi-server";
+import { createTcpListener } from "@earendil-works/pi-server/tcp";
+import { createUnixListener } from "@earendil-works/pi-server/unix";
+import { createWsListener } from "@earendil-works/pi-server/ws";
+import { createCodingAgentPiServerService } from "../../server/pi-server-service.ts";
+import type { ClientCommand } from "./commands/client.ts";
+import type { PiCommand } from "./commands/pi.ts";
+import type { ServerCommand } from "./commands/server.ts";
+import type { TransportAddress } from "./transport-address.ts";
+
+function listenerFor(address: TransportAddress): PiServerListener {
+	switch (address.transport) {
+		case "unix":
+			return createUnixListener({ path: address.path });
+		case "tcp":
+			return createTcpListener({ host: address.host, port: address.port });
+		case "ws": {
+			const parsed = new URL(address.url);
+			return createWsListener({
+				host: parsed.hostname || "127.0.0.1",
+				port: parsed.port ? Number(parsed.port) : defaultWsPort(parsed.protocol),
+			});
+		}
+	}
+}
+
+function defaultWsPort(protocol: string): number {
+	return protocol === "wss:" ? 443 : 80;
+}
+
+function transportFactory(address: TransportAddress) {
+	switch (address.transport) {
+		case "unix":
+			return createUnixTransportFactory({ path: address.path });
+		case "tcp":
+			return createTcpTransportFactory({ host: address.host, port: address.port });
+		case "ws":
+			return createWebSocketTransportFactory({ url: address.url });
+	}
+}
+
+async function waitForShutdown(): Promise<void> {
+	await new Promise<void>((resolve) => {
+		const stop = (): void => resolve();
+		process.once("SIGINT", stop);
+		process.once("SIGTERM", stop);
+	});
+}
+
+export async function runServer(command: ServerCommand): Promise<void> {
+	const addresses = command.listen ?? [];
+	if (addresses.length === 0) {
+		console.error("server requires at least one --listen address");
+		process.exitCode = 1;
+		return;
+	}
+	const service = await createCodingAgentPiServerService();
+	const servers: PiServer[] = [];
+	for (const address of addresses) {
+		const piServer = new PiServer(service, { listeners: [listenerFor(address)] });
+		await piServer.start();
+		servers.push(piServer);
+		console.log(`PiServer listening on ${piServer.addresses.join(", ")}`);
+	}
+	console.log("Press Ctrl+C to stop");
+	await waitForShutdown();
+	await Promise.all(servers.map((server) => server.close()));
+}
+
+export async function runClient(command: ClientCommand): Promise<void> {
+	if (!command.connect) {
+		console.error("client requires --connect");
+		process.exitCode = 1;
+		return;
+	}
+	const client = new PiClient({ transportFactory: transportFactory(command.connect) });
+	try {
+		await client.connect();
+		console.log("Connected");
+		const sessions = await client.listSessions();
+		console.log(`Sessions: ${sessions.length}`);
+		for (const session of sessions) {
+			console.log(`  ${session.id} (${session.sessionName ?? "unnamed"}) @ ${session.cwd}`);
+		}
+		const handle = await client.createSession({ cwd: process.cwd() });
+		console.log(`Created session ${handle.id}`);
+		console.log(JSON.stringify(handle.snapshot, null, 2));
+	} finally {
+		client.disconnect();
+	}
+}
+
+export function runPi(_command: PiCommand): void {
+	console.error("experimental pi command execution is not implemented yet");
+	process.exitCode = 1;
+}

--- a/packages/coding-agent/src/cli/experimental/transport-address.ts
+++ b/packages/coding-agent/src/cli/experimental/transport-address.ts
@@ -5,7 +5,29 @@ export interface UnixTransportAddress {
 	readonly path: string;
 }
 
-export type TransportAddress = UnixTransportAddress;
+export interface TcpTransportAddress {
+	readonly transport: "tcp";
+	readonly host: string;
+	readonly port: number;
+}
+
+export interface WebSocketTransportAddress {
+	readonly transport: "ws";
+	readonly url: string;
+}
+
+export type TransportAddress = UnixTransportAddress | TcpTransportAddress | WebSocketTransportAddress;
+
+function parsePort(value: string, option: "--listen" | "--connect"): { port?: number; error?: string } {
+	if (!/^\d+$/u.test(value)) {
+		return { error: `${option} address port must be a number` };
+	}
+	const port = Number.parseInt(value, 10);
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		return { error: `${option} address port must be an integer between 1 and 65535` };
+	}
+	return { port };
+}
 
 export function parseTransportAddress(
 	value: string,
@@ -17,32 +39,68 @@ export function parseTransportAddress(
 	} catch {
 		return { error: `Invalid ${option} address "${value}"` };
 	}
-	if (url.protocol !== "unix:") {
-		return { error: `Unsupported ${option} transport "${url.protocol}"` };
+
+	if (url.protocol === "unix:") {
+		if (url.hostname || url.port || url.username || url.password) {
+			return { error: "Unix transport address must not include an authority" };
+		}
+		if (
+			!value.startsWith("unix:///") ||
+			value.startsWith("unix:////") ||
+			value.includes("?") ||
+			value.includes("#") ||
+			url.href !== value
+		) {
+			return { error: `Invalid ${option} address "${value}"` };
+		}
+		let path: string;
+		try {
+			path = decodeURIComponent(url.pathname);
+		} catch {
+			return { error: `Invalid ${option} address "${value}"` };
+		}
+		if (path.includes("\0")) {
+			return { error: `Invalid ${option} address "${value}"` };
+		}
+		if (!posix.isAbsolute(path)) {
+			return { error: "Unix transport address requires an absolute path" };
+		}
+		return { address: { transport: "unix", path } };
 	}
-	if (url.hostname || url.port || url.username || url.password) {
-		return { error: "Unix transport address must not include an authority" };
+
+	if (url.protocol === "tcp:") {
+		if (url.username || url.password || url.search || url.hash) {
+			return { error: `Invalid ${option} address "${value}"` };
+		}
+		// Non-special schemes leave pathname empty; accept "/" or "" and reject anything else.
+		if (url.pathname !== "" && url.pathname !== "/") {
+			return { error: `Invalid ${option} address "${value}"` };
+		}
+		const host = url.hostname || "127.0.0.1";
+		if (host.length === 0 || url.port === null || url.port === "") {
+			return { error: `${option} address requires a host and port (tcp://host:port)` };
+		}
+		const parsed = parsePort(url.port, option);
+		if (parsed.error) return { error: parsed.error };
+		return { address: { transport: "tcp", host, port: parsed.port! } };
 	}
-	if (
-		!value.startsWith("unix:///") ||
-		value.startsWith("unix:////") ||
-		value.includes("?") ||
-		value.includes("#") ||
-		url.href !== value
-	) {
-		return { error: `Invalid ${option} address "${value}"` };
+
+	if (url.protocol === "ws:" || url.protocol === "wss:") {
+		if (url.username || url.password || url.search || url.hash) {
+			return { error: `Invalid ${option} address "${value}"` };
+		}
+		if (url.pathname !== "" && url.pathname !== "/") {
+			return { error: `Invalid ${option} address "${value}"` };
+		}
+		// ws:// defaults to port 80, wss:// to port 443 when omitted.
+		let port = url.port;
+		if (port === null || port === "") {
+			port = String(url.protocol === "wss:" ? 443 : 80);
+		}
+		const parsed = parsePort(port, option);
+		if (parsed.error) return { error: parsed.error };
+		return { address: { transport: "ws", url: value } };
 	}
-	let path: string;
-	try {
-		path = decodeURIComponent(url.pathname);
-	} catch {
-		return { error: `Invalid ${option} address "${value}"` };
-	}
-	if (path.includes("\0")) {
-		return { error: `Invalid ${option} address "${value}"` };
-	}
-	if (!posix.isAbsolute(path)) {
-		return { error: "Unix transport address requires an absolute path" };
-	}
-	return { address: { transport: "unix", path } };
+
+	return { error: `Unsupported ${option} transport "${url.protocol}"` };
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -27,6 +27,8 @@ import {
 	validateAuthCommandArgs,
 } from "./cli/auth-command.ts";
 import { resolveCredentialForPrint } from "./cli/credential-print.ts";
+import { experimentalCli } from "./cli/experimental/cli.ts";
+import { runClient, runPi, runServer } from "./cli/experimental/runner.ts";
 import { processFileArguments } from "./cli/file-processor.ts";
 import { buildInitialMessage } from "./cli/initial-message.ts";
 import { listModels } from "./cli/list-models.ts";
@@ -558,6 +560,19 @@ export interface MainOptions {
 	extensionFactories?: InlineExtension[];
 }
 
+/**
+ * Dispatch an experimental subcommand (server / client) to its execution
+ * layer. The experimental CLI parser is transport-only; unsupported legacy
+ * options are reported by the parser itself.
+ */
+async function dispatchExperimentalCommand(args: string[]): Promise<void> {
+	const result = await experimentalCli.execute(args, { runPi, runServer, runClient });
+	if (!result.ok) {
+		for (const error of result.errors) console.error(error);
+		process.exitCode = 1;
+	}
+}
+
 export async function main(args: string[], options?: MainOptions) {
 	resetTimings();
 	const extensionFactories = [...builtInExtensions, ...(options?.extensionFactories ?? [])];
@@ -565,6 +580,13 @@ export async function main(args: string[], options?: MainOptions) {
 	if (offlineMode) {
 		process.env.PI_OFFLINE = "1";
 		process.env.PI_SKIP_VERSION_CHECK = "1";
+	}
+
+	// Experimental subcommands (pi server / pi client) are dispatched before
+	// the legacy parser, which does not understand their transport options.
+	if (args[0] === "server" || args[0] === "client") {
+		await dispatchExperimentalCommand(args);
+		return;
 	}
 
 	if (await runAuthCommand(args)) {

--- a/packages/coding-agent/src/server/pi-server-service.ts
+++ b/packages/coding-agent/src/server/pi-server-service.ts
@@ -1,0 +1,295 @@
+/**
+ * PiServerService adapter backed by coding-agent's AgentSession.
+ *
+ * Turns `pi server` into a real persistent coding-agent service: sessions are
+ * created/opened via the standard SessionManager (JSONL), each acquired
+ * session runs a full AgentSession (prompt/steer/abort/setModel/setThinking),
+ * and snapshots/events are translated to the wire protocol.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ToolCall } from "@earendil-works/pi-ai";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { createAgentSession, ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
+import type {
+	ModelMetadata,
+	ModelRef,
+	SessionMetadata,
+	SessionSnapshot,
+	ThinkingLevel,
+	TranscriptProgress,
+	UserTranscriptItem,
+} from "@earendil-works/pi-protocol";
+import type {
+	CreateSessionOptions,
+	PiServerService,
+	PiSessionRuntime,
+	PiSessionRuntimeEvent,
+	PromptInput,
+	SteerInput,
+} from "@earendil-works/pi-server";
+import {
+	PiServerError,
+	SessionBusyError,
+	SessionNotFoundError,
+	toProtocolAssistantMessage,
+	toProtocolToolResultMessage,
+	toProtocolUserMessage,
+} from "@earendil-works/pi-server";
+import { getAgentDir } from "../config.ts";
+import { getDefaultSessionDir } from "../core/session-manager.ts";
+
+/** Map an AgentMessage[] transcript into protocol transcript items. */
+function toProtocolTranscript(messages: AgentMessage[]): SessionSnapshot["transcript"] {
+	const items: SessionSnapshot["transcript"] = [];
+	let sequence = 0;
+	for (const message of messages) {
+		const id = `m-${sequence++}-${randomUUID().slice(0, 8)}`;
+		switch (message.role) {
+			case "user":
+				items.push(toProtocolUserMessage(message, { id }));
+				break;
+			case "assistant":
+				items.push(toProtocolAssistantMessage(message, { id }));
+				break;
+			case "toolResult": {
+				const call = findToolCall(items, message.toolCallId);
+				if (!call) continue;
+				items.push(toProtocolToolResultMessage(message, { id, call }));
+				break;
+			}
+			default:
+				// Custom/skill messages do not map to the protocol transcript.
+				break;
+		}
+	}
+	return items;
+}
+
+function findToolCall(items: SessionSnapshot["transcript"], toolCallId: string): ToolCall | undefined {
+	for (let index = items.length - 1; index >= 0; index--) {
+		const item = items[index];
+		if (item.role !== "assistant") continue;
+		for (const part of item.content) {
+			if (part.type === "toolCall" && part.toolCallId === toolCallId) {
+				return {
+					type: "toolCall",
+					id: part.toolCallId,
+					name: part.toolName,
+					arguments: part.input as ToolCall["arguments"],
+				};
+			}
+		}
+	}
+	return undefined;
+}
+
+function sessionPhase(session: AgentSession): SessionSnapshot["phase"] {
+	if (session.isCompacting) return "compaction";
+	if (session.isStreaming) return "turn";
+	return "idle";
+}
+
+function toSessionSnapshot(session: AgentSession, revision: number): SessionSnapshot {
+	const model = session.model;
+	return {
+		id: session.sessionId,
+		...(session.sessionName === undefined ? {} : { name: session.sessionName }),
+		cwd: session.sessionManager.getCwd(),
+		createdAt: 0,
+		updatedAt: Date.now(),
+		phase: sessionPhase(session),
+		model: model ? { provider: model.provider, id: model.id } : { provider: "unknown", id: "unknown" },
+		thinkingLevel: session.thinkingLevel,
+		attached: true,
+		locked: session.isStreaming || session.isCompacting,
+		revision,
+		transcript: toProtocolTranscript(session.messages),
+		queuedSteer: [] as UserTranscriptItem[],
+		queuedSteerCount: 0,
+	};
+}
+
+export class CodingAgentPiSessionRuntime implements PiSessionRuntime {
+	private readonly session: AgentSession;
+	private revision = 0;
+	private readonly listeners = new Set<(event: PiSessionRuntimeEvent) => void>();
+	private readonly unsubscribe: () => void;
+
+	constructor(session: AgentSession) {
+		this.session = session;
+		this.unsubscribe = session.subscribe(() => this.emitSnapshot());
+	}
+
+	snapshot(): SessionSnapshot {
+		return toSessionSnapshot(this.session, this.revision);
+	}
+
+	getPhase(): SessionSnapshot["phase"] {
+		return sessionPhase(this.session);
+	}
+
+	async prompt(input: PromptInput): Promise<void> {
+		if (this.session.isStreaming) throw new SessionBusyError();
+		await this.session.prompt(input.text, { source: "rpc" });
+		this.emitSnapshot();
+	}
+
+	async steer(input: SteerInput): Promise<void> {
+		if (!this.session.isStreaming) throw new SessionBusyError("There is no active prompt to steer");
+		await this.session.steer(input.text);
+		this.emitSnapshot();
+	}
+
+	async abort(): Promise<void> {
+		if (!this.session.isStreaming) throw new SessionBusyError("There is no active prompt to abort");
+		this.session.abort();
+		this.emitSnapshot();
+	}
+
+	async setModel(model: ModelRef): Promise<void> {
+		if (this.session.isStreaming) throw new SessionBusyError();
+		const next = this.session.modelRuntime.getModel(model.provider, model.id);
+		if (!next) throw new PiServerError("not_found", `Unknown model: ${model.provider}/${model.id}`);
+		await this.session.setModel(next);
+		this.emitSnapshot();
+	}
+
+	async setThinking(thinkingLevel: ThinkingLevel): Promise<void> {
+		if (this.session.isStreaming) throw new SessionBusyError();
+		this.session.setThinkingLevel(thinkingLevel);
+		this.emitSnapshot();
+	}
+
+	subscribe(listener: (event: PiSessionRuntimeEvent) => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	async dispose(): Promise<void> {
+		this.unsubscribe();
+		this.session.dispose();
+	}
+
+	private emitSnapshot(): void {
+		this.revision += 1;
+		for (const listener of this.listeners) listener({ type: "snapshot" });
+		const snapshot = this.snapshot();
+		const last = snapshot.transcript.at(-1);
+		if (last && last.role === "assistant") {
+			const progress: TranscriptProgress =
+				last.status === "streaming" ? { type: "item_updated", item: last } : { type: "item_finished", item: last };
+			for (const listener of this.listeners) listener({ type: "progress", progress });
+		}
+	}
+}
+
+/** PiServerService that hosts coding-agent sessions in a shared agentDir. */
+export class CodingAgentPiServerService implements PiServerService {
+	private readonly agentDir: string;
+	private readonly modelRuntime: ModelRuntime;
+	private readonly sessionDir: string;
+	private readonly runtimes = new Map<string, CodingAgentPiSessionRuntime>();
+	private readonly locked = new Set<string>();
+
+	constructor(options: { agentDir: string; modelRuntime: ModelRuntime }, sessionDir?: string) {
+		this.agentDir = options.agentDir;
+		this.modelRuntime = options.modelRuntime;
+		this.sessionDir = sessionDir ?? getDefaultSessionDir(process.cwd(), this.agentDir);
+	}
+
+	async listSessions(): Promise<SessionMetadata[]> {
+		const sessions = await SessionManager.listAll(this.sessionDir);
+		return sessions.map((info) => ({
+			id: info.id,
+			createdAt: Math.floor(info.created.getTime()),
+			...(info.name === undefined ? {} : { sessionName: info.name }),
+			...(info.cwd === undefined || info.cwd === "" ? {} : { cwd: info.cwd }),
+			updatedAt: Math.floor(info.modified.getTime()),
+		}));
+	}
+
+	async listModels(): Promise<ModelMetadata[]> {
+		const models = this.modelRuntime.getModels();
+		return models.map(toProtocolModelMetadata);
+	}
+
+	async createSession(options: CreateSessionOptions): Promise<PiSessionRuntime> {
+		if (this.locked.has(options.id)) throw new SessionBusyError(`Session is locked: ${options.id}`);
+		this.locked.add(options.id);
+		try {
+			const cwd = options.cwd ?? process.cwd();
+			const sessionManager = SessionManager.create(cwd, this.sessionDir, { id: options.id });
+			if (options.name !== undefined) sessionManager.appendSessionInfo(options.name);
+			const { session } = await createAgentSession({
+				cwd,
+				agentDir: this.agentDir,
+				sessionManager,
+				modelRuntime: this.modelRuntime,
+				...(options.model === undefined ? {} : { model: resolveModel(this.modelRuntime, options.model) }),
+				...(options.thinkingLevel === undefined ? {} : { thinkingLevel: options.thinkingLevel }),
+			});
+			const runtime = new CodingAgentPiSessionRuntime(session);
+			this.runtimes.set(options.id, runtime);
+			return runtime;
+		} finally {
+			this.locked.delete(options.id);
+		}
+	}
+
+	async openSession(sessionId: string): Promise<PiSessionRuntime> {
+		const existing = this.runtimes.get(sessionId);
+		if (existing) {
+			if (this.locked.has(sessionId)) throw new SessionBusyError(`Session is locked: ${sessionId}`);
+			return existing;
+		}
+		const sessions = await SessionManager.listAll(this.sessionDir);
+		const info = sessions.find((candidate) => candidate.id === sessionId);
+		if (!info) throw new SessionNotFoundError(`Unknown session: ${sessionId}`);
+		const sessionManager = SessionManager.open(info.path, this.sessionDir);
+		const { session } = await createAgentSession({
+			cwd: info.cwd || sessionManager.getCwd(),
+			agentDir: this.agentDir,
+			sessionManager,
+			modelRuntime: this.modelRuntime,
+		});
+		const runtime = new CodingAgentPiSessionRuntime(session);
+		this.runtimes.set(sessionId, runtime);
+		return runtime;
+	}
+}
+
+function resolveModel(modelRuntime: ModelRuntime, ref: ModelRef) {
+	const model = modelRuntime.getModel(ref.provider, ref.id);
+	if (!model) throw new PiServerError("not_found", `Unknown model: ${ref.provider}/${ref.id}`);
+	return model;
+}
+
+function toProtocolModelMetadata(model: ReturnType<ModelRuntime["getModels"]>[number]): ModelMetadata {
+	const clampCost = (value: number): number => (Number.isFinite(value) ? Math.max(0, value) : 0);
+	return {
+		provider: model.provider,
+		id: model.id,
+		name: model.name,
+		api: model.api,
+		reasoning: model.reasoning,
+		input: [...model.input],
+		contextWindow: Math.max(1, Math.floor(model.contextWindow)),
+		maxTokens: Math.max(1, Math.floor(model.maxTokens)),
+		cost: {
+			input: clampCost(model.cost.input),
+			output: clampCost(model.cost.output),
+			cacheRead: clampCost(model.cost.cacheRead),
+			cacheWrite: clampCost(model.cost.cacheWrite),
+		},
+		supportedThinkingLevels: model.reasoning ? ["off", "low", "medium", "high"] : ["off"],
+		authenticated: true,
+	};
+}
+
+export async function createCodingAgentPiServerService(sessionDir?: string): Promise<CodingAgentPiServerService> {
+	const agentDir = getAgentDir();
+	const modelRuntime = await ModelRuntime.create();
+	return new CodingAgentPiServerService({ agentDir, modelRuntime }, sessionDir);
+}

--- a/packages/coding-agent/test/experimental-cli-command.test.ts
+++ b/packages/coding-agent/test/experimental-cli-command.test.ts
@@ -38,6 +38,36 @@ describe("experimental CLI commands", () => {
 		});
 	});
 
+	test("parses a TCP server listener", () => {
+		expect(experimentalCli.parse(["server", "--listen", "tcp://127.0.0.1:7000"])).toEqual({
+			ok: true,
+			command: {
+				command: "server",
+				listen: [{ transport: "tcp", host: "127.0.0.1", port: 7000 }],
+			},
+		});
+	});
+
+	test("parses a WebSocket server listener", () => {
+		expect(experimentalCli.parse(["server", "--listen", "ws://127.0.0.1:8080"])).toEqual({
+			ok: true,
+			command: {
+				command: "server",
+				listen: [{ transport: "ws", url: "ws://127.0.0.1:8080" }],
+			},
+		});
+	});
+
+	test("accepts a WebSocket listener with a default port", () => {
+		expect(experimentalCli.parse(["server", "--listen", "ws://127.0.0.1"])).toEqual({
+			ok: true,
+			command: {
+				command: "server",
+				listen: [{ transport: "ws", url: "ws://127.0.0.1" }],
+			},
+		});
+	});
+
 	test("leaves experimental-looking existing option values with the existing parser", () => {
 		expect(experimentalCli.parse(["--system-prompt", "--listen", "unix:///tmp/pi.sock"])).toMatchObject({
 			ok: true,
@@ -65,6 +95,26 @@ describe("experimental CLI commands", () => {
 			command: {
 				command: "client",
 				connect: { transport: "unix", path: "/tmp/pi.sock" },
+			},
+		});
+	});
+
+	test("parses a TCP client address", () => {
+		expect(experimentalCli.parse(["client", "--connect", "tcp://127.0.0.1:7000"])).toEqual({
+			ok: true,
+			command: {
+				command: "client",
+				connect: { transport: "tcp", host: "127.0.0.1", port: 7000 },
+			},
+		});
+	});
+
+	test("parses a WebSocket client address", () => {
+		expect(experimentalCli.parse(["client", "--connect", "ws://127.0.0.1:8080"])).toEqual({
+			ok: true,
+			command: {
+				command: "client",
+				connect: { transport: "ws", url: "ws://127.0.0.1:8080" },
 			},
 		});
 	});
@@ -116,8 +166,12 @@ describe("experimental CLI commands", () => {
 			"--auth-token-file may only be specified once",
 		],
 		[["--listen", "/tmp/pi.sock"], 'Invalid --listen address "/tmp/pi.sock"'],
-		[["--listen", "ws://localhost:8080"], 'Unsupported --listen transport "ws:"'],
 		[["--listen", "unix://relative.sock"], "Unix transport address must not include an authority"],
+		[["--listen", "tcp://127.0.0.1"], "port must be a number"],
+		[["--listen", "tcp://127.0.0.1:0"], "port must be an integer between 1 and 65535"],
+		[["--listen", "tcp://127.0.0.1:99999"], "port must be an integer between 1 and 65535"],
+		[["--listen", "ws://127.0.0.1:0"], "port must be an integer between 1 and 65535"],
+		[["--listen", "ws://127.0.0.1:99999"], "port must be an integer between 1 and 65535"],
 		[["--listen", "unix:///tmp/pi.sock?wrong=value"], 'Invalid --listen address "unix:///tmp/pi.sock?wrong=value"'],
 		[["--listen", "unix:///tmp/pi.sock#fragment"], 'Invalid --listen address "unix:///tmp/pi.sock#fragment"'],
 		[["--listen", "unix:/tmp/pi.sock"], 'Invalid --listen address "unix:/tmp/pi.sock"'],
@@ -130,7 +184,7 @@ describe("experimental CLI commands", () => {
 			["server", "--connect", "unix:///tmp/pi.sock"],
 			"The experimental server command does not support existing CLI options yet",
 		],
-		[["client", "--connect", "ws://localhost:8080"], 'Unsupported --connect transport "ws:"'],
+		[["client", "--connect", "tcp://localhost"], "port must be a number"],
 		[["--listen"], "--listen requires a value"],
 		[["--connect="], "--connect is only valid for client mode"],
 	] as const)("rejects invalid experimental input %j", (argv, error) => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,14 @@
 		"./unix": {
 			"types": "./dist/transports/unix/index.d.ts",
 			"import": "./dist/transports/unix/index.js"
+		},
+		"./tcp": {
+			"types": "./dist/transports/tcp/index.d.ts",
+			"import": "./dist/transports/tcp/index.js"
+		},
+		"./ws": {
+			"types": "./dist/transports/ws/index.d.ts",
+			"import": "./dist/transports/ws/index.js"
 		}
 	},
 	"files": [

--- a/packages/server/src/transports/tcp/index.ts
+++ b/packages/server/src/transports/tcp/index.ts
@@ -1,0 +1,3 @@
+export { createTcpListener } from "./listener.ts";
+export { createTcpServer } from "./preset.ts";
+export type { TcpListenerOptions, TcpServerOptions } from "./types.ts";

--- a/packages/server/src/transports/tcp/listener.ts
+++ b/packages/server/src/transports/tcp/listener.ts
@@ -1,0 +1,271 @@
+import { createServer, type Server, type Socket } from "node:net";
+import { DEFAULT_MAX_FRAME_LENGTH } from "@earendil-works/pi-protocol";
+import type { ByteConnection, ByteConnectionAcceptor } from "../../connection.ts";
+import type { PiServerListener } from "../../listener.ts";
+import type { TcpListenerOptions } from "./types.ts";
+
+const DEFAULT_GRACEFUL_CLOSE_TIMEOUT_MS = 5_000;
+const MAX_UINT32 = 0xffff_ffff;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+interface ResolvedTcpListenerOptions {
+	host: string;
+	port: number;
+	maxPendingBytes: number;
+	gracefulCloseTimeoutMs: number;
+	onError?: (error: Error) => void;
+}
+
+export class TcpListener implements PiServerListener {
+	private readonly options: ResolvedTcpListenerOptions;
+	private readonly connections = new Set<TcpByteConnection>();
+	private server?: Server;
+	private boundPort?: number;
+	private closing = false;
+	private closePromise?: Promise<void>;
+	private accept?: ByteConnectionAcceptor;
+
+	constructor(options: TcpListenerOptions) {
+		this.options = resolveTcpListenerOptions(options);
+	}
+
+	get address(): string | undefined {
+		return this.boundPort === undefined ? undefined : `${this.options.host}:${this.boundPort}`;
+	}
+
+	async start(accept: ByteConnectionAcceptor): Promise<void> {
+		if (this.server) throw new Error("TCP listener is already started");
+		if (this.closing) throw new Error("TCP listener is closing or closed");
+		this.accept = accept;
+
+		const server = createServer((socket) => this.acceptSocket(socket));
+		server.on("error", (error) => this.reportError(error));
+		this.server = server;
+		try {
+			await new Promise<void>((resolve, reject) => {
+				const onError = (error: Error): void => {
+					server.off("listening", onListening);
+					reject(error);
+				};
+				const onListening = (): void => {
+					server.off("error", onError);
+					resolve();
+				};
+				server.once("error", onError);
+				server.once("listening", onListening);
+				server.listen(this.options.port, this.options.host);
+			});
+			const address = server.address();
+			this.boundPort = typeof address === "object" && address !== null ? address.port : this.options.port;
+		} catch (error) {
+			this.server = undefined;
+			throw error;
+		}
+	}
+
+	async close(): Promise<void> {
+		if (this.closePromise) return this.closePromise;
+		this.closing = true;
+		this.closePromise = this.closeInternal();
+		return this.closePromise;
+	}
+
+	private acceptSocket(socket: Socket): void {
+		if (this.closing) {
+			socket.destroy();
+			return;
+		}
+		const connection = new TcpByteConnection(
+			socket,
+			this.options.gracefulCloseTimeoutMs,
+			this.options.maxPendingBytes,
+		);
+		this.connections.add(connection);
+		const accept = this.accept;
+		if (!accept) {
+			socket.destroy();
+			return;
+		}
+		const handler = accept(connection);
+		socket.on("data", (chunk) => {
+			handler.onData(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+		});
+		socket.on("error", (error) => {
+			handler.onError(error);
+			socket.destroy();
+		});
+		socket.once("close", () => {
+			connection.markClosed();
+			this.connections.delete(connection);
+			handler.onClose();
+		});
+	}
+
+	private async closeInternal(): Promise<void> {
+		this.boundPort = undefined;
+		const serverClosed = this.server ? closeNetServer(this.server, (error) => this.reportError(error)) : undefined;
+		await Promise.all([...this.connections].map((connection) => connection.close()));
+		await serverClosed;
+		this.connections.clear();
+		this.server = undefined;
+	}
+
+	private reportError(error: unknown): void {
+		try {
+			this.options.onError?.(error instanceof Error ? error : new Error(String(error)));
+		} catch {
+			// Error observers cannot affect listener state.
+		}
+	}
+}
+
+/** @internal Exported only for transport-level verification. */
+export class TcpByteConnection implements ByteConnection {
+	private readonly socket: Socket;
+	private readonly gracefulCloseTimeoutMs: number;
+	private readonly maxPendingBytes: number;
+	private pendingBytes = 0;
+	private closedValue = false;
+	private closing = false;
+	private writeTail: Promise<void> = Promise.resolve();
+	private closePromise?: Promise<void>;
+	private resolveClose?: () => void;
+
+	constructor(socket: Socket, gracefulCloseTimeoutMs: number, maxPendingBytes: number) {
+		this.socket = socket;
+		this.gracefulCloseTimeoutMs = gracefulCloseTimeoutMs;
+		this.maxPendingBytes = maxPendingBytes;
+	}
+
+	get closed(): boolean {
+		return this.closedValue;
+	}
+
+	send(chunk: Uint8Array): Promise<void> {
+		if (!(chunk instanceof Uint8Array)) {
+			return Promise.reject(new TypeError("TCP connection chunks must be Uint8Array"));
+		}
+		if (this.closedValue || this.closing) return Promise.reject(new Error("TCP connection is closed"));
+		if (this.pendingBytes + chunk.byteLength > this.maxPendingBytes) {
+			return Promise.reject(new Error("TCP connection exceeded its pending byte limit"));
+		}
+		this.pendingBytes += chunk.byteLength;
+		const bytes = chunk.slice();
+		const write = this.writeTail.then(() => this.write(bytes));
+		const tracked = write.finally(() => {
+			this.pendingBytes -= bytes.byteLength;
+		});
+		this.writeTail = tracked.catch(() => {});
+		return tracked;
+	}
+
+	close(finalChunk?: Uint8Array): Promise<void> {
+		if (this.closedValue || this.socket.destroyed) {
+			this.markClosed();
+			return Promise.resolve();
+		}
+		if (this.closePromise) return this.closePromise;
+		this.closing = true;
+		const finalBytes = finalChunk?.slice();
+		this.closePromise = new Promise<void>((resolve) => {
+			this.resolveClose = resolve;
+			const timer = setTimeout(() => {
+				if (!this.socket.destroyed) this.socket.destroy();
+				this.markClosed();
+			}, this.gracefulCloseTimeoutMs);
+			timer.unref();
+			this.socket.once("close", () => clearTimeout(timer));
+			void this.writeTail.then(() => {
+				if (this.socket.destroyed) {
+					this.markClosed();
+					return;
+				}
+				try {
+					if (finalBytes) this.socket.end(finalBytes);
+					else this.socket.end();
+				} catch {
+					this.socket.destroy();
+				}
+			});
+		});
+		return this.closePromise;
+	}
+
+	markClosed(): void {
+		if (this.closedValue) return;
+		this.closedValue = true;
+		this.closing = true;
+		this.resolveClose?.();
+		this.resolveClose = undefined;
+	}
+
+	private write(chunk: Uint8Array): Promise<void> {
+		if (this.closedValue || this.closing || !this.socket.writable) {
+			return Promise.reject(new Error("TCP connection is closed"));
+		}
+		return new Promise<void>((resolve, reject) => {
+			let settled = false;
+			const onClose = (): void => finish(new Error("TCP connection closed during write"));
+			const finish = (error?: Error | null): void => {
+				if (settled) return;
+				settled = true;
+				this.socket.off("close", onClose);
+				if (error) reject(error);
+				else resolve();
+			};
+			this.socket.once("close", onClose);
+			try {
+				this.socket.write(chunk, finish);
+			} catch (error) {
+				finish(error instanceof Error ? error : new Error(String(error)));
+			}
+		});
+	}
+}
+
+export function createTcpListener(options: TcpListenerOptions): PiServerListener {
+	return new TcpListener(options);
+}
+
+function resolveTcpListenerOptions(options: TcpListenerOptions): ResolvedTcpListenerOptions {
+	const host = options.host ?? "127.0.0.1";
+	if (typeof host !== "string" || host.length === 0) {
+		throw new TypeError("TCP listener host must be a non-empty string");
+	}
+	if (!Number.isInteger(options.port) || options.port < 0 || options.port > 65535) {
+		throw new TypeError("TCP listener port must be an integer between 0 and 65535 (0 for ephemeral)");
+	}
+	const maxFrameLength = options.maxFrameLength ?? DEFAULT_MAX_FRAME_LENGTH;
+	if (!Number.isSafeInteger(maxFrameLength) || maxFrameLength <= 0 || maxFrameLength > MAX_UINT32) {
+		throw new TypeError(`PiServer maxFrameLength must be an integer between 1 and ${MAX_UINT32}`);
+	}
+	const maxPendingBytes = options.maxPendingBytes ?? maxFrameLength * 4;
+	if (!Number.isSafeInteger(maxPendingBytes) || maxPendingBytes < maxFrameLength + 4) {
+		throw new TypeError("PiServer maxPendingBytes must be a safe integer at least maxFrameLength + 4");
+	}
+	const gracefulCloseTimeoutMs = options.gracefulCloseTimeoutMs ?? DEFAULT_GRACEFUL_CLOSE_TIMEOUT_MS;
+	if (
+		!Number.isSafeInteger(gracefulCloseTimeoutMs) ||
+		gracefulCloseTimeoutMs <= 0 ||
+		gracefulCloseTimeoutMs > MAX_TIMER_DELAY_MS
+	) {
+		throw new TypeError(`PiServer gracefulCloseTimeoutMs must be an integer between 1 and ${MAX_TIMER_DELAY_MS}`);
+	}
+	return {
+		host,
+		port: options.port,
+		maxPendingBytes,
+		gracefulCloseTimeoutMs,
+		onError: options.onError,
+	};
+}
+
+function closeNetServer(server: Server, reportError: (error: Error) => void): Promise<void> {
+	if (!server.listening) return Promise.resolve();
+	return new Promise<void>((resolve) => {
+		server.close((error) => {
+			if (error) reportError(error);
+			resolve();
+		});
+	});
+}

--- a/packages/server/src/transports/tcp/preset.ts
+++ b/packages/server/src/transports/tcp/preset.ts
@@ -1,0 +1,23 @@
+import { PiServer } from "../../server.ts";
+import type { PiServerService } from "../../types.ts";
+import { createTcpListener } from "./listener.ts";
+import type { TcpServerOptions } from "./types.ts";
+
+/** Compose PiServer with one TCP socket listener. */
+export function createTcpServer(service: PiServerService, options: TcpServerOptions): PiServer {
+	const listener = createTcpListener({
+		host: options.host,
+		port: options.port,
+		maxFrameLength: options.maxFrameLength,
+		maxPendingBytes: options.maxPendingBytes,
+		gracefulCloseTimeoutMs: options.gracefulCloseTimeoutMs,
+		onError: options.onError,
+	});
+	return new PiServer(service, {
+		listeners: [listener],
+		maxFrameLength: options.maxFrameLength,
+		handshakeTimeoutMs: options.handshakeTimeoutMs,
+		serverId: options.serverId,
+		onError: options.onError,
+	});
+}

--- a/packages/server/src/transports/tcp/types.ts
+++ b/packages/server/src/transports/tcp/types.ts
@@ -1,0 +1,13 @@
+import type { PiServerOptions } from "../../types.ts";
+
+export interface TcpListenerOptions {
+	host?: string;
+	port: number;
+	maxPendingBytes?: number;
+	gracefulCloseTimeoutMs?: number;
+	/** Used to derive and validate maxPendingBytes. Must match the server when customized. */
+	maxFrameLength?: number;
+	onError?: (error: Error) => void;
+}
+
+export interface TcpServerOptions extends Omit<PiServerOptions, "listeners">, TcpListenerOptions {}

--- a/packages/server/src/transports/ws/frames.ts
+++ b/packages/server/src/transports/ws/frames.ts
@@ -1,0 +1,213 @@
+/**
+ * Minimal RFC 6455 WebSocket frame codec for the PiServer WS transport.
+ *
+ * Implements the server half of the protocol: incremental frame decoding
+ * (including masking, which clients must use) and frame encoding (the server
+ * never masks its own frames). Control frames are surfaced to the caller so
+ * the listener can answer pings and react to close frames.
+ *
+ * Only binary payloads are supported; the transport layer ignores text frames.
+ */
+
+const MAX_UINT32 = 0xffff_ffff;
+
+export const WS_OPCODE_CONTINUATION = 0x0;
+export const WS_OPCODE_TEXT = 0x1;
+export const WS_OPCODE_BINARY = 0x2;
+export const WS_OPCODE_CLOSE = 0x8;
+export const WS_OPCODE_PING = 0x9;
+export const WS_OPCODE_PONG = 0xa;
+
+export interface WsFrame {
+	readonly fin: boolean;
+	readonly opcode: number;
+	readonly payload: Uint8Array;
+}
+
+export class WsProtocolError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "WsProtocolError";
+	}
+}
+
+function readUint16BE(bytes: Uint8Array, offset: number): number {
+	return (bytes[offset]! << 8) | bytes[offset + 1]!;
+}
+
+function readUint64BE(bytes: Uint8Array, offset: number): number {
+	// 53-bit safe range is sufficient for frame length limits well below 2^53.
+	let value = 0;
+	for (let index = 0; index < 8; index++) {
+		value = value * 256 + bytes[offset + index]!;
+	}
+	return value;
+}
+
+function isControlOpcode(opcode: number): boolean {
+	return opcode >= 0x8;
+}
+
+/**
+ * Incrementally splits arbitrary byte chunks into complete WebSocket frames.
+ * Throws WsProtocolError on malformed input. A close frame with a non-empty
+ * payload carries an optional status code in the first two bytes.
+ */
+export class WsFrameDecoder {
+	private readonly maxFrameLength: number;
+	private readonly chunks: Uint8Array[] = [];
+	private length = 0;
+	private failed = false;
+
+	constructor(maxFrameLength = 16 * 1024 * 1024) {
+		if (!Number.isSafeInteger(maxFrameLength) || maxFrameLength <= 0 || maxFrameLength > MAX_UINT32) {
+			throw new TypeError("WsFrameDecoder maxFrameLength must be an integer between 1 and 0xffffffff");
+		}
+		this.maxFrameLength = maxFrameLength;
+	}
+
+	push(chunk: Uint8Array): WsFrame[] {
+		if (this.failed) throw new WsProtocolError("WebSocket frame decoder has failed");
+		this.chunks.push(chunk);
+		this.length += chunk.byteLength;
+		const frames: WsFrame[] = [];
+		for (;;) {
+			const frame = this.tryReadFrame();
+			if (!frame) break;
+			frames.push(frame);
+		}
+		return frames;
+	}
+
+	private tryReadFrame(): WsFrame | undefined {
+		const header = this.peek(2);
+		if (!header) return undefined;
+		const first = header[0]!;
+		const second = header[1]!;
+		const fin = (first & 0x80) !== 0;
+		const opcode = first & 0x0f;
+		const masked = (second & 0x80) !== 0;
+		let payloadLength = second & 0x7f;
+
+		if (isControlOpcode(opcode) && !fin) {
+			throw new WsProtocolError("WebSocket control frames must not be fragmented");
+		}
+		if (isControlOpcode(opcode) && payloadLength > 125) {
+			throw new WsProtocolError("WebSocket control frame payload is too large");
+		}
+
+		let headerLength = 2;
+		if (payloadLength === 126) {
+			const extended = this.peek(4);
+			if (!extended) return undefined;
+			payloadLength = readUint16BE(extended, 2);
+			headerLength = 4;
+		} else if (payloadLength === 127) {
+			const extended = this.peek(10);
+			if (!extended) return undefined;
+			payloadLength = readUint64BE(extended, 2);
+			headerLength = 10;
+		}
+
+		if (payloadLength > this.maxFrameLength) {
+			throw new WsProtocolError(
+				`WebSocket frame payload ${payloadLength} exceeds configured limit of ${this.maxFrameLength}`,
+			);
+		}
+		if (masked) headerLength += 4;
+
+		const full = this.peek(headerLength + payloadLength);
+		if (!full) return undefined;
+		this.consume(headerLength + payloadLength);
+
+		let payload = full.subarray(headerLength, headerLength + payloadLength);
+		if (masked) {
+			const maskKey = full.subarray(headerLength - 4, headerLength);
+			payload = unmask(payload, maskKey);
+		}
+		return { fin, opcode, payload };
+	}
+
+	private peek(count: number): Uint8Array | undefined {
+		if (this.length < count) return undefined;
+		const buffer = new Uint8Array(count);
+		let offset = 0;
+		for (const chunk of this.chunks) {
+			const take = Math.min(chunk.byteLength, count - offset);
+			buffer.set(chunk.subarray(0, take), offset);
+			offset += take;
+			if (offset === count) break;
+		}
+		return buffer;
+	}
+
+	private consume(count: number): void {
+		let remaining = count;
+		while (remaining > 0 && this.chunks.length > 0) {
+			const first = this.chunks[0]!;
+			if (first.byteLength <= remaining) {
+				remaining -= first.byteLength;
+				this.length -= first.byteLength;
+				this.chunks.shift();
+			} else {
+				this.chunks[0] = first.subarray(remaining);
+				this.length -= remaining;
+				remaining = 0;
+			}
+		}
+	}
+}
+
+function unmask(payload: Uint8Array, maskKey: Uint8Array): Uint8Array {
+	const result = new Uint8Array(payload.byteLength);
+	for (let index = 0; index < payload.byteLength; index++) {
+		result[index] = payload[index]! ^ maskKey[index % 4]!;
+	}
+	return result;
+}
+
+/** Encodes one unmasked binary frame (server-to-client). */
+export function encodeWsFrame(payload: Uint8Array, opcode = WS_OPCODE_BINARY): Uint8Array {
+	if (!(payload instanceof Uint8Array)) throw new TypeError("WebSocket frame payload must be a Uint8Array");
+	if (payload.byteLength > MAX_UINT32) {
+		throw new RangeError("WebSocket frame payload exceeds the unsigned 32-bit length limit");
+	}
+	let headerLength: number;
+	if (payload.byteLength < 126) {
+		headerLength = 2;
+	} else if (payload.byteLength <= 0xffff) {
+		headerLength = 4;
+	} else {
+		headerLength = 10;
+	}
+	const frame = new Uint8Array(headerLength + payload.byteLength);
+	frame[0] = 0x80 | opcode; // FIN + opcode, no RSV bits
+	const length = payload.byteLength;
+	if (headerLength === 2) {
+		frame[1] = length;
+	} else if (headerLength === 4) {
+		frame[1] = 126;
+		frame[2] = length >>> 8;
+		frame[3] = length;
+	} else {
+		frame[1] = 127;
+		// 8-byte big-endian length; safe for the 32-bit range we allow.
+		let value = length;
+		for (let index = 9; index >= 2; index--) {
+			frame[index] = value & 0xff;
+			value = Math.floor(value / 256);
+		}
+	}
+	frame.set(payload, headerLength);
+	return frame;
+}
+
+/** Encodes a close frame with an optional status code. */
+export function encodeWsCloseFrame(code = 1000, reason = ""): Uint8Array {
+	const reasonBytes = new TextEncoder().encode(reason);
+	const payload = new Uint8Array(2 + reasonBytes.byteLength);
+	payload[0] = (code >>> 8) & 0xff;
+	payload[1] = code & 0xff;
+	payload.set(reasonBytes, 2);
+	return encodeWsFrame(payload, WS_OPCODE_CLOSE);
+}

--- a/packages/server/src/transports/ws/handshake.ts
+++ b/packages/server/src/transports/ws/handshake.ts
@@ -1,0 +1,67 @@
+/**
+ * RFC 6455 server-side handshake for the PiServer WS transport.
+ *
+ * The Node HTTP server performs the request parsing; this module validates the
+ * Upgrade request and produces the 101 Switching Protocols response bytes.
+ */
+
+import { createHash } from "node:crypto";
+
+const WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+export class WsHandshakeError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "WsHandshakeError";
+	}
+}
+
+export interface WsHandshakeRequest {
+	readonly headers: Record<string, string | string[] | undefined>;
+}
+
+function headerValue(headers: Record<string, string | string[] | undefined>, name: string): string | undefined {
+	const value = headers[name];
+	if (Array.isArray(value)) return value[0];
+	return value;
+}
+
+/**
+ * Validates an Upgrade request and returns the accept key for the response.
+ * Throws WsHandshakeError when the request is not a valid WebSocket upgrade.
+ */
+export function prepareWsHandshake(request: WsHandshakeRequest): string {
+	const upgrade = headerValue(request.headers, "upgrade");
+	if (typeof upgrade !== "string" || upgrade.toLowerCase() !== "websocket") {
+		throw new WsHandshakeError("Request is not a WebSocket upgrade");
+	}
+	const connection = headerValue(request.headers, "connection");
+	if (typeof connection !== "string" || !connection.toLowerCase().includes("upgrade")) {
+		throw new WsHandshakeError("Connection header does not include upgrade");
+	}
+	const key = headerValue(request.headers, "sec-websocket-key");
+	if (typeof key !== "string" || key.length === 0) {
+		throw new WsHandshakeError("Missing Sec-WebSocket-Key header");
+	}
+	const version = headerValue(request.headers, "sec-websocket-version");
+	if (version !== "13") {
+		throw new WsHandshakeError(`Unsupported Sec-WebSocket-Version: ${version ?? "missing"}`);
+	}
+	const accept = createHash("sha1")
+		.update(key + WEBSOCKET_GUID)
+		.digest("base64");
+	return accept;
+}
+
+/** Builds the 101 Switching Protocols response bytes for an accept key. */
+export function buildWsHandshakeResponse(acceptKey: string): Uint8Array {
+	const head = [
+		"HTTP/1.1 101 Switching Protocols",
+		"Upgrade: websocket",
+		"Connection: Upgrade",
+		`Sec-WebSocket-Accept: ${acceptKey}`,
+		"",
+		"",
+	].join("\r\n");
+	return new TextEncoder().encode(head);
+}

--- a/packages/server/src/transports/ws/index.ts
+++ b/packages/server/src/transports/ws/index.ts
@@ -1,0 +1,16 @@
+export {
+	encodeWsCloseFrame,
+	encodeWsFrame,
+	WS_OPCODE_BINARY,
+	WS_OPCODE_CLOSE,
+	WS_OPCODE_CONTINUATION,
+	WS_OPCODE_PING,
+	WS_OPCODE_PONG,
+	WS_OPCODE_TEXT,
+	type WsFrame,
+	WsFrameDecoder,
+	WsProtocolError,
+} from "./frames.ts";
+export { buildWsHandshakeResponse, prepareWsHandshake, WsHandshakeError } from "./handshake.ts";
+export { createWsListener, type WsListenerOptions } from "./listener.ts";
+export { createWsServer, type WsServerOptions } from "./preset.ts";

--- a/packages/server/src/transports/ws/listener.ts
+++ b/packages/server/src/transports/ws/listener.ts
@@ -1,0 +1,396 @@
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import type { Duplex } from "node:stream";
+import type { ByteConnection, ByteConnectionAcceptor } from "../../connection.ts";
+import type { PiServerListener } from "../../listener.ts";
+import {
+	encodeWsCloseFrame,
+	encodeWsFrame,
+	WS_OPCODE_BINARY,
+	WS_OPCODE_CLOSE,
+	WS_OPCODE_PING,
+	WS_OPCODE_PONG,
+	WS_OPCODE_TEXT,
+	type WsFrame,
+	WsFrameDecoder,
+	WsProtocolError,
+} from "./frames.ts";
+import { buildWsHandshakeResponse, prepareWsHandshake, WsHandshakeError } from "./handshake.ts";
+
+const DEFAULT_GRACEFUL_CLOSE_TIMEOUT_MS = 5_000;
+const MAX_UINT32 = 0xffff_ffff;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export interface WsListenerOptions {
+	host?: string;
+	port: number;
+	maxPendingBytes?: number;
+	gracefulCloseTimeoutMs?: number;
+	/** Used to derive and validate maxPendingBytes. Must match the server when customized. */
+	maxFrameLength?: number;
+	onError?: (error: Error) => void;
+}
+
+interface ResolvedWsListenerOptions {
+	host: string;
+	port: number;
+	maxFrameLength: number;
+	maxPendingBytes: number;
+	gracefulCloseTimeoutMs: number;
+	onError?: (error: Error) => void;
+}
+
+/** Server-side WebSocket listener backed by Node's HTTP server upgrade event. */
+export class WsListener implements PiServerListener {
+	private readonly options: ResolvedWsListenerOptions;
+	private readonly connections = new Set<WsByteConnection>();
+	private server?: HttpServer;
+	private boundPort?: number;
+	private closing = false;
+	private closePromise?: Promise<void>;
+	private accept?: ByteConnectionAcceptor;
+
+	constructor(options: WsListenerOptions) {
+		this.options = resolveWsListenerOptions(options);
+	}
+
+	get address(): string | undefined {
+		return this.boundPort === undefined ? undefined : `${this.options.host}:${this.boundPort}`;
+	}
+
+	async start(accept: ByteConnectionAcceptor): Promise<void> {
+		if (this.server) throw new Error("WebSocket listener is already started");
+		if (this.closing) throw new Error("WebSocket listener is closing or closed");
+		this.accept = accept;
+
+		const server = createHttpServer((_request, response) => {
+			response.writeHead(426, { "Content-Type": "text/plain" });
+			response.end("Upgrade Required: this endpoint speaks WebSocket");
+		});
+		server.on("upgrade", (request, socket, head) => this.acceptUpgrade(request, socket, head));
+		server.on("error", (error) => this.reportError(error));
+		this.server = server;
+		try {
+			await new Promise<void>((resolve, reject) => {
+				const onError = (error: Error): void => {
+					server.off("listening", onListening);
+					reject(error);
+				};
+				const onListening = (): void => {
+					server.off("error", onError);
+					resolve();
+				};
+				server.once("error", onError);
+				server.once("listening", onListening);
+				server.listen(this.options.port, this.options.host);
+			});
+			const address = server.address();
+			this.boundPort = typeof address === "object" && address !== null ? address.port : this.options.port;
+		} catch (error) {
+			this.server = undefined;
+			throw error;
+		}
+	}
+
+	async close(): Promise<void> {
+		if (this.closePromise) return this.closePromise;
+		this.closing = true;
+		this.closePromise = this.closeInternal();
+		return this.closePromise;
+	}
+
+	private acceptUpgrade(request: import("node:http").IncomingMessage, socket: Duplex, head: Buffer): void {
+		if (this.closing) {
+			socket.destroy();
+			return;
+		}
+		let acceptKey: string;
+		try {
+			acceptKey = prepareWsHandshake(request);
+		} catch (error) {
+			if (error instanceof WsHandshakeError) {
+				socket.end(buildWsHandshakeRejection());
+				return;
+			}
+			this.reportError(error);
+			socket.destroy();
+			return;
+		}
+		socket.write(buildWsHandshakeResponse(acceptKey));
+
+		const connection = new WsByteConnection(socket, head, this.options);
+		this.connections.add(connection);
+		const accept = this.accept;
+		if (!accept) {
+			connection.close();
+			return;
+		}
+		const handler = accept(connection);
+		connection.onFrame = (frame) => {
+			if (frame.opcode === WS_OPCODE_BINARY) {
+				handler.onData(frame.payload);
+			}
+			// Text frames are ignored; the protocol is binary-only.
+		};
+		connection.onClose = () => {
+			this.connections.delete(connection);
+			handler.onClose();
+		};
+		connection.onError = (error) => {
+			handler.onError(error);
+			void connection.close();
+		};
+	}
+
+	private async closeInternal(): Promise<void> {
+		this.boundPort = undefined;
+		const serverClosed = this.server ? closeHttpServer(this.server, (error) => this.reportError(error)) : undefined;
+		await Promise.all([...this.connections].map((connection) => connection.close()));
+		await serverClosed;
+		this.connections.clear();
+		this.server = undefined;
+	}
+
+	private reportError(error: unknown): void {
+		try {
+			this.options.onError?.(error instanceof Error ? error : new Error(String(error)));
+		} catch {
+			// Error observers cannot affect listener state.
+		}
+	}
+}
+
+function buildWsHandshakeRejection(): Uint8Array {
+	return new TextEncoder().encode(["HTTP/1.1 400 Bad Request", "Connection: close", "", ""].join("\r\n"));
+}
+
+/** @internal Exported only for transport-level verification. */
+export class WsByteConnection implements ByteConnection {
+	onFrame?: (frame: WsFrame) => void;
+	onClose?: () => void;
+	onError?: (error: Error) => void;
+
+	private readonly socket: Duplex;
+	private readonly decoder: WsFrameDecoder;
+	private readonly maxPendingBytes: number;
+	private readonly gracefulCloseTimeoutMs: number;
+	private pendingBytes = 0;
+	private closedValue = false;
+	private closing = false;
+	private writeTail: Promise<void> = Promise.resolve();
+	private closePromise?: Promise<void>;
+	private resolveClose?: () => void;
+
+	constructor(socket: Duplex, head: Buffer, options: ResolvedWsListenerOptions) {
+		this.socket = socket;
+		this.decoder = new WsFrameDecoder(options.maxFrameLength);
+		this.maxPendingBytes = options.maxPendingBytes;
+		this.gracefulCloseTimeoutMs = options.gracefulCloseTimeoutMs;
+		socket.on("data", (chunk) => this.receive(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)));
+		socket.on("error", (error) => this.handleError(error));
+		socket.once("close", () => this.handleClosed());
+		if (head.byteLength > 0) this.receive(new Uint8Array(head.buffer, head.byteOffset, head.byteLength));
+	}
+
+	get closed(): boolean {
+		return this.closedValue;
+	}
+
+	send(chunk: Uint8Array): Promise<void> {
+		if (!(chunk instanceof Uint8Array)) {
+			return Promise.reject(new TypeError("WebSocket connection chunks must be Uint8Array"));
+		}
+		if (this.closedValue || this.closing) return Promise.reject(new Error("WebSocket connection is closed"));
+		if (this.pendingBytes + chunk.byteLength > this.maxPendingBytes) {
+			return Promise.reject(new Error("WebSocket connection exceeded its pending byte limit"));
+		}
+		this.pendingBytes += chunk.byteLength;
+		const frame = encodeWsFrame(chunk, WS_OPCODE_BINARY);
+		const write = this.writeTail.then(() => this.write(frame));
+		const tracked = write.finally(() => {
+			this.pendingBytes -= chunk.byteLength;
+		});
+		this.writeTail = tracked.catch(() => {});
+		return tracked;
+	}
+
+	close(finalChunk?: Uint8Array): Promise<void> {
+		if (this.closedValue) {
+			this.markClosed();
+			return Promise.resolve();
+		}
+		if (this.closePromise) return this.closePromise;
+		this.closing = true;
+		this.closePromise = new Promise<void>((resolve) => {
+			this.resolveClose = resolve;
+			void this.writeTail.then(() => {
+				if (this.closedValue || this.socket.destroyed) {
+					this.markClosed();
+					return;
+				}
+				try {
+					const finalFrame =
+						finalChunk && finalChunk.byteLength > 0 ? encodeWsFrame(finalChunk, WS_OPCODE_BINARY) : undefined;
+					const closeFrame = encodeWsCloseFrame();
+					const payload = finalFrame ? concatBytes(finalFrame, closeFrame) : closeFrame;
+					this.socket.end(payload, () => this.markClosed());
+				} catch (error) {
+					this.socket.destroy();
+					this.markClosed();
+					if (error instanceof Error) this.handleError(error);
+				}
+			});
+		});
+		return this.closePromise;
+	}
+
+	markClosed(): void {
+		if (this.closedValue) return;
+		this.closedValue = true;
+		this.closing = true;
+		this.resolveClose?.();
+		this.resolveClose = undefined;
+		this.onClose?.();
+	}
+
+	private receive(chunk: Uint8Array): void {
+		if (this.closedValue || this.closing) return;
+		let frames: WsFrame[];
+		try {
+			frames = this.decoder.push(chunk);
+		} catch (error) {
+			this.handleProtocolError(error);
+			return;
+		}
+		for (const frame of frames) {
+			if (this.closedValue || this.closing) return;
+			try {
+				this.dispatch(frame);
+			} catch (error) {
+				this.handleProtocolError(error);
+				return;
+			}
+		}
+	}
+
+	private dispatch(frame: WsFrame): void {
+		switch (frame.opcode) {
+			case WS_OPCODE_BINARY:
+			case WS_OPCODE_TEXT:
+				this.onFrame?.(frame);
+				return;
+			case WS_OPCODE_PING:
+				// Answer pings immediately so load balancers keep the connection alive.
+				void this.writeTail.then(() => {
+					if (this.closedValue || this.closing || this.socket.destroyed) return;
+					this.socket.write(encodeWsFrame(frame.payload, WS_OPCODE_PONG));
+				});
+				return;
+			case WS_OPCODE_PONG:
+				return;
+			case WS_OPCODE_CLOSE:
+				void this.writeTail.then(() => {
+					if (this.closedValue || this.socket.destroyed) return;
+					try {
+						this.socket.end(encodeWsCloseFrame(1000));
+					} catch {
+						this.socket.destroy();
+					}
+					this.markClosed();
+				});
+				return;
+			default:
+				throw new WsProtocolError(`Unsupported WebSocket opcode: ${frame.opcode}`);
+		}
+	}
+
+	private handleProtocolError(error: unknown): void {
+		this.handleError(error instanceof Error ? error : new Error(String(error)));
+		void this.close();
+	}
+
+	private handleError(error: Error): void {
+		this.onError?.(error);
+	}
+
+	private handleClosed(): void {
+		this.markClosed();
+	}
+
+	private write(frame: Uint8Array): Promise<void> {
+		if (this.closedValue || this.closing || !this.socket.writable) {
+			return Promise.reject(new Error("WebSocket connection is closed"));
+		}
+		return new Promise<void>((resolve, reject) => {
+			let settled = false;
+			const onClose = (): void => finish(new Error("WebSocket connection closed during write"));
+			const finish = (error?: Error | null): void => {
+				if (settled) return;
+				settled = true;
+				this.socket.off("close", onClose);
+				if (error) reject(error);
+				else resolve();
+			};
+			this.socket.once("close", onClose);
+			try {
+				this.socket.write(frame, finish);
+			} catch (error) {
+				finish(error instanceof Error ? error : new Error(String(error)));
+			}
+		});
+	}
+}
+
+function concatBytes(first: Uint8Array, second: Uint8Array): Uint8Array {
+	const result = new Uint8Array(first.byteLength + second.byteLength);
+	result.set(first, 0);
+	result.set(second, first.byteLength);
+	return result;
+}
+
+export function createWsListener(options: WsListenerOptions): PiServerListener {
+	return new WsListener(options);
+}
+
+function resolveWsListenerOptions(options: WsListenerOptions): ResolvedWsListenerOptions {
+	const host = options.host ?? "127.0.0.1";
+	if (typeof host !== "string" || host.length === 0) {
+		throw new TypeError("WebSocket listener host must be a non-empty string");
+	}
+	if (!Number.isInteger(options.port) || options.port < 0 || options.port > 65535) {
+		throw new TypeError("WebSocket listener port must be an integer between 0 and 65535 (0 for ephemeral)");
+	}
+	const maxFrameLength = options.maxFrameLength ?? 16 * 1024 * 1024;
+	if (!Number.isSafeInteger(maxFrameLength) || maxFrameLength <= 0 || maxFrameLength > MAX_UINT32) {
+		throw new TypeError(`PiServer maxFrameLength must be an integer between 1 and ${MAX_UINT32}`);
+	}
+	const maxPendingBytes = options.maxPendingBytes ?? maxFrameLength * 4;
+	if (!Number.isSafeInteger(maxPendingBytes) || maxPendingBytes < maxFrameLength + 4) {
+		throw new TypeError("PiServer maxPendingBytes must be a safe integer at least maxFrameLength + 4");
+	}
+	const gracefulCloseTimeoutMs = options.gracefulCloseTimeoutMs ?? DEFAULT_GRACEFUL_CLOSE_TIMEOUT_MS;
+	if (
+		!Number.isSafeInteger(gracefulCloseTimeoutMs) ||
+		gracefulCloseTimeoutMs <= 0 ||
+		gracefulCloseTimeoutMs > MAX_TIMER_DELAY_MS
+	) {
+		throw new TypeError(`PiServer gracefulCloseTimeoutMs must be an integer between 1 and ${MAX_TIMER_DELAY_MS}`);
+	}
+	return {
+		host,
+		port: options.port,
+		maxFrameLength,
+		maxPendingBytes,
+		gracefulCloseTimeoutMs,
+		onError: options.onError,
+	};
+}
+
+function closeHttpServer(server: HttpServer, reportError: (error: Error) => void): Promise<void> {
+	if (!server.listening) return Promise.resolve();
+	return new Promise<void>((resolve) => {
+		server.close((error) => {
+			if (error) reportError(error);
+			resolve();
+		});
+	});
+}

--- a/packages/server/src/transports/ws/preset.ts
+++ b/packages/server/src/transports/ws/preset.ts
@@ -1,0 +1,25 @@
+import { PiServer } from "../../server.ts";
+import type { PiServerOptions, PiServerService } from "../../types.ts";
+import type { WsListenerOptions } from "./listener.ts";
+import { createWsListener } from "./listener.ts";
+
+export interface WsServerOptions extends Omit<PiServerOptions, "listeners">, WsListenerOptions {}
+
+/** Compose PiServer with one WebSocket listener. */
+export function createWsServer(service: PiServerService, options: WsServerOptions): PiServer {
+	const listener = createWsListener({
+		host: options.host,
+		port: options.port,
+		maxFrameLength: options.maxFrameLength,
+		maxPendingBytes: options.maxPendingBytes,
+		gracefulCloseTimeoutMs: options.gracefulCloseTimeoutMs,
+		onError: options.onError,
+	});
+	return new PiServer(service, {
+		listeners: [listener],
+		maxFrameLength: options.maxFrameLength,
+		handshakeTimeoutMs: options.handshakeTimeoutMs,
+		serverId: options.serverId,
+		onError: options.onError,
+	});
+}


### PR DESCRIPTION
…server/client, Ollama provider

- client: createTcpTransportFactory and createWebSocketTransportFactory (Node built-in WebSocket, zero deps)
- server: hand-rolled RFC 6455 WS listener and TCP listener with PiServer preset exports
- coding-agent: transport-address supports tcp:// and ws://; experimental server/client commands wired into main with a real AgentSession-backed PiServerService adapter
- ai: Ollama dynamic provider (radius-style, keyless, /api/tags discovery)
- dependency wiring: coding-agent -> pi-server (lockfile, shrinkwrap, install-lock in sync)