### PR TITLE
fix(agent): map signal-killed processes to non-zero exit codes

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -14,7 +14,7 @@ import {
 	rm,
 	writeFile,
 } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { homedir, constants as osConstants, tmpdir } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
@@ -287,11 +287,15 @@ function killProcessTree(pid: number): void {
 	}
 }
 
-function waitForChildProcess(child: ChildProcess, spillIsDraining: () => boolean): Promise<number | null> {
+function waitForChildProcess(
+	child: ChildProcess,
+	spillIsDraining: () => boolean,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
 	return new Promise((resolvePromise, reject) => {
 		let settled = false;
 		let exited = false;
 		let exitCode: number | null = null;
+		let exitSignal: NodeJS.Signals | null = null;
 		let postExitTimer: ReturnType<typeof setTimeout> | undefined;
 		let stdoutEnded = child.stdout === null;
 		let stderrEnded = child.stderr === null;
@@ -306,22 +310,22 @@ function waitForChildProcess(child: ChildProcess, spillIsDraining: () => boolean
 			child.stdout?.removeListener("data", onData);
 			child.stderr?.removeListener("data", onData);
 		};
-		const finalize = (code: number | null): void => {
+		const finalize = (): void => {
 			if (settled) return;
 			settled = true;
 			cleanup();
 			child.stdout?.destroy();
 			child.stderr?.destroy();
-			resolvePromise(code);
+			resolvePromise({ code: exitCode, signal: exitSignal });
 		};
 		const maybeFinalizeAfterExit = (): void => {
-			if (exited && stdoutEnded && stderrEnded) finalize(exitCode);
+			if (exited && stdoutEnded && stderrEnded) finalize();
 		};
 		const armIdleTimer = (): void => {
 			if (postExitTimer) clearTimeout(postExitTimer);
 			postExitTimer = setTimeout(() => {
 				if (spillIsDraining()) armIdleTimer();
-				else finalize(exitCode);
+				else finalize();
 			}, EXIT_STDIO_GRACE_MS);
 		};
 		const onData = (): void => {
@@ -341,13 +345,18 @@ function waitForChildProcess(child: ChildProcess, spillIsDraining: () => boolean
 			cleanup();
 			reject(error);
 		};
-		const onExit = (code: number | null): void => {
+		const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
 			exited = true;
 			exitCode = code;
+			exitSignal = signal;
 			maybeFinalizeAfterExit();
 			if (!settled) armIdleTimer();
 		};
-		const onClose = (code: number | null): void => finalize(code);
+		const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+			exitCode = code;
+			exitSignal = signal;
+			finalize();
+		};
 
 		child.stdout?.once("end", onStdoutEnd);
 		child.stderr?.once("end", onStderrEnd);
@@ -577,7 +586,7 @@ export class NodeExecutionEnv implements ExecutionEnv {
 					spillStart !== undefined &&
 					(spillStream === undefined || spillBackpressured),
 			).then(
-				async (code) => {
+				async ({ code, signal: exitSignal }) => {
 					await finishSpill();
 					try {
 						capture.finish();
@@ -602,9 +611,13 @@ export class NodeExecutionEnv implements ExecutionEnv {
 						return;
 					}
 					const output = capture.snapshot();
+					// A process killed by a signal (e.g. OOM killer) has no exit code; map it
+					// to the conventional 128 + signal number so callers do not mistake it
+					// for a successful exit.
+					const exitCode = code ?? (exitSignal ? 128 + (osConstants.signals[exitSignal] ?? 0) : 1);
 					settle(
 						ok({
-							exitCode: code ?? 0,
+							exitCode,
 							truncation: output.truncation,
 							...(output.spillPath === undefined ? {} : { spillPath: output.spillPath }),
 							...(output.lastLineBytes === undefined ? {} : { lastLineBytes: output.lastLineBytes }),

--- a/packages/agent/test/harness/nodejs-env.test.ts
+++ b/packages/agent/test/harness/nodejs-env.test.ts
@@ -519,6 +519,14 @@ describe("NodeExecutionEnv", () => {
 		expect(result.truncation.totalBytes).toBe(0);
 	});
 
+	// Regression test for https://github.com/earendil-works/pi/issues/8992
+	it.skipIf(process.platform === "win32")("maps signal-killed processes to a non-zero exit code", async () => {
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		const result = getOrThrow(await env.exec("kill -9 $$", undefined, BACKGROUND_CONTEXT));
+		expect(result.exitCode).toBe(128 + 9);
+	});
+
 	it("returns timeout errors for commands exceeding the timeout", async () => {
 		const root = createTempDir();
 		const env = new NodeExecutionEnv({ cwd: root });


### PR DESCRIPTION
fixes #8992

`waitForChildProcess` resolved `null` for the exit code when a child was killed by a signal (e.g. the OOM killer terminating a long-running bash tool call), and `exec` mapped it with `code ?? 0`. The bash tool only checks `exitCode !== 0`, so a killed command looked like a success and the model saw truncated output presented as a completed command.

The fix tracks the termination signal from the `exit`/`close` events and falls back to the shell convention of 128 + signal number (137 for SIGKILL) when no exit code is available.

Repro before the fix:

```ts
const env = new NodeExecutionEnv({ cwd: process.cwd() });
const result = await env.exec("kill -9 $$");
// result.ok === true and result.value.exitCode === 0
```

A regression test (`kill -9 $$` must yield exit code 137) is included; it fails before the fix and passes after. `npm run check` and `./test.sh` pass.
