### PR TITLE
feat(coding-agent): deferred extension reload (requestReload, coalesced at settle)

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -627,6 +627,15 @@ export class AgentSession {
 		try {
 			await this._extensionRunner.emit({ type: "agent_settled" });
 			this._emit({ type: "agent_settled" });
+			try {
+				await this._extensionRunner.consumePendingReload();
+			} catch (err) {
+				this._extensionRunner.emitError({
+					extensionPath: "runtime-reload",
+					event: "agent_settled",
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
 		} finally {
 			this._resolveIdleWaitIfIdle();
 		}

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -182,7 +182,7 @@ export type SwitchSessionHandler = (
 	options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 ) => Promise<{ cancelled: boolean }>;
 
-export type ReloadHandler = () => Promise<void>;
+export type ReloadHandler = (followUp?: string) => Promise<void>;
 
 export type ShutdownHandler = () => void;
 
@@ -292,6 +292,9 @@ export class ExtensionRunner {
 	private navigateTreeHandler: NavigateTreeHandler = async () => ({ cancelled: false });
 	private switchSessionHandler: SwitchSessionHandler = async () => ({ cancelled: false });
 	private reloadHandler: ReloadHandler = async () => {};
+	private reloadBound = false;
+	private reloadRequested = false;
+	private reloadFollowUp: string | undefined;
 	private shutdownHandler: ShutdownHandler = () => {};
 	private shortcutDiagnostics: ResourceDiagnostic[] = [];
 	private commandDiagnostics: ResourceDiagnostic[] = [];
@@ -422,6 +425,7 @@ export class ExtensionRunner {
 			this.navigateTreeHandler = actions.navigateTree;
 			this.switchSessionHandler = actions.switchSession;
 			this.reloadHandler = actions.reload;
+			this.reloadBound = true;
 			return;
 		}
 
@@ -431,6 +435,7 @@ export class ExtensionRunner {
 		this.navigateTreeHandler = async () => ({ cancelled: false });
 		this.switchSessionHandler = async () => ({ cancelled: false });
 		this.reloadHandler = async () => {};
+		this.reloadBound = false;
 	}
 
 	setUIContext(uiContext?: ExtensionUIContext, mode: ExtensionMode = "print"): void {
@@ -605,6 +610,31 @@ export class ExtensionRunner {
 		}
 	}
 
+	/**
+	 * Request a deferred extension runtime reload. Repeated requests are
+	 * coalesced; the reload runs once the current agent run has settled
+	 * (see consumePendingReload), never mid-turn.
+	 * Returns whether a real reload handler is bound; false means the request
+	 * is a no-op in this mode (default handler) and callers should say so.
+	 */
+	requestExtensionReload(followUp?: string): boolean {
+		this.reloadRequested = true;
+		if (followUp?.trim()) this.reloadFollowUp = followUp.trim();
+		return this.reloadBound;
+	}
+
+	/**
+	 * Run the bound reload handler if a reload was requested. Called by the
+	 * session once per agent settle, when the session is idle.
+	 */
+	async consumePendingReload(): Promise<void> {
+		if (!this.reloadRequested) return;
+		this.reloadRequested = false;
+		const followUp = this.reloadFollowUp;
+		this.reloadFollowUp = undefined;
+		await this.reloadHandler(followUp);
+	}
+
 	onError(listener: ExtensionErrorListener): () => void {
 		this.errorListeners.add(listener);
 		return () => this.errorListeners.delete(listener);
@@ -776,6 +806,10 @@ export class ExtensionRunner {
 			abort: () => {
 				runner.assertActive();
 				runner.abortFn();
+			},
+			requestReload: (options) => {
+				runner.assertActive();
+				return runner.requestExtensionReload(options?.followUp);
 			},
 			hasPendingMessages: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -346,6 +346,16 @@ export interface ExtensionContext {
 	compact(options?: CompactOptions): void;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/**
+	 * Request an extension runtime reload. The reload is coalesced and runs
+	 * once the current agent run has fully settled (not immediately), so it is
+	 * safe to call from tools and event handlers. The reloaded runtime is
+	 * active from the next turn. Pass options.followUp to submit a user turn
+	 * immediately after a successful reload (no delay), e.g. to continue an
+	 * unattended task on the new runtime. Returns whether a real reload
+	 * handler is bound; false means the request is a no-op in this mode.
+	 */
+	requestReload(options?: { followUp?: string }): boolean;
 }
 
 /**
@@ -1752,7 +1762,7 @@ export interface ExtensionCommandContextActions {
 		sessionPath: string,
 		options?: { withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	) => Promise<{ cancelled: boolean }>;
-	reload: () => Promise<void>;
+	reload: (followUp?: string) => Promise<void>;
 }
 
 /**

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1908,8 +1908,8 @@ export class InteractiveMode {
 				switchSession: async (sessionPath, options) => {
 					return this.handleResumeSession(sessionPath, options);
 				},
-				reload: async () => {
-					await this.handleReloadCommand();
+				reload: async (followUp) => {
+					await this.handleReloadCommand(followUp);
 				},
 			},
 			shutdownHandler: () => {
@@ -2052,6 +2052,9 @@ export class InteractiveMode {
 			hasPendingMessages: () => this.session.pendingMessageCount > 0,
 			shutdown: () => {
 				this.shutdownRequested = true;
+			},
+			requestReload: (options) => {
+				return this.session.extensionRunner.requestExtensionReload(options?.followUp);
 			},
 			getContextUsage: () => this.session.getContextUsage(),
 			compact: (options) => {
@@ -5967,7 +5970,7 @@ export class InteractiveMode {
 	// Command handlers
 	// =========================================================================
 
-	private async handleReloadCommand(): Promise<void> {
+	private async handleReloadCommand(followUp?: string): Promise<void> {
 		if (this.session.isStreaming) {
 			this.showWarning("Wait for the current response to finish before reloading.");
 			return;
@@ -6049,6 +6052,13 @@ export class InteractiveMode {
 			);
 			dismissReloadBox(this.editor as Component);
 			reloadBoxDismissed = true;
+			if (followUp) {
+				void this.session.prompt(followUp).catch((error) => {
+					this.showError(
+						`Follow-up after reload failed: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				});
+			}
 		} catch (error) {
 			if (!reloadBoxDismissed) {
 				dismissReloadBox(previousEditor as Component);

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -16,6 +16,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		isProjectTrusted: () => true,
 		signal: undefined,
 		abort: vi.fn(),
+		requestReload: vi.fn(() => false),
 		hasPendingMessages: () => false,
 		shutdown: vi.fn(),
 		getContextUsage: () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 }),


### PR DESCRIPTION
ExtensionContext.requestReload queues a reload that runs once the agent run settles (never mid-turn) and returns whether a real reload handler is bound so callers can report a no-op honestly. ReloadHandler gains an optional followUp so the TUI can submit a user turn right after a successful reload.
