### PR TITLE
fix(ai): fail fast when a dynamic model's api has no matching implementation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed single-API providers silently streaming dynamic overlay models whose `api` does not match the provider's implementation. They now fail fast with a clear error instead of hitting an invalid endpoint (as happened when the OpenRouter catalog switched `anthropic/*` models to `anthropic-messages`, producing a raw HTML 404).
 - Fixed the Qwen Token Plan Individual catalog to include Qwen3.8 Flash ([#9021](https://github.com/earendil-works/pi/issues/9021)).
 - Removed the unnecessary Chord dependency from pi-ai by defining its exported `JsonValue` type directly.
 - Fixed GitHub Copilot Claude Fable 5 requests to use the Anthropic Messages adapter so selected reasoning levels are sent ([#8961](https://github.com/earendil-works/pi/issues/8961)).

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -791,12 +791,22 @@ export function createProvider<TApi extends Api = Api>(input: CreateProviderOpti
 
 	const apiFor = (model: Model<Api>): ProviderStreams | undefined => single ?? byApi?.[model.api];
 
+	const apiMismatch = (model: Model<Api>): boolean => {
+		if (single) {
+			// A single implementation covers only APIs that baseline models declare.
+			// A dynamic overlay model with a different api would route into the wrong
+			// protocol. Fail fast instead of hitting an invalid endpoint.
+			return baselineModels.length > 0 && baselineModels.every((baseline) => baseline.api !== model.api);
+		}
+		return byApi?.[model.api] === undefined;
+	};
+
 	const dispatch = (
 		model: Model<Api>,
 		run: (streams: ProviderStreams) => AssistantMessageEventStream,
 	): AssistantMessageEventStream => {
 		const streams = apiFor(model);
-		if (!streams) {
+		if (!streams || apiMismatch(model)) {
 			return lazyStream(model, async () => {
 				throw new ModelsError("stream", `Provider ${input.id} has no API implementation for "${model.api}"`);
 			});

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -510,6 +510,28 @@ describe("createProvider", () => {
 		expect(result.errorMessage).toContain("no API implementation");
 	});
 
+	it("rejects a dynamic overlay model whose api differs from the single baseline api", async () => {
+		// A remote catalog can introduce models that use an api the single
+		// implementation does not speak. Streaming them through it hits invalid
+		// endpoints. Fail fast instead.
+		const calls: string[] = [];
+		const provider = createProvider({
+			id: "mixed",
+			auth: { apiKey: { name: "Test", resolve: async () => ({ auth: {} }) } },
+			models: [testModel("api-a", "model-a")],
+			api: recordingStreams("a", calls),
+		});
+
+		const ok = await provider.streamSimple(testModel("api-a", "model-a"), context).result();
+		expect(ok.stopReason).toBe("stop");
+		expect(calls).toEqual(["a:model-a"]);
+
+		const result = await provider.streamSimple(testModel("api-b", "model-b"), context).result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain('Provider mixed has no API implementation for "api-b"');
+		expect(calls).toEqual(["a:model-a"]);
+	});
+
 	it("lets a newer dynamic refresh bypass and supersede older network work", async () => {
 		let fetches = 0;
 		let markFirstStarted: (() => void) | undefined;


### PR DESCRIPTION
## Problem

On 0.84.4, every `openrouter/anthropic/*` model (e.g. `anthropic/claude-opus-5`) fails with a giant HTML 404 page as the error message:

```
pi --mode print --model openrouter/anthropic/claude-opus-5 "say hi"
# 404 <!DOCTYPE html><html ...><title>Not Found | OpenRouter</title>...
```

Root cause chain:

1. The remote model catalog (pi.dev overlay, refreshed every 4h into `~/.pi/agent/models-store.json`) switched `anthropic/*` OpenRouter models to `api: "anthropic-messages"`, `baseUrl: "https://openrouter.ai/api"` (commit 4e69b0c on main routes these models through the Messages API).
2. In 0.84.4, `openrouterProvider()` registers a **single** API implementation (`api: openAICompletionsApi()`). Per `createProvider`, a single `api` streams **all** models; `model.api` is ignored for dispatch.
3. So the overlay model kept its new `baseUrl` but was streamed by the OpenAI completions client, which appends `/chat/completions` -> `POST https://openrouter.ai/api/chat/completions` (missing `/v1`). OpenRouter doesn't route that path, so its Next.js frontend returns an HTML 404 page, which pi prints raw.

The primary fix (routing OpenRouter Claude models through the Messages API via an API map) already landed on main in 4e69b0c, so 0.84.4 users just need a release. This PR fixes the underlying failure mode that made it a silent, confusing breakage.

## Fix

`createProvider` now rejects a model at dispatch time when its `api` cannot be served:

- **API map** (unchanged behavior, existing error path): no entry for `model.api`.
- **Single implementation** (new): the model's `api` differs from every baseline model's `api`, which means the model came from a dynamic overlay and the single implementation does not speak its protocol. Instead of streaming it into the wrong endpoint, the stream fails fast with:

  `Provider openrouter has no API implementation for "anthropic-messages"`

The baseline check uses the static model list only, so custom/overlay models that share the baseline api still stream normally, and a single-API provider with an empty baseline (purely dynamic catalog) is unaffected.

## Verification

- New unit test: single-API provider rejects an overlay model with a different api while still serving baseline models (`packages/ai/test/providers.test.ts`).
- Full `packages/ai` vitest run before/after: identical failure sets (all pre-existing, environment-dependent E2E failures: missing AWS/Copilot credentials, OpenRouter guardrails, model deprecations).
- Manually verified the end-to-end scenario against the installed 0.84.4 build: patching the provider to an API map resolves the 404 for `openrouter/anthropic/claude-opus-5` while `openai-completions` models keep working.
