### PR TITLE
fix(ai): clamp OpenRouter :free maxTokens to base model

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -8,6 +8,7 @@ import {
 	getOpenRouterThinkingLevelMap,
 	type OpenRouterReasoningMetadata,
 } from "./openrouter-reasoning-options.ts";
+import { clampOpenRouterFreeVariantLimits } from "./openrouter-variant-limits.ts";
 import {
 	CLOUDFLARE_AI_GATEWAY_ANTHROPIC_BASE_URL,
 	CLOUDFLARE_AI_GATEWAY_COMPAT_BASE_URL,
@@ -2943,6 +2944,9 @@ async function generateModels() {
 		applyOpenAIExplicitPromptCacheMetadata(model);
 	}
 	applyAnthropicAllowedFallbackModelMetadata(allModels.filter(isAnthropicFallbackMetadataModel));
+
+	// OpenRouter :free variants often inherit inflated limits from bad catalog data (#8760).
+	clampOpenRouterFreeVariantLimits(allModels);
 
 	// Group by provider and deduplicate by model ID
 	const providers: Record<string, Record<string, Model<any>>> = {};

--- a/packages/ai/scripts/openrouter-variant-limits.ts
+++ b/packages/ai/scripts/openrouter-variant-limits.ts
@@ -1,0 +1,37 @@
+import type { Api, Model } from "../src/types.ts";
+
+type LimitFields = Pick<Model<Api>, "provider" | "id" | "maxTokens" | "contextWindow">;
+
+/**
+ * OpenRouter `:free` routes often advertise larger context/output limits than the
+ * matching base entry. Pi then sends that inflated `maxTokens` as `max_tokens`,
+ * and upstream providers reject the request (HTTP 400).
+ *
+ * Example from #8760: `minimax/minimax-m3:free` advertised maxTokens 943718 while
+ * `minimax/minimax-m3` is 512000; GMICloud rejects anything above 524288.
+ *
+ * Clamp free-variant limits down to the base model when both are present.
+ * Mutates models in place (same pattern as other catalog overrides).
+ */
+export function clampOpenRouterFreeVariantLimits<T extends LimitFields>(models: T[]): T[] {
+	const openrouterById = new Map<string, T>();
+	for (const model of models) {
+		if (model.provider === "openrouter") {
+			openrouterById.set(model.id, model);
+		}
+	}
+
+	for (const model of models) {
+		if (model.provider !== "openrouter" || !model.id.endsWith(":free")) continue;
+		const base = openrouterById.get(model.id.slice(0, -":free".length));
+		if (!base) continue;
+		if (model.maxTokens > base.maxTokens) {
+			model.maxTokens = base.maxTokens;
+		}
+		if (model.contextWindow > base.contextWindow) {
+			model.contextWindow = base.contextWindow;
+		}
+	}
+
+	return models;
+}

--- a/packages/ai/test/openrouter-variant-limits.test.ts
+++ b/packages/ai/test/openrouter-variant-limits.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { clampOpenRouterFreeVariantLimits } from "../scripts/openrouter-variant-limits.ts";
+
+function model(partial: { id: string; provider?: string; maxTokens: number; contextWindow: number }) {
+	return {
+		provider: partial.provider ?? "openrouter",
+		id: partial.id,
+		maxTokens: partial.maxTokens,
+		contextWindow: partial.contextWindow,
+	};
+}
+
+describe("clampOpenRouterFreeVariantLimits", () => {
+	// #8760
+	it("clamps OpenRouter :free maxTokens and contextWindow down to the base model", () => {
+		const base = model({
+			id: "minimax/minimax-m3",
+			maxTokens: 512000,
+			contextWindow: 524288,
+		});
+		const free = model({
+			id: "minimax/minimax-m3:free",
+			maxTokens: 943718,
+			contextWindow: 1048576,
+		});
+
+		clampOpenRouterFreeVariantLimits([base, free]);
+
+		expect(free.maxTokens).toBe(512000);
+		expect(free.contextWindow).toBe(524288);
+		expect(base.maxTokens).toBe(512000);
+		expect(base.contextWindow).toBe(524288);
+	});
+
+	it("does not raise free-variant limits when they are already below the base", () => {
+		const base = model({
+			id: "acme/widget",
+			maxTokens: 128000,
+			contextWindow: 256000,
+		});
+		const free = model({
+			id: "acme/widget:free",
+			maxTokens: 8192,
+			contextWindow: 32000,
+		});
+
+		clampOpenRouterFreeVariantLimits([base, free]);
+
+		expect(free.maxTokens).toBe(8192);
+		expect(free.contextWindow).toBe(32000);
+	});
+
+	it("leaves free variants unchanged when no base model exists", () => {
+		const free = model({
+			id: "orphan/model:free",
+			maxTokens: 943718,
+			contextWindow: 1048576,
+		});
+
+		clampOpenRouterFreeVariantLimits([free]);
+
+		expect(free.maxTokens).toBe(943718);
+		expect(free.contextWindow).toBe(1048576);
+	});
+
+	it("ignores non-openrouter providers and non-:free ids", () => {
+		const paid = model({
+			id: "minimax/minimax-m3",
+			provider: "openrouter",
+			maxTokens: 512000,
+			contextWindow: 524288,
+		});
+		const otherProviderFree = model({
+			id: "minimax/minimax-m3:free",
+			provider: "vercel-ai-gateway",
+			maxTokens: 943718,
+			contextWindow: 1048576,
+		});
+		const openrouterPaid = model({
+			id: "minimax/minimax-m3",
+			provider: "openrouter",
+			maxTokens: 999999,
+			contextWindow: 999999,
+		});
+
+		clampOpenRouterFreeVariantLimits([paid, otherProviderFree, openrouterPaid]);
+
+		expect(otherProviderFree.maxTokens).toBe(943718);
+		expect(openrouterPaid.maxTokens).toBe(999999);
+	});
+});


### PR DESCRIPTION
## Summary

OpenRouter :free catalog entries often advertise larger maxTokens/contextWindow than the matching base model. Pi defaults request max_tokens from that catalog value, so selecting e.g. minimax/minimax-m3:free sends ~943k and GMICloud 400s with "does not support max tokens > 524288".

## Fix

During model generation, clamp OpenRouter :free variants down to their base entry when both are present (same pattern as other temporary catalog overrides). For the MiniMax case that becomes 512000 / 524288, which is within the upstream hard limit.

## Tests

- packages/ai/test/openrouter-variant-limits.test.ts - fixture mirroring #8760 plus pass-through cases
- npm run check (biome, deps, tsgo, smoke) - passed
- packages/ai vitest suite - 1015 passed
- Full ./test.sh hit unrelated missing-dist / package-export failures in other workspaces on this fresh clone; relevant packages/ai tests above passed after generate-models

## Contributor gate

I understand new-contributor PRs may be auto-closed without maintainer lgtm. Happy to iterate after review / lgtm if this gets closed.

Fixes #8760
