### PR TITLE
feat(ai): add sendStrictToolField compat flag

### DIFF
--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -195,6 +195,7 @@ function getAnthropicCompat(
 		supportsTemperature: model.compat?.supportsTemperature ?? true,
 		allowEmptySignature: model.compat?.allowEmptySignature ?? false,
 		supportsStrictTools: model.compat?.supportsStrictTools ?? false,
+		sendStrictToolField: model.compat?.sendStrictToolField ?? true,
 		supportsToolReferences: model.compat?.supportsToolReferences ?? defaultSupportsToolReferences(model),
 	};
 }
@@ -1105,6 +1106,7 @@ function buildParams(
 				isOAuthToken,
 				compat.supportsEagerToolInputStreaming,
 				compat.supportsStrictTools,
+				compat.sendStrictToolField,
 				compat.supportsCacheControlOnTools ? cacheControl : undefined,
 			),
 			...convertTools(
@@ -1112,6 +1114,7 @@ function buildParams(
 				isOAuthToken,
 				compat.supportsEagerToolInputStreaming,
 				compat.supportsStrictTools,
+				compat.sendStrictToolField,
 				undefined,
 				true,
 			),
@@ -1426,6 +1429,7 @@ function convertTools(
 	isOAuthToken: boolean,
 	supportsEagerToolInputStreaming: boolean,
 	supportsStrictTools: boolean,
+	sendStrictToolField: boolean,
 	cacheControl?: CacheControlEphemeral,
 	deferLoading = false,
 ): BetaTool[] {
@@ -1452,7 +1456,7 @@ function convertTools(
 			name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
 			description: tool.description,
 			...(supportsEagerToolInputStreaming ? { eager_input_streaming: true } : {}),
-			...(strict === true ? { strict: true } : {}),
+			...(strict === true && sendStrictToolField ? { strict: true } : {}),
 			input_schema: inputSchema,
 			...(deferLoading ? { defer_loading: true } : {}),
 			...(cacheControl && index === tools.length - 1 ? { cache_control: cacheControl } : {}),

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -712,6 +712,15 @@ export interface AnthropicMessagesCompat {
 	allowEmptySignature?: boolean;
 	/** Whether the provider supports Anthropic strict tool schemas. Default: false; generated Anthropic models enable it explicitly. */
 	supportsStrictTools?: boolean;
+	/**
+	 * Whether to send the per-tool `strict: true` field when strict tool schemas
+	 * are active. Some Anthropic-compatible gateways (e.g. AWS Bedrock proxies)
+	 * require the strict-shaped `input_schema` (with `additionalProperties: false`)
+	 * but reject the `strict` field itself. Set to `false` to keep the strict
+	 * schema while omitting the field.
+	 * Default: true.
+	 */
+	sendStrictToolField?: boolean;
 	/** Whether the exact model transport supports effort-only system messages and thinking binding controls. Default: false. */
 	supportsMidConvoEffort?: boolean;
 	/**

--- a/packages/coding-agent/src/core/model-config.ts
+++ b/packages/coding-agent/src/core/model-config.ts
@@ -134,6 +134,7 @@ const AnthropicMessagesCompatSchema = Type.Object({
 	forceAdaptiveThinking: Type.Optional(Type.Boolean()),
 	allowEmptySignature: Type.Optional(Type.Boolean()),
 	supportsStrictTools: Type.Optional(Type.Boolean()),
+	sendStrictToolField: Type.Optional(Type.Boolean()),
 	supportsMidConvoEffort: Type.Optional(Type.Boolean()),
 	supportsToolReferences: Type.Optional(Type.Boolean()),
 });


### PR DESCRIPTION
Some Anthropic-compatible gateways (e.g. AWS Bedrock proxies) require the strict-shaped tool input_schema (additionalProperties: false) but reject the per-tool `strict` field itself. Since pi couples the two, such gateways can neither omit the schema constraint nor accept the field, returning 400.

Add a `sendStrictToolField` compat flag (default true, preserving existing behavior) that keeps the strict-shaped schema while omitting the `strict` field when set to false.