### PR TITLE
feat(tui): add collapsible work process grouping with alt+o toggle

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -159,6 +159,7 @@ This routing remains configurable through the ordinary action bindings. For exam
 | Keybinding id | Default | Description |
 |--------|---------|-------------|
 | `app.tools.expand` | `ctrl+o` | Collapse or expand tool output |
+| `app.process.toggle` | `alt+o` | Collapse or expand work process groups |
 | `app.message.copy` | `ctrl+x` | Copy the selected message in `/tree`; otherwise copy the last assistant message, or the active fullscreen text selection when `fullscreenCopyOnSelect` is disabled |
 | `app.message.followUp` | `alt+enter` (`ctrl+q` on Windows and WSL) | Queue follow-up message |
 | `app.message.dequeue` | `alt+up` (`alt+q` on Windows and WSL) | Restore queued messages to editor |

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -22,6 +22,7 @@ export interface AppKeybindings {
 	"app.model.select": true;
 	"app.tools.expand": true;
 	"app.thinking.toggle": true;
+	"app.process.toggle": true;
 	"app.session.toggleNamedFilter": true;
 	"app.editor.external": true;
 	"app.message.copy": true;
@@ -113,6 +114,10 @@ export const KEYBINDINGS = {
 	"app.thinking.toggle": {
 		defaultKeys: "ctrl+t",
 		description: "Toggle thinking blocks",
+	},
+	"app.process.toggle": {
+		defaultKeys: "alt+o",
+		description: "Toggle work process groups",
 	},
 	"app.session.toggleNamedFilter": {
 		defaultKeys: "ctrl+n",

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -36,3 +36,4 @@ export { TrustSelectorComponent } from "./trust-selector.ts";
 export { UserMessageComponent } from "./user-message.ts";
 export { UserMessageSelectorComponent } from "./user-message-selector.ts";
 export { truncateToVisualLines, type VisualTruncateResult } from "./visual-truncate.ts";
+export { extractThinkingPreview, WorkProcessComponent } from "./work-process.ts";

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -112,6 +112,9 @@ export class ToolExecutionComponent extends Container {
 
 		this.updateDisplay();
 	}
+	getToolName(): string {
+		return this.toolName;
+	}
 
 	private getCallRenderer(): ToolDefinition<any, any>["renderCall"] | undefined {
 		return this.toolDefinition?.renderCall;
@@ -171,7 +174,7 @@ export class ToolExecutionComponent extends Container {
 
 	private createResultRegion(component: Component): MouseRegion {
 		return new MouseRegion(component, (event) => {
-			if (!this.result || event.type !== "click" || event.button !== "left") return undefined;
+			if (event.type !== "click" || event.button !== "left") return undefined;
 			this.setExpanded(!this.expanded);
 			return { handled: true };
 		});
@@ -414,7 +417,17 @@ export class ToolExecutionComponent extends Container {
 		}
 		const output = this.getTextOutput();
 		if (output) {
-			text += `\n${output}`;
+			if (this.expanded) {
+				text += `\n${output}`;
+			} else {
+				const lines = output.split("\n");
+				const displayLines = lines.slice(0, FALLBACK_PREVIEW_LINES);
+				const remaining = lines.length - displayLines.length;
+				text += `\n${displayLines.join("\n")}`;
+				if (remaining > 0) {
+					text += `\n... (${remaining} more lines, ${keyHint("app.tools.expand", "to expand")})`;
+				}
+			}
 		}
 		return text;
 	}

--- a/packages/coding-agent/src/modes/interactive/components/work-process.ts
+++ b/packages/coding-agent/src/modes/interactive/components/work-process.ts
@@ -1,0 +1,174 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { type Component, Container, MouseRegion, Text, type TuiMouseEvent } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.ts";
+
+/**
+ * UI-only grouping of one agent request's tool-using work: assistant messages that issued tool
+ * calls plus their tool execution components. Collapsing renders a single summary line; it never
+ * touches session entries or the LLM context.
+ *
+ * The final assistant answer of a request is not held here; it stays a direct child of the chat
+ * container so it remains visible while the work process is collapsed.
+ */
+export class WorkProcessComponent extends Container {
+	private collapsed = false;
+	private startedAt?: number;
+	private completedAt?: number;
+	private toolCounts = new Map<string, number>();
+	private toolOrder: string[] = [];
+	private erroredToolNames = new Set<string>();
+	private thinkingPreview?: string;
+	private headerText?: Text;
+	private headerRegion?: MouseRegion;
+	private headerLines = 0;
+
+	constructor(startedAt?: number) {
+		super();
+		this.startedAt = startedAt;
+	}
+
+	setCollapsed(collapsed: boolean): void {
+		if (this.collapsed === collapsed) return;
+		this.collapsed = collapsed;
+		this.invalidate();
+	}
+
+	isCollapsed(): boolean {
+		return this.collapsed;
+	}
+
+	setCompleted(completedAt: number): void {
+		this.completedAt = completedAt;
+		this.invalidate();
+	}
+
+	setThinkingPreview(preview: string): void {
+		if (this.thinkingPreview) return;
+		this.thinkingPreview = preview;
+		this.invalidate();
+	}
+
+	/** Record one tool execution for the summary line. */
+	trackTool(name: string): void {
+		const count = this.toolCounts.get(name) ?? 0;
+		if (count === 0) {
+			this.toolOrder.push(name);
+		}
+		this.toolCounts.set(name, count + 1);
+		this.invalidate();
+	}
+
+	/** Mark that a tool execution of this name ended with an error. */
+	markToolErrored(name: string): void {
+		this.erroredToolNames.add(name);
+		this.invalidate();
+	}
+
+	/** Children rendered below the summary header when expanded. */
+	contentChildren(): readonly Component[] {
+		return this.children;
+	}
+
+	override render(width: number): string[] {
+		this.ensureHeader();
+		const headerLines = this.headerRegion?.render(width) ?? [];
+		this.headerLines = headerLines.length;
+		const childLines = super.render(width);
+		if (this.collapsed) {
+			return headerLines;
+		}
+		return [...headerLines, ...childLines];
+	}
+
+	override handleMouse(event: TuiMouseEvent): ReturnType<Container["handleMouse"]> {
+		if (event.y >= 0 && event.y < this.headerLines) {
+			if (event.type === "click" && event.button === "left") {
+				this.setCollapsed(!this.collapsed);
+				return {
+					handled: true,
+					target: {
+						component: this,
+						originX: event.screenX - event.x,
+						originY: event.screenY - event.y,
+						width: event.width,
+						height: event.height,
+					},
+				};
+			}
+			return undefined;
+		}
+		return super.handleMouse({
+			...event,
+			y: event.y - this.headerLines,
+			height: event.height - this.headerLines,
+		});
+	}
+
+	private ensureHeader(): void {
+		const line = this.renderHeaderLine();
+		if (!this.headerText || !this.headerRegion) {
+			this.headerText = new Text(line, 0, 0);
+			this.headerRegion = new MouseRegion(this.headerText, (event) => {
+				if (event.type !== "click" || event.button !== "left") return undefined;
+				this.setCollapsed(!this.collapsed);
+				return { handled: true };
+			});
+			return;
+		}
+		this.headerText.setText(line);
+	}
+
+	private renderHeaderLine(): string {
+		const arrow = this.collapsed ? "▶" : "▼";
+		const separator = theme.fg("muted", " · ");
+		const parts: string[] = [];
+		const duration = this.renderDuration();
+		if (duration) parts.push(duration);
+		const tools = this.renderToolSummary();
+		if (tools) parts.push(tools);
+		if (this.thinkingPreview) {
+			parts.push(`${theme.fg("muted", "thinking: ")}${theme.fg("dim", this.thinkingPreview)}`);
+		}
+		const label = parts.join(separator);
+		return `${theme.fg("accent", arrow)} ${theme.fg("toolTitle", label)}`;
+	}
+
+	private renderDuration(): string | undefined {
+		if (this.startedAt === undefined) {
+			return undefined;
+		}
+		const end = this.completedAt ?? Date.now();
+		const seconds = Math.max(0, Math.floor((end - this.startedAt) / 1000));
+		if (seconds < 60) {
+			return `Worked ${seconds}s`;
+		}
+		return `Worked ${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+	}
+
+	private renderToolSummary(): string | undefined {
+		if (this.toolOrder.length === 0) {
+			return undefined;
+		}
+		return this.toolOrder
+			.map((name) => {
+				const count = this.toolCounts.get(name) ?? 1;
+				const label = this.erroredToolNames.has(name) ? theme.fg("error", name) : name;
+				return count > 1 ? `${label}×${count}` : label;
+			})
+			.join(theme.fg("muted", " "));
+	}
+}
+
+/** Extracts the first thinking sentence of an assistant message for the summary line. */
+export function extractThinkingPreview(message: AssistantMessage): string | undefined {
+	for (const block of message.content) {
+		if (block.type !== "thinking") continue;
+		const text = block.thinking.trim();
+		if (!text) continue;
+		const collapsed = text.replace(/\s+/g, " ");
+		const sentenceMatch = collapsed.match(/^[\s\S]*?[.!?\u3002\uff01\uff1f](\s|$)/);
+		const firstSentence = sentenceMatch ? sentenceMatch[0].trim() : collapsed;
+		return firstSentence.length > 80 ? `${firstSentence.slice(0, 77)}…` : firstSentence;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -153,6 +153,7 @@ import { TreeSelectorComponent } from "./components/tree-selector.ts";
 import { TrustSelectorComponent } from "./components/trust-selector.ts";
 import { UserMessageComponent } from "./components/user-message.ts";
 import { UserMessageSelectorComponent } from "./components/user-message-selector.ts";
+import { extractThinkingPreview, WorkProcessComponent } from "./components/work-process.ts";
 import { editInExternalEditor } from "./external-editor.ts";
 import { refreshModelCatalogs } from "./model-catalog-refresh.ts";
 import { getModelSearchText } from "./model-search.ts";
@@ -429,6 +430,13 @@ export class InteractiveMode {
 
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
+
+	// Work process grouping (request-level, UI-only; never persisted into session entries)
+	private currentWorkProcess: WorkProcessComponent | undefined = undefined;
+	private pendingWorkComponents: Component[] = [];
+	private currentWorkProcessFailed = false;
+	private agentStartedAt: number | undefined = undefined;
+	private lastWorkChild: Component | undefined = undefined;
 
 	// Tool output expansion state
 	private toolOutputExpanded = false;
@@ -2171,7 +2179,7 @@ export class InteractiveMode {
 
 	private setHiddenThinkingLabel(label?: string): void {
 		this.hiddenThinkingLabel = label ?? this.defaultHiddenThinkingLabel;
-		for (const child of this.chatContainer.children) {
+		for (const child of this.walkChatComponents()) {
 			if (child instanceof AssistantMessageComponent) {
 				child.setHiddenThinkingLabel(this.hiddenThinkingLabel);
 			}
@@ -2890,6 +2898,7 @@ export class InteractiveMode {
 		this.defaultEditor.onAction("app.model.select", () => this.showModelSelector());
 		this.defaultEditor.onAction("app.tools.expand", () => this.toggleToolOutputExpansion());
 		this.defaultEditor.onAction("app.thinking.toggle", () => this.toggleThinkingBlockVisibility());
+		this.defaultEditor.onAction("app.process.toggle", () => this.toggleWorkProcessCollapse());
 		this.defaultEditor.onAction("app.editor.external", () => void this.handleOpenExternalEditor());
 		this.defaultEditor.onAction(
 			"app.message.copy",
@@ -3172,6 +3181,8 @@ export class InteractiveMode {
 		switch (event.type) {
 			case "agent_start":
 				this.pendingTools.clear();
+				this.agentStartedAt = Date.now();
+				this.resetWorkProcessState();
 				// Restore main escape handler if retry handler is still active
 				// (retry success event fires later, but we need main handler now)
 				if (this.retryEscapeHandler) {
@@ -3235,7 +3246,7 @@ export class InteractiveMode {
 						this.getMarkdownTransformers(),
 					);
 					this.streamingMessage = event.message;
-					this.chatContainer.addChild(this.streamingComponent);
+					this.addWorkChild(this.streamingComponent);
 					this.streamingComponent.updateContent(this.streamingMessage, true);
 					this.ui.requestRender();
 				}
@@ -3262,7 +3273,9 @@ export class InteractiveMode {
 									this.sessionManager.getCwd(),
 								);
 								component.setExpanded(this.toolOutputExpanded);
-								this.chatContainer.addChild(component);
+								this.ensureWorkProcessOpen();
+								this.addWorkChild(component);
+								this.currentWorkProcess?.trackTool(content.name);
 								this.pendingTools.set(content.id, component);
 							} else {
 								const component = this.pendingTools.get(content.id);
@@ -3301,6 +3314,9 @@ export class InteractiveMode {
 								isError: true,
 							});
 						}
+						for (const [, component] of this.pendingTools.entries()) {
+							this.currentWorkProcess?.markToolErrored(component.getToolName());
+						}
 						this.pendingTools.clear();
 					} else {
 						// Args are now complete - trigger diff computation for edit tools
@@ -3309,6 +3325,15 @@ export class InteractiveMode {
 						}
 						this.maybeShowAssistantDiagnostics(this.streamingMessage);
 						this.maybeShowCacheMissNotice(this.streamingMessage);
+						const preview = extractThinkingPreview(this.streamingMessage);
+						if (preview) {
+							this.currentWorkProcess?.setThinkingPreview(preview);
+						}
+						if (!this.streamingMessage.content.some((c) => c.type === "toolCall")) {
+							// Final answer of the request: keep it outside the work process so it stays
+							// visible when the process is collapsed.
+							this.moveComponentToFinalAnswer(this.streamingComponent);
+						}
 					}
 					this.streamingComponent = undefined;
 					this.streamingMessage = undefined;
@@ -3337,7 +3362,9 @@ export class InteractiveMode {
 						this.sessionManager.getCwd(),
 					);
 					component.setExpanded(this.toolOutputExpanded);
-					this.chatContainer.addChild(component);
+					this.ensureWorkProcessOpen();
+					this.addWorkChild(component);
+					this.currentWorkProcess?.trackTool(event.toolName);
 					this.pendingTools.set(event.toolCallId, component);
 				}
 				component.markExecutionStarted();
@@ -3358,6 +3385,9 @@ export class InteractiveMode {
 				const component = this.pendingTools.get(event.toolCallId);
 				if (component) {
 					component.updateResult({ ...event.result, isError: event.isError });
+					if (event.isError) {
+						this.currentWorkProcess?.markToolErrored(component.getToolName());
+					}
 					this.pendingTools.delete(event.toolCallId);
 					this.ui.requestRender();
 				}
@@ -3370,11 +3400,12 @@ export class InteractiveMode {
 				}
 				this.clearStatusIndicator("working");
 				if (this.streamingComponent) {
-					this.chatContainer.removeChild(this.streamingComponent);
+					this.removeWorkChild(this.streamingComponent);
 					this.streamingComponent = undefined;
 					this.streamingMessage = undefined;
 				}
 				this.pendingTools.clear();
+				this.closeWorkProcess();
 
 				this.ui.requestRender();
 				break;
@@ -3554,6 +3585,100 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	/**
+	 * Direct chat children plus the children of any work process group, so display-wide updates
+	 * (thinking visibility, tool expansion, images, padding) also reach nested components.
+	 */
+	private *walkChatComponents(): Iterable<Component> {
+		for (const child of this.chatContainer.children) {
+			yield child;
+			if (child instanceof WorkProcessComponent) {
+				yield* child.contentChildren();
+			}
+		}
+	}
+
+	/** Add an assistant/tool component created during an agent request to the current grouping.
+	 * Components stay in the chat container until the first tool call appears; after that they
+	 * are held by the work process component.
+	 */
+	private addWorkChild(component: Component): void {
+		this.lastWorkChild = component;
+		if (this.currentWorkProcess) {
+			this.currentWorkProcess.addChild(component);
+			return;
+		}
+		this.chatContainer.addChild(component);
+		this.pendingWorkComponents.push(component);
+	}
+
+	private removeWorkChild(component: Component): void {
+		if (this.currentWorkProcess?.contentChildren().includes(component)) {
+			this.currentWorkProcess.removeChild(component);
+		} else {
+			this.chatContainer.removeChild(component);
+		}
+	}
+
+	private resetWorkProcessState(): void {
+		this.currentWorkProcess = undefined;
+		this.pendingWorkComponents = [];
+		this.currentWorkProcessFailed = false;
+		this.lastWorkChild = undefined;
+	}
+
+	/** Open the request-level work process group on the first tool call of a request. */
+	private ensureWorkProcessOpen(): WorkProcessComponent {
+		if (!this.currentWorkProcess) {
+			const group = new WorkProcessComponent(this.agentStartedAt);
+			this.currentWorkProcess = group;
+			const first = this.pendingWorkComponents[0];
+			const insertIndex = first ? this.chatContainer.children.indexOf(first) : this.chatContainer.children.length;
+			if (insertIndex >= 0) {
+				this.chatContainer.children.splice(insertIndex, 0, group);
+			} else {
+				this.chatContainer.addChild(group);
+			}
+			for (const component of this.pendingWorkComponents) {
+				const index = this.chatContainer.children.indexOf(component);
+				if (index >= 0) {
+					this.chatContainer.children.splice(index, 1);
+				}
+				group.addChild(component);
+			}
+			this.pendingWorkComponents = [];
+		}
+		return this.currentWorkProcess;
+	}
+
+	/** Move a component out of the work process group, right after it (final answer placement). */
+	private moveComponentToFinalAnswer(component: Component): void {
+		const group = this.currentWorkProcess;
+		if (!group) return;
+		group.removeChild(component);
+		const groupIndex = this.chatContainer.children.indexOf(group);
+		if (groupIndex >= 0) {
+			this.chatContainer.children.splice(groupIndex + 1, 0, component);
+		} else {
+			this.chatContainer.addChild(component);
+		}
+	}
+
+	/** Complete the current work process group; auto-collapse unless the request failed. */
+	private closeWorkProcess(): void {
+		const group = this.currentWorkProcess;
+		const failed = this.currentWorkProcessFailed;
+		this.currentWorkProcess = undefined;
+		this.pendingWorkComponents = [];
+		this.currentWorkProcessFailed = false;
+		this.lastWorkChild = undefined;
+		if (!group) return;
+		group.setCompleted(Date.now());
+		if (!failed) {
+			group.setCollapsed(true);
+		}
+	}
+
 	private addCustomEntryToChat(entry: Extract<SessionEntry, { type: "custom" }>): void {
 		const renderer = this.session.extensionRunner.getEntryRenderer(entry.customType);
 		if (!renderer) {
@@ -3566,7 +3691,12 @@ export class InteractiveMode {
 		}
 
 		if (this.streamingComponent) {
-			const streamingIndex = this.chatContainer.children.indexOf(this.streamingComponent);
+			// The streaming assistant may be nested inside the work process group; custom entries
+			// then go before the whole group, keeping them outside the collapsible area.
+			const insertBefore = this.currentWorkProcess?.contentChildren().includes(this.streamingComponent)
+				? this.currentWorkProcess
+				: this.streamingComponent;
+			const streamingIndex = this.chatContainer.children.indexOf(insertBefore);
 			if (streamingIndex >= 0) {
 				this.chatContainer.children.splice(streamingIndex, 0, component);
 				return;
@@ -3670,7 +3800,11 @@ export class InteractiveMode {
 					this.outputPad,
 					this.getMarkdownTransformers(),
 				);
-				this.chatContainer.addChild(assistantComponent);
+				this.addWorkChild(assistantComponent);
+				const preview = extractThinkingPreview(message);
+				if (preview) {
+					this.currentWorkProcess?.setThinkingPreview(preview);
+				}
 				break;
 			}
 			case "toolResult": {
@@ -3688,6 +3822,7 @@ export class InteractiveMode {
 		options: { updateFooter?: boolean; populateHistory?: boolean } = {},
 	): void {
 		this.pendingTools.clear();
+		this.resetWorkProcessState();
 		const renderedPendingTools = new Map<string, ToolExecutionComponent>();
 		// Cache-miss notices are not persisted; re-derive them from the full entry
 		// list and re-inject them after the assistant messages that paid for them.
@@ -3702,10 +3837,12 @@ export class InteractiveMode {
 
 		for (const item of items) {
 			if (isCustomSessionEntry(item)) {
+				this.closeWorkProcess();
 				this.addCustomEntryToChat(item);
 				continue;
 			}
 			if (isCompactionCostNotice(item)) {
+				this.closeWorkProcess();
 				this.addCompactionCostNotice(item);
 				continue;
 			}
@@ -3713,6 +3850,10 @@ export class InteractiveMode {
 			const message = item;
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
+				const hasToolCalls = message.content.some((c) => c.type === "toolCall");
+				if (hasToolCalls) {
+					this.ensureWorkProcessOpen();
+				}
 				this.addMessageToChat(message);
 				// Render tool call components
 				for (const content of message.content) {
@@ -3730,7 +3871,8 @@ export class InteractiveMode {
 							this.sessionManager.getCwd(),
 						);
 						component.setExpanded(this.toolOutputExpanded);
-						this.chatContainer.addChild(component);
+						this.addWorkChild(component);
+						this.ensureWorkProcessOpen().trackTool(content.name);
 
 						if (message.stopReason === "aborted" || message.stopReason === "error") {
 							let errorMessage: string;
@@ -3744,12 +3886,23 @@ export class InteractiveMode {
 								errorMessage = message.errorMessage || "Error";
 							}
 							component.updateResult({ content: [{ type: "text", text: errorMessage }], isError: true });
+							this.ensureWorkProcessOpen().markToolErrored(content.name);
 						} else {
 							renderedPendingTools.set(content.id, component);
 						}
 					}
 				}
-				if (message.stopReason !== "aborted" && message.stopReason !== "error") {
+				if (message.stopReason === "aborted" || message.stopReason === "error") {
+					this.currentWorkProcessFailed = true;
+				} else {
+					if (!hasToolCalls) {
+						// Final answer of the request: move it out of the work process group so it
+						// stays visible when the group is collapsed.
+						const assistantComponent = this.lastWorkChild;
+						if (assistantComponent instanceof AssistantMessageComponent) {
+							this.moveComponentToFinalAnswer(assistantComponent);
+						}
+					}
 					this.maybeShowAssistantDiagnostics(message);
 					const miss = cacheMisses.get(message);
 					if (miss) this.addCacheMissNotice(miss);
@@ -3763,10 +3916,12 @@ export class InteractiveMode {
 				}
 			} else {
 				// All other messages use standard rendering
+				this.closeWorkProcess();
 				this.addMessageToChat(message, options);
 			}
 		}
 
+		this.closeWorkProcess();
 		for (const [toolCallId, component] of renderedPendingTools) {
 			this.pendingTools.set(toolCallId, component);
 		}
@@ -4210,6 +4365,24 @@ export class InteractiveMode {
 		this.setToolsExpanded(!this.toolOutputExpanded);
 	}
 
+	private toggleWorkProcessCollapse(): void {
+		const groups: WorkProcessComponent[] = [];
+		for (const child of this.chatContainer.children) {
+			if (child instanceof WorkProcessComponent) {
+				groups.push(child);
+			}
+		}
+		if (groups.length === 0) {
+			this.showStatus("No work process to toggle");
+			return;
+		}
+		const collapse = groups.some((group) => !group.isCollapsed());
+		for (const group of groups) {
+			group.setCollapsed(collapse);
+		}
+		this.showStatus(`Work process: ${collapse ? "collapsed" : "expanded"}`);
+	}
+
 	private setToolsExpanded(expanded: boolean): void {
 		if (expanded === this.toolOutputExpanded) return;
 
@@ -4218,11 +4391,14 @@ export class InteractiveMode {
 		if (isExpandable(activeHeader)) {
 			activeHeader.setExpanded(expanded);
 		}
-		for (const container of [this.loadedResourcesContainer, this.chatContainer]) {
-			for (const child of container.children) {
-				if (isExpandable(child)) {
-					child.setExpanded(expanded);
-				}
+		for (const child of this.loadedResourcesContainer.children) {
+			if (isExpandable(child)) {
+				child.setExpanded(expanded);
+			}
+		}
+		for (const child of this.walkChatComponents()) {
+			if (isExpandable(child)) {
+				child.setExpanded(expanded);
 			}
 		}
 		this.showStatus(`Tool output: ${expanded ? "expanded" : "collapsed"}`);
@@ -4230,7 +4406,7 @@ export class InteractiveMode {
 
 	/** Update rendered assistant messages without rebuilding live tool components. */
 	private updateThinkingBlockVisibility(): void {
-		for (const child of this.chatContainer.children) {
+		for (const child of this.walkChatComponents()) {
 			if (child instanceof AssistantMessageComponent) {
 				child.setHideThinkingBlock(this.hideThinkingBlock);
 			}
@@ -4608,7 +4784,7 @@ export class InteractiveMode {
 					},
 					onShowImagesChange: (enabled) => {
 						this.settingsManager.setShowImages(enabled);
-						for (const child of this.chatContainer.children) {
+						for (const child of this.walkChatComponents()) {
 							if (child instanceof ToolExecutionComponent) {
 								child.setShowImages(enabled);
 							}
@@ -4616,7 +4792,7 @@ export class InteractiveMode {
 					},
 					onImageWidthCellsChange: (width) => {
 						this.settingsManager.setImageWidthCells(width);
-						for (const child of this.chatContainer.children) {
+						for (const child of this.walkChatComponents()) {
 							if (child instanceof ToolExecutionComponent) {
 								child.setImageWidthCells(width);
 							}
@@ -4720,7 +4896,7 @@ export class InteractiveMode {
 						this.settingsManager.setOutputPad(padding);
 						this.outputPad = padding;
 						if (this.streamingComponent || this.session.isStreaming) {
-							for (const child of this.chatContainer.children) {
+							for (const child of this.walkChatComponents()) {
 								if (
 									child instanceof AssistantMessageComponent ||
 									child instanceof CustomMessageComponent ||
@@ -6321,6 +6497,7 @@ export class InteractiveMode {
 		const selectModel = this.getAppKeyDisplay("app.model.select");
 		const expandTools = this.getAppKeyDisplay("app.tools.expand");
 		const toggleThinking = this.getAppKeyDisplay("app.thinking.toggle");
+		const toggleProcess = this.getAppKeyDisplay("app.process.toggle");
 		const externalEditor = this.getAppKeyDisplay("app.editor.external");
 		const cycleModelBackward = this.getAppKeyDisplay("app.model.cycleBackward");
 		const copyMessage = this.getAppKeyDisplay("app.message.copy");
@@ -6366,6 +6543,7 @@ export class InteractiveMode {
 | \`${selectModel}\` | Open model selector |
 | \`${expandTools}\` | Toggle tool output expansion |
 | \`${toggleThinking}\` | Toggle thinking block visibility |
+| \`${toggleProcess}\` | Toggle work process groups |
 | \`${externalEditor}\` | Edit message in external editor |
 | \`${copyMessage}\` | Copy last assistant message |
 | \`${followUp}\` | Queue follow-up message |

--- a/packages/coding-agent/test/work-process.test.ts
+++ b/packages/coding-agent/test/work-process.test.ts
@@ -1,0 +1,171 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.ts";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { extractThinkingPreview, WorkProcessComponent } from "../src/modes/interactive/components/work-process.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+initTheme();
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	overrides: Partial<Pick<AssistantMessage, "stopReason">> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-4o-mini",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+		stopReason: "stop",
+		...overrides,
+	};
+}
+
+function createToolComponent(name: string): ToolExecutionComponent {
+	return new ToolExecutionComponent(name, `call-${name}`, {}, {}, undefined, {} as never, "/tmp");
+}
+
+describe("WorkProcessComponent", () => {
+	test("collapsed render is a single summary line with tool counts", () => {
+		const group = new WorkProcessComponent();
+		const assistant = new AssistantMessageComponent();
+		assistant.updateContent(
+			createAssistantMessage([{ type: "thinking", thinking: "Let me check the render pipeline first." }]),
+		);
+		group.addChild(assistant);
+		group.setThinkingPreview(
+			extractThinkingPreview(
+				createAssistantMessage([{ type: "thinking", thinking: "Let me check the render pipeline first." }]),
+			) ?? "",
+		);
+		group.trackTool("read");
+		group.trackTool("bash");
+		group.trackTool("bash");
+		group.setCompleted(Date.now());
+
+		group.setCollapsed(true);
+		const lines = group.render(80);
+		expect(lines).toHaveLength(1);
+		const text = stripAnsi(lines[0] ?? "");
+		expect(text).toContain("▶");
+		expect(text).toContain("read");
+		expect(text).toContain("bash×2");
+		expect(text).toContain("thinking: Let me check the render pipeline first.");
+	});
+
+	test("expanded render shows header plus all children", () => {
+		const group = new WorkProcessComponent();
+		const assistant = new AssistantMessageComponent();
+		assistant.updateContent(createAssistantMessage([{ type: "text", text: "Working on it." }]));
+		group.addChild(assistant);
+		group.trackTool("bash");
+		group.setCompleted(Date.now());
+
+		const lines = group.render(80).map(stripAnsi);
+		expect(lines[0]).toContain("▼");
+		const text = lines.join("\n");
+		expect(text).toContain("Working on it.");
+		expect(text).toContain("bash");
+	});
+
+	test("history groups without startedAt omit the duration", () => {
+		const group = new WorkProcessComponent();
+		group.trackTool("read");
+		group.setCollapsed(true);
+		const text = stripAnsi(group.render(80)[0] ?? "");
+		expect(text).not.toContain("Worked");
+		expect(text).toContain("read");
+	});
+
+	test("click on header toggles collapse", () => {
+		const group = new WorkProcessComponent();
+		const assistant = new AssistantMessageComponent();
+		assistant.updateContent(createAssistantMessage([{ type: "text", text: "hello" }]));
+		group.addChild(assistant);
+		group.trackTool("read");
+		group.render(80);
+
+		const click = {
+			type: "click" as const,
+			button: "left" as const,
+			x: 0,
+			y: 0,
+			screenX: 0,
+			screenY: 0,
+			width: 80,
+			height: 10,
+			shift: false,
+			alt: false,
+			ctrl: false,
+		};
+		const result = group.handleMouse(click);
+		expect(result?.handled).toBe(true);
+		expect(group.isCollapsed()).toBe(true);
+
+		const lines = group.render(80);
+		expect(lines).toHaveLength(1);
+
+		group.handleMouse(click);
+		expect(group.isCollapsed()).toBe(false);
+		expect(group.render(80).length).toBeGreaterThan(1);
+	});
+
+	test("clicks below the header are forwarded to children", () => {
+		const group = new WorkProcessComponent();
+		const tool = createToolComponent("read");
+		tool.updateResult({ content: [{ type: "text", text: "line\n".repeat(30) }], isError: false });
+		group.addChild(tool);
+		group.trackTool("read");
+		const lines = group.render(80);
+		expect(lines.length).toBeGreaterThan(2);
+
+		const click = {
+			type: "click" as const,
+			button: "left" as const,
+			x: 0,
+			y: 2,
+			screenX: 0,
+			screenY: 2,
+			width: 80,
+			height: lines.length,
+			shift: false,
+			alt: false,
+			ctrl: false,
+		};
+		group.handleMouse(click);
+	});
+
+	test("unregistered tool fallback truncates output while collapsed", () => {
+		const tool = createToolComponent("unknown-tool");
+		tool.updateResult({ content: [{ type: "text", text: "out\n".repeat(30) }], isError: false });
+
+		const collapsedLines = tool.render(80).map(stripAnsi).join("\n");
+		expect(collapsedLines).toContain("more lines");
+
+		tool.setExpanded(true);
+		const expandedLines = tool.render(80).map(stripAnsi).join("\n");
+		expect(expandedLines).not.toContain("more lines");
+		expect(expandedLines.split("out").length).toBeGreaterThan(28);
+	});
+
+	test("extractThinkingPreview returns the first sentence", () => {
+		const message = createAssistantMessage([{ type: "thinking", thinking: "First idea.\nSecond thought." }]);
+		expect(extractThinkingPreview(message)).toBe("First idea.");
+	});
+
+	test("extractThinkingPreview skips empty thinking", () => {
+		const message = createAssistantMessage([{ type: "thinking", thinking: "  " }]);
+		expect(extractThinkingPreview(message)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Adds request-level collapsible "work process" grouping in interactive TUI mode. When an agent invocation runs multiple tool calls across one or more agent turns, the intermediate thinking blocks and tool execution outputs automatically collapse into a concise, informative summary line upon completion, leaving the final assistant answer visible.

Users can toggle work process collapse globally using a new keyboard action `app.process.toggle` (default `alt+o`), or by clicking the summary line in fullscreen TUI mode.
