### PR TITLE
fix(coding-agent): preserve compaction boundary when forking

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1422,10 +1422,27 @@ export class SessionManager {
 		// Because labels are real tree entries, later entries can be children of labels;
 		// removing labels requires re-chaining the retained path to avoid orphaned subtrees.
 		const pathWithoutLabels: SessionEntry[] = [];
+		const replacementByLabelId = new Map<string, string>();
+		const pendingLabelIds: string[] = [];
 		let pathParentId: string | null = null;
 		for (const entry of path) {
-			if (entry.type === "label") continue;
-			pathWithoutLabels.push({ ...entry, parentId: pathParentId });
+			if (entry.type === "label") {
+				pendingLabelIds.push(entry.id);
+				continue;
+			}
+			for (const labelId of pendingLabelIds) {
+				replacementByLabelId.set(labelId, entry.id);
+			}
+			pendingLabelIds.length = 0;
+			pathWithoutLabels.push(
+				entry.type === "compaction"
+					? {
+							...entry,
+							parentId: pathParentId,
+							firstKeptEntryId: replacementByLabelId.get(entry.firstKeptEntryId) ?? entry.firstKeptEntryId,
+						}
+					: { ...entry, parentId: pathParentId },
+			);
 			pathParentId = entry.id;
 		}
 

--- a/packages/coding-agent/test/suite/regressions/8989-fork-compaction-label-boundary.test.ts
+++ b/packages/coding-agent/test/suite/regressions/8989-fork-compaction-label-boundary.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { type CompactionEntry, SessionManager } from "../../../src/core/session-manager.ts";
+import { userMsg } from "../../utilities.ts";
+
+describe("regression #8989", () => {
+	it("preserves compaction context when a fork removes the boundary label", () => {
+		const session = SessionManager.inMemory();
+		const oldId = session.appendMessage(userMsg("old"));
+		// findCutPoint() can move a compaction boundary back to this context-invisible label.
+		const labelId = session.appendLabelChange(oldId, "checkpoint");
+		const keptId = session.appendMessage(userMsg("kept"));
+		const compactionId = session.appendCompaction("summary", labelId, 100);
+		const leafId = session.appendMessage(userMsg("after"));
+
+		session.createBranchedSession(leafId);
+
+		expect((session.getEntry(compactionId) as CompactionEntry).firstKeptEntryId).toBe(keptId);
+		expect(session.buildSessionContext().messages).toMatchObject([
+			{ role: "compactionSummary", summary: "summary" },
+			{ role: "user", content: "kept" },
+			{ role: "user", content: "after" },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- remap compaction boundaries that point to labels removed while forking
- preserve the retained provider context in the fork
- add an in-memory regression for the boundary remap

## Scope

This only rewrites `firstKeptEntryId` when it names a label removed from the copied path. Existing compaction boundaries remain unchanged.

#5669 re-chained `parentId` after removing labels from this path. It did not remap `CompactionEntry.firstKeptEntryId`.

Stopping `findCutPoint()` before labels could prevent new occurrences, but would not repair existing sessions that already store a label boundary.

The replacement is the first copied entry after that label, so the fork retains the same provider-visible messages.

## Tests

- targeted `8989-fork-compaction-label-boundary.test.ts` regression
- `npm run check`
- `./test.sh`

Fixes #8989
