### PR TITLE
fix(coding-agent): improve light theme warning contrast

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3540,13 +3540,13 @@ export class InteractiveMode {
 		const secondLast = children.length > 1 ? children[children.length - 2] : undefined;
 
 		if (last && secondLast && last === this.lastStatusText && secondLast === this.lastStatusSpacer) {
-			this.lastStatusText.setText(theme.fg("dim", message));
+			this.lastStatusText.setText(message);
 			this.ui.requestRender();
 			return;
 		}
 
 		const spacer = new Spacer(1);
-		const text = new Text(theme.fg("dim", message), 1, 0);
+		const text = new Text(message, 1, 0, (content) => theme.fg("dim", content));
 		this.chatContainer.addChild(spacer);
 		this.chatContainer.addChild(text);
 		this.lastStatusSpacer = spacer;
@@ -4272,13 +4272,15 @@ export class InteractiveMode {
 
 	showError(errorMessage: string): void {
 		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new Text(theme.fg("error", `Error: ${errorMessage}`), this.outputPad, 0));
+		this.chatContainer.addChild(
+			new Text(`Error: ${errorMessage}`, this.outputPad, 0, (text) => theme.fg("error", text)),
+		);
 		this.ui.requestRender();
 	}
 
 	showWarning(warningMessage: string): void {
 		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+		this.chatContainer.addChild(new Text(`Warning: ${warningMessage}`, 1, 0, (text) => theme.fg("warning", text)));
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/src/modes/interactive/theme/light.json
+++ b/packages/coding-agent/src/modes/interactive/theme/light.json
@@ -6,7 +6,7 @@
 		"blue": "#547da7",
 		"green": "#588458",
 		"red": "#aa5555",
-		"yellow": "#9a7326",
+		"yellow": "#855f16",
 		"text": "#1f2328",
 		"mediumGray": "#6c6c6c",
 		"dimGray": "#767676",

--- a/packages/coding-agent/test/interactive-mode-theme-notifications.test.ts
+++ b/packages/coding-agent/test/interactive-mode-theme-notifications.test.ts
@@ -1,0 +1,38 @@
+import { Container } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { getThemeByName, initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+function render(container: Container): string {
+	container.invalidate();
+	return container.children.flatMap((child) => child.render(120)).join("\n");
+}
+
+afterEach(() => initTheme("dark"));
+
+describe("interactive notifications", () => {
+	it("recolors an existing warning when the theme changes", () => {
+		const chatContainer = new Container();
+		const context = {
+			chatContainer,
+			ui: { requestRender: vi.fn() },
+		};
+		const showWarning = (
+			InteractiveMode.prototype as unknown as {
+				showWarning(this: typeof context, message: string): void;
+			}
+		).showWarning;
+		const darkWarning = getThemeByName("dark")?.getFgAnsi("warning");
+		const lightWarning = getThemeByName("light")?.getFgAnsi("warning");
+		if (!darkWarning || !lightWarning) throw new Error("Built-in warning colors must be defined");
+
+		initTheme("dark");
+		showWarning.call(context, "Check contrast");
+		expect(render(chatContainer)).toContain(darkWarning);
+
+		initTheme("light");
+		const lightRender = render(chatContainer);
+		expect(lightRender).toContain(lightWarning);
+		expect(lightRender).not.toContain(darkWarning);
+	});
+});

--- a/packages/coding-agent/test/theme-contrast.test.ts
+++ b/packages/coding-agent/test/theme-contrast.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getResolvedThemeColors, getThemeExportColors } from "../src/modes/interactive/theme/theme.ts";
+
+function relativeLuminance(color: string): number {
+	const channels = color
+		.slice(1)
+		.match(/.{2}/g)
+		?.map((channel) => Number.parseInt(channel, 16) / 255)
+		.map((channel) => (channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4));
+	if (!channels || channels.length !== 3) throw new Error(`Expected a six-digit hex color, got ${color}`);
+	return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastRatio(first: string, second: string): number {
+	const lighter = Math.max(relativeLuminance(first), relativeLuminance(second));
+	const darker = Math.min(relativeLuminance(first), relativeLuminance(second));
+	return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("built-in theme contrast", () => {
+	it("keeps light-theme warnings readable on built-in light backgrounds", () => {
+		const colors = getResolvedThemeColors("light");
+		const exportColors = getThemeExportColors("light");
+		const backgrounds = ["#ffffff", exportColors.pageBg, exportColors.cardBg, exportColors.infoBg];
+
+		for (const background of backgrounds) {
+			if (!background) throw new Error("Built-in light export backgrounds must be defined");
+			expect(contrastRatio(colors.warning, background)).toBeGreaterThanOrEqual(4.5);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Warnings are rendered with ANSI colors when they are added to the transcript. After an automatic light/dark theme change, existing warnings keep the previous theme's color. The built-in light warning color also falls below the WCAG AA 4.5:1 contrast threshold on light backgrounds.

## Changes

- Apply warning, error, and status colors at render time so existing notifications follow theme changes.
- Darken the built-in light yellow from `#9a7326` to `#855f16`.
- Add regression coverage for notification recoloring and light-theme warning contrast.

## Validation

- Targeted Vitest tests pass: `theme-contrast.test.ts` and `interactive-mode-theme-notifications.test.ts`.
- `npm run check` completes formatting, dependency, graph, shrinkwrap, and install-lock checks, then hits an unrelated existing TypeScript error in `packages/ai/src/api/google-shared.ts:402` involving `FinishReason.TOO_MANY_TOOL_CALLS`.
