### PR TITLE
fix(coding-agent): clear mouse selection on session switch

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3783,6 +3783,10 @@ export class InteractiveMode {
 		entries: SessionEntry[],
 		options: { updateFooter?: boolean; populateHistory?: boolean } = {},
 	): void {
+		if (TuiLayouts.isViewportTUI(this.renderer)) {
+			this.renderer.clearTextSelection();
+			this.renderer.resetClickHistory();
+		}
 		const items = entries.flatMap((entry): RenderSessionItem[] => {
 			if (entry.type === "custom") {
 				return [entry];

--- a/packages/tui/src/tui-alt-screen.ts
+++ b/packages/tui/src/tui-alt-screen.ts
@@ -862,7 +862,7 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		return count;
 	}
 
-	private clearTextSelection(): void {
+	clearTextSelection(): void {
 		this.stopSelectionAutoScroll();
 		this.selectionPressActive = false;
 		this.selectionAnchor = undefined;
@@ -871,6 +871,10 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		this.selectionInitialRange = undefined;
 		this.pressedUrl = undefined;
 		this.selectionDragged = false;
+	}
+
+	resetClickHistory(): void {
+		this.lastClick = undefined;
 	}
 
 	private handleMouseEvent(raw: SgrMouseEvent): void {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -456,6 +456,8 @@ export const VIEWPORT_TUI = Symbol.for("@earendil-works/pi-tui/viewport");
 export interface ViewportTUI extends TUI {
 	readonly [VIEWPORT_TUI]: true;
 	setLayoutRoot(component: Component | undefined): void;
+	clearTextSelection(): void;
+	resetClickHistory(): void;
 }
 
 export function isViewportTUI(tui: TUI): tui is ViewportTUI {


### PR DESCRIPTION
when selecting text in fullscreen mode and then switching sessions, the selection was previously persisted in the other session too.

this pr fixes that issue :)