### PR TITLE
Always place cursor at the end while navigating through history

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -468,7 +468,7 @@ export class Editor implements Component, Focusable {
 				this.setTextInternal("");
 			}
 		} else {
-			this.setTextInternal(this.history[this.historyIndex] || "", direction === -1 ? "start" : "end");
+			this.setTextInternal(this.history[this.historyIndex] || "");
 		}
 	}
 
@@ -478,11 +478,11 @@ export class Editor implements Component, Focusable {
 	}
 
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
-	private setTextInternal(text: string, cursorPlacement: "start" | "end" = "end"): void {
+	private setTextInternal(text: string): void {
 		const lines = text.split("\n");
 		this.state.lines = lines.length === 0 ? [""] : lines;
-		this.state.cursorLine = cursorPlacement === "start" ? 0 : this.state.lines.length - 1;
-		this.setCursorCol(cursorPlacement === "start" ? 0 : this.state.lines[this.state.cursorLine]?.length || 0);
+		this.state.cursorLine = this.state.lines.length - 1;
+		this.setCursorCol(this.state.lines[this.state.cursorLine]?.length || 0);
 		// Reset scroll - render() will adjust to show cursor
 		this.scrollOffset = 0;
 

--- a/packages/tui/test/editor-history-keybindings.test.ts
+++ b/packages/tui/test/editor-history-keybindings.test.ts
@@ -27,7 +27,7 @@ describe("Editor prompt history keybindings", () => {
 
 		editor.handleInput("\x10"); // Ctrl+P
 		assert.strictEqual(editor.getText(), "newer\nmultiline prompt");
-		assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 0 });
+		assert.deepStrictEqual(editor.getCursor(), { line: 1, col: 16 });
 
 		editor.handleInput("\x10"); // Ctrl+P
 		assert.strictEqual(editor.getText(), "older prompt");

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -125,7 +125,7 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "draft");
 		});
 
-		it("exits history mode when typing a character", () => {
+		it("places typed characters after a retrieved history entry", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 
 			editor.addToHistory("old prompt");
@@ -133,7 +133,7 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[A"); // Up - shows "old prompt"
 			editor.handleInput("x"); // Type a character - exits history mode
 
-			assert.strictEqual(editor.getText(), "xold prompt");
+			assert.strictEqual(editor.getText(), "old promptx");
 		});
 
 		it("exits history mode on setText", () => {
@@ -233,19 +233,14 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "prompt 5");
 		});
 
-		it("places cursor at start after browsing history upward", () => {
+		it("places cursor at end after browsing history upward", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 
-			editor.addToHistory("older entry");
 			editor.addToHistory("line1\nline2\nline3");
 
-			editor.handleInput("\x1b[A"); // Up - shows multi-line entry at start
+			editor.handleInput("\x1b[A"); // Up - shows multi-line entry at end
 			assert.strictEqual(editor.getText(), "line1\nline2\nline3");
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 0 });
-
-			editor.handleInput("\x1b[A"); // Up again - immediately navigates to older entry
-			assert.strictEqual(editor.getText(), "older entry");
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 0 });
+			assert.deepStrictEqual(editor.getCursor(), { line: 2, col: 5 });
 		});
 
 		it("places cursor at end after browsing history downward", () => {
@@ -267,20 +262,16 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "newer entry");
 		});
 
-		it("allows opposite-direction cursor movement within multi-line history entry", () => {
+		it("uses Down to leave a recovered multi-line history entry", () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 
 			editor.addToHistory("line1\nline2\nline3");
 
-			editor.handleInput("\x1b[A"); // Up - shows entry at start
-			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 0 });
+			editor.handleInput("\x1b[A"); // Up - shows entry at end
+			assert.deepStrictEqual(editor.getCursor(), { line: 2, col: 5 });
 
-			editor.handleInput("\x1b[B"); // Down - cursor moves to line2
-			assert.strictEqual(editor.getText(), "line1\nline2\nline3");
-			assert.deepStrictEqual(editor.getCursor(), { line: 1, col: 0 });
-
-			editor.handleInput("\x1b[A"); // Up - cursor moves back to line1
-			assert.strictEqual(editor.getText(), "line1\nline2\nline3");
+			editor.handleInput("\x1b[B"); // Down - restores draft
+			assert.strictEqual(editor.getText(), "");
 			assert.deepStrictEqual(editor.getCursor(), { line: 0, col: 0 });
 		});
 	});


### PR DESCRIPTION
Pressing up to navigate back through message history should keep the cursor at the end. That's consistent with every other similar UI, including bash. Pi had some logic that just makes navigation less consistent.