### PR TITLE
fix(approve-contributor): stop inserting blank lines before new entries

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -147,247 +147,125 @@ wirjo pr
 jay-aye-see-kay pr
 lucasmeijer pr
 Evizero pr
-
 ofa1 pr
-
 crisog issue
-
 mpazik pr
-
 vekexasia pr
-
 Michaelliv pr
-
 cmraible pr
-
 dljsjr pr
-
 drio pr
-
 jlaneve pr
-
 tantara pr
-
 Nutlope pr
-
 xl0 pr
-
 mdsjip pr
-
 Exrun94 pr
-
 marcbloech pr
-
 pidalf pr
-
 injaneity pr
-
 thirtythreeforty pr
-
 justinpbarnett pr
-
 cristinaponcela pr
-
 LooSik pr
-
 mchenco pr
-
 Phoen1xCode pr
-
 louis030195 pr
-
 technocidal pr
-
 pandada8 pr
-
 npupko issue
-
 chrisvariety pr
-
 maximilianzuern pr
-
 brianmichel pr
-
 abhinavmathur-atlan pr
-
 mattiacerutti pr
-
 josephyoung pr
-
 mbazso pr
-
 AJM10565 pr
-
 DanielThomas pr
-
 MichaelYochpaz pr
-
 stephanmck pr
-
 rolfvreijdenberger pr
-
 psoukie pr
-
 vastxie pr
-
 ItsumoSeito pr
-
 davidlifschitz pr
-
 vdxz pr
-
 dangooddd pr
-
 Mearman pr
-
 dodiego pr
-
 any-victor pr
-
 geraschenko pr
-
 skhoroshavin pr
-
 cyzlmh pr
-
 xz-dev pr
-
 rajp152k pr
-
 affanali2k3 pr
-
 ArcadiaLin pr
-
 anilgulecha pr
-
 DeviosLang pr
-
 HarrodRen pr
-
 aaronkyriesenbach pr
-
 farid-fari pr
-
 petrroll pr
-
 vibeinging pr
-
 DivineDominion pr
-
 ananthakumaran pr
-
 andrebreijao pr
-
 anh-chu pr
-
 rsaryev pr
-
 QuintinShaw pr
-
 R-Taneja pr
-
 zaycruz pr
-
 mteam88 pr
-
 christianbasch pr
-
 cpacker pr
-
 rgarcia pr
-
 renaudhartert-db pr
-
 HyeokjaeLee pr
-
 arajkumar pr
-
 brianstanley pr
-
 scruffymongrel pr
-
 SI-RUI-ZHANG pr
-
 sunnyyoung pr
-
 muyiyr pr
-
 hi-neason pr
-
 acmerfight pr
-
 tizmagik pr
-
 jingtao-wisdomgraph pr
-
 XRX193 pr
-
 autopeasant pr
-
 Snail-Turbo pr
-
 futile pr
-
 arasovic pr
-
 xXJSONDeruloXx pr
-
 Marvae pr
-
 skkdevcraft pr
-
 PierrunoYT pr
-
 zhichli pr
-
 wesleyzhangwq pr
-
 dgokeeffe pr
-
 vipentti pr
-
 midastruth pr
-
 Maximo-Guk pr
-
 bigoldcat123 pr
-
 johnatbasicas pr
-
 powerfooI pr
-
 yearth pr
-
 pablasso pr
-
 bilby91 pr
-
 giannisCKS pr
-
 Panoplos pr
-
 haoyongchun1125-maker pr
-
 gwokhou pr
-
 gaoyk19 pr
-
 cad0p pr
-
 Jaaneek pr
-
 CaiJichang212 pr
-
 Mallikarjun-0 pr
-
 wutongyuonce pr
-
 Terminator666666 pr
-
 y-nk pr
-
 edverma pr
-
 Charlie0113-T pr
-
 RedBeard0531 pr

--- a/.github/workflows/approve-contributor.yml
+++ b/.github/workflows/approve-contributor.yml
@@ -114,16 +114,22 @@ jobs:
               return { entries, users };
             }
 
-            function stringifyApprovedUsers(entries) {
-              const normalizedEntries = [...entries];
+            function trimTrailingBlankEntries(entries) {
+              const trimmed = [...entries];
 
-              while (normalizedEntries.length > 0) {
-                const lastEntry = normalizedEntries[normalizedEntries.length - 1];
+              while (trimmed.length > 0) {
+                const lastEntry = trimmed[trimmed.length - 1];
                 if (lastEntry.type !== 'other' || lastEntry.line.trim() !== '') {
                   break;
                 }
-                normalizedEntries.pop();
+                trimmed.pop();
               }
+
+              return trimmed;
+            }
+
+            function stringifyApprovedUsers(entries) {
+              const normalizedEntries = trimTrailingBlankEntries(entries);
 
               return `${normalizedEntries
                 .map((entry) => (entry.type === 'user' ? `${entry.username} ${entry.capability}` : entry.line))
@@ -131,7 +137,8 @@ jobs:
             }
 
             const content = fs.readFileSync(APPROVED_FILE, 'utf8');
-            const { entries, users } = parseApprovedUsers(content);
+            const { entries: parsedEntries, users } = parseApprovedUsers(content);
+            const entries = trimTrailingBlankEntries(parsedEntries);
             const mentionedUsers = parseMentionedUsers(commentBody);
             const approvalTargets = mentionedUsers.length > 0 ? mentionedUsers : [issueAuthor];
             const changedTargets = [];


### PR DESCRIPTION
parseApprovedUsers turned the file's trailing newline into a phantom blank "other" entry. Newly approved contributors were appended after that entry instead of replacing it, so stringifyApprovedUsers (which only strips trailing blanks) never removed it — permanently baking a blank line in before every single-user approval since ofa1.

Trim trailing blank entries right after parsing, before any new entries are appended, and clean up the ~120 stray blank lines that had already accumulated in APPROVED_CONTRIBUTORS.