### PR TITLE
feat(tui): group long tool-call runs

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/tool-call-group.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-call-group.ts
@@ -1,0 +1,99 @@
+import { Container, MouseRegion, Text, type TUI } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.ts";
+import type { ToolExecutionComponent } from "./tool-execution.ts";
+
+export const TOOL_CALL_GROUP_THRESHOLD = 6;
+
+export function formatToolCallGroupSummary(
+	toolNames: readonly string[],
+	errorCount: number,
+): { calls: string; counts: string; errors?: string } {
+	const counts = new Map<string, number>();
+	for (const toolName of toolNames) {
+		counts.set(toolName, (counts.get(toolName) ?? 0) + 1);
+	}
+
+	return {
+		calls: `${toolNames.length} tool calls`,
+		counts: [...counts.entries()]
+			.map(([toolName, count]) => `${count} ${toolName.charAt(0).toUpperCase()}${toolName.slice(1)}`)
+			.join(" "),
+		errors: errorCount > 0 ? `${errorCount} error${errorCount === 1 ? "" : "s"}` : undefined,
+	};
+}
+
+/** A collapsible transcript entry for a consecutive run of tool calls. */
+export class ToolCallGroupComponent extends Container {
+	private readonly tools: ToolExecutionComponent[];
+	private readonly header: Text;
+	private readonly toolsContainer = new Container();
+	private readonly ui: TUI;
+	private expanded: boolean;
+
+	constructor(tools: readonly ToolExecutionComponent[], ui: TUI, expanded = false) {
+		super();
+		this.tools = [...tools];
+		this.ui = ui;
+		this.expanded = expanded;
+		this.header = new Text("", 1, 0);
+		this.addChild(
+			new MouseRegion(this.header, (event) => {
+				if (event.type !== "click" || event.button !== "left") return undefined;
+				this.setGroupExpanded(!this.expanded);
+				return { handled: true, render: true };
+			}),
+		);
+		this.addChild(this.toolsContainer);
+		this.updateDisplay();
+	}
+
+	addTool(tool: ToolExecutionComponent): void {
+		this.tools.push(tool);
+		this.updateDisplay();
+	}
+
+	setExpanded(expanded: boolean): void {
+		for (const tool of this.tools) {
+			tool.setExpanded(expanded);
+		}
+		this.setGroupExpanded(expanded);
+	}
+
+	override invalidate(): void {
+		super.invalidate();
+		this.updateDisplay();
+	}
+
+	override render(width: number): string[] {
+		// Tool results can settle between renders, so refresh the aggregate error count here.
+		this.updateDisplay();
+		return super.render(width);
+	}
+
+	private setGroupExpanded(expanded: boolean): void {
+		if (this.expanded === expanded) return;
+		this.expanded = expanded;
+		this.updateDisplay();
+		this.ui.requestRender();
+	}
+
+	private updateDisplay(): void {
+		const summary = formatToolCallGroupSummary(
+			this.tools.map((tool) => tool.getToolName()),
+			this.tools.filter((tool) => tool.isError()).length,
+		);
+		let text = theme.fg("muted", this.expanded ? "▾" : "▸");
+		text += ` ${theme.fg("toolTitle", summary.calls)}`;
+		if (summary.counts) text += ` ${theme.fg("muted", summary.counts)}`;
+		if (summary.errors) text += ` ${theme.fg("error", summary.errors)}`;
+		text += ` ${theme.fg("accent", this.expanded ? "collapse" : "expand")}`;
+		this.header.setText(text);
+
+		this.toolsContainer.clear();
+		for (const tool of this.tools) {
+			if (this.expanded || tool.isError()) {
+				this.toolsContainer.addChild(tool);
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -236,6 +236,14 @@ export class ToolExecutionComponent extends Container {
 		this.updateDisplay();
 	}
 
+	getToolName(): string {
+		return this.toolName;
+	}
+
+	isError(): boolean {
+		return this.result?.isError ?? false;
+	}
+
 	setShowImages(show: boolean): void {
 		this.showImages = show;
 		this.updateDisplay();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -148,6 +148,7 @@ import {
 	WorkingStatusIndicator,
 } from "./components/status-indicator.ts";
 import { ThinkingSelectorComponent } from "./components/thinking-selector.ts";
+import { TOOL_CALL_GROUP_THRESHOLD, ToolCallGroupComponent } from "./components/tool-call-group.ts";
 import { ToolExecutionComponent } from "./components/tool-execution.ts";
 import { TreeSelectorComponent } from "./components/tree-selector.ts";
 import { TrustSelectorComponent } from "./components/trust-selector.ts";
@@ -429,6 +430,8 @@ export class InteractiveMode {
 
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
+	private ungroupedToolRun: ToolExecutionComponent[] = [];
+	private activeToolCallGroup: ToolCallGroupComponent | undefined;
 
 	// Tool output expansion state
 	private toolOutputExpanded = false;
@@ -3226,6 +3229,7 @@ export class InteractiveMode {
 					this.updatePendingMessagesDisplay();
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {
+					this.resetToolCallGrouping();
 					this.streamingComponent = new AssistantMessageComponent(
 						undefined,
 						this.hideThinkingBlock,
@@ -3262,7 +3266,7 @@ export class InteractiveMode {
 									this.sessionManager.getCwd(),
 								);
 								component.setExpanded(this.toolOutputExpanded);
-								this.chatContainer.addChild(component);
+								this.addToolToChat(component);
 								this.pendingTools.set(content.id, component);
 							} else {
 								const component = this.pendingTools.get(content.id);
@@ -3337,7 +3341,7 @@ export class InteractiveMode {
 						this.sessionManager.getCwd(),
 					);
 					component.setExpanded(this.toolOutputExpanded);
-					this.chatContainer.addChild(component);
+					this.addToolToChat(component);
 					this.pendingTools.set(event.toolCallId, component);
 				}
 				component.markExecutionStarted();
@@ -3554,6 +3558,30 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private resetToolCallGrouping(): void {
+		this.ungroupedToolRun = [];
+		this.activeToolCallGroup = undefined;
+	}
+
+	private addToolToChat(component: ToolExecutionComponent): void {
+		if (this.activeToolCallGroup) {
+			this.activeToolCallGroup.addTool(component);
+			return;
+		}
+
+		this.ungroupedToolRun.push(component);
+		this.chatContainer.addChild(component);
+		if (this.ungroupedToolRun.length < TOOL_CALL_GROUP_THRESHOLD) return;
+
+		const group = new ToolCallGroupComponent(this.ungroupedToolRun, this.ui, this.toolOutputExpanded);
+		for (const tool of this.ungroupedToolRun) {
+			this.chatContainer.removeChild(tool);
+		}
+		this.chatContainer.addChild(group);
+		this.ungroupedToolRun = [];
+		this.activeToolCallGroup = group;
+	}
+
 	private addCustomEntryToChat(entry: Extract<SessionEntry, { type: "custom" }>): void {
 		const renderer = this.session.extensionRunner.getEntryRenderer(entry.customType);
 		if (!renderer) {
@@ -3713,6 +3741,7 @@ export class InteractiveMode {
 			const message = item;
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
+				this.resetToolCallGrouping();
 				this.addMessageToChat(message);
 				// Render tool call components
 				for (const content of message.content) {
@@ -3730,7 +3759,7 @@ export class InteractiveMode {
 							this.sessionManager.getCwd(),
 						);
 						component.setExpanded(this.toolOutputExpanded);
-						this.chatContainer.addChild(component);
+						this.addToolToChat(component);
 
 						if (message.stopReason === "aborted" || message.stopReason === "error") {
 							let errorMessage: string;

--- a/packages/coding-agent/test/tool-call-group.test.ts
+++ b/packages/coding-agent/test/tool-call-group.test.ts
@@ -1,0 +1,50 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+	formatToolCallGroupSummary,
+	TOOL_CALL_GROUP_THRESHOLD,
+	ToolCallGroupComponent,
+} from "../src/modes/interactive/components/tool-call-group.ts";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+const tui = { requestRender: () => {} } as any;
+
+describe("tool call groups", () => {
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	it("groups only runs of six or more calls", () => {
+		expect(TOOL_CALL_GROUP_THRESHOLD).toBe(6);
+	});
+
+	it("summarizes calls in first-seen tool order", () => {
+		expect(formatToolCallGroupSummary(["read", "glob", "read", "bash", "read", "bash", "grep", "read"], 2)).toEqual({
+			calls: "8 tool calls",
+			counts: "4 Read 1 Glob 2 Bash 1 Grep",
+			errors: "2 errors",
+		});
+	});
+
+	it("keeps successful members hidden while retaining failed calls and error metadata", () => {
+		const tools = ["read", "read", "bash", "read", "grep", "bash"].map(
+			(name, index) => new ToolExecutionComponent(name, `call-${index}`, {}, {}, undefined, tui, "/tmp"),
+		);
+		tools[4]?.updateResult({ content: [{ type: "text", text: "failed" }], isError: true });
+
+		const group = new ToolCallGroupComponent(tools, tui);
+		const collapsed = stripAnsi(group.render(120).join("\n"));
+		expect(collapsed).toContain("6 tool calls 3 Read 2 Bash 1 Grep 1 error expand");
+		expect(collapsed).toContain("failed");
+
+		group.setExpanded(true);
+		const expanded = stripAnsi(group.render(120).join("\n"));
+		expect(expanded).toContain("collapse");
+		expect(expanded).toContain("failed");
+	});
+
+	it("omits the error count when every call succeeds", () => {
+		expect(formatToolCallGroupSummary(["read"], 0).errors).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- collapse consecutive runs of six or more tool calls into an aggregate transcript row
- retain failed calls while collapsed and provide click-to-expand interaction
- add summary and collapsed/expanded rendering tests

## Verification
- `npm --workspace=@earendil-works/pi-coding-agent test -- tool-call-group.test.ts`
- `npx biome check --error-on-warnings …`

`npx tsgo --noEmit` currently fails on existing model-catalog expectation drift in `packages/ai/test` after rebasing on `main`; this change introduces none of those errors.