### PR TITLE
fix(agent): end agentLoop stream with error result on loop rejection

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -47,9 +47,13 @@ export function agentLoop(
 		},
 		signal,
 		streamFn,
-	).then((messages) => {
-		stream.end(messages);
-	});
+	)
+		.then((messages) => {
+			stream.end(messages);
+		})
+		.catch((error: unknown) => {
+			endStreamWithError(stream, config, signal, error);
+		});
 
 	return stream;
 }
@@ -86,9 +90,13 @@ export function agentLoopContinue(
 		},
 		signal,
 		streamFn,
-	).then((messages) => {
-		stream.end(messages);
-	});
+	)
+		.then((messages) => {
+			stream.end(messages);
+		})
+		.catch((error: unknown) => {
+			endStreamWithError(stream, config, signal, error);
+		});
 
 	return stream;
 }
@@ -148,6 +156,46 @@ function createAgentStream(): EventStream<AgentEvent, AgentMessage[]> {
 		(event: AgentEvent) => event.type === "agent_end",
 		(event: AgentEvent) => (event.type === "agent_end" ? event.messages : []),
 	);
+}
+
+const EMPTY_USAGE = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+/**
+ * Terminate the stream after runAgentLoop/runAgentLoopContinue rejects.
+ * Without this, the rejection is unhandled (crashing Node) and the stream never
+ * ends, so consumers awaiting result() or iterating events hang forever.
+ * Mirrors Agent's run failure handling: an error assistant message followed by
+ * the message/turn/agent end events, so subscribers see the same sequence.
+ */
+function endStreamWithError(
+	stream: EventStream<AgentEvent, AgentMessage[]>,
+	config: AgentLoopConfig,
+	signal: AbortSignal | undefined,
+	error: unknown,
+): void {
+	const failureMessage: AssistantMessage = {
+		role: "assistant",
+		content: [{ type: "text", text: "" }],
+		api: config.model.api,
+		provider: config.model.provider,
+		model: config.model.id,
+		usage: EMPTY_USAGE,
+		stopReason: signal?.aborted ? "aborted" : "error",
+		errorMessage: error instanceof Error ? error.message : String(error),
+		timestamp: Date.now(),
+	};
+	stream.push({ type: "message_start", message: failureMessage });
+	stream.push({ type: "message_end", message: failureMessage });
+	stream.push({ type: "turn_end", message: failureMessage, toolResults: [] });
+	stream.push({ type: "agent_end", messages: [failureMessage] });
+	stream.end();
 }
 
 /**

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1608,3 +1608,62 @@ describe("agentLoopContinue with AgentMessage", () => {
 		expect(messages[0].role).toBe("assistant");
 	});
 });
+
+describe("agentLoop rejection handling", () => {
+	const throwingStreamFn = () => {
+		throw new Error("streamFn exploded");
+	};
+
+	it("ends the stream with an error result when streamFn throws synchronously", async () => {
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = { model: createModel(), convertToLlm: identityConverter };
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, throwingStreamFn);
+
+		// Without rejection handling this hangs forever and the rejection is
+		// unhandled (vitest fails the test in both cases).
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const last = messages[messages.length - 1];
+		expect(last.role).toBe("assistant");
+		if (last.role === "assistant") {
+			expect(last.stopReason).toBe("error");
+			expect(last.errorMessage).toBe("streamFn exploded");
+		}
+
+		// Subscribers see the same terminal sequence the Agent path emits on failure.
+		const eventTypes = events.map((e) => e.type);
+		expect(eventTypes[0]).toBe("agent_start");
+		expect(eventTypes[eventTypes.length - 1]).toBe("agent_end");
+		expect(eventTypes).toContain("turn_end");
+	});
+
+	it("ends the stream with an error result when streamFn throws synchronously (continue)", async () => {
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [createUserMessage("Hello")],
+			tools: [],
+		};
+		const config: AgentLoopConfig = { model: createModel(), convertToLlm: identityConverter };
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoopContinue(context, config, undefined, throwingStreamFn);
+
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		const messages = await stream.result();
+		const last = messages[messages.length - 1];
+		expect(last.role).toBe("assistant");
+		if (last.role === "assistant") {
+			expect(last.stopReason).toBe("error");
+			expect(last.errorMessage).toBe("streamFn exploded");
+		}
+		expect(events[events.length - 1].type).toBe("agent_end");
+	});
+});


### PR DESCRIPTION
`agentLoop()` and `agentLoopContinue()` launched the loop with `void runAgentLoop(...).then(...)` and no rejection handler. Any loop rejection — a synchronously throwing `streamFn`, a rejecting `getApiKey` (e.g. OAuth refresh failure), or `convertToLlm`/`transformContext`/`getSteeringMessages`/`prepareNextTurn` throwing — produced an unhandled promise rejection (fatal on Node >= 15) and left the returned `EventStream` open forever, so consumers awaiting `stream.result()` or iterating events hung indefinitely. The `Agent` class masks this via `runWithLifecycle`, but these two functions are public API.

Both wrappers now chain `.catch` into a shared `endStreamWithError` helper that mirrors `Agent`'s run failure handling: it synthesizes an error assistant message (`stopReason: "error"`, or `"aborted"` when the abort signal fired), pushes the same terminal event sequence (`message_start`, `message_end`, `turn_end`, `agent_end`), and ends the stream. `stream.result()` resolves with the failure message instead of hanging, and subscribers see the same event sequence as the `Agent` path.

Repro before the fix:

```ts
const stream = agentLoop([userMessage], context, config, undefined, () => {
	throw new Error("boom");
});
// unhandled rejection (process crash); stream.result() never settles
```

Regression tests cover a sync-throwing `streamFn` through both `agentLoop` and `agentLoopContinue`; they fail before the fix (unhandled rejection kills the suite) and pass after. `npm run check` and `./test.sh` pass.
