### PR TITLE
fix(coding-agent): expose queued agent message state

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1041,9 +1041,11 @@ pi.on("tool_result", async (event, ctx) => {
 });
 ```
 
-### ctx.isIdle() / ctx.abort() / ctx.hasPendingMessages()
+### ctx.isIdle() / ctx.abort() / ctx.hasPendingMessages() / ctx.hasQueuedAgentMessages()
 
 Control flow helpers. `ctx.isIdle()` is false while Pi is processing an agent run, automatic retry, auto-compaction retry, or queued continuation.
+
+`ctx.hasPendingMessages()` reports text messages tracked by the session for the editor and queue UI. `ctx.hasQueuedAgentMessages()` reports the low-level agent queue directly, including custom messages queued with `pi.sendMessage(..., { deliverAs: "steer" | "followUp" })`. Use the latter when deciding whether the agent loop still has work to process; it does not include `deliverAs: "nextTurn"` messages.
 
 ### ctx.shutdown()
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2626,6 +2626,7 @@ export class AgentSession {
 					void this.abort();
 				},
 				hasPendingMessages: () => this.pendingMessageCount > 0,
+				hasQueuedAgentMessages: () => this.agent.hasQueuedMessages(),
 				shutdown: () => {
 					this._extensionShutdownHandler?.();
 				},

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -283,6 +283,7 @@ export class ExtensionRunner {
 	private waitForIdleFn: () => Promise<void> = async () => {};
 	private abortFn: () => void = () => {};
 	private hasPendingMessagesFn: () => boolean = () => false;
+	private hasQueuedAgentMessagesFn: () => boolean = () => false;
 	private getContextUsageFn: () => ContextUsage | undefined = () => undefined;
 	private compactFn: (options?: CompactOptions) => void = () => {};
 	private getSystemPromptFn: () => string = () => "";
@@ -347,6 +348,7 @@ export class ExtensionRunner {
 		this.getSignalFn = contextActions.getSignal;
 		this.abortFn = contextActions.abort;
 		this.hasPendingMessagesFn = contextActions.hasPendingMessages;
+		this.hasQueuedAgentMessagesFn = contextActions.hasQueuedAgentMessages;
 		this.shutdownHandler = contextActions.shutdown;
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.compactFn = contextActions.compact;
@@ -780,6 +782,10 @@ export class ExtensionRunner {
 			hasPendingMessages: () => {
 				runner.assertActive();
 				return runner.hasPendingMessagesFn();
+			},
+			hasQueuedAgentMessages: () => {
+				runner.assertActive();
+				return runner.hasQueuedAgentMessagesFn();
 			},
 			shutdown: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -338,6 +338,8 @@ export interface ExtensionContext {
 	abort(): void;
 	/** Whether there are queued messages waiting */
 	hasPendingMessages(): boolean;
+	/** Whether the low-level agent has queued steering or follow-up messages waiting */
+	hasQueuedAgentMessages(): boolean;
 	/** Gracefully shutdown pi and exit. Available in all contexts. */
 	shutdown(): void;
 	/** Get current context usage for the active model. */
@@ -1716,6 +1718,7 @@ export interface ExtensionContextActions {
 	getSignal: () => AbortSignal | undefined;
 	abort: () => void;
 	hasPendingMessages: () => boolean;
+	hasQueuedAgentMessages: () => boolean;
 	shutdown: () => void;
 	getContextUsage: () => ContextUsage | undefined;
 	compact: (options?: CompactOptions) => void;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2097,6 +2097,7 @@ export class InteractiveMode {
 				this.restoreQueuedMessagesToEditor({ abort: true });
 			},
 			hasPendingMessages: () => this.session.pendingMessageCount > 0,
+			hasQueuedAgentMessages: () => this.session.agent.hasQueuedMessages(),
 			shutdown: () => {
 				this.shutdownRequested = true;
 			},

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -95,6 +95,7 @@ describe("ExtensionRunner", () => {
 		getSignal: () => undefined,
 		abort: () => {},
 		hasPendingMessages: () => false,
+		hasQueuedAgentMessages: () => false,
 		shutdown: () => {},
 		getContextUsage: () => undefined,
 		compact: () => {},
@@ -539,6 +540,26 @@ describe("ExtensionRunner", () => {
 
 			const ctx = runner.createContext();
 			expect(ctx.isProjectTrusted()).toBe(false);
+		});
+
+		it("exposes low-level agent queue state separately from session pending text", async () => {
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+			let queued = false;
+
+			runner.bindCore(extensionActions, {
+				...extensionContextActions,
+				hasPendingMessages: () => false,
+				hasQueuedAgentMessages: () => queued,
+			});
+
+			const ctx = runner.createContext();
+			expect(ctx.hasPendingMessages()).toBe(false);
+			expect(ctx.hasQueuedAgentMessages()).toBe(false);
+
+			queued = true;
+			expect(ctx.hasPendingMessages()).toBe(false);
+			expect(ctx.hasQueuedAgentMessages()).toBe(true);
 		});
 
 		it("exposes rpc mode with hasUI true when an RPC UI context is provided", async () => {

--- a/packages/coding-agent/test/plan-mode-extension.test.ts
+++ b/packages/coding-agent/test/plan-mode-extension.test.ts
@@ -77,6 +77,7 @@ function setup(options: { activeTools?: string[]; selectChoice?: string; editorT
 		sessionManager: { getEntries: () => [] },
 		isIdle: () => false,
 		hasPendingMessages: () => false,
+		hasQueuedAgentMessages: () => false,
 	} as unknown as ExtensionContext;
 
 	async function runCommand(name: string): Promise<void> {

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -422,13 +422,20 @@ describe("AgentSession queue characterization", () => {
 
 	it("delivers follow-ups queued during agent_end", async () => {
 		let sent = false;
+		let pendingTextAtQueue = false;
+		let queuedAgentMessageAtQueue = false;
 		const harness = await createHarness({
 			extensionFactories: [
 				(pi: ExtensionAPI) => {
-					pi.on("agent_end", async () => {
+					pi.on("agent_end", async (_event, ctx) => {
 						if (sent) return;
 						sent = true;
-						pi.sendUserMessage("conflict report", { deliverAs: "followUp" });
+						pi.sendMessage(
+							{ customType: "conflict-report", content: "conflict report", display: true, details: {} },
+							{ deliverAs: "followUp" },
+						);
+						pendingTextAtQueue = ctx.hasPendingMessages();
+						queuedAgentMessageAtQueue = ctx.hasQueuedAgentMessages();
 					});
 				},
 			],
@@ -440,6 +447,12 @@ describe("AgentSession queue characterization", () => {
 		await harness.session.prompt("hello");
 		await harness.session.agent.waitForIdle();
 
-		expect(getUserTexts(harness)).toEqual(["hello", "conflict report"]);
+		expect(pendingTextAtQueue).toBe(false);
+		expect(queuedAgentMessageAtQueue).toBe(true);
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "conflict-report",
+			),
+		).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -17,6 +17,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		signal: undefined,
 		abort: vi.fn(),
 		hasPendingMessages: () => false,
+		hasQueuedAgentMessages: () => false,
 		shutdown: vi.fn(),
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),
 		compact,


### PR DESCRIPTION
## Summary

Adds `ctx.hasQueuedAgentMessages()` for extensions that need to observe custom `steer` and `followUp` messages queued directly on the Agent.

`ctx.hasPendingMessages()` remains the session/UI text queue. The new helper delegates to `Agent.hasQueuedMessages()` and intentionally excludes `deliverAs: "nextTurn"` messages.

## Testing

- `npm run check`
- `npm run build:offline`
- `npm test --workspace @earendil-works/pi-coding-agent -- test/extensions-runner.test.ts test/suite/agent-session-queue.test.ts` (53 passed)
- `npm run test:scripts`
- CLI `--version` / `--help`

Fixes #8349