### PR TITLE
fix(coding-agent): update source checkouts via rebase

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -67,6 +67,16 @@ function makeSelfUpdateCommand(
 	};
 }
 
+function makeSelfUpdateCommandSequence(steps: SelfUpdateCommandStep[]): SelfUpdateCommand | undefined {
+	const [firstStep] = steps;
+	if (!firstStep) return undefined;
+	return {
+		...firstStep,
+		display: steps.map((step) => step.display).join(" && "),
+		steps,
+	};
+}
+
 function makeSelfUpdateCommandStep(command: string, args: string[]): SelfUpdateCommandStep {
 	return {
 		command,
@@ -293,6 +303,67 @@ function getEntrypointPackageDir(): string | undefined {
 		dir = dirname(dir);
 	}
 	return undefined;
+}
+
+interface PackageJsonShape {
+	name?: unknown;
+	scripts?: unknown;
+}
+
+function readPackageJson(path: string): PackageJsonShape | undefined {
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as PackageJsonShape;
+	} catch {
+		return undefined;
+	}
+}
+
+function hasBuildScript(packageJson: PackageJsonShape | undefined): boolean {
+	const scripts = packageJson?.scripts;
+	return typeof scripts === "object" && scripts !== null && typeof (scripts as { build?: unknown }).build === "string";
+}
+
+function pathContainsNodeModules(path: string): boolean {
+	return resolve(path)
+		.split(/[\\/]+/)
+		.some((part) => part.toLowerCase() === "node_modules");
+}
+
+function findSourceCheckoutRoot(packageDir: string): string | undefined {
+	if (pathContainsNodeModules(packageDir)) return undefined;
+	let dir = resolve(packageDir);
+	while (dir !== dirname(dir)) {
+		if (existsSync(join(dir, ".git")) && hasBuildScript(readPackageJson(join(dir, "package.json")))) {
+			return dir;
+		}
+		dir = dirname(dir);
+	}
+	return undefined;
+}
+
+export function getSourceCheckoutSelfUpdateCommand(packageName = PACKAGE_NAME): SelfUpdateCommand | undefined {
+	if (isBunBinary) return undefined;
+
+	const packageDir = getPackageDir();
+	const packageJson = readPackageJson(join(packageDir, "package.json"));
+	if (packageJson?.name !== packageName) return undefined;
+
+	const sourceRoot = findSourceCheckoutRoot(packageDir);
+	if (!sourceRoot) return undefined;
+
+	return makeSelfUpdateCommandSequence([
+		makeSelfUpdateCommandStep("git", ["-C", sourceRoot, "pull", "--rebase"]),
+		makeSelfUpdateCommandStep("npm", ["--prefix", sourceRoot, "ci", "--ignore-scripts", "--include=dev"]),
+		makeSelfUpdateCommandStep("npm", ["--prefix", sourceRoot, "run", "build"]),
+		makeSelfUpdateCommandStep("git", [
+			"-C",
+			sourceRoot,
+			"checkout",
+			"--",
+			"packages/ai/src/models.generated.ts",
+			"packages/ai/src/image-models.generated.ts",
+		]),
+	]);
 }
 
 function isSelfUpdatePathWritable(): boolean {

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -22,6 +22,7 @@ import {
 	getPackageDir,
 	getSelfUpdateCommand,
 	getSelfUpdateUnavailableInstruction,
+	getSourceCheckoutSelfUpdateCommand,
 	PACKAGE_NAME,
 	type SelfUpdateCommand,
 	type SelfUpdatePackageTarget,
@@ -1030,6 +1031,21 @@ export async function handlePackageCommand(
 						process.exitCode = 1;
 						return true;
 					}
+					const sourceCheckoutSelfUpdateCommand = getSourceCheckoutSelfUpdateCommand(PACKAGE_NAME);
+					if (sourceCheckoutSelfUpdateCommand) {
+						try {
+							await runSelfUpdate(sourceCheckoutSelfUpdateCommand);
+						} catch (error: unknown) {
+							const message = error instanceof Error ? error.message : "Unknown package command error";
+							console.error(chalk.red(`Error: ${message}`));
+							printSelfUpdateFallback(sourceCheckoutSelfUpdateCommand);
+							process.exitCode = 1;
+							return true;
+						}
+						console.log(chalk.green(`Updated ${APP_NAME}`));
+						return true;
+					}
+
 					const selfUpdatePlan = await getSelfUpdatePlan(options.force);
 					if (!selfUpdatePlan.shouldRun) {
 						return true;

--- a/packages/coding-agent/test/config.test.ts
+++ b/packages/coding-agent/test/config.test.ts
@@ -7,6 +7,7 @@ import {
 	findNodePackageDir,
 	getSelfUpdateCommand,
 	getSelfUpdateUnavailableInstruction,
+	getSourceCheckoutSelfUpdateCommand,
 	getUpdateInstruction,
 } from "../src/config.ts";
 
@@ -122,6 +123,23 @@ function createBunGlobalInstall(): { packageDir: string } {
 	return { packageDir };
 }
 
+function createSourceCheckout(packageDirRelative = join("packages", "coding-agent")): {
+	repoRoot: string;
+	packageDir: string;
+} {
+	const repoRoot = mkdtempSync(join(tmpdir(), "pi-source-"));
+	const packageDir = join(repoRoot, packageDirRelative);
+	mkdirSync(join(repoRoot, ".git"), { recursive: true });
+	mkdirSync(packageDir, { recursive: true });
+	writeFileSync(join(repoRoot, "package.json"), JSON.stringify({ scripts: { build: "echo build" } }));
+	writeFileSync(join(packageDir, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent" }));
+	tempDir = repoRoot;
+	process.env.PI_PACKAGE_DIR = packageDir;
+	setExecPath(join(packageDir, "dist", "cli.js"));
+	process.argv[1] = join(packageDir, "dist", "cli.js");
+	return { repoRoot, packageDir };
+}
+
 function createFakePnpmScript(root: string): string {
 	if (process.platform === "win32") {
 		return `@echo off\r\nif "%1"=="root" if "%2"=="-g" echo ${root}\r\n`;
@@ -179,6 +197,54 @@ describe("detectInstallMethod", () => {
 		expect(getUpdateInstruction("@earendil-works/pi-coding-agent")).toBe(
 			"Update @earendil-works/pi-coding-agent using the package manager, wrapper, or source checkout that provides this installation.",
 		);
+	});
+
+	test("self-updates source checkouts by rebasing, installing, and building", () => {
+		const { repoRoot } = createSourceCheckout();
+
+		const command = getSourceCheckoutSelfUpdateCommand("@earendil-works/pi-coding-agent");
+
+		expect(detectInstallMethod()).toBe("unknown");
+		expect(command).toEqual({
+			command: "git",
+			args: ["-C", repoRoot, "pull", "--rebase"],
+			display: `git -C ${repoRoot} pull --rebase && npm --prefix ${repoRoot} ci --ignore-scripts --include=dev && npm --prefix ${repoRoot} run build && git -C ${repoRoot} checkout -- packages/ai/src/models.generated.ts packages/ai/src/image-models.generated.ts`,
+			steps: [
+				{
+					command: "git",
+					args: ["-C", repoRoot, "pull", "--rebase"],
+					display: `git -C ${repoRoot} pull --rebase`,
+				},
+				{
+					command: "npm",
+					args: ["--prefix", repoRoot, "ci", "--ignore-scripts", "--include=dev"],
+					display: `npm --prefix ${repoRoot} ci --ignore-scripts --include=dev`,
+				},
+				{
+					command: "npm",
+					args: ["--prefix", repoRoot, "run", "build"],
+					display: `npm --prefix ${repoRoot} run build`,
+				},
+				{
+					command: "git",
+					args: [
+						"-C",
+						repoRoot,
+						"checkout",
+						"--",
+						"packages/ai/src/models.generated.ts",
+						"packages/ai/src/image-models.generated.ts",
+					],
+					display: `git -C ${repoRoot} checkout -- packages/ai/src/models.generated.ts packages/ai/src/image-models.generated.ts`,
+				},
+			],
+		});
+	});
+
+	test("does not treat node_modules packages as source checkouts", () => {
+		createSourceCheckout(join("node_modules", "@earendil-works", "pi-coding-agent"));
+
+		expect(getSourceCheckoutSelfUpdateCommand("@earendil-works/pi-coding-agent")).toBeUndefined();
 	});
 
 	test("self-updates npm installs from custom prefixes", () => {

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -659,6 +659,7 @@ fs.writeFileSync(recordPath,JSON.stringify(records));
 	});
 
 	it("retries a transient self-update version check", async () => {
+		process.env.PI_PACKAGE_DIR = join(tempDir, "node_modules", "@earendil-works", "pi-coding-agent");
 		const previousSkipVersionCheck = process.env.PI_SKIP_VERSION_CHECK;
 		delete process.env.PI_SKIP_VERSION_CHECK;
 		const fetchMock = vi

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -556,7 +556,83 @@ if (process.platform !== "win32") fs.chmodSync(piPath, 0o755);
 		}
 	});
 
+	it("updates source checkout self installs without checking the api", async () => {
+		const repoRoot = join(tempDir, "source-checkout");
+		const selfPackageDir = join(repoRoot, "packages", "coding-agent");
+		const fakeBinDir = join(tempDir, "fake-bin");
+		const recordPath = join(tempDir, "source-self-update.json");
+		const recorderPath = join(tempDir, "record-command.cjs");
+		mkdirSync(join(repoRoot, ".git"), { recursive: true });
+		mkdirSync(selfPackageDir, { recursive: true });
+		mkdirSync(fakeBinDir, { recursive: true });
+		writeFileSync(join(repoRoot, "package.json"), JSON.stringify({ scripts: { build: "echo build" } }, null, 2));
+		writeFileSync(join(selfPackageDir, "package.json"), JSON.stringify({ name: PACKAGE_NAME }, null, 2));
+		writeFileSync(
+			recorderPath,
+			`const fs=require("node:fs");
+const recordPath=${JSON.stringify(recordPath)};
+const command=process.argv[2];
+const args=process.argv.slice(3);
+const records=fs.existsSync(recordPath)?JSON.parse(fs.readFileSync(recordPath,"utf-8")):[];
+records.push({command,args});
+fs.writeFileSync(recordPath,JSON.stringify(records));
+`,
+		);
+		for (const commandName of ["git", "npm"]) {
+			const commandPath = join(fakeBinDir, process.platform === "win32" ? `${commandName}.cmd` : commandName);
+			if (process.platform === "win32") {
+				writeFileSync(commandPath, `@echo off\r\n"${originalExecPath}" "${recorderPath}" ${commandName} %*\r\n`);
+			} else {
+				writeFileSync(
+					commandPath,
+					`#!/bin/sh\nexec ${JSON.stringify(originalExecPath)} ${JSON.stringify(recorderPath)} ${commandName} "$@"\n`,
+				);
+				chmodSync(commandPath, 0o755);
+			}
+		}
+		process.env.PATH = `${fakeBinDir}${delimiter}${originalPath ?? ""}`;
+		process.env.PI_PACKAGE_DIR = selfPackageDir;
+		Object.defineProperty(process, "execPath", {
+			value: join(selfPackageDir, "dist", "cli.js"),
+			configurable: true,
+		});
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			await expect(main(["update", "--self"])).resolves.toBeUndefined();
+
+			expect(process.exitCode).toBeUndefined();
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(fetchMock).not.toHaveBeenCalled();
+			const recordedCalls = JSON.parse(readFileSync(recordPath, "utf-8")) as { command: string; args: string[] }[];
+			expect(recordedCalls).toEqual([
+				{ command: "git", args: ["-C", repoRoot, "pull", "--rebase"] },
+				{ command: "npm", args: ["--prefix", repoRoot, "ci", "--ignore-scripts", "--include=dev"] },
+				{ command: "npm", args: ["--prefix", repoRoot, "run", "build"] },
+				{
+					command: "git",
+					args: [
+						"-C",
+						repoRoot,
+						"checkout",
+						"--",
+						"packages/ai/src/models.generated.ts",
+						"packages/ai/src/image-models.generated.ts",
+					],
+				},
+			]);
+		} finally {
+			logSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("allows explicit self-update checks when automatic version checks are disabled", async () => {
+		process.env.PI_PACKAGE_DIR = join(tempDir, "node_modules", "@earendil-works", "pi-coding-agent");
 		const previousSkipVersionCheck = process.env.PI_SKIP_VERSION_CHECK;
 		process.env.PI_SKIP_VERSION_CHECK = "1";
 		const fetchMock = vi.fn(async () => Response.json({ version: VERSION }));


### PR DESCRIPTION
## Summary

`pi update` did not know how to update a source-checkout installation: it fell through to package-manager messaging and told the user to update the checkout themselves. This adds a source-checkout self-update path that runs the correct sequence automatically: `git pull --rebase`, `npm ci`, `npm run build`, then reverts build-generated churn in the checked-in generated model files.

## Implementation

- `getSourceCheckoutSelfUpdateCommand()` detects a source checkout by walking up from the running package directory to a directory containing `.git` and a `package.json` with a `build` script, refusing anything inside `node_modules` and skipping Bun binaries.
- The update runs as an ordered `SelfUpdateCommand` step sequence (`git -C <root> pull --rebase` → `npm ci --ignore-scripts --include=dev` → `npm run build` → `git checkout -- packages/ai/src/models.generated.ts packages/ai/src/image-models.generated.ts`), with a combined `display` string so fallback instructions show the full sequence.
- In `package-manager-cli.ts` the source-checkout branch runs before the managed/npm self-update plan and returns early, so managed installations are untouched; on failure it prints the same sequence as manual instructions.
- Coexists with the managed-install `--force` guard added upstream.

## Tests

New cases in `config.test.ts` (checkout detection, node_modules rejection, Bun skip) and `package-command-paths.test.ts` (command routing, step sequence, failure fallback, isolation of the generated-file revert). Full `coding-agent` vitest suite passes.
