### PR TITLE
fix(tui): guard optional invalidate in MouseRegion

### DIFF
--- a/packages/tui/src/components/mouse-region.ts
+++ b/packages/tui/src/components/mouse-region.ts
@@ -28,6 +28,6 @@ export class MouseRegion implements Component {
 	}
 
 	invalidate(): void {
-		this.child.invalidate();
+		this.child.invalidate?.();
 	}
 }

--- a/packages/tui/test/mouse-components.test.ts
+++ b/packages/tui/test/mouse-components.test.ts
@@ -2,9 +2,10 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import { Editor, type EditorTheme } from "../src/components/editor.ts";
 import { Input } from "../src/components/input.ts";
+import { MouseRegion } from "../src/components/mouse-region.ts";
 import { SelectList, type SelectListTheme } from "../src/components/select-list.ts";
 import { SettingsList, type SettingsListTheme } from "../src/components/settings-list.ts";
-import { Container, type TuiMouseEvent, type TuiMouseEventType } from "../src/tui.ts";
+import { Container, type Component, type TuiMouseEvent, type TuiMouseEventType } from "../src/tui.ts";
 import { TuiAltScreen } from "../src/tui-alt-screen.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
@@ -60,6 +61,13 @@ class InputOverlay extends Container {
 }
 
 describe("mouse-aware components", () => {
+	it("invalidates safely when a wrapped component has no invalidate method", () => {
+		const child = { render: () => ["content"] } as Component;
+		const region = new MouseRegion(child, () => undefined);
+
+		assert.doesNotThrow(() => region.invalidate());
+	});
+
 	it("positions a single-line input cursor on press", () => {
 		const input = new Input();
 		input.setValue("hello");


### PR DESCRIPTION
## Problem

`MouseRegion.invalidate()` unconditionally calls `this.child.invalidate()`, but custom components supplied by extensions can implement rendering and mouse handling without an `invalidate` method. A theme change or redraw then crashes pi with `TypeError: this.child.invalidate is not a function`.

## Change

- Guard the child invalidation with optional chaining.
- Add a regression test covering a wrapped component without `invalidate`.

## Verification

`node --test test/mouse-components.test.ts` passes (11 tests).
