### PR TITLE
fix(coding-agent): fork-free executable lookup in findExecutableOnPath and commandExists

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `ctx.modelRegistry.stream()` and `streamSimple()` for extension model calls through configured providers with resolved authentication ([#8964](https://github.com/earendil-works/pi/issues/8964)).
 
+### Fixed
+
+- `findExecutableOnPath()` and `commandExists()` no longer spawn processes on POSIX: they scan `PATH` with `existsSync` instead. Forking from a multi-threaded host process can deadlock the caller on Android/Termux (the forked child stays stuck between fork and exec while `uv_spawn` blocks on the child's error pipe), and these helpers run on hot paths such as every grep/glob tool call.
+
 ### Changed
 
 - Moved compaction, branch summarization, and retry spinners into the editor border alongside the working indicator. Custom editors use the same embedding opt-in for all status spinners.

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -42,13 +42,20 @@ function findExecutableOnPath(executable: string): string | null {
 		return null;
 	}
 
-	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
+	// Unix: scan PATH directly instead of spawning `which`. A spawnSync on the
+	// main thread of a multi-threaded process (for example the pi-web-ui server,
+	// which runs the agent in-process) can deadlock the whole process on
+	// Android/Termux: fork() races with other threads, the forked child stays
+	// stuck between fork and exec, and libuv's uv_spawn blocks its caller
+	// reading the child's error pipe. existsSync on PATH entries is equivalent
+	// for locating an executable.
 	try {
-		const result = spawnSync("which", [executable], { encoding: "utf-8", timeout: 5000 });
-		if (result.status === 0 && result.stdout) {
-			const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
-			if (firstMatch) {
-				return firstMatch;
+		const dirs = process.env.PATH ? process.env.PATH.split(delimiter) : [];
+		for (const dir of dirs) {
+			if (!dir) continue;
+			const candidate = join(dir, executable);
+			if (existsSync(candidate)) {
+				return candidate;
 			}
 		}
 	} catch {

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -1,7 +1,7 @@
 import { type SpawnSyncReturns, spawnSync } from "child_process";
 import { chmodSync, createWriteStream, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from "fs";
 import { arch, platform } from "os";
-import { join } from "path";
+import { delimiter, join } from "path";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import { APP_NAME, getBinDir } from "../config.ts";
@@ -68,15 +68,29 @@ const TOOLS: Record<string, ToolConfig> = {
 	},
 };
 
-// Check if a command exists in PATH by trying to run it
+// Check if a command exists in PATH. On POSIX this is a plain PATH scan —
+// spawnSync(cmd, ["--version"]) used to fork on the calling thread of
+// multi-threaded hosts (for example the in-process pi-web-ui server, which
+// runs this per grep/glob tool call via ensureTool("rg"/"fd")), and a fork()
+// in a multi-threaded process can deadlock the whole process on
+// Android/Termux: the forked child stays stuck between fork and exec while
+// libuv's uv_spawn blocks its caller reading the child's error pipe.
 function commandExists(cmd: string): boolean {
 	try {
-		const result = spawnSync(cmd, ["--version"], { stdio: "pipe" });
-		// Check for ENOENT error (command not found)
-		return result.error === undefined || result.error === null;
+		if (cmd.includes("/")) return existsSync(cmd);
+		if (platform === "win32") {
+			const result = spawnSync(cmd, ["--version"], { stdio: "pipe" });
+			// Check for ENOENT error (command not found)
+			return result.error === undefined || result.error === null;
+		}
+		const dirs = process.env.PATH ? process.env.PATH.split(delimiter) : [];
+		for (const dir of dirs) {
+			if (dir && existsSync(join(dir, cmd))) return true;
+		}
 	} catch {
 		return false;
 	}
+	return false;
 }
 
 // Get the path to a tool (system-wide or in our tools dir)


### PR DESCRIPTION
## Problem

`findExecutableOnPath()` (src/utils/shell.ts) spawns `which` on POSIX, and `commandExists()` (src/utils/tools-manager.ts) spawns `<cmd> --version` on every call. On hosts where these run on the main thread of a multi-threaded process, a `fork()` can deadlock the entire process on Android/Termux: the forked child stays stuck between fork and exec on an inherited lock, while libuv's `uv_spawn` blocks its caller reading the child's error pipe.

Concrete trace (pi-web-ui server, agent running in-process, Android 17/Pixel 10 Pro, Node 26.3.1): every grep/glob tool call goes through `ensureTool("rg"/"fd")` -> `commandExists("rg")` -> `spawnSync("rg", ["--version"])` on the server's main thread. During active websocket/snapshot traffic this fork intermittently deadlocked the server: process alive, event loop dead, port no longer accepting connections. Reproduced 8 times over two days; after removing the forks, 3+ days clean (pi-web-ui issue #78, fix PR #88 covers the pi-web-ui side; this PR covers the SDK hot paths).

## Solution

Both helpers scan `PATH` with `existsSync` on POSIX instead of spawning:

- `findExecutableOnPath()`: POSIX branch is a plain PATH scan. The win32 `where` branch is unchanged.
- `commandExists()`: PATH scan on POSIX; the win32 `--version` probe is unchanged. `cmd` containing a path separator short-circuits to `existsSync`.

This also removes a per-tool-call fork: `commandExists` runs via `ensureTool("rg"/"fd")` on every grep/glob invocation.

## Verification

- `npm run check:pinned-deps`, `check:runtime-deps`, `check:ts-imports`, `check:entry-graphs`, `check:shrinkwrap`, `check:install-lock:coding-agent` pass.
- `biome check` and `tsgo --noEmit` could not run on-device (no aarch64-android builds for the Biome CLI / tsgo); formatting follows the existing style, CI will confirm.
- `tools-manager.test.ts`: 7/8 on-device; the one failure (`surfaces the error cause chain when a download fails`) is host-dependent and fails identically on unpatched `main` — on Android, `os.platform()` is `android`, so `ensureTool` takes the `pkg install` branch instead of the download path the test asserts. Passes on Linux CI.

Prepared with the pi coding agent on-device; I reviewed and understand the changes.

pkg:coding-agent
