### PR TITLE
feat(examples): add model-preference-guard with multi-select picker & search

### DIFF
--- a/packages/coding-agent/examples/extensions/README.md
+++ b/packages/coding-agent/examples/extensions/README.md
@@ -23,6 +23,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `protected-paths.ts` | Blocks writes to protected paths (.env, .git/, node_modules/) |
 | `confirm-destructive.ts` | Confirms before destructive session actions (clear, switch, fork) |
 | `dirty-repo-guard.ts` | Prevents session changes with uncommitted git changes |
+| `model-preference-guard.ts` | Guards against unintended model usage by checking against preferred model list with multi-select UI |
 | `sandbox/` | OS-level sandboxing using `@anthropic-ai/sandbox-runtime` with per-project config |
 | `gondolin/` | Route built-in tools and `!` commands into a Gondolin micro-VM |
 
@@ -59,6 +60,7 @@ cp permission-gate.ts ~/.pi/agent/extensions/
 | `hidden-thinking-label.ts` | Customizes the collapsed thinking label via `ctx.ui.setHiddenThinkingLabel()` |
 | `working-indicator.ts` | Customizes the streaming working indicator via `ctx.ui.setWorkingIndicator()` |
 | `model-status.ts` | Shows model changes in status bar via `model_select` hook |
+| `model-preference-guard.ts` | Multi-select checkbox picker for model preferences with `/model-pref` command |
 | `snake.ts` | Snake game with custom UI, keyboard handling, and session persistence |
 | `tic-tac-toe.ts` | Tic-tac-toe vs the agent with `executionMode: "sequential"` tools to prevent race conditions on shared cursor state |
 | `send-user-message.ts` | Demonstrates `pi.sendUserMessage()` for sending user messages from extensions |

--- a/packages/coding-agent/examples/extensions/model-preference-guard.ts
+++ b/packages/coding-agent/examples/extensions/model-preference-guard.ts
@@ -75,18 +75,16 @@ function formatModel(pref: ModelPreference): string {
 function isModelAllowed(current: { provider: string; id: string }, config: PreferenceConfig): boolean {
 	if (!config.enabled) return true;
 	if (config.allowedModels.length === 0) return true; // No preferences = no guard
-	return config.allowedModels.some(
-		(p) => p.provider === current.provider && p.model === current.id,
-	);
+	return config.allowedModels.some((p) => p.provider === current.provider && p.model === current.id);
 }
 
 // ─── Multi-Select Picker with Search ───────────────────────────────────
 
 interface PickerItem {
-	value: string;       // "provider/model"
-	label: string;       // "provider/model"
-	checked: boolean;    // currently selected
-	available: boolean;  // has API key configured
+	value: string; // "provider/model"
+	label: string; // "provider/model"
+	checked: boolean; // currently selected
+	available: boolean; // has API key configured
 }
 
 async function showModelPicker(
@@ -191,8 +189,8 @@ async function showModelPicker(
 				}
 				return;
 			}
-			// Space toggles (only when not searching)
-			if (data === " " && !searchTerm) {
+			// Space toggles
+			if (data === " ") {
 				toggle(cursorIndex);
 				const filtered = getFilteredIndices();
 				if (cursorIndex < filtered.length - 1) {
@@ -236,7 +234,12 @@ async function showModelPicker(
 
 			// Search bar
 			lines.push(theme.fg("dim", ` 🔍 ${searchTerm || ""}_`));
-			lines.push(theme.fg("dim", ` ${items.filter((i) => i.checked).length}/${items.length} selected, ${filtered.length} shown`));
+			lines.push(
+				theme.fg(
+					"dim",
+					` ${items.filter((i) => i.checked).length}/${items.length} selected, ${filtered.length} shown`,
+				),
+			);
 			lines.push("");
 
 			for (let i = 0; i < Math.min(filteredItems.length, maxVisible); i++) {
@@ -276,7 +279,9 @@ async function showModelPicker(
 
 		return {
 			render,
-			invalidate: () => { cachedLines = undefined; },
+			invalidate: () => {
+				cachedLines = undefined;
+			},
 			handleInput,
 		};
 	});
@@ -302,10 +307,7 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 					ctx.ui.notify("No model preferences saved. All models allowed.", "info");
 				} else {
 					const list = config.allowedModels.map((m) => `  • ${formatModel(m)}`).join("\n");
-					ctx.ui.notify(
-						`Guard: ${config.enabled ? "ON" : "OFF"}\nAllowed models:\n${list}`,
-						"info",
-					);
+					ctx.ui.notify(`Guard: ${config.enabled ? "ON" : "OFF"}\nAllowed models:\n${list}`, "info");
 				}
 				return;
 			}
@@ -332,7 +334,8 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 				}
 
 				const currentSet = new Set(config.allowedModels.map(formatModel));
-				const title = sub === "add" ? "Select models to ADD to preferences" : "Select models to REMOVE from preferences";
+				const title =
+					sub === "add" ? "Select models to ADD to preferences" : "Select models to REMOVE from preferences";
 
 				const result = await showModelPicker(ctx, title, allModels, currentSet);
 				if (!result) {
@@ -352,6 +355,7 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 					if (newModels.length > 0) {
 						config.allowedModels.push(...newModels);
 						saveConfig(config);
+						updateStatus(ctx, config);
 						ctx.ui.notify(`Added ${newModels.length} model(s): ${newModels.map(formatModel).join(", ")}`, "info");
 					} else {
 						ctx.ui.notify("No new models added", "info");
@@ -363,6 +367,7 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 					const removed = before - config.allowedModels.length;
 					if (removed > 0) {
 						saveConfig(config);
+						updateStatus(ctx, config);
 						ctx.ui.notify(`Removed ${removed} model(s)`, "info");
 					} else {
 						ctx.ui.notify("No models removed", "info");
@@ -386,12 +391,7 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 				}
 
 				ctx.ui.notify("No preferences set yet. Pick your preferred models:", "info");
-				const result = await showModelPicker(
-					ctx,
-					"Select your PREFERRED models",
-					allModels,
-					new Set(),
-				);
+				const result = await showModelPicker(ctx, "Select your PREFERRED models", allModels, new Set());
 
 				if (!result || result.size === 0) {
 					ctx.ui.notify("No models selected. All models remain allowed.", "info");
@@ -403,6 +403,7 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 					return { provider, model: modelParts.join("/") };
 				});
 				saveConfig(config);
+				updateStatus(ctx, config);
 				config = loadConfig();
 				ctx.ui.notify(
 					`Saved ${config.allowedModels.length} preferred model(s):\n${config.allowedModels.map((m) => `  • ${formatModel(m)}`).join("\n")}`,
@@ -436,10 +437,8 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 				return { provider, model: modelParts.join("/") };
 			});
 			saveConfig(config);
-			ctx.ui.notify(
-				`Updated preferences: ${config.allowedModels.length} model(s) allowed`,
-				"info",
-			);
+			updateStatus(ctx, config);
+			ctx.ui.notify(`Updated preferences: ${config.allowedModels.length} model(s) allowed`, "info");
 		},
 	});
 
@@ -452,10 +451,7 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 		// Show hint if no preferences saved and guard hasn't been disabled
 		if (config.enabled && config.allowedModels.length === 0 && !hintShown) {
 			hintShown = true;
-			ctx.ui.notify(
-				"💡 No model preferences set. Run /model-pref to choose preferred models.",
-				"info",
-			);
+			ctx.ui.notify("💡 No model preferences set. Run /model-pref to choose preferred models.", "info");
 		}
 
 		updateStatus(ctx, config);
@@ -530,13 +526,20 @@ export default function modelPreferenceGuard(pi: ExtensionAPI) {
 
 function updateStatus(ctx: ExtensionContext, config: PreferenceConfig) {
 	if (!config.enabled) {
-		ctx.ui.setStatus("model-guard", ctx.ui.theme.fg("dim", "guard:off"));
+		ctx.ui.setStatus("model-guard", ctx.ui.theme.fg("dim", "model guard: off"));
 	} else if (config.allowedModels.length === 0) {
-		ctx.ui.setStatus("model-guard", ctx.ui.theme.fg("dim", "guard:—"));
+		ctx.ui.setStatus("model-guard", ctx.ui.theme.fg("dim", "model guard: —"));
 	} else {
+		// List model names, truncate if too long
+		const modelNames = config.allowedModels.map((m) => `${m.provider}/${m.model}`);
+		const maxLen = 60;
+		let displayNames = modelNames.join(", ");
+		if (displayNames.length > maxLen) {
+			displayNames = displayNames.slice(0, maxLen - 3) + "...";
+		}
 		ctx.ui.setStatus(
 			"model-guard",
-			ctx.ui.theme.fg("accent", `guard:${config.allowedModels.length}`),
+			ctx.ui.theme.fg("accent", `model guard (${config.allowedModels.length}): ${displayNames}`),
 		);
 	}
 }

--- a/packages/coding-agent/examples/extensions/model-preference-guard.ts
+++ b/packages/coding-agent/examples/extensions/model-preference-guard.ts
@@ -1,0 +1,494 @@
+/**
+ * Model Preference Guard Extension
+ *
+ * Guards against unintended model usage by letting you select preferred
+ * LLM + provider combinations. When starting a conversation, checks if
+ * the current model is in your saved preferences and prompts for
+ * confirmation if not.
+ *
+ * Commands:
+ *   /model-pref        - Open picker to manage preferences
+ *   /model-pref list   - Show current allowed models
+ *   /model-pref toggle - Enable/disable guard without deleting preferences
+ *   /model-pref add    - Open model picker to add more
+ *   /model-pref remove - Open model picker to remove
+ *
+ * Config: ~/.pi/agent/model-preferences.json
+ *
+ * Usage: pi -e ./model-preference-guard.ts
+ *   Or place in ~/.pi/agent/extensions/ for auto-discovery.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { Key, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+interface ModelPreference {
+	provider: string;
+	model: string;
+}
+
+interface PreferenceConfig {
+	enabled: boolean;
+	allowedModels: ModelPreference[];
+}
+
+// ─── Config File ────────────────────────────────────────────────────────
+
+const CONFIG_FILENAME = "model-preferences.json";
+
+function getConfigPath(): string {
+	return join(getAgentDir(), CONFIG_FILENAME);
+}
+
+function loadConfig(): PreferenceConfig {
+	const configPath = getConfigPath();
+	if (!existsSync(configPath)) {
+		return { enabled: true, allowedModels: [] };
+	}
+	try {
+		const content = readFileSync(configPath, "utf-8");
+		const parsed = JSON.parse(content);
+		return {
+			enabled: parsed.enabled !== false,
+			allowedModels: Array.isArray(parsed.allowedModels) ? parsed.allowedModels : [],
+		};
+	} catch {
+		return { enabled: true, allowedModels: [] };
+	}
+}
+
+function saveConfig(config: PreferenceConfig): void {
+	writeFileSync(getConfigPath(), JSON.stringify(config, null, 2), "utf-8");
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function formatModel(pref: ModelPreference): string {
+	return `${pref.provider}/${pref.model}`;
+}
+
+function isModelAllowed(current: { provider: string; id: string }, config: PreferenceConfig): boolean {
+	if (!config.enabled) return true;
+	if (config.allowedModels.length === 0) return true; // No preferences = no guard
+	return config.allowedModels.some(
+		(p) => p.provider === current.provider && p.model === current.id,
+	);
+}
+
+// ─── Multi-Select Picker ────────────────────────────────────────────────
+
+interface PickerItem {
+	value: string;       // "provider/model"
+	label: string;       // "provider/model"
+	checked: boolean;    // currently selected
+	available: boolean;  // has API key configured
+}
+
+async function showModelPicker(
+	ctx: ExtensionContext,
+	title: string,
+	allModels: Array<{ provider: string; id: string; available: boolean }>,
+	initialChecked: Set<string>,
+): Promise<Set<string> | null> {
+	// Build items: pre-checked models first, then unchecked
+	const items: PickerItem[] = allModels.map((m) => ({
+		value: `${m.provider}/${m.id}`,
+		label: `${m.provider}/${m.id}`,
+		checked: initialChecked.has(`${m.provider}/${m.id}`),
+		available: m.available,
+	}));
+
+	// Sort: checked first, then available, then by value
+	items.sort((a, b) => {
+		if (a.checked !== b.checked) return a.checked ? -1 : 1;
+		if (a.available !== b.available) return a.available ? -1 : 1;
+		return a.value.localeCompare(b.value);
+	});
+
+	const result = await ctx.ui.custom<Set<string> | null>((tui, theme, _kb, done) => {
+		let cursorIndex = 0;
+		let scrollOffset = 0;
+		const maxVisible = Math.min(items.length, 20);
+		let cachedLines: string[] | undefined;
+
+		function refresh() {
+			cachedLines = undefined;
+			tui.requestRender();
+		}
+
+		function toggle(index: number) {
+			const item = items[index];
+			item.checked = !item.checked;
+			refresh();
+		}
+
+		function submit() {
+			const selected = new Set<string>();
+			for (const item of items) {
+				if (item.checked) selected.add(item.value);
+			}
+			done(selected);
+		}
+
+		function handleInput(data: string) {
+			if (matchesKey(data, Key.up)) {
+				cursorIndex = Math.max(0, cursorIndex - 1);
+				if (cursorIndex < scrollOffset) scrollOffset = cursorIndex;
+				refresh();
+				return;
+			}
+			if (matchesKey(data, Key.down)) {
+				cursorIndex = Math.min(items.length - 1, cursorIndex + 1);
+				if (cursorIndex >= scrollOffset + maxVisible) scrollOffset = cursorIndex - maxVisible + 1;
+				refresh();
+				return;
+			}
+			if (matchesKey(data, Key.enter)) {
+				submit();
+				return;
+			}
+			if (matchesKey(data, Key.escape)) {
+				done(null);
+				return;
+			}
+			// Space also toggles
+			if (data === " ") {
+				toggle(cursorIndex);
+				if (cursorIndex < items.length - 1) {
+					cursorIndex++;
+					if (cursorIndex >= scrollOffset + maxVisible) scrollOffset = cursorIndex - maxVisible + 1;
+				}
+				refresh();
+				return;
+			}
+			// 'a' = select all, 'n' = select none
+			if (data === "a") {
+				for (const item of items) item.checked = true;
+				refresh();
+				return;
+			}
+			if (data === "n") {
+				for (const item of items) item.checked = false;
+				refresh();
+				return;
+			}
+		}
+
+		function render(width: number): string[] {
+			if (cachedLines) return cachedLines;
+
+			const lines: string[] = [];
+			const rw = Math.max(1, width);
+
+			lines.push(theme.fg("accent", "─".repeat(rw)));
+			lines.push(theme.fg("text", theme.bold(` ${title}`)));
+			lines.push(theme.fg("dim", ` ${items.filter((i) => i.checked).length}/${items.length} selected`));
+			lines.push("");
+
+			const visibleItems = items.slice(scrollOffset, scrollOffset + maxVisible);
+
+			for (let i = 0; i < visibleItems.length; i++) {
+				const globalIdx = scrollOffset + i;
+				const item = visibleItems[i];
+				const isSelected = globalIdx === cursorIndex;
+				const checkbox = item.checked ? "☑" : "☐";
+				const avail = item.available ? "" : theme.fg("warning", " ⚠ no key");
+
+				const label = `${checkbox} ${item.label}${avail}`;
+
+				// Wrap long lines
+				const prefixWidth = 2;
+				const contentWidth = Math.max(1, rw - prefixWidth);
+				const wrapped = wrapTextWithAnsi(label, contentWidth);
+				for (let j = 0; j < wrapped.length; j++) {
+					const p = j === 0 ? (isSelected ? theme.fg("accent", "> ") : "  ") : "  ";
+					const c = isSelected ? "accent" : item.checked ? "success" : "text";
+					lines.push(`${p}${theme.fg(c, wrapped[j])}`);
+				}
+			}
+
+			// Scroll indicator
+			if (items.length > maxVisible) {
+				const scrollInfo = ` ${scrollOffset + 1}-${Math.min(scrollOffset + maxVisible, items.length)} of ${items.length}`;
+				lines.push(theme.fg("dim", scrollInfo));
+			}
+
+			lines.push("");
+			lines.push(theme.fg("dim", "  Space toggle • a=select all • n=select none • Enter to confirm • Esc cancel"));
+			lines.push(theme.fg("accent", "─".repeat(rw)));
+
+			cachedLines = lines;
+			return lines;
+		}
+
+		return {
+			render,
+			invalidate: () => { cachedLines = undefined; },
+			handleInput,
+		};
+	});
+
+	return result;
+}
+
+// ─── Extension ──────────────────────────────────────────────────────────
+
+export default function modelPreferenceGuard(pi: ExtensionAPI) {
+	let config = loadConfig();
+	let hintShown = false;
+
+	// ── /model-pref command ──────────────────────────────────────────
+
+	pi.registerCommand("model-pref", {
+		description: "Manage model preferences (guard against unintended model usage)",
+		handler: async (args, ctx) => {
+			const sub = args?.trim().toLowerCase();
+
+			if (sub === "list") {
+				if (config.allowedModels.length === 0) {
+					ctx.ui.notify("No model preferences saved. All models allowed.", "info");
+				} else {
+					const list = config.allowedModels.map((m) => `  • ${formatModel(m)}`).join("\n");
+					ctx.ui.notify(
+						`Guard: ${config.enabled ? "ON" : "OFF"}\nAllowed models:\n${list}`,
+						"info",
+					);
+				}
+				return;
+			}
+
+			if (sub === "toggle") {
+				config.enabled = !config.enabled;
+				saveConfig(config);
+				ctx.ui.notify(`Model guard ${config.enabled ? "enabled" : "disabled"}`, "info");
+				updateStatus(ctx, config);
+				return;
+			}
+
+			if (sub === "add" || sub === "remove") {
+				// Get all available models
+				const allModels = ctx.modelRegistry.getAvailable().map((m) => ({
+					provider: m.provider,
+					id: m.id,
+					available: true,
+				}));
+
+				if (allModels.length === 0) {
+					ctx.ui.notify("No models available. Check your API keys.", "warning");
+					return;
+				}
+
+				const currentSet = new Set(config.allowedModels.map(formatModel));
+				const title = sub === "add" ? "Select models to ADD to preferences" : "Select models to REMOVE from preferences";
+
+				const result = await showModelPicker(ctx, title, allModels, currentSet);
+				if (!result) {
+					ctx.ui.notify("Cancelled", "info");
+					return;
+				}
+
+				if (sub === "add") {
+					// Add newly checked models that weren't in the list
+					const newModels: ModelPreference[] = [];
+					for (const val of result) {
+						if (!currentSet.has(val)) {
+							const [provider, ...modelParts] = val.split("/");
+							newModels.push({ provider, model: modelParts.join("/") });
+						}
+					}
+					if (newModels.length > 0) {
+						config.allowedModels.push(...newModels);
+						saveConfig(config);
+						ctx.ui.notify(`Added ${newModels.length} model(s): ${newModels.map(formatModel).join(", ")}`, "info");
+					} else {
+						ctx.ui.notify("No new models added", "info");
+					}
+				} else {
+					// Remove: keep only models that are still in the result set
+					const before = config.allowedModels.length;
+					config.allowedModels = config.allowedModels.filter((m) => result.has(formatModel(m)));
+					const removed = before - config.allowedModels.length;
+					if (removed > 0) {
+						saveConfig(config);
+						ctx.ui.notify(`Removed ${removed} model(s)`, "info");
+					} else {
+						ctx.ui.notify("No models removed", "info");
+					}
+				}
+				return;
+			}
+
+			// No subcommand or unknown → full picker
+			if (config.allowedModels.length === 0) {
+				// First time: show all available models, none checked
+				const allModels = ctx.modelRegistry.getAvailable().map((m) => ({
+					provider: m.provider,
+					id: m.id,
+					available: true,
+				}));
+
+				if (allModels.length === 0) {
+					ctx.ui.notify("No models available. Check your API keys.", "warning");
+					return;
+				}
+
+				ctx.ui.notify("No preferences set yet. Pick your preferred models:", "info");
+				const result = await showModelPicker(
+					ctx,
+					"Select your PREFERRED models",
+					allModels,
+					new Set(),
+				);
+
+				if (!result || result.size === 0) {
+					ctx.ui.notify("No models selected. All models remain allowed.", "info");
+					return;
+				}
+
+				config.allowedModels = [...result].map((val) => {
+					const [provider, ...modelParts] = val.split("/");
+					return { provider, model: modelParts.join("/") };
+				});
+				saveConfig(config);
+				config = loadConfig();
+				ctx.ui.notify(
+					`Saved ${config.allowedModels.length} preferred model(s):\n${config.allowedModels.map((m) => `  • ${formatModel(m)}`).join("\n")}`,
+					"info",
+				);
+				return;
+			}
+
+			// Existing preferences: show toggle view
+			const allModels = ctx.modelRegistry.getAvailable().map((m) => ({
+				provider: m.provider,
+				id: m.id,
+				available: true,
+			}));
+
+			const currentSet = new Set(config.allowedModels.map(formatModel));
+			const result = await showModelPicker(
+				ctx,
+				"Toggle model preferences (checked = allowed)",
+				allModels,
+				currentSet,
+			);
+
+			if (!result) {
+				ctx.ui.notify("Cancelled", "info");
+				return;
+			}
+
+			config.allowedModels = [...result].map((val) => {
+				const [provider, ...modelParts] = val.split("/");
+				return { provider, model: modelParts.join("/") };
+			});
+			saveConfig(config);
+			ctx.ui.notify(
+				`Updated preferences: ${config.allowedModels.length} model(s) allowed`,
+				"info",
+			);
+		},
+	});
+
+	// ── Session start: load config, show hint if first time ──────────
+
+	pi.on("session_start", async (_event, ctx) => {
+		config = loadConfig();
+		hintShown = false;
+
+		// Show hint if no preferences saved and guard hasn't been disabled
+		if (config.enabled && config.allowedModels.length === 0 && !hintShown) {
+			hintShown = true;
+			ctx.ui.notify(
+				"💡 No model preferences set. Run /model-pref to choose preferred models.",
+				"info",
+			);
+		}
+
+		updateStatus(ctx, config);
+	});
+
+	// ── Input: check model against preferences before agent runs ────
+
+	pi.on("input", async (event, ctx) => {
+		// Only check interactive typed input
+		if (event.source !== "interactive") return;
+
+		// Skip in non-TUI mode
+		if (ctx.mode !== "tui") return;
+
+		// Reload config to pick up changes
+		config = loadConfig();
+
+		// Skip if guard is disabled
+		if (!config.enabled) return;
+
+		// Skip if no preferences saved
+		if (config.allowedModels.length === 0) return;
+
+		const model = ctx.model;
+		if (!model) return;
+
+		if (isModelAllowed({ provider: model.provider, id: model.id }, config)) {
+			return; // Model is in the allowed list, continue normally
+		}
+
+		// Model NOT in allowed list → confirm with user
+		const modelName = `${model.provider}/${model.id}`;
+		const allowed = config.allowedModels.map(formatModel).join(", ");
+
+		const ok = await ctx.ui.confirm(
+			"⚠️  Model Not Preferred",
+			`Current model: ${modelName}\n\nThis model is NOT in your preferred list:\n${allowed}\n\nContinue with ${modelName}?`,
+		);
+
+		if (!ok) {
+			// User declined — block the agent entirely
+			return { action: "handled" };
+		}
+
+		// User confirmed — continue with the un-preferred model
+		return { action: "continue" };
+	});
+
+	// ── Model select: show status on change ──────────────────────────
+
+	pi.on("model_select", async (event, ctx) => {
+		config = loadConfig();
+
+		if (event.source === "restore") return;
+
+		const model = event.model;
+		if (!model) return;
+
+		const modelName = `${model.provider}/${model.id}`;
+
+		if (config.enabled && config.allowedModels.length > 0) {
+			if (isModelAllowed({ provider: model.provider, id: model.id }, config)) {
+				ctx.ui.notify(`✅ ${modelName} — in preferred models`, "info");
+			} else {
+				ctx.ui.notify(`⚠️  ${modelName} — NOT in preferred models`, "warning");
+			}
+		}
+
+		updateStatus(ctx, config);
+	});
+}
+
+function updateStatus(ctx: ExtensionContext, config: PreferenceConfig) {
+	if (!config.enabled) {
+		ctx.ui.setStatus("model-guard", ctx.ui.theme.fg("dim", "guard:off"));
+	} else if (config.allowedModels.length === 0) {
+		ctx.ui.setStatus("model-guard", ctx.ui.theme.fg("dim", "guard:—"));
+	} else {
+		ctx.ui.setStatus(
+			"model-guard",
+			ctx.ui.theme.fg("accent", `guard:${config.allowedModels.length}`),
+		);
+	}
+}

--- a/packages/coding-agent/examples/extensions/model-preference-guard.ts
+++ b/packages/coding-agent/examples/extensions/model-preference-guard.ts
@@ -80,7 +80,7 @@ function isModelAllowed(current: { provider: string; id: string }, config: Prefe
 	);
 }
 
-// ─── Multi-Select Picker ────────────────────────────────────────────────
+// ─── Multi-Select Picker with Search ───────────────────────────────────
 
 interface PickerItem {
 	value: string;       // "provider/model"
@@ -113,8 +113,19 @@ async function showModelPicker(
 	const result = await ctx.ui.custom<Set<string> | null>((tui, theme, _kb, done) => {
 		let cursorIndex = 0;
 		let scrollOffset = 0;
+		let searchTerm = "";
 		const maxVisible = Math.min(items.length, 20);
 		let cachedLines: string[] | undefined;
+
+		// Filter items by search term
+		function getFilteredIndices(): number[] {
+			if (!searchTerm) return items.map((_, i) => i);
+			const term = searchTerm.toLowerCase();
+			return items
+				.map((item, i) => ({ item, i }))
+				.filter(({ item }) => item.value.toLowerCase().includes(term))
+				.map(({ i }) => i);
+		}
 
 		function refresh() {
 			cachedLines = undefined;
@@ -122,8 +133,9 @@ async function showModelPicker(
 		}
 
 		function toggle(index: number) {
-			const item = items[index];
-			item.checked = !item.checked;
+			const filtered = getFilteredIndices();
+			const itemIdx = filtered[index];
+			if (itemIdx !== undefined) items[itemIdx].checked = !items[itemIdx].checked;
 			refresh();
 		}
 
@@ -137,13 +149,19 @@ async function showModelPicker(
 
 		function handleInput(data: string) {
 			if (matchesKey(data, Key.up)) {
-				cursorIndex = Math.max(0, cursorIndex - 1);
+				const filtered = getFilteredIndices();
+				const maxIdx = filtered.length - 1;
+				if (maxIdx < 0) return;
+				cursorIndex = Math.max(0, Math.min(cursorIndex, maxIdx) - 1);
 				if (cursorIndex < scrollOffset) scrollOffset = cursorIndex;
 				refresh();
 				return;
 			}
 			if (matchesKey(data, Key.down)) {
-				cursorIndex = Math.min(items.length - 1, cursorIndex + 1);
+				const filtered = getFilteredIndices();
+				const maxIdx = filtered.length - 1;
+				if (maxIdx < 0) return;
+				cursorIndex = Math.min(maxIdx, Math.max(0, cursorIndex) + 1);
 				if (cursorIndex >= scrollOffset + maxVisible) scrollOffset = cursorIndex - maxVisible + 1;
 				refresh();
 				return;
@@ -153,27 +171,53 @@ async function showModelPicker(
 				return;
 			}
 			if (matchesKey(data, Key.escape)) {
-				done(null);
+				if (searchTerm) {
+					searchTerm = "";
+					cursorIndex = 0;
+					scrollOffset = 0;
+					refresh();
+				} else {
+					done(null);
+				}
 				return;
 			}
-			// Space also toggles
-			if (data === " ") {
+			// Backspace to delete search char
+			if (matchesKey(data, Key.backspace) || data === "\x7f") {
+				if (searchTerm.length > 0) {
+					searchTerm = searchTerm.slice(0, -1);
+					cursorIndex = 0;
+					scrollOffset = 0;
+					refresh();
+				}
+				return;
+			}
+			// Space toggles (only when not searching)
+			if (data === " " && !searchTerm) {
 				toggle(cursorIndex);
-				if (cursorIndex < items.length - 1) {
+				const filtered = getFilteredIndices();
+				if (cursorIndex < filtered.length - 1) {
 					cursorIndex++;
 					if (cursorIndex >= scrollOffset + maxVisible) scrollOffset = cursorIndex - maxVisible + 1;
 				}
 				refresh();
 				return;
 			}
-			// 'a' = select all, 'n' = select none
-			if (data === "a") {
-				for (const item of items) item.checked = true;
+			// 'a' = select all (filtered), 'n' = select none
+			if (data === "a" && !searchTerm) {
+				for (const idx of getFilteredIndices()) items[idx].checked = true;
 				refresh();
 				return;
 			}
-			if (data === "n") {
-				for (const item of items) item.checked = false;
+			if (data === "n" && !searchTerm) {
+				for (const idx of getFilteredIndices()) items[idx].checked = false;
+				refresh();
+				return;
+			}
+			// Printable characters → type into search
+			if (data.length === 1 && data >= " " && data < "\x7f" && data !== " ") {
+				searchTerm += data;
+				cursorIndex = 0;
+				scrollOffset = 0;
 				refresh();
 				return;
 			}
@@ -184,17 +228,21 @@ async function showModelPicker(
 
 			const lines: string[] = [];
 			const rw = Math.max(1, width);
+			const filtered = getFilteredIndices();
+			const filteredItems = filtered.map((i) => items[i]);
 
 			lines.push(theme.fg("accent", "─".repeat(rw)));
 			lines.push(theme.fg("text", theme.bold(` ${title}`)));
-			lines.push(theme.fg("dim", ` ${items.filter((i) => i.checked).length}/${items.length} selected`));
+
+			// Search bar
+			lines.push(theme.fg("dim", ` 🔍 ${searchTerm || ""}_`));
+			lines.push(theme.fg("dim", ` ${items.filter((i) => i.checked).length}/${items.length} selected, ${filtered.length} shown`));
 			lines.push("");
 
-			const visibleItems = items.slice(scrollOffset, scrollOffset + maxVisible);
-
-			for (let i = 0; i < visibleItems.length; i++) {
+			for (let i = 0; i < Math.min(filteredItems.length, maxVisible); i++) {
 				const globalIdx = scrollOffset + i;
-				const item = visibleItems[i];
+				const item = filteredItems[globalIdx];
+				if (!item) break;
 				const isSelected = globalIdx === cursorIndex;
 				const checkbox = item.checked ? "☑" : "☐";
 				const avail = item.available ? "" : theme.fg("warning", " ⚠ no key");
@@ -213,13 +261,13 @@ async function showModelPicker(
 			}
 
 			// Scroll indicator
-			if (items.length > maxVisible) {
-				const scrollInfo = ` ${scrollOffset + 1}-${Math.min(scrollOffset + maxVisible, items.length)} of ${items.length}`;
+			if (filteredItems.length > maxVisible) {
+				const scrollInfo = ` ${scrollOffset + 1}-${Math.min(scrollOffset + maxVisible, filteredItems.length)} of ${filteredItems.length}`;
 				lines.push(theme.fg("dim", scrollInfo));
 			}
 
 			lines.push("");
-			lines.push(theme.fg("dim", "  Space toggle • a=select all • n=select none • Enter to confirm • Esc cancel"));
+			lines.push(theme.fg("dim", "  Type to search • Space toggle • a=all • n=none • Enter confirm • Esc cancel"));
 			lines.push(theme.fg("accent", "─".repeat(rw)));
 
 			cachedLines = lines;


### PR DESCRIPTION
# What

 Adds model-preference-guard.ts — guards against unintended model usage by letting users select preferred LLM + provider combinations via a multi-select picker.

 Practical value: prevents unintentional spending at wrong models.

 # Why

 No existing example demonstrates:
 - Multi-select checkbox UI — all others use single-select SelectList
 - Input-time model guard — validates model before agent runs, not after
 - Preference persistence — saves to ~/.pi/agent/model-preferences.json

 # Patterns Shown

 1. Custom multi-select picker (ctx.ui.custom()) with checkboxes, scroll, select all/none
 2. Type-to-search filter — real-time filtering with 🔍 bar
 3. Input event interception — confirms non-preferred models before agent runs
 4. Status bar integration via ctx.ui.setStatus()
 5. Config persistence to JSON file

 # UI

 Multi-select picker with search:

 ```
     Select your PREFERRED models
    🔍 claude_
     3/12 selected, 4 shown

    >☑ anthropic/claude-sonnet-4-5
     ☑ anthropic/claude-opus-4
     ☑ anthropic/claude-haiku-3.5
     ☐ anthropic/claude-3.7-sonnet

     Type to search • Space toggle • a=all • n=none • Enter confirm • Esc cancel
 ```

 Confirmation for non-preferred model:

 ```
     ⚠️  Model Not Preferred

     Current model: openai/gpt-4o
     This model is NOT in your preferred list

     Continue with openai/gpt-4o?

                 [ Yes ]  [ No ]
 ```

 Status bar: guard:3 / guard:off / guard:—

# Usage

 ```bash
   pi -e ./model-preference-guard.ts
   # or
   cp model-preference-guard.ts ~/.pi/agent/extensions/
 ```

# Commands

 - /model-pref — Open picker to manage preferences
 - /model-pref list — Show current allowed models
 - /model-pref toggle — Enable/disable guard
 - /model-pref add / remove — Add or remove models