### PR TITLE
Skip .disabled entries in extension discovery

### DIFF
--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -717,6 +717,7 @@ function resolveExtensionEntries(dir: string): string[] | null {
  * 3. Subdirectory with package.json: `extensions/* /package.json` with "pi" field → load what it declares
  *
  * No recursion beyond one level. Complex packages must use package.json manifest.
+ * Entries whose name ends with `.disabled` are skipped, whether file or directory.
  */
 function discoverExtensionsInDir(dir: string): string[] {
 	if (!fs.existsSync(dir)) {
@@ -729,6 +730,15 @@ function discoverExtensionsInDir(dir: string): string[] {
 		const entries = fs.readdirSync(dir, { withFileTypes: true });
 
 		for (const entry of entries) {
+			// A ".disabled" suffix opts an entry out of discovery. Files named
+			// "foo.ts.disabled" were already skipped implicitly (isExtensionFile
+			// matches only *.ts/*.js); without this guard, a directory renamed to
+			// "my-extension.disabled" still loads via its index.ts, which makes the
+			// rename-to-disable convention silently ineffective for directories.
+			if (entry.name.endsWith(".disabled")) {
+				continue;
+			}
+
 			const entryPath = path.join(dir, entry.name);
 
 			// 1. Direct files: *.ts or *.js

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -249,6 +249,28 @@ describe("extensions discovery", () => {
 		expect(result.extensions[0].path).toContain("index.ts");
 	});
 
+	it("skips directories with a .disabled suffix even when they contain index.ts", async () => {
+		const subdir = path.join(extensionsDir, "my-extension.disabled");
+		fs.mkdirSync(subdir);
+		fs.writeFileSync(path.join(subdir, "index.ts"), extensionCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions).toHaveLength(0);
+	});
+
+	it("skips files with a .disabled suffix", async () => {
+		fs.writeFileSync(path.join(extensionsDir, "foo.ts.disabled"), extensionCode);
+		fs.writeFileSync(path.join(extensionsDir, "bar.ts"), extensionCode);
+
+		const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions).toHaveLength(1);
+		expect(path.basename(result.extensions[0].path)).toBe("bar.ts");
+	});
+
 	it("ignores subdirectory without index or package.json", async () => {
 		const subdir = path.join(extensionsDir, "not-an-extension");
 		fs.mkdirSync(subdir);


### PR DESCRIPTION
## Problem

Extension discovery has an inconsistent disable convention:

- A **file** renamed to `foo.ts.disabled` stops loading — implicitly, because `isExtensionFile` only matches names ending in `.ts`/`.js`.
- A **directory** renamed to `my-extension.disabled` **keeps loading**: `discoverExtensionsInDir` inspects every subdirectory for `index.ts`/`index.js`/a `pi` manifest and never looks at the directory's name.

So the natural "rename it to disable it" gesture works for single-file extensions and silently does nothing for directory extensions. Worse, the loaded extension computes paths relative to its (now `.disabled`) directory, so if the user later moves or restores the directory, running sessions start spawning helpers at paths that no longer exist. In practice this surfaced as a repeating per-turn warning:

```
Error: Cannot find module '.../extensions/obvious-next-step-guard.disabled/obvious-next-step-check.mjs'
    code: 'MODULE_NOT_FOUND'
```

from a directory extension the user believed was disabled.

## Fix

`discoverExtensionsInDir` now skips any entry whose name ends with `.disabled`, file or directory, before classification. This makes the existing implicit file behavior an explicit, uniform contract, documented in the discovery-rules comment.

No config surface, no behavior change for any entry not deliberately renamed. One early `continue`.

## Tests

Two cases added to `extensions-discovery.test.ts`:

- `skips directories with a .disabled suffix even when they contain index.ts`
- `skips files with a .disabled suffix` (pins the previously implicit behavior so it can't regress if `isExtensionFile` ever loosens)

`npx vitest run test/extensions-discovery.test.ts`: 32 passed (30 existing + 2 new).
