### PR TITLE
feat(coding-agent): apply a steering message promptly by interrupting the running turn

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `Agent.abort(reason)` and the `INTERRUPT_ABORT_REASON` constant. The agent loop stops cleanly on a submit-interrupt and suppresses the otherwise-empty "aborted" assistant message so the follow-up prompt is delivered without a confusing artifact.
+
 ## [0.85.0] - 2026-09-04
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -22,6 +22,7 @@ import type {
 	PrepareNextTurnContext,
 	StreamFn,
 } from "./types.ts";
+import { INTERRUPT_ABORT_REASON } from "./types.ts";
 
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
@@ -173,6 +174,13 @@ async function runLoop(
 
 		// Inner loop: process tool calls and steering messages
 		while (hasMoreToolCalls || pendingMessages.length > 0) {
+			// A user submit-interrupt cuts off the current turn. Stop cleanly instead of
+			// re-streaming, which would produce an empty "aborted" assistant message and
+			// consume a provider response that should stay queued. Other aborts (Esc,
+			// session switch) keep the existing behavior of emitting a final aborted message.
+			if (signal?.aborted && signal.reason === INTERRUPT_ABORT_REASON) {
+				break;
+			}
 			if (lastCompletedTurn) {
 				const nextTurnSnapshot = await config.prepareNextTurn?.(lastCompletedTurn);
 				if (nextTurnSnapshot) {
@@ -344,28 +352,42 @@ async function streamAssistantResponse(
 			case "done":
 			case "error": {
 				const finalMessage = await response.result();
+				// A user submit-interrupt (reason "interrupt") discards the aborted stream;
+				// skip the empty "aborted" message so the follow-up prompt is delivered
+				// without a confusing artifact.
+				const suppressMessage = finalMessage.stopReason === "aborted" && signal?.reason === INTERRUPT_ABORT_REASON;
 				if (addedPartial) {
 					context.messages[context.messages.length - 1] = finalMessage;
 				} else {
 					context.messages.push(finalMessage);
 				}
-				if (!addedPartial) {
+				if (!addedPartial && !suppressMessage) {
 					await emit({ type: "message_start", message: { ...finalMessage } });
 				}
-				await emit({ type: "message_end", message: finalMessage });
+				if (!suppressMessage) {
+					await emit({ type: "message_end", message: finalMessage });
+				}
 				return finalMessage;
 			}
 		}
 	}
 
 	const finalMessage = await response.result();
+	// A user submit-interrupt (reason "interrupt") discards the aborted stream; skip the
+	// empty "aborted" message so the follow-up prompt is delivered without a confusing
+	// artifact.
+	const suppressMessage = finalMessage.stopReason === "aborted" && signal?.reason === INTERRUPT_ABORT_REASON;
 	if (addedPartial) {
 		context.messages[context.messages.length - 1] = finalMessage;
 	} else {
 		context.messages.push(finalMessage);
-		await emit({ type: "message_start", message: { ...finalMessage } });
+		if (!suppressMessage) {
+			await emit({ type: "message_start", message: { ...finalMessage } });
+		}
 	}
-	await emit({ type: "message_end", message: finalMessage });
+	if (!suppressMessage) {
+		await emit({ type: "message_end", message: finalMessage });
+	}
 	return finalMessage;
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -28,6 +28,8 @@ import type {
 	ToolExecutionMode,
 } from "./types.ts";
 
+import { INTERRUPT_ABORT_REASON } from "./types.ts";
+export { INTERRUPT_ABORT_REASON };
 export type { QueueMode } from "./types.ts";
 
 function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
@@ -315,9 +317,9 @@ export class Agent {
 		return this.activeRun?.abortController.signal;
 	}
 
-	/** Abort the current run, if one is active. */
-	abort(): void {
-		this.activeRun?.abortController.abort();
+	/** Abort the current run, if one is active. Pass INTERRUPT_ABORT_REASON for a user submit-interrupt. */
+	abort(reason?: string): void {
+		this.activeRun?.abortController.abort(reason);
 	}
 
 	/**
@@ -502,13 +504,18 @@ export class Agent {
 		try {
 			await executor(abortController.signal);
 		} catch (error) {
-			await this.handleRunFailure(error, abortController.signal.aborted);
+			await this.handleRunFailure(error, abortController.signal.aborted, abortController.signal);
 		} finally {
 			this.finishRun();
 		}
 	}
 
-	private async handleRunFailure(error: unknown, aborted: boolean): Promise<void> {
+	private async handleRunFailure(error: unknown, aborted: boolean, signal?: AbortSignal): Promise<void> {
+		// A user submit-interrupt (reason "interrupt") stops the current turn to
+		// deliver the follow-up prompt immediately. Skip the otherwise-empty
+		// "aborted" assistant message so the transcript stays clean (the queued
+		// user message provides the context, matching Claude Code's behavior).
+		const isInterrupt = aborted && signal?.reason === INTERRUPT_ABORT_REASON;
 		const failureMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: "" }],
@@ -520,10 +527,15 @@ export class Agent {
 			errorMessage: error instanceof Error ? error.message : String(error),
 			timestamp: Date.now(),
 		} satisfies AgentMessage;
-		await this.processEvents({ type: "message_start", message: failureMessage });
-		await this.processEvents({ type: "message_end", message: failureMessage });
+		if (!isInterrupt) {
+			await this.processEvents({ type: "message_start", message: failureMessage });
+			await this.processEvents({ type: "message_end", message: failureMessage });
+		}
 		await this.processEvents({ type: "turn_end", message: failureMessage, toolResults: [] });
-		await this.processEvents({ type: "agent_end", messages: [failureMessage] });
+		await this.processEvents({
+			type: "agent_end",
+			messages: isInterrupt ? this._state.messages.slice() : [failureMessage],
+		});
 	}
 
 	private finishRun(): void {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -49,6 +49,14 @@ export type ToolExecutionMode = "sequential" | "parallel";
  */
 export type QueueMode = "all" | "one-at-a-time";
 
+/**
+ * Abort reason used when the user interrupts a running turn by submitting a new
+ * prompt (Claude Code-style submit-interrupt). The agent loop suppresses the
+ * otherwise-empty "aborted" assistant message for this reason so the follow-up
+ * user message is delivered without a confusing artifact.
+ */
+export const INTERRUPT_ABORT_REASON = "interrupt";
+
 /** A single tool call content block emitted by an assistant message. */
 export type AgentToolCall = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added submit-interrupt: submitting a new prompt while the agent is running now interrupts the in-progress turn (instead of waiting for it to finish) and processes the new message immediately, without leaving an empty "Operation aborted" message.
+
 ### Fixed
 
 - Fixed configurable save keybindings in the model and thinking selectors ([#8797](https://github.com/earendil-works/pi/issues/8797)).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -25,6 +25,7 @@ import type {
 	PrepareNextTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
+import { INTERRUPT_ABORT_REASON } from "@earendil-works/pi-agent-core";
 import { contentText } from "@earendil-works/pi-ai";
 import type {
 	AssistantMessage,
@@ -639,6 +640,10 @@ export class AgentSession {
 	// Track last assistant message for auto-compaction check
 	private _lastAssistantMessage: AssistantMessage | undefined = undefined;
 
+	// Set by interrupt() so the post-run handler skips retry/compaction on a stale
+	// message (the interrupted run may not have produced a terminal assistant message).
+	private _lastRunWasInterrupted = false;
+
 	/** Internal handler for agent events - shared by subscribe and reconnect */
 	private _handleAgentEvent = async (event: AgentEvent): Promise<void> => {
 		// When a user message starts, check if it's from either queue and remove it BEFORE emitting
@@ -1118,10 +1123,16 @@ export class AgentSession {
 	}
 
 	private async _handlePostAgentRun(): Promise<boolean> {
+		const wasInterrupted = this._lastRunWasInterrupted;
+		this._lastRunWasInterrupted = false;
 		const msg = this._lastAssistantMessage;
 		this._lastAssistantMessage = undefined;
-		if (!msg) {
-			return false;
+		// A submit-interrupt (interrupt()) aborts the run before the agent loop drains
+		// its queues, so deliver any queued messages now — even when no assistant
+		// message completed. For a normal run the loop drains the queues before
+		// agent_end and hasQueuedMessages() is false here.
+		if (wasInterrupted || !msg) {
+			return this.agent.hasQueuedMessages();
 		}
 
 		if (this._isRetryableError(msg) && (await this._prepareRetry(msg))) {
@@ -1621,6 +1632,27 @@ export class AgentSession {
 		this.abortCompaction();
 		this.abortBranchSummary();
 		this.agent.abort();
+		await this.waitForIdle();
+	}
+
+	/**
+	 * Interrupt the running turn as a user-initiated correction (Claude Code-style
+	 * submit-interrupt). Aborts in-flight work with {@link INTERRUPT_ABORT_REASON},
+	 * which suppresses the otherwise-empty "aborted" assistant message, then waits
+	 * for the run to settle. Typically followed by `prompt()` to deliver the new
+	 * message as a fresh turn.
+	 */
+	async interrupt(): Promise<void> {
+		// Only mark the run interrupted when there is something to interrupt, otherwise
+		// a stale flag would make the next post-run skip its retry/compaction checks.
+		if (!this.isIdle) {
+			this._lastRunWasInterrupted = true;
+		}
+		this.abortRetry();
+		this.abortCompaction();
+		this.abortBranchSummary();
+		this.abortBash();
+		this.agent.abort(INTERRUPT_ABORT_REASON);
 		await this.waitForIdle();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3132,12 +3132,16 @@ export class InteractiveMode {
 				return;
 			}
 
-			// If streaming, use prompt() with steer behavior
-			// This handles extension commands (execute immediately), prompt template expansion, and queueing
+			// If streaming, interrupt the running turn so the new message is processed
+			// immediately instead of waiting for the current turn to finish (Claude
+			// Code-style submit-interrupt). interrupt() aborts in-flight work with an
+			// "interrupt" reason that suppresses the empty aborted assistant message,
+			// then prompt() delivers the new message as a fresh turn.
 			if (this.session.isStreaming) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.session.prompt(text, { streamingBehavior: "steer" });
+				await this.session.interrupt();
+				await this.session.prompt(text);
 				this.updatePendingMessagesDisplay();
 				this.ui.requestRender();
 				return;

--- a/packages/coding-agent/test/suite/agent-session-interrupt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-interrupt.test.ts
@@ -1,0 +1,96 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "./harness.ts";
+
+/**
+ * A tool that stays running until the run's abort signal fires, then returns
+ * immediately. This lets interrupt() observe an in-flight tool without hanging
+ * on an unresolved promise.
+ */
+function abortableWaitTool(): AgentTool {
+	return {
+		name: "wait",
+		label: "Wait",
+		description: "Wait until the run is aborted",
+		parameters: Type.Object({}),
+		execute: async (_id, _args, signal) => {
+			await new Promise<void>((resolve) => {
+				if (signal?.aborted) {
+					resolve();
+					return;
+				}
+				signal?.addEventListener("abort", () => resolve());
+			});
+			return {
+				content: [{ type: "text", text: "released" }],
+				details: {},
+			};
+		},
+	};
+}
+
+function waitForToolStart(harness: Harness, toolName: string): Promise<void> {
+	return new Promise((resolve) => {
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "tool_execution_start" && event.toolName === toolName) {
+				unsubscribe();
+				resolve();
+			}
+		});
+	});
+}
+
+describe("AgentSession submit-interrupt", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("interrupt() aborts the running turn without leaving an empty aborted assistant message", async () => {
+		const harness = await createHarness({
+			tools: [abortableWaitTool()],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" })]);
+
+		const promptPromise = harness.session.prompt("start");
+		await waitForToolStart(harness, "wait");
+		await harness.session.interrupt();
+		await promptPromise;
+
+		expect(harness.session.isIdle).toBe(true);
+		expect(harness.getPendingResponseCount()).toBe(0);
+
+		// A submit-interrupt must not surface an empty "aborted" assistant message.
+		const aborted = harness.session.messages.filter(
+			(message) => message.role === "assistant" && message.stopReason === "aborted",
+		);
+		expect(aborted).toEqual([]);
+	});
+
+	it("delivers a prompt after interrupt() as a fresh turn", async () => {
+		const harness = await createHarness({
+			tools: [abortableWaitTool()],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("handled correction"),
+		]);
+
+		const promptPromise = harness.session.prompt("start");
+		await waitForToolStart(harness, "wait");
+		await harness.session.interrupt();
+		await promptPromise;
+
+		await harness.session.prompt("correction");
+
+		expect(getUserTexts(harness)).toContain("correction");
+		expect(getAssistantTexts(harness)).toContain("handled correction");
+	});
+});

--- a/vitest.base.ts
+++ b/vitest.base.ts
@@ -13,6 +13,7 @@ export const workspaceSourcePaths = {
 	aiCompat: fileURLToPath(new URL("./packages/ai/src/compat.ts", import.meta.url)),
 	aiOAuth: fileURLToPath(new URL("./packages/ai/src/oauth.ts", import.meta.url)),
 	aiProviders: fileURLToPath(new URL("./packages/ai/src/providers", import.meta.url)),
+	aiUtils: fileURLToPath(new URL("./packages/ai/src/utils", import.meta.url)),
 	agentIndex: fileURLToPath(new URL("./packages/agent/src/index.ts", import.meta.url)),
 	agentNode: fileURLToPath(new URL("./packages/agent/src/node.ts", import.meta.url)),
 	protocolIndex: fileURLToPath(new URL("./packages/protocol/src/index.ts", import.meta.url)),
@@ -40,6 +41,10 @@ export default defineConfig({
 			{
 				find: /^@earendil-works\/pi-ai\/providers\/(.+)$/,
 				replacement: `${workspaceSourcePaths.aiProviders}/$1.ts`,
+			},
+			{
+				find: /^@earendil-works\/pi-ai\/utils\/(.+)$/,
+				replacement: `${workspaceSourcePaths.aiUtils}/$1.ts`,
 			},
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: workspaceSourcePaths.agentIndex },
 			{ find: /^@earendil-works\/pi-agent-core\/node$/, replacement: workspaceSourcePaths.agentNode },


### PR DESCRIPTION
## Problem

While a long-running tool call is executing (e.g. installing a dependency from
a slow registry/mirror, or a long test/build), a steering message the user sends
is not applied promptly. pi queues it and only processes it once the in-progress
turn fully finishes, so the correction feels stuck — e.g. the user cannot switch
to a faster mirror until the slow install completes.

## Change

Introduce submit-interrupt: when a prompt is submitted while the agent is
running, abort the in-progress turn and deliver the new message as a fresh turn
instead of waiting for the current turn to finish.

### Agent core (`packages/agent`)

- Added `Agent.abort(reason)` and a new `INTERRUPT_ABORT_REASON = "interrupt"`.
- The agent loop now stops cleanly on a submit-interrupt instead of re-streaming
  after the interrupted tool call, which previously produced an empty
  `stopReason: "aborted"` assistant message and consumed a provider response
  that should have stayed queued.
- `streamAssistantResponse` and `handleRunFailure` suppress the otherwise-empty
  "aborted" assistant message for an interrupt, so the transcript stays clean.

### Session & interactive mode (`packages/coding-agent`)

- Added `AgentSession.interrupt()`: aborts in-flight work with
  `INTERRUPT_ABORT_REASON`, waits for the run to settle, and skips
  retry/compaction on the interrupted run's stale last message.
- Interactive mode's submit handler now calls `interrupt()` then `prompt()` on a
  mid-turn submit (previously it used `streamingBehavior: "steer"`, which just
  queued the message for the next turn boundary).

### Test infrastructure

- Added a `@earendil-works/pi-ai/utils/*` Vitest alias (consistent with the
  existing `/providers` and `/compat` aliases) so the test suite resolves from
  source.

## Behavior

- Other aborts (Esc, session-switch) are unchanged: they still emit the final
  "Operation aborted" message.
- Existing steer / follow-up queue semantics are unchanged.
- Only the interactive submit path aborts; extension-driven `steer()` /
  `sendUserMessage(..., { deliverAs: "steer" })` still queue at the turn
  boundary.

## Test plan

- `packages/coding-agent/test/suite/agent-session-interrupt.test.ts` (new):
  verifies `interrupt()` aborts a running turn without an empty "aborted"
  assistant message, and that a follow-up prompt is delivered as a fresh turn.
- Ran the agent and coding-agent session suites (`agent-session-*`, `agent-loop`,
  `agent`) — all pass.
- `npm run check` passes.

## Summary of files

- `packages/agent/src/types.ts` — `INTERRUPT_ABORT_REASON`
- `packages/agent/src/agent.ts` — `abort(reason)`, suppress interrupt message
- `packages/agent/src/agent-loop.ts` — stop cleanly on submit-interrupt, skip
  empty aborted message
- `packages/coding-agent/src/core/agent-session.ts` — `interrupt()`, post-run
  handling
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` — submit
  handler
- `packages/coding-agent/test/suite/agent-session-interrupt.test.ts` — new tests
- `vitest.base.ts` — `@earendil-works/pi-ai/utils/*` alias
