### PR TITLE
feat(coding-agent): confirm device-code browser and clipboard actions

### DIFF
--- a/packages/ai/src/auth/types.ts
+++ b/packages/ai/src/auth/types.ts
@@ -141,6 +141,10 @@ export type AuthEvent =
 			type: "device_code";
 			userCode: string;
 			verificationUri: string;
+			/** Offer best-effort browser opening on user confirmation. Defaults to true; clients may ignore it. */
+			openBrowserOnConfirm?: boolean;
+			/** Offer copying of userCode on user confirmation, replacing the clipboard. Defaults to true. */
+			copyCodeOnConfirm?: boolean;
 			intervalSeconds?: number;
 			expiresInSeconds?: number;
 	  }

--- a/packages/ai/src/compat/extension-oauth-types.ts
+++ b/packages/ai/src/compat/extension-oauth-types.ts
@@ -17,6 +17,10 @@ export interface OAuthAuthInfo {
 export interface OAuthDeviceCodeInfo {
 	userCode: string;
 	verificationUri: string;
+	/** Offer best-effort browser opening on user confirmation. Defaults to true; clients may ignore it. */
+	openBrowserOnConfirm?: boolean;
+	/** Offer copying of userCode on user confirmation, replacing the clipboard. Defaults to true. */
+	copyCodeOnConfirm?: boolean;
 	intervalSeconds?: number;
 	expiresInSeconds?: number;
 }

--- a/packages/coding-agent/docs/custom-provider.md
+++ b/packages/coding-agent/docs/custom-provider.md
@@ -362,6 +362,8 @@ interface OAuthLoginCallbacks {
   onDeviceCode(params: {
     userCode: string;
     verificationUri: string;
+    openBrowserOnConfirm?: boolean;
+    copyCodeOnConfirm?: boolean;
     intervalSeconds?: number;
     expiresInSeconds?: number;
   }): void;
@@ -379,6 +381,8 @@ interface OAuthLoginCallbacks {
   }): Promise<string | undefined>;
 }
 ```
+
+Device-code login offers browser opening and code copying on Enter (`tui.select.confirm`) by default. Set `openBrowserOnConfirm` or `copyCodeOnConfirm` to `false` to disable either action. Native `AuthEvent` notifications support the same flags.
 
 ### OAuthCredentials
 

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -1,5 +1,15 @@
 import type { AuthInfoLink, OAuthDeviceCodeInfo } from "@earendil-works/pi-ai";
-import { Container, type Focusable, getKeybindings, Input, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
+import {
+	Container,
+	type Focusable,
+	getKeybindings,
+	Input,
+	Spacer,
+	Text,
+	TruncatedText,
+	type TUI,
+} from "@earendil-works/pi-tui";
+import { copyToClipboard } from "../../../utils/clipboard.ts";
 import { openBrowser } from "../../../utils/open-browser.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
@@ -15,6 +25,8 @@ export class LoginDialogComponent extends Container implements Focusable {
 	private abortController = new AbortController();
 	private inputResolver?: (value: string) => void;
 	private inputRejecter?: (error: Error) => void;
+	private deviceCodeAction?: { info: OAuthDeviceCodeInfo; hint: Container };
+	private deviceCodeHint?: Container;
 	private onComplete: (success: boolean, message?: string) => void;
 
 	// Focusable implementation - propagate to input for IME cursor positioning
@@ -80,7 +92,16 @@ export class LoginDialogComponent extends Container implements Focusable {
 		);
 	}
 
+	private clearDeviceCodeAction(): void {
+		if (this.deviceCodeHint) {
+			this.contentContainer.removeChild(this.deviceCodeHint);
+		}
+		this.deviceCodeHint = undefined;
+		this.deviceCodeAction = undefined;
+	}
+
 	private cancel(): void {
+		this.clearDeviceCodeAction();
 		this.abortController.abort();
 		if (this.inputRejecter) {
 			this.inputRejecter(new Error("Login cancelled"));
@@ -94,6 +115,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Called by onAuth callback - show URL and optional instructions
 	 */
 	showAuth(url: string, instructions?: string): void {
+		this.clearDeviceCodeAction();
 		this.contentContainer.clear();
 		this.contentContainer.addChild(new Spacer(1));
 		const linkedUrl = `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`;
@@ -116,6 +138,12 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Called by onDeviceCode callback - show URL and user code.
 	 */
 	showDeviceCode(info: OAuthDeviceCodeInfo): void {
+		info = {
+			...info,
+			openBrowserOnConfirm: info.openBrowserOnConfirm ?? true,
+			copyCodeOnConfirm: info.copyCodeOnConfirm ?? true,
+		};
+		this.clearDeviceCodeAction();
 		this.contentContainer.clear();
 		this.contentContainer.addChild(new Spacer(1));
 		const linkedUrl = `\x1b]8;;${info.verificationUri}\x07${info.verificationUri}\x1b]8;;\x07`;
@@ -127,13 +155,52 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("warning", `Enter code: ${info.userCode}`), 1, 0));
 
+		if (!this.signal.aborted && (info.openBrowserOnConfirm || info.copyCodeOnConfirm)) {
+			const actionLabel = info.openBrowserOnConfirm
+				? info.copyCodeOnConfirm
+					? "to open browser and copy code"
+					: "to open browser"
+				: "to copy code";
+			// Reuse this single row for progress/result text, including in narrow terminals.
+			const hint = new Container();
+			hint.addChild(new TruncatedText(`(${keyHint("tui.select.confirm", actionLabel)})`, 1, 0));
+			this.contentContainer.addChild(hint);
+			this.deviceCodeHint = hint;
+			this.deviceCodeAction = { info, hint };
+		}
 		this.tui.requestRender();
+	}
+
+	private setDeviceCodeStatus(hint: Container, message: string): void {
+		if (this.signal.aborted || !this.focused || !this.contentContainer.children.includes(hint)) return;
+		hint.children = [new TruncatedText(theme.fg("dim", message), 1, 0)];
+		this.tui.requestRender();
+	}
+
+	private activateDeviceCode(info: OAuthDeviceCodeInfo, hint: Container): void {
+		this.setDeviceCodeStatus(hint, info.copyCodeOnConfirm ? "Copying code..." : "Browser open requested");
+		if (info.copyCodeOnConfirm) {
+			// Do not delay polling or browser opening while clipboard tools are running.
+			void copyToClipboard(info.userCode)
+				.then(() => this.setDeviceCodeStatus(hint, "Code copied to clipboard"))
+				.catch(() => this.setDeviceCodeStatus(hint, "Copy code manually"));
+		}
+		if (info.openBrowserOnConfirm) {
+			try {
+				// The shared launcher also opens files; device-code login must only open web URLs.
+				const url = new URL(info.verificationUri);
+				if (url.protocol === "https:" || url.protocol === "http:") openBrowser(url.href);
+			} catch {
+				// Invalid URLs or launcher failures must not interrupt login.
+			}
+		}
 	}
 
 	/**
 	 * Show input for manual code/URL entry (for callback server providers)
 	 */
 	showManualInput(prompt: string): Promise<string> {
+		this.clearDeviceCodeAction();
 		this.input.setValue("");
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("dim", prompt), 1, 0));
@@ -152,6 +219,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Note: Does NOT clear content, appends to existing (preserves URL from showAuth)
 	 */
 	showPrompt(message: string, placeholder?: string): Promise<string> {
+		this.clearDeviceCodeAction();
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("text", message), 1, 0));
 		if (placeholder) {
@@ -177,6 +245,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 
 	/** Show informational text before another login step. */
 	showDetails(lines: string[]): void {
+		this.clearDeviceCodeAction();
 		this.contentContainer.clear();
 		this.contentContainer.addChild(new Spacer(1));
 		for (const line of lines) {
@@ -224,6 +293,21 @@ export class LoginDialogComponent extends Container implements Focusable {
 
 		if (kb.matches(data, "tui.select.cancel")) {
 			this.cancel();
+			return;
+		}
+
+		if (
+			this.deviceCodeAction &&
+			!this.inputResolver &&
+			!this.signal.aborted &&
+			this.focused &&
+			kb.matches(data, "tui.select.confirm")
+		) {
+			const action = this.deviceCodeAction;
+			// Consume once so a repeated Enter cannot launch multiple browsers or clipboard writes.
+			this.deviceCodeAction = undefined;
+			this.activateDeviceCode(action.info, action.hint);
+			this.tui.requestRender();
 			return;
 		}
 

--- a/packages/coding-agent/test/login-dialog-device-code.test.ts
+++ b/packages/coding-agent/test/login-dialog-device-code.test.ts
@@ -1,0 +1,87 @@
+import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.ts";
+import { LoginDialogComponent } from "../src/modes/interactive/components/login-dialog.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+import { copyToClipboard } from "../src/utils/clipboard.ts";
+import { openBrowser } from "../src/utils/open-browser.ts";
+
+vi.mock("../src/utils/clipboard.ts", () => ({ copyToClipboard: vi.fn() }));
+vi.mock("../src/utils/open-browser.ts", () => ({ openBrowser: vi.fn() }));
+
+const device = { userCode: "ABCD-EFGH", verificationUri: "https://example.com/device" };
+
+function createDialog() {
+	const onComplete = vi.fn();
+	const dialog = new LoginDialogComponent({ requestRender: vi.fn() } as unknown as TUI, "custom-provider", onComplete);
+	dialog.focused = true;
+	return { dialog, onComplete };
+}
+
+function render(dialog: LoginDialogComponent): string {
+	return stripAnsi(dialog.render(120).join("\n"));
+}
+
+// Regression #9282: device-code convenience actions require explicit confirmation.
+describe("device-code login", () => {
+	beforeAll(() => initTheme("dark"));
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.mocked(copyToClipboard).mockResolvedValue(undefined);
+		setKeybindings(new KeybindingsManager());
+	});
+
+	it("opens the verification page and copies the code once after confirmation", async () => {
+		const { dialog } = createDialog();
+		const domain = dialog.showPrompt("GitHub Enterprise URL/domain (blank for github.com)");
+		dialog.handleInput("\r");
+		await expect(domain).resolves.toBe("");
+		dialog.showDeviceCode(device);
+		dialog.showWaiting("Waiting for authentication...");
+		expect(render(dialog)).toContain("to open browser and copy code");
+		expect(openBrowser).not.toHaveBeenCalled();
+		expect(copyToClipboard).not.toHaveBeenCalled();
+
+		dialog.handleInput("\r");
+		await Promise.resolve();
+		dialog.handleInput("\r");
+		expect(openBrowser).toHaveBeenCalledExactlyOnceWith(device.verificationUri);
+		expect(copyToClipboard).toHaveBeenCalledExactlyOnceWith(device.userCode);
+		expect(render(dialog)).toContain("Code copied to clipboard");
+		expect(render(dialog)).toContain(`Enter code: ${device.userCode}`);
+		expect(render(dialog)).toContain("Waiting for authentication...");
+		expect(render(dialog)).not.toContain("to open browser and copy code");
+	});
+
+	it("cancels without opening a browser or changing the clipboard", () => {
+		const { dialog, onComplete } = createDialog();
+		dialog.showDeviceCode(device);
+		dialog.handleInput("\x1b");
+		dialog.handleInput("\r");
+		expect(dialog.signal.aborted).toBe(true);
+		expect(onComplete).toHaveBeenCalledExactlyOnceWith(false, "Login cancelled");
+		expect(openBrowser).not.toHaveBeenCalled();
+		expect(copyToClipboard).not.toHaveBeenCalled();
+	});
+
+	it("keeps manual login available when browser and clipboard access fail", async () => {
+		vi.mocked(openBrowser).mockImplementation(() => {
+			throw new Error("Browser unavailable");
+		});
+		vi.mocked(copyToClipboard).mockRejectedValue(new Error("Clipboard unavailable"));
+		const { dialog, onComplete } = createDialog();
+		dialog.showDeviceCode(device);
+		dialog.showWaiting("Waiting for authentication...");
+		expect(() => dialog.handleInput("\r")).not.toThrow();
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(openBrowser).toHaveBeenCalledExactlyOnceWith(device.verificationUri);
+		expect(copyToClipboard).toHaveBeenCalledExactlyOnceWith(device.userCode);
+		expect(render(dialog)).toContain(device.verificationUri);
+		expect(render(dialog)).toContain(`Enter code: ${device.userCode}`);
+		expect(render(dialog)).toContain("Copy code manually");
+		expect(render(dialog)).toContain("Waiting for authentication...");
+		expect(dialog.signal.aborted).toBe(false);
+		expect(onComplete).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Fixes #9282.

Knowing how annoying re-loggins in corpo envs can be, I think we can have automatically opened browser and copy code to clipboard (what the users asks for) without forcing it upon users (which I assume was the reason it was removed in 8f0e9251b9265e73cb85e97b8a190db40c96e57c).

This change adds optional browswer open and code copy on device login **after additional confirm (usually enter)**. It should work for all providers but there's optional opt-out (by provider creator, not user settings).

It's idenpontent, it should handle additional prompts well, etc. 

<img width="583" height="302" alt="image" src="https://github.com/user-attachments/assets/fa4725e8-8ac3-4dff-9e5a-34602937957a" />
<img width="548" height="278" alt="image" src="https://github.com/user-attachments/assets/daca468b-7fba-4a9f-932d-050e5abd0fab" />