### PR TITLE
fix(extensions): never serve a stale pre-trust runtime to the final load pass

### DIFF
--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -575,6 +575,19 @@ export class DefaultResourceLoader implements ResourceLoader {
 		extensionPaths: string[],
 		preTrustExtensions: LoadExtensionsResult | undefined,
 	): Promise<LoadExtensionsResult> {
+		if (preTrustExtensions) {
+			// A pre-trust runtime that was invalidated while project trust was being
+			// resolved (session replaced during the trust window) must never be
+			// served to the final load pass: every remaining factory would throw
+			// "ctx is stale" on its first registration call, permanently failing to
+			// load those extensions. Drop it and take the full-reload path with a
+			// fresh runtime instead.
+			try {
+				preTrustExtensions.runtime.assertActive();
+			} catch {
+				preTrustExtensions = undefined;
+			}
+		}
 		if (!preTrustExtensions) {
 			const extensionsResult = await loadExtensionsCached(extensionPaths, this.cwd, this.eventBus);
 			const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime);


### PR DESCRIPTION
## Problem

When a session is replaced (fork / resume / newSession) while project trust is being resolved, the pre-trust extension runtime gets invalidated — the old session's `dispose()` / `oldRunner.invalidate()` propagates to the runtime it shares with the ResourceLoader. `loadFinalExtensionSet` then happily reused that dead runtime for the post-trust load pass, so every remaining extension factory threw on its first registration call:

```
Failed to load extension: This extension ctx is stale after session replacement
or reload. Do not use a captured pi or command ctx after ctx.newSession(), ...
```

Observed in the wild with `pi-better-subagents` and `pi-better-background-tasks` after a fork: both extensions permanently failed to load for the whole session, silently disabling subagents and background tasks.

## Fix

Before reusing `preTrustExtensions.runtime` for the final load pass, check it with `assertActive()`. If it was invalidated, drop `preTrustExtensions` and take the existing full-reload path with a fresh runtime. This is the only correct outcome anyway: the pre-trust extensions were bound to the dead runtime and their event-bus subscriptions were already unsubscribed by `invalidate()`.

## Testing

Minimal reproduction (loading two extensions, invalidating the runtime, then calling the loader with it) goes from `Failed to load extension: stale` ×2 to both extensions loading with zero errors. Happy to turn it into a unit test if you point me at the test file you'd prefer.