### PR TITLE
fix(coding-agent): enable reasoning and reasoning effort for llama.cpp provider

### DIFF
--- a/packages/coding-agent/src/extensions/llama/provider.ts
+++ b/packages/coding-agent/src/extensions/llama/provider.ts
@@ -55,7 +55,7 @@ function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-comp
 		api: "openai-completions",
 		provider: LLAMA_PROVIDER_ID,
 		baseUrl: llamaInferenceUrl(serverUrl),
-		reasoning: false,
+		reasoning: true,
 		input: model.architecture?.input_modalities?.includes("image") ? ["text", "image"] : ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow,
@@ -63,7 +63,7 @@ function toPiModel(model: LlamaModelInfo, serverUrl: string): Model<"openai-comp
 		compat: {
 			supportsStore: false,
 			supportsDeveloperRole: false,
-			supportsReasoningEffort: false,
+			supportsReasoningEffort: true,
 			supportsUsageInStreaming: true,
 			supportsStrictMode: false,
 			maxTokensField: "max_tokens",

--- a/packages/coding-agent/test/llama-extension.test.ts
+++ b/packages/coding-agent/test/llama-extension.test.ts
@@ -91,6 +91,20 @@ describe("llama.cpp extension", () => {
 		]);
 	});
 
+	it("exposes reasoning and supportsReasoningEffort for per-request thinking control", () => {
+		const controller = createLlamaProvider();
+		controller.setCatalog(
+			[{ id: "qwen3-8b", status: { value: "loaded" }, meta: { n_ctx: 131072 } }],
+			"http://localhost:8080",
+		);
+
+		const model = controller.provider.getModels()[0];
+		expect(model).toBeDefined();
+		expect(model?.reasoning).toBe(true);
+		expect(model?.compat?.supportsReasoningEffort).toBe(true);
+		expect(model?.compat?.supportsUsageInStreaming).toBe(true);
+	});
+
 	it("persists and restores selectable models for cache-only startup refreshes", async () => {
 		let cachedEntry: ModelsStoreEntry | undefined;
 		const { url } = await listen((request, response) => {


### PR DESCRIPTION
## What

Enable per-request `reasoning_effort` for the built-in `llama.cpp` provider.

## Why

`llama.cpp` added `reasoning_effort` support via the OpenAI-compatible API in [PR #26045](https://github.com/ggml-org/llama.cpp/pull/26045) (July 2026). The built-in pi provider was created before that feature existed and had `reasoning` and `supportsReasoningEffort` hardcoded to `false`.

This prevents users from switching thinking levels (minimal/low/medium/high/xhigh/max) per-request without model reload — a capability that `llama-server` has supported since July 2026.

## Changes

- `packages/coding-agent/src/extensions/llama/provider.ts`: `reasoning: false → true`, `supportsReasoningEffort: false → true`
- `packages/coding-agent/test/llama-extension.test.ts`: add test verifying both flags are `true`

## Testing

All 11 tests in `test/llama-extension.test.ts` pass, including the new reasoning capability test.

## Related

- Fixes: [#5917](https://github.com/earendil-works/pi/issues/5917) — pi does not set thinking on/off (thinking level) when used with llama.cpp llama-server
- Related: [#7259](https://github.com/earendil-works/pi/issues/7259) — streaming usage fix (merged as #7258, but left `supportsReasoningEffort` as false)
