### PR TITLE
fix(ai): capture and replay Gemini thoughtSignature on openai-completions tool calls

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -389,6 +389,7 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 				type?: string;
 				function?: { name?: string; arguments?: string };
 				custom?: { name?: string; input?: string };
+				thoughtSignature?: string;
 			};
 
 			let textBlock: TextContent | null = null;
@@ -637,6 +638,9 @@ export const stream: StreamFunction<"openai-completions", OpenAICompletionsOptio
 							const name = toolCall.function?.name ?? toolCall.custom?.name;
 							if (!block.name && name) {
 								block.name = name;
+							}
+							if (toolCall.thoughtSignature) {
+								block.thoughtSignature = toolCall.thoughtSignature;
 							}
 
 							let delta = "";
@@ -1328,27 +1332,30 @@ export function convertMessages(
 			}
 
 			if (toolCalls.length > 0) {
-				assistantMsg.tool_calls = toolCalls.map((tc): ChatCompletionMessageToolCall => {
-					const customInputProperty = options?.grammarToolInputProperties?.get(tc.name);
-					if (customInputProperty !== undefined) {
+				assistantMsg.tool_calls = toolCalls.map(
+					(tc): ChatCompletionMessageToolCall & { thoughtSignature?: string } => {
+						const customInputProperty = options?.grammarToolInputProperties?.get(tc.name);
+						if (customInputProperty !== undefined) {
+							return {
+								id: tc.id,
+								type: "custom",
+								custom: {
+									name: tc.name,
+									input: sanitizeSurrogates(getGrammarToolInput(tc.name, tc.arguments, customInputProperty)),
+								},
+							};
+						}
 						return {
 							id: tc.id,
-							type: "custom",
-							custom: {
+							type: "function",
+							function: {
 								name: tc.name,
-								input: sanitizeSurrogates(getGrammarToolInput(tc.name, tc.arguments, customInputProperty)),
+								arguments: JSON.stringify(tc.arguments),
 							},
+							...(tc.thoughtSignature ? { thoughtSignature: tc.thoughtSignature } : {}),
 						};
-					}
-					return {
-						id: tc.id,
-						type: "function",
-						function: {
-							name: tc.name,
-							arguments: JSON.stringify(tc.arguments),
-						},
-					};
-				});
+					},
+				);
 			}
 			if (preservedReasoningDetails) {
 				assistantMsg.reasoning_details = preservedReasoningDetails;


### PR DESCRIPTION
## What

`openai-completions.ts` never captures `thoughtSignature` from streamed `tool_calls[]` deltas, so a Gemini model served behind an OpenAI-compatible gateway loses the signature on every response. The internal `ToolCall` type already declares `thoughtSignature?: string`, and the replay path already reads it back off a tool call when building the next request (`parseLegacyEncryptedReasoningDetail`). That path expects a JSON-encoded `reasoning.encrypted` detail, not the raw opaque string some Gemini gateways send directly on each `tool_calls[]` entry, so capture silently produced nothing to replay. A multi-turn tool-using conversation against such a gateway then fails on the second request:

```
400 status code (no body)
```

(the underlying gateway error is "Function call is missing a thought_signature", which the OpenAI-compatible response surfaces with no body).

## Fix

- Add `thoughtSignature?: string` to the streaming tool-call delta type and capture it into the block, same pattern already used for `id`/`name`.
- Send it back verbatim on each replayed `tool_calls[]` entry, alongside the existing `reasoning_details` path (which stays as-is for providers that use that structured format).

## Verification

Ran a real 4-tool-call multi-turn conversation against a Gemini model on an OpenAI-compatible endpoint:

- Before: second request 400s with no body, agent run dies silently in `-p` mode.
- After: all 4 tool calls carry a captured `thoughtSignature`, all 5 assistant turns complete with `stopReason: "stop"`, task finishes correctly.

`npm run check` and `./test.sh` both pass with this change (identical to a clean checkout aside from the new code).
