### PR TITLE
fix(coding-agent): preserve host UI prototype methods and Proxy traps in wrapUIPromptContext

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -439,8 +439,8 @@ export class ExtensionRunner {
 	}
 
 	private wrapUIPromptContext(ui: ExtensionUIContext): ExtensionUIContext {
-		return {
-			...ui,
+		// 使用 Object.create(ui) 而非 {...ui} 展开复制，以保留宿主类实例的原型方法以及 Proxy get 拦截属性
+		const overrides: Pick<ExtensionUIContext, "select" | "confirm" | "input" | "editor" | "custom"> = {
 			select: (title, options, opts) => this.withUIPrompt("select", title, () => ui.select(title, options, opts)),
 			confirm: (title, message, opts) => this.withUIPrompt("confirm", title, () => ui.confirm(title, message, opts)),
 			input: (title, placeholder, opts) =>
@@ -448,6 +448,7 @@ export class ExtensionRunner {
 			editor: (title, prefill) => this.withUIPrompt("editor", title, () => ui.editor(title, prefill)),
 			custom: (factory, options) => this.withUIPrompt("custom", undefined, () => ui.custom(factory, options)),
 		};
+		return Object.assign(Object.create(ui) as ExtensionUIContext, overrides);
 	}
 
 	private withUIPrompt<T>(kind: UIPromptKind, title: string | undefined, run: () => Promise<T>): Promise<T> {

--- a/packages/coding-agent/test/suite/regressions/8829-wrap-ui-prompt-context.test.ts
+++ b/packages/coding-agent/test/suite/regressions/8829-wrap-ui-prompt-context.test.ts
@@ -1,0 +1,123 @@
+// Issue #8829: wrapUIPromptContext copying by spread loses UI prototype methods
+import { describe, expect, it } from "vitest";
+import type { ExtensionError, ExtensionUIContext } from "../../../src/core/extensions/index.ts";
+import { createHarness } from "../harness.ts";
+
+describe("issue #8829: wrapUIPromptContext host UI shapes", () => {
+	it("lets a session_start handler call class prototype setStatus/notify", async () => {
+		class HostUi {
+			statuses: Array<[string, string | undefined]> = [];
+			notices: string[] = [];
+			setStatus(key: string, text: string | undefined) {
+				this.statuses.push([key, text]);
+			}
+			notify(message: string) {
+				this.notices.push(message);
+			}
+		}
+
+		const host = new HostUi();
+		const errors: ExtensionError[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						ctx.ui.setStatus("0-claude-max", "🧠 5h 19%");
+						ctx.ui.notify("hello", "info");
+					});
+				},
+			],
+		});
+
+		try {
+			await harness.session.bindExtensions({
+				mode: "rpc",
+				uiContext: host as unknown as ExtensionUIContext,
+				onError: (error) => errors.push(error),
+			});
+
+			expect(errors).toEqual([]);
+			expect(host.statuses).toEqual([["0-claude-max", "🧠 5h 19%"]]);
+			expect(host.notices).toEqual(["hello"]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("lets a session_start handler read a Proxy get-trap brand", async () => {
+		const brand = Symbol("relay-ui");
+		let seen: unknown;
+		const proxied = new Proxy(
+			{},
+			{
+				get(_target, prop) {
+					if (prop === brand) return "child";
+					return undefined;
+				},
+			},
+		);
+
+		const errors: ExtensionError[] = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", (_event, ctx) => {
+						seen = Reflect.get(ctx.ui, brand);
+					});
+				},
+			],
+		});
+
+		try {
+			await harness.session.bindExtensions({
+				mode: "rpc",
+				uiContext: proxied as unknown as ExtensionUIContext,
+				onError: (error) => errors.push(error),
+			});
+
+			expect(errors).toEqual([]);
+			expect(seen).toBe("child");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("still wraps prompt methods with ui_prompt_start and ui_prompt_end events", async () => {
+		const promptEvents: string[] = [];
+		const selectMock = async (title: string, _options: string[]) => `selected:${title}`;
+
+		const hostUi = {
+			select: selectMock,
+		};
+
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					pi.on("ui_prompt_start", (event) => {
+						promptEvents.push(`start:${event.kind}:${event.title}`);
+					});
+					pi.on("ui_prompt_end", (event) => {
+						promptEvents.push(`end:${event.kind}:${event.title}`);
+					});
+				},
+			],
+		});
+
+		try {
+			await harness.session.bindExtensions({
+				mode: "rpc",
+				uiContext: hostUi as unknown as ExtensionUIContext,
+			});
+
+			const result = await harness.session.extensionRunner.getUIContext().select("choose one", ["a", "b"]);
+			expect(result).toBe("selected:choose one");
+
+			// Allow queued microtasks to flush
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(promptEvents).toEqual(["start:select:choose one", "end:select:choose one"]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

In `packages/coding-agent/src/core/extensions/runner.ts`, `ExtensionRunner.prototype.wrapUIPromptContext` previously wrapped `ExtensionUIContext` using object spread (`{ ...ui, ... }`). Because object spread only copies own enumerable properties, embedder-provided UI contexts implemented as class instances or Proxy objects (e.g. `pi-web-ui` or `rpiv-pi`) lost prototype methods and `get` trap properties.

This change switches to prototype delegation via `Object.assign(Object.create(ui) as ExtensionUIContext, overrides)` so class prototype methods, getters, and Proxy `get` traps are preserved while keeping prompt lifecycle wrapping intact.

## Testing

- Added regression tests in `packages/coding-agent/test/suite/regressions/8829-wrap-ui-prompt-context.test.ts` verifying:
  - Class prototype methods (`setStatus`, `notify`) survive wrapping and execute successfully.
  - Proxy `get` trap properties survive wrapping.
  - Prompt methods still emit `ui_prompt_start` and `ui_prompt_end` events.
- All existing extension runner tests pass: `node ../../node_modules/vitest/dist/cli.js --run test/extensions-runner.test.ts` (38/38 passed).
- Monorepo checks pass: `npm run check` (0 errors, 0 warnings).

Fixes #8829
