### PR TITLE
fix(tui): rank skill autocomplete by bare name

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -327,7 +327,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					};
 				});
 
-				const filtered = fuzzyFilter(commandItems, prefix, (item) => item.name).map((item) => ({
+				const filtered = fuzzyFilter(commandItems, prefix, (item) =>
+					!prefix.startsWith("skill:") && item.name.startsWith("skill:")
+						? item.name.slice("skill:".length)
+						: item.name,
+				).map((item) => ({
 					value: item.name,
 					label: item.label,
 					...(item.description && { description: item.description }),

--- a/packages/tui/test/autocomplete-skill-slash.test.ts
+++ b/packages/tui/test/autocomplete-skill-slash.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { CombinedAutocompleteProvider } from "../src/autocomplete.ts";
+
+describe("CombinedAutocompleteProvider slash-command filter", () => {
+	const commands = [
+		{ name: "skill:deep-research", description: "Multi-agent deep research" },
+		{ name: "skill:research-idea", description: "Refine a raw idea into a falsifiable seed" },
+		{ name: "skill:to-sidecar", description: "Route work to a sidecar" },
+		{ name: "model", description: "Select the active model" },
+	];
+
+	async function suggestionsFor(prefix: string): Promise<string[]> {
+		const provider = new CombinedAutocompleteProvider(commands, process.cwd());
+		const line = `/${prefix}`;
+		const result = await provider.getSuggestions([line], 0, line.length, {
+			signal: new AbortController().signal,
+		});
+		assert.ok(result, `expected suggestions for "/${prefix}"`);
+		return result.items.map((item) => item.value);
+	}
+
+	it("ranks skill:research-idea first for query 'idea'", async () => {
+		const items = await suggestionsFor("idea");
+		assert.equal(items[0], "skill:research-idea");
+		assert.ok(!items.includes("skill:deep-research"));
+	});
+
+	it("keeps ordinary slash commands matching", async () => {
+		const items = await suggestionsFor("mod");
+		assert.ok(items.includes("model"));
+	});
+
+	it("keeps explicit skill: queries working", async () => {
+		const items = await suggestionsFor("skill:side");
+		assert.ok(items.includes("skill:to-sidecar"));
+	});
+});


### PR DESCRIPTION
## Summary

Fix skill slash autocomplete ranking for bare queries.

## Problem

Skill commands are fuzzy-matched using the full `skill:<name>` string. The fixed `skill:` prefix can influence the score more than the actual skill name. With these loaded skills:

- `skill:deep-research`
- `skill:research-idea`

typing `/idea` ranked `skill:deep-research` above `skill:research-idea` in a local reproduction. The expected result is `skill:research-idea`, because `idea` occurs in the bare skill name.

## Changes

- Match skill commands by their bare name for non-explicit queries.
- Preserve full-command matching for explicit `/skill:...` queries.
- Add regression coverage for the reported ranking and both preserved query paths.

Fixes #8813

## Validation

- Focused skill autocomplete tests: passed
- `npm -w packages/tui test`: passed
- `npm run check`: passed
- `./test.sh`: has unrelated failures in other workspace/generated-model tests in this checkout; the `packages/tui` tests and checks pass.

This PR was prepared with AI assistance and reviewed by the contributor.
