### PR TITLE
fix(tui): detect Orca terminals as Kitty-image capable

### DIFF
--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -83,6 +83,10 @@ export function detectCapabilities(tmuxForwardsHyperlink: () => boolean = probeT
 		return { images: null, trueColor: hasTrueColorHint, hyperlinks: false };
 	}
 
+	if (termProgram === "orca") {
+		return { images: "kitty", trueColor: true, hyperlinks: true };
+	}
+
 	if (process.env.KITTY_WINDOW_ID || termProgram === "kitty") {
 		return { images: "kitty", trueColor: true, hyperlinks: true };
 	}

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -83,7 +83,7 @@ export function detectCapabilities(tmuxForwardsHyperlink: () => boolean = probeT
 		return { images: null, trueColor: hasTrueColorHint, hyperlinks: false };
 	}
 
-	if (termProgram === "orca") {
+	if (termProgram === "orca" && process.env['ORCA_IMAGE_PROTOCOL'] === "kitty") {
 		return { images: "kitty", trueColor: true, hyperlinks: true };
 	}
 

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -279,6 +279,15 @@ describe("detectCapabilities", () => {
 		});
 	});
 
+	it("enables images and hyperlinks for Orca", () => {
+		withEnv({ TERM_PROGRAM: "Orca" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.images, "kitty");
+			assert.strictEqual(caps.trueColor, true);
+			assert.strictEqual(caps.hyperlinks, true);
+		});
+	});
+
 	it("enables images and hyperlinks for Warp via TERM_PROGRAM", () => {
 		withEnv({ TERM_PROGRAM: "WarpTerminal" }, () => {
 			const caps = detectCapabilities();

--- a/packages/tui/test/terminal-image.test.ts
+++ b/packages/tui/test/terminal-image.test.ts
@@ -27,6 +27,7 @@ import { visibleWidth } from "../src/utils.ts";
 const ENV_KEYS = [
 	"TERM",
 	"TERM_PROGRAM",
+	"ORCA_IMAGE_PROTOCOL",
 	"TERMINAL_EMULATOR",
 	"COLORTERM",
 	"TMUX",
@@ -279,8 +280,15 @@ describe("detectCapabilities", () => {
 		});
 	});
 
-	it("enables images and hyperlinks for Orca", () => {
+	it("keeps images disabled for Orca without an image capability signal", () => {
 		withEnv({ TERM_PROGRAM: "Orca" }, () => {
+			const caps = detectCapabilities();
+			assert.strictEqual(caps.images, null);
+		});
+	});
+
+	it("enables images and hyperlinks for Orca advertising Kitty support", () => {
+		withEnv({ TERM_PROGRAM: "Orca", ORCA_IMAGE_PROTOCOL: "kitty" }, () => {
 			const caps = detectCapabilities();
 			assert.strictEqual(caps.images, "kitty");
 			assert.strictEqual(caps.trueColor, true);


### PR DESCRIPTION
```
## Summary

Treat `TERM_PROGRAM=Orca` as Kitty-image capable in `pi-tui`'s terminal capability detection, so image components render inline instead of falling back to text when running inside Orca.

- Recognize Orca as supporting Kitty inline images, true color, and OSC 8 hyperlinks.
- Preserve the existing tmux and screen precedence guards.
- Gate images on Orca's capability advertisement: require both `TERM_PROGRAM=Orca` and Orca's `ORCA_IMAGE_PROTOCOL=kitty` signal before enabling Kitty output, so existing Orca releases that do not yet advertise image support safely keep the text fallback.
- Add a regression test and the package/CLI changesets.

## Related

- Requested by maintainer approval in [earendil-works/pi#7357](https://github.com/earendil-works/pi/issues/7357) (lgtm).
- Complements the Orca-side support that advertises the capability in [stablyai/orca#11706](https://github.com/stablyai/orca/pull/11706).

## Testing

- `pnpm --filter @moonshot-ai/pi-tui test` — focused regression suite passes.
- `pnpm --filter @moonshot-ai/pi-tui typecheck` — passes.
```
