### PR TITLE
Feature/model display name

### DIFF
--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -31,6 +31,7 @@ Use `/trust` in interactive mode to save a project trust decision for future ses
 | `defaultModel` | string | - | Startup model ID (saved with Ctrl+S in `/model`, or edited manually) |
 | `defaultThinkingLevel` | string | - | Startup thinking level (saved with Ctrl+S in `/thinking`, or edited manually): `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` |
 | `modelThinkingLevels` | object | - | Per-model startup thinking levels keyed by `"provider/modelId"`; configure from `/settings` → Default thinking level per model or edit manually |
+| `modelDisplay` | string | `"auto"` | How models are labeled in the footer status and `/model` selector: `"id"` always shows the model `id`, `"name"` always shows the human-readable `name`, and `"auto"` shows `name` only when the `id` is an opaque identifier such as an Amazon Bedrock inference profile ARN (otherwise `id`) |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `showCacheMissNotices` | boolean | `false` | Show transcript notices for significant prompt-cache misses and compaction or branch-summary usage |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level. Anthropic, Google, and Bedrock use these natively. OpenAI-compatible models use them when `compat.thinkingTokenBudgetField` (or `supportsThinkingTokenBudget`) is set. |

--- a/packages/coding-agent/src/core/index.ts
+++ b/packages/coding-agent/src/core/index.ts
@@ -29,6 +29,12 @@ export { type BashExecutorOptions, type BashResult, executeBashWithOperations } 
 export type { CompactionResult } from "./compaction/index.ts";
 export { createEventBus, type EventBus, type EventBusController } from "./event-bus.ts";
 export { areExperimentalFeaturesEnabled } from "./experimental.ts";
+export {
+	DEFAULT_MODEL_DISPLAY_MODE,
+	getModelDisplayLabel,
+	isOpaqueModelId,
+	type ModelDisplayMode,
+} from "./model-display.ts";
 // Extensions system
 export {
 	type AgentEndEvent,

--- a/packages/coding-agent/src/core/model-display.ts
+++ b/packages/coding-agent/src/core/model-display.ts
@@ -1,0 +1,49 @@
+import type { Model } from "@earendil-works/pi-ai";
+
+/**
+ * Controls how a model is labeled in the footer status and `/model` selector.
+ * - "id": always show the model's `id` (the value passed to the provider API).
+ * - "name": always show the model's human-readable `name`.
+ * - "auto" (default): show `name` when the `id` is opaque (e.g. a Bedrock
+ *   application inference profile ARN), otherwise show `id`.
+ */
+export type ModelDisplayMode = "id" | "name" | "auto";
+
+export const DEFAULT_MODEL_DISPLAY_MODE: ModelDisplayMode = "auto";
+
+/**
+ * Matches Amazon Bedrock inference profile ARNs, e.g.
+ * `arn:aws:bedrock:eu-central-1:123456789012:application-inference-profile/abc123`
+ * or `arn:aws:bedrock:us-east-1:123456789012:inference-profile/xyz`.
+ * These IDs carry no human-readable model information, so we prefer `name`.
+ */
+const BEDROCK_INFERENCE_PROFILE_ARN =
+	/^arn:aws[a-z-]*:bedrock:[^:]*:[0-9]*:(?:application-)?inference-profile\//i;
+
+/**
+ * Returns true when the model's `id` is an opaque identifier that does not tell
+ * the user which model it actually is (currently: Bedrock inference profile ARNs).
+ */
+export function isOpaqueModelId(id: string): boolean {
+	return BEDROCK_INFERENCE_PROFILE_ARN.test(id);
+}
+
+/**
+ * Picks the label to display for a model given the configured display mode.
+ * Falls back to `id` when a `name` is unavailable.
+ */
+export function getModelDisplayLabel(
+	model: Pick<Model<any>, "id" | "name">,
+	mode: ModelDisplayMode = DEFAULT_MODEL_DISPLAY_MODE,
+): string {
+	const name = model.name?.trim();
+	switch (mode) {
+		case "name":
+			return name || model.id;
+		case "id":
+			return model.id;
+		default:
+			// "auto": prefer name only when the id is opaque.
+			return name && isOpaqueModelId(model.id) ? name : model.id;
+	}
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -9,6 +9,7 @@ import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
+import { DEFAULT_MODEL_DISPLAY_MODE, type ModelDisplayMode } from "./model-display.ts";
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
@@ -98,6 +99,7 @@ export interface Settings {
 	defaultThinkingLevel?: ThinkingLevel;
 	modelThinkingLevels?: Record<string, ThinkingLevel>; // per-model default thinking level overrides keyed by "provider/modelId"
 	transport?: TransportSetting; // default: "auto"
+	modelDisplay?: ModelDisplayMode; // default: "auto" - how models are labeled in the footer and /model list ("id" | "name" | "auto")
 	steeringMode?: "all" | "one-at-a-time";
 	followUpMode?: "all" | "one-at-a-time";
 	theme?: string;
@@ -749,6 +751,18 @@ export class SettingsManager {
 	setSteeringMode(mode: "all" | "one-at-a-time"): void {
 		this.globalSettings.steeringMode = mode;
 		this.markModified("steeringMode");
+		this.save();
+	}
+
+	getModelDisplayMode(): ModelDisplayMode {
+		const value = this.settings.modelDisplay;
+		if (value === "id" || value === "name" || value === "auto") return value;
+		return DEFAULT_MODEL_DISPLAY_MODE;
+	}
+
+	setModelDisplayMode(mode: ModelDisplayMode): void {
+		this.globalSettings.modelDisplay = mode;
+		this.markModified("modelDisplay");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -2,6 +2,7 @@ import { isAbsolute, relative, resolve, sep } from "node:path";
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { AgentSession } from "../../../core/agent-session.ts";
 import { areExperimentalFeaturesEnabled } from "../../../core/experimental.ts";
+import { getModelDisplayLabel } from "../../../core/model-display.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
 import { addUsageToTotals, createUsageTotals } from "../../../core/usage-totals.ts";
 import { theme } from "../theme/theme.ts";
@@ -166,7 +167,9 @@ export class FooterComponent implements Component {
 		let statsLeft = statsParts.join(" ");
 
 		// Add model name on the right side, plus thinking level if model supports it
-		const modelName = state.model?.id || "no-model";
+		const modelName = state.model
+			? getModelDisplayLabel(state.model, this.session.settingsManager.getModelDisplayMode())
+			: "no-model";
 
 		let statsLeftWidth = visibleWidth(statsLeft);
 

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -11,6 +11,7 @@ import {
 	type TUI,
 } from "@earendil-works/pi-tui";
 import type { ModelRuntime } from "../../../core/model-runtime.ts";
+import { DEFAULT_MODEL_DISPLAY_MODE, getModelDisplayLabel, type ModelDisplayMode } from "../../../core/model-display.ts";
 import { refreshModelCatalogs } from "../model-catalog-refresh.ts";
 import { getModelSelectorSearchText } from "../model-search.ts";
 import { theme } from "../theme/theme.ts";
@@ -67,6 +68,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private tui: TUI;
 	private scopedModels: ReadonlyArray<ScopedModelItem>;
 	private defaultModel?: DefaultModelReference;
+	private modelDisplayMode: ModelDisplayMode = DEFAULT_MODEL_DISPLAY_MODE;
 	private scope: ModelScope = "all";
 	private scopeText?: Text;
 	private scopeHintText?: Text;
@@ -84,6 +86,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		initialSearchInput?: string,
 		onSelectAsDefault?: (model: Model<any>) => void,
 		defaultModel?: DefaultModelReference,
+		modelDisplayMode: ModelDisplayMode = DEFAULT_MODEL_DISPLAY_MODE,
 	) {
 		super();
 
@@ -92,6 +95,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.modelRuntime = modelRuntime;
 		this.scopedModels = scopedModels;
 		this.defaultModel = defaultModel;
+		this.modelDisplayMode = modelDisplayMode;
 		this.scope = scopedModels.length > 0 ? "scoped" : "all";
 		this.onSelectCallback = onSelect;
 		this.onSelectAsDefaultCallback = onSelectAsDefault;
@@ -318,7 +322,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 			const cursor = isSelected ? theme.fg("accent", "→ ") : "  ";
 			const currentMarker = isCurrent ? theme.fg("accent", "✓ ") : "  ";
-			const modelText = isSelected ? theme.fg("accent", item.id) : item.id;
+			const label = getModelDisplayLabel(item.model, this.modelDisplayMode);
+			const modelText = isSelected ? theme.fg("accent", label) : label;
 			const providerBadge = theme.fg("muted", `[${item.provider}]`);
 			const line = `${cursor}${currentMarker}${modelText} ${providerBadge}${defaultBadge}`;
 
@@ -342,8 +347,15 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			this.listContainer.addChild(new Text(theme.fg("muted", "  No matching models"), 0, 0));
 		} else {
 			const selected = this.filteredModels[this.selectedIndex];
+			const label = getModelDisplayLabel(selected.model, this.modelDisplayMode);
 			this.listContainer.addChild(new Spacer(1));
-			this.listContainer.addChild(new Text(theme.fg("muted", `  Model Name: ${selected.model.name}`), 0, 0));
+			// Always surface both name and id; the primary label (shown in the list) is
+			// whichever getModelDisplayLabel returned, so show the other field as detail.
+			const detail =
+				label === selected.model.id
+					? `Model Name: ${selected.model.name}`
+					: `Model ID: ${selected.model.id}`;
+			this.listContainer.addChild(new Text(theme.fg("muted", `  ${detail}`), 0, 0));
 		}
 		if (this.refreshStatusMessage) {
 			this.listContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -89,6 +89,7 @@ import {
 	findExactModelReferenceMatch,
 	resolveModelScopeFromModels,
 } from "../../core/model-resolver.ts";
+import { getModelDisplayLabel } from "../../core/model-display.ts";
 import { CredentialSynchronizationError } from "../../core/model-runtime.ts";
 import { DefaultPackageManager } from "../../core/package-manager.ts";
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
@@ -705,8 +706,11 @@ export class InteractiveMode {
 
 				return createFuzzyAutocompleteItems(items, prefix, getModelSearchText, (item) => ({
 					value: item.label,
-					label: item.id,
-					description: item.provider,
+					label: getModelDisplayLabel(
+						{ id: item.id, name: item.name },
+						this.settingsManager.getModelDisplayMode(),
+					),
+					description: `${item.provider} · ${item.id}`,
 				}));
 			};
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5001,6 +5001,7 @@ export class InteractiveMode {
 				initialSearchInput,
 				(model) => selectModel(model, true),
 				defaultProvider && defaultModel ? { provider: defaultProvider, id: defaultModel } : undefined,
+				this.settingsManager.getModelDisplayMode(),
 			);
 			return { component: selector, focus: selector, dispose: () => selector.dispose() };
 		});

--- a/packages/coding-agent/test/model-display.test.ts
+++ b/packages/coding-agent/test/model-display.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { getModelDisplayLabel, isOpaqueModelId } from "../src/core/model-display.ts";
+
+const arn = "arn:aws:bedrock:eu-central-1:306656769644:application-inference-profile/9ljl0hmyfkly";
+const arnGov = "arn:aws-us-gov:bedrock:us-gov-west-1:123456789012:inference-profile/abc";
+
+describe("isOpaqueModelId", () => {
+	it("matches Bedrock application inference profile ARNs", () => {
+		expect(isOpaqueModelId(arn)).toBe(true);
+	});
+
+	it("matches Bedrock inference profile ARNs (including GovCloud)", () => {
+		expect(isOpaqueModelId("arn:aws:bedrock:us-east-1:123456789012:inference-profile/xyz")).toBe(true);
+		expect(isOpaqueModelId(arnGov)).toBe(true);
+	});
+
+	it("does not match ordinary model IDs", () => {
+		expect(isOpaqueModelId("gpt-5")).toBe(false);
+		expect(isOpaqueModelId("claude-sonnet-4-5")).toBe(false);
+		expect(isOpaqueModelId("anthropic.claude-3-5-sonnet-20241022-v2:0")).toBe(false);
+	});
+});
+
+describe("getModelDisplayLabel", () => {
+	const opaque = { id: arn, name: "juergen-botz-haiku-4-5" };
+	const normal = { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" };
+
+	it("auto: uses name only when the id is opaque", () => {
+		expect(getModelDisplayLabel(opaque, "auto")).toBe("juergen-botz-haiku-4-5");
+		expect(getModelDisplayLabel(normal, "auto")).toBe("claude-sonnet-4-5");
+	});
+
+	it("auto is the default mode", () => {
+		expect(getModelDisplayLabel(opaque)).toBe("juergen-botz-haiku-4-5");
+		expect(getModelDisplayLabel(normal)).toBe("claude-sonnet-4-5");
+	});
+
+	it("id: always returns the id", () => {
+		expect(getModelDisplayLabel(opaque, "id")).toBe(arn);
+		expect(getModelDisplayLabel(normal, "id")).toBe("claude-sonnet-4-5");
+	});
+
+	it("name: always returns the name", () => {
+		expect(getModelDisplayLabel(opaque, "name")).toBe("juergen-botz-haiku-4-5");
+		expect(getModelDisplayLabel(normal, "name")).toBe("Claude Sonnet 4.5");
+	});
+
+	it("falls back to id when name is missing or blank", () => {
+		expect(getModelDisplayLabel({ id: arn, name: "" }, "auto")).toBe(arn);
+		expect(getModelDisplayLabel({ id: arn, name: "   " }, "name")).toBe(arn);
+	});
+});


### PR DESCRIPTION
I'm using AWS Bedrock backend with custom "Application Inference Profiles".  This at the moment the only way to separate and track cost across multiple users and models; every user has their own set of inference profiles and these have tags registered as cost-allocation tags.

The problem is that we have to specify the ARN of the inference profiles as the "model id" and the ARNs don't have any useful information such as which model they actually reference.  `models.json` entries have an `id` and a `name` and the we can specify a human-friendly name here, but Pi wasn't displaying it either in the footer (current model) or the `/model` selection list.  So I asked Pi (with Opus 4.8) to add code to detect if the `id` field is an ARN, and if it is use the `name` field in both those cases instead.