### PR TITLE
fix(ai): remove Grok Build 0.1 from built-in xAI model catalog

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -419,6 +419,7 @@ const XAI_BUILTIN_EXCLUDED_MODEL_IDS = new Set([
 	"grok-3-fast",
 	"grok-4.20-0309-non-reasoning",
 	"grok-4.20-0309-reasoning",
+	"grok-build-0.1",
 	"grok-code-fast-1",
 ]);
 const XAI_RESPONSES_COMPAT: OpenAIResponsesCompat = {
@@ -876,8 +877,8 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	) {
 		mergeThinkingLevelMap(model, { off: "none" });
 	}
-	// xAI models without verified effort options (e.g. grok-build-0.1) must not
-	// send the undocumented "none"/"minimal" efforts.
+	// xAI models without verified effort options must not send the undocumented
+	// "none"/"minimal" efforts.
 	if (model.provider === "xai" && model.api === "openai-responses" && model.thinkingLevelMap === undefined) {
 		mergeThinkingLevelMap(model, { off: null, minimal: null });
 	}

--- a/packages/ai/test/xai-responses.test.ts
+++ b/packages/ai/test/xai-responses.test.ts
@@ -118,6 +118,7 @@ describe("xAI Responses provider", () => {
 			"grok-3-fast",
 			"grok-4.20-0309-non-reasoning",
 			"grok-4.20-0309-reasoning",
+			"grok-build-0.1",
 			"grok-code-fast-1",
 		]) {
 			expect(Object.keys(XAI_MODELS)).not.toContain(modelId);
@@ -131,7 +132,6 @@ describe("xAI Responses provider", () => {
 		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.5"])).toEqual(["low", "medium", "high"]);
 		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.6"])).toEqual(["low", "medium", "high", "xhigh"]);
 		expect(getSupportedThinkingLevels(XAI_MODELS["grok-4.3"])).toEqual(["off", "low", "medium", "high"]);
-		expect(getSupportedThinkingLevels(XAI_MODELS["grok-build-0.1"])).toEqual(["low", "medium", "high"]);
 	});
 
 	it("uses /responses with bearer auth and xAI-compatible request fields", async () => {


### PR DESCRIPTION
Adds grok-build-0.1 to XAI_BUILTIN_EXCLUDED_MODEL_IDS so the built-in xAI catalog only lists grok-4.3, grok-4.5 and grok-4.6.