### PR TITLE
fix(ai,coding-agent): three easy fixes (#8919, #8717, #8720)

### DIFF
--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -227,7 +227,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 				? msg.content.filter((c): c is ImageContent => c.type === "image")
 				: [];
 
-			const hasText = textResult.length > 0;
+			const hasText = textResult.trim().length > 0;
 			const hasImages = imageContent.length > 0;
 
 			// Gemini 3+ models support multimodal function responses with images nested inside

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1389,7 +1389,7 @@ export function convertMessages(
 				const hasImages = toolMsg.content.some((c) => c.type === "image");
 
 				// Always send tool result with text (or placeholder if only images)
-				const hasText = textResult.length > 0;
+				const hasText = textResult.trim().length > 0;
 				const toolResultText = hasText ? textResult : hasImages ? "(see attached image)" : "(no tool output)";
 				// Some providers require the 'name' field in tool results
 				const toolResultMsg: ChatCompletionToolMessageParam = {

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -83,7 +83,7 @@ function convertToolResultOutput<TApi extends Api>(
 		.map((c) => c.text)
 		.join("\n");
 	const images = content.filter((c): c is ImageContent => c.type === "image");
-	const hasText = textResult.length > 0;
+	const hasText = textResult.trim().length > 0;
 
 	if (images.length === 0 || !model.input.includes("image")) {
 		return sanitizeSurrogates(hasText ? textResult : images.length > 0 ? "(see attached image)" : "(no tool output)");

--- a/packages/ai/test/whitespace-tool-result.test.ts
+++ b/packages/ai/test/whitespace-tool-result.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { convertMessages as convertGoogleMessages } from "../src/api/google-shared.ts";
+import { convertMessages as convertCompletionsMessages } from "../src/api/openai-completions.ts";
+import { convertResponsesMessages } from "../src/api/openai-responses-shared.ts";
+import { getModel } from "../src/compat.ts";
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	OpenAICompletionsCompat,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.ts";
+
+// Regression tests for #8720: whitespace-only tool output permanently bricks the session.
+// Providers reject whitespace-only content with HTTP 400, so it must fall back to the
+// "(no tool output)" placeholder, same as the already-handled empty-string case.
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const compat: Omit<
+	Required<OpenAICompletionsCompat>,
+	"deferredToolsMode" | "thinkingTokenBudgetField" | "vllmPriority"
+> & {
+	deferredToolsMode?: OpenAICompletionsCompat["deferredToolsMode"];
+	thinkingTokenBudgetField?: OpenAICompletionsCompat["thinkingTokenBudgetField"];
+} = {
+	supportsStore: true,
+	supportsDeveloperRole: true,
+	supportsReasoningEffort: true,
+	supportsUsageInStreaming: true,
+	supportsFinishReason: true,
+	maxTokensField: "max_completion_tokens",
+	requiresToolResultName: false,
+	requiresAssistantAfterToolResult: false,
+	requiresThinkingAsText: false,
+	requiresReasoningContentOnAssistantMessages: false,
+	thinkingFormat: "openai",
+	openRouterRouting: {},
+	vercelGatewayRouting: {},
+	chatTemplateKwargs: {},
+	chatTemplateArgs: {},
+	zaiToolStream: false,
+	supportsThinkingTokenBudget: false,
+	thinkingTokenBudgetField: undefined,
+	supportsStrictMode: true,
+	supportsOpenAIGrammarTools: false,
+	cacheControlFormat: "anthropic",
+	sendSessionAffinityHeaders: false,
+	sessionAffinityFormat: "openai",
+	supportsLongCacheRetention: true,
+};
+
+function buildWhitespaceToolResult(toolCallId: string, text: string, timestamp: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "bash",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	};
+}
+
+const whitespaceVariants = [
+	{ label: "\\r\\n", value: "\r\n" },
+	{ label: "spaces", value: "   " },
+	{ label: "\\n\\t", value: "\n\t" },
+	{ label: "single newline", value: "\n" },
+];
+
+// #8720
+describe("openai-completions: whitespace-only tool result uses placeholder", () => {
+	for (const { label, value } of whitespaceVariants) {
+		it(`falls back to "(no tool output)" for ${label}`, () => {
+			const { compat: _compat, ...baseModel } = getModel("openai", "gpt-4o-mini");
+			const model: Model<"openai-completions"> = {
+				...baseModel,
+				api: "openai-completions",
+				input: ["text"],
+			};
+
+			const now = Date.now();
+			const assistant: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "echo" } }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: emptyUsage,
+				stopReason: "toolUse",
+				timestamp: now,
+			};
+
+			const context: Context = {
+				messages: [
+					{ role: "user", content: "run it", timestamp: now - 1 },
+					assistant,
+					buildWhitespaceToolResult("tool-1", value, now + 1),
+				],
+			};
+
+			const messages = convertCompletionsMessages(model, context, compat);
+			const toolMessage = messages.find((m) => m.role === "tool") as { role: "tool"; content: string } | undefined;
+			expect(toolMessage).toBeTruthy();
+			expect(toolMessage?.content).toBe("(no tool output)");
+		});
+	}
+});
+
+// #8720
+describe("openai-responses: whitespace-only tool result uses placeholder", () => {
+	for (const { label, value } of whitespaceVariants) {
+		it(`falls back to "(no tool output)" for ${label}`, () => {
+			const model = getModel("openai", "gpt-4o-mini");
+			const now = Date.now();
+			const assistant: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "echo" } }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: emptyUsage,
+				stopReason: "toolUse",
+				timestamp: now,
+			};
+
+			const context: Context = {
+				messages: [
+					{ role: "user", content: "run it", timestamp: now - 1 },
+					assistant,
+					buildWhitespaceToolResult("tool-1", value, now + 1),
+				],
+			};
+
+			const input = convertResponsesMessages(model, context, new Set(["openai", "openai-codex", "opencode"]));
+			const functionCallOutput = input.find((item) => item.type === "function_call_output") as
+				| { type: "function_call_output"; output: string }
+				| undefined;
+			expect(functionCallOutput).toBeTruthy();
+			expect(functionCallOutput?.output).toBe("(no tool output)");
+		});
+	}
+});
+
+// #8720
+describe("google-shared: whitespace-only tool result uses empty string fallback", () => {
+	for (const { label, value } of whitespaceVariants) {
+		it(`falls back to empty string for ${label}`, () => {
+			const model: Model<"google-generative-ai"> = {
+				id: "gemini-2.5-flash",
+				name: "gemini-2.5-flash",
+				api: "google-generative-ai",
+				provider: "google",
+				baseUrl: "https://example.com",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 8192,
+			};
+
+			const now = Date.now();
+			const context: Context = {
+				messages: [
+					{ role: "user", content: "run it", timestamp: now },
+					{
+						role: "assistant",
+						content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: { command: "echo" } }],
+						api: model.api,
+						provider: model.provider,
+						model: model.id,
+						usage: emptyUsage,
+						stopReason: "toolUse",
+						timestamp: now,
+					},
+					buildWhitespaceToolResult("call_1", value, now + 1),
+				],
+			};
+
+			const contents = convertGoogleMessages(model, context);
+			// The tool result should be in a model turn followed by a user turn with functionResponse
+			const functionResponseTurn = contents.find(
+				(c) => c.role === "user" && c.parts?.some((p: { functionResponse?: unknown }) => p.functionResponse),
+			);
+			expect(functionResponseTurn).toBeTruthy();
+			const frPart = functionResponseTurn!.parts!.find(
+				(p: { functionResponse?: unknown }) => p.functionResponse,
+			) as { functionResponse: { response: { output?: string } } };
+			// Google path uses empty string as the fallback for no-text tool results
+			expect(frPart.functionResponse.response.output).toBe("");
+		});
+	}
+});

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -829,9 +829,9 @@ Response:
   "success": true,
   "data": {
     "commands": [
-      {"name": "session-name", "description": "Set or clear session name", "source": "extension", "path": "/home/user/.pi/agent/extensions/session.ts"},
-      {"name": "fix-tests", "description": "Fix failing tests", "source": "prompt", "location": "project", "path": "/home/user/myproject/.pi/agent/prompts/fix-tests.md"},
-      {"name": "skill:brave-search", "description": "Web search via Brave API", "source": "skill", "location": "user", "path": "/home/user/.pi/agent/skills/brave-search/SKILL.md"}
+      {"name": "session-name", "description": "Set or clear session name", "source": "extension", "sourceInfo": {"path": "/home/user/.pi/agent/extensions/session.ts", "source": "auto", "scope": "user", "origin": "top-level", "baseDir": "/home/user/.pi/agent"}},
+      {"name": "fix-tests", "description": "Fix failing tests", "source": "prompt", "sourceInfo": {"path": "/home/user/myproject/.pi/agent/prompts/fix-tests.md", "source": "auto", "scope": "project", "origin": "top-level", "baseDir": "/home/user/myproject/.pi/agent"}},
+      {"name": "skill:brave-search", "description": "Web search via Brave API", "source": "skill", "sourceInfo": {"path": "/home/user/.pi/agent/skills/brave-search/SKILL.md", "source": "auto", "scope": "user", "origin": "top-level", "baseDir": "/home/user/.pi/agent"}}
     ]
   }
 }
@@ -844,11 +844,12 @@ Each command has:
   - `"extension"`: Registered via `pi.registerCommand()` in an extension
   - `"prompt"`: Loaded from a prompt template `.md` file
   - `"skill"`: Loaded from a skill directory (name is prefixed with `skill:`)
-- `location`: Where it was loaded from (optional, not present for extensions):
-  - `"user"`: User-level (`~/.pi/agent/`)
-  - `"project"`: Project-level (`./.pi/agent/`)
-  - `"path"`: Explicit path via CLI or settings
-- `path`: Absolute file path to the command source (optional)
+- `sourceInfo`: Source metadata object:
+  - `path`: Absolute file path to the command source
+  - `source`: How the resource was discovered (e.g. `"auto"`, `"cli"`)
+  - `scope`: Where it was loaded from (`"user"`, `"project"`, or `"temporary"`)
+  - `origin`: Whether it comes from a package or is top-level (`"package"` or `"top-level"`)
+  - `baseDir`: Base directory of the owning resource (optional)
 
 **Note**: Built-in TUI commands (`/settings`, `/hotkeys`, etc.) are not included. They are handled only in interactive mode and would not execute if sent via `prompt`.
 

--- a/packages/coding-agent/src/modes/interactive/chat-viewport.ts
+++ b/packages/coding-agent/src/modes/interactive/chat-viewport.ts
@@ -34,7 +34,7 @@ export function createChatViewport(options: ChatViewportOptions): ChatViewport {
 		...(options.widgetsAbove === undefined ? [] : [{ component: options.widgetsAbove, shrink: 1, minSize: 0 }]),
 		{ component: options.editor, shrink: 1, minSize: 3 },
 		...(options.widgetsBelow === undefined ? [] : [{ component: options.widgetsBelow, shrink: 1, minSize: 0 }]),
-		{ component: options.footer, shrink: 1, minSize: 1 },
+		{ component: options.footer, shrink: 1, minSize: 0 },
 	]);
 	return {
 		transcript,


### PR DESCRIPTION
Three small, independent fixes bundled for review convenience.

## Changes

### fix(coding-agent): allow zero-row custom footers in fullscreen mode (closes #8919)

The fullscreen dock reserved one row for the footer unconditionally via `minSize: 1`. Custom footers rendering zero rows could never collapse. Changed to `minSize: 0`. The built-in footer always renders >=1 row intrinsically, so no visual change for default usage.

### docs(coding-agent): fix get_commands response shape in RPC docs (closes #8717)

`docs/rpc.md` documented fictional flat `path`/`location` fields for `get_commands`. The actual response uses `sourceInfo: { path, source, scope, origin, baseDir }`, matching the `RpcSlashCommand` type in `rpc-types.ts`.

### fix(ai): treat whitespace-only tool output as empty (closes #8720)

Whitespace-only tool output (e.g. `"\r\n"` from Windows bash) passed the `length > 0` check and was sent verbatim to providers, which reject it with HTTP 400. The bad message stays in history, permanently bricking the session.

Changed `textResult.length > 0` to `textResult.trim().length > 0` in `openai-completions.ts`, `openai-responses-shared.ts`, and `google-shared.ts`. Added 12 regression tests covering 4 whitespace variants across all 3 adapters.

## Verification

- `npm run check` passes
- All new tests pass (12/12)
- All existing related tests pass
