### PR TITLE
docs(plan-mode): note the questionnaire tool stays enabled

### DIFF
--- a/packages/coding-agent/examples/extensions/plan-mode/README.md
+++ b/packages/coding-agent/examples/extensions/plan-mode/README.md
@@ -4,7 +4,7 @@ Read-only exploration mode for safe code analysis.
 
 ## Features
 
-- **Built-in write tools disabled**: Disables edit/write while preserving other active tools
+- **Built-in write tools disabled**: Disables edit/write while preserving other active read-only tools, including questionnaire
 - **Bash allowlist**: Only read-only bash commands are allowed
 - **Plan extraction**: Extracts numbered steps from `Plan:` sections
 - **Progress tracking**: Widget shows completion status during execution


### PR DESCRIPTION
## Summary

One-line docs fix in the plan-mode example extension README: the feature list said write tools are disabled "while preserving other active tools"; it now correctly says "other active read-only tools, including questionnaire", matching the extension's actual behavior.
