### PR TITLE
fix(interactive): resume session before closing selector

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5361,8 +5361,8 @@ export class InteractiveMode {
 						? SessionManager.listAll(onProgress)
 						: SessionManager.listAll(this.sessionManager.getSessionDir(), onProgress),
 				async (sessionPath) => {
-					done();
 					await this.handleResumeSession(sessionPath);
+					done();
 				},
 				() => {
 					done();


### PR DESCRIPTION
## Problem

When a user selects a session from the session selector (via /resume or app.session.resume), the selector was closed (done()) before the session was actually resumed (handleResumeSession). This caused the selector to disappear silently without any visible feedback, making users think nothing happened.

## Root Cause

In `showSessionSelector()`, the `onSelect` callback called `done()` before `handleResumeSession()`:

```typescript
async (sessionPath) => {
    done();  // Selector closes immediately
    await this.handleResumeSession(sessionPath);  // Resume happens after
},
```

Since `handleResumeSession` is async and shows status messages via `showStatus()`, calling `done()` first meant the selector closed before the user could see any feedback.

## Fix

Reorder the operations: resume the session first (which shows appropriate status messages), then close the selector and return focus to the editor:

```typescript
async (sessionPath) => {
    await this.handleResumeSession(sessionPath);
    done();
},
```

This ensures:
1. The session resume happens first
2. Status messages ("Resumed session", "Resume cancelled", or errors) are visible to the user
3. Then the selector closes and focus returns to the editor

## Testing

- [ ] Select a session from the session selector
- [ ] Verify status message is shown before selector closes
- [ ] Verify selector closes after resume completes
- [ ] Test with a session that fails to resume (should show error)