### PR TITLE
fix(coding-agent): reject tree navigation during compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3117,6 +3117,11 @@ export class AgentSession {
 		if (this.isStreaming) {
 			throw new Error("Wait for the current response to finish before navigating the session tree.");
 		}
+		if (this.isCompacting) {
+			throw new Error(
+				"Wait for the current compaction or tree navigation to finish before navigating the session tree.",
+			);
+		}
 
 		const oldLeafId = this.sessionManager.getLeafId();
 

--- a/packages/coding-agent/test/suite/regressions/9178-tree-during-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/9178-tree-during-compaction.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { assistantMsg, userMsg } from "../../utilities.ts";
+import { createHarness, getMessageText, type Harness } from "../harness.ts";
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((promiseResolve) => {
+		resolve = promiseResolve;
+	});
+	return { promise, resolve };
+}
+
+describe("issue #9178: tree navigation during manual compaction", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => harness?.cleanup());
+
+	it("rejects navigation before the active leaf can change", async () => {
+		const compactionStarted = createDeferred();
+		const compactionReleased = createDeferred();
+
+		harness = await createHarness({
+			settings: { compaction: { keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						compactionStarted.resolve();
+						await compactionReleased.promise;
+						return {
+							compaction: {
+								summary: "summary",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
+				},
+			],
+		});
+
+		harness.sessionManager.appendMessage(userMsg("first user"));
+		const navigationTargetId = harness.sessionManager.appendMessage(assistantMsg("first assistant"));
+		harness.sessionManager.appendMessage(userMsg("second user"));
+		const originalLeafId = harness.sessionManager.appendMessage(assistantMsg("second assistant"));
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		const compactionPromise = harness.session.compact();
+		await compactionStarted.promise;
+
+		expect(harness.session.isCompacting).toBe(true);
+		try {
+			await expect(harness.session.navigateTree(navigationTargetId, { summarize: false })).rejects.toThrow(
+				"Wait for the current compaction or tree navigation to finish before navigating the session tree.",
+			);
+			expect(harness.sessionManager.getLeafId()).toBe(originalLeafId);
+		} finally {
+			compactionReleased.resolve();
+		}
+		await compactionPromise;
+
+		expect(harness.sessionManager.getEntries().at(-1)).toMatchObject({
+			type: "compaction",
+			parentId: originalLeafId,
+		});
+		expect(harness.session.messages.map(getMessageText)).toContain("second assistant");
+	});
+
+	it("rejects a second navigation while the first is waiting", async () => {
+		const navigationStarted = createDeferred();
+		const navigationReleased = createDeferred();
+		harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_tree", async () => {
+						navigationStarted.resolve();
+						await navigationReleased.promise;
+					});
+				},
+			],
+		});
+
+		const secondTargetId = harness.sessionManager.appendMessage(userMsg("first user"));
+		const firstTargetId = harness.sessionManager.appendMessage(assistantMsg("first assistant"));
+		harness.sessionManager.appendMessage(userMsg("second user"));
+		const originalLeafId = harness.sessionManager.appendMessage(assistantMsg("second assistant"));
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		const firstNavigation = harness.session.navigateTree(firstTargetId, { summarize: false });
+		await navigationStarted.promise;
+
+		const secondNavigation = harness.session.navigateTree(secondTargetId, { summarize: false });
+		expect(harness.sessionManager.getLeafId()).toBe(originalLeafId);
+		navigationReleased.resolve();
+
+		await expect(secondNavigation).rejects.toThrow(
+			"Wait for the current compaction or tree navigation to finish before navigating the session tree.",
+		);
+		await firstNavigation;
+		expect(harness.sessionManager.getLeafId()).toBe(firstTargetId);
+	});
+});


### PR DESCRIPTION
## Summary

- reject tree navigation while compaction or another tree navigation is active
- keep compaction results and retained context on the branch from which they were prepared
- cover both races with regression tests

## Scope

`compact()` prepares a summary from the current branch, then awaits extension hooks or the model. A concurrent `navigateTree()` can change the leaf during that wait, causing `appendCompaction()` to attach the old branch's summary and `firstKeptEntryId` to the new branch.

The fix uses the existing `isCompacting` state, which covers manual compaction, automatic compaction, and the tree-navigation window tracked by the branch-summary controller. Idle tree navigation and the current streaming guard are unchanged.

#9155 covers the inverse ordering: a prompt starts during tree navigation. This PR covers tree navigation starting during compaction. Rejecting the conflicting operation follows the manual-compaction behavior in #7383.

## Tests

- [CI](https://github.com/earendil-works/pi/actions/runs/33941187027): build, check, and full test suite
- targeted regression: 2 passed

Fixes #9178
