### PR TITLE
fix(agent): surface proxy stream EOF without terminal event as an error

### DIFF
--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -181,6 +181,19 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 			reader = response.body!.getReader();
 			const decoder = new TextDecoder();
 			let buffer = "";
+			let sawTerminalEvent = false;
+
+			const processLine = (line: string): void => {
+				if (!line.startsWith("data: ")) return;
+				const data = line.slice(6).trim();
+				if (!data) return;
+				const proxyEvent = JSON.parse(data) as ProxyAssistantMessageEvent;
+				const event = processProxyEvent(proxyEvent, partial);
+				if (event) {
+					if (event.type === "done" || event.type === "error") sawTerminalEvent = true;
+					stream.push(event);
+				}
+			};
 
 			while (true) {
 				const { done, value } = await reader.read();
@@ -195,21 +208,32 @@ export function streamProxy(model: Model<any>, context: Context, options: ProxyS
 				buffer = lines.pop() || "";
 
 				for (const line of lines) {
-					if (line.startsWith("data: ")) {
-						const data = line.slice(6).trim();
-						if (data) {
-							const proxyEvent = JSON.parse(data) as ProxyAssistantMessageEvent;
-							const event = processProxyEvent(proxyEvent, partial);
-							if (event) {
-								stream.push(event);
-							}
-						}
-					}
+					processLine(line);
 				}
 			}
 
 			if (options.signal?.aborted) {
 				throw new Error("Request aborted by user");
+			}
+
+			// The final event may not be newline-terminated; flush the decoder and
+			// process whatever is left in the buffer.
+			buffer += decoder.decode();
+			if (buffer) {
+				processLine(buffer);
+			}
+
+			if (!sawTerminalEvent) {
+				// A clean EOF without a done/error event means the server dropped the
+				// response mid-stream. Surface it as an error instead of leaving
+				// consumers waiting on a result that never arrives.
+				partial.stopReason = "error";
+				partial.errorMessage = "Connection closed by proxy server before the response completed";
+				stream.push({
+					type: "error",
+					reason: "error",
+					error: partial,
+				});
 			}
 
 			stream.end();

--- a/packages/agent/test/proxy.test.ts
+++ b/packages/agent/test/proxy.test.ts
@@ -76,4 +76,53 @@ describe("streamProxy", () => {
 			namespace: "dynamic_tools",
 		});
 	});
+
+	// Regression tests for https://github.com/earendil-works/pi/issues/8996
+	it("processes a terminal event that is not newline-terminated", async () => {
+		const start = `data: ${JSON.stringify({ type: "start" })}\n\n`;
+		const done = `data: ${JSON.stringify({ type: "done", reason: "stop", usage })}`;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(start + done, { status: 200 })),
+		);
+
+		const stream = streamProxy(
+			model,
+			{ systemPrompt: "", messages: [] },
+			{
+				authToken: "test-token",
+				proxyUrl: "https://proxy.example.com",
+			},
+		);
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) events.push(event);
+		const result = await stream.result();
+
+		expect(events.map((event) => event.type)).toEqual(["start", "done"]);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("emits an error instead of hanging when the stream ends without a terminal event", async () => {
+		const body = `data: ${JSON.stringify({ type: "start" })}\n\n`;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(body, { status: 200 })),
+		);
+
+		const stream = streamProxy(
+			model,
+			{ systemPrompt: "", messages: [] },
+			{
+				authToken: "test-token",
+				proxyUrl: "https://proxy.example.com",
+			},
+		);
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) events.push(event);
+		const result = await stream.result();
+
+		expect(events.map((event) => event.type)).toEqual(["start", "error"]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Connection closed by proxy server");
+	});
 });


### PR DESCRIPTION
fixes #8996

`streamProxy` could leave consumers hanging forever when the proxy server closed the SSE connection without a terminal `done`/`error` event:

1. The residual line buffer (`buffer = lines.pop()`) was never processed after the read loop, so a final `data: {...}` line without a trailing newline was silently dropped — even if it was the `done` event.
2. When no terminal event had been seen, `stream.end()` was called without a result, which never resolves `EventStream.result()`. `agentLoop` awaits `response.result()`, so the agent hung indefinitely.

The fix flushes the decoder and processes the residual buffer after EOF, and pushes a synthesized `error` event ("Connection closed by proxy server before the response completed") when the stream ends without a terminal event.

Regression tests cover both cases (non-newline-terminated terminal event; EOF without a terminal event). Both hang/fail before the fix and pass after. `npm run check` and the `packages/agent` test suite (420 tests) pass.
