### PR TITLE
feat: carry model and effort over on /new

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -30,6 +30,7 @@ Use `/trust` in interactive mode to save a project trust decision for future ses
 | `defaultProvider` | string | - | Startup provider (e.g., `"anthropic"`, `"openai"`; saved with Ctrl+S in `/model`, or edited manually) |
 | `defaultModel` | string | - | Startup model ID (saved with Ctrl+S in `/model`, or edited manually) |
 | `defaultThinkingLevel` | string | - | Startup thinking level (saved with Ctrl+S in `/thinking`, or edited manually): `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` |
+| `newSessionInherits` | string | `"none"` | What `/new` carries over from the current session: `"none"`, `"model"`, `"effort"`, or `"both"` |
 | `modelThinkingLevels` | object | - | Per-model startup thinking levels keyed by `"provider/modelId"`; configure from `/settings` → Default thinking level per model or edit manually |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `showCacheMissNotices` | boolean | `false` | Show transcript notices for significant prompt-cache misses, compaction or branch-summary usage, and provider recovery diagnostics such as dropped Anthropic thinking blocks |

--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -10,6 +10,7 @@ import type {
 	SessionStartEvent,
 } from "./extensions/index.ts";
 import { emitSessionShutdownEvent } from "./extensions/runner.ts";
+import type { SessionInheritState } from "./model-resolver.ts";
 import type { CreateAgentSessionResult } from "./sdk.ts";
 import { assertSessionCwdExists } from "./session-cwd.ts";
 import { SessionManager } from "./session-manager.ts";
@@ -38,6 +39,7 @@ export type CreateAgentSessionRuntimeFactory = (options: {
 	sessionManager: SessionManager;
 	sessionStartEvent?: SessionStartEvent;
 	projectTrustContext?: ProjectTrustContext;
+	inherit?: SessionInheritState;
 }) => Promise<CreateAgentSessionRuntimeResult>;
 
 /**
@@ -249,6 +251,7 @@ export class AgentSessionRuntime {
 				agentDir: this.services.agentDir,
 				sessionManager,
 				sessionStartEvent: { type: "session_start", reason: "new", previousSessionFile },
+				inherit: { model: this.session.model, thinkingLevel: this.session.thinkingLevel },
 			}),
 		);
 		if (options?.setup) {

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -15,6 +15,7 @@ import { minimatch } from "minimatch";
 import { isValidThinkingLevel } from "../cli/args.ts";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import type { ModelRuntime } from "./model-runtime.ts";
+import type { NewSessionInheritMode } from "./settings-manager.ts";
 
 /** Default model IDs for each known provider */
 export const defaultModelPerProvider: Record<KnownProvider, string> = {
@@ -618,6 +619,30 @@ export interface InitialModelResult {
  * 4. Saved default from settings
  * 5. First available model with valid API key
  */
+
+/** Current session state that /new can carry over when configured. */
+export interface SessionInheritState {
+	model?: Model<any>;
+	thinkingLevel?: ThinkingLevel;
+}
+
+/**
+ * Apply the previous session's model/effort to new session options.
+ * CLI-provided values win and are never overwritten.
+ */
+export function applySessionInherit(
+	options: { model?: Model<any>; thinkingLevel?: ThinkingLevel },
+	inherit: SessionInheritState | undefined,
+	mode: NewSessionInheritMode | undefined,
+): void {
+	if (!inherit || mode === undefined || mode === "none") return;
+	if ((mode === "model" || mode === "both") && inherit.model && !options.model) {
+		options.model = inherit.model;
+	}
+	if ((mode === "effort" || mode === "both") && inherit.thinkingLevel && options.thinkingLevel === undefined) {
+		options.thinkingLevel = inherit.thinkingLevel;
+	}
+}
 export async function findInitialModel(options: {
 	cliProvider?: string;
 	cliModel?: string;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -72,6 +72,9 @@ export interface WarningSettings {
 
 export type DefaultProjectTrust = "ask" | "always" | "never";
 
+/** What `/new` carries over from the current session. */
+export type NewSessionInheritMode = "none" | "model" | "effort" | "both";
+
 export type TransportSetting = Transport;
 
 /**
@@ -96,6 +99,7 @@ export interface Settings {
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: ThinkingLevel;
+	newSessionInherits?: NewSessionInheritMode; // default: "none" - what /new carries over from the current session
 	modelThinkingLevels?: Record<string, ThinkingLevel>; // per-model default thinking level overrides keyed by "provider/modelId"
 	transport?: TransportSetting; // default: "auto"
 	steeringMode?: "all" | "one-at-a-time";
@@ -786,6 +790,16 @@ export class SettingsManager {
 	setDefaultThinkingLevel(level: ThinkingLevel): void {
 		this.globalSettings.defaultThinkingLevel = level;
 		this.markModified("defaultThinkingLevel");
+		this.save();
+	}
+
+	getNewSessionInherits(): NewSessionInheritMode {
+		return this.settings.newSessionInherits ?? "none";
+	}
+
+	setNewSessionInherits(mode: NewSessionInheritMode): void {
+		this.globalSettings.newSessionInherits = mode;
+		this.markModified("newSessionInherits");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -45,7 +45,13 @@ import { AuthStorage, ReadOnlyAuthStorage } from "./core/auth-storage.ts";
 import { exportFromFile } from "./core/export-html/index.ts";
 import type { InlineExtension } from "./core/extensions/types.ts";
 import { applyHttpProxySettings, configureHttpDispatcher } from "./core/http-dispatcher.ts";
-import { resolveCliModel, resolveModelScope, type ScopedModel } from "./core/model-resolver.ts";
+import {
+	applySessionInherit,
+	resolveCliModel,
+	resolveModelScope,
+	type ScopedModel,
+	type SessionInheritState,
+} from "./core/model-resolver.ts";
 import { ModelRuntime } from "./core/model-runtime.ts";
 import { restoreStdout, takeOverStdout } from "./core/output-guard.ts";
 import { type AppMode, resolveProjectTrusted } from "./core/project-trust.ts";
@@ -448,6 +454,7 @@ function buildSessionOptions(
 	hasExistingSession: boolean,
 	modelRuntime: ModelRuntime,
 	settingsManager: SettingsManager,
+	inherit?: SessionInheritState,
 ): {
 	options: CreateAgentSessionOptions;
 	cliThinkingFromModel: boolean;
@@ -483,6 +490,10 @@ function buildSessionOptions(
 			}
 		}
 	}
+
+	// Carry the previous session's model/effort into /new when configured.
+	// Runs before scoped/saved defaults so the inherited values win.
+	applySessionInherit(options, inherit, settingsManager.getNewSessionInherits());
 
 	if (!options.model && scopedModels.length > 0 && !hasExistingSession) {
 		// Check if saved default is in scoped models - use it if so, otherwise first scoped model
@@ -715,6 +726,7 @@ export async function main(args: string[], options?: MainOptions) {
 		sessionManager,
 		sessionStartEvent,
 		projectTrustContext,
+		inherit,
 	}) => {
 		const isInitialRuntime = sessionStartEvent === undefined;
 		const projectTrustDiagnostics: AgentSessionRuntimeDiagnostic[] = [];
@@ -799,6 +811,7 @@ export async function main(args: string[], options?: MainOptions) {
 			sessionManager.buildSessionContext().messages.length > 0,
 			modelRuntime,
 			settingsManager,
+			inherit,
 		);
 		diagnostics.push(...sessionOptionDiagnostics);
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -16,6 +16,7 @@ import type {
 	DefaultProjectTrust,
 	FullscreenExitOutput,
 	MermaidRenderingMode,
+	NewSessionInheritMode,
 	TuiMode,
 	WarningSettings,
 } from "../../../core/settings-manager.ts";
@@ -79,6 +80,7 @@ export interface SettingsConfig {
 	autocompleteMaxVisible: number;
 	quietStartup: boolean;
 	defaultProjectTrust: DefaultProjectTrust;
+	newSessionInherits: NewSessionInheritMode;
 	clearOnShrink: boolean;
 	showTerminalProgress: boolean;
 	tuiMode: TuiMode;
@@ -116,6 +118,7 @@ export interface SettingsCallbacks {
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
 	onDefaultProjectTrustChange: (defaultProjectTrust: DefaultProjectTrust) => void;
+	onNewSessionInheritsChange: (mode: NewSessionInheritMode) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onShowTerminalProgressChange: (enabled: boolean) => void;
 	onTuiModeChange: (mode: TuiMode) => void;
@@ -545,6 +548,13 @@ export class SettingsSelectorComponent extends Container {
 				values: Object.values(DEFAULT_PROJECT_TRUST_LABELS),
 			},
 			{
+				id: "new-session-inherits",
+				label: "New session inherits",
+				description: "What /new carries over from the current session",
+				currentValue: config.newSessionInherits,
+				values: ["none", "model", "effort", "both"],
+			},
+			{
 				id: "double-escape-action",
 				label: "Double-escape action",
 				description: "Action when pressing Escape twice with empty editor",
@@ -888,6 +898,9 @@ export class SettingsSelectorComponent extends Container {
 						}
 						break;
 					}
+					case "new-session-inherits":
+						callbacks.onNewSessionInheritsChange(newValue as NewSessionInheritMode);
+						break;
 					case "double-escape-action":
 						callbacks.onDoubleEscapeActionChange(newValue as "fork" | "tree");
 						break;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4600,6 +4600,7 @@ export class InteractiveMode {
 					showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
 					showCacheMissNotices: this.settingsManager.getShowCacheMissNotices(),
 					defaultProjectTrust: this.settingsManager.getDefaultProjectTrust(),
+					newSessionInherits: this.settingsManager.getNewSessionInherits(),
 					editorPaddingX: this.settingsManager.getEditorPaddingX(),
 					outputPad: this.settingsManager.getOutputPad(),
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
@@ -4709,6 +4710,9 @@ export class InteractiveMode {
 					},
 					onDefaultProjectTrustChange: (defaultProjectTrust) => {
 						this.settingsManager.setDefaultProjectTrust(defaultProjectTrust);
+					},
+					onNewSessionInheritsChange: (mode) => {
+						this.settingsManager.setNewSessionInherits(mode);
 					},
 					onDoubleEscapeActionChange: (action) => {
 						this.settingsManager.setDoubleEscapeAction(action);

--- a/packages/coding-agent/test/agent-session-runtime-events.test.ts
+++ b/packages/coding-agent/test/agent-session-runtime-events.test.ts
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Model } from "@earendil-works/pi-ai";
 import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -10,6 +12,7 @@ import {
 	createAgentSessionServices,
 } from "../src/core/agent-session-runtime.ts";
 import { AuthStorage } from "../src/core/auth-storage.ts";
+import { applySessionInherit, type SessionInheritState } from "../src/core/model-resolver.ts";
 import { ModelRuntime } from "../src/core/model-runtime.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import type {
@@ -35,11 +38,15 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		}
 	});
 
-	async function createRuntimeHost(extensionFactory: ExtensionFactory) {
+	async function createRuntimeHost(
+		extensionFactory: ExtensionFactory,
+		fauxOptions: { models?: Array<{ id: string; reasoning?: boolean }> } = {},
+	) {
 		const tempDir = join(tmpdir(), `pi-runtime-events-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(tempDir, { recursive: true });
+		let lastInherit: SessionInheritState | undefined;
 
-		const faux = registerFauxProvider();
+		const faux = registerFauxProvider(fauxOptions);
 		faux.setResponses([fauxAssistantMessage("one"), fauxAssistantMessage("two"), fauxAssistantMessage("three")]);
 
 		const authStorage = AuthStorage.inMemory();
@@ -78,17 +85,26 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 				noThemes: true,
 			},
 		};
-		const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+		const createRuntime: CreateAgentSessionRuntimeFactory = async ({
+			cwd,
+			sessionManager,
+			sessionStartEvent,
+			inherit,
+		}) => {
+			lastInherit = inherit;
 			const services = await createAgentSessionServices({
 				...runtimeOptions,
 				cwd,
 			});
+			const sessionOptions: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = {};
+			applySessionInherit(sessionOptions, inherit, "both");
 			return {
 				...(await createAgentSessionFromServices({
 					services,
 					sessionManager,
 					sessionStartEvent,
-					model: faux.getModel(),
+					model: sessionOptions.model ?? faux.getModel(),
+					thinkingLevel: sessionOptions.thinkingLevel,
 				})),
 				services,
 				diagnostics: services.diagnostics,
@@ -109,7 +125,7 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 			}
 		});
 
-		return { runtimeHost, faux };
+		return { runtimeHost, faux, lastInherit: () => lastInherit };
 	}
 
 	it("emits session_before_switch and session_start for new and resume flows", async () => {
@@ -178,6 +194,41 @@ describe("AgentSessionRuntime session lifecycle events", () => {
 		expect(result.cancelled).toBe(true);
 		expect(runtimeHost.session.sessionFile).toBe(originalSessionFile);
 		expect(events).toEqual([{ type: "session_before_switch", reason: "new", targetSessionFile: undefined }]);
+	});
+
+	it("passes current model and thinking level as inherit state on new session", async () => {
+		const { runtimeHost, lastInherit } = await createRuntimeHost(() => {}, {
+			models: [{ id: "faux-thinking", reasoning: true }],
+		});
+		await runtimeHost.session.prompt("hello");
+		const levels = runtimeHost.session.getAvailableThinkingLevels();
+		expect(levels.length).toBeGreaterThan(0);
+		const level = levels[levels.length - 1];
+		await runtimeHost.session.setThinkingLevel(level, { persist: false });
+
+		const modelBefore = runtimeHost.session.model!;
+		await runtimeHost.newSession();
+		await runtimeHost.session.bindExtensions({});
+
+		expect(lastInherit()).toEqual({
+			model: expect.objectContaining({ provider: modelBefore.provider, id: modelBefore.id }),
+			thinkingLevel: level,
+		});
+		expect(runtimeHost.session.model!.provider).toBe(modelBefore.provider);
+		expect(runtimeHost.session.model!.id).toBe(modelBefore.id);
+		expect(runtimeHost.session.thinkingLevel).toBe(level);
+	});
+
+	it("does not pass inherit state when resuming a session", async () => {
+		const { runtimeHost, lastInherit } = await createRuntimeHost(() => {});
+		await runtimeHost.session.prompt("hello");
+		const originalSessionFile = runtimeHost.session.sessionFile;
+
+		const switchResult = await runtimeHost.switchSession(originalSessionFile!);
+		expect(switchResult.cancelled).toBe(false);
+		await runtimeHost.session.bindExtensions({});
+
+		expect(lastInherit()).toBeUndefined();
 	});
 
 	it("runs beforeSessionInvalidate after session_shutdown and before rebindSession", async () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import { Agent } from "@earendil-works/pi-agent-core";
 import type { Model } from "@earendil-works/pi-ai";
 import { getModel, streamSimple } from "@earendil-works/pi-ai/compat";
@@ -9,6 +10,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { AgentSession } from "../src/core/agent-session.ts";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import {
+	applySessionInherit,
 	defaultModelPerProvider,
 	findInitialModel,
 	parseModelPattern,
@@ -912,5 +914,62 @@ describe("default model selection", () => {
 			]);
 			expect(settingsManager.getEnabledModels()).toEqual([`${sonnet.provider}/${sonnet.id}`]);
 		});
+	});
+});
+
+describe("applySessionInherit", () => {
+	const model1 = { provider: "anthropic", id: "claude-opus-4-8" } as Model<any>;
+	const model2 = { provider: "openai", id: "gpt-5.5" } as Model<any>;
+
+	test("mode none keeps options unchanged", () => {
+		const options: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = {};
+		applySessionInherit(options, { model: model1, thinkingLevel: "high" }, "none");
+		expect(options.model).toBeUndefined();
+		expect(options.thinkingLevel).toBeUndefined();
+	});
+
+	test("mode model inherits only the model", () => {
+		const options: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = {};
+		applySessionInherit(options, { model: model1, thinkingLevel: "high" }, "model");
+		expect(options.model).toBe(model1);
+		expect(options.thinkingLevel).toBeUndefined();
+	});
+
+	test("mode effort inherits only the thinking level", () => {
+		const options: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = {};
+		applySessionInherit(options, { model: model1, thinkingLevel: "high" }, "effort");
+		expect(options.model).toBeUndefined();
+		expect(options.thinkingLevel).toBe("high");
+	});
+
+	test("mode both inherits model and thinking level", () => {
+		const options: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = {};
+		applySessionInherit(options, { model: model2, thinkingLevel: "low" }, "both");
+		expect(options.model).toBe(model2);
+		expect(options.thinkingLevel).toBe("low");
+	});
+
+	test("CLI-provided model is never overwritten", () => {
+		const options: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = { model: model1 };
+		applySessionInherit(options, { model: model2, thinkingLevel: "high" }, "both");
+		expect(options.model).toBe(model1);
+		expect(options.thinkingLevel).toBe("high");
+	});
+
+	test("CLI-provided thinking level is never overwritten", () => {
+		const options: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = {
+			model: model1,
+			thinkingLevel: "off",
+		};
+		applySessionInherit(options, { model: model2, thinkingLevel: "high" }, "both");
+		expect(options.model).toBe(model1);
+		expect(options.thinkingLevel).toBe("off");
+	});
+
+	test("missing inherit state is a no-op", () => {
+		const options: { model?: Model<any>; thinkingLevel?: ThinkingLevel } = {};
+		applySessionInherit(options, undefined, "both");
+		expect(options.model).toBeUndefined();
+		expect(options.thinkingLevel).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## What

`/new` currently resets the session to the saved default model and thinking level, even when the current session used a different model/effort picked without "set as default". This adds a `newSessionInherits` setting that lets `/new` carry over the current session's model and/or effort.

## Behavior

- New setting `newSessionInherits`: `"none" | "model" | "effort" | "both"`, default `"none"` (current behavior unchanged).
- `"model"`: the new session starts with the previous session's model.
- `"effort"`: the new session starts with the previous session's thinking level.
- `"both"`: both.
- CLI `--model`/`--thinking` still take precedence; inheriting only applies when they are absent.
- `/resume` and `/fork` are untouched (they already restore model/effort from session data).

## How

- `AgentSessionRuntime.newSession()` passes the current session's model and thinking level to the runtime factory as `inherit` state.
- `main.ts` applies it in `buildSessionOptions` via `applySessionInherit()` (in `model-resolver.ts`), before scoped/saved defaults are considered.
- New getter/setter in `SettingsManager`, exposed in `/settings` as "New session inherits".

## Tests

- Unit tests for `applySessionInherit` (modes, CLI precedence, no-op cases).
- Runtime tests: `/new` receives `inherit` state matching the previous session; `/resume` does not.

## Docs

`docs/settings.md` updated with the new setting.