### PR TITLE
feat(coding-agent): add PI_DISABLE_MOUSE to opt out of fullscreen mouse tracking

### DIFF
--- a/packages/coding-agent/docs/environment-variables.md
+++ b/packages/coding-agent/docs/environment-variables.md
@@ -87,6 +87,7 @@ These variables are read by Pi itself:
 | `PI_CACHE_RETENTION` | Set to `long` for extended provider prompt caching where supported |
 | `PI_SHARE_VIEWER_URL` | Override the base URL used by `/share` |
 | `PI_HARDWARE_CURSOR` | Set to `1` to show the hardware cursor; see [Terminal setup](terminal-setup.md) |
+| `PI_DISABLE_MOUSE` | Set to `1`/`true`/`yes` to disable mouse tracking in fullscreen mode; useful when the terminal or a multiplexer mishandles mouse reports |
 | `PI_HYPERLINKS` | Override OSC 8 hyperlink detection with `1`, `0`, or `auto` |
 | `PI_IMAGE_PROTOCOL` | Override inline image detection with `kitty`, `iterm2`, `none`, or `auto` |
 | `PI_TRUE_COLOR` | Override truecolor detection with `1`, `0`, or `auto` |

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -173,6 +173,11 @@ import {
 } from "./theme/theme.ts";
 import { InteractiveThemeController } from "./theme/theme-controller.ts";
 
+function isTruthyEnvFlag(value: string | undefined): boolean {
+	if (!value) return false;
+	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
+}
+
 /** Interface for components that can be expanded/collapsed */
 interface Expandable {
 	setExpanded(expanded: boolean): void;
@@ -370,7 +375,9 @@ export function createInteractiveTui(options: InteractiveTuiOptions): TuiMainScr
 	const terminal = options.terminal ?? new ProcessTerminal();
 	if (options.tuiMode === "fullscreen") {
 		const styleSearchMatch = (text: string) => theme.bg("searchMatchBg", theme.fg("searchMatchText", text));
+		const mouseDisabled = isTruthyEnvFlag(process.env.PI_DISABLE_MOUSE);
 		return new TuiAltScreen(terminal, options.showHardwareCursor, options.logDirectory, {
+			mouse: !mouseDisabled,
 			searchMatchStyle: (text) => theme.underline(styleSearchMatch(text)),
 			searchCurrentMatchStyle: (text) => theme.bold(theme.inverse(styleSearchMatch(text))),
 			openUrl: openBrowser,

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -65,7 +65,29 @@ describe("createInteractiveTui", () => {
 		altTui.start();
 		await altTerminal.waitForRender();
 		expect(altTerminal.writes.some((write) => write.includes("\x1b[?1049h"))).toBe(true);
+		expect(altTerminal.writes.some((write) => write.includes("\x1b[?1000h"))).toBe(true);
 		altTui.stop();
+	});
+
+	it("disables fullscreen mouse tracking when PI_DISABLE_MOUSE is set", async () => {
+		process.env.PI_DISABLE_MOUSE = "1";
+		try {
+			const terminal = new RecordingTerminal();
+			const tui = createInteractiveTui({
+				tuiMode: "fullscreen",
+				showHardwareCursor: false,
+				logDirectory: "/tmp",
+				terminal,
+			});
+			expect(tui.mode).toBe("fullscreen");
+			tui.start();
+			await terminal.waitForRender();
+			expect(terminal.writes.some((write) => write.includes("\x1b[?1049h"))).toBe(true);
+			expect(terminal.writes.some((write) => write.includes("\x1b[?1000h"))).toBe(false);
+			tui.stop();
+		} finally {
+			delete process.env.PI_DISABLE_MOUSE;
+		}
 	});
 
 	it("replaces the renderer and restores the previous screen for resume-hint exits", async () => {


### PR DESCRIPTION
Adds `PI_DISABLE_MOUSE` so fullscreen mode can opt out of mouse tracking.

`TuiAltScreenOptions.mouse` already existed but the construction site never passed it, so `?1000/1002/1003` were always requested in fullscreen. With this set, no mouse sequences are emitted (alt screen and keyboard navigation are unaffected).

Closes #8913

This PR is AI-generated by `/wr`.
