### PR TITLE
Fix the edit preview flicker on remote edits

### DIFF
--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -2121,7 +2121,12 @@ Built-in tool implementations:
 Built-in tools support pluggable operations for delegating to remote systems (SSH, containers, etc.):
 
 ```typescript
-import { createReadTool, createBashTool, type ReadOperations } from "@earendil-works/pi-coding-agent";
+import {
+  createBashTool,
+  createEditToolDefinition,
+  createReadTool,
+  type ReadOperations,
+} from "@earendil-works/pi-coding-agent";
 
 // Create tool with custom operations
 const remoteRead = createReadTool(cwd, {
@@ -2146,6 +2151,19 @@ pi.registerTool({
 ```
 
 **Operations interfaces:** `ReadOperations`, `WriteOperations`, `EditOperations`, `BashOperations`, `PowerShellOperations`, `LsOperations`, `GrepOperations`, `FindOperations`
+
+To retain pre-execution diffs for remote edits, use a `ToolDefinition` whose renderer reads through the same operations used for execution:
+
+```typescript
+const remoteEdit = createEditToolDefinition(cwd, { operations: remoteEditOperations });
+pi.registerTool(remoteEdit);
+```
+
+Preview reads are speculative: `readFile` may run before `access`, `execute`, and `tool_call` permission hooks, including for calls that are later blocked. It must be safe to call independently and concurrently with execution. Preview reads receive no abort signal and may outlive a cancelled call; late previews cannot replace a settled result. Previews do not invoke `access` or `writeFile`, and execution does not wait for them.
+
+`createEditTool()` returns an agent-runtime tool without renderer metadata. Registering that tool remains valid and opts out of pre-execution previews: renderer-only fallbacks perform no filesystem reads and display the authoritative result diff instead. When wrapping a definition, set `renderCall: undefined` to opt out while retaining its other metadata and result renderer. Use this when reads must wait for authorization or depend on execution-time setup.
+
+When selecting local or remote execution dynamically, delegate `renderCall` and `execute` to definitions backed by the corresponding operations. Keep their cwd resolution consistent with the operations' path mapping; the render context and execution context may have a different cwd from `process.cwd()`. See [examples/extensions/ssh.ts](../examples/extensions/ssh.ts) and [examples/extensions/gondolin/index.ts](../examples/extensions/gondolin/index.ts).
 
 For `user_bash`, extensions can reuse pi's local shell backend via `createLocalBashOperations()` instead of reimplementing local process spawning, shell resolution, and process-tree termination.
 

--- a/packages/coding-agent/examples/extensions/gondolin/index.ts
+++ b/packages/coding-agent/examples/extensions/gondolin/index.ts
@@ -25,7 +25,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import {
 	type BashOperations,
 	createBashTool,
-	createEditTool,
+	createEditToolDefinition,
 	createFindTool,
 	createGrepTool,
 	createLsTool,
@@ -109,13 +109,15 @@ function createGondolinWriteOps(vm: VM, localCwd: string): WriteOperations {
 	};
 }
 
-function createGondolinEditOps(vm: VM, localCwd: string): EditOperations {
-	const readOps = createGondolinReadOps(vm, localCwd);
-	const writeOps = createGondolinWriteOps(vm, localCwd);
+function createGondolinEditOps(getVm: () => Promise<VM>, localCwd: string): EditOperations {
 	return {
-		readFile: readOps.readFile,
-		writeFile: writeOps.writeFile,
-		access: readOps.access,
+		readFile: async (filePath) => (await getVm()).fs.readFile(toGuestPath(localCwd, filePath)),
+		writeFile: async (filePath, content) => {
+			await (await getVm()).fs.writeFile(toGuestPath(localCwd, filePath), content, { encoding: "utf8" });
+		},
+		access: async (filePath) => {
+			await (await getVm()).fs.access(toGuestPath(localCwd, filePath));
+		},
 	};
 }
 
@@ -366,7 +368,6 @@ export default function (pi: ExtensionAPI) {
 	const localCwd = process.cwd();
 	const localRead = createReadTool(localCwd);
 	const localWrite = createWriteTool(localCwd);
-	const localEdit = createEditTool(localCwd);
 	const localBash = createBashTool(localCwd);
 	const localGrep = createGrepTool(localCwd);
 	const localFind = createFindTool(localCwd);
@@ -406,6 +407,10 @@ export default function (pi: ExtensionAPI) {
 		}
 		return vmStarting;
 	}
+
+	const editTool = createEditToolDefinition(GUEST_WORKSPACE, {
+		operations: createGondolinEditOps(() => ensureVm(), localCwd),
+	});
 
 	pi.on("session_start", async (_event, ctx) => {
 		await ensureVm(ctx);
@@ -462,14 +467,22 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	// Keep relative edit paths aligned with the guest cwd used by the other routed tools.
 	pi.registerTool({
-		...localEdit,
+		...editTool,
+		renderCall(args, theme, context) {
+			return editTool.renderCall!(args, theme, { ...context, cwd: GUEST_WORKSPACE });
+		},
+		renderResult(result, options, theme, context) {
+			return editTool.renderResult!(
+				result as Parameters<NonNullable<typeof editTool.renderResult>>[0],
+				options,
+				theme,
+				{ ...context, cwd: GUEST_WORKSPACE },
+			);
+		},
 		async execute(id, params, signal, onUpdate, ctx) {
-			const activeVm = await ensureVm(ctx);
-			const tool = createEditTool(GUEST_WORKSPACE, {
-				operations: createGondolinEditOps(activeVm, localCwd),
-			});
-			return tool.execute(id, params, signal, onUpdate);
+			return editTool.execute(id, params, signal, onUpdate, { ...ctx, cwd: GUEST_WORKSPACE });
 		},
 	});
 

--- a/packages/coding-agent/examples/extensions/ssh.ts
+++ b/packages/coding-agent/examples/extensions/ssh.ts
@@ -18,7 +18,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	type BashOperations,
 	createBashTool,
-	createEditTool,
+	createEditToolDefinition,
 	createReadTool,
 	createWriteTool,
 	type EditOperations,
@@ -117,11 +117,12 @@ export default function (pi: ExtensionAPI) {
 	const localCwd = process.cwd();
 	const localRead = createReadTool(localCwd);
 	const localWrite = createWriteTool(localCwd);
-	const localEdit = createEditTool(localCwd);
+	const localEdit = createEditToolDefinition(localCwd);
 	const localBash = createBashTool(localCwd);
 
 	// Resolved lazily on session_start (CLI flags not available during factory)
 	let resolvedSsh: { remote: string; remoteCwd: string } | null = null;
+	let remoteEdit: typeof localEdit | undefined;
 
 	const getSsh = () => resolvedSsh;
 
@@ -153,19 +154,20 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerTool({
+	// Resolve edit paths from the same cwd used by the other tools and the remote path mapping.
+	const editTool: typeof localEdit = {
 		...localEdit,
-		async execute(id, params, signal, onUpdate, _ctx) {
-			const ssh = getSsh();
-			if (ssh) {
-				const tool = createEditTool(localCwd, {
-					operations: createRemoteEditOps(ssh.remote, ssh.remoteCwd, localCwd),
-				});
-				return tool.execute(id, params, signal, onUpdate);
-			}
-			return localEdit.execute(id, params, signal, onUpdate);
+		renderCall(args, theme, context) {
+			return (remoteEdit ?? localEdit).renderCall!(args, theme, { ...context, cwd: localCwd });
 		},
-	});
+		renderResult(result, options, theme, context) {
+			return localEdit.renderResult!(result, options, theme, { ...context, cwd: localCwd });
+		},
+		async execute(id, params, signal, onUpdate, ctx) {
+			return (remoteEdit ?? localEdit).execute(id, params, signal, onUpdate, { ...ctx, cwd: localCwd });
+		},
+	};
+	pi.registerTool(editTool);
 
 	pi.registerTool({
 		...localBash,
@@ -194,6 +196,9 @@ export default function (pi: ExtensionAPI) {
 				const pwd = (await sshExec(remote, "pwd")).toString().trim();
 				resolvedSsh = { remote, remoteCwd: pwd };
 			}
+			remoteEdit = createEditToolDefinition(localCwd, {
+				operations: createRemoteEditOps(resolvedSsh.remote, resolvedSsh.remoteCwd, localCwd),
+			});
 			ctx.ui.setStatus("ssh", ctx.ui.theme.fg("accent", `SSH: ${resolvedSsh.remote}:${resolvedSsh.remoteCwd}`));
 			ctx.ui.notify(`SSH mode: ${resolvedSsh.remote}:${resolvedSsh.remoteCwd}`, "info");
 		}

--- a/packages/coding-agent/src/core/tools/edit-diff.ts
+++ b/packages/coding-agent/src/core/tools/edit-diff.ts
@@ -3,8 +3,7 @@
  */
 
 import * as Diff from "diff";
-import { constants } from "fs";
-import { access, readFile } from "fs/promises";
+import { readFile } from "fs/promises";
 import { splitBom } from "../../utils/text.ts";
 import { resolveToCwd } from "./path-utils.ts";
 
@@ -192,6 +191,15 @@ export interface Edit {
 	oldText: string;
 	newText: string;
 }
+
+export interface EditPreviewOperations {
+	/** Read the content used to compute a non-mutating preview. */
+	readFile: (absolutePath: string) => Promise<Buffer>;
+}
+
+const defaultEditPreviewOperations: EditPreviewOperations = {
+	readFile: (path) => readFile(path),
+};
 
 export interface AppliedEditsResult {
 	baseContent: string;
@@ -515,20 +523,18 @@ export async function computeEditsDiff(
 	path: string,
 	edits: Edit[],
 	cwd: string,
+	operations: EditPreviewOperations = defaultEditPreviewOperations,
 ): Promise<EditDiffResult | EditDiffError> {
 	const absolutePath = resolveToCwd(path, cwd);
 
 	try {
-		// Check if file exists and is readable
+		let rawContent: string;
 		try {
-			await access(absolutePath, constants.R_OK);
+			rawContent = (await operations.readFile(absolutePath)).toString("utf-8");
 		} catch (error: unknown) {
 			const errorMessage = error instanceof Error && "code" in error ? `Error code: ${error.code}` : String(error);
 			return { error: `Could not edit file: ${path}. ${errorMessage}.` };
 		}
-
-		// Read the file
-		const rawContent = await readFile(absolutePath, "utf-8");
 
 		// Strip BOM before matching (LLM won't include invisible BOM in oldText)
 		const { text: content } = splitBom(rawContent);

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -15,7 +15,7 @@ import {
 } from "./edit-diff.ts";
 import { withFileMutationQueue } from "./file-mutation-queue.ts";
 import { resolveToCwd } from "./path-utils.ts";
-import { type EditRenderState, editRenderers } from "./renderers/edit.ts";
+import { createEditRenderers, type EditRenderState } from "./renderers/edit.ts";
 import { wrapToolDefinition } from "./tool-definition-wrapper.ts";
 
 const replaceEditSchema = Type.Object(
@@ -81,7 +81,11 @@ export interface EditToolDetails {
  * Override these to delegate file editing to remote systems (for example SSH).
  */
 export interface EditOperations {
-	/** Read file contents as a Buffer */
+	/**
+	 * Read file contents as a Buffer. Also used for speculative previews before access(),
+	 * execute(), and tool_call hooks, potentially concurrently with execution. Must be safe
+	 * to call independently; preview reads receive no abort signal and may outlive the call.
+	 */
 	readFile: (absolutePath: string) => Promise<Buffer>;
 	/** Write content to a file */
 	writeFile: (absolutePath: string, content: string) => Promise<void>;
@@ -211,7 +215,7 @@ export function createEditToolDefinition(
 				};
 			});
 		},
-		...editRenderers,
+		...createEditRenderers(ops),
 	};
 }
 

--- a/packages/coding-agent/src/core/tools/renderers/edit.ts
+++ b/packages/coding-agent/src/core/tools/renderers/edit.ts
@@ -11,7 +11,13 @@ import { renderDiff } from "../../../modes/interactive/components/diff.ts";
 import type { Theme } from "../../../modes/interactive/theme/theme.ts";
 import type { ToolDefinition } from "../../extensions/types.ts";
 import type { EditToolDetails } from "../edit.ts";
-import { computeEditsDiff, type Edit, type EditDiffError, type EditDiffResult } from "../edit-diff.ts";
+import {
+	computeEditsDiff,
+	type Edit,
+	type EditDiffError,
+	type EditDiffResult,
+	type EditPreviewOperations,
+} from "../edit-diff.ts";
 import { renderToolPath, str } from "../render-utils.ts";
 
 type EditPreview = EditDiffResult | EditDiffError;
@@ -33,6 +39,8 @@ type EditCallRenderComponent = Box & {
 	preview?: EditPreview;
 	previewArgsKey?: string;
 	previewPending?: boolean;
+	/** A final result arrived, so speculative preview work must not update or restart. */
+	settled?: boolean;
 	settledError?: boolean;
 };
 function createEditCallRenderComponent(): EditCallRenderComponent {
@@ -40,6 +48,7 @@ function createEditCallRenderComponent(): EditCallRenderComponent {
 		preview: undefined as EditPreview | undefined,
 		previewArgsKey: undefined as string | undefined,
 		previewPending: false,
+		settled: false,
 		settledError: false,
 	});
 }
@@ -168,71 +177,104 @@ function setEditPreview(
 	return changed;
 }
 
-export const editRenderers: Pick<ToolDefinition<any, any>, "renderCall" | "renderResult"> = {
-	renderCall(args, theme, context) {
-		const component = getEditCallRenderComponent(context.state, context.lastComponent);
-		const previewInput = getRenderablePreviewInput(args as RenderableEditArgs | undefined);
-		const argsKey = previewInput ? JSON.stringify({ path: previewInput.path, edits: previewInput.edits }) : undefined;
+export function createEditRenderers(
+	previewOperations?: EditPreviewOperations,
+): Pick<ToolDefinition<any, any>, "renderCall" | "renderResult"> {
+	return {
+		renderCall(args, theme, context) {
+			const component = getEditCallRenderComponent(context.state, context.lastComponent);
+			const previewInput = getRenderablePreviewInput(args as RenderableEditArgs | undefined);
+			const argsKey = previewInput
+				? JSON.stringify({ path: previewInput.path, edits: previewInput.edits })
+				: undefined;
 
-		if (component.previewArgsKey !== argsKey) {
-			component.preview = undefined;
-			component.previewArgsKey = argsKey;
-			component.previewPending = false;
-			component.settledError = false;
-		}
+			if (component.previewArgsKey !== argsKey) {
+				component.preview = undefined;
+				component.previewArgsKey = argsKey;
+				component.previewPending = false;
+				component.settled = false;
+				component.settledError = false;
+			}
 
-		if (context.argsComplete && previewInput && !component.preview && !component.previewPending) {
-			component.previewPending = true;
-			const requestKey = argsKey;
-			void computeEditsDiff(previewInput.path, previewInput.edits, context.cwd).then((preview) => {
-				if (component.previewArgsKey === requestKey) {
-					setEditPreview(component, preview, requestKey);
-					context.invalidate();
+			// Result slots can be overridden independently of this call renderer.
+			if (!context.isPartial) {
+				component.settled = true;
+			}
+
+			if (
+				previewOperations &&
+				context.argsComplete &&
+				previewInput &&
+				!component.preview &&
+				!component.previewPending &&
+				!component.settled
+			) {
+				component.previewPending = true;
+				const requestKey = argsKey;
+				void computeEditsDiff(previewInput.path, previewInput.edits, context.cwd, previewOperations).then(
+					(preview) => {
+						if (component.previewArgsKey === requestKey && !component.settled) {
+							setEditPreview(component, preview, requestKey);
+							context.invalidate();
+						}
+					},
+				);
+			}
+
+			return buildEditCallComponent(component, args as RenderableEditArgs | undefined, theme, context.cwd);
+		},
+		renderResult(result, options, theme, context) {
+			const callComponent = context.state.callComponent;
+			const previewInput = getRenderablePreviewInput(context.args as RenderableEditArgs | undefined);
+			const argsKey = previewInput
+				? JSON.stringify({ path: previewInput.path, edits: previewInput.edits })
+				: undefined;
+			const typedResult = result as EditToolResultLike;
+			const resultDiff = !context.isError ? typedResult.details?.diff : undefined;
+			let changed = false;
+			if (callComponent) {
+				if (!options.isPartial) {
+					callComponent.settled = true;
 				}
-			});
-		}
-
-		return buildEditCallComponent(component, args as RenderableEditArgs | undefined, theme, context.cwd);
-	},
-	renderResult(result, _options, theme, context) {
-		const callComponent = context.state.callComponent;
-		const previewInput = getRenderablePreviewInput(context.args as RenderableEditArgs | undefined);
-		const argsKey = previewInput ? JSON.stringify({ path: previewInput.path, edits: previewInput.edits }) : undefined;
-		const typedResult = result as EditToolResultLike;
-		const resultDiff = !context.isError ? typedResult.details?.diff : undefined;
-		let changed = false;
-		if (callComponent) {
-			if (typeof resultDiff === "string") {
-				changed =
-					setEditPreview(
+				if (typeof resultDiff === "string") {
+					changed =
+						setEditPreview(
+							callComponent,
+							{ diff: resultDiff, firstChangedLine: typedResult.details?.firstChangedLine },
+							argsKey,
+						) || changed;
+				}
+				if (callComponent.settledError !== context.isError) {
+					callComponent.settledError = context.isError;
+					changed = true;
+				}
+				if (changed) {
+					buildEditCallComponent(
 						callComponent,
-						{ diff: resultDiff, firstChangedLine: typedResult.details?.firstChangedLine },
-						argsKey,
-					) || changed;
+						context.args as RenderableEditArgs | undefined,
+						theme,
+						context.cwd,
+					);
+				}
 			}
-			if (callComponent.settledError !== context.isError) {
-				callComponent.settledError = context.isError;
-				changed = true;
-			}
-			if (changed) {
-				buildEditCallComponent(callComponent, context.args as RenderableEditArgs | undefined, theme, context.cwd);
-			}
-		}
 
-		const output = formatEditResult(
-			context.args as RenderableEditArgs | undefined,
-			callComponent?.preview,
-			typedResult,
-			theme,
-			context.isError,
-		);
-		const component = (context.lastComponent as Container | undefined) ?? new Container();
-		component.clear();
-		if (!output) {
+			const output = formatEditResult(
+				context.args as RenderableEditArgs | undefined,
+				callComponent?.preview,
+				typedResult,
+				theme,
+				context.isError,
+			);
+			const component = (context.lastComponent as Container | undefined) ?? new Container();
+			component.clear();
+			if (!output) {
+				return component;
+			}
+			component.addChild(new Spacer(1));
+			component.addChild(new Text(output, 1, 0));
 			return component;
-		}
-		component.addChild(new Spacer(1));
-		component.addChild(new Text(output, 1, 0));
-		return component;
-	},
-};
+		},
+	};
+}
+
+export const editRenderers = createEditRenderers();

--- a/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
+++ b/packages/coding-agent/test/edit-tool-no-full-redraw.test.ts
@@ -2,9 +2,11 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Container, type Terminal, Text, type TUI, TuiMainScreen } from "@earendil-works/pi-tui";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { createEditToolDefinition } from "../src/core/tools/edit.ts";
-import { computeEditsDiff, type Edit } from "../src/core/tools/edit-diff.ts";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ToolDefinition } from "../src/core/extensions/types.ts";
+import { createEditToolDefinition, type EditOperations } from "../src/core/tools/edit.ts";
+import * as editDiff from "../src/core/tools/edit-diff.ts";
+import { withBuiltInRenderers } from "../src/core/tools/renderers/index.ts";
 import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 
@@ -57,7 +59,7 @@ async function waitForRenderedText(
 	throw new Error(`Timed out waiting for render to include "${expectedText}". Last render:\n${lastRender}`);
 }
 
-function createLargeEdits(lines: string[]): Edit[] {
+function createLargeEdits(lines: string[]): editDiff.Edit[] {
 	const targets = [50, 150, 250, 350, 450, 550, 650, 750, 850, 950];
 	return targets.map((lineNumber) => ({
 		oldText: `${lines[lineNumber - 1]}\n${lines[lineNumber]}\n${lines[lineNumber + 1]}`,
@@ -73,6 +75,7 @@ describe("edit tool TUI rendering", () => {
 	});
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 	});
 
@@ -88,7 +91,7 @@ describe("edit tool TUI rendering", () => {
 		);
 		const lines = (await readFile(filePath, "utf8")).trimEnd().split("\n");
 		const edits = createLargeEdits(lines);
-		const diff = await computeEditsDiff(filePath, edits, process.cwd());
+		const diff = await editDiff.computeEditsDiff(filePath, edits, process.cwd());
 		if ("error" in diff) {
 			throw new Error(diff.error);
 		}
@@ -161,7 +164,7 @@ describe("edit tool TUI rendering", () => {
 		);
 		const lines = (await readFile(filePath, "utf8")).trimEnd().split("\n");
 		const edits = createLargeEdits(lines).slice(0, 2);
-		const diff = await computeEditsDiff(filePath, edits, process.cwd());
+		const diff = await editDiff.computeEditsDiff(filePath, edits, process.cwd());
 		if ("error" in diff) {
 			throw new Error(diff.error);
 		}
@@ -196,6 +199,146 @@ describe("edit tool TUI rendering", () => {
 		const rendered = component.render(80).join("\n");
 		expect(rendered).toContain("line 50 changed");
 		expect(rendered).toContain("line 150 changed");
+	});
+
+	it("uses injected edit operations for the call preview", async () => {
+		const filePath = "/remote/workspace/file.txt";
+		const accessedPaths: string[] = [];
+		const readPaths: string[] = [];
+		const operations: EditOperations = {
+			access: async (path) => {
+				accessedPaths.push(path);
+			},
+			readFile: async (path) => {
+				readPaths.push(path);
+				return Buffer.from("before\n");
+			},
+			writeFile: async () => {},
+		};
+		const component = new ToolExecutionComponent(
+			"edit",
+			"tool-call-remote-preview",
+			{ path: filePath, edits: [{ oldText: "before", newText: "after" }] },
+			{},
+			createEditToolDefinition(process.cwd(), { operations }),
+			{ requestRender: () => {} } as unknown as TUI,
+			process.cwd(),
+		);
+		component.setArgsComplete();
+		await vi.waitFor(() => expect(component.render(80).join("\n")).toContain("after"));
+
+		expect(accessedPaths).toEqual([]);
+		expect(readPaths).toEqual([filePath]);
+		expect(component.render(80).join("\n")).not.toContain("Could not edit file");
+	});
+
+	it.each([
+		{ customResult: false, isError: false },
+		{ customResult: false, isError: true },
+		{ customResult: true, isError: false },
+		{ customResult: true, isError: true },
+	])(
+		"ignores late previews after settlement (customResult=$customResult, isError=$isError)",
+		async ({ customResult, isError }) => {
+			const filePath = "/remote/workspace/slow.txt";
+			let resolveRead!: (content: Buffer) => void;
+			const pendingRead = new Promise<Buffer>((resolve) => {
+				resolveRead = resolve;
+			});
+			const readFile = vi.fn(() => pendingRead);
+			const operations: EditOperations = {
+				access: async () => {},
+				readFile,
+				writeFile: async () => {},
+			};
+			const definition = createEditToolDefinition(process.cwd(), { operations });
+			if (customResult) definition.renderResult = () => new Text("Custom result", 0, 0);
+			const component = new ToolExecutionComponent(
+				"edit",
+				"tool-call-late-preview",
+				{ path: filePath, edits: [{ oldText: "before", newText: "after" }] },
+				{},
+				definition,
+				{ requestRender: () => {} } as unknown as TUI,
+				process.cwd(),
+			);
+			component.setArgsComplete();
+			expect(readFile).toHaveBeenCalledOnce();
+			component.updateResult(
+				{
+					content: [{ type: "text", text: isError ? "Operation aborted" : "Successfully replaced 1 block." }],
+					details: isError
+						? undefined
+						: { ...editDiff.generateDiffString("settled before\n", "settled after\n"), patch: "" },
+					isError,
+				},
+				false,
+			);
+			component.setExpanded(true);
+			component.setExpanded(false);
+			resolveRead(Buffer.from("preview-only context\nbefore\n"));
+			await waitForRender();
+
+			const rendered = component.render(80).join("\n");
+			expect(readFile).toHaveBeenCalledOnce();
+			expect(rendered).toContain(customResult ? "Custom result" : isError ? "Operation aborted" : "settled after");
+			expect(rendered).not.toContain("preview-only context");
+		},
+	);
+
+	it("does not start a preview for a settled row with a custom result renderer", () => {
+		const readFile = vi.fn(async () => Buffer.from("before\n"));
+		const definition = createEditToolDefinition(process.cwd(), {
+			operations: { readFile, access: async () => {}, writeFile: async () => {} },
+		});
+		definition.renderResult = () => new Text("Custom result", 0, 0);
+		const component = new ToolExecutionComponent(
+			"edit",
+			"tool-call-already-settled",
+			{ path: "file.txt", edits: [{ oldText: "before", newText: "after" }] },
+			{},
+			definition,
+			{ requestRender: () => {} } as unknown as TUI,
+			process.cwd(),
+		);
+		component.updateResult({ content: [], isError: true });
+		component.setArgsComplete();
+		component.setExpanded(true);
+		expect(readFile).not.toHaveBeenCalled();
+		expect(component.render(80).join("\n")).toContain("Custom result");
+	});
+
+	it("does not read files when an edit definition opts out of call previews", () => {
+		const preview = vi.spyOn(editDiff, "computeEditsDiff");
+		const readFile = vi.fn(async () => Buffer.from("before\n"));
+		const definition = createEditToolDefinition(process.cwd(), {
+			operations: { readFile, access: async () => {}, writeFile: async () => {} },
+		});
+		const filePath = "/remote-only/missing.txt";
+		const component = new ToolExecutionComponent(
+			"edit",
+			"tool-call-renderer-only",
+			{ path: filePath, edits: [{ oldText: "before", newText: "after" }] },
+			{},
+			withBuiltInRenderers("edit", { ...definition, renderCall: undefined } as ToolDefinition),
+			{ requestRender: () => {} } as unknown as TUI,
+			process.cwd(),
+		);
+
+		component.setArgsComplete();
+		expect(preview).not.toHaveBeenCalled();
+		expect(readFile).not.toHaveBeenCalled();
+
+		const diff = editDiff.generateDiffString("before\n", "after\n");
+		component.updateResult({
+			content: [{ type: "text", text: "Successfully replaced 1 block." }],
+			details: { ...diff, patch: "" },
+			isError: false,
+		});
+		component.setExpanded(true);
+		expect(component.render(80).join("\n")).toContain("after");
+		expect(preview).not.toHaveBeenCalled();
+		expect(readFile).not.toHaveBeenCalled();
 	});
 
 	it("shows a preflight error without rendering a diff when the edits do not apply", async () => {

--- a/packages/coding-agent/test/gondolin-extension.test.ts
+++ b/packages/coding-agent/test/gondolin-extension.test.ts
@@ -1,0 +1,82 @@
+import { fileURLToPath } from "node:url";
+import type { TUI } from "@earendil-works/pi-tui";
+import { createJiti } from "jiti";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { ExtensionAPI, ExtensionContext, ExtensionFactory, ToolDefinition } from "../src/core/extensions/index.ts";
+import * as tools from "../src/core/tools/index.ts";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+
+type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+describe("Gondolin edit routing", () => {
+	beforeAll(() => initTheme("dark"));
+
+	it.each([
+		{ path: "file.txt", guestPath: "/workspace/file.txt" },
+		{ path: "../file.txt", guestPath: "/file.txt" },
+	])("uses guest cwd for preview and execution of $path", async ({ path, guestPath }) => {
+		const fs = {
+			readFile: vi.fn(async (_path: string) => Buffer.from("before\n")),
+			access: vi.fn(async (_path: string) => {}),
+			writeFile: vi.fn(async (_path: string, _content: string, _options: { encoding: string }) => {}),
+		};
+		const vm = { id: "test-vm", fs, exec: async () => ({ stdout: "/bin/sh\n" }), close: vi.fn(async () => {}) };
+		const createVm = vi.fn(async () => vm);
+		// Load like an extension so the optional VM dependency stays outside the root TypeScript graph.
+		const jiti = createJiti(import.meta.url, {
+			moduleCache: false,
+			virtualModules: {
+				"@earendil-works/pi-coding-agent": tools,
+				"@earendil-works/gondolin": { VM: { create: createVm }, RealFSProvider: vi.fn() },
+			},
+		});
+		const extension = await jiti.import<ExtensionFactory>(
+			fileURLToPath(new URL("../examples/extensions/gondolin/index.ts", import.meta.url)),
+			{ default: true },
+		);
+		const registeredTools = new Map<string, ToolDefinition>();
+		const handlers = new Map<string, ExtensionHandler>();
+		await extension({
+			registerTool: (tool: ToolDefinition) => registeredTools.set(tool.name, tool),
+			registerCommand: vi.fn(),
+			on: (event: string, handler: ExtensionHandler) => handlers.set(event, handler),
+		} as unknown as ExtensionAPI);
+		expect(createVm).not.toHaveBeenCalled();
+
+		const context = {
+			cwd: process.cwd(),
+			ui: { theme, setStatus: vi.fn(), notify: vi.fn() },
+		} as unknown as ExtensionContext;
+		await handlers.get("session_start")!({}, context);
+		try {
+			const edit = registeredTools.get("edit")!;
+			const args = { path, edits: [{ oldText: "before", newText: "after" }] };
+			const component = new ToolExecutionComponent(
+				"edit",
+				"gondolin-edit",
+				args,
+				{},
+				edit,
+				{ requestRender: () => {} } as unknown as TUI,
+				context.cwd,
+			);
+			component.setArgsComplete();
+			await vi.waitFor(() => expect(component.render(80).join("\n")).toContain("after"));
+			expect(fs.readFile.mock.calls).toEqual([[guestPath]]);
+			expect(fs.access).not.toHaveBeenCalled();
+			expect(fs.writeFile).not.toHaveBeenCalled();
+
+			const result = await edit.execute("gondolin-edit", args, undefined, undefined, context);
+			component.updateResult({ ...result, isError: false });
+			expect(component.render(80).join("\n")).toContain("after");
+			expect(fs.readFile.mock.calls).toEqual([[guestPath], [guestPath]]);
+			expect(fs.access.mock.calls).toEqual([[guestPath]]);
+			expect(fs.writeFile.mock.calls).toEqual([[guestPath, "after\n", { encoding: "utf8" }]]);
+			expect(createVm).toHaveBeenCalledOnce();
+		} finally {
+			await handlers.get("session_shutdown")!({}, context);
+		}
+		expect(vm.close).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/coding-agent/test/ssh-extension.test.ts
+++ b/packages/coding-agent/test/ssh-extension.test.ts
@@ -1,0 +1,144 @@
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { PassThrough } from "node:stream";
+import type { TUI } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import sshExtension from "../examples/extensions/ssh.ts";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../src/core/extensions/index.ts";
+import { createBashTool } from "../src/core/tools/bash.ts";
+import { createEditToolDefinition } from "../src/core/tools/edit.ts";
+import { createReadTool } from "../src/core/tools/read.ts";
+import { createWriteTool } from "../src/core/tools/write.ts";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+
+// Use the real source factories without loading the package's built entry point.
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	createBashTool: (...args: Parameters<typeof createBashTool>) => createBashTool(...args),
+	createEditToolDefinition: (...args: Parameters<typeof createEditToolDefinition>) =>
+		createEditToolDefinition(...args),
+	createReadTool: (...args: Parameters<typeof createReadTool>) => createReadTool(...args),
+	createWriteTool: (...args: Parameters<typeof createWriteTool>) => createWriteTool(...args),
+}));
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+
+type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+function registerSshExtension(ssh: string | undefined) {
+	const tools = new Map<string, ToolDefinition>();
+	const handlers = new Map<string, ExtensionHandler>();
+	const pi = {
+		registerFlag: vi.fn(),
+		registerTool: (tool: ToolDefinition) => tools.set(tool.name, tool),
+		on: (event: string, handler: ExtensionHandler) => handlers.set(event, handler),
+		getFlag: () => ssh,
+	} as unknown as ExtensionAPI;
+	sshExtension(pi);
+	return { edit: tools.get("edit")!, handlers };
+}
+
+function createContext(cwd: string): ExtensionContext {
+	return {
+		cwd,
+		ui: { theme, setStatus: vi.fn(), notify: vi.fn() },
+	} as unknown as ExtensionContext;
+}
+
+function createEditRow(edit: ToolDefinition, cwd: string) {
+	return new ToolExecutionComponent(
+		"edit",
+		"ssh-edit",
+		{ path: "file.txt", edits: [{ oldText: "before", newText: "after" }] },
+		{},
+		edit,
+		{ requestRender: () => {} } as unknown as TUI,
+		cwd,
+	);
+}
+
+describe("SSH extension example", () => {
+	const tempDirs: string[] = [];
+	const remote = "example.test";
+	const remoteCwd = "/srv/project";
+
+	beforeAll(() => initTheme("dark"));
+	beforeEach(() => {
+		vi.mocked(spawn).mockReset();
+		vi.mocked(spawn).mockImplementation((_command, args) => {
+			const child = Object.assign(new EventEmitter(), { stdout: new PassThrough(), stderr: new PassThrough() });
+			queueMicrotask(() => {
+				const command = Array.isArray(args) ? args[1] : undefined;
+				if (command?.startsWith("cat ")) child.stdout.emit("data", Buffer.from("before\n"));
+				child.emit("close", 0);
+			});
+			return child as unknown as ReturnType<typeof spawn>;
+		});
+	});
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+	});
+
+	it("keeps remote preview and execution aligned when the session cwd differs", async () => {
+		const localCwd = process.cwd();
+		const context = createContext(resolve(localCwd, "../resumed-project"));
+		const { edit, handlers } = registerSshExtension(`${remote}:${remoteCwd}`);
+		await handlers.get("session_start")!({}, context);
+		const component = createEditRow(edit, context.cwd);
+		component.setArgsComplete();
+		await vi.waitFor(() => expect(component.render(80).join("\n")).toContain("after"));
+
+		const remotePath = join(localCwd, "file.txt").replace(localCwd, remoteCwd);
+		expect(vi.mocked(spawn).mock.calls.map(([, args]) => args)).toEqual([
+			[remote, `cat ${JSON.stringify(remotePath)}`],
+		]);
+
+		const result = await edit.execute(
+			"ssh-edit",
+			{ path: "file.txt", edits: [{ oldText: "before", newText: "after" }] },
+			undefined,
+			undefined,
+			context,
+		);
+		component.updateResult({ ...result, isError: false });
+		expect(component.render(80).join("\n")).toContain("after");
+		expect(vi.mocked(spawn).mock.calls.map(([, args]) => args)).toEqual([
+			[remote, `cat ${JSON.stringify(remotePath)}`],
+			[remote, `test -r ${JSON.stringify(remotePath)}`],
+			[remote, `cat ${JSON.stringify(remotePath)}`],
+			[remote, `echo "YWZ0ZXIK" | base64 -d > ${JSON.stringify(remotePath)}`],
+		]);
+	});
+
+	it("keeps local preview and execution on the captured cwd without --ssh", async () => {
+		const localCwd = await mkdtemp(join(tmpdir(), "pi-ssh-local-"));
+		tempDirs.push(localCwd);
+		await writeFile(join(localCwd, "file.txt"), "before\n");
+		// Only the synchronous extension factory sees this cwd; the host process never changes directories.
+		const cwd = vi.spyOn(process, "cwd").mockReturnValue(localCwd);
+		let registered: ReturnType<typeof registerSshExtension>;
+		try {
+			registered = registerSshExtension(undefined);
+		} finally {
+			cwd.mockRestore();
+		}
+		const { edit, handlers } = registered;
+		const context = createContext(resolve(localCwd, "../different-session"));
+		await handlers.get("session_start")!({}, context);
+		const component = createEditRow(edit, context.cwd);
+		component.setArgsComplete();
+		await vi.waitFor(() => expect(component.render(80).join("\n")).toContain("after"));
+		await edit.execute(
+			"ssh-edit",
+			{ path: "file.txt", edits: [{ oldText: "before", newText: "after" }] },
+			undefined,
+			undefined,
+			context,
+		);
+		expect(await readFile(join(localCwd, "file.txt"), "utf8")).toBe("after\n");
+		expect(spawn).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION

pi got a flicker!

When the edit tool uses injected remote operations, the tool row briefly turns red with a local "Could not edit file" error before the remote operation replaces it with the correct diff.

https://github.com/user-attachments/assets/7b8c1dbf-3b9f-4243-944f-36717922b8d3

Preview and execution used different backends. Execution honored the operations injected into the edit tool, but the pre-execution preview always read the local filesystem. The renderer therefore reported a missing local file even though the target existed remotely. If the same path existed locally, it could instead show a diff for an unrelated file.

This change passes the edit definition's operations to its preview renderer, so preview and execution read from the same filesystem. Definitions without custom operations still use the local filesystem. The edit arguments, result shape, and factory signatures do not change.

A renderer without a bound backend now skips the speculative read and displays the result diff instead of assuming the file is local. This covers renderer inheritance, display-only clients, and tools built with `createEditTool()`, which intentionally omits renderer metadata. An extension whose reads must wait for authorization or execution-time setup can opt out by clearing `renderCall` while retaining the rest of the definition.

Extensions may replace `renderCall` and `renderResult` independently. The call renderer therefore marks the row settled when a final result is present instead of relying on the built-in result renderer. A late preview cannot overwrite a settled row. Preview work remains speculative: execution does not wait for it, mutation ordering is unchanged, and cancellation is unaffected.

The SSH and Gondolin examples now use the same backend and working directory for preview and execution. This preserves relative-path resolution when the session cwd differs from the mapping root. The extension docs state that `readFile` may run before `access`, `execute`, and `tool_call` hooks, may run concurrently with execution, and receives no abort signal.
