### PR TITLE
fix(tui): let overlays cover terminal images

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -383,9 +383,12 @@ export class Container implements Component {
  */
 const SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";
 
-/** Remove Kitty graphics payloads while preserving surrounding text and styles. */
-function stripKittyImageSequences(line: string): string {
-	return line.replace(/\x1b_G[\s\S]*?\x1b\\/g, "");
+/** Remove terminal image payloads while preserving surrounding text and styles. */
+function stripImageSequences(line: string): string {
+	return line
+		.replace(/\x1b\[\d+A(?=\x1b_G|\x1b\]1337;File=)/g, "")
+		.replace(/\x1b_G[\s\S]*?(?:\x1b\\|\x07)/g, "")
+		.replace(/\x1b\]1337;File=[\s\S]*?(?:\x07|\x1b\\)/g, "");
 }
 
 /** Composite overlay content into a terminal line at a fixed column. */
@@ -1373,7 +1376,7 @@ export abstract class TuiBase extends Container implements TUI {
 		overlayWidth: number,
 		totalWidth: number,
 	): string {
-		return compositeTuiLine(stripKittyImageSequences(baseLine), overlayLine, startCol, overlayWidth, totalWidth);
+		return compositeTuiLine(stripImageSequences(baseLine), overlayLine, startCol, overlayWidth, totalWidth);
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -383,6 +383,11 @@ export class Container implements Component {
  */
 const SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07";
 
+/** Remove Kitty graphics payloads while preserving surrounding text and styles. */
+function stripKittyImageSequences(line: string): string {
+	return line.replace(/\x1b_G[\s\S]*?\x1b\\/g, "");
+}
+
 /** Composite overlay content into a terminal line at a fixed column. */
 export function compositeTuiLine(
 	baseLine: string,
@@ -1368,7 +1373,7 @@ export abstract class TuiBase extends Container implements TUI {
 		overlayWidth: number,
 		totalWidth: number,
 	): string {
-		return compositeTuiLine(baseLine, overlayLine, startCol, overlayWidth, totalWidth);
+		return compositeTuiLine(stripKittyImageSequences(baseLine), overlayLine, startCol, overlayWidth, totalWidth);
 	}
 
 	/**

--- a/packages/tui/test/regression-overlay-cjk-boundary.test.ts
+++ b/packages/tui/test/regression-overlay-cjk-boundary.test.ts
@@ -45,7 +45,9 @@ describe("overlay CJK boundary regression", () => {
 	});
 
 	it("keeps image lines intact for regular layout composition", () => {
-		const imageLine = "\x1b_Ga=T,c=2,r=1;AAAA\x1b\\";
-		assert.strictEqual(compositeTuiLine(imageLine, "sibling", 0, 7, 20), imageLine);
+		const imageLines = ["\x1b_Ga=T,c=2,r=1;AAAA\x1b\\", "\x1b]1337;File=inline=1;width=2;height=auto:AAAA\x07"];
+		for (const imageLine of imageLines) {
+			assert.strictEqual(compositeTuiLine(imageLine, "sibling", 0, 7, 20), imageLine);
+		}
 	});
 });

--- a/packages/tui/test/regression-overlay-cjk-boundary.test.ts
+++ b/packages/tui/test/regression-overlay-cjk-boundary.test.ts
@@ -43,4 +43,9 @@ describe("overlay CJK boundary regression", () => {
 		assert.strictEqual(visibleWidth(overlay), 4);
 		assert.strictEqual(overlay.includes("│XX│"), true);
 	});
+
+	it("keeps image lines intact for regular layout composition", () => {
+		const imageLine = "\x1b_Ga=T,c=2,r=1;AAAA\x1b\\";
+		assert.strictEqual(compositeTuiLine(imageLine, "sibling", 0, 7, 20), imageLine);
+	});
 });

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -245,6 +245,57 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 	});
 
+	it("composites an overlay over a Kitty image and clears its placement", async () => {
+		setCapabilities({ images: "kitty", trueColor: true, hyperlinks: true });
+		try {
+			const terminal = new RecordingTerminal(20, 3);
+			const tui = new TuiAltScreen(terminal);
+			const imageId = 700;
+			const imageLine = encodeKitty("AAAA", { columns: 2, rows: 1, imageId, moveCursor: false });
+			registerKittyImageMetadata({ imageId, columns: 2, rows: 1, widthPx: 100, heightPx: 50 });
+			tui.addChild({ render: () => [imageLine], invalidate: () => {} });
+			tui.start();
+			await terminal.waitForRender();
+
+			const eventCount = terminal.events.length;
+			const overlayHandle = tui.showOverlay(new InputOverlay(), { anchor: "top-left", width: 20 });
+			await terminal.waitForRender();
+			const overlayWrites = terminal.events
+				.slice(eventCount)
+				.filter((event): event is { type: "write"; data: string } => event.type === "write")
+				.map((event) => event.data)
+				.join("");
+
+			assert.ok(overlayWrites.includes("overlay"));
+			assert.ok(overlayWrites.includes("\x1b_Ga=d,d=a,q=2\x1b\\"));
+			assert.ok(!overlayWrites.includes(imageLine));
+
+			const steadyEventCount = terminal.events.length;
+			tui.requestRender();
+			await terminal.waitForRender();
+			const steadyWrites = terminal.events
+				.slice(steadyEventCount)
+				.filter((event): event is { type: "write"; data: string } => event.type === "write")
+				.map((event) => event.data)
+				.join("");
+			assert.ok(!steadyWrites.includes("\x1b_Ga=d"));
+			assert.ok(!steadyWrites.includes("\x1b[2K"));
+
+			const restoreEventCount = terminal.events.length;
+			overlayHandle.hide();
+			await terminal.waitForRender();
+			const restoreWrites = terminal.events
+				.slice(restoreEventCount)
+				.filter((event): event is { type: "write"; data: string } => event.type === "write")
+				.map((event) => event.data)
+				.join("");
+			assert.ok(restoreWrites.includes("\x1b_Ga=p,q=2"));
+			tui.stop();
+		} finally {
+			resetCapabilitiesCache();
+		}
+	});
+
 	it("routes wheel input to the scroll view under the pointer", async () => {
 		const terminal = new VirtualTerminal(20, 4);
 		const tui = new TuiAltScreen(terminal);

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -296,6 +296,46 @@ describe("TuiAltScreen", () => {
 		}
 	});
 
+	it("composites an overlay over an iTerm2 image and restores it", async () => {
+		setCapabilities({ images: "iterm2", trueColor: true, hyperlinks: true });
+		try {
+			const terminal = new RecordingTerminal(20, 3);
+			const tui = new TuiAltScreen(terminal);
+			const imageLine = "\x1b]1337;File=inline=1;width=2;height=auto:AAAA\x07";
+			tui.addChild({ render: () => [imageLine], invalidate: () => {} });
+			tui.start();
+			await terminal.waitForRender();
+
+			const overlayEventCount = terminal.events.length;
+			const overlayHandle = tui.showOverlay(new InputOverlay(), { anchor: "top-left", width: 20 });
+			await terminal.waitForRender();
+			const overlayWrites = terminal.events
+				.slice(overlayEventCount)
+				.filter((event): event is { type: "write"; data: string } => event.type === "write")
+				.map((event) => event.data)
+				.join("");
+
+			assert.ok(overlayWrites.includes("overlay"));
+			assert.ok(overlayWrites.includes("\x1b[2J"));
+			assert.ok(!overlayWrites.includes(imageLine));
+
+			const restoreEventCount = terminal.events.length;
+			overlayHandle.hide();
+			await terminal.waitForRender();
+			const restoreWrites = terminal.events
+				.slice(restoreEventCount)
+				.filter((event): event is { type: "write"; data: string } => event.type === "write")
+				.map((event) => event.data)
+				.join("");
+
+			assert.ok(restoreWrites.includes("\x1b[2J"));
+			assert.ok(restoreWrites.includes(imageLine));
+			tui.stop();
+		} finally {
+			resetCapabilitiesCache();
+		}
+	});
+
 	it("routes wheel input to the scroll view under the pointer", async () => {
 		const terminal = new VirtualTerminal(20, 4);
 		const tui = new TuiAltScreen(terminal);


### PR DESCRIPTION
## Summary

I ran into this after sending a screenshot in Ghostty and then opening `/agents`. The screenshot stayed visible on top of the overlay, which covered the agent list and made it hard to use.

I traced it to overlay composition in the TUI. Image lines were returned unchanged, so the overlay text never replaced the Kitty or iTerm2 image payload on that row.

## What I changed

The renderer now removes the image payload before compositing an overlay over that row. This is limited to overlays. Regular layout composition still leaves image lines alone, so image rendering beside other components keeps its existing behaviour.

When the overlay opens, Kitty placements are deleted and iTerm2 images trigger a screen clear. When it closes, the image is drawn again.

## Test plan

- [x] Open an overlay over a Kitty image and check that the overlay is visible
- [x] Close the overlay and check that the Kitty image placement returns
- [x] Repeat the same clear and restore flow for iTerm2
- [x] Check that a steady overlay render does not keep deleting or repainting the image row
- [x] Check that ordinary layout composition still preserves image lines
- [x] Run the focused TUI overlay suite: 93 tests passed
- [x] Run Biome, the TUI TypeScript check, and `git diff --check`