### PR TITLE
fix(coding-agent): remove unreachable tool_result_end listener in subagent example

### DIFF
--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -380,11 +380,6 @@ async function runSingleAgent(
 					}
 					emitUpdate();
 				}
-
-				if (event.type === "tool_result_end" && event.message) {
-					currentResult.messages.push(event.message as Message);
-					emitUpdate();
-				}
 			};
 
 			proc.stdout.on("data", (data) => {


### PR DESCRIPTION
The subagent example listens for a tool_result_end event that pi never emits. Tool result messages are delivered as message_end events with role "toolResult" and are already collected by the existing handler, so the branch is unreachable dead code.