### PR TITLE
fix(tui): stop wordWrapLine infinite recursion on unsplittable wide grapheme

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -167,9 +167,13 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 			wrapOppIndex = -1;
 		}
 
-		if (gWidth > maxWidth) {
+		if (gWidth > maxWidth && (segments.length > 1 || isPasteMarker(grapheme))) {
 			// Single atomic segment wider than maxWidth (e.g. paste marker
 			// in a narrow terminal). Re-wrap it at grapheme granularity.
+			// Skipped when the line is a lone non-marker grapheme: recursion
+			// would receive identical input and never terminate. An atomic
+			// wide grapheme cannot be split, so fall through to the normal
+			// advance and let the chunk overflow maxWidth instead.
 
 			// The segment remains logically atomic for cursor
 			// movement / editing — the split is purely visual for word-wrap layout.

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1192,6 +1192,27 @@ describe("Editor component", () => {
 			const reconstructed = chunks.map((c) => line.slice(c.startIndex, c.endIndex)).join("");
 			assert.strictEqual(reconstructed, line);
 		});
+
+		it("accepts a single unsplittable wide grapheme as an over-wide chunk", () => {
+			// A width-2 grapheme with maxWidth 1 cannot be split further;
+			// recursing would loop on identical input (stack overflow).
+			const chunks = wordWrapLine("😀", 1);
+
+			assert.strictEqual(chunks.length, 1);
+			assert.strictEqual(chunks[0]!.text, "😀");
+			assert.strictEqual(chunks[0]!.startIndex, 0);
+			assert.strictEqual(chunks[0]!.endIndex, "😀".length);
+		});
+
+		it("does not recurse forever on a wide grapheme inside a longer line", () => {
+			const line = "hello 😀 world";
+			const chunks = wordWrapLine(line, 1);
+
+			// The wide grapheme overflows as its own chunk; nothing is lost.
+			assert.ok(chunks.some((c) => c.text === "😀"));
+			const reconstructed = chunks.map((c) => line.slice(c.startIndex, c.endIndex)).join("");
+			assert.strictEqual(reconstructed, line);
+		});
 	});
 
 	describe("Kill ring", () => {


### PR DESCRIPTION
`wordWrapLine()` re-wraps an over-wide segment at grapheme granularity via `wordWrapLine(grapheme, maxWidth)`. When the segment is a single atomic grapheme (emoji/CJK, width 2) and `maxWidth` is 1, the recursive call re-segments to the identical single segment and recurses with unchanged arguments forever, ending in `RangeError: Maximum call stack size exceeded` and killing the process.

Reachable in the app: the editor computes `layoutWidth = Math.max(1, ...)`, so a terminal resized to 1-2 columns (narrow tmux/tiling pane) with an emoji in the prompt buffer crashes the session and loses unsubmitted input. Repro before the fix:

```ts
wordWrapLine("hello 😀 world", 1);
// RangeError: Maximum call stack size exceeded
```

The branch now only recurses when recursion can make progress: `segments.length > 1 || isPasteMarker(grapheme)`. A lone unsplittable grapheme falls through to the normal advance and overflows `maxWidth` as its own chunk instead of crashing. The `isPasteMarker` disjunct preserves the existing paste-marker behavior: a whole-line paste marker is a single merged multi-grapheme segment that the recursion legitimately splits (covered by the existing test at `editor.test.ts`, which still passes). Downstream, `Editor.render` clamps padding with `Math.max(0, ...)`, so an over-wide chunk renders as overflow without introducing a new crash path.

Two regression tests added (`wordWrapLine("😀", 1)` returns one chunk; wide grapheme inside a longer line wraps without losing content). `npm run check` and `./test.sh` pass.
