### PR TITLE
Invoke skills and prompt templates mid-sentence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Mid-sentence skill and prompt template invocation** — `/name` tokens expand anywhere in a message except the very start, not just at position 0. Skill output is identical to `/skill:name`; template output is identical to line-1 expansion. Names resolve against templates first (on a collision the template wins), then skills by exact, unique case-insensitive, or unique prefix match; unresolvable names stay literal ([#8457](https://github.com/earendil-works/pi/issues/8457)).
+
 ## [0.85.1] - 2026-09-05
 
 ### New Features

--- a/packages/coding-agent/docs/prompt-templates.md
+++ b/packages/coding-agent/docs/prompt-templates.md
@@ -62,6 +62,15 @@ Type `/` followed by the template name in the editor. Autocomplete shows availab
 /component Button "click handler" # Multiple arguments
 ```
 
+Templates also expand mid-sentence: a `/name` token anywhere in the message except the very start expands in place, with the rest of the line as arguments.
+
+```
+wrap this up please /review the staged changes
+and be strict
+```
+
+Mid-sentence names resolve against templates first; on a name shared with a skill, the template wins. Unknown names stay literal. The very start of the message is unaffected: a slash at position 0 begins a line-1 command, which consumes the whole first line.
+
 ## Arguments
 
 Templates support positional arguments, defaults, and simple slicing:

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -82,6 +82,14 @@ Skills register as `/skill:name` commands:
 
 Arguments after the command are appended to the skill content as `User: <args>`.
 
+Skills can also be invoked mid-sentence: a `/name` token anywhere in the message except the very start expands in place, with the rest of the line as arguments.
+
+```bash
+can you check the build please run /verify-build on the current branch
+```
+
+The expansion is identical to the `/skill:name` command. Mid-sentence names resolve against prompt templates first; on a name shared with a template, the template wins. Unique prefixes and unique case-insensitive variants of a skill name also resolve; unknown names stay literal. Works for skills with `disable-model-invocation: true` too: they stay hidden from the system prompt but remain invocable anywhere in the message.
+
 Toggle skill commands via `/settings` in interactive mode or in `settings.json`:
 
 ```json

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -48,7 +48,6 @@ import {
 	streamSimple,
 } from "@earendil-works/pi-ai/compat";
 import { getThemeByName, theme } from "../modes/interactive/theme/theme.ts";
-import { stripFrontmatter } from "../utils/frontmatter.ts";
 import { sleep } from "../utils/sleep.ts";
 import { normalizeToolResultImages } from "../utils/tool-result-images.ts";
 import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.ts";
@@ -97,6 +96,7 @@ import {
 } from "./extensions/index.ts";
 import { emitSessionShutdownEvent } from "./extensions/runner.ts";
 import type { BashExecutionMessage, CustomMessage } from "./messages.ts";
+import { buildSkillInvocation, expandMidsentence } from "./midsentence.ts";
 import { ModelRegistry } from "./model-registry.ts";
 import type { ModelRuntime } from "./model-runtime.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
@@ -1199,9 +1199,12 @@ export class AgentSession {
 				}
 			}
 
-			// Expand skill commands (/skill:name args) and prompt templates (/template args)
+			// Expand mid-sentence /name tokens (line 2+), then the native line-1
+			// expansions (skill commands and prompt templates) so their output is
+			// never rescanned
 			let expandedText = currentText;
 			if (expandPromptTemplates) {
+				expandedText = this._expandMidsentence(expandedText);
 				expandedText = this._expandSkillCommand(expandedText);
 				expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 			}
@@ -1362,9 +1365,7 @@ export class AgentSession {
 
 		try {
 			const content = readFileSync(skill.filePath, "utf-8");
-			const body = stripFrontmatter(content).trim();
-			const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
-			return args ? `${skillBlock}\n\n${args}` : skillBlock;
+			return buildSkillInvocation(skill, content, args);
 		} catch (err) {
 			// Emit error like extension commands do
 			this._extensionRunner.emitError({
@@ -1374,6 +1375,19 @@ export class AgentSession {
 			});
 			return text; // Return original on error
 		}
+	}
+
+	/**
+	 * Expand mid-sentence `/name args` invocations (skills and prompt templates)
+	 * anywhere after the first line. Runs before the native expansions so native
+	 * line-1 output is never rescanned.
+	 */
+	private _expandMidsentence(text: string): string {
+		return expandMidsentence(
+			text,
+			{ skills: this.resourceLoader.getSkills().skills, templates: [...this.promptTemplates] },
+			{ readSkillFile: (filePath) => readFileSync(filePath, "utf-8") },
+		);
 	}
 
 	/**
@@ -1390,8 +1404,9 @@ export class AgentSession {
 			this._throwIfExtensionCommand(text);
 		}
 
-		// Expand skill commands and prompt templates
-		let expandedText = this._expandSkillCommand(text);
+		// Expand mid-sentence tokens, then skill commands and prompt templates
+		let expandedText = this._expandMidsentence(text);
+		expandedText = this._expandSkillCommand(expandedText);
 		expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 
 		await this._queueSteer(expandedText, images);
@@ -1410,8 +1425,9 @@ export class AgentSession {
 			this._throwIfExtensionCommand(text);
 		}
 
-		// Expand skill commands and prompt templates
-		let expandedText = this._expandSkillCommand(text);
+		// Expand mid-sentence tokens, then skill commands and prompt templates
+		let expandedText = this._expandMidsentence(text);
+		expandedText = this._expandSkillCommand(expandedText);
 		expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 
 		await this._queueFollowUp(expandedText, images);

--- a/packages/coding-agent/src/core/midsentence.ts
+++ b/packages/coding-agent/src/core/midsentence.ts
@@ -1,0 +1,187 @@
+import { stripFrontmatter } from "../utils/frontmatter.ts";
+import { type PromptTemplate, parseCommandArgs, substituteArgs } from "./prompt-templates.ts";
+import type { Skill } from "./skills.ts";
+
+/**
+ * Mid-sentence invocation of skills and prompt templates.
+ *
+ * `/skill:name args` and `/template args` only expand at the start of the input
+ * (line 1). This module extends the same expansion to `/name args` tokens
+ * anywhere from line 2 on, replacing the token in place.
+ *
+ * Semantics:
+ * - Word boundary: the slash must be preceded by whitespace or a newline, so
+ *   paths and ratios (`C:/x`, `a/b`, `n/d`, `km/h`) never trigger.
+ * - The start of the input is native territory: when the text begins with a
+ *   slash, the whole first line is skipped (line-1 commands like
+ *   `/skill:name` consume it). Mid-line tokens on the first line expand:
+ *   `hello /name args` is not a line-1 command, so nothing else would expand
+ *   it.
+ * - The name is `[A-Za-z0-9][A-Za-z0-9_-]*` (2+ chars) and must end at a
+ *   boundary. A colon right after the name (e.g. `/skill:foo`) stays literal.
+ * - Args run to the end of the line (exclusive); text after the newline is
+ *   preserved. A token followed by another token candidate on the same line
+ *   expands bare (its args would otherwise swallow the sibling invocation).
+ * - Name resolution tries prompt templates first (on a name collision the
+ *   template wins), then skills. Each registry resolves exact match, then a
+ *   unique case-insensitive variant, then a unique prefix.
+ * - Skill output is byte-identical to the native `/skill:name` expansion;
+ *   template output is identical to the native line-1 expansion.
+ * - Fail-soft: unresolvable names and unreadable files stay literal.
+ * - Single pass: the output is never rescanned, so expansions cannot recurse.
+ */
+
+/** Candidate token name after a whitespace-preceded slash. */
+const NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*/;
+
+/** A later ` /name` candidate on the same line marks a token as a list member. */
+const NEXT_TOKEN_RE = /\s\/[A-Za-z0-9]/;
+
+export interface ExpandMidsentenceRegistries {
+	skills: Skill[];
+	templates: PromptTemplate[];
+}
+
+export interface ExpandMidsentenceDeps {
+	/** Skill file reader (injected to keep this module pure and testable). */
+	readSkillFile: (filePath: string) => string;
+}
+
+/**
+ * Build the inline skill invocation (block + args), identical to the native
+ * `/skill:name args` expansion.
+ */
+export function buildSkillInvocation(skill: Skill, rawContent: string, args: string): string {
+	const body = stripFrontmatter(rawContent).trim();
+	const skillBlock = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`;
+	return args ? `${skillBlock}\n\n${args}` : skillBlock;
+}
+
+/**
+ * Resolve a typed name against a registry: exact match, then a unique
+ * case-insensitive variant, then a unique prefix. Ambiguous or missing stays
+ * unresolved.
+ */
+function resolveUnique<T>(items: T[], getName: (item: T) => string, typed: string): T | undefined {
+	const exact = items.find((item) => getName(item) === typed);
+	if (exact) return exact;
+
+	const lower = typed.toLowerCase();
+	const caseVariants = items.filter((item) => getName(item).toLowerCase() === lower);
+	if (caseVariants.length === 1) return caseVariants[0];
+
+	const prefixed = items.filter((item) => getName(item).startsWith(typed));
+	return prefixed.length === 1 ? prefixed[0] : undefined;
+}
+
+function resolveAndExpand(
+	name: string,
+	args: string,
+	registries: ExpandMidsentenceRegistries,
+	deps: ExpandMidsentenceDeps,
+): string | undefined {
+	// Templates first: on a name collision the template wins.
+	const template = resolveUnique(registries.templates, (t) => t.name, name);
+	if (template) {
+		return substituteArgs(template.content, parseCommandArgs(args));
+	}
+
+	const skill = resolveUnique(registries.skills, (s) => s.name, name);
+	if (skill) {
+		try {
+			return buildSkillInvocation(skill, deps.readSkillFile(skill.filePath), args);
+		} catch {
+			return undefined; // Fail-soft: unreadable file stays literal
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Expand every mid-sentence `/name args` token (skill or prompt template) in a
+ * single pass, in position order. The start of the input stays native.
+ */
+export function expandMidsentence(
+	text: string,
+	registries: ExpandMidsentenceRegistries,
+	deps: ExpandMidsentenceDeps,
+): string {
+	let i = 0;
+	let out = "";
+
+	while (true) {
+		const slash = text.indexOf("/", i);
+		if (slash === -1) {
+			out += text.slice(i);
+			break;
+		}
+
+		// Absolute start of input is native: a slash at position 0 begins a
+		// line-1 command, which consumes the whole first line.
+		if (slash === 0) {
+			const nl = text.search(/[\n\r]/);
+			const stop = nl === -1 ? text.length : nl;
+			out += text.slice(0, stop);
+			i = stop;
+			continue;
+		}
+
+		// Word boundary: the character before the slash must be whitespace.
+		if (!/\s/.test(text[slash - 1]!)) {
+			out += text.slice(i, slash + 1);
+			i = slash + 1;
+			continue;
+		}
+
+		const candidate = NAME_RE.exec(text.slice(slash + 1));
+		if (!candidate || candidate[0].length < 2) {
+			out += text.slice(i, slash + 1);
+			i = slash + 1;
+			continue;
+		}
+
+		const name = candidate[0];
+		const afterName = slash + 1 + name.length;
+		const nextCh = text[afterName] ?? "";
+
+		// The name must end at a boundary.
+		if (nextCh && /[A-Za-z0-9_-]/.test(nextCh)) {
+			out += text.slice(i, slash + 1);
+			i = slash + 1;
+			continue;
+		}
+
+		// Namespace guard: `/name:...` (e.g. `/skill:foo`) is not a sigil.
+		if (nextCh === ":") {
+			out += text.slice(i, slash + 1);
+			i = slash + 1;
+			continue;
+		}
+
+		// Args run to the end of the line (exclusive), unless a sibling token
+		// candidate follows on the same line (then this token expands bare).
+		let args = "";
+		let end = afterName;
+		if (nextCh && /\s/.test(nextCh)) {
+			const relNl = text.slice(afterName).search(/[\n\r]/);
+			const lineEnd = relNl === -1 ? text.length : afterName + relNl;
+			if (!NEXT_TOKEN_RE.test(text.slice(afterName, lineEnd))) {
+				args = text.slice(afterName, lineEnd).trim();
+				end = lineEnd;
+			}
+		}
+
+		const replacement = resolveAndExpand(name, args, registries, deps);
+		if (replacement === undefined) {
+			out += text.slice(i, afterName);
+			i = afterName;
+			continue;
+		}
+
+		out += text.slice(i, slash) + replacement;
+		i = end;
+	}
+
+	return out;
+}

--- a/packages/coding-agent/test/midsentence-agent-session.test.ts
+++ b/packages/coding-agent/test/midsentence-agent-session.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Integration tests: mid-sentence expansion flows through AgentSession
+ * prompt/steer/followUp with a mocked streamFn.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream, getModel } from "@earendil-works/pi-ai/compat";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import type { PromptTemplate } from "../src/core/prompt-templates.ts";
+import type { ResourceLoader } from "../src/core/resource-loader.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") throw event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+const SKILL_BODY = "Run the full build checks.";
+
+describe("AgentSession mid-sentence expansion", () => {
+	let session: AgentSession;
+	let tempDir: string;
+	let userTexts: string[];
+	let lastQueue: { steering: string[]; followUp: string[] };
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-midsentence-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+		userTexts = [];
+		lastQueue = { steering: [], followUp: [] };
+	});
+
+	afterEach(() => {
+		if (session) session.dispose();
+		if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	async function createSession(loader: ResourceLoader): Promise<AgentSession> {
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const msg = createAssistantMessage("ok");
+					stream.push({ type: "start", partial: msg });
+					stream.push({ type: "done", reason: "stop", message: msg });
+				});
+				return stream;
+			},
+		});
+
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = await createModelRegistry(authStorage, tempDir);
+		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settingsManager,
+			cwd: tempDir,
+			modelRuntime: getModelRuntime(modelRegistry),
+			resourceLoader: loader,
+		});
+
+		session.subscribe((event) => {
+			if (event.type === "message_end" && event.message.role === "user") {
+				const content = event.message.content;
+				if (Array.isArray(content)) {
+					for (const part of content) {
+						if (part.type === "text") userTexts.push(part.text);
+					}
+				}
+			}
+			if (event.type === "queue_update") {
+				lastQueue = { steering: [...event.steering], followUp: [...event.followUp] };
+			}
+		});
+		return session;
+	}
+
+	function loaderWith(skillSpecs: Array<{ name: string; body: string }>, templates: PromptTemplate[]): ResourceLoader {
+		const skillDir = join(tempDir, "skills");
+		mkdirSync(skillDir, { recursive: true });
+		const skills = skillSpecs.map(({ name, body }) => {
+			const filePath = join(skillDir, name, "SKILL.md");
+			mkdirSync(join(skillDir, name), { recursive: true });
+			writeFileSync(filePath, `---\nname: ${name}\ndescription: ${name} description\n---\n${body}`);
+			return {
+				name,
+				description: `${name} description`,
+				filePath,
+				baseDir: join(skillDir, name),
+				sourceInfo: {
+					path: filePath,
+					source: "local",
+					scope: "temporary" as const,
+					origin: "top-level" as const,
+				},
+				disableModelInvocation: false,
+			};
+		});
+		return {
+			...createTestResourceLoader(),
+			getSkills: () => ({ skills, diagnostics: [] }),
+			getPrompts: () => ({ prompts: templates, diagnostics: [] }),
+		} as ResourceLoader;
+	}
+
+	function template(name: string, content: string): PromptTemplate {
+		return {
+			name,
+			description: `${name} description`,
+			content,
+			sourceInfo: {
+				path: `/prompts/${name}.md`,
+				source: "local",
+				scope: "temporary" as const,
+				origin: "top-level" as const,
+			},
+			filePath: `/prompts/${name}.md`,
+		};
+	}
+
+	it("prompt() expands a mid-sentence skill token and delivers the block to the model", async () => {
+		const s = await createSession(loaderWith([{ name: "verify-build", body: SKILL_BODY }], []));
+		await s.prompt("please run\n/verify-build on this branch");
+		expect(userTexts[0]).toContain("please run");
+		expect(userTexts[0]).toContain('<skill name="verify-build"');
+		expect(userTexts[0]).toContain(SKILL_BODY);
+		expect(userTexts[0]).toContain("on this branch");
+	});
+
+	it("prompt() expands a single-line mid-sentence token (PR example shape)", async () => {
+		const s = await createSession(loaderWith([{ name: "verify-build", body: SKILL_BODY }], []));
+		await s.prompt("can you check the build please run /verify-build on the current branch and summarize");
+		expect(userTexts[0]).toContain('can you check the build please run <skill name="verify-build"');
+		expect(userTexts[0]).toContain("on the current branch and summarize");
+	});
+
+	it("prompt() expands a mid-sentence prompt template with args", async () => {
+		const s = await createSession(loaderWith([], [template("review", "Review this: $ARGUMENTS")]));
+		await s.prompt("header\nthen /review the code please");
+		expect(userTexts[0]).toBe("header\nthen Review this: the code please");
+	});
+
+	it("multiple mid-sentence tokens all expand in position order", async () => {
+		const s = await createSession(
+			loaderWith([{ name: "verify-build", body: SKILL_BODY }], [template("review", "R: $ARGUMENTS")]),
+		);
+		await s.prompt("h\nfirst /review the code\nthen /verify-build now");
+		const posA = userTexts[0].indexOf("R: the code");
+		const posB = userTexts[0].indexOf('<skill name="verify-build"');
+		expect(posA).toBeGreaterThan(-1);
+		expect(posB).toBeGreaterThan(posA);
+	});
+
+	it("native line-1 expansion is unchanged by mid-sentence support", async () => {
+		const s = await createSession(
+			loaderWith([{ name: "verify-build", body: SKILL_BODY }], [template("review", "R: $ARGUMENTS")]),
+		);
+		await s.prompt("/skill:verify-build now");
+		expect(userTexts[0]).toBe(
+			`<skill name="verify-build" location="${join(tempDir, "skills", "verify-build", "SKILL.md")}">\nReferences are relative to ${join(tempDir, "skills", "verify-build")}.\n\n${SKILL_BODY}\n</skill>\n\nnow`,
+		);
+		await s.prompt("/review the code");
+		expect(userTexts[1]).toBe("R: the code");
+	});
+
+	it("expandPromptTemplates: false disables mid-sentence expansion", async () => {
+		const s = await createSession(loaderWith([{ name: "verify-build", body: SKILL_BODY }], []));
+		await s.prompt("please run\n/verify-build now", { expandPromptTemplates: false });
+		expect(userTexts[0]).toBe("please run\n/verify-build now");
+	});
+
+	it("steer() expands mid-sentence tokens before queuing", async () => {
+		const s = await createSession(loaderWith([{ name: "verify-build", body: SKILL_BODY }], []));
+		await s.steer("please run\n/verify-build now");
+		expect(lastQueue.steering).toHaveLength(1);
+		expect(lastQueue.steering[0]).toContain('<skill name="verify-build"');
+		expect(lastQueue.steering[0]).toContain("now");
+	});
+
+	it("followUp() expands mid-sentence tokens before queuing", async () => {
+		const s = await createSession(loaderWith([{ name: "verify-build", body: SKILL_BODY }], []));
+		await s.followUp("please run\n/verify-build now");
+		expect(lastQueue.followUp).toHaveLength(1);
+		expect(lastQueue.followUp[0]).toContain('<skill name="verify-build"');
+		expect(lastQueue.followUp[0]).toContain("now");
+	});
+});

--- a/packages/coding-agent/test/midsentence.test.ts
+++ b/packages/coding-agent/test/midsentence.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Unit tests for mid-sentence skill/prompt-template expansion
+ * (`expandMidsentence` in src/core/midsentence.ts).
+ */
+
+import { describe, expect, test } from "vitest";
+import { buildSkillInvocation, expandMidsentence } from "../src/core/midsentence.ts";
+import type { PromptTemplate } from "../src/core/prompt-templates.ts";
+import type { Skill } from "../src/core/skills.ts";
+import { createSyntheticSourceInfo } from "../src/core/source-info.ts";
+
+function makeSkill(overrides?: Partial<Skill>): Skill {
+	return {
+		name: "verify-build",
+		description: "Verify the build",
+		filePath: "/skills/verify-build/SKILL.md",
+		baseDir: "/skills/verify-build",
+		sourceInfo: createSyntheticSourceInfo("/skills/verify-build/SKILL.md", { source: "local", baseDir: "/skills" }),
+		disableModelInvocation: false,
+		...overrides,
+	};
+}
+
+function makeTemplate(overrides?: Partial<PromptTemplate>): PromptTemplate {
+	return {
+		name: "review",
+		description: "Review the diff",
+		content: "Review this: $ARGUMENTS",
+		sourceInfo: createSyntheticSourceInfo("/prompts/review.md", { source: "local", baseDir: "/prompts" }),
+		filePath: "/prompts/review.md",
+		...overrides,
+	};
+}
+
+function readerFor(map: Record<string, string>): (filePath: string) => string {
+	return (filePath) => {
+		const content = map[filePath];
+		if (content === undefined) throw new Error(`ENOENT: ${filePath}`);
+		return content;
+	};
+}
+
+const SKILL_MD = `---
+name: verify-build
+description: Verify the build
+---
+
+Run the full build checks.`;
+
+function expand(
+	text: string,
+	skills: Skill[] = [],
+	templates: PromptTemplate[] = [],
+	reader = readerFor({ "/skills/verify-build/SKILL.md": SKILL_MD }),
+) {
+	return expandMidsentence(text, { skills, templates }, { readSkillFile: reader });
+}
+
+describe("expandMidsentence", () => {
+	describe("trigger and non-trigger", () => {
+		test("expands a skill token from line 2 on", () => {
+			const skill = makeSkill();
+			const out = expand("please run\n/verify-build now", [skill]);
+			expect(out).toBe(`please run\n${buildSkillInvocation(skill, SKILL_MD, "now")}`);
+		});
+
+		test("expands a token mid-line when preceded by whitespace", () => {
+			const skill = makeSkill();
+			const out = expand("header\ncan you run /verify-build on this branch", [skill]);
+			expect(out).toBe(`header\ncan you run ${buildSkillInvocation(skill, SKILL_MD, "on this branch")}`);
+		});
+
+		test("does not trigger on paths and ratios (no whitespace before slash)", () => {
+			const skill = makeSkill();
+			const text = "look at C:/x and a/b, n/d and 24/7 and km/h please";
+			expect(expand(text, [skill])).toBe(text);
+			expect(expand(`header\n${text}`, [skill])).toBe(`header\n${text}`);
+		});
+
+		test("position 0 is native: line-1 commands stay untouched", () => {
+			const skill = makeSkill();
+			const text = "/verify-build now\nand /summarize";
+			expect(expand(text, [skill])).toBe(text);
+		});
+
+		test("mid-line token on the first line expands (not a line-1 command)", () => {
+			const skill = makeSkill();
+			const out = expand("run /verify-build now\nand summarize", [skill]);
+			expect(out).toBe(`run ${buildSkillInvocation(skill, SKILL_MD, "now")}\nand summarize`);
+		});
+
+		test("single-line input starting with a slash stays native", () => {
+			const skill = makeSkill();
+			expect(expand("/verify-build now", [skill])).toBe("/verify-build now");
+		});
+
+		test("plain text without tokens passes through unchanged", () => {
+			const skill = makeSkill();
+			expect(expand("plain text", [skill])).toBe("plain text");
+		});
+
+		test("first-line /skill: and /template commands stay exactly as they are", () => {
+			const template = makeTemplate();
+			const text = "/review the diff\nthen /verify-build it";
+			expect(expand(text, [makeSkill()], [template])).toBe(
+				`/review the diff\nthen ${buildSkillInvocation(makeSkill(), SKILL_MD, "it")}`,
+			);
+		});
+	});
+
+	describe("args and multiline", () => {
+		test("args run to end of line; text after the newline is preserved", () => {
+			const skill = makeSkill();
+			const out = expand("h\n/verify-build these args\nrest stays", [skill]);
+			expect(out).toBe(`h\n${buildSkillInvocation(skill, SKILL_MD, "these args")}\nrest stays`);
+		});
+
+		test("token followed by non-whitespace (e.g. punctuation) expands bare", () => {
+			const skill = makeSkill();
+			const out = expand("h\n(see /verify-build, then report)", [skill]);
+			expect(out).toBe(`h\n(see ${buildSkillInvocation(skill, SKILL_MD, "")}, then report)`);
+		});
+
+		test("multiline skill bodies keep their newlines", () => {
+			const skill = makeSkill();
+			const out = expand("h\n/verify-build\nnext line", [skill]);
+			expect(out).toBe(
+				`h\n<skill name="verify-build" location="/skills/verify-build/SKILL.md">\nReferences are relative to /skills/verify-build.\n\nRun the full build checks.\n</skill>\nnext line`,
+			);
+		});
+	});
+
+	describe("multiple tokens", () => {
+		test("same line: earlier tokens expand bare when a sibling token follows", () => {
+			const a = makeSkill();
+			const b = makeSkill({
+				name: "summarize",
+				filePath: "/skills/summarize/SKILL.md",
+				baseDir: "/skills/summarize",
+			});
+			const reader = readerFor({
+				"/skills/verify-build/SKILL.md": SKILL_MD,
+				"/skills/summarize/SKILL.md": "---\nname: summarize\ndescription: Summarize\n---\nSum it up.",
+			});
+			const out = expandMidsentence(
+				"h\n/verify-build /summarize quickly",
+				{ skills: [a, b], templates: [] },
+				{ readSkillFile: reader },
+			);
+			expect(out).toBe(
+				`h\n${buildSkillInvocation(a, SKILL_MD, "")} ${buildSkillInvocation(b, "---\nname: summarize\ndescription: Summarize\n---\nSum it up.", "quickly")}`,
+			);
+		});
+
+		test("different lines: all expand in position order", () => {
+			const a = makeSkill();
+			const template = makeTemplate();
+			const out = expand("h\nfirst /review the code\nthen /verify-build\nend", [a], [template]);
+			expect(out).toBe(`h\nfirst Review this: the code\nthen ${buildSkillInvocation(a, SKILL_MD, "")}\nend`);
+		});
+
+		test("a non-sibling slash later on the line does not make args disappear", () => {
+			const skill = makeSkill();
+			// `1/2` has no whitespace before the slash: not a sibling candidate
+			const out = expand("h\n/verify-build scale 1/2", [skill]);
+			expect(out).toBe(`h\n${buildSkillInvocation(skill, SKILL_MD, "scale 1/2")}`);
+		});
+	});
+
+	describe("name resolution ladder", () => {
+		test("exact match wins over case variants and prefixes", () => {
+			const exact = makeSkill();
+			const other = makeSkill({
+				name: "verify-build-fast",
+				filePath: "/skills/fast/SKILL.md",
+				baseDir: "/skills/fast",
+			});
+			const out = expand("h\n/verify-build go", [exact, other]);
+			expect(out).toBe(`h\n${buildSkillInvocation(exact, SKILL_MD, "go")}`);
+		});
+
+		test("unique case-insensitive variant resolves", () => {
+			const skill = makeSkill();
+			const out = expand("h\n/VERIFY-BUILD go", [skill]);
+			expect(out).toBe(`h\n${buildSkillInvocation(skill, SKILL_MD, "go")}`);
+		});
+
+		test("unique prefix resolves", () => {
+			const skill = makeSkill();
+			const out = expand("h\n/verify go", [skill]);
+			expect(out).toBe(`h\n${buildSkillInvocation(skill, SKILL_MD, "go")}`);
+		});
+
+		test("ambiguous prefix stays literal", () => {
+			const a = makeSkill();
+			const b = makeSkill({ name: "verify-tests", filePath: "/skills/t/SKILL.md", baseDir: "/skills/t" });
+			const text = "h\n/verify go";
+			expect(expand(text, [a, b])).toBe(text);
+		});
+
+		test("ambiguous case variants stay literal", () => {
+			const a = makeSkill();
+			const b = makeSkill({ name: "Verify-Build", filePath: "/skills/v/SKILL.md", baseDir: "/skills/v" });
+			const text = "h\n/VERIFY-BUILD go";
+			expect(expand(text, [a, b])).toBe(text);
+		});
+
+		test("template/skill name collision: the template wins", () => {
+			const template = makeTemplate({ name: "verify-build", content: "T: $ARGUMENTS" });
+			const skill = makeSkill();
+			const out = expand("h\n/verify-build now", [skill], [template]);
+			expect(out).toBe("h\nT: now");
+		});
+
+		test("skill resolves when no template matches the typed name", () => {
+			const template = makeTemplate({ name: "review" });
+			const skill = makeSkill();
+			const out = expand("h\n/verify-build now", [skill], [template]);
+			expect(out).toBe(`h\n${buildSkillInvocation(skill, SKILL_MD, "now")}`);
+		});
+	});
+
+	describe("guards", () => {
+		test("colon after the name stays literal (/skill:foo mid-sentence)", () => {
+			const text = "h\nrun /skill:foo bar";
+			expect(expand(text, [makeSkill()])).toBe(text);
+		});
+
+		test("longer name does not match a shorter skill (name must end at boundary)", () => {
+			const skill = makeSkill();
+			const text = "h\n/verify-buildx now";
+			expect(expand(text, [skill])).toBe(text);
+		});
+
+		test("single-character names never trigger", () => {
+			const text = "h\n/a and /b";
+			expect(expand(text, [makeSkill()])).toBe(text);
+		});
+	});
+
+	describe("fail-soft and recursion", () => {
+		test("unresolvable name stays literal, silently", () => {
+			const text = "h\nrun /nope now";
+			expect(expand(text, [makeSkill()])).toBe(text);
+		});
+
+		test("unreadable skill file stays literal", () => {
+			const skill = makeSkill();
+			const text = "h\n/verify-build now";
+			expect(expand(text, [skill], [], readerFor({}))).toBe(text);
+		});
+
+		test("expanded bodies are never rescanned (no recursion)", () => {
+			const skill = makeSkill();
+			const recursive = makeSkill({
+				name: "self-echo",
+				filePath: "/skills/self/SKILL.md",
+				baseDir: "/skills/self",
+			});
+			const reader = readerFor({
+				"/skills/verify-build/SKILL.md":
+					"---\nname: verify-build\ndescription: d\n---\nAlso run /self-echo please.",
+				"/skills/self/SKILL.md": "---\nname: self-echo\ndescription: d\n---\nEcho.",
+			});
+			const out = expandMidsentence(
+				"h\n/verify-build",
+				{ skills: [skill, recursive], templates: [] },
+				{ readSkillFile: reader },
+			);
+			expect(out).toContain("/self-echo please."); // literal inside the expanded body
+			expect(out).not.toContain('<skill name="self-echo"');
+		});
+
+		test("skills with disable-model-invocation expand mid-sentence", () => {
+			const skill = makeSkill({ disableModelInvocation: true });
+			const out = expand("h\n/verify-build now", [skill]);
+			expect(out).toBe(`h\n${buildSkillInvocation(skill, SKILL_MD, "now")}`);
+		});
+	});
+
+	describe("templates", () => {
+		test("expands with argument substitution identical to line-1 native behavior", () => {
+			const template = makeTemplate({ content: "Do $1 then $2" });
+			expect(expand("h\n/review alpha beta", [], [template])).toBe("h\nDo alpha then beta");
+		});
+
+		test("args without placeholders are dropped exactly like line-1 expansion", () => {
+			const template = makeTemplate({ content: "No placeholders" });
+			expect(expand("h\n/review extra words", [], [template])).toBe("h\nNo placeholders");
+		});
+
+		test("quoted args parse like the native command", () => {
+			const template = makeTemplate({ content: "Do $1 and $2" });
+			expect(expand(`h\n/review "two words" single`, [], [template])).toBe("h\nDo two words and single");
+		});
+	});
+});
+
+describe("buildSkillInvocation matches the native /skill: expansion", () => {
+	test("byte-identical block shape with and without args", () => {
+		expect(buildSkillInvocation(makeSkill(), SKILL_MD, "extra")).toBe(
+			`<skill name="verify-build" location="/skills/verify-build/SKILL.md">\nReferences are relative to /skills/verify-build.\n\nRun the full build checks.\n</skill>\n\nextra`,
+		);
+		expect(buildSkillInvocation(makeSkill(), SKILL_MD, "")).toBe(
+			`<skill name="verify-build" location="/skills/verify-build/SKILL.md">\nReferences are relative to /skills/verify-build.\n\nRun the full build checks.\n</skill>`,
+		);
+	});
+});


### PR DESCRIPTION
## Problem

`/skill:name args` and `/template args` only expand at the start of the input (#8457). A skill or template referenced in the middle of a message stays literal, so the user has to split the message and resend the invocation as its own line.

Skills with `disable-model-invocation: true` cannot be invoked at all unless the token is at position 0: they are hidden from the system prompt, and the native expansion only fires when the text starts with the command.

Extensions cannot fix this: the extension API exposes no way to read loaded skills (only to contribute paths via `resources_discover`), so an extension would have to duplicate the skill loader and drift.

## Example

```text
User input:
  can you check the build please run /verify-build on the current branch and summarize

Model receives (at the invocation site):
  can you check the build please run <skill name="verify-build" location="...">
  References are relative to ...

  (skill body)
  </skill>

  on the current branch and summarize
```

Multiple tokens in one message all expand, in position order.

## Solution

A single-pass scanner (`src/core/midsentence.ts`) expands `/name args` tokens anywhere except the very start of the message (a slash at position 0 begins a line-1 command, which consumes the whole first line; `/skill:foo` after a space also stays literal). Names resolve against prompt templates first, then skills, by exact match, unique case-insensitive variant, or unique prefix. Skill output is byte-identical to the native `/skill:name` expansion (shared builder), template output identical to line-1 expansion (`parseCommandArgs` + `substituteArgs`). Unresolvable names and unreadable files stay literal, silently. The output is never rescanned, so expansions cannot recurse.

Wired into `prompt()`, `steer()`, and `followUp()` before the native expansions, respecting the `expandPromptTemplates` option, so native line-1 output is never rescanned. Arguably this also makes `disable-model-invocation` skills reachable in practice: the user can invoke them anywhere in the message without giving up the surrounding prose.

The same works for prompt templates: `/templatename args` anywhere except the very start expands the template body with the arguments, identical to line-1 behavior. If a skill and a template share a name, the template wins.
