### PR TITLE
feat(coding-agent): hop to a fallback provider on transport errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Anthropic per-turn effort persistence, deterministic historical effort markers, and signed-thinking mismatch recovery for supported Claude models across Anthropic Messages transports, including OpenRouter.
+- Added `isUnreachableAssistantError` to classify transport/timeout failures separately from same-provider retryable errors ([#9242](https://github.com/earendil-works/pi/issues/9242)).
 
 ### Fixed
 

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -89,6 +89,34 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
 	"ResourceExhausted",
 ]);
 
+const UNREACHABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+	// Transport / gateway reachability. Used by coding-agent provider fallback
+	// hops so 429/5xx/overloaded stay on the same-provider retry path.
+	"network.?error",
+	"connection.?error",
+	"connection.?refused",
+	"connection.?lost",
+	"other side closed",
+	"fetch failed",
+	"getaddrinfo",
+	"ENOTFOUND",
+	"EAI_AGAIN",
+	"ENETUNREACH",
+	"EHOSTUNREACH",
+	"ECONNREFUSED",
+	"ECONNRESET",
+	"ETIMEDOUT",
+	"EPIPE",
+	"upstream.?connect",
+	"reset before headers",
+	"socket hang up",
+	"socket connection was closed",
+	"timed? out",
+	"timeout",
+	"network.?unreachable",
+	"host.?unreachable",
+]);
+
 /**
  * Retry policy: bounded attempts with exponential backoff (`baseDelayMs * 2^(attempt-1)`).
  * Matches `settings.retry` (`enabled`, `maxRetries`, `baseDelayMs`) in coding-agent; kept
@@ -226,4 +254,18 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
 	const errorMessage = message.errorMessage;
 	if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) return false;
 	return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage);
+}
+
+/**
+ * Classifies whether a failed assistant message looks like the current
+ * provider/gateway is unreachable (DNS, connect, timeout, dropped socket).
+ *
+ * Auth and quota/billing errors are never unreachable. Overloaded, 429, and
+ * 5xx responses are retryable on the same provider but are not hops.
+ */
+export function isUnreachableAssistantError(message: AssistantMessage): boolean {
+	if (message.stopReason !== "error" || !message.errorMessage) return false;
+	const errorMessage = message.errorMessage;
+	if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) return false;
+	return UNREACHABLE_PROVIDER_ERROR_PATTERN.test(errorMessage);
 }

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { fauxAssistantMessage } from "../src/providers/faux.ts";
-import { isRetryableAssistantError, type RetryPolicy, retryAssistantCall } from "../src/utils/retry.ts";
+import {
+	isRetryableAssistantError,
+	isUnreachableAssistantError,
+	type RetryPolicy,
+	retryAssistantCall,
+} from "../src/utils/retry.ts";
 
 const openAIExplicitRetryMessage =
 	"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_******** in your message.";
@@ -86,6 +91,42 @@ describe("provider retry classification", () => {
 			),
 		).toBe(true);
 		expect(isRetryableAssistantError(fauxAssistantMessage("not an error"))).toBe(false);
+	});
+});
+
+describe("unreachable provider classification", () => {
+	it.each([
+		"connect ECONNREFUSED 127.0.0.1:9",
+		"fetch failed",
+		"getaddrinfo ENOTFOUND api.example.com",
+		"connect ETIMEDOUT 1.2.3.4:443",
+		"Provider finish_reason: network_error",
+		wrappedDnsLookupError,
+	])("matches transport/unreachable wording: %s", (errorMessage) => {
+		expect(isUnreachableAssistantError(fauxAssistantMessage("", { stopReason: "error", errorMessage }))).toBe(true);
+	});
+
+	it("does not hop on overloaded, 429, or quota errors", () => {
+		expect(
+			isUnreachableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			),
+		).toBe(false);
+		expect(
+			isUnreachableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: "429 too many requests" }),
+			),
+		).toBe(false);
+		expect(
+			isUnreachableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: "insufficient_quota" }),
+			),
+		).toBe(false);
+		expect(
+			isUnreachableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: "401 unauthorized" }),
+			),
+		).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `retry.fallbackChains` so a session can hop to another registered provider/model on transport/unreachable errors ([#9242](https://github.com/earendil-works/pi/issues/9242)).
+
 ### Fixed
 
 - Fixed branch summaries failing when reasoning consumes the previous 2048-token output cap ([#8845](https://github.com/earendil-works/pi/issues/8845)).

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -739,13 +739,13 @@ Header availability depends on provider and transport. Providers that abstract H
 
 #### model_select
 
-Fired when the model changes via `/model` command, model cycling (`Ctrl+P`), or session restore.
+Fired when the model changes via `/model` command, model cycling (`Ctrl+P`), session restore, or a transport-error fallback hop.
 
 ```typescript
 pi.on("model_select", async (event, ctx) => {
   // event.model - newly selected model
   // event.previousModel - previous model (undefined if first selection)
-  // event.source - "set" | "cycle" | "restore"
+  // event.source - "set" | "cycle" | "restore" | "fallback"
 
   const prev = event.previousModel
     ? `${event.previousModel.provider}/${event.previousModel.id}`

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -877,6 +877,7 @@ Events are streamed to stdout as JSON lines during agent operation. Events do no
 | `compaction_end` | Compaction completes |
 | `auto_retry_start` | Auto-retry begins (after transient error) |
 | `auto_retry_end` | Auto-retry completes (success or final failure) |
+| `provider_fallback` | Session hopped to the next model in `retry.fallbackChains` after a transport/unreachable error |
 | `summarization_retry_scheduled` | Retry scheduled for a transient compaction or branch-summary summarization error |
 | `summarization_retry_attempt_start` | Retried summarization request starts |
 | `summarization_retry_finished` | Summarization retry loop completes |
@@ -1135,6 +1136,19 @@ On final failure (max retries exceeded):
   "success": false,
   "attempt": 3,
   "finalError": "529 overloaded_error: Overloaded"
+}
+```
+
+### provider_fallback
+
+Emitted when the session hops to the next `provider/model` in `retry.fallbackChains` after a transport/unreachable error. Auth and quota failures do not emit this event.
+
+```json
+{
+  "type": "provider_fallback",
+  "from": { "provider": "primary-gw", "modelId": "kimi" },
+  "to": { "provider": "backup-gw", "modelId": "kimi" },
+  "errorMessage": "connect ECONNREFUSED 127.0.0.1:9"
 }
 ```
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -319,6 +319,7 @@ session.subscribe((event) => {
     case "compaction_end":
     case "auto_retry_start":
     case "auto_retry_end":
+    case "provider_fallback":
     case "summarization_retry_scheduled":
     case "summarization_retry_attempt_start":
     case "summarization_retry_finished":

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -146,6 +146,7 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the Pi version update check. Use `--off
 | `retry.provider.timeoutMs` | number | SDK default | Provider/SDK request timeout in milliseconds |
 | `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
+| `retry.fallbackChains` | `string[][]` | unset | Ordered `provider/modelId` hop lists. On transport/unreachable errors, Pi hops to the next registered, authenticated entry in the matching chain. Auth and quota failures do not hop. 429/5xx/overloaded stay on same-provider retry. The hop is session-only and is not saved as the default model. Project settings replace the whole list (arrays do not merge). |
 
 When a provider requests a retry delay longer than `retry.provider.maxRetryDelayMs`, the request fails immediately with an informative error instead of waiting silently. Set it to `0` to disable the limit.
 
@@ -161,7 +162,10 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
       "timeoutMs": 3600000,
       "maxRetries": 0,
       "maxRetryDelayMs": 60000
-    }
+    },
+    "fallbackChains": [
+      ["primary-gw/kimi", "backup-gw/kimi"]
+    ]
   }
 }
 ```

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -42,6 +42,7 @@ import {
 	isContextOverflow,
 	isRecoverableLength,
 	isRetryableAssistantError,
+	isUnreachableAssistantError,
 	modelsAreEqual,
 	type RetryCallbacks,
 	resetApiProviders,
@@ -79,6 +80,7 @@ import {
 	type MessageEndEvent,
 	type MessageStartEvent,
 	type MessageUpdateEvent,
+	type ModelSelectSource,
 	type ReplacedSessionContext,
 	type SessionBeforeCompactResult,
 	type SessionBeforeTreeResult,
@@ -100,6 +102,7 @@ import type { BashExecutionMessage, CustomMessage } from "./messages.ts";
 import { ModelRegistry } from "./model-registry.ts";
 import type { ModelRuntime } from "./model-runtime.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
+import { findNextFallbackRefs } from "./provider-fallback.ts";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.ts";
 import { exportSessionToJsonl } from "./session-export.ts";
 import type { BranchSummaryEntry, CompactionEntry, SessionEntry, SessionManager } from "./session-manager.ts";
@@ -168,6 +171,12 @@ export type AgentSessionEvent =
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+	| {
+			type: "provider_fallback";
+			from: { provider: string; modelId: string };
+			to: { provider: string; modelId: string };
+			errorMessage: string;
+	  }
 	| {
 			type: "summarization_retry_scheduled";
 			attempt: number;
@@ -723,16 +732,20 @@ export class AgentSession {
 	};
 
 	private _willRetryAfterAgentEnd(event: Extract<AgentEvent, { type: "agent_end" }>): boolean {
-		const settings = this.settingsManager.getRetrySettings();
-		if (!settings.enabled || this._retryAttempt >= settings.maxRetries) {
-			return false;
-		}
-
 		for (let i = event.messages.length - 1; i >= 0; i--) {
 			const message = event.messages[i];
-			if (message.role === "assistant") {
-				return this._isRetryableError(message as AssistantMessage);
+			if (message.role !== "assistant") {
+				continue;
 			}
+			const assistantMessage = message as AssistantMessage;
+			if (this._hasProviderFallback(assistantMessage)) {
+				return true;
+			}
+			const settings = this.settingsManager.getRetrySettings();
+			if (!settings.enabled || this._retryAttempt >= settings.maxRetries) {
+				return false;
+			}
+			return this._isRetryableError(assistantMessage);
 		}
 		return false;
 	}
@@ -1122,6 +1135,10 @@ export class AgentSession {
 		this._lastAssistantMessage = undefined;
 		if (!msg) {
 			return false;
+		}
+
+		if (this._isUnreachableProviderError(msg) && (await this._prepareProviderFallback(msg))) {
+			return true;
 		}
 
 		if (this._isRetryableError(msg) && (await this._prepareRetry(msg))) {
@@ -1638,7 +1655,7 @@ export class AgentSession {
 	private async _emitModelSelect(
 		nextModel: Model<any>,
 		previousModel: Model<any> | undefined,
-		source: "set" | "cycle" | "restore",
+		source: ModelSelectSource,
 	): Promise<void> {
 		if (modelsAreEqual(previousModel, nextModel)) return;
 		await this._extensionRunner.emit({
@@ -2856,6 +2873,75 @@ export class AgentSession {
 		return isRetryableAssistantError(message);
 	}
 
+	private _isUnreachableProviderError(message: AssistantMessage): boolean {
+		if (isContextOverflow(message, this.model?.contextWindow ?? 0)) return false;
+		return isUnreachableAssistantError(message);
+	}
+
+	private _nextFallbackModels(): Model<any>[] {
+		const current = this.model;
+		if (!current) {
+			return [];
+		}
+		const refs = findNextFallbackRefs(
+			{ provider: current.provider, modelId: current.id },
+			this.settingsManager.getFallbackChains(),
+		);
+		const models: Model<any>[] = [];
+		for (const ref of refs) {
+			const model = this._modelRuntime.getModel(ref.provider, ref.modelId);
+			if (!model || !this._modelRuntime.hasConfiguredAuth(ref.provider)) {
+				continue;
+			}
+			models.push(model);
+		}
+		return models;
+	}
+
+	private _hasProviderFallback(message: AssistantMessage): boolean {
+		return this._isUnreachableProviderError(message) && this._nextFallbackModels().length > 0;
+	}
+
+	private _dropLastAssistantError(): void {
+		const messages = this.agent.state.messages;
+		if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+			this.agent.state.messages = messages.slice(0, -1);
+		}
+	}
+
+	/**
+	 * Hop to the next registered, authenticated model in a matching fallback chain.
+	 * Transport/unreachable only. Does not persist the hop as the default model.
+	 */
+	private async _prepareProviderFallback(message: AssistantMessage): Promise<boolean> {
+		const current = this.model;
+		if (!current) {
+			return false;
+		}
+
+		for (const candidate of this._nextFallbackModels()) {
+			if (!(await this._modelRuntime.checkAuth(candidate.provider))) {
+				continue;
+			}
+
+			const thinkingLevel = this._getThinkingLevelForModelSwitch(candidate);
+			this.agent.state.model = candidate;
+			this.sessionManager.appendModelChange(candidate.provider, candidate.id);
+			this.setThinkingLevel(thinkingLevel);
+			this._dropLastAssistantError();
+			this._emit({
+				type: "provider_fallback",
+				from: { provider: current.provider, modelId: current.id },
+				to: { provider: candidate.provider, modelId: candidate.id },
+				errorMessage: message.errorMessage || "Unknown error",
+			});
+			await this._emitModelSelect(candidate, current, "fallback");
+			return true;
+		}
+
+		return false;
+	}
+
 	/**
 	 * Retry policy + callbacks shared by compaction and branch-summary summarization calls.
 	 * Uses the same `settings.retry` budget/backoff as agent-turn retries so a single transient
@@ -2916,10 +3002,7 @@ export class AgentSession {
 		});
 
 		// Remove error message from agent state (keep in session for history)
-		const messages = this.agent.state.messages;
-		if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
-			this.agent.state.messages = messages.slice(0, -1);
-		}
+		this._dropLastAssistantError();
 
 		// Wait with exponential backoff (abortable)
 		this._retryAbortController = new AbortController();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -824,7 +824,7 @@ export interface ToolExecutionEndEvent {
 // Model Events
 // ============================================================================
 
-export type ModelSelectSource = "set" | "cycle" | "restore";
+export type ModelSelectSource = "set" | "cycle" | "restore" | "fallback";
 
 /** Fired when a new model is selected */
 export interface ModelSelectEvent {

--- a/packages/coding-agent/src/core/provider-fallback.ts
+++ b/packages/coding-agent/src/core/provider-fallback.ts
@@ -1,0 +1,72 @@
+/**
+ * Parse and resolve opt-in `retry.fallbackChains` entries.
+ *
+ * Each chain is an ordered list of `provider/modelId` refs. Model IDs may
+ * contain slashes; the first slash separates provider from model.
+ */
+
+export interface FallbackModelRef {
+	provider: string;
+	modelId: string;
+}
+
+export function parseFallbackModelRef(value: string): FallbackModelRef | undefined {
+	const trimmed = value.trim();
+	const slash = trimmed.indexOf("/");
+	if (slash <= 0 || slash >= trimmed.length - 1) {
+		return undefined;
+	}
+	const provider = trimmed.slice(0, slash).trim();
+	const modelId = trimmed.slice(slash + 1).trim();
+	if (!provider || !modelId) {
+		return undefined;
+	}
+	return { provider, modelId };
+}
+
+export function parseFallbackChains(value: unknown): FallbackModelRef[][] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+
+	const chains: FallbackModelRef[][] = [];
+	for (const chain of value) {
+		if (!Array.isArray(chain)) {
+			continue;
+		}
+		const refs: FallbackModelRef[] = [];
+		for (const entry of chain) {
+			if (typeof entry !== "string") {
+				continue;
+			}
+			const ref = parseFallbackModelRef(entry);
+			if (ref) {
+				refs.push(ref);
+			}
+		}
+		if (refs.length >= 2) {
+			chains.push(refs);
+		}
+	}
+	return chains;
+}
+
+export function fallbackModelRefKey(ref: FallbackModelRef): string {
+	return `${ref.provider}/${ref.modelId}`.toLowerCase();
+}
+
+/** Remaining hops after the current model in the first matching chain. */
+export function findNextFallbackRefs(
+	current: FallbackModelRef,
+	chains: readonly FallbackModelRef[][],
+): FallbackModelRef[] {
+	const currentKey = fallbackModelRefKey(current);
+	for (const chain of chains) {
+		const index = chain.findIndex((ref) => fallbackModelRefKey(ref) === currentKey);
+		if (index === -1) {
+			continue;
+		}
+		return chain.slice(index + 1);
+	}
+	return [];
+}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -9,6 +9,9 @@ import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
+import { type FallbackModelRef, parseFallbackChains } from "./provider-fallback.ts";
+
+export type { FallbackModelRef };
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
@@ -32,6 +35,11 @@ export interface RetrySettings {
 	maxRetries?: number; // default: 3
 	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
 	provider?: ProviderRetrySettings;
+	/**
+	 * Ordered provider/model hop lists used when the current provider is
+	 * unreachable (transport/timeout). Each entry is `provider/modelId`.
+	 */
+	fallbackChains?: string[][];
 }
 
 export type TuiMode = RendererTuiMode;
@@ -885,6 +893,10 @@ export class SettingsManager {
 			maxRetries: this.settings.retry?.maxRetries ?? 3,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
 		};
+	}
+
+	getFallbackChains(): FallbackModelRef[][] {
+		return parseFallbackChains(this.settings.retry?.fallbackChains);
 	}
 
 	getHttpIdleTimeoutMs(): number {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -258,6 +258,7 @@ export {
 export {
 	type CompactionSettings,
 	type DefaultProjectTrust,
+	type FallbackModelRef,
 	type FullscreenExitOutput,
 	type ImageSettings,
 	type PackageSource,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3411,6 +3411,23 @@ export class InteractiveMode {
 				break;
 			}
 
+			case "provider_fallback": {
+				this.chatContainer.addChild(new Spacer(1));
+				this.chatContainer.addChild(
+					new Text(
+						theme.fg(
+							"warning",
+							`Fell back from ${event.from.provider}/${event.from.modelId} to ${event.to.provider}/${event.to.modelId}`,
+						),
+						1,
+						0,
+					),
+				);
+				this.footer.invalidate();
+				this.ui.requestRender();
+				break;
+			}
+
 			case "auto_retry_end": {
 				// Restore escape handler
 				if (this.retryEscapeHandler) {

--- a/packages/coding-agent/test/agent-session-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback.test.ts
@@ -1,0 +1,255 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, EventStream } from "@earendil-works/pi-ai/compat";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentSession } from "../src/core/agent-session.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import type { ProviderModelConfig } from "../src/core/extensions/types.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "./utilities.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string, overrides?: Partial<AssistantMessage>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-completions",
+		provider: "primary-gw",
+		model: "kimi",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+function openaiCompatModel(id: string, name: string): ProviderModelConfig {
+	return {
+		id,
+		name,
+		api: "openai-completions",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	};
+}
+
+describe("AgentSession provider fallback", () => {
+	let session: AgentSession;
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `pi-fallback-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (session) {
+			session.dispose();
+		}
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true });
+		}
+	});
+
+	async function createFallbackSession(options: {
+		errorMessage: string;
+		fallbackChains?: string[][];
+		registerBackup?: boolean;
+		authBackup?: boolean;
+		retryEnabled?: boolean;
+	}) {
+		const registerBackup = options.registerBackup ?? true;
+		const authBackup = options.authBackup ?? true;
+		const providersSeen: string[] = [];
+
+		const sessionManager = SessionManager.inMemory();
+		const settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		const modelRegistry = await createModelRegistry(authStorage, tempDir);
+		const modelRuntime = getModelRuntime(modelRegistry);
+
+		modelRegistry.registerProvider("primary-gw", {
+			name: "Primary Gateway",
+			baseUrl: "http://127.0.0.1:9/v1",
+			apiKey: "primary-key",
+			api: "openai-completions",
+			models: [openaiCompatModel("kimi", "Kimi")],
+		});
+		if (registerBackup) {
+			modelRegistry.registerProvider("backup-gw", {
+				name: "Backup Gateway",
+				baseUrl: "http://127.0.0.1:10/v1",
+				apiKey: authBackup ? "backup-key" : undefined,
+				api: "openai-completions",
+				models: [openaiCompatModel("kimi", "Kimi")],
+			});
+		}
+		await authStorage.modify("primary-gw", async () => ({ type: "api_key", key: "primary-key" }));
+		if (registerBackup && authBackup) {
+			await authStorage.modify("backup-gw", async () => ({ type: "api_key", key: "backup-key" }));
+		}
+
+		const primary = modelRuntime.getModel("primary-gw", "kimi");
+		if (!primary) {
+			throw new Error("primary-gw/kimi was not registered");
+		}
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model: primary, systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				const provider = agent.state.model?.provider ?? "unknown";
+				providersSeen.push(provider);
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (provider === "primary-gw") {
+						const msg = createAssistantMessage("", {
+							provider,
+							stopReason: "error",
+							errorMessage: options.errorMessage,
+						});
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "error", reason: "error", error: msg });
+						return;
+					}
+					const msg = createAssistantMessage("Recovered on backup", {
+						provider,
+						model: agent.state.model?.id ?? "kimi",
+					});
+					stream.push({ type: "start", partial: msg });
+					stream.push({ type: "done", reason: "stop", message: msg });
+				});
+				return stream;
+			},
+		});
+
+		settingsManager.applyOverrides({
+			retry: {
+				enabled: options.retryEnabled ?? true,
+				maxRetries: 2,
+				baseDelayMs: 1,
+				fallbackChains: options.fallbackChains ?? [["primary-gw/kimi", "backup-gw/kimi"]],
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRuntime,
+			resourceLoader: createTestResourceLoader(),
+		});
+
+		return { session, providersSeen };
+	}
+
+	it("hops to another registered provider on transport/unreachable errors", async () => {
+		const created = await createFallbackSession({
+			errorMessage: "connect ECONNREFUSED 127.0.0.1:9",
+		});
+		const events: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "provider_fallback") {
+				events.push(`${event.from.provider}/${event.from.modelId}->${event.to.provider}/${event.to.modelId}`);
+			}
+			if (event.type === "auto_retry_start") {
+				events.push("retry");
+			}
+		});
+
+		await created.session.prompt("Test");
+
+		expect(created.providersSeen).toEqual(["primary-gw", "backup-gw"]);
+		expect(events).toEqual(["primary-gw/kimi->backup-gw/kimi"]);
+		expect(created.session.model?.provider).toBe("backup-gw");
+		expect(created.session.model?.id).toBe("kimi");
+	});
+
+	it("does not hop on auth or quota errors", async () => {
+		const created = await createFallbackSession({
+			errorMessage: "insufficient_quota",
+		});
+		const hops: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "provider_fallback") hops.push("hop");
+		});
+
+		await created.session.prompt("Test");
+
+		expect(created.providersSeen).toEqual(["primary-gw"]);
+		expect(hops).toEqual([]);
+		expect(created.session.model?.provider).toBe("primary-gw");
+	});
+
+	it("keeps 429/overloaded on the same-provider retry path", async () => {
+		const created = await createFallbackSession({
+			errorMessage: "overloaded_error",
+		});
+		const events: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "provider_fallback") events.push("hop");
+			if (event.type === "auto_retry_start") events.push(`retry:${event.attempt}`);
+		});
+
+		await created.session.prompt("Test");
+
+		expect(created.providersSeen).toEqual(["primary-gw", "primary-gw", "primary-gw"]);
+		expect(events).toEqual(["retry:1", "retry:2"]);
+		expect(created.session.model?.provider).toBe("primary-gw");
+	});
+
+	it("hops on transport errors even when same-provider retry is disabled", async () => {
+		const created = await createFallbackSession({
+			errorMessage: "fetch failed",
+			retryEnabled: false,
+		});
+
+		await created.session.prompt("Test");
+
+		expect(created.providersSeen).toEqual(["primary-gw", "backup-gw"]);
+		expect(created.session.model?.provider).toBe("backup-gw");
+	});
+
+	it("skips an unregistered hop and stays on the primary", async () => {
+		const created = await createFallbackSession({
+			errorMessage: "fetch failed",
+			registerBackup: false,
+		});
+		const hops: string[] = [];
+		created.session.subscribe((event) => {
+			if (event.type === "provider_fallback") hops.push("hop");
+		});
+
+		await created.session.prompt("Test");
+
+		expect(hops).toEqual([]);
+		expect(created.session.model?.provider).toBe("primary-gw");
+	});
+});

--- a/packages/coding-agent/test/provider-fallback.test.ts
+++ b/packages/coding-agent/test/provider-fallback.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { findNextFallbackRefs, parseFallbackChains, parseFallbackModelRef } from "../src/core/provider-fallback.ts";
+import { InMemorySettingsStorage, SettingsManager } from "../src/core/settings-manager.ts";
+
+describe("parseFallbackModelRef", () => {
+	it("splits on the first slash so model ids may contain slashes", () => {
+		expect(parseFallbackModelRef("openai/gpt-5")).toEqual({ provider: "openai", modelId: "gpt-5" });
+		expect(parseFallbackModelRef("openrouter/anthropic/claude-sonnet-4")).toEqual({
+			provider: "openrouter",
+			modelId: "anthropic/claude-sonnet-4",
+		});
+	});
+
+	it("rejects empty or provider-only refs", () => {
+		expect(parseFallbackModelRef("")).toBeUndefined();
+		expect(parseFallbackModelRef("openai")).toBeUndefined();
+		expect(parseFallbackModelRef("/model")).toBeUndefined();
+		expect(parseFallbackModelRef("openai/")).toBeUndefined();
+	});
+});
+
+describe("parseFallbackChains", () => {
+	it("keeps chains with at least two valid refs and drops junk", () => {
+		expect(
+			parseFallbackChains([
+				["primary-gw/kimi", "backup-gw/kimi"],
+				["lonely/model"],
+				"not-a-chain",
+				["bad", { nope: true }, "ok/model", "other/model"],
+			]),
+		).toEqual([
+			[
+				{ provider: "primary-gw", modelId: "kimi" },
+				{ provider: "backup-gw", modelId: "kimi" },
+			],
+			[
+				{ provider: "ok", modelId: "model" },
+				{ provider: "other", modelId: "model" },
+			],
+		]);
+	});
+
+	it("returns an empty list for missing or invalid settings", () => {
+		expect(parseFallbackChains(undefined)).toEqual([]);
+		expect(parseFallbackChains({})).toEqual([]);
+	});
+});
+
+describe("findNextFallbackRefs", () => {
+	const chains = parseFallbackChains([
+		["primary-gw/kimi", "backup-gw/kimi", "openai/gpt-5"],
+		["anthropic/claude-sonnet-4-5", "google/gemini-3.1-pro"],
+	]);
+
+	it("returns remaining hops from the first matching chain", () => {
+		expect(findNextFallbackRefs({ provider: "primary-gw", modelId: "kimi" }, chains)).toEqual([
+			{ provider: "backup-gw", modelId: "kimi" },
+			{ provider: "openai", modelId: "gpt-5" },
+		]);
+		expect(findNextFallbackRefs({ provider: "backup-gw", modelId: "kimi" }, chains)).toEqual([
+			{ provider: "openai", modelId: "gpt-5" },
+		]);
+	});
+
+	it("is case-insensitive and returns nothing at the end of a chain", () => {
+		expect(findNextFallbackRefs({ provider: "Primary-GW", modelId: "Kimi" }, chains)).toHaveLength(2);
+		expect(findNextFallbackRefs({ provider: "openai", modelId: "gpt-5" }, chains)).toEqual([]);
+		expect(findNextFallbackRefs({ provider: "missing", modelId: "model" }, chains)).toEqual([]);
+	});
+});
+
+describe("SettingsManager fallbackChains", () => {
+	it("exposes normalized chains from retry.fallbackChains", () => {
+		const manager = SettingsManager.inMemory({
+			retry: {
+				fallbackChains: [["primary-gw/kimi", "backup-gw/kimi"]],
+			},
+		});
+		expect(manager.getFallbackChains()).toEqual([
+			[
+				{ provider: "primary-gw", modelId: "kimi" },
+				{ provider: "backup-gw", modelId: "kimi" },
+			],
+		]);
+	});
+
+	it("lets project fallbackChains replace the global list", () => {
+		const storage = new InMemorySettingsStorage();
+		storage.withLock("global", () =>
+			JSON.stringify({
+				retry: { fallbackChains: [["global-a/model", "global-b/model"]] },
+			}),
+		);
+		storage.withLock("project", () =>
+			JSON.stringify({
+				retry: { fallbackChains: [["project-a/model", "project-b/model"]] },
+			}),
+		);
+
+		const manager = SettingsManager.fromStorage(storage);
+		expect(manager.getFallbackChains()).toEqual([
+			[
+				{ provider: "project-a", modelId: "model" },
+				{ provider: "project-b", modelId: "model" },
+			],
+		]);
+	});
+});

--- a/vitest.base.ts
+++ b/vitest.base.ts
@@ -13,6 +13,7 @@ export const workspaceSourcePaths = {
 	aiCompat: fileURLToPath(new URL("./packages/ai/src/compat.ts", import.meta.url)),
 	aiOAuth: fileURLToPath(new URL("./packages/ai/src/oauth.ts", import.meta.url)),
 	aiProviders: fileURLToPath(new URL("./packages/ai/src/providers", import.meta.url)),
+	aiUtils: fileURLToPath(new URL("./packages/ai/src/utils", import.meta.url)),
 	agentIndex: fileURLToPath(new URL("./packages/agent/src/index.ts", import.meta.url)),
 	agentNode: fileURLToPath(new URL("./packages/agent/src/node.ts", import.meta.url)),
 	protocolIndex: fileURLToPath(new URL("./packages/protocol/src/index.ts", import.meta.url)),
@@ -40,6 +41,10 @@ export default defineConfig({
 			{
 				find: /^@earendil-works\/pi-ai\/providers\/(.+)$/,
 				replacement: `${workspaceSourcePaths.aiProviders}/$1.ts`,
+			},
+			{
+				find: /^@earendil-works\/pi-ai\/utils\/(.+)$/,
+				replacement: `${workspaceSourcePaths.aiUtils}/$1.ts`,
 			},
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: workspaceSourcePaths.agentIndex },
 			{ find: /^@earendil-works\/pi-agent-core\/node$/, replacement: workspaceSourcePaths.agentNode },


### PR DESCRIPTION
## Summary
Adds an optional cross-provider fallback hop when the active provider hits transport / unreachable errors, so a coding-agent session can continue on a configured fallback provider instead of hard-failing.

Fixes #9242

## Changes
- Provider fallback helper and settings wiring
- Agent session hop on transport errors
- Retry path awareness + tests and docs

## Test plan
- [ ] Unit tests for fallback selection and hop
- [ ] Manual: configure fallback provider, force transport failure, confirm hop
- [ ] Manual: no fallback configured → behavior unchanged