### PR TITLE
fix(coding-agent): download statically linked musl builds of fd and ripgrep on Linux

### DIFF
--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -39,7 +39,7 @@ const TOOLS: Record<string, ToolConfig> = {
 				return `fd-v${version}-${archStr}-apple-darwin.tar.gz`;
 			} else if (plat === "linux") {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
-				return `fd-v${version}-${archStr}-unknown-linux-gnu.tar.gz`;
+				return `fd-v${version}-${archStr}-unknown-linux-musl.tar.gz`;
 			} else if (plat === "win32") {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
 				return `fd-v${version}-${archStr}-pc-windows-msvc.zip`;
@@ -57,10 +57,8 @@ const TOOLS: Record<string, ToolConfig> = {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
 				return `ripgrep-${version}-${archStr}-apple-darwin.tar.gz`;
 			} else if (plat === "linux") {
-				if (architecture === "arm64") {
-					return `ripgrep-${version}-aarch64-unknown-linux-gnu.tar.gz`;
-				}
-				return `ripgrep-${version}-x86_64-unknown-linux-musl.tar.gz`;
+				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
+				return `ripgrep-${version}-${archStr}-unknown-linux-musl.tar.gz`;
 			} else if (plat === "win32") {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
 				return `ripgrep-${version}-${archStr}-pc-windows-msvc.zip`;


### PR DESCRIPTION
fixes #9033

On Linux, `tools-manager.ts` picked the `unknown-linux-gnu` release asset for fd (both arches) and for ripgrep on arm64. Those binaries are dynamically linked against glibc and fail with `No such file or directory` on NixOS and Alpine, so the find/grep tools break for users without fd/rg on PATH.

Changes:

- `packages/coding-agent/src/utils/tools-manager.ts`: select `${arch}-unknown-linux-musl.tar.gz` for fd and ripgrep on Linux. ripgrep x86_64 already used musl; this makes all Linux cases consistent. Exported `getToolAssetName()` so asset selection can be tested without network.
- `packages/coding-agent/test/tools-manager.test.ts`: tests for fd linux x64/arm64, ripgrep linux arm64, and the unchanged macOS asset.
- `packages/coding-agent/docs/nixos.md` (+ `index.md`, `docs.json`): platform setup page alongside `windows.md` and `termux.md`. Happy to drop this part if you would rather not carry it.

Verified fd v10.5.0 and ripgrep 15.2.0 publish musl assets for x86_64 and aarch64, and that the archives extract to `<name>/fd` and `<name>/rg`, which `downloadTool` already handles. Branch is based on current main (includes #8708). `npm run check` and `./test.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
