### PR TITLE
fix(coding-agent): cap per-message chars in compaction token estimate

### DIFF
--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -260,8 +260,23 @@ function estimateTextAndImageContentChars(content: string | Array<{ type: string
 }
 
 /**
+ * Upper bound on chars counted per message when estimating tokens.
+ *
+ * Machine-generated payloads (multi-MB tool results, `web_fetch` dumps) would
+ * otherwise dominate the chars/4 heuristic and misfire threshold compaction
+ * right after a compaction just finished (see #9476). The estimate stays
+ * conservative below the cap; only pathological sizes are clamped.
+ */
+export const MAX_ESTIMATED_CHARS_PER_MESSAGE = 100_000;
+
+function estimatedTokensForChars(chars: number): number {
+	return Math.ceil(Math.min(chars, MAX_ESTIMATED_CHARS_PER_MESSAGE) / 4);
+}
+
+/**
  * Estimate token count for a message using chars/4 heuristic.
- * This is conservative (overestimates tokens).
+ * This is conservative (overestimates tokens) up to
+ * MAX_ESTIMATED_CHARS_PER_MESSAGE chars per message.
  */
 export function estimateTokens(message: AgentMessage): number {
 	let chars = 0;
@@ -271,7 +286,7 @@ export function estimateTokens(message: AgentMessage): number {
 			chars = estimateTextAndImageContentChars(
 				(message as { content: string | Array<{ type: string; text?: string }> }).content,
 			);
-			return Math.ceil(chars / 4);
+			return estimatedTokensForChars(chars);
 		}
 		case "assistant": {
 			const assistant = message as AssistantMessage;
@@ -284,21 +299,21 @@ export function estimateTokens(message: AgentMessage): number {
 					chars += block.name.length + JSON.stringify(block.arguments).length;
 				}
 			}
-			return Math.ceil(chars / 4);
+			return estimatedTokensForChars(chars);
 		}
 		case "custom":
 		case "toolResult": {
 			chars = estimateTextAndImageContentChars(message.content);
-			return Math.ceil(chars / 4);
+			return estimatedTokensForChars(chars);
 		}
 		case "bashExecution": {
 			chars = message.command.length + message.output.length;
-			return Math.ceil(chars / 4);
+			return estimatedTokensForChars(chars);
 		}
 		case "branchSummary":
 		case "compactionSummary": {
 			chars = message.summary.length;
-			return Math.ceil(chars / 4);
+			return estimatedTokensForChars(chars);
 		}
 	}
 

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -10,8 +10,10 @@ import {
 	compact,
 	DEFAULT_COMPACTION_SETTINGS,
 	estimateContextTokens,
+	estimateTokens,
 	findCutPoint,
 	getLastAssistantUsage,
+	MAX_ESTIMATED_CHARS_PER_MESSAGE,
 	prepareCompaction,
 	shouldCompact,
 } from "../src/core/compaction/index.ts";
@@ -268,6 +270,26 @@ describe("estimateContextTokens", () => {
 		expect(estimate.lastUsageIndex).toBe(1);
 		expect(estimate.trailingTokens).toBeGreaterThan(0);
 		expect(estimate.tokens).toBe(150 + estimate.trailingTokens);
+	});
+});
+
+describe("estimateTokens", () => {
+	it("caps huge tool results so they cannot misfire threshold compaction", () => {
+		// Regression test for #9476: a multi-MB tool result (e.g. a web_fetch
+		// API dump) must not dominate the chars/4 heuristic and trigger a
+		// second compaction minutes after one just finished.
+		const huge: AgentMessage = {
+			role: "toolResult",
+			content: [{ type: "text", text: "x".repeat(4_600_000) }],
+			timestamp: Date.now(),
+		} as AgentMessage;
+
+		expect(estimateTokens(huge)).toBe(Math.ceil(MAX_ESTIMATED_CHARS_PER_MESSAGE / 4));
+	});
+
+	it("leaves ordinary messages unclamped", () => {
+		const small = createUserMessage("Hello, world");
+		expect(estimateTokens(small)).toBe(Math.ceil("Hello, world".length / 4));
 	});
 });
 


### PR DESCRIPTION
Fixes #9476.

## Problem

Auto-compaction misfired 3 minutes after a compaction just finished, with only 16 new messages and ~17k provider-reported usage in between.

Root cause: two `web_fetch` tool results totaling ~6.6MB of JSON landed in history. `_compactBeforeNextAssistantResponse` uses `estimateContextTokens`, whose chars/4 heuristic estimated those 16 messages at ~1.7M tokens (~100x the real 17k usage), tripping `shouldCompact`.

## Fix

Clamp each message to `MAX_ESTIMATED_CHARS_PER_MESSAGE` (100k chars ~= 25k tokens) inside `estimateTokens`. The estimate stays conservative below the cap; only pathological sizes are clamped. In the reported session this takes the two offending tool results from ~1.65M estimated tokens down to 50k — well under any realistic threshold.

## Tests

- Added regression tests in `packages/coding-agent/test/compaction.test.ts` (huge tool result is capped; ordinary messages unaffected).
- `biome check` passes on both touched files.
- Note: `vitest run test/compaction.test.ts` could not run locally — the shallow checkout is missing `packages/ai/src/providers/data/*.json` (pre-existing, fails identically without this change). Relying on CI for the full suite.