### PR TITLE
fix(coding-agent): accept dots and underscores in skill names

### DIFF
--- a/packages/agent/src/harness/skills.ts
+++ b/packages/agent/src/harness/skills.ts
@@ -311,11 +311,12 @@ function validateName(name: string, parentDirName: string): string[] {
 	const errors: string[] = [];
 	if (name !== parentDirName) errors.push(`name "${name}" does not match parent directory "${parentDirName}"`);
 	if (name.length > MAX_NAME_LENGTH) errors.push(`name exceeds ${MAX_NAME_LENGTH} characters (${name.length})`);
-	if (!/^[a-z0-9-]+$/.test(name)) {
-		errors.push("name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)");
+	if (!/^[a-z0-9._-]+$/.test(name)) {
+		errors.push("name contains invalid characters (must be lowercase a-z, 0-9, hyphens, dots, or underscores)");
 	}
-	if (name.startsWith("-") || name.endsWith("-")) errors.push("name must not start or end with a hyphen");
-	if (name.includes("--")) errors.push("name must not contain consecutive hyphens");
+	if (/^[._-]|[._-]$/.test(name))
+		errors.push("name must not start or end with a separator (hyphen, dot, or underscore)");
+	if (/[._-]{2}/.test(name)) errors.push("name must not contain consecutive separators");
 	return errors;
 }
 

--- a/packages/agent/test/harness/skills.test.ts
+++ b/packages/agent/test/harness/skills.test.ts
@@ -37,6 +37,28 @@ Use this skill.
 		]);
 	});
 
+	it("loads dotted and underscored names without diagnostics", async () => {
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		await env.createDir(".agents/skills/pdf.tools", { recursive: true }, BACKGROUND_CONTEXT);
+		await env.writeFile(
+			".agents/skills/pdf.tools/SKILL.md",
+			"---\nname: pdf.tools\ndescription: Example skill\n---\nUse this skill.",
+			BACKGROUND_CONTEXT,
+		);
+		await env.createDir(".agents/skills/data_analysis", { recursive: true }, BACKGROUND_CONTEXT);
+		await env.writeFile(
+			".agents/skills/data_analysis/SKILL.md",
+			"---\nname: data_analysis\ndescription: Example skill\n---\nUse this skill.",
+			BACKGROUND_CONTEXT,
+		);
+
+		const { skills, diagnostics } = await loadSkills(env, ".agents/skills", BACKGROUND_CONTEXT);
+
+		expect(diagnostics).toEqual([]);
+		expect(skills.map((skill) => skill.name).sort()).toEqual(["data_analysis", "pdf.tools"]);
+	});
+
 	it("loads skills through symlinked directories", async () => {
 		const root = createTempDir();
 		const env = new NodeExecutionEnv({ cwd: root });

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -4,7 +4,7 @@
 
 Skills are self-contained capability packages that the agent loads on-demand. A skill provides specialized workflows, setup instructions, helper scripts, and reference documentation for specific tasks.
 
-Pi implements the [Agent Skills standard](https://agentskills.io/specification), warning about most violations but remaining lenient. Pi allows skill names to differ from their parent directory even though the standard disallows it; that rule is suboptimal for shared skill directories used across multiple agent harnesses.
+Pi implements the [Agent Skills standard](https://agentskills.io/specification), warning about most violations but remaining lenient. Pi allows skill names to differ from their parent directory even though the standard disallows it; that rule is suboptimal for shared skill directories used across multiple agent harnesses. Pi also accepts dots and underscores in names beyond the standard alphabet, so shared skill directories (for example Claude Code's) load without warnings.
 
 ## Table of Contents
 
@@ -141,7 +141,7 @@ Per the [Agent Skills specification](https://agentskills.io/specification#frontm
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Max 64 chars. Lowercase a-z, 0-9, hyphens. Unlike the standard, Pi does not require this to match the parent directory because that standard requirement is suboptimal for shared skill directories. |
+| `name` | Yes | Max 64 chars. Lowercase a-z, 0-9, hyphens, dots, underscores. Unlike the standard, Pi does not require this to match the parent directory because that standard requirement is suboptimal for shared skill directories. |
 | `description` | Yes | Max 1024 chars. What the skill does and when to use it. |
 | `license` | No | License name or reference to bundled file. |
 | `compatibility` | No | Max 500 chars. Environment requirements. |
@@ -152,9 +152,9 @@ Per the [Agent Skills specification](https://agentskills.io/specification#frontm
 ### Name Rules
 
 - 1-64 characters
-- Lowercase letters, numbers, hyphens only
-- No leading/trailing hyphens
-- No consecutive hyphens
+- Lowercase letters, numbers, hyphens, dots, underscores
+- No leading/trailing separators (hyphen, dot, underscore)
+- No consecutive separators
 Pi does not require the name to match the parent directory. The Agent Skills standard does, but that requirement is suboptimal for shared skill directories used by multiple tools.
 
 Valid: `pdf-processing`, `data-analysis`, `code-review`
@@ -179,7 +179,7 @@ description: Helps with PDFs.
 Pi validates skills against the Agent Skills standard. Most issues produce warnings but still load the skill:
 
 - Name exceeds 64 characters or contains invalid characters
-- Name starts/ends with hyphen or has consecutive hyphens
+- Name starts/ends with a separator or has consecutive separators
 - Description exceeds 1024 characters
 
 Unknown frontmatter fields are ignored.

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -86,7 +86,7 @@ export interface LoadSkillsResult {
 }
 
 /**
- * Validate skill name per Agent Skills spec.
+ * Validate skill name per Agent Skills spec, extended with dots and underscores.
  * Returns array of validation error messages (empty if valid).
  */
 function validateName(name: string): string[] {
@@ -96,16 +96,16 @@ function validateName(name: string): string[] {
 		errors.push(`name exceeds ${MAX_NAME_LENGTH} characters (${name.length})`);
 	}
 
-	if (!/^[a-z0-9-]+$/.test(name)) {
-		errors.push(`name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)`);
+	if (!/^[a-z0-9._-]+$/.test(name)) {
+		errors.push(`name contains invalid characters (must be lowercase a-z, 0-9, hyphens, dots, or underscores)`);
 	}
 
-	if (name.startsWith("-") || name.endsWith("-")) {
-		errors.push(`name must not start or end with a hyphen`);
+	if (/^[._-]|[._-]$/.test(name)) {
+		errors.push(`name must not start or end with a separator (hyphen, dot, or underscore)`);
 	}
 
-	if (name.includes("--")) {
-		errors.push(`name must not contain consecutive hyphens`);
+	if (/[._-]{2}/.test(name)) {
+		errors.push(`name must not contain consecutive separators`);
 	}
 
 	return errors;

--- a/packages/coding-agent/test/fixtures/skills/dotted-name/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/dotted-name/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: skill-codetool.csharp-lint
+description: A skill with a dotted name, which loads without warnings.
+---
+
+# Dotted name
+
+This skill uses a dot in the name.

--- a/packages/coding-agent/test/fixtures/skills/underscore-name/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/underscore-name/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: data_analysis
+description: A skill with an underscored name, which loads without warnings.
+---
+
+# Underscored name
+
+This skill uses an underscore in the name.

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -64,6 +64,28 @@ describe("skills", () => {
 			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("invalid characters"))).toBe(true);
 		});
 
+		it("should load dotted names without warnings", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "dotted-name"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].name).toBe("skill-codetool.csharp-lint");
+			expect(diagnostics).toHaveLength(0);
+		});
+
+		it("should load underscored names without warnings", () => {
+			const { skills, diagnostics } = loadSkillsFromDir({
+				dir: join(fixturesDir, "underscore-name"),
+				source: "test",
+			});
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].name).toBe("data_analysis");
+			expect(diagnostics).toHaveLength(0);
+		});
+
 		it("should warn when name exceeds 64 characters", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "long-name"),
@@ -150,14 +172,14 @@ describe("skills", () => {
 			expect(diagnostics).toHaveLength(0);
 		});
 
-		it("should warn when name contains consecutive hyphens", () => {
+		it("should warn when name contains consecutive separators", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "consecutive-hyphens"),
 				source: "test",
 			});
 
 			expect(skills).toHaveLength(1);
-			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("consecutive hyphens"))).toBe(true);
+			expect(diagnostics.some((d: ResourceDiagnostic) => d.message.includes("consecutive separators"))).toBe(true);
 		});
 
 		it("should load all skills from fixture directory", () => {
@@ -167,7 +189,7 @@ describe("skills", () => {
 			});
 
 			// Should load all skills that have descriptions (even with warnings)
-			// valid-skill, name-mismatch, invalid-name-chars, long-name, unknown-field, nested/child-skill, consecutive-hyphens
+			// valid-skill, name-mismatch, invalid-name-chars, long-name, unknown-field, nested/child-skill, consecutive-hyphens, dotted-name, underscore-name
 			// NOT: missing-description, no-frontmatter (both missing descriptions)
 			expect(skills.length).toBeGreaterThanOrEqual(6);
 		});


### PR DESCRIPTION
## Summary

- Extend the skill name alphabet beyond the Agent Skills standard to also accept dots and underscores, in both validateName copies (packages/coding-agent/src/core/skills.ts, packages/agent/src/harness/skills.ts)
- Rationale: shared skill directories from other harnesses (for example Claude Code's ~/.claude/skills wired through the settings `skills` array) commonly use dotted family prefixes such as `skill-codetool.csharp-lint`; today every such name emits "name contains invalid characters" on the loaded-resources screen even though the skill loads fine
- This follows the existing documented deviation pattern (Pi already allows names that differ from the parent directory, docs/skills.md)
- Guard rules generalized to any separator: no leading/trailing separator, no consecutive separators, 64 char limit unchanged; lenient behavior unchanged (violation warns, skill still loads)
- docs/skills.md name rules and validation section updated
- Fixtures and tests added for dotted and underscored names in both packages; the consecutive-hyphens test became the consecutive-separators test

## Test plan

- `npm run check` (root): exit 0
- `packages/coding-agent`: `vitest --run test/skills.test.ts`: 30 passed
- `packages/agent`: `vitest --run test/harness/skills.test.ts`: 7 passed
- `./test.sh` (root): 2170 passed, 5 failed; all 5 failures reproduce on pristine origin/main (4 need git >= 2.28 for `git init --initial-branch`, local git is 2.25.0; 1 is test/tool-execution-component.test.ts, verified failing with this PR's source files reverted)