### PR TITLE
fix(bedrock-converse): normalize gross usage.input to net per model family

### DIFF
--- a/packages/ai/src/api/bedrock-converse-stream.ts
+++ b/packages/ai/src/api/bedrock-converse-stream.ts
@@ -593,11 +593,21 @@ function handleMetadata(
 	output: AssistantMessage,
 ): void {
 	if (event.usage) {
-		output.usage.input = event.usage.inputTokens || 0;
+		const cacheRead = event.usage.cacheReadInputTokens || 0;
+		const cacheWrite = event.usage.cacheWriteInputTokens || 0;
+		const inputTokens = event.usage.inputTokens || 0;
+		// Anthropic models report inputTokens net of cache, but other Bedrock
+		// families (OpenAI-compatible, DeepSeek, Nova) report it gross: the
+		// count already includes cacheRead + cacheWrite. Copying it through
+		// makes cost and cache-miss math treat cached tokens twice. Normalize
+		// to the net convention pi expects everywhere else.
+		output.usage.input = isAnthropicClaudeModel(model)
+			? inputTokens
+			: Math.max(0, inputTokens - cacheRead - cacheWrite);
 		output.usage.output = event.usage.outputTokens || 0;
-		output.usage.cacheRead = event.usage.cacheReadInputTokens || 0;
-		output.usage.cacheWrite = event.usage.cacheWriteInputTokens || 0;
-		output.usage.totalTokens = event.usage.totalTokens || output.usage.input + output.usage.output;
+		output.usage.cacheRead = cacheRead;
+		output.usage.cacheWrite = cacheWrite;
+		output.usage.totalTokens = event.usage.totalTokens || inputTokens + output.usage.output;
 		calculateCost(model, output.usage);
 	}
 }

--- a/packages/ai/test/bedrock-usage-normalization.test.ts
+++ b/packages/ai/test/bedrock-usage-normalization.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bedrockMock = vi.hoisted(() => ({
+	send: undefined as { kind: "resolve"; response: unknown } | undefined,
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+	class BedrockRuntimeClient {
+		middlewareStack = { add: () => {} };
+
+		send(): Promise<unknown> {
+			const outcome = bedrockMock.send;
+			if (!outcome) return Promise.reject(new Error("test did not configure a send outcome"));
+			return Promise.resolve(outcome.response);
+		}
+	}
+
+	class ConverseStreamCommand {
+		readonly input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+
+	return {
+		BedrockRuntimeClient,
+		ConverseStreamCommand,
+		StopReason: {
+			END_TURN: "end_turn",
+			STOP_SEQUENCE: "stop_sequence",
+			MAX_TOKENS: "max_tokens",
+			MODEL_CONTEXT_WINDOW_EXCEEDED: "model_context_window_exceeded",
+			TOOL_USE: "tool_use",
+		},
+		CachePointType: { DEFAULT: "default" },
+		CacheTTL: { ONE_HOUR: "ONE_HOUR" },
+		ConversationRole: { ASSISTANT: "assistant", USER: "user" },
+		ImageFormat: { JPEG: "jpeg", PNG: "png", GIF: "gif", WEBP: "webp" },
+		ToolResultStatus: { ERROR: "error", SUCCESS: "success" },
+	};
+});
+
+import { stream as streamBedrock } from "../src/api/bedrock-converse-stream.ts";
+import { getModel } from "../src/compat.ts";
+import type { AssistantMessage, Context, Model } from "../src/types.ts";
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+
+function respondWithUsage(usage: Record<string, number>): void {
+	bedrockMock.send = {
+		kind: "resolve",
+		response: {
+			$metadata: { httpStatusCode: 200, requestId: "req" },
+			stream: (async function* () {
+				yield { messageStart: { role: "assistant" } };
+				yield {
+					contentBlockDelta: { contentBlockIndex: 0, delta: { text: "OK" } },
+				};
+				yield {
+					messageStop: { stopReason: "end_turn" },
+				};
+				yield { metadata: { usage } };
+			})(),
+		},
+	};
+}
+
+async function runBedrock(model: Model<"bedrock-converse-stream">): Promise<AssistantMessage> {
+	return streamBedrock(model, context, { cacheRetention: "none" }).result();
+}
+
+beforeEach(() => {
+	bedrockMock.send = undefined;
+});
+
+describe("bedrock-converse usage.input normalization", () => {
+	it("keeps Anthropic inputTokens net of cache as reported", async () => {
+		respondWithUsage({
+			inputTokens: 2,
+			outputTokens: 10,
+			cacheReadInputTokens: 13923,
+			cacheWriteInputTokens: 7262,
+		});
+
+		const message = await runBedrock(getModel("amazon-bedrock", "us.anthropic.claude-opus-4-8"));
+
+		expect(message.usage.input).toBe(2);
+		expect(message.usage.cacheRead).toBe(13923);
+		expect(message.usage.cacheWrite).toBe(7262);
+		expect(message.usage.output).toBe(10);
+	});
+
+	it("subtracts cache tokens from gross input on OpenAI-family models", async () => {
+		respondWithUsage({
+			inputTokens: 12401,
+			outputTokens: 10,
+			cacheReadInputTokens: 8367,
+			cacheWriteInputTokens: 4032,
+		});
+
+		const message = await runBedrock(getModel("amazon-bedrock", "us.deepseek.r1-v1:0"));
+
+		// Gross input 12401 includes cacheRead 8367 + cacheWrite 4032 = 12399.
+		expect(message.usage.input).toBe(2);
+		expect(message.usage.cacheRead).toBe(8367);
+		expect(message.usage.cacheWrite).toBe(4032);
+	});
+
+	it("leaves cache-less usage untouched on non-Anthropic models", async () => {
+		respondWithUsage({ inputTokens: 500, outputTokens: 10 });
+
+		const message = await runBedrock(getModel("amazon-bedrock", "us.deepseek.r1-v1:0"));
+
+		expect(message.usage.input).toBe(500);
+		expect(message.usage.cacheRead).toBe(0);
+		expect(message.usage.cacheWrite).toBe(0);
+	});
+
+	it("floors at zero when cache tokens exceed the reported input", async () => {
+		respondWithUsage({
+			inputTokens: 100,
+			outputTokens: 10,
+			cacheReadInputTokens: 90,
+			cacheWriteInputTokens: 50,
+		});
+
+		const message = await runBedrock(getModel("amazon-bedrock", "us.deepseek.r1-v1:0"));
+
+		expect(message.usage.input).toBe(0);
+	});
+});


### PR DESCRIPTION
Fixes #8752

## Problem

On Bedrock Converse, `usage.inputTokens` follows two different conventions depending on model family:

- **Anthropic Claude models** report `inputTokens` **net** of cache (cache hits land in `cacheReadInputTokens` / `cacheWriteInputTokens` instead).
- **Other families** routed through the OpenAI-compatible backend (DeepSeek, Nova, etc.) report `inputTokens` **gross** — the count already includes cached tokens.

`handleMetadata` copied the value through unchanged, so for non-Anthropic models cached tokens were counted twice: cost math roughly doubled, and the cache-miss heuristic (which compares `input` against `cacheRead + cacheWrite`) fired a spurious cache-miss notice on nearly every turn.

## Change

Normalize to the net convention pi expects everywhere else, gated on model family rather than arithmetic sniffing (as noted in the issue, arithmetic detection misfires on net-family models with fresh long prompts):

```ts
output.usage.input = isAnthropicClaudeModel(model)
    ? inputTokens
    : Math.max(0, inputTokens - cacheRead - cacheWrite);
```

- Anthropic passthrough unchanged.
- Cache-less models (`cacheRead == cacheWrite == 0`) are a no-op.
- Floored at 0 for malformed usage where cache exceeds input.

## Tests

New `packages/ai/test/bedrock-usage-normalization.test.ts` (4 cases, all passing):

1. Anthropic keeps net `input` as reported
2. OpenAI-family gross → net (12401 − 8367 − 4032 = 2)
3. Cache-less usage untouched on non-Anthropic models
4. Floors at 0 when cache tokens exceed reported input

```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

Note: the monorepo-wide `tsgo --noEmit` pre-commit hook also flags several **pre-existing** errors in unrelated test files (`empty.test.ts`, `stream.test.ts`, `tokens.test.ts`, …) caused by locally generated model data missing newer models; none reference files touched here. Biome lint/format pass clean.