### PR TITLE
fix(coding-agent): resolve Windows shells from installation directories

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -16,7 +16,7 @@ import {
 	writeFile,
 } from "node:fs/promises";
 import { homedir, constants as osConstants, tmpdir } from "node:os";
-import { basename, isAbsolute, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Context } from "../context.ts";
 import {
@@ -192,8 +192,17 @@ interface ShellConfig {
 	commandTransport?: "argv" | "stdin";
 }
 
+// Keep in sync with packages/coding-agent/src/utils/shell.ts.
 function isLegacyWslBashPath(path: string): boolean {
-	const normalized = path.replace(/\//g, "\\").toLowerCase();
+	const normalized = win32.normalize(path).toLowerCase();
+	const systemRoot = process.env.SystemRoot;
+	if (systemRoot) {
+		if (!/^[a-z]:[\\/]/i.test(systemRoot)) return false;
+		return ["System32", "Sysnative"].some(
+			(directory) => normalized === win32.join(systemRoot, directory, "bash.exe").toLowerCase(),
+		);
+	}
+	// Fall back to conventional launcher paths only when the Windows directory is unknown.
 	return /^[a-z]:\\windows\\(?:system32|sysnative)\\bash\.exe$/.test(normalized);
 }
 
@@ -262,7 +271,7 @@ function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
 		try {
 			const child = spawn(
-				join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe"),
+				join(process.env.SystemRoot || "C:\\Windows", "System32", "taskkill.exe"),
 				["/F", "/T", "/PID", String(pid)],
 				{
 					stdio: "ignore",

--- a/packages/agent/test/harness/nodejs-env.test.ts
+++ b/packages/agent/test/harness/nodejs-env.test.ts
@@ -4,7 +4,7 @@ import { access, chmod, realpath, symlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { BACKGROUND_CONTEXT, withAbortSignal } from "../../src/harness/context.ts";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
 import { FileError, getOrThrow, type ShellExecOptions, type ShellOutputView } from "../../src/harness/types.ts";
@@ -392,10 +392,16 @@ describe("NodeExecutionEnv", () => {
 		}
 	});
 
-	it("uses stdin command transport for legacy WSL bash paths", async () => {
+	// #9490: legacy WSL detection must also handle a custom Windows directory.
+	it.each([
+		["C:\\Windows\\System32\\bash.exe", undefined, "-s"],
+		["D:\\WinNT\\System32\\bash.exe", "D:\\WinNT", "-s"],
+		["D:\\WinNT\\Sysnative\\bash.exe", "D:\\WinNT", "-s"],
+		["D:\\WinNT\\System32\\bash.exe", "", "-c"],
+		["E:\\Windows\\System32\\bash.exe", "D:\\WinNT", "-c"],
+	] as const)("selects command transport for %s (SystemRoot=%j)", async (shellPath, systemRoot, expectedArg) => {
 		if (process.platform === "win32") return;
 		const root = createTempDir();
-		const shellPath = "C:\\Windows\\System32\\bash.exe";
 		const env = new NodeExecutionEnv({ cwd: root });
 		getOrThrow(
 			await env.writeFile(
@@ -412,6 +418,7 @@ describe("NodeExecutionEnv", () => {
 		try {
 			process.chdir(root);
 			process.env.PATH = `${root}${delimiter}${originalPath ?? ""}`;
+			vi.stubEnv("SystemRoot", systemRoot);
 			Object.defineProperty(process, "platform", {
 				configurable: true,
 				value: "win32",
@@ -427,11 +434,12 @@ describe("NodeExecutionEnv", () => {
 			);
 			const result = getOrThrow(collected.result);
 			expect(collected.output?.text).toContain("Hello, World!");
-			expect(collected.output?.text).toContain("args:-s");
+			expect(collected.output?.text).toContain(`args:${expectedArg}`);
 			expect(result.exitCode).toBe(0);
 		} finally {
 			process.chdir(originalCwd);
 			process.env.PATH = originalPath;
+			vi.unstubAllEnvs();
 			if (platformDescriptor) {
 				Object.defineProperty(process, "platform", platformDescriptor);
 			}

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -3,14 +3,22 @@
 Pi uses Git Bash by default on Windows. Checked locations (in order):
 
 1. Custom path from `~/.pi/agent/settings.json`
-2. Git Bash (`C:\Program Files\Git\bin\bash.exe`)
-3. `bash.exe` on PATH (Cygwin, MSYS2, WSL)
+2. Git Bash at `%ProgramFiles%\Git\bin\bash.exe`
+3. Git Bash at `%ProgramFiles(x86)%\Git\bin\bash.exe`
+4. `bash.exe` on PATH (Cygwin, MSYS2, WSL)
 
 For most users, [Git for Windows](https://git-scm.com/download/win) is sufficient.
 
 ## PowerShell Tool
 
 The optional `powershell` tool runs commands through `pwsh.exe` when available, otherwise Windows PowerShell. It starts PowerShell with `-NoProfile -NonInteractive -ExecutionPolicy Bypass`. Administrator-enforced execution policies can still take precedence.
+
+PowerShell discovery checks these locations in order:
+
+1. `pwsh.exe` on PATH
+2. `%ProgramFiles%\PowerShell\7\pwsh.exe`
+3. `powershell.exe` on PATH
+4. `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`
 
 Use `defaultTools` to replace the model-facing `bash` tool:
 
@@ -29,6 +37,12 @@ Or enable both while comparing behavior:
 ```
 
 The `!` and `!!` editor commands still use Bash.
+
+## WSL
+
+WSL path conversion on Windows and extra Git branch polling in WSL recognize `/mnt/<drive>`, not custom mount roots.
+
+When using the legacy WSL `bash.exe` launcher from Windows, Pi sends commands over stdin to avoid command-line quoting problems.
 
 ## Custom Bash Path
 

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import { delimiter, join, win32 } from "node:path";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
 
@@ -9,11 +9,17 @@ export interface ShellConfig {
 	commandTransport?: "argv" | "stdin";
 }
 
-/**
- * Find bash executable on PATH (cross-platform)
- */
+// Keep in sync with packages/agent/src/harness/env/nodejs.ts.
 function isLegacyWslBashPath(path: string): boolean {
-	const normalized = path.replace(/\//g, "\\").toLowerCase();
+	const normalized = win32.normalize(path).toLowerCase();
+	const systemRoot = process.env.SystemRoot;
+	if (systemRoot) {
+		if (!/^[a-z]:[\\/]/i.test(systemRoot)) return false;
+		return ["System32", "Sysnative"].some(
+			(directory) => normalized === win32.join(systemRoot, directory, "bash.exe").toLowerCase(),
+		);
+	}
+	// Fall back to conventional launcher paths only when the Windows directory is unknown.
 	return /^[a-z]:\\windows\\(?:system32|sysnative)\\bash\.exe$/.test(normalized);
 }
 
@@ -127,7 +133,21 @@ export function getPowerShellConfig(): ShellConfig {
 		throw new Error("The powershell tool is only available on Windows.");
 	}
 
-	const shell = findExecutableOnPath("pwsh.exe") ?? findExecutableOnPath("powershell.exe");
+	let shell = findExecutableOnPath("pwsh.exe");
+	// Installation directories may be on any drive and need not be on PATH.
+	const programFiles = process.env.ProgramFiles;
+	if (!shell && programFiles) {
+		const pwsh7 = win32.join(programFiles, "PowerShell", "7", "pwsh.exe");
+		if (existsSync(pwsh7)) shell = pwsh7;
+	}
+
+	shell ??= findExecutableOnPath("powershell.exe");
+	const systemRoot = process.env.SystemRoot;
+	if (!shell && systemRoot) {
+		const windowsPowerShell = win32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+		if (existsSync(windowsPowerShell)) shell = windowsPowerShell;
+	}
+
 	if (!shell) {
 		throw new Error("No PowerShell executable found. Install PowerShell or add powershell.exe/pwsh.exe to PATH.");
 	}
@@ -218,7 +238,7 @@ export function killProcessTree(pid: number): void {
 		// Use the trusted System32 executable so cleanup does not depend on PATH.
 		try {
 			const child = spawn(
-				join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe"),
+				join(process.env.SystemRoot || "C:\\Windows", "System32", "taskkill.exe"),
 				["/F", "/T", "/PID", String(pid)],
 				{
 					stdio: "ignore",

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -206,7 +206,7 @@ function extractTarGzArchive(archivePath: string, extractDir: string, assetName:
 }
 
 function getWindowsTarCommand(): string {
-	const systemRoot = process.env.SystemRoot ?? process.env.WINDIR;
+	const systemRoot = process.env.SystemRoot;
 	if (systemRoot) {
 		const systemTar = join(systemRoot, "System32", "tar.exe");
 		if (existsSync(systemTar)) {

--- a/packages/coding-agent/test/powershell-config.test.ts
+++ b/packages/coding-agent/test/powershell-config.test.ts
@@ -1,0 +1,76 @@
+import type * as ChildProcess from "node:child_process";
+import type * as Fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getPowerShellConfig, POWERSHELL_ARGS } from "../src/utils/shell.ts";
+
+const { existsSyncMock, spawnSyncMock } = vi.hoisted(() => ({
+	existsSyncMock: vi.fn(),
+	spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => ({
+	...(await importOriginal<typeof Fs>()),
+	existsSync: existsSyncMock,
+}));
+
+vi.mock("child_process", async (importOriginal) => ({
+	...(await importOriginal<typeof ChildProcess>()),
+	spawnSync: spawnSyncMock,
+}));
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+const pwsh7 = "D:\\Applications\\PowerShell\\7\\pwsh.exe";
+const windowsPowerShell = "E:\\WinNT\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+
+beforeEach(() => {
+	Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+	vi.stubEnv("ProgramFiles", "D:\\Applications");
+	vi.stubEnv("SystemRoot", "E:\\WinNT");
+	existsSyncMock.mockReset().mockReturnValue(false);
+	spawnSyncMock.mockReset().mockReturnValue({ status: 1, stdout: "" });
+});
+
+afterEach(() => {
+	Object.defineProperty(process, "platform", platformDescriptor);
+	vi.unstubAllEnvs();
+});
+
+// #9490: discover PowerShell outside PATH without assuming a drive or Windows directory name.
+describe("getPowerShellConfig", () => {
+	it("prefers PowerShell 7 on PATH over known installation locations", () => {
+		const shell = "E:\\Tools\\pwsh.exe";
+		spawnSyncMock.mockReturnValue({ status: 0, stdout: `${shell}\r\n` });
+		existsSyncMock.mockReturnValue(true);
+
+		expect(getPowerShellConfig()).toEqual({ shell, args: [...POWERSHELL_ARGS] });
+	});
+
+	it("finds PowerShell 7 under ProgramFiles before Windows PowerShell on PATH", () => {
+		spawnSyncMock.mockImplementation((_command: string, args: string[]) => ({
+			status: args[0] === "powershell.exe" ? 0 : 1,
+			stdout: args[0] === "powershell.exe" ? windowsPowerShell : "",
+		}));
+		existsSyncMock.mockImplementation((path: string) => [pwsh7, windowsPowerShell].includes(path));
+
+		expect(getPowerShellConfig()).toEqual({ shell: pwsh7, args: [...POWERSHELL_ARGS] });
+	});
+
+	it("prefers Windows PowerShell on PATH over its system installation", () => {
+		const shell = "E:\\Tools\\powershell.exe";
+		spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "" }).mockReturnValueOnce({ status: 0, stdout: shell });
+		existsSyncMock.mockImplementation((path: string) => [shell, windowsPowerShell].includes(path));
+
+		expect(getPowerShellConfig()).toEqual({ shell, args: [...POWERSHELL_ARGS] });
+	});
+
+	it("finds Windows PowerShell under SystemRoot when PATH lookup is unavailable", () => {
+		spawnSyncMock.mockReturnValue({ status: null, stdout: null, error: new Error("spawn where ENOENT") });
+		existsSyncMock.mockImplementation((path: string) => path === windowsPowerShell);
+
+		expect(getPowerShellConfig()).toEqual({ shell: windowsPowerShell, args: [...POWERSHELL_ARGS] });
+	});
+
+	it("reports an error when no PowerShell installation exists", () => {
+		expect(() => getPowerShellConfig()).toThrow("No PowerShell executable found");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/6596-taskkill-enoent.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6596-taskkill-enoent.test.ts
@@ -1,4 +1,4 @@
-import type { ChildProcess } from "node:child_process";
+import type * as ChildProcess from "node:child_process";
 import { EventEmitter } from "node:events";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
 
 vi.mock("child_process", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("child_process")>();
+	const actual = await importOriginal<typeof ChildProcess>();
 	return { ...actual, spawn: spawnMock };
 });
 
@@ -24,26 +24,26 @@ function withWindowsPlatform(test: () => void): void {
 
 afterEach(() => {
 	spawnMock.mockReset();
+	vi.unstubAllEnvs();
 });
 
 describe("issue #6596 taskkill spawn failures", () => {
-	it("uses System32 taskkill and consumes its asynchronous spawn error", () => {
-		const child = new EventEmitter() as ChildProcess;
-		const previousSystemRoot = process.env.SystemRoot;
-		process.env.SystemRoot = "C:\\CustomWindows";
+	// #9490: missing or empty SystemRoot must retain an absolute taskkill fallback.
+	it.each([
+		["D:\\CustomWindows", "D:\\CustomWindows"],
+		[undefined, "C:\\Windows"],
+		["", "C:\\Windows"],
+	] as const)("uses System32 taskkill and consumes its spawn error with SystemRoot=%j", (systemRoot, expectedRoot) => {
+		const child = new EventEmitter();
+		vi.stubEnv("SystemRoot", systemRoot);
 		spawnMock.mockReturnValue(child);
 
-		try {
-			withWindowsPlatform(() => {
-				killProcessTree(1234);
-			});
-		} finally {
-			if (previousSystemRoot === undefined) delete process.env.SystemRoot;
-			else process.env.SystemRoot = previousSystemRoot;
-		}
+		withWindowsPlatform(() => {
+			killProcessTree(1234);
+		});
 
 		expect(spawnMock).toHaveBeenCalledWith(
-			join("C:\\CustomWindows", "System32", "taskkill.exe"),
+			join(expectedRoot, "System32", "taskkill.exe"),
 			["/F", "/T", "/PID", "1234"],
 			{ detached: true, stdio: "ignore", windowsHide: true },
 		);

--- a/packages/coding-agent/test/windows-shell-config.test.ts
+++ b/packages/coding-agent/test/windows-shell-config.test.ts
@@ -1,0 +1,37 @@
+import type * as Fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getShellConfig } from "../src/utils/shell.ts";
+
+vi.mock("node:fs", async (importOriginal) => ({
+	...(await importOriginal<typeof Fs>()),
+	existsSync: () => true,
+}));
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+
+beforeEach(() => {
+	Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+});
+
+afterEach(() => {
+	Object.defineProperty(process, "platform", platformDescriptor);
+	vi.unstubAllEnvs();
+});
+
+// #9490: identify legacy WSL launchers under the actual Windows directory.
+describe("legacy WSL bash detection", () => {
+	it.each([
+		["D:\\WinNT\\", "d:/WINNT/System32/BASH.EXE", true],
+		["D:\\WinNT", "D:\\WinNT\\Sysnative\\bash.exe", true],
+		[undefined, "E:\\Windows\\System32\\bash.exe", true],
+		["D:\\WinNT", "D:\\Git\\bin\\bash.exe", false],
+		["D:\\WinNT", "E:\\Windows\\System32\\bash.exe", false],
+		["WinNT", "C:\\Windows\\System32\\bash.exe", false],
+	] as const)("resolves %j / %j to stdin=%j", (systemRoot, shell, stdin) => {
+		vi.stubEnv("SystemRoot", systemRoot);
+
+		expect(getShellConfig(shell)).toEqual(
+			stdin ? { shell, args: ["-s"], commandTransport: "stdin" } : { shell, args: ["-c"] },
+		);
+	});
+});


### PR DESCRIPTION
The system for findings various binaries on windows was all over the place. Sometimes hardcoding the path, other times using env variable, or even multiple as fallback. 

Tried to unify + document things better in widnows-specific part of the docs. 

Pi should now work susbtentially better with non-standard windows installation (folder or drive letter).

Partially inspired by #9490