### PR TITLE
fix(tui): prevent cursor marker leaks

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1353,13 +1353,9 @@ export abstract class TuiBase extends Container implements TUI {
 	protected applyLineResets(lines: string[]): string[] {
 		const reset = SEGMENT_RESET;
 		for (let i = 0; i < lines.length; i++) {
-			let line = lines[i];
-			// Cursor markers are internal render metadata and must never reach terminal output.
-			if (line.includes(CURSOR_MARKER)) line = line.replaceAll(CURSOR_MARKER, "");
+			const line = lines[i];
 			if (!isImageLine(line)) {
 				lines[i] = normalizeTerminalOutput(line) + reset;
-			} else {
-				lines[i] = line;
 			}
 		}
 		return lines;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1353,9 +1353,13 @@ export abstract class TuiBase extends Container implements TUI {
 	protected applyLineResets(lines: string[]): string[] {
 		const reset = SEGMENT_RESET;
 		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
+			let line = lines[i];
+			// Cursor markers are internal render metadata and must never reach terminal output.
+			if (line.includes(CURSOR_MARKER)) line = line.replaceAll(CURSOR_MARKER, "");
 			if (!isImageLine(line)) {
 				lines[i] = normalizeTerminalOutput(line) + reset;
+			} else {
+				lines[i] = line;
 			}
 		}
 		return lines;
@@ -1390,8 +1394,9 @@ export abstract class TuiBase extends Container implements TUI {
 				const beforeMarker = line.slice(0, markerIndex);
 				const col = visibleWidth(beforeMarker);
 
-				// Strip marker from the line
-				lines[row] = line.slice(0, markerIndex) + line.slice(markerIndex + CURSOR_MARKER.length);
+				// Strip all markers from the selected line. The first marker determines the
+				// hardware cursor position; any others are stale internal sentinels.
+				lines[row] = line.replaceAll(CURSOR_MARKER, "");
 
 				return { row, col };
 			}

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1226,7 +1226,7 @@ export function sliceWithWidth(
 		const ansi = extractAnsiCode(line, i);
 		if (ansi) {
 			if (currentCol >= startCol && currentCol < endCol) result += ansi.code;
-			else if (currentCol < startCol) pendingAnsi += ansi.code;
+			else if (currentCol < startCol && !ansi.code.startsWith("\x1b_")) pendingAnsi += ansi.code;
 			i += ansi.length;
 			continue;
 		}

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -1226,6 +1226,7 @@ export function sliceWithWidth(
 		const ansi = extractAnsiCode(line, i);
 		if (ansi) {
 			if (currentCol >= startCol && currentCol < endCol) result += ansi.code;
+			// APC sequences are positional one-shot commands, not persistent style state.
 			else if (currentCol < startCol && !ansi.code.startsWith("\x1b_")) pendingAnsi += ansi.code;
 			i += ansi.length;
 			continue;

--- a/packages/tui/test/tab-width.test.ts
+++ b/packages/tui/test/tab-width.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import type { Component, TUI } from "../src/tui.ts";
+import { type Component, CURSOR_MARKER, type TUI } from "../src/tui.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
 import { extractSegments, normalizeTerminalOutput, sliceWithWidth, visibleWidth } from "../src/utils.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
@@ -42,6 +42,20 @@ describe("tab width accounting", () => {
 		assert.strictEqual(slice.text, "out 192M");
 		assert.strictEqual(slice.width, 8);
 		assert.strictEqual(visibleWidth(slice.text), slice.width);
+	});
+
+	it("does not carry cursor markers into later slices", () => {
+		// Regression for #9332: APC markers are positional metadata, not persistent style.
+		const line = `ab${CURSOR_MARKER}cdefghij`;
+
+		assert.deepStrictEqual(sliceWithWidth(line, 4, 2, true), { text: "ef", width: 2 });
+		assert.deepStrictEqual(sliceWithWidth(line, 6, 4, true), { text: "ghij", width: 4 });
+	});
+
+	it("continues to carry persistent styling into later slices", () => {
+		const line = "\x1b[31mabcdefghij\x1b[0m";
+
+		assert.deepStrictEqual(sliceWithWidth(line, 4, 2, true), { text: "\x1b[31mef", width: 2 });
 	});
 
 	it("keeps overlay segment widths consistent with visible width", () => {

--- a/packages/tui/test/tab-width.test.ts
+++ b/packages/tui/test/tab-width.test.ts
@@ -53,6 +53,7 @@ describe("tab width accounting", () => {
 	});
 
 	it("continues to carry persistent styling into later slices", () => {
+		// Regression for #9332: excluding APC must not disable persistent SGR styling.
 		const line = "\x1b[31mabcdefghij\x1b[0m";
 
 		assert.deepStrictEqual(sliceWithWidth(line, 4, 2, true), { text: "\x1b[31mef", width: 2 });

--- a/packages/tui/test/tui-alt-screen.test.ts
+++ b/packages/tui/test/tui-alt-screen.test.ts
@@ -20,7 +20,7 @@ import {
 	resetCapabilitiesCache,
 	setCapabilities,
 } from "../src/terminal-image.ts";
-import type { TuiMouseEvent } from "../src/tui.ts";
+import { CURSOR_MARKER, type TuiMouseEvent } from "../src/tui.ts";
 import { TuiAltScreen } from "../src/tui-alt-screen.ts";
 import { stripTerminalSequences, visibleWidth } from "../src/utils.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
@@ -62,6 +62,34 @@ class RecordingTerminal extends VirtualTerminal {
 }
 
 describe("TuiAltScreen", () => {
+	it("does not leak cursor markers while selecting after the caret", async () => {
+		const terminal = new RecordingTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal, undefined, undefined, { copyOnSelect: false });
+		// Regression for #9257 and #9332: selection slicing must not duplicate cursor markers.
+		tui.addChild({
+			render: () => [`ab${CURSOR_MARKER}cdefghij`],
+			invalidate() {},
+		});
+
+		tui.start();
+		await terminal.waitForRender();
+		const eventCount = terminal.events.length;
+
+		terminal.sendInput("\x1b[<0;5;1M");
+		terminal.sendInput("\x1b[<32;7;1M");
+		await terminal.waitForRender();
+
+		const output = terminal.events
+			.slice(eventCount)
+			.filter((event) => event.type === "write")
+			.map((event) => event.data)
+			.join("");
+		assert.ok(output.includes("\x1b[7m"), "dragged text should be highlighted");
+		assert.ok(!output.includes(CURSOR_MARKER), "internal cursor markers must not reach the terminal");
+		terminal.sendInput("\x1b[<0;7;1m");
+		tui.stop();
+	});
+
 	it("renders a terminal-height viewport and preserves manual scroll position", async () => {
 		const terminal = new VirtualTerminal(20, 4);
 		const tui = new TuiAltScreen(terminal);

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -178,22 +178,6 @@ describe("TUI bounded render output", () => {
 		assert.ok(output.includes("\x1b[5G"), "the first marker should keep the cursor at visible column 4");
 	});
 
-	it("does not write cursor markers above the visible viewport", () => {
-		const terminal = new BoundedWriteTerminal();
-		terminal.rows = 2;
-		const tui = new TuiMainScreen(terminal);
-		const component = new TestComponent();
-		// Regression for #9257: offscreen cursor markers must not reach full terminal renders.
-		component.lines = [`history${CURSOR_MARKER}`, "visible", `prompt${CURSOR_MARKER}`];
-		tui.addChild(component);
-
-		tui.renderNow();
-
-		const output = terminal.writes.join("");
-		assert.ok(output.includes("history"), "full renders should preserve scrollback content");
-		assert.ok(!output.includes(CURSOR_MARKER), "offscreen cursor markers must not reach the terminal");
-	});
-
 	it("splits a large full render without changing its output", () => {
 		const terminal = new BoundedWriteTerminal();
 		const tui = new TuiMainScreen(terminal);

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -13,7 +13,7 @@ import {
 	setCapabilities,
 	setCellDimensions,
 } from "../src/terminal-image.ts";
-import type { Component, TUI } from "../src/tui.ts";
+import { type Component, CURSOR_MARKER, type TUI } from "../src/tui.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
@@ -162,6 +162,38 @@ describe("TUI debug logging", () => {
 });
 
 describe("TUI bounded render output", () => {
+	it("does not write duplicate cursor markers to the terminal", () => {
+		const terminal = new BoundedWriteTerminal();
+		const tui = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		// Regression for #9257: terminals may render the payload of a leaked APC marker.
+		component.lines = [`\x1b[31m界🙂\x1b[0m${CURSOR_MARKER} world${CURSOR_MARKER}`];
+		tui.addChild(component);
+
+		tui.renderNow();
+
+		const output = terminal.writes.join("");
+		assert.ok(output.includes("\x1b[31m界🙂\x1b[0m world"), "visible styled text should be preserved");
+		assert.ok(!output.includes(CURSOR_MARKER), "internal cursor markers must not reach the terminal");
+		assert.ok(output.includes("\x1b[5G"), "the first marker should keep the cursor at visible column 4");
+	});
+
+	it("does not write cursor markers above the visible viewport", () => {
+		const terminal = new BoundedWriteTerminal();
+		terminal.rows = 2;
+		const tui = new TuiMainScreen(terminal);
+		const component = new TestComponent();
+		// Regression for #9257: offscreen cursor markers must not reach full terminal renders.
+		component.lines = [`history${CURSOR_MARKER}`, "visible", `prompt${CURSOR_MARKER}`];
+		tui.addChild(component);
+
+		tui.renderNow();
+
+		const output = terminal.writes.join("");
+		assert.ok(output.includes("history"), "full renders should preserve scrollback content");
+		assert.ok(!output.includes(CURSOR_MARKER), "offscreen cursor markers must not reach the terminal");
+	});
+
 	it("splits a large full render without changing its output", () => {
 		const terminal = new BoundedWriteTerminal();
 		const tui = new TuiMainScreen(terminal);


### PR DESCRIPTION
## Summary

Fix cursor-marker leakage across the full-screen selection and terminal rendering paths.

- Treat APC cursor markers as positional metadata instead of persistent styling, so `sliceWithWidth()` does not replay them into later selection slices.
- Preserve the bottommost valid visible marker as the hardware-cursor position and remove duplicate markers from that cursor line.
- Enforce the output-boundary invariant by stripping all remaining cursor markers from every non-image rendered line, including other visible lines and scrollback lines written during a main-screen full render.

This combines the duplicate-marker cleanup reported in #9257 with the upstream selection-slicing cause identified in #9332. The `sliceWithWidth()` root cause and Ghostty behavior were identified by @Andy8647 in #9332. The duplicate-marker cleanup direction was also independently proposed by @bluefateludi in #9257.

Closes #9257
Closes #9332

## Test Plan

- Confirmed the `sliceWithWidth()` regression test fails before the fix because later slices contain `CURSOR_MARKER`.
- Confirmed APC cursor markers are not carried into later slices while persistent SGR styling still is.
- Confirmed the regular-screen duplicate-marker test preserves the first marker's cursor column and emits no marker bytes.
- Confirmed a 2-row main-screen render with markers above the viewport and on multiple visible lines preserves the content, uses the bottom visible marker for cursor positioning, and emits no marker bytes.
- Confirmed the full-screen regression starts with one caret marker, performs a real mouse drag after the caret, renders the selection highlight, and emits no marker bytes.
- `npm test --workspace @earendil-works/pi-tui`
- `tsgo -p packages/tui/tsconfig.build.json --noEmit`
- `biome check --error-on-warnings` on the five changed files

The current GitHub Actions failure occurs in the unrelated `packages/ai/src/api/google-shared.ts` build on `FinishReason.TOO_MANY_TOOL_CALLS`; current `main` fails on the same error. The `pi-tui` build, complete package test suite, type check, and changed-file formatting checks pass.

This PR was prepared with AI assistance and reviewed by me.
