### PR TITLE
fix(coding-agent): preserve model selector selection after refresh

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -205,8 +205,24 @@ export class ModelSelectorComponent extends Container implements Focusable {
 					this.refreshStatusSuccess = true;
 				}
 			}
+			const highlightedModel = this.filteredModels[this.selectedIndex]?.model;
 			this.loadModelsFromSnapshot();
 			this.filterModels(this.searchInput.getValue());
+			const restoredIndex = highlightedModel
+				? this.filteredModels.findIndex((item) => modelsAreEqual(highlightedModel, item.model))
+				: -1;
+			if (restoredIndex >= 0) {
+				this.selectedIndex = restoredIndex;
+				this.updateList();
+			} else {
+				const fallbackIndex = this.filteredModels.findIndex((item) =>
+					modelsAreEqual(this.currentModel, item.model),
+				);
+				if (fallbackIndex >= 0) {
+					this.selectedIndex = fallbackIndex;
+					this.updateList();
+				}
+			}
 			this.tui.requestRender();
 		} catch (error) {
 			if (this.closed) return;

--- a/packages/coding-agent/test/model-selector.test.ts
+++ b/packages/coding-agent/test/model-selector.test.ts
@@ -1,3 +1,4 @@
+import type { ModelsRefreshResult } from "@earendil-works/pi-ai";
 import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
@@ -8,6 +9,14 @@ import { createHarness, type Harness } from "./suite/harness.ts";
 
 function createFakeTui(): TUI {
 	return { requestRender: () => {} } as unknown as TUI;
+}
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolvePromise!: (value: T) => void;
+	const promise = new Promise<T>((resolve) => {
+		resolvePromise = resolve;
+	});
+	return { promise, resolve: resolvePromise };
 }
 
 describe("model selector", () => {
@@ -102,5 +111,111 @@ describe("model selector", () => {
 			const rendered = stripAnsi(selector.render(120).join("\n"));
 			expect(rendered).toContain("Could not refresh 2 model catalogs (openai, anthropic); showing cached models.");
 		});
+	});
+
+	// #9109: Preserve model selector selection after background refresh
+	it("preserves the user's highlighted selection after background refresh completes", async () => {
+		harness = await createHarness({
+			models: [
+				{ id: "current-model", name: "Current Model", reasoning: true },
+				{ id: "browsed-model", name: "Browsed Model", reasoning: true },
+				{ id: "third-model", name: "Third Model", reasoning: true },
+			],
+		});
+		const deferred = createDeferred<ModelsRefreshResult>();
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(() => deferred.promise);
+
+		const currentModel = harness.getModel("current-model")!;
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			currentModel,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+
+		const getSelectedId = (): string | undefined => {
+			const line = stripAnsi(selector.render(120).join("\n"))
+				.split("\n")
+				.find((l) => l.startsWith("→ "));
+			return line
+				?.replace(/^→\s*(?:✓\s*)?/, "")
+				.split(" [")[0]
+				?.trim();
+		};
+
+		expect(getSelectedId()).toBe("current-model");
+
+		// User navigates down while refresh is in flight
+		selector.handleInput("\x1b[B");
+		expect(getSelectedId()).toBe("browsed-model");
+
+		// Refresh completes
+		deferred.resolve({ aborted: false, errors: new Map() });
+
+		await vi.waitFor(() => {
+			const rendered = stripAnsi(selector.render(120).join("\n"));
+			expect(rendered).toContain("Model catalogs refreshed.");
+		});
+
+		// Selection must remain on browsed-model, not reset to current-model
+		expect(getSelectedId()).toBe("browsed-model");
+		selector.dispose();
+	});
+
+	// #9109: Preserve filtered selection after background refresh
+	it("preserves filtered selection after background refresh completes", async () => {
+		harness = await createHarness({
+			models: [
+				{ id: "alpha-1", name: "Alpha One", reasoning: true },
+				{ id: "alpha-2", name: "Alpha Two", reasoning: true },
+				{ id: "beta-1", name: "Beta One", reasoning: true },
+			],
+		});
+		const deferred = createDeferred<ModelsRefreshResult>();
+		vi.spyOn(harness.session.modelRuntime, "refresh").mockImplementation(() => deferred.promise);
+
+		const currentModel = harness.getModel("alpha-1")!;
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			currentModel,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+		);
+
+		const getSelectedId = (): string | undefined => {
+			const line = stripAnsi(selector.render(120).join("\n"))
+				.split("\n")
+				.find((l) => l.startsWith("→ "));
+			return line
+				?.replace(/^→\s*(?:✓\s*)?/, "")
+				.split(" [")[0]
+				?.trim();
+		};
+
+		// User types a query to filter
+		for (const char of "alpha") {
+			selector.handleInput(char);
+		}
+		expect(getSelectedId()).toBe("alpha-1");
+
+		// Move to second matching model
+		selector.handleInput("\x1b[B");
+		expect(getSelectedId()).toBe("alpha-2");
+
+		// Refresh completes
+		deferred.resolve({ aborted: false, errors: new Map() });
+
+		await vi.waitFor(() => {
+			const rendered = stripAnsi(selector.render(120).join("\n"));
+			expect(rendered).toContain("Model catalogs refreshed.");
+		});
+
+		// Selection must remain on alpha-2
+		expect(getSelectedId()).toBe("alpha-2");
+		selector.dispose();
 	});
 });


### PR DESCRIPTION
## Summary

When opening `/model` (or `Ctrl+L`), the model selector immediately renders cached models while `refreshModelCatalogs` runs in the background.

If the user browses or moves the selection cursor while the catalog refresh is in flight, the completion handler in `ModelSelectorComponent.refreshModels()` reloads the snapshot and recalculates `selectedIndex` against `this.currentModel`. This resets the highlight back to the active session model instead of preserving the user's cursor position.

This change snapshots the currently highlighted model before reloading and restores `selectedIndex` to that model in the refreshed `filteredModels` list, falling back to `currentModel` only if the highlighted model was removed from the catalog.

closes #9109

## Changes

- `packages/coding-agent/src/modes/interactive/components/model-selector.ts`:
  - In `refreshModels()`, capture `this.filteredModels[this.selectedIndex]?.model` before reloading from snapshot.
  - After re-applying search filters, restore `selectedIndex` to the highlighted model's index in `filteredModels`.
  - Fall back to `this.currentModel` if the highlighted model was removed, or clamp within bounds.
  - Leave `filterModels` untouched so typing in the search box still resets to row 0 as intended.
- `packages/coding-agent/test/model-selector.test.ts`:
  - Added regression test verifying cursor position is preserved when background refresh resolves while browsing.
  - Added regression test verifying cursor position is preserved when background refresh resolves with an active search filter.

## Test plan

- [x] `npm run check` passes with zero errors
- [x] `vitest test/model-selector.test.ts` passes (5/5)
- [x] `vitest test/suite/regressions/7209-model-selector-filter-resets-selection.test.ts` passes (2/2)
- [x] Manual headless interactive test in `tmux`: opened model selector with `Ctrl+L`, moved down while `Refreshing model catalogs…` was displayed, verified cursor stayed on the browsed model when `Model catalogs refreshed.` completed.
