### PR TITLE
feat(coding-agent): use Cmd+V for clipboard image paste on macOS

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `super+v` (Cmd+V) for clipboard image paste on macOS; `ctrl+v` keeps working as a fallback for terminals without Super-key reporting.
+
 ## [0.85.0] - 2026-09-04
 
 ### New Features

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -127,7 +127,7 @@ This routing remains configurable through the ordinary action bindings. For exam
 | `app.exit` | `ctrl+d` | Exit (when editor empty) |
 | `app.suspend` | `ctrl+z` (none on Windows) | Suspend to background |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`externalEditor`, `$VISUAL`, `$EDITOR`, Notepad on Windows, or `nano` elsewhere) |
-| `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows and WSL) | Paste image or text from clipboard |
+| `app.clipboard.pasteImage` | `ctrl+v` (plus `super+v` on macOS; `alt+v` on Windows and WSL) | Paste image or text from clipboard |
 
 ### Sessions
 

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -135,7 +135,7 @@ export const KEYBINDINGS = {
 		description: "Restore queued messages",
 	},
 	"app.clipboard.pasteImage": {
-		defaultKeys: windowsKeybindings ? "alt+v" : "ctrl+v",
+		defaultKeys: process.platform === "darwin" ? ["super+v", "ctrl+v"] : windowsKeybindings ? "alt+v" : "ctrl+v",
 		description: "Paste image from clipboard (text fallback)",
 	},
 	"app.session.new": { defaultKeys: [], description: "Start a new session" },

--- a/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
+++ b/packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts
@@ -10,7 +10,13 @@ export interface KeyTextFormatOptions {
 }
 
 function formatKeyPart(part: string, options: KeyTextFormatOptions): string {
-	const displayPart = process.platform === "darwin" && part.toLowerCase() === "alt" ? "option" : part;
+	const lower = part.toLowerCase();
+	const displayPart =
+		process.platform === "darwin" && lower === "alt"
+			? "option"
+			: process.platform === "darwin" && lower === "super"
+				? "cmd"
+				: part;
 	return options.capitalize ? displayPart.charAt(0).toUpperCase() + displayPart.slice(1) : displayPart;
 }
 

--- a/packages/coding-agent/test/keybindings.test.ts
+++ b/packages/coding-agent/test/keybindings.test.ts
@@ -24,7 +24,9 @@ describe("Windows keybinding defaults", () => {
 		const windowsKeybindings = useWindowsKeybindings();
 		const nativeWindows = process.platform === "win32";
 
-		expect(KEYBINDINGS["app.clipboard.pasteImage"].defaultKeys).toBe(windowsKeybindings ? "alt+v" : "ctrl+v");
+		expect(KEYBINDINGS["app.clipboard.pasteImage"].defaultKeys).toEqual(
+			process.platform === "darwin" ? ["super+v", "ctrl+v"] : windowsKeybindings ? "alt+v" : "ctrl+v",
+		);
 		expect(KEYBINDINGS["tui.altScreen.search"].defaultKeys).toBe(windowsKeybindings ? "ctrl+f" : "ctrl+shift+f");
 		expect(KEYBINDINGS["app.message.followUp"].defaultKeys).toBe(windowsKeybindings ? "ctrl+q" : "alt+enter");
 		expect(KEYBINDINGS["app.model.cycleBackward"].defaultKeys).toBe(windowsKeybindings ? "alt+p" : "shift+ctrl+p");


### PR DESCRIPTION
## Problem

On macOS, clipboard image paste only worked with `Ctrl+V`, against platform convention. `Cmd+V` (Super) never triggered `app.clipboard.pasteImage`.

## Solution

Bind `app.clipboard.pasteImage` to `super+v` on darwin, keeping `ctrl+v` as a fallback for terminals that don't forward the Super modifier (e.g. Terminal.app, tmux without extended-keys). Render `super` as `Cmd` in macOS keybinding hints, matching the existing `alt` to `Option` mapping.

Cmd+V requires a terminal that forwards Super via the Kitty keyboard protocol (Ghostty, Kitty, WezTerm, recent iTerm2). Elsewhere, `Ctrl+V` behavior is unchanged.

## Changes

- `packages/coding-agent/src/core/keybindings.ts`: darwin default `["super+v", "ctrl+v"]`
- `packages/coding-agent/src/modes/interactive/components/keybinding-hints.ts`: display `super` as `Cmd` on macOS
- `packages/coding-agent/test/keybindings.test.ts`: updated expectation
- `packages/coding-agent/docs/keybindings.md`, `packages/coding-agent/CHANGELOG.md`: docs and changelog entry

## Verification

- `npm run check`: green (biome, tsgo, lockfile/entry-graph checks)
- `./test.sh`: full suite green (2091 passed; 11 `find`-tool failures during the run were a missing `fd` binary in the sandbox, resolved separately — re-ran green, 87/87)
- `test/keybindings.test.ts`: 5/5 pass
- Exercised the real key parser: Kitty `super+v` parses/matches, yields no printable character, legacy `ctrl+v` unchanged
