### PR TITLE
feat(ai): add thinking-level overrides for Fireworks GLM 5.3

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -975,6 +975,12 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	if (model.provider === "fireworks" && model.id.includes("glm-5p2")) {
 		mergeThinkingLevelMap(model, { off: "none", minimal: null, low: "high", medium: "high", max: "max" });
 	}
+	if (model.provider === "fireworks" && model.id.includes("glm-5p3")) {
+		// GLM 5.3 and GLM 5.3 Flash are thinking-only: reasoning_effort "none" is a 400
+		// ("GLM-5.3 is a thinking-only model"), so "off" stays unmapped. Both take only
+		// "high" and "max", so low/medium ride on "high" like GLM 5.2.
+		mergeThinkingLevelMap(model, { off: null, minimal: null, low: "high", medium: "high", max: "max" });
+	}
 	if (model.provider === "opencode-go" && model.id === "glm-5.2") {
 		mergeThinkingLevelMap(model, OPENCODE_GO_GLM52_THINKING_LEVEL_MAP);
 	}


### PR DESCRIPTION
models.dev now lists `accounts/fireworks/models/glm-5p3` and `glm-5p3-flash` under fireworks-ai, so both arrive in the Fireworks catalog on the next regeneration. This adds the thinking-level override they need.

Probed live against the Fireworks API (2026-08-31):

- Both models are **thinking-only**: `reasoning_effort: "none"` returns a 400 — `"GLM-5.3 is a thinking-only model; disabling thinking (reasoning_effort='none') is not supported."` (the flash deployment words it slightly differently). So unlike the GLM 5.2 override, `off` stays unmapped.
- Both accept only `"high"` and `"max"`, so `low`/`medium` ride on `"high"`, matching the GLM 5.2 precedent.

Verified end to end by hand-applying the resulting catalog entries to a 0.84.2 install: both models stream through `streamSimple` with reasoning captured and cost computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)