### PR TITLE
fix: let registerProvider apiKey read plugin auth files

### DIFF
--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1515,8 +1515,8 @@ export interface ProviderConfig {
 	name?: string;
 	/** Base URL for the API endpoint. Required when defining models. */
 	baseUrl?: string;
-	/** API key literal, env interpolation ($ENV_VAR or ${ENV_VAR}), or leading !command. Required when defining models (unless oauth provided). */
-	apiKey?: string;
+	/** API key literal, env interpolation ($ENV_VAR or ${ENV_VAR}), leading !command, or a function read at request time (plugin auth files). Required when defining models (unless oauth provided). */
+	apiKey?: string | (() => string | undefined);
 	/** API type. Required at provider or model level when defining models. */
 	api?: Api;
 	/**

--- a/packages/coding-agent/src/core/provider-api-key.ts
+++ b/packages/coding-agent/src/core/provider-api-key.ts
@@ -1,0 +1,7 @@
+export type ProviderApiKey = string | (() => string | undefined);
+
+export function resolveConfiguredApiKey(rawKey: ProviderApiKey | undefined): string | undefined {
+	if (rawKey === undefined) return undefined;
+	if (typeof rawKey === "function") return rawKey();
+	return rawKey;
+}

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -29,6 +29,8 @@ import {
 	resolveConfigValueOrThrow,
 	resolveHeadersOrThrow,
 } from "./resolve-config-value.ts";
+import { type ProviderApiKey, resolveConfiguredApiKey } from "./provider-api-key.ts";
+export type { ProviderApiKey };
 
 export interface ExtensionOAuthConfig {
 	name: string;
@@ -46,7 +48,7 @@ export interface ExtensionOAuthConfig {
 export interface ProviderConfigInput {
 	name?: string;
 	baseUrl?: string;
-	apiKey?: string;
+	apiKey?: ProviderApiKey;
 	api?: Api;
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	headers?: Record<string, string>;
@@ -281,7 +283,7 @@ function withConfiguredAuth(
 function configuredApiKey(
 	config: ModelsJsonProvider | undefined,
 	extension: ProviderConfigInput | undefined,
-): string | undefined {
+): ProviderApiKey | undefined {
 	return extension?.apiKey ?? config?.apiKey;
 }
 
@@ -336,6 +338,11 @@ function composeApiKeyAuth(
 				return resolved ? { type: "api_key", source: resolved.source } : undefined;
 			}
 			if (rawKey !== undefined) {
+				if (typeof rawKey === "function") {
+					return resolveConfiguredApiKey(rawKey)
+						? { type: "api_key", source: "configured API key" }
+						: undefined;
+				}
 				if (isCommandConfigValue(rawKey)) return { type: "api_key", source: "configured API key" };
 				const envNames = getConfigValueEnvVarNames(rawKey);
 				for (const name of envNames) {
@@ -356,11 +363,20 @@ function composeApiKeyAuth(
 						? { auth: { apiKey: input.credential.key }, env: input.credential.env, source: "stored credential" }
 						: undefined;
 			} else if (rawKey !== undefined) {
-				const env = await configContextEnv([rawKey], input.ctx);
-				const key = resolveConfigValueOrThrow(rawKey, `API key for provider "${providerId}"`, env);
-				result = inherited
-					? await inherited.resolve({ ...input, credential: { type: "api_key", key } })
-					: { auth: { apiKey: key }, source: "configured API key" };
+				if (typeof rawKey === "function") {
+					const key = resolveConfiguredApiKey(rawKey);
+					result = key
+						? inherited
+							? await inherited.resolve({ ...input, credential: { type: "api_key", key } })
+							: { auth: { apiKey: key }, source: "configured API key" }
+						: undefined;
+				} else {
+					const env = await configContextEnv([rawKey], input.ctx);
+					const key = resolveConfigValueOrThrow(rawKey, `API key for provider "${providerId}"`, env);
+					result = inherited
+						? await inherited.resolve({ ...input, credential: { type: "api_key", key } })
+						: { auth: { apiKey: key }, source: "configured API key" };
+				}
 			} else {
 				result = await inherited?.resolve(input);
 			}

--- a/packages/coding-agent/test/provider-api-key-resolver.test.ts
+++ b/packages/coding-agent/test/provider-api-key-resolver.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { resolveConfiguredApiKey } from "../src/core/provider-api-key.ts";
+
+describe("registerProvider apiKey function", () => {
+	it("reads a plugin auth-file key at request time", () => {
+		expect(resolveConfiguredApiKey(() => "from-plugin-auth-file")).toBe("from-plugin-auth-file");
+		expect(resolveConfiguredApiKey(() => undefined)).toBeUndefined();
+		expect(resolveConfiguredApiKey("literal")).toBe("literal");
+		expect(resolveConfiguredApiKey(undefined)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
`registerProvider` only accepted a static apiKey string. Plugins that store keys in their own auth file (not /login) still hit "No API key found".

apiKey can now be a function, resolved when auth is checked. Plugins can return the file key at request time.

Closes https://github.com/earendil-works/pi/issues/9079

Test: `npx vitest run test/provider-api-key-resolver.test.ts` in packages/coding-agent (1 passed).
