### PR TITLE
fix: keep root and workspace versions in lockstep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-monorepo",
-	"version": "0.0.3",
+	"version": "0.84.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-monorepo",
-			"version": "0.0.3",
+			"version": "0.84.4",
 			"workspaces": [
 				"packages/*",
 				"packages/session-backends/*",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",
 		"test": "npm run test:scripts && npm run test --workspaces --if-present",
 		"test:scripts": "node --test scripts/*.test.mjs",
-		"version:patch": "npm version patch --workspaces --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",
-		"version:minor": "npm version minor --workspaces --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",
-		"version:major": "npm version major --workspaces --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",
-		"version:set": "npm version --workspaces --no-workspaces-update",
+		"version:patch": "npm version patch --workspaces --include-workspace-root --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",
+		"version:minor": "npm version minor --workspaces --include-workspace-root --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",
+		"version:major": "npm version major --workspaces --include-workspace-root --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",
+		"version:set": "npm version --workspaces --include-workspace-root --no-workspaces-update",
 		"prepublishOnly": "npm run clean && npm run build && npm run check",
 		"publish": "npm run prepublishOnly && node scripts/publish.mjs",
 		"publish:dry": "npm run prepublishOnly && node scripts/publish.mjs --dry-run",
@@ -62,7 +62,7 @@
 	"engines": {
 		"node": ">=22.19.0"
 	},
-	"version": "0.0.3",
+	"version": "0.84.4",
 	"overrides": {
 		"protobufjs": "7.6.5",
 		"rimraf": "6.1.2",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -48,7 +48,7 @@ function run(cmd, options = {}) {
 }
 
 function getVersion() {
-	const pkg = JSON.parse(readFileSync("packages/ai/package.json", "utf-8"));
+	const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
 	return pkg.version;
 }
 
@@ -152,7 +152,7 @@ function bumpOrSetVersion(target) {
 		}
 
 		console.log(`Setting explicit version (${target})...`);
-		run(`npm version ${target} --workspaces --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts`);
+		run(`npm version ${target} --workspaces --include-workspace-root --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts`);
 	}
 
 	// npm version can temporarily install the previous workspace versions before

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -12,6 +12,8 @@ import { findPackageDirectories } from "./package-workspaces.mjs";
 const GENERATED_PACKAGE_SUFFIXES = [join("coding-agent", "install-lock")];
 
 const packageRoot = process.argv[2] ?? "packages";
+const rootPackagePath = join(packageRoot, "..", "package.json");
+const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8"));
 const workspacePackages = findPackageDirectories(packageRoot)
 	.filter((directory) => !GENERATED_PACKAGE_SUFFIXES.some((suffix) => directory.endsWith(suffix)))
 	.map((directory) => {
@@ -36,7 +38,13 @@ if (versions.size > 1) {
 	process.exit(1);
 }
 
-console.log("\nAll non-private packages are at the same version (lockstep).");
+const [publishedVersion] = versions;
+if (publishedVersion && rootPackage.version !== publishedVersion) {
+	console.error(`\nERROR: Root package version ${rootPackage.version} does not match published package version ${publishedVersion}.`);
+	process.exit(1);
+}
+
+console.log("\nThe root and all non-private packages are at the same version (lockstep).");
 
 let totalUpdates = 0;
 const updatedPackages = new Set();

--- a/scripts/sync-versions.test.mjs
+++ b/scripts/sync-versions.test.mjs
@@ -28,6 +28,11 @@ function runSyncVersions(root) {
 test("synchronizes private dependencies without touching registry aliases, generated manifests, or published lockstep", async () => {
 	const root = await mkdtemp(join(tmpdir(), "pi-sync-versions-"));
 	try {
+		await writeManifest(root, ".", {
+			name: "pi-monorepo",
+			version: "2.0.0",
+			private: true,
+		});
 		await writeManifest(root, "packages/ai", {
 			name: "@earendil-works/pi-ai",
 			version: "2.0.0",
@@ -63,6 +68,20 @@ test("synchronizes private dependencies without touching registry aliases, gener
 		const generatedManifest = await readManifest(root, "packages/coding-agent/install-lock");
 		assert.equal(generatedManifest.dependencies["@earendil-works/pi-coding-agent"], "^1.0.0");
 
+		await writeManifest(root, ".", {
+			name: "pi-monorepo",
+			version: "1.0.0",
+			private: true,
+		});
+		const rootLockstepFailure = runSyncVersions(root);
+		assert.equal(rootLockstepFailure.status, 1, rootLockstepFailure.stderr);
+		assert.match(rootLockstepFailure.stderr, /root package version/i);
+
+		await writeManifest(root, ".", {
+			name: "pi-monorepo",
+			version: "2.0.0",
+			private: true,
+		});
 		await writeManifest(root, "packages/ai", {
 			name: "@earendil-works/pi-ai",
 			version: "3.0.0",

--- a/scripts/versioning.test.mjs
+++ b/scripts/versioning.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { getPublicWorkspacePackages } from "./release-packages.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+
+test("uses the root manifest as the lockstep version source", async () => {
+	const rootManifest = JSON.parse(await readFile(join(repositoryRoot, "package.json"), "utf8"));
+	const publicVersions = new Set(getPublicWorkspacePackages().map((pkg) => pkg.version));
+
+	assert.deepEqual([...publicVersions], [rootManifest.version]);
+	for (const name of ["version:patch", "version:minor", "version:major", "version:set"]) {
+		assert.match(rootManifest.scripts[name], /--include-workspace-root/);
+	}
+});


### PR DESCRIPTION
## Summary

  - align the private root manifest and lockfile with the public workspace version
  - include the workspace root in all version update commands
  - use the root manifest as the release version source
  - reject root and public package version mismatches during synchronization
  - add regression coverage for lockstep validation and version command configuration

  ## Testing

  - npm run test:scripts
  - npm run check
  - Not run: ./test.sh