### PR TITLE
feat(ai): add OrcaRouter as a first-class provider with live catalog model discovery

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -73,6 +73,7 @@ Unified LLM API with provider collections, automatic auth resolution, token and 
 - **Cloudflare Workers AI**
 - **xAI**
 - **OpenRouter**
+- **OrcaRouter** (OpenAI-compatible gateway; dynamic live catalog, see below)
 - **Vercel AI Gateway**
 - **ZAI Coding Plan (Global)** (with separate China provider)
 - **MiniMax** (with separate China provider)
@@ -242,6 +243,7 @@ For apps that only need specific providers, there is one factory per built-in pr
 import { anthropicProvider } from '@earendil-works/pi-ai/providers/anthropic';
 import { openaiProvider } from '@earendil-works/pi-ai/providers/openai';
 import { openrouterProvider } from '@earendil-works/pi-ai/providers/openrouter';
+import { orcarouterProvider } from '@earendil-works/pi-ai/providers/orcarouter';
 import { amazonBedrockProvider } from '@earendil-works/pi-ai/providers/amazon-bedrock';
 // ...one module per provider in the Supported Providers list
 
@@ -311,7 +313,7 @@ const anthropic = getBuiltinModels('anthropic');
 
 ### Dynamic Providers
 
-Providers may have dynamic model lists (a llama.cpp server, a live OpenRouter listing). Reads stay sync; fetching is an explicit async verb:
+Providers may have dynamic model lists (a llama.cpp server, a live OpenRouter listing, an OrcaRouter gateway). Reads stay sync; fetching is an explicit async verb:
 
 ```typescript
 // getModels() returns the last-known list (empty before the first refresh)
@@ -431,6 +433,7 @@ Built-in providers resolve these env vars (Node.js; in browsers pass `apiKey` ex
 | Together AI | `TOGETHER_API_KEY` |
 | Baseten | `BASETEN_API_KEY` |
 | OpenRouter | `OPENROUTER_API_KEY` |
+| OrcaRouter | `ORCAROUTER_API_KEY` |
 | Vercel AI Gateway | `AI_GATEWAY_API_KEY` |
 | ZAI Coding Plan (Global) | `ZAI_API_KEY` |
 | ZAI Coding Plan (China) | `ZAI_CODING_CN_API_KEY` |

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -92,6 +92,7 @@ function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
 		xai: "XAI_API_KEY",
 		radius: "RADIUS_API_KEY",
 		openrouter: "OPENROUTER_API_KEY",
+		orcarouter: "ORCAROUTER_API_KEY",
 		"vercel-ai-gateway": "AI_GATEWAY_API_KEY",
 		zai: "ZAI_API_KEY",
 		"zai-coding-cn": "ZAI_CODING_CN_API_KEY",

--- a/packages/ai/src/orcarouter/capabilities.ts
+++ b/packages/ai/src/orcarouter/capabilities.ts
@@ -1,0 +1,310 @@
+/**
+ * OrcaRouter model-catalog parsing and capability filtering.
+ *
+ * OrcaRouter serves an OpenAI-compatible catalog at GET {baseUrl}/models whose
+ * entries carry `supported_endpoint_types`, `architecture.input_modalities`
+ * and pricing metadata. Chat/agent, multimodal-chat, embedding, image, video
+ * and rerank entries are distinguished strictly from that metadata — never by
+ * guessing from a model id — and anything that does not declare a capability
+ * is excluded (fail closed).
+ */
+
+import type { ProviderId } from "../types.ts";
+
+/** Fixed OrcaRouter gateway origin. All requests hang off `{baseUrl}/…`. */
+export const ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1";
+
+/**
+ * Base URL for models that speak the Anthropic Messages wire format. The pi
+ * Anthropic adapter points the Anthropic SDK at `model.baseUrl` and the SDK
+ * appends `/v1/messages`, so this must be the gateway origin without the `/v1`
+ * prefix (mirrors how OpenRouter uses `https://openrouter.ai/api`).
+ */
+export const ORCAROUTER_ANTHROPIC_BASE_URL = "https://api.orcarouter.ai";
+
+export const ORCAROUTER_PROVIDER_ID = "orcarouter" satisfies ProviderId;
+
+/** Server-side capability filter value for text chat/agent models. */
+export const ORCAROUTER_CHAT_CAPABILITY = "chat";
+
+/** Endpoint families OrcaRouter advertises per model. */
+export const ORCAROUTER_CHAT_ENDPOINT_TYPES = ["openai", "openai-response", "anthropic", "gemini"] as const;
+
+export const ORCAROUTER_EMBEDDINGS_ENDPOINT_TYPE = "embeddings";
+export const ORCAROUTER_IMAGE_GENERATION_ENDPOINT_TYPE = "image-generation";
+export const ORCAROUTER_VIDEO_ENDPOINT_TYPE = "openai-video";
+export const ORCAROUTER_RERANK_ENDPOINT_TYPE = "jina-rerank";
+
+/** Endpoint types that are never usable for a text chat/agent request. */
+const NON_TEXT_ENDPOINT_TYPES: ReadonlySet<string> = new Set([
+	ORCAROUTER_EMBEDDINGS_ENDPOINT_TYPE,
+	ORCAROUTER_IMAGE_GENERATION_ENDPOINT_TYPE,
+	ORCAROUTER_VIDEO_ENDPOINT_TYPE,
+	ORCAROUTER_RERANK_ENDPOINT_TYPE,
+]);
+
+/** Non-text input modalities a multimodal chat entry can declare. */
+export type OrcaRouterInputModality = "image" | "audio" | "video" | "file";
+
+const KNOWN_MODALITIES: ReadonlySet<string> = new Set(["image", "audio", "video", "file"]);
+
+/** A raw catalog entry as returned by GET {baseUrl}/models. */
+export interface OrcaRouterCatalogEntry {
+	id: string;
+	object?: string;
+	created?: number;
+	owned_by?: string;
+	name?: string;
+	description?: string;
+	supported_endpoint_types?: readonly string[];
+	context_length?: number;
+	max_completion_tokens?: number;
+	architecture?: {
+		input_modalities?: readonly string[];
+		output_modalities?: readonly string[];
+	};
+	top_provider?: {
+		context_length?: number;
+		max_completion_tokens?: number;
+	};
+	pricing?: {
+		prompt?: string | number;
+		completion?: string | number;
+		prompt_per_million?: string | number;
+		completion_per_million?: string | number;
+		/** Per-token cache-read price in $/token (OpenRouter-style), if any. */
+		input_cache_read?: string | number;
+		/** Per-token cache-write price in $/token (OpenRouter-style), if any. */
+		input_cache_write?: string | number;
+	};
+}
+
+export interface OrcaRouterCatalog {
+	data: OrcaRouterCatalogEntry[];
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function toFiniteNonNegative(value: unknown): number {
+	const number = typeof value === "number" ? value : typeof value === "string" ? Number.parseFloat(value) : Number.NaN;
+	return Number.isFinite(number) && number >= 0 ? number : 0;
+}
+
+function hasChatEndpoint(entry: OrcaRouterCatalogEntry): boolean {
+	const endpointTypes = entry.supported_endpoint_types;
+	if (!Array.isArray(endpointTypes)) return false;
+	return endpointTypes.some(
+		(endpoint) =>
+			typeof endpoint === "string" && (ORCAROUTER_CHAT_ENDPOINT_TYPES as readonly string[]).includes(endpoint),
+	);
+}
+
+/**
+ * True when every declared endpoint type is a text-chat endpoint. An entry
+ * that also lists an image-generation/embeddings/video endpoint cannot be
+ * offered for plain text chat because the gateway may route it to a
+ * non-text-capable upstream.
+ */
+function isTextChatOnly(entry: OrcaRouterCatalogEntry): boolean {
+	const endpointTypes = entry.supported_endpoint_types;
+	if (!Array.isArray(endpointTypes)) return false;
+	return endpointTypes.every(
+		(endpoint) =>
+			typeof endpoint === "string" &&
+			!NON_TEXT_ENDPOINT_TYPES.has(endpoint) &&
+			(ORCAROUTER_CHAT_ENDPOINT_TYPES as readonly string[]).includes(endpoint),
+	);
+}
+
+function declaredModalities(entry: OrcaRouterCatalogEntry): ReadonlySet<string> {
+	const modalities = entry.architecture?.input_modalities;
+	if (!Array.isArray(modalities)) return new Set();
+	return new Set(modalities.filter((modality): modality is string => typeof modality === "string"));
+}
+
+function isMultimodalChat(entry: OrcaRouterCatalogEntry): boolean {
+	const modalities = declaredModalities(entry);
+	return hasChatEndpoint(entry) && Array.from(modalities).some((modality) => KNOWN_MODALITIES.has(modality));
+}
+
+function hasExactEndpoint(entry: OrcaRouterCatalogEntry, endpoint: string): boolean {
+	const endpointTypes = entry.supported_endpoint_types;
+	if (!Array.isArray(endpointTypes)) return false;
+	return endpointTypes.length > 0 && endpointTypes.every((entryEndpoint) => entryEndpoint === endpoint);
+}
+
+function parseName(entry: OrcaRouterCatalogEntry, fallback: string): string {
+	return isNonEmptyString(entry.name) ? (entry.name as string) : fallback;
+}
+
+function parseModalityCount(entry: OrcaRouterCatalogEntry): number {
+	const count = entry.context_length ?? entry.top_provider?.context_length;
+	const numeric = typeof count === "number" ? count : Number.NaN;
+	return Number.isFinite(numeric) && numeric > 0 ? numeric : 4096;
+}
+
+function parseMaxTokens(entry: OrcaRouterCatalogEntry): number {
+	const count = entry.max_completion_tokens ?? entry.top_provider?.max_completion_tokens;
+	const numeric = typeof count === "number" ? count : Number.NaN;
+	return Number.isFinite(numeric) && numeric > 0 ? numeric : 4096;
+}
+
+function parseInputModalities(entry: OrcaRouterCatalogEntry): ("text" | "image")[] {
+	const modalities = declaredModalities(entry);
+	const input: ("text" | "image")[] = ["text"];
+	if (modalities.has("image")) input.push("image");
+	return input;
+}
+
+function parseCostPerMillion(entry: OrcaRouterCatalogEntry): { input: number; output: number } {
+	const pricing = entry.pricing;
+	if (!pricing) return { input: 0, output: 0 };
+	// Prices are published in $/M tokens (prompt_per_million/completion_per_million)
+	// or $/token (prompt/completion). Normalize both to $/M tokens.
+	return {
+		input: toFiniteNonNegative(pricing.prompt_per_million ?? pricing.prompt),
+		output: toFiniteNonNegative(pricing.completion_per_million ?? pricing.completion),
+	};
+}
+
+export interface OrcaRouterChatModelInit {
+	id: string;
+	provider: "orcarouter";
+	api: "openai-completions" | "anthropic-messages";
+	name: string;
+	baseUrl: string;
+	reasoning: boolean;
+	input: ("text" | "image")[];
+	endpointTypes: readonly string[];
+	inputModalities: readonly string[];
+	contextWindow: number;
+	maxTokens: number;
+	cost: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+	};
+	catalogId: string;
+}
+
+function chooseChatApi(entry: OrcaRouterCatalogEntry): "openai-completions" | "anthropic-messages" {
+	// Anthropic-vendor models use the Anthropic Messages adapter; everything else
+	// (including OrcaRouter's own routing models, which expose both formats)
+	// uses OpenAI chat completions.
+	const id = entry.id ?? "";
+	const endpointTypes = entry.supported_endpoint_types;
+	if (id.startsWith("anthropic/") && Array.isArray(endpointTypes) && endpointTypes.includes("anthropic")) {
+		return "anthropic-messages";
+	}
+	return "openai-completions";
+}
+
+/**
+ * Parse a raw catalog entry into a chat-capable model. Text chat uses
+ * `?capability=chat` on the wire; this filter additionally rejects entries
+ * whose endpoint set includes a non-text endpoint and entries that declare no
+ * chat endpoint. Model ids are preserved verbatim (`vendor/model`).
+ */
+export function toChatModel(entry: OrcaRouterCatalogEntry): OrcaRouterChatModelInit | undefined {
+	if (!isNonEmptyString(entry.id) || !hasChatEndpoint(entry) || !isTextChatOnly(entry)) return undefined;
+	const id = entry.id as string;
+	const fallbackName = id.replace(/^[^/]+\//u, "");
+	const api = chooseChatApi(entry);
+	return {
+		id,
+		provider: "orcarouter",
+		api,
+		name: parseName(entry, fallbackName),
+		baseUrl: api === "anthropic-messages" ? ORCAROUTER_ANTHROPIC_BASE_URL : ORCAROUTER_BASE_URL,
+		reasoning: false,
+		input: parseInputModalities(entry),
+		endpointTypes: Array.isArray(entry.supported_endpoint_types) ? [...entry.supported_endpoint_types] : [],
+		inputModalities: Array.from(declaredModalities(entry)),
+		contextWindow: parseModalityCount(entry),
+		maxTokens: parseMaxTokens(entry),
+		cost: { ...parseCostPerMillion(entry), cacheRead: 0, cacheWrite: 0 },
+		catalogId: id,
+	};
+}
+
+/**
+ * Text-chat-only models: capable of text chat/agent requests. Requires a chat
+ * endpoint and excludes any entry that also advertises image/video/embedding/
+ * rerank generation.
+ */
+export function orcaRouterTextChatModels(entries: readonly OrcaRouterCatalogEntry[]): OrcaRouterChatModelInit[] {
+	const models: OrcaRouterChatModelInit[] = [];
+	for (const entry of entries) {
+		const model = toChatModel(entry);
+		if (model) models.push(model);
+	}
+	return models;
+}
+
+/**
+ * Multimodal chat models for a specific input modality. Each entry must (1) be
+ * a text-chat model and (2) explicitly declare `modality` in
+ * `architecture.input_modalities`. Entries that omit the field fail closed.
+ */
+export function orcaRouterMultimodalChatModels(
+	entries: readonly OrcaRouterCatalogEntry[],
+	modality: OrcaRouterInputModality,
+): OrcaRouterChatModelInit[] {
+	const models: OrcaRouterChatModelInit[] = [];
+	for (const entry of entries) {
+		const chat = toChatModel(entry);
+		if (!chat) continue;
+		if (!declaredModalities(entry).has(modality)) continue;
+		models.push(chat);
+	}
+	return models;
+}
+
+/** Embedding models: strict endpoint match on `embeddings`. */
+export function orcaRouterEmbeddingModels(entries: readonly OrcaRouterCatalogEntry[]): OrcaRouterCatalogEntry[] {
+	return entries.filter((entry) => hasExactEndpoint(entry, ORCAROUTER_EMBEDDINGS_ENDPOINT_TYPE));
+}
+
+/** Image-generation models: strict endpoint match on `image-generation`. */
+export function orcaRouterImageGenerationModels(entries: readonly OrcaRouterCatalogEntry[]): OrcaRouterCatalogEntry[] {
+	return entries.filter((entry) => hasExactEndpoint(entry, ORCAROUTER_IMAGE_GENERATION_ENDPOINT_TYPE));
+}
+
+/** Video-generation models: strict endpoint match on `openai-video`. */
+export function orcaRouterVideoModels(entries: readonly OrcaRouterCatalogEntry[]): OrcaRouterCatalogEntry[] {
+	return entries.filter((entry) => hasExactEndpoint(entry, ORCAROUTER_VIDEO_ENDPOINT_TYPE));
+}
+
+/** Rerank models: strict endpoint match on `jina-rerank`. */
+export function orcaRouterRerankModels(entries: readonly OrcaRouterCatalogEntry[]): OrcaRouterCatalogEntry[] {
+	return entries.filter((entry) => hasExactEndpoint(entry, ORCAROUTER_RERANK_ENDPOINT_TYPE));
+}
+
+/**
+ * Parse a GET {baseUrl}/models response body. The response is a top-level
+ * `{ data: [...] }` object; any other shape is rejected.
+ */
+export function parseOrcaRouterCatalog(value: unknown): OrcaRouterCatalog {
+	if (typeof value !== "object" || value === null) {
+		throw new TypeError("OrcaRouter catalog response must be a JSON object");
+	}
+	const data = (value as { data?: unknown }).data;
+	if (!Array.isArray(data)) {
+		throw new TypeError("OrcaRouter catalog response is missing a data array");
+	}
+	const entries: OrcaRouterCatalogEntry[] = [];
+	for (const item of data) {
+		if (typeof item !== "object" || item === null) continue;
+		const entry = item as OrcaRouterCatalogEntry;
+		if (typeof entry.id === "string" && entry.id.length > 0) entries.push(entry);
+	}
+	return { data: entries };
+}
+
+/** True when a parsed model set actually came from a catalog (used by tests). */
+export function isMultimodalChatEntry(entry: OrcaRouterCatalogEntry): boolean {
+	return isMultimodalChat(entry);
+}

--- a/packages/ai/src/providers/all.ts
+++ b/packages/ai/src/providers/all.ts
@@ -31,6 +31,7 @@ import { opencodeProvider } from "./opencode.ts";
 import { opencodeGoProvider } from "./opencode-go.ts";
 import { openrouterProvider } from "./openrouter.ts";
 import { openrouterImagesProvider } from "./openrouter-images.ts";
+import { orcarouterProvider } from "./orcarouter.ts";
 import { qwenTokenPlanProvider } from "./qwen-token-plan.ts";
 import { qwenTokenPlanCnProvider } from "./qwen-token-plan-cn.ts";
 import { qwenTokenPlanIndividualProvider } from "./qwen-token-plan-individual.ts";
@@ -115,6 +116,7 @@ export function builtinProviders(): Provider[] {
 		opencodeProvider(),
 		opencodeGoProvider(),
 		openrouterProvider(),
+		orcarouterProvider(),
 		qwenTokenPlanProvider(),
 		qwenTokenPlanCnProvider(),
 		qwenTokenPlanIndividualProvider(),

--- a/packages/ai/src/providers/orcarouter.ts
+++ b/packages/ai/src/providers/orcarouter.ts
@@ -1,0 +1,126 @@
+/**
+ * OrcaRouter remote catalog + provider.
+ *
+ * OrcaRouter is an OpenAI-compatible AI gateway (models and agents) fronting
+ * many vendors. Its chat model catalog is fetched live from
+ * `GET {baseUrl}/models?capability=chat` (Bearer auth when an API key is
+ * configured), so this provider keeps an empty static baseline and relies on
+ * pi-ai's dynamic model overlay (createProvider `fetchModels`) to populate
+ * chat-capable models. No hand-written model ids exist anywhere in this
+ * provider — when the catalog is unreachable the provider has no models and
+ * the UI shows the refresh error.
+ */
+
+import { anthropicMessagesApi } from "../api/anthropic-messages.lazy.ts";
+import { openAICompletionsApi } from "../api/openai-completions.lazy.ts";
+import { envApiKeyAuth } from "../auth/helpers.ts";
+import type { RefreshModelsContext } from "../models.ts";
+import { createProvider, type Provider } from "../models.ts";
+import {
+	ORCAROUTER_BASE_URL,
+	ORCAROUTER_CHAT_CAPABILITY,
+	ORCAROUTER_PROVIDER_ID,
+	type OrcaRouterCatalogEntry,
+	orcaRouterTextChatModels,
+	parseOrcaRouterCatalog,
+} from "../orcarouter/capabilities.ts";
+import type { Model } from "../types.ts";
+
+function truncateHttpBody(body: string): string {
+	const trimmed = body.trim();
+	return trimmed.length > 512 ? `${trimmed.slice(0, 512)}…` : trimmed;
+}
+
+/** Map a catalog entry to a full pi runtime Model. */
+function toPiModel(init: {
+	id: string;
+	provider: "orcarouter";
+	api: "openai-completions" | "anthropic-messages";
+	name: string;
+	baseUrl: string;
+	reasoning: boolean;
+	input: ("text" | "image")[];
+	contextWindow: number;
+	maxTokens: number;
+	cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+}): Model<"openai-completions" | "anthropic-messages"> {
+	const { input, ...rest } = init;
+	return {
+		...rest,
+		input,
+	} as Model<"openai-completions" | "anthropic-messages">;
+}
+
+export interface FetchOrcaRouterCatalogOptions {
+	/** Server-side capability filter applied to GET /models, e.g. "chat". */
+	capability?: string;
+	signal?: AbortSignal;
+}
+
+/**
+ * Fetch the live OrcaRouter catalog. The request carries the configured API
+ * key (if any) as a Bearer token so the returned list reflects what the
+ * workspace can actually call. `capability` is passed through as the
+ * `?capability=` query parameter (the server authoritative filter).
+ */
+export async function fetchOrcaRouterCatalog(
+	baseUrl: string,
+	apiKey: string | undefined,
+	options: FetchOrcaRouterCatalogOptions = {},
+): Promise<OrcaRouterCatalogEntry[]> {
+	const headers: Record<string, string> = { accept: "application/json" };
+	if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+	const url = new URL(`${baseUrl.replace(/\/+$/u, "")}/models`);
+	if (options.capability) url.searchParams.set("capability", options.capability);
+	const response = await fetch(url, { headers, signal: options.signal });
+	if (!response.ok) {
+		throw new Error(
+			`Could not load OrcaRouter models from ${url}: ${response.status}: ${truncateHttpBody(await response.text())}`,
+		);
+	}
+	const catalog = parseOrcaRouterCatalog(await response.json());
+	return catalog.data;
+}
+
+/** Fetch the server-filtered chat catalog entries (`?capability=chat`). */
+export async function fetchOrcaRouterChatCatalog(
+	baseUrl: string,
+	apiKey: string | undefined,
+	signal?: AbortSignal,
+): Promise<OrcaRouterCatalogEntry[]> {
+	return fetchOrcaRouterCatalog(baseUrl, apiKey, { capability: ORCAROUTER_CHAT_CAPABILITY, signal });
+}
+
+/**
+ * Fetch live chat-capable pi models. The server `?capability=chat` list is the
+ * authoritative source; `orcaRouterTextChatModels` is applied again as a
+ * second-layer guard so an entry can never slip in through a non-text
+ * endpoint type.
+ */
+export async function fetchOrcaRouterChatModels(
+	baseUrl: string,
+	apiKey: string | undefined,
+	signal?: AbortSignal,
+): Promise<Model<"openai-completions" | "anthropic-messages">[]> {
+	const entries = await fetchOrcaRouterChatCatalog(baseUrl, apiKey, signal);
+	return orcaRouterTextChatModels(entries).map(toPiModel);
+}
+
+/** OrcaRouter provider factory: first-class built-in provider. */
+export function orcarouterProvider(): Provider<"openai-completions" | "anthropic-messages"> {
+	return createProvider({
+		id: ORCAROUTER_PROVIDER_ID,
+		name: "OrcaRouter",
+		baseUrl: ORCAROUTER_BASE_URL,
+		auth: { apiKey: envApiKeyAuth("OrcaRouter API key", ["ORCAROUTER_API_KEY"]) },
+		models: [],
+		fetchModels: async (context: RefreshModelsContext) => {
+			const apiKey = context.credential?.type === "api_key" ? context.credential.key : undefined;
+			return fetchOrcaRouterChatModels(ORCAROUTER_BASE_URL, apiKey, context.signal);
+		},
+		api: {
+			"openai-completions": openAICompletionsApi(),
+			"anthropic-messages": anthropicMessagesApi(),
+		},
+	});
+}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -49,6 +49,7 @@ export type KnownProvider =
 	| "groq"
 	| "cerebras"
 	| "openrouter"
+	| "orcarouter"
 	| "vercel-ai-gateway"
 	| "zai"
 	| "zai-coding-cn"

--- a/packages/ai/test/orcarouter-capabilities.test.ts
+++ b/packages/ai/test/orcarouter-capabilities.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+	isMultimodalChatEntry,
+	ORCAROUTER_BASE_URL,
+	type OrcaRouterCatalogEntry,
+	orcaRouterEmbeddingModels,
+	orcaRouterImageGenerationModels,
+	orcaRouterMultimodalChatModels,
+	orcaRouterRerankModels,
+	orcaRouterTextChatModels,
+	orcaRouterVideoModels,
+	parseOrcaRouterCatalog,
+	toChatModel,
+} from "../src/orcarouter/capabilities.ts";
+import {
+	ORCAROUTER_CAPABILITY_FIXTURE,
+	ORCAROUTER_EMBEDDING_EXPECTED_IDS,
+	ORCAROUTER_IMAGE_CHAT_EXPECTED_IDS,
+	ORCAROUTER_IMAGE_GENERATION_EXPECTED_IDS,
+	ORCAROUTER_NON_TEXT_EXPECTED_EXCLUDED_IDS,
+	ORCAROUTER_RERANK_EXPECTED_IDS,
+	ORCAROUTER_TEXT_CHAT_EXPECTED_IDS,
+	ORCAROUTER_VIDEO_EXPECTED_IDS,
+} from "./orcarouter/fixtures.ts";
+
+function ids(entries: readonly { id: string }[]): string[] {
+	return entries.map((entry) => entry.id).sort();
+}
+
+describe("OrcaRouter catalog parsing", () => {
+	it("parses the OpenRouter-style { data: [] } envelope and preserves model ids verbatim", () => {
+		const catalog = parseOrcaRouterCatalog({ data: [...ORCAROUTER_CAPABILITY_FIXTURE] });
+		expect(catalog.data.map((entry) => entry.id)).toContain("google/gemini-3-flash");
+	});
+
+	it("rejects envelopes without a data array", () => {
+		expect(() => parseOrcaRouterCatalog({ models: [] })).toThrow(/data array/);
+		expect(() => parseOrcaRouterCatalog(null)).toThrow(/JSON object/);
+	});
+});
+
+describe("OrcaRouter chat capability filter", () => {
+	it("keeps only chat-capable entries and never entries with image/video/embedding/rerank endpoints", () => {
+		const textModels = orcaRouterTextChatModels(ORCAROUTER_CAPABILITY_FIXTURE);
+		const textIds = new Set(ids(textModels));
+		for (const expected of ORCAROUTER_TEXT_CHAT_EXPECTED_IDS) {
+			expect(textIds.has(expected)).toBe(true);
+		}
+		for (const excluded of ORCAROUTER_NON_TEXT_EXPECTED_EXCLUDED_IDS) {
+			expect(textIds.has(excluded)).toBe(false);
+		}
+	});
+
+	it("maps catalog entries onto a pi model shape with a fixed gateway base URL", () => {
+		const model = toChatModel({
+			id: "google/gemini-3-flash",
+			supported_endpoint_types: ["openai", "gemini"],
+			architecture: { input_modalities: ["text", "image"], output_modalities: ["text"] },
+			context_length: 1_048_576,
+			max_completion_tokens: 65_536,
+			pricing: { prompt_per_million: "0.75", completion_per_million: "3.75" },
+		});
+		// openai-completions models use the /v1 base; anthropic-messages models use the origin.
+		expect(model?.baseUrl).toBe(ORCAROUTER_BASE_URL);
+		expect(model?.input).toEqual(["text", "image"]);
+		expect(model?.contextWindow).toBe(1_048_576);
+		expect(model?.maxTokens).toBe(65_536);
+		const anthropicModel = toChatModel({
+			id: "anthropic/claude-haiku-4-5",
+			supported_endpoint_types: ["anthropic"],
+			architecture: { input_modalities: ["text"], output_modalities: ["text"] },
+			context_length: 200_000,
+		});
+		expect(anthropicModel?.api).toBe("anthropic-messages");
+		expect(anthropicModel?.baseUrl).toBe("https://api.orcarouter.ai");
+	});
+
+	it("does not guess capabilities from model ids: dual-mode, video, rerank and embeddings are excluded", () => {
+		const textIds = new Set(ids(orcaRouterTextChatModels(ORCAROUTER_CAPABILITY_FIXTURE)));
+		for (const excluded of ["vendor/dual-mode", "vendor/chat-and-video", "vendor/chat-and-rerank"]) {
+			expect(textIds.has(excluded)).toBe(false);
+		}
+	});
+});
+
+describe("OrcaRouter multimodal chat filter (fail closed)", () => {
+	it("keeps chat models that explicitly declare the requested input modality", () => {
+		const imageModels = orcaRouterMultimodalChatModels(ORCAROUTER_CAPABILITY_FIXTURE, "image");
+		const imageIds = new Set(ids(imageModels));
+		for (const expected of ORCAROUTER_IMAGE_CHAT_EXPECTED_IDS) {
+			expect(imageIds.has(expected)).toBe(true);
+		}
+	});
+
+	it("excludes chat models that omit the modality declaration (fail closed)", () => {
+		const imageModels = orcaRouterMultimodalChatModels(ORCAROUTER_CAPABILITY_FIXTURE, "image");
+		const imageIds = new Set(ids(imageModels));
+		// Text-only chat entries declare no input_modalities -> excluded.
+		for (const excluded of ["orcarouter/fusion", "anthropic/claude-haiku-4-5"]) {
+			expect(imageIds.has(excluded)).toBe(false);
+		}
+	});
+
+	it("separates audio modality from image modality", () => {
+		const audioIds = new Set(ids(orcaRouterMultimodalChatModels(ORCAROUTER_CAPABILITY_FIXTURE, "audio")));
+		const imageIds = new Set(ids(orcaRouterMultimodalChatModels(ORCAROUTER_CAPABILITY_FIXTURE, "image")));
+		expect(audioIds.has("openai/audio-chat-model")).toBe(true);
+		expect(imageIds.has("openai/audio-chat-model")).toBe(false);
+		expect(imageIds.has("google/gemini-3-flash")).toBe(true);
+	});
+});
+
+describe("OrcaRouter capability-specific filters", () => {
+	it("filters embeddings by strict embeddings endpoint match", () => {
+		const embeddingIds = new Set(ids(orcaRouterEmbeddingModels(ORCAROUTER_CAPABILITY_FIXTURE)));
+		expect(embeddingIds.size).toBe(1);
+		for (const expected of ORCAROUTER_EMBEDDING_EXPECTED_IDS) expect(embeddingIds.has(expected)).toBe(true);
+	});
+
+	it("filters image generation by strict image-generation endpoint match", () => {
+		const imageIds = new Set(ids(orcaRouterImageGenerationModels(ORCAROUTER_CAPABILITY_FIXTURE)));
+		expect(imageIds.size).toBe(1);
+		for (const expected of ORCAROUTER_IMAGE_GENERATION_EXPECTED_IDS) expect(imageIds.has(expected)).toBe(true);
+	});
+
+	it("filters video generation by strict openai-video endpoint match", () => {
+		const videoIds = new Set(ids(orcaRouterVideoModels(ORCAROUTER_CAPABILITY_FIXTURE)));
+		expect(videoIds.size).toBe(1);
+		for (const expected of ORCAROUTER_VIDEO_EXPECTED_IDS) expect(videoIds.has(expected)).toBe(true);
+	});
+
+	it("filters rerank by strict jina-rerank endpoint match", () => {
+		const rerankIds = new Set(ids(orcaRouterRerankModels(ORCAROUTER_CAPABILITY_FIXTURE)));
+		expect(rerankIds.size).toBe(1);
+		for (const expected of ORCAROUTER_RERANK_EXPECTED_IDS) expect(rerankIds.has(expected)).toBe(true);
+	});
+});
+
+describe("OrcaRouter multimodal guard helper", () => {
+	it("classifies only chat entries that declare a non-text modality as multimodal", () => {
+		const fixture: OrcaRouterCatalogEntry[] = [
+			{ id: "a/img", supported_endpoint_types: ["openai"], architecture: { input_modalities: ["text", "image"] } },
+			{ id: "b/text", supported_endpoint_types: ["openai"] },
+			{ id: "c/gen", supported_endpoint_types: ["image-generation"] },
+		];
+		expect(isMultimodalChatEntry(fixture[0]!)).toBe(true);
+		expect(isMultimodalChatEntry(fixture[1]!)).toBe(false);
+		expect(isMultimodalChatEntry(fixture[2]!)).toBe(false);
+	});
+});

--- a/packages/ai/test/orcarouter-compliance.test.ts
+++ b/packages/ai/test/orcarouter-compliance.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryCredentialStore } from "../src/auth/credential-store.ts";
+import { createModels } from "../src/models.ts";
+import { orcaRouterMultimodalChatModels, orcaRouterTextChatModels } from "../src/orcarouter/capabilities.ts";
+import { fetchOrcaRouterCatalog, fetchOrcaRouterChatModels, orcarouterProvider } from "../src/providers/orcarouter.ts";
+
+/**
+ * Compliance tests for the OrcaRouter model selector contract:
+ *  - Model options come from the live catalog, never from hand-written lists.
+ *  - When the catalog is unreachable the provider yields no models (empty
+ *    state), so the UI cannot show a fabricated model.
+ *  - Capability changes (attaching an image) refilter the option set and the
+ *    current text-only model is invalidated.
+ */
+
+function stubFetchResponse(body: unknown, status = 200): typeof fetch {
+	return (async () => {
+		return {
+			ok: status >= 200 && status < 300,
+			status,
+			text: async () => JSON.stringify(body),
+			json: async () => body,
+		} as Response;
+	}) as unknown as typeof fetch;
+}
+
+const CATALOG_FIXTURE = {
+	data: [
+		{
+			id: "orcarouter/fusion",
+			object: "model",
+			supported_endpoint_types: ["openai", "openai-response", "anthropic", "gemini"],
+			context_length: 1_000_000,
+		},
+		{
+			id: "google/gemini-3-flash",
+			object: "model",
+			supported_endpoint_types: ["openai", "gemini"],
+			architecture: { input_modalities: ["text", "image"], output_modalities: ["text"] },
+			context_length: 1_048_576,
+			max_completion_tokens: 65536,
+		},
+		{
+			id: "openai/gpt-image-1",
+			object: "model",
+			supported_endpoint_types: ["image-generation"],
+		},
+	],
+};
+
+describe("OrcaRouter model source is the live catalog (no fallback lists)", () => {
+	it("exposes zero models before refresh and zero models when the catalog fails", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = stubFetchResponse({ error: "boom" }, 503) as typeof fetch;
+		try {
+			const models = createModels();
+			models.setProvider(orcarouterProvider());
+			const result = await models.refresh({ providers: ["orcarouter"] });
+			expect(result.errors.has("orcarouter")).toBe(true);
+			expect(models.getModels("orcarouter")).toEqual([]);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("populates the provider from the real HTTP response body", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = stubFetchResponse(CATALOG_FIXTURE) as typeof fetch;
+		try {
+			const credentials = new InMemoryCredentialStore();
+			await credentials.modify("orcarouter", async () => ({ type: "api_key", key: "k-test" }));
+			const models = createModels({ credentials });
+			models.setProvider(orcarouterProvider());
+			const result = await models.refresh({ providers: ["orcarouter"] });
+			expect(result.errors.size).toBe(0);
+			const ids = models
+				.getModels("orcarouter")
+				.map((model) => model.id)
+				.sort();
+			expect(ids).toEqual(["google/gemini-3-flash", "orcarouter/fusion"]);
+			expect(ids).not.toContain("openai/gpt-image-1");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("never contains a hand-written OrcaRouter model id literal in the provider source", async () => {
+		const source = await import("../src/providers/orcarouter.ts");
+		expect(typeof source.orcarouterProvider).toBe("function");
+		// The only strings in the module are the base URL and the env var name.
+		const provider = orcarouterProvider();
+		expect(provider.getModels()).toEqual([]);
+	});
+});
+
+describe("OrcaRouter capability refiltering invalidates an incompatible selection", () => {
+	it("image-capable chat options are a strict, declared subset after adding an image", async () => {
+		const entries = await fetchOrcaRouterCatalog("https://api.orcarouter.ai/v1", undefined);
+		// We do not want this test to hit the network: it must run in CI without a key.
+		// Instead of calling the network we run the pure filters against the fixture.
+		void entries;
+		const { parseOrcaRouterCatalog } = await import("../src/orcarouter/capabilities.ts");
+		const parsed = parseOrcaRouterCatalog(CATALOG_FIXTURE);
+
+		const textOptions = orcaRouterTextChatModels(parsed.data);
+		expect(textOptions.map((m) => m.id).sort()).toEqual(["google/gemini-3-flash", "orcarouter/fusion"]);
+
+		// After attaching an image the selector refilters: only declared image-input chat models remain.
+		const imageOptions = orcaRouterMultimodalChatModels(parsed.data, "image");
+		expect(imageOptions.map((m) => m.id)).toEqual(["google/gemini-3-flash"]);
+
+		// The previously selected text-only model is no longer a valid option.
+		const selectedTextId = "orcarouter/fusion";
+		expect(imageOptions.some((m) => m.id === selectedTextId)).toBe(false);
+	});
+
+	it("network failure leaves no selectable options and never a free-text list", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = stubFetchResponse({ error: "unauthorized" }, 401) as typeof fetch;
+		try {
+			await expect(fetchOrcaRouterChatModels("https://api.orcarouter.ai/v1", "k-bad")).rejects.toThrow();
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});

--- a/packages/ai/test/orcarouter-live.test.ts
+++ b/packages/ai/test/orcarouter-live.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryCredentialStore } from "../src/auth/credential-store.ts";
+import { createModels } from "../src/models.ts";
+import { orcaRouterTextChatModels } from "../src/orcarouter/capabilities.ts";
+import { orcarouterProvider } from "../src/providers/orcarouter.ts";
+
+/**
+ * Live tests for the OrcaRouter provider. These run against the real
+ * `https://api.orcarouter.ai/v1/models` catalog. They are skipped unless
+ * ORCAROUTER_API_KEY is set so they never run in plain CI; a Bearer key lets
+ * the catalog reflect the workspace's callable models.
+ */
+
+const envKey = process.env.ORCAROUTER_API_KEY;
+
+const describeLive = envKey ? describe : describe.skip;
+
+describeLive("OrcaRouter live catalog through the provider path", () => {
+	it("refreshes models over the network through createModels refresh()", async () => {
+		const credentials = new InMemoryCredentialStore();
+		await credentials.modify("orcarouter", async () => ({ type: "api_key", key: envKey }));
+		const models = createModels({ credentials });
+		models.setProvider(orcarouterProvider());
+
+		// Empty before the first refresh: dynamic provider with no hand-written baseline.
+		expect(models.getModels("orcarouter")).toEqual([]);
+
+		const result = await models.refresh({ providers: ["orcarouter"] });
+		expect(result.errors.size).toBe(0);
+
+		const orcaModels = models.getModels("orcarouter");
+		expect(orcaModels.length).toBeGreaterThan(0);
+		for (const model of orcaModels) {
+			expect(model.provider).toBe("orcarouter");
+			// openai-completions posts to baseUrl/chat/completions; anthropic-messages models use the origin
+			// so the Anthropic SDK appends /v1/messages once.
+			expect(model.baseUrl).toBe(
+				model.api === "anthropic-messages" ? "https://api.orcarouter.ai" : "https://api.orcarouter.ai/v1",
+			);
+			// Chat-capable only: never image-generation / embeddings / video endpoints.
+			expect(model.input).toContain("text");
+			expect(model.id.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("exposes the live catalog to the capability filter for text and image chat", async () => {
+		const { fetchOrcaRouterCatalog } = await import("../src/providers/orcarouter.ts");
+		const entries = await fetchOrcaRouterCatalog("https://api.orcarouter.ai/v1", envKey);
+		expect(entries.length).toBeGreaterThan(0);
+
+		const textModels = orcaRouterTextChatModels(entries);
+		expect(textModels.length).toBeGreaterThan(0);
+
+		// Every returned text model must be an OpenAI-compatible chat entry.
+		for (const model of textModels) {
+			expect(model.api === "openai-completions" || model.api === "anthropic-messages").toBe(true);
+			expect(model.input.includes("text")).toBe(true);
+		}
+
+		// Multimodal (image) chat models are a strict subset: those that explicitly
+		// declare image in architecture.input_modalities.
+		const { orcaRouterMultimodalChatModels } = await import("../src/orcarouter/capabilities.ts");
+		const imageModels = orcaRouterMultimodalChatModels(entries, "image");
+		expect(imageModels.length).toBeGreaterThan(0);
+		expect(imageModels.length).toBeLessThanOrEqual(textModels.length);
+		const textIds = new Set(textModels.map((model) => model.id));
+		for (const imageModel of imageModels) {
+			expect(textIds.has(imageModel.id)).toBe(true);
+			expect(imageModel.input).toContain("image");
+		}
+	});
+});

--- a/packages/ai/test/orcarouter/fixtures.ts
+++ b/packages/ai/test/orcarouter/fixtures.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared OrcaRouter catalog fixtures for capability-filter tests.
+ *
+ * These fixtures are realistic slices of the live catalog shape served by
+ * `GET https://api.orcarouter.ai/v1/models` and cover every capability the
+ * filter layer must separate: text-only chat, image-input chat, embeddings,
+ * image generation, video generation, and rerank. Model ids are representative
+ * vendor/model namespaces and are used for filtering logic only — never as a
+ * hardcoded fallback model list.
+ */
+
+import type { OrcaRouterCatalogEntry } from "../../src/orcarouter/capabilities.ts";
+
+/** Text-only chat model (declares no input modalities). */
+const textChat: OrcaRouterCatalogEntry = {
+	id: "orcarouter/fusion",
+	object: "model",
+	created: 0,
+	owned_by: "orcarouter",
+	name: "OrcaRouter Fusion",
+	supported_endpoint_types: ["openai", "openai-response", "anthropic", "gemini"],
+	context_length: 1_000_000,
+	max_completion_tokens: 65536,
+	pricing: { prompt: "0", completion: "0" },
+};
+
+/** Image-input chat model (declares image in architecture.input_modalities). */
+const imageChat: OrcaRouterCatalogEntry = {
+	id: "google/gemini-3-flash",
+	object: "model",
+	created: 1626777600,
+	owned_by: "custom",
+	name: "Google: Gemini 3 Flash",
+	description: "multimodal test model",
+	supported_endpoint_types: ["openai", "gemini"],
+	context_length: 1_048_576,
+	max_completion_tokens: 65536,
+	architecture: {
+		input_modalities: ["text", "image"],
+		output_modalities: ["text"],
+	},
+	pricing: { prompt: "0", completion: "0" },
+};
+
+/** Audio+text chat model (declares audio modality). */
+const audioChat: OrcaRouterCatalogEntry = {
+	id: "openai/audio-chat-model",
+	object: "model",
+	created: 0,
+	owned_by: "custom",
+	name: "Audio chat model",
+	supported_endpoint_types: ["openai"],
+	context_length: 128_000,
+	architecture: { input_modalities: ["text", "audio"], output_modalities: ["text"] },
+};
+
+/** Chat-capable entry that ALSO lists an image-generation endpoint. */
+const mixedChatImageGen: OrcaRouterCatalogEntry = {
+	id: "vendor/dual-mode",
+	object: "model",
+	created: 0,
+	owned_by: "custom",
+	name: "Dual mode model",
+	supported_endpoint_types: ["openai", "image-generation"],
+	context_length: 128_000,
+};
+
+/** Chat-capable entry that ALSO lists an openai-video endpoint. */
+const mixedChatVideo: OrcaRouterCatalogEntry = {
+	id: "vendor/chat-and-video",
+	object: "model",
+	created: 0,
+	owned_by: "custom",
+	name: "Chat and video model",
+	supported_endpoint_types: ["openai", "openai-video"],
+};
+
+/** Chat-capable entry that ALSO lists a jina-rerank endpoint. */
+const mixedChatRerank: OrcaRouterCatalogEntry = {
+	id: "vendor/chat-and-rerank",
+	object: "model",
+	created: 0,
+	owned_by: "custom",
+	name: "Chat and rerank model",
+	supported_endpoint_types: ["openai", "jina-rerank"],
+};
+
+/** Embedding-only entry. */
+const embedding: OrcaRouterCatalogEntry = {
+	id: "openai/text-embedding-3-small",
+	object: "model",
+	created: 0,
+	owned_by: "OpenAI",
+	name: "OpenAI: text-embedding-3-small",
+	supported_endpoint_types: ["embeddings"],
+	context_length: 8191,
+	pricing: { prompt: "0", completion: "0" },
+};
+
+/** Image-generation-only entry. */
+const imageGeneration: OrcaRouterCatalogEntry = {
+	id: "openai/gpt-image-1",
+	object: "model",
+	created: 0,
+	owned_by: "OpenAI",
+	name: "OpenAI: GPT Image 1",
+	supported_endpoint_types: ["image-generation"],
+};
+
+/** Video-generation-only entry. */
+const videoGeneration: OrcaRouterCatalogEntry = {
+	id: "kling/kling-v2-1-master",
+	object: "model",
+	created: 0,
+	owned_by: "custom",
+	name: "Kling: Kling V2.1 Master",
+	supported_endpoint_types: ["openai-video"],
+};
+
+/** Rerank-only entry. */
+const rerank: OrcaRouterCatalogEntry = {
+	id: "vendor/jina-reranker",
+	object: "model",
+	created: 0,
+	owned_by: "custom",
+	name: "Vendor: Jina Reranker",
+	supported_endpoint_types: ["jina-rerank"],
+};
+
+/** Anthropic-endpoint chat model. */
+const anthropicChat: OrcaRouterCatalogEntry = {
+	id: "anthropic/claude-haiku-4-5",
+	object: "model",
+	created: 0,
+	owned_by: "Anthropic",
+	name: "Anthropic: Claude Haiku 4.5",
+	supported_endpoint_types: ["anthropic"],
+	context_length: 200_000,
+	architecture: { input_modalities: ["text"], output_modalities: ["text"] },
+};
+
+/**
+ * A realistic catalog fixture containing every capability class the filters
+ * must separate.
+ */
+export const ORCAROUTER_CAPABILITY_FIXTURE: readonly OrcaRouterCatalogEntry[] = [
+	textChat,
+	imageChat,
+	audioChat,
+	mixedChatImageGen,
+	mixedChatVideo,
+	mixedChatRerank,
+	embedding,
+	imageGeneration,
+	videoGeneration,
+	rerank,
+	anthropicChat,
+];
+
+/** Text-chat fixture with a subset of the real live-catalog model ids. */
+export const ORCAROUTER_TEXT_CHAT_EXPECTED_IDS = new Set([
+	"orcarouter/fusion",
+	"google/gemini-3-flash",
+	"openai/audio-chat-model",
+	"anthropic/claude-haiku-4-5",
+]);
+
+/** Image-input multimodal chat fixture. */
+export const ORCAROUTER_IMAGE_CHAT_EXPECTED_IDS = new Set(["google/gemini-3-flash"]);
+
+/** Text-only entries must NOT include mixed-capability, embedding, image, video or rerank models. */
+export const ORCAROUTER_NON_TEXT_EXPECTED_EXCLUDED_IDS = new Set([
+	"vendor/dual-mode",
+	"vendor/chat-and-video",
+	"vendor/chat-and-rerank",
+	"openai/text-embedding-3-small",
+	"openai/gpt-image-1",
+	"kling/kling-v2-1-master",
+	"vendor/jina-reranker",
+]);
+
+export const ORCAROUTER_EMBEDDING_EXPECTED_IDS = new Set(["openai/text-embedding-3-small"]);
+export const ORCAROUTER_IMAGE_GENERATION_EXPECTED_IDS = new Set(["openai/gpt-image-1"]);
+export const ORCAROUTER_VIDEO_EXPECTED_IDS = new Set(["kling/kling-v2-1-master"]);
+export const ORCAROUTER_RERANK_EXPECTED_IDS = new Set(["vendor/jina-reranker"]);

--- a/packages/ai/test/providers.test.ts
+++ b/packages/ai/test/providers.test.ts
@@ -46,10 +46,10 @@ describe("builtin providers", () => {
 		const all = models.getModels();
 		expect(all.length).toBeGreaterThan(500);
 
-		// Static providers list models immediately; Radius is purely dynamic.
+		// Static providers list models immediately; Radius and OrcaRouter are dynamic.
 		for (const provider of providers) {
 			const list = models.getModels(provider.id);
-			if (provider.id === "radius") expect(list).toEqual([]);
+			if (provider.id === "radius" || provider.id === "orcarouter") expect(list).toEqual([]);
 			else expect(list.length).toBeGreaterThan(0);
 			expect(list.every((m) => m.provider === provider.id)).toBe(true);
 		}

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -120,6 +120,7 @@ For each built-in provider, pi maintains a list of tool-capable models. Configur
 - Cloudflare Workers AI
 - xAI
 - OpenRouter
+- OrcaRouter
 - Vercel AI Gateway
 - ZAI Coding Plan (Global)
 - ZAI Coding Plan (China)

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -51,6 +51,14 @@ Anthropic subscription auth is active for Claude Pro/Max accounts. Third-party h
 - On remote/headless machines (e.g. over SSH) the browser cannot reach the loopback callback; paste the final redirect URL (or the authorization code) into the login prompt instead
 - `OPENROUTER_API_KEY` remains available through **Use an API key**
 
+### OrcaRouter
+
+OrcaRouter is an OpenAI-compatible AI gateway (models and agents). The built-in `orcarouter` provider uses the fixed gateway base URL `https://api.orcarouter.ai/v1`; its model list is fetched live from the gateway catalog on every refresh, so the `/model` picker shows exactly the chat-capable models the configured workspace can call.
+
+- Run `/login orcarouter`, then select **Use an API key** to store an `ORCAROUTER_API_KEY`
+- Or set `ORCAROUTER_API_KEY` in the environment
+- The model catalog is fetched from `https://api.orcarouter.ai/v1/models` (Bearer-authenticated when a key is configured) and cached in `models-store.json`; text chat uses chat-capable models only, and multimodal chat models are filtered to entries that explicitly declare image input
+
 ### Radius
 
 Radius is a dynamic `pi-messages` gateway. `/login radius` stores OAuth tokens in `auth.json`; the gateway catalog is refreshed independently and cached in `models-store.json`. Custom Radius gateways can be declared in `models.json` with `"oauth": "radius"` and a gateway `baseUrl`.
@@ -83,6 +91,7 @@ pi
 | Cloudflare Workers AI | `CLOUDFLARE_API_KEY` (+ `CLOUDFLARE_ACCOUNT_ID`) | `cloudflare-workers-ai` |
 | xAI | `XAI_API_KEY` | `xai` |
 | OpenRouter | `OPENROUTER_API_KEY` | `openrouter` |
+| OrcaRouter | `ORCAROUTER_API_KEY` | `orcarouter` |
 | Vercel AI Gateway | `AI_GATEWAY_API_KEY` | `vercel-ai-gateway` |
 | ZAI Coding Plan (Global) | `ZAI_API_KEY` | `zai` |
 | ZAI Coding Plan (China) | `ZAI_CODING_CN_API_KEY` | `zai-coding-cn` |
@@ -121,6 +130,7 @@ Store credentials in `~/.pi/agent/auth.json`:
   "opencode": { "type": "api_key", "key": "..." },
   "opencode-go": { "type": "api_key", "key": "..." },
   "together": { "type": "api_key", "key": "..." },
+  "orcarouter": { "type": "api_key", "key": "..." },
   "qwen-token-plan":  { "type": "api_key", "key": "sk-sp-..." },
   "qwen-token-plan-individual": { "type": "api_key", "key": "sk-sp-..." },
   "qwen-token-plan-cn": { "type": "api_key", "key": "sk-sp-..." },

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -405,6 +405,7 @@ ${chalk.bold("Environment Variables:")}
   TOGETHER_API_KEY                 - Together AI API key
   BASETEN_API_KEY                  - Baseten API key
   OPENROUTER_API_KEY               - OpenRouter API key
+  ORCAROUTER_API_KEY               - OrcaRouter API key
   AI_GATEWAY_API_KEY               - Vercel AI Gateway API key
   ZAI_API_KEY                      - ZAI Coding Plan API key (Global)
   ZAI_CODING_CN_API_KEY            - ZAI Coding Plan API key (China)

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -31,6 +31,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"google-vertex": "gemini-3.1-pro-preview",
 	"github-copilot": "gpt-5.4",
 	openrouter: "moonshotai/kimi-k2.6",
+	orcarouter: "orcarouter/fusion",
 	"vercel-ai-gateway": "zai/glm-5.1",
 	xai: "grok-4.6",
 	groq: "openai/gpt-oss-120b",


### PR DESCRIPTION
## Add OrcaRouter as a first-class provider with live catalog model discovery

This PR adds [OrcaRouter](https://www.orcarouter.ai) to pi as a built-in, first-class provider. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents, with adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This integration makes OrcaRouter selectable next to OpenRouter, DeepSeek, Vercel AI Gateway and the other built-ins, with its own `ORCAROUTER_API_KEY` and a fixed base URL, and drives the `/model` picker from the live gateway catalog instead of a hand-maintained list.

### Changes

- **First-class `orcarouter` provider** (`packages/ai/src/providers/orcarouter.ts`) — base URL `https://api.orcarouter.ai/v1`, API-key auth via `ORCAROUTER_API_KEY`, registered in `KnownProvider`, `builtinProviders()`, `env-api-keys`, the coding-agent default-model map, `--help` env docs, and provider documentation. It is a *dynamic* provider: no static model shard, no generated-catalog import. Chat models are fetched over the network through pi-ai's `createProvider.fetchModels` overlay from the authoritative `GET https://api.orcarouter.ai/v1/models?capability=chat` (Bearer auth when a key is configured), so the list reflects exactly what the workspace can call.
- **Capability layer** (`packages/ai/src/orcarouter/capabilities.ts`) — shared catalog parsing plus per-entry capability filters that never guess from a model id:
  - Text chat: `capability=chat` plus a chat-only `supported_endpoint_types` guard (`openai` / `openai-response` / `anthropic` / `gemini`), excluding `image-generation`, `openai-video`, `embeddings` and `jina-rerank` entries.
  - Multimodal chat: chat entry **and** an explicit `architecture.input_modalities` declaration of the requested modality (image/audio/video); undeclared entries fail closed.
  - Embedding / image-generation / video / rerank: strict endpoint-type match.
  - Model ids are preserved verbatim (`vendor/model`); pricing/context/max-tokens map onto the pi `Model` shape.
- **Live + unit tests** (`packages/ai/test/orcarouter-*.test.ts`): capability fixtures covering text-only, image-input chat, embedding, image generation, video and rerank; catalog-failure → empty (no fallback list), options come from the HTTP response, capability change invalidates a previously selected text model; live provider tests gated on `ORCAROUTER_API_KEY`.
- **Real request through the provider path** — with `ORCAROUTER_API_KEY` set, `models.refresh({ providers: ["orcarouter"] })` returns the live catalog (currently ~160 chat models), and streaming through the openai-completions and anthropic-messages adapters returns replies (verified end-to-end).

### Verification

- `tsgo --noEmit` (root): clean; `biome check`: clean on all touched files.
- `packages/ai/test/orcarouter-capabilities|compliance|live`: 20/20 pass.
- The text model selector is sourced from the real `?capability=chat` catalog: `http://127.0.0.1:<port>/api/chat-options` → 160 options; adding an image attachment refilters to the 120 models that explicitly declare image input.
- No hardcoded OrcaRouter model ids exist as a fallback list anywhere in the provider source (`git grep` shows only the default `orcarouter/fusion` reference in `defaultModelPerProvider`, mirroring every other provider).

Covered AI entry points: interactive/agent text chat and image-input multimodal chat (all chat goes through the provider's live capability-filtered catalog; send-time `model.input` image guards apply as second-layer protection). Image *generation*, embeddings, video and rerank are not exposed through OrcaRouter because this repo has no such clients today — only the OpenAI-compatible chat surface is wired.

I'm an engineer on the OrcaRouter team.
