### PR TITLE
fix(coding-agent): prevent broken package root publication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5426,6 +5426,7 @@
 				"@earendil-works/pi-ai": "^0.85.0",
 				"@earendil-works/pi-client": "^0.85.0",
 				"@earendil-works/pi-protocol": "^0.85.0",
+				"@earendil-works/pi-server": "^0.85.0",
 				"@earendil-works/pi-tui": "^0.85.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",

--- a/packages/coding-agent/install-lock/package-lock.json
+++ b/packages/coding-agent/install-lock/package-lock.json
@@ -523,6 +523,7 @@
 				"@earendil-works/pi-ai": "^0.85.0",
 				"@earendil-works/pi-client": "^0.85.0",
 				"@earendil-works/pi-protocol": "^0.85.0",
+				"@earendil-works/pi-server": "^0.85.0",
 				"@earendil-works/pi-tui": "^0.85.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
@@ -557,6 +558,19 @@
 			"dependencies": {
 				"@earendil-works/chord": "^0.85.0",
 				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-server": {
+			"version": "0.85.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-server/-/pi-server-0.85.0.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/chord": "^0.85.0",
+				"@earendil-works/pi-agent-core": "^0.85.0",
+				"@earendil-works/pi-protocol": "^0.85.0"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -14,6 +14,7 @@
 				"@earendil-works/pi-ai": "^0.85.0",
 				"@earendil-works/pi-client": "^0.85.0",
 				"@earendil-works/pi-protocol": "^0.85.0",
+				"@earendil-works/pi-server": "^0.85.0",
 				"@earendil-works/pi-tui": "^0.85.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
@@ -547,6 +548,19 @@
 			"dependencies": {
 				"@earendil-works/chord": "^0.85.0",
 				"typebox": "1.3.7"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-server": {
+			"version": "0.85.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-server/-/pi-server-0.85.0.tgz",
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/chord": "^0.85.0",
+				"@earendil-works/pi-agent-core": "^0.85.0",
+				"@earendil-works/pi-protocol": "^0.85.0"
 			},
 			"engines": {
 				"node": ">=22.19.0"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -54,6 +54,7 @@
 		"@earendil-works/pi-ai": "^0.85.0",
 		"@earendil-works/pi-client": "^0.85.0",
 		"@earendil-works/pi-protocol": "^0.85.0",
+		"@earendil-works/pi-server": "^0.85.0",
 		"@earendil-works/pi-tui": "^0.85.0",
 		"@silvia-odwyer/photon-node": "0.3.4",
 		"chalk": "5.6.2",

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -75,10 +75,12 @@ function verifyCodingAgentPackageRoot(tarballs, directory) {
 		overrides,
 	};
 	writeFileSync(join(consumer, "package.json"), `${JSON.stringify(packageJson, undefined, "\t")}\n`);
+	console.log(`Verifying packed ${codingAgentPackageName} in an isolated install...`);
 	run("npm", ["install", "--omit=dev", "--ignore-scripts"], { cwd: consumer });
 	run("node", ["--input-type=module", "--eval", `import "${codingAgentPackageName}";`], {
 		cwd: consumer,
 	});
+	console.log(`Verified packed ${codingAgentPackageName} installs and imports from its public root.`);
 }
 
 function isPublished(name, version) {

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
 import { getPublicWorkspacePackages } from "./release-packages.mjs";
 
 const packages = getPublicWorkspacePackages();
+const codingAgentPackageName = "@earendil-works/pi-coding-agent";
 
 const dryRun = process.argv.includes("--dry-run");
 const unknownArgs = process.argv.slice(2).filter((arg) => arg !== "--dry-run");
@@ -41,10 +43,42 @@ function assertBuildOutputExists(directory) {
 	}
 }
 
-function validatePack(directory) {
-	const result = run("npm", ["pack", "--dry-run", "--ignore-scripts", "--json"], { capture: true, cwd: directory });
+function fileSpecifier(fromDirectory, file) {
+	const relativePath = relative(fromDirectory, file).replaceAll("\\", "/");
+	return `file:${relativePath.startsWith(".") ? relativePath : `./${relativePath}`}`;
+}
+
+function packPackage(pkg, destination) {
+	const result = run("npm", ["pack", "--ignore-scripts", "--json", "--pack-destination", destination], {
+		capture: true,
+		cwd: pkg.directory,
+	});
 	const packed = JSON.parse(result.stdout)[0];
 	console.log(`  ${packed.filename}: ${packed.files.length} files, ${packed.size} bytes packed, ${packed.unpackedSize} bytes unpacked`);
+	return join(destination, packed.filename);
+}
+
+function verifyCodingAgentPackageRoot(tarballs, directory) {
+	const codingAgentTarball = tarballs.get(codingAgentPackageName);
+	if (codingAgentTarball === undefined) {
+		throw new Error(`${codingAgentPackageName} tarball is missing`);
+	}
+	const consumer = join(directory, "coding-agent-consumer");
+	mkdirSync(consumer);
+	const overrides = Object.fromEntries(
+		[...tarballs].map(([name, tarball]) => [name, fileSpecifier(consumer, tarball)]),
+	);
+	const packageJson = {
+		private: true,
+		type: "module",
+		dependencies: { [codingAgentPackageName]: fileSpecifier(consumer, codingAgentTarball) },
+		overrides,
+	};
+	writeFileSync(join(consumer, "package.json"), `${JSON.stringify(packageJson, undefined, "\t")}\n`);
+	run("npm", ["install", "--omit=dev", "--ignore-scripts"], { cwd: consumer });
+	run("node", ["--input-type=module", "--eval", `import "${codingAgentPackageName}";`], {
+		cwd: consumer,
+	});
 }
 
 function isPublished(name, version) {
@@ -74,23 +108,30 @@ if (versions.length !== 1) {
 
 console.log(`Publishing pi packages at ${versions[0]}${dryRun ? " (dry run)" : ""}\n`);
 
+const destination = mkdtempSync(join(tmpdir(), "pi-publish-check-"));
+const tarballs = new Map();
 const packageStates = packages.map((pkg) => ({
 	...pkg,
 	published: false,
 	version: packageVersions.get(pkg.name),
 }));
 
-for (const pkg of packageStates) {
-	assertBuildOutputExists(pkg.directory);
-	pkg.published = isPublished(pkg.name, pkg.version);
+try {
+	for (const pkg of packageStates) {
+		assertBuildOutputExists(pkg.directory);
+		pkg.published = isPublished(pkg.name, pkg.version);
 
-	if (pkg.published) {
-		console.log(`${pkg.name}@${pkg.version} is already published; validating package contents only.`);
-	} else {
-		console.log(`${pkg.name}@${pkg.version} is not published; validating package contents before publish.`);
+		if (pkg.published) {
+			console.log(`${pkg.name}@${pkg.version} is already published; validating package contents only.`);
+		} else {
+			console.log(`${pkg.name}@${pkg.version} is not published; validating package contents before publish.`);
+		}
+		tarballs.set(pkg.name, packPackage(pkg, destination));
+		console.log();
 	}
-	validatePack(pkg.directory);
-	console.log();
+	verifyCodingAgentPackageRoot(tarballs, destination);
+} finally {
+	rmSync(destination, { recursive: true, force: true });
 }
 
 if (dryRun) {

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -76,7 +76,7 @@ function verifyCodingAgentPackageRoot(tarballs, directory) {
 	};
 	writeFileSync(join(consumer, "package.json"), `${JSON.stringify(packageJson, undefined, "\t")}\n`);
 	console.log(`Verifying packed ${codingAgentPackageName} in an isolated install...`);
-	run("npm", ["install", "--omit=dev", "--ignore-scripts"], { cwd: consumer });
+	run("npm", ["install", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"], { cwd: consumer });
 	run("node", ["--input-type=module", "--eval", `import "${codingAgentPackageName}";`], {
 		cwd: consumer,
 	});


### PR DESCRIPTION
Depends on #9170. That PR fixes the current missing `@earendil-works/pi-server` dependency; this follow-up prevents the same class of packaging defect from being published again.

Review the [`ee4214c89...1d6726bbc` commit range](https://github.com/victor-software-house/pi/compare/ee4214c89eb07674435c081373e57a49355716ee...1d6726bbc1f09e2e8c21eda33b49676781f4eda2), which changes only `scripts/publish.mjs`.

## Problem

Publication currently checks package contents with `npm pack --dry-run`, but never installs or loads the resulting artifact. Workspace builds and local release installs can also mask an undeclared internal dependency because every Pi package is already available.

Consequently, source and `package.json` can drift without failing the release gate. A fresh consumer discovers the defect only after publication.

## Prevention

Before publishing any package, the release script now:

- packs the actual public workspace tarballs
- creates a temporary consumer with only `@earendil-works/pi-coding-agent` as its direct dependency
- makes the other local tarballs available as overrides, without installing them unless the coding-agent dependency graph requires them
- imports the coding-agent public root under Node

A future runtime import without a matching package dependency therefore fails before the first npm publication.

## Validation

- `npm run check`
- `node scripts/publish.mjs --dry-run`
- applying only this guard to [`17de82d7b`](https://github.com/earendil-works/pi/commit/17de82d7bea18a6589677a9761baabc2060c9efb) reproduces the prevented failure: the isolated root import stops with `ERR_MODULE_NOT_FOUND` for `@earendil-works/pi-server`


