### PR TITLE
feat(tree): add permanent branch deletion from session tree

### DIFF
--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -173,6 +173,7 @@ This routing remains configurable through the ordinary action bindings. For exam
 | `app.tree.unfoldOrDown` | `ctrl+right`, `alt+right` | Unfold current branch segment, or jump to the next segment start or branch end |
 | `app.tree.editLabel` | `shift+l` | Edit the label on the selected tree node |
 | `app.tree.toggleLabelTimestamp` | `shift+t` | Toggle label timestamps in the tree |
+| `app.tree.deleteBranch` | `shift+d` | Delete the selected branch and its descendants |
 | `app.tree.filter.default` | `ctrl+d` | Set tree filter to default view |
 | `app.tree.filter.noTools` | `ctrl+t` | Toggle tree filter that hides tool results |
 | `app.tree.filter.userOnly` | `ctrl+u` | Toggle tree filter that shows only user messages |

--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -434,6 +434,8 @@ Key methods for working with sessions programmatically.
 - `getChildren(parentId)` - Get direct children
 - `getLabel(id)` - Get label for entry
 - `branch(entryId)` - Move leaf to earlier entry
+- `pruneBranch(entryId)` - Permanently delete an off-path entry and its subtree; returns `{ removedEntryIds, contextChanged }`
+- `countSubtree(entryId)` - Count an entry plus its descendants
 - `resetLeaf()` - Reset leaf to null (before any entries)
 - `branchWithSummary(entryId, summary, details?, fromHook?, usage?)` - Branch with context summary; `entryId` may be `null` to branch from the root
 
@@ -441,6 +443,10 @@ Key methods for working with sessions programmatically.
 - `buildContextEntries()` - Get active branch entries with compaction applied
 - `buildSessionContext()` - Get messages, thinkingLevel, and model for LLM
 - `getEntries()` - All entries (excluding header)
+
+### Deleting branches
+
+`pruneBranch(entryId)` removes the entry and all of its descendants from the session and rewrites the file in place. It never moves the leaf pointer and rejects entries on the active path (the leaf or its ancestors). Labels whose target was removed are dropped (surviving children are re-parented past them); a surviving compaction whose `firstKeptEntryId` pointed at a dropped label is re-pointed, and `contextChanged` reports whether that compaction is on the active path. `branch_summary.fromId` is informational only and may dangle after a prune. Note that `getSessionStats()` aggregates over all entries as a billing ledger, so pruning discards billed-token evidence from the deleted branch.
 - `getHeader()` - Session header metadata
 - `getSessionName()` - Get display name from latest session_info entry
 - `getCwd()` - Working directory

--- a/packages/coding-agent/docs/sessions.md
+++ b/packages/coding-agent/docs/sessions.md
@@ -93,11 +93,16 @@ Example shape:
 | Ctrl+←/Ctrl+→ or Alt+←/Alt+→ | Fold/unfold or jump between branch segments |
 | Shift+L | Set or clear a label on the selected entry |
 | Shift+T | Toggle label timestamps |
+| Shift+D | Delete the selected branch and its descendants (permanent) |
 | Enter | Select entry |
 | Escape/Ctrl+C | Cancel |
 | Ctrl+O | Cycle filter mode |
 
 Filter modes are: default, no-tools, user-only, labeled-only, and all. Configure the default with `treeFilterMode` in [Settings](settings.md).
+
+### Deleting branches
+
+Put the cursor on a branch and press Shift+D, then confirm with Enter (Escape cancels). This permanently removes that entry and its whole subtree from the session file. The active path (root to current leaf) is protected and cannot be deleted. Use `/clone` when you want a non-destructive copy of the active branch into a new session instead.
 
 ### Selection Behavior
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -994,6 +994,11 @@ export class AgentSession {
 		return this.agent.state.messages;
 	}
 
+	/** Rebuild agent messages from the session manager (e.g. after pruning a branch). */
+	syncMessagesFromSession(): void {
+		this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+	}
+
 	/** Current steering mode */
 	get steeringMode(): "all" | "one-at-a-time" {
 		return this.agent.steeringMode;

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -37,6 +37,7 @@ export interface AppKeybindings {
 	"app.tree.unfoldOrDown": true;
 	"app.tree.editLabel": true;
 	"app.tree.toggleLabelTimestamp": true;
+	"app.tree.deleteBranch": true;
 	"app.session.togglePath": true;
 	"app.session.toggleSort": true;
 	"app.session.rename": true;
@@ -162,6 +163,10 @@ export const KEYBINDINGS = {
 	"app.tree.toggleLabelTimestamp": {
 		defaultKeys: "shift+t",
 		description: "Toggle tree label timestamps",
+	},
+	"app.tree.deleteBranch": {
+		defaultKeys: "shift+d",
+		description: "Delete tree branch",
 	},
 	"app.session.togglePath": {
 		defaultKeys: "ctrl+p",

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -155,6 +155,12 @@ export type SessionEntry =
 /** Raw file entry (includes header) */
 export type FileEntry = SessionHeader | SessionEntry;
 
+export interface PruneBranchResult {
+	removedEntryIds: string[];
+	/** True if a surviving on-path compaction's firstKeptEntryId was re-pointed. */
+	contextChanged: boolean;
+}
+
 /** Tree node for getTree() - defensive copy of session structure */
 export interface SessionTreeNode {
 	entry: SessionEntry;
@@ -843,12 +849,13 @@ async function listSessionsFromDir(
 }
 
 /**
- * Manages conversation sessions as append-only trees stored in JSONL files.
+ * Manages conversation sessions as trees stored in JSONL files.
  *
  * Each session entry has an id and parentId forming a tree structure. The "leaf"
  * pointer tracks the current position. Appending creates a child of the current leaf.
  * Branching moves the leaf to an earlier entry, allowing new branches without
- * modifying history.
+ * modifying history. pruneBranch() permanently removes an entry off the active
+ * path along with its whole subtree.
  *
  * Use buildSessionContext() to get the resolved message list for the LLM, which
  * handles compaction summaries and follows the path from root to current leaf.
@@ -1309,8 +1316,8 @@ export class SessionManager {
 
 	/**
 	 * Get all session entries (excludes header). Returns a shallow copy.
-	 * The session is append-only: use appendXXX() to add entries, branch() to
-	 * change the leaf pointer. Entries cannot be modified or deleted.
+	 * Use appendXXX() to add entries, branch() to change the leaf pointer,
+	 * and pruneBranch() to permanently remove an off-path subtree.
 	 */
 	getEntries(): SessionEntry[] {
 		return this.fileEntries.filter((e): e is SessionEntry => e.type !== "session");
@@ -1541,6 +1548,160 @@ export class SessionManager {
 		this.sessionId = newSessionId;
 		this._buildIndex();
 		return undefined;
+	}
+
+	/**
+	 * Count an entry and its whole descendant subtree (including the entry itself).
+	 * Returns 0 when the entry does not exist. Built from getEntries(), not from
+	 * presentation-ordered tree snapshots.
+	 */
+	countSubtree(entryId: string): number {
+		if (!this.byId.has(entryId)) return 0;
+		const childrenByParent = new Map<string | null, SessionEntry[]>();
+		for (const entry of this.byId.values()) {
+			const list = childrenByParent.get(entry.parentId);
+			if (list) list.push(entry);
+			else childrenByParent.set(entry.parentId, [entry]);
+		}
+		let count = 0;
+		const stack: string[] = [entryId];
+		while (stack.length > 0) {
+			const id = stack.pop()!;
+			count++;
+			for (const child of childrenByParent.get(id) ?? []) {
+				stack.push(child.id);
+			}
+		}
+		return count;
+	}
+
+	/**
+	 * Permanently remove an entry and its whole descendant subtree from the session.
+	 * Rejected when the entry is on the active path (leaf or ancestor of the leaf).
+	 * Does not move the leaf pointer; survivors keep ids/timestamps, and parent links
+	 * are preserved except for re-parented children of dropped labels. A surviving
+	 * compaction whose firstKeptEntryId pointed at a dropped label is re-pointed to
+	 * the first surviving entry at/after it on the root-to-compaction path (or to the
+	 * compaction itself), and branch_summary.fromId references are left as-is
+	 * (informational only, never resolved).
+	 */
+	pruneBranch(entryId: string): PruneBranchResult {
+		const target = this.byId.get(entryId);
+		if (!target) {
+			throw new Error(`Entry ${entryId} not found`);
+		}
+
+		// Active-path guard: walk leaf -> root.
+		const activePathIds = new Set<string>();
+		let cursor: SessionEntry | undefined = this.leafId ? this.byId.get(this.leafId) : undefined;
+		while (cursor) {
+			activePathIds.add(cursor.id);
+			cursor = cursor.parentId ? this.byId.get(cursor.parentId) : undefined;
+		}
+		if (activePathIds.has(entryId)) {
+			throw new Error("Cannot delete the branch you are currently on");
+		}
+
+		// Collect entryId plus all descendants.
+		const childrenByParent = new Map<string | null, SessionEntry[]>();
+		for (const entry of this.byId.values()) {
+			const list = childrenByParent.get(entry.parentId);
+			if (list) list.push(entry);
+			else childrenByParent.set(entry.parentId, [entry]);
+		}
+		const removedIds = new Set<string>();
+		{
+			const stack: string[] = [entryId];
+			while (stack.length > 0) {
+				const id = stack.pop()!;
+				if (removedIds.has(id)) continue;
+				removedIds.add(id);
+				for (const child of childrenByParent.get(id) ?? []) {
+					stack.push(child.id);
+				}
+			}
+		}
+
+		// Labels outside the removed set whose target was removed are dead bookmarks
+		// that may still be structural ancestors of surviving branches. Drop the label
+		// and re-parent its surviving children to the nearest surviving ancestor.
+		const droppedLabelIds = new Set<string>();
+		for (const entry of this.byId.values()) {
+			// Never drop the leaf label: removedIds is disjoint from the active path,
+			// but this extra removal could otherwise delete the leaf itself and leave
+			// leafId dangling. A kept label with a removed target is harmless (labels
+			// contribute no context messages and resolve per-node).
+			if (
+				entry.type === "label" &&
+				!removedIds.has(entry.id) &&
+				removedIds.has(entry.targetId) &&
+				entry.id !== this.leafId
+			) {
+				droppedLabelIds.add(entry.id);
+			}
+		}
+
+		const nearestSurvivingAncestor = (labelId: string): string | null => {
+			let parentId: string | null = this.byId.get(labelId)?.parentId ?? null;
+			while (parentId !== null && (removedIds.has(parentId) || droppedLabelIds.has(parentId))) {
+				parentId = this.byId.get(parentId)?.parentId ?? null;
+			}
+			return parentId;
+		};
+
+		// Re-point surviving compactions whose firstKeptEntryId pointed at a dropped label.
+		let contextChanged = false;
+		for (const entry of this.byId.values()) {
+			if (entry.type !== "compaction" || removedIds.has(entry.id) || droppedLabelIds.has(entry.id)) continue;
+			if (!droppedLabelIds.has(entry.firstKeptEntryId)) continue;
+			// Build the root -> compaction path from pre-prune parent links.
+			const path: SessionEntry[] = [];
+			let node: SessionEntry | undefined = entry;
+			while (node) {
+				path.push(node);
+				node = node.parentId ? this.byId.get(node.parentId) : undefined;
+			}
+			path.reverse();
+			const keptIndex = path.findIndex((e) => e.id === entry.firstKeptEntryId);
+			let replacement: string | null = null;
+			if (keptIndex >= 0) {
+				for (let i = keptIndex; i < path.length; i++) {
+					const candidate = path[i];
+					if (candidate.id === entry.id) continue;
+					if (!removedIds.has(candidate.id) && !droppedLabelIds.has(candidate.id)) {
+						replacement = candidate.id;
+						break;
+					}
+				}
+			}
+			entry.firstKeptEntryId = replacement ?? entry.id;
+			if (activePathIds.has(entry.id)) {
+				contextChanged = true;
+			}
+		}
+
+		// Re-parent surviving children of dropped labels.
+		for (const entry of this.byId.values()) {
+			if (removedIds.has(entry.id) || droppedLabelIds.has(entry.id)) continue;
+			if (entry.parentId !== null && droppedLabelIds.has(entry.parentId)) {
+				entry.parentId = nearestSurvivingAncestor(entry.parentId);
+			}
+		}
+
+		const removedEntryIds = [...removedIds, ...droppedLabelIds];
+		const doomed = new Set(removedEntryIds);
+		const header = this.fileEntries.find((e) => e.type === "session");
+		const survivors = this.fileEntries.filter((e) => e.type === "session" || !doomed.has((e as SessionEntry).id));
+		const leaf = this.leafId;
+		this.fileEntries = header ? [header, ...survivors.filter((e) => e.type !== "session")] : survivors;
+		this._buildIndex();
+		this.leafId = leaf;
+
+		if (this.flushed) {
+			this._rewriteFile();
+		}
+
+		return { removedEntryIds, contextChanged };
 	}
 
 	/**

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -242,6 +242,7 @@ export {
 	type ModelChangeEntry,
 	migrateSessionEntries,
 	type NewSessionOptions,
+	type PruneBranchResult,
 	parseSessionEntries,
 	type SessionContext,
 	type SessionEntry,

--- a/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tree-selector.ts
@@ -124,6 +124,10 @@ class TreeList implements Component {
 	public onCancel?: () => void;
 	public onCopy?: (text: string | undefined) => void;
 	public onLabelEdit?: (entryId: string, currentLabel: string | undefined) => void;
+	public onDeleteBranch?: (entryId: string) => void;
+	public onDeleteBlocked?: (reason: string) => void;
+	public getSubtreeCount?: (entryId: string) => number;
+	private confirmingDeleteId: string | null = null;
 
 	constructor(
 		tree: SessionTreeNode[],
@@ -664,6 +668,11 @@ class TreeList implements Component {
 	render(width: number): string[] {
 		const lines: string[] = [];
 
+		const confirmText = this.getDeleteConfirmText();
+		if (confirmText) {
+			lines.push(truncateToWidth(theme.fg("error", `  ${confirmText}`), width));
+		}
+
 		if (this.filteredNodes.length === 0) {
 			lines.push(truncateToWidth(theme.fg("muted", "  No entries found"), width));
 			lines.push(truncateToWidth(theme.fg("muted", `  (0/0)${this.getStatusLabels()}`), width));
@@ -993,8 +1002,104 @@ class TreeList implements Component {
 		}
 	}
 
+	getConfirmingDeleteId(): string | null {
+		return this.confirmingDeleteId;
+	}
+
+	isConfirmingDelete(): boolean {
+		return this.confirmingDeleteId !== null;
+	}
+
+	isOnActivePath(entryId: string): boolean {
+		return this.activePathIds.has(entryId);
+	}
+
+	/** Number of entries in the subtree rooted at entryId (including itself). */
+	countSubtree(entryId: string): number {
+		if (this.getSubtreeCount) return this.getSubtreeCount(entryId);
+		const entryMap = new Map<string, FlatNode>();
+		for (const flatNode of this.flatNodes) {
+			entryMap.set(flatNode.node.entry.id, flatNode);
+		}
+		if (!entryMap.has(entryId)) return 0;
+		const childrenByParent = new Map<string | null, string[]>();
+		for (const flatNode of this.flatNodes) {
+			const parentId = flatNode.node.entry.parentId ?? null;
+			const list = childrenByParent.get(parentId);
+			if (list) list.push(flatNode.node.entry.id);
+			else childrenByParent.set(parentId, [flatNode.node.entry.id]);
+		}
+		let count = 0;
+		const stack: string[] = [entryId];
+		while (stack.length > 0) {
+			const id = stack.pop()!;
+			count++;
+			for (const childId of childrenByParent.get(id) ?? []) stack.push(childId);
+		}
+		return count;
+	}
+
+	getDeleteConfirmText(): string | null {
+		if (!this.confirmingDeleteId) return null;
+		const count = this.countSubtree(this.confirmingDeleteId);
+		const preview = this.getDeletePreview(this.confirmingDeleteId);
+		return `Delete branch "${preview}" and ${count} ${count === 1 ? "entry" : "entries"}? enter=confirm · esc=cancel`;
+	}
+
+	private getDeletePreview(entryId: string): string {
+		for (const flatNode of this.flatNodes) {
+			if (flatNode.node.entry.id !== entryId) continue;
+			if (flatNode.node.label) return flatNode.node.label.slice(0, 60);
+			const text = this.getSearchableText(flatNode.node).replace(/\s+/g, " ").trim().slice(0, 60);
+			return text || entryId.slice(0, 8);
+		}
+		return entryId.slice(0, 8);
+	}
+
+	/** Replace the tree snapshot after a prune and reselect near the removed node. */
+	setTree(roots: SessionTreeNode[], reselectId?: string | null): void {
+		this.confirmingDeleteId = null;
+		this.flatNodes = this.flattenTree(roots);
+		this.multipleRoots = roots.length > 1;
+		this.buildActivePath();
+		const liveIds = new Set(this.flatNodes.map((n) => n.node.entry.id));
+		for (const id of [...this.foldedNodes]) {
+			if (!liveIds.has(id)) this.foldedNodes.delete(id);
+		}
+		this.filteredNodes = [];
+		this.lastSelectedId = reselectId ?? null;
+		this.selectedIndex = 0;
+		this.applyFilter();
+		if (this.filteredNodes.length > 0) {
+			this.selectedIndex = Math.min(this.selectedIndex, this.filteredNodes.length - 1);
+			this.lastSelectedId = this.filteredNodes[this.selectedIndex]?.node.entry.id ?? null;
+		}
+	}
+
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
+		if (this.confirmingDeleteId !== null) {
+			if (kb.matches(keyData, "tui.select.confirm")) {
+				const id = this.confirmingDeleteId;
+				this.confirmingDeleteId = null;
+				this.onDeleteBranch?.(id);
+			} else if (kb.matches(keyData, "tui.select.cancel")) {
+				this.confirmingDeleteId = null;
+			}
+			return;
+		}
+		if (kb.matches(keyData, "app.tree.deleteBranch")) {
+			const selected = this.filteredNodes[this.selectedIndex];
+			if (selected) {
+				const id = selected.node.entry.id;
+				if (this.activePathIds.has(id)) {
+					this.onDeleteBlocked?.("Cannot delete the branch you are currently on");
+				} else {
+					this.confirmingDeleteId = id;
+				}
+			}
+			return;
+		}
 		if (kb.matches(keyData, "tui.select.up")) {
 			this.selectedIndex = this.selectedIndex === 0 ? this.filteredNodes.length - 1 : this.selectedIndex - 1;
 		} else if (kb.matches(keyData, "tui.select.down")) {
@@ -1221,6 +1326,7 @@ const TREE_HELP_ITEMS: Array<{ keys: Keybinding[]; label: string; labelFirst?: b
 	{ keys: ["app.message.copy"], label: "copy" },
 	{ keys: ["app.tree.editLabel"], label: "label" },
 	{ keys: ["app.tree.toggleLabelTimestamp"], label: "label time" },
+	{ keys: ["app.tree.deleteBranch"], label: "delete" },
 	{
 		keys: [
 			"app.tree.filter.default",
@@ -1332,6 +1438,8 @@ export class TreeSelectorComponent extends Container implements Focusable {
 	private treeContainer: Container;
 	private onLabelChangeCallback?: (entryId: string, label: string | undefined) => void;
 	public onCopy?: (text: string | undefined) => void;
+	public onDeleteBranch?: (entryId: string) => void;
+	public onDeleteBlocked?: (reason: string) => void;
 
 	// Focusable implementation - propagate to labelInput when active for IME cursor positioning
 	private _focused = false;
@@ -1366,6 +1474,8 @@ export class TreeSelectorComponent extends Container implements Focusable {
 		this.treeList.onCancel = onCancel;
 		this.treeList.onCopy = (text) => this.onCopy?.(text);
 		this.treeList.onLabelEdit = (entryId, currentLabel) => this.showLabelInput(entryId, currentLabel);
+		this.treeList.onDeleteBranch = (entryId) => this.onDeleteBranch?.(entryId);
+		this.treeList.onDeleteBlocked = (reason) => this.onDeleteBlocked?.(reason);
 
 		this.treeContainer = new Container();
 		this.treeContainer.addChild(this.treeList);
@@ -1411,6 +1521,15 @@ export class TreeSelectorComponent extends Container implements Focusable {
 		this.labelInputContainer.clear();
 		this.treeContainer.clear();
 		this.treeContainer.addChild(this.treeList);
+	}
+
+	/** Refresh the tree snapshot in place after a prune. */
+	refresh(tree: SessionTreeNode[], reselectId?: string | null): void {
+		this.treeList.setTree(tree, reselectId);
+	}
+
+	setSubtreeCounter(fn: (entryId: string) => number): void {
+		this.treeList.getSubtreeCount = fn;
 	}
 
 	handleInput(keyData: string): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5347,6 +5347,31 @@ export class InteractiveMode {
 					this.showError(error instanceof Error ? error.message : String(error));
 				}
 			};
+			selector.setSubtreeCounter((entryId) => this.sessionManager.countSubtree(entryId));
+			selector.onDeleteBlocked = (reason) => {
+				this.showStatus(reason);
+			};
+			selector.onDeleteBranch = (entryId) => {
+				if (this.session.isStreaming || this.session.isCompacting) {
+					this.showStatus("Wait for the current response to finish before deleting a branch");
+					return;
+				}
+				try {
+					const deletedParentId = this.sessionManager.getEntry(entryId)?.parentId ?? null;
+					const result = this.sessionManager.pruneBranch(entryId);
+					this.session.syncMessagesFromSession();
+					selector.refresh(this.sessionManager.getTree(), deletedParentId);
+					this.ui.requestRender();
+					const count = result.removedEntryIds.length;
+					this.showStatus(`Deleted branch (${count} ${count === 1 ? "entry" : "entries"})`);
+					if (result.contextChanged) {
+						this.chatContainer.clear();
+						this.renderInitialMessages();
+					}
+				} catch (error) {
+					this.showError(error instanceof Error ? error.message : String(error));
+				}
+			};
 			return { component: selector, focus: selector };
 		});
 	}

--- a/packages/coding-agent/test/interactive-mode-tree-navigation.test.ts
+++ b/packages/coding-agent/test/interactive-mode-tree-navigation.test.ts
@@ -142,3 +142,112 @@ describe("InteractiveMode tree navigation availability", () => {
 		expect(ui.session.navigateTree).not.toHaveBeenCalled();
 	});
 });
+
+describe("InteractiveMode tree branch deletion", () => {
+	function createDeleteUI() {
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage(userMsg("A"));
+		const b = sessionManager.appendMessage(assistantMsg("B"));
+		const d = sessionManager.appendMessage(userMsg("D"));
+		sessionManager.branch(b);
+		const e = sessionManager.appendMessage(userMsg("E"));
+		sessionManager.appendMessage(assistantMsg("F"));
+		sessionManager.branch(d);
+
+		let selector: TreeSelectorComponent | undefined;
+		const ui = {
+			sessionManager,
+			settingsManager: SettingsManager.inMemory(),
+			session: {
+				isStreaming: false,
+				isCompacting: false,
+				syncMessagesFromSession: vi.fn(),
+			},
+			defaultEditor: { onEscape: vi.fn() },
+			editor: { getText: () => "", setText: vi.fn() },
+			chatContainer: new Container(),
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			ui: { terminal: { rows: 24, setProgress: vi.fn() }, requestRender: vi.fn() },
+			showSelector: (
+				create: (done: () => void) => { component: TreeSelectorComponent; focus: TreeSelectorComponent },
+			) => {
+				selector = create(vi.fn()).component;
+			},
+			renderInitialMessages: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+		};
+		const showTreeSelector = Reflect.get(InteractiveMode.prototype, "showTreeSelector") as (this: typeof ui) => void;
+		showTreeSelector.call(ui);
+		expect(selector).toBeDefined();
+		return { ui, selector: selector!, ids: { b, d, e } };
+	}
+
+	it("prunes the branch, syncs messages, refreshes the selector, and shows a status", () => {
+		const { ui, selector, ids } = createDeleteUI();
+
+		selector.onDeleteBranch!(ids.e);
+
+		expect(ui.sessionManager.getEntry(ids.e)).toBeUndefined();
+		expect(ui.session.syncMessagesFromSession).toHaveBeenCalledOnce();
+		expect(ui.showStatus).toHaveBeenCalledWith("Deleted branch (2 entries)");
+		expect(ui.showError).not.toHaveBeenCalled();
+		// No compaction window changed, so the chat is not re-rendered.
+		expect(ui.renderInitialMessages).not.toHaveBeenCalled();
+		// Selector stays mounted with the pruned tree and reselects the parent.
+		expect(selector.getTreeList().getSelectedNode()?.entry.id).toBe(ids.b);
+		expect(ui.ui.requestRender).toHaveBeenCalled();
+	});
+
+	it("re-renders the chat when the prune reports contextChanged", () => {
+		const { ui, selector } = createDeleteUI();
+		// Build an on-path compaction whose firstKept points at a label that will be dropped.
+		const mgr = ui.sessionManager;
+		const leaf = mgr.getLeafId()!;
+		mgr.branch(mgr.getEntries()[0].id);
+		const x = mgr.appendMessage(userMsg("X"));
+		mgr.branch(leaf);
+		const label = mgr.appendLabelChange(x, "mark");
+		mgr.appendMessage(userMsg("B2"));
+		mgr.appendCompaction("summary", label, 1000);
+		mgr.appendMessage(userMsg("tail"));
+
+		selector.onDeleteBranch!(x);
+
+		expect(ui.session.syncMessagesFromSession).toHaveBeenCalledOnce();
+		expect(ui.renderInitialMessages).toHaveBeenCalledOnce();
+		expect(ui.showStatus).toHaveBeenCalledWith(expect.stringContaining("Deleted branch"));
+	});
+
+	it.each(["streaming", "compacting"] as const)("blocks the prune while %s", (kind) => {
+		const { ui, selector, ids } = createDeleteUI();
+		if (kind === "streaming") ui.session.isStreaming = true;
+		else ui.session.isCompacting = true;
+
+		selector.onDeleteBranch!(ids.e);
+
+		expect(ui.sessionManager.getEntry(ids.e)).toBeDefined();
+		expect(ui.session.syncMessagesFromSession).not.toHaveBeenCalled();
+		expect(ui.renderInitialMessages).not.toHaveBeenCalled();
+		expect(ui.showStatus).toHaveBeenCalledWith("Wait for the current response to finish before deleting a branch");
+		expect(ui.showError).not.toHaveBeenCalled();
+	});
+
+	it("surfaces the active-path message from onDeleteBlocked", () => {
+		const { ui, selector } = createDeleteUI();
+
+		selector.onDeleteBlocked!("Cannot delete the branch you are currently on");
+
+		expect(ui.showStatus).toHaveBeenCalledWith("Cannot delete the branch you are currently on");
+	});
+
+	it("shows an error when pruning an active-path entry", () => {
+		const { ui, selector, ids } = createDeleteUI();
+
+		selector.onDeleteBranch!(ids.d);
+
+		expect(ui.showError).toHaveBeenCalledWith("Cannot delete the branch you are currently on");
+		expect(ui.session.syncMessagesFromSession).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/session-manager/prune-branch.test.ts
+++ b/packages/coding-agent/test/session-manager/prune-branch.test.ts
@@ -1,0 +1,296 @@
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { assistantMsg, userMsg } from "../utilities.ts";
+
+/** Build A -> B -> C -> D with a side branch C -> E -> F; leaf restored to D. */
+function buildBranchedSession() {
+	const session = SessionManager.inMemory();
+	const a = session.appendMessage(userMsg("A"));
+	const b = session.appendMessage(userMsg("B"));
+	const c = session.appendMessage(userMsg("C"));
+	const d = session.appendMessage(userMsg("D"));
+	session.branch(c);
+	const e = session.appendMessage(userMsg("E"));
+	const f = session.appendMessage(assistantMsg("F"));
+	session.branch(d);
+	return { session, ids: { a, b, c, d, e, f } };
+}
+
+describe("SessionManager.pruneBranch", () => {
+	it("removes a side subtree and keeps survivor ids and parent links", () => {
+		const { session, ids } = buildBranchedSession();
+
+		const result = session.pruneBranch(ids.e);
+
+		expect(result.contextChanged).toBe(false);
+		expect(result.removedEntryIds).toHaveLength(2);
+		expect(new Set(result.removedEntryIds)).toEqual(new Set([ids.e, ids.f]));
+
+		const entries = session.getEntries();
+		expect(entries.map((e) => e.id).sort()).toEqual([ids.a, ids.b, ids.c, ids.d].sort());
+
+		// Survivor parent links are intact.
+		const byId = new Map(entries.map((e) => [e.id, e]));
+		expect(byId.get(ids.b)!.parentId).toBe(ids.a);
+		expect(byId.get(ids.c)!.parentId).toBe(ids.b);
+		expect(byId.get(ids.d)!.parentId).toBe(ids.c);
+
+		// The C -> E edge is gone from the tree.
+		const tree = session.getTree();
+		expect(tree).toHaveLength(1);
+		const nodeC = tree[0].children[0].children[0];
+		expect(nodeC.entry.id).toBe(ids.c);
+		expect(nodeC.children.map((c) => c.entry.id)).toEqual([ids.d]);
+
+		// Leaf stays on D.
+		expect(session.getLeafId()).toBe(ids.d);
+	});
+
+	it("keeps buildSessionContext() unchanged for the active leaf", () => {
+		const { session, ids } = buildBranchedSession();
+		const before = session.buildSessionContext();
+
+		session.pruneBranch(ids.e);
+
+		const after = session.buildSessionContext();
+		expect(after).toEqual(before);
+		expect(session.countSubtree(ids.e)).toBe(0);
+	});
+
+	it("removes a deep branch and counts the whole subtree", () => {
+		const session = SessionManager.inMemory();
+		const root = session.appendMessage(userMsg("root"));
+		const leaf = session.appendMessage(userMsg("leaf"));
+		session.branch(root);
+		const e1 = session.appendMessage(userMsg("e1"));
+		const e2 = session.appendMessage(userMsg("e2"));
+		const e3 = session.appendMessage(assistantMsg("e3"));
+		session.branch(leaf);
+
+		expect(session.countSubtree(e1)).toBe(3);
+		expect(session.countSubtree(root)).toBe(5);
+
+		const result = session.pruneBranch(e1);
+		expect(new Set(result.removedEntryIds)).toEqual(new Set([e1, e2, e3]));
+		expect(
+			session
+				.getEntries()
+				.map((e) => e.id)
+				.sort(),
+		).toEqual([root, leaf].sort());
+		expect(session.getLeafId()).toBe(leaf);
+	});
+
+	it("returns 0 from countSubtree for an unknown id", () => {
+		const { session } = buildBranchedSession();
+		expect(session.countSubtree("does-not-exist")).toBe(0);
+	});
+
+	it("throws for the leaf and for ancestors of the leaf", () => {
+		const { session, ids } = buildBranchedSession();
+
+		expect(() => session.pruneBranch(ids.d)).toThrow("Cannot delete the branch you are currently on");
+		expect(() => session.pruneBranch(ids.c)).toThrow("Cannot delete the branch you are currently on");
+		expect(() => session.pruneBranch(ids.a)).toThrow("Cannot delete the branch you are currently on");
+		// Failed prunes leave the session untouched.
+		expect(session.getEntries()).toHaveLength(6);
+		expect(session.getLeafId()).toBe(ids.d);
+	});
+
+	it("throws for an unknown id", () => {
+		const { session } = buildBranchedSession();
+		expect(() => session.pruneBranch("nope")).toThrow("Entry nope not found");
+	});
+
+	it("drops label entries inside the removed set (set-then-clear across branches)", () => {
+		const session = SessionManager.inMemory();
+		const a = session.appendMessage(userMsg("A"));
+		const b = session.appendMessage(userMsg("B"));
+		const c = session.appendMessage(userMsg("C"));
+		// Set a bookmark on C from the main branch.
+		const setLabel = session.appendLabelChange(c, "bar");
+		// Clear the same bookmark from a side branch.
+		session.branch(b);
+		const e = session.appendMessage(userMsg("E"));
+		session.appendLabelChange(c, undefined);
+		session.branch(setLabel);
+
+		const result = session.pruneBranch(e);
+		expect(result.removedEntryIds).toContain(e);
+
+		// The clear is gone with the deleted branch, so the live bookmark survives.
+		expect(session.getLabel(c)).toBe("bar");
+		expect(session.getEntries().map((e) => e.id)).toContain(a);
+		expect(session.getEntries().map((e) => e.id)).toContain(setLabel);
+	});
+
+	it("re-parents surviving children past a dropped label (orphan regression)", () => {
+		const session = SessionManager.inMemory();
+		const r = session.appendMessage(userMsg("R"));
+		const a = session.appendMessage(userMsg("A"));
+		// Side branch carrying the label target.
+		session.branch(r);
+		const x = session.appendMessage(userMsg("X"));
+		// Continue the active branch from a label on X.
+		session.branch(a);
+		const label = session.appendLabelChange(x, "mark");
+		const b = session.appendMessage(userMsg("B"));
+		const branchBefore = session.getBranch().map((e) => e.id);
+		const contextBefore = session.buildSessionContext();
+		expect(branchBefore).toEqual([r, a, label, b]);
+
+		const result = session.pruneBranch(x);
+		expect(result.contextChanged).toBe(false);
+		expect(result.removedEntryIds).toContain(x);
+		expect(result.removedEntryIds).toContain(label);
+
+		// B is re-parented to the label's nearest surviving ancestor (A).
+		expect(session.getEntry(b)!.parentId).toBe(a);
+		expect(session.getBranch().map((e) => e.id)).toEqual([r, a, b]);
+		expect(session.buildSessionContext()).toEqual(contextBefore);
+	});
+
+	it("re-parents past chained labels (single-hop re-parent would dangle)", () => {
+		const session = SessionManager.inMemory();
+		const r = session.appendMessage(userMsg("R"));
+		const a = session.appendMessage(userMsg("A"));
+		session.branch(r);
+		const x = session.appendMessage(userMsg("X"));
+		session.branch(a);
+		// Two labels back-to-back on the deleted target.
+		const l1 = session.appendLabelChange(x, "one");
+		const l2 = session.appendLabelChange(x, "two");
+		const b = session.appendMessage(userMsg("B"));
+		expect(session.getBranch().map((e) => e.id)).toEqual([r, a, l1, l2, b]);
+
+		session.pruneBranch(x);
+
+		expect(session.getEntry(l1)).toBeUndefined();
+		expect(session.getEntry(l2)).toBeUndefined();
+		expect(session.getEntry(b)!.parentId).toBe(a);
+		expect(session.getBranch().map((e) => e.id)).toEqual([r, a, b]);
+	});
+
+	it("keeps an active-path label that is the leaf when its target is pruned", () => {
+		const session = SessionManager.inMemory();
+		const r = session.appendMessage(userMsg("R"));
+		const a = session.appendMessage(userMsg("A"));
+		session.branch(r);
+		const x = session.appendMessage(userMsg("X"));
+		session.branch(a);
+		// The label advances the leaf, so it IS the leaf here.
+		const label = session.appendLabelChange(x, "mark");
+		expect(session.getLeafId()).toBe(label);
+		const contextBefore = session.buildSessionContext();
+
+		const result = session.pruneBranch(x);
+
+		// The label survives as a structural node; the leaf still resolves.
+		expect(result.removedEntryIds).not.toContain(label);
+		expect(session.getLeafId()).toBe(label);
+		expect(session.getLeafEntry()).toBeDefined();
+		expect(session.getBranch().map((e) => e.id)).toEqual([r, a, label]);
+		expect(session.buildSessionContext()).toEqual(contextBefore);
+	});
+
+	it("re-points a surviving on-path compaction past a dropped label", () => {
+		const session = SessionManager.inMemory();
+		const r = session.appendMessage(userMsg("R"));
+		const a = session.appendMessage(userMsg("A"));
+		session.branch(r);
+		const x = session.appendMessage(userMsg("X"));
+		session.branch(a);
+		const label = session.appendLabelChange(x, "mark");
+		const b = session.appendMessage(userMsg("B"));
+		const compaction = session.appendCompaction("summary", label, 1000);
+		const tail = session.appendMessage(userMsg("tail"));
+
+		const result = session.pruneBranch(x);
+
+		expect(result.contextChanged).toBe(true);
+		const kept = session.getEntry(compaction);
+		expect(kept?.type).toBe("compaction");
+		if (kept?.type === "compaction") {
+			expect(kept.firstKeptEntryId).toBe(b);
+		}
+		// Active branch and context remain valid.
+		expect(session.getBranch().map((e) => e.id)).toEqual([r, a, b, compaction, tail]);
+		expect(session.buildSessionContext().messages.length).toBeGreaterThan(0);
+	});
+
+	it("rewrites the file for persisted sessions; reopening yields survivors", () => {
+		const tempDir = join(tmpdir(), `session-prune-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+		try {
+			const session = SessionManager.create(tempDir, tempDir);
+			session.appendMessage(userMsg("A"));
+			session.appendMessage(assistantMsg("B"));
+			const c = session.appendMessage(userMsg("C"));
+			const d = session.appendMessage(assistantMsg("D"));
+			session.branch(c);
+			const e = session.appendMessage(userMsg("E"));
+			session.appendMessage(assistantMsg("F"));
+			session.branch(d);
+
+			const file = session.getSessionFile()!;
+			expect(existsSync(file)).toBe(true);
+
+			session.pruneBranch(e);
+
+			const reopened = SessionManager.open(file, tempDir);
+			expect(
+				reopened
+					.getEntries()
+					.map((en) => en.id)
+					.sort(),
+			).toEqual(
+				session
+					.getEntries()
+					.map((en) => en.id)
+					.sort(),
+			);
+			expect(reopened.getEntry(e)).toBeUndefined();
+			expect(reopened.getLeafId()).toBe(d);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not create the file early for persisted sessions with no assistant", () => {
+		const tempDir = join(tmpdir(), `session-prune-deferred-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+		try {
+			const session = SessionManager.create(tempDir, tempDir);
+			const a = session.appendMessage(userMsg("A"));
+			const b = session.appendMessage(userMsg("B"));
+			session.branch(b);
+			const e = session.appendMessage(userMsg("side"));
+			session.branch(b);
+
+			session.pruneBranch(e);
+
+			const file = session.getSessionFile()!;
+			expect(existsSync(file)).toBe(false);
+			expect(
+				session
+					.getEntries()
+					.map((en) => en.id)
+					.sort(),
+			).toEqual([a, b].sort());
+			expect(session.getEntry(e)).toBeUndefined();
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("createBranchedSession still works after a prune (in-memory)", () => {
+		const { session, ids } = buildBranchedSession();
+		session.pruneBranch(ids.e);
+
+		session.createBranchedSession(ids.d);
+		expect(session.getEntries().map((e) => e.id)).toEqual([ids.a, ids.b, ids.c, ids.d]);
+	});
+});

--- a/packages/coding-agent/test/tree-selector.test.ts
+++ b/packages/coding-agent/test/tree-selector.test.ts
@@ -700,3 +700,136 @@ describe("TreeSelectorComponent", () => {
 		});
 	});
 });
+
+describe("TreeSelectorComponent branch deletion", () => {
+	function buildDeletionTree() {
+		const entries: SessionEntry[] = [
+			userMessage("user-1", null, "first message"),
+			assistantMessage("asst-1", "user-1", "response 1"),
+			userMessage("user-2", "asst-1", "second message"),
+			assistantMessage("asst-2", "user-2", "response 2"),
+			// Active branch (leaf asst-4a)
+			userMessage("user-3a", "asst-2", "branch A start"),
+			assistantMessage("asst-4a", "user-3a", "branch A leaf"),
+			// Side branch (3 entries)
+			userMessage("user-3b", "asst-2", "branch B start"),
+			assistantMessage("asst-3b", "user-3b", "branch B response"),
+			userMessage("user-4b", "asst-3b", "branch B deep"),
+		];
+		return { entries, tree: buildTree(entries) };
+	}
+
+	function selectSideBranch(onSelect: () => void = () => {}) {
+		const { tree } = buildDeletionTree();
+		const selector = new TreeSelectorComponent(tree, "asst-4a", 24, onSelect, () => {}, undefined, "user-3b");
+		const list = selector.getTreeList();
+		expect(list.getSelectedNode()?.entry.id).toBe("user-3b");
+		return { selector, list };
+	}
+
+	test("delete key enters confirm state; enter fires onDeleteBranch with the selected id", () => {
+		const { selector, list } = selectSideBranch();
+		const deleted: string[] = [];
+		const blocked: string[] = [];
+		list.onDeleteBranch = (id) => deleted.push(id);
+		list.onDeleteBlocked = (reason) => blocked.push(reason);
+
+		selector.handleInput("D"); // shift+d
+		expect(list.isConfirmingDelete()).toBe(true);
+		expect(deleted).toEqual([]);
+
+		selector.handleInput("\r"); // enter
+		expect(deleted).toEqual(["user-3b"]);
+		expect(blocked).toEqual([]);
+		expect(list.isConfirmingDelete()).toBe(false);
+	});
+
+	test("esc cancels the confirm state without deleting", () => {
+		const { selector, list } = selectSideBranch();
+		const deleted: string[] = [];
+		list.onDeleteBranch = (id) => deleted.push(id);
+
+		selector.handleInput("D");
+		expect(list.isConfirmingDelete()).toBe(true);
+
+		selector.handleInput("\x1b"); // esc
+		expect(list.isConfirmingDelete()).toBe(false);
+		expect(deleted).toEqual([]);
+
+		// Enter now selects instead of deleting.
+		let selected: string | undefined;
+		list.onSelect = (id) => {
+			selected = id;
+		};
+		selector.handleInput("\r");
+		expect(selected).toBe("user-3b");
+		expect(deleted).toEqual([]);
+	});
+
+	test("other keys are ignored while confirming", () => {
+		const { selector, list } = selectSideBranch();
+		const deleted: string[] = [];
+		list.onDeleteBranch = (id) => deleted.push(id);
+
+		selector.handleInput("D");
+		expect(list.isConfirmingDelete()).toBe(true);
+
+		selector.handleInput("\x1b[B"); // down (ignored)
+		selector.handleInput("x"); // search char (ignored)
+		expect(list.isConfirmingDelete()).toBe(true);
+		expect(list.getSelectedNode()?.entry.id).toBe("user-3b");
+		expect(list.getSearchQuery()).toBe("");
+		expect(deleted).toEqual([]);
+
+		selector.handleInput("\r");
+		expect(deleted).toEqual(["user-3b"]);
+	});
+
+	test("active-path selection triggers onDeleteBlocked and does not confirm", () => {
+		const { tree } = buildDeletionTree();
+		const selector = new TreeSelectorComponent(
+			tree,
+			"asst-4a",
+			24,
+			() => {},
+			() => {},
+			undefined,
+			"asst-2",
+		);
+		const list = selector.getTreeList();
+		expect(list.getSelectedNode()?.entry.id).toBe("asst-2");
+		const deleted: string[] = [];
+		const blocked: string[] = [];
+		list.onDeleteBranch = (id) => deleted.push(id);
+		list.onDeleteBlocked = (reason) => blocked.push(reason);
+
+		selector.handleInput("D");
+		expect(blocked).toEqual(["Cannot delete the branch you are currently on"]);
+		expect(list.isConfirmingDelete()).toBe(false);
+		expect(deleted).toEqual([]);
+	});
+
+	test("confirmation hint renders the removed count", () => {
+		const { selector, list } = selectSideBranch();
+		list.onDeleteBranch = () => {};
+
+		selector.handleInput("D");
+		const rendered = stripVTControlCharacters(list.render(120).join("\n"));
+		expect(rendered).toContain("Delete branch");
+		expect(rendered).toContain("3 entries");
+	});
+
+	test("setTree reselects the nearest surviving visible ancestor", () => {
+		const { entries } = buildDeletionTree();
+		const { list } = selectSideBranch();
+
+		// Simulate the prune: drop the side branch, reselect its parent.
+		const survivors = entries.filter((e) => e.id !== "user-3b" && e.id !== "asst-3b" && e.id !== "user-4b");
+		list.setTree(buildTree(survivors), "asst-2");
+
+		expect(list.getSelectedNode()?.entry.id).toBe("asst-2");
+		expect(list.isConfirmingDelete()).toBe(false);
+		const rendered = stripVTControlCharacters(list.render(120).join("\n"));
+		expect(rendered).not.toContain("user-3b");
+	});
+});


### PR DESCRIPTION
Implements tree-branch-deletion-plan.md.

- SessionManager.pruneBranch(entryId) + countSubtree(): remove an off-path entry and its whole subtree. Active path protected, leaf preserved, labels re-chained, surviving compactions re-pointed.
- /tree selector: shift+d (app.tree.deleteBranch) with inline confirm, tree refreshed in place. AgentSession.syncMessagesFromSession() keeps agent state current without the UI poking agent.state.
- Docs (keybindings, sessions, session-format) and tests (new prune-branch suite + tree-selector and interactive-mode extensions).

Gates: npm run check and ./test.sh both pass. CHANGELOG untouched.

Note (not part of this PR, left uncommitted): packages/ai/src/api/google-shared.ts is broken at HEAD with a fresh pinned install - @google/genai@2.21.0 ships FinishReason.TOO_MANY_TOOL_CALLS, which the exhaustive switch in mapStopReason doesn't handle. One-line fix (add it to the error group alongside the other tool-call abnormalities); happy to send separately if wanted.