### PR TITLE
fix(tui): allow zero-row custom footers

### DIFF
--- a/packages/coding-agent/src/modes/interactive/chat-viewport.ts
+++ b/packages/coding-agent/src/modes/interactive/chat-viewport.ts
@@ -34,7 +34,8 @@ export function createChatViewport(options: ChatViewportOptions): ChatViewport {
 		...(options.widgetsAbove === undefined ? [] : [{ component: options.widgetsAbove, shrink: 1, minSize: 0 }]),
 		{ component: options.editor, shrink: 1, minSize: 3 },
 		...(options.widgetsBelow === undefined ? [] : [{ component: options.widgetsBelow, shrink: 1, minSize: 0 }]),
-		{ component: options.footer, shrink: 1, minSize: 1 },
+		// A custom footer may intentionally render no rows; do not reserve a blank dock row for it.
+		{ component: options.footer, shrink: 1, minSize: 0 },
 	]);
 	return {
 		transcript,


### PR DESCRIPTION
Fixes #8919.

A custom footer may intentionally render `[]`. In fullscreen mode, its dock slot previously had `minSize: 1`, leaving a blank terminal row even though no footer content existed. Set its minimum size to zero.

The built-in footer still has intrinsic height, so its normal layout is unchanged.

Tested manually with `pi-zentui` footer style `hidden` on Pi 0.85.1 (including a mobile terminal).

Automated test note: the fresh checkout has no installed workspace dependencies, so `npm test --workspace=@earendil-works/pi-coding-agent -- --run test/chat-viewport.test.ts` could not start (`vitest: command not found`).