### PR TITLE
fix(coding-agent): use --no-extensions flag in RPC extension UI example

### DIFF
--- a/packages/coding-agent/examples/rpc-extension-ui.ts
+++ b/packages/coding-agent/examples/rpc-extension-ui.ts
@@ -258,7 +258,7 @@ async function main() {
 
 	const agent = spawn(
 		"node",
-		[cliPath, "--mode", "rpc", "--no-session", "--no-extension", "--extension", extensionPath],
+		[cliPath, "--mode", "rpc", "--no-session", "--no-extensions", "--extension", extensionPath],
 		{ stdio: ["pipe", "pipe", "pipe"] },
 	);
 


### PR DESCRIPTION
The RPC extension UI example (`examples/rpc-extension-ui.ts`) spawns the agent with `--no-extension`, which is not a recognized CLI flag. The agent exits immediately with `Unknown option: --no-extension`, so the example never reaches the extension UI dialogs it demonstrates.

Rename it to `--no-extensions` (the flag defined in `src/cli/args.ts`, aliased `-ne`). It disables auto-discovered extensions while explicit `--extension` paths are still loaded, which is exactly the intent here: run only the example's own `rpc-demo.ts` extension.

Verified by running the example: the agent starts in `--mode rpc` and the `rpc-demo` extension's select/confirm/input/editor UI requests are handled by the client.
