### PR TITLE
feat(coding-agent): add manual retry api/command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `ctx.modelRegistry.stream()` and `streamSimple()` for extension model calls through configured providers with resolved authentication ([#8964](https://github.com/earendil-works/pi/issues/8964)).
+- Added `/retry` to resume the last turn after an errored, aborted, or truncated assistant response, with matching `session.retry()` SDK, `ctx.retry()` extension, and `retry` RPC entry points. See [Retrying an Interrupted Turn](docs/sdk.md#retrying-an-interrupted-turn) and [RPC retry](docs/rpc.md#retry).
 
 ### Changed
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -191,6 +191,7 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | `/fork` | Create a new session from a previous user message |
 | `/clone` | Duplicate the current active branch into a new session |
 | `/compact [prompt]` | Manually compact context, optional custom instructions |
+| `/retry` | Retry the last interrupted turn (errored, aborted, or truncated response) |
 | `/copy` | Copy last assistant message to clipboard |
 | `/export [file]` | Export session to HTML or JSONL file |
 | `/import <file>` | Import and resume a session from a JSONL file |

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1330,6 +1330,28 @@ Important behavior:
 
 For predictable behavior, treat reload as terminal for that handler (`await ctx.reload(); return;`).
 
+### ctx.retry()
+
+Run the same retry flow as `/retry`: re-send the last request after an errored, aborted, or truncated (`length`) assistant response, or continue a transcript that ends in a user or tool-result message. Tool calls interrupted by abort are not re-executed; the model sees their "Operation aborted" results and decides.
+
+```typescript
+pi.registerCommand("retry-last", {
+  description: "Retry the last interrupted turn",
+  handler: async (_args, ctx) => {
+    if (!ctx.isIdle()) {
+      ctx.ui.notify("Wait for the agent to finish first", "warning");
+      return;
+    }
+    await ctx.retry();
+  },
+});
+```
+
+Important behavior:
+- It rejects while a response is streaming or compaction is running, so check `ctx.isIdle()` or call `ctx.waitForIdle()` first
+- It rejects when the last assistant response completed normally; use `pi.sendUserMessage()` to start a new turn instead
+- It resolves after the full run finishes, including auto-retries and auto-compaction
+
 Tools run with `ExtensionContext`, so they cannot call `ctx.reload()` directly. Use a command as the reload entrypoint, then expose a tool that queues that command as a follow-up user message.
 
 Example tool the LLM can call to trigger reload:

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -448,6 +448,27 @@ Response:
 
 ### Retry
 
+#### retry
+
+Retry the last interrupted turn or continue from the current transcript. Same as `/retry` in interactive mode.
+
+```json
+{"type": "retry"}
+```
+
+Response:
+```json
+{"type": "response", "command": "retry", "success": true}
+```
+
+Response semantics match `prompt`: the success response is emitted once the retry is accepted, before the run's events stream. A failure response is emitted when preflight rejects, for example while a response is streaming, while compacting, or when the last assistant response completed normally:
+
+```json
+{"type": "response", "command": "retry", "success": false, "error": "Cannot retry from a completed assistant response."}
+```
+
+An errored, aborted, or truncated (`length`) assistant response at the end of the transcript is dropped from agent state (the session file keeps it) and its request is sent again. A transcript ending in a user or tool-result message is continued as-is. A tool batch interrupted by abort ends this way, with "Operation aborted" results: the model reacts to those results, the tools are not re-executed.
+
 #### set_auto_retry
 
 Enable or disable automatic retry on transient errors (overloaded, rate limit, 5xx).

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -103,6 +103,13 @@ interface AgentSession {
   compact(customInstructions?: string): Promise<CompactionResult>;
   abortCompaction(): void;
 
+  // Retry
+  retry(options?: RetryOptions): Promise<void>;
+  abortRetry(): void;
+  isRetrying: boolean;
+  autoRetryEnabled: boolean;
+  setAutoRetryEnabled(enabled: boolean): void;
+
   // Abort current operation
   abort(): Promise<void>;
 
@@ -234,6 +241,30 @@ await session.followUp("After you're done, also do this");
 ```
 
 Both `steer()` and `followUp()` expand file-based prompt templates but error on extension commands (extension commands cannot be queued).
+
+### Retrying an Interrupted Turn
+
+`retry()` resumes the last turn without adding a new user message. It is the programmatic form of `/retry`, for when auto-retry is disabled, exhausted, or the run was aborted:
+
+```typescript
+try {
+  await session.prompt("Refactor the parser");
+} finally {
+  const last = session.messages.at(-1);
+  if (last?.role === "assistant" && last.stopReason === "error") {
+    await session.retry();
+  }
+}
+```
+
+**Behavior:**
+- **Errored, aborted, or truncated (`length`) assistant response last**: It is dropped from agent state (the session file keeps it, as with auto-retry) and the request that produced it is sent again. For a truncation this is the manual form of overflow recovery: `/compact` first if the context was full.
+- **User or tool-result message last**: The transcript is continued from that message. A tool batch interrupted by abort ends this way, with "Operation aborted" results: the model reacts to those results, the tools are not re-executed, since they may have half-run.
+- **Completed assistant response last**: Throws. There is nothing to retry; send a new prompt instead.
+- **While streaming or compacting**: Throws. Wait for `agent_settled` (or `agent.waitForIdle()`) first.
+- **No model or credentials**: Throws the same errors as `prompt()`.
+
+`retry()` resolves after the full run finishes, including auto-retries and auto-compaction. `RetryOptions.preflightResult` fires once, with `true` when the retry was accepted and `false` when preflight rejected it, mirroring `PromptOptions.preflightResult`.
 
 ### Agent and AgentState
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -51,6 +51,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/fork` | Create a new session from a previous user message |
 | `/clone` | Duplicate the current active branch into a new session |
 | `/compact [prompt]` | Manually compact context, optionally with custom instructions |
+| `/retry` | Retry the last interrupted turn (errored, aborted, or truncated response) |
 | `/copy` | Copy last assistant message to clipboard |
 | `/export [file]` | Export session to HTML or JSONL |
 | `/import <file>` | Import and resume a session from a JSONL file |

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -252,6 +252,11 @@ export interface PromptOptions {
 	preflightResult?: (success: boolean) => void;
 }
 
+export interface RetryOptions {
+	/** Internal hook used by RPC mode to observe retry preflight acceptance or rejection. */
+	preflightResult?: (success: boolean) => void;
+}
+
 /** Options for model/thinking mutations. */
 export interface ModelMutationOptions {
 	/** Persist the new value to global defaults. Defaults to session-only. */
@@ -1117,6 +1122,28 @@ export class AgentSession {
 		}
 	}
 
+	/** Throw if no model is selected or the selected provider has no usable credentials. */
+	private async _assertModelReady(): Promise<void> {
+		if (!this.model) {
+			throw new Error(formatNoModelSelectedMessage());
+		}
+
+		const hasConfiguredAuth =
+			this._modelRuntime.hasConfiguredAuth(this.model.provider) ||
+			(await this._modelRuntime.checkAuth(this.model.provider)) !== undefined;
+		if (!hasConfiguredAuth) {
+			const isOAuth = this._modelRuntime.isUsingOAuth(this.model.provider);
+			if (isOAuth) {
+				throw new Error(
+					`Authentication failed for "${this.model.provider}". ` +
+						`Credentials may have expired or network is unavailable. ` +
+						`Run '/login ${this.model.provider}' to re-authenticate.`,
+				);
+			}
+			throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
+		}
+	}
+
 	private async _handlePostAgentRun(): Promise<boolean> {
 		const msg = this._lastAssistantMessage;
 		this._lastAssistantMessage = undefined;
@@ -1226,25 +1253,7 @@ export class AgentSession {
 			this._flushPendingBashMessages();
 			this._flushPendingCustomMessages();
 
-			// Validate model
-			if (!this.model) {
-				throw new Error(formatNoModelSelectedMessage());
-			}
-
-			const hasConfiguredAuth =
-				this._modelRuntime.hasConfiguredAuth(this.model.provider) ||
-				(await this._modelRuntime.checkAuth(this.model.provider)) !== undefined;
-			if (!hasConfiguredAuth) {
-				const isOAuth = this._modelRuntime.isUsingOAuth(this.model.provider);
-				if (isOAuth) {
-					throw new Error(
-						`Authentication failed for "${this.model.provider}". ` +
-							`Credentials may have expired or network is unavailable. ` +
-							`Run '/login ${this.model.provider}' to re-authenticate.`,
-					);
-				}
-				throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
-			}
+			await this._assertModelReady();
 
 			// Check if we need to compact before sending (catches aborted responses).
 			// The user's new prompt is sent below, so do not call agent.continue() here.
@@ -2965,6 +2974,74 @@ export class AgentSession {
 	 */
 	setAutoRetryEnabled(enabled: boolean): void {
 		this.settingsManager.setRetryEnabled(enabled);
+	}
+
+	/**
+	 * Retry the last interrupted turn or continue from the current transcript.
+	 *
+	 * An errored, aborted, or truncated (length) assistant response at the end of the transcript
+	 * is dropped from agent state (it stays in the session file, as with auto-retry) and the
+	 * request that produced it is sent again. A truncated response only ends the transcript when
+	 * it carried no tool calls; otherwise agent-core has already failed those calls and their
+	 * results are last. A transcript ending in a user or tool-result message is
+	 * continued as-is; this covers tool batches interrupted by abort, whose "Operation aborted"
+	 * results are handed to the model rather than re-executed, because tools may have
+	 * half-run. A completed assistant response cannot be retried.
+	 *
+	 * @throws Error while streaming or compacting, when no model or credentials are available,
+	 *   when the transcript is empty, or when the last assistant response completed normally
+	 */
+	async retry(options?: RetryOptions): Promise<void> {
+		const preflightResult = options?.preflightResult;
+
+		try {
+			if (this.isStreaming) {
+				throw new Error("Wait for the current response to finish before retrying.");
+			}
+			if (this.isCompacting) {
+				throw new Error("Wait for compaction to finish before retrying.");
+			}
+
+			this._flushPendingBashMessages();
+			this._flushPendingCustomMessages();
+
+			await this._assertModelReady();
+
+			const messages = this.agent.state.messages;
+			const lastMessage = messages[messages.length - 1];
+			if (!lastMessage) {
+				throw new Error("Nothing to retry: the session has no messages.");
+			}
+			if (lastMessage.role === "assistant") {
+				const assistantMessage = lastMessage as AssistantMessage;
+				if (
+					assistantMessage.stopReason === "error" ||
+					assistantMessage.stopReason === "aborted" ||
+					assistantMessage.stopReason === "length"
+				) {
+					this.agent.state.messages = messages.slice(0, -1);
+				} else if (!this.agent.hasQueuedMessages()) {
+					throw new Error("Cannot retry from a completed assistant response.");
+				}
+			}
+		} catch (error) {
+			preflightResult?.(false);
+			throw error;
+		}
+
+		preflightResult?.(true);
+		this._isAgentRunActive = true;
+		try {
+			await this.agent.continue();
+			while (await this._handlePostAgentRun()) {
+				await this.agent.continue();
+			}
+		} finally {
+			this._systemPromptOverride = undefined;
+			this._flushPendingBashMessages();
+			this._flushPendingCustomMessages();
+			await this._emitAgentSettled();
+		}
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -184,6 +184,8 @@ export type SwitchSessionHandler = (
 
 export type ReloadHandler = () => Promise<void>;
 
+export type RetryHandler = () => Promise<void>;
+
 export type ShutdownHandler = () => void;
 
 /**
@@ -292,6 +294,7 @@ export class ExtensionRunner {
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private reloadHandler: ReloadHandler = async () => {};
+	private retryHandler: RetryHandler = async () => {};
 	private shutdownHandler: ShutdownHandler = () => {};
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
@@ -422,6 +425,7 @@ export class ExtensionRunner {
 			this.navigateTreeHandler = actions.navigateTree;
 			this.switchSessionHandler = actions.switchSession;
 			this.reloadHandler = actions.reload;
+			this.retryHandler = actions.retry;
 			return;
 		}
 
@@ -431,6 +435,7 @@ export class ExtensionRunner {
 		this.navigateTreeHandler = async () => ({ cancelled: false });
 		this.switchSessionHandler = async () => ({ cancelled: false });
 		this.reloadHandler = async () => {};
+		this.retryHandler = async () => {};
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext, mode: ExtensionMode = "print"): void {
@@ -835,6 +840,10 @@ export class ExtensionRunner {
 		context.reload = () => {
 			this.assertActive();
 			return this.reloadHandler();
+		};
+		context.retry = () => {
+			this.assertActive();
+			return this.retryHandler();
 		};
 		return context;
 	}

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -386,6 +386,9 @@ export interface ExtensionCommandContext extends ExtensionContext {
 
 	/** Reload extensions, skills, prompts, themes, and context files. */
 	reload(): Promise<void>;
+
+	/** Retry the last interrupted turn or continue from the current transcript. */
+	retry(): Promise<void>;
 }
 
 /**
@@ -1753,6 +1756,7 @@ export interface ExtensionCommandContextActions {
 		options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	) => Promise<{ cancelled: boolean }>;
 	reload: () => Promise<void>;
+	retry: () => Promise<void>;
 }
 
 /**

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -37,6 +37,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "logout", description: "Remove provider authentication" },
 	{ name: "new", description: "Start a new session" },
 	{ name: "compact", description: "Manually compact the session context" },
+	{ name: "retry", description: "Retry the last interrupted turn" },
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, themes, and context files" },
 	{ name: "quit", description: `Quit ${APP_NAME}` },

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -21,6 +21,7 @@ export {
 	type ParsedSkillBlock,
 	type PromptOptions,
 	parseSkillBlock,
+	type RetryOptions,
 	type SessionStats,
 } from "./core/agent-session.ts";
 export { readStoredCredential } from "./core/auth-storage.ts";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1911,6 +1911,9 @@ export class InteractiveMode {
 				reload: async () => {
 					await this.handleReloadCommand();
 				},
+				retry: async () => {
+					await this.handleRetryCommand();
+				},
 			},
 			shutdownHandler: () => {
 				this.shutdownRequested = true;
@@ -3074,6 +3077,11 @@ export class InteractiveMode {
 			if (text === "/reload") {
 				this.editor.setText("");
 				await this.handleReloadCommand();
+				return;
+			}
+			if (text === "/retry") {
+				this.editor.setText("");
+				await this.handleRetryCommand();
 				return;
 			}
 			if (text === "/debug") {
@@ -6054,6 +6062,16 @@ export class InteractiveMode {
 				dismissReloadBox(previousEditor as Component);
 			}
 			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	private async handleRetryCommand(): Promise<void> {
+		this.clearStatusIndicator();
+
+		try {
+			await this.session.retry();
+		} catch (error) {
+			this.showError(`Retry failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -97,6 +97,9 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 				reload: async () => {
 					await session.reload();
 				},
+				retry: async () => {
+					await session.retry();
+				},
 			},
 			onError: (err) => {
 				console.error(`Extension error (${err.extensionPath}): ${err.error}`);

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -327,6 +327,13 @@ export class RpcClient {
 	}
 
 	/**
+	 * Retry the last interrupted turn or continue from the current transcript.
+	 */
+	async retry(): Promise<void> {
+		await this.send({ type: "retry" });
+	}
+
+	/**
 	 * Set auto-retry enabled/disabled.
 	 */
 	async setAutoRetry(enabled: boolean): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -341,6 +341,9 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 				reload: async () => {
 					await session.reload();
 				},
+				retry: async () => {
+					await session.retry();
+				},
 			},
 			shutdownHandler: () => {
 				shutdownRequested = true;
@@ -545,6 +548,27 @@ export async function runRpcMode(runtimeHost: AgentSessionRuntime): Promise<neve
 			// =================================================================
 			// Retry
 			// =================================================================
+
+			case "retry": {
+				// Same response semantics as "prompt": respond once the retry is accepted, before
+				// the run finishes, so the caller sees the response ahead of the event stream.
+				let preflightSucceeded = false;
+				void session
+					.retry({
+						preflightResult: (didSucceed) => {
+							if (didSucceed) {
+								preflightSucceeded = true;
+								output(success(id, "retry"));
+							}
+						},
+					})
+					.catch((e) => {
+						if (!preflightSucceeded) {
+							output(error(id, "retry", e.message));
+						}
+					});
+				return undefined;
+			}
 
 			case "set_auto_retry": {
 				session.setAutoRetryEnabled(command.enabled);

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -48,6 +48,7 @@ export type RpcCommand =
 	| { id?: string; type: "set_auto_compaction"; enabled: boolean }
 
 	// Retry
+	| { id?: string; type: "retry" }
 	| { id?: string; type: "set_auto_retry"; enabled: boolean }
 	| { id?: string; type: "abort_retry" }
 
@@ -180,6 +181,7 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "set_auto_compaction"; success: true }
 
 	// Retry
+	| { id?: string; type: "response"; command: "retry"; success: true }
 	| { id?: string; type: "response"; command: "set_auto_retry"; success: true }
 	| { id?: string; type: "response"; command: "abort_retry"; success: true }
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -942,10 +942,11 @@ describe("ExtensionRunner", () => {
 	});
 
 	describe("command context", () => {
-		it("passes fork options through to the bound handler", async () => {
+		it("passes command actions through to the bound handlers", async () => {
 			const runtime = createExtensionRuntime();
 			const runner = new ExtensionRunner([], runtime, tempDir, sessionManager, modelRegistry);
 			const fork = vi.fn(async () => ({ cancelled: false }));
+			const retry = vi.fn(async () => {});
 
 			runner.bindCommandContext({
 				waitForIdle: async () => {},
@@ -954,6 +955,7 @@ describe("ExtensionRunner", () => {
 				navigateTree: async () => ({ cancelled: false }),
 				switchSession: async () => ({ cancelled: false }),
 				reload: async () => {},
+				retry,
 			});
 
 			const commandContext = runner.createCommandContext();
@@ -962,6 +964,9 @@ describe("ExtensionRunner", () => {
 
 			await commandContext.fork("entry-2", { position: "at" });
 			expect(fork).toHaveBeenLastCalledWith("entry-2", { position: "at" });
+
+			await commandContext.retry();
+			expect(retry).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -85,10 +85,14 @@ function parseOutputLines(outputLines: string[]): ParsedOutputLine[] {
 		.map((line) => JSON.parse(line) as ParsedOutputLine);
 }
 
-function getPromptResponses(outputLines: string[], id: string): ParsedOutputLine[] {
+function getResponses(outputLines: string[], id: string, command: string): ParsedOutputLine[] {
 	return parseOutputLines(outputLines).filter(
-		(record) => record.id === id && record.type === "response" && record.command === "prompt",
+		(record) => record.id === id && record.type === "response" && record.command === command,
 	);
+}
+
+function getPromptResponses(outputLines: string[], id: string): ParsedOutputLine[] {
+	return getResponses(outputLines, id, "prompt");
 }
 
 function sleep(ms: number): Promise<void> {
@@ -279,6 +283,62 @@ describe("RPC prompt response semantics", () => {
 			});
 
 			await sleep(150);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("emits one failure response when retry preflight rejects during streaming", async () => {
+		const { lineHandler, cleanup } = await startRpcMode({ withAuth: true, responseDelayMs: 200 });
+
+		try {
+			lineHandler(JSON.stringify({ id: "r1-start", type: "prompt", message: "Start" }));
+			await vi.waitFor(() => {
+				expect(getPromptResponses(rpcIo.outputLines, "r1-start")).toHaveLength(1);
+			});
+
+			lineHandler(JSON.stringify({ id: "r1", type: "retry" }));
+
+			await vi.waitFor(() => {
+				const responses = getResponses(rpcIo.outputLines, "r1", "retry");
+				expect(responses).toHaveLength(1);
+				expect(responses[0]).toMatchObject({
+					id: "r1",
+					type: "response",
+					command: "retry",
+					success: false,
+					error: "Wait for the current response to finish before retrying.",
+				});
+			});
+
+			await sleep(250);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("emits one failure response when retry preflight rejects after a completed response", async () => {
+		const { lineHandler, cleanup } = await startRpcMode({ withAuth: true, responseDelayMs: 0 });
+
+		try {
+			lineHandler(JSON.stringify({ id: "r2-start", type: "prompt", message: "Start" }));
+			await vi.waitFor(() => {
+				expect(parseOutputLines(rpcIo.outputLines).some((record) => record.type === "agent_settled")).toBe(true);
+			});
+
+			lineHandler(JSON.stringify({ id: "r2", type: "retry" }));
+
+			await vi.waitFor(() => {
+				const responses = getResponses(rpcIo.outputLines, "r2", "retry");
+				expect(responses).toHaveLength(1);
+				expect(responses[0]).toMatchObject({
+					id: "r2",
+					type: "response",
+					command: "retry",
+					success: false,
+					error: "Cannot retry from a completed assistant response.",
+				});
+			});
 		} finally {
 			await cleanup();
 		}

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -132,6 +132,110 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
 	});
 
+	it("manually retries an interrupted turn when auto-retry is disabled", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),
+			fauxAssistantMessage("manual recovery"),
+		]);
+
+		await harness.session.prompt("test");
+		await harness.session.retry();
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.session.messages.at(-1)).toMatchObject({ role: "assistant" });
+	});
+
+	it("manually retries an aborted turn", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("x".repeat(20_000)), fauxAssistantMessage("after abort")]);
+
+		const sawMessageUpdate = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "message_update") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("test");
+		await sawMessageUpdate;
+		await harness.session.abort();
+		await promptPromise;
+		expect(harness.session.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+
+		await harness.session.retry();
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.session.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "stop" });
+		expect(harness.session.messages.filter((message) => message.role === "user")).toHaveLength(1);
+		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_settled");
+	});
+
+	it("manually retries a truncated response", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 1_000_000, maxTokens: 100 }],
+			settings: { retry: { enabled: false } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("x".repeat(400), { stopReason: "length" }),
+			fauxAssistantMessage("complete"),
+		]);
+
+		await harness.session.prompt("test");
+		expect(harness.session.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "length" });
+
+		await harness.session.retry();
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.session.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "stop" });
+		expect(harness.session.messages.filter((message) => message.role === "user")).toHaveLength(1);
+	});
+
+	it("rejects manual retry while a response is streaming", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("x".repeat(20_000))]);
+
+		const sawMessageUpdate = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "message_update") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+		const promptPromise = harness.session.prompt("test");
+		await sawMessageUpdate;
+
+		await expect(harness.session.retry()).rejects.toThrow("Wait for the current response to finish before retrying.");
+		await promptPromise;
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+
+	it("rejects manual retry on an empty session", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
+		harnesses.push(harness);
+
+		await expect(harness.session.retry()).rejects.toThrow("Nothing to retry: the session has no messages.");
+		expect(harness.faux.state.callCount).toBe(0);
+	});
+
+	it("rejects manual retry after a completed assistant response", async () => {
+		const harness = await createHarness({ settings: { retry: { enabled: false } } });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+
+		await harness.session.prompt("test");
+
+		await expect(harness.session.retry()).rejects.toThrow("Cannot retry from a completed assistant response.");
+		expect(harness.faux.state.callCount).toBe(1);
+	});
+
 	it("does not retry non-retryable errors", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
 		harnesses.push(harness);

--- a/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2860-replaced-session-context.test.ts
@@ -124,6 +124,9 @@ describe("regression #2860: replaced session callbacks", () => {
 					reload: async () => {
 						await session.reload();
 					},
+					retry: async () => {
+						await session.retry();
+					},
 				},
 			});
 		};

--- a/packages/coding-agent/test/suite/regressions/6363-agent-settled-event.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6363-agent-settled-event.test.ts
@@ -123,6 +123,7 @@ describe("regression #6363: agent settled event and idle waiting", () => {
 				navigateTree: async () => ({ cancelled: false }),
 				switchSession: async () => ({ cancelled: false }),
 				reload: async () => {},
+				retry: async () => {},
 			},
 		});
 		const toolStarted = new Promise<void>((resolve) => {


### PR DESCRIPTION
**Edit:** I forgot to submit my [issue for this PR](https://github.com/earendil-works/pi/issues/9293) first. My apologies.

Auto-retry is nice, but sometimes you know better. Auto-retry also doesn't attempt to recover from everything it could, and gives up for good at some point.

Some example use-cases:
- Continue after auth failure, which auto-retry doesn't try to recover from
- Continue after truncated output
- Retry with auto-retry disabled
- Retry immediately without waiting for auto-retry cooldown, if you already know that the issue is resolved
- Re-arm auto-retry, if enabled

The session already supports continuing from the existing ontext without adding a new message, as opposed to a "continue" prompt, for example. Auto-retry already uses the same method, but the primitive was not exposed to extensions nor the user.

You could also argue that there shouldn't be a new built-in command, but it seems appropriate for a primitive of the interactive loop.

I was debating whether to call the builtin command `/continue`, since that's what the underlying session method is called, but I figure that might be too ambiguous with existing user-facing session continue/resume terminology. So I went with `/retry`, since it's more accurate to the mechanism, and easy to alias if people prefer it.

Closes #9293