### PR TITLE
fix(ai): use reasoning_effort for Mistral-hosted GLM (zai-glm-5-2)

### DIFF
--- a/packages/ai/src/api/mistral-conversations.ts
+++ b/packages/ai/src/api/mistral-conversations.ts
@@ -892,7 +892,13 @@ function buildToolResultText(text: string, hasImages: boolean, supportsImages: b
 
 function usesReasoningEffort(model: Model<"mistral-conversations">): boolean {
 	return (
-		model.id === "mistral-small-2603" || model.id === "mistral-small-latest" || model.id.startsWith("mistral-medium-")
+		model.id === "mistral-small-2603" ||
+		model.id === "mistral-small-latest" ||
+		model.id.startsWith("mistral-medium-") ||
+		// Mistral-hosted GLM (zai-glm-5-2) only honors reasoning via
+		// reasoning_effort; prompt_mode is silently ignored for these models
+		// (no thinking items, no reasoning tokens in usage).
+		model.id === "zai-glm-5-2"
 	);
 }
 

--- a/packages/ai/test/mistral-reasoning-mode.test.ts
+++ b/packages/ai/test/mistral-reasoning-mode.test.ts
@@ -99,6 +99,26 @@ describe("Mistral reasoning mode selection", () => {
 		expect(payload.promptMode).toBeUndefined();
 	});
 
+	// Mistral-hosted GLM must use reasoning_effort, not Magistral's prompt_mode:
+	// Mistral's API silently ignores prompt_mode for these models, so thinking
+	// would never be requested and the model answers inline with no thinking
+	// blocks and no reasoning tokens in usage.
+	describe("zai-glm-5-2", () => {
+		it("uses reasoning_effort when thinking is enabled", async () => {
+			const payload = await capturePayload(makeModel("zai-glm-5-2", true), { reasoning: "medium" });
+
+			expect(payload.reasoningEffort).toBe("high");
+			expect(payload.promptMode).toBeUndefined();
+		});
+
+		it("omits reasoning controls when thinking is off", async () => {
+			const payload = await capturePayload(makeModel("zai-glm-5-2", true));
+
+			expect(payload.reasoningEffort).toBeUndefined();
+			expect(payload.promptMode).toBeUndefined();
+		});
+	});
+
 	it("uses the session id as prompt cache key", async () => {
 		const payload = await capturePayload(makeModel("mistral-large-latest", false), {
 			sessionId: "session-123",


### PR DESCRIPTION
# fix(ai): use reasoning_effort for Mistral-hosted GLM (zai-glm-5-2)

## Problem

Mistral's catalog advertises `reasoning: true` for GLM-5.2 (`zai-glm-5-2`), but Mistral's chat completions API only honors reasoning for these models via `reasoning_effort`. `prompt_mode: "reasoning"` — what pi currently sends — is a **silent no-op**: no thinking content items, no reasoning tokens in usage, the model just answers inline (verified against `api.mistral.ai` on 2026-09-09; details in the linked issue).

Since GLM-5.2 is not on the `usesReasoningEffort()` allowlist, `usesPromptModeReasoning()` routes it into `prompt_mode`, so thinking is never actually requested.

## Fix

Add `zai-glm-5-2` to the `usesReasoningEffort()` allowlist, alongside the existing Mistral Small / Medium entries that use the same mechanism (#8700). Also adds regression tests to `mistral-reasoning-mode.test.ts` mirroring the #8700 pattern: `reasoningEffort: "high"` + no `promptMode` when thinking is on, and no reasoning controls when thinking is off.

With this change, Mistral streams `delta.content: [{type: "thinking", ...}]` chunks, which `consumeChatStream` already parses into `thinking_delta` events — no response-side changes needed.

## Testing

- `npx vitest --run test/mistral-reasoning-mode.test.ts` → 12/12 pass (10 pre-existing + 2 new).
- End-to-end against the live API: `reasoning_effort: "high"` produces thinking items; `prompt_mode: "reasoning"` does not (curl transcripts in the issue).

Refs: issue "GLM-5.2 (Mistral provider): prompt_mode is silently ignored — model never thinks, should use reasoning_effort"
