### PR TITLE
fix(coding-agent): preserve compaction queued prompts

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -321,6 +321,7 @@ export class AgentSession {
 	private _isAgentRunActive = false;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
+	private _pendingStreamingPromptPreflights = new Set<Promise<void>>();
 
 	/** Tracks pending steering messages for UI display. Removed when delivered. */
 	private _steeringMessages: string[] = [];
@@ -1143,6 +1144,12 @@ export class AgentSession {
 			return true;
 		}
 
+		// A compaction_end listener can submit a prompt that awaits input hooks before queueing.
+		// Wait for those dispatches so the final queue snapshot cannot miss them.
+		while (this._pendingStreamingPromptPreflights.size > 0) {
+			await Promise.all(this._pendingStreamingPromptPreflights);
+		}
+
 		// The agent loop drains both queues before emitting agent_end. Any messages
 		// here were queued by agent_end extension handlers and need a continuation.
 		return this.agent.hasQueuedMessages();
@@ -1161,6 +1168,7 @@ export class AgentSession {
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 		const preflightResult = options?.preflightResult;
 		let messages: AgentMessage[] | undefined;
+		let finishStreamingPreflight: (() => void) | undefined;
 
 		try {
 			// Handle extension commands first (execute immediately, even during streaming)
@@ -1178,6 +1186,19 @@ export class AgentSession {
 				throw new Error(
 					"Cannot submit a prompt while compaction is in progress. Wait for compaction to finish and retry.",
 				);
+			}
+
+			if (this.isStreaming && options?.streamingBehavior) {
+				// Publish the continuation intent before input hooks introduce an async gap.
+				let resolveStreamingPreflight!: () => void;
+				const streamingPreflight = new Promise<void>((resolve) => {
+					resolveStreamingPreflight = resolve;
+				});
+				this._pendingStreamingPromptPreflights.add(streamingPreflight);
+				finishStreamingPreflight = () => {
+					this._pendingStreamingPromptPreflights.delete(streamingPreflight);
+					resolveStreamingPreflight();
+				};
 			}
 
 			// Emit input event for extension interception (before skill/template expansion)
@@ -1307,6 +1328,8 @@ export class AgentSession {
 		} catch (error) {
 			preflightResult?.(false);
 			throw error;
+		} finally {
+			finishStreamingPreflight?.();
 		}
 
 		if (!messages) {

--- a/packages/coding-agent/test/suite/regressions/5886-compaction-input-hook-race.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5886-compaction-input-hook-race.test.ts
@@ -1,0 +1,59 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getUserTexts, type Harness } from "../harness.ts";
+
+describe("issue #5886: compaction queue with async input hook", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	// Regression test for #5886.
+	it("delivers a prompt submitted from compaction_end after an async input hook", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 100 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 8_000 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("input", async () => {
+						await Promise.resolve();
+						return { action: "continue" };
+					});
+					pi.on("session_before_compact", (event) => ({
+						compaction: {
+							summary: "compacted",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first response"), fauxAssistantMessage("queued response")]);
+
+		let queuedPrompt: Promise<void> | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.reason === "threshold") {
+				queuedPrompt = harness.session.prompt("queued during compaction", { streamingBehavior: "steer" });
+			}
+		});
+
+		await harness.session.prompt(`initial prompt ${"x".repeat(9_000)}`);
+		if (!queuedPrompt) throw new Error("compaction_end did not submit the queued prompt");
+		await queuedPrompt;
+
+		expect(harness.eventsOfType("compaction_end").map((event) => event.reason)).toEqual(["threshold"]);
+		expect(harness.session.isIdle).toBe(true);
+		expect(harness.session.pendingMessageCount).toBe(0);
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(getUserTexts(harness).filter((text) => text === "queued during compaction")).toEqual([
+			"queued during compaction",
+		]);
+		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary

- publish streaming continuation intent before async input hooks
- wait for pending streaming prompt preflights before the final queue and settlement decision
- add a faux-provider regression for the compaction/input-hook race in #5886

## Problem

When threshold compaction ends, a queued prompt can enter an async `input` hook before it reaches the steering queue. The post-run loop can observe an empty queue during that gap, settle the session, and leave the message stranded.

## Solution

Track prompt preflights that begin with an explicit streaming behavior while a run is active. Before the final queued-work check, wait until those preflights have either queued their message or completed without continuation work.

## Tests

- `npm run check`
- focused #5886 regression test
- related AgentSession settlement, compaction, concurrency, and TUI compaction tests

Refs #5886
