### PR TITLE
fix(agent): scope JSONL session ids by cwd when directory encodings collide

### DIFF
--- a/packages/agent/src/harness/session/jsonl/repo.ts
+++ b/packages/agent/src/harness/session/jsonl/repo.ts
@@ -41,9 +41,14 @@ function sessionDirectoryName(cwd: string): string {
 	return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
 }
 
-function sessionFileName(createdAt: number, id: string): string {
+function sessionIdFileSuffix(id: string): string {
+	return `_${encodeURIComponent(id)}.jsonl`;
+}
+
+function sessionFileName(createdAt: number, id: string, collisionIndex = 0): string {
 	const timestamp = new Date(createdAt).toISOString().replace(/[:.]/g, "-");
-	return `${timestamp}_${encodeURIComponent(id)}.jsonl`;
+	const stamp = collisionIndex === 0 ? timestamp : `${timestamp}-${collisionIndex}`;
+	return `${stamp}${sessionIdFileSuffix(id)}`;
 }
 
 /** File-backed format-4 session repository lifecycle. */
@@ -272,29 +277,40 @@ export class JsonlSessionRepo
 
 	private async resolveNewSessionPath(cwd: string, createdAt: number, id: string, context: Context): Promise<string> {
 		const directory = await this.sessionDirectory(cwd, context);
-		await this.assertSessionIdAvailable(directory, id, context);
+		await this.assertSessionIdAvailable(directory, id, cwd, context);
 		fileValue(
 			await this.fileSystem.createDir(directory, undefined, context),
 			`Failed to create sessions directory ${directory}`,
 		);
-		return fileValue(
-			await this.fileSystem.joinPath([directory, sessionFileName(createdAt, id)], context),
-			`Failed to resolve path for session ${id}`,
-		);
+		for (let collisionIndex = 0; ; collisionIndex++) {
+			const path = fileValue(
+				await this.fileSystem.joinPath([directory, sessionFileName(createdAt, id, collisionIndex)], context),
+				`Failed to resolve path for session ${id}`,
+			);
+			if (!fileValue(await this.fileSystem.exists(path, context), `Failed to check session path ${path}`)) {
+				return path;
+			}
+		}
 	}
 
-	private async assertSessionIdAvailable(directory: string, id: string, context: Context): Promise<void> {
+	private async assertSessionIdAvailable(directory: string, id: string, cwd: string, context: Context): Promise<void> {
 		if (
 			!fileValue(await this.fileSystem.exists(directory, context), `Failed to check sessions directory ${directory}`)
 		)
 			return;
 
-		const suffix = `_${encodeURIComponent(id)}.jsonl`;
-		const idExists = fileValue(
+		const suffix = sessionIdFileSuffix(id);
+		const entries = fileValue(
 			await this.fileSystem.listDir(directory, context),
 			`Failed to list sessions directory ${directory}`,
-		).some((entry) => entry.kind !== "directory" && entry.name.endsWith(suffix));
-		if (idExists) throw new Error(`Session already exists: ${id}`);
+		);
+		for (const entry of entries) {
+			if (entry.kind === "directory" || !entry.name.endsWith(suffix)) continue;
+			const discovered = await this.readSessionMetadata(entry, context);
+			if (discovered !== undefined && discovered.id === id && discovered.cwd === cwd) {
+				throw new Error(`Session already exists: ${id}`);
+			}
+		}
 	}
 
 	private async loadClosedForkSourceSnapshot(

--- a/packages/agent/test/harness/jsonl-session-repo.test.ts
+++ b/packages/agent/test/harness/jsonl-session-repo.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { BACKGROUND_CONTEXT, type Context } from "../../src/harness/context.ts";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
@@ -194,6 +195,30 @@ describe("JsonlSessionRepo cwd-scoped lifecycle", () => {
 			repo.open(second.metadata, BACKGROUND_CONTEXT),
 		]);
 		await Promise.all(reopened.map((session) => session.close(BACKGROUND_CONTEXT)));
+		await repo.close(BACKGROUND_CONTEXT);
+	});
+
+	it("allows the same id when working-directory encodings collide", async () => {
+		// #9073
+		const root = createTempDir();
+		const fileSystem = new NodeExecutionEnv({ cwd: root });
+		const repo = new JsonlSessionRepo({ fileSystem, sessionsRoot: "sessions", now: () => NOW });
+		const firstCwd = join(root, "tenant-a", "project");
+		const secondCwd = join(root, "tenant", "a-project");
+
+		const first = await repo.create({ id: "same", cwd: firstCwd }, BACKGROUND_CONTEXT);
+		await first.close(BACKGROUND_CONTEXT);
+		const second = await repo.create({ id: "same", cwd: secondCwd }, BACKGROUND_CONTEXT);
+
+		expect(first.metadata.path).not.toBe(second.metadata.path);
+		expect(await repo.list({ cwd: firstCwd }, BACKGROUND_CONTEXT)).toMatchObject([
+			{ id: "same", cwd: firstCwd, path: first.metadata.path },
+		]);
+		expect(await repo.list({ cwd: secondCwd }, BACKGROUND_CONTEXT)).toMatchObject([
+			{ id: "same", cwd: secondCwd, path: second.metadata.path },
+		]);
+
+		await second.close(BACKGROUND_CONTEXT);
 		await repo.close(BACKGROUND_CONTEXT);
 	});
 });


### PR DESCRIPTION
## Summary

Session IDs are scoped by resolved cwd, but directory encoding is lossy (tenant-a/project and tenant/a-project can share one folder). Availability now checks the header exact cwd+id match, and if that filename is taken it picks another that still ends with the id suffix.

## Test plan

- [x] packages/agent/test/harness/jsonl-session-repo.test.ts

Fixes #9073
