### PR TITLE
fix(coding-agent): make tool cwd resolution opt-in via customCwd with ctx.cwd fallback

### DIFF
--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -220,7 +220,7 @@ export interface ShellToolConfig {
 }
 
 export function createShellToolDefinition(
-	cwd: string,
+	customCwd: string | undefined,
 	config: ShellToolConfig,
 	options?: BashToolOptions,
 ): ToolDefinition<typeof bashSchema, BashToolDetails | undefined, BashRenderState> {
@@ -246,7 +246,7 @@ export function createShellToolDefinition(
 			const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
 			const spawnContext = resolveSpawnContext(
 				resolvedCommand,
-				ctx?.cwd || cwd,
+				customCwd ?? ctx?.cwd ?? process.cwd(),
 				spawnHook,
 				exposeSessionEnvironment,
 				ctx,
@@ -383,14 +383,14 @@ const bashToolConfig: ShellToolConfig = {
 };
 
 export function createBashToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: BashToolOptions,
 ): ToolDefinition<typeof bashSchema, BashToolDetails | undefined, BashRenderState> {
-	return createShellToolDefinition(cwd, bashToolConfig, options);
+	return createShellToolDefinition(customCwd, bashToolConfig, options);
 }
 
-export function createBashTool(cwd: string, options?: BashToolOptions): AgentTool<typeof bashSchema> {
-	const definition = createBashToolDefinition(cwd, options);
+export function createBashTool(customCwd?: string, options?: BashToolOptions): AgentTool<typeof bashSchema> {
+	const definition = createBashToolDefinition(customCwd, options);
 	const tool = wrapToolDefinition(definition);
 	Object.assign(tool, {
 		promptSnippet: definition.promptSnippet,

--- a/packages/coding-agent/src/core/tools/edit.ts
+++ b/packages/coding-agent/src/core/tools/edit.ts
@@ -141,7 +141,7 @@ function validateEditInput(input: EditToolInput): { path: string; edits: Edit[] 
 }
 
 export function createEditToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: EditToolOptions,
 ): ToolDefinition<typeof editSchema, EditToolDetails | undefined, EditRenderState> {
 	const ops = options?.operations ?? defaultEditOperations;
@@ -158,7 +158,7 @@ export function createEditToolDefinition(
 		prepareArguments: prepareEditArguments,
 		async execute(_toolCallId, input: EditToolInput, signal?: AbortSignal, _onUpdate?, ctx?: ExtensionContext) {
 			const { path, edits } = validateEditInput(input);
-			const absolutePath = resolveToCwd(path, ctx?.cwd || cwd);
+			const absolutePath = resolveToCwd(path, customCwd ?? ctx?.cwd ?? process.cwd());
 
 			return withFileMutationQueue(absolutePath, async () => {
 				// Do not reject from an abort event listener here: that would release the
@@ -215,6 +215,6 @@ export function createEditToolDefinition(
 	};
 }
 
-export function createEditTool(cwd: string, options?: EditToolOptions): AgentTool<typeof editSchema> {
-	return wrapToolDefinition(createEditToolDefinition(cwd, options));
+export function createEditTool(customCwd?: string, options?: EditToolOptions): AgentTool<typeof editSchema> {
+	return wrapToolDefinition(createEditToolDefinition(customCwd, options));
 }

--- a/packages/coding-agent/src/core/tools/find.ts
+++ b/packages/coding-agent/src/core/tools/find.ts
@@ -68,7 +68,7 @@ export interface FindToolOptions {
 }
 
 export function createFindToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: FindToolOptions,
 ): ToolDefinition<typeof findSchema, FindToolDetails | undefined> {
 	const customOps = options?.operations;
@@ -108,7 +108,7 @@ export function createFindToolDefinition(
 
 				(async () => {
 					try {
-						const searchPath = resolveToCwd(searchDir || ".", ctx?.cwd || cwd);
+						const searchPath = resolveToCwd(searchDir || ".", customCwd ?? ctx?.cwd ?? process.cwd());
 						const effectiveLimit = limit ?? DEFAULT_LIMIT;
 						const ops = customOps ?? defaultFindOperations;
 
@@ -313,6 +313,6 @@ export function createFindToolDefinition(
 	};
 }
 
-export function createFindTool(cwd: string, options?: FindToolOptions): AgentTool<typeof findSchema> {
-	return wrapToolDefinition(createFindToolDefinition(cwd, options));
+export function createFindTool(customCwd?: string, options?: FindToolOptions): AgentTool<typeof findSchema> {
+	return wrapToolDefinition(createFindToolDefinition(customCwd, options));
 }

--- a/packages/coding-agent/src/core/tools/grep.ts
+++ b/packages/coding-agent/src/core/tools/grep.ts
@@ -68,7 +68,7 @@ export interface GrepToolOptions {
 }
 
 export function createGrepToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: GrepToolOptions,
 ): ToolDefinition<typeof grepSchema, GrepToolDetails | undefined> {
 	const customOps = options?.operations;
@@ -122,7 +122,7 @@ export function createGrepToolDefinition(
 							return;
 						}
 
-						const searchPath = resolveToCwd(searchDir || ".", ctx?.cwd || cwd);
+						const searchPath = resolveToCwd(searchDir || ".", customCwd ?? ctx?.cwd ?? process.cwd());
 						const ops = customOps ?? defaultGrepOperations;
 						let isDirectory: boolean;
 						try {
@@ -318,6 +318,6 @@ export function createGrepToolDefinition(
 	};
 }
 
-export function createGrepTool(cwd: string, options?: GrepToolOptions): AgentTool<typeof grepSchema> {
-	return wrapToolDefinition(createGrepToolDefinition(cwd, options));
+export function createGrepTool(customCwd?: string, options?: GrepToolOptions): AgentTool<typeof grepSchema> {
+	return wrapToolDefinition(createGrepToolDefinition(customCwd, options));
 }

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -115,110 +115,110 @@ export interface ToolsOptions {
 	ls?: LsToolOptions;
 }
 
-export function createToolDefinition(toolName: ToolName, cwd: string, options?: ToolsOptions): ToolDef {
+export function createToolDefinition(toolName: ToolName, customCwd?: string, options?: ToolsOptions): ToolDef {
 	switch (toolName) {
 		case "read":
-			return createReadToolDefinition(cwd, options?.read);
+			return createReadToolDefinition(customCwd, options?.read);
 		case "bash":
-			return createBashToolDefinition(cwd, options?.bash);
+			return createBashToolDefinition(customCwd, options?.bash);
 		case "powershell":
-			return createPowerShellToolDefinition(cwd, options?.powershell);
+			return createPowerShellToolDefinition(customCwd, options?.powershell);
 		case "edit":
-			return createEditToolDefinition(cwd, options?.edit);
+			return createEditToolDefinition(customCwd, options?.edit);
 		case "write":
-			return createWriteToolDefinition(cwd, options?.write);
+			return createWriteToolDefinition(customCwd, options?.write);
 		case "grep":
-			return createGrepToolDefinition(cwd, options?.grep);
+			return createGrepToolDefinition(customCwd, options?.grep);
 		case "find":
-			return createFindToolDefinition(cwd, options?.find);
+			return createFindToolDefinition(customCwd, options?.find);
 		case "ls":
-			return createLsToolDefinition(cwd, options?.ls);
+			return createLsToolDefinition(customCwd, options?.ls);
 		default:
 			throw new Error(`Unknown tool name: ${toolName}`);
 	}
 }
 
-export function createTool(toolName: ToolName, cwd: string, options?: ToolsOptions): Tool {
+export function createTool(toolName: ToolName, customCwd?: string, options?: ToolsOptions): Tool {
 	switch (toolName) {
 		case "read":
-			return createReadTool(cwd, options?.read);
+			return createReadTool(customCwd, options?.read);
 		case "bash":
-			return createBashTool(cwd, options?.bash);
+			return createBashTool(customCwd, options?.bash);
 		case "powershell":
-			return createPowerShellTool(cwd, options?.powershell);
+			return createPowerShellTool(customCwd, options?.powershell);
 		case "edit":
-			return createEditTool(cwd, options?.edit);
+			return createEditTool(customCwd, options?.edit);
 		case "write":
-			return createWriteTool(cwd, options?.write);
+			return createWriteTool(customCwd, options?.write);
 		case "grep":
-			return createGrepTool(cwd, options?.grep);
+			return createGrepTool(customCwd, options?.grep);
 		case "find":
-			return createFindTool(cwd, options?.find);
+			return createFindTool(customCwd, options?.find);
 		case "ls":
-			return createLsTool(cwd, options?.ls);
+			return createLsTool(customCwd, options?.ls);
 		default:
 			throw new Error(`Unknown tool name: ${toolName}`);
 	}
 }
 
-export function createCodingToolDefinitions(cwd: string, options?: ToolsOptions): ToolDef[] {
+export function createCodingToolDefinitions(customCwd?: string, options?: ToolsOptions): ToolDef[] {
 	return [
-		createReadToolDefinition(cwd, options?.read),
-		createBashToolDefinition(cwd, options?.bash),
-		createEditToolDefinition(cwd, options?.edit),
-		createWriteToolDefinition(cwd, options?.write),
+		createReadToolDefinition(customCwd, options?.read),
+		createBashToolDefinition(customCwd, options?.bash),
+		createEditToolDefinition(customCwd, options?.edit),
+		createWriteToolDefinition(customCwd, options?.write),
 	];
 }
 
-export function createReadOnlyToolDefinitions(cwd: string, options?: ToolsOptions): ToolDef[] {
+export function createReadOnlyToolDefinitions(customCwd?: string, options?: ToolsOptions): ToolDef[] {
 	return [
-		createReadToolDefinition(cwd, options?.read),
-		createGrepToolDefinition(cwd, options?.grep),
-		createFindToolDefinition(cwd, options?.find),
-		createLsToolDefinition(cwd, options?.ls),
+		createReadToolDefinition(customCwd, options?.read),
+		createGrepToolDefinition(customCwd, options?.grep),
+		createFindToolDefinition(customCwd, options?.find),
+		createLsToolDefinition(customCwd, options?.ls),
 	];
 }
 
-export function createAllToolDefinitions(cwd: string, options?: ToolsOptions): Record<ToolName, ToolDef> {
+export function createAllToolDefinitions(customCwd?: string, options?: ToolsOptions): Record<ToolName, ToolDef> {
 	return {
-		read: createReadToolDefinition(cwd, options?.read),
-		bash: createBashToolDefinition(cwd, options?.bash),
-		powershell: createPowerShellToolDefinition(cwd, options?.powershell),
-		edit: createEditToolDefinition(cwd, options?.edit),
-		write: createWriteToolDefinition(cwd, options?.write),
-		grep: createGrepToolDefinition(cwd, options?.grep),
-		find: createFindToolDefinition(cwd, options?.find),
-		ls: createLsToolDefinition(cwd, options?.ls),
+		read: createReadToolDefinition(customCwd, options?.read),
+		bash: createBashToolDefinition(customCwd, options?.bash),
+		powershell: createPowerShellToolDefinition(customCwd, options?.powershell),
+		edit: createEditToolDefinition(customCwd, options?.edit),
+		write: createWriteToolDefinition(customCwd, options?.write),
+		grep: createGrepToolDefinition(customCwd, options?.grep),
+		find: createFindToolDefinition(customCwd, options?.find),
+		ls: createLsToolDefinition(customCwd, options?.ls),
 	};
 }
 
-export function createCodingTools(cwd: string, options?: ToolsOptions): Tool[] {
+export function createCodingTools(customCwd?: string, options?: ToolsOptions): Tool[] {
 	return [
-		createReadTool(cwd, options?.read),
-		createBashTool(cwd, options?.bash),
-		createEditTool(cwd, options?.edit),
-		createWriteTool(cwd, options?.write),
+		createReadTool(customCwd, options?.read),
+		createBashTool(customCwd, options?.bash),
+		createEditTool(customCwd, options?.edit),
+		createWriteTool(customCwd, options?.write),
 	];
 }
 
-export function createReadOnlyTools(cwd: string, options?: ToolsOptions): Tool[] {
+export function createReadOnlyTools(customCwd?: string, options?: ToolsOptions): Tool[] {
 	return [
-		createReadTool(cwd, options?.read),
-		createGrepTool(cwd, options?.grep),
-		createFindTool(cwd, options?.find),
-		createLsTool(cwd, options?.ls),
+		createReadTool(customCwd, options?.read),
+		createGrepTool(customCwd, options?.grep),
+		createFindTool(customCwd, options?.find),
+		createLsTool(customCwd, options?.ls),
 	];
 }
 
-export function createAllTools(cwd: string, options?: ToolsOptions): Record<ToolName, Tool> {
+export function createAllTools(customCwd?: string, options?: ToolsOptions): Record<ToolName, Tool> {
 	return {
-		read: createReadTool(cwd, options?.read),
-		bash: createBashTool(cwd, options?.bash),
-		powershell: createPowerShellTool(cwd, options?.powershell),
-		edit: createEditTool(cwd, options?.edit),
-		write: createWriteTool(cwd, options?.write),
-		grep: createGrepTool(cwd, options?.grep),
-		find: createFindTool(cwd, options?.find),
-		ls: createLsTool(cwd, options?.ls),
+		read: createReadTool(customCwd, options?.read),
+		bash: createBashTool(customCwd, options?.bash),
+		powershell: createPowerShellTool(customCwd, options?.powershell),
+		edit: createEditTool(customCwd, options?.edit),
+		write: createWriteTool(customCwd, options?.write),
+		grep: createGrepTool(customCwd, options?.grep),
+		find: createFindTool(customCwd, options?.find),
+		ls: createLsTool(customCwd, options?.ls),
 	};
 }

--- a/packages/coding-agent/src/core/tools/ls.ts
+++ b/packages/coding-agent/src/core/tools/ls.ts
@@ -52,7 +52,7 @@ export interface LsToolOptions {
 }
 
 export function createLsToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: LsToolOptions,
 ): ToolDefinition<typeof lsSchema, LsToolDetails | undefined> {
 	const ops = options?.operations ?? defaultLsOperations;
@@ -80,7 +80,7 @@ export function createLsToolDefinition(
 
 				(async () => {
 					try {
-						const dirPath = resolveToCwd(path || ".", ctx?.cwd || cwd);
+						const dirPath = resolveToCwd(path || ".", customCwd ?? ctx?.cwd ?? process.cwd());
 						const effectiveLimit = limit ?? DEFAULT_LIMIT;
 
 						// Check if path exists.
@@ -170,6 +170,6 @@ export function createLsToolDefinition(
 	};
 }
 
-export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<typeof lsSchema> {
-	return wrapToolDefinition(createLsToolDefinition(cwd, options));
+export function createLsTool(customCwd?: string, options?: LsToolOptions): AgentTool<typeof lsSchema> {
+	return wrapToolDefinition(createLsToolDefinition(customCwd, options));
 }

--- a/packages/coding-agent/src/core/tools/powershell.ts
+++ b/packages/coding-agent/src/core/tools/powershell.ts
@@ -47,17 +47,20 @@ const powershellToolConfig: ShellToolConfig = {
 };
 
 export function createPowerShellToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: PowerShellToolOptions,
 ): ReturnType<typeof createShellToolDefinition> {
-	return createShellToolDefinition(cwd, powershellToolConfig, {
+	return createShellToolDefinition(customCwd, powershellToolConfig, {
 		...options,
 		operations: options?.operations ?? createLocalPowerShellOperations(),
 	});
 }
 
-export function createPowerShellTool(cwd: string, options?: PowerShellToolOptions): ReturnType<typeof createBashTool> {
-	const definition = createPowerShellToolDefinition(cwd, options);
+export function createPowerShellTool(
+	customCwd?: string,
+	options?: PowerShellToolOptions,
+): ReturnType<typeof createBashTool> {
+	const definition = createPowerShellToolDefinition(customCwd, options);
 	const tool = wrapToolDefinition(definition);
 	Object.assign(tool, {
 		promptSnippet: definition.promptSnippet,

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -62,7 +62,7 @@ function getNonVisionImageNote(model: Model<Api> | undefined): string | undefine
 }
 
 export function createReadToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: ReadToolOptions,
 ): ToolDefinition<typeof readSchema, ReadToolDetails | undefined> {
 	const autoResizeImages = options?.autoResizeImages ?? true;
@@ -97,7 +97,7 @@ export function createReadToolDefinition(
 
 					(async () => {
 						try {
-							const absolutePath = await resolveReadPathAsync(path, ctx?.cwd || cwd);
+							const absolutePath = await resolveReadPathAsync(path, customCwd ?? ctx?.cwd ?? process.cwd());
 							if (aborted) return;
 							// Check if file exists and is readable.
 							await ops.access(absolutePath);
@@ -192,6 +192,6 @@ export function createReadToolDefinition(
 	};
 }
 
-export function createReadTool(cwd: string, options?: ReadToolOptions): AgentTool<typeof readSchema> {
-	return wrapToolDefinition(createReadToolDefinition(cwd, options));
+export function createReadTool(customCwd?: string, options?: ReadToolOptions): AgentTool<typeof readSchema> {
+	return wrapToolDefinition(createReadToolDefinition(customCwd, options));
 }

--- a/packages/coding-agent/src/core/tools/write.ts
+++ b/packages/coding-agent/src/core/tools/write.ts
@@ -42,7 +42,7 @@ export interface WriteToolOptions {
 }
 
 export function createWriteToolDefinition(
-	cwd: string,
+	customCwd?: string,
 	options?: WriteToolOptions,
 ): ToolDefinition<typeof writeSchema, undefined> {
 	const ops = options?.operations ?? defaultWriteOperations;
@@ -62,7 +62,7 @@ export function createWriteToolDefinition(
 			_onUpdate?,
 			ctx?: ExtensionContext,
 		) {
-			const absolutePath = resolveToCwd(path, ctx?.cwd || cwd);
+			const absolutePath = resolveToCwd(path, customCwd ?? ctx?.cwd ?? process.cwd());
 			const dir = dirname(absolutePath);
 			return withFileMutationQueue(absolutePath, async () => {
 				// Do not reject from an abort event listener here: that would release the
@@ -92,6 +92,6 @@ export function createWriteToolDefinition(
 	};
 }
 
-export function createWriteTool(cwd: string, options?: WriteToolOptions): AgentTool<typeof writeSchema> {
-	return wrapToolDefinition(createWriteToolDefinition(cwd, options));
+export function createWriteTool(customCwd?: string, options?: WriteToolOptions): AgentTool<typeof writeSchema> {
+	return wrapToolDefinition(createWriteToolDefinition(customCwd, options));
 }

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -917,10 +917,10 @@ describe("tool cwd resolution", () => {
 		rmSync(testDir, { recursive: true, force: true });
 	});
 
-	it("read uses ctx.cwd when provided", async () => {
+	it("read uses ctx.cwd when no creation cwd is provided", async () => {
 		const testFile = join(testDir, "ctx-cwd-read.txt");
 		writeFileSync(testFile, "hello from ctx.cwd");
-		const tool = createReadToolDefinition("/");
+		const tool = createReadToolDefinition();
 		const result = await tool.execute(
 			"test-read-ctx-cwd",
 			{ path: "ctx-cwd-read.txt" },
@@ -932,8 +932,8 @@ describe("tool cwd resolution", () => {
 		expect(output).toContain("hello from ctx.cwd");
 	});
 
-	it("write uses ctx.cwd when provided", async () => {
-		const tool = createWriteToolDefinition("/");
+	it("write uses ctx.cwd when no creation cwd is provided", async () => {
+		const tool = createWriteToolDefinition();
 		await tool.execute(
 			"test-write-ctx-cwd",
 			{ path: "ctx-cwd-write.txt", content: "written via ctx.cwd" },
@@ -945,10 +945,10 @@ describe("tool cwd resolution", () => {
 		expect(content).toBe("written via ctx.cwd");
 	});
 
-	it("edit uses ctx.cwd when provided", async () => {
+	it("edit uses ctx.cwd when no creation cwd is provided", async () => {
 		const testFile = join(testDir, "ctx-cwd-edit.txt");
 		writeFileSync(testFile, "old text");
-		const tool = createEditToolDefinition("/");
+		const tool = createEditToolDefinition();
 		await tool.execute(
 			"test-edit-ctx-cwd",
 			{ path: "ctx-cwd-edit.txt", edits: [{ oldText: "old text", newText: "new text" }] },
@@ -960,10 +960,10 @@ describe("tool cwd resolution", () => {
 		expect(content).toBe("new text");
 	});
 
-	it("grep uses ctx.cwd when provided", async () => {
+	it("grep uses ctx.cwd when no creation cwd is provided", async () => {
 		const testFile = join(testDir, "ctx-cwd-grep.txt");
 		writeFileSync(testFile, "match in ctx.cwd");
-		const tool = createGrepToolDefinition("/");
+		const tool = createGrepToolDefinition();
 		const result = await tool.execute(
 			"test-grep-ctx-cwd",
 			{ pattern: "match" },
@@ -975,9 +975,9 @@ describe("tool cwd resolution", () => {
 		expect(output).toContain("ctx-cwd-grep.txt");
 	});
 
-	it("find uses ctx.cwd when provided", async () => {
+	it("find uses ctx.cwd when no creation cwd is provided", async () => {
 		writeFileSync(join(testDir, "ctx-cwd-find.txt"), "find me");
-		const tool = createFindToolDefinition("/");
+		const tool = createFindToolDefinition();
 		const result = await tool.execute(
 			"test-find-ctx-cwd",
 			{ pattern: "ctx-cwd-find.txt" },
@@ -989,16 +989,16 @@ describe("tool cwd resolution", () => {
 		expect(output).toContain("ctx-cwd-find.txt");
 	});
 
-	it("ls uses ctx.cwd when provided", async () => {
+	it("ls uses ctx.cwd when no creation cwd is provided", async () => {
 		writeFileSync(join(testDir, "ctx-cwd-ls.txt"), "list me");
-		const tool = createLsToolDefinition("/");
+		const tool = createLsToolDefinition();
 		const result = await tool.execute("test-ls-ctx-cwd", {}, undefined, undefined, fakeCtx(testDir));
 		const output = getTextOutput(result);
 		expect(output).toContain("ctx-cwd-ls.txt");
 	});
 
-	it("bash uses ctx.cwd when provided", async () => {
-		const tool = createBashToolDefinition("/", { exposeSessionEnvironment: false });
+	it("bash uses ctx.cwd when no creation cwd is provided", async () => {
+		const tool = createBashToolDefinition(undefined, { exposeSessionEnvironment: false });
 		const result = await tool.execute(
 			"test-bash-ctx-cwd",
 			{ command: "pwd" },


### PR DESCRIPTION
Fixes the [issue](https://github.com/earendil-works/pi/pull/8627#issuecomment-5580874018) that was raised after merging https://github.com/earendil-works/pi/pull/8627: maintains backwards-compatibility for tool creation with an explicit `cwd` (now renamed as `customCwd` to be clearer of intent). If consumers don't pass a `customCwd` (or leave it `undefined` like in the bash tool), Pi will use `ExtensionContext.cwd`.