### PR TITLE
fix(coding-agent): summarize multiline bash in collapsed tools

### DIFF
--- a/packages/coding-agent/src/core/tools/renderers/bash.ts
+++ b/packages/coding-agent/src/core/tools/renderers/bash.ts
@@ -32,11 +32,34 @@ class BashResultRenderComponent extends Container {
 function formatDuration(ms: number): string {
 	return `${(ms / 1000).toFixed(1)}s`;
 }
-function formatShellCall(args: { command?: string; timeout?: number } | undefined, prompt: string): string {
+function splitCommandLines(command: string): string[] {
+	const lines = command.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+	while (lines.length > 1 && lines[lines.length - 1]?.trim() === "") {
+		lines.pop();
+	}
+	return lines;
+}
+function formatShellCall(
+	args: { command?: string; timeout?: number } | undefined,
+	prompt: string,
+	expanded = true,
+): string {
 	const command = str(args?.command);
 	const timeout = args?.timeout as number | undefined;
 	const timeoutSuffix = timeout ? theme.fg("muted", ` (timeout ${timeout}s)`) : "";
-	const commandDisplay = command === null ? invalidArgText(theme) : command ? command : theme.fg("toolOutput", "...");
+	let commandDisplay: string;
+	if (command === null) {
+		commandDisplay = invalidArgText(theme);
+	} else if (!command) {
+		commandDisplay = theme.fg("toolOutput", "...");
+	} else {
+		const commandLines = splitCommandLines(command);
+		if (!expanded && commandLines.length > 1) {
+			commandDisplay = `${theme.fg("toolOutput", "bash script")} ${theme.fg("muted", `(${commandLines.length} lines)`)}`;
+		} else {
+			commandDisplay = command;
+		}
+	}
 	return theme.fg("toolTitle", theme.bold(`${prompt} ${commandDisplay}`)) + timeoutSuffix;
 }
 function rebuildBashResultRenderComponent(
@@ -131,7 +154,7 @@ export function createShellRenderers(prompt: string): Pick<ToolDefinition<any, a
 				state.endedAt = undefined;
 			}
 			const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-			text.setText(formatShellCall(args as { command?: string; timeout?: number } | undefined, prompt));
+			text.setText(formatShellCall(args as { command?: string; timeout?: number } | undefined, prompt, context.expanded));
 			return text;
 		},
 		renderResult(result, options, _theme, context) {

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -155,6 +155,44 @@ describe("ToolExecutionComponent parity", () => {
 		await promise;
 	});
 
+	test("collapses multiline bash call headers to a script summary", () => {
+		const command = "set -euo pipefail\necho one\necho two\n";
+		const component = new ToolExecutionComponent(
+			"bash",
+			"tool-bash-multiline-collapsed",
+			{ command },
+			{},
+			createBashToolDefinition(process.cwd()),
+			createFakeTui(),
+			process.cwd(),
+		);
+
+		const collapsed = stripAnsi(component.render(160).join("\n"));
+		expect(collapsed).toContain("$ bash script (3 lines)");
+		expect(collapsed).not.toContain("set -euo pipefail");
+
+		component.setExpanded(true);
+		const expanded = stripAnsi(component.render(160).join("\n"));
+		expect(expanded).toContain("set -euo pipefail");
+		expect(expanded).toContain("echo one");
+	});
+
+	test("keeps single-line bash call headers visible when collapsed", () => {
+		const component = new ToolExecutionComponent(
+			"bash",
+			"tool-bash-single-line-collapsed",
+			{ command: "git status --short" },
+			{},
+			createBashToolDefinition(process.cwd()),
+			createFakeTui(),
+			process.cwd(),
+		);
+
+		const collapsed = stripAnsi(component.render(160).join("\n"));
+		expect(collapsed).toContain("$ git status --short");
+		expect(collapsed).not.toContain("bash script");
+	});
+
 	test("bash renderer does not duplicate final full output truncation details", async () => {
 		const operations: BashOperations = {
 			exec: async (_command, _cwd, { onData }) => {


### PR DESCRIPTION
## Summary

Collapsed tool rows for multiline shell commands currently dump the entire command into the call header, which makes collapsed history noisy and hard to scan. With this change a collapsed multiline command renders as `bash script (N lines)`; the full command is still shown verbatim when the row is expanded, and single-line commands are unchanged.

## Before / after

- Collapsed: `$ set -euo pipefail\necho one\necho two` (full script in the header)
- Collapsed (fixed): `$ bash script (3 lines)`
- Expanded (unchanged): full command text
- Single-line collapsed (unchanged): `$ git status --short`

## Implementation

- `splitCommandLines()` normalizes `\r\n`/`\r` and trims trailing blank lines before counting.
- `formatShellCall()` gains an `expanded` parameter (defaults to `true`, so existing callers keep current behavior) and substitutes the summary only when collapsed and the command spans more than one line.
- `createShellRenderers()` passes `context.expanded` through, so every shell tool built on the shared renderers gets the behavior.
- Trailing-newline handling means a command like `"echo hi\n"` still counts as one line and stays visible.

## Tests

Two new cases in `tool-execution-component.test.ts`: collapsed multiline collapses to the summary (and restores on expand), and collapsed single-line stays verbatim. Full `coding-agent` vitest suite passes.
