### PR TITLE
fix(tui): expand repeated large paste markers

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -224,6 +224,7 @@ interface EditorSnapshot {
 	state: EditorState;
 	pastes: Map<number, string>;
 	pasteCounter: number;
+	autoSpacedPasteIds: Set<number>;
 }
 
 interface LayoutLine {
@@ -317,6 +318,7 @@ export class Editor implements Component, Focusable {
 	// Paste tracking for large pastes
 	private pastes: Map<number, string> = new Map();
 	private pasteCounter: number = 0;
+	private autoSpacedPasteIds: Set<number> = new Set();
 
 	// Bracketed paste mode buffering
 	private pasteBuffer: string = "";
@@ -1094,6 +1096,52 @@ export class Editor implements Component, Focusable {
 		return { line: this.state.cursorLine, col: this.state.cursorCol };
 	}
 
+	private findMatchingPasteMarkerBeforeCursor(
+		pasteContent: string,
+	): { pasteId: number; pasteContent: string; startCol: number; endCol: number } | null {
+		const line = this.state.lines[this.state.cursorLine] || "";
+		if (this.state.cursorCol === 0 || !line.includes("[paste #")) return null;
+
+		for (const match of line.matchAll(PASTE_MARKER_REGEX)) {
+			const marker = match[0];
+			const startCol = match.index;
+			const endCol = startCol + marker.length;
+			if (endCol !== this.state.cursorCol) continue;
+
+			const pasteId = Number.parseInt(match[1]!, 10);
+			const storedPasteContent = this.pastes.get(pasteId);
+			if (storedPasteContent === undefined) continue;
+			if (storedPasteContent === pasteContent) {
+				return { pasteId, pasteContent: storedPasteContent, startCol, endCol };
+			}
+			if (
+				this.autoSpacedPasteIds.has(pasteId) &&
+				/^[/~.]/.test(pasteContent) &&
+				storedPasteContent === ` ${pasteContent}`
+			) {
+				return { pasteId, pasteContent: storedPasteContent, startCol, endCol };
+			}
+		}
+
+		return null;
+	}
+
+	private replaceCurrentLineRangeWithText(startCol: number, endCol: number, text: string): void {
+		const currentLine = this.state.lines[this.state.cursorLine] || "";
+		this.state.lines[this.state.cursorLine] = currentLine.slice(0, startCol) + currentLine.slice(endCol);
+		this.setCursorCol(startCol);
+		this.insertTextAtCursorInternal(text);
+	}
+
+	private countPasteMarkerOccurrences(pasteId: number): number {
+		let count = 0;
+		const markerRegex = new RegExp(`\\[paste #${pasteId}( (\\+\\d+ lines|\\d+ chars))?\\]`, "g");
+		for (const line of this.state.lines) {
+			count += [...line.matchAll(markerRegex)].length;
+		}
+		return count;
+	}
+
 	setText(text: string): void {
 		this.cancelAutocomplete();
 		this.lastAction = null;
@@ -1270,11 +1318,13 @@ export class Editor implements Component, Focusable {
 
 		// If pasting a file path (starts with /, ~, or .) and the character before
 		// the cursor is a word character, prepend a space for better readability
+		let autoSpacedPaste = false;
 		if (/^[/~.]/.test(filteredText)) {
 			const currentLine = this.state.lines[this.state.cursorLine] || "";
 			const charBeforeCursor = this.state.cursorCol > 0 ? currentLine[this.state.cursorCol - 1] : "";
 			if (charBeforeCursor && /\w/.test(charBeforeCursor)) {
 				filteredText = ` ${filteredText}`;
+				autoSpacedPaste = true;
 			}
 		}
 
@@ -1284,10 +1334,26 @@ export class Editor implements Component, Focusable {
 		// Check if this is a large paste (> 10 lines or > 1000 characters)
 		const totalChars = filteredText.length;
 		if (pastedLines.length > 10 || totalChars > 1000) {
+			const matchingMarker = this.findMatchingPasteMarkerBeforeCursor(filteredText);
+			if (matchingMarker) {
+				const shouldDeletePaste = this.countPasteMarkerOccurrences(matchingMarker.pasteId) <= 1;
+				this.replaceCurrentLineRangeWithText(
+					matchingMarker.startCol,
+					matchingMarker.endCol,
+					matchingMarker.pasteContent,
+				);
+				if (shouldDeletePaste) {
+					this.pastes.delete(matchingMarker.pasteId);
+					this.autoSpacedPasteIds.delete(matchingMarker.pasteId);
+				}
+				return;
+			}
+
 			// Store the paste and insert a marker
 			this.pasteCounter++;
 			const pasteId = this.pasteCounter;
 			this.pastes.set(pasteId, filteredText);
+			if (autoSpacedPaste) this.autoSpacedPasteIds.add(pasteId);
 
 			// Insert marker like "[paste #1 +123 lines]" or "[paste #1 1234 chars]"
 			const marker =
@@ -1350,6 +1416,7 @@ export class Editor implements Component, Focusable {
 
 		this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
 		this.pastes.clear();
+		this.autoSpacedPasteIds.clear();
 		this.pasteCounter = 0;
 		this.exitHistoryBrowsing();
 		this.scrollOffset = 0;
@@ -2097,7 +2164,12 @@ export class Editor implements Component, Focusable {
 	}
 
 	private pushUndoSnapshot(): void {
-		this.undoStack.push({ state: this.state, pastes: this.pastes, pasteCounter: this.pasteCounter });
+		this.undoStack.push({
+			state: this.state,
+			pastes: this.pastes,
+			pasteCounter: this.pasteCounter,
+			autoSpacedPasteIds: this.autoSpacedPasteIds,
+		});
 	}
 
 	private undo(): void {
@@ -2107,6 +2179,7 @@ export class Editor implements Component, Focusable {
 		Object.assign(this.state, snapshot.state);
 		this.pastes = snapshot.pastes;
 		this.pasteCounter = snapshot.pasteCounter;
+		this.autoSpacedPasteIds = snapshot.autoSpacedPasteIds;
 		this.lastAction = null;
 		this.preferredVisualCol = null;
 		if (this.onChange) {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3590,6 +3590,109 @@ describe("Editor component", () => {
 			assert.match(text, /\[paste #\d+ \+\d+ lines\]/);
 		});
 
+		it("expands an adjacent matching paste marker when pasted again", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigContent = "line\n".repeat(20).trimEnd();
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.match(editor.getText(), /\[paste #\d+ \+20 lines\]/);
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.strictEqual(editor.getText(), bigContent);
+			assert.deepStrictEqual(editor.getCursor(), { line: 19, col: 4 });
+		});
+
+		it("expands repeated paste in place while preserving prefix and suffix", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigContent = "line\n".repeat(20).trimEnd();
+
+			editor.handleInput("A");
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			editor.handleInput("B");
+			editor.handleInput("\x1b[D");
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.strictEqual(editor.getText(), `A${bigContent}B`);
+			assert.deepStrictEqual(editor.getCursor(), { line: 19, col: 4 });
+		});
+
+		it("undo after expanding a repeated paste restores a backed marker", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigContent = "line\n".repeat(20).trimEnd();
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			const markerText = editor.getText();
+			assert.match(markerText, /\[paste #\d+ \+20 lines\]/);
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.strictEqual(editor.getText(), bigContent);
+
+			editor.handleInput("\x1b[45;5u"); // Ctrl+- (undo)
+			assert.strictEqual(editor.getText(), markerText);
+			assert.strictEqual(editor.getExpandedText(), bigContent);
+		});
+
+		it("does not expand marker-like literals after repeated paste expansion", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigContent = `[paste #1 +20 lines]\n${"line\n".repeat(20).trimEnd()}`;
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.match(editor.getText(), /\[paste #1 \+21 lines\]/);
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.strictEqual(editor.getText(), bigContent);
+			assert.strictEqual(editor.getExpandedText(), bigContent);
+		});
+
+		it("keeps paste backing when one duplicated marker occurrence is expanded", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigContent = "line\n".repeat(20).trimEnd();
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			const markerText = editor.getText();
+			editor.insertTextAtCursor(` ${markerText}`);
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			assert.strictEqual(editor.getText(), `${markerText} ${bigContent}`);
+			assert.strictEqual(editor.getExpandedText(), `${bigContent} ${bigContent}`);
+		});
+
+		it("expands repeated path-like large paste that received an automatic leading space", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigPath = `/${"a".repeat(1000)}`;
+
+			editor.handleInput("go");
+			editor.handleInput(`\x1b[200~${bigPath}\x1b[201~`);
+			assert.match(editor.getText(), /^go\[paste #\d+ 1002 chars\]$/);
+
+			editor.handleInput(`\x1b[200~${bigPath}\x1b[201~`);
+			assert.strictEqual(editor.getText(), `go ${bigPath}`);
+			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 3 + bigPath.length });
+		});
+
+		it("does not treat an original leading space as automatic path spacing", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigPath = `/${"a".repeat(1000)}`;
+
+			editor.handleInput(`\x1b[200~ ${bigPath}\x1b[201~`);
+			editor.handleInput(`\x1b[200~${bigPath}\x1b[201~`);
+
+			const markers = [...editor.getText().matchAll(/\[paste #\d+ 100[12] chars\]/g)];
+			assert.strictEqual(markers.length, 2);
+		});
+
+		it("creates another marker when the repeated paste is not adjacent", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			const bigContent = "line\n".repeat(20).trimEnd();
+
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+			editor.handleInput(" ");
+			editor.handleInput(`\x1b[200~${bigContent}\x1b[201~`);
+
+			const markers = [...editor.getText().matchAll(/\[paste #\d+ \+20 lines\]/g)];
+			assert.strictEqual(markers.length, 2);
+		});
+
 		it("treats paste marker as single unit for right arrow", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 			editor.handleInput("A");


### PR DESCRIPTION
## Summary

After a large paste is collapsed into a `[paste #N …]` marker, pasting the *same* content again immediately after the marker used to stack a second duplicate marker (`[paste #1 +50 lines][paste #2 +50 lines]`). The editor now treats a repeated paste of identical content right after its marker as "expand it": the marker is replaced inline with the full pasted text, and no duplicate paste entry is created.

## Details

- `findMatchingPasteMarkerBeforeCursor()` matches a marker that ends exactly at the cursor and compares the new paste against the stored content for that marker id.
- Handles the auto-space variant: path-like pastes (`/`, `~`, `.`) that had a space prepended for readability still match, tracked via `autoSpacedPasteIds`.
- When the expanded marker was the last remaining reference, the stored paste entry is dropped instead of leaking.
- Undo snapshots carry the new `autoSpacedPasteIds` state so undo/redo stays consistent.
- Non-identical content, pastes not adjacent to a marker, and small pastes are all unaffected.

## Tests

103 new lines in `test/editor.test.ts` covering identical repeated paste expansion, the auto-spaced path variant, non-matching content stacking normally, and paste-store cleanup. Full `tui` node:test suite passes (193 editor tests, 968 total).
