### PR TITLE
fix(coding-agent): never overwrite existing session files on /import

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { resolvePath } from "../utils/paths.ts";
 import type { AgentSession } from "./agent-session.ts";
@@ -62,6 +62,22 @@ function extractUserMessageText(content: string | Array<{ type: string; text?: s
 		.filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
 		.map((part) => part.text)
 		.join("");
+}
+
+/**
+ * Pick a destination path for an imported session file that never overwrites an
+ * existing file: `foo.jsonl` becomes `foo-1.jsonl`, `foo-2.jsonl`, ...
+ */
+function resolveImportDestination(sessionDir: string, fileName: string): string {
+	let candidate = join(sessionDir, fileName);
+	if (!existsSync(candidate)) return candidate;
+	const dotIndex = fileName.lastIndexOf(".");
+	const stem = dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName;
+	const extension = dotIndex > 0 ? fileName.slice(dotIndex) : "";
+	for (let suffix = 1; ; suffix++) {
+		candidate = join(sessionDir, `${stem}-${suffix}${extension}`);
+		if (!existsSync(candidate)) return candidate;
+	}
 }
 
 /**
@@ -354,6 +370,10 @@ export class AgentSessionRuntime {
 	/**
 	 * Import a session JSONL file and switch runtime state to the imported session.
 	 *
+	 * The file is copied into the session directory. When a file with the same name
+	 * already exists there, a unique destination name is chosen instead of
+	 * overwriting it. If the import fails after copying, the copy is removed again.
+	 *
 	 * @returns `{ cancelled: true }` when cancelled by `session_before_switch`, otherwise `{ cancelled: false }`.
 	 * @throws {SessionImportFileNotFoundError} When the input path does not exist.
 	 * @throws {MissingSessionCwdError} When the imported session cwd cannot be resolved and no override is provided.
@@ -369,30 +389,39 @@ export class AgentSessionRuntime {
 			mkdirSync(sessionDir, { recursive: true });
 		}
 
-		const destinationPath = join(sessionDir, basename(resolvedPath));
+		const isInPlace = resolve(join(sessionDir, basename(resolvedPath))) === resolvedPath;
+		const destinationPath = isInPlace ? resolvedPath : resolveImportDestination(sessionDir, basename(resolvedPath));
 		const beforeResult = await this.emitBeforeSwitch("resume", destinationPath);
 		if (beforeResult.cancelled) {
 			return beforeResult;
 		}
 
 		const previousSessionFile = this.session.sessionFile;
-		if (resolve(destinationPath) !== resolvedPath) {
+		if (!isInPlace) {
 			copyFileSync(resolvedPath, destinationPath);
 		}
 
-		const sessionManager = SessionManager.open(destinationPath, sessionDir, cwdOverride);
-		assertSessionCwdExists(sessionManager, this.cwd);
-		await this.teardownCurrent("resume", sessionManager.getSessionFile());
-		this.apply(
-			await this.createRuntime({
-				cwd: sessionManager.getCwd(),
-				agentDir: this.services.agentDir,
-				sessionManager,
-				sessionStartEvent: { type: "session_start", reason: "resume", previousSessionFile },
-			}),
-		);
-		await this.finishSessionReplacement();
-		return { cancelled: false };
+		try {
+			const sessionManager = SessionManager.open(destinationPath, sessionDir, cwdOverride);
+			assertSessionCwdExists(sessionManager, this.cwd);
+			await this.teardownCurrent("resume", sessionManager.getSessionFile());
+			this.apply(
+				await this.createRuntime({
+					cwd: sessionManager.getCwd(),
+					agentDir: this.services.agentDir,
+					sessionManager,
+					sessionStartEvent: { type: "session_start", reason: "resume", previousSessionFile },
+				}),
+			);
+			await this.finishSessionReplacement();
+			return { cancelled: false };
+		} catch (error) {
+			// A failed import must not leave the copied file behind.
+			if (!isInPlace) {
+				rmSync(destinationPath, { force: true });
+			}
+			throw error;
+		}
 	}
 
 	async dispose(): Promise<void> {

--- a/packages/coding-agent/test/agent-session-runtime-import.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-import.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.ts";
+import {
+	AgentSessionRuntime,
+	type AgentSessionServices,
+	type CreateAgentSessionRuntimeFactory,
+	type CreateAgentSessionRuntimeResult,
+} from "../src/core/agent-session-runtime.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+
+function sessionFileContent(id: string, cwd: string): string {
+	return `${JSON.stringify({ type: "session", version: 3, id, timestamp: new Date().toISOString(), cwd })}\n`;
+}
+
+function createStubSession(sessionManager: SessionManager): AgentSession {
+	return {
+		sessionManager,
+		sessionFile: sessionManager.getSessionFile(),
+		extensionRunner: { hasHandlers: () => false, emit: async () => undefined },
+		abort: async () => {},
+		dispose: () => {},
+	} as unknown as AgentSession;
+}
+
+function createImportRuntime(cwd: string, sessionDir: string): AgentSessionRuntime {
+	const sessionManager = SessionManager.create(cwd, sessionDir);
+	const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd: nextCwd, sessionManager: nextManager }) => {
+		const services = { cwd: nextCwd, agentDir: nextCwd } as unknown as AgentSessionServices;
+		return {
+			session: createStubSession(nextManager),
+			extensionsResult: { extensions: [], errors: [], runtimeContext: {} },
+			services,
+			diagnostics: [],
+		} as unknown as CreateAgentSessionRuntimeResult;
+	};
+	const services = { cwd, agentDir: cwd } as unknown as AgentSessionServices;
+	return new AgentSessionRuntime(createStubSession(sessionManager), services, createRuntime);
+}
+
+// Regression tests for https://github.com/earendil-works/pi/issues/8993
+describe("AgentSessionRuntime.importFromJsonl", () => {
+	const tempDirs: string[] = [];
+
+	function createTempDir(): string {
+		const dir = mkdtempSync(join(tmpdir(), "pi-import-test-"));
+		tempDirs.push(dir);
+		return dir;
+	}
+
+	afterEach(() => {
+		while (tempDirs.length > 0) {
+			rmSync(tempDirs.pop()!, { recursive: true, force: true });
+		}
+	});
+
+	it("renames the imported file instead of overwriting an existing session with the same name", async () => {
+		const cwd = createTempDir();
+		const sessionDir = join(cwd, "sessions");
+		const sourceDir = createTempDir();
+
+		const runtime = createImportRuntime(cwd, sessionDir);
+
+		const existingPath = join(sessionDir, "shared.jsonl");
+		const existingContent = sessionFileContent("11111111-1111-4111-8111-111111111111", cwd);
+		writeFileSync(existingPath, existingContent);
+
+		const sourcePath = join(sourceDir, "shared.jsonl");
+		const importedContent = sessionFileContent("22222222-2222-4222-8222-222222222222", cwd);
+		writeFileSync(sourcePath, importedContent);
+
+		const result = await runtime.importFromJsonl(sourcePath);
+
+		expect(result).toEqual({ cancelled: false });
+		// The pre-existing session file is untouched.
+		expect(readFileSync(existingPath, "utf8")).toBe(existingContent);
+		// The import landed under a unique name with the imported content.
+		const renamedPath = join(sessionDir, "shared-1.jsonl");
+		expect(readFileSync(renamedPath, "utf8")).toBe(importedContent);
+		expect(runtime.session.sessionManager.getSessionFile()).toBe(resolve(renamedPath));
+	});
+
+	it("does not overwrite or leave files behind when the imported file is not a valid session", async () => {
+		const cwd = createTempDir();
+		const sessionDir = join(cwd, "sessions");
+		const sourceDir = createTempDir();
+
+		const runtime = createImportRuntime(cwd, sessionDir);
+
+		const existingPath = join(sessionDir, "broken.jsonl");
+		const existingContent = sessionFileContent("33333333-3333-4333-8333-333333333333", cwd);
+		writeFileSync(existingPath, existingContent);
+
+		const sourcePath = join(sourceDir, "broken.jsonl");
+		writeFileSync(sourcePath, "this is not a pi session\n");
+
+		await expect(runtime.importFromJsonl(sourcePath)).rejects.toThrow("not a valid");
+
+		expect(readFileSync(existingPath, "utf8")).toBe(existingContent);
+		expect(readdirSync(sessionDir).sort()).toEqual(["broken.jsonl"]);
+	});
+
+	it("imports a file already inside the session directory in place", async () => {
+		const cwd = createTempDir();
+		const sessionDir = join(cwd, "sessions");
+
+		const runtime = createImportRuntime(cwd, sessionDir);
+
+		const inPlacePath = join(sessionDir, "in-place.jsonl");
+		writeFileSync(inPlacePath, sessionFileContent("44444444-4444-4444-8444-444444444444", cwd));
+
+		const result = await runtime.importFromJsonl(inPlacePath);
+
+		expect(result).toEqual({ cancelled: false });
+		expect(runtime.session.sessionManager.getSessionFile()).toBe(resolve(inPlacePath));
+		expect(existsSync(join(sessionDir, "in-place-1.jsonl"))).toBe(false);
+	});
+});


### PR DESCRIPTION
fixes #8993

`importFromJsonl` copied the imported file into the session directory with `copyFileSync`, silently overwriting an existing session file with the same basename. The copy also happened before validation, so importing an invalid file that shared a name with an existing session destroyed the existing session content before `SessionManager.open` raised an error.

The fix:

- On a name collision, pick a unique destination name (`foo-1.jsonl`, `foo-2.jsonl`, ...) instead of overwriting.
- If the import fails after copying, remove the copied file again so a failed import leaves no garbage in the session directory.
- Importing a file that already lives inside the session directory still opens it in place, as before.

Regression tests cover the collision rename, the failed-import cleanup, and the in-place case; they fail before the fix and pass after. `npm run check` and `./test.sh` pass.
