### PR TITLE
fix(coding-agent): bound Case 3 compaction estimate and getContextUsage display on failed/aborted turns

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2225,27 +2225,31 @@ export class AgentSession {
 					return false;
 				}
 			}
-			// A message this checked assistantMessage itself failed with (stopReason
-			// "error") never confirms how much of its own rendered content the
-			// provider actually processed - it may have failed before sending
-			// anything at all. Once a reliable post-compaction baseline exists
-			// (estimate.usageTokens, from the last real, non-error usage), trust
-			// that baseline alone for THIS specific failed turn rather than adding
-			// the crude per-character trailingTokens estimate of everything since
-			// it on top: a provider whose bridge resends the full conversation as
-			// quoted text on every turn (no cross-turn prompt-cache reuse) can make
-			// that single trailing estimate far larger than the real, cached
-			// context a healthy turn would actually use, which both overstates the
-			// trigger relative to the displayed context and can refire
-			// auto-compaction immediately after a real compaction completed. A
-			// zero-usage response whose own stopReason is not "error" (the
-			// malformed-response case this fallback also exists for) still adds
-			// trailingTokens as before: only a confirmed failure narrows the
-			// estimate, never an ordinary response missing its usage field.
-			contextTokens =
-				assistantMessage.stopReason === "error" && estimate.lastUsageIndex !== null
-					? estimate.usageTokens
-					: estimate.tokens;
+			// A message this checked assistantMessage itself failed or was aborted
+			// with (stopReason "error" or "aborted") never confirms how much of its
+			// own rendered content the provider actually processed - it may have
+			// failed, or been interrupted, before sending anything at all. The
+			// pre-prompt check (the caller that passes skipAbortedCheck: false so an
+			// aborted lastAssistant still reaches this method, ahead of the user's
+			// next prompt) is exactly where an aborted message shows up here. Once a
+			// reliable post-compaction baseline exists (estimate.usageTokens, from
+			// the last real, non-failed usage), trust that baseline alone for THIS
+			// specific failed/aborted turn rather than adding the crude
+			// per-character trailingTokens estimate of everything since it on top:
+			// a provider whose bridge resends the full conversation as quoted text
+			// on every turn (no cross-turn prompt-cache reuse) can make that single
+			// trailing estimate far larger than the real, cached context a healthy
+			// turn would actually use, which both overstates the trigger relative
+			// to the displayed context (readings past 100% are exactly this) and can
+			// refire auto-compaction immediately after a real compaction completed,
+			// or immediately ahead of the very next prompt after an abort, with no
+			// new reliable usage in between. A zero-usage response whose own
+			// stopReason is neither "error" nor "aborted" (the malformed-response
+			// case this fallback also exists for) still adds trailingTokens as
+			// before: only a confirmed failure or abort narrows the estimate, never
+			// an ordinary response missing its usage field.
+			const confirmedFailure = assistantMessage.stopReason === "error" || assistantMessage.stopReason === "aborted";
+			contextTokens = confirmedFailure && estimate.lastUsageIndex !== null ? estimate.usageTokens : estimate.tokens;
 			// However it was derived, an estimate can never legitimately exceed the
 			// real context window: the provider would have rejected an over-window
 			// request outright, so anything past that is already an artifact of

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2225,7 +2225,32 @@ export class AgentSession {
 					return false;
 				}
 			}
-			contextTokens = estimate.tokens;
+			// A message this checked assistantMessage itself failed with (stopReason
+			// "error") never confirms how much of its own rendered content the
+			// provider actually processed - it may have failed before sending
+			// anything at all. Once a reliable post-compaction baseline exists
+			// (estimate.usageTokens, from the last real, non-error usage), trust
+			// that baseline alone for THIS specific failed turn rather than adding
+			// the crude per-character trailingTokens estimate of everything since
+			// it on top: a provider whose bridge resends the full conversation as
+			// quoted text on every turn (no cross-turn prompt-cache reuse) can make
+			// that single trailing estimate far larger than the real, cached
+			// context a healthy turn would actually use, which both overstates the
+			// trigger relative to the displayed context and can refire
+			// auto-compaction immediately after a real compaction completed. A
+			// zero-usage response whose own stopReason is not "error" (the
+			// malformed-response case this fallback also exists for) still adds
+			// trailingTokens as before: only a confirmed failure narrows the
+			// estimate, never an ordinary response missing its usage field.
+			contextTokens =
+				assistantMessage.stopReason === "error" && estimate.lastUsageIndex !== null
+					? estimate.usageTokens
+					: estimate.tokens;
+			// However it was derived, an estimate can never legitimately exceed the
+			// real context window: the provider would have rejected an over-window
+			// request outright, so anything past that is already an artifact of
+			// this heuristic, not a real, actionable size.
+			contextTokens = Math.min(contextTokens, contextWindow);
 		} else {
 			contextTokens = directContextTokens;
 		}

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3451,10 +3451,27 @@ export class AgentSession {
 		}
 
 		const estimate = estimateContextTokens(this.messages);
-		const percent = (estimate.tokens / contextWindow) * 100;
+
+		// Same reasoning as _checkCompaction()'s Case 3: a most-recent assistant
+		// message that itself failed or was aborted never confirms how much of
+		// its own rendered content the provider actually processed, so adding
+		// the crude per-character trailingTokens estimate of everything since
+		// the last reliable usage on top of that baseline can read far past what
+		// a healthy turn would actually use - this is the displayed-context
+		// counterpart of the trigger-side estimate _checkCompaction() already
+		// narrows, and needs the identical narrowing so the two never diverge.
+		const lastAssistant = this._findLastAssistantMessage();
+		const lastIsUnreliable = lastAssistant?.stopReason === "error" || lastAssistant?.stopReason === "aborted";
+		let tokens = lastIsUnreliable && estimate.lastUsageIndex !== null ? estimate.usageTokens : estimate.tokens;
+
+		// A displayed percentage past 100% is never meaningful: the provider
+		// would have rejected an over-window request outright, so anything
+		// larger is already an artifact of the heuristic, not a real size.
+		tokens = Math.min(tokens, contextWindow);
+		const percent = (tokens / contextWindow) * 100;
 
 		return {
-			tokens: estimate.tokens,
+			tokens,
 			contextWindow,
 			percent,
 		};

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -34,15 +34,20 @@ function createUsage(totalTokens: number): Usage {
 	};
 }
 
-function createAssistantMessage(text: string, totalTokens: number, timestamp: number): AssistantMessage {
+function createAssistantMessage(
+	text: string,
+	totalTokens: number,
+	timestamp: number,
+	stopReason: AssistantMessage["stopReason"] = "stop",
+): AssistantMessage {
 	return {
 		role: "assistant",
-		content: [{ type: "text", text }],
+		content: stopReason === "error" ? [] : [{ type: "text", text }],
 		api: model.api,
 		provider: model.provider,
 		model: model.id,
 		usage: createUsage(totalTokens),
-		stopReason: "stop",
+		stopReason,
 		timestamp,
 	};
 }
@@ -276,6 +281,88 @@ describe("AgentSession.getSessionStats", () => {
 			expect(stats.contextUsage).toBeDefined();
 			expect(stats.contextUsage?.tokens).not.toBeNull();
 			expect(stats.contextUsage?.tokens ?? 0).toBeGreaterThan(25_000);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	// Reported live shape: a footer/get_session_stats reading past 100% after
+	// the most recent assistant message errored or was aborted following a
+	// huge quoted turn. getContextUsage() computed its own full-array estimate
+	// independently of _checkCompaction()'s Case 3, so the trigger-side fix
+	// there left this display path unpatched - these tests cover the display
+	// path's own narrowing and clamp, mirroring the trigger-side fix exactly.
+	it("narrows displayed context to the last reliable usage when the most recent assistant errored", async () => {
+		const { session, sessionManager } = await createSession();
+
+		try {
+			sessionManager.appendMessage(createUserMessage("first", 1));
+			sessionManager.appendMessage(createAssistantMessage("response1", 68_000, 2)); // reliable baseline: 6.8% of window
+			sessionManager.appendMessage(createUserMessage("x".repeat(4_000_000), 3)); // one action's worth of quoted content alone estimates past the window
+			sessionManager.appendMessage(createAssistantMessage("", 0, 4, "error")); // failed before reporting any usage
+			syncAgentMessages(session, sessionManager);
+
+			const stats = session.getSessionStats();
+			expect(stats.contextUsage?.tokens).toBe(68_000);
+			expect(stats.contextUsage?.percent).toBe((68_000 / model.contextWindow) * 100);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("narrows displayed context to the last reliable usage when the most recent assistant was aborted", async () => {
+		const { session, sessionManager } = await createSession();
+
+		try {
+			sessionManager.appendMessage(createUserMessage("first", 1));
+			sessionManager.appendMessage(createAssistantMessage("response1", 68_000, 2));
+			sessionManager.appendMessage(createUserMessage("x".repeat(4_000_000), 3));
+			sessionManager.appendMessage(createAssistantMessage("", 0, 4, "aborted"));
+			syncAgentMessages(session, sessionManager);
+
+			const stats = session.getSessionStats();
+			expect(stats.contextUsage?.tokens).toBe(68_000);
+			expect(stats.contextUsage?.percent).toBe((68_000 / model.contextWindow) * 100);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("never reports a displayed percent above 100%, even with no reliable baseline to narrow to", async () => {
+		const { session, sessionManager } = await createSession();
+
+		try {
+			// No prior reliable usage anywhere: the narrowing branch cannot apply
+			// (estimate.lastUsageIndex stays null), so this exercises the plain
+			// full-array estimate - which must still be clamped to the window,
+			// the same #8328 case the trigger-side fix also had to keep serving.
+			sessionManager.appendMessage(createUserMessage("x".repeat(8_000_000), 1)); // ~2M estimated tokens, 2x the window
+			sessionManager.appendMessage(createAssistantMessage("", 0, 2, "error"));
+			syncAgentMessages(session, sessionManager);
+
+			const stats = session.getSessionStats();
+			expect(stats.contextUsage?.tokens).toBeLessThanOrEqual(model.contextWindow);
+			expect(stats.contextUsage?.percent).toBeLessThanOrEqual(100);
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("does not narrow when the most recent assistant message completed normally with zero usage (malformed, not failed)", async () => {
+		const { session, sessionManager } = await createSession();
+
+		try {
+			sessionManager.appendMessage(createUserMessage("first", 1));
+			sessionManager.appendMessage(createAssistantMessage("response1", 68_000, 2));
+			sessionManager.appendMessage(createUserMessage("x".repeat(4_000_000), 3));
+			sessionManager.appendMessage(createAssistantMessage("", 0, 4, "stop")); // zero usage but not a confirmed failure
+			syncAgentMessages(session, sessionManager);
+
+			const stats = session.getSessionStats();
+			// Unaffected by the narrowing: still adds the trailing estimate, only
+			// clamped to the window like every other path.
+			expect(stats.contextUsage?.tokens).toBeGreaterThan(68_000);
+			expect(stats.contextUsage?.tokens).toBeLessThanOrEqual(model.contextWindow);
 		} finally {
 			session.dispose();
 		}

--- a/packages/coding-agent/test/suite/regressions/post-compaction-error-fallback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-error-fallback.test.ts
@@ -139,4 +139,63 @@ describe("post-compaction error turn does not retrigger auto-compact from a low 
 
 		expect(runAutoCompactionSpy).toHaveBeenCalledOnce();
 	});
+
+	// Reported shape: "Auto-compact triggered at >=80% context", then the turn
+	// itself surfaces "This operation was aborted", then the displayed context
+	// reads 416.2% of the window. Traced to the pre-prompt check
+	// (_checkCompaction(lastAssistant, false), the caller that explicitly
+	// passes skipAbortedCheck: false so an aborted lastAssistant still reaches
+	// this method ahead of the user's next prompt): an aborted message's own
+	// usage is unreliable in exactly the same way a failed "error" message's
+	// is, so it must narrow to the last reliable baseline the same way -
+	// never the full unbounded trailing estimate, and never a value past the
+	// context window (a >100% display is definitionally impossible from a
+	// window-bounded estimate).
+	it('narrows to the last reliable usage instead of the full trailing estimate when the next turn is "aborted", keeping the estimate within the window (no >100% display, no unwarranted re-trigger)', async () => {
+		const harness = await createPostCompactionHarness();
+		const baseline = assistantWithUsage(harness, 68, "stop"); // last reliable post-compaction baseline, well under threshold
+		const abortedTurn = assistantWithUsage(harness, 0, "aborted"); // usage cleared: "This operation was aborted"
+
+		// Same shape as the error-path test: a huge amount of raw text between
+		// the reliable baseline and the aborted turn, large enough on its own
+		// that the unbounded chars/4 estimate would blow past the window
+		// (reproducing the reported 416.2%/1.0M overflow) if this fallback did
+		// not narrow aborted turns the same way it narrows error turns.
+		harness.session.agent.state.messages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "kept-recent context after compaction" }],
+				timestamp: Date.now() - 3,
+			},
+			baseline,
+			{ role: "user", content: [{ type: "text", text: "x".repeat(20000) }], timestamp: Date.now() - 1 }, // ~5000 estimated tokens - 5x the 1000-token window alone
+			abortedTurn,
+		];
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
+
+		// Mirrors the pre-prompt check's own call shape: skipAbortedCheck: false,
+		// the exact call site that let an aborted lastAssistant reach Case 3 in
+		// the reported case.
+		await sessionInternals._checkCompaction(abortedTurn, false);
+
+		expect(runAutoCompactionSpy).not.toHaveBeenCalled();
+	});
+
+	it('still compacts from the full trailing estimate when an "aborted" turn has no reliable usage anywhere before it (the #8328 case this fallback also serves)', async () => {
+		const harness = await createPostCompactionHarness();
+		const abortedTurn = assistantWithUsage(harness, 0, "aborted");
+
+		harness.session.agent.state.messages = [
+			{ role: "user", content: [{ type: "text", text: "x".repeat(4000) }], timestamp: Date.now() - 1 },
+			abortedTurn,
+		];
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
+
+		await sessionInternals._checkCompaction(abortedTurn, false);
+
+		expect(runAutoCompactionSpy).toHaveBeenCalledOnce();
+		expect(runAutoCompactionSpy).toHaveBeenCalledWith("threshold", false);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/post-compaction-error-fallback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/post-compaction-error-fallback.test.ts
@@ -1,0 +1,142 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+// Reported shape: "Compacted from 1,665,423 tokens", footer/visible context
+// reading 6.8% immediately after, then auto-compaction firing again shortly
+// after while the visible context still read low - the failing turn in
+// between reported stopReason "error". Traced to _checkCompaction's Case 3:
+// once a reliable post-compaction usage baseline exists, a turn that then
+// fails with stopReason "error" never confirms how much of its own rendered
+// content the provider actually processed (it may have failed before
+// sending anything), so adding the crude per-character trailingTokens
+// estimate of everything since that baseline on top of it overstated the
+// trigger far past what the visible context showed - and, for a bridge
+// provider that resends the full conversation as quoted text on every turn
+// (no cross-turn prompt-cache reuse), that trailing estimate can be far
+// larger than the real, cached context a healthy turn would use.
+
+type SessionWithCompactionInternals = {
+	_checkCompaction: (assistantMessage: AssistantMessage, skipAbortedCheck?: boolean) => Promise<boolean>;
+	_runAutoCompaction: (reason: "overflow" | "threshold", willRetry: boolean) => Promise<boolean>;
+};
+
+function assistantWithUsage(
+	harness: Harness,
+	totalTokens: number,
+	stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+	const model = harness.getModel();
+	return {
+		role: "assistant",
+		content: stopReason === "error" ? [] : [{ type: "text", text: "response" }],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: totalTokens,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+describe("post-compaction error turn does not retrigger auto-compact from a low visible baseline", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	// A 1000-token window scaled proportionally to the reported case: 6.8% of
+	// 1,000,000 is 68,000; here 6.8% of 1000 is 68. reserveTokens stays small
+	// (matching the #8328 regression test's own convention) so the threshold
+	// sits just under the window, not because the real bug depends on it.
+	async function createPostCompactionHarness(): Promise<Harness> {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 1000, maxTokens: 200 }],
+			settings: { compaction: { enabled: true, reserveTokens: 10 } },
+		});
+		harnesses.push(harness);
+		return harness;
+	}
+
+	it("uses the last reliable post-compaction usage instead of the full trailing estimate when the next turn errors", async () => {
+		const harness = await createPostCompactionHarness();
+		const baseline = assistantWithUsage(harness, 68, "stop"); // the reported 6.8% of window
+		const failedTurn = assistantWithUsage(harness, 0, "error"); // usage cleared: this is what the provider reports on a spawn/response failure
+
+		// Between the reliable baseline and the failed turn: one action's worth
+		// of real content large enough that a naive chars/4 sum over it alone
+		// would cross the compaction threshold, reproducing the reported
+		// "visible 6.8%, auto-compact fires again" shape if left unbounded.
+		harness.session.agent.state.messages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "kept-recent context after compaction" }],
+				timestamp: Date.now() - 3,
+			},
+			baseline,
+			{ role: "user", content: [{ type: "text", text: "x".repeat(4000) }], timestamp: Date.now() - 1 }, // ~1000 estimated tokens - alone exceeds the 990-token threshold
+			failedTurn,
+		];
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
+
+		await sessionInternals._checkCompaction(failedTurn);
+
+		expect(runAutoCompactionSpy).not.toHaveBeenCalled();
+	});
+
+	it("still compacts from the full trailing estimate when no reliable usage exists at all (the #8328 case this fallback also serves)", async () => {
+		const harness = await createPostCompactionHarness();
+		const failedTurn = assistantWithUsage(harness, 0, "error");
+
+		// No earlier valid usage anywhere in the array: estimate.lastUsageIndex
+		// is null, so this must still fall through to the full message-size
+		// estimate exactly as before this change - the malformed-response case
+		// #8328 fixed must keep working.
+		harness.session.agent.state.messages = [
+			{ role: "user", content: [{ type: "text", text: "x".repeat(4000) }], timestamp: Date.now() - 1 },
+			failedTurn,
+		];
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
+
+		await sessionInternals._checkCompaction(failedTurn);
+
+		expect(runAutoCompactionSpy).toHaveBeenCalledOnce();
+		expect(runAutoCompactionSpy).toHaveBeenCalledWith("threshold", false);
+	});
+
+	it('still compacts from the trailing estimate when the zero-usage response\'s own stopReason is not "error" (a malformed-but-not-failed response)', async () => {
+		const harness = await createPostCompactionHarness();
+		const baseline = assistantWithUsage(harness, 68, "stop");
+		const zeroUsageButNotError = assistantWithUsage(harness, 0, "stop");
+
+		harness.session.agent.state.messages = [
+			{
+				role: "user",
+				content: [{ type: "text", text: "kept-recent context after compaction" }],
+				timestamp: Date.now() - 3,
+			},
+			baseline,
+			{ role: "user", content: [{ type: "text", text: "x".repeat(4000) }], timestamp: Date.now() - 1 },
+			zeroUsageButNotError,
+		];
+		const sessionInternals = harness.session as unknown as SessionWithCompactionInternals;
+		const runAutoCompactionSpy = vi.spyOn(sessionInternals, "_runAutoCompaction").mockResolvedValue(false);
+
+		await sessionInternals._checkCompaction(zeroUsageButNotError);
+
+		expect(runAutoCompactionSpy).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## Summary

Ports three already-fixed compaction/context-display bugs from a downstream fork onto current upstream `main`, so they land in the official release line instead of being silently discarded on every `pi update`.

- **Case 3 trigger narrowing** (2 commits): `_checkCompaction()`'s Case 3 estimates context from the full message array whenever the just-checked response has `stopReason` `"error"` or all-zero usage. Once a reliable post-compaction usage baseline exists, a turn that then fails or aborts never confirms how much of its own rendered content the provider actually processed. Adding the full trailing estimate on top of that baseline in that case can overstate the trigger far past what the displayed context shows, and can retrigger auto-compaction immediately after a real compaction just completed — most visible with a bridge provider that resends the full conversation as quoted text on every turn. This narrows Case 3's fallback to the last reliable usage baseline alone when the checked message is a confirmed failure (`"error"`) or `"aborted"`, and clamps whatever estimate Case 3 produces to the real context window either way.
- **`getContextUsage()` bound** (1 commit): `getContextUsage()` (the source for `get_session_stats().contextUsage` and the TUI footer) computes its own full-array estimate independently of `_checkCompaction()`'s Case 3, so the trigger-side fix above left this display path unpatched. A live RPC test against the deployed trigger fix (real abort, real huge quoted turn) reproduced a displayed percent over 100% even though the trigger correctly stayed silent. Applies the identical narrowing and clamp on the display path.

Each commit carries its own detailed rationale and regression tests; see the individual commit messages.

## Test plan

- [x] Targeted regression suites pass: `packages/coding-agent/test/compaction.test.ts`, `test/agent-session-stats.test.ts`, `test/suite/regressions/post-compaction-error-fallback.test.ts`, `test/suite/agent-session-compaction.test.ts`
- [x] Full `packages/coding-agent` test suite passes on top of these commits: 2176 passed, 50 skipped, 0 failed
- [x] Same 3 commits cherry-pick cleanly onto current upstream `main` with no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014j1yuH3LGgAALYoazhoi5s
