### PR TITLE
fix(tui): recognize Orca terminal capabilities

### DIFF
--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -85,6 +85,11 @@ function detectCapabilitiesFromEnvironment(tmuxForwardsHyperlink: () => boolean)
 		return { images: null, trueColor: hasTrueColorHint, hyperlinks: false };
 	}
 
+	// Orca's embedded terminal does not inherit its launcher's image protocols.
+	if (termProgram === "orca") {
+		return { images: null, trueColor: true, hyperlinks: true };
+	}
+
 	if (process.env.KITTY_WINDOW_ID || termProgram === "kitty") {
 		return { images: "kitty", trueColor: true, hyperlinks: true };
 	}

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -6,7 +6,9 @@ import assert from "node:assert";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
+import { stripVTControlCharacters } from "node:util";
 import { Image } from "../src/components/image.ts";
+import { Markdown } from "../src/components/markdown.ts";
 import {
 	cropKittyImageLine,
 	deleteAllKittyImages,
@@ -29,6 +31,7 @@ import {
 	setCellDimensions,
 } from "../src/terminal-image.ts";
 import { visibleWidth } from "../src/utils.ts";
+import { defaultMarkdownTheme } from "./test-themes.ts";
 
 const ENV_KEYS = [
 	"TERM",
@@ -216,6 +219,88 @@ describe("isImageLine", () => {
 });
 
 describe("detectCapabilities", () => {
+	// Regression: https://github.com/stablyai/orca/issues/6880
+	it("recognizes Orca without inheriting another emulator's image capabilities", () => {
+		for (const termProgram of ["Orca", "orca", "ORCA"]) {
+			for (const marker of [
+				undefined,
+				"KITTY_WINDOW_ID",
+				"GHOSTTY_RESOURCES_DIR",
+				"WEZTERM_PANE",
+				"ITERM_SESSION_ID",
+				"WARP_SESSION_ID",
+				"WARP_TERMINAL_SESSION_UUID",
+			]) {
+				withEnv(
+					{ TERM_PROGRAM: termProgram, TERM: "xterm-256color", ...(marker ? { [marker]: "outer" } : {}) },
+					() => {
+						assert.deepStrictEqual(
+							detectCapabilities(),
+							{ images: null, trueColor: true, hyperlinks: true },
+							`${termProgram}: ${marker ?? "clean"}`,
+						);
+					},
+				);
+			}
+		}
+	});
+
+	it("keeps multiplexer detection ahead of Orca recognition", () => {
+		for (const env of [{ TMUX: "/tmp/tmux-test", TERM: "xterm-256color" }, { TERM: "tmux-256color" }]) {
+			withEnv({ ...env, TERM_PROGRAM: "Orca", COLORTERM: "truecolor" }, () => {
+				for (const forwards of [false, true]) {
+					let probes = 0;
+					assert.deepStrictEqual(
+						detectCapabilities(() => {
+							probes++;
+							return forwards;
+						}),
+						{ images: null, trueColor: true, hyperlinks: forwards },
+					);
+					assert.strictEqual(probes, 1);
+				}
+			});
+		}
+		withEnv({ TERM_PROGRAM: "Orca", TERM: "screen-256color" }, () => {
+			assert.deepStrictEqual(detectCapabilities(), { images: null, trueColor: false, hyperlinks: false });
+		});
+	});
+
+	it("preserves explicit capability overrides in Orca", () => {
+		withEnv({ TERM_PROGRAM: "Orca", PI_HYPERLINKS: "0", PI_IMAGE_PROTOCOL: "iterm2", PI_TRUE_COLOR: "0" }, () => {
+			assert.deepStrictEqual(detectCapabilities(), { images: "iterm2", trueColor: false, hyperlinks: false });
+		});
+	});
+
+	it("renders compact Markdown links and image placeholders in Orca without overrides", () => {
+		withEnv({ TERM_PROGRAM: "Orca", TERM: "xterm-256color", ITERM_SESSION_ID: "outer" }, () => {
+			resetCapabilitiesCache();
+			try {
+				for (const url of [
+					"https://example.com/long/path?q=hello%20world#section",
+					"https://gitlab.com/group/project/-/issues/123",
+					"file:///tmp/pi%20report.md",
+				]) {
+					const lines = new Markdown(`[Example](${url})`, 0, 0, defaultMarkdownTheme).render(18);
+					assert.strictEqual(lines.length, 1);
+					assert.strictEqual(stripVTControlCharacters(lines[0]).trim(), "Example");
+					assert.ok(lines[0].includes(`\x1b]8;;${url}\x1b\\`));
+					assert.ok(lines[0].includes("\x1b]8;;\x1b\\"));
+				}
+				const lines = new Image(
+					"AAAA",
+					"image/png",
+					{ fallbackColor: (value) => value },
+					{},
+					{ widthPx: 10, heightPx: 10 },
+				).render(40);
+				assert.deepStrictEqual(lines, ["[Image: [image/png] 10x10]"]);
+			} finally {
+				resetCapabilitiesCache();
+			}
+		});
+	});
+
 	it("defaults to hyperlinks: false for unknown terminals", () => {
 		withEnv({}, () => {
 			const caps = detectCapabilities();


### PR DESCRIPTION
# fix(tui): recognize Orca terminal capabilities

Pi treats `TERM_PROGRAM=Orca` as unknown, so `[Example](https://example.com/long/path?q=hello%20world#section)` expands into a label plus a wrapped URL instead of emitting the OSC 8 hyperlink Orca supports. Inherited iTerm/Kitty/etc. environment markers can also select unsupported image protocols and reserve blank image rows.

Recognize Orca in the existing capability detector: hyperlinks and truecolor enabled, images disabled. The five-line production change runs after tmux/screen checks and before inherited emulator hints. Explicit user capability overrides retain their existing precedence. No force flags, terminal identity spoofing, new dependencies, or per-agent launch wrappers.

Related: stablyai/orca#6880. This addresses Pi capability detection; inline-image rendering and stablyai/orca#12296's separate reveal interaction are not implemented here.

## Proof

- Against upstream `b2602be`, the new Orca tests fail twice: clean Orca is detected without hyperlinks; an inherited iTerm session produces 18 blank rows followed by an unsupported OSC 1337 image instead of the expected one-line placeholder. The multiplexer and explicit-override tests already pass.
- After the fix, all 150 image/Markdown tests pass, including the four new Orca tests.
- Entire TUI suite passes (`node --test --test-reporter=dot test/*.test.ts`).
- Full `npm run check` passes (format/lint, dependency contracts, import and entry graphs, shrinkwrap/install locks, monorepo typecheck, browser import smoke check). On a fresh checkout, first run `npm run hydrate:model-data` to populate the ignored provider JSON needed by typechecking.
- Separate interoperability probe feeds actual patched Pi Markdown output into Orca's installed xterm. Fifteen cases preserve complete URLs: short labels, wrapped labels, bare URLs, GitLab URLs, and file URLs with spaces, each in clean Orca and with inherited iTerm/Kitty markers. All three image cases produce a one-line text placeholder without capability overrides.
- Coverage retains both tmux probe outcomes, both tmux detection paths, screen behavior, case-insensitive Orca identity, six inherited image markers, and explicit user overrides.

```sh
# pi/packages/tui
ORCA_BACKGROUND_LAUNCH=1 node --test test/terminal-image.test.ts test/markdown.test.ts
ORCA_BACKGROUND_LAUNCH=1 node --test --test-reporter=dot test/*.test.ts

# pi root
npm ci --ignore-scripts
ORCA_BACKGROUND_LAUNCH=1 npm run hydrate:model-data
ORCA_BACKGROUND_LAUNCH=1 npm run check
```

Validation uses programmatic rendering and terminal parsing. It does not claim a rendered Orca hover/click test or an SSH end-to-end test. tmux forwarding results are injected through Pi's existing probe callback. Pi's full monorepo `test.sh` has not been run.
