### PR TITLE
feat(ai): add mid-conversation system messages

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -32,7 +32,11 @@ export type { QueueMode } from "./types.ts";
 
 function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
 	return messages.filter(
-		(message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+		(message) =>
+			message.role === "system" ||
+			message.role === "user" ||
+			message.role === "assistant" ||
+			message.role === "toolResult",
 	);
 }
 

--- a/packages/agent/src/harness/messages.ts
+++ b/packages/agent/src/harness/messages.ts
@@ -156,6 +156,7 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 						],
 						timestamp: m.timestamp,
 					};
+				case "system":
 				case "user":
 				case "assistant":
 				case "toolResult":

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -152,7 +152,7 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	/**
 	 * Converts AgentMessage[] to LLM-compatible Message[] before each LLM call.
 	 *
-	 * Each AgentMessage must be converted to a UserMessage, AssistantMessage, or ToolResultMessage
+	 * Each AgentMessage must be converted to a SystemMessage, UserMessage, AssistantMessage, or ToolResultMessage
 	 * that the LLM can understand. AgentMessages that cannot be converted (e.g., UI-only notifications,
 	 * status messages) should be filtered out.
 	 *
@@ -435,7 +435,7 @@ export type AgentEvent =
 	// Turn lifecycle - a turn is one assistant response + any tool calls/results
 	| { type: "turn_start" }
 	| { type: "turn_end"; message: AgentMessage; toolResults: ToolResultMessage[] }
-	// Message lifecycle - emitted for user, assistant, and toolResult messages
+	// Message lifecycle - emitted for system, user, assistant, and toolResult messages
 	| { type: "message_start"; message: AgentMessage }
 	// Only emitted for assistant messages during streaming
 	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -134,6 +134,24 @@ describe("Agent", () => {
 		expect(agent.state.thinkingLevel).toBe("low");
 	});
 
+	it("passes system messages through the default LLM converter", async () => {
+		let roles: string[] = [];
+		const agent = new Agent({
+			streamFn: (_model, context) => {
+				roles = context.messages.map((message) => message.role);
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("ok") });
+				});
+				return stream;
+			},
+		});
+
+		await agent.prompt({ role: "system", content: "updated guidance", timestamp: Date.now() });
+
+		expect(roles).toEqual(["system"]);
+	});
+
 	it("should subscribe to events", () => {
 		const agent = new Agent({ streamFn: unusedStreamFunction });
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -572,6 +572,13 @@ function supportsAnthropicMidConvoEffort(modelId: string): boolean {
 	);
 }
 
+function supportsAnthropicMidConvoSystemMessages(modelId: string): boolean {
+	return (
+		/^claude-opus-(?:4-8|5)(?:-\d{8})?$/.test(modelId) ||
+		/^claude-(?:fable|mythos)-5(?:[.-]1)?(?:-\d{8})?$/.test(modelId)
+	);
+}
+
 function isAnthropicAdaptiveThinkingModel(modelId: string): boolean {
 	return (
 		modelId.includes("opus-4-6") ||
@@ -1067,6 +1074,10 @@ function getAnthropicMessagesCompat(provider: string, modelId: string): Anthropi
 		supportsAnthropicMidConvoEffort(modelId)
 	) {
 		compat.supportsMidConvoEffort = true;
+	}
+	if (provider === "anthropic" && supportsAnthropicMidConvoSystemMessages(modelId)) {
+		compat.supportsMidConvoSystemMessages = true;
+		compat.supportsMidConvoToolChanges = true;
 	}
 	if (EAGER_TOOL_INPUT_STREAMING_UNSUPPORTED_ANTHROPIC_MODELS.has(`${provider}:${modelId}`)) {
 		compat.supportsEagerToolInputStreaming = false;

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -10,6 +10,7 @@ import type {
 	BetaRawMessageStreamEvent as RawMessageStreamEvent,
 	BetaRefusalStopDetails as RefusalStopDetails,
 } from "@anthropic-ai/sdk/resources/beta/messages/messages.js";
+import { Type } from "typebox";
 import { calculateCost } from "../models.ts";
 import type {
 	Api,
@@ -31,7 +32,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.ts";
-import { splitDeferredTools } from "../utils/deferred-tools.ts";
+import { declaredTools, resolveToolHistory, splitDeferredTools, type ToolHistory } from "../utils/deferred-tools.ts";
 import { appendAssistantMessageDiagnostic } from "../utils/diagnostics.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
@@ -40,7 +41,12 @@ import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
-
+import {
+	extractInitialSystemPrompt,
+	getSystemMessageText,
+	renderSystemMessageAsUserText,
+	supportsMidConversationToolChanges,
+} from "../utils/system-messages.ts";
 import { getJsonSchemaToolParameters, resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.ts";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampMaxTokensToContext } from "./simple-options.ts";
@@ -176,6 +182,20 @@ const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
 const SERVER_SIDE_FALLBACK_BETA = "server-side-fallback-2026-07-01";
 const MID_CONVERSATION_OUTPUT_CONFIG_BETA = "mid-conversation-output-config-2026-07-01";
 const THINKING_BINDING_CONTROLS_BETA = "thinking-binding-controls-2026-08-01";
+const MID_CONVERSATION_TOOL_CHANGES_BETA = "mid-conversation-tool-changes-2026-07-01";
+
+/**
+ * Deferred placeholder that enables transcript tool additions and references.
+ *
+ * Native tool changes keep real definitions as normal declarations. Legacy
+ * tool-result references can still defer their referenced definitions. This
+ * reserved placeholder is present exactly once when either mechanism needs it.
+ */
+const DEFERRED_TOOL_PLACEHOLDER: Tool = {
+	name: "__pi_deferred_tool_placeholder__",
+	description: "Reserved placeholder that keeps deferred tool loading active. Never call this tool.",
+	parameters: Type.Object({}),
+};
 
 function shouldUseServerSideFallbackBeta(model: Model<"anthropic-messages">): boolean {
 	return (model.compat?.allowedFallbackModels?.length ?? 0) > 0;
@@ -193,6 +213,8 @@ function getAnthropicCompat(model: Model<"anthropic-messages">) {
 		allowEmptySignature: model.compat?.allowEmptySignature ?? false,
 		supportsStrictTools: model.compat?.supportsStrictTools ?? false,
 		supportsToolReferences: model.compat?.supportsToolReferences ?? defaultSupportsToolReferences(model),
+		supportsMidConvoSystemMessages: model.compat?.supportsMidConvoSystemMessages ?? false,
+		supportsMidConvoToolChanges: model.compat?.supportsMidConvoToolChanges ?? false,
 	};
 }
 
@@ -563,6 +585,7 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 				client = created.client;
 				isOAuth = created.isOAuthToken;
 			}
+			const outputTools = declaredTools(context);
 			let params = buildParams(model, context, isOAuth, options);
 			const nextParams = await options?.onPayload?.(params, model);
 			if (nextParams !== undefined) {
@@ -650,7 +673,7 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 							type: "toolCall",
 							id: event.content_block.id,
 							name: isOAuth
-								? fromClaudeCodeName(event.content_block.name, context.tools)
+								? fromClaudeCodeName(event.content_block.name, outputTools)
 								: event.content_block.name,
 							arguments: (event.content_block.input as Record<string, any>) ?? {},
 							partialJson: "",
@@ -1015,6 +1038,11 @@ function getBetaFeatures(
 	if (model.compat?.supportsMidConvoEffort === true) {
 		features.push(MID_CONVERSATION_OUTPUT_CONFIG_BETA, THINKING_BINDING_CONTROLS_BETA);
 	}
+	// Sent whenever the model supports it rather than only when a request carries tool
+	// changes, so the beta set stays constant for the whole conversation.
+	if (supportsMidConversationToolChanges(model)) {
+		features.push(MID_CONVERSATION_TOOL_CHANGES_BETA);
+	}
 	return [...new Set(features)];
 }
 
@@ -1026,28 +1054,46 @@ function buildParams(
 ): MessageCreateParamsStreaming {
 	const { cacheControl } = getCacheControl(model, options?.cacheRetention, options?.env);
 	const compat = getAnthropicCompat(model);
+	if (!compat.supportsMidConvoSystemMessages) context = extractInitialSystemPrompt(context);
 	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
 	const normalizeToolName = isOAuthToken ? toClaudeCodeName : (name: string) => name;
-	const toolPlacement = splitDeferredTools(
-		{ ...context, messages: transformedMessages },
-		compat.supportsToolReferences,
-		normalizeToolName,
-	);
-	let immediateTools = toolPlacement.immediate;
-	let deferredTools = [...toolPlacement.deferred.values()];
-	if (immediateTools.length === 0 && deferredTools.length > 0) {
-		immediateTools = deferredTools;
+	const systemToolChanges = supportsMidConversationToolChanges(model);
+	const needsDeferredPlaceholder = systemToolChanges || compat.supportsToolReferences;
+	const historyContext = { ...context, messages: transformedMessages };
+	const history = resolveToolHistory(historyContext, normalizeToolName);
+	let normalTools: Tool[];
+	let deferredTools: Tool[];
+	if (systemToolChanges) {
+		normalTools = [...history.definitions.values()];
 		deferredTools = [];
+	} else {
+		const placement = splitDeferredTools(historyContext, {
+			toolResultMarkers: compat.supportsToolReferences,
+			systemMarkers: false,
+			normalizeName: normalizeToolName,
+		});
+		normalTools = placement.immediate;
+		deferredTools = [...placement.deferred.values()];
 	}
-	const deferredToolNames = new Set(deferredTools.map((tool) => normalizeToolName(tool.name)));
+	if (needsDeferredPlaceholder) deferredTools.unshift(DEFERRED_TOOL_PLACEHOLDER);
+	const reservedName = normalizeToolName(DEFERRED_TOOL_PLACEHOLDER.name);
+	normalTools = normalTools.filter(
+		(tool) => !needsDeferredPlaceholder || normalizeToolName(tool.name) !== reservedName,
+	);
+	deferredTools = deferredTools.filter((tool, index) => normalizeToolName(tool.name) !== reservedName || index === 0);
 	const converted = convertMessages(
 		transformedMessages,
 		isOAuthToken,
 		cacheControl,
 		compat.allowEmptySignature,
-		deferredToolNames,
 		normalizeToolName,
+		history,
 		model.compat?.supportsMidConvoEffort === true ? model.provider : undefined,
+		{
+			native: compat.supportsMidConvoSystemMessages,
+			toolChanges: systemToolChanges,
+			toolReferences: compat.supportsToolReferences,
+		},
 	);
 	const activeEffort = options?.effort ?? "high";
 	const betaFeatures = getBetaFeatures(model, context, isOAuthToken, options);
@@ -1099,14 +1145,14 @@ function buildParams(
 		params.temperature = options.temperature;
 	}
 
-	if (immediateTools.length > 0 || deferredTools.length > 0) {
+	if (normalTools.length > 0 || deferredTools.length > 0) {
 		params.tools = [
 			...convertTools(
-				immediateTools,
+				normalTools,
 				isOAuthToken,
 				compat.supportsEagerToolInputStreaming,
 				compat.supportsStrictTools,
-				compat.supportsCacheControlOnTools ? cacheControl : undefined,
+				!systemToolChanges && compat.supportsCacheControlOnTools ? cacheControl : undefined,
 			),
 			...convertTools(
 				deferredTools,
@@ -1182,20 +1228,17 @@ function normalizeToolCallId(id: string): string {
 
 function convertToolResult(
 	msg: ToolResultMessage,
-	isOAuthToken: boolean,
-	deferredToolNames: ReadonlySet<string>,
+	history: ToolHistory,
 	loadedToolNames: Set<string>,
 	normalizeToolName: (name: string) => string,
+	toolReferences: boolean,
 ): { toolResult: ContentBlockParam; siblingContent: ContentBlockParam[] } {
 	const references: Array<{ type: "tool_reference"; tool_name: string }> = [];
-	for (const name of msg.addedToolNames ?? []) {
-		const normalizedName = normalizeToolName(name);
-		if (!deferredToolNames.has(normalizedName) || loadedToolNames.has(normalizedName)) continue;
+	for (const tool of toolReferences ? (history.changes.get(msg)?.added ?? []) : []) {
+		const normalizedName = normalizeToolName(tool.name);
+		if (loadedToolNames.has(normalizedName)) continue;
 		loadedToolNames.add(normalizedName);
-		references.push({
-			type: "tool_reference",
-			tool_name: isOAuthToken ? toClaudeCodeName(name) : name,
-		});
+		references.push({ type: "tool_reference", tool_name: normalizedName });
 	}
 	const convertedContent = convertContentBlocks(msg.content);
 	// Anthropic rejects tool references mixed with ordinary tool-result content.
@@ -1220,22 +1263,70 @@ interface ConvertedAnthropicMessages {
 	assistantLevels: Map<number, AnthropicEffort>;
 }
 
+interface SystemMessageRendering {
+	/** Whether the model accepts `role: "system"` entries inside `messages`. Otherwise they render as user text. */
+	native: boolean;
+	/** Whether native system messages may carry `tool_addition` and `tool_removal` blocks. */
+	toolChanges: boolean;
+	/** Whether deprecated tool-result markers may emit tool references. */
+	toolReferences: boolean;
+}
+
 function convertMessages(
 	transformedMessages: Message[],
 	isOAuthToken: boolean,
 	cacheControl?: CacheControlEphemeral,
 	allowEmptySignature = false,
-	deferredToolNames: ReadonlySet<string> = new Set(),
 	normalizeToolName: (name: string) => string = (name) => name,
+	history: ToolHistory = resolveToolHistory({ messages: [] }, normalizeToolName),
 	managedProvider?: string,
+	systemMessages: SystemMessageRendering = { native: false, toolChanges: false, toolReferences: false },
 ): ConvertedAnthropicMessages {
 	const params: MessageParam[] = [];
 	const assistantLevels = new Map<number, AnthropicEffort>();
-	const loadedToolNames = new Set<string>();
+	const loadedToolNames = new Set(history.initial.map((tool) => normalizeToolName(tool.name)));
+	// Anthropic rejects a `role: "system"` message unless it directly precedes an assistant
+	// message or ends the array (verified against the API: "role 'system' must precede an
+	// 'assistant' message or end the array"). Dropping an aborted assistant turn leaves
+	// `[user, system, user]`, so native system messages are held back until the next
+	// assistant message or the end. No assistant turn lies in between, so the model sees
+	// the same content before it next acts, and the prefix up to the moved message is kept.
+	const pendingSystem: MessageParam[] = [];
+	const flushPendingSystem = (): void => {
+		params.push(...pendingSystem);
+		pendingSystem.length = 0;
+	};
 
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const msg = transformedMessages[i];
 
+		if (msg.role === "system") {
+			if (!systemMessages.native) {
+				const text = renderSystemMessageAsUserText(msg);
+				if (text.length > 0)
+					params.push({ role: "user", content: [{ type: "text", text: sanitizeSurrogates(text) }] });
+				continue;
+			}
+			const blocks: ContentBlockParam[] = [];
+			const text = getSystemMessageText(msg);
+			if (text.length > 0) blocks.push({ type: "text", text: sanitizeSurrogates(text) });
+			if (systemMessages.toolChanges) {
+				const change = history.changes.get(msg);
+				// Withdraw before re-offering so a same-name pair nets out as offered.
+				for (const tool of change?.removed ?? []) {
+					const name = normalizeToolName(tool.name);
+					loadedToolNames.delete(name);
+					blocks.push({ type: "tool_removal", tool: { type: "tool_reference", name } });
+				}
+				for (const tool of change?.added ?? []) {
+					const name = normalizeToolName(tool.name);
+					loadedToolNames.add(name);
+					blocks.push({ type: "tool_addition", tool: { type: "tool_reference", name } });
+				}
+			}
+			if (blocks.length > 0) pendingSystem.push({ role: "system", content: blocks });
+			continue;
+		}
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				if (msg.content.trim().length > 0) {
@@ -1329,6 +1420,7 @@ function convertMessages(
 				}
 			}
 			if (blocks.length === 0) continue;
+			flushPendingSystem();
 			const messageIndex = params.length;
 			params.push({
 				role: "assistant",
@@ -1350,10 +1442,10 @@ function convertMessages(
 			while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
 				const converted = convertToolResult(
 					transformedMessages[j] as ToolResultMessage,
-					isOAuthToken,
-					deferredToolNames,
+					history,
 					loadedToolNames,
 					normalizeToolName,
+					systemMessages.toolReferences,
 				);
 				toolResults.push(converted.toolResult);
 				siblingContent.push(...converted.siblingContent);
@@ -1371,15 +1463,21 @@ function convertMessages(
 		}
 	}
 
-	// Add cache_control to the last user message to cache conversation history
+	flushPendingSystem();
+
+	// Add cache_control to the last user or system message to cache conversation history
 	if (cacheControl && params.length > 0) {
 		const lastMessage = params[params.length - 1];
-		if (lastMessage.role === "user") {
+		if (lastMessage.role === "user" || lastMessage.role === "system") {
 			if (Array.isArray(lastMessage.content)) {
 				const lastBlock = lastMessage.content[lastMessage.content.length - 1];
 				if (
 					lastBlock &&
-					(lastBlock.type === "text" || lastBlock.type === "image" || lastBlock.type === "tool_result")
+					(lastBlock.type === "text" ||
+						lastBlock.type === "image" ||
+						lastBlock.type === "tool_result" ||
+						lastBlock.type === "tool_addition" ||
+						lastBlock.type === "tool_removal")
 				) {
 					(lastBlock as any).cache_control = cacheControl;
 				}
@@ -1419,7 +1517,7 @@ function insertThinkingLevelMessages(
 }
 
 function shouldUseFineGrainedToolStreamingBeta(model: Model<"anthropic-messages">, context: Context): boolean {
-	return !!context.tools?.length && !getAnthropicCompat(model).supportsEagerToolInputStreaming;
+	return declaredTools(context).length > 0 && !getAnthropicCompat(model).supportsEagerToolInputStreaming;
 }
 
 function convertTools(

--- a/packages/ai/src/api/azure-openai-responses.ts
+++ b/packages/ai/src/api/azure-openai-responses.ts
@@ -10,6 +10,7 @@ import type {
 	StreamFunction,
 	StreamOptions,
 } from "../types.ts";
+import { declaredTools, splitDeferredTools } from "../utils/deferred-tools.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
@@ -104,7 +105,7 @@ export const stream: StreamFunction<"azure-openai-responses", AzureOpenAIRespons
 			}
 			const client = createClient(model, apiKey, options);
 			const grammarToolInputProperties = createGrammarToolInputProperties(
-				context.tools,
+				declaredTools(context),
 				model.compat?.supportsOpenAIGrammarTools ?? false,
 			);
 			let params = buildParams(model, context, options, deploymentName, grammarToolInputProperties);
@@ -278,12 +279,28 @@ function buildParams(
 	options: AzureOpenAIResponsesOptions | undefined,
 	deploymentName: string,
 	grammarToolInputProperties: ReadonlyMap<string, string> = createGrammarToolInputProperties(
-		context.tools,
+		declaredTools(context),
 		model.compat?.supportsOpenAIGrammarTools ?? false,
 	),
 ) {
+	const deferredToolsMode = model.compat?.supportsAdditionalTools
+		? "additional-tools"
+		: model.compat?.supportsToolSearch
+			? "tool-search"
+			: undefined;
+	const placement = splitDeferredTools(context, {
+		toolResultMarkers: deferredToolsMode !== undefined,
+		systemMarkers: deferredToolsMode !== undefined,
+	});
+	const tools = deferredToolsMode === "additional-tools" ? [] : placement.immediate;
 	const messages = convertResponsesMessages(model, context, AZURE_TOOL_CALL_PROVIDERS, {
 		grammarToolInputProperties,
+		deferredToolsMode,
+		deferredTools: placement.deferred,
+		toolOptions: {
+			supportsStrictMode: model.compat?.supportsStrictMode ?? true,
+			supportsOpenAIGrammarTools: model.compat?.supportsOpenAIGrammarTools ?? false,
+		},
 	});
 
 	const params: ResponseCreateParamsStreaming = {
@@ -302,8 +319,8 @@ function buildParams(
 		params.temperature = options?.temperature;
 	}
 
-	if (context.tools && context.tools.length > 0) {
-		params.tools = convertResponsesTools(context.tools, {
+	if (tools.length > 0) {
+		params.tools = convertResponsesTools(tools, {
 			supportsStrictMode: model.compat?.supportsStrictMode ?? true,
 			supportsOpenAIGrammarTools: model.compat?.supportsOpenAIGrammarTools ?? false,
 		});

--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -48,6 +48,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.ts";
+import { declaredTools } from "../utils/deferred-tools.ts";
 import { appendAssistantMessageDiagnostic } from "../utils/diagnostics.ts";
 import { normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
@@ -56,6 +57,7 @@ import { parseStreamingJson } from "../utils/json-parse.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { extractInitialSystemPrompt, renderSystemMessageAsUserText } from "../utils/system-messages.ts";
 import { getJsonSchemaToolParameters, resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import {
 	adjustMaxTokensForThinking,
@@ -121,6 +123,7 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 	const stream = new AssistantMessageEventStream();
 
 	(async () => {
+		context = extractInitialSystemPrompt(context);
 		const output: AssistantMessage = {
 			role: "assistant",
 			content: [],
@@ -256,7 +259,7 @@ export const stream: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 					...(inferenceMaxTokens !== undefined && { maxTokens: inferenceMaxTokens }),
 					...(options.temperature !== undefined && { temperature: options.temperature }),
 				},
-				toolConfig: convertToolConfig(context.tools, options.toolChoice, supportsStrictMode),
+				toolConfig: convertToolConfig(declaredTools(context), options.toolChoice, supportsStrictMode),
 				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
 				...(options.requestMetadata !== undefined && { requestMetadata: options.requestMetadata }),
 			};
@@ -938,6 +941,12 @@ function convertMessages(
 		const m = transformedMessages[i];
 
 		switch (m.role) {
+			case "system": {
+				// The Converse API has no mid-conversation system role; append operator context as user text.
+				const text = renderSystemMessageAsUserText(m);
+				if (text.length > 0) result.push({ role: "user", content: [createRequiredTextBlock(text)] });
+				continue;
+			}
 			case "user": {
 				const content: ContentBlock[] = [];
 				if (typeof m.content === "string") {

--- a/packages/ai/src/api/google-generative-ai.ts
+++ b/packages/ai/src/api/google-generative-ai.ts
@@ -19,11 +19,13 @@ import type {
 	ThinkingContent,
 	ToolCall,
 } from "../types.ts";
+import { declaredTools } from "../utils/deferred-tools.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { extractInitialSystemPrompt } from "../utils/system-messages.ts";
 import type { GoogleApiThinkingLevel, ResolvedGoogleThinkingLevel } from "./google-shared.ts";
 import {
 	convertMessages,
@@ -361,7 +363,9 @@ function buildParams(
 	context: Context,
 	options: GoogleOptions = {},
 ): GenerateContentParameters {
+	context = extractInitialSystemPrompt(context);
 	const contents = convertMessages(model, context);
+	const tools = declaredTools(context);
 
 	const generationConfig: GenerateContentConfig = {};
 	if (options.temperature !== undefined) {
@@ -372,16 +376,15 @@ function buildParams(
 	}
 
 	const supportsStrictMode = supportsGoogleStrictToolSampling(model.id);
-	const functionCallingMode = context.tools?.length
-		? resolveGoogleFunctionCallingMode(context.tools, options.toolChoice, supportsStrictMode)
+	const functionCallingMode = tools.length
+		? resolveGoogleFunctionCallingMode(tools, options.toolChoice, supportsStrictMode)
 		: undefined;
 	const config: GenerateContentConfig = {
 		...(Object.keys(generationConfig).length > 0 && generationConfig),
 		...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
-		...(context.tools &&
-			context.tools.length > 0 && {
-				tools: convertTools(context.tools, false, supportsStrictMode),
-			}),
+		...(tools.length > 0 && {
+			tools: convertTools(tools, false, supportsStrictMode),
+		}),
 		...(functionCallingMode !== undefined && {
 			toolConfig: { functionCallingConfig: { mode: functionCallingMode } },
 		}),

--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { renderSystemMessageAsUserText } from "../utils/system-messages.ts";
 import { getJsonSchemaToolParameters, resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import { transformMessages } from "./transform-messages.ts";
 
@@ -138,7 +139,11 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
 
 	for (const msg of transformedMessages) {
-		if (msg.role === "user") {
+		if (msg.role === "system") {
+			// Gemini has no mid-conversation system role; append operator context as user text.
+			const text = renderSystemMessageAsUserText(msg);
+			if (text.length > 0) contents.push({ role: "user", parts: [{ text: sanitizeSurrogates(text) }] });
+		} else if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				contents.push({
 					role: "user",

--- a/packages/ai/src/api/google-vertex.ts
+++ b/packages/ai/src/api/google-vertex.ts
@@ -23,12 +23,14 @@ import type {
 	ThinkingContent,
 	ToolCall,
 } from "../types.ts";
+import { declaredTools } from "../utils/deferred-tools.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { extractInitialSystemPrompt } from "../utils/system-messages.ts";
 import type { GoogleApiThinkingLevel, ResolvedGoogleThinkingLevel } from "./google-shared.ts";
 import {
 	convertMessages,
@@ -460,7 +462,9 @@ function buildParams(
 	context: Context,
 	options: GoogleVertexOptions = {},
 ): GenerateContentParameters {
+	context = extractInitialSystemPrompt(context);
 	const contents = convertMessages(model, context);
+	const tools = declaredTools(context);
 
 	const generationConfig: GenerateContentConfig = {};
 	if (options.temperature !== undefined) {
@@ -471,16 +475,15 @@ function buildParams(
 	}
 
 	const supportsStrictMode = supportsGoogleStrictToolSampling(model.id);
-	const functionCallingMode = context.tools?.length
-		? resolveGoogleFunctionCallingMode(context.tools, options.toolChoice, supportsStrictMode)
+	const functionCallingMode = tools.length
+		? resolveGoogleFunctionCallingMode(tools, options.toolChoice, supportsStrictMode)
 		: undefined;
 	const config: GenerateContentConfig = {
 		...(Object.keys(generationConfig).length > 0 && generationConfig),
 		...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
-		...(context.tools &&
-			context.tools.length > 0 && {
-				tools: convertTools(context.tools, false, supportsStrictMode),
-			}),
+		...(tools.length > 0 && {
+			tools: convertTools(tools, false, supportsStrictMode),
+		}),
 		...(functionCallingMode !== undefined && {
 			toolConfig: { functionCallingConfig: { mode: functionCallingMode } },
 		}),

--- a/packages/ai/src/api/mistral-conversations.ts
+++ b/packages/ai/src/api/mistral-conversations.ts
@@ -13,12 +13,14 @@ import type {
 	Tool,
 	ToolCall,
 } from "../types.ts";
+import { declaredTools } from "../utils/deferred-tools.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { getSystemMessageText } from "../utils/system-messages.ts";
 import { getJsonSchemaToolParameters, resolveJsonSchemaStrictSampling } from "./constrained-sampling.ts";
 import { buildBaseOptions } from "./simple-options.ts";
 import { transformMessages } from "./transform-messages.ts";
@@ -512,7 +514,8 @@ function buildChatPayload(
 		messages: toChatMessages(messages, model.input.includes("image")),
 	};
 
-	if (context.tools?.length) payload.tools = toFunctionTools(context.tools);
+	const tools = declaredTools(context);
+	if (tools.length) payload.tools = toFunctionTools(tools);
 	if (options?.temperature !== undefined) payload.temperature = options.temperature;
 	if (options?.maxTokens !== undefined) payload.maxTokens = options.maxTokens;
 	if (options?.toolChoice) payload.toolChoice = mapToolChoice(options.toolChoice);
@@ -785,6 +788,11 @@ function toChatMessages(messages: Message[], supportsImages: boolean): MistralCh
 	const result: MistralChatMessage[] = [];
 
 	for (const msg of messages) {
+		if (msg.role === "system") {
+			const text = getSystemMessageText(msg);
+			if (text.length > 0) result.push({ role: "system", content: sanitizeSurrogates(text) });
+			continue;
+		}
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				result.push({ role: "user", content: sanitizeSurrogates(msg.content) });

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -21,7 +21,7 @@ import type {
 	Usage,
 } from "../types.ts";
 import { combineAbortSignals } from "../utils/abort-signals.ts";
-import { splitDeferredTools } from "../utils/deferred-tools.ts";
+import { declaredTools, splitDeferredTools } from "../utils/deferred-tools.ts";
 import {
 	appendAssistantMessageDiagnostic,
 	createAssistantMessageDiagnostic,
@@ -261,7 +261,7 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 
 			const accountId = extractAccountId(apiKey);
 			const grammarToolInputProperties = createGrammarToolInputProperties(
-				context.tools,
+				declaredTools(context),
 				model.compat?.supportsOpenAIGrammarTools ?? false,
 			);
 			const cacheSessionId = options?.cacheRetention === "none" ? undefined : options?.sessionId;
@@ -522,7 +522,7 @@ function buildRequestBody(
 	options: OpenAICodexResponsesOptions | undefined,
 	cacheSessionId: string | undefined,
 	grammarToolInputProperties: ReadonlyMap<string, string> = createGrammarToolInputProperties(
-		context.tools,
+		declaredTools(context),
 		model.compat?.supportsOpenAIGrammarTools ?? false,
 	),
 ): RequestBody {
@@ -533,7 +533,10 @@ function buildRequestBody(
 		: model.compat?.supportsToolSearch
 			? "tool-search"
 			: undefined;
-	const toolPlacement = splitDeferredTools(context, deferredToolsMode !== undefined);
+	const toolPlacement = splitDeferredTools(context, {
+		toolResultMarkers: deferredToolsMode !== undefined,
+		systemMarkers: deferredToolsMode !== undefined,
+	});
 	const messages = convertResponsesMessages(model, context, CODEX_TOOL_CALL_PROVIDERS, {
 		includeSystemPrompt: false,
 		grammarToolInputProperties,
@@ -567,7 +570,7 @@ function buildRequestBody(
 		body.service_tier = options.serviceTier;
 	}
 
-	if (toolPlacement.immediate.length > 0) {
+	if (deferredToolsMode !== "additional-tools" && toolPlacement.immediate.length > 0) {
 		body.tools = convertResponsesTools(toolPlacement.immediate, {
 			strict: null,
 			supportsStrictMode,

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -36,6 +36,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.ts";
+import { declaredTools, splitDeferredTools } from "../utils/deferred-tools.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
@@ -45,6 +46,7 @@ import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { addedToolNames, getSystemMessageText } from "../utils/system-messages.ts";
 import {
 	appendGrammarToolInputJsonDelta,
 	createGrammarToolInputProperties,
@@ -91,26 +93,6 @@ function hasToolHistory(messages: Message[]): boolean {
 		}
 	}
 	return false;
-}
-
-function getDeferredToolNames(messages: Message[]): Set<string> {
-	const names = new Set<string>();
-	for (const message of messages) {
-		if (message.role === "toolResult") {
-			for (const name of message.addedToolNames ?? []) {
-				names.add(name);
-			}
-		}
-	}
-	return names;
-}
-
-function getToolsByName(tools: Tool[] | undefined, names: Iterable<string>): Tool[] {
-	if (!tools) return [];
-	const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
-	return Array.from(names)
-		.map((name) => toolsByName.get(name))
-		.filter((tool): tool is Tool => tool !== undefined);
 }
 
 function isTextContentBlock(block: { type: string }): block is TextContent {
@@ -169,6 +151,8 @@ export interface OpenAICompletionsOptions extends StreamOptions {
 
 export interface ConvertCompletionsMessagesOptions {
 	grammarToolInputProperties?: ReadonlyMap<string, string>;
+	/** Definitions that load at their transcript marker through Kimi tool system messages. */
+	deferredTools?: ReadonlyMap<string, Tool>;
 }
 
 interface OpenAICompatCacheControl {
@@ -347,7 +331,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 			const apiKey = getClientApiKey(model.provider, options?.apiKey, options?.headers);
 			const compat = getCompat(model);
 			const grammarToolInputProperties = createGrammarToolInputProperties(
-				context.tools,
+				declaredTools(context),
 				compat.supportsOpenAIGrammarTools,
 			);
 			const cacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env);
@@ -796,11 +780,18 @@ function buildParams(
 	compat: ResolvedOpenAICompletionsCompat = getCompat(model),
 	cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env),
 	grammarToolInputProperties: ReadonlyMap<string, string> = createGrammarToolInputProperties(
-		context.tools,
+		declaredTools(context),
 		compat.supportsOpenAIGrammarTools,
 	),
 ) {
-	const messages = convertMessages(model, context, compat, { grammarToolInputProperties });
+	const toolPlacement = splitDeferredTools(context, {
+		toolResultMarkers: compat.deferredToolsMode === "kimi",
+		systemMarkers: compat.deferredToolsMode === "kimi",
+	});
+	const messages = convertMessages(model, context, compat, {
+		grammarToolInputProperties,
+		deferredTools: toolPlacement.deferred,
+	});
 	const cacheControl = getCompatCacheControl(compat, cacheRetention);
 
 	const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
@@ -835,11 +826,8 @@ function buildParams(
 		params.temperature = options.temperature;
 	}
 
-	const deferredToolNames =
-		compat.deferredToolsMode === "kimi" ? getDeferredToolNames(context.messages) : new Set<string>();
-	const activeTools = context.tools?.filter((tool) => !deferredToolNames.has(tool.name));
-	if (activeTools && activeTools.length > 0) {
-		params.tools = convertTools(activeTools, compat);
+	if (toolPlacement.immediate.length > 0) {
+		params.tools = convertTools(toolPlacement.immediate, compat);
 		if (compat.zaiToolStream) {
 			(params as any).tool_stream = true;
 		}
@@ -1182,6 +1170,18 @@ export function convertMessages(
 	options?: ConvertCompletionsMessagesOptions,
 ): ChatCompletionMessageParam[] {
 	const params: ChatCompletionMessageParam[] = [];
+	const loadedDeferredToolNames = new Set<string>();
+	/** Deferred definitions that become available at this point and were not loaded earlier. */
+	const takeDeferredToolLoads = (names: readonly string[]): Tool[] => {
+		const loads: Tool[] = [];
+		for (const name of names) {
+			const tool = options?.deferredTools?.get(name);
+			if (!tool || loadedDeferredToolNames.has(name)) continue;
+			loadedDeferredToolNames.add(name);
+			loads.push(tool);
+		}
+		return loads;
+	};
 
 	const normalizeToolCallId = (id: string): string => {
 		// Handle pipe-separated IDs from OpenAI Responses API
@@ -1211,10 +1211,9 @@ export function convertMessages(
 
 	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));
 
+	const instructionRole = model.reasoning && compat.supportsDeveloperRole ? "developer" : "system";
 	if (context.systemPrompt) {
-		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
-		const role = useDeveloperRole ? "developer" : "system";
-		params.push({ role: role, content: sanitizeSurrogates(context.systemPrompt) });
+		params.push({ role: instructionRole, content: sanitizeSurrogates(context.systemPrompt) });
 	}
 
 	let lastRole: string | null = null;
@@ -1230,7 +1229,20 @@ export function convertMessages(
 			});
 		}
 
-		if (msg.role === "user") {
+		if (msg.role === "system") {
+			const addedTools = takeDeferredToolLoads(addedToolNames(msg));
+			if (addedTools.length > 0) {
+				const kimiToolMessage: KimiToolSystemMessageParam = {
+					role: "system",
+					tools: convertTools(addedTools, compat),
+				};
+				params.push(kimiToolMessage as unknown as ChatCompletionMessageParam);
+			}
+			const text = getSystemMessageText(msg);
+			if (text.length > 0) {
+				params.push({ role: instructionRole, content: sanitizeSurrogates(text) });
+			}
+		} else if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				params.push({
 					role: "user",
@@ -1375,7 +1387,7 @@ export function convertMessages(
 			params.push(assistantMsg);
 		} else if (msg.role === "toolResult") {
 			const imageBlocks: Array<{ type: "image_url"; image_url: { url: string } }> = [];
-			const deferredToolNames = new Set<string>();
+			const deferredTools: Tool[] = [];
 			let j = i;
 
 			for (; j < transformedMessages.length && transformedMessages[j].role === "toolResult"; j++) {
@@ -1402,11 +1414,7 @@ export function convertMessages(
 				}
 				params.push(toolResultMsg);
 
-				if (compat.deferredToolsMode === "kimi") {
-					for (const name of toolMsg.addedToolNames ?? []) {
-						deferredToolNames.add(name);
-					}
-				}
+				deferredTools.push(...takeDeferredToolLoads(addedToolNames(toolMsg)));
 
 				if (hasImages && model.input.includes("image")) {
 					for (const block of toolMsg.content) {
@@ -1447,16 +1455,13 @@ export function convertMessages(
 				lastRole = "toolResult";
 			}
 
-			if (deferredToolNames.size > 0) {
-				const deferredTools = getToolsByName(context.tools, deferredToolNames);
-				if (deferredTools.length > 0) {
-					const kimiToolMessage: KimiToolSystemMessageParam = {
-						role: "system",
-						tools: convertTools(deferredTools, compat),
-					};
-					// Kimi accepts a system message with tools but omits the standard content field.
-					params.push(kimiToolMessage as unknown as ChatCompletionMessageParam);
-				}
+			if (deferredTools.length > 0) {
+				const kimiToolMessage: KimiToolSystemMessageParam = {
+					role: "system",
+					tools: convertTools(deferredTools, compat),
+				};
+				// Kimi accepts a system message with tools but omits the standard content field.
+				params.push(kimiToolMessage as unknown as ChatCompletionMessageParam);
 			}
 			continue;
 		}

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -28,10 +28,12 @@ import type {
 	ToolCall,
 	Usage,
 } from "../types.ts";
+import { resolveToolHistory } from "../utils/deferred-tools.ts";
 import type { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { addedToolNames, getSystemMessageText } from "../utils/system-messages.ts";
 import {
 	appendGrammarToolInputJsonDelta,
 	type GrammarToolInputJsonBuffer,
@@ -116,11 +118,13 @@ export interface OpenAIResponsesStreamOptions {
 	) => void;
 }
 
+export type ResponsesDeferredToolsMode = "additional-tools" | "tool-search";
+
 export interface ConvertResponsesMessagesOptions {
 	includeSystemPrompt?: boolean;
 	grammarToolInputProperties?: ReadonlyMap<string, string>;
 	deferredTools?: ReadonlyMap<string, Tool>;
-	deferredToolsMode?: "additional-tools" | "tool-search";
+	deferredToolsMode?: ResponsesDeferredToolsMode;
 	toolOptions?: ConvertResponsesToolsOptions;
 }
 
@@ -170,20 +174,77 @@ export function convertResponsesMessages<TApi extends Api>(
 	};
 
 	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
+	const grammarToolInputProperties = options?.grammarToolInputProperties ?? new Map<string, string>();
+	const toolHistory = resolveToolHistory({ ...context, messages: transformedMessages });
+	const activeTools = new Map(toolHistory.initial.map((tool) => [tool.name, tool]));
+	const appendToolSnapshot = (): void => {
+		messages.push({
+			type: "additional_tools",
+			role: "developer",
+			tools: convertResponsesTools(
+				[...activeTools.values()].sort((left, right) => left.name.localeCompare(right.name)),
+				options?.toolOptions,
+			),
+		});
+	};
+
+	/** Load deferred definitions at this point of the transcript, once each. */
+	const appendDeferredToolLoads = (names: readonly string[], seed: string): void => {
+		if (options?.deferredToolsMode !== "tool-search") return;
+		const added: Tool[] = [];
+		for (const name of names) {
+			const tool = options.deferredTools?.get(name);
+			if (!tool || loadedToolNames.has(name)) continue;
+			loadedToolNames.add(name);
+			added.push(tool);
+		}
+		if (added.length === 0) return;
+		const addedNames = added.map((tool) => tool.name);
+		const searchCallId = `pi_tool_load_${shortHash(`${seed}:${addedNames.join(",")}`)}`;
+		messages.push({
+			type: "tool_search_call",
+			call_id: searchCallId,
+			execution: "client",
+			status: "completed",
+			arguments: { query: addedNames.join(" "), limit: addedNames.length },
+		} satisfies ResponseInputItem);
+		messages.push({
+			type: "tool_search_output",
+			call_id: searchCallId,
+			execution: "client",
+			status: "completed",
+			tools: convertResponsesTools(added, { ...options.toolOptions, deferLoading: true }),
+		} satisfies ResponseToolSearchOutputItemParam);
+	};
 
 	const includeSystemPrompt = options?.includeSystemPrompt ?? true;
+	const compat = model.compat as { supportsDeveloperRole?: boolean } | undefined;
+	const instructionRole = model.reasoning && compat?.supportsDeveloperRole !== false ? "developer" : "system";
 	if (includeSystemPrompt && context.systemPrompt) {
-		const compat = model.compat as { supportsDeveloperRole?: boolean } | undefined;
-		const role = model.reasoning && compat?.supportsDeveloperRole !== false ? "developer" : "system";
 		messages.push({
-			role,
+			role: instructionRole,
 			content: sanitizeSurrogates(context.systemPrompt),
 		});
 	}
 
+	if (options?.deferredToolsMode === "additional-tools" && activeTools.size > 0) appendToolSnapshot();
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {
-		if (msg.role === "user") {
+		if (options?.deferredToolsMode === "additional-tools" && msg.role === "system") {
+			const change = toolHistory.changes.get(msg);
+			if (change) {
+				for (const tool of change.removed) activeTools.delete(tool.name);
+				for (const tool of change.added) activeTools.set(tool.name, tool);
+				appendToolSnapshot();
+			}
+		}
+		if (msg.role === "system") {
+			appendDeferredToolLoads(addedToolNames(msg), `system:${msgIndex}`);
+			const text = getSystemMessageText(msg);
+			if (text.length > 0) {
+				messages.push({ role: instructionRole, content: sanitizeSurrogates(text) });
+			}
+		} else if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				messages.push({
 					role: "user",
@@ -247,7 +308,7 @@ export function convertResponsesMessages<TApi extends Api>(
 				} else if (block.type === "toolCall") {
 					const toolCall = block as ToolCall;
 					const [callId, itemIdRaw] = toolCall.id.split("|");
-					const customInputProperty = options?.grammarToolInputProperties?.get(toolCall.name);
+					const customInputProperty = grammarToolInputProperties.get(toolCall.name);
 					let itemId: string | undefined = itemIdRaw;
 
 					// For different-model messages, set id to undefined to avoid pairing validation.
@@ -262,7 +323,10 @@ export function convertResponsesMessages<TApi extends Api>(
 						itemId = undefined;
 					}
 
-					const canReplayNamespace = isSameModel || options?.deferredTools?.has(toolCall.name) === true;
+					const canReplayNamespace =
+						isSameModel ||
+						options?.deferredTools?.has(toolCall.name) === true ||
+						(options?.deferredToolsMode === "additional-tools" && toolHistory.definitions.has(toolCall.name));
 
 					if (customInputProperty !== undefined) {
 						output.push({
@@ -297,7 +361,7 @@ export function convertResponsesMessages<TApi extends Api>(
 			const [callId] = msg.toolCallId.split("|");
 			const output = convertToolResultOutput(model, msg.content);
 
-			if (options?.grammarToolInputProperties?.has(msg.toolName)) {
+			if (grammarToolInputProperties.has(msg.toolName)) {
 				messages.push({
 					type: "custom_tool_call_output",
 					call_id: callId,
@@ -311,40 +375,15 @@ export function convertResponsesMessages<TApi extends Api>(
 				});
 			}
 
-			const deferredTools: Tool[] = [];
-			for (const name of msg.addedToolNames ?? []) {
-				const tool = options?.deferredTools?.get(name);
-				if (!tool || loadedToolNames.has(name)) continue;
-				loadedToolNames.add(name);
-				deferredTools.push(tool);
+			if (options?.deferredToolsMode === "additional-tools") {
+				const change = toolHistory.changes.get(msg);
+				if (change) {
+					for (const tool of change.removed) activeTools.delete(tool.name);
+					for (const tool of change.added) activeTools.set(tool.name, tool);
+					appendToolSnapshot();
+				}
 			}
-			if (deferredTools.length > 0 && options?.deferredToolsMode === "additional-tools") {
-				messages.push({
-					type: "additional_tools",
-					role: "developer",
-					tools: convertResponsesTools(deferredTools, options.toolOptions),
-				} satisfies ResponseInputItem);
-			} else if (deferredTools.length > 0 && options?.deferredToolsMode === "tool-search") {
-				const names = deferredTools.map((tool) => tool.name);
-				const searchCallId = `pi_tool_load_${shortHash(`${msg.toolCallId}:${names.join(",")}`)}`;
-				messages.push({
-					type: "tool_search_call",
-					call_id: searchCallId,
-					execution: "client",
-					status: "completed",
-					arguments: { query: names.join(" "), limit: names.length },
-				} satisfies ResponseInputItem);
-				messages.push({
-					type: "tool_search_output",
-					call_id: searchCallId,
-					execution: "client",
-					status: "completed",
-					tools: convertResponsesTools(deferredTools, {
-						...options.toolOptions,
-						deferLoading: true,
-					}),
-				} satisfies ResponseToolSearchOutputItemParam);
-			}
+			appendDeferredToolLoads(addedToolNames(msg), msg.toolCallId);
 		}
 		msgIndex++;
 	}

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -15,7 +15,7 @@ import type {
 	StreamOptions,
 	Usage,
 } from "../types.ts";
-import { splitDeferredTools } from "../utils/deferred-tools.ts";
+import { declaredTools, splitDeferredTools } from "../utils/deferred-tools.ts";
 import { formatProviderError, normalizeProviderError } from "../utils/error-body.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
@@ -147,7 +147,7 @@ export const stream: StreamFunction<"openai-responses", OpenAIResponsesOptions> 
 			const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
 			const compat = getCompat(model);
 			const grammarToolInputProperties = createGrammarToolInputProperties(
-				context.tools,
+				declaredTools(context),
 				compat.supportsOpenAIGrammarTools,
 			);
 			const client = createClient(model, context, apiKey, options?.headers, options?.fetch, cacheSessionId);
@@ -278,7 +278,7 @@ function buildParams(
 	options: OpenAIResponsesOptions | undefined,
 	compat: Required<OpenAIResponsesCompat> = getCompat(model),
 	grammarToolInputProperties: ReadonlyMap<string, string> = createGrammarToolInputProperties(
-		context.tools,
+		declaredTools(context),
 		compat.supportsOpenAIGrammarTools,
 	),
 ) {
@@ -287,7 +287,10 @@ function buildParams(
 		: compat.supportsToolSearch
 			? "tool-search"
 			: undefined;
-	const toolPlacement = splitDeferredTools(context, deferredToolsMode !== undefined);
+	const toolPlacement = splitDeferredTools(context, {
+		toolResultMarkers: deferredToolsMode !== undefined,
+		systemMarkers: deferredToolsMode !== undefined,
+	});
 	const messages = convertResponsesMessages(model, context, OPENAI_TOOL_CALL_PROVIDERS, {
 		grammarToolInputProperties,
 		deferredTools: toolPlacement.deferred,
@@ -323,7 +326,7 @@ function buildParams(
 		params.service_tier = options.serviceTier;
 	}
 
-	if (toolPlacement.immediate.length > 0) {
+	if (deferredToolsMode !== "additional-tools" && toolPlacement.immediate.length > 0) {
 		params.tools = convertResponsesTools(toolPlacement.immediate, {
 			supportsStrictMode: compat.supportsStrictMode,
 			supportsOpenAIGrammarTools: compat.supportsOpenAIGrammarTools,

--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -75,8 +75,8 @@ export function transformMessages<TApi extends Api>(
 
 	// First pass: transform messages (unsupported image downgrade, thinking blocks, tool call ID normalization)
 	const transformed = imageAwareMessages.map((msg) => {
-		// User messages pass through unchanged
-		if (msg.role === "user") {
+		// System and user messages pass through unchanged.
+		if (msg.role === "system" || msg.role === "user") {
 			return msg;
 		}
 
@@ -207,8 +207,8 @@ export function transformMessages<TApi extends Api>(
 		} else if (msg.role === "toolResult") {
 			existingToolResultIds.add(msg.toolCallId);
 			result.push(msg);
-		} else if (msg.role === "user") {
-			// User message interrupts tool flow - insert synthetic results for orphaned calls
+		} else if (msg.role === "system" || msg.role === "user") {
+			// A new instruction boundary cannot sit inside an unresolved tool flow.
 			insertSyntheticToolResults();
 			result.push(msg);
 		} else {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -42,6 +42,7 @@ export * from "./utils/event-stream.ts";
 export * from "./utils/json-parse.ts";
 export * from "./utils/overflow.ts";
 export * from "./utils/retry.ts";
+export * from "./utils/system-messages.ts";
 export { contentText } from "./utils/text.ts";
 export * from "./utils/typebox-helpers.ts";
 export { uuidv7 } from "./utils/uuid.ts";

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -19,6 +19,7 @@ import type {
 	Usage,
 } from "../types.ts";
 import { createAssistantMessageEventStream } from "../utils/event-stream.ts";
+import { getSystemMessageText } from "../utils/system-messages.ts";
 
 const DEFAULT_API = "faux";
 const DEFAULT_PROVIDER = "faux";
@@ -45,6 +46,8 @@ export interface FauxModelDefinition {
 	cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 	contextWindow?: number;
 	maxTokens?: number;
+	/** Compatibility flags for capability helpers such as `supportsMidConversationSystemMessages`. */
+	compat?: Record<string, boolean>;
 }
 
 export type FauxContentBlock = TextContent | ThinkingContent | ToolCall;
@@ -194,6 +197,9 @@ function toolResultToText(message: ToolResultMessage): string {
 }
 
 function messageToText(message: Message): string {
+	if (message.role === "system") {
+		return getSystemMessageText(message);
+	}
 	if (message.role === "user") {
 		return contentToText(message.content);
 	}
@@ -483,6 +489,7 @@ export function createFauxCore(options: RegisterFauxProviderOptions) {
 		cost: definition.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: definition.contextWindow ?? 128000,
 		maxTokens: definition.maxTokens ?? 16384,
+		...(definition.compat === undefined ? {} : { compat: definition.compat }),
 	})) as [Model<string>, ...Model<string>[]];
 
 	const resolveResponse = async (

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -419,6 +419,34 @@ export interface DeferredHandle {
 	data?: JsonValue;
 }
 
+/**
+ * Operator instruction appended to the transcript after the conversation started.
+ *
+ * Providers with native mid-conversation system messages send it as one; others render
+ * it as a tagged user turn. Either way it is appended, never folded into the top-level
+ * system prompt, so the cached prefix and any provider conversation checks stay valid.
+ *
+ * Rendering of a persisted message must depend only on the fields stored on it and on
+ * the model. Adapters must never reinterpret existing fields, because a resumed session
+ * that renders history differently than it was sent invalidates the provider cache and,
+ * on models that bind thinking blocks to the conversation, every later thinking block.
+ * New behavior must arrive as new optional fields that older messages lack.
+ *
+ * Every system message keeps its transcript position, including one at index
+ * zero. If no `Context.systemPrompt` exists and the transport only has a
+ * top-level system channel, a leading message is serialized through that
+ * channel. Initial tools belong in `Context.tools`.
+ */
+export interface SystemMessage {
+	role: "system";
+	content: string | TextContent[];
+	/** Complete definitions of tools that become available at this point. */
+	toolsAdded?: Tool[];
+	/** Tools that stop being available at this point. Names identify removals. */
+	toolsRemoved?: Tool[];
+	timestamp: number; // Unix timestamp in milliseconds
+}
+
 export interface UserMessage {
 	role: "user";
 	content: string | (TextContent | ImageContent)[];
@@ -458,16 +486,17 @@ export interface ToolResultMessage<TDetails = any> {
 	/** Usage from the tool execution itself, if available. Not part of main LLM context accounting. */
 	usage?: Usage;
 	/**
-	 * Names from `Context.tools` that became available after this result.
-	 * Providers with native deferred tool loading use this as the load point;
-	 * other providers ignore it and use `Context.tools` normally.
+	 * Names of tools that became available after this result.
+	 * @deprecated Record new availability transitions with `SystemMessage.toolsAdded`.
+	 * Names are resolved best-effort against definitions in `Context.tools` and
+	 * `SystemMessage.toolsAdded`; unresolved names are ignored.
 	 */
 	addedToolNames?: string[];
 	isError: boolean;
 	timestamp: number; // Unix timestamp in milliseconds
 }
 
-export type Message = UserMessage | AssistantMessage | ToolResultMessage;
+export type Message = SystemMessage | UserMessage | AssistantMessage | ToolResultMessage;
 
 export type ImagesInputContent = TextContent | ImageContent;
 export type ImagesOutputContent = TextContent | ImageContent;
@@ -522,8 +551,10 @@ export interface Tool<TParameters extends TSchema = TSchema> {
 }
 
 export interface Context {
+	/** Explicit initial instructions, sent through the provider's top-level instruction field. */
 	systemPrompt?: string;
 	messages: Message[];
+	/** Initial provider-visible tool loadout. Later definitions live on `SystemMessage.toolsAdded`. */
 	tools?: Tool[];
 }
 
@@ -729,6 +760,19 @@ export interface AnthropicMessagesCompat {
 	 * except Haiku and models older than Claude 4.5; false for other providers.
 	 */
 	supportsToolReferences?: boolean;
+	/**
+	 * Whether the model accepts `role: "system"` messages inside `messages`.
+	 * Generated metadata enables this for verified first-party models. Default:
+	 * false. Unsupported models receive system messages as tagged user turns.
+	 */
+	supportsMidConvoSystemMessages?: boolean;
+	/**
+	 * Whether the model accepts `tool_addition` and `tool_removal` blocks in
+	 * mid-conversation system messages (beta). Generated metadata enables this
+	 * for verified first-party models. Default: false. Requires
+	 * `supportsMidConvoSystemMessages` as well.
+	 */
+	supportsMidConvoToolChanges?: boolean;
 }
 
 /** Compatibility settings for Amazon Bedrock models. */

--- a/packages/ai/src/utils/deferred-tools.ts
+++ b/packages/ai/src/utils/deferred-tools.ts
@@ -1,39 +1,116 @@
-import type { Context, Tool } from "../types.ts";
+import type { Context, Message, Tool } from "../types.ts";
 
-type ToolNameNormalizer = (name: string) => string;
+export type ToolNameNormalizer = (name: string) => string;
 
 const identityToolName: ToolNameNormalizer = (name) => name;
 
-/** Split current tools into prefix and transcript-loaded definitions. */
-export function splitDeferredTools(
-	context: Context,
-	enabled: boolean,
-	normalizeName: ToolNameNormalizer = identityToolName,
-): { immediate: Tool[]; deferred: Map<string, Tool> } {
-	const uniqueTools = new Map<string, Tool>();
-	for (const tool of context.tools ?? []) uniqueTools.set(normalizeName(tool.name), tool);
-	if (!enabled) return { immediate: [...uniqueTools.values()], deferred: new Map() };
+export interface ToolChange {
+	added: Tool[];
+	removed: Tool[];
+}
 
-	const deferredNames = new Set<string>();
-	const usedNames = new Set<string>();
+export interface ToolHistory {
+	/** Initial availability before any transcript transitions. */
+	initial: Tool[];
+	/** All definitions known anywhere in the context. */
+	definitions: Map<string, Tool>;
+	/** Tool changes keyed by the transcript message that records them. */
+	changes: Map<Message, ToolChange>;
+}
+
+/** Resolve initial tools, transcript definitions, and chronological availability changes. */
+export function resolveToolHistory(
+	context: Context,
+	normalizeName: ToolNameNormalizer = identityToolName,
+): ToolHistory {
+	const definitions = new Map<string, Tool>();
+	const initial = new Map<string, Tool>();
+	for (const tool of context.tools ?? []) {
+		const name = normalizeName(tool.name);
+		definitions.set(name, tool);
+		initial.set(name, tool);
+	}
 	for (const message of context.messages) {
-		if (message.role === "assistant") {
-			for (const block of message.content) {
-				if (block.type === "toolCall") usedNames.add(normalizeName(block.name));
-			}
-		} else if (message.role === "toolResult") {
-			for (const name of message.addedToolNames ?? []) {
-				const normalizedName = normalizeName(name);
-				if (!usedNames.has(normalizedName)) deferredNames.add(normalizedName);
-			}
+		if (message.role !== "system") continue;
+		for (const tool of [...(message.toolsAdded ?? []), ...(message.toolsRemoved ?? [])]) {
+			const name = normalizeName(tool.name);
+			if (!definitions.has(name)) definitions.set(name, tool);
 		}
 	}
 
-	const immediate: Tool[] = [];
-	const deferred = new Map<string, Tool>();
-	for (const [name, tool] of uniqueTools) {
-		if (deferredNames.has(name)) deferred.set(name, tool);
-		else immediate.push(tool);
+	const changes = new Map<Message, ToolChange>();
+	const seen = new Set<string>();
+	for (const message of context.messages) {
+		if (message.role === "system") {
+			const added = message.toolsAdded ?? [];
+			const removed = message.toolsRemoved ?? [];
+			if (added.length > 0 || removed.length > 0) changes.set(message, { added, removed });
+			for (const tool of added) seen.add(normalizeName(tool.name));
+		} else if (message.role === "assistant") {
+			for (const part of message.content) {
+				if (part.type === "toolCall") seen.add(normalizeName(part.name));
+			}
+		} else if (message.role === "toolResult" && message.addedToolNames) {
+			const added: Tool[] = [];
+			for (const rawName of message.addedToolNames) {
+				const name = normalizeName(rawName);
+				const tool = definitions.get(name);
+				if (tool && !seen.has(name)) {
+					added.push(tool);
+					initial.delete(name);
+					seen.add(name);
+				}
+			}
+			if (added.length > 0) changes.set(message, { added, removed: [] });
+		}
 	}
+
+	return { initial: [...initial.values()], definitions, changes };
+}
+
+/** All tool definitions known to the context, sorted for stable fallback declarations. */
+export function declaredTools(context: Context): Tool[] {
+	return [...resolveToolHistory(context).definitions.entries()]
+		.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+		.map(([, tool]) => tool);
+}
+
+export interface ToolPlacementOptions {
+	/** Whether a deprecated tool-result marker can load a tool at that result. */
+	toolResultMarkers: boolean;
+	/** Whether a system transition can load a tool at that message. */
+	systemMarkers: boolean;
+	normalizeName?: ToolNameNormalizer;
+}
+
+export interface ToolPlacement {
+	/** Tools declared from the first request on. */
+	immediate: Tool[];
+	/** Tools that load at a transcript marker, keyed by normalized name, in marker order. */
+	deferred: Map<string, Tool>;
+}
+
+/** Decide which known definitions are immediate and which can load at transcript markers. */
+export function splitDeferredTools(context: Context, options: ToolPlacementOptions): ToolPlacement {
+	const normalizeName = options.normalizeName ?? identityToolName;
+	const history = resolveToolHistory(context, normalizeName);
+	const initialNames = new Set(history.initial.map((tool) => normalizeName(tool.name)));
+	const deferred = new Map<string, Tool>();
+
+	for (const message of context.messages) {
+		const markerEnabled =
+			(message.role === "toolResult" && options.toolResultMarkers) ||
+			(message.role === "system" && options.systemMarkers);
+		if (!markerEnabled) continue;
+		for (const tool of history.changes.get(message)?.added ?? []) {
+			const name = normalizeName(tool.name);
+			if (!initialNames.has(name) && !deferred.has(name)) deferred.set(name, tool);
+		}
+	}
+
+	const immediate = [...history.definitions.entries()]
+		.filter(([name]) => !deferred.has(name))
+		.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+		.map(([, tool]) => tool);
 	return { immediate, deferred };
 }

--- a/packages/ai/src/utils/estimate.ts
+++ b/packages/ai/src/utils/estimate.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage, Context, ImageContent, Message, TextContent, Tool, Usage } from "../types.ts";
+import { addedToolNames, getSystemMessageText } from "./system-messages.ts";
 
 export interface ContextUsageEstimate {
 	/** Estimated total context tokens. */
@@ -45,6 +46,13 @@ export function estimateTextAndImageContentTokens(content: string | Array<TextCo
 export function estimateMessageTokens(message: Message): number {
 	let chars = 0;
 
+	if (message.role === "system") {
+		return (
+			estimateTextTokens(getSystemMessageText(message)) +
+			estimateToolsTokens(message.toolsAdded) +
+			estimateToolsTokens(message.toolsRemoved)
+		);
+	}
 	if (message.role === "user") return estimateTextAndImageContentTokens(message.content);
 	if (message.role === "toolResult") return estimateTextAndImageContentTokens(message.content);
 
@@ -116,13 +124,19 @@ export function estimateContextTokens(context: Context | readonly Message[]): Co
 
 	const estimate = estimateMessages(context.messages);
 	if (estimate.lastUsageIndex !== null) {
-		const addedNames = new Set(
-			context.messages
-				.slice(estimate.lastUsageIndex + 1)
-				.filter((message) => message.role === "toolResult")
-				.flatMap((message) => message.addedToolNames ?? []),
+		const trailingMessages = context.messages.slice(estimate.lastUsageIndex + 1);
+		// System messages carry their own definitions and are counted above; only tool-result markers
+		// still need the live definition from `context.tools`.
+		const systemAddedNames = new Set(
+			trailingMessages.filter((message) => message.role === "system").flatMap(addedToolNames),
 		);
-		const addedToolTokens = estimateToolsTokens(context.tools?.filter((tool) => addedNames.has(tool.name)));
+		const legacyAddedNames = new Set(
+			trailingMessages
+				.filter((message) => message.role === "toolResult")
+				.flatMap(addedToolNames)
+				.filter((name) => !systemAddedNames.has(name)),
+		);
+		const addedToolTokens = estimateToolsTokens(context.tools?.filter((tool) => legacyAddedNames.has(tool.name)));
 		return {
 			tokens: estimate.tokens + addedToolTokens,
 			usageTokens: estimate.usageTokens,

--- a/packages/ai/src/utils/system-messages.ts
+++ b/packages/ai/src/utils/system-messages.ts
@@ -1,0 +1,106 @@
+import type { Api, Context, Message, Model, SystemMessage } from "../types.ts";
+
+export interface TranscriptCapabilities {
+	midConversationSystemMessages: boolean;
+	midConversationToolAdditions: boolean;
+	midConversationToolRemovals: boolean;
+}
+
+const NO_TRANSCRIPT_CAPABILITIES: TranscriptCapabilities = {
+	midConversationSystemMessages: false,
+	midConversationToolAdditions: false,
+	midConversationToolRemovals: false,
+};
+
+const RESPONSES_APIS: ReadonlySet<Api> = new Set([
+	"openai-responses",
+	"openai-codex-responses",
+	"azure-openai-responses",
+]);
+
+/** Report native transcript semantics for a model, excluding lossy fallback handling. */
+export function getTranscriptCapabilities(model: Model<Api>): TranscriptCapabilities {
+	const compat = model.compat as
+		| {
+				supportsAdditionalTools?: boolean;
+				supportsToolSearch?: boolean;
+				deferredToolsMode?: "kimi";
+				supportsMidConvoSystemMessages?: boolean;
+				supportsMidConvoToolChanges?: boolean;
+		  }
+		| undefined;
+
+	if (compat?.supportsMidConvoSystemMessages === true) {
+		return {
+			midConversationSystemMessages: true,
+			midConversationToolAdditions: compat.supportsMidConvoToolChanges === true,
+			midConversationToolRemovals: compat.supportsMidConvoToolChanges === true,
+		};
+	}
+	if (RESPONSES_APIS.has(model.api)) {
+		return {
+			midConversationSystemMessages: true,
+			midConversationToolAdditions: compat?.supportsAdditionalTools === true || compat?.supportsToolSearch === true,
+			midConversationToolRemovals: compat?.supportsAdditionalTools === true,
+		};
+	}
+	if (model.api === "kimi-coding" || compat?.deferredToolsMode === "kimi") {
+		return {
+			midConversationSystemMessages: true,
+			midConversationToolAdditions: true,
+			midConversationToolRemovals: false,
+		};
+	}
+	if (model.api === "openai-completions" || model.api === "mistral-conversations") {
+		return {
+			midConversationSystemMessages: true,
+			midConversationToolAdditions: false,
+			midConversationToolRemovals: false,
+		};
+	}
+	return NO_TRANSCRIPT_CAPABILITIES;
+}
+
+/** Whether the model natively supports complete mid-conversation tool replacement semantics. */
+export function supportsMidConversationToolChanges(model: Model<Api>): boolean {
+	const capabilities = getTranscriptCapabilities(model);
+	return capabilities.midConversationToolAdditions && capabilities.midConversationToolRemovals;
+}
+
+/** Names made available at a system transition or deprecated tool-result marker. */
+export function addedToolNames(message: Message): string[] {
+	if (message.role === "system") return (message.toolsAdded ?? []).map((tool) => tool.name);
+	if (message.role === "toolResult") return [...new Set(message.addedToolNames ?? [])];
+	return [];
+}
+
+/** Extract the instruction text carried by a system-message transition. */
+export function getSystemMessageText(message: SystemMessage): string {
+	return typeof message.content === "string" ? message.content : message.content.map((block) => block.text).join("\n");
+}
+
+/**
+ * Map a leading system message to a transport's top-level system channel when
+ * no explicit top-level prompt exists. Tool changes remain on the message.
+ */
+export function extractInitialSystemPrompt(context: Context): Context {
+	if (context.systemPrompt) return context;
+	const first = context.messages[0];
+	if (first?.role !== "system") return context;
+	const text = getSystemMessageText(first);
+	if (!text) return context;
+	return {
+		...context,
+		systemPrompt: text,
+		messages: [{ ...first, content: "" }, ...context.messages.slice(1)],
+	};
+}
+
+/**
+ * Render a system-message transition for APIs without a native system role.
+ * Tool changes remain provider-side metadata and are not embedded in user-visible text.
+ */
+export function renderSystemMessageAsUserText(message: SystemMessage): string {
+	const text = getSystemMessageText(message);
+	return text ? `<system_update>\n${text}\n</system_update>` : "";
+}

--- a/packages/ai/test/bedrock-convert-messages.test.ts
+++ b/packages/ai/test/bedrock-convert-messages.test.ts
@@ -96,6 +96,33 @@ async function capturePayload(context: Context, model = baseModel): Promise<unkn
 	return capturedPayload;
 }
 
+describe("Bedrock leading system messages", () => {
+	it("uses the top-level system field and retains tool metadata", async () => {
+		const context: Context = {
+			messages: [
+				{
+					role: "system",
+					content: "initial instructions",
+					toolsAdded: [
+						{ name: "read", description: "Read a file", parameters: Type.Object({ path: Type.String() }) },
+					],
+					timestamp: 1,
+				},
+				{ role: "user", content: "hello", timestamp: 2 },
+			],
+		};
+		const payload = (await capturePayload(context)) as {
+			system?: Array<{ text?: string }>;
+			messages: Array<{ role?: string }>;
+			toolConfig?: { tools: Array<{ toolSpec?: { name?: string } }> };
+		};
+
+		expect(payload.system?.map((block) => block.text)).toEqual(["initial instructions"]);
+		expect(payload.messages.map((message) => message.role)).toEqual(["user"]);
+		expect(payload.toolConfig?.tools[0]?.toolSpec?.name).toBe("read");
+	});
+});
+
 describe("Bedrock constrained sampling", () => {
 	it("gates native strict tool use by model capability", async () => {
 		const context: Context = {

--- a/packages/ai/test/deferred-tools.test.ts
+++ b/packages/ai/test/deferred-tools.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { convertMessages } from "../src/api/openai-completions.ts";
 import { getModel, streamSimple } from "../src/compat.ts";
 import type { Api, AssistantMessage, Context, Model, Tool, ToolResultMessage, UserMessage } from "../src/types.ts";
+import { splitDeferredTools } from "../src/utils/deferred-tools.ts";
 import { estimateContextTokens } from "../src/utils/estimate.ts";
 
 interface AnthropicToolPayload {
@@ -48,7 +49,7 @@ interface OpenAIToolSearchOutput {
 interface OpenAIAdditionalTools {
 	type: "additional_tools";
 	role: "developer";
-	tools: Array<{ type: string; name: string; defer_loading?: boolean }>;
+	tools: Array<{ type: string; name: string; description?: string; defer_loading?: boolean }>;
 }
 
 interface OpenAIPayload {
@@ -56,6 +57,12 @@ interface OpenAIPayload {
 	input?: Array<
 		OpenAIAdditionalTools | OpenAIToolSearchCall | OpenAIToolSearchOutput | { type?: string; name?: string }
 	>;
+}
+
+type OpenAIInputItem = NonNullable<OpenAIPayload["input"]>[number];
+
+function isOpenAIAdditionalTools(item: OpenAIInputItem): item is OpenAIAdditionalTools {
+	return item.type === "additional_tools" && "tools" in item;
 }
 
 interface KimiTool {
@@ -176,8 +183,21 @@ function findAnthropicToolResult(payload: AnthropicPayload): AnthropicContentBlo
 	return result;
 }
 
+const PLACEHOLDER = "__pi_deferred_tool_placeholder__";
+
+/** Anthropic tools without the always-present deferred placeholder. */
+function anthropicUserTools(payload: AnthropicPayload): AnthropicToolPayload[] {
+	return (payload.tools ?? []).filter((tool) => tool.name !== PLACEHOLDER);
+}
+
 function openAIToolNames(payload: OpenAIPayload): string[] {
 	return (payload.tools ?? []).map((tool) => tool.name ?? tool.function?.name ?? "");
+}
+
+function additionalToolSnapshots(payload: OpenAIPayload): string[][] {
+	return (payload.input ?? []).flatMap((item) =>
+		isOpenAIAdditionalTools(item) ? [item.tools.map((tool) => tool.name)] : [],
+	);
 }
 
 function makeCodexToken(): string {
@@ -189,7 +209,11 @@ describe("deferred tools", () => {
 		const context = makeContext([makeTool("base_tool"), makeTool("late_tool")]);
 		const payload = await capturePayload<AnthropicPayload>(getModel("anthropic", "claude-opus-4-6"), context);
 
-		expect(payload.tools).toMatchObject([{ name: "base_tool" }, { name: "late_tool", defer_loading: true }]);
+		expect(payload.tools).toMatchObject([
+			{ name: "base_tool" },
+			{ name: PLACEHOLDER, defer_loading: true },
+			{ name: "late_tool", defer_loading: true },
+		]);
 		expect(findAnthropicToolResult(payload).content).toEqual([{ type: "tool_reference", tool_name: "late_tool" }]);
 	});
 
@@ -237,7 +261,7 @@ describe("deferred tools", () => {
 
 		const payload = await capturePayload<AnthropicPayload>(getModel("anthropic", "claude-opus-4-8"), context);
 
-		expect(payload.tools).toMatchObject([{ name: "base_tool" }, { name: "late_tool", defer_loading: true }]);
+		expect(anthropicUserTools(payload)).toMatchObject([{ name: "base_tool" }, { name: "late_tool" }]);
 		expect(findAnthropicToolResult(payload).content).toEqual([{ type: "tool_reference", tool_name: "late_tool" }]);
 	});
 
@@ -245,7 +269,7 @@ describe("deferred tools", () => {
 		const context = makeContext([makeTool("base_tool")]);
 		const payload = await capturePayload<AnthropicPayload>(getModel("anthropic", "claude-opus-4-6"), context);
 
-		expect(payload.tools?.map((tool) => tool.name)).toEqual(["base_tool"]);
+		expect(anthropicUserTools(payload).map((tool) => tool.name)).toEqual(["base_tool"]);
 		const content = findAnthropicToolResult(payload).content;
 		expect(Array.isArray(content) && content.some((block) => block.type === "tool_reference")).toBe(false);
 	});
@@ -256,8 +280,8 @@ describe("deferred tools", () => {
 		assistant.content = [{ type: "toolCall", id: "call_1", name: "late_tool", arguments: {} }];
 		const payload = await capturePayload<AnthropicPayload>(getModel("anthropic", "claude-opus-4-6"), context);
 
-		expect(payload.tools?.map((tool) => tool.name)).toEqual(["base_tool", "late_tool"]);
-		expect(payload.tools?.every((tool) => !tool.defer_loading)).toBe(true);
+		expect(anthropicUserTools(payload).map((tool) => tool.name)).toEqual(["base_tool", "late_tool"]);
+		expect(anthropicUserTools(payload).every((tool) => !tool.defer_loading)).toBe(true);
 	});
 
 	it("normalizes OAuth names before checking prior tool usage", async () => {
@@ -270,8 +294,8 @@ describe("deferred tools", () => {
 			"sk-ant-oat-fake",
 		);
 
-		expect(payload.tools?.map((tool) => tool.name)).toEqual(["base_tool", "Read"]);
-		expect(payload.tools?.every((tool) => !tool.defer_loading)).toBe(true);
+		expect(anthropicUserTools(payload).map((tool) => tool.name)).toEqual(["Read", "base_tool"]);
+		expect(anthropicUserTools(payload).every((tool) => !tool.defer_loading)).toBe(true);
 		const content = findAnthropicToolResult(payload).content;
 		expect(Array.isArray(content) && content.some((block) => block.type === "tool_reference")).toBe(false);
 	});
@@ -284,7 +308,7 @@ describe("deferred tools", () => {
 			"sk-ant-oat-fake",
 		);
 
-		expect(payload.tools).toMatchObject([{ name: "base_tool" }, { name: "Read", defer_loading: true }]);
+		expect(anthropicUserTools(payload)).toMatchObject([{ name: "base_tool" }, { name: "Read", defer_loading: true }]);
 		const content = findAnthropicToolResult(payload).content;
 		expect(
 			Array.isArray(content) &&
@@ -303,7 +327,7 @@ describe("deferred tools", () => {
 			"sk-ant-oat-fake",
 		);
 
-		expect(payload.tools).toMatchObject([{ name: "Read", description: "Canonical definition" }]);
+		expect(anthropicUserTools(payload)).toMatchObject([{ name: "Read", description: "Canonical definition" }]);
 	});
 
 	it("uses the normal tool list when Anthropic tool references are unsupported", async () => {
@@ -320,14 +344,17 @@ describe("deferred tools", () => {
 		}
 	});
 
-	it("keeps one immediate Anthropic tool when every current tool is marked", async () => {
+	it("keeps the Anthropic placeholder when every real tool is deferred", async () => {
 		const context = makeContext([makeTool("late_tool")]);
 		const payload = await capturePayload<AnthropicPayload>(getModel("anthropic", "claude-opus-4-6"), context);
 
-		expect(payload.tools).toMatchObject([{ name: "late_tool" }]);
-		expect(payload.tools?.[0]?.defer_loading).toBeUndefined();
+		expect(payload.tools).toMatchObject([
+			{ name: PLACEHOLDER, defer_loading: true },
+			{ name: "late_tool", defer_loading: true },
+		]);
+		expect(payload.tools?.every((tool) => tool.defer_loading === true)).toBe(true);
 		const content = findAnthropicToolResult(payload).content;
-		expect(Array.isArray(content) && content.some((block) => block.type === "tool_reference")).toBe(false);
+		expect(Array.isArray(content) && content.some((block) => block.type === "tool_reference")).toBe(true);
 	});
 
 	it("supports explicit Anthropic compatibility overrides", async () => {
@@ -340,10 +367,19 @@ describe("deferred tools", () => {
 		const payload = await capturePayload<AnthropicPayload>(model, context);
 
 		expect(payload.tools?.find((tool) => tool.name === "late_tool")?.defer_loading).toBe(true);
+		expect(payload.tools?.find((tool) => tool.name === PLACEHOLDER)?.defer_loading).toBe(true);
 	});
 
-	it("serializes Kimi deferred tools as system tool definitions", async () => {
-		const context = makeContext([makeTool("base_tool"), makeTool("late_tool")]);
+	it("deduplicates legacy and first-class Kimi tool additions", async () => {
+		const baseTool = makeTool("base_tool");
+		const lateTool = makeTool("late_tool");
+		const context = makeContext([baseTool, lateTool]);
+		context.messages.splice(3, 0, {
+			role: "system",
+			content: "",
+			toolsAdded: [lateTool],
+			timestamp: 4,
+		});
 		const payload = await capturePayload<KimiPayload>(makeKimiModel("kimi"), context);
 
 		expect(payload.tools?.map((tool) => tool.function.name)).toEqual(["base_tool"]);
@@ -352,6 +388,7 @@ describe("deferred tools", () => {
 		expect(toolResultIndex).toBeGreaterThanOrEqual(0);
 		expect(systemToolIndex).toBeGreaterThan(toolResultIndex);
 		expect(payload.messages[systemToolIndex]?.tools?.map((tool) => tool.function.name)).toEqual(["late_tool"]);
+		expect(payload.messages.filter((message) => message.tools !== undefined)).toHaveLength(1);
 	});
 
 	it("emits Kimi deferred schemas after all tool results in a batch", () => {
@@ -361,31 +398,37 @@ describe("deferred tools", () => {
 			toolCallId: "call_2",
 		});
 
-		const messages = convertMessages(makeKimiModel("kimi"), context, {
-			supportsStore: false,
-			supportsDeveloperRole: false,
-			supportsReasoningEffort: false,
-			supportsUsageInStreaming: true,
-			supportsFinishReason: true,
-			maxTokensField: "max_tokens",
-			requiresToolResultName: false,
-			requiresAssistantAfterToolResult: false,
-			requiresThinkingAsText: false,
-			requiresReasoningContentOnAssistantMessages: false,
-			thinkingFormat: "openai",
-			openRouterRouting: {},
-			vercelGatewayRouting: {},
-			chatTemplateKwargs: {},
-			chatTemplateArgs: {},
-			zaiToolStream: false,
-			supportsStrictMode: false,
-			supportsOpenAIGrammarTools: false,
-			cacheControlFormat: undefined,
-			sendSessionAffinityHeaders: false,
-			deferredToolsMode: "kimi",
-			sessionAffinityFormat: "openai",
-			supportsLongCacheRetention: false,
-		});
+		const placement = splitDeferredTools(context, { toolResultMarkers: true, systemMarkers: true });
+		const messages = convertMessages(
+			makeKimiModel("kimi"),
+			context,
+			{
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: false,
+				supportsUsageInStreaming: true,
+				supportsFinishReason: true,
+				maxTokensField: "max_tokens",
+				requiresToolResultName: false,
+				requiresAssistantAfterToolResult: false,
+				requiresThinkingAsText: false,
+				requiresReasoningContentOnAssistantMessages: false,
+				thinkingFormat: "openai",
+				openRouterRouting: {},
+				vercelGatewayRouting: {},
+				chatTemplateKwargs: {},
+				chatTemplateArgs: {},
+				zaiToolStream: false,
+				supportsStrictMode: false,
+				supportsOpenAIGrammarTools: false,
+				cacheControlFormat: undefined,
+				sendSessionAffinityHeaders: false,
+				deferredToolsMode: "kimi",
+				sessionAffinityFormat: "openai",
+				supportsLongCacheRetention: false,
+			},
+			{ deferredTools: placement.deferred },
+		);
 
 		expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "tool", "tool", "system", "user"]);
 		expect((messages[4] as { tools?: KimiTool[] }).tools?.map((tool) => tool.function.name)).toEqual([
@@ -402,6 +445,22 @@ describe("deferred tools", () => {
 		expect(payload.messages.some((message) => message.tools !== undefined)).toBe(false);
 	});
 
+	it("projects OpenAI Completions system updates as developer messages", async () => {
+		const model: Model<"openai-completions"> = {
+			...makeKimiModel(),
+			provider: "openai",
+			reasoning: true,
+			compat: { supportsDeveloperRole: true },
+		};
+		const context: Context = {
+			messages: [makeUserMessage(1), { role: "system", content: "updated instructions", timestamp: 2 }],
+		};
+		const payload = await capturePayload<KimiPayload>(model, context);
+
+		expect(payload.messages.map((message) => message.role)).toEqual(["user", "developer"]);
+		expect(payload.messages[1]?.content).toBe("updated instructions");
+	});
+
 	it("loads an OpenAI Responses tool through additional_tools", async () => {
 		const context = makeContext([makeTool("base_tool"), makeTool("late_tool")]);
 		const payload = await capturePayload<OpenAIPayload>(getModel("openai", "gpt-5.4"), context);
@@ -409,9 +468,10 @@ describe("deferred tools", () => {
 			(item): item is OpenAIAdditionalTools => item.type === "additional_tools",
 		);
 
-		expect(openAIToolNames(payload)).toEqual(["base_tool"]);
+		expect(openAIToolNames(payload)).toEqual([]);
 		expect(additionalTools).toMatchObject({ role: "developer" });
-		expect(additionalTools?.tools).toMatchObject([{ type: "function", name: "late_tool" }]);
+		expect(additionalToolSnapshots(payload)).toEqual([["base_tool"], ["base_tool", "late_tool"]]);
+		expect(additionalTools?.tools).toMatchObject([{ type: "function", name: "base_tool" }]);
 		expect(additionalTools?.tools.every((tool) => tool.defer_loading === undefined)).toBe(true);
 		expect(payload.input?.some((item) => item.type === "tool_search_call")).toBe(false);
 		expect(payload.input?.some((item) => item.type === "tool_search_output")).toBe(false);
@@ -440,9 +500,9 @@ describe("deferred tools", () => {
 			(item) => item.type === "function_call" && item.name === "late_tool",
 		);
 
-		expect(additionalToolIndexes).toHaveLength(1);
+		expect(additionalToolIndexes).toHaveLength(2);
 		expect(additionalToolIndexes[0]).toBeLessThan(lateCallIndex);
-		expect(openAIToolNames(payload)).toEqual(["base_tool"]);
+		expect(openAIToolNames(payload)).toEqual([]);
 	});
 
 	it("falls back to client tool search when additional_tools is unsupported", async () => {
@@ -507,7 +567,7 @@ describe("deferred tools", () => {
 			makeCodexToken(),
 		);
 
-		expect(openAIToolNames(additionalTools)).toEqual(["base_tool"]);
+		expect(openAIToolNames(additionalTools)).toEqual([]);
 		expect(additionalTools.input?.some((item) => item.type === "additional_tools")).toBe(true);
 		expect(additionalTools.input?.some((item) => item.type === "tool_search_output")).toBe(false);
 		expect(openAIToolNames(toolSearch)).toEqual(["base_tool"]);
@@ -543,7 +603,6 @@ describe("deferred tools", () => {
 			messages: [assistant, makeToolResult(["late_tool"])],
 			tools: [lateTool],
 		});
-
 		expect(marked.tokens).toBeGreaterThan(plain.tokens + 500);
 		expect(marked.trailingTokens).toBeGreaterThan(plain.trailingTokens + 500);
 	});

--- a/packages/ai/test/fireworks-models.test.ts
+++ b/packages/ai/test/fireworks-models.test.ts
@@ -434,7 +434,8 @@ describe("Anthropic-compatible session affinity and tool compat", () => {
 		const model = createAnthropicModel();
 		const request = await captureAnthropicRequest(model, createContext());
 
-		const tools = getTools(request.body);
+		// The breakpoint sits on the last immediate tool; deferred entries follow it.
+		const tools = getTools(request.body).filter((tool) => tool.defer_loading !== true);
 		const lastTool = tools[tools.length - 1];
 		expect(lastTool.cache_control).toBeDefined();
 		expect((lastTool.cache_control as { type: string }).type).toBe("ephemeral");

--- a/packages/ai/test/openai-responses-compat.test.ts
+++ b/packages/ai/test/openai-responses-compat.test.ts
@@ -9,7 +9,9 @@ type CapturedHeaders = Headers | string[][] | Record<string, string | readonly s
 interface CapturedResponsesPayload {
 	prompt_cache_key?: string;
 	session_id?: string;
+	tool_choice?: string;
 	tools?: Array<{ name?: string; strict?: boolean }>;
+	input?: Array<{ type?: string; tools?: Array<{ name?: string; strict?: boolean }> }>;
 }
 
 function getHeader(headers: CapturedHeaders, name: string): string | null {
@@ -148,10 +150,12 @@ describe("openai-responses provider defaults", () => {
 			if (event.type === "done" || event.type === "error") break;
 		}
 
-		expect(capturedPayload).toMatchObject({
-			tool_choice: "required",
-			tools: [expect.objectContaining({ name: "ping" })],
-		});
+		expect(capturedPayload).toMatchObject({ tool_choice: "required" });
+		const payload = capturedPayload as CapturedResponsesPayload;
+		expect(payload.tools).toBeUndefined();
+		expect(payload.input?.find((item) => item.type === "additional_tools")?.tools).toEqual([
+			expect.objectContaining({ name: "ping" }),
+		]);
 	});
 
 	it("sets strict mode explicitly for Cloudflare OpenAI Responses tools", async () => {
@@ -199,9 +203,10 @@ describe("openai-responses provider defaults", () => {
 		}
 
 		expect(model.compat?.supportsStrictMode).toBe(true);
+		// Declared tools are sorted by name so the order never depends on history.
 		expect(capturedPayload?.tools).toEqual([
-			expect.objectContaining({ name: "ordinary", strict: false }),
 			expect.objectContaining({ name: "constrained", strict: true }),
+			expect.objectContaining({ name: "ordinary", strict: false }),
 		]);
 	});
 

--- a/packages/ai/test/system-messages.test.ts
+++ b/packages/ai/test/system-messages.test.ts
@@ -1,0 +1,215 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { getModel, streamSimple } from "../src/compat.ts";
+import type { Api, AssistantMessage, Context, Model, Tool } from "../src/types.ts";
+import { getTranscriptCapabilities, supportsMidConversationToolChanges } from "../src/utils/system-messages.ts";
+
+const PLACEHOLDER = "__pi_deferred_tool_placeholder__";
+
+function makeTool(name: string): Tool {
+	return { name, description: `The ${name} tool`, parameters: Type.Object({}) };
+}
+
+function makeAssistant(stopReason: "stop" | "aborted" = "stop"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: stopReason === "aborted" ? [] : [{ type: "text", text: "ok" }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-fable-5-1",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: 3,
+	};
+}
+
+interface Payload {
+	betas?: string[];
+	tools?: Array<{ name?: string; defer_loading?: boolean }>;
+	instructions?: string;
+	system?: Array<{ text?: string }>;
+	input?: Array<{
+		type?: string;
+		role?: string;
+		content?: unknown;
+		tools?: Array<{ name?: string }>;
+	}>;
+	messages?: Array<{
+		role: string;
+		content: string | Array<{ type: string; text?: string; tool?: { name?: string } }>;
+		output_config?: unknown;
+	}>;
+}
+
+async function capture(model: Model<Api>, context: Context): Promise<Payload> {
+	let captured: Payload | undefined;
+	await streamSimple({ ...model, baseUrl: "http://127.0.0.1:9" }, context, {
+		apiKey:
+			model.api === "openai-codex-responses"
+				? `header.${btoa(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "test" } }))}.signature`
+				: "fake-key",
+		onPayload(payload) {
+			captured = payload as Payload;
+			throw new Error("payload captured");
+		},
+	}).result();
+	if (!captured) throw new Error("Expected payload capture");
+	return captured;
+}
+
+function snapshots(payload: Payload): string[][] {
+	return (payload.input ?? [])
+		.filter((item) => item.type === "additional_tools")
+		.map((item) => item.tools?.map((tool) => tool.name ?? "") ?? []);
+}
+
+function contentRoles(payload: Payload): string[] {
+	return (payload.messages ?? [])
+		.filter((message) => message.output_config === undefined)
+		.map((message) => message.role);
+}
+
+describe("transcript system messages", () => {
+	it("reports the native capability matrix", () => {
+		const cases = [
+			[getModel("openai", "gpt-5.4"), [true, true, true]],
+			[{ ...getModel("openai", "gpt-5.4"), compat: { supportsToolSearch: true } }, [true, true, false]],
+			[getModel("anthropic", "claude-fable-5-1"), [true, true, true]],
+			[getModel("openai", "gpt-5.3-chat-latest"), [true, false, false]],
+			[getModel("moonshotai", "kimi-k3"), [true, true, false]],
+			[getModel("google", "gemini-2.5-flash"), [false, false, false]],
+		] as const;
+		for (const [model, expected] of cases) {
+			const capabilities = getTranscriptCapabilities(model);
+			expect([
+				capabilities.midConversationSystemMessages,
+				capabilities.midConversationToolAdditions,
+				capabilities.midConversationToolRemovals,
+			]).toEqual(expected);
+			expect(supportsMidConversationToolChanges(model)).toBe(expected[1] && expected[2]);
+		}
+	});
+
+	it("replays complete tool snapshots on Responses transports", async () => {
+		const read = makeTool("read");
+		const edit = makeTool("edit");
+		const context: Context = {
+			systemPrompt: "initial instructions",
+			tools: [read],
+			messages: [
+				{ role: "system", content: "edit available", toolsAdded: [edit], timestamp: 1 },
+				{ role: "user", content: "hello", timestamp: 2 },
+				{ role: "system", content: "read unavailable", toolsRemoved: [read], timestamp: 3 },
+				{ role: "system", content: "edit unavailable", toolsRemoved: [edit], timestamp: 4 },
+				{ role: "system", content: "read available", toolsAdded: [read], timestamp: 5 },
+			],
+		};
+		const models: Model<Api>[] = [
+			getModel("openai", "gpt-5.4"),
+			getModel("openai-codex", "gpt-5.6-sol"),
+			{
+				...getModel("openai", "gpt-5.4"),
+				api: "azure-openai-responses",
+				provider: "azure-openai-responses",
+			} satisfies Model<"azure-openai-responses">,
+		];
+
+		for (const model of models) {
+			const payload = await capture(model, context);
+			expect(payload.tools).toBeUndefined();
+			expect(snapshots(payload)).toEqual([["read"], ["edit", "read"], ["edit"], [], ["read"]]);
+			expect(payload.input).toContainEqual(
+				expect.objectContaining({ role: "developer", content: "edit available" }),
+			);
+			if (model.api === "openai-codex-responses") expect(payload.instructions).toBe("initial instructions");
+			if (model.api === "openai-responses") {
+				const prefix = await capture(model, { ...context, messages: context.messages.slice(0, 2) });
+				expect(payload.input?.slice(0, prefix.input?.length)).toEqual(prefix.input);
+			}
+		}
+	});
+
+	it("sends native Anthropic instructions and availability changes", async () => {
+		const read = makeTool("read");
+		const edit = makeTool("edit");
+		const late = makeTool("late");
+		const payload = await capture(getModel("anthropic", "claude-fable-5-1"), {
+			systemPrompt: "base",
+			tools: [read, edit],
+			messages: [
+				{ role: "user", content: "hello", timestamp: 1 },
+				{
+					role: "system",
+					content: "tools changed",
+					toolsAdded: [late],
+					toolsRemoved: [edit],
+					timestamp: 2,
+				},
+			],
+		});
+
+		expect(payload.betas).toContain("mid-conversation-tool-changes-2026-07-01");
+		expect(payload.tools?.map((tool) => `${tool.name}${tool.defer_loading ? "(d)" : ""}`)).toEqual([
+			"read",
+			"edit",
+			"late",
+			`${PLACEHOLDER}(d)`,
+		]);
+		expect(contentRoles(payload)).toEqual(["user", "system"]);
+		expect(payload.messages?.[1]?.content).toEqual([
+			{ type: "text", text: "tools changed" },
+			{ type: "tool_removal", tool: { type: "tool_reference", name: "edit" } },
+			{
+				type: "tool_addition",
+				tool: { type: "tool_reference", name: "late" },
+				cache_control: { type: "ephemeral" },
+			},
+		]);
+	});
+
+	it("uses the append-only fallback without duplicating a leading instruction", async () => {
+		const late = makeTool("late");
+		const edit = makeTool("edit");
+		const payload = await capture(getModel("anthropic", "claude-haiku-4-5"), {
+			tools: [makeTool("read"), edit],
+			messages: [
+				{ role: "system", content: "initial", toolsAdded: [late], timestamp: 1 },
+				{ role: "user", content: "hello", timestamp: 2 },
+				{ role: "system", content: "edit unavailable", toolsRemoved: [edit], timestamp: 3 },
+			],
+		});
+
+		expect(payload.system?.map((block) => block.text)).toEqual(["initial"]);
+		expect(payload.tools?.map((tool) => tool.name)).toEqual(["edit", "late", "read"]);
+		expect(contentRoles(payload)).toEqual(["user", "user"]);
+		expect(payload.messages?.[1]?.content).toEqual([
+			{
+				type: "text",
+				text: "<system_update>\nedit unavailable\n</system_update>",
+				cache_control: { type: "ephemeral" },
+			},
+		]);
+	});
+
+	it("moves a native Anthropic system message past a dropped aborted turn", async () => {
+		const payload = await capture(getModel("anthropic", "claude-fable-5-1"), {
+			systemPrompt: "base",
+			messages: [
+				{ role: "user", content: "hello", timestamp: 1 },
+				{ role: "system", content: "changed", timestamp: 2 },
+				makeAssistant("aborted"),
+				{ role: "user", content: "next", timestamp: 4 },
+				makeAssistant(),
+			],
+		});
+
+		expect(contentRoles(payload)).toEqual(["user", "user", "system", "assistant"]);
+	});
+});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -677,6 +677,7 @@ export class AgentSession {
 					event.message.details,
 				);
 			} else if (
+				event.message.role === "system" ||
 				event.message.role === "user" ||
 				event.message.role === "assistant" ||
 				event.message.role === "toolResult"

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -267,6 +267,15 @@ export function estimateTokens(message: AgentMessage): number {
 	let chars = 0;
 
 	switch (message.role) {
+		case "system": {
+			chars =
+				(typeof message.content === "string"
+					? message.content.length
+					: message.content.reduce((total, block) => total + block.text.length, 0)) +
+				JSON.stringify(message.toolsAdded ?? []).length +
+				JSON.stringify(message.toolsRemoved ?? []).length;
+			return Math.ceil(chars / 4);
+		}
 		case "user": {
 			chars = estimateTextAndImageContentChars(
 				(message as { content: string | Array<{ type: string; text?: string }> }).content,
@@ -314,6 +323,7 @@ function isCutPointMessage(message: AgentMessage): boolean {
 		case "branchSummary":
 		case "compactionSummary":
 			return true;
+		case "system":
 		case "toolResult":
 			return false;
 	}
@@ -328,6 +338,7 @@ function isTurnStartMessage(message: AgentMessage): boolean {
 		case "branchSummary":
 		case "compactionSummary":
 			return true;
+		case "system":
 		case "assistant":
 		case "toolResult":
 			return false;

--- a/packages/coding-agent/src/core/compaction/utils.ts
+++ b/packages/coding-agent/src/core/compaction/utils.ts
@@ -110,7 +110,11 @@ export function serializeConversation(messages: Message[]): string {
 	const parts: string[] = [];
 
 	for (const msg of messages) {
-		if (msg.role === "user") {
+		if (msg.role === "system") {
+			const content =
+				typeof msg.content === "string" ? msg.content : msg.content.map((block) => block.text).join("\n");
+			if (content) parts.push(`[System]: ${content}`);
+		} else if (msg.role === "user") {
 			const content = contentText(msg.content, "");
 			if (content) parts.push(`[User]: ${content}`);
 		} else if (msg.role === "assistant") {

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -181,6 +181,7 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 						],
 						timestamp: m.timestamp,
 					};
+				case "system":
 				case "user":
 				case "assistant":
 				case "toolResult":

--- a/packages/coding-agent/src/core/model-config.ts
+++ b/packages/coding-agent/src/core/model-config.ts
@@ -135,6 +135,8 @@ const AnthropicMessagesCompatSchema = Type.Object({
 	allowEmptySignature: Type.Optional(Type.Boolean()),
 	supportsStrictTools: Type.Optional(Type.Boolean()),
 	supportsMidConvoEffort: Type.Optional(Type.Boolean()),
+	supportsMidConvoSystemMessages: Type.Optional(Type.Boolean()),
+	supportsMidConvoToolChanges: Type.Optional(Type.Boolean()),
 	supportsToolReferences: Type.Optional(Type.Boolean()),
 });
 

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -385,6 +385,9 @@ export function sessionEntryToContextMessages(entry: SessionEntry): AgentMessage
 		const message = entry.message;
 		// Session files are parsed without validation; old versions, forks, or
 		// hand-edited files can contain messages with null/missing content.
+		if (message.role === "system" && message.content == null) {
+			return [{ ...message, content: "" }];
+		}
 		if (
 			(message.role === "user" || message.role === "assistant" || message.role === "toolResult") &&
 			message.content == null

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3620,6 +3620,10 @@ export class InteractiveMode {
 				this.chatContainer.addChild(component);
 				break;
 			}
+			case "system": {
+				// System updates are durable model context but remain hidden from the chat transcript.
+				break;
+			}
 			case "user": {
 				const textContent = this.getUserMessageText(message);
 				if (textContent) {


### PR DESCRIPTION
First layer of the split of #8998 (stacked; the coding agent integration follows in the next PR). This one is limited to pi-ai plus the minimum needed so that pi-agent-core and the coding agent pass the new role through without breaking.

## Problem

Anything that changes mid-session (an extension toggling tools, a plan-mode loadout switch, a new working directory) currently has to be expressed by rewriting the top-level system prompt or the tool list. That invalidates the provider's cached prefix, and on recent Anthropic models that bind thinking blocks to the conversation prefix it drops the thinking blocks too.

```
request 2:  system="...tools: read, edit, bash..."   tools=[read, edit, bash]
request 3:  system="...tools: read, bash..."         tools=[read, bash]      -> kv miss
```

## What this adds

- `Message` gains `SystemMessage` (`role: "system"`, `content`, optional `toolsAdded`/`toolsRemoved` carrying complete tool definitions). It is appended to the transcript, never folded into `Context.systemPrompt`. Consumers switching on `message.role` now need a `"system"` case.
- Provider rendering:
  - Anthropic models with the new `supportsMidConvoSystemMessages` / `supportsMidConvoToolChanges` compat flags (Opus 4.8/5, Fable 5/5.1, Mythos 5/5.1, set by the generator) get real `system` messages with `tool_addition`/`tool_removal` blocks and the `mid-conversation-tool-changes` beta. The API requires a `system` message to directly precede an assistant turn, so pending system messages are held until the next assistant message.
  - OpenAI Completions and Responses transports get `developer` (or `system`) items. Responses models with `supportsAdditionalTools` load system-added tools through `additional_tools`; Kimi loads them through its tool system message.
  - Bedrock, Gemini, and Anthropic models without the flag render the text as a `<system_update>` user turn.
- `splitDeferredTools` takes an options object (`toolResultMarkers`, `systemMarkers`, `normalizeName`). The declared tool set is now append-only for the life of a conversation and sorted by name: every `Context.tools` entry plus every tool a system message added or removed earlier. A removed tool stays declared so the prefix does not change; definitions carried by messages win over live ones. New `declaredTools` helper for transports without deferred loading.
- Anthropic always declares a deferred placeholder tool (`__pi_deferred_tool_placeholder__`) when tool references are supported. The first deferred tool in a request adds a section to the tools block ahead of `system`, which was a full prefix miss (`cache_miss_reason: tools_changed`) on Fable 5.1; declaring it up front makes later deferred loads cache-neutral. Claude Code does the same.
- New exports: `getSystemMessageText`, `renderSystemMessageAsUserText`, `supportsMidConversationToolChanges`, `addedToolNames`. Token estimation accounts for system messages and their tool definitions. The faux provider accepts `compat`.

## Passthrough in pi-agent-core and the coding agent

No integration yet, only "do not freak out": `convertToLlm` keeps `system` messages, the session persists them, compaction estimates and cut points handle them, summaries render them as `[System]:`, interactive mode hides them, and `models.json` accepts the two new Anthropic compat flags.
