### PR TITLE
fix(ai): route Copilot GPT models through Responses (fixes astra)

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -2093,11 +2093,11 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 
 				// Claude 4.x and 5.x models route to Anthropic Messages API
 				const isCopilotClaude = /^claude-(haiku|sonnet|opus|fable)-[45]([.\-]|$)/.test(modelId);
-				// Grok, gpt-5, oswe, and MAI-Code models are only served through
+				// GPT, Grok, OSWE, and MAI-Code models are only served through
 				// the Copilot /responses endpoint.
 				const needsResponsesApi =
+					modelId.startsWith("gpt-") ||
 					modelId.startsWith("grok-") ||
-					modelId.startsWith("gpt-5") ||
 					modelId.startsWith("oswe") ||
 					modelId.startsWith("mai-");
 

--- a/packages/ai/test/model-catalog-types.test.ts
+++ b/packages/ai/test/model-catalog-types.test.ts
@@ -15,3 +15,11 @@ it("routes GitHub Copilot Grok 4.5 through the Responses API", () => {
 	expectTypeOf(GITHUB_COPILOT_MODELS["grok-4.5"].api).toEqualTypeOf<"openai-responses">();
 	expect(GITHUB_COPILOT_MODELS["grok-4.5"].api).toBe("openai-responses");
 });
+
+// Regression test for https://github.com/earendil-works/pi/issues/9209
+it("routes all GitHub Copilot GPT models through the Responses API", () => {
+	const gptModels = Object.values(GITHUB_COPILOT_MODELS).filter((model) => model.id.startsWith("gpt-"));
+	expect(gptModels.length).toBeGreaterThan(0);
+	expect(gptModels.every((model) => model.api === "openai-responses")).toBe(true);
+	expectTypeOf(GITHUB_COPILOT_MODELS["gpt-6-astra"].api).toEqualTypeOf<"openai-responses">();
+});


### PR DESCRIPTION
Fixes #9209

Also tries to be future looking, there are no gpt4 models in github catalog anymore (both in their docs / APIs or on model.dev) (only as utility models and that is not relevant here)  so the change is safe. 