### PR TITLE
fix(coding-agent): resolve model auth live instead of from startup snapshot

### DIFF
--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -674,15 +674,23 @@ export async function findInitialModel(options: {
 	// 3. Try saved default from settings if auth is configured.
 	if (defaultProvider && defaultModelId) {
 		const found = modelRuntime.getModel(defaultProvider, defaultModelId);
-		if (found && modelRuntime.hasConfiguredAuth(found.provider)) {
-			model = found;
-			const perModel = modelThinkingLevels?.[`${defaultProvider}/${defaultModelId}`];
-			if (perModel) {
-				thinkingLevel = perModel;
-			} else if (defaultThinkingLevel) {
-				thinkingLevel = defaultThinkingLevel;
+		if (found) {
+			// Resolve auth live instead of from the startup availability
+			// snapshot. That snapshot is populated by an unawaited background
+			// refresh and can be unsettled when findInitialModel() runs, which
+			// intermittently hides a configured credential and yields a spurious
+			// "No models available" warning.
+			const auth = await modelRuntime.checkAuth(found.provider);
+			if (auth) {
+				model = found;
+				const perModel = modelThinkingLevels?.[`${defaultProvider}/${defaultModelId}`];
+				if (perModel) {
+					thinkingLevel = perModel;
+				} else if (defaultThinkingLevel) {
+					thinkingLevel = defaultThinkingLevel;
+				}
+				return { model, thinkingLevel, fallbackMessage: undefined };
 			}
-			return { model, thinkingLevel, fallbackMessage: undefined };
 		}
 	}
 

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -199,8 +199,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// If session has data, try to restore model from it
 	if (!model && hasExistingSession && existingSession.model) {
 		const restoredModel = modelRuntime.getModel(existingSession.model.provider, existingSession.model.modelId);
-		if (restoredModel && modelRuntime.hasConfiguredAuth(restoredModel.provider)) {
-			model = restoredModel;
+		if (restoredModel) {
+			// Resolve auth live instead of from the startup availability snapshot
+			// (see findInitialModel): the snapshot can be unsettled at startup,
+			// intermittently producing a spurious "Could not restore model" warning.
+			const auth = await modelRuntime.checkAuth(restoredModel.provider);
+			if (auth) {
+				model = restoredModel;
+			}
 		}
 		if (!model) {
 			modelFallbackMessage = `Could not restore model ${existingSession.model.provider}/${existingSession.model.modelId}`;

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -810,7 +810,10 @@ describe("default model selection", () => {
 				provider === savedDeepSeekModel.provider && modelId === savedDeepSeekModel.id
 					? savedDeepSeekModel
 					: undefined,
-			hasConfiguredAuth: (provider: string) => provider === "spark-two",
+			// findInitialModel resolves saved-default auth live via checkAuth.
+			// Only the local ("spark-two") copy is authenticated, so the saved
+			// default (deepseek) must be ignored.
+			checkAuth: (provider: string) => Promise.resolve(provider === "spark-two" ? { type: "api_key" } : undefined),
 			getAvailableSnapshot: () => [localDeepSeekModel],
 		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
 
@@ -824,6 +827,46 @@ describe("default model selection", () => {
 
 		expect(result.model?.provider).toBe("spark-two");
 		expect(result.model?.id).toBe("deepseek-v4-flash");
+	});
+
+	test("findInitialModel selects a saved default when the availability snapshot is unsettled", async () => {
+		// Regression: at startup the availability snapshot (read by hasConfiguredAuth)
+		// can be unsettled because it is populated by an unawaited background refresh.
+		// When that snapshot is empty but the credential is actually configured, the
+		// saved default must still resolve. findInitialModel now resolves auth live via
+		// checkAuth, which is authoritative.
+		const savedModel: Model<"anthropic-messages"> = {
+			id: "local-model",
+			name: "Local Model",
+			api: "anthropic-messages",
+			provider: "llama.cpp",
+			baseUrl: "http://localhost:8080/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		};
+		const registry = {
+			getModel: (provider: string, modelId: string) =>
+				provider === savedModel.provider && modelId === savedModel.id ? savedModel : undefined,
+			// The snapshot is unsettled (empty), so hasConfiguredAuth reports false.
+			hasConfiguredAuth: () => false,
+			// The live check finds the credential is configured.
+			checkAuth: (provider: string) => Promise.resolve(provider === "llama.cpp" ? { type: "api_key" } : undefined),
+			getAvailableSnapshot: () => [savedModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: "llama.cpp",
+			defaultModelId: "local-model",
+			modelRuntime: registry,
+		});
+
+		expect(result.model?.provider).toBe("llama.cpp");
+		expect(result.model?.id).toBe("local-model");
 	});
 
 	describe("persisted default model scoping", () => {


### PR DESCRIPTION
## Problem

At startup, two code paths gate model resolution on `modelRuntime.hasConfiguredAuth()`, which reads the `configuredProviders` set in the availability snapshot. That snapshot is populated by an unawaited background refresh and can be unsettled when these code paths run. When it is, `hasConfiguredAuth()` returns false for a provider whose credential is actually configured, producing:

- a spurious `No models available.` warning on fresh startup
- a spurious `Could not restore model ... Using ...` warning on session resume

This is timing-dependent, so it appears intermittently.

## Fix

Both code paths (`findInitialModel` step 3 in `model-resolver.ts` and the session-restore block in `createAgentSession()` in `sdk.ts`) now call `await modelRuntime.checkAuth()` directly. `checkAuth` resolves the credential from the local credential store and is authoritative — it does not depend on the background snapshot.

## Tests

- Updated the existing `findInitialModel ignores an unauthenticated saved default` test to mock `checkAuth` (async) instead of `hasConfiguredAuth` (sync), preserving the original assertion.
- Added a new regression test that encodes the race: `hasConfiguredAuth` returns false (empty snapshot) while `checkAuth` returns a valid credential, and asserts the saved default is still selected.
