### PR TITLE
Fix #9522 Pi's own blocking prompts do not emit ui_prompt_start / ui_prompt_end

### DIFF
--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -450,14 +450,28 @@ export class ExtensionRunner {
 		};
 	}
 
-	private withUIPrompt<T>(kind: UIPromptKind, title: string | undefined, run: () => Promise<T>): Promise<T> {
+	/**
+	 * Opens a waiting span for a blocking prompt Pi shows itself, and returns the function that
+	 * closes it.
+	 *
+	 * Extension prompts go through `withUIPrompt`, which uses this. Pi's own prompts - the model
+	 * picker, the settings selector, the session tree - block a person in exactly the same way and
+	 * had no span, so anything reporting "waiting for user" saw only half of them.
+	 *
+	 * The returned function is safe to call more than once: a selector can be dismissed and
+	 * disposed, and both paths lead here.
+	 */
+	beginUIPrompt(kind: UIPromptKind, title?: string): () => void {
 		const outerPrompt = this.uiPromptDepth++ === 0;
 		if (outerPrompt) {
 			this.activeUIPrompt = { kind, title };
 			this.emitUIPromptEvent({ type: "ui_prompt_start", reason: "ui_prompt", kind, ...(title ? { title } : {}) });
 		}
 
-		const finish = () => {
+		let ended = false;
+		return () => {
+			if (ended) return;
+			ended = true;
 			if (--this.uiPromptDepth > 0) return;
 			this.uiPromptDepth = 0;
 
@@ -470,6 +484,10 @@ export class ExtensionRunner {
 				...(prompt.title ? { title: prompt.title } : {}),
 			});
 		};
+	}
+
+	private withUIPrompt<T>(kind: UIPromptKind, title: string | undefined, run: () => Promise<T>): Promise<T> {
+		const finish = this.beginUIPrompt(kind, title);
 
 		try {
 			return run().finally(finish);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -393,6 +393,8 @@ export class InteractiveMode {
 	private editorContainer: Container;
 	private activeSelectorToken?: object;
 	private activeSelectorDispose?: () => void;
+	/** Closes the waiting span of the selector on screen, so a status integration sees it end. */
+	private activeSelectorEndPrompt?: () => void;
 	private footer: FooterComponent;
 	private footerContainer: Container;
 	private footerDataProvider: FooterDataProvider;
@@ -4517,9 +4519,14 @@ export class InteractiveMode {
 
 	private disposeActiveSelector(): void {
 		const dispose = this.activeSelectorDispose;
+		const endPrompt = this.activeSelectorEndPrompt;
 		this.activeSelectorToken = undefined;
 		this.activeSelectorDispose = undefined;
+		this.activeSelectorEndPrompt = undefined;
 		dispose?.();
+		// A selector replaced by another one never reaches its own `done`, and its span would
+		// otherwise stay open for the rest of the session.
+		endPrompt?.();
 	}
 
 	/**
@@ -4531,11 +4538,17 @@ export class InteractiveMode {
 	): void {
 		const token = {};
 		let dispose: (() => void) | undefined;
+		// Pi is blocked on a person from here until the selector closes, exactly as it is for an
+		// extension's prompt. Same span, so the two cannot be told apart from outside - and they
+		// should not be.
+		const endPrompt = this.session.extensionRunner.beginUIPrompt("select");
 		const done = () => {
 			dispose?.();
+			endPrompt();
 			if (this.activeSelectorToken !== token) return;
 			this.activeSelectorToken = undefined;
 			this.activeSelectorDispose = undefined;
+			this.activeSelectorEndPrompt = undefined;
 			this.editorContainer.clear();
 			this.editorContainer.addChild(this.editor);
 			this.ui.setFocus(this.editor);
@@ -4545,6 +4558,7 @@ export class InteractiveMode {
 		this.disposeActiveSelector();
 		this.activeSelectorToken = token;
 		this.activeSelectorDispose = dispose;
+		this.activeSelectorEndPrompt = endPrompt;
 		this.editorContainer.clear();
 		this.editorContainer.addChild(created.component);
 		this.ui.setFocus(created.focus);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1061,4 +1061,90 @@ describe("ExtensionRunner", () => {
 			expect(errors[0].error).toContain("header handler boom");
 		});
 	});
+	describe("beginUIPrompt", () => {
+		const writeRecordingExtension = () => {
+			fs.writeFileSync(
+				path.join(extensionsDir, "record-prompts.ts"),
+				`export default function (pi) {
+					pi.on("ui_prompt_start", (event) => {
+						globalThis.__uiPromptLog.push(["start", event.kind, event.title ?? ""]);
+					});
+					pi.on("ui_prompt_end", (event) => {
+						globalThis.__uiPromptLog.push(["end", event.kind, event.title ?? ""]);
+					});
+				}`,
+			);
+		};
+
+		const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+		beforeEach(() => {
+			(globalThis as Record<string, unknown>).__uiPromptLog = [];
+		});
+
+		it("reports a prompt Pi shows itself, not only an extension's", async () => {
+			// Pi's own selectors block a person exactly as an extension's prompt does. Before this
+			// span existed they were invisible, so a status integration reported "running" while
+			// somebody was staring at the model picker.
+			writeRecordingExtension();
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			const end = runner.beginUIPrompt("select", "Model");
+			await flush();
+			expect((globalThis as Record<string, unknown>).__uiPromptLog).toEqual([["start", "select", "Model"]]);
+
+			end();
+			await flush();
+			expect((globalThis as Record<string, unknown>).__uiPromptLog).toEqual([
+				["start", "select", "Model"],
+				["end", "select", "Model"],
+			]);
+		});
+
+		it("closes the span once however often it is asked to", async () => {
+			// A selector can be dismissed and disposed, and both paths close the span. A second
+			// call must not unbalance the depth and swallow the next prompt's start.
+			writeRecordingExtension();
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			const end = runner.beginUIPrompt("select");
+			end();
+			end();
+			await flush();
+
+			const second = runner.beginUIPrompt("confirm");
+			second();
+			await flush();
+
+			expect((globalThis as Record<string, unknown>).__uiPromptLog).toEqual([
+				["start", "select", ""],
+				["end", "select", ""],
+				["start", "confirm", ""],
+				["end", "confirm", ""],
+			]);
+		});
+
+		it("coalesces a nested prompt into the outer one", async () => {
+			// Documented behaviour of the existing span, kept here because a second entry point
+			// into it is where that would be lost.
+			writeRecordingExtension();
+			const result = await discoverAndLoadExtensions([], tempDir, tempDir);
+			const runner = new ExtensionRunner(result.extensions, result.runtime, tempDir, sessionManager, modelRegistry);
+
+			const outer = runner.beginUIPrompt("select", "Outer");
+			const inner = runner.beginUIPrompt("confirm", "Inner");
+			inner();
+			await flush();
+			expect((globalThis as Record<string, unknown>).__uiPromptLog).toEqual([["start", "select", "Outer"]]);
+
+			outer();
+			await flush();
+			expect((globalThis as Record<string, unknown>).__uiPromptLog).toEqual([
+				["start", "select", "Outer"],
+				["end", "select", "Outer"],
+			]);
+		});
+	});
 });


### PR DESCRIPTION
The ui_prompt_start/_end events fired only for prompts an extension opened. Pi's own selectors - model picker, settings, resume, session tree - funnel through showSelector() and emitted nothing, so a status integration reporting 'waiting for user' saw half the cases and reported 'running' for the rest.

Splits the existing span out of withUIPrompt into beginUIPrompt(), which returns an idempotent close function, and opens it in showSelector(). Closed in done() and in disposeActiveSelector(), because a selector replaced by another never reaches its own done. No new event type; nesting and coalescing are unchanged.

Fixes issue #9522 