### PR TITLE
fix(ai): remove invalid Fable 5 fallback target

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -272,7 +272,7 @@ const EAGER_TOOL_INPUT_STREAMING_UNSUPPORTED_ANTHROPIC_MODELS = new Set([
 	"github-copilot:claude-sonnet-4.5",
 ]);
 const ANTHROPIC_ALLOWED_FALLBACK_MODELS = {
-	"claude-fable-5": ["claude-opus-4-8", "claude-opus-5"],
+	"claude-fable-5": ["claude-opus-5"],
 	"claude-opus-5": ["claude-opus-4-8"],
 } satisfies Record<string, string[]>;
 


### PR DESCRIPTION
Keep Opus 5 as the only built-in fallback for Claude Fable 5. Cover generated fallback metadata and low-effort API-key/OAuth payloads, including Fable 5.1.

Also inquired on models.dev v2 issue whether they plan to model fallback models in their API/model so that we don't need to hard code this.

That being said, I'm not sure why defaulting to `default` or doing more involved filtering of "this is what I prefer, but then fallback to default / nothing" if it's not among the returned allowed ones wouldn't be better way.

Especially now that Fable 5 defaults to opus 5 but fable 5.1. doesn't and just fails. Happy to adjust to go to `default` but that felt as more of "opinion" change and I didn't feel like doing that :).

(the allowed fallbacks are on API that's guarded behind API key so they might be account specific)

Fixes #9294