### PR TITLE
fix(agent): reject stale JSONL session writes after delete

### DIFF
--- a/packages/agent/src/harness/session/jsonl/storage.ts
+++ b/packages/agent/src/harness/session/jsonl/storage.ts
@@ -265,6 +265,9 @@ export class JsonlSessionStorage implements SessionStorage<JsonlSessionMetadata>
 	}
 
 	private async appendMutation(mutation: SessionMutation): Promise<void> {
+		if (!fileResult(await this.fs.exists(this.metadata.path), `Failed to check session ${this.metadata.path}`)) {
+			throw new SessionError("not_found", `Session not found: ${this.metadata.id}`);
+		}
 		fileResult(
 			await this.fs.appendFile(this.metadata.path, encodeMutation(mutation)),
 			`Failed to append session ${this.metadata.path}`,

--- a/packages/agent/test/harness/session/jsonl.test.ts
+++ b/packages/agent/test/harness/session/jsonl.test.ts
@@ -342,6 +342,23 @@ describe("JSONL v4 persistence", () => {
 		expect((await verified.getStats()).messageCount).toBe(3);
 	});
 
+	it("rejects stale writes after deleting the session file", async () => {
+		const root = createTempDir();
+		const repository = createRepository(root);
+		const session = await repository.create({ id: "victim", cwd: root });
+		await session.appendMessage({ role: "user", content: [{ type: "text", text: "before delete" }], timestamp: 1 });
+		const metadata = await session.getMetadata();
+
+		await repository.delete(metadata);
+		expect(existsSync(metadata.path)).toBe(false);
+
+		await expect(
+			session.appendMessage({ role: "user", content: [{ type: "text", text: "after delete" }], timestamp: 2 }),
+		).rejects.toMatchObject({ code: "not_found" });
+		expect(existsSync(metadata.path)).toBe(false);
+		await expect(repository.create({ id: "victim", cwd: root })).resolves.toBeDefined();
+	});
+
 	it("reopens a tree fork with its lanes and facts", async () => {
 		const root = createTempDir();
 		const repository = createRepository(root);


### PR DESCRIPTION
Fixes #9038.

## Summary
- Reject stale JSONL session writes after `JsonlSessionRepo.delete()` has removed the backing file.
- Cover the stale-handle case so it cannot recreate a headerless JSONL file.

## Verification
- `npm run check` passes in CI.
- `node "$(git rev-parse --show-toplevel)/node_modules/vitest/dist/cli.js" --run test/harness/session/jsonl.test.ts --reporter verbose` passes locally: 65 tests.
- CI `npm test` currently fails on `packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts`, the same unrelated failure already present on upstream `main` at `4e69b0c28`.
