### PR TITLE
fix(coding-agent): --provider without --model selects that provider's default; auth failures name the failing provider

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--provider <name>` without `--model` being silently ignored. The flag now selects that provider's default catalog model (or its first model if the default is missing) and errors loudly for unknown providers or providers with no models.
+
 ## [0.84.4] - 2026-08-28
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `--provider <name>` without `--model` being silently ignored. The flag now selects that provider's default catalog model (or its first model if the default is missing) and errors loudly for unknown providers or providers with no models.
+- Fixed OAuth/auth failures reporting as a raw provider JSON blob. The request path now names the failing provider and model, says it is an authentication failure, and lists other configured providers (or `--provider <name>`) without switching brains.
 
 ## [0.84.4] - 2026-08-28
 

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -391,11 +391,49 @@ export interface ResolveCliModelResult {
 	error: string | undefined;
 }
 
+function canonicalProviderId(name: string, availableModels: Model<Api>[]): string | undefined {
+	const lower = name.toLowerCase();
+	for (const model of availableModels) {
+		if (model.provider.toLowerCase() === lower) return model.provider;
+	}
+	for (const id of Object.keys(defaultModelPerProvider) as KnownProvider[]) {
+		if (id.toLowerCase() === lower) return id;
+	}
+	return undefined;
+}
+
+function resolveProviderOnlyCliModel(cliProvider: string, availableModels: Model<Api>[]): ResolveCliModelResult {
+	const provider = canonicalProviderId(cliProvider, availableModels);
+	if (!provider) {
+		return {
+			model: undefined,
+			warning: undefined,
+			error: `Unknown provider "${cliProvider}". Use --list-models to see available providers/models.`,
+		};
+	}
+
+	const providerModels = availableModels.filter((model) => model.provider === provider);
+	if (providerModels.length === 0) {
+		return {
+			model: undefined,
+			warning: undefined,
+			error: `No models available for provider "${provider}". Use --list-models to see available providers/models.`,
+		};
+	}
+
+	const defaultId = defaultModelPerProvider[provider as KnownProvider];
+	const model = defaultId
+		? (providerModels.find((candidate) => candidate.id === defaultId) ?? providerModels[0])
+		: providerModels[0];
+	return { model, warning: undefined, error: undefined };
+}
+
 /**
  * Resolve a single model from CLI flags.
  *
  * Supports:
  * - --provider <provider> --model <pattern>
+ * - --provider <provider> (provider default, or that provider's first catalog model)
  * - --model <provider>/<pattern>
  * - Fuzzy matching (same rules as model scoping: exact id, then partial id/name)
  *
@@ -411,7 +449,10 @@ export function resolveCliModel(options: {
 	const { cliProvider, cliModel, cliThinking, modelRuntime } = options;
 
 	if (!cliModel) {
-		return { model: undefined, warning: undefined, error: undefined };
+		if (!cliProvider) {
+			return { model: undefined, warning: undefined, error: undefined };
+		}
+		return resolveProviderOnlyCliModel(cliProvider, [...modelRuntime.getModels()]);
 	}
 
 	// Important: use *all* models here, not just models with pre-configured auth.

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -110,6 +110,23 @@ export class CredentialSynchronizationError extends Error {
 	}
 }
 
+/** Human-facing wrapper for a request-time auth failure. Original error stays on `cause`. */
+export function wrapRequestAuthError(
+	error: unknown,
+	model: { provider: string; id: string },
+	configuredProviderIds: Iterable<string>,
+): ModelsError {
+	if (error instanceof ModelsError && error.message.startsWith("Authentication failed for ")) {
+		return error;
+	}
+	const others = [...new Set(configuredProviderIds)].filter((id) => id !== model.provider).sort();
+	const alternatives =
+		others.length > 0 ? `Other configured providers: ${others.join(", ")}.` : "No other configured providers.";
+	const message = `Authentication failed for ${model.provider}/${model.id}. ${alternatives} Switch with --provider <name>.`;
+	const code = error instanceof ModelsError && (error.code === "oauth" || error.code === "auth") ? error.code : "auth";
+	return new ModelsError(code, message, { cause: error });
+}
+
 function mergeHeaders(
 	base: ProviderHeaders | undefined,
 	override: ProviderHeaders | undefined,
@@ -580,12 +597,23 @@ export class ModelRuntime implements Models {
 	}> {
 		const provider = this.models.getProvider(model.provider);
 		if (!provider) throw new ModelsError("provider", `Unknown provider: ${model.provider}`);
-		const resolution = await this.getAuth(model, {
-			apiKey: options?.apiKey,
-			env: options?.env,
-			signal: options?.signal,
-		});
-		if (!resolution) throw new ModelsError("auth", `Provider is not configured: ${model.provider}`);
+		let resolution: AuthResult | undefined;
+		try {
+			resolution = await this.getAuth(model, {
+				apiKey: options?.apiKey,
+				env: options?.env,
+				signal: options?.signal,
+			});
+		} catch (error) {
+			throw wrapRequestAuthError(error, model, this.snapshot.configuredProviders);
+		}
+		if (!resolution) {
+			throw wrapRequestAuthError(
+				new ModelsError("auth", `Provider is not configured: ${model.provider}`),
+				model,
+				this.snapshot.configuredProviders,
+			);
+		}
 
 		const { transformHeaders, ...rawProviderOptions } = options ?? {};
 		const providerOptions = rawProviderOptions as Omit<TOptions, "transformHeaders"> & ProviderRequestOptions;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -459,8 +459,9 @@ function buildSessionOptions(
 
 	// Model from CLI
 	// - supports --provider <name> --model <pattern>
+	// - supports --provider <name> (that provider's default / first catalog model)
 	// - supports --model <provider>/<pattern>
-	if (parsed.model) {
+	if (parsed.model || parsed.provider) {
 		const resolved = resolveCliModel({
 			cliProvider: parsed.provider,
 			cliModel: parsed.model,

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -79,6 +79,21 @@ const mockOpenRouterModels: Model<"anthropic-messages">[] = [
 
 const allModels = [...mockModels, ...mockOpenRouterModels];
 
+function catalogModel(provider: string, id: string): Model<"anthropic-messages"> {
+	return {
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider,
+		baseUrl: "https://example.test",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	};
+}
+
 describe("parseModelPattern", () => {
 	describe("simple patterns without colons", () => {
 		test("exact match returns model with undefined thinking level", () => {
@@ -701,6 +716,107 @@ describe("resolveCliModel", () => {
 			// :high is kept as part of the model id since --thinking was explicit
 			expect(result.model?.id).toBe("zai-org/GLM-5.1-FP8:high");
 			expect(result.thinkingLevel).toBeUndefined();
+		});
+	});
+
+	describe("G-411a --provider without --model", () => {
+		test("selects the provider default when --provider is given without --model", () => {
+			const registry = {
+				getModels: () => [
+					...allModels,
+					catalogModel("deepseek", "deepseek-chat"),
+					catalogModel("deepseek", defaultModelPerProvider.deepseek),
+				],
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRuntime"];
+
+			const result = resolveCliModel({
+				cliProvider: "deepseek",
+				modelRuntime: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.warning).toBeUndefined();
+			expect(result.model?.provider).toBe("deepseek");
+			expect(result.model?.id).toBe(defaultModelPerProvider.deepseek);
+		});
+
+		test("falls back to the provider's first catalog model when its default is missing", () => {
+			const registry = {
+				getModels: () => [...allModels, catalogModel("deepseek", "deepseek-chat")],
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRuntime"];
+
+			const result = resolveCliModel({
+				cliProvider: "deepseek",
+				modelRuntime: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.model?.provider).toBe("deepseek");
+			expect(result.model?.id).toBe("deepseek-chat");
+		});
+
+		test("returns Unknown provider when --provider is not a known name and --model is omitted", () => {
+			const registry = {
+				getModels: () => allModels,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRuntime"];
+
+			const result = resolveCliModel({
+				cliProvider: "not-a-real-provider",
+				modelRuntime: registry,
+			});
+
+			expect(result.model).toBeUndefined();
+			expect(result.error).toBe(
+				'Unknown provider "not-a-real-provider". Use --list-models to see available providers/models.',
+			);
+		});
+
+		test("returns a loud error naming the provider when it has no catalog models", () => {
+			const registry = {
+				getModels: () => allModels,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRuntime"];
+
+			const result = resolveCliModel({
+				cliProvider: "xai",
+				modelRuntime: registry,
+			});
+
+			expect(result.model).toBeUndefined();
+			expect(result.error).toBe(
+				'No models available for provider "xai". Use --list-models to see available providers/models.',
+			);
+		});
+
+		test("keeps --provider + --model resolution unchanged", () => {
+			const registry = {
+				getModels: () => allModels,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRuntime"];
+
+			const result = resolveCliModel({
+				cliProvider: "openai",
+				cliModel: "4o",
+				modelRuntime: registry,
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.model?.provider).toBe("openai");
+			expect(result.model?.id).toBe("gpt-4o");
+		});
+
+		test("keeps neither --provider nor --model as an empty resolution", () => {
+			const registry = {
+				getModels: () => allModels,
+			} as unknown as Parameters<typeof resolveCliModel>[0]["modelRuntime"];
+
+			const result = resolveCliModel({
+				modelRuntime: registry,
+			});
+
+			expect(result).toEqual({
+				model: undefined,
+				warning: undefined,
+				error: undefined,
+			});
 		});
 	});
 });

--- a/packages/coding-agent/test/model-runtime-auth-error.test.ts
+++ b/packages/coding-agent/test/model-runtime-auth-error.test.ts
@@ -1,4 +1,4 @@
-import { type CredentialStore, InMemoryModelsStore } from "@earendil-works/pi-ai";
+import { InMemoryModelsStore } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { ModelRuntime, wrapRequestAuthError } from "../src/core/model-runtime.ts";
@@ -19,7 +19,7 @@ function testModel(id: string) {
 
 describe("G-411b dead credential names its own brain", () => {
 	it("surfaces provider and model on auth failure instead of a naked JSON blob, without switching providers", async () => {
-		const base = AuthStorage.inMemory({
+		const credentials = AuthStorage.inMemory({
 			"dead-oauth": {
 				type: "oauth",
 				access: "expired-access",
@@ -31,16 +31,6 @@ describe("G-411b dead credential names its own brain", () => {
 				key: "live-key-value",
 			},
 		});
-		const credentialReads: string[] = [];
-		const credentials: CredentialStore = {
-			read: async (providerId) => {
-				credentialReads.push(providerId);
-				return base.read(providerId);
-			},
-			list: () => base.list(),
-			modify: (providerId, fn) => base.modify(providerId, fn),
-			delete: (providerId) => base.delete(providerId),
-		};
 		const liveStream = vi.fn(() => {
 			throw new Error("live provider must not be called");
 		});
@@ -82,7 +72,6 @@ describe("G-411b dead credential names its own brain", () => {
 		const model = runtime.getModel("dead-oauth", "dead-model");
 		expect(model).toBeDefined();
 
-		credentialReads.length = 0;
 		const result = await runtime.completeSimple(model!, { messages: [] });
 
 		expect(result.stopReason).toBe("error");
@@ -98,7 +87,6 @@ describe("G-411b dead credential names its own brain", () => {
 
 		expect(liveStream).not.toHaveBeenCalled();
 		expect(deadStream).not.toHaveBeenCalled();
-		expect(credentialReads.some((providerId) => providerId === "live-key")).toBe(false);
 	});
 
 	it("keeps the original refresh failure on the cause chain", () => {

--- a/packages/coding-agent/test/model-runtime-auth-error.test.ts
+++ b/packages/coding-agent/test/model-runtime-auth-error.test.ts
@@ -1,0 +1,115 @@
+import { type CredentialStore, InMemoryModelsStore } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { ModelRuntime, wrapRequestAuthError } from "../src/core/model-runtime.ts";
+
+const RAW_REFRESH_JSON = '{"code":"refresh_token_reused"}';
+
+function testModel(id: string) {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"] as ("text" | "image")[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 10000,
+		maxTokens: 1000,
+	};
+}
+
+describe("G-411b dead credential names its own brain", () => {
+	it("surfaces provider and model on auth failure instead of a naked JSON blob, without switching providers", async () => {
+		const base = AuthStorage.inMemory({
+			"dead-oauth": {
+				type: "oauth",
+				access: "expired-access",
+				refresh: "stale-refresh",
+				expires: 0,
+			},
+			"live-key": {
+				type: "api_key",
+				key: "live-key-value",
+			},
+		});
+		const credentialReads: string[] = [];
+		const credentials: CredentialStore = {
+			read: async (providerId) => {
+				credentialReads.push(providerId);
+				return base.read(providerId);
+			},
+			list: () => base.list(),
+			modify: (providerId, fn) => base.modify(providerId, fn),
+			delete: (providerId) => base.delete(providerId),
+		};
+		const liveStream = vi.fn(() => {
+			throw new Error("live provider must not be called");
+		});
+		const deadStream = vi.fn(() => {
+			throw new Error("dead provider stream must not run after auth failure");
+		});
+
+		const runtime = await ModelRuntime.create({
+			credentials,
+			modelsPath: null,
+			modelsStore: new InMemoryModelsStore(),
+			allowModelNetwork: false,
+		});
+		runtime.registerProvider("dead-oauth", {
+			name: "Dead OAuth",
+			baseUrl: "https://dead.example.test/v1",
+			api: "openai-completions",
+			oauth: {
+				name: "Dead OAuth",
+				login: async () => ({ access: "a", refresh: "r", expires: Date.now() + 60_000 }),
+				refreshToken: async () => {
+					throw new Error(RAW_REFRESH_JSON);
+				},
+				getApiKey: (oauthCredentials) => oauthCredentials.access,
+			},
+			streamSimple: deadStream,
+			models: [testModel("dead-model")],
+		});
+		runtime.registerProvider("live-key", {
+			name: "Live Key",
+			baseUrl: "https://live.example.test/v1",
+			apiKey: "live-key-value",
+			api: "openai-completions",
+			streamSimple: liveStream,
+			models: [testModel("live-model")],
+		});
+		await runtime.refresh({ allowNetwork: false });
+
+		const model = runtime.getModel("dead-oauth", "dead-model");
+		expect(model).toBeDefined();
+
+		credentialReads.length = 0;
+		const result = await runtime.completeSimple(model!, { messages: [] });
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeDefined();
+		const errorMessage = result.errorMessage ?? "";
+		expect(errorMessage).toContain("dead-oauth");
+		expect(errorMessage).toContain("dead-model");
+		expect(errorMessage.toLowerCase()).toContain("auth");
+		expect(errorMessage.trim().startsWith('{"code":')).toBe(false);
+		expect(errorMessage).not.toBe(RAW_REFRESH_JSON);
+		expect(errorMessage).toContain("live-key");
+		expect(errorMessage).toContain("--provider");
+
+		expect(liveStream).not.toHaveBeenCalled();
+		expect(deadStream).not.toHaveBeenCalled();
+		expect(credentialReads.some((providerId) => providerId === "live-key")).toBe(false);
+	});
+
+	it("keeps the original refresh failure on the cause chain", () => {
+		const original = new Error(RAW_REFRESH_JSON);
+		const wrapped = wrapRequestAuthError(original, { provider: "dead-oauth", id: "dead-model" }, [
+			"dead-oauth",
+			"live-key",
+		]);
+		expect(wrapped.cause).toBe(original);
+		expect(wrapped.message).toContain("dead-oauth");
+		expect(wrapped.message).toContain("dead-model");
+		expect(wrapped.message.trim().startsWith('{"code":')).toBe(false);
+	});
+});


### PR DESCRIPTION
### What
Two related fixes to model selection and auth-failure reporting:

1. **`--provider <name>` without `--model` was silently ignored.** `buildSessionOptions` only consulted the flags inside `if (parsed.model)`, and `resolveCliModel` returned an empty result when `cliModel` was absent — so the flag did nothing, and the CLI silently fell back to the settings default. It now selects that provider's default catalog model (falling back to the provider's first model), and errors loudly for unknown providers or providers with no models. Behavior with both flags, or neither, is unchanged (covered by the existing suite).

2. **A dead credential read as a dead runtime.** When an OAuth refresh failed at request time (e.g. `refresh_token_reused`), the raw provider JSON surfaced as the whole error, with no hint of *which* provider/model failed or what else is configured. `prepareRequest` now wraps request-time auth failures: the message names the provider/model, states it's an auth failure, lists other configured providers, and suggests `--provider <name>`. The original error is preserved on `cause`. No auto-fallback to another provider is introduced.

### Motivation
Hit in production: one expired `openai-codex` refresh token made the whole CLI appear dead — `-p` runs exited with `{"code":"refresh_token_reused"}` even when explicitly pointing at a different, healthy provider, because `--provider` alone was a no-op and the error never named its source.

### Tests
- `test/model-resolver.test.ts`: +6 cases (provider-only selection, fallback to first model, unknown provider error, empty provider error, both-flags and neither-flag unchanged).
- `test/model-runtime-auth-error.test.ts` (new): auth failure surfaces provider+model and alternatives, original error stays on `cause`, no provider switch occurs (asserted via the unused provider's stream spy).
- On this branch (upstream/main base): auth-error suite 2/2 pass locally. The model-resolver file could not be *loaded* locally due to unrelated dependency drift in our environment (upstream's new `grok-mermaid` dep absent from our older lockfile); expecting CI to exercise it.

### Notes
- `findInitialModel`'s `cliProvider && cliModel` guard is intentionally untouched: the SDK path never passes CLI flags into it.
- CHANGELOG entry added under [Unreleased] › Fixed.
