### PR TITLE
feat(agent): default 3 minute timeout for every tool call

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -23,6 +23,17 @@ import type {
 	StreamFn,
 } from "./types.ts";
 
+/**
+ * Default per-tool-call timeout in milliseconds.
+ *
+ * Every tool call gets this timer unless the model specifies otherwise for
+ * that call. Tools that accept a numeric `timeout` argument in seconds (for
+ * example `bash`/`powershell`) use it as the override: a finite number
+ * replaces the default for that call, `0` disables the timer, and an omitted
+ * argument keeps the default.
+ */
+export const DEFAULT_TOOL_TIMEOUT_MS = 180_000;
+
 export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
 
 /**
@@ -456,7 +467,7 @@ async function executeToolCallsSequential(
 				isError: preparation.isError,
 			};
 		} else {
-			const executed = await executePreparedToolCall(preparation, signal, emit);
+			const executed = await executePreparedToolCall(preparation, config, signal, emit);
 			finalized = await finalizeExecutedToolCall(
 				currentContext,
 				assistantMessage,
@@ -527,7 +538,7 @@ async function executeToolCallsParallel(
 				await emitToolExecutionEnd(finalized, emit);
 				return finalized;
 			}
-			const executed = await executePreparedToolCall(preparation, signal, emit);
+			const executed = await executePreparedToolCall(preparation, config, signal, emit);
 			const finalized = await finalizeExecutedToolCall(
 				currentContext,
 				assistantMessage,
@@ -674,46 +685,99 @@ async function prepareToolCall(
 	}
 }
 
+/**
+ * Resolve the loop-level timeout for one tool call.
+ *
+ * Tools that accept a numeric `timeout` argument in seconds let the model
+ * specify otherwise per call: a finite number replaces the default for that
+ * call and `0` disables the timer. Unknown, non-numeric, or negative values
+ * keep the default so a malformed override cannot silently disable the timer.
+ */
+function resolveToolTimeoutMs(args: unknown, toolTimeoutMs: number | undefined): number | undefined {
+	const effectiveDefault = toolTimeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS;
+	if (
+		typeof args === "object" &&
+		args !== null &&
+		"timeout" in args &&
+		typeof (args as { timeout?: unknown }).timeout === "number"
+	) {
+		const overrideSeconds = (args as { timeout: number }).timeout;
+		if (overrideSeconds === 0) return undefined;
+		if (Number.isFinite(overrideSeconds) && overrideSeconds > 0) return overrideSeconds * 1000;
+	}
+	if (effectiveDefault === 0) return undefined;
+	if (!Number.isFinite(effectiveDefault) || effectiveDefault < 0) return DEFAULT_TOOL_TIMEOUT_MS;
+	return effectiveDefault;
+}
+
+function formatToolTimeoutError(toolName: string, timeoutMs: number): string {
+	const seconds = Math.round(timeoutMs / 100) / 10;
+	return (
+		`Tool "${toolName}" timed out after ${seconds} seconds. ` +
+		`The tool call exceeded its time limit; re-issue it with a longer ` +
+		`timeout (for example a "timeout" argument in seconds) or split the work into smaller steps.`
+	);
+}
+
 async function executePreparedToolCall(
 	prepared: PreparedToolCall,
+	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 ): Promise<ExecutedToolCallOutcome> {
 	const updateEvents: Promise<void>[] = [];
 	let acceptingUpdates = true;
+	const timeoutMs = resolveToolTimeoutMs(prepared.args, config.toolTimeoutMs);
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+	let timedOut = false;
 
 	try {
-		const result = await prepared.tool.execute(
-			prepared.toolCall.id,
-			prepared.args as never,
-			signal,
-			(partialResult) => {
-				if (!acceptingUpdates) return;
-				updateEvents.push(
-					Promise.resolve(
-						emit({
-							type: "tool_execution_update",
-							toolCallId: prepared.toolCall.id,
-							toolName: prepared.toolCall.name,
-							args: prepared.toolCall.arguments,
-							partialResult,
-						}),
-					),
-				);
-			},
-		);
+		const execution = prepared.tool.execute(prepared.toolCall.id, prepared.args as never, signal, (partialResult) => {
+			if (!acceptingUpdates) return;
+			updateEvents.push(
+				Promise.resolve(
+					emit({
+						type: "tool_execution_update",
+						toolCallId: prepared.toolCall.id,
+						toolName: prepared.toolCall.name,
+						args: prepared.toolCall.arguments,
+						partialResult,
+					}),
+				),
+			);
+		});
+		let result: AgentToolResult<any>;
+		if (timeoutMs === undefined) {
+			result = await execution;
+		} else {
+			result = await new Promise<AgentToolResult<any>>((resolve, reject) => {
+				timeoutHandle = setTimeout(() => {
+					timedOut = true;
+					acceptingUpdates = false;
+					reject(new Error(formatToolTimeoutError(prepared.toolCall.name, timeoutMs)));
+				}, timeoutMs);
+				execution.then(resolve, reject);
+			});
+		}
 		acceptingUpdates = false;
 		await Promise.all(updateEvents);
 		return { result, isError: false };
 	} catch (error) {
 		acceptingUpdates = false;
 		await Promise.all(updateEvents);
+		if (timedOut && signal?.aborted) {
+			return {
+				result: createErrorToolResult("Operation aborted"),
+				isError: true,
+			};
+		}
 		return {
 			result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
 			isError: true,
 		};
 	} finally {
 		acceptingUpdates = false;
+		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
 	}
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -120,6 +120,7 @@ export interface AgentOptions {
 	transport?: Transport;
 	maxRetryDelayMs?: number;
 	toolExecution?: ToolExecutionMode;
+	toolTimeoutMs?: number;
 }
 
 class PendingMessageQueue {
@@ -212,6 +213,8 @@ export class Agent {
 	public maxRetryDelayMs?: number;
 	/** Tool execution strategy for assistant messages that contain multiple tool calls. */
 	public toolExecution: ToolExecutionMode;
+	/** Default per-tool-call timeout in milliseconds. See AgentLoopConfig.toolTimeoutMs. */
+	public toolTimeoutMs: number | undefined;
 
 	constructor(options: AgentOptions) {
 		// Older compiled consumers may omit options or streamFn even though the current API requires them.
@@ -235,6 +238,7 @@ export class Agent {
 		this.transport = runtimeOptions.transport ?? "auto";
 		this.maxRetryDelayMs = runtimeOptions.maxRetryDelayMs;
 		this.toolExecution = runtimeOptions.toolExecution ?? "parallel";
+		this.toolTimeoutMs = runtimeOptions.toolTimeoutMs;
 	}
 
 	/**
@@ -455,6 +459,7 @@ export class Agent {
 			thinkingBudgets: this.thinkingBudgets,
 			maxRetryDelayMs: this.maxRetryDelayMs,
 			toolExecution: this.toolExecution,
+			toolTimeoutMs: this.toolTimeoutMs,
 			beforeToolCall: this.beforeToolCall,
 			afterToolCall: this.afterToolCall,
 			shouldStopAfterTurn: shouldStopAfterTurn

--- a/packages/agent/src/harness/tools/bash.ts
+++ b/packages/agent/src/harness/tools/bash.ts
@@ -10,7 +10,12 @@ const BASH_CHECKPOINT_INTERVAL_MS = 2_000;
 
 const bashSchema = Type.Object({
 	command: Type.String({ description: "Bash command to execute" }),
-	timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (optional, no default timeout)" })),
+	timeout: Type.Optional(
+		Type.Number({
+			description:
+				"Timeout in seconds. Defaults to 180 (3 minutes) when omitted; pass 0 to disable the timer, or a finite number of seconds for a longer limit.",
+		}),
+	),
 });
 
 export type BashToolInput = Static<typeof bashSchema>;
@@ -54,7 +59,7 @@ export function createBashTool<TContext extends ExecutionToolContext = Execution
 	return {
 		name: "bash",
 		label: "bash",
-		description: `Execute a bash command in the current working directory. Returns combined stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.`,
+		description: `Execute a bash command in the current working directory. Returns combined stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Timeout defaults to 180 seconds; pass a timeout in seconds for a longer limit, or 0 to disable the timer.`,
 		parameters: bashSchema,
 		async execute(_toolCallId, { command, timeout }, onUpdate, toolContext, _invocation, context) {
 			validateTimeout(timeout);

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -269,6 +269,23 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	toolExecution?: ToolExecutionMode;
 
 	/**
+	 * Default per-tool-call timeout in milliseconds.
+	 *
+	 * The loop enforces this timer around every tool `execute()` call. When it
+	 * fires, the tool result becomes an error naming the tool and the elapsed
+	 * limit. The model can specify otherwise per call through a numeric
+	 * `timeout` argument in seconds on tools that accept one (for example
+	 * `bash`/`powershell`): a finite number replaces the default for that call
+	 * and `0` disables the timer.
+	 *
+	 * Set to `0` to disable the loop-level timer entirely (tools may still
+	 * enforce their own timeouts). Must be a finite number >= 0.
+	 *
+	 * Default: 180000 (3 minutes).
+	 */
+	toolTimeoutMs?: number;
+
+	/**
 	 * Called before a tool is executed, after arguments have been validated.
 	 *
 	 * Return `{ block: true }` to prevent execution. The loop emits an error tool result instead.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -7,7 +7,7 @@ import {
 	type UserMessage,
 } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agentLoop, agentLoopContinue } from "../src/agent-loop.ts";
 import { setDefaultStreamFn } from "../src/index.ts";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
@@ -1482,6 +1482,163 @@ describe("agentLoop with AgentMessage", () => {
 		}
 
 		expect(llmCalls).toBe(1);
+	});
+
+	it("should time out a tool call after the default 3 minute limit", async () => {
+		vi.useFakeTimers();
+		try {
+			const toolSchema = Type.Object({ value: Type.String() });
+			const tool: AgentTool<typeof toolSchema, { value: string }> = {
+				name: "echo",
+				label: "Echo",
+				description: "Echo tool",
+				parameters: toolSchema,
+				async execute(_toolCallId, params) {
+					await new Promise((resolve) => setTimeout(resolve, 60_000));
+					return {
+						content: [{ type: "text", text: `echoed: ${params.value}` }],
+						details: { value: params.value },
+					};
+				},
+			};
+
+			const context: AgentContext = {
+				systemPrompt: "",
+				messages: [],
+				tools: [tool],
+			};
+
+			const config: AgentLoopConfig = {
+				model: createModel(),
+				convertToLlm: identityConverter,
+				toolTimeoutMs: 1_000,
+			};
+
+			let callIndex = 0;
+			const streamFn = () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (callIndex === 0) {
+						const message = createAssistantMessage(
+							[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } }],
+							"toolUse",
+						);
+						stream.push({ type: "done", reason: "toolUse", message });
+					} else {
+						const message = createAssistantMessage([{ type: "text", text: "done" }]);
+						stream.push({ type: "done", reason: "stop", message });
+					}
+					callIndex++;
+				});
+				return stream;
+			};
+
+			const events: AgentEvent[] = [];
+			const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, streamFn);
+			const consumer = (async () => {
+				for await (const event of stream) {
+					events.push(event);
+				}
+			})();
+			await vi.advanceTimersByTimeAsync(2_000);
+			await consumer;
+
+			const toolEnd = events.find((e) => e.type === "tool_execution_end");
+			expect(toolEnd).toBeDefined();
+			if (toolEnd?.type === "tool_execution_end") {
+				expect(toolEnd.isError).toBe(true);
+				const text = toolEnd.result.content.find((c: { type: string }) => c.type === "text");
+				expect(text && "text" in text ? text.text : "").toContain('Tool "echo" timed out');
+			}
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("should honor a per-call timeout override and timeout 0 to disable the timer", async () => {
+		vi.useFakeTimers();
+		try {
+			const toolSchema = Type.Object({
+				value: Type.String(),
+				timeout: Type.Optional(Type.Number()),
+			});
+			const finished: string[] = [];
+			const tool: AgentTool<typeof toolSchema, { value: string }> = {
+				name: "echo",
+				label: "Echo",
+				description: "Echo tool",
+				parameters: toolSchema,
+				async execute(_toolCallId, params) {
+					await new Promise((resolve) => setTimeout(resolve, 500));
+					finished.push(params.value);
+					return {
+						content: [{ type: "text", text: `echoed: ${params.value}` }],
+						details: { value: params.value },
+					};
+				},
+			};
+
+			const runOnce = async (args: Record<string, unknown>, toolTimeoutMs?: number) => {
+				const context: AgentContext = {
+					systemPrompt: "",
+					messages: [],
+					tools: [tool],
+				};
+				const config: AgentLoopConfig = {
+					model: createModel(),
+					convertToLlm: identityConverter,
+					toolTimeoutMs,
+				};
+				let callIndex = 0;
+				const streamFn = () => {
+					const stream = new MockAssistantStream();
+					queueMicrotask(() => {
+						if (callIndex === 0) {
+							const message = createAssistantMessage(
+								[{ type: "toolCall", id: "tool-1", name: "echo", arguments: args }],
+								"toolUse",
+							);
+							stream.push({ type: "done", reason: "toolUse", message });
+						} else {
+							const message = createAssistantMessage([{ type: "text", text: "done" }]);
+							stream.push({ type: "done", reason: "stop", message });
+						}
+						callIndex++;
+					});
+					return stream;
+				};
+				const events: AgentEvent[] = [];
+				const stream = agentLoop([createUserMessage("run")], context, config, undefined, streamFn);
+				const consumer = (async () => {
+					for await (const event of stream) {
+						events.push(event);
+					}
+				})();
+				await vi.advanceTimersByTimeAsync(2_000);
+				await consumer;
+				return events.find((e) => e.type === "tool_execution_end");
+			};
+
+			// A longer per-call override (2s) survives the 100ms default.
+			finished.length = 0;
+			const overridden = await runOnce({ value: "long", timeout: 2 }, 100);
+			expect(overridden?.type === "tool_execution_end" ? overridden.isError : undefined).toBe(false);
+			expect(finished).toEqual(["long"]);
+
+			// timeout 0 disables the timer entirely.
+			finished.length = 0;
+			const disabled = await runOnce({ value: "unlimited", timeout: 0 }, 100);
+			expect(disabled?.type === "tool_execution_end" ? disabled.isError : undefined).toBe(false);
+			expect(finished).toEqual(["unlimited"]);
+
+			// No override keeps the 100ms default and times out the 500ms tool.
+			finished.length = 0;
+			const timedOut = await runOnce({ value: "slow" }, 100);
+			expect(timedOut?.type === "tool_execution_end" ? timedOut.isError : undefined).toBe(true);
+			expect(finished).toEqual([]);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -211,6 +211,7 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
 | `transport` | string | `"auto"` | Preferred transport for providers that support multiple transports: `"sse"`, `"websocket"`, `"websocket-cached"`, or `"auto"` |
 | `httpIdleTimeoutMs` | number | `300000` | HTTP header/body idle timeout in milliseconds, also used by providers with explicit stream idle timeouts. Set to `0` to disable. |
 | `websocketConnectTimeoutMs` | number | `15000` | WebSocket connect/open handshake timeout in milliseconds for providers that support WebSocket transports. Set to `0` to disable. |
+| `toolTimeoutMs` | number | `180000` | Default per-tool-call timeout in milliseconds (3 minutes). Every tool call gets this timer unless the model specifies otherwise for that call through a numeric `timeout` argument in seconds (for example `bash`/`powershell`): a finite number replaces the default for that call, `0` disables the timer. Set to `0` to disable the loop-level timer entirely. |
 
 ### Terminal & Images
 

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -368,6 +368,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		followUpMode: settingsManager.getFollowUpMode(),
 		transport: settingsManager.getTransport(),
 		thinkingBudgets: settingsManager.getThinkingBudgets(),
+		toolTimeoutMs: settingsManager.getToolTimeoutMs(),
 		maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
 	});
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -151,6 +151,7 @@ export interface Settings {
 	httpProxy?: string; // Proxy URL applied as HTTP_PROXY and HTTPS_PROXY for Pi-managed HTTP clients
 	httpIdleTimeoutMs?: number; // HTTP header/body idle timeout in milliseconds; 0 disables it
 	websocketConnectTimeoutMs?: number; // WebSocket connect/open handshake timeout in milliseconds; 0 disables it
+	toolTimeoutMs?: number; // Default per-tool-call timeout in milliseconds; 0 disables the loop-level timer; default: 180000
 	tuiMode?: TuiMode; // default: "regular"
 	fullscreenExitOutput?: FullscreenExitOutput; // default: "transcript"; no effect in regular TUI mode
 	fullscreenScrollbar?: ScrollViewScrollbar; // default: "auto"; no effect in regular TUI mode
@@ -956,6 +957,24 @@ export class SettingsManager {
 
 	getWebSocketConnectTimeoutMs(): number | undefined {
 		return parseTimeoutSetting(this.settings.websocketConnectTimeoutMs, "websocketConnectTimeoutMs");
+	}
+
+	getToolTimeoutMs(): number {
+		const value = this.settings.toolTimeoutMs;
+		if (value === undefined) return 180_000;
+		if (!Number.isFinite(value) || value < 0) {
+			throw new Error(`Invalid toolTimeoutMs setting: ${String(value)}`);
+		}
+		return Math.floor(value);
+	}
+
+	setToolTimeoutMs(timeoutMs: number): void {
+		if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+			throw new Error(`Invalid toolTimeoutMs setting: ${String(timeoutMs)}`);
+		}
+		this.globalSettings.toolTimeoutMs = Math.floor(timeoutMs);
+		this.markModified("toolTimeoutMs");
+		this.save();
 	}
 
 	getHideThinkingBlock(): boolean {

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -20,11 +20,14 @@ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult
 
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const MAX_TIMEOUT_SECONDS = MAX_TIMEOUT_MS / 1000;
+/** Default shell timeout in seconds, matching the agent loop default of 3 minutes. */
+const DEFAULT_SHELL_TIMEOUT_S = 180;
 
 function resolveTimeoutMs(timeout: number | undefined): number | undefined {
-	if (timeout === undefined) return undefined;
-	if (!Number.isFinite(timeout) || timeout <= 0) {
-		throw new Error("Invalid timeout: must be a finite number of seconds");
+	if (timeout === undefined) return DEFAULT_SHELL_TIMEOUT_S * 1000;
+	if (timeout === 0) return undefined;
+	if (!Number.isFinite(timeout) || timeout < 0) {
+		throw new Error("Invalid timeout: must be a finite number of seconds, or 0 to disable the timer");
 	}
 
 	const timeoutMs = timeout * 1000;
@@ -36,7 +39,12 @@ function resolveTimeoutMs(timeout: number | undefined): number | undefined {
 
 const bashSchema = Type.Object({
 	command: Type.String({ description: "Shell command to execute" }),
-	timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (optional, no default timeout)" })),
+	timeout: Type.Optional(
+		Type.Number({
+			description:
+				"Timeout in seconds. Defaults to 180 (3 minutes) when omitted; pass 0 to disable the timer, or a finite number of seconds for a longer limit.",
+		}),
+	),
 });
 
 export const bashToolSystemPromptContribution = {
@@ -231,7 +239,7 @@ export function createShellToolDefinition(
 	return {
 		name: config.name,
 		label: config.label,
-		description: `Execute a ${config.shellName} command in the current working directory. Returns stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.`,
+		description: `Execute a ${config.shellName} command in the current working directory. Returns stdout and stderr. Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file. Timeout defaults to 180 seconds; pass a timeout in seconds for a longer limit, or 0 to disable the timer.`,
 		promptSnippet: config.promptSnippet,
 		promptGuidelines: exposeSessionEnvironment && config.promptGuidelines ? [...config.promptGuidelines] : undefined,
 		parameters: bashSchema,


### PR DESCRIPTION
## Problem

Tool calls have no default time bound: only `bash`/`powershell` accept an opt-in `timeout`, and every other tool (plus `bash` without the argument) can run forever, hanging the agent on a stuck call.

Concrete trace: model issues a `bash` call without `timeout` that blocks (e.g. waiting on a pipe) — the loop awaits `tool.execute()` with no timer, no error result is ever produced, and the turn never completes.

## Solution

Enforce a default 180s timer around every tool `execute()` in `agent-loop.ts` (`DEFAULT_TOOL_TIMEOUT_MS`, `AgentLoopConfig.toolTimeoutMs` / `Agent.toolTimeoutMs`). When it fires, the tool result becomes an error naming the tool and the elapsed limit, so the model can retry with a longer limit or split the work. This is the loop-level default; the alternative of adding per-tool timers piecemeal leaves every current and future tool unbounded.

- The model specifies otherwise per call through a numeric `timeout` argument in seconds on tools that accept one: a finite number replaces the default for that call, `0` disables the timer. Malformed values keep the default so a bad override cannot silently disable the timer.
- `toolTimeoutMs: 0` disables the loop timer entirely (tools may still enforce their own).
- Global `toolTimeoutMs` setting in coding-agent, wired through `createAgentSession`.
- `bash`/`powershell` (classic + harness) now default their own process kill to 180s and treat `0` as disable, so shell children are actually terminated and the tool descriptions tell the model the default and override.

## Verification

- New regression tests in `packages/agent/test/agent-loop.test.ts`: default timeout fires, per-call override wins, `timeout: 0` disables.
- `biome check` clean on all touched files.
- Timer semantics verified standalone against the patched source (10/10: default, override, disable, malformed-override, slow/fast/overridden/disabled execution).
- `npm run check` was not green in this checkout: the pristine tree already fails on model-catalog type drift (`packages/ai` / `packages/coding-agent` tests), unrelated to this change; no errors reference the touched files.

No `CHANGELOG.md` edits per CONTRIBUTING.md.
