### PR TITLE
fix(coding-agent): pin undici connect lookup to system dns.lookup

### DIFF
--- a/packages/coding-agent/docs/environment-variables.md
+++ b/packages/coding-agent/docs/environment-variables.md
@@ -96,4 +96,6 @@ These variables are read by Pi itself:
 
 Provider credentials such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and cloud-provider configuration are listed in [Providers](providers.md#environment-variables-or-auth-file).
 
+Node outbound fetch pins undici `connect.lookup` to `dns.lookup` (getaddrinfo / system resolver). Names that resolve via nsswitch or Tailscale MagicDNS should not need a process-wide `dns.lookup` patch. On older builds, `NODE_OPTIONS=--dns-result-order=verbatim` is the supported Node workaround to keep lookup order aligned with getaddrinfo.
+
 `PI_SERVER_DIR` and `PI_SERVER_ID` apply only to the source-only [experimental remote harness](development.md#experimental-remote-harness), not distributed builds.

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -1,5 +1,11 @@
+import * as dns from "node:dns";
 import { EventEmitter } from "node:events";
 import * as undici from "undici";
+
+// Node dns.lookup is getaddrinfo / nsswitch (system resolver). Undici's
+// default connect path can use the process stub resolver (127.0.0.1), which
+// misses split-horizon names such as MagicDNS that resolve via getaddrinfo.
+export const lookupWithSystemResolver = dns.lookup;
 
 export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
 // Node's 250ms default can terminate valid connection attempts on high-latency routes.
@@ -91,6 +97,7 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 			bodyTimeout: normalizedTimeoutMs,
 			connect: {
 				autoSelectFamilyAttemptTimeout: DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS,
+				lookup: lookupWithSystemResolver,
 			},
 			headersTimeout: normalizedTimeoutMs,
 			clientFactory: createUndiciClient,

--- a/packages/coding-agent/test/http-dispatcher.test.ts
+++ b/packages/coding-agent/test/http-dispatcher.test.ts
@@ -3,7 +3,11 @@ import net from "node:net";
 import tls from "node:tls";
 import * as undici from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { applyHttpProxySettings, configureHttpDispatcher } from "../src/core/http-dispatcher.ts";
+import {
+	applyHttpProxySettings,
+	configureHttpDispatcher,
+	lookupWithSystemResolver,
+} from "../src/core/http-dispatcher.ts";
 
 const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY"] as const;
 const DISPATCHER_PROXY_ENV_KEYS = [...PROXY_ENV_KEYS, "http_proxy", "https_proxy", "NO_PROXY", "no_proxy"] as const;
@@ -148,6 +152,7 @@ describe("http dispatcher", () => {
 	});
 
 	it("allows two seconds for HTTPS connection attempts without changing the Node default", async () => {
+		// #9244 also asserts connect.lookup is Node dns.lookup (getaddrinfo).
 		// Preserve a deliberate host fetch override while testing the dispatcher itself.
 		globalThis.fetch = async () => {
 			throw new Error("Unexpected global fetch");
@@ -163,6 +168,7 @@ describe("http dispatcher", () => {
 		expect(connectSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
 				autoSelectFamilyAttemptTimeout: 2_000,
+				lookup: lookupWithSystemResolver,
 			}),
 		);
 		expect(connectSpy.mock.calls[0]?.[0]).not.toHaveProperty("autoSelectFamily");


### PR DESCRIPTION
## Summary
Pins undici's connect DNS lookup to Node's system `dns.lookup` so MagicDNS-style / split-horizon hostnames that resolve via the OS resolver work with the coding-agent HTTP dispatcher.

Related to #9244 (issue may already be closed).

## Changes
- `http-dispatcher` undici connect lookup override
- Docs + unit coverage

## Test plan
- [ ] Unit tests for dispatcher lookup wiring
- [ ] Manual: host that only resolves via system DNS succeeds under undici path
