### PR TITLE
feat(tui,coding-agent): terminal.contentWidth — cap UI render width

### DIFF
--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -40,6 +40,7 @@ export type FullscreenExitOutput = "transcript" | "resume-hint";
 export interface TerminalSettings {
 	showImages?: boolean; // default: true (only relevant if terminal supports images)
 	imageWidthCells?: number; // default: 60 (preferred inline image width in terminal cells)
+	contentWidth?: number; // default: full terminal width (max render width in columns; text wraps at this width, never hidden)
 	clearOnShrink?: boolean; // default: false (clear empty rows when content shrinks)
 	showTerminalProgress?: boolean; // default: false (OSC 9;4 terminal progress indicators)
 	hyperlinks?: boolean | "auto";
@@ -1166,6 +1167,33 @@ export class SettingsManager {
 		}
 		this.globalSettings.terminal.imageWidthCells = Math.max(1, Math.floor(width));
 		this.markModified("terminal", "imageWidthCells");
+		this.save();
+	}
+
+	/**
+	 * Maximum width, in columns, at which the whole TUI renders. Returns `undefined`
+	 * when unset, meaning "use the full terminal width". When set, all text *wraps*
+	 * at this width (nothing is hidden) and the remaining right-hand columns are left
+	 * blank, so extension overlays / side panels can sit there without covering text.
+	 */
+	getContentWidth(): number | undefined {
+		const width = this.settings.terminal?.contentWidth;
+		if (typeof width !== "number" || !Number.isFinite(width)) {
+			return undefined;
+		}
+		return Math.max(1, Math.floor(width));
+	}
+
+	setContentWidth(width: number | undefined): void {
+		if (!this.globalSettings.terminal) {
+			this.globalSettings.terminal = {};
+		}
+		if (width === undefined || !Number.isFinite(width)) {
+			delete this.globalSettings.terminal.contentWidth;
+		} else {
+			this.globalSettings.terminal.contentWidth = Math.max(1, Math.floor(width));
+		}
+		this.markModified("terminal", "contentWidth");
 		this.save();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -522,6 +522,7 @@ export class InteractiveMode {
 			logDirectory: getAgentDir(),
 			onRightClickPaste: this.onRightClickPaste,
 			fullscreenCopyOnSelect: this.settingsManager.getFullscreenCopyOnSelect(),
+			contentWidth: this.settingsManager.getContentWidth(),
 		});
 		this.ui = createInteractiveTuiReference(() => this.renderer);
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
@@ -807,6 +808,7 @@ export class InteractiveMode {
 			terminal,
 			onRightClickPaste: this.onRightClickPaste,
 			fullscreenCopyOnSelect: this.settingsManager.getFullscreenCopyOnSelect(),
+			contentWidth: this.settingsManager.getContentWidth(),
 		});
 		nextUi.setClearOnShrink(clearOnShrink);
 		nextUi.onDebug = onDebug;

--- a/packages/coding-agent/src/modes/interactive/tui-renderer.ts
+++ b/packages/coding-agent/src/modes/interactive/tui-renderer.ts
@@ -11,6 +11,7 @@ export interface InteractiveTuiOptions {
 	readonly terminal?: Terminal;
 	readonly onRightClickPaste?: () => void;
 	readonly fullscreenCopyOnSelect?: boolean;
+	readonly contentWidth?: number;
 }
 
 /** Composition root shared by coding-agent presentations. */
@@ -35,9 +36,12 @@ export function createInteractiveTui(options: InteractiveTuiOptions): TuiMainScr
 					return false;
 				}
 			},
+			contentWidth: options.contentWidth,
 		});
 	}
-	return new TuiMainScreen(terminal, options.showHardwareCursor, options.logDirectory);
+	return new TuiMainScreen(terminal, options.showHardwareCursor, options.logDirectory, {
+		contentWidth: options.contentWidth,
+	});
 }
 
 /** Stable reference for components while InteractiveMode replaces the active renderer. */

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -130,6 +130,7 @@ export {
 	type OverlayUnfocusOptions,
 	type SizeValue,
 	type TUI,
+	type TuiBaseOptions,
 	type TuiInputListener,
 	type TuiInputListenerResult,
 	type TuiMode,

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -39,6 +39,7 @@ import {
 	type OverlayHandle,
 	retargetMouseEvent,
 	TuiBase,
+	type TuiBaseOptions,
 	type TuiMouseButton,
 	type TuiMouseDispatchResult,
 	type TuiMouseDispatchTarget,
@@ -153,7 +154,7 @@ interface SearchHighlightRange {
 	current: boolean;
 }
 
-export interface TuiAltScreenOptions {
+export interface TuiAltScreenOptions extends TuiBaseOptions {
 	/** Number of logical lines moved for each mouse-wheel event. */
 	wheelScrollLines?: number;
 	/** Capture mouse events for viewport scrolling and application-owned text selection. */
@@ -363,7 +364,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		if (options.preserveScreen) {
 			this.terminal.write(`${BEGIN_SYNCHRONIZED_OUTPUT}${EXIT_ALT_SCREEN}\x1b[?25h${END_SYNCHRONIZED_OUTPUT}`);
 		} else {
-			const width = Math.max(1, this.terminal.columns);
+			const width = this.effectiveColumns();
 			const documentLines = this.render(width).map((line) => line.replace(OSC133_ZONE_PREFIX, ""));
 			this.lastDocument = this.applyLineResets(documentLines.map((line) => line.replaceAll(CURSOR_MARKER, ""))).map(
 				(line) => (isImageLine(line) || visibleWidth(line) <= width ? line : sliceByColumn(line, 0, width, true)),
@@ -1528,7 +1529,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 
 	protected override doRender(): void {
 		if (this.stopped || !this.altScreenActive) return;
-		const width = Math.max(1, this.terminal.columns);
+		const width = this.effectiveColumns();
 		const height = Math.max(1, this.terminal.rows);
 		const root = this.layoutRoot ?? this.implicitScrollView;
 		let nextLayout = renderLayoutFrame(root, width, height, () => this.requestRender());

--- a/packages/tui/src/tui-main-screen.ts
+++ b/packages/tui/src/tui-main-screen.ts
@@ -246,7 +246,7 @@ export class TuiMainScreen extends TuiBase implements TUI {
 
 	protected doRender(): void {
 		if (this.stopped) return;
-		const width = this.terminal.columns;
+		const width = this.effectiveColumns();
 		const height = this.terminal.rows;
 		const widthChanged = this.previousWidth !== 0 && this.previousWidth !== width;
 		const heightChanged = this.previousHeight !== 0 && this.previousHeight !== height;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -451,9 +451,21 @@ export function isViewportTUI(tui: TUI): tui is ViewportTUI {
 	return (tui as Partial<ViewportTUI>)[VIEWPORT_TUI] === true;
 }
 
+export interface TuiBaseOptions {
+	/**
+	 * Maximum width, in columns, at which the whole UI renders. When set, the
+	 * transcript, editor and all wrapping are computed at this width instead of the
+	 * full terminal width, leaving the remaining right-hand columns blank. Text
+	 * *wraps* at the boundary — it is never hidden. Omit to use the full terminal width.
+	 */
+	contentWidth?: number;
+}
+
 export abstract class TuiBase extends Container implements TUI {
 	abstract readonly mode: TuiMode;
 	public terminal: Terminal;
+	/** Maximum render width in columns; undefined means "full terminal width". */
+	private contentWidth?: number;
 	private focusedComponent: Component | null = null;
 	private inputListeners = new Set<TuiInputListener>();
 
@@ -485,10 +497,32 @@ export abstract class TuiBase extends Container implements TUI {
 	}
 	private overlayFocusRestore: OverlayFocusRestoreState = { status: "inactive" };
 
-	constructor(terminal: Terminal, showHardwareCursor?: boolean, logDirectory?: string) {
+	/**
+	 * The width in columns the whole UI should render at. Clamped to the terminal's
+	 * current width so a configured `contentWidth` never exceeds the available space.
+	 * This is the single source of truth for layout width; both render passes use it
+	 * so that narrowing the width wraps (rather than hides) all text.
+	 */
+	protected effectiveColumns(): number {
+		const full = Math.max(1, this.terminal.columns);
+		if (typeof this.contentWidth === "number" && Number.isFinite(this.contentWidth)) {
+			return Math.max(1, Math.min(full, Math.floor(this.contentWidth)));
+		}
+		return full;
+	}
+
+	/** Set the maximum render width in columns (see {@link TuiBaseOptions.contentWidth}). */
+	setContentWidth(width: number | undefined): void {
+		this.contentWidth =
+			typeof width === "number" && Number.isFinite(width) ? Math.max(1, Math.floor(width)) : undefined;
+		this.requestRender();
+	}
+
+	constructor(terminal: Terminal, showHardwareCursor?: boolean, logDirectory?: string, options?: TuiBaseOptions) {
 		super();
 		this.terminal = terminal;
 		this.logDirectory = logDirectory;
+		this.contentWidth = options?.contentWidth;
 		if (showHardwareCursor !== undefined) {
 			this.showHardwareCursor = showHardwareCursor;
 		}


### PR DESCRIPTION
## Summary

Adds a **`terminal.contentWidth`** setting (columns) that caps the width at which the **whole TUI renders**. Text **wraps** at the boundary — nothing is hidden — and the remaining right-hand columns are left blank, giving a reserved gutter that extension overlays / side panels can occupy **without covering transcript text**.

Motivation: extensions that want a persistent right-side panel currently have only `ctx.ui.custom({overlay:true})` (composites *on top of* chat, hiding long lines) or `setWidget` (above/below editor only). There is no way to *reserve* a column. #2790 and #3769 asked for side panels; #2820 attempted them and was closed. This takes the smaller, non-breaking step first: let the main column render narrower, so a side panel can sit in the freed space with zero text hidden.

## How it works

- **pi-tui** — new `TuiBaseOptions.contentWidth` and `TuiBase.effectiveColumns()`, the single source of truth for layout width. The two render seams now use it instead of `terminal.columns`:
  - `TuiAltScreen.doRender()` and `TuiAltScreen.afterTerminalStop()` (preserve-on-exit repaint)
  - `TuiMainScreen.doRender()`
  - Clamped to the terminal width so a large value never overflows.
- **coding-agent** — `TerminalSettings.contentWidth` + `getContentWidth()/setContentWidth()`, mirroring the existing `imageWidthCells` pattern; wired through `InteractiveTuiOptions` into both TUI constructors and the regular/fullscreen mode-switch rebuild.

Defaults to **full terminal width when unset** — no behavior change for existing users.

## Validation

- `tsc --noEmit`: all changed files clean (the repo has unrelated pre-existing errors from unbuilt generated model data).
- `biome check`: clean.
- Unit probe of `effectiveColumns()`: `contentWidth:60` -> 60, unset -> 100, `999` -> 100 (clamped), `setContentWidth(40)` -> 40.

## Suggested follow-up (not in this PR)

A public `ctx.ui.setSidePanel(position, ...)` that renders into the reserved gutter (the full #3769 ask) can be layered on top now that the main column can be narrowed. Kept separate — it is the larger layout change and a distinct feature.

CC @badlogic