### PR TITLE
fix(coding-agent): accept Windows Store shell aliases

### DIFF
--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
@@ -21,9 +21,21 @@ function getBashShellConfig(shell: string): ShellConfig {
 	return isLegacyWslBashPath(shell) ? { shell, args: ["-s"], commandTransport: "stdin" } : { shell, args: ["-c"] };
 }
 
+// Backport the access(F_OK) check from harness-v2's async refactor (617d8b317).
+// Unlike existsSync(), it accepts runnable Windows Store aliases (nodejs/node#36790).
+function shellPathExists(path: string): boolean {
+	if (process.platform !== "win32") return existsSync(path);
+	try {
+		accessSync(path, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function findExecutableOnPath(executable: string): string | null {
 	if (process.platform === "win32") {
-		// Windows: Use 'where' and verify file exists (where can return non-existent paths)
+		// Windows: use 'where' and check the returned path.
 		try {
 			const result = spawnSync("where", [executable], {
 				encoding: "utf-8",
@@ -32,7 +44,7 @@ function findExecutableOnPath(executable: string): string | null {
 			});
 			if (result.status === 0 && result.stdout) {
 				const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
-				if (firstMatch && existsSync(firstMatch)) {
+				if (firstMatch && shellPathExists(firstMatch)) {
 					return firstMatch;
 				}
 			}
@@ -67,7 +79,7 @@ function findExecutableOnPath(executable: string): string | null {
 export function getShellConfig(customShellPath?: string): ShellConfig {
 	// 1. Check user-specified shell path
 	if (customShellPath) {
-		if (existsSync(customShellPath)) {
+		if (shellPathExists(customShellPath)) {
 			return getBashShellConfig(customShellPath);
 		}
 		throw new Error(`Custom shell path not found: ${customShellPath}`);
@@ -86,7 +98,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 		}
 
 		for (const path of paths) {
-			if (existsSync(path)) {
+			if (shellPathExists(path)) {
 				return getBashShellConfig(path);
 			}
 		}

--- a/packages/coding-agent/test/windows-shell-alias.test.ts
+++ b/packages/coding-agent/test/windows-shell-alias.test.ts
@@ -1,0 +1,72 @@
+import type * as ChildProcess from "node:child_process";
+import type * as Fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getPowerShellConfig, getShellConfig } from "../src/utils/shell.ts";
+
+const { accessSyncMock, spawnSyncMock } = vi.hoisted(() => ({
+	accessSyncMock: vi.fn(),
+	spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof Fs>();
+	return {
+		...actual,
+		accessSync: accessSyncMock,
+		existsSync: (path: Fs.PathLike) =>
+			typeof path === "string" && path.startsWith("D:\\")
+				? !path.includes("\\WindowsApps\\")
+				: actual.existsSync(path),
+	};
+});
+
+vi.mock("child_process", async (importOriginal) => ({
+	...(await importOriginal<typeof ChildProcess>()),
+	spawnSync: spawnSyncMock,
+}));
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+const aliasesDir = "D:\\Users\\test\\AppData\\Local\\Microsoft\\WindowsApps";
+
+beforeEach(() => {
+	Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+	vi.stubEnv("ProgramFiles", undefined);
+	vi.stubEnv("ProgramFiles(x86)", undefined);
+	accessSyncMock.mockReset();
+	spawnSyncMock.mockReset();
+});
+
+afterEach(() => {
+	Object.defineProperty(process, "platform", platformDescriptor);
+	vi.unstubAllEnvs();
+});
+
+// nodejs/node#36790: runnable Store aliases pass access(F_OK) but fail existsSync's stat check.
+describe("Windows Store shell aliases", () => {
+	it.each(["bash.exe", "pwsh.exe"])("accepts %s found on PATH", (executable) => {
+		const alias = `${aliasesDir}\\${executable}`;
+		spawnSyncMock.mockReturnValue({ status: 0, stdout: `${alias}\r\n` });
+
+		const config = executable === "pwsh.exe" ? getPowerShellConfig() : getShellConfig();
+
+		expect(config.shell).toBe(alias);
+	});
+
+	it("accepts an explicitly configured shell alias", () => {
+		const alias = `${aliasesDir}\\bash.exe`;
+
+		expect(getShellConfig(alias).shell).toBe(alias);
+	});
+
+	it("still rejects PATH results that fail the existence check", () => {
+		const windowsPowerShell = "D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+		spawnSyncMock
+			.mockReturnValueOnce({ status: 0, stdout: `${aliasesDir}\\pwsh.exe` })
+			.mockReturnValueOnce({ status: 0, stdout: windowsPowerShell });
+		accessSyncMock.mockImplementationOnce(() => {
+			throw Object.assign(new Error("not found"), { code: "ENOENT" });
+		});
+
+		expect(getPowerShellConfig().shell).toBe(windowsPowerShell);
+	});
+});


### PR DESCRIPTION
Use accessSync(F_OK) for Windows shell validation, matching the check introduced incidentally by harness-v2's async refactor (617d8b317).

Node's existsSync() can reject runnable Store aliases because its stat check fails with EACCES (nodejs/node#36790). Keep Unix behavior and shell search order unchanged.

This would theoretically not be needed if libuv merges this fix (and node picks it up, and pi's users pick up new node): https://github.com/libuv/libuv/pull/4986?notification_referrer_id=NT_kwHOABrtcdoAJFJlcG9zaXRvcnk7MTQ4MTI3Mzk7SXNzdWU7Mzc3NTE2NjM0Mg#issuecomment-5641157433 or if pi switches main platform to be deno https://github.com/denoland/deno/issues/18598#issuecomment-5641354293 but seeing as both are unlikely to happen, this is best we can do for now.