### PR TITLE
fix(coding-agent): declare pi-server runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5426,6 +5426,7 @@
 				"@earendil-works/pi-ai": "^0.85.0",
 				"@earendil-works/pi-client": "^0.85.0",
 				"@earendil-works/pi-protocol": "^0.85.0",
+				"@earendil-works/pi-server": "^0.85.0",
 				"@earendil-works/pi-tui": "^0.85.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",

--- a/packages/coding-agent/install-lock/package-lock.json
+++ b/packages/coding-agent/install-lock/package-lock.json
@@ -523,6 +523,7 @@
 				"@earendil-works/pi-ai": "^0.85.0",
 				"@earendil-works/pi-client": "^0.85.0",
 				"@earendil-works/pi-protocol": "^0.85.0",
+				"@earendil-works/pi-server": "^0.85.0",
 				"@earendil-works/pi-tui": "^0.85.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
@@ -557,6 +558,19 @@
 			"dependencies": {
 				"@earendil-works/chord": "^0.85.0",
 				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-server": {
+			"version": "0.85.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-server/-/pi-server-0.85.0.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/chord": "^0.85.0",
+				"@earendil-works/pi-agent-core": "^0.85.0",
+				"@earendil-works/pi-protocol": "^0.85.0"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -14,6 +14,7 @@
 				"@earendil-works/pi-ai": "^0.85.0",
 				"@earendil-works/pi-client": "^0.85.0",
 				"@earendil-works/pi-protocol": "^0.85.0",
+				"@earendil-works/pi-server": "^0.85.0",
 				"@earendil-works/pi-tui": "^0.85.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
@@ -547,6 +548,19 @@
 			"dependencies": {
 				"@earendil-works/chord": "^0.85.0",
 				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-server": {
+			"version": "0.85.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-server/-/pi-server-0.85.0.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/chord": "^0.85.0",
+				"@earendil-works/pi-agent-core": "^0.85.0",
+				"@earendil-works/pi-protocol": "^0.85.0"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -54,6 +54,7 @@
 		"@earendil-works/pi-ai": "^0.85.0",
 		"@earendil-works/pi-client": "^0.85.0",
 		"@earendil-works/pi-protocol": "^0.85.0",
+		"@earendil-works/pi-server": "^0.85.0",
 		"@earendil-works/pi-tui": "^0.85.0",
 		"@silvia-odwyer/photon-node": "0.3.4",
 		"chalk": "5.6.2",


### PR DESCRIPTION
## Problem

A fresh install of `@earendil-works/pi-coding-agent@0.85.0` cannot import the public package root.

`dist/index.js` exports `main` from `main.js`, which statically imports `experimental/server.js`. That module imports `@earendil-works/pi-server` and `@earendil-works/pi-server/unix`, but `pi-server` is absent from the coding-agent runtime dependencies.

This affects ordinary SDK imports, not only direct use of the experimental server. The bundled `pi` executable remains loadable because its server code is inlined.

## Fix

Declare `@earendil-works/pi-server` alongside the other lockstep Pi runtime dependencies, then regenerate the root package lock, coding-agent shrinkwrap, and installer lock.

The server path is statically reachable from the public package root, so the dependency belongs to `pi-coding-agent`; downstream packages should not have to declare it.

## Verification

- `npm run check`
- `npm run build`
- A fresh install of the locally packed tarball imports the package root under Node and Bun.
- The fresh tree resolves `@earendil-works/pi-server@0.85.0` transitively from `pi-coding-agent`.

Closes #9132. Related: #9140, #9156, and #9158.