### PR TITLE
fix(ai): bound and CRLF-aware Codex SSE parsing

### DIFF
--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -762,12 +762,33 @@ function normalizeCodexStatus(status: unknown): CodexResponseStatus | undefined 
 // SSE Parsing
 // ============================================================================
 
+// An SSE event ends at a blank line. Per the WHATWG event stream spec a line
+// may end with CRLF, LF or CR, so a blank line is any two consecutive
+// terminators. Matching only "\n\n" makes a CRLF stream unparseable, and the
+// pending buffer then grows to the size of the whole response.
+const SSE_EVENT_BOUNDARY = /\r\n\r\n|\r\n\r|\r\n\n|\r\r\n|\n\r\n|\r\r|\n\r|\n\n/gu;
+const SSE_LINE_BREAK = /\r\n|\r|\n/u;
+const SSE_MAX_BOUNDARY_LENGTH = 4;
+
+// A single Codex SSE event is at most a few megabytes (the terminal
+// response.completed event carries the full response object). Anything past
+// this means we are not going to find a boundary at all, so fail loudly
+// instead of accumulating until the process aborts on heap exhaustion.
+const SSE_MAX_PENDING_EVENT_BYTES = 64 * 1024 * 1024;
+
+function findSseEventBoundary(buffer: string, from: number): { index: number; length: number } | undefined {
+	SSE_EVENT_BOUNDARY.lastIndex = from;
+	const match = SSE_EVENT_BOUNDARY.exec(buffer);
+	return match ? { index: match.index, length: match[0].length } : undefined;
+}
+
 async function* parseSSE(response: Response, signal?: AbortSignal): AsyncGenerator<Record<string, unknown>> {
 	if (!response.body) return;
 
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
+	let scanned = 0;
 	const onAbort = () => {
 		void reader.cancel().catch(() => {});
 	};
@@ -785,13 +806,19 @@ async function* parseSSE(response: Response, signal?: AbortSignal): AsyncGenerat
 			if (done) break;
 			buffer += decoder.decode(value, { stream: true });
 
-			let idx = buffer.indexOf("\n\n");
-			while (idx !== -1) {
-				const chunk = buffer.slice(0, idx);
-				buffer = buffer.slice(idx + 2);
+			// Resume the boundary search where the last one stopped instead of
+			// rescanning the whole buffer on every read, which is quadratic.
+			// Back off by one terminator so a boundary split across two reads
+			// is still found.
+			let searchFrom = Math.max(0, scanned - (SSE_MAX_BOUNDARY_LENGTH - 1));
+			let boundary = findSseEventBoundary(buffer, searchFrom);
+			while (boundary) {
+				const chunk = buffer.slice(0, boundary.index);
+				buffer = buffer.slice(boundary.index + boundary.length);
+				searchFrom = 0;
 
 				const dataLines = chunk
-					.split("\n")
+					.split(SSE_LINE_BREAK)
 					.filter((l) => l.startsWith("data:"))
 					.map((l) => l.slice(5).trim());
 				if (dataLines.length > 0) {
@@ -807,7 +834,15 @@ async function* parseSSE(response: Response, signal?: AbortSignal): AsyncGenerat
 						}
 					}
 				}
-				idx = buffer.indexOf("\n\n");
+				boundary = findSseEventBoundary(buffer, searchFrom);
+			}
+			scanned = buffer.length;
+
+			if (buffer.length > SSE_MAX_PENDING_EVENT_BYTES) {
+				throw new CodexProtocolError(
+					`Codex SSE event exceeded ${SSE_MAX_PENDING_EVENT_BYTES} bytes without an event boundary; ` +
+						"the response stream is malformed or is being rewritten in transit.",
+				);
 			}
 		}
 	} finally {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -2620,4 +2620,127 @@ describe("openai-codex streaming", () => {
 		expect(result.content.find((content) => content.type === "text")?.text).toBe("Hello");
 		expect(codexRequests).toBe(4);
 	});
+
+	// https://github.com/earendil-works/pi/issues/9036
+	it("parses SSE events delimited by CRLF blank lines", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		const encoder = new TextEncoder();
+		const sse = buildSSEPayload({ status: "completed" }).replaceAll("\n", "\r\n");
+
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode(sse));
+				controller.close();
+			},
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+			}
+			return new Response("not found", { status: 404 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await Promise.race([
+			streamOpenAICodexResponses(model, context, { apiKey: token, transport: "sse" }).result(),
+			new Promise<never>((_, reject) => {
+				setTimeout(() => reject(new Error("Timed out waiting for CRLF SSE stream")), 5000);
+			}),
+		]);
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.find((content) => content.type === "text")?.text).toBe("Hello");
+	});
+
+	// https://github.com/earendil-works/pi/issues/9036
+	it("fails with a protocol error instead of buffering an SSE event without end", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-codex-stream-"));
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		const token = mockToken();
+		// A body that never emits an event boundary. Before the pending-event
+		// cap this grew a single string until the process aborted with
+		// "JavaScript heap out of memory".
+		const chunk = new TextEncoder().encode(`data: ${"x".repeat(1024 * 1024 - 6)}\n`);
+		let emitted = 0;
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (emitted >= 128) {
+					controller.close();
+					return;
+				}
+				emitted++;
+				controller.enqueue(chunk);
+			},
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+			}
+			return new Response("not found", { status: 404 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const model: Model<"openai-codex-responses"> = {
+			id: "gpt-5.1-codex",
+			name: "GPT-5.1 Codex",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 400000,
+			maxTokens: 128000,
+		};
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+		};
+
+		const result = await streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			transport: "sse",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("without an event boundary");
+		// The cap must stop the read well before the whole body is consumed.
+		expect(emitted).toBeLessThan(128);
+	});
 });


### PR DESCRIPTION
Fixes #9036.

`parseSSE` in `packages/ai/src/api/openai-codex-responses.ts` accumulated the Codex response into a single `buffer` string with no upper bound, and only drained it where `buffer.indexOf("\n\n")` matched. Two things go wrong with that.

The WHATWG event stream spec lets a line end with CRLF, LF or CR, so a blank line is any two consecutive terminators. A CRLF stream is valid SSE, but `indexOf("\n\n")` never matches `\r\n\r\n`. No event is parsed, the whole response body accumulates in one string, and a long response aborts the process with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`. The SSE path is a normal fallback whenever the WebSocket transport is unavailable, so this is reachable in ordinary use behind anything that rewrites line endings in transit. Second, the search restarted at offset 0 on every read, so scanning was quadratic in the accumulated size.

Measured by driving the real `stream()` with `transport: "sse"` against a synthetic body and sampling `heapUsed`. Feeding 128 MB of otherwise identical events, before this change: LF parsed everything in 0.5 s at 24 MB peak heap, CRLF parsed nothing in 39 s at 275 MB peak heap and still climbing. With `--max-old-space-size=512` and a 1 GB body, `heapUsed` tracked the streamed bytes one for one to 502 MB and then aborted; a heap snapshot at the limit held a single 508 MB string beginning `data: xxxx...`, 98 percent of all string memory and the only object above 5 MB, retained by a live concatenated string, which is `buffer` mid-append. After this change the CRLF body parses in 0.5 s at 28 MB peak heap, and the 1 GB unterminated body stops at the cap in 0.2 s with the error below.

The change is three things in `parseSSE`:

- Match any of the blank-line forms the spec allows, and split event lines on CRLF, LF or CR, matching what `mistral-conversations.ts` already does.
- Resume the boundary search where the previous one stopped, backing off three characters so a boundary split across two reads is still found.
- Cap the pending, undrained event at 64 MiB. Past that no boundary is coming, so it throws `CodexProtocolError`. A single legitimate Codex event is a few megabytes at most, since the largest is the terminal `response.completed` carrying the full response object. It throws rather than truncating: silently dropping part of a model response would be worse than the crash it replaces.

Two regression tests in `packages/ai/test/openai-codex-stream.test.ts`. The first streams the existing SSE fixture with CRLF line endings and expects the message to parse; before the fix it ends with `stopReason: "error"`. The second streams a body with no event boundary and expects the capped protocol error; before the fix it consumes the whole body and reports `OpenAI Responses stream ended before a terminal response event`.

I looked at the three other SSE parsers in the repo. `anthropic-messages.ts`, `mistral-conversations.ts` and `pi-messages.ts` all have unbounded pending buffers too, but all three already recognise CRLF, so they drain normally and I could not make any of them grow. I have not changed them, since I have no measured failure there and the trigger proven here is specific to the Codex parser.

`npm run check` passes. `./test.sh` passes for every package except two pre-existing failures in `packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts` (`TypeError: this.maybeShowAssistantDiagnostics is not a function`), which reproduce unchanged on `main` at `4e69b0c` and are unrelated to this change. `packages/ai` is 981 passed, 0 failed.
