### PR TITLE
fix(coding-agent): skip session events on invalidated extension runners

### DIFF
--- a/packages/coding-agent/src/core/agent-session-runtime.ts
+++ b/packages/coding-agent/src/core/agent-session-runtime.ts
@@ -135,7 +135,7 @@ export class AgentSessionRuntime {
 		targetSessionFile?: string,
 	): Promise<{ cancelled: boolean }> {
 		const runner = this.session.extensionRunner;
-		if (!runner.hasHandlers("session_before_switch")) {
+		if (!runner.isActive || !runner.hasHandlers("session_before_switch")) {
 			return { cancelled: false };
 		}
 
@@ -152,7 +152,7 @@ export class AgentSessionRuntime {
 		options: { position: "before" | "at" },
 	): Promise<{ cancelled: boolean }> {
 		const runner = this.session.extensionRunner;
-		if (!runner.hasHandlers("session_before_fork")) {
+		if (!runner.isActive || !runner.hasHandlers("session_before_fork")) {
 			return { cancelled: false };
 		}
 

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -189,16 +189,21 @@ export type ShutdownHandler = () => void;
 /**
  * Helper function to emit session_shutdown event to extensions.
  * Returns true if the event was emitted, false if there were no handlers.
+ *
+ * A runner that was already invalidated (its session disposed) must not be
+ * re-emitted: its shutdown already ran during the teardown that disposed it,
+ * and emitting again makes every `session_shutdown` handler throw the stale
+ * context error (double teardown races during session replacement).
  */
 export async function emitSessionShutdownEvent(
 	extensionRunner: ExtensionRunner,
 	event: SessionShutdownEvent,
 ): Promise<boolean> {
-	if (extensionRunner.hasHandlers("session_shutdown")) {
-		await extensionRunner.emit(event);
-		return true;
+	if (!extensionRunner.isActive || !extensionRunner.hasHandlers("session_shutdown")) {
+		return false;
 	}
-	return false;
+	await extensionRunner.emit(event);
+	return true;
 }
 
 export async function emitProjectTrustEvent(
@@ -597,6 +602,11 @@ export class ExtensionRunner {
 			this.staleMessage = message;
 			this.runtime.invalidate(message);
 		}
+	}
+
+	/** Whether this runner's context is still active (not invalidated by session replacement or reload). */
+	get isActive(): boolean {
+		return !this.staleMessage;
 	}
 
 	private assertActive(): void {

--- a/packages/coding-agent/test/suite/regressions/stale-session-shutdown.test.ts
+++ b/packages/coding-agent/test/suite/regressions/stale-session-shutdown.test.ts
@@ -1,0 +1,137 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type CreateAgentSessionRuntimeFactory,
+	createAgentSessionFromServices,
+	createAgentSessionRuntime,
+	createAgentSessionServices,
+} from "../../../src/core/agent-session-runtime.ts";
+import { AuthStorage } from "../../../src/core/auth-storage.ts";
+import { ModelRuntime } from "../../../src/core/model-runtime.ts";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import type { ExtensionAPI, ExtensionError, ExtensionFactory } from "../../../src/index.ts";
+
+// Regression: repeated session teardown must not re-emit `session_shutdown` to an
+// invalidated extension runner.
+//
+// Real-world trigger: during session replacement (`/new`, or Ctrl+C quit racing a
+// pending `/new`), the outgoing session is disposed (which invalidates the shared
+// extension runtime) and a second teardown can still run against the current,
+// already-disposed session. Every `session_shutdown` handler that touches its ctx
+// then throws "This extension ctx is stale after session replacement or reload.",
+// surfacing one extension error per handler.
+
+describe("regression: stale extension ctx on repeated session teardown", () => {
+	const cleanups: Array<() => Promise<void> | void> = [];
+
+	afterEach(async () => {
+		while (cleanups.length > 0) {
+			await cleanups.pop()?.();
+		}
+	});
+
+	async function createRuntimeForTest(extensionFactory: ExtensionFactory) {
+		const tempDir = join(tmpdir(), `pi-stale-shutdown-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+
+		const faux = registerFauxProvider({ models: [{ id: "faux-1", reasoning: false }] });
+		faux.setResponses([fauxAssistantMessage("one")]);
+
+		const authStorage = AuthStorage.inMemory();
+		await authStorage.modify(faux.getModel().provider, async () => ({ type: "api_key", key: "faux-key" }));
+		const modelRuntime = await ModelRuntime.create({
+			credentials: authStorage,
+			modelsPath: join(tempDir, "models.json"),
+		});
+
+		const createRuntime: CreateAgentSessionRuntimeFactory = async ({ cwd, sessionManager, sessionStartEvent }) => {
+			const services = await createAgentSessionServices({
+				cwd,
+				agentDir: tempDir,
+				modelRuntime,
+				resourceLoaderOptions: {
+					extensionFactories: [
+						(pi: ExtensionAPI) => {
+							pi.registerProvider(faux.getModel().provider, {
+								baseUrl: faux.getModel().baseUrl,
+								apiKey: "faux-key",
+								api: faux.api,
+								models: faux.models.map((registeredModel) => ({
+									id: registeredModel.id,
+									name: registeredModel.name,
+									api: registeredModel.api,
+									reasoning: registeredModel.reasoning,
+									input: registeredModel.input,
+									cost: registeredModel.cost,
+									contextWindow: registeredModel.contextWindow,
+									maxTokens: registeredModel.maxTokens,
+								})),
+							});
+							extensionFactory(pi);
+						},
+					],
+					noSkills: true,
+					noPromptTemplates: true,
+					noThemes: true,
+				},
+			});
+			return {
+				...(await createAgentSessionFromServices({
+					services,
+					sessionManager,
+					sessionStartEvent,
+					model: faux.getModel(),
+					thinkingLevel: undefined,
+				})),
+				services,
+				diagnostics: services.diagnostics,
+			};
+		};
+		const runtime = await createAgentSessionRuntime(createRuntime, {
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.create(tempDir),
+		});
+		await runtime.session.bindExtensions({});
+
+		cleanups.push(async () => {
+			await runtime.dispose();
+			faux.unregister();
+			if (existsSync(tempDir)) {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		return { runtime };
+	}
+
+	it("emits session_shutdown once and never against an invalidated runner", async () => {
+		const shutdownCount: number[] = [];
+		const { runtime } = await createRuntimeForTest((pi: ExtensionAPI) => {
+			pi.on("session_shutdown", (_event, ctx) => {
+				// Touching ctx after invalidation throws the stale-context error,
+				// exactly like real extensions do (ctx.hasUI, ctx.mode, pi.getActiveTools()).
+				void ctx.mode;
+				shutdownCount.push(shutdownCount.length);
+			});
+		});
+
+		const errors: ExtensionError[] = [];
+		const unsubscribe = runtime.session.extensionRunner.onError((error) => errors.push(error));
+
+		await runtime.dispose();
+		expect(shutdownCount).toHaveLength(1);
+		expect(errors).toEqual([]);
+
+		// Second teardown against the already-disposed session: the shutdown event
+		// must be skipped, not re-emitted into a stale context.
+		await runtime.dispose();
+		unsubscribe();
+
+		expect(shutdownCount).toHaveLength(1);
+		expect(errors).toEqual([]);
+	});
+});


### PR DESCRIPTION
Issue: #9181

## Problem

During session replacement (`/new`, or Ctrl+C quit racing a pending `/new`), `teardownCurrent()` disposes the outgoing session, which invalidates the shared extension runtime. A second teardown that races the first — while it is still awaiting `createRuntime()` (extension reload takes seconds with a large extension set) — runs against the current, already-disposed session and re-emits `session_shutdown` / `session_before_switch` / `session_before_fork` into the stale context. Every handler that touches its ctx then throws:

```
Extension ".../ask-user/index.ts" error: This extension ctx is stale after session replacement or reload. ...
```

one error per registered handler (8+ extensions x 2 rounds from a single double-trigger).

## Approach

Add `ExtensionRunner.isActive` (derived from the existing `staleMessage`) and skip the three session-lifecycle emissions when the runner is already invalidated. A disposed session's shutdown already ran during the teardown that disposed it, so re-emitting can only fail.

## Validation

- New deterministic regression: `packages/coding-agent/test/suite/regressions/stale-session-shutdown.test.ts` — a `session_shutdown` handler touching `ctx.mode`, double `runtime.dispose()`. Fails pre-fix with the stale error recorded via `onError`; passes post-fix.
- `npm run check` passes.
- `./test.sh` passes (exit 0, all packages).
- Real-world repro on installed 0.85.0 (interactive TUI driven over a pty: model turn streaming, then `/new` fired repeatedly during the reload window): 20 stale-ctx extension errors before the fix, 0 after.
